### PR TITLE
Potential fix for code scanning alert no. 630: Implicit narrowing conversion in compound assignment

### DIFF
--- a/system/Testing/src/com/percussion/test/http/HttpRequest.java
+++ b/system/Testing/src/com/percussion/test/http/HttpRequest.java
@@ -644,7 +644,7 @@ public class HttpRequest
     *
     * @return A value >= 0.
     */
-   public int getBytesSent()
+   public long getBytesSent()
    {
       return m_bytesSent;
    }
@@ -654,7 +654,7 @@ public class HttpRequest
     * of <code>sendRequest</code>. 0 until this method called at least once.
     * Use {@link #getBytesSent} to retrieve.
     */
-   protected int m_bytesSent = 0;
+   protected long m_bytesSent = 0L;
    protected Socket m_sock;
    protected LogSink m_logger;
 


### PR DESCRIPTION
Potential fix for [https://github.com/intersoftdatalabs-in/percussioncms/security/code-scanning/630](https://github.com/intersoftdatalabs-in/percussioncms/security/code-scanning/630)

In general, to fix implicit narrowing in a compound assignment, ensure the left-hand side variable is at least as wide as the right-hand side expression, or explicitly handle the narrowing (e.g., with checked bounds or a cast) if truncation is truly intended.

Here, the best fix without changing behavior for normal-sized values is to change `m_bytesSent` from `int` to `long` and adjust the getter `getBytesSent()` to also return `long`. This removes the implicit cast in `m_bytesSent += bytesSent;` because both operands become `long`. Since `bytesSent` is already `long`, the change is straightforward. Within the provided snippet, we need to:
- Update the field declaration at line 657 from `int` to `long`.
- Update the return type and body of `getBytesSent()` at lines 647–649 from `int` to `long`.
No additional imports or helper methods are required; `long` is a primitive type.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
