### PR TITLE
bugfix/862: Fix ClassCastException String to RowKeySet by upgrading l…

### DIFF
--- a/docs/ai-generated/tasks/862-ClassCastException-RowKeySet/README.md
+++ b/docs/ai-generated/tasks/862-ClassCastException-RowKeySet/README.md
@@ -1,0 +1,32 @@
+# Task: 8.1.7 Publishing Design, Publishing Runtime, and Admin tabs fail to load and redirect back to CMS due to ClassCastException: java.lang.String cannot be cast to RowKeySet (Issue #862)
+
+## Objective
+
+Fix the `ClassCastException` that occurs when users click on the "Publishing Design", "Publishing Runtime", or "Admin" tabs. The underlying exception happens during the JSF state-saving phase when `UIXNavigationTree` attempts to cast the value of `disclosedRowKeys` to `RowKeySet`. Because the layout tag files were declared with JSP version `"1.2"`, deferred EL expressions (`#{}`) were not parsed natively by the JSP container and were instead passed as literal String values, leading to a `ClassCastException`.
+
+## Changes Made
+
+Updated the `<jsp:root>` version attribute from `"1.2"` to `"2.1"` in the following layout and navigation JSP tag files:
+
+1. **[admin.tag](file:///home/nate/projects/java8/percussioncms/system/ear/WEB-INF/tags/layout/admin.tag)**:
+   - Changed `version="1.2"` to `version="2.1"`.
+2. **[publishing.tag](file:///home/nate/projects/java8/percussioncms/system/ear/WEB-INF/tags/layout/publishing.tag)**:
+   - Changed `version="1.2"` to `version="2.1"`.
+3. **[pubruntime.tag](file:///home/nate/projects/java8/percussioncms/system/ear/WEB-INF/tags/layout/pubruntime.tag)**:
+   - Changed `version="1.2"` to `version="2.1"`.
+4. **[adminbreadcrumbs.tag](file:///home/nate/projects/java8/percussioncms/system/ear/WEB-INF/tags/nav/adminbreadcrumbs.tag)**:
+   - Changed `version="1.2"` to `version="2.1"`.
+5. **[editorbreadcrumbs.tag](file:///home/nate/projects/java8/percussioncms/system/ear/WEB-INF/tags/nav/editorbreadcrumbs.tag)**:
+   - Changed `version="1.2"` to `version="2.1"`.
+6. **[listbreadcrumbs.tag](file:///home/nate/projects/java8/percussioncms/system/ear/WEB-INF/tags/nav/listbreadcrumbs.tag)**:
+   - Changed `version="1.2"` to `version="2.1"`.
+7. **[runtimebreadcrumbs.tag](file:///home/nate/projects/java8/percussioncms/system/ear/WEB-INF/tags/nav/runtimebreadcrumbs.tag)**:
+   - Changed `version="1.2"` to `version="2.1"`.
+
+Upgrading the tag file declarations to JSP version `2.1` forces the container to correctly compile and resolve the deferred EL expressions (`#{}`) as JSF `ValueExpression` objects, which evaluate to the actual backing bean's `RowKeySet` properties rather than literal String objects.
+
+## Verification
+
+- Built the `system` module and its dependencies via `./mvn-env.sh clean install -pl system -am -DskipTests` successfully.
+- Verified compilation and layout tag validation success.
+

--- a/system/ear/WEB-INF/tags/layout/admin.tag
+++ b/system/ear/WEB-INF/tags/layout/admin.tag
@@ -5,7 +5,7 @@
 	xmlns:tr="http://myfaces.apache.org/trinidad"
 	xmlns:trh="http://myfaces.apache.org/trinidad/html"
 	xmlns:rxb="urn:jsptagdir:/WEB-INF/tags/banner"
-	version="1.2">
+	version="2.1">
 	<f:view>
 		<tr:document styleClass="backgroundcolor" 
 			title="#{page_title}" onload="#{page_onload}" >

--- a/system/ear/WEB-INF/tags/layout/publishing.tag
+++ b/system/ear/WEB-INF/tags/layout/publishing.tag
@@ -5,7 +5,7 @@
 	xmlns:tr="http://myfaces.apache.org/trinidad"
 	xmlns:trh="http://myfaces.apache.org/trinidad/html"
 	xmlns:rxb="urn:jsptagdir:/WEB-INF/tags/banner"
-	version="1.2">
+	version="2.1">
 	<f:view>
 		<tr:document styleClass="backgroundcolor" title="#{page_title}">
 			<f:facet name="metaContainer">

--- a/system/ear/WEB-INF/tags/layout/pubruntime.tag
+++ b/system/ear/WEB-INF/tags/layout/pubruntime.tag
@@ -5,7 +5,7 @@
 	xmlns:tr="http://myfaces.apache.org/trinidad"
 	xmlns:trh="http://myfaces.apache.org/trinidad/html"
 	xmlns:rxb="urn:jsptagdir:/WEB-INF/tags/banner"
-	version="1.2">
+	version="2.1">
 	<f:view>
 		<tr:document styleClass="backgroundcolor" 
 			title="#{page_title}" onload="#{page_onload}" >

--- a/system/ear/WEB-INF/tags/nav/adminbreadcrumbs.tag
+++ b/system/ear/WEB-INF/tags/nav/adminbreadcrumbs.tag
@@ -2,7 +2,7 @@
 <jsp:root xmlns:jsp="http://java.sun.com/JSP/Page"
 	xmlns:f="http://java.sun.com/jsf/core"
 	xmlns:tr="http://myfaces.apache.org/trinidad"
-	version="1.2">
+	version="2.1">
 	<tr:breadCrumbs value="#{sys_admin_navigation.tree}" var="node">
 		<f:facet name="nodeStamp">
 			<tr:commandNavigationItem  styleClass="pub-breadcrumb-label"

--- a/system/ear/WEB-INF/tags/nav/editorbreadcrumbs.tag
+++ b/system/ear/WEB-INF/tags/nav/editorbreadcrumbs.tag
@@ -2,7 +2,7 @@
 <jsp:root xmlns:jsp="http://java.sun.com/JSP/Page"
 	xmlns:f="http://java.sun.com/jsf/core"
 	xmlns:tr="http://myfaces.apache.org/trinidad"
-	version="1.2">
+	version="2.1">
 	<tr:breadCrumbs value="#{sys_design_navigation.tree}" var="node">
 		<f:facet name="nodeStamp">
 			<tr:outputText value="#{node.label}" styleClass="pub-breadcrumb-label" />

--- a/system/ear/WEB-INF/tags/nav/listbreadcrumbs.tag
+++ b/system/ear/WEB-INF/tags/nav/listbreadcrumbs.tag
@@ -2,7 +2,7 @@
 <jsp:root xmlns:jsp="http://java.sun.com/JSP/Page"
 	xmlns:f="http://java.sun.com/jsf/core"
 	xmlns:tr="http://myfaces.apache.org/trinidad"
-	version="1.2">
+	version="2.1">
 	<tr:breadCrumbs value="#{sys_design_navigation.tree}" var="node">
 		<f:facet name="nodeStamp">
 			<tr:commandNavigationItem styleClass="pub-breadcrumb-label"

--- a/system/ear/WEB-INF/tags/nav/runtimebreadcrumbs.tag
+++ b/system/ear/WEB-INF/tags/nav/runtimebreadcrumbs.tag
@@ -3,7 +3,7 @@
 	xmlns:f="http://java.sun.com/jsf/core"
 	xmlns:h="http://java.sun.com/jsf/html"
 	xmlns:tr="http://myfaces.apache.org/trinidad"
-	version="1.2">
+	version="2.1">
 	<tr:breadCrumbs value="#{sys_runtime_navigation.tree}" var="node">
 		<f:facet name="nodeStamp">
 		  <h:panelGroup>


### PR DESCRIPTION
### Summary of Completed Work

  1. JSP Version Upgrades:
  Updated the  <jsp:root>  version attribute from  "1.2"  to  "2.1"  in the following layout and breadcrumbs tag files to enable unified deferred expression ( #{} ) handling:
      • admin.tag
      • publishing.tag
      • pubruntime.tag
      • adminbreadcrumbs.tag
      • editorbreadcrumbs.tag
      • listbreadcrumbs.tag
      • runtimebreadcrumbs.tag
  2. Documentation:
  Added the task README in README.md.
  3. Validation:
      • Compiled the code successfully using the JDK 1.8.0 compiler ( amazon-corretto-1.8.0 ).
      • Ran  spotless:check  to ensure full compliance with the Google Java Code Style formatting.