### PR TITLE
Fix #882: Undeprecate Google Setup, Traffic, and What's Working gadgets

### DIFF
--- a/WebUI/src/main/resources/com/percussion/webui/gadget/servlets/GadgetRegistry.xml
+++ b/WebUI/src/main/resources/com/percussion/webui/gadget/servlets/GadgetRegistry.xml
@@ -8,22 +8,22 @@
         <gadget name="Cookie Consent" baseuri="/cm/gadgets/repository/perc_cookie_consent_gadget" file="perc_cookie_consent_gadget.xml"/>
         <gadget name="Forms Tracker" baseuri="/cm/gadgets/repository/PercFormTrackerGadget" file="PercFormTrackerGadget.xml"/>
         <gadget name="Global Variables" baseuri="/cm/gadgets/repository/PercGlobalVariablesGadget" file="PercGlobalVariablesGadget.xml"/>
+        <gadget name="Google Setup" baseuri="/cm/gadgets/repository/perc_google_setup_gadget" file="perc_google_setup_gadget.xml"/>
         <gadget name="Iframe" baseuri="/cm/gadgets/repository/perc_iframe_gadget" file="perc_iframe_gadget.xml"/>
         <gadget name="Pages By Status" baseuri="/cm/gadgets/repository/perc_workflow_status_gadget" file="perc_workflow_status_gadget.xml"/>
         <gadget name="Process Monitor" baseuri="/cm/gadgets/repository/PercProcessorMonitorGadget" file="PercProcessorMonitorGadget.xml"/>
         <gadget name="Reports" baseuri="/cm/gadgets/repository/perc_reports_gadget" file="perc_reports_gadget.xml"/>
         <gadget name="SEO Audit" baseuri="/cm/gadgets/repository/perc_seo_gadget" file="perc_seo_status_gadget.xml"/>
         <gadget name="Sitewide Framework"  baseuri="/cm/gadgets/repository/PercSiteFrameworkGadget" file="perc_sitewide_framework_gadget.xml"/>
+        <gadget name="Traffic" baseuri="/cm/gadgets/repository/perc_traffic_gadget" file="perc_traffic_gadget.xml"/>
         <gadget name="Welcome" baseuri="/cm/gadgets/repository/cm1_welcome_gadget" file="perc_welcome_gadget.xml"/>
+        <gadget name="What's Working" baseuri="/cm/gadgets/repository/perc_effectiveness_gadget" file="perc_effectiveness_gadget.xml"/>
     </group>
     <group name="Deprecated">
         <gadget name="Activity" baseuri="/cm/gadgets/repository/perc_activity_gadget" file="perc_activity_gadget.xml"/>
-        <gadget name="Google Setup" baseuri="/cm/gadgets/repository/perc_google_setup_gadget" file="perc_google_setup_gadget.xml"/>
         <gadget name="Siteimprove" baseuri="/cm/gadgets/repository/perc_site_improve_gadget" file="perc_site_improve_gadget.xml"/>
         <gadget name="Membership" baseuri="/cm/gadgets/repository/perc_membership_gadget" file="perc_membership_gadget.xml"/>
         <gadget name="Redirect Management" baseuri="/cm/gadgets/repository/perc_website_config_gadget" file="perc_website_config_gadget.xml"/>
-        <gadget name="Traffic" baseuri="/cm/gadgets/repository/perc_traffic_gadget" file="perc_traffic_gadget.xml"/>
         <gadget name="Widget Configuration" baseuri="/cm/gadgets/repository/PercWidgetConfigGadget" file="PercWidgetConfigGadget.xml"/>
-        <gadget name="What's Working" baseuri="/cm/gadgets/repository/perc_effectiveness_gadget" file="perc_effectiveness_gadget.xml"/>
     </group>
 </gadgets>


### PR DESCRIPTION
  ### Summary of Actions

  1. Created Feature Branch: Checked out and pulled from  development-8.1.x , then created and switched to the feature branch  bugfix/882-undeprecate-gadgets .
  2. Undeprecated Gadgets: Modified GadgetRegistry.xml to move Google Setup, Traffic, and What's Working gadgets from the  Deprecated  group to the main  Percussion  group in
  alphabetical order.
  3. Formatted and Built: Applied the repository formatting rules using  spotless:apply  and successfully built the  WebUI  module to verify correctness.
