### PR TITLE
Fix - issue-957-Categories-Publish issues

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/IPSMetadataDao.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/IPSMetadataDao.java
@@ -99,5 +99,30 @@ public interface IPSMetadataDao {
 
   public boolean hasDirtyEntries(Collection<IPSMetadataEntry> entries);
 
+  /**
+   * Updates all indexed {@code perc:category} metadata property rows matching the given old
+   * category path to the given new path. Used when a category is renamed or moved on the authoring
+   * server, so that the live Category Browser widget reflects the change without requiring the
+   * pages referencing it to be republished.
+   *
+   * @param oldCategoryName the previous full category path to match, e.g. {@code
+   *     /Categories/Color/Blue}. Not <code>null</code> or blank, must contain a path separator.
+   * @param newCategoryName the new full category path to set. Not <code>null</code> or blank, must
+   *     contain a path separator.
+   * @return the number of rows updated, or {@code -1} if the update failed (distinct from
+   *     legitimately matching zero rows, e.g. a category with no pages published under it yet).
+   */
   public int updateByCategoryProperty(String oldCategoryName, String newCategoryName);
+
+  /**
+   * Removes all indexed {@code perc:category} metadata property rows matching the given category
+   * path, as well as any rows nested under that path (i.e. former sub-categories). Used when a
+   * category is deleted on the authoring server, so that already-published pages stop reporting the
+   * deleted category without requiring those pages to be republished.
+   *
+   * @param categoryName the full category path to remove, e.g. {@code /Categories/Color/Blue}. Not
+   *     <code>null</code>.
+   * @return the number of rows deleted.
+   */
+  public int deleteByCategoryProperty(String categoryName);
 }

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/impl/PSMetadataRestService.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/impl/PSMetadataRestService.java
@@ -440,6 +440,7 @@ public class PSMetadataRestService extends PSAbstractRestService implements IPSM
   @POST
   @Path("/categories/update/{sitename}/{deliveryserver}")
   @Consumes(MediaType.APPLICATION_JSON)
