### PR TITLE
Fix #879: Friendly error message for orphaned pages

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSSitePathItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSSitePathItemService.java
@@ -113,7 +113,7 @@ public class PSSitePathItemService extends PSPathItemService {
                 ? "Oops.  We can't find the site "
                     + sfp.getSiteId()
                     + ".  It may have been deleted."
-                : "Oops. We're sorry. This page should have been deleted when its site was deleted. Please contact Customer Success for assistance.";
+                : "Oops. We're sorry. The requested page is no longer available.";
         throw new PSPathNotFoundServiceException(msg);
       }
     }


### PR DESCRIPTION
Replaces internal error details with friendly message: Oops. We're sorry. The requested page is no longer available.