### PR TITLE
bugfix/757: Revert editor styling overrides to keep original min-heig…

### DIFF
--- a/WebUI/war/css/perc_decoration.css
+++ b/WebUI/war/css/perc_decoration.css
@@ -3,10 +3,10 @@
 /* Region CSS
 ----------------------------------*/
 
-.vspan_2 { height : 120px !important; min-height: 0 !important; }
-.vspan_4 { height : 240px !important; min-height: 0 !important; }
-.vspan_6 { height : 360px !important; min-height: 0 !important; }
-.vspan_8 { height : 480px !important; min-height: 0 !important; }
+.vspan_2 { height : 120px }
+.vspan_4 { height : 240px }
+.vspan_6 { height : 360px }
+.vspan_8 { height : 480px }
 
 .hspan_2  { width : 160px }
 .hspan_8  { width : 640px }

--- a/docs/ai-generated/tasks/860-traffic-gadget-date-format/README.md
+++ b/docs/ai-generated/tasks/860-traffic-gadget-date-format/README.md
@@ -10,7 +10,6 @@ Fix an HTTP 500 error in the Traffic Gadget when loading traffic data from the G
    - Added a new `QUERY_DATE_FORMAT` of type `FastDateFormat` mapped to pattern `"yyyy-MM-dd"`.
    - Exposed a new synchronized getter method `getQueryDateFormat()` to retrieve the new formatter.
    - Kept the original `DATE_FORMAT` (`"yyyyMMdd"`) unchanged, as it is still used by `parseDate()` to parse returned date values from the Google Analytics API responses.
-
 2. **PSGoogleAnalyticsProviderQueryHandler (`projects/sitemanage/src/main/java/com/percussion/analytics/service/impl/google/PSGoogleAnalyticsProviderQueryHandler.java`)**:
    - Modified `createQueryForPageViewsByPathPrefix` to format query dates (`startDate` and `endDate`) using the new helper method `getQueryDateFormat()`.
    - Modified `createQueryForVisitsViews` to format query dates (`startDate` and `endDate`) using the new helper method `getQueryDateFormat()`.
@@ -21,3 +20,4 @@ Fix an HTTP 500 error in the Traffic Gadget when loading traffic data from the G
 - Built the `sitemanage` module along with its dependencies via `./mvn-env.sh clean install -pl projects/sitemanage -am -DskipTests` successfully.
 - Ran tests in `sitemanage` via `./mvn-env.sh test -pl projects/sitemanage` successfully.
 - Verified that all PMD, Checkstyle, and other validations pass using `./mvn-env.sh verify -pl projects/sitemanage -DskipTests` successfully.
+


### PR DESCRIPTION
### Summary of Completed Work

  • Reverted Editor Styling:
      • Reverted  .vspan_X  rule overrides in  WebUI/war/css/perc_decoration.css  to remove  !important  and  min-height: 0 !important;  declarations.
      • This ensures only the original, main published page stylesheet change ( theme.css  using  min-height  instead of  height ) is retained.
  • Code Formatting:
      • Ran  spotless:apply  to clean up whitespace violations in task documentation.
