### PR TITLE
Fix Lucene ParseException for path-based search terms

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchRestService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchRestService.java
@@ -43,7 +43,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.queryparser.flexible.standard.QueryParserUtil;
+import org.apache.lucene.queryparser.classic.QueryParser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -79,7 +79,7 @@ public class PSSearchRestService {
 
       if (q != null) {
         q = SecureStringUtils.sanitizeStringForHTML(q);
-        q = QueryParserUtil.escape(q);
+        q = QueryParser.escape(q);
 
         criteria.setQuery(q);
       }

--- a/projects/sitemanage/src/test/java/com/percussion/searchmanagement/service/impl/PSSearchRestServiceTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/searchmanagement/service/impl/PSSearchRestServiceTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 1999-2023 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.searchmanagement.service.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.percussion.searchmanagement.data.PSSearchCriteria;
+import org.junit.Test;
+
+public class PSSearchRestServiceTest {
+
+  @Test
+  public void testSanitizeCriteriaEscapesSlashesAndDashes() {
+    PSSearchRestService restService = new PSSearchRestService(null, null, null);
+
+    PSSearchCriteria criteria = new PSSearchCriteria();
+    criteria.setQuery("people/donna-williams");
+
+    restService.sanitizeCriteria(criteria);
+
+    assertNotNull(criteria.getQuery());
+    // In Lucene 8 classic QueryParser.escape(), both / and - should be escaped.
+    // So "people/donna-williams" becomes "people\/donna\-williams"
+    assertEquals("people\\/donna\\-williams", criteria.getQuery());
+  }
+}


### PR DESCRIPTION
Fixes #878

Changes:
- Replaced `QueryParserUtil.escape(q)` (flexible query parser utility) in `PSSearchRestService.java` with the classic `QueryParser.escape(q)`.
- The flexible `QueryParserUtil.escape` did not escape the forward slash (`/`), which is required by the classic `QueryParser` implementation used in `PSSearchQueryImpl.java` to avoid interpreting paths as regular expression query syntax and causing `ParseException`.
- Created a new JUnit test `PSSearchRestServiceTest` to verify that both forward slashes and dashes are escaped.