### PR TITLE
Fix #879: Use curly apostrophe to prevent HTML encoding of error messages

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSSitePathItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSSitePathItemService.java
@@ -113,13 +113,13 @@ public class PSSitePathItemService extends PSPathItemService {
             sfp.isOnlySiteId()
                 ? PSI18NTranslationKeyValues.getInstance()
                         .getTranslationValue(
-                            "perc.ui.pathmanagement@Oops.  We can't find the site ")
+                            "perc.ui.pathmanagement@Oops.  We can\u2019t find the site ")
                     + sfp.getSiteId()
                     + PSI18NTranslationKeyValues.getInstance()
                         .getTranslationValue("perc.ui.pathmanagement@.  It may have been deleted.")
                 : PSI18NTranslationKeyValues.getInstance()
                     .getTranslationValue(
-                        "perc.ui.pathmanagement@Oops. We're sorry. The requested page is no longer available.");
+                        "perc.ui.pathmanagement@Oops. We\u2019re sorry. The requested page is no longer available.");
         throw new PSPathNotFoundServiceException(msg);
       }
     }

--- a/system/cms/content/applications/sys_resources/ApplicationFiles/i18n/CmsUi.tmx
+++ b/system/cms/content/applications/sys_resources/ApplicationFiles/i18n/CmsUi.tmx
@@ -15911,11 +15911,11 @@ Documentación' href='https://percussioncmshelp.intsof.com/'&gt;percussioncmshel
 		<seg>Su navegador no soporta iframes.</seg>
 	</tuv>
 </tu>
-<tu tuid="perc.ui.pathmanagement@Oops.  We can't find the site ">
+<tu tuid="perc.ui.pathmanagement@Oops.  We can&#8217;t find the site ">
 	<prop type="sectionname" xml:lang="en-us">Error</prop>
 	<note xml:lang="en-us"></note>
 	<tuv xml:lang="en-us">
-		<seg>Oops.  We can't find the site </seg>
+		<seg>Oops.  We can&#8217;t find the site </seg>
 	</tuv>
 	<tuv xml:lang="es">
 		<seg>Oops. No podemos encontrar el sitio </seg>
@@ -15931,11 +15931,11 @@ Documentación' href='https://percussioncmshelp.intsof.com/'&gt;percussioncmshel
 		<seg>. Es posible que haya sido eliminado.</seg>
 	</tuv>
 </tu>
-<tu tuid="perc.ui.pathmanagement@Oops. We're sorry. The requested page is no longer available.">
+<tu tuid="perc.ui.pathmanagement@Oops. We&#8217;re sorry. The requested page is no longer available.">
 	<prop type="sectionname" xml:lang="en-us">Error</prop>
 	<note xml:lang="en-us"></note>
 	<tuv xml:lang="en-us">
-		<seg>Oops. We're sorry. The requested page is no longer available.</seg>
+		<seg>Oops. We&#8217;re sorry. The requested page is no longer available.</seg>
 	</tuv>
 	<tuv xml:lang="es">
 		<seg>Oops. Lo sentimos. La página solicitada ya no está disponible.</seg>


### PR DESCRIPTION
## Summary
- Fixes HTML entity encoding issue where `&#39;` was displayed instead of apostrophes in error messages
- Root cause: `SecureStringUtils.sanitizeStringForHTML()` converts straight apostrophes to `&#39;`
- Solution: Use curly apostrophe (U+2019 / `&#8217;`) which renders correctly

## Changes
- `PSSitePathItemService.java`: Updated lookup keys to use curly apostrophe (Unicode `\u2019`)
- `CmsUi.tmx`: Updated translation entries to use curly apostrophe in both keys and values

## Testing
- Verify orphaned page error message displays correctly with apostrophe instead of `&#39;`