### PR TITLE
Fix NullPointerException during publish for newly created sites

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/PSPageUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/PSPageUtils.java
@@ -87,7 +87,6 @@ import com.percussion.services.linkmanagement.data.PSManagedLink;
 import com.percussion.services.memory.IPSCacheAccess;
 import com.percussion.services.memory.PSCacheAccessLocator;
 import com.percussion.services.pubserver.data.PSPubServer;
-import com.percussion.services.pubserver.data.PSPubServerProperty;
 import com.percussion.services.relationship.IPSRelationshipService;
 import com.percussion.services.relationship.data.PSRelationshipData;
 import com.percussion.services.sitemgr.IPSSite;
@@ -2944,8 +2943,8 @@ public class PSPageUtils extends PSJexlUtilBase {
       serverBase = deliveryInfoService.findBaseByServerType(PSPubServer.STAGING);
     } else {
       if (serverId != null && pubServer != null) {
-        PSPubServerProperty p = pubServer.getProperty("publishServer");
-        serverBase = deliveryInfoService.findBaseByServerName(p.getValue());
+        String publishServer = pubServer.getPublishServer();
+        serverBase = deliveryInfoService.findBaseByServerName(publishServer);
       } else {
         serverBase = deliveryInfoService.findBaseByServerType(PSPubServer.PRODUCTION);
       }

--- a/system/business/src/com/percussion/rx/delivery/impl/PSMetadataDeliveryHandler.java
+++ b/system/business/src/com/percussion/rx/delivery/impl/PSMetadataDeliveryHandler.java
@@ -113,7 +113,7 @@ public class PSMetadataDeliveryHandler extends PSBaseDeliveryHandler
         super.init(jobid, site, pubServer);
 
         //If there is no DTS configured then this delivery service is not enabled.
-        this.enabled = !pubServer.getProperty("publishServer").getValue().equalsIgnoreCase("none");
+        this.enabled = !pubServer.getPublishServer().equalsIgnoreCase("none");
 
         //  Be careful with object fields.  This instance is shared between jobs.  m_jobData and workers are
         //  used to create job specific data.

--- a/system/services/src/com/percussion/services/pubserver/data/PSPubServer.java
+++ b/system/services/src/com/percussion/services/pubserver/data/PSPubServer.java
@@ -28,6 +28,8 @@ import com.percussion.share.data.PSAbstractDataObject;
 import com.percussion.utils.guid.IPSGuid;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Fetch;
@@ -69,6 +71,8 @@ public class PSPubServer extends PSAbstractDataObject implements Serializable, I
     * 
     */
    private static final long serialVersionUID = 1L;
+
+   private static final Logger log = LogManager.getLogger(PSPubServer.class);
 
    @Id
    @Column(name = "PUBSERVERID")
@@ -465,16 +469,21 @@ public class PSPubServer extends PSAbstractDataObject implements Serializable, I
        return true;
    }
 
-   public String getPublishServer(){
-      PSDeliveryInfoService psDeliveryInfoService = (PSDeliveryInfoService) PSDeliveryInfoServiceLocator.getDeliveryInfoService();
-      List psDeliveryInfoServiceList = psDeliveryInfoService.getAdminUrls(this.serverType);
-      String server = this.getPropertyValue(IPSPubServerDao.PUBLISH_SERVER_PROPERTY,null);
-      if(psDeliveryInfoServiceList.contains(server)){
-         return server;
-      }else{
-         addProperty(IPSPubServerDao.PUBLISH_SERVER_PROPERTY,DEFAULT_DTS);
-         return DEFAULT_DTS;
-      }
-   }
+    public String getPublishServer(){
+       PSDeliveryInfoService psDeliveryInfoService = (PSDeliveryInfoService) PSDeliveryInfoServiceLocator.getDeliveryInfoService();
+       List psDeliveryInfoServiceList = psDeliveryInfoService.getAdminUrls(this.serverType);
+       String server = this.getPropertyValue(IPSPubServerDao.PUBLISH_SERVER_PROPERTY,null);
+       if(psDeliveryInfoServiceList.contains(server)){
+          return server;
+       }else{
+          if (server == null) {
+             log.warn("No DTS server is currently configured for the site's default publishing server: '{}'. Defaulting to 'NONE'.", this.name);
+          } else if (!server.equalsIgnoreCase(DEFAULT_DTS)) {
+             log.warn("Configured DTS server '{}' for publishing server '{}' is not valid or not found in delivery-servers.xml. Defaulting to 'NONE'.", server, this.name);
+          }
+          addProperty(IPSPubServerDao.PUBLISH_SERVER_PROPERTY,DEFAULT_DTS);
+          return DEFAULT_DTS;
+       }
+    }
 
 }


### PR DESCRIPTION
- Use getPublishServer() instead of getProperty("publishServer") directly, ensuring safe fallback and initialization of DTS configuration.
- Solves publishing failures occurring immediately after site creation before manual configuration save.

Addresses: https://github.com/intersoftdatalabs-in/percussioncms/issues/847