### PR TITLE
Fix search query ParseException on path-based terms (fixes #878)

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchRestService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchRestService.java
@@ -29,7 +29,9 @@ import com.percussion.services.useritems.data.PSUserItem;
 import com.percussion.share.data.PSPagedItemList;
 import com.percussion.share.data.PSPagedItemPropertiesList;
 import com.percussion.share.service.IPSDataService;
+import com.percussion.share.service.exception.PSParametersValidationException;
 import com.percussion.share.service.exception.PSValidationException;
+import com.percussion.share.validation.PSValidationErrorsBuilder;
 import com.percussion.webservices.PSWebserviceUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.ArrayList;
@@ -126,7 +128,11 @@ public class PSSearchRestService {
           }
           itemList = searchService.search(criteria, contentIds);
         } else {
-          itemList = searchService.search(criteria);
+          try {
+            itemList = searchService.search(criteria);
+          } catch (PSSearchServiceException e) {
+            checkAndThrowValidationException(e, criteria);
+          }
         }
       }
       return itemList;
@@ -151,7 +157,34 @@ public class PSSearchRestService {
     sanitizeCriteria(criteria);
 
     PSPagedItemPropertiesList itemList;
-    itemList = searchService.getExtendedSearchResults(criteria);
+    try {
+      itemList = searchService.getExtendedSearchResults(criteria);
+    } catch (PSSearchServiceException e) {
+      try {
+        checkAndThrowValidationException(e, criteria);
+      } catch (PSValidationException ve) {
+        throw new WebApplicationException(ve);
+      }
+      throw e;
+    }
     return itemList;
+  }
+
+  private void checkAndThrowValidationException(
+      PSSearchServiceException e, PSSearchCriteria criteria) throws PSValidationException {
+    Throwable cause = e.getCause();
+    while (cause != null) {
+      if (cause instanceof org.apache.lucene.queryparser.classic.ParseException) {
+        PSValidationErrorsBuilder builder = new PSValidationErrorsBuilder("PSSearchRestService");
+        builder.rejectField(
+            "query",
+            "invalid",
+            "The search query is invalid: " + cause.getMessage(),
+            criteria.getQuery());
+        throw new PSParametersValidationException(builder.build());
+      }
+      cause = cause.getCause();
+    }
+    throw e;
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchService.java
@@ -486,6 +486,9 @@ public class PSSearchService implements IPSSearchService {
    * @return returns the escaped query
    */
   private String escapeLuceneQuery(String query) {
+    if (StringUtils.isBlank(query)) {
+      return query;
+    }
     String escapedQuery = query;
 
     for (String specialCharacter : luceneSpecialCharacters) {
@@ -495,6 +498,7 @@ public class PSSearchService implements IPSSearchService {
         break;
       }
     }
+    escapedQuery = escapedQuery.replaceAll("(?<!\\\\)/", "\\\\/");
     return escapedQuery;
   }
 


### PR DESCRIPTION
This PR escapes slashes '/' in search queries to prevent Lucene query parser from throwing a ParseException when path-based terms are used. It also captures nested ParseExceptions in the REST resources and exposes them as a user-friendly validation exception instead of returning an HTTP 500 server error.