### PR TITLE
bugfix/867: Suppress false 'Path not found' dialog after folder rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Common Changelog](https://common-changelog.org/).
 
 - Fixed PSPackageBuilderTest#testAllPackagesMatchReferenceStructure test failure by syncing reference .ppkg files with source content type labels (#1153). Updated perc.widget.registration and perc.widget.secureLogin reference packages to mark content types as "(Deprecated)".
 
+## [8.1.7 Build GH_POST_PR_COMMIT_RUN_ID] - 2026-06-26
+
+### Fixed
+
+- Fixed misleading "Path not found" error dialog that appeared immediately after a folder create or rename (#867). After rename, `update_btn` in `perc_delete_page_button.js` would call `open_path` on the new path while the JCR was still indexing it; the existing 3x200ms client retry was insufficient and the error handler showed a false-positive alert. Increased the client retry to 6x300ms in `perc_path_manager.js` and made `update_btn` silently disable the delete button on lookup failure (the path was just navigated to, so it must exist) instead of showing the error dialog.
+
 ## [8.1.7 Build 922] - 2026-06-25
 
 ### Fixed

--- a/WebUI/war/plugins/perc_path_manager.js
+++ b/WebUI/war/plugins/perc_path_manager.js
@@ -172,8 +172,8 @@
         }
 
         if (!$.perc_fakes.path_service) {
-            var maxRetries = 3;
-            var retryDelay = 200;
+            var maxRetries = 6;
+            var retryDelay = 300;
             var retryCount = 0;
 
             function doOpen() {

--- a/WebUI/war/plugins/perc_utils.js
+++ b/WebUI/war/plugins/perc_utils.js
@@ -35,6 +35,7 @@
     $.ajaxSetup( { cache: false } );
     $.Percussion = $.Percussion || {};
 
+    var isRenamingFolder = false;
 
     $.perc_fakes = {
         path_service: false,
@@ -1518,6 +1519,10 @@
                     return oldName;
                 if(value.toLowerCase() !== oldName.toLowerCase())
                 {
+                    if(isRenamingFolder){
+                        return oldName;
+                    }
+                    isRenamingFolder = true;
                     $.PercBlockUI($.PercBlockUIMode.CURSORONLY);
                     $.PercPathService.renameFolder(
                         pathItem.path,
@@ -1532,11 +1537,13 @@
                                 $.perc_finder().lastClickPath = null;
                                 $.perc_finder().open(pth);
                                 $.unblockUI();
+                                isRenamingFolder = false;
                             }
                             else
                             {
                                 $nameEl.text(oldName); // Reset back to old name
                                 $.unblockUI();
+                                isRenamingFolder = false;
                                 var errorMsg = "";
                                 if (code === "renameFolderItem.reservedName" || code === "renameFolderItem.longName" ||
                                     code === "renameFolderItem.invalidCharInName")

--- a/WebUI/war/widgets/perc_delete_page_button.js
+++ b/WebUI/war/widgets/perc_delete_page_button.js
@@ -572,8 +572,12 @@
                     }
                 },
                 function (request) {
-                    var msg = $.PercServiceUtils.extractDefaultErrorMessage(request);
-                    $.perc_utils.alert_dialog({ title: I18N.message("perc.ui.publish.title@Error"), content: msg });
+                    // The path was just navigated to in the finder (e.g. immediately
+                    // after folder create/rename), so it must exist. The lookup can
+                    // transiently fail with a 404/500 while the JCR finishes indexing
+                    // the new/renamed path - silently disable the delete button
+                    // rather than showing a misleading "Path not found" error dialog.
+                    $(".perc-finder-menu #perc-finder-delete").removeClass('ui-enabled').addClass('ui-disabled').off('click');
                 }
             );
 


### PR DESCRIPTION
## Summary

Fixes the misleading "Path not found" error dialog that appears immediately after a folder create or rename, even though the operation succeeded.

## Root Cause

After a folder rename, `$.perc_finder().open(newPath)` fires `path_changed`, which triggers the delete-button listener (`update_btn` in `perc_delete_page_button.js`). That listener calls `open_path` on the just-renamed path while the JCR is still indexing it, returning a 404. The existing client retry (3×200ms = 600ms) was insufficient, and on failure the error handler showed a false-positive alert dialog.

The stack trace from the issue shows the failure path:
```
open_path @ perc_path_manager.js:186
update_btn @ perc_delete_page_button.js:534
path_changed @ perc_finder.js:1876
```

## Changes

- **`perc_path_manager.js`** — Increased client retry in `open_path` from 3×200ms to 6×300ms (1.8s total) to better absorb longer JCR indexing delays and match the backend `addFolder` retry timing.
- **`perc_delete_page_button.js`** — Made `update_btn` silently disable the delete button on lookup failure instead of showing an alert dialog. The path was just navigated to in the finder, so it must exist; any transient 404/500 is a JCR indexing delay, not a real error.
- **`perc_utils.js`** — Added an `isRenamingFolder` re-entry guard in the rename editable callback to prevent duplicate rename requests when the user submits quickly.
- **`CHANGELOG.md`** — Added changelog entry per AGENTS.md guidelines.

## Test Plan

1. Log in to Percussion CMS.
2. Navigate to a site folder.
3. Right-click a folder, choose **Rename**, type a new name, press Enter.
4. Confirm no "Path not found" dialog appears.
5. Confirm the folder appears in the finder with the new name.
6. Repeat for creating a new folder and naming it inline.
7. Verify the delete button is correctly enabled/disabled based on the new path's permissions after rename.

Fixes #867