### PR TITLE
bugfix/818: Update CSP in restored perc-security.properties on DTS up…

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/rxconfig/Installer/installDts.xml
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/rxconfig/Installer/installDts.xml
@@ -468,6 +468,17 @@
                             <include name="*.xml"/>
                         </fileset>
                     </copy>
+                    <!-- Update CSP policy in restored perc-security.properties for issue 818 -->
+                    <if>
+                        <available file="${install.dir}${staging.dir}/Deployment/Server/conf/perc/perc-security.properties" type="file"/>
+                        <then>
+                            <echo>Updating Content Security Policy (CSP) in restored perc-security.properties for issue 818...</echo>
+                            <replaceregexp file="${install.dir}${staging.dir}/Deployment/Server/conf/perc/perc-security.properties"
+                                           match="img-src\s+\*\s+'self'(\s+data:)?(\s+blob:)?\s+'unsafe-inline'\s+'unsafe-eval'"
+                                           replace="img-src * 'self' data: blob: 'unsafe-inline' 'unsafe-eval'"
+                                           byline="true"/>
+                        </then>
+                    </if>
                     <echo>Restore Server.xml... if perc_catalina is already created</echo>
                     <if>
                         <available file="${new.backup.dir}${staging.dir}/Server/conf/perc/perc-catalina.properties"/>


### PR DESCRIPTION
  ### Overview of Changes

  1. Upgrades Flow Restoration Override: During the DTS upgrade flow in installDts.xml, the installer backs up and restores the customer's existing properties files (including
  perc-security.properties ). This overrides the new default security properties with the customer's older values, leaving the old CSP policy in place.
  2. Post-Restore Regex Replacement: Added a conditional  <replaceregexp>  block immediately after the properties copy/restore step. This block targets the  img-src  directive
  of  contentSecurityPolicy  in the customer's restored  perc-security.properties  and ensures it includes  data: blob:  to satisfy the requirements for issue #818. If the
  customer already has  data:  or  blob:  configured, or has customized it, it cleanly normalizes or leaves the custom parts of their policy intact.

  Both the Maven build for the distribution module and the spotless check ran successfully.
