### PR TITLE
bugfix/849: Handle concurrency exceptions gracefully during publish jobs

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSAbstractWorkflowExtension.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSAbstractWorkflowExtension.java
@@ -374,7 +374,17 @@ public abstract class PSAbstractWorkflowExtension implements IPSExtension {
     }
 
     protected void handleError(WorkflowItem wfItem, String action, Exception e) {
-      log.error("Failed to " + action + " item: " + wfItem, e);
+      if (isConcurrencyException(e)) {
+        log.info(
+            "Concurrent modification detected while attempting to {} item: {}. This item was likely updated by another concurrent publish job.",
+            action,
+            wfItem);
+        if (log.isDebugEnabled()) {
+          log.debug("Concurrent modification exception details:", e);
+        }
+      } else {
+        log.error("Failed to " + action + " item: " + wfItem, e);
+      }
       wfItem.error = e;
       wfItem.status = ItemStatus.FAILED;
     }
@@ -775,6 +785,20 @@ public abstract class PSAbstractWorkflowExtension implements IPSExtension {
 
   public void setPubServerService(IPSPubServerService pubServerService) {
     this.pubServerService = pubServerService;
+  }
+
+  public static boolean isConcurrencyException(Throwable t) {
+    while (t != null) {
+      String name = t.getClass().getName();
+      if (name.contains("LockAcquisitionException")
+          || name.contains("OptimisticLockException")
+          || name.contains("ConcurrencyFailureException")
+          || name.contains("PessimisticLockException")) {
+        return true;
+      }
+      t = t.getCause();
+    }
+    return false;
   }
 
   /** The log instance to use for this class, never <code>null</code>. */

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/task/impl/PSWorkflowEditionTask.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/task/impl/PSWorkflowEditionTask.java
@@ -104,20 +104,33 @@ public class PSWorkflowEditionTask extends PSAbstractWorkflowExtension implement
     }
     log.debug("Finished workflowing items for jobId: {}", jobId);
 
-    if (!pubIds.isEmpty()) {
-      log.debug("Started updating post date for items for jobId: {}", jobId);
-      getCmsObjectManager().setPostDate(pubIds);
-      log.debug("Finished updating post date for items for jobId: {}", jobId);
+    try {
+      if (!pubIds.isEmpty()) {
+        log.debug("Started updating post date for items for jobId: {}", jobId);
+        getCmsObjectManager().setPostDate(pubIds);
+        log.debug("Finished updating post date for items for jobId: {}", jobId);
 
-      log.debug("Started clearing start date for items for jobId: {}", jobId);
-      getCmsObjectManager().clearStartDate(pubIds);
-      log.debug("Finished clearing start date for items for jobId: {}", jobId);
-    }
+        log.debug("Started clearing start date for items for jobId: {}", jobId);
+        getCmsObjectManager().clearStartDate(pubIds);
+        log.debug("Finished clearing start date for items for jobId: {}", jobId);
+      }
 
-    if (!unpubIds.isEmpty()) {
-      log.debug("Started clearing expiry date for items for jobId: {}", jobId);
-      getCmsObjectManager().clearExpiryDate(unpubIds);
-      log.debug("Finished clearing expiry date for items for jobId: {}", jobId);
+      if (!unpubIds.isEmpty()) {
+        log.debug("Started clearing expiry date for items for jobId: {}", jobId);
+        getCmsObjectManager().clearExpiryDate(unpubIds);
+        log.debug("Finished clearing expiry date for items for jobId: {}", jobId);
+      }
+    } catch (Exception e) {
+      if (isConcurrencyException(e)) {
+        log.info(
+            "Concurrent modification detected while updating content dates for jobId: {}. The dates will be/were updated by another concurrent publish job.",
+            jobId);
+        if (log.isDebugEnabled()) {
+          log.debug("Concurrent modification details:", e);
+        }
+      } else {
+        throw e;
+      }
     }
   }
 }

--- a/system/services/src/com/percussion/services/contentmgr/impl/legacy/PSContentRepository.java
+++ b/system/services/src/com/percussion/services/contentmgr/impl/legacy/PSContentRepository.java
@@ -2019,7 +2019,7 @@ public class PSContentRepository
         PSTypeConfiguration type = ms_configuration.get(key);
         if (type == null)
         {
-            ms_log.warn("Query problem: type not found for type id: {}", typeid);
+            ms_log.debug("Query problem: type not found for type id: {}", typeid);
             return null;
         }
 


### PR DESCRIPTION
- Check for LockAcquisitionException, OptimisticLockException, ConcurrencyFailureException, and PessimisticLockException in PSAbstractWorkflowExtension.
- Log concurrent modification exceptions during workflow transitions at INFO/DEBUG level rather than ERROR level to avoid misleading error logs.
- Wrap content post/clear date updates in PSWorkflowEditionTask with try-catch and handle concurrency exceptions gracefully without propagating/failing the publish job.
- Change the query problem warning 'type not found for type id' in PSContentRepository to DEBUG level.