### PR TITLE
Add Jakarta dependencies and update version constraints in dependabot…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -90,7 +90,7 @@ updates:
           - ">=2.2.0"
       - dependency-name: "org.eclipse.jetty:jetty-maven-plugin"
         versions:
-          - ">=10" 
+          - ">=10"
       - dependency-name: "org.mortbay.jasper:apache-jsp"
         versions:
           - ">=10"
@@ -136,6 +136,40 @@ updates:
       - dependency-name: "com.google.inject:guice"
         versions:
           - ">=5.2"
+      # Jakarta namespace - all Jakarta dependencies require Java 11+
+      - dependency-name: "jakarta.annotation:*"
+      - dependency-name: "jakarta.servlet:*"
+      - dependency-name: "jakarta.servlet.jsp:*"
+      - dependency-name: "jakarta.servlet.jsp.jstl:*"
+      - dependency-name: "jakarta.ws.rs:*"
+      - dependency-name: "jakarta.persistence:*"
+      - dependency-name: "jakarta.el:*"
+      - dependency-name: "jakarta.mail:*"
+      - dependency-name: "jakarta.validation:*"
+      - dependency-name: "jakarta.transaction:*"
+      - dependency-name: "jakarta.xml.bind:*"
+      - dependency-name: "jakarta.activation:*"
+      - dependency-name: "jakarta.inject:*"
+      - dependency-name: "jakarta.json:*"
+      # Trinidad 3.x requires Jakarta namespace
+      - dependency-name: "org.apache.myfaces.trinidad:*"
+        versions:
+          - ">=3"
+      # XML APIs 2.x may require Java 9+
+      - dependency-name: "xml-apis:xml-apis"
+        versions:
+          - ">=2"
+      # PDF Box - keep 3.x series, avoid backporting to 2.x
+      - dependency-name: "org.apache.pdfbox:*"
+        versions:
+          - "<3"
+      # Velocity 3.x may have compatibility issues
+      - dependency-name: "org.apache.velocity:velocity-engine-core"
+        versions:
+          - ">=3"
+      - dependency-name: "org.apache.velocity.tools:*"
+        versions:
+          - ">=4"
   - package-ecosystem: "maven"
     directory: "/"
     schedule:


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to expand and clarify the set of dependencies that Dependabot monitors, especially with regard to Jakarta, XML, PDF, and Velocity libraries. The changes ensure that dependency updates are better aligned with Java version requirements and compatibility considerations.

**Dependency monitoring improvements:**

* Added monitoring for all major Jakarta dependencies (e.g., `jakarta.annotation:*`, `jakarta.servlet:*`, etc.), with a note that these require Java 11 or higher.
* Included `org.apache.myfaces.trinidad:*` (Trinidad 3.x) dependencies, specifying version constraints to ensure use of the Jakarta namespace.
* Added monitoring for `xml-apis:xml-apis` version 2.x and above, noting possible Java 9+ requirements.
* Updated PDFBox dependency rules to only track the 3.x series and avoid backporting to 2.x.
* Added monitoring for `org.apache.velocity:velocity-engine-core` (version 3.x and above) and `org.apache.velocity.tools:*` (version 4.x and above), noting potential compatibility issues.….yml