### PR TITLE
Fix build number format startup crash

### DIFF
--- a/.github/workflows/update-build-number.yml
+++ b/.github/workflows/update-build-number.yml
@@ -27,10 +27,17 @@ jobs:
           BUILD_NUM=$((915 + GITHUB_RUN_NUMBER))
           echo "Calculated Build Number: $BUILD_NUM"
 
-          # 1. Update Version.properties files and CHANGELOG.md using the placeholder
+          # Calculate build date in YYYYMMDD format (e.g. 20260624)
+          BUILD_DATE=$(date -u +%Y%m%d)
+          echo "Calculated Build Date: $BUILD_DATE"
+
+          # 1. Update Version.properties files and CHANGELOG.md using the placeholders
           sed -i "s/GH_POST_PR_COMMIT_RUN_ID/$BUILD_NUM/g" system/VersionControl/Version.properties
           sed -i "s/GH_POST_PR_COMMIT_RUN_ID/$BUILD_NUM/g" modules/DesktopContentExplorer/src/main/resources/com/percussion/cx/Version.properties
           sed -i "s/GH_POST_PR_COMMIT_RUN_ID/$BUILD_NUM/g" CHANGELOG.md
+
+          sed -i "s/GH_POST_PR_COMMIT_DATE/$BUILD_DATE/g" system/VersionControl/Version.properties
+          sed -i "s/GH_POST_PR_COMMIT_DATE/$BUILD_DATE/g" modules/DesktopContentExplorer/src/main/resources/com/percussion/cx/Version.properties
 
           # 3. Commit and push back
           git config --global user.name "github-actions[bot]"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Common Changelog](https://common-changelog.org/).
 
+## [8.1.7 Build GH_POST_PR_COMMIT_RUN_ID] - 2026-06-24
+
+### Fixed
+
+- Fixed server startup crash (StringIndexOutOfBoundsException) by restoring date format to `buildNumber` and mapping the sequential run number to `buildId`. Retained defensive robustness checks in `PSFormatVersion` and `PSLogHandler` to prevent future build version format crashes.
+
 ## [8.1.7 Build 917] - 2026-06-24
 
 ### Added

--- a/deployer/src/main/java/com/percussion/deployer/server/PSLogHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSLogHandler.java
@@ -835,9 +835,10 @@ public class PSLogHandler {
 
     String sqlDatePattern = "yyyy-mm-dd hh:mm:ss"; // JDBC Date format.
     FastDateFormat dateFormat = FastDateFormat.getInstance(sqlDatePattern);
+    Date buildDate = archiveInfo.getServerBuildDate();
     col =
         new PSJdbcColumnData(
-            ALS_SRC_SERVER_BUILD_DATE, dateFormat.format(archiveInfo.getServerBuildDate()));
+            ALS_SRC_SERVER_BUILD_DATE, buildDate != null ? dateFormat.format(buildDate) : "");
     cols.add(col);
 
     Document doc = PSXmlDocumentBuilder.createXmlDocument();

--- a/modules/DesktopContentExplorer/src/main/resources/com/percussion/cx/Version.properties
+++ b/modules/DesktopContentExplorer/src/main/resources/com/percussion/cx/Version.properties
@@ -42,10 +42,10 @@ microVersion=${parsedVersion.incrementalVersion}
 
 # This is a monotonically increasing value that increments every time a
 # release build is created.
-buildId=0
+buildId=GH_POST_PR_COMMIT_RUN_ID
 
 # The build number, which is automatically updated by a GitHub Actions workflow upon merge.
-buildNumber=917
+buildNumber=GH_POST_PR_COMMIT_DATE
 
 # This is a monotonically increasing value that is only incremented when
 # changes are made to the workbench and server such that the workbench is no

--- a/system/VersionControl/Version.properties
+++ b/system/VersionControl/Version.properties
@@ -42,10 +42,10 @@ microVersion=${parsedVersion.incrementalVersion}
 
 # This is a monotonically increasing value that increments every time a
 # release build is created.
-buildId=0
+buildId=GH_POST_PR_COMMIT_RUN_ID
 
 # The build number, which is automatically updated by a GitHub Actions workflow upon merge.
-buildNumber=917
+buildNumber=GH_POST_PR_COMMIT_DATE
 
 # This is a monotonically increasing value that is only incremented when
 # changes are made to the workbench and server such that the workbench is no

--- a/system/src/main/java/com/percussion/util/PSFormatVersion.java
+++ b/system/src/main/java/com/percussion/util/PSFormatVersion.java
@@ -190,9 +190,21 @@ public class PSFormatVersion {
     sb.append(getVersion());
     sb.append(exportString);
     sb.append("  Build ");
-    sb.append(getBuildNumber().substring(0, 6));
-    sb.append(ms_buildTypeMap.get(buildType));
-    sb.append(getBuildNumber().substring(6));
+
+    String buildNum = getBuildNumber();
+    String typeCode = ms_buildTypeMap.get(buildType);
+    if (buildNum != null && buildNum.length() >= 6) {
+      sb.append(buildNum.substring(0, 6));
+      if (typeCode != null) {
+        sb.append(typeCode);
+      }
+      sb.append(buildNum.substring(6));
+    } else {
+      sb.append(buildNum);
+      if (typeCode != null) {
+        sb.append(typeCode);
+      }
+    }
     sb.append(" (");
     sb.append(getBuildId());
     sb.append(")");


### PR DESCRIPTION
Restores YYYYMMDD date format to buildNumber and maps the sequential run number to buildId. Retains defensive robustness fixes in PSFormatVersion and PSLogHandler to prevent crashes on startup/deploy logging if build versions deviate.