### PR TITLE
Bugfix/833 sitewide framework gadget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# ai dirs
+.kilo
+.antigravitycli
+
 # temp directories
 tmp/*
 .tmp/*

--- a/kilo.json
+++ b/kilo.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://app.kilo.ai/config.json",
+  "model": "kilo/minimax/minimax-m2.7"
+}

--- a/kilo.json
+++ b/kilo.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://app.kilo.ai/config.json",
-  "model": "kilo/minimax/minimax-m2.7"
-}

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/PSPageUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/PSPageUtils.java
@@ -644,6 +644,42 @@ public class PSPageUtils extends PSJexlUtilBase {
   }
 
   @IPSJexlMethod(
+      description =
+          "Process framework content. If the content is a URL, wrap it in a script or link tag.",
+      params = {@IPSJexlParam(name = "source", description = "The raw content to process")},
+      returns = "The processed content")
+  public String processFrameworkContent(String source) {
+    if (isBlank(source)) {
+      return "";
+    }
+    String trimmed = source.trim();
+    if (trimmed.contains("<") && trimmed.contains(">")) {
+      return source;
+    }
+    if (trimmed.startsWith("http://")
+        || trimmed.startsWith("https://")
+        || trimmed.startsWith("//")
+        || trimmed.startsWith("/")) {
+      String path = trimmed;
+      int queryIdx = path.indexOf('?');
+      if (queryIdx != -1) {
+        path = path.substring(0, queryIdx);
+      }
+      int hashIdx = path.indexOf('#');
+      if (hashIdx != -1) {
+        path = path.substring(0, hashIdx);
+      }
+      path = path.trim();
+      if (path.endsWith(".js")) {
+        return "<script src=\"" + trimmed + "\"></script>";
+      } else if (path.endsWith(".css")) {
+        return "<link rel=\"stylesheet\" href=\"" + trimmed + "\" />";
+      }
+    }
+    return source;
+  }
+
+  @IPSJexlMethod(
       description = "Strip canonical link",
       params = {
         @IPSJexlParam(name = "source", description = "The source that may contain canonical link")

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/assembler/PSPageUtilsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/assembler/PSPageUtilsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 1999-2023 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.assembler;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class PSPageUtilsTest {
+
+  @Test
+  public void testProcessFrameworkContent() {
+    PSPageUtils utils = new PSPageUtils();
+
+    // Null and empty checks
+    assertEquals("", utils.processFrameworkContent(null));
+    assertEquals("", utils.processFrameworkContent(""));
+    assertEquals("", utils.processFrameworkContent("   "));
+
+    // Plain text / script tags / HTML should not be modified
+    assertEquals(
+        "<script src=\"https://code.jquery.com/jquery-3.7.1.min.js\"></script>",
+        utils.processFrameworkContent(
+            "<script src=\"https://code.jquery.com/jquery-3.7.1.min.js\"></script>"));
+    assertEquals(
+        "console.log(\"hello\");", utils.processFrameworkContent("console.log(\"hello\");"));
+
+    // CDN / Web URLs ending in .js should be wrapped in script tags
+    assertEquals(
+        "<script src=\"https://code.jquery.com/jquery-3.7.1.min.js\"></script>",
+        utils.processFrameworkContent("https://code.jquery.com/jquery-3.7.1.min.js"));
+    assertEquals(
+        "<script src=\"http://code.jquery.com/jquery-3.7.1.js?v=2\"></script>",
+        utils.processFrameworkContent("http://code.jquery.com/jquery-3.7.1.js?v=2"));
+    assertEquals(
+        "<script src=\"//code.jquery.com/ui/1.13.3/jquery-ui.min.js\"></script>",
+        utils.processFrameworkContent("//code.jquery.com/ui/1.13.3/jquery-ui.min.js"));
+
+    // Relative URLs ending in .js
+    assertEquals(
+        "<script src=\"/js/custom.js\"></script>", utils.processFrameworkContent("/js/custom.js"));
+
+    // CDN / Web URLs ending in .css should be wrapped in link tags
+    assertEquals(
+        "<link rel=\"stylesheet\" href=\"https://code.jquery.com/ui/1.13.3/themes/smoothness/jquery-ui.css\" />",
+        utils.processFrameworkContent(
+            "https://code.jquery.com/ui/1.13.3/themes/smoothness/jquery-ui.css"));
+    assertEquals(
+        "<link rel=\"stylesheet\" href=\"//example.com/styles.css?foo=bar#baz\" />",
+        utils.processFrameworkContent("//example.com/styles.css?foo=bar#baz"));
+
+    // URLs with other extensions or not looking like JS/CSS should not be modified
+    assertEquals(
+        "https://example.com/image.png",
+        utils.processFrameworkContent("https://example.com/image.png"));
+  }
+}

--- a/system/cms/content/applications/sys_resources/ApplicationFiles/vm/sys_assembly.vm
+++ b/system/cms/content/applications/sys_resources/ApplicationFiles/vm/sys_assembly.vm
@@ -602,7 +602,7 @@ $__style
 #end##
 
 ##Print JQuery and JQuery-UI scripts on top and rest below them##
-#perc_displayText("$!perc.linkContext.site.siteAdditionalHeadContent")##
+#perc_displayText($rx.pageutils.processFrameworkContent("$!perc.linkContext.site.siteAdditionalHeadContent"))##
 #if($jqueryWidgetInstances.size() > 0)##
 #if($perc.isEditMode())##
 <script src="/cm/jslib/profiles/3x/jquery/jquery-3.6.0.js"></script>
@@ -664,7 +664,7 @@ display:none;
 ##
 #print_jquery("afterBodyStart")##
 #print_jqueryUI("afterBodyStart")##
-#perc_displayText("$!perc.linkContext.site.siteAfterBodyOpenContent")##
+#perc_displayText($rx.pageutils.processFrameworkContent("$!perc.linkContext.site.siteAfterBodyOpenContent"))##
 #perc_displayText("$!perc.template.afterBodyStartContent")##
 #perc_displayText("$!perc.page.afterBodyStartContent")##
 #end##
@@ -684,7 +684,7 @@ display:none;
 <script defer src='/Rhythmyx/web_resources/cm/foundation/js/foundation.min.js'></script>
 #end##
 #end##
-#perc_displayText("$!perc.linkContext.site.siteBeforeBodyCloseContent")##
+#perc_displayText($rx.pageutils.processFrameworkContent("$!perc.linkContext.site.siteBeforeBodyCloseContent"))##
 #perc_displayText("$!perc.page.beforeBodyCloseContent")##
 #perc_displayText("$!perc.template.beforeBodyCloseContent")##
 #set($jqueryUIwidget = $rx.pageutils.findWidgetInstances($sys.assemblyItem, $NULL, "percJQueryUIWidget"))##


### PR DESCRIPTION
Fix #833 

### Summary of Work

  1. Created Feature Branch: Switched to a new local branch named  bugfix/833-sitewide-framework-gadget  from  development-8.1.x .
  2. Added Helper Method: Added a Jexl-exposed method  processFrameworkContent  to PSPageUtils.java. It checks if a given string starts with a URL prefix (e.g.,  http:// ,      
  https:// ,  // ,  / ) and contains no HTML tags ( <  and  > ):
      • If the URL ends with  .js  (ignoring query parameters/hashes), it wraps it in a  <script>  tag.
      • If the URL ends with  .css , it wraps it in a  <link rel="stylesheet">  tag.
      • Otherwise, it returns the input string unchanged.
  3. Updated Assembly Template: Modified sys_assembly.vm to process framework configurations through the new method:
      •  siteAdditionalHeadContent 
      •  siteAfterBodyOpenContent 
      •  siteBeforeBodyCloseContent 
  4. Created Unit Tests: Created PSPageUtilsTest.java to thoroughly test the new formatting logic.
  5. Validated:
      • Spotless formatting was successfully applied.
      • Unit tests compile and pass.
      • No PMD/checkstyle violations were introduced in the modified files