### PR TITLE
bugfix: Skip running Dependency Submission workflow on dependency submission commits (#348)

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   dependency-submission:  
     runs-on: ubuntu-latest
-    if: github.event_name != 'push' || !contains(github.event.head_commit.message, 'Dependency Submission')
+    if: github.event_name != 'push' || (!contains(github.event.head_commit.message, 'Dependency Submission') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, 'chore: update build number'))
     
     steps: 
     - uses: actions/checkout@v4

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   dependency-submission:  
     runs-on: ubuntu-latest
+    if: github.event_name != 'push' || !contains(github.event.head_commit.message, 'Dependency Submission')
     
     steps: 
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,4 +13,5 @@ The format is based on [Common Changelog](https://common-changelog.org/).
 ### Changed
 
 - Updated `Version.properties` buildNumber to use `GH_POST_PR_COMMIT_RUN_ID` placeholder and updated `AGENTS.md` guidelines to use the automated workflow instead of manual increments.
+- Configured the Dependency Submission workflow to be skipped when triggered by a commit containing "Dependency Submission" in its message (#348).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,5 @@ The format is based on [Common Changelog](https://common-changelog.org/).
 ### Changed
 
 - Updated `Version.properties` buildNumber to use `GH_POST_PR_COMMIT_RUN_ID` placeholder and updated `AGENTS.md` guidelines to use the automated workflow instead of manual increments.
-- Configured the Dependency Submission workflow to be skipped when triggered by a commit containing "Dependency Submission" in its message (#348).
+- Configured the Dependency Submission workflow to be skipped when triggered by commits containing "Dependency Submission", "[skip ci]", or "chore: update build number" to prevent redundant runs (#348).
 


### PR DESCRIPTION
Skip running the Dependency Submission workflow for push events if the commit message contains 'Dependency Submission' to avoid redundant runs.