### PR TITLE
1182-Fix stale user lock issue

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/category/data/PSCategoryLockInfo.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/data/PSCategoryLockInfo.java
@@ -18,6 +18,7 @@
 package com.percussion.category.data;
 
 import com.percussion.server.PSRequest;
+import com.percussion.server.PSUserSessionManager;
 import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.user.service.IPSUserService;
 import java.io.File;
@@ -26,6 +27,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codehaus.jettison.json.JSONException;
@@ -92,6 +94,11 @@ public class PSCategoryLockInfo {
         }
 
         jsonObject = new JSONObject(new String(lockInfo, "UTF-8"));
+
+        if (isLockStale(jsonObject)) {
+          removeLockInfo();
+          return null;
+        }
       } catch (FileNotFoundException e) {
         log.error("File not found with FileReader - PSCategoryService.getLockInfo()", e);
       } catch (IOException e) {
@@ -115,19 +122,38 @@ public class PSCategoryLockInfo {
     return jsonObject;
   }
 
+  private static boolean isLockStale(JSONObject jsonObject) {
+    if (jsonObject == null) {
+      return false;
+    }
+
+    try {
+      String sessionId = jsonObject.getString("sessionId");
+      if (StringUtils.isNotBlank(sessionId)) {
+        if (PSUserSessionManager.getUserSession(sessionId) == null) {
+          log.debug(
+              "Removing stale category tab lock for sessionId: {} - session no longer exists",
+              sessionId);
+          return true;
+        }
+      }
+    } catch (JSONException e) {
+      log.error(
+          "JSON Exception occurred while validating lock - PSCategoryLockInfo.isLockStale()", e);
+    }
+
+    return false;
+  }
+
   public static void removeLockInfo() {
 
-    JSONObject jsonObject = getLockInfo();
+    File file = new File(LOCKINFOFILE);
 
-    if (jsonObject != null) {
-      File file = new File(LOCKINFOFILE);
-
-      if (file.exists()) {
-        file.setWritable(true);
-        if (file.delete()) {
-          log.debug(
-              "File containing the user information who locked the Categories Tab has been deleted successfully.");
-        }
+    if (file.exists()) {
+      file.setWritable(true);
+      if (file.delete()) {
+        log.debug(
+            "File containing the user information who locked the Categories Tab has been deleted successfully.");
       }
     }
   }


### PR DESCRIPTION
**Changes**
**New imports**
com.percussion.server.PSUserSessionManager — to check if a session is still active
org.apache.commons.lang.StringUtils — for blank-string checks
New method isLockStale(JSONObject)
Reads the sessionId from the lock file
Calls PSUserSessionManager.getUserSession(sessionId) to check if that session still exists in the server's active session map
Returns true if the session is gone (covers logout, idle timeout, and server restart — since the session map is reset on JVM start)
getLockInfo() updated
After parsing the lock file, calls isLockStale()
If stale, deletes the lock file via removeLockInfo() and returns null (i.e., behaves as if no lock exists)
removeLockInfo() simplified
No longer calls getLockInfo() first (which would have caused recursion now that getLockInfo() calls removeLockInfo())
Directly checks file existence and deletes it
**Effect**
isFileLocked() (unchanged, delegates to getLockInfo()) now correctly reports false for stale locks
Genuinely active locks (session still exists) are unaffected — the "lock is in use" dialog still shows correctly for real concurrent edits
No new configuration needed; reuses the existing server session timeout/lifecycle already governing logout, idle expiry, and restart behavior
Verified with spotless:apply/check, checkstyle:check, and module compile/test — all pass.