### PR TITLE
bugfix/866: Stop validator early on folder-not-found to prevent dupli…

### DIFF
--- a/docs/ai-generated/tasks/866-duplicate-nav-error/README.md
+++ b/docs/ai-generated/tasks/866-duplicate-nav-error/README.md
@@ -1,0 +1,19 @@
+# Task: 8.1.7 Navigation error message displays duplicate "folder not found" validation when converting folder to section (Issue #866)
+
+## Objective
+
+Fix a bug where attempting to create/convert a Section from a folder that does not exist in Percussion CMS displays duplicate validation errors in the error dialog (e.g. "folder with that path cannot be found" displayed twice). When the source folder does not exist, the validation should stop early and return only the primary root cause error rather than continuing to validate parent path and dependent landing page existence.
+
+## Changes Made
+
+1. **[PSSiteSectionService (`projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionService.java`)](file:///home/nate/projects/java8/percussioncms/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionService.java)**:
+   - Modified `PSCreateSectionFromFolderValidator.doValidation` method to add `return;` statements after rejecting the request when:
+     - The source path category is not a `Category.FOLDER`
+     - An exception occurs while looking up the source folder path (folder does not exist)
+   - This prevents execution of subsequent validation steps (parent folder existence and landing page existence checks) when the primary folder itself is invalid or missing, thereby avoiding duplicate/dependent validation messages.
+
+## Verification
+
+- Formatted the codebase using `./mvn-env.sh spotless:apply`.
+- Built the `sitemanage` module along with its dependencies via `./mvn-env.sh clean install -pl projects/sitemanage -am -DskipTests` successfully.
+

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionService.java
@@ -2243,6 +2243,7 @@ public class PSSiteSectionService implements IPSSiteSectionService {
               new Object[] {req.getSourceFolderPath()},
               "Cannot create a section from the folder with path \"{0}\" "
                   + "as the path does not correspond to a folder.");
+          return;
         }
       } catch (Exception ex) {
         e.reject(
@@ -2250,6 +2251,7 @@ public class PSSiteSectionService implements IPSSiteSectionService {
             new Object[] {req.getSourceFolderPath()},
             "Cannot create a section from the folder with path \"{0}\" "
                 + "because a folder with that path cannot be found.");
+        return;
       }
       try {
         IPSItemSummary itemSum = folderHelper.findFolder(req.getParentFolderPath());


### PR DESCRIPTION
  ### Summary of Completed Work

  1. early-return validation logic:
  Added  return;  statements to PSSiteSectionService.java within  PSCreateSectionFromFolderValidator.doValidation  when the folder is invalid or cannot be found. This stops
further
  validation processing, avoiding duplicate and dependent validation error displays when the source folder path is incorrect.
  2. Documentation:
  Added the task README in README.md.
  3. Validation:
      • Formatted the codebase using  spotless:apply .
      • Verified that the  sitemanage  module compiles and builds correctly.
