### PR TITLE
Fix #571 for new PDFbox version

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ To ensure Maven uses JDK 8, use the provided environment setup scripts instead o
 
    - Linux example: `export JAVA_HOME_8=/usr/lib/jvm/java-1.8.0-amazon-corretto`
    - macOS example: `export JAVA_HOME_8=/Library/Java/JavaVirtualMachines/jdk-1.8.jdk/Contents/Home`
-
 2. Run Maven commands using the script:
 
    ```bash
@@ -106,7 +105,6 @@ To ensure Maven uses JDK 8, use the provided environment setup scripts instead o
 1. Set `JAVA_HOME_8` as an environment variable:
    - Open System Properties > Environment Variables.
    - Add a new user variable `JAVA_HOME_8` with value `C:\path\to\jdk-8` (e.g., `C:\Program Files\Java\jdk-8`).
-
 2. Run Maven commands using the script:
 
    ```batch

--- a/pom.xml
+++ b/pom.xml
@@ -1155,10 +1155,30 @@
                 <groupId>org.apache.pdfbox</groupId>
                 <artifactId>pdfbox</artifactId>
                 <version>${pdfbox.version}</version>
+                <exclusions>
+                    <!-- Exclude JAXB-related dependencies that PDFBox 3.0 no longer needs directly -->
+                    <exclusion>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.sun.xml.bind</groupId>
+                        <artifactId>jaxb-impl</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.sun.xml.bind</groupId>
+                        <artifactId>jaxb-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.pdfbox</groupId>
                 <artifactId>pdfbox-tools</artifactId>
+                <version>${pdfbox.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.pdfbox</groupId>
+                <artifactId>pdfbox-io</artifactId>
                 <version>${pdfbox.version}</version>
             </dependency>
             <dependency>

--- a/system/pom.xml
+++ b/system/pom.xml
@@ -635,6 +635,10 @@
             <artifactId>pdfbox-tools</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox-io</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
         </dependency>

--- a/system/src/main/java/com/percussion/search/lucene/textconverter/PSTextConverterPdf.java
+++ b/system/src/main/java/com/percussion/search/lucene/textconverter/PSTextConverterPdf.java
@@ -22,6 +22,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 
@@ -52,7 +54,9 @@ public class PSTextConverterPdf implements IPSLuceneTextConverter {
     String resultText = "";
     PDDocument pdfDocument = null;
     try {
-      pdfDocument = PDDocument.load(is);
+      // PDFBox 3.0 requires using RandomAccessRead instead of InputStream
+      // RandomAccessReadBuffer accepts InputStream in constructor
+      pdfDocument = Loader.loadPDF(new RandomAccessReadBuffer(is));
       if (pdfDocument.isEncrypted()) {
         // Just try using the default password and move on
 


### PR DESCRIPTION
This pull request updates dependencies and code to improve compatibility with PDFBox 3.0, removes unnecessary JAXB dependencies, and updates documentation for JDK 8 setup. The most significant changes are dependency updates in `pom.xml` files, a code change to support PDFBox 3.0's new API, and minor documentation cleanups.

**Dependency updates and exclusions:**
* In `pom.xml`, excluded JAXB-related dependencies (`jaxb-api`, `jaxb-impl`, `jaxb-core`) from the `pdfbox` dependency, as PDFBox 3.0 no longer requires them directly. Also, added an explicit dependency on `pdfbox-io` to ensure all required modules are present.
* In `system/pom.xml`, added the `pdfbox-io` dependency to match the modularization in PDFBox 3.0.

**Code updates for PDFBox 3.0 compatibility:**
* In `PSTextConverterPdf.java`, updated imports to use `Loader` and `RandomAccessReadBuffer` as required by PDFBox 3.0.
* Changed the way PDF documents are loaded: replaced `PDDocument.load(is)` with `Loader.loadPDF(new RandomAccessReadBuffer(is))` to comply with PDFBox 3.0's requirement for a `RandomAccessRead` input.

**Documentation cleanup:**
* Cleaned up redundant instructions for setting `JAVA_HOME_8` in the `README.md` for both Linux/macOS and Windows sections. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L109)