### PR TITLE
bugfix/871: Escape hyphen in workflow name and step name regex patter…

### DIFF
--- a/WebUI/war/app/percWorkflow.jsp
+++ b/WebUI/war/app/percWorkflow.jsp
@@ -43,7 +43,7 @@ if(locale==null){
                         <div  id="perc-wf-new-editor" class="perc-wf-editor" style="display: none;">
                             <span class="perc-required-label"><label><i18n:message key = "perc.ui.general@Denotes Required Field"/></label></span>
                              <div id="perc-new-wf-name-label" class = "perc-required-field"><label class="perc-name-label"><i18n:message key = "perc.ui.workflow@Name"/><br></label>
-                                <input tabindex="0" maxlength = '50' required pattern='^[a-zA-Z0-9-_\. ]{1,50}$' title='1 to 50 letters,numbers,-, _, or space' id="perc-new-workflow-name">
+                                <input tabindex="0" maxlength = '50' required pattern='^[a-zA-Z0-9_\.\- ]{1,50}$' title='1 to 50 letters,numbers,-, _, or space' id="perc-new-workflow-name">
                             </div>
 							<div class = "perc-wf-default"><input tabindex="0" aria-required='true' title='<i18n:message key = "perc.ui.workflow@Make Default"/>' type="checkbox" id="perc-wf-default-new-checkbox" /> <label for ="perc-wf-default-new-checkbox"><i18n:message key = "perc.ui.workflow@Make Default"/></label></div>
                             <!-- control gets generated here in percWorkflowView -->
@@ -58,7 +58,7 @@ if(locale==null){
                         <div  id="perc-wf-update-editor"  class="perc-wf-editor" style="display: none;">
                             <span class="perc-required-label"><label><i18n:message key = "perc.ui.general@Denotes Required Field"/></label></span>
                              <div id="perc-update-wf-name-label" class = "perc-required-field" ><label class="perc-name-label"><i18n:message key = "perc.ui.workflow@Name"/><br></label>
-                                <input maxlength = '50' aria-required='true' required pattern='^[a-zA-Z0-9-_\. ]{1,50}$' title='1 to 50 letters,numbers,-, _, or space' id="perc-update-workflow-name">
+                                <input maxlength = '50' aria-required='true' required pattern='^[a-zA-Z0-9_\.\- ]{1,50}$' title='1 to 50 letters,numbers,-, _, or space' id="perc-update-workflow-name">
                             </div>
 							 <div class = "perc-wf-default"><input tabindex="0" title='<i18n:message key = "perc.ui.workflow@Make Default"/>' type = "checkbox" id="perc-wf-default-update-checkbox" /> <label for="perc-wf-default-update-checkbox"><i18n:message key = "perc.ui.workflow@Make Default"/></label></div>
                              <!-- control gets generated here in percWorkflowView -->

--- a/WebUI/war/views/PercEditWorkflowStepDialog.js
+++ b/WebUI/war/views/PercEditWorkflowStepDialog.js
@@ -46,7 +46,7 @@
             dialog = $(" <div id='perc-workflow-addstep-dialog'>" +
                 "     <div id='perc-wfconfig-wrapper'>" +
                 "         <span style='position: relative; float: right; margin-top: -28px;'><label>" +I18N.message("perc.ui.general@Denotes Required Field") + "</label></span>" +
-                "         <div class = 'perc-required-field'>" +I18N.message("perc.ui.edit.workflow.step.dialog@Step Name") + "<br/><input maxlength = '50' required pattern='^[a-zA-Z0-9-_\\. ]{1,50}$' title='1 to 50 letters,numbers,-, _, or space' name='perc-wfstep-name' id='perc-wfstep-name' class = '" +
+                "         <div class = 'perc-required-field'>" +I18N.message("perc.ui.edit.workflow.step.dialog@Step Name") + "<br/><input maxlength = '50' required pattern='^[a-zA-Z0-9_\\.\\- ]{1,50}$' title='1 to 50 letters,numbers,-, _, or space' name='perc-wfstep-name' id='perc-wfstep-name' class = '" +
                 className +
                 "' type='text'" +
                 isreadOnly +


### PR DESCRIPTION
 ### Summary of Actions:

  1. Identified Issue: Modern browsers strict-validate regex character classes when evaluating input  pattern  attributes. An unescaped hyphen  -  placed adjacent to  _  in   
  ^[a-zA-Z0-9-_\. ]{1,50}$  threw a  SyntaxError  during  checkValidity()  calls in the browser console.
  2. Applied Fixes:
      • Escaped the hyphen ( \- ) inside the pattern regexes on lines 46 and 61 of percWorkflow.jsp.
      • Escaped the hyphen ( \\- ) inside the javascript string pattern regex on line 49 of PercEditWorkflowStepDialog.js.
