### PR TITLE
Update extensions-main module for java 21.  Update readme.

### DIFF
--- a/modules/extensions-main/README.md
+++ b/modules/extensions-main/README.md
@@ -1,10 +1,58 @@
 # extensions-main
 
-This module contains all main extensions for Java and JS Main Features
+The **extensions-main** module provides a collection of server-side extension
+classes and utilities that ship with Percussion CMS.  It houses all of the
+standard Java exits, UDFs, and other extension points that are used by the
+core application and by customers when they implement custom behavior.  The
+code here is intended to be lightweight, backward‑compatible and safe to run
+in both production and development environments.  In addition to Java
+implementations, the module also contains supporting JavaScript resources used
+by the Rhythmyx engine.
 
-## Building
+## Key responsibilities
 
+* Common extension base classes (`PSGenericAssembly`, `PSSimpleJavaUdf_…`,
+  etc.)
+* CMS-specific business logic exits (search handlers, community ACL helpers)
+* Utility helpers for string manipulation, date conversion, etc.
+* Preprocessors and result document processors used by the Content
+  Management clients.
+
+## Developer guide
+
+Before building, make sure you're using **JDK 21** (see project README for
+wrapper scripts).  The module is built with Maven and is part of the parent
+multi‑module project, so its lifecycle is managed by the top‑level POM.
+
+From the workspace root you can compile just this module with:
+
+```bash
+# use wrapper so JAVA_HOME is set correctly
+cd modules/extensions-main
+../../mvn-env.sh clean compile
 ```
-mvn clean install
+
+Run the unit tests with:
+
+```bash
+../../mvn-env.sh test
 ```
+
+Because the module depends on other components of the system, a full
+`clean install` from the root is usually required when making cross‑module
+changes:
+
+```bash
+./mvn-env.sh clean install -DskipTests
+```
+
+### Notes for contributors
+
+* Keep public APIs backward compatible; avoid breaking changes in classes
+  under `com.percussion.extensions`.
+* Add new tests alongside any new code; the module uses JUnit 5.
+* Run `./mvn-env.sh spotless:check` before committing and apply fixes with
+  `spotless:apply` if needed.
+
+---
 

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSGenericAssembly.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSGenericAssembly.java
@@ -28,6 +28,7 @@ import com.percussion.server.IPSRequestContext;
 import com.percussion.system.utils.IPSHtmlParameters;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.HashMap;
+import java.util.Map;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.w3c.dom.Document;
@@ -82,7 +83,8 @@ public class PSGenericAssembly extends PSDefaultExtension implements IPSAssembly
 
       String resource = params[0].toString().trim();
 
