### PR TITLE
bugfix/879: Replace straight apostrophes with curly apostrophes in user-facing site path service error messages

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSSitePathItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSSitePathItemService.java
@@ -22,6 +22,7 @@ import static org.apache.commons.lang.Validate.notNull;
 import com.percussion.assetmanagement.service.IPSAssetService;
 import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
 import com.percussion.fastforward.managednav.IPSManagedNavService;
+import com.percussion.i18n.ui.PSI18NTranslationKeyValues;
 import com.percussion.itemmanagement.service.IPSItemWorkflowService;
 import com.percussion.pagemanagement.service.IPSPageService;
 import com.percussion.pathmanagement.data.PSDeleteFolderCriteria;
@@ -110,10 +111,15 @@ public class PSSitePathItemService extends PSPathItemService {
         // Site not found, if we have assume we have a valid path and the path item is orphaned
         String msg =
             sfp.isOnlySiteId()
-                ? "Oops.  We can’t find the site "
+                ? PSI18NTranslationKeyValues.getInstance()
+                        .getTranslationValue(
+                            "perc.ui.pathmanagement@Oops.  We can't find the site ")
                     + sfp.getSiteId()
-                    + ".  It may have been deleted."
-                : "Oops. We’re sorry. The requested page is no longer available.";
+                    + PSI18NTranslationKeyValues.getInstance()
+                        .getTranslationValue("perc.ui.pathmanagement@.  It may have been deleted.")
+                : PSI18NTranslationKeyValues.getInstance()
+                    .getTranslationValue(
+                        "perc.ui.pathmanagement@Oops. We're sorry. The requested page is no longer available.");
         throw new PSPathNotFoundServiceException(msg);
       }
     }

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSSitePathItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSSitePathItemService.java
@@ -110,10 +110,10 @@ public class PSSitePathItemService extends PSPathItemService {
         // Site not found, if we have assume we have a valid path and the path item is orphaned
         String msg =
             sfp.isOnlySiteId()
-                ? "Oops.  We can't find the site "
+                ? "Oops.  We can’t find the site "
                     + sfp.getSiteId()
                     + ".  It may have been deleted."
-                : "Oops. We're sorry. The requested page is no longer available.";
+                : "Oops. We’re sorry. The requested page is no longer available.";
         throw new PSPathNotFoundServiceException(msg);
       }
     }

--- a/system/cms/content/applications/sys_resources/ApplicationFiles/i18n/CmsUi.tmx
+++ b/system/cms/content/applications/sys_resources/ApplicationFiles/i18n/CmsUi.tmx
@@ -15911,5 +15911,35 @@ Documentación' href='https://percussioncmshelp.intsof.com/'&gt;percussioncmshel
 		<seg>Su navegador no soporta iframes.</seg>
 	</tuv>
 </tu>
+<tu tuid="perc.ui.pathmanagement@Oops.  We can't find the site ">
+	<prop type="sectionname" xml:lang="en-us">Error</prop>
+	<note xml:lang="en-us"></note>
+	<tuv xml:lang="en-us">
+		<seg>Oops.  We can't find the site </seg>
+	</tuv>
+	<tuv xml:lang="es">
+		<seg>Oops. No podemos encontrar el sitio </seg>
+	</tuv>
+</tu>
+<tu tuid="perc.ui.pathmanagement@.  It may have been deleted.">
+	<prop type="sectionname" xml:lang="en-us">Error</prop>
+	<note xml:lang="en-us"></note>
+	<tuv xml:lang="en-us">
+		<seg>.  It may have been deleted.</seg>
+	</tuv>
+	<tuv xml:lang="es">
+		<seg>. Es posible que haya sido eliminado.</seg>
+	</tuv>
+</tu>
+<tu tuid="perc.ui.pathmanagement@Oops. We're sorry. The requested page is no longer available.">
+	<prop type="sectionname" xml:lang="en-us">Error</prop>
+	<note xml:lang="en-us"></note>
+	<tuv xml:lang="en-us">
+		<seg>Oops. We're sorry. The requested page is no longer available.</seg>
+	</tuv>
+	<tuv xml:lang="es">
+		<seg>Oops. Lo sentimos. La página solicitada ya no está disponible.</seg>
+	</tuv>
+</tu>
     </body>
 </tmx>


### PR DESCRIPTION
Closes #879