### PR TITLE
Hardcode buildNumber in Version.properties and establish update guidelines

### DIFF
--- a/.github/workflows/update-build-number.yml
+++ b/.github/workflows/update-build-number.yml
@@ -1,0 +1,46 @@
+name: Update Build Number and Changelog
+
+on:
+  push:
+    branches:
+      - development-8.1.x
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-build-number:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Calculate and Update Build Number
+        env:
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          # Use run number with offset to match the manual build sequence starting at 916
+          # (e.g., if this is run 1, build number will be 916)
+          BUILD_NUM=$((915 + GITHUB_RUN_NUMBER))
+          echo "Calculated Build Number: $BUILD_NUM"
+
+          # 1. Update Version.properties files and CHANGELOG.md using the placeholder
+          sed -i "s/GH_POST_PR_COMMIT_RUN_ID/$BUILD_NUM/g" system/VersionControl/Version.properties
+          sed -i "s/GH_POST_PR_COMMIT_RUN_ID/$BUILD_NUM/g" modules/DesktopContentExplorer/src/main/resources/com/percussion/cx/Version.properties
+          sed -i "s/GH_POST_PR_COMMIT_RUN_ID/$BUILD_NUM/g" CHANGELOG.md
+
+          # 3. Commit and push back
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add system/VersionControl/Version.properties modules/DesktopContentExplorer/src/main/resources/com/percussion/cx/Version.properties CHANGELOG.md
+          
+          # Only commit and push if changes were made
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: update build number to $BUILD_NUM [skip ci]"
+            git push origin development-8.1.x
+          else
+            echo "No changes to commit."
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,9 @@ This file provides guidance for AI agents operating in the Percussion CMS codeba
 - On every pull request:
   1. The `buildNumber` in `Version.properties` files (e.g., in `system/VersionControl/Version.properties`) must be incremented.
   2. A corresponding changelog entry must be written to the repository `CHANGELOG.md` file.
