### PR TITLE
Revert "Bump javax.jcr:jcr from 1.0 to 2.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -659,7 +659,7 @@
             <dependency>
                 <groupId>javax.jcr</groupId>
                 <artifactId>jcr</artifactId>
-                <version>2.0</version>
+                <version>1.0</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.jettison</groupId>


### PR DESCRIPTION
Reverts intersoftdatalabs-in/percussioncms#496.  Too many changes in this api version.