### PR TITLE
bugfix/728: Prevent bulk upload queue count from going negative when …

### DIFF
--- a/docs/ai-generated/tasks/728-bulk-upload-zero-size-msg/README.md
+++ b/docs/ai-generated/tasks/728-bulk-upload-zero-size-msg/README.md
@@ -1,0 +1,26 @@
+# Bug Fix #728 – Bulk Upload Gadget: Queue Count Becomes Negative on Removing Failed or Rejected Files
+
+## Problem Summary
+
+- In the Bulk Upload Gadget, if the user uploads a zero-byte file, it is correctly rejected with the message `Cannot upload empty (0 byte) files`.
+- However, if the user then clicks the close `[X]` icon to remove/dismiss the rejected file row from the queue, the upload status details display a negative queued file count (e.g. `-1 file(s) queued for upload` instead of `0 file(s) queued for upload`).
+- The same issue happens if an actual file upload fails, and the user clicks `[X]` to dismiss the failed row.
+
+## Root Cause
+
+- In [perc_bulk_file_upload.js](file:///home/nate/projects/java8/percussioncms/system/Packages/perc.gadget.bulkFileUpload/sys__UserDependency--cm/gadgets/repository/perc_bulk_file_upload_gadget/js/perc_bulk_file_upload.js):
+  - When a file is added, `TOTAL_IN_QUEUE` is incremented, and `generateButtonHTML` is called to create the row and attach a click handler to the `[X]` close button.
+  - If a file is a zero-byte file or if a file fails to upload, `TOTAL_IN_QUEUE` is decremented early to exclude it from the pending/queued count.
+  - However, the click handler on `[X]` was unconditionally decrementing `TOTAL_IN_QUEUE` again when removing the row. This double-decrement caused the count to become negative (`-1`).
+
+## Solution
+
+- Modified the close button click handler in `generateButtonHTML` inside [perc_bulk_file_upload.js](file:///home/nate/projects/java8/percussioncms/system/Packages/perc.gadget.bulkFileUpload/sys__UserDependency--cm/gadgets/repository/perc_bulk_file_upload_gadget/js/perc_bulk_file_upload.js):
+  - Check if the row has the `alert-danger` class (which is set on both early rejected zero-byte files and failed uploads).
+  - Only decrement `TOTAL_IN_QUEUE` if the row does not have `alert-danger` (i.e. it is still a pending/queued file).
+  - If the row has `alert-danger`, the queue count is not decremented, preventing the count from going negative.
+
+## Validation
+
+- Ran spotless check successfully.
+- Re-built `perc-packages` module successfully, ensuring the `perc.gadget.bulkFileUpload` package compiles and packages correctly.

--- a/docs/ai-generated/tasks/818-csp-rss-feed-data-uri-images/README.md
+++ b/docs/ai-generated/tasks/818-csp-rss-feed-data-uri-images/README.md
@@ -15,7 +15,7 @@
 ## Solution
 
 1. **Updated Distribution Config**: Updated [perc-security.properties](file:///home/nate/projects/java8/percussioncms/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/conf/perc/perc-security.properties) and the installer file [installDts.xml](file:///home/nate/projects/java8/percussioncms/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/rxconfig/Installer/installDts.xml) to add `data: blob:` to the default `img-src` directive.
-2. **Updated Individual Module Properties & Beans**: 
+2. **Updated Individual Module Properties & Beans**:
    - Found all other default fallback configuration files (properties and Spring XML beans files) for comments, feeds, forms, integrations, membership, metadata, and polls delivery services.
    - For configs containing `default-src 'self' *;` as a default, appended `img-src * 'self' data: blob:;` to explicitly allow data/blob images without exposing other resources (like scripts) to the data URI scheme.
    - For configs containing `default-src 'self';` as a default, appended `img-src 'self' data: blob:;`.
@@ -24,3 +24,4 @@
 
 - Ran spotless check (`./mvn-env.sh spotless:check`) and spotless formatting (`./mvn-env.sh spotless:apply`) successfully.
 - Re-built the `feeds` module and its dependencies via `./mvn-env.sh clean install -pl deliverytiersuite/delivery-tier-suite/feeds -am -DskipTests` successfully.
+

--- a/system/Packages/perc.gadget.bulkFileUpload/sys__UserDependency--cm/gadgets/repository/perc_bulk_file_upload_gadget/js/perc_bulk_file_upload.js
+++ b/system/Packages/perc.gadget.bulkFileUpload/sys__UserDependency--cm/gadgets/repository/perc_bulk_file_upload_gadget/js/perc_bulk_file_upload.js
@@ -207,10 +207,13 @@ generateButtonHTML = function(data) {
     var buttonHtml = $('<button class="btn perc-button" aria-label="remove item from queue">' +
          '<span><i class="fa fa-times" aria-hidden="true"></i></span></button>')
         .on("click",function () {
+            var isFailedOrRejected = $(data.context).hasClass('alert-danger');
             $(data.context).fadeOut('slow', function() {
                 data.context.remove();
-                TOTAL_IN_QUEUE--;
-                $('#perc-bulk-status').text(TOTAL_IN_QUEUE + MSG_QUEUED_FOR_UPLOAD);
+                if (!isFailedOrRejected) {
+                    TOTAL_IN_QUEUE--;
+                    $('#perc-bulk-status').text(TOTAL_IN_QUEUE + MSG_QUEUED_FOR_UPLOAD);
+                }
             });
             data.files.pop();
         });


### PR DESCRIPTION
I have successfully investigated and resolved the remaining issue #728. Here is the summary:

  1. Root Cause:
      • When a zero-byte file is added or if a file upload fails,  TOTAL_IN_QUEUE  is decremented early to exclude it from the pending/queued count.
      • However, clicking the close  [X]  button on these failed/rejected rows was unconditionally decrementing  TOTAL_IN_QUEUE  again, resulting in the queued count going
      negative (e.g.,  -1 file(s) queued for upload ).
  2. Solution:
      • Modified the close button handler in perc_bulk_file_upload.js to check if the target row has the  alert-danger  class (which is set on both early rejected zero-byte
files and
      actual upload failures).
      • The handler now only decrements  TOTAL_IN_QUEUE  if the row does not have  alert-danger  (meaning the file is still a pending/queued upload).
      • Re-ran spotless check and built the  perc-packages  module successfully.
      • Created the task documentation at README.md.