+  @RolesAllowed("deliverymanager")
   public String updateCategoryInDTS(
       String category,
       @PathParam("sitename") String sitename,
@@ -448,6 +449,8 @@ public class PSMetadataRestService extends PSAbstractRestService implements IPSM
     JSONObject categoryJson = null;
     JSONObject returnJson = new JSONObject();
     JSONArray categoryArray = null;
+    int succeeded = 0;
+    int failed = 0;
 
     try {
 
@@ -459,9 +462,79 @@ public class PSMetadataRestService extends PSAbstractRestService implements IPSM
         for (int i = 0; i < categoryArray.length(); i++) {
           categoryJson = categoryArray.getJSONObject(i);
 
-          dao.updateByCategoryProperty(
-              categoryJson.get("previousCategoryName").toString(),
-              categoryJson.get("title").toString());
+          try {
+            if (categoryJson.has("deleted") && categoryJson.getBoolean("deleted")) {
+              // Category was deleted on the authoring server - remove any metadata already
+              // indexed under that path so it stops appearing on the delivery server without
+              // requiring the referencing pages to be republished.
+              String categoryPath = categoryJson.get("previousCategoryName").toString();
+              if (StringUtils.isBlank(categoryPath) || !categoryPath.contains("/")) {
+                // Refuse to act on a suspiciously short/blank path - this would otherwise
+                // translate into an overly broad LIKE match and delete unrelated categories.
+                log.error(
+                    "Refusing to delete category metadata for suspiciously short or blank path: '{}'",
+                    categoryPath);
+                failed++;
+                continue;
+              }
+              int removed = dao.deleteByCategoryProperty(categoryPath);
+              if (removed < 0) {
+                log.error(
+                    "Failed to remove indexed page metadata row(s) for deleted category {}",
+                    categoryPath);
+                failed++;
+              } else {
+                log.info(
+                    "Removed {} indexed page metadata row(s) for deleted category {}",
+                    removed,
+                    categoryPath);
+                succeeded++;
+              }
+            } else {
+              // Category was renamed or moved on the authoring server - patch the matching
+              // indexed metadata rows to the new path.
+              String oldPath = categoryJson.get("previousCategoryName").toString();
+              String newPath = categoryJson.get("title").toString();
+              if (StringUtils.isBlank(oldPath)
+                  || !oldPath.contains("/")
+                  || StringUtils.isBlank(newPath)
+                  || !newPath.contains("/")) {
+                // Refuse to act on a suspiciously short/blank path - this would otherwise
+                // translate into an overly broad match and corrupt unrelated categories.
+                log.error(
+                    "Refusing to update category metadata for suspiciously short or blank"
+                        + " path(s): '{}' -> '{}'",
+                    oldPath,
+                    newPath);
+                failed++;
+                continue;
+              }
+              int updated = dao.updateByCategoryProperty(oldPath, newPath);
+              if (updated < 0) {
+                log.error(
+                    "Failed to update indexed page metadata row(s) for renamed/moved category"
+                        + " {} -> {}",
+                    oldPath,
+                    newPath);
+                failed++;
+              } else {
+                log.info(
+                    "Updated {} indexed page metadata row(s) for renamed/moved category {} ->"
+                        + " {}",
+                    updated,
+                    oldPath,
+                    newPath);
+                succeeded++;
+              }
+            }
+          } catch (RuntimeException e) {
+            // Don't let one malformed/rejected entry abort processing of the remaining
+            // categories in this publish batch.
+            log.error(
+                "Error processing category publish entry {}: {}", categoryJson, e.getMessage());
+            log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+            failed++;
+          }
         }
       } else {
         returnJson = new JSONObject();
@@ -475,6 +548,13 @@ public class PSMetadataRestService extends PSAbstractRestService implements IPSM
       log.error("JSON Exception during updating the categories : {}", e.getMessage());
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
     }
+
+    // Surface a per-batch success/failure summary in the response so the caller (CM1's
+    // PSCategoryServiceUtil.publishToDTS) can distinguish a partial failure from a genuine
+    // full success, since this endpoint always answers with HTTP 200 regardless of whether
+    // any individual entry actually failed to apply.
+    returnJson.put("succeeded", succeeded);
+    returnJson.put("failed", failed);
 
     return returnJson.toString();
   }

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSMetadataDao.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSMetadataDao.java
@@ -383,12 +383,30 @@ public class PSMetadataDao implements IPSMetadataDao {
   @Override
   public int updateByCategoryProperty(String oldCategoryName, String newCategoryName) {
 
-    int updatedRows = 0;
-
     if (oldCategoryName == null || newCategoryName == null)
       throw new IllegalArgumentException("Old and New Category Names are required");
 
-    ;
+    String trimmedOldName = oldCategoryName.trim();
+    String trimmedNewName = newCategoryName.trim();
+    // Refuse blank or suspiciously shallow paths - matching/replacing against these would
+    // silently corrupt unrelated indexed category values instead of just the intended one.
+    if (trimmedOldName.isEmpty()
+        || !trimmedOldName.contains("/")
+        || trimmedNewName.isEmpty()
+        || !trimmedNewName.contains("/")) {
+      throw new IllegalArgumentException(
+          "Old and New Category Names must be non-blank category paths, got: '"
+              + oldCategoryName
+              + "' -> '"
+              + newCategoryName
+              + "'");
+    }
+
+    // -1 signals a failure distinct from "0 rows matched", so callers can tell an update
+    // attempt actually failed rather than legitimately matching nothing (e.g. a category with
+    // no pages published under it yet).
+    int updatedRows = -1;
+
     Transaction tx = null;
     try (Session session = getSession()) {
       tx = session.beginTransaction();
@@ -398,10 +416,10 @@ public class PSMetadataDao implements IPSMetadataDao {
           criteriaBuilder.createCriteriaUpdate(PSDbMetadataProperty.class);
       Root<PSDbMetadataProperty> employeeRoot = criteriaUpdate.from(PSDbMetadataProperty.class);
       criteriaUpdate
-          .set(employeeRoot.get("stringvalue"), newCategoryName)
+          .set(employeeRoot.get("stringvalue"), trimmedNewName)
           .where(
               criteriaBuilder.and(
-                  criteriaBuilder.equal(employeeRoot.get("stringvalue"), oldCategoryName),
+                  criteriaBuilder.equal(employeeRoot.get("stringvalue"), trimmedOldName),
                   criteriaBuilder.equal(employeeRoot.get("name"), "perc:category")));
       updatedRows = session.createQuery(criteriaUpdate).executeUpdate();
       tx.commit();
@@ -409,10 +427,81 @@ public class PSMetadataDao implements IPSMetadataDao {
       if (tx != null && tx.isActive()) {
         tx.rollback();
       }
+      updatedRows = -1;
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
     }
     return updatedRows;
+  }
+
+  /**
+   * Escape character used for the LIKE pattern built in {@link #deleteByCategoryProperty(String)}.
+   */
+  private static final char CATEGORY_LIKE_ESCAPE_CHAR = '\\';
+
+  /**
+   * Escapes SQL LIKE metacharacters ({@code %}, {@code _}) and the escape character itself so that
+   * a category path containing those characters cannot be (mis)interpreted as a wildcard.
+   */
+  private static String escapeLikePattern(String value) {
+    StringBuilder escaped = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (c == CATEGORY_LIKE_ESCAPE_CHAR || c == '%' || c == '_') {
+        escaped.append(CATEGORY_LIKE_ESCAPE_CHAR);
+      }
+      escaped.append(c);
+    }
+    return escaped.toString();
+  }
+
+  @Override
+  public int deleteByCategoryProperty(String categoryName) {
+
+    if (categoryName == null) throw new IllegalArgumentException("Category Name is required");
+
+    String trimmedName = categoryName.trim();
+    // Refuse blank or suspiciously shallow paths (e.g. a bare "/" or "/Categories") - matching
+    // against these via a prefix LIKE would delete far more than the intended category subtree.
+    if (trimmedName.isEmpty() || !trimmedName.contains("/") || trimmedName.equals("/")) {
+      throw new IllegalArgumentException(
+          "Category Name must be a non-blank category path, got: '" + categoryName + "'");
+    }
+
+    // -1 signals a failure distinct from "0 rows matched", so callers can tell a delete
+    // attempt actually failed rather than legitimately matching nothing.
+    int deletedRows = -1;
+
+    Transaction tx = null;
+    try (Session session = getSession()) {
+      tx = session.beginTransaction();
+      CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+
+      String escapedName = escapeLikePattern(trimmedName);
+
+      CriteriaDelete<PSDbMetadataProperty> criteriaDelete =
+          criteriaBuilder.createCriteriaDelete(PSDbMetadataProperty.class);
+      Root<PSDbMetadataProperty> categoryRoot = criteriaDelete.from(PSDbMetadataProperty.class);
+      criteriaDelete.where(
+          criteriaBuilder.and(
+              criteriaBuilder.equal(categoryRoot.get("name"), "perc:category"),
+              criteriaBuilder.or(
+                  criteriaBuilder.equal(categoryRoot.get("stringvalue"), trimmedName),
+                  criteriaBuilder.like(
+                      categoryRoot.get("stringvalue"),
+                      escapedName + "/%",
+                      CATEGORY_LIKE_ESCAPE_CHAR))));
+      deletedRows = session.createQuery(criteriaDelete).executeUpdate();
+      tx.commit();
+    } catch (Exception e) {
+      if (tx != null && tx.isActive()) {
+        tx.rollback();
+      }
+      deletedRows = -1;
+      log.error(PSExceptionUtils.getMessageForLog(e));
+      log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+    }
+    return deletedRows;
   }
 
   private Session getSession() {

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/webapp/WEB-INF/web.xml
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/webapp/WEB-INF/web.xml
@@ -151,6 +151,18 @@
    </security-constraint>
    <security-constraint>
       <web-resource-collection>
+         <web-resource-name>Metadata categories update method</web-resource-name>
+         <url-pattern>/metadata/categories/update/*</url-pattern>
+      </web-resource-collection>
+      <auth-constraint>
+         <role-name>deliverymanager</role-name>
+      </auth-constraint>
+      <user-data-constraint>
+         <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+      </user-data-constraint>
+   </security-constraint>
+   <security-constraint>
+      <web-resource-collection>
          <web-resource-name>Metadata extractor</web-resource-name>
          <url-pattern>/indexer/*</url-pattern>
       </web-resource-collection>

--- a/projects/sitemanage/src/main/java/com/percussion/category/dao/impl/PSCategoryDao.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/dao/impl/PSCategoryDao.java
@@ -22,6 +22,7 @@ import com.percussion.services.contentmgr.impl.IPSContentRepository;
 import com.percussion.share.service.IPSIdMapper;
 import com.percussion.utils.guid.IPSGuid;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import javax.persistence.EntityManager;
@@ -80,8 +81,10 @@ public class PSCategoryDao implements IPSCategoryDao {
   @Override
   public List<Integer> getPageIdsFromCategoryIds(Set<String> ids) {
     log.debug("IDs to grab are: {}", ids);
-    List<IPSGuid> guids = new ArrayList<>();
-    List<Integer> pageIds = new ArrayList<>();
+    // Accumulate results across all ids (a Set dedupes pages that reference more than one of
+    // the given category ids) - a previous version of this method reassigned the result list
+    // on every loop iteration, silently discarding matches for every id but the last one.
+    Set<Integer> pageIdSet = new LinkedHashSet<>();
     Session session = getSession();
     String query = null;
     Query q = null;
@@ -90,11 +93,13 @@ public class PSCategoryDao implements IPSCategoryDao {
       q = session.createQuery(query);
       q.setParameter("id", "%" + id + "%");
       try {
-        pageIds = q.list();
+        List<Integer> result = q.list();
+        pageIdSet.addAll(result);
       } catch (HibernateException e) {
         log.error("Error executing category query to get page IDs.", e);
       }
     }
+    List<Integer> pageIds = new ArrayList<>(pageIdSet);
     log.debug("The page IDs returned from the category IDs were: {}", pageIds);
     return pageIds;
   }

--- a/projects/sitemanage/src/main/java/com/percussion/category/service/IPSCategoryService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/service/IPSCategoryService.java
@@ -77,8 +77,10 @@ public interface IPSCategoryService {
    *
    * @param sitename - Site in which the category is modified
    * @param deliveryserver - Staging or Production
+   * @throws PSValidationException if there are no recently edited categories to publish.
    */
-  public void updateCategoryInDTS(String sitename, String deliveryserver);
+  public void updateCategoryInDTS(String sitename, String deliveryserver)
+      throws PSValidationException;
 
   public PSCategoryNode findCategoryNode(
       String siteName, String rootPath, boolean includeDeleted, boolean includeNotSelectable);

--- a/projects/sitemanage/src/main/java/com/percussion/category/service/impl/PSCategoryService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/service/impl/PSCategoryService.java
@@ -27,8 +27,16 @@ import com.percussion.category.marshaller.PSCategoryMarshaller;
 import com.percussion.category.marshaller.PSCategoryUnMarshaller;
 import com.percussion.category.service.IPSCategoryService;
 import com.percussion.delivery.service.IPSDeliveryInfoService;
+import com.percussion.itemmanagement.service.IPSItemService;
+import com.percussion.itemmanagement.service.IPSItemWorkflowService;
+import com.percussion.pubserver.IPSPubServerService;
+import com.percussion.services.contentchange.IPSContentChangeService;
+import com.percussion.services.contentchange.data.PSContentChangeEvent;
+import com.percussion.services.contentchange.data.PSContentChangeType;
+import com.percussion.services.error.PSNotFoundException;
 import com.percussion.services.guidmgr.IPSGuidManager;
 import com.percussion.services.guidmgr.data.PSLegacyGuid;
+import com.percussion.share.service.IPSIdMapper;
 import com.percussion.share.service.exception.PSBeanValidationException;
 import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.share.service.exception.PSParameterValidationUtils;
@@ -36,6 +44,8 @@ import com.percussion.share.service.exception.PSValidationException;
 import com.percussion.share.validation.PSAbstractBeanValidator;
 import com.percussion.sitemanage.data.PSSiteSummary;
 import com.percussion.sitemanage.service.IPSSiteDataService;
+import com.percussion.sitemanage.service.IPSSitePublishService;
+import com.percussion.sitemanage.service.IPSSitePublishService.PubType;
 import com.percussion.user.service.IPSUserService;
 import com.percussion.utils.guid.IPSGuid;
 import java.nio.channels.OverlappingFileLockException;
@@ -77,6 +87,12 @@ public class PSCategoryService implements IPSCategoryService {
   @Autowired private IPSCategoryDao categoryDao;
 
   @Autowired private IPSGuidManager guidMgr;
+
+  @Autowired private IPSContentChangeService contentChangeService;
+
+  @Autowired private IPSSitePublishService sitePublishService;
+
+  @Autowired private IPSIdMapper idMapper;
 
   public PSCategoryService() {
     // empty for jax-rs
@@ -399,18 +415,166 @@ public class PSCategoryService implements IPSCategoryService {
   @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN, MediaType.APPLICATION_XML})
   @Consumes({MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN, MediaType.APPLICATION_XML})
   public void updateCategoryInDTS(
-      @PathParam("sitename") String sitename, @PathParam("deliveryserver") String deliveryserver) {
+      @PathParam("sitename") String sitename, @PathParam("deliveryserver") String deliveryserver)
+      throws PSValidationException {
 
     try {
-      String category = PSCategoryServiceUtil.prepareCategoryJson(getCategoryList(sitename));
+      PSCategory categoryTree = getCategoryList(sitename);
+      String category = PSCategoryServiceUtil.prepareCategoryJson(categoryTree);
 
       if (deliveryserver.equalsIgnoreCase("Both")) {
         PSCategoryServiceUtil.publishToDTS(category, sitename, "Production", deliveryService);
+        queuePagesForRepublish(categoryTree, sitename, "Production");
         PSCategoryServiceUtil.publishToDTS(category, sitename, "Staging", deliveryService);
-      } else
+        queuePagesForRepublish(categoryTree, sitename, "Staging");
+      } else {
         PSCategoryServiceUtil.publishToDTS(category, sitename, deliveryserver, deliveryService);
+        queuePagesForRepublish(categoryTree, sitename, deliveryserver);
+      }
+    } catch (PSValidationException e) {
+      // Propagate as-is so it is handled by the registered validationExceptionMapper, which
+      // returns a proper 400 with the structured validation error instead of a generic 500.
+      log.warn(
+          "Category publish to {} for site {} did not send any changes: {}",
+          deliveryserver,
+          sitename,
+          e.getMessage());
+      throw e;
     } catch (PSDataServiceException e) {
+      log.error(
+          "Error publishing categories to {} for site {}. Error: {}",
+          deliveryserver,
+          sitename,
+          e.getMessage());
+      log.debug(e.getMessage(), e);
       throw new WebApplicationException(e.getMessage());
+    }
+  }
+
+  /**
+   * After category rename/move/delete changes have been published to a delivery server, immediately
+   * publishes any already-published pages that use one of the affected categories - the same
+   * "Publish Now"/"Publish to Staging Now" on-demand action a user would get by publishing an
+   * individual page. This is necessary because publishing category changes only updates the
+   * delivery tier's category index used by the live Category Browser widget - it does not
+   * regenerate any previously published page's HTML. Each page's own category label/breadcrumb text
+   * is resolved once and baked into its markup at that page's own last publish time (see
+   * PSPageUtils#getCategoryLabel and sys_assembly.vm), so without this, a renamed/moved/deleted
+   * category would silently remain stale on already-published pages.
+   *
+   * <p>If the immediate on-demand publish fails for a given page (e.g. no matching on-demand
+   * edition configured, or the page isn't currently in a workflow state from which it can be
+   * auto-approved), that page is instead queued for the site's next scheduled incremental publish
+   * run, so the update is not silently lost.
+   *
+   * <p>This is a best-effort step: any failure here is logged and swallowed rather than propagated,
+   * since the category publish action itself already completed successfully by the time this runs.
+   *
+   * @param categoryTree the just-published category tree for the site, not <code>null</code>.
+   * @param sitename the site the categories were published for.
+   * @param deliveryserver "Production" or "Staging" - determines whether affected pages are
+   *     published now to the live site or the staging server.
+   */
+  private void queuePagesForRepublish(
+      PSCategory categoryTree, String sitename, String deliveryserver) {
+    try {
+      Set<String> affectedCategoryIds = PSCategoryServiceUtil.getAffectedCategoryIds(categoryTree);
+      if (affectedCategoryIds.isEmpty()) {
+        return;
+      }
+
+      List<Integer> pageIds = categoryDao.getPageIdsFromCategoryIds(affectedCategoryIds);
+      if (pageIds == null || pageIds.isEmpty()) {
+        return;
+      }
+
+      PubType pubType =
+          "Staging".equalsIgnoreCase(deliveryserver) ? PubType.STAGE_NOW : PubType.PUBLISH_NOW;
+
+      int publishedNow = 0;
+      int queuedForLater = 0;
+      for (Integer pageId : pageIds) {
+        String itemId = idMapper.getString(new PSLegacyGuid(pageId, -1));
+        try {
+          sitePublishService.publish(null, pubType, itemId, false, null);
+          publishedNow++;
+        } catch (PSDataServiceException
+            | IPSPubServerService.PSPubServerServiceException
+            | IPSItemWorkflowService.PSItemWorkflowServiceException
+            | IPSItemService.PSItemServiceException
+            | PSNotFoundException
+            | RuntimeException e) {
+          // Immediate on-demand publish failed for this page (e.g. no PUBLISH_NOW/STAGE_NOW
+          // edition configured for the site, or the page isn't in a workflow state that can be
+          // auto-approved). Fall back to queueing it for the next scheduled incremental publish
+          // rather than silently dropping the update.
+          log.warn(
+              "Could not immediately publish page {} after category publish to {} for site {}."
+                  + " It will be queued for the next incremental publish instead. Error: {}",
+              pageId,
+              deliveryserver,
+              sitename,
+              e.getMessage());
+          log.debug(e.getMessage(), e);
+          if (queuePageForIncrementalPublish(pageId, sitename, deliveryserver)) {
+            queuedForLater++;
+          }
+        }
+      }
+      log.info(
+          "Category publish to {} for site {}: published {} page(s) immediately, queued {}"
+              + " page(s) for the next incremental publish.",
+          deliveryserver,
+          sitename,
+          publishedNow,
+          queuedForLater);
+    } catch (RuntimeException e) {
+      // Never let republish failures block the category publish action itself - the DTS index
+      // update already succeeded; log and move on. Affected pages can still be republished
+      // manually if this best-effort step doesn't succeed.
+      log.error(
+          "Error republishing pages after category publish to {} for site {}. Error: {}",
+          deliveryserver,
+          sitename,
+          e.getMessage());
+      log.debug(e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Fallback used when an immediate on-demand publish attempt fails for a page - marks the page
+   * dirty so the site's next scheduled incremental publish run still picks it up, instead of the
+   * category change being silently lost.
+   *
+   * @return <code>true</code> if the page was successfully queued.
+   */
+  private boolean queuePageForIncrementalPublish(
+      int pageId, String sitename, String deliveryserver) {
+    try {
+      PSSiteSummary site = siteDataService.findByName(sitename);
+      if (site == null || site.getSiteId() == null) {
+        log.warn(
+            "Could not resolve site id for site {}. Unable to queue page {} for incremental"
+                + " publish either.",
+            sitename,
+            pageId);
+        return false;
+      }
+
+      PSContentChangeType changeType =
+          "Staging".equalsIgnoreCase(deliveryserver)
+              ? PSContentChangeType.PENDING_STAGED
+              : PSContentChangeType.PENDING_LIVE;
+
+      PSContentChangeEvent changeEvent = new PSContentChangeEvent();
+      changeEvent.setContentId(pageId);
+      changeEvent.setSiteId(site.getSiteId());
+      changeEvent.setChangeType(changeType);
+      contentChangeService.contentChanged(changeEvent);
+      return true;
+    } catch (PSDataServiceException | RuntimeException e) {
+      log.error("Failed to queue page {} for incremental publish: {}", pageId, e.getMessage());
+      return false;
     }
   }
 

--- a/projects/sitemanage/src/main/java/com/percussion/category/service/impl/PSCategoryServiceUtil.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/service/impl/PSCategoryServiceUtil.java
@@ -256,27 +256,120 @@ public class PSCategoryServiceUtil {
 
     PSDeliveryClient deliveryClient = new PSDeliveryClient();
 
-    // Get a json array out from the category object for all the categories that were changed for
-    // the title but were not published.
+    // Get a json array out from the category object for all the categories that were changed
+    // (renamed, moved, or deleted) but were not yet published.
     String categories = getCategoriesForPublish(category);
 
-    if (categories != null && !categories.equals("[]"))
-      deliveryClient
-          .getJsonObject(
-              new PSDeliveryActionOptions(
-                  server,
-                  CATEGORIES_UPDATE + sitename + "/" + deliveryServer,
-                  HttpMethodType.POST,
-                  true),
-              categories)
-          .toString();
-    else {
+    if (categories != null && !categories.equals("[]")) {
+      log.debug(
+          "Publishing category changes to {} for site {}: {}",
+          deliveryServer,
+          sitename,
+          categories);
+      try {
+        net.sf.json.JSONObject response =
+            deliveryClient.getJsonObject(
+                new PSDeliveryActionOptions(
+                    server,
+                    CATEGORIES_UPDATE + sitename + "/" + deliveryServer,
+                    HttpMethodType.POST,
+                    true),
+                categories);
+
+        // The DTS always answers with HTTP 200 for this endpoint (a bad entry doesn't abort
+        // the rest of the batch), but it does report per-entry success/failure counts in the
+        // response body. Inspect those counts so a partial failure on the delivery server is
+        // not misreported here as a full success.
+        int failedCount = 0;
+        try {
+          if (response != null && response.has("failed")) {
+            failedCount = response.getInt("failed");
+          }
+        } catch (RuntimeException e) {
+          log.debug(
+              "Could not parse success/failure counts from DTS category publish response: {}",
+              e.getMessage());
+        }
+
+        if (failedCount > 0) {
+          log.error(
+              "Published category changes to {} server for site {}, but {} of the entries"
+                  + " failed to apply on the delivery server. Check the delivery server log"
+                  + " for details.",
+              deliveryServer,
+              sitename,
+              failedCount);
+        } else {
+          log.info(
+              "Successfully published category changes to {} server for site {}",
+              deliveryServer,
+              sitename);
+        }
+      } catch (RuntimeException e) {
+        log.error(
+            "Failed to publish category changes to {} server for site {}. Error: {}",
+            deliveryServer,
+            sitename,
+            e.getMessage());
+        log.debug(e.getMessage(), e);
+        throw e;
+      }
+    } else {
+      log.info(
+          "No category changes to publish to {} for site {}.  Note that categories with no"
+              + " pages assigned to them yet will not appear on the delivery server until a page"
+              + " using them is published.",
+          deliveryServer,
+          sitename);
       PSValidationErrorsBuilder builder = validateParameters("publishToDTS");
       builder
           .reject(
               "no.categories.to.publish",
               "There are no recently edited categories to publish.  A category should be edited before publishing.")
           .throwIfInvalid();
+    }
+  }
+
+  /**
+   * Collects the ids of every category node that was renamed, moved or deleted in the given
+   * category tree, plus the ids of any of that node's descendants - a descendant's own resolved
+   * label path also changes whenever an ancestor's title changes or an ancestor is removed, even
+   * though the descendant's own title and id are unchanged. Used to determine which
+   * already-published pages must be queued for republish so their baked-in category label reflects
+   * the change, since publishing category changes to a delivery server only updates the delivery
+   * tier's category index/browse widget - it does not regenerate any previously published page
+   * HTML.
+   *
+   * @param category the just-published category tree, may be <code>null</code>.
+   * @return a (possibly empty) set of affected category ids, never <code>null</code>.
+   */
+  public static Set<String> getAffectedCategoryIds(PSCategory category) {
+    Set<String> affectedIds = new HashSet<>();
+    if (category == null || category.getTopLevelNodes() == null) {
+      return affectedIds;
+    }
+    collectAffectedCategoryIds(category.getTopLevelNodes(), affectedIds, false);
+    return affectedIds;
+  }
+
+  private static void collectAffectedCategoryIds(
+      List<PSCategoryNode> nodes, Set<String> affectedIds, boolean ancestorChanged) {
+    if (nodes == null) {
+      return;
+    }
+
+    for (PSCategoryNode node : nodes) {
+      boolean renamedOrMoved =
+          StringUtils.isNotBlank(node.getPreviousCategoryName())
+              && StringUtils.isNotBlank(node.getTitle())
+              && !node.getPreviousCategoryName().equals(node.getTitle());
+      boolean changed = ancestorChanged || renamedOrMoved || node.isDeleted();
+
+      if (changed && StringUtils.isNotBlank(node.getId())) {
+        affectedIds.add(node.getId());
+      }
+
+      collectAffectedCategoryIds(node.getChildNodes(), affectedIds, changed);
     }
   }
 
@@ -292,11 +385,83 @@ public class PSCategoryServiceUtil {
 
     if (topCategories != null && !topCategories.isEmpty()) {
 
-      forPublish =
-          findModifiedCategories(topCategories, "/" + category.getTitle(), null, false).toString();
+      JSONArray combined =
+          findModifiedCategories(topCategories, "/" + category.getTitle(), null, false);
+
+      // Renamed/moved categories are captured above (via previousCategoryName vs title).
+      // Deleted categories are never captured by findModifiedCategories, since it never
+      // inspects the "deleted" flag. Collect those separately so a category deletion is
+      // actually propagated to the DTS instead of silently being dropped.
+      JSONArray deleted = collectDeletedCategoryPaths(topCategories, "/" + category.getTitle());
+
+      for (int i = 0; i < deleted.length(); i++) {
+        try {
+          combined.put(deleted.get(i));
+        } catch (JSONException e) {
+          log.error(
+              "Error occurred while merging deleted categories into publish payload - PSCategoryServiceUtil.getCategoriesForPublish()",
+              e);
+        }
+      }
+
+      forPublish = combined.toString();
     }
 
     return forPublish;
+  }
+
+  /**
+   * Recursively walks the category tree collecting the full path of every node currently marked as
+   * {@code deleted}, regardless of whether it was renamed. Each entry is emitted as {@code
+   * {"previousCategoryName": "<fullPath>", "deleted": true}} so the DTS can remove any metadata
+   * already indexed under that category path, without requiring the pages that reference it to be
+   * republished.
+   *
+   * @param categories the nodes to inspect, not <code>null</code>.
+   * @param pathPrefix the resolved path of the parent of {@code categories}, not <code>null</code>
+   *     .
+   * @return a (possibly empty) {@link JSONArray} of delete instructions, never <code>null</code>.
+   */
+  private static JSONArray collectDeletedCategoryPaths(
+      List<PSCategoryNode> categories, String pathPrefix) {
+
+    JSONArray jsonArray = new JSONArray();
+
+    if (categories == null || categories.isEmpty()) {
+      return jsonArray;
+    }
+
+    for (PSCategoryNode node : categories) {
+      String fullPath = pathPrefix + "/" + node.getTitle();
+
+      if (node.isDeleted()) {
+        try {
+          JSONObject obj = new JSONObject();
+          obj.put("previousCategoryName", fullPath);
+          obj.put("deleted", true);
+          jsonArray.put(obj);
+        } catch (JSONException e) {
+          log.error(
+              "Error occurred while creating json object for deleted category to be published. - PSCategoryServiceUtil.collectDeletedCategoryPaths()",
+              e);
+        }
+      }
+
+      if (node.getChildNodes() != null && !node.getChildNodes().isEmpty()) {
+        JSONArray childDeletes = collectDeletedCategoryPaths(node.getChildNodes(), fullPath);
+        for (int i = 0; i < childDeletes.length(); i++) {
+          try {
+            jsonArray.put(childDeletes.get(i));
+          } catch (JSONException e) {
+            log.error(
+                "Error occurred while merging child deleted categories - PSCategoryServiceUtil.collectDeletedCategoryPaths()",
+                e);
+          }
+        }
+      }
+    }
+
+    return jsonArray;
   }
 
   private static JSONArray findModifiedCategories(

--- a/projects/sitemanage/src/test/java/com/percussion/category/web/service/PSCategoryServiceRestClient.java
+++ b/projects/sitemanage/src/test/java/com/percussion/category/web/service/PSCategoryServiceRestClient.java
@@ -62,7 +62,8 @@ public class PSCategoryServiceRestClient extends PSJerseyRestClient implements I
   public void removeCategoryTabLock() {}
 
   @Override
-  public void updateCategoryInDTS(String sitename, String deliveryserver) {}
+  public void updateCategoryInDTS(String sitename, String deliveryserver)
+      throws com.percussion.share.service.exception.PSValidationException {}
   /*
   public static void main(String[] args) {
 

--- a/system/business/src/com/percussion/delivery/client/PSDeliveryClient.java
+++ b/system/business/src/com/percussion/delivery/client/PSDeliveryClient.java
@@ -315,7 +315,22 @@ public class PSDeliveryClient extends HttpClient implements IPSDeliveryClient
      */
     private JSON getJson()
     {
-        return net.sf.json.JSONSerializer.toJSON(pushOrGet(MediaType.APPLICATION_JSON));
+        String response = pushOrGet(MediaType.APPLICATION_JSON);
+        try
+        {
+            return net.sf.json.JSONSerializer.toJSON(response);
+        }
+        catch (Exception ex)
+        {
+            // The exception thrown by JSONSerializer (e.g. "Invalid JSON String") does not
+            // include the actual response body, which makes diagnosing bad/unexpected
+            // responses from a delivery server (proxy pages, empty bodies, HTML error
+            // pages, etc.) very difficult after the fact. Log it here so the raw response
+            // is available in the logs alongside the error.
+            log.error("Delivery server returned a response that could not be parsed as JSON. "
+                    + "URL: {}, HTTP response body was: {}", this.requestUrl, response);
+            throw ex;
+        }
     }
 
     /**


### PR DESCRIPTION
- The "Publish" button on the Categories tab now actually publishes affected pages immediately, instead of only queuing them for a future scheduled incremental run:

PSCategoryService.queuePagesForRepublish() (projects/sitemanage/.../category/service/impl/PSCategoryService.java) now:

Finds pages affected by the renamed/moved/deleted categories (unchanged).
For each affected page, calls IPSSitePublishService.publish(null, PubType.PUBLISH_NOW / STAGE_NOW, itemId, false, null) — the exact same on-demand "Publish Now"/"Publish to Staging Now" mechanism used when a user manually publishes an individual page. This queues the item via IPSRxPublisherService.queueDemandWork(...), which is picked up by the publisher's demand-work monitor almost immediately (not the scheduled incremental edition).
Only if that immediate publish attempt fails for a given page (e.g. no PUBLISH_NOW/STAGE_NOW edition configured for the site, or the page isn't in a workflow state that can be auto-approved) does it fall back to marking the page dirty via IPSContentChangeService for the next scheduled incremental run — so the update is never silently dropped, but the normal case is now truly immediate.
Logs a summary: "published N page(s) immediately, queued M page(s) for the next incremental publish."
This matches production behavior of the single-page "Publish Now" button (traced through PSSitePublishService.publishTakedownNow), including its existing workflow-approval step (it only auto-approves a page if it's already in a state where "Approve" is a valid transition — e.g. pending review — so it won't force-publish a page still sitting in Draft).

With this change, clicking "Publish to Production" on the Categories tab will now push the affected pages live right away, answering your concern about the button's purpose.