### PR TITLE
Downgrade PDFBox to 2.0.31 to fix NoSuchMethodError in Tika

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
         <opencsv.version>5.12.0</opencsv.version>
         <oracle.version>12.1.0.1</oracle.version>
         <owasp.csrfguard.version>4.5.0</owasp.csrfguard.version>
-        <pdfbox.version>3.0.6</pdfbox.version>
+        <pdfbox.version>2.0.31</pdfbox.version>
         <plexus.component.metadata.version>2.2.0</plexus.component.metadata.version>
         <poi.version>5.2.2</poi.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -1176,11 +1176,6 @@
             <dependency>
                 <groupId>org.apache.pdfbox</groupId>
                 <artifactId>pdfbox-tools</artifactId>
-                <version>${pdfbox.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.pdfbox</groupId>
-                <artifactId>pdfbox-io</artifactId>
                 <version>${pdfbox.version}</version>
             </dependency>
             <dependency>

--- a/system/pom.xml
+++ b/system/pom.xml
@@ -630,10 +630,6 @@
             <artifactId>pdfbox-tools</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.pdfbox</groupId>
-            <artifactId>pdfbox-io</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
         </dependency>

--- a/system/src/main/java/com/percussion/search/lucene/textconverter/PSTextConverterPdf.java
+++ b/system/src/main/java/com/percussion/search/lucene/textconverter/PSTextConverterPdf.java
@@ -22,8 +22,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
-import org.apache.pdfbox.Loader;
-import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 
@@ -54,9 +52,7 @@ public class PSTextConverterPdf implements IPSLuceneTextConverter {
     String resultText = "";
     PDDocument pdfDocument = null;
     try {
-      // PDFBox 3.0 requires using RandomAccessRead instead of InputStream
-      // RandomAccessReadBuffer accepts InputStream in constructor
-      pdfDocument = Loader.loadPDF(new RandomAccessReadBuffer(is));
+      pdfDocument = PDDocument.load(is);
       if (pdfDocument.isEncrypted()) {
         // Just try using the default password and move on
 


### PR DESCRIPTION
This PR downgrades PDFBox to 2.0.31 (reverting the bump to 3.0.6) and adjusts direct usages to use the 2.x API. This resolves a binary incompatibility () with Tika 2.9.4, since Tika 2.x is only compatible with PDFBox 2.x, and upgrading Tika to 3.x is not possible because it requires JDK 11+.