### PR TITLE
bugfix(803): remove duplicate twitter:site tag insertion block

### DIFF
--- a/system/Packages/perc.twitterSummaryCards/sys__UserDependency--rxconfig/Widgets/percTwitterSummaryCards.xml
+++ b/system/Packages/perc.twitterSummaryCards/sys__UserDependency--rxconfig/Widgets/percTwitterSummaryCards.xml
@@ -209,10 +209,6 @@
 		}
 	}
 
-	if(!empty($use_twitter_site)){
-		$addlHead = $perc.page.getAdditionalHeadContent();
-		$perc.page.setAdditionalHeadContent($nl.format("%s%n%s", $addlHead, $meta_sitename));
-	}
 
 	if(!empty($use_title)){
 		$addlHead = $perc.page.getAdditionalHeadContent();


### PR DESCRIPTION
  ### Root Cause of Re-opened Issue #803:

  In the previously merged PR for #803, two blocks were present in  percTwitterSummaryCards.xml  checking  if(!empty($use_twitter_site))  sequentially:

  1. The first block correctly checked  if (! $addlHead.contains("twitter:site"))  before appending.
  2. The second block immediately after ran unconditionally and appended the tag without any duplicate check, leading to duplicate  twitter:site  tags being emitted in the
  HTML  <head> .

  ### Resolution Steps Performed:

  1. Hard-reset local  development-8.1.x  to align exactly with  origin/development-8.1.x  (getting rid of local commits that had diverged).
  2. Cleaned up the local  bugfix/803-twitter-site-metadata  feature branch by resetting it to the clean  development-8.1.x .
  3. Deleted the duplicate JEXL/Velocity execution block from:
  percTwitterSummaryCards.xml
  4. Validated XML structure to ensure well-formedness.
  5. Staged, committed, and force-pushed the branch cleanly to the remote origin.
