### PR TITLE
Deprecate Secure Login widget and associated DTS security configurations

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/webapp/WEB-INF/security.xml
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/webapp/WEB-INF/security.xml
@@ -9,6 +9,11 @@
 	http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!--
+       @deprecated This Spring Security configuration is deprecated because the Secure Login widget
+       and perc-secure-membership module are deprecated.
+    -->
+
     <security:http pattern="/favicon.ico" security='none' />
     <security:http  create-session="stateless" use-expressions="true" auto-config="true">
         <security:csrf disabled="${disableCSRFProtection}" token-repository-ref="tokenRepository" request-matcher-ref="requestMatcher" />

--- a/deliverytiersuite/delivery-tier-suite/comments/src/test/resources/security.xml
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/test/resources/security.xml
@@ -11,6 +11,11 @@
 	http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!--
+       @deprecated This Spring Security configuration is deprecated because the Secure Login widget
+       and perc-secure-membership module are deprecated.
+    -->
+
     <security:http pattern="/favicon.ico" security='none' />
 
     <security:http  create-session="stateless" use-expressions="true" auto-config="true">

--- a/deliverytiersuite/delivery-tier-suite/common/src/main/java/com/percussion/delivery/spring/CustomAuthenticationProvider.java
+++ b/deliverytiersuite/delivery-tier-suite/common/src/main/java/com/percussion/delivery/spring/CustomAuthenticationProvider.java
@@ -26,6 +26,11 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.stereotype.Component;
 
+/**
+ * @deprecated This class is part of the deprecated secure-membership/DTS spring security
+ *     integration.
+ */
+@Deprecated
 @Component
 public class CustomAuthenticationProvider
     implements AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> {

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/webapp/WEB-INF/security.xml
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/webapp/WEB-INF/security.xml
@@ -9,6 +9,11 @@
 	http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!--
+       @deprecated This Spring Security configuration is deprecated because the Secure Login widget
+       and perc-secure-membership module are deprecated.
+    -->
+
     <security:http pattern="/favicon.ico" security='none' />
     <security:http  create-session="stateless" use-expressions="true" auto-config="true">
         <security:csrf disabled="${disableCSRFProtection}" token-repository-ref="tokenRepository" request-matcher-ref="requestMatcher" />

--- a/deliverytiersuite/delivery-tier-suite/forms/src/main/java/webapp/WEB-INF/security.xml
+++ b/deliverytiersuite/delivery-tier-suite/forms/src/main/java/webapp/WEB-INF/security.xml
@@ -9,6 +9,11 @@
 	http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!--
+       @deprecated This Spring Security configuration is deprecated because the Secure Login widget
+       and perc-secure-membership module are deprecated.
+    -->
+
     <security:http pattern="/favicon.ico" security='none' />
     <security:http  create-session="stateless" use-expressions="true" auto-config="true">
         <security:csrf disabled="${disableCSRFProtection}" token-repository-ref="tokenRepository" request-matcher-ref="requestMatcher" />

--- a/deliverytiersuite/delivery-tier-suite/forms/src/test/webapp/WEB-INF/security.xml
+++ b/deliverytiersuite/delivery-tier-suite/forms/src/test/webapp/WEB-INF/security.xml
@@ -11,6 +11,11 @@
 	http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!--
+       @deprecated This Spring Security configuration is deprecated because the Secure Login widget
+       and perc-secure-membership module are deprecated.
+    -->
+
     <security:http pattern="/favicon.ico" security='none' />
 
 

--- a/deliverytiersuite/delivery-tier-suite/integrations/src/main/java/com/percussion/delivery/integrations/ems/CustomAuthenticationProvider.java
+++ b/deliverytiersuite/delivery-tier-suite/integrations/src/main/java/com/percussion/delivery/integrations/ems/CustomAuthenticationProvider.java
@@ -26,6 +26,11 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.stereotype.Component;
 
+/**
+ * @deprecated This class is part of the deprecated secure-membership/DTS spring security
+ *     integration.
+ */
+@Deprecated
 @Component
 public class CustomAuthenticationProvider
     implements AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> {

--- a/deliverytiersuite/delivery-tier-suite/integrations/src/main/java/webapp/WEB-INF/security.xml
+++ b/deliverytiersuite/delivery-tier-suite/integrations/src/main/java/webapp/WEB-INF/security.xml
@@ -9,6 +9,11 @@
 	http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!--
+       @deprecated This Spring Security configuration is deprecated because the Secure Login widget
+       and perc-secure-membership module are deprecated.
+    -->
+
     <security:http pattern="/favicon.ico" security='none' />
     <security:http  create-session="stateless" use-expressions="true" auto-config="true">
         <security:csrf disabled="${disableCSRFProtection}" token-repository-ref="tokenRepository" request-matcher-ref="requestMatcher" />

--- a/deliverytiersuite/delivery-tier-suite/membership/src/main/java/webapp/WEB-INF/security.xml
+++ b/deliverytiersuite/delivery-tier-suite/membership/src/main/java/webapp/WEB-INF/security.xml
@@ -9,6 +9,11 @@
 	http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!--
+       @deprecated This Spring Security configuration is deprecated because the Secure Login widget
+       and perc-secure-membership module are deprecated.
+    -->
+
     <security:http pattern="/favicon.ico" security='none' />
     <security:http  create-session="stateless" use-expressions="true" auto-config="true">
         <security:csrf disabled="${disableCSRFProtection}" token-repository-ref="tokenRepository" request-matcher-ref="requestMatcher" />

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/webapp/WEB-INF/security.xml
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/webapp/WEB-INF/security.xml
@@ -9,6 +9,11 @@
 	http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!--
+       @deprecated This Spring Security configuration is deprecated because the Secure Login widget
+       and perc-secure-membership module are deprecated.
+    -->
+
     <security:http pattern="/favicon.ico" security='none' />
     <security:http  create-session="stateless" use-expressions="true" auto-config="true">
         <security:csrf disabled="${disableCSRFProtection}" token-repository-ref="tokenRepository" request-matcher-ref="requestMatcher" />

--- a/deliverytiersuite/delivery-tier-suite/polls/src/main/java/webapp/WEB-INF/security.xml
+++ b/deliverytiersuite/delivery-tier-suite/polls/src/main/java/webapp/WEB-INF/security.xml
@@ -9,6 +9,11 @@
 	http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!--
+       @deprecated This Spring Security configuration is deprecated because the Secure Login widget
+       and perc-secure-membership module are deprecated.
+    -->
+
     <security:http pattern="/favicon.ico" security='none' />
 
     <security:http create-session="stateless" use-expressions="true" auto-config="true">

--- a/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/data/PSMembershipConfiguration.java
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/data/PSMembershipConfiguration.java
@@ -18,6 +18,8 @@ package com.percussion.secure.data;
 
 import org.apache.commons.lang.Validate;
 
+/** @deprecated This class is part of the deprecated secure-membership module. */
+@Deprecated
 public class PSMembershipConfiguration {
   // set by spring beans config
   private String membershipServiceHost;

--- a/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/AuthFormProcessingFilter.java
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/AuthFormProcessingFilter.java
@@ -27,6 +27,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 
+/** @deprecated This class is part of the deprecated secure-membership module. */
+@Deprecated
 public class AuthFormProcessingFilter extends AbstractAuthenticationProcessingFilter {
   public static final String SPRING_SECURITY_FORM_USERNAME_KEY = "j_username";
   public static final String SPRING_SECURITY_FORM_PASSWORD_KEY = "j_password";

--- a/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSCacheControlFilter.java
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSCacheControlFilter.java
@@ -26,6 +26,8 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 
+/** @deprecated This class is part of the deprecated secure-membership module. */
+@Deprecated
 public class PSCacheControlFilter implements Filter {
 
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)

--- a/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSLdapMembershipAuthProvider.java
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSLdapMembershipAuthProvider.java
@@ -56,7 +56,9 @@ import org.springframework.util.StringUtils;
  * Works to provide authentication for Active Directory users using Spring Security
  *
  * @author Shweta Patel
+ * @deprecated This class is part of the deprecated secure-membership module.
  */
+@Deprecated
 public class PSLdapMembershipAuthProvider extends AbstractLdapAuthenticationProvider {
   private static final Pattern SUB_ERROR_CODE = Pattern.compile(".*data\\s([0-9a-f]{3,4}).*");
 

--- a/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSLdapUserDetailsMapper.java
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSLdapUserDetailsMapper.java
@@ -47,7 +47,9 @@ import org.xml.sax.SAXException;
  * Class to handle User Details Mapping for authorization.
  *
  * @author Shweta Patel
+ * @deprecated This class is part of the deprecated secure-membership module.
  */
+@Deprecated
 public class PSLdapUserDetailsMapper extends LdapUserDetailsMapper {
   private static final String ROLE_TEST = "role_test";
   private static final String ROLE_ADMIN = "Domain Admins";

--- a/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSMembershipAuthProvider.java
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSMembershipAuthProvider.java
@@ -47,7 +47,10 @@ import org.springframework.security.core.userdetails.UserDetails;
 /**
  * Works to provide authentication for Active Directory users and CM1 registered members using
  * Spring Security
+ *
+ * @deprecated This class is part of the deprecated secure-membership module.
  */
+@Deprecated
 public class PSMembershipAuthProvider extends AbstractUserDetailsAuthenticationProvider {
   /**
    * Stores the current thread session id so that it can be obtained elsewhere to set the membership

--- a/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSMembershipAuthUtils.java
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSMembershipAuthUtils.java
@@ -40,6 +40,8 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
+/** @deprecated This class is part of the deprecated secure-membership module. */
+@Deprecated
 public class PSMembershipAuthUtils {
 
   private static final Logger log = LogManager.getLogger(PSMembershipAuthUtils.class);

--- a/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSMembershipLoginHandler.java
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSMembershipLoginHandler.java
@@ -29,7 +29,9 @@ import org.springframework.security.web.authentication.SavedRequestAwareAuthenti
  * Class to handle setting the membership session cookie after a successful authentication
  *
  * @author JaySeletz
+ * @deprecated This class is part of the deprecated secure-membership module.
  */
+@Deprecated
 public class PSMembershipLoginHandler extends SavedRequestAwareAuthenticationSuccessHandler {
   private PSMembershipConfiguration membershipConfig;
 

--- a/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSMembershipLogoutHandler.java
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSMembershipLogoutHandler.java
@@ -38,7 +38,9 @@ import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuc
  * Handle logging out of membership
  *
  * @author JaySeletz
+ * @deprecated This class is part of the deprecated secure-membership module.
  */
+@Deprecated
 public class PSMembershipLogoutHandler extends SimpleUrlLogoutSuccessHandler {
 
   private static Client ms_client = ClientBuilder.newClient();

--- a/projects/sitemanage/src/main/resources/com/percussion/pagemanagement/service/impl/WidgetRegistry.xml
+++ b/projects/sitemanage/src/main/resources/com/percussion/pagemanagement/service/impl/WidgetRegistry.xml
@@ -34,7 +34,6 @@
         <widget name="Rich Text"/>
         <widget name="RSS"/>
         <widget name="Result"/>
-        <widget name="Secure Login"/>
         <widget name="Social Buttons"/>
         <widget name="Twitter Summary Cards"/>
         <widget name="Facebook Open Graph"/>
@@ -56,5 +55,6 @@
         <widget name="Share This"/>
         <widget name="Calendar"/>
         <widget name="Flash"/>
+        <widget name="Secure Login (Deprecated)"/>
     </group>
 </widgets>

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -680,7 +680,7 @@ public class ContentTypesResource {
                                     + "        \"uuid\": 367\n"
                                     + "      },\n"
                                     + "      \"hideFromMenu\": false,\n"
-                                    + "      \"label\": \"Secure Login\",\n"
+                                    + "      \"label\": \"Secure Login (Deprecated)\",\n"
                                     + "      \"name\": \"percSecureLogin\"\n"
                                     + "    },\n"
                                     + "    {\n"

--- a/system/Packages/perc.widget.secureLogin/percSecureLogin.itemDef.contentType
+++ b/system/Packages/perc.widget.secureLogin/percSecureLogin.itemDef.contentType
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ItemDefData appName="psx_cepercSecureLogin" isHidden="true" objectType="1">
-   <PSXItemDefSummary editorUrl="../psx_cepercSecureLogin/percSecureLogin.html" id="369" label="Secure Login" name="percSecureLogin" typeId="369"/>
+   <PSXItemDefSummary editorUrl="../psx_cepercSecureLogin/percSecureLogin.html" id="369" label="Secure Login (Deprecated)" name="percSecureLogin" typeId="369"/>
    <PSXContentEditor contentType="369" enableRelatedContent="yes" iconSource="0" iconValue="" objectType="1" producesResource="no" workflowId="6">
       <PSXDataSet id="768">
          <name>percSecureLogin</name>

--- a/system/Packages/perc.widget.secureLogin/percSecureLogin.nodeDef.contentType
+++ b/system/Packages/perc.widget.secureLogin/percSecureLogin.nodeDef.contentType
@@ -4,7 +4,7 @@
     <hide-from-menu>true</hide-from-menu>
     <id>369</id>
     <internal-name>percSecureLogin</internal-name>
-    <label>Secure Login</label>
+    <label>Secure Login (Deprecated)</label>
     <mandatory>false</mandatory>
     <name>rx:percSecureLogin</name>
     <new-request>../psx_cepercSecureLogin/percSecureLogin.html</new-request>

--- a/system/Packages/perc.widget.secureLogin/sys__UserDependency--rxconfig/Widgets/percSecureLogin.xml
+++ b/system/Packages/perc.widget.secureLogin/sys__UserDependency--rxconfig/Widgets/percSecureLogin.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Widget>
-	<WidgetPrefs title="Secure Login"
+	<WidgetPrefs title="Secure Login (Deprecated)"
 				 contenttype_name="percSecureLogin"
 				 category="integration"
-				 description="Login widget to access secured content."
+				 description="Login widget to access secured content. (Deprecated)"
 				 author="Percussion Software Inc."
 				 thumbnail="/rx_resources/widgets/percSecureLogin/images/widgetIconLogin.gif"
 				 preferred_editor_width="780"


### PR DESCRIPTION
- Move Secure Login widget to the deprecated group in WidgetRegistry.xml
- Append "(Deprecated)" to Secure Login widget labels and description
- Add @Deprecated annotation to all classes in the secure-membership module
- Add @Deprecated annotation to CustomAuthenticationProvider classes in DTS
- Add deprecation XML comments to security.xml configurations in DTS modules

Addresses: https://github.com/intersoftdatalabs-in/percussioncms/issues/845