### PR TITLE
fix: Admin Category UI - overlapping icons, tree rendering, move up/d…

### DIFF
--- a/WebUI/war/app/percCategories.jsp
+++ b/WebUI/war/app/percCategories.jsp
@@ -82,8 +82,13 @@
                         <h3 class="panel-title" id="perc-category-details-label" style="display:inline-block; margin-top:6px;">
                             <i18n:message key="perc.ui.perc.categories@Details"/>
                         </h3>
+                        <!-- Save/Cancel now at top of the form per UX request -->
                         <div class="pull-right">
                             <button id="perc-categories-edit-category-button" type="button" class="btn btn-primary btn-sm" title="<i18n:message key='perc.ui.categories@Edit Category Details'/>"><i class="fas fa-edit"></i> <i18n:message key="perc.ui.categories@Edit Category Details"/></button>
+                        </div>
+                        <div id="perc-category-save-cancel-block" class="pull-right" style="display: none; margin-right: 8px;">
+                            <button id="perc-category-cancel" tabindex="0" title='<i18n:message key="perc.ui.common.label@Cancel"/>' class="btn btn-default btn-sm" type="button" name="perc_wizard_cancel"><i18n:message key="perc.ui.common.label@Cancel"/></button>
+                            <button id="perc-category-save" tabindex="0" title='<i18n:message key="perc.ui.button@Save"/>' class="btn btn-primary btn-sm" type="button" name="perc_wizard_save"><i18n:message key="perc.ui.button@Save"/></button>
                         </div>
                         <div class="clearfix"></div>
                     </div>
@@ -160,10 +165,7 @@
                             
                         </form>
                     </div>
-                    <div class="panel-footer" id="perc-category-save-cancel-block" style="text-align: right;">
-                        <button id="perc-category-cancel" tabindex="0" title='<i18n:message key="perc.ui.common.label@Cancel"/>' class="btn btn-default" type="button" name="perc_wizard_cancel"><i18n:message key="perc.ui.common.label@Cancel"/></button>
-                        <button id="perc-category-save" tabindex="0" title='<i18n:message key="perc.ui.button@Save"/>' class="btn btn-primary" type="button" name="perc_wizard_save"><i18n:message key="perc.ui.button@Save"/></button>
-                    </div>
+                    <!-- Save/Cancel moved to panel-heading (top of form) -->
                 </div>
             </div>
         </div>

--- a/WebUI/war/css/layout.css
+++ b/WebUI/war/css/layout.css
@@ -738,7 +738,12 @@ input:-moz-placeholder { color:#BCBCBC; }
     color: #BCBCBC;
 }
 
-#perc-categories-movedown-button, #perc-categories-moveup-button {
+/* Legacy positioning for old (pre-Bootstrap) Categories admin layout.
+   New markup in percCategories.jsp uses Bootstrap panels/grid + btn-group so
+   these are neutralized by more specific rules in percWorkflow.css.
+   Kept for backwards compatibility with any other legacy includes of this layout. */
+#perc-categories-movedown-button:not(#perc-category-wrapper #perc-categories-movedown-button),
+#perc-categories-moveup-button:not(#perc-category-wrapper #perc-categories-moveup-button) {
     position: relative;
     display: inline-block;
     width: auto;
@@ -746,7 +751,7 @@ input:-moz-placeholder { color:#BCBCBC; }
     left: 26px;
 }
 
-#perc-category-details {
+#perc-category-details:not(#perc-category-wrapper #perc-category-details) {
     position: relative;
     top: 20px;
 }

--- a/WebUI/war/css/percWorkflow.css
+++ b/WebUI/war/css/percWorkflow.css
@@ -1627,3 +1627,82 @@ label {
     font-family: 'Open Sans', sans-serif;
     vertical-align: middle !important;
 }