-      HashMap<String, String> newHTMLParams = new HashMap<>();
+      // request.getInternalRequest expects a map of <String,Object>
+      Map<String, Object> newHTMLParams = new HashMap<>();
       if ((params.length >= 2)
           && (params[1] != null)
           && (params[1].toString().trim().length() > 0)) {

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSSearchCommunityHandler.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSSearchCommunityHandler.java
@@ -39,11 +39,15 @@ import com.percussion.xml.PSXmlTreeWalker;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import com.percussion.services.security.PSServiceSecurityException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+
+// required for exception handling of security errors
+import com.percussion.security.PSSecurityException;
 
 /**
  * Walk the search properties in the request document. For sys_community, remove the property and
@@ -151,7 +155,7 @@ public class PSSearchCommunityHandler implements IPSRequestPreProcessor {
         acls.add(object_acl);
         asvc.saveAcls(acls);
       }
-    } catch (PSSecurityException e1) {
+    } catch (PSSecurityException | PSServiceSecurityException e1) {
       ms_log.error(e1);
     }
   }

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_dateAdjust.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_dateAdjust.java
@@ -106,16 +106,18 @@ public class PSSimpleJavaUdf_dateAdjust extends PSSimpleJavaUdfExtension {
     else if (params[0] instanceof Date) {
       day = (Date) params[0];
     } else {
-      // parseStringToDate now throws unchecked exceptions on failure, handle accordingly
+      // parseStringToDate throws IllegalArgumentException for null/empty input,
+      // and returns null when the string cannot be parsed as a date.
+      String paramContext =
+          "Param 1 is (" + params[0].toString() + ") PSSimpleJavaUdf_dateAdjust/processUdf";
       try {
         day = com.percussion.util.PSDataTypeConverter.parseStringToDate(params[0].toString());
       } catch (IllegalArgumentException e) {
-        int errCode = 0;
-        Object[] args = {
-          e.toString(),
-          "Param 1 is (" + params[0].toString() + ")" + " PSSimpleJavaUdf_dateAdjust/processUdf"
-        };
-        throw new PSConversionException(errCode, args);
+        throw new PSConversionException(0, new Object[] {e.toString(), paramContext});
+      }
+      if (day == null) {
+        throw new PSConversionException(
+            0, new Object[] {"Unable to parse date string", paramContext});
       }
     }
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_dateAdjust.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_dateAdjust.java
@@ -18,7 +18,7 @@
 package com.percussion.extensions.general;
 
 import com.percussion.data.PSConversionException;
-import com.percussion.data.PSDataConverter;
+// PSDataConverter was used only for parseStringToDate which is now private
 import com.percussion.extension.PSSimpleJavaUdfExtension;
 import com.percussion.server.IPSRequestContext;
 import com.percussion.system.utils.PSCalculation;
@@ -106,9 +106,10 @@ public class PSSimpleJavaUdf_dateAdjust extends PSSimpleJavaUdfExtension {
     else if (params[0] instanceof Date) {
       day = (Date) params[0];
     } else {
+      // parseStringToDate now throws unchecked exceptions on failure, handle accordingly
       try {
-        day = PSDataConverter.parseStringToDate(params[0].toString());
-      } catch (java.text.ParseException e) {
+        day = com.percussion.util.PSDataTypeConverter.parseStringToDate(params[0].toString());
+      } catch (IllegalArgumentException e) {
         int errCode = 0;
         Object[] args = {
           e.toString(),
@@ -121,7 +122,7 @@ public class PSSimpleJavaUdf_dateAdjust extends PSSimpleJavaUdfExtension {
     // First initialize spaces for -all- adjust numbers to 0
     Number[] paramArray = new Number[MAX_PARAMS - 1];
     for (int i = 0; i < MAX_PARAMS - 1; i++) {
-      paramArray[i] = new Integer(0);
+      paramArray[i] = Integer.valueOf(0);
     }
 
     // All parameters after 1 are the adjustment numbers

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSTranslationKeyValueAccessor.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSTranslationKeyValueAccessor.java
@@ -73,7 +73,7 @@ public class PSTranslationKeyValueAccessor implements IPSResultDocumentProcessor
       System.arraycopy(ps, 0, packages, 0, ps.length);
     }
 
-    Map keyValueMap = getMapFromKeys(theLang, packages);
+    Map<String, PSTmxUnit> keyValueMap = getMapFromKeys(theLang, packages);
     if (keyValueMap == null) {
       Object[] errs = {getClass().getName(), theLang};
 
@@ -101,17 +101,17 @@ public class PSTranslationKeyValueAccessor implements IPSResultDocumentProcessor
    * @return may return <code>null</code> if default language or the passed language isn't
    *     supported.
    */
-  private Map getMapFromKeys(String language, String[] packages) {
+  private Map<String, PSTmxUnit> getMapFromKeys(String language, String[] packages) {
     // this calls a method that will already check the default.
-    Iterator it = PSI18nUtils.getKeys(getActiveLocale(language));
-    Map keyValueMap = null;
+    Iterator<String> it = PSI18nUtils.getKeys(getActiveLocale(language));
+    Map<String, PSTmxUnit> keyValueMap = null;
 
     if (it != null) {
-      keyValueMap = new HashMap();
+      keyValueMap = new HashMap<>();
 
       String theKey = "";
       while (it.hasNext()) {
-        theKey = (String) it.next();
+        theKey = it.next();
         String value = PSI18nUtils.getString(theKey, language);
         String mnemonic = PSI18nUtils.getMnemonic(theKey, language);
         String tooltip = PSI18nUtils.getTooltip(theKey, language);
@@ -150,7 +150,8 @@ public class PSTranslationKeyValueAccessor implements IPSResultDocumentProcessor
   private String getActiveLocale(String lang) {
     IPSCmsObjectMgr mgr = PSCmsObjectMgrLocator.getObjectManager();
     List<String> langs = new ArrayList<>();
-    List<PSLocale> locales = mgr.findLocaleByStatus(PSLocale.STATUS_ACTIVE);
+    // findLocaleByStatus was removed; use the stream-based replacement
+    List<PSLocale> locales = mgr.findLocalesByStatus(PSLocale.STATUS_ACTIVE).toList();
     for (PSLocale locale : locales) {
       langs.add(locale.getLanguageString());
     }

--- a/modules/extensions-main/src/test/java/com/percussion/extensions/general/PSParamStringListToMultiParamsTest.java
+++ b/modules/extensions-main/src/test/java/com/percussion/extensions/general/PSParamStringListToMultiParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/extensions-main/src/test/java/com/percussion/extensions/general/PSParamStringListToMultiParamsTest.java
+++ b/modules/extensions-main/src/test/java/com/percussion/extensions/general/PSParamStringListToMultiParamsTest.java
@@ -19,10 +19,13 @@ package com.percussion.extensions.general;
 import com.percussion.extension.PSParameterMismatchException;
 import com.percussion.server.PSRequest;
 import com.percussion.server.PSRequestContext;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /** Unit test for the <code>PSParamStringListToMultiParams</code> exit. */
 public class PSParamStringListToMultiParamsTest {
-  /** Tets all exit contracts and functionality. */
+  /** Test all exit contracts and functionality. */
+  @Test
   public void testExit() throws Exception {
     PSParamStringListToMultiParams test = new PSParamStringListToMultiParams();
 
@@ -44,7 +47,7 @@ public class PSParamStringListToMultiParamsTest {
     parameters[0] = null;
     try {
       test.preProcessRequest(parameters, request);
-      assertTrue("Expected exception", false);
+      assertTrue(false, "Expected exception");
     } catch (PSParameterMismatchException e) {
       // expected
     }
@@ -53,7 +56,7 @@ public class PSParamStringListToMultiParamsTest {
     parameters[0] = " ";
     try {
       test.preProcessRequest(parameters, request);
-      assertTrue("Expected exception", false);
+      assertTrue(false, "Expected exception");
     } catch (IllegalArgumentException e) {
       // expected
     }
@@ -64,7 +67,7 @@ public class PSParamStringListToMultiParamsTest {
     parameters[1] = null;
     try {
       test.preProcessRequest(parameters, request);
-      assertTrue("Expected exception", false);
+      assertTrue(false, "Expected exception");
     } catch (PSParameterMismatchException e) {
       // expected
     }
@@ -75,7 +78,7 @@ public class PSParamStringListToMultiParamsTest {
     parameters[2] = null;
     try {
       test.preProcessRequest(parameters, request);
-      assertTrue("Expected exception", false);
+      assertTrue(false, "Expected exception");
     } catch (PSParameterMismatchException e) {
       // expected
     }
@@ -84,7 +87,7 @@ public class PSParamStringListToMultiParamsTest {
     parameters[2] = " ";
     try {
       test.preProcessRequest(parameters, request);
-      assertTrue("Expected exception", false);
+      assertTrue(false, "Expected exception");
     } catch (IllegalArgumentException e) {
       // expected
     }

--- a/modules/extensions-main/src/test/java/com/percussion/extensions/general/PSParamStringListToMultiParamsTest.java
+++ b/modules/extensions-main/src/test/java/com/percussion/extensions/general/PSParamStringListToMultiParamsTest.java
@@ -47,7 +47,7 @@ public class PSParamStringListToMultiParamsTest {
     parameters[0] = null;
     try {
       test.preProcessRequest(parameters, request);
-      assertTrue(false, "Expected exception");
+      fail("Expected exception");
     } catch (PSParameterMismatchException e) {
       // expected
     }
@@ -56,7 +56,7 @@ public class PSParamStringListToMultiParamsTest {
     parameters[0] = " ";
     try {
       test.preProcessRequest(parameters, request);
-      assertTrue(false, "Expected exception");
+      fail("Expected exception");
     } catch (IllegalArgumentException e) {
       // expected
     }
@@ -67,7 +67,7 @@ public class PSParamStringListToMultiParamsTest {
     parameters[1] = null;
     try {
       test.preProcessRequest(parameters, request);
-      assertTrue(false, "Expected exception");
+      fail("Expected exception");
     } catch (PSParameterMismatchException e) {
       // expected
     }
@@ -78,7 +78,7 @@ public class PSParamStringListToMultiParamsTest {
     parameters[2] = null;
     try {
       test.preProcessRequest(parameters, request);
-      assertTrue(false, "Expected exception");
+      fail("Expected exception");
     } catch (PSParameterMismatchException e) {
       // expected
     }
@@ -87,7 +87,7 @@ public class PSParamStringListToMultiParamsTest {
     parameters[2] = " ";
     try {
       test.preProcessRequest(parameters, request);
-      assertTrue(false, "Expected exception");
+      fail("Expected exception");
     } catch (IllegalArgumentException e) {
       // expected
     }


### PR DESCRIPTION
This pull request introduces several improvements to the `extensions-main` module, focusing on code modernization, enhanced documentation, and better type safety. The changes include a rewritten module README for clarity, refactoring and updating Java code to use generics and modern conventions, improved exception handling, and updates to unit tests for accuracy and compliance with JUnit 5 standards.

Documentation improvements:

* Expanded and clarified the `README.md` for `extensions-main`, detailing module responsibilities, developer guidelines, and build instructions.

Code modernization and type safety:

* Refactored various classes to use Java generics, such as changing raw `Map` and `Iterator` types to parameterized types in `PSTranslationKeyValueAccessor`, and updated method signatures and variable declarations accordingly. [[1]](diffhunk://#diff-bb67002310ba8e69601f269c7da1bc1c087e29588cd9eca6eea9c1c40f70b6e1L76-R76) [[2]](diffhunk://#diff-bb67002310ba8e69601f269c7da1bc1c087e29588cd9eca6eea9c1c40f70b6e1L104-R114)
* Updated `PSGenericAssembly` to use `Map<String, Object>` instead of `HashMap<String, String>` for compatibility with internal request expectations.
* Replaced deprecated or removed methods (e.g., `findLocaleByStatus`) with their modern equivalents using streams in `PSTranslationKeyValueAccessor`.
* Modernized code style, such as using `Integer.valueOf(0)` instead of `new Integer(0)` in `PSSimpleJavaUdf_dateAdjust`.

Exception handling enhancements:

* Improved exception handling in `PSSearchCommunityHandler` by catching both `PSSecurityException` and `PSServiceSecurityException` for robust error logging.
* Updated `PSSimpleJavaUdf_dateAdjust` to use `com.percussion.util.PSDataTypeConverter.parseStringToDate` and handle unchecked exceptions, replacing the previous checked exception handling.

Testing updates:

* Converted the unit test for `PSParamStringListToMultiParams` to use JUnit 5 annotations and assertions, improving clarity and compliance with modern testing practices. [[1]](diffhunk://#diff-6253f7594b7691bc175044a8de89c9a659fac3936131de56cc8e279a1b5676b3R22-R28) [[2]](diffhunk://#diff-6253f7594b7691bc175044a8de89c9a659fac3936131de56cc8e279a1b5676b3L47-R50) [[3]](diffhunk://#diff-6253f7594b7691bc175044a8de89c9a659fac3936131de56cc8e279a1b5676b3L56-R59) [[4]](diffhunk://#diff-6253f7594b7691bc175044a8de89c9a659fac3936131de56cc8e279a1b5676b3L67-R70) [[5]](diffhunk://#diff-6253f7594b7691bc175044a8de89c9a659fac3936131de56cc8e279a1b5676b3L78-R81) [[6]](diffhunk://#diff-6253f7594b7691bc175044a8de89c9a659fac3936131de56cc8e279a1b5676b3L87-R90)