### PR TITLE
Fix #878: Search fails for path-based terms + compilation fix

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSPathItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSPathItemService.java
@@ -329,6 +329,9 @@ public abstract class PSPathItemService implements IPSPathService {
     if (lastException != null) {
       throw lastException;
     }
+    // This should never be reached as either return or throw should occur above,
+    // but added for compiler safety
+    return find(path);
   }
 
   public PSPathItem addNewFolder(String path)


### PR DESCRIPTION
## Summary
- **Issue #878**: Search was failing for path-based search terms like `people/donna-williams` due to Lucene ParseException
- **Secondary fix**: Added missing return statement in `PSPathItemService.addFolder()` that was causing compilation errors

## Issue #878 Details
The `escapeLuceneQuery()` method was not escaping forward slashes (`/`) which caused Lucene to throw a ParseException when searching for path-based terms.

**Note**: The main fix for issue #878 (escaping slashes and proper exception handling) was already implemented in commit `4721406d8` which is included in this branch. This PR just includes the compilation fix.

## Files Changed
- `PSPathItemService.java`: Added return statement after retry loop to fix compilation error

## Testing
- Unit test `PSSearchRestServiceTest.testSanitizeCriteriaEscapesSlashesAndDashes` passes