### PR TITLE
fix: #750 missing bullets + #753 Category List fancytree errors in de…

### DIFF
--- a/modules/perc-distribution-tree/src/main/resources/installDistributionFiles.xml
+++ b/modules/perc-distribution-tree/src/main/resources/installDistributionFiles.xml
@@ -282,13 +282,11 @@
         <!-- jQuery.cookie-->
         <copy tofile="${assembly-directory}/web_resources/cm/jslib/jquery.cookie.js" file="${assembly-directory}/jetty/base/webapps/Rhythmyx/cm/jslib/profiles/3x/jquery/plugins/jquery-perc-retiredjs/jquery.cookie.js"/>
         <copy tofile="${assembly-directory}/web_resources/cm/jslib/jquery.cookie.min.js" file="${assembly-directory}/jetty/base/webapps/Rhythmyx/cm/jslib/profiles/3x/jquery/plugins/jquery-perc-retiredjs/jquery.cookie.js"/>
-        <!-- jQuery.dynatree removed - replaced by fancytree -->
-        
-        
-        
-        
-        
-        
+        <!-- jQuery fancytree (replaces dynatree) for published site widgets (e.g. Category List widget) -->
+        <copy todir="${assembly-directory}/web_resources/cm/jslib/profiles/3x/jquery/plugins/jquery-fancytree">
+            <fileset dir="${basedir}/../../WebUI/war/jslib/profiles/3x/jquery/plugins/jquery-fancytree" />
+        </copy>
+
         <!-- jQuery Validate -->
         <copy tofile="${assembly-directory}/web_resources/cm/jslib/jquery.validate.js" file="${assembly-directory}/jetty/base/webapps/Rhythmyx/cm/jslib/profiles/3x/jquery/plugins/jquery-validation/jquery.validate.js"/>
 

--- a/system/cms/content/applications/rx_resources/ApplicationFiles/default_theme/theme.css
+++ b/system/cms/content/applications/rx_resources/ApplicationFiles/default_theme/theme.css
@@ -251,7 +251,7 @@ margin-right: 15px;
 
 .perc-list-element {
 
-    list-style-image: url("/rx_resources/default_theme/images/bullet.png");
+    list-style-image: url("images/bullet.png");
 }
 
 /*Root class for all image auto list widgets*/
@@ -647,7 +647,7 @@ textarea.form-error-msg {
 
 ul.perc-list-main-container  li.perc-tag-element, li.perc-archive-year, ul.perc-archive-flat li.perc-archive-month {
 
-    list-style-image: url("/rx_resources/default_theme/images/bullet.png");
+    list-style-image: url("images/bullet.png");
 }
 
 ul.perc-comma-separated-main-container li.perc-tag-element, ul.perc-archive-hierarchical li.perc-archive-month {
@@ -1635,7 +1635,7 @@ margin-right: 15px;
 
 .perc-list-element {
 
-    list-style-image: url("/rx_resources/default_theme/images/bullet.png");
+    list-style-image: url("images/bullet.png");
 }
 
 /*Root class for all image auto list widgets*/
@@ -2031,7 +2031,7 @@ textarea.form-error-msg {
 
 ul.perc-list-main-container  li.perc-tag-element, li.perc-archive-year, ul.perc-archive-flat li.perc-archive-month {
 
-    list-style-image: url("/rx_resources/default_theme/images/bullet.png");
+    list-style-image: url("images/bullet.png");
 }
 
 ul.perc-comma-separated-main-container li.perc-tag-element, ul.perc-archive-hierarchical li.perc-archive-month {


### PR DESCRIPTION
…fault Percussion theme on published sites

- Change list-style-image URLs for bullet.png from absolute /rx_resources/... (CM-only) to relative "images/..." so they resolve correctly under both /rx_resources/default_theme/ (authoring) and /web_resources/themes/percussion/ (published/delivery).
- Add <copy> step in distribution installer for jquery-fancytree plugin tree so the assets declared by percCategoryList.xml (and used by perc_common_ui.js) are present for published widgets.

Combined fixes for two related publishing/asset bugs on 8.1.x.

Fixes https://github.com/intersoftdatalabs-in/percussioncms/issues/750 Fixes https://github.com/intersoftdatalabs-in/percussioncms/issues/753