+     - The changelog entry header must include both the version and the new build number/id (e.g., `## [8.1.7 Build 916] - 2026-06-24`).
+     - The changelog must follow the [Common Changelog](https://common-changelog.org/) format.
+     - In the event of a merge conflict on the changelog and build number due to parallel PRs, the agent must update their feature branch with the latest base branch, resolve the conflict, increment the build number based on the latest value, and re-push.
 
 ## Build Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,9 @@ This file provides guidance for AI agents operating in the Percussion CMS codeba
   2. Use existing GitHub issue or create new one first
   3. Include issue number in branch name (e.g., `bugfix/123-fix-logging`)
 - All changes must be tested locally before pushing
+- On every pull request:
+  1. The `buildNumber` in `Version.properties` files (e.g., in `system/VersionControl/Version.properties`) must be incremented.
+  2. A corresponding changelog entry must be written to the repository `CHANGELOG.md` file.
 
 ## Build Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,11 +20,11 @@ This file provides guidance for AI agents operating in the Percussion CMS codeba
   3. Include issue number in branch name (e.g., `bugfix/123-fix-logging`)
 - All changes must be tested locally before pushing
 - On every pull request:
-  1. The `buildNumber` in `Version.properties` files (e.g., in `system/VersionControl/Version.properties`) must be incremented.
+  1. Do NOT manually increment the `buildNumber` in `Version.properties` files (e.g., in `system/VersionControl/Version.properties`). This is automatically handled by a GitHub Actions workflow upon merge.
   2. A corresponding changelog entry must be written to the repository `CHANGELOG.md` file.
-     - The changelog entry header must include both the version and the new build number/id (e.g., `## [8.1.7 Build 916] - 2026-06-24`).
+     - The changelog entry header must use the placeholder `GH_POST_PR_COMMIT_RUN_ID` for the build number (e.g., `## [8.1.7 Build GH_POST_PR_COMMIT_RUN_ID] - YYYY-MM-DD`).
      - The changelog must follow the [Common Changelog](https://common-changelog.org/) format.
-     - In the event of a merge conflict on the changelog and build number due to parallel PRs, the agent must update their feature branch with the latest base branch, resolve the conflict, increment the build number based on the latest value, and re-push.
+     - When the PR is merged into `development-8.1.x`, the workflow will automatically replace the `GH_POST_PR_COMMIT_RUN_ID` placeholder with the correct sequential build number.
 
 ## Build Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## [8.1.7] - 2026-06-24
+## [8.1.7 Build 916] - 2026-06-24
 
 ### Changed
 
-- Changed buildNumber in `Version.properties` to be a hardcoded number (`20260624`) and established guidelines for incrementing it on every PR.
+- Changed buildNumber in `Version.properties` to be a hardcoded number (`916`) and established guidelines for incrementing it on every PR.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Common Changelog](https://common-changelog.org/).
 
-## [8.1.7 Build 916] - 2026-06-24
+## [8.1.7 Build GH_POST_PR_COMMIT_RUN_ID] - 2026-06-24
+
+### Added
+
+- Added GitHub Actions workflow to automatically update and commit the build number in `Version.properties` files and `CHANGELOG.md` upon pushes to `development-8.1.x`.
 
 ### Changed
 
-- Changed buildNumber in `Version.properties` to be a hardcoded number (`916`) and established guidelines for incrementing it on every PR.
+- Updated `Version.properties` buildNumber to use `GH_POST_PR_COMMIT_RUN_ID` placeholder and updated `AGENTS.md` guidelines to use the automated workflow instead of manual increments.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [8.1.7] - 2026-06-24
+
+### Changed
+
+- Changed buildNumber in `Version.properties` to be a hardcoded number (`20260624`) and established guidelines for incrementing it on every PR.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Common Changelog](https://common-changelog.org/).
+
 ## [8.1.7 Build 916] - 2026-06-24
 
 ### Changed

--- a/modules/DesktopContentExplorer/src/main/resources/com/percussion/cx/Version.properties
+++ b/modules/DesktopContentExplorer/src/main/resources/com/percussion/cx/Version.properties
@@ -47,7 +47,7 @@ buildId=${jenkins.buildNumber}
 # the build number, in the format YYYYMMNN, eg 20011231. This is the year/month and counter for
 # the build and is used by everyone outside development to reference
 # a build. Always 8 digits. (this will be replaced while the JAR is built)
-buildNumber=${buildNumber}
+buildNumber=20260624
 
 # This is a monotonically increasing value that is only incremented when
 # changes are made to the workbench and server such that the workbench is no

--- a/modules/DesktopContentExplorer/src/main/resources/com/percussion/cx/Version.properties
+++ b/modules/DesktopContentExplorer/src/main/resources/com/percussion/cx/Version.properties
@@ -47,7 +47,7 @@ buildId=${jenkins.buildNumber}
 # the build number, in the format YYYYMMNN, eg 20011231. This is the year/month and counter for
 # the build and is used by everyone outside development to reference
 # a build. Always 8 digits. (this will be replaced while the JAR is built)
-buildNumber=20260624
+buildNumber=916
 
 # This is a monotonically increasing value that is only incremented when
 # changes are made to the workbench and server such that the workbench is no

--- a/modules/DesktopContentExplorer/src/main/resources/com/percussion/cx/Version.properties
+++ b/modules/DesktopContentExplorer/src/main/resources/com/percussion/cx/Version.properties
@@ -41,12 +41,10 @@ minorVersion=${parsedVersion.minorVersion}
 microVersion=${parsedVersion.incrementalVersion}
 
 # This is a monotonically increasing value that increments every time a
-# release build is created. (this will be replaced while the JAR is built)
-buildId=${jenkins.buildNumber}
+# release build is created.
+buildId=0
 
-# the build number, in the format YYYYMMNN, eg 20011231. This is the year/month and counter for
-# the build and is used by everyone outside development to reference
-# a build. Always 8 digits. (this will be replaced while the JAR is built)
+# The build number, which is a hardcoded sequential number manually incremented on every PR.
 buildNumber=916
 
 # This is a monotonically increasing value that is only incremented when

--- a/modules/DesktopContentExplorer/src/main/resources/com/percussion/cx/Version.properties
+++ b/modules/DesktopContentExplorer/src/main/resources/com/percussion/cx/Version.properties
@@ -44,8 +44,8 @@ microVersion=${parsedVersion.incrementalVersion}
 # release build is created.
 buildId=0
 
-# The build number, which is a hardcoded sequential number manually incremented on every PR.
-buildNumber=916
+# The build number, which is automatically updated by a GitHub Actions workflow upon merge.
+buildNumber=GH_POST_PR_COMMIT_RUN_ID
 
 # This is a monotonically increasing value that is only incremented when
 # changes are made to the workbench and server such that the workbench is no

--- a/system/VersionControl/Version.properties
+++ b/system/VersionControl/Version.properties
@@ -47,7 +47,7 @@ buildId=${jenkins.buildNumber}
 # the build number, in the format YYYYMMNN, eg 20011231. This is the year/month and counter for
 # the build and is used by everyone outside development to reference
 # a build. Always 8 digits. (this will be replaced while the JAR is built)
-buildNumber=${buildNumber}
+buildNumber=20260624
 
 # This is a monotonically increasing value that is only incremented when
 # changes are made to the workbench and server such that the workbench is no

--- a/system/VersionControl/Version.properties
+++ b/system/VersionControl/Version.properties
@@ -47,7 +47,7 @@ buildId=${jenkins.buildNumber}
 # the build number, in the format YYYYMMNN, eg 20011231. This is the year/month and counter for
 # the build and is used by everyone outside development to reference
 # a build. Always 8 digits. (this will be replaced while the JAR is built)
-buildNumber=20260624
+buildNumber=916
 
 # This is a monotonically increasing value that is only incremented when
 # changes are made to the workbench and server such that the workbench is no

--- a/system/VersionControl/Version.properties
+++ b/system/VersionControl/Version.properties
@@ -41,12 +41,10 @@ minorVersion=${parsedVersion.minorVersion}
 microVersion=${parsedVersion.incrementalVersion}
 
 # This is a monotonically increasing value that increments every time a
-# release build is created. (this will be replaced while the JAR is built)
-buildId=${jenkins.buildNumber}
+# release build is created.
+buildId=0
 
-# the build number, in the format YYYYMMNN, eg 20011231. This is the year/month and counter for
-# the build and is used by everyone outside development to reference
-# a build. Always 8 digits. (this will be replaced while the JAR is built)
+# The build number, which is a hardcoded sequential number manually incremented on every PR.
 buildNumber=916
 
 # This is a monotonically increasing value that is only incremented when

--- a/system/VersionControl/Version.properties
+++ b/system/VersionControl/Version.properties
@@ -44,8 +44,8 @@ microVersion=${parsedVersion.incrementalVersion}
 # release build is created.
 buildId=0
 
-# The build number, which is a hardcoded sequential number manually incremented on every PR.
-buildNumber=916
+# The build number, which is automatically updated by a GitHub Actions workflow upon merge.
+buildNumber=GH_POST_PR_COMMIT_RUN_ID
 
 # This is a monotonically increasing value that is only incremented when
 # changes are made to the workbench and server such that the workbench is no


### PR DESCRIPTION
This PR hardcodes  in the main  files, creates the  file, and updates  to establish the workflow rule requiring agents to increment the build number and write a changelog entry for every pull request.