### PR TITLE
Fix #880 #881: Remove global jQuery UI tooltip that caused tooltips t…

### DIFF
--- a/cui/widgets/contentList/contentList.ViewModel.js
+++ b/cui/widgets/contentList/contentList.ViewModel.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-define(['knockout', 'pubsub', 'utils', 'jquery-ui'], function(ko,PubSub, utils) {
+define(['knockout', 'pubsub', 'utils'], function(ko,PubSub, utils) {
     return function ContentListViewModel(options) {
         var self = this;
         self.options = options;
@@ -371,14 +371,6 @@ define(['knockout', 'pubsub', 'utils', 'jquery-ui'], function(ko,PubSub, utils) 
                 });
             };
         };
-
-        $(function() {
-            $( document ).tooltip({
-                show: {
-                    delay: 1000
-                }
-            });
-        });
 
         //Custom binding for jquery fadeout/fadein as well as inverting the menu if not visible
         ko.bindingHandlers.fadeVisible = {


### PR DESCRIPTION
…o persist on Home dashboard

- Removed .tooltip() initialization that was overriding native browser tooltip behavior and causing tooltips to render as persistent page conhttps://github.com/intersoftdatalabs-in/percussioncms/compare/development-8.1.x...intersoftdatalabs-in:percussioncms:bugfix/880-881-classcast-rowkeyset?expand=1tent
- Removed unused jquery-ui dependency from AMD module definition
- This fixes the tooltip lifecycle issues where tooltips were not dismissed when hovering away or navigating between dashboard tabs (My Recent, My Bookmarks, Search Results)

Fixes: #880 Tooltips rendered as persistent page content
Fixes: #881 Tooltips not dismissed and persist across tabs