### PR TITLE
bugfix/862: Add implicit.tld files to force JSP 2.1 compilation for implicit tag libraries

### DIFF
--- a/docs/ai-generated/tasks/862-ClassCastException-RowKeySet/README.md
+++ b/docs/ai-generated/tasks/862-ClassCastException-RowKeySet/README.md
@@ -30,3 +30,18 @@ Upgrading the tag file declarations to JSP version `2.1` forces the container to
 - Built the `system` module and its dependencies via `./mvn-env.sh clean install -pl system -am -DskipTests` successfully.
 - Verified compilation and layout tag validation success.
 
+## Re-opening & Additional Fix
+
+### Cause of Re-opening
+
+Even though the layout tag files were updated with `version="2.1"`, the JSP container by default treats implicit tag libraries (loaded via `tagdir` directive) as JSP version 2.0. Consequently, the container ignores the `version="2.1"` inside the `<jsp:root>` element and compiles the tags as JSP 2.0. As a result, deferred EL expressions (`#{}`) are treated as literal String values instead of JSF `ValueExpression` objects, which led to the same `ClassCastException` on `disclosedRowKeys`.
+
+### Resolution
+
+To force the JSP container to treat the implicit tag libraries as JSP version 2.1, we created `implicit.tld` files in the directories containing the tag files. These explicit implicit TLDs declare the tag library version as `2.1`, ensuring the container evaluates the deferred expressions correctly.
+
+The following files were created:
+1. **[system/ear/WEB-INF/tags/layout/implicit.tld](file:///home/nate/projects/java8/percussioncms/system/ear/WEB-INF/tags/layout/implicit.tld)**: Declares version `2.1` for layout tag library.
+2. **[system/ear/WEB-INF/tags/nav/implicit.tld](file:///home/nate/projects/java8/percussioncms/system/ear/WEB-INF/tags/nav/implicit.tld)**: Declares version `2.1` for navigation tag library.
+3. **[system/ear/WEB-INF/tags/banner/implicit.tld](file:///home/nate/projects/java8/percussioncms/system/ear/WEB-INF/tags/banner/implicit.tld)**: Declares version `2.1` for banner tag library.
+

--- a/system/ear/WEB-INF/tags/banner/implicit.tld
+++ b/system/ear/WEB-INF/tags/banner/implicit.tld
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<taglib xmlns="http://java.sun.com/xml/ns/javaee" 
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd" 
+        version="2.1">
+    
+    <tlib-version>1.0</tlib-version>
+    <short-name>bannerTags</short-name>
+    
+</taglib>

--- a/system/ear/WEB-INF/tags/layout/implicit.tld
+++ b/system/ear/WEB-INF/tags/layout/implicit.tld
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<taglib xmlns="http://java.sun.com/xml/ns/javaee" 
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd" 
+        version="2.1">
+    
+    <tlib-version>1.0</tlib-version>
+    <short-name>layoutTags</short-name>
+    
+</taglib>

--- a/system/ear/WEB-INF/tags/nav/implicit.tld
+++ b/system/ear/WEB-INF/tags/nav/implicit.tld
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<taglib xmlns="http://java.sun.com/xml/ns/javaee" 
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd" 
+        version="2.1">
+    
+    <tlib-version>1.0</tlib-version>
+    <short-name>navTags</short-name>
+    
+</taglib>


### PR DESCRIPTION
Resolves the ClassCastException: String cannot be cast to RowKeySet when accessing Publishing Design, Publishing Runtime, or Admin tabs by forcing implicit tag library directories to load under JSP version 2.1.