### PR TITLE
GH-891: Support leading Sites/ in Page by Path REST resource

### DIFF
--- a/rest/src/main/java/com/percussion/rest/pages/PagesResource.java
+++ b/rest/src/main/java/com/percussion/rest/pages/PagesResource.java
@@ -109,7 +109,7 @@ public class PagesResource {
       // UTF-8 always supported
     }
 
-    Matcher m = p.matcher(path);
+    Matcher m = p.matcher(normalizePath(path));
     String siteName = "";
     String pageName = "";
     String apiPath = "";
@@ -161,7 +161,7 @@ public class PagesResource {
       // UTF-8 always supported
     }
 
-    Matcher m = p.matcher(path);
+    Matcher m = p.matcher(normalizePath(path));
     String siteName = "";
     String pageName = "";
     String apiPath = "";
@@ -233,7 +233,7 @@ public class PagesResource {
       // UTF-8 always supported
     }
 
-    Matcher m = p.matcher(path);
+    Matcher m = p.matcher(normalizePath(path));
     String siteName = "";
     String pageName = "";
     String apiPath = "";
@@ -277,7 +277,7 @@ public class PagesResource {
       // UTF-8 always supported
     }
 
-    Matcher m = p.matcher(path);
+    Matcher m = p.matcher(normalizePath(path));
     String siteName = "";
     String pageName = "";
     String apiPath = "";
@@ -437,5 +437,19 @@ public class PagesResource {
         "attachment; filename=" + APIUtilities.getReportFileName("all-pages", "csv"));
 
     return r.build();
+  }
+
+  private String normalizePath(String path) {
+    if (path == null) {
+      return "";
+    }
+    String temp = path;
+    if (temp.startsWith("/")) {
+      temp = temp.substring(1);
+    }
+    if (temp.startsWith("Sites/")) {
+      temp = temp.substring(6);
+    }
+    return temp;
   }
 }

--- a/rest/src/test/java/com/percussion/rest/pages/PageTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/pages/PageTestAdaptor.java
@@ -43,6 +43,10 @@ public class PageTestAdaptor implements IPageAdaptor {
   @Override
   public Page getPage(URI baseUri, String siteName, String path, String pageName) {
 
+    if ("Sites".equals(siteName)) {
+      throw new IllegalArgumentException("siteName cannot be Sites");
+    }
+
     Page page = Examples.SAMPLE_PAGE;
 
     page.setName(pageName);
@@ -65,11 +69,17 @@ public class PageTestAdaptor implements IPageAdaptor {
 
   @Override
   public void deletePage(URI baseUri, String siteName, String path, String pageName) {
+    if ("Sites".equals(siteName)) {
+      throw new IllegalArgumentException("siteName cannot be Sites");
+    }
     if (pageName.equals("testNotFound")) throw new PageNotFoundException();
   }
 
   @Override
   public Page renamePage(URI baseURI, String siteName, String path, String pageName, String name) {
+    if ("Sites".equals(siteName)) {
+      throw new IllegalArgumentException("siteName cannot be Sites");
+    }
     // Not really sure how useful these tests are
     Page p = new Page();
     p.setName(name);

--- a/rest/src/test/java/com/percussion/rest/pages/PagesTest.java
+++ b/rest/src/test/java/com/percussion/rest/pages/PagesTest.java
@@ -204,4 +204,25 @@ public class PagesTest extends MainTest {
     assertTrue("Should Never be Null", p.getBookmarkedUsers() != null);
     assertTrue("Should Never be Null", p.getRecentUsers() != null);
   }
+
+  @Test
+  public void testPageWithLeadingSitesPath() {
+    String responseMsg =
+        target("pages/by-path/Sites/sitea/path1/pathsub%20/pathsub2/pathsub3/page1.html")
+            .request(MediaType.APPLICATION_JSON)
+            .get(String.class);
+    assertTrue("Name should match", responseMsg.contains("page1.html"));
+
+    String responseMsgLeadingSlash =
+        target("pages/by-path//Sites/sitea/path1/pathsub%20/pathsub2/pathsub3/page1.html")
+            .request(MediaType.APPLICATION_JSON)
+            .get(String.class);
+    assertTrue("Name should match", responseMsgLeadingSlash.contains("page1.html"));
+
+    Response deleteResponse =
+        target("pages/by-path/Sites/sitea/path1/pathsub%20/pathsub2/pathsub3/page1.html")
+            .request()
+            .delete();
+    assertEquals(Response.Status.OK.getStatusCode(), deleteResponse.getStatus());
+  }
 }


### PR DESCRIPTION
This PR adds path normalization to strip leading  or  from the path parameter in  before parsing, preventing incorrect mappings when users or Swagger pass full page paths.