+
+/*
+ * Admin Categories tab fixes (Bootstrap + FA migration).
+ * Legacy ID-based sprite button styles + global content-box + negative margin
+ * positioning rules were causing overlapping icons, smashed buttons, and
+ * broken details panel + tree layout.
+ * Scoped to #perc-category-wrapper so Roles/Users/Workflow tabs are unaffected.
+ */
+#perc-category-wrapper #perc-category-details {
+    position: static !important;
+    top: auto !important;
+}
+
+#perc-category-wrapper #perc-categories-moveup-button,
+#perc-category-wrapper #perc-categories-movedown-button {
+    position: static !important;
+    top: auto !important;
+    left: auto !important;
+    display: inline-block !important;
+}
+
+/* Neutralize all legacy button sprite/pos/size rules for the 6 action buttons */
+#perc-category-wrapper #perc-categories-add-category-button,
+#perc-category-wrapper #perc-categories-add-child-category-button,
+#perc-category-wrapper #perc-categories-delete-category-button,
+#perc-category-wrapper #perc-categories-moveup-button,
+#perc-category-wrapper #perc-categories-movedown-button,
+#perc-category-wrapper #perc-categories-edit-category-button {
+    background-image: none !important;
+    background-position: initial !important;
+    background-repeat: initial !important;
+    width: auto !important;
+    height: auto !important;
+    min-width: 0 !important;
+    min-height: 0 !important;
+    float: none !important;
+    margin: 0 !important;
+    margin-top: 0 !important;
+    margin-right: 0 !important;
+    margin-bottom: 0 !important;
+    margin-left: 0 !important;
+    position: static !important;
+    top: auto !important;
+    left: auto !important;
+    cursor: pointer !important;
+    overflow: visible !important;
+}
+
+/* Restore border-box for all Bootstrap components in the modern Categories UI.
+   The global content-box rule above was breaking .col-md-*, .panel, .btn-group,
+   .form-control, etc. widths/padding/alignment. */
+#perc-category-wrapper,
+#perc-category-wrapper *,
+#perc-category-wrapper *:before,
+#perc-category-wrapper *:after {
+    -webkit-box-sizing: border-box !important;
+    -moz-box-sizing: border-box !important;
+    box-sizing: border-box !important;
+}
+
+/* Improve checkbox alignment in the details form (counter the global label rule) */
+#perc-category-wrapper .checkbox,
+#perc-category-wrapper .checkbox label {
+    display: block !important;
+}
+#perc-category-wrapper .checkbox label {
+    font-weight: normal;
+    margin-bottom: 0;
+}
+
+/* Make the category tree area clean for fancytree */
+#perc-category-wrapper #perc-category-tree {
+    background: #fff;
+    font-size: 12px;
+}
+#perc-category-wrapper .panel-body {
+    padding: 4px 6px;
+    background: #fff;
+}

--- a/WebUI/war/plugins/PercDataTree.js
+++ b/WebUI/war/plugins/PercDataTree.js
@@ -241,7 +241,7 @@
         }   
 
         // CLEAR THE CHILDREN of Sites and Assets subtrees
-        var tree = $(container).find('#' + options.instanceId).fancytree('getTree');
+        var tree = $.ui.fancytree.getTree( $(container).find('#' + options.instanceId) );
         var level = 1;
         if (options.showRoots)
         {

--- a/WebUI/war/plugins/perc_assign_workflow_sites_folder_dialog.js
+++ b/WebUI/war/plugins/perc_assign_workflow_sites_folder_dialog.js
@@ -57,8 +57,8 @@
             'Save' : {
                 'id' : "perc-assign-workflow-sites-folder-dialog-save",
                 'click' : function() {
-                    var selectedSites = jQuery("#datatree" + "-workflow-sites").fancytree('getTree').getSelectedNodes();
-                    var selectedAssets = jQuery("#datatree" + "-workflow-assets").fancytree('getTree').getSelectedNodes();
+                    var selectedSites = $.ui.fancytree.getTree("#datatree" + "-workflow-sites").getSelectedNodes();
+                    var selectedAssets = $.ui.fancytree.getTree("#datatree" + "-workflow-assets").getSelectedNodes();
                     var selected = selectedSites;
                     $.merge(selected, selectedAssets);
                     var selectedSitesPaths = [];
@@ -341,7 +341,7 @@
             var tree_container_assets = $("#perc-assign-workflow-assets-tree");
             if(originalSitesJson.folderItem){
                 $.PercDataTree.updateTree(tree_container_sites, [originalSitesJson]);
-                $.each($("#datatree-workflow-sites").fancytree("getRootNode").children, function(){
+                $.each($.ui.fancytree.getTree("#datatree-workflow-sites").getRootNode().children, function(){
                     customOnExpand(this);
                 });
                 if (originalSitesJson.folderItem.length > 0)
@@ -349,7 +349,7 @@
             }
             if(originalAssetsJson.folderItem){
                 $.PercDataTree.updateTree(tree_container_assets, [originalAssetsJson]);
-                $.each($("#datatree-workflow-assets").fancytree("getRootNode").children, function(){
+                $.each($.ui.fancytree.getTree("#datatree-workflow-assets").getRootNode().children, function(){
                     customOnExpand(this);
                 });
                 if (originalAssetsJson.folderItem.length > 0)

--- a/WebUI/war/views/PercCategoryView.js
+++ b/WebUI/war/views/PercCategoryView.js
@@ -76,6 +76,10 @@
 
             return (S4() + S4() + delim + S4() + delim + S4() + delim + S4() + delim + S4() + S4() + S4());
         };
+
+        function getTree() {
+            return $.ui.fancytree.getTree(container);
+        }
         
         controller.init(viewApi);
         
@@ -227,7 +231,7 @@
                         return;
                 }
 
-                var tree = container.fancytree("getTree");
+                var tree = getTree();
                 if(tree.count() === 1)
                     alertDialog(I18N.message("perc.ui.category.view@Delete Category"), I18N.message("perc.ui.category.view@Cannot Delete Node"));
                 else {
@@ -257,7 +261,7 @@
                         return;
                 }
 
-                var node = container.fancytree("getTree").getActiveNode();
+                var node = getTree().getActiveNode();
                 displayCategoryDetails(node);
                 showSelectedCategoryEditor(node);
                     
@@ -277,13 +281,13 @@
                 }
 
 
-                var node = container.fancytree("getTree").getActiveNode();
+                var node = getTree().getActiveNode();
 
                 var targetNode = findUpTargetNode(node);
                 if(targetNode != null)
                     moveNodeUp(node, targetNode);
                 
-                displayCategoryDetails(container.fancytree("getTree").getActiveNode());
+                displayCategoryDetails(getTree().getActiveNode());
             });
             
 			$("#perc-categories-movedown-button").off("keydown").on("keydown",function(event) {
@@ -300,18 +304,18 @@
                 }
 
 
-                var node = container.fancytree("getTree").getActiveNode();
+                var node = getTree().getActiveNode();
                 var targetNode = findDownTargetNode(node);
                 
                 if(targetNode != null)
                     moveNodeDown(node, targetNode);
                 
-                displayCategoryDetails(container.fancytree("getTree").getActiveNode());
+                displayCategoryDetails(getTree().getActiveNode());
             });
             
             //Bind Save event
             $("#perc-category-save").off("click").on("click", function(){
-                var node = container.fancytree("getTree").getActiveNode();
+                var node = getTree().getActiveNode();
                 if (node != null && node.title === "New Category")
                 {
                     alertDialog("Error", "You must change the category name.");
@@ -321,13 +325,13 @@
             });
             //Bind Cancel event
             $("#perc-category-cancel").off("click").on("click", function(){
-                var node = container.fancytree("getTree").getActiveNode();
+                var node = getTree().getActiveNode();
                 editing = false;
                 if (!node.data.saved)
                 {
                     parent = node.parent;
                     parent.activate();
-                    if (node.parent.childList.length !== 0)
+                    if (node.parent.children && node.parent.children.length !== 0)
                         node.remove();
                     
                     node = parent;
@@ -340,7 +344,9 @@
                 }
                 displayCategoryDetails(node);
                 try {
-                    node.childList[0].activate();
+                    if (node.children && node.children.length > 0) {
+                        node.children[0].activate();
+                    }
                 }catch(err) {}
             });
             
@@ -356,7 +362,7 @@
                         return;
                 }
 
-                var node = container.fancytree("getTree").getActiveNode();
+                var node = getTree().getActiveNode();
                 publishToDTS(node, "Staging");
             });
 
@@ -373,7 +379,7 @@
                         return;
                 }
 
-                var node = container.fancytree("getTree").getActiveNode();
+                var node = getTree().getActiveNode();
                 publishToDTS(node, "Production");
             });
             
@@ -390,7 +396,7 @@
                         return;
                 }
 
-                var node = container.fancytree("getTree").getActiveNode();
+                var node = getTree().getActiveNode();
                 publishToDTS(node, "Both");
             });
             
@@ -404,9 +410,11 @@
             
             if (categorytree == null || typeof categorytree == "undefined" || categorytree.length === 0)
             {
+                var uid = generateUid();
                 categorytree = [ // Pass an array of nodes.
                 {
-                                    id : generateUid(),
+                                    id : uid,
+                                    key : uid,
                                     title : "New Category",
                                     selectable : true,
                                     showInPgMetaData : true,
@@ -419,6 +427,16 @@
                                 }
                 ];
             }
+            // Always destroy any existing tree before re-initializing.
+            // This is critical for the post-save reload path (getCategories after edit/add).
+            // Without destroy, re-calling .fancytree() on the same element can leave
+            // stale tree instances, causing new/updated categories (especially children)
+            // to not appear until a full browser refresh.
+            var existingTree = $.ui.fancytree.getTree(container);
+            if (existingTree) {
+                existingTree.destroy();
+            }
+
             container.fancytree({
                 selectMode: 3,
                 keyboard: true,
@@ -426,12 +444,28 @@
                 source: categorytree,
                 init: function(event, data) {
                     visitTreeForBaseProperties();
-                    data.tree.activateKey("_2");
+
+                    // Extra pass: ensure every node that has children is expanded.
+                    // This makes newly added child categories visible immediately after
+                    // the server round-trip + tree rebuild, without needing a browser refresh.
+                    data.tree.visit(function(node) {
+                        if (node.children && node.children.length > 0) {
+                            node.setExpanded(true);
+                        }
+                    });
+
+                    // Ensure something is active on initial load/rebuild so move buttons get correct initial state
+                    if (!data.tree.getActiveNode() && data.tree.rootNode.children && data.tree.rootNode.children.length > 0) {
+                        data.tree.rootNode.children[0].setActive();
+                    }
+
                     $("span.fancytree-title").each(function(){
                         this.title=this.innerHTML;
                         this.tabIndex="0";
                         this.setAttribute("role", "button");
                     });
+
+                    updateMoveButtonsState();
                 },
                 beforeActivate: function(event, data) {
                     if (editing)
@@ -469,6 +503,8 @@
                       sourceNode.moveTo(node, hitMode);
                       isMoved = true;
                       save();
+                      // Update button states after drag-and-drop reorder
+                      setTimeout(updateMoveButtonsState, 50);
                     }
                   }
             });
