### PR TITLE
Fix category name input issues and improve validation alerts in Admin…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Common Changelog](https://common-changelog.org/).
 
+## [8.1.7 Build GH_POST_PR_COMMIT_RUN_ID] - 2026-07-03
+
+### Fixed
+
+- Fixed the "Category Name" placeholder text overlapping user input when adding a new category in Admin → Categories. The default title "New Category" was being written into the input's actual `value` in `displayCategoryDetails()` (`PercCategoryView.js`), with a fragile `.select()` call relied on to let the first keystroke overwrite it; any click or focus timing issue broke the selection and left the literal text behind. Added a real `placeholder` attribute (new `perc.ui.perc.categories@New Category` i18n key) to `#perc-category-name-field` in `percCategories.jsp`, and updated `displayCategoryDetails()` to leave the field genuinely empty for new, unsaved categories so the browser natively shows/hides the placeholder as the user types.
+- Fixed a `TypeError: Cannot read properties of null (reading 'setTitle')` thrown from the category name field's `keyup` handler after dismissing the "You must change the category name." validation alert in `PercCategoryView.js`. The alert reused the shared `alertDialog()` helper, whose `okCallBack` unconditionally rebuilt the category tree via `controller.getCategories()`; since the user was still mid-edit on the unsaved node, the rebuild left no active node (blocked by `beforeActivate` while `editing` was still true) while the name field stayed enabled, so the next keystroke crashed. Added a `validationAlert()` helper that shows the same message without reloading the tree, and used it for this check so the in-progress edit/active node is preserved.
+
 ## [8.1.7 Build 928] - 2026-06-25
 
 ### Fixed

--- a/WebUI/war/app/percCategories.jsp
+++ b/WebUI/war/app/percCategories.jsp
@@ -99,7 +99,7 @@
                             <div class="form-group" id="perc-category-name-label">
                                 <label class="col-sm-4 control-label"><i18n:message key="perc.ui.perc.categories@Category Name"/></label>
                                 <div class="col-sm-8">
-                                    <input type="text" class="form-control" id="perc-category-name-field" maxlength="255" title='<i18n:message key="perc.ui.perc.categories@Category Name"/>'/>
+                                    <input type="text" class="form-control" id="perc-category-name-field" maxlength="255" title='<i18n:message key="perc.ui.perc.categories@Category Name"/>' placeholder='<i18n:message key="perc.ui.perc.categories@New Category"/>'/>
                                 </div>
                             </div>
                             

--- a/WebUI/war/views/PercCategoryView.js
+++ b/WebUI/war/views/PercCategoryView.js
@@ -318,7 +318,29 @@
                 var node = getTree().getActiveNode();
                 if (node != null && node.title === "New Category")
                 {
-                    alertDialog("Error", "You must change the category name.");
+                    // Use a plain alert here (not alertDialog()) - alertDialog()'s
+                    // okCallBack unconditionally calls controller.getCategories(),
+                    // which destroys and rebuilds the fancytree. Since the user is
+                    // still mid-edit on this unsaved node, that rebuild orphans the
+                    // active node while `editing` stays true (so beforeActivate blocks
+                    // re-activation), leaving the still-enabled name field's keyup
+                    // handler pointed at a null active node and throwing on next
+                    // keystroke. This is only a client-side validation message, so
+                    // nothing needs to be reloaded - just let the user keep editing.
+                    validationAlert("Error", "You must change the category name.");
+                    return;
+                }
+                // Covers both brand-new categories whose name was typed into and then
+                // fully cleared again (node.title becomes the literal "[empty]" marker
+                // via the keyup handler below, not "New Category", so the check above
+                // doesn't catch it) and existing categories whose name was cleared
+                // during edit. Without this, editCategories() reads the real (empty)
+                // field value, saves it as the title/name, and the server persists it
+                // as null instead of the validation being surfaced to the user.
+                var categoryname = $("#perc-category-name-field").val().trim();
+                if (categoryname === "")
+                {
+                    validationAlert("Error", "You must enter a category name.");
                     return;
                 }
                 save();
@@ -599,7 +621,15 @@ container.fancytree({
             $("#perc-category-name-field").prop("disabled", true);
 			$("#perc-category-name-field").attr("aria-disabled","true");
 
-            $("#perc-category-name-field").val(node.title);
+            // For a brand new, unsaved category, leave the input truly empty so the
+            // native HTML placeholder (see percCategories.jsp) is displayed instead of
+            // pre-filling the literal default title text into the field's real value.
+            // A real placeholder automatically hides itself as soon as the user types,
+            // and reappears if the field is cleared again - unlike stuffing the default
+            // text into .val(), which the browser treats as actual content that must be
+            // manually selected/deleted before typing.
+            var isUnsavedDefaultTitle = !node.data.saved && node.title === "New Category";
+            $("#perc-category-name-field").val(isUnsavedDefaultTitle ? "" : node.title);
             
             $("#perc-category-selectable-field").prop("disabled", true);
 			$("#perc-category-selectable-field").attr("aria-disabled","true");
@@ -671,12 +701,10 @@ container.fancytree({
             var $nameField = $("#perc-category-name-field");
             $nameField.trigger("focus");
 
-            // UX improvement for new categories: if the field still contains the
-            // default placeholder "New Category", select the text so the user can
-            // immediately start typing to overwrite it.
-            if (!node.data.saved && $nameField.val() === "New Category") {
-                $nameField.select();
-            }
+            // The name field is left empty for brand new, unsaved categories (see
+            // displayCategoryDetails()), so the native HTML placeholder attribute on
+            // #perc-category-name-field handles showing "New Category" and automatically
+            // hiding it as soon as the user types - no manual select()/clear needed.
 
             // Hitting Enter in the category name field should trigger Save (issue request)
             $nameField.off("keydown.enterSave").on("keydown.enterSave", function(e) {
@@ -732,6 +760,21 @@ container.fancytree({
                 {
                     
                 }
+            });
+        }
+
+        function validationAlert(title, message, w) {
+            if(w == null || w === undefined || w === "" || w < 1)
+                w = 400;
+            // Intentionally does NOT reload the category tree (unlike alertDialog()):
+            // this is a client-side validation message shown while the user is still
+            // mid-edit on an unsaved node, and reloading would discard that in-progress
+            // edit/active node while leaving the enabled name field's handlers pointed
+            // at a stale/null node.
+            $.perc_utils.alert_dialog({
+                title: title,
+                content: message,
+                width: w
             });
         }
 

--- a/system/cms/content/applications/sys_resources/ApplicationFiles/i18n/CmsUi.tmx
+++ b/system/cms/content/applications/sys_resources/ApplicationFiles/i18n/CmsUi.tmx
@@ -12418,6 +12418,16 @@ Documentación' href='https://percussioncmshelp.intsof.com/'&gt;percussioncmshel
 	        <seg>Nombre de la Categoría:</seg>
 	    </tuv>
 	 </tu>
+	 <tu tuid="perc.ui.perc.categories@New Category">
+	    <prop type="sectionname" xml:lang="en-us">Label</prop>
+	    <note xml:lang="en-us"></note>
+	    <tuv xml:lang="en-us">
+	        <seg>New Category</seg>
+	    </tuv>
+	      <tuv xml:lang="es">
+	        <seg>Nueva Categoría</seg>
+	    </tuv>
+	 </tu>
 	 <tu tuid="perc.ui.perc.categories@Is It Selectable">
 	    <prop type="sectionname" xml:lang="en-us">Question</prop>
 	    <note xml:lang="en-us"></note>


### PR DESCRIPTION
- Fixed the "Category Name" placeholder text overlapping user input when adding a new category in Admin → Categories. The default title "New Category" was being written into the input's actual `value` in `displayCategoryDetails()` (`PercCategoryView.js`), with a fragile `.select()` call relied on to let the first keystroke overwrite it; any click or focus timing issue broke the selection and left the literal text behind. Added a real `placeholder` attribute (new `perc.ui.perc.categories@New Category` i18n key) to `#perc-category-name-field` in `percCategories.jsp`, and updated `displayCategoryDetails()` to leave the field genuinely empty for new, unsaved categories so the browser natively shows/hides the placeholder as the user types.
- Fixed a `TypeError: Cannot read properties of null (reading 'setTitle')` thrown from the category name field's `keyup` handler after dismissing the "You must change the category name." validation alert in `PercCategoryView.js`. The alert reused the shared `alertDialog()` helper, whose `okCallBack` unconditionally rebuilt the category tree via `controller.getCategories()`; since the user was still mid-edit on the unsaved node, the rebuild left no active node (blocked by `beforeActivate` while `editing` was still true) while the name field stayed enabled, so the next keystroke crashed. Added a `validationAlert()` helper that shows the same message without reloading the tree, and used it for this check so the in-progress edit/active node is preserved.