### PR TITLE
bugfix/757: Fix footer misalignment by using min-height for vspan reg…

### DIFF
--- a/docs/ai-generated/tasks/757-footer-alignment-fix/task.md
+++ b/docs/ai-generated/tasks/757-footer-alignment-fix/task.md
@@ -1,0 +1,68 @@
+# Bug Fix #757 – Footer Text/Value Not Properly Aligned on Published Page
+
+## Problem
+
+When adding the following widgets to an index page template (e.g., Box or "L Left"):
+
+1. **Title widget** in the title/header section
+2. **Archive List**, **Categories**, and **Tags List** widgets in the Left sidebar section
+3. **Rich Text** widget in the Footer section (e.g., "Copy rights(c) XXX")
+
+…the published page shows the footer content appearing in the **wrong location** — visually mixed with or displaced below the sidebar widget content.
+
+## Root Cause
+
+The `vspan_X` CSS classes in `theme.css` (the published-page stylesheet) used **fixed `height`** values:
+
+```css
+.vspan_2 { height : 120px }
+.vspan_4 { height : 240px }
+.vspan_6 { height : 360px }
+.vspan_8 { height : 480px }
+```
+
+These classes are applied to page region `<div>` elements in the template HTML (e.g., `<div id="leftsidebar" class="perc-region perc-vertical vspan_4 hspan_2">`).
+
+In the page editor, fixed heights are desirable so empty placeholder regions are visibly sized. However, on a **published page** the actual widget content can exceed the fixed height. Because `overflow` defaults to `visible`, the content **bleeds beyond the region boundary** downward. Meanwhile, the footer `<div>` is positioned in the DOM immediately after the sidebar section's layout height — not after the visual overflow extent.
+
+**Net effect:** Three widgets (Archive List + Categories + Tags) in a 240 px (vspan_4) or 360 px (vspan_6) sidebar produce far more than that in rendered content. The sidebar content overflows visually into the area occupied by the footer, making the footer text appear misaligned or displaced.
+
+## Fix
+
+Changed all `vspan_X` rules in `theme.css` from fixed `height` to `min-height`:
+
+```css
+.vspan_2 { min-height : 120px }
+.vspan_4 { min-height : 240px }
+.vspan_6 { min-height : 360px }
+.vspan_8 { min-height : 480px }
+```
+
+With `min-height`, a sidebar region will:
+- Be *at least* the specified height (preserving layout aesthetics when content is sparse), and
+- **Expand** to accommodate actual widget output when content exceeds that height.
+
+The `clear-float` div inside the `perc-horizontal` wrapper then correctly computes the expanded height as the parent's height, which in turn pushes the footer `<div>` to appear **below** the sidebar content — its intended location.
+
+## CSS Cascade Impact on the Editor
+
+The editor loads **both** `perc_decoration.css` (unchanged; still uses `height: Xpx`) and `theme.css`. Because CSS `height` and `min-height` are separate properties:
+- When `height` is explicitly set (not `auto`), it overrides `min-height`.
+- In edit mode: `height: Xpx` from `perc_decoration.css` still governs the region size for placeholder display. ✓
+- On published pages: only `theme.css` is loaded, so `min-height: Xpx` allows natural growth. ✓
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `system/cms/content/applications/rx_resources/ApplicationFiles/default_theme/theme.css` | Changed all 4 occurrences of `vspan_X { height: Xpx }` to `vspan_X { min-height: Xpx }` |
+
+## Testing
+
+1. Create/use an index page with the Box or L-Left template.
+2. Add Title widget to the header/title section.
+3. Add Archive List, Categories, and Tags List widgets to the Left section.
+4. Add a Rich Text widget to the Footer section with text such as "Copyright © 2024".
+5. Save, approve, and publish the page.
+6. **Expected:** Footer text appears at the bottom of the page, below all sidebar widget content.
+7. **Previously:** Footer text appeared overlapping with sidebar widget content.

--- a/system/cms/content/applications/rx_resources/ApplicationFiles/default_theme/theme.css
+++ b/system/cms/content/applications/rx_resources/ApplicationFiles/default_theme/theme.css
@@ -52,10 +52,10 @@ body {
 /* Region CSS
 ----------------------------------*/
 
-.vspan_2 { height : 120px }
-.vspan_4 { height : 240px }
-.vspan_6 { height : 360px }
-.vspan_8 { height : 480px }
+.vspan_2 { min-height : 120px }
+.vspan_4 { min-height : 240px }
+.vspan_6 { min-height : 360px }
+.vspan_8 { min-height : 480px }
 
 .hspan_2  { width : 160px }
 .hspan_8  { width : 640px }
@@ -1375,10 +1375,10 @@ font-weight: normal;
     }
     
     /* old perc_decoration.css entries */
-    .vspan_2 { height : 120px }
-.vspan_4 { height : 240px }
-.vspan_6 { height : 360px }
-.vspan_8 { height : 480px }
+    .vspan_2 { min-height : 120px }
+.vspan_4 { min-height : 240px }
+.vspan_6 { min-height : 360px }
+.vspan_8 { min-height : 480px }
 .hspan_2  { width : 160px }
 .hspan_8  { width : 640px }
 .hspan_10 { width : 800px }
@@ -1436,10 +1436,10 @@ body {
 /* Region CSS
 ----------------------------------*/
 
-.vspan_2 { height : 120px }
-.vspan_4 { height : 240px }
-.vspan_6 { height : 360px }
-.vspan_8 { height : 480px }
+.vspan_2 { min-height : 120px }
+.vspan_4 { min-height : 240px }
+.vspan_6 { min-height : 360px }
+.vspan_8 { min-height : 480px }
 
 .hspan_2  { width : 160px }
 .hspan_8  { width : 640px }
@@ -2759,10 +2759,10 @@ font-weight: normal;
     }
     
     /* old perc_decoration.css entries */
-    .vspan_2 { height : 120px }
-.vspan_4 { height : 240px }
-.vspan_6 { height : 360px }
-.vspan_8 { height : 480px }
+    .vspan_2 { min-height : 120px }
+.vspan_4 { min-height : 240px }
+.vspan_6 { min-height : 360px }
+.vspan_8 { min-height : 480px }
 .hspan_2  { width : 160px }
 .hspan_8  { width : 640px }
 .hspan_10 { width : 800px }


### PR DESCRIPTION
…ion classes

On published pages, the vspan_X CSS classes in theme.css used fixed 'height' values (e.g. height: 240px). When sidebar widgets (Archive List, Categories, Tags List) produced more content than the fixed height, the content overflowed visually into the footer area, making the footer appear misaligned.

Changed all vspan_X rules from 'height' to 'min-height' so that sidebar regions grow with their actual content. The clear-float mechanism then correctly expands the parent section, pushing the footer below all widget content.

The editor is unaffected: perc_decoration.css still uses fixed height for vspan_X classes. Since CSS 'height' overrides 'min-height' when explicitly set, edit-mode placeholder regions display at the expected sizes.

Fixes #757