### PR TITLE
Potential fix for code scanning alert no. 642: Implicit narrowing conversion in compound assignment

### DIFF
--- a/system/src/main/java/com/percussion/server/cache/PSAutotuneCache.java
+++ b/system/src/main/java/com/percussion/server/cache/PSAutotuneCache.java
@@ -213,7 +213,7 @@ public class PSAutotuneCache {
   private long calcSpaceForSmallerTables() {
     long kb = 0;
     for (String key : smallTables.keySet()) {
-      kb += ehcacheDbRowCountValues.get(key) * smallTables.get(key);
+      kb += (long) (ehcacheDbRowCountValues.get(key) * smallTables.get(key));
     }
     log.debug(
         "The current amount of MB allocated for entries in the cache for smaller tables are: {}",


### PR DESCRIPTION
Potential fix for [https://github.com/intersoftdatalabs-in/percussioncms/security/code-scanning/642](https://github.com/intersoftdatalabs-in/percussioncms/security/code-scanning/642)

In general, to fix this type of problem you either (a) make the accumulator variable wide enough to hold the full precision of the expression (e.g., change it to `double`), or (b) ensure that the expression is converted to the accumulator type in a single, explicit cast so the behavior is clear and tool warnings are silenced.

Here, `calcSpaceForSmallerTables` returns a `long`, and is described as returning “a representation in bytes”, while the log statement divides `kb` by `KB_TO_MB` and formats with `DF2`, implying that any fractional component during summation is probably a meaningful intermediate that we might want to preserve before rounding. The least intrusive fix that preserves existing method signatures and semantics is to compute each product in `double`, cast that product explicitly to `long`, and then add that to `kb`. This removes the implicit narrowing in the compound assignment and makes the truncation explicit and local. Concretely, in `calcSpaceForSmallerTables` we will change the loop body from:

```java
kb += ehcacheDbRowCountValues.get(key) * smallTables.get(key);
```

to:

```java
kb += (long) (ehcacheDbRowCountValues.get(key) * smallTables.get(key));
```

This keeps `kb` as `long`, preserves the method’s return type and callers, avoids introducing new fields or imports, and makes the cast explicit so that both static analysis tools and human readers can see that truncation is intentional at the per-key level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