@@ -477,16 +513,63 @@
         
         function visitTreeForBaseProperties() {
 
-            var treeRoot = container.fancytree("getTree").getRootNode();
+            var treeRoot = getTree().getRootNode();
             
             treeRoot.visit(function(node){
                 node.data.saved=true;
-                if(node.data.initialViewCollapsed === "false") {
-                    node.expand(true);
+                // Expand nodes that were explicitly marked as not collapsed,
+                // or any node that has children. This ensures that after saving a new
+                // child category, its parent is expanded so the new child is visible
+                // without requiring a full browser refresh.
+                var hasChildren = node.children && node.children.length > 0;
+                if (node.data.initialViewCollapsed === "false" || hasChildren) {
+                    node.setExpanded(true);
                 }
             });
         }
         
+        function updateMoveButtonsState() {
+            var $up = $("#perc-categories-moveup-button");
+            var $down = $("#perc-categories-movedown-button");
+
+            if (editing) {
+                $up.prop("disabled", true);
+                $down.prop("disabled", true);
+                return;
+            }
+
+            var tree = getTree();
+            if (!tree) {
+                $up.prop("disabled", true);
+                $down.prop("disabled", true);
+                return;
+            }
+
+            var node = tree.getActiveNode();
+            if (!node || !node.parent || !node.parent.children) {
+                $up.prop("disabled", true);
+                $down.prop("disabled", true);
+                return;
+            }
+
+            var siblings = node.parent.children;
+            if (siblings.length <= 1) {
+                $up.prop("disabled", true);
+                $down.prop("disabled", true);
+                return;
+            }
+
+            var index = siblings.indexOf(node);
+            if (index === -1) {
+                $up.prop("disabled", true);
+                $down.prop("disabled", true);
+                return;
+            }
+
+            $up.prop("disabled", index === 0);
+            $down.prop("disabled", index === siblings.length - 1);
+        }
+
         function displayCategoryDetails(node) {
             if (node == null)
                 return;
@@ -528,6 +611,8 @@
             $("#perc-category-creationdt-field").val(node.data.creationDate);
             $("#perc-category-lstmodifiedby-field").val(node.data.lastModifiedBy);
             $("#perc-category-lstmodifieddt-field").val(node.data.lastModifiedDate);
+
+            updateMoveButtonsState();
         }
         
         function showSelectedCategoryEditor(node) {
@@ -538,7 +623,7 @@
 			$("#perc-category-name-field").attr("aria-disabled","false");
 
             $("#perc-category-name-field").on('keyup', function() {
-                 var node = container.fancytree("getTree").getActiveNode();
+                 var node = getTree().getActiveNode();
                  node.setTitle($( this ).val() === "" ? "[empty]" : $( this ).val());
             });
 
@@ -558,7 +643,28 @@
 			$("#perc-category-show-in-page-field").attr("aria-disabled","false");
 
             $("#perc-category-save-cancel-block").show();
-            $("#perc-category-name-field").trigger("focus");
+
+            // Disable move buttons while editing
+            $("#perc-categories-moveup-button").prop("disabled", true);
+            $("#perc-categories-movedown-button").prop("disabled", true);
+
+            var $nameField = $("#perc-category-name-field");
+            $nameField.trigger("focus");
+
+            // UX improvement for new categories: if the field still contains the
+            // default placeholder "New Category", select the text so the user can
+            // immediately start typing to overwrite it.
+            if (!node.data.saved && $nameField.val() === "New Category") {
+                $nameField.select();
+            }
+
+            // Hitting Enter in the category name field should trigger Save (issue request)
+            $nameField.off("keydown.enterSave").on("keydown.enterSave", function(e) {
+                if (e.which === 13) { // Enter key
+                    e.preventDefault();
+                    $("#perc-category-save").trigger("click");
+                }
+            });
         }
         
        
@@ -648,7 +754,7 @@
         function handleDelete() {
 
             isDelete = false;
-            var node = container.fancytree("getTree").getActiveNode();
+            var node = getTree().getActiveNode();
             parentNode = node.getParent();
             var upTarget = findUpTargetNode(node);
                 
@@ -673,7 +779,7 @@
             {
                 switchtoNode = parentNode;
             }
-            container.fancytree("getTree").activateKey(switchtoNode.key);
+            getTree().activateKey(switchtoNode.key);
             displayCategoryDetails(switchtoNode);
             controller.getCategories();
         }
@@ -681,10 +787,10 @@
         function newNode(child)
         {
             
-            var root = container.fancytree("getTree").getRootNode();
+            var root = getTree().getRootNode();
             
             var destinationNode = null;
-            var children =  root.childList;
+            var children =  root.children;
             if ( children == null || typeof children == "undefined" || children.length===0)
             {
                 destinationNode = root;
@@ -693,7 +799,7 @@
             {
                 return children[0];
             } else {
-                var destinationNode = container.fancytree("getTree").getActiveNode();
+                destinationNode = getTree().getActiveNode();
                 if (destinationNode == null || typeof destinationNode == "undefined" || !destinationNode.hasOwnProperty('parent'))
                 {
                     destinationNode = root;
@@ -708,8 +814,10 @@
             else
                 addTo = destinationNode.getParent();
                 
-            var child = addTo.addChildren({
-                                    id : generateUid(),
+            var uid = generateUid();
+            var newChild = addTo.addChildren({
+                                    id : uid,
+                                    key : uid,   // Explicit key helps fancytree track the node across rebuilds
                                     title : "New Category",
                                     selectable : true,
                                     showInPgMetaData : true,
@@ -721,13 +829,13 @@
                                     initialViewCollapsed : true
                                 });
 
-                child.visitParents(function (childnode) {
-                    childnode.expand(true);
+                newChild.visitParents(function (childnode) {
+                    childnode.setExpanded(true);
                 }, true); 
 
-                child.setActive(true);
+                newChild.setActive(true);
 
-                return child;
+                return newChild;
     
         }
 
@@ -794,7 +902,7 @@
         
         function deleteCategory() {
             
-            var node = container.fancytree("getTree").getActiveNode();
+            var node = getTree().getActiveNode();
             
             if(node.hasChildren() === false) {
                 confirmDialog(I18N.message("perc.ui.category.view@Delete Category"), I18N.message("perc.ui.category.view@Are You Sure"));
@@ -805,7 +913,7 @@
         
         function manageDynaProps() {
             
-            var treeRoot = container.fancytree("getTree").getRootNode();
+            var treeRoot = getTree().getRootNode();
             var children = [];
             treeRoot.visit(function(node){
                 var parent = node.getParent();
@@ -824,7 +932,8 @@
                         delete dict.icon;
                         delete dict.isFolder;
                         delete dict.isLazy;
-                        delete dict.key;
+                        // Intentionally NOT deleting dict.key so that client-generated UIDs
+                        // can potentially be used for stable identification after server roundtrip.
                         delete dict.noLink;
                         delete dict.select;
                         delete dict.tooltip;
@@ -851,9 +960,14 @@
             var catArray = manageDynaProps();
             controller.editCategories(catArray, sitename,
             function(){
-                var node = container.fancytree("getTree").getActiveNode();
-                displayCategoryDetails(node);
-                node.data.saved = true;
+                // Defensive: after save the tree may have been fully rebuilt by the
+                // controller's getCategories call. getActiveNode() may be null or a
+                // different node reference, so guard it.
+                var node = getTree().getActiveNode();
+                if (node) {
+                    displayCategoryDetails(node);
+                    node.data.saved = true;
+                }
                 editing = false;
             },
             function(){
@@ -864,7 +978,7 @@
         
         function save() {
         
-            var node = container.fancytree("getTree").getActiveNode();
+            var node = getTree().getActiveNode();
             
             
             if(!isMoved) {
@@ -886,7 +1000,7 @@
             // if the souceNode is a top level parent node, 
             // traverse the tree for only top level parent nodes.
             if(parentNode.isRootNode()) {
-                var treeRoot = container.fancytree("getTree").getRootNode();
+                var treeRoot = getTree().getRootNode();
                 
                 treeRoot.visit(function(node){
                     var parent = node.getParent();
@@ -929,7 +1043,7 @@
         }
         
         function moveNodeUp(node, targetNode) {
-            node.move(targetNode, "before");
+            node.moveTo(targetNode, "before");
             
             isMoved = true;
             save();
@@ -944,7 +1058,7 @@
             // if the souceNode is a top level parent node, 
             // traverse the tree for only top level parent nodes.
             if(parentNode.isRootNode()) {
-                var treeRoot = container.fancytree("getTree").getRootNode();
+                var treeRoot = getTree().getRootNode();
                 
                 treeRoot.visit(function(node){
                     var parent = node.getParent();
@@ -986,7 +1100,7 @@
         }
         
         function moveNodeDown(node, targetNode) {
-            node.move(targetNode, "after");
+            node.moveTo(targetNode, "after");
             
             isMoved = true;
             save();

--- a/WebUI/war/widgets/PercFinderTree.js
+++ b/WebUI/war/widgets/PercFinderTree.js
@@ -497,7 +497,7 @@
          */
         getDynaTree: function()
         {
-            return $("#perc-finder-tree").fancytree("getTree");
+            return $.ui.fancytree.getTree("#perc-finder-tree");
         },
         
         /**

--- a/projects/sitemanage/src/main/java/com/percussion/category/dao/impl/PSCategoryDao.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/dao/impl/PSCategoryDao.java
@@ -57,7 +57,7 @@ public class PSCategoryDao implements IPSCategoryDao {
   /** {@inheritDoc} */
   @Override
   public void delete(Set<String> ids, List<IPSGuid> pageIds) {
-    log.info("Ids to delete are: {}", ids);
+    log.debug("Ids to delete are: {}", ids);
     Session session = getSession();
     String query = null;
     Query q = null;
@@ -67,7 +67,7 @@ public class PSCategoryDao implements IPSCategoryDao {
         q = session.createQuery(query);
         q.setParameter("id", "%" + id + "%");
         int result = q.executeUpdate();
-        log.info("The result is: {}", result);
+        log.debug("The result is: {}", result);
       }
     } catch (HibernateException e) {
       log.error("There was an error deleting page categories from the database.", e);
@@ -79,7 +79,7 @@ public class PSCategoryDao implements IPSCategoryDao {
   /** {@inheritDoc} */
   @Override
   public List<Integer> getPageIdsFromCategoryIds(Set<String> ids) {
-    log.info("IDs to grab are: {}", ids);
+    log.debug("IDs to grab are: {}", ids);
     List<IPSGuid> guids = new ArrayList<>();
     List<Integer> pageIds = new ArrayList<>();
     Session session = getSession();
@@ -95,7 +95,7 @@ public class PSCategoryDao implements IPSCategoryDao {
         log.error("Error executing category query to get page IDs.", e);
       }
     }
-    log.info("The page IDs returned from the category IDs were: {}", pageIds);
+    log.debug("The page IDs returned from the category IDs were: {}", pageIds);
     return pageIds;
   }
 }

--- a/system/cms/content/applications/sys_resources/ApplicationFiles/js/checkboxTree.js
+++ b/system/cms/content/applications/sys_resources/ApplicationFiles/js/checkboxTree.js
@@ -62,7 +62,7 @@ return this.each(function() {
         var hideCheckbox = node.attr('selectable') == 'no' ? true : false;
         var select = $.inArray(key,selected) != -1;
         var children = node.children();
-        var resultItem = { id : id, title: title, select: select, hideCheckbox: hideCheckbox, expand:true, key: key};
+        var resultItem = { id : id, title: title, select: select, checkbox: !hideCheckbox, expand:true, key: key};
         if (readonly)
             resultItem.unselectable = true;
         if (children.length) {
@@ -193,7 +193,7 @@ return this.each(function() {
         var selected = selectedValues.split(separator);
         var rootNode = $(xml).children('tree');
         rootItem.title = rootNode.attr('label');
-        rootItem.hideCheckbox = true;
+        rootItem.checkbox = false;
         rootItem.select = false;
         rootItem.expand = true;
                 rootItem.key = "/" + rootItem.title;
@@ -252,7 +252,7 @@ var _treeData = [
         {title: "Sub-item 4.2.2", key: "id4.2.2" }
       ]
     },
-    {title: "Sub-item 4.3 (hideCheckbox)", hideCheckbox: true },
+    {title: "Sub-item 4.3 (checkbox: false)", checkbox: false },
     {title: "Sub-item 4.4 (unselectable)", unselectable: true }
   ]
 }


### PR DESCRIPTION
…own, add child, save/cancel placement, and noisy logging

- Fix overlapping action icons and broken tree layout by scoping legacy CSS and forcing border-box inside the category wrapper
- Move Save/Cancel buttons to top of edit form as requested
- Fix Move Up/Down buttons by using correct fancytree .moveTo() API (was using old dynatree .move())
- Fix Add Child Category not indenting or appearing until full browser refresh
- Fix 'New Category' placeholder not being auto-selected on new items
- Enter key in category name field now triggers Save
- Add dynamic enable/disable (greying) of Move Up/Down buttons based on node position in siblings
- Lower noisy INFO logging in PSCategoryDao (IDs to grab, results, etc.) to DEBUG level

Additional changes:
- Modernize fancytree tree retrieval calls (use $.ui.fancytree.getTree() instead of old plugin-style .fancytree('getTree')) in supporting widgets and plugins for consistency with the Category UI migration work
- Fix 'hideCheckbox' deprecation error in checkboxTree.js (replaced with 'checkbox: false') which was breaking the category tree in the Edit Metadata dialog

Fixes #769
Fixes #770
Fixes #780