### PR TITLE
Deprecate Registration widget

### DIFF
--- a/projects/sitemanage/src/main/resources/com/percussion/pagemanagement/service/impl/WidgetRegistry.xml
+++ b/projects/sitemanage/src/main/resources/com/percussion/pagemanagement/service/impl/WidgetRegistry.xml
@@ -30,7 +30,6 @@
         <widget name="Navigation"/>
         <widget name="Page Auto List"/>
         <widget name="Polls"/>
-        <widget name="Registration"/>
         <widget name="Rich Text"/>
         <widget name="RSS"/>
         <widget name="Result"/>
@@ -56,5 +55,6 @@
         <widget name="Calendar"/>
         <widget name="Flash"/>
         <widget name="Secure Login (Deprecated)"/>
+        <widget name="Registration (Deprecated)"/>
     </group>
 </widgets>

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -652,7 +652,7 @@ public class ContentTypesResource {
                                     + "        \"uuid\": 363\n"
                                     + "      },\n"
                                     + "      \"hideFromMenu\": false,\n"
-                                    + "      \"label\": \"Registration Asset\",\n"
+                                    + "      \"label\": \"Registration Asset (Deprecated)\",\n"
                                     + "      \"name\": \"percRegistrationAsset\"\n"
                                     + "    },\n"
                                     + "    {\n"

--- a/system/Packages/perc.widget.registration/percRegistrationAsset.itemDef.contentType
+++ b/system/Packages/perc.widget.registration/percRegistrationAsset.itemDef.contentType
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ItemDefData appName="psx_cepercRegistrationAsset" isHidden="true" objectType="1">
-   <PSXItemDefSummary editorUrl="../psx_cepercRegistrationAsset/percRegistrationAsset.html" id="369" label="Registration Asset" name="percRegistrationAsset" typeId="369"/>
+   <PSXItemDefSummary editorUrl="../psx_cepercRegistrationAsset/percRegistrationAsset.html" id="369" label="Registration Asset (Deprecated)" name="percRegistrationAsset" typeId="369"/>
    <PSXContentEditor contentType="369" enableRelatedContent="yes" iconSource="1" iconValue="filetypeIconsRegistration.png" objectType="1" producesResource="no" workflowId="6">
       <PSXDataSet id="768">
          <name>percRegistrationAsset</name>

--- a/system/Packages/perc.widget.registration/percRegistrationAsset.nodeDef.contentType
+++ b/system/Packages/perc.widget.registration/percRegistrationAsset.nodeDef.contentType
@@ -4,7 +4,7 @@
     <hide-from-menu>true</hide-from-menu>
     <id>369</id>
     <internal-name>percRegistrationAsset</internal-name>
-    <label>Registration Asset</label>
+    <label>Registration Asset (Deprecated)</label>
     <mandatory>false</mandatory>
     <name>rx:percRegistrationAsset</name>
     <new-request>../psx_cepercRegistrationAsset/percRegistrationAsset.html</new-request>

--- a/system/Packages/perc.widget.registration/sys__UserDependency--rxconfig/Widgets/percRegistration.xml
+++ b/system/Packages/perc.widget.registration/sys__UserDependency--rxconfig/Widgets/percRegistration.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Widget>
-    <WidgetPrefs title="Registration"
+    <WidgetPrefs title="Registration (Deprecated)"
                  contenttype_name="percRegistrationAsset"
                  category="integration"
-                 description="Widget to build and render a registration form"
+                 description="Widget to build and render a registration form. (Deprecated)"
                  author="Percussion Software Inc"
                  thumbnail="/rx_resources/widgets/registration/images/widgetIconRegistration.gif"
                  preferred_editor_width="800"


### PR DESCRIPTION
- Move Registration widget to the deprecated group in WidgetRegistry.xml
- Append "(Deprecated)" to Registration widget labels and description

Addresses: https://github.com/intersoftdatalabs-in/percussioncms/issues/844