### PR TITLE
bugfix/867: Fix folder creation path-not-found error caused by incorr…

### DIFF
--- a/WebUI/war/plugins/perc_utils.js
+++ b/WebUI/war/plugins/perc_utils.js
@@ -1525,11 +1525,9 @@
                         function(status, result, code){
                             if(status === $.PercServiceUtils.STATUS_SUCCESS)
                             {
-                                var pth = $.perc_finder().lastClickPath;
-                                if($.perc_finder().lastClickPath === null ||  typeof $.perc_finder().lastClickPath === "undefined")
-                                {
-                                    pth = result.PathItem.path.split("/");
-                                    pth.push(value);
+                                var pth = result.PathItem.path.split("/");
+                                if (pth[pth.length - 1] === "") {
+                                    pth.pop();
                                 }
                                 $.perc_finder().lastClickPath = null;
                                 $.perc_finder().open(pth);


### PR DESCRIPTION
  ### Summary of Actions:

  1. Identified Root Cause: In perc_utils.js, the rename success callback was either using a stale  lastClickPath  (referring to the old folder name/path) or incorrectly
  splitting the new path and pushing the new folder name a second time due to trailing slash mismatching.
  2. Applied Fix: Cleaned up the success callback in  perc_utils.js  so it dynamically splits  result.PathItem.path  (which already has the new name), pops the trailing empty
  element from the slash suffix, and resets  lastClickPath  to  null  before navigating.
  3. Validated & Tested: Formatted with Spotless and ran a successful clean install verification on  sitemanage .
