### PR TITLE
Potential fix for code scanning alert no. 640: Implicit narrowing conversion in compound assignment

### DIFF
--- a/system/src/main/java/com/percussion/HTTPClient/RespInputStream.java
+++ b/system/src/main/java/com/percussion/HTTPClient/RespInputStream.java
@@ -59,7 +59,7 @@ final class RespInputStream extends InputStream implements GlobalConstants {
   private int end = 0;
 
   /** the total number of bytes of entity data read from the demux so far */
-  int count = 0;
+  long count = 0L;
 
   static {
     try {


### PR DESCRIPTION
Potential fix for [https://github.com/intersoftdatalabs-in/percussioncms/security/code-scanning/640](https://github.com/intersoftdatalabs-in/percussioncms/security/code-scanning/640)

To fix the problem, the left-hand side variable in the compound assignment should be at least as wide as the right-hand side. In this case, we should avoid casting the `long` value `skpd` down to `int` when updating `count`. The cleanest way is to change the type of `count` from `int` to `long`, so it can safely hold large byte counts and match the type returned by `skip`.

Concretely, in `system/src/main/java/com/percussion/HTTPClient/RespInputStream.java`:
- Change the declaration of `count` on line 62 from `int` to `long`.
- Change the update on line 144 from `count += skpd;` to `count += (int) skpd;` or adjust types? Given the goal of avoiding narrowing, the best fix is to keep everything in `long`: after making `count` a `long`, we should sum in `long` as well. So line 144 should become `count += skpd;` but now both operands are `long`, eliminating the implicit narrowing. No additional imports or methods are needed, and this preserves functionality except that `count` can now represent values beyond the `int` range, which is safer and more accurate.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
