### PR TITLE
Fix: Fully reset Organization, Department, and search values when clearing filters

### DIFF
--- a/system/Packages/perc.widget.directory/sys__UserDependency--web_resources/widgets/directory/js/perc-directory.js
+++ b/system/Packages/perc.widget.directory/sys__UserDependency--web_resources/widgets/directory/js/perc-directory.js
@@ -230,13 +230,18 @@ $(document).ready(function() {
     $('#perc-clear-alpha-filter').on('click', function() {
         $('.perc-alpha-sort.active').removeClass('active');
         if (DirectoryList) {
-            DirectoryList.filter();
+            $('#search-directory').val("");
+            DirectoryList.search();
+            $('#perc-org-filter').each(function () {
+                this.selectedIndex = 0;
+            });
             if (!percDirectorySearchAllOrgs) {
-                $('#perc-dpt-filter').show();
+                $('#perc-dpt-filter').val("all").show();
             }
             else {
-                $('#perc-dpt-filter').hide();
+                $('#perc-dpt-filter').val("all").hide();
             }
+            DirectoryList.filter();
             $('#perc-clear-alpha-filter').hide();
             resetAlphaFilters();
         }


### PR DESCRIPTION
Fixes #887

Changes:
- Updated the Clear Filter click event handler in `perc-directory.js` to reset the Organization dropdown selection back to index 0 ("all") and reset the search query field.
- Correctly reset the Department filter value and show/hide it based on whether all organizations are searchable (`percDirectorySearchAllOrgs`).