### PR TITLE
Revert "Bump commons-digester:commons-digester from 1.8.1 to 2.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -996,7 +996,7 @@
             <dependency>
                 <groupId>commons-digester</groupId>
                 <artifactId>commons-digester</artifactId>
-                <version>2.1</version>
+                <version>1.8.1</version>
             </dependency>
             <dependency>
                 <groupId>commons-discovery</groupId>


### PR DESCRIPTION
Reverts intersoftdatalabs-in/percussioncms#384

This breaks all xml serialization that relies on betwixt still.