### PR TITLE
Fix #930: Repopulate department dropdown when clearing last name filter

### DIFF
--- a/system/Packages/perc.widget.directory/sys__UserDependency--web_resources/widgets/directory/js/perc-directory.js
+++ b/system/Packages/perc.widget.directory/sys__UserDependency--web_resources/widgets/directory/js/perc-directory.js
@@ -250,6 +250,7 @@ $(document).ready(function() {
             $('#search-directory').val("");
             DirectoryList.search();
             applyDirectoryFilters();
+            configureDptDropDown();
             $('#perc-clear-alpha-filter').hide();
         }
     });


### PR DESCRIPTION
## Summary
- Fixes issue where "Filter By Department" dropdown was not repopulated after clearing the last name filter
- When user clicks Clear Filter, the directory results reset but the department dropdown was retaining stale values

## Root Cause
The `configureDptDropDown()` function was only called on page initialization. When clearing the alpha filter, only `applyDirectoryFilters()` was called, which filtered results but didn't refresh the dropdown options.

## Fix
Added call to `configureDptDropDown()` in the clear filter click handler to repopulate the dropdown with all available departments from the current result set.

## Testing
1. Navigate to Directory page
2. Click a letter under "Filter by Last Name"
3. Click "Clear Filter"
4. Verify the "Filter By Department" dropdown shows all departments