### PR TITLE
fix(bulk upload gadget): show error message when zero-size file uploa…

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetService.java
@@ -2093,19 +2093,26 @@ public class PSAssetService extends PSAbstractFullDataService<PSAsset, PSAssetSu
    */
   private String extractContent(PSExtractedAssetRequest request) throws IOException {
     String content = IOUtils.toString(request.getFileContents(), StandardCharsets.UTF_8);
-    String selector = request.getSelector();
-    String extractedContent = null;
+    String fileName = request.getFileName();
 
-    extractedContent =
+    if (isBlank(content)) {
+      throw new PSExtractHTMLException(
+          "The uploaded file '"
+              + (fileName != null ? fileName : "")
+              + "' is empty (0 bytes). Cannot create a text-based asset from an empty file.");
+    }
+
+    String selector = request.getSelector();
+    String extractedContent =
         PSHtmlUtils.extractHtml(
-            selector, content, request.getFileName(), request.shouldIncludeOuterHtml());
+            selector, content, fileName, request.shouldIncludeOuterHtml());
 
     if (isBlank(extractedContent)) {
       String warning =
           "CSS Selector \""
               + selector
               + "\" does not exist in file '"
-              + request.getFileName()
+              + fileName
               + ".'";
       throw new PSExtractHTMLException(warning);
     }

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetUploadServlet.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetUploadServlet.java
@@ -72,9 +72,8 @@ public class PSAssetUploadServlet extends HttpServlet {
     boolean approveOnUpload = approve != null && approve.equalsIgnoreCase("true");
 
     PrintWriter out = null;
+    String fileName = null;
     try {
-      String fileName = null;
-
       PSAsset newAsset = null;
       for (Part part : request.getParts()) {
 
@@ -104,12 +103,39 @@ public class PSAssetUploadServlet extends HttpServlet {
         response.setCharacterEncoding("UTF-8");
         out.print(jsonObject.toString());
         out.flush();
+      } else {
+        // No asset created (e.g. empty part or no file) - return explicit error
+        writeErrorResponse(response, fileName, "No valid file was provided for upload.", 400);
       }
     } catch (PSExtractHTMLException caE) {
-      handleExtractionError(caE, response);
+      handleExtractionError(caE, response, fileName);
     } catch (Exception e) {
       logger.error(PSExceptionUtils.getMessageForLog(e));
-      response.setStatus(500);
+      String msg = e.getMessage();
+      if (msg == null || msg.trim().isEmpty()) {
+        msg = "Upload failed due to an unexpected server error.";
+      }
+      writeErrorResponse(response, fileName, msg, 500);
+    }
+  }
+
+  /**
+   * Writes a JSON error response for upload failures.
+   */
+  private void writeErrorResponse(
+      HttpServletResponse response, String fileName, String message, int statusCode)
+      throws IOException {
+    response.setStatus(statusCode);
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
+    try (PrintWriter w = response.getWriter()) {
+      JSONObject err = new JSONObject();
+      err.put("error", message != null ? message : "Upload failed.");
+      if (fileName != null && !fileName.isEmpty()) {
+        err.put("name", fileName);
+      }
+      w.print(err.toString());
+      w.flush();
     }
   }
 
@@ -118,14 +144,20 @@ public class PSAssetUploadServlet extends HttpServlet {
    *
    * @param e the extraction error / exception, assumed not <code>null</code>.
    * @param response the HTTP response, assumed not <code>null</code>.
+   * @param fileName the name of the file being uploaded (may be null).
    */
-  private void handleExtractionError(PSExtractHTMLException e, HttpServletResponse response) {
+  private void handleExtractionError(
+      PSExtractHTMLException e, HttpServletResponse response, String fileName) {
 
     logger.error(PSExceptionUtils.getMessageForLog(e));
     logger.debug(PSExceptionUtils.getDebugMessageForLog(e));
 
+    String msg = e.getMessage();
+    if (msg == null || msg.trim().isEmpty()) {
+      msg = "Failed to extract content from the uploaded file.";
+    }
     try {
-      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      writeErrorResponse(response, fileName, msg, HttpServletResponse.SC_BAD_REQUEST);
     } catch (IOException ex) {
       response.setStatus(500);
     }

--- a/system/Packages/perc.gadget.bulkFileUpload/sys__UserDependency--cm/gadgets/repository/perc_bulk_file_upload_gadget/js/perc_bulk_file_upload.js
+++ b/system/Packages/perc.gadget.bulkFileUpload/sys__UserDependency--cm/gadgets/repository/perc_bulk_file_upload_gadget/js/perc_bulk_file_upload.js
@@ -51,6 +51,27 @@ $(function () {
 
             var buttonHtml = generateButtonHTML(data);
             data.context = buttonHtml;
+
+            // Client-side early rejection for zero-byte files (addresses the reported bulk upload bug)
+            var file = (data.files && data.files.length > 0) ? data.files[0] : null;
+            if (file && file.size === 0) {
+                DID_UPLOAD_FAIL = true;
+                var $row = $(data.context);
+                $row.addClass('alert alert-danger');
+                var $typeCell = $row.find('td').eq(2);
+                var $err = $('<div class="perc-upload-error"></div>')
+                    .css({ 'color': '#a94442', 'font-size': '10px', 'margin-top': '2px' })
+                    .text('Cannot upload empty (0 byte) files.');
+                $typeCell.append($err);
+
+                NUM_FAILED++; // count it toward the final failure tally
+                TOTAL_IN_QUEUE--; // don't count it as pending
+                $('#perc-bulk-status').text(TOTAL_IN_QUEUE + MSG_QUEUED_FOR_UPLOAD);
+                // Prevent this item from being submitted
+                data.files = [];
+                return;
+            }
+
             $('#perc-upload-trigger').on("click",function() {
                 $('#perc-upload-clear').prop('disabled', true);
                 $(this).off();
@@ -104,7 +125,28 @@ $(function () {
             TOTAL_IN_QUEUE--;
             NUM_FAILED++;
             DID_UPLOAD_FAIL = true;
-            $(data.context).addClass('alert alert-danger');
+
+            var $row = $(data.context);
+            $row.addClass('alert alert-danger');
+
+            var errorMsg = getUploadErrorMessage(data);
+            // Display the error message in the row (in the Type column area)
+            var $typeCell = $row.find('td').eq(2);
+            if ($typeCell.length) {
+                var $err = $('<div class="perc-upload-error"></div>')
+                    .css({
+                        'color': '#a94442',
+                        'font-size': '10px',
+                        'margin-top': '2px',
+                        'word-break': 'break-word'
+                    })
+                    .text(errorMsg);
+                $typeCell.append($err);
+            } else {
+                // Fallback: set title so user can hover to see details
+                $row.attr('title', errorMsg);
+            }
+
             $('#perc-bulk-status').text(TOTAL_IN_QUEUE + MSG_QUEUED_FOR_UPLOAD);
             var numActive = $(this).fileupload('active');
             if (numActive === 1) {
@@ -298,4 +340,60 @@ cancelAllRequests = function() {
         XHR_REQUESTS[i].abort();
     }
     XHR_REQUESTS = [];
+};
+
+/**
+ * Extracts a human-readable error message from a fileupload 'fail' data object.
+ * Handles the JSON error responses now returned by PSAssetUploadServlet.
+ */
+getUploadErrorMessage = function(data) {
+    var msg = 'Upload failed';
+
+    // 1. Check explicit errorThrown from the transport
+    if (data.errorThrown && typeof data.errorThrown === 'string' && data.errorThrown.trim() !== '') {
+        msg = data.errorThrown.trim();
+    }
+
+    // 2. Try to read the response body (preferred path after our servlet changes)
+    var respText = null;
+    if (data.jqXHR && data.jqXHR.responseText) {
+        respText = data.jqXHR.responseText;
+    } else if (data._response && data._response.jqXHR && data._response.jqXHR.responseText) {
+        respText = data._response.jqXHR.responseText;
+    }
+
+    if (respText) {
+        try {
+            var parsed = JSON.parse(respText);
+            if (parsed) {
+                if (typeof parsed.error === 'string' && parsed.error.trim() !== '') {
+                    msg = parsed.error.trim();
+                } else if (parsed.files && Array.isArray(parsed.files) && parsed.files.length > 0) {
+                    var f0 = parsed.files[0];
+                    if (f0 && typeof f0.error === 'string' && f0.error.trim() !== '') {
+                        msg = f0.error.trim();
+                    }
+                }
+            }
+        } catch (ignore) {
+            // Not JSON — use a truncated version of the raw text if it's short and useful
+            var trimmed = respText.trim();
+            if (trimmed.length > 0 && trimmed.length < 300) {
+                msg = trimmed;
+            }
+        }
+    }
+
+    // 3. Fall back to HTTP status text if we have nothing better
+    if (msg === 'Upload failed' && data.jqXHR && data.jqXHR.statusText) {
+        var st = data.jqXHR.statusText;
+        if (st && st.toLowerCase() !== 'error') {
+            msg = st;
+        }
+        if (data.jqXHR.status) {
+            msg += ' (HTTP ' + data.jqXHR.status + ')';
+        }
+    }
+
+    return msg;
 };


### PR DESCRIPTION
…d fails (#728)

- Return structured JSON error responses from PSAssetUploadServlet
- Add explicit empty-file check with clear message in PSAssetService for extracted assets (Rich Text etc.)
- Client-side early rejection + error display in perc_bulk_file_upload.js fail handler and add callback
- Addresses missing user feedback reported in #728