### PR TITLE
bugfix/860: Fix invalid Google Analytics date format in Traffic Gadget

### DIFF
--- a/docs/ai-generated/tasks/860-traffic-gadget-date-format/README.md
+++ b/docs/ai-generated/tasks/860-traffic-gadget-date-format/README.md
@@ -1,0 +1,23 @@
+# Task: Traffic Gadget Fails with HTTP 500 Due to Invalid Google Analytics Date Format When Selecting and Saving a Site (Issue #860)
+
+## Objective
+
+Fix an HTTP 500 error in the Traffic Gadget when loading traffic data from the Google Analytics (GA4) API. The GA4 Data API requires the `startDate` and `endDate` parameters to be formatted as `YYYY-MM-DD`, but the application was sending them in the `yyyyMMdd` format, causing an `InvalidArgumentException` / `StatusRuntimeException`.
+
+## Changes Made
+
+1. **PSGoogleAnalyticsProviderHelper (`projects/sitemanage/src/main/java/com/percussion/analytics/service/impl/google/PSGoogleAnalyticsProviderHelper.java`)**:
+   - Added a new `QUERY_DATE_FORMAT` of type `FastDateFormat` mapped to pattern `"yyyy-MM-dd"`.
+   - Exposed a new synchronized getter method `getQueryDateFormat()` to retrieve the new formatter.
+   - Kept the original `DATE_FORMAT` (`"yyyyMMdd"`) unchanged, as it is still used by `parseDate()` to parse returned date values from the Google Analytics API responses.
+
+2. **PSGoogleAnalyticsProviderQueryHandler (`projects/sitemanage/src/main/java/com/percussion/analytics/service/impl/google/PSGoogleAnalyticsProviderQueryHandler.java`)**:
+   - Modified `createQueryForPageViewsByPathPrefix` to format query dates (`startDate` and `endDate`) using the new helper method `getQueryDateFormat()`.
+   - Modified `createQueryForVisitsViews` to format query dates (`startDate` and `endDate`) using the new helper method `getQueryDateFormat()`.
+
+## Verification
+
+- Ran `./mvn-env.sh spotless:apply` to ensure Google Java Format is correctly applied to the codebase.
+- Built the `sitemanage` module along with its dependencies via `./mvn-env.sh clean install -pl projects/sitemanage -am -DskipTests` successfully.
+- Ran tests in `sitemanage` via `./mvn-env.sh test -pl projects/sitemanage` successfully.
+- Verified that all PMD, Checkstyle, and other validations pass using `./mvn-env.sh verify -pl projects/sitemanage -DskipTests` successfully.

--- a/projects/sitemanage/src/main/java/com/percussion/analytics/service/impl/google/PSGoogleAnalyticsProviderHelper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/analytics/service/impl/google/PSGoogleAnalyticsProviderHelper.java
@@ -201,12 +201,19 @@ public class PSGoogleAnalyticsProviderHelper {
   /** Date format to use to parse date from a google query. Never <code>null</code>. */
   private final FastDateFormat DATE_FORMAT = FastDateFormat.getInstance("yyyyMMdd");
 
+  /** Date format to use for query date ranges (GA4 Data API requires YYYY-MM-DD). */
+  private final FastDateFormat QUERY_DATE_FORMAT = FastDateFormat.getInstance("yyyy-MM-dd");
+
   public static final String ANALYTICS_LAUNCH_DATE = "11/14/2005";
 
   public static final String APPLICATION_NAME = "Percussion CMS";
 
   public synchronized FastDateFormat getDateFormat() {
     return DATE_FORMAT;
+  }
+
+  public synchronized FastDateFormat getQueryDateFormat() {
+    return QUERY_DATE_FORMAT;
   }
 
   /** Mappings of Google exceptions to our own cause enums. */

--- a/projects/sitemanage/src/main/java/com/percussion/analytics/service/impl/google/PSGoogleAnalyticsProviderQueryHandler.java
+++ b/projects/sitemanage/src/main/java/com/percussion/analytics/service/impl/google/PSGoogleAnalyticsProviderQueryHandler.java
@@ -199,9 +199,9 @@ public class PSGoogleAnalyticsProviderQueryHandler implements IPSAnalyticsProvid
       String siteName, String pathPrefix, PSDateRange range) throws PSAnalyticsProviderException {
 
     String startDate =
-        PSGoogleAnalyticsProviderHelper.getInstance().getDateFormat().format(range.getStart());
+        PSGoogleAnalyticsProviderHelper.getInstance().getQueryDateFormat().format(range.getStart());
     String endDate =
-        PSGoogleAnalyticsProviderHelper.getInstance().getDateFormat().format(range.getEnd());
+        PSGoogleAnalyticsProviderHelper.getInstance().getQueryDateFormat().format(range.getEnd());
 
     DateRange dateRange =
         DateRange.newBuilder().setStartDate(startDate).setEndDate(endDate).build();
@@ -227,9 +227,9 @@ public class PSGoogleAnalyticsProviderQueryHandler implements IPSAnalyticsProvid
   private RunReportRequest createQueryForVisitsViews(PSDateRange range)
       throws PSAnalyticsProviderException {
     String startDate =
-        PSGoogleAnalyticsProviderHelper.getInstance().getDateFormat().format(range.getStart());
+        PSGoogleAnalyticsProviderHelper.getInstance().getQueryDateFormat().format(range.getStart());
     String endDate =
-        PSGoogleAnalyticsProviderHelper.getInstance().getDateFormat().format(range.getEnd());
+        PSGoogleAnalyticsProviderHelper.getInstance().getQueryDateFormat().format(range.getEnd());
 
     DateRange dateRange =
         DateRange.newBuilder().setStartDate(startDate).setEndDate(endDate).build();


### PR DESCRIPTION
### Summary of Changes

  1. Created a new feature branch:  bugfix/860-google-analytics-date-format 
  2. Fixed Date Formatting:
      • The Google Analytics 4 (GA4) API requires dates (such as  startDate  and  endDate ) to be in  YYYY-MM-DD  format.
      • Exposed a new  getQueryDateFormat()  method ( yyyy-MM-dd ) in PSGoogleAnalyticsProviderHelper.java.
      • Updated PSGoogleAnalyticsProviderQueryHandler.java to format the start/end dates for reports using  getQueryDateFormat() .
      • Maintained the original  DATE_FORMAT  ( yyyyMMdd ) for parsing response dates since the GA4 API continues to return dimensions formatted as  YYYYMMDD .
  3. Documentation:
      • Added task plan details to the required path: README.md.
  4. Validation:
      • Ran  spotless:apply  to apply the Google Java Format.
      • Built the  sitemanage  module successfully.
      • Ran all unit tests and verified Checkstyle/PMD checks successfully.
