### PR TITLE
bugfix/868: Fix theme list serialization and load error in style gall…

### DIFF
--- a/WebUI/war/views/PercCSSGalleryView.js
+++ b/WebUI/war/views/PercCSSGalleryView.js
@@ -52,7 +52,10 @@
                     //////////////////////////////////
                     // Iterate over each theme entry
                     //////////////////////////////////
-                    var themes = data.ThemeSummary;
+                    var themes = data ? (data.ThemeSummary || data) : [];
+                    if (!Array.isArray(themes)) {
+                        themes = themes ? [themes] : [];
+                    }
                     root.append("<table id='perc-themes-table'><tr id='perc-themes-table-row'></tr><table>");
                     if (themes.length > 0) {
                         $(themes).each(function() {

--- a/projects/sitemanage/src/main/java/com/percussion/theme/service/impl/PSThemeRestService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/theme/service/impl/PSThemeRestService.java
@@ -31,6 +31,7 @@ import com.percussion.theme.data.PSRichTextCustomStyle;
 import com.percussion.theme.data.PSRichTextCustomStyleList;
 import com.percussion.theme.data.PSTheme;
 import com.percussion.theme.data.PSThemeSummary;
+import com.percussion.theme.data.PSThemeSummaryList;
 import com.percussion.theme.service.IPSThemeService;
 import java.util.List;
 import javax.ws.rs.Consumes;
@@ -70,8 +71,8 @@ public class PSThemeRestService {
   @GET
   @Path("/summary/all")
   @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-  public List<PSThemeSummary> findAll() {
-    return themeService.findAll();
+  public PSThemeSummaryList findAll() {
+    return new PSThemeSummaryList(themeService.findAll());
   }
 
   /*


### PR DESCRIPTION
### Summary of Actions Taken:

  1. Created Branch: Started a feature branch  bugfix/868-theme-list-undefined  off  development-8.1.x .
  2. Fixed REST Response Wrapping: Added the import and wrapped the returned theme list in  PSThemeSummaryList  in PSThemeRestService.java.
  3. Robust Client-Side Checks: Updated PercCSSGalleryView.js to defensively retrieve the theme list (checking both the wrapper field and raw array payload, and defaulting to
[] ).
  4. Spotless & Compilation: Re-formatted modified Java source with Spotless, verified correct compilation of the  sitemanage  module, and confirmed all local unit tests
  passed successfully.
