### PR TITLE
docs: recommend using mvn-env.sh for JDK 21 in READMEs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -106,8 +106,7 @@ Always use the #codebase context when resolving missing interfaces or classes.
 * Use the provided environment scripts to ensure Maven uses JDK 21 when running locally:
 - Linux/macOS: `./mvn-env.sh <maven-args>`
 - Windows: `mvn-env.bat <maven-args>`
-These scripts set `JAVA_HOME` from `JAVA_HOME_21`.
-* Example: `export JAVA_HOME=/usr/lib/jvm/java-1.21.0-amazon-corretto` before running `mvn` commands
+These scripts set `JAVA_HOME` from `JAVA_HOME_21`.* **Before committing:** run `./mvn-env.sh spotless:check` and, if it fails, run `./mvn-env.sh spotless:apply` and re-run the check before pushing changes. (Spotless enforces code formatting/style; `google-java-format` used by Spotless requires JDK 21, so run Spotless via the wrapper scripts.)* Example: `export JAVA_HOME=/usr/lib/jvm/java-1.21.0-amazon-corretto` before running `mvn` commands
 == Dependencies
 * Upgrade dependencies to their latest versions that are compatible with JDK 21.0
 * Dependency versions are managed in the parent pom.xml file

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -103,6 +103,10 @@ Always use the #codebase context when resolving missing interfaces or classes.
 * Ensure all code is compatible with JDK 21
 * Build and test the project using JDK 21
 * **ALWAYS set JAVA_HOME to a Java 21 JRE before running any build or shell commands**
+* Use the provided environment scripts to ensure Maven uses JDK 21 when running locally:
+- Linux/macOS: `./mvn-env.sh <maven-args>`
+- Windows: `mvn-env.bat <maven-args>`
+These scripts set `JAVA_HOME` from `JAVA_HOME_21`.
 * Example: `export JAVA_HOME=/usr/lib/jvm/java-1.21.0-amazon-corretto` before running `mvn` commands
 == Dependencies
 * Upgrade dependencies to their latest versions that are compatible with JDK 21.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,6 +160,13 @@ Before you start working on a bug or feature, discuss the issue in GitHub Issues
 
 When starting work, create a new feature branch.
 
+**Before committing**
+
+- Use the project wrapper scripts so Maven runs with JDK 21: `./mvn-env.sh <maven-args>` (Linux/macOS) or `mvn-env.bat <maven-args>` (Windows).
+- Run `./mvn-env.sh spotless:check` (Spotless enforces code formatting/style). If the check fails, run `./mvn-env.sh spotless:apply` to auto-fix formatting and re-run `spotless:check` until it passes.
+  - Note: the `google-java-format` implementation used by Spotless needs JDK 21 at runtime; run Spotless via the wrapper scripts so the formatter runs under JDK 21.
+- Run `./mvn-env.sh -DskipTests validate` or `./mvn-env.sh clean verify` to ensure the module builds before pushing your commit.
+
 IntelliJ makes some of this a lot easier, especially when searching for specific error messages across modules in the code base.
 
 The examples below show the typical command line for create a feature branch and pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,8 +120,10 @@ git pull
 ## Pre-Requisites for Building
 
 - Apache Maven > 3.6
-- Java 1.8 OpenJDK
-- Oracle 1.8 JDK (for JavaFX) TODO: Pull JavaFX from maven
+- JDK 21 (set `JAVA_HOME_21` to your JDK 21 installation)
+- Use the provided environment setup scripts to run Maven so it uses JDK 21:
+  - Linux/macOS: `./mvn-env.sh <maven-args>`
+  - Windows: `mvn-env.bat <maven-args>`
 
 ## Maven Configuration
 

--- a/deliverytiersuite/delivery-tier-suite/README.md
+++ b/deliverytiersuite/delivery-tier-suite/README.md
@@ -14,6 +14,6 @@ And all other supporting services modules.
 ## Building
 
 ```
-mvn clean install
+Use `./mvn-env.sh clean install` (or `mvn-env.bat clean install` on Windows) so Maven runs with JDK 21.
 ```
 

--- a/modules/perc-distribution-tree/README.md
+++ b/modules/perc-distribution-tree/README.md
@@ -6,6 +6,6 @@ It uses ANT for Install and Upgrades.
 ## Building
 
 ```
-mvn clean install
+Use `./mvn-env.sh clean install` (or `mvn-env.bat clean install` on Windows) so Maven runs with JDK 21.
 ```
 

--- a/modules/tlsutils/README.md
+++ b/modules/tlsutils/README.md
@@ -51,14 +51,14 @@ Ensure you have the following installed:
 # Navigate to the tlsutils module directory
 cd modules/tlsutils
 
-# Clean and compile the project
-mvn clean compile
+# Clean and compile the project (use wrapper so Maven runs with JDK 21)
+./mvn-env.sh clean compile
 
 # Package the module (creates JAR file)
-mvn clean package
+./mvn-env.sh clean package
 
 # Install to local Maven repository
-mvn clean install
+./mvn-env.sh clean install
 ```
 
 ### Build from Parent Project

--- a/projects/sitemanage/README.md
+++ b/projects/sitemanage/README.md
@@ -9,4 +9,4 @@ This module contains support for following :
 
 ## Building
 
-mvn clean install
+Use `./mvn-env.sh clean install` (or `mvn-env.bat clean install` on Windows) so Maven runs with JDK 21.

--- a/system/README.md
+++ b/system/README.md
@@ -13,7 +13,7 @@
 - No breaking changes to public interfaces.
 - All legacy logging replaced with Log4j 2.x.
 - JUnit5 is now required for all tests.
-- Please run `mvn clean verify` and `mvn spotless:check` before commits.
+- Please run `./mvn-env.sh clean verify` and `./mvn-env.sh spotless:check` (or `mvn-env.bat` on Windows) before commits to ensure Maven runs with JDK 21.
 
 ### Usage Example
 

--- a/system/README.md
+++ b/system/README.md
@@ -13,7 +13,7 @@
 - No breaking changes to public interfaces.
 - All legacy logging replaced with Log4j 2.x.
 - JUnit5 is now required for all tests.
-- Please run `./mvn-env.sh clean verify` and `./mvn-env.sh spotless:check` (or `mvn-env.bat` on Windows) before commits to ensure Maven runs with JDK 21.
+- Please run `./mvn-env.sh spotless:check` (Spotless enforces code formatting/style — if it fails, run `./mvn-env.sh spotless:apply`), then `./mvn-env.sh clean verify` (or `mvn-env.bat` on Windows) before commits. Note: `google-java-format` (used by Spotless) requires JDK 21 to run, so use the wrapper scripts to execute Spotless under JDK 21.
 
 ### Usage Example
 


### PR DESCRIPTION
Add instructions to use the provided mvn-env.sh / mvn-env.bat wrapper scripts (set JAVA_HOME from JAVA_HOME_21) and to run Spotless before committing. Updated CONTRIBUTING.md, system/README.md, .github/copilot-instructions.md, and several module READMEs. Verified formatting with ./mvn-env.sh spotless:apply and ./mvn-env.sh spotless:check.

No functional code changes.