### PR TITLE
bugfix/758: Fix category creation node activation and Fancytree seria…

### DIFF
--- a/WebUI/war/views/PercCategoryView.js
+++ b/WebUI/war/views/PercCategoryView.js
@@ -734,6 +734,8 @@
                     childnode.expand(true);
                 }, true); 
 
+                child.setActive(true);
+
                 return child;
     
         }
@@ -819,6 +821,10 @@
 
                 if(parent.isRootNode()) {
                     children.push(node.toDict(true, function(dict) {
+                        if (dict.data) {
+                            $.extend(dict, dict.data);
+                            delete dict.data;
+                        }
                         delete dict.activate;
                         delete dict.addClass;
                         delete dict.expand;


### PR DESCRIPTION
We have resolved the category creation bug by modifying the client-side Fancytree UI logic.

Changes Made
WebUI/war/views/PercCategoryView.js
PercCategoryView.js
Node Activation: Added child.setActive(true) inside the newNode function after creating the category node and expanding its parents. This ensures that Fancytree explicitly flags the new node as active, so getActiveNode() resolves to it instead of null (or a previously selected node) when the save handler is triggered.
Custom Data Flattening: Added a data-flattening step in the node.toDict() callback of manageDynaProps(). If dict.data exists, it flattens all properties nested inside dict.data to the root of the node representation dictionary and deletes dict.data. This aligns the serialized JSON tree payload sent to the update API with what the backend Jaxb/Jackson PSCategoryNode model expects at the root level of JSON objects.