### PR TITLE
GH-876: Enforce size constraints on theme preview thumbnails in Style tab

### DIFF
--- a/WebUI/war/css/perc_css_editor.css
+++ b/WebUI/war/css/perc_css_editor.css
@@ -25,6 +25,14 @@
     float: left;
 }
 
+.perc-css-gallery-item img {
+    max-width: 150px;
+    max-height: 120px;
+    width: auto;
+    height: auto;
+    object-fit: contain;
+}
+
 #perc-css-gallery-button-bar {
     float: right;
 }


### PR DESCRIPTION
This PR adds CSS constraints on theme thumbnail previews within the Style Gallery to prevent UI expansion and horizontal scroll distortion.