### PR TITLE
Potential fix for code scanning alert no. 797: Server-side request forgery

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/services/PSFeedService.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/services/PSFeedService.java
@@ -511,16 +511,26 @@ public class PSFeedService extends PSAbstractRestService implements IPSFeedsRest
     String protocol = null;
     Client client;
 
+    // Sanitize the scheme from the incoming request to avoid using unexpected values
+    String scheme = httpRequest.getScheme();
+    if (scheme != null) {
+      scheme = scheme.toLowerCase();
+    }
+    if (!"http".equals(scheme) && !"https".equals(scheme)) {
+      // Fallback to a safe default if the scheme is not one of the allowed values
+      scheme = "http";
+    }
+
     try {
       client = this.httpClient.getSSLClient();
       uri = new URI(desc.getLink());
       if (isIPV4Address) {
-        url = httpRequest.getScheme() + "://" + this.rssFeedsIP + ":" + httpRequest.getLocalPort();
+        url = scheme + "://" + this.rssFeedsIP + ":" + httpRequest.getLocalPort();
       } else if (isIPV6Address) {
         url =
-            httpRequest.getScheme() + "://[" + this.rssFeedsIP + "]:" + httpRequest.getLocalPort();
+            scheme + "://[" + this.rssFeedsIP + "]:" + httpRequest.getLocalPort();
       } else {
-        url = httpRequest.getScheme() + "://" + this.rssFeedsIP + ":" + httpRequest.getLocalPort();
+        url = scheme + "://" + this.rssFeedsIP + ":" + httpRequest.getLocalPort();
       }
 
       protocol = uri.getScheme() + "://";


### PR DESCRIPTION
Potential fix for [https://github.com/intersoftdatalabs-in/percussioncms/security/code-scanning/797](https://github.com/intersoftdatalabs-in/percussioncms/security/code-scanning/797)

In general, to fix SSRF issues you should avoid using user-controlled input directly when building outbound request URLs, and instead either (a) derive scheme/host/port only from trusted configuration or (b) validate them against a strict allowlist. In this case, the host and port are already constrained, but the scheme comes from `httpRequest.getScheme()` (which in turn returns `m_scheme` from `PSServletRequestWrapper`). We can eliminate the taint and make the behavior explicit by enforcing that only `"http"` or `"https"` are used, and falling back to a safe default if the request scheme is anything else.

The best minimal fix is inside `PSFeedService.generateFeed(...)`: before we build `url`, read `httpRequest.getScheme()`, normalize it, validate it against an allowlist (`"http"` / `"https"`), and then use this validated variable instead of the raw `httpRequest.getScheme()` in all three `url = ...` branches. This keeps existing functionality (still preferring the incoming request’s scheme where it is valid) but prevents any unexpected or malicious scheme values from influencing the constructed URL. We do not need to touch `PSServletRequestWrapper` for this fix; we only need to adjust `generateFeed` to sanitize the scheme locally.

Concretely:

- In `PSFeedService.generateFeed`, introduce a local `String scheme = httpRequest.getScheme();` and then normalize and validate it: convert to lower case, and if it is not exactly `"http"` or `"https"`, replace it with a safe default (e.g., `"http"`).
- Replace each occurrence of `httpRequest.getScheme()` in the URL construction block with this sanitized `scheme` variable.
- No new external libraries are required; use `StringUtils` (already imported) to check for blankness or compare values if desired, or simple string comparison.

This change keeps the endpoint, path, host, and port logic unchanged, but ensures the protocol used for the outbound request cannot be manipulated into an unexpected value via a tainted `HttpServletRequest` / wrapper.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
