### PR TITLE
Fix duplicate validation errors and map validation exceptions to BAD_REQUEST (#866)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Common Changelog](https://common-changelog.org/).
 
+## [8.1.7 Build GH_POST_PR_COMMIT_RUN_ID] - 2026-06-25
+
+### Fixed
+
+- Fixed duplicate validation error displays and incorrect error status responses when converting a folder to a section (#866). Updated `PSValidationExceptionMapper`, `PSBeanValidationExceptionMapper`, and `PSSpringValidationExceptionMapper` to map validation errors to standard `400 BAD_REQUEST` instead of `500 INTERNAL_SERVER_ERROR`. Fixed `PercServiceUtils.js` to use an `else if` for `globalError` parsing to prevent duplicate extraction of the same error message when both `globalErrors` and `globalError` are populated in the response.
+
 ## [8.1.7 Build 920] - 2026-06-24
 
 ### Fixed

--- a/WebUI/war/services/PercServiceUtils.js
+++ b/WebUI/war/services/PercServiceUtils.js
@@ -775,7 +775,7 @@
                 if (buff !== "") buff += "<br/>";
                 buff += objectErrorToString(verrors.globalErrors);
             }
-            if (verrors.globalError !== undefined && verrors.globalError !== null) {
+            else if (verrors.globalError !== undefined && verrors.globalError !== null) {
                 if (buff !== "") buff += "<br/>";
                 buff += objectErrorToString(verrors.globalError);
             }

--- a/docs/ai-generated/tasks/866-duplicate-nav-error/README.md
+++ b/docs/ai-generated/tasks/866-duplicate-nav-error/README.md
@@ -1,0 +1,19 @@
+# Task: 8.1.7 Navigation error message displays duplicate "folder not found" validation when converting folder to section (Issue #866)
+
+## Objective
+
+Fix a bug where attempting to create/convert a Section from a folder that does not exist in Percussion CMS displays duplicate validation errors in the error dialog (e.g. "folder with that path cannot be found" displayed twice). When the source folder does not exist, the validation should stop early and return only the primary root cause error rather than continuing to validate parent path and dependent landing page existence.
+
+## Changes Made
+
+1. **[PSSiteSectionService (`projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionService.java`)](file:///home/nate/projects/java8/percussioncms/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionService.java)**:
+   - Modified `PSCreateSectionFromFolderValidator.doValidation` method to add `return;` statements after rejecting the request when:
+     - The source path category is not a `Category.FOLDER`
+     - An exception occurs while looking up the source folder path (folder does not exist)
+   - This prevents execution of subsequent validation steps (parent folder existence and landing page existence checks) when the primary folder itself is invalid or missing, thereby avoiding duplicate/dependent validation messages.
+
+## Verification
+
+- Formatted the codebase using `./mvn-env.sh spotless:apply`.
+- Built the `sitemanage` module along with its dependencies via `./mvn-env.sh clean install -pl projects/sitemanage -am -DskipTests` successfully.
+

--- a/docs/ai-generated/tasks/866-duplicate-nav-error/README.md
+++ b/docs/ai-generated/tasks/866-duplicate-nav-error/README.md
@@ -11,9 +11,17 @@ Fix a bug where attempting to create/convert a Section from a folder that does n
      - The source path category is not a `Category.FOLDER`
      - An exception occurs while looking up the source folder path (folder does not exist)
    - This prevents execution of subsequent validation steps (parent folder existence and landing page existence checks) when the primary folder itself is invalid or missing, thereby avoiding duplicate/dependent validation messages.
+2. **Server-side Validation Exception Mappers (`projects/sitemanage/src/main/java/com/percussion/share/web/service/`)**:
+   - Updated `PSValidationExceptionMapper`, `PSBeanValidationExceptionMapper`, and `PSSpringValidationExceptionMapper` to return `Response.Status.BAD_REQUEST` (400) status codes instead of `500 INTERNAL_SERVER_ERROR`.
+3. **Client-side Error Handling (`WebUI/war/services/PercServiceUtils.js`)**:
+   - Modified `extractDefaultErrorMessage` to use `else if` for `globalError` checking. Since `globalError` is just an alias for the first element in `globalErrors` list, this prevents extracting and showing the same global error twice in the UI error dialog.
+4. **Unit Tests (`projects/sitemanage/src/test/java/com/percussion/share/web/service/PSValidationExceptionMapperTest.java`)**:
+   - Added new test cases to verify status mappings for all three validation exception mappers.
 
 ## Verification
 
 - Formatted the codebase using `./mvn-env.sh spotless:apply`.
-- Built the `sitemanage` module along with its dependencies via `./mvn-env.sh clean install -pl projects/sitemanage -am -DskipTests` successfully.
+- Built the `sitemanage` module successfully.
+- Ran new `PSValidationExceptionMapperTest` suite successfully.
+- Ran all unit tests in the `projects/sitemanage` module successfully.
 

--- a/projects/sitemanage/src/main/java/com/percussion/share/web/service/PSBeanValidationExceptionMapper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/web/service/PSBeanValidationExceptionMapper.java
@@ -51,6 +51,6 @@ public class PSBeanValidationExceptionMapper
   @Override
   @Produces(MediaType.APPLICATION_JSON)
   protected Response.Status getStatus(PSBeanValidationException exception) {
-    return super.getStatus(exception);
+    return Response.Status.BAD_REQUEST;
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/share/web/service/PSSpringValidationExceptionMapper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/web/service/PSSpringValidationExceptionMapper.java
@@ -51,4 +51,10 @@ public class PSSpringValidationExceptionMapper
     log.debug(ERROR_MESSAGE, exception);
     return exception.getValidationErrors();
   }
+
+  @Override
+  @Produces(MediaType.APPLICATION_JSON)
+  protected javax.ws.rs.core.Response.Status getStatus(PSSpringValidationException exception) {
+    return javax.ws.rs.core.Response.Status.BAD_REQUEST;
+  }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/share/web/service/PSValidationExceptionMapper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/web/service/PSValidationExceptionMapper.java
@@ -53,6 +53,6 @@ public class PSValidationExceptionMapper extends PSAbstractExceptionMapper<PSVal
   @Override
   @Produces(MediaType.APPLICATION_JSON)
   protected Status getStatus(PSValidationException exception) {
-    return super.getStatus(exception);
+    return Status.BAD_REQUEST;
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteSectionService.java
@@ -2243,6 +2243,7 @@ public class PSSiteSectionService implements IPSSiteSectionService {
               new Object[] {req.getSourceFolderPath()},
               "Cannot create a section from the folder with path \"{0}\" "
                   + "as the path does not correspond to a folder.");
+          return;
         }
       } catch (Exception ex) {
         e.reject(
@@ -2250,6 +2251,7 @@ public class PSSiteSectionService implements IPSSiteSectionService {
             new Object[] {req.getSourceFolderPath()},
             "Cannot create a section from the folder with path \"{0}\" "
                 + "because a folder with that path cannot be found.");
+        return;
       }
       try {
         IPSItemSummary itemSum = folderHelper.findFolder(req.getParentFolderPath());

--- a/projects/sitemanage/src/test/java/com/percussion/share/web/service/PSValidationExceptionMapperTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/web/service/PSValidationExceptionMapperTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 1999-2023 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.share.web.service;
+
+import static org.junit.Assert.assertEquals;
+
+import com.percussion.share.service.exception.PSBeanValidationException;
+import com.percussion.share.service.exception.PSSpringValidationException;
+import com.percussion.share.service.exception.PSValidationException;
+import javax.ws.rs.core.Response;
+import org.junit.Test;
+
+public class PSValidationExceptionMapperTest {
+
+  private final PSValidationExceptionMapper validationMapper = new PSValidationExceptionMapper();
+
+  private final PSBeanValidationExceptionMapper beanValidationMapper =
+      new PSBeanValidationExceptionMapper();
+
+  private final PSSpringValidationExceptionMapper springValidationMapper =
+      new PSSpringValidationExceptionMapper();
+
+  private static class DummyValidationException extends PSValidationException {
+    private static final long serialVersionUID = 1L;
+
+    public DummyValidationException(String message) {
+      super(message);
+    }
+  }
+
+  private static class DummySpringValidationException extends PSSpringValidationException {
+    private static final long serialVersionUID = 1L;
+
+    public DummySpringValidationException(String message) {
+      super(message);
+    }
+  }
+
+  @Test
+  public void testValidationExceptionMapper_getStatus() {
+    DummyValidationException ex = new DummyValidationException("Invalid input");
+    assertEquals(Response.Status.BAD_REQUEST, validationMapper.getStatus(ex));
+  }
+
+  @Test
+  public void testBeanValidationExceptionMapper_getStatus() {
+    Object target = new Object();
+    PSBeanValidationException ex = new PSBeanValidationException(target, "testMethod");
+    assertEquals(Response.Status.BAD_REQUEST, beanValidationMapper.getStatus(ex));
+  }
+
+  @Test
+  public void testSpringValidationExceptionMapper_getStatus() {
+    DummySpringValidationException ex =
+        new DummySpringValidationException("Spring validation failed");
+    assertEquals(Response.Status.BAD_REQUEST, springValidationMapper.getStatus(ex));
+  }
+}


### PR DESCRIPTION
This PR fixes issue #866. It changes the client-side parsing in PercServiceUtils.js to avoid duplicate extraction of global errors, maps all three validation exception mappers to HTTP 400 Bad Request, and adds a test suite.