### PR TITLE
bugfix/663: Backport WCAG 2.1 AA navigation landmarks and aria-label …

### DIFF
--- a/docs/ai-generated/tasks/663-backport-aria-label-nav-widgets/README.md
+++ b/docs/ai-generated/tasks/663-backport-aria-label-nav-widgets/README.md
@@ -1,0 +1,18 @@
+# Task: Backport aria-label Navigation Widgets (Issue #663)
+
+## Objective
+Backport WCAG 2.1 AA accessibility fixes for the Navigation and Breadcrumb widgets from the 8.2 development branch to the 8.1.x branch.
+
+## Changes Made
+1. **Breadcrumb Widget (`system/Packages/perc.widgets.nav/sys__UserDependency--rxconfig/Widgets/percNavBreadcrumb.xml`)**:
+   - Added the `navLabel` UserPref with a default value of `"Breadcrumb Navigation"`.
+   - Updated nested `<nav>` elements (both normal and edit-mode) to include `aria-label="$!{navLabel}"`.
+2. **Navigation Widget (`system/Packages/perc.widgets.nav/sys__UserDependency--rxconfig/Widgets/percNavBar.xml`)**:
+   - Added the `navLabel` UserPref with a default value of `"Main Navigation"`.
+   - Updated the primary `<nav>` element to include `aria-label="$!{navLabel}"`.
+3. **Package Versioning (`system/Packages/perc.widgets.nav/psx_archiveInfo.xml`)**:
+   - Incremented the package version from `1.3.2` to `1.3.3` to ensure correct upgrade application by the CMS Package Manager.
+
+## Verification
+- Ran `./mvn-env.sh spotless:apply` successfully.
+- Re-built `perc-packages` module via `./mvn-env.sh clean install -pl modules/perc-packages -DskipTests` to ensure widget package `perc.widgets.nav.ppkg` builds and archives correctly.

--- a/system/Packages/perc.widgets.nav/psx_archiveInfo.xml
+++ b/system/Packages/perc.widgets.nav/psx_archiveInfo.xml
@@ -16,7 +16,7 @@
             <Description>Navigation Widget	</Description>
             <Publisher name="Percussion Software Inc." url="https://www.percussion.com"/>
             <CmsVersion max="9.0.0" min="1.0.0"/>
-            <Version>1.3.2</Version>
+            <Version>1.3.3</Version>
             <ImplConfigFile/>
             <LocalConfigFile/>
             <PKGDependencies/>

--- a/system/Packages/perc.widgets.nav/sys__UserDependency--rxconfig/Widgets/percNavBar.xml
+++ b/system/Packages/perc.widgets.nav/sys__UserDependency--rxconfig/Widgets/percNavBar.xml
@@ -57,6 +57,10 @@
               display_name="Skip link tabindex value"
               default_value="-1"
               datatype="number" />
+    <UserPref name="navLabel"
+              display_name="Navigation Label"
+              default_value="Main Navigation"
+              datatype="string" />
     <CssPref name="rootclass"
              display_name="CSS Root Class"
              datatype="string" />
@@ -134,7 +138,7 @@ $(this).removeAttr('tabindex');
 </script>
 <a href="#$!{skipLinkRegionId}" class="perc-navigation-skiplink" tabindex="$!{tabindexValue}">$!{skipLinkText}</a>
 #end##
-<nav>
+<nav aria-label="$!{navLabel}">
 <ul class="$!{layout}">
 #if($!{nav})##
 #perc_processNavigationNode($nav.getRoot(), 1, 1, $addTitleAttrs, $titleNavigateToText, $maxRootItems, $maxSubItems)##

--- a/system/Packages/perc.widgets.nav/sys__UserDependency--rxconfig/Widgets/percNavBreadcrumb.xml
+++ b/system/Packages/perc.widgets.nav/sys__UserDependency--rxconfig/Widgets/percNavBreadcrumb.xml
@@ -26,6 +26,10 @@
               display_name="Aria Label"
               default_value=""
               datatype="string" />
+    <UserPref name="navLabel"
+              display_name="Navigation Label"
+              default_value="Breadcrumb Navigation"
+              datatype="string" />
     <CssPref name="rootclass"
              display_name="CSS root class"
              datatype="string" />
@@ -63,7 +67,7 @@
 #set($d=$ancestors.add($navSelf))##
 #end##
 #if ($ancestors.size() > 0)##
-<nav>
+<nav aria-label="$!{navLabel}">
 <ul class="perc-breadcrumb-main">
 #foreach($node in $ancestors)##
 #set($liclass="perc-list-element")##
@@ -93,7 +97,7 @@
 </nav>
 #end##
 #elseif ($perc.isEditMode())##
-<nav>
+<nav aria-label="$!{navLabel}">
 <ul class="perc-breadcrumb-main" $sampleTooltip>
 #set ($sampleContent = ["Section 1", "Section 2"])##
 #foreach($node in $sampleContent)##


### PR DESCRIPTION
  I have successfully completed the backport of the WCAG 2.1 AA improvements for the Navigation and Breadcrumb widgets from the 8.2  development  branch to the 8.1.x branch.

  ### Summary of Changes:

  1. Breadcrumb Widget (percNavBreadcrumb.xml):
      • Added the  navLabel  UserPref (default:  "Breadcrumb Navigation" ).
      • Applied  aria-label="$!{navLabel}"  to all nested  <nav>  elements to ensure that when multiple landmarks are present on the page, they are uniquely and cleanly
      labeled.
  2. Navigation Widget (percNavBar.xml):
      • Added the  navLabel  UserPref (default:  "Main Navigation" ).
      • Applied  aria-label="$!{navLabel}"  to the primary  <nav>  tag.
  3. Nav Package version bump (psx_archiveInfo.xml):
      • Bumped version from  1.3.2  to  1.3.3  (matching the 8.2 branch version) to ensure the Package Manager upgrades it correctly during deployment.
  4. Verification:
      • Spotless checks and automatic code formatting successfully executed.
      • Built the  perc-packages  module to guarantee that the  perc.widgets.nav  package bundles perfectly.
  5. Documentation:
      • Added a task summary in README.md.

