### PR TITLE
Bugfix/847 dts server dropdown none

### DIFF
--- a/WebUI/war/views/PercPublishMinuetView.js
+++ b/WebUI/war/views/PercPublishMinuetView.js
@@ -110,22 +110,21 @@ function getAllPublishingServer(serverType,serverObj) {
     publishingServerListDeferred.done(function(pslLst) {
         publishingServerList = pslLst;
         $("#publishServer").empty();
+        $('#publishServer').append(new Option("NONE", "NONE"));
         for(var i in publishingServerList) {
-            $('#publishServer').append(new Option(publishingServerList[i],publishingServerList[i]));
+            if (publishingServerList[i] !== "NONE") {
+                $('#publishServer').append(new Option(publishingServerList[i], publishingServerList[i]));
+            }
         }
-        var selectedserver;
-        if(publishingServerList.length > 1){
-            selectedserver = publishingServerList[0];
-        }
+        var selectedserver = "NONE";
 
         if(typeof serverObj !== 'undefined' && typeof serverObj.serverInfo !== 'undefined'){
             var selectedserverProp = getArrayProperty(serverObj.serverInfo.properties, "key", "publishServer");
-            //Selecting Second Record as default because first one is us gov.
-            if( typeof selectedserverProp !== 'undefined' && selectedserverProp !== null && typeof selectedserverProp.value !== 'undefined'){
+            if( typeof selectedserverProp !== 'undefined' && selectedserverProp !== null && typeof selectedserverProp.value !== 'undefined' && selectedserverProp.value !== ""){
                 selectedserver = selectedserverProp.value;
             }
         }
-        var isExist = publishingServerList.includes(selectedserver);
+        var isExist = publishingServerList.includes(selectedserver) || selectedserver === "NONE";
         if(isExist){
             $('#publishServer').val(selectedserver);
         }else{

--- a/docs/ai-generated/tasks/663-backport-aria-label-nav-widgets/README.md
+++ b/docs/ai-generated/tasks/663-backport-aria-label-nav-widgets/README.md
@@ -23,4 +23,3 @@ Backport WCAG 2.1 AA accessibility fixes for the Navigation and Breadcrumb widge
 - Re-built `perc-packages` module via `./mvn-env.sh clean install -pl modules/perc-packages -DskipTests` to ensure widget package `perc.widgets.nav.ppkg` builds and archives correctly.
 - Verified that `perc.widgets.nav` package passes the package reference structure tests.
 
-

--- a/docs/ai-generated/tasks/847-dts-server-dropdown-none/README.md
+++ b/docs/ai-generated/tasks/847-dts-server-dropdown-none/README.md
@@ -1,0 +1,17 @@
+# Task: DTS Server Dropdown Default to NONE (Issue #847)
+
+## Objective
+
+Fix a bug in the publishing server configuration UI where the Select DTS Server dropdown incorrectly displays a configured server even when NONE is configured (e.g. for newly created sites). It should default to NONE when no DTS server is configured.
+
+## Changes Made
+
+1. **Minuet Publisher View (`WebUI/war/views/PercPublishMinuetView.js`)**:
+   - Added `"NONE"` explicitly as a valid option to the DTS Server select dropdown.
+   - Refactored the selected server logic so that if the server configuration does not specify a DTS server (or specifies an empty/NONE value), it correctly defaults `selectedserver` to `"NONE"` instead of defaulting to the first available server in the list.
+   - Verified that if the default selection is `"NONE"` or a valid DTS server, it selects the option correctly.
+
+## Verification
+
+- Ran `./mvn-env.sh spotless:apply` to ensure code formatting complies with project standards.
+- Re-built `perc-web-ui` module via `./mvn-env.sh clean install -pl WebUI -DskipTests` successfully.

--- a/docs/ai-generated/tasks/847-dts-server-dropdown-none/README.md
+++ b/docs/ai-generated/tasks/847-dts-server-dropdown-none/README.md
@@ -2,11 +2,15 @@
 
 ## Objective
 
-Fix a bug in the publishing server configuration UI where the Select DTS Server dropdown incorrectly displays a configured server even when NONE is configured (e.g. for newly created sites). It should default to NONE when no DTS server is configured.
+Fix a bug in the publishing server configuration UI and backend where newly created sites fail their initial publish due to missing DTS server configuration (resulting in NullPointerExceptions, fallback warnings, or NONE values) until the publish configuration is manually saved. The DTS server association must be properly initialized and persisted during site creation.
 
 ## Changes Made
 
-1. **Minuet Publisher View (`WebUI/war/views/PercPublishMinuetView.js`)**:
+1. **Publishing Server DAO (`system/services/src/com/percussion/services/pubserver/impl/PSPubServerDao.java`)**:
+   - Updated `createServer` method to query the `PSDeliveryInfoService` for the available DTS URLs of the corresponding server type (e.g. `PRODUCTION`).
+   - Automatically initialize the `publishServer` property of the newly created publishing server to the first available DTS server URL if configured, or default it to `"NONE"`.
+   - Wrap the lookup in a try-catch block to fall back safely to `"NONE"` in case the services are not fully initialized or lookup fails.
+2. **Minuet Publisher View (`WebUI/war/views/PercPublishMinuetView.js`)**:
    - Added `"NONE"` explicitly as a valid option to the DTS Server select dropdown.
    - Refactored the selected server logic so that if the server configuration does not specify a DTS server (or specifies an empty/NONE value), it correctly defaults `selectedserver` to `"NONE"` instead of defaulting to the first available server in the list.
    - Verified that if the default selection is `"NONE"` or a valid DTS server, it selects the option correctly.
@@ -15,3 +19,5 @@ Fix a bug in the publishing server configuration UI where the Select DTS Server 
 
 - Ran `./mvn-env.sh spotless:apply` to ensure code formatting complies with project standards.
 - Re-built `perc-web-ui` module via `./mvn-env.sh clean install -pl WebUI -DskipTests` successfully.
+- Re-built `perc-system` module via `./mvn-env.sh clean install -pl system -DskipTests` successfully.
+

--- a/system/services/src/com/percussion/services/pubserver/impl/PSPubServerDao.java
+++ b/system/services/src/com/percussion/services/pubserver/impl/PSPubServerDao.java
@@ -17,6 +17,8 @@
 package com.percussion.services.pubserver.impl;
 
 import com.percussion.cms.IPSConstants;
+import com.percussion.delivery.service.PSDeliveryInfoServiceLocator;
+import com.percussion.delivery.service.impl.PSDeliveryInfoService;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.error.PSNotFoundException;
 import com.percussion.services.guidmgr.IPSGuidManager;
@@ -95,6 +97,20 @@ public class PSPubServerDao
       pubServer.addProperty(PUBLISH_DRIVER_PROPERTY, DEFAULT_PUBLISH_DRIVER);
       pubServer.addProperty(PUBLISH_OWN_SERVER_PROPERTY, "false");
       pubServer.addProperty(PUBLISH_FORMAT_PROPERTY, "HTML");
+
+      try
+      {
+         PSDeliveryInfoService psDeliveryInfoService =
+               (PSDeliveryInfoService) PSDeliveryInfoServiceLocator.getDeliveryInfoService();
+         List<String> adminUrls = psDeliveryInfoService.getAdminUrls(pubServer.getServerType());
+         String dtsServer = (adminUrls != null && !adminUrls.isEmpty()) ? adminUrls.get(0) : "NONE";
+         pubServer.addProperty(PUBLISH_SERVER_PROPERTY, dtsServer);
+      }
+      catch (Exception e)
+      {
+         log.error("Failed to initialize default DTS server for site: {}", site.getName(), e);
+         pubServer.addProperty(PUBLISH_SERVER_PROPERTY, "NONE");
+      }
 
       return pubServer;
    }


### PR DESCRIPTION
### Solution

  1. Backend Initialization: Updated  PSPubServerDao.createServer(site)  (in
  PSPubServerDao.java) to query the  PSDeliveryInfoService  for all configured
DTS
  admin URLs of the site's default server type (e.g.  PRODUCTION ). It now
  automatically sets  publishServer  to the first available URL (or fallback
  to  "NONE"  if none are defined).
  2. Robust Lookup: Wrapped the DTS server lookup in a try-catch block to
  gracefully default to  "NONE"  and avoid startup issues in case
  context/services are not fully initialized.
  3. UI Sync: Together with the previous fix in  PercPublishMinuetView.js ,
  the UI dropdown now correctly synchronizes with the database state. If a
  default DTS server is configured, it is selected and persisted
  automatically; if none is present, the select dropdown cleanly displays    
  "NONE" .
  4. Documentation: Updated the task README at README.md to document the
  backend changes.
