### PR TITLE
Add org.dom4j:dom4j dependency to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -84,6 +84,9 @@ updates:
       - dependency-name: "org.dom4j:dom4j"
         versions:
           - ">=2.2.0"
+      - dependency-name: "org.eclipse.jetty:jetty-maven-plugin"
+        versions:
+          - ">=10"    
   - package-ecosystem: "maven"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,7 +81,9 @@ updates:
         versions:
           - ">=2.9"
       - dependency-name: "com.percussion:*"
-
+      - dependency-name: "org.dom4j:dom4j"
+        versions:
+          - ">=2.2.0"
   - package-ecosystem: "maven"
     directory: "/"
     schedule:


### PR DESCRIPTION
Ignore dom4j 2.2.0 as it requires java 11