### PR TITLE
bugfix/867: Fix folder creation 'Path not found' error popup

### DIFF
--- a/WebUI/war/plugins/perc_path_manager.js
+++ b/WebUI/war/plugins/perc_path_manager.js
@@ -182,12 +182,13 @@
                         type: 'GET',
                         success: callback,
                         error: function(xhr, status, error) {
-                            if (retryCount < maxRetries) {
+                            // Only retry on server errors (500), not on client errors (404, 403, etc.)
+                            if (xhr.status === 500 && retryCount < maxRetries) {
                                 retryCount++;
                                 console.log("open_path retry " + retryCount + " of " + maxRetries + " for path: " + path_str);
                                 setTimeout(doOpen, retryDelay);
                             } else {
-                                err(error);
+                                err(xhr, status, error);
                             }
                         },
                         url: serviceUrl,
@@ -200,12 +201,13 @@
                         type: 'GET',
                         success: callback,
                         error: function(xhr, status, error) {
-                            if (retryCount < maxRetries) {
+                            // Only retry on server errors (500), not on client errors (404, 403, etc.)
+                            if (xhr.status === 500 && retryCount < maxRetries) {
                                 retryCount++;
                                 console.log("open_path retry " + retryCount + " of " + maxRetries + " for path: " + path_str);
                                 setTimeout(doOpen, retryDelay);
                             } else {
-                                err(error);
+                                err(xhr, status, error);
                             }
                         },
                         url: $.perc_paths.PATH_ITEM + path_str,

--- a/WebUI/war/plugins/perc_path_manager.js
+++ b/WebUI/war/plugins/perc_path_manager.js
@@ -172,26 +172,50 @@
         }
 
         if (!$.perc_fakes.path_service) {
-            if (folder) {
-                $.ajax({
-                    type: 'GET',
-                    success: callback,
-                    error: err,
-                    url: serviceUrl,
-                    dataType: 'json',
-                    cache: false
-                });
+            var maxRetries = 3;
+            var retryDelay = 200;
+            var retryCount = 0;
+
+            function doOpen() {
+                if (folder) {
+                    $.ajax({
+                        type: 'GET',
+                        success: callback,
+                        error: function(xhr, status, error) {
+                            if (retryCount < maxRetries) {
+                                retryCount++;
+                                console.log("open_path retry " + retryCount + " of " + maxRetries + " for path: " + path_str);
+                                setTimeout(doOpen, retryDelay);
+                            } else {
+                                err(error);
+                            }
+                        },
+                        url: serviceUrl,
+                        dataType: 'json',
+                        cache: false
+                    });
+                }
+                else {
+                    $.ajax({
+                        type: 'GET',
+                        success: callback,
+                        error: function(xhr, status, error) {
+                            if (retryCount < maxRetries) {
+                                retryCount++;
+                                console.log("open_path retry " + retryCount + " of " + maxRetries + " for path: " + path_str);
+                                setTimeout(doOpen, retryDelay);
+                            } else {
+                                err(error);
+                            }
+                        },
+                        url: $.perc_paths.PATH_ITEM + path_str,
+                        dataType: 'json',
+                        cache: false
+                    });
+                }
             }
-            else {
-                $.ajax({
-                    type: 'GET',
-                    success: callback,
-                    error: err,
-                    url: $.perc_paths.PATH_ITEM + path_str,
-                    dataType: 'json',
-                    cache: false
-                });
-            }
+
+            doOpen();
         }
         else {
             var fakes = {

--- a/WebUI/war/plugins/perc_path_manager.js
+++ b/WebUI/war/plugins/perc_path_manager.js
@@ -182,8 +182,8 @@
                         type: 'GET',
                         success: callback,
                         error: function(xhr, status, error) {
-                            // Only retry on server errors (500), not on client errors (404, 403, etc.)
-                            if (xhr.status === 500 && retryCount < maxRetries) {
+                            // Retry on server errors (500) AND path-not-found (404) since folder may not be indexed yet
+                            if ((xhr.status === 500 || xhr.status === 404) && retryCount < maxRetries) {
                                 retryCount++;
                                 console.log("open_path retry " + retryCount + " of " + maxRetries + " for path: " + path_str);
                                 setTimeout(doOpen, retryDelay);
@@ -201,8 +201,8 @@
                         type: 'GET',
                         success: callback,
                         error: function(xhr, status, error) {
-                            // Only retry on server errors (500), not on client errors (404, 403, etc.)
-                            if (xhr.status === 500 && retryCount < maxRetries) {
+                            // Retry on server errors (500) AND path-not-found (404) since folder may not be indexed yet
+                            if ((xhr.status === 500 || xhr.status === 404) && retryCount < maxRetries) {
                                 retryCount++;
                                 console.log("open_path retry " + retryCount + " of " + maxRetries + " for path: " + path_str);
                                 setTimeout(doOpen, retryDelay);

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSPathItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSPathItemService.java
@@ -307,7 +307,8 @@ public abstract class PSPathItemService implements IPSPathService {
       throw new PSPathServiceException("Failed to add folder: " + path, e);
     }
 
-    int retryCount = 3;
+    int retryCount = 5;
+    int retryDelayMs = 200;
     PSPathNotFoundServiceException lastException = null;
     for (int i = 0; i < retryCount; i++) {
       try {
@@ -319,7 +320,7 @@ public abstract class PSPathItemService implements IPSPathService {
             i + 1,
             retryCount);
         try {
-          Thread.sleep(100);
+          Thread.sleep(retryDelayMs);
         } catch (InterruptedException ie) {
           Thread.currentThread().interrupt();
           break;


### PR DESCRIPTION
## Summary

Fixes the issue where folder creation displays a "Path not found" error dialog even though the folder is successfully created.

### Root Cause

After folder creation, there is a timing issue where:
1. Backend creates the folder but it may not be immediately findable
2. UI tries to navigate/refresh to the new folder
3. The lookup fails before the folder is fully available

### Changes

1. **Backend** (`PSPathItemService.java`): Increased retry count from 3→5 and delay from 100ms→200ms when looking up a folder after creation (total retry time: 1s vs 300ms)

2. **Frontend** (`perc_path_manager.js`): Added defensive retry mechanism in `open_path()` - 3 retries with 200ms delay before calling the error handler, giving the server time to process folder creation

### Testing

- Console logging added to track retry attempts: `open_path retry X of 3 for path: ...`

Fixes: https://github.com/intersoftdatalabs-in/percussioncms/issues/867