### PR TITLE
Revert "fix: align pathServiceExceptionMapper indentation to 12-space convention"

### DIFF
--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -503,7 +503,6 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
             <ref bean="runtimeExceptionMapper"/>
             <ref bean="jacksonProvider"/>
             <ref bean="jacksonContextResolver"/>
-            <ref bean="pathServiceExceptionMapper"/>
         </jaxrs:providers>
         <jaxrs:features>
             <!--  <bean class="org.apache.cxf.jaxrs.swagger.Swagger2Feature">


### PR DESCRIPTION
Reverts intersoftdatalabs-in/percussioncms#927