### PR TITLE
bugfix: Guard elements in setCaretToEnd on Admin Console (#906)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,7 @@ The format is based on [Common Changelog](https://common-changelog.org/).
 
 - Updated `Version.properties` buildNumber to use `GH_POST_PR_COMMIT_RUN_ID` placeholder and updated `AGENTS.md` guidelines to use the automated workflow instead of manual increments.
 
+### Fixed
+
+- Fixed a JavaScript TypeError ("Cannot read properties of null (reading 'scrollHeight')") on the Admin Console page by ensuring DOM elements exist before referencing them (#906).
+

--- a/system/ear/jsps/ui/admin/console.jsp
+++ b/system/ear/jsps/ui/admin/console.jsp
@@ -14,12 +14,16 @@
 <c:set var="page_script" scope="request">
    <script>
          function setCaretToEnd() {
-           input = document.getElementById("dispResults");
-           input.scrollTop = input.scrollHeight;
+           var input = document.getElementById("dispResults");
+           if (input) {
+             input.scrollTop = input.scrollHeight;
+           }
            
            // leave focus in command field  
-           cmd = document.getElementById("command");
-           cmd.focus();
+           var cmd = document.getElementById("command");
+           if (cmd) {
+             cmd.focus();
+           }
          }
    </script>
 </c:set>


### PR DESCRIPTION
Add element existence safety checks to setCaretToEnd function in console.jsp to prevent JavaScript TypeError when page elements are not present or rendered yet.