### PR TITLE
Add 006-systemd-linux-services spec artifacts

### DIFF
--- a/specs/006-systemd-linux-services/checklists/requirements.md
+++ b/specs/006-systemd-linux-services/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Systemd Linux Service Scripts (Replace init.d)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-11
+**Feature**: [spec.md](./spec.md)
+**Source issue**: intersoftdatalabs-in/percussioncms#962
+**Feature directory**: `specs/006-systemd-linux-services`
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs) — spec names systemd / unit files / environment files as the user-visible concept, not as implementation choice
+- [x] Focused on user value and business needs — every story ties to integrator / operator experience
+- [x] Written for non-technical stakeholders — uses operator terminology (install, upgrade, status)
+- [x] All mandatory sections completed — Module Scope, User Scenarios, Requirements, Success Criteria, Assumptions all present
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain — three open questions are listed in the "Open Questions" section for the dedicated `/speckit.clarify` pass (which is the prescribed flow per the speckit handoff)
+- [x] Requirements are testable and unambiguous — each FR-XXX has a single, observable outcome
+- [x] Success criteria are measurable — SC-001..SC-006 each have a metric or a verifiable check
+- [x] Success criteria are technology-agnostic — measured in operator-visible terms (time, file presence, port reachability, command exit), not in JVM / Maven terms
+- [x] All acceptance scenarios are defined — four user stories, each with 2-4 Given/When/Then scenarios
+- [x] Edge cases are identified — non-systemd hosts, containers, non-root paths, multi-instance, partial migration, SELinux, power-loss interruption
+- [x] Scope is clearly bounded — explicitly about Linux service scripts for CMS and DTS; explicitly NOT changing the CMS runtime
+- [x] Dependencies and assumptions identified — Jetty wrapper unchanged, distro tree is the ship vehicle, JDK 21 build wiring
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria — FR-001..FR-013 map to user stories or success criteria
+- [x] User scenarios cover primary flows — fresh install, in-place upgrade, operator lifecycle, DTS coverage
+- [x] Feature meets measurable outcomes defined in Success Criteria — SC-001..SC-006 are achievable by the FR set
+- [x] No implementation details leak into specification — no class names, no Maven coordinates, no code snippets
+
+## Notes
+
+- The three "Open Questions" (Q1 supported-platform matrix / Q2 init.d removal scope / Q3 multi-instance) are RESOLVED via `/speckit.clarify` (2026-07-11). Resolutions are recorded in the spec's `## Clarifications` section and applied to FR-004a, FR-006a, FR-007, and the multi-instance edge case.
+- The spec references concrete existing paths (`system/release/installer/Linux/percussion-service.sh`, `modules/perc-jetty/.../rxjetty.sh`, `deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/DTSStagingService.sh`) to ground the change in the real codebase, per constitution principle II (Evidence Over Invention).
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan` — none currently incomplete.

--- a/specs/006-systemd-linux-services/contracts/env-file.md
+++ b/specs/006-systemd-linux-services/contracts/env-file.md
@@ -1,0 +1,75 @@
+# Contract: /etc/percussion/cms-<instance>.env
+
+**Date**: 2026-07-11
+
+This contract specifies the per-instance environment file read by the systemd unit via `EnvironmentFile=`.
+
+## File location
+
+`/etc/percussion/cms-<instance>.env`
+
+Where `<instance>` matches the systemd template instance name (`default` for a single-instance install; `instance2`, `instance3`, … for multi-instance).
+
+## File mode / ownership
+
+- Mode: `0640`
+- Owner: `root:<JETTY_USER-group>` (group matches the runtime user)
+- The unit's `User=` and `Group=` (set from this file) MUST have read access.
+
+## Format
+
+Plain text, one `key=value` per line, `LF` line endings. No `export` prefix. No command substitution. systemd reads the file as `key=value` without shell expansion.
+
+## Required keys
+
+| Key | Example | Description |
+|-----|---------|-------------|
+| `PERC_ROOT` | `/opt/percussion/perc-cms` | Install root |
+| `JETTY_HOME` | `/opt/percussion/perc-cms/Jetty/upstream` | Jetty home |
+| `JETTY_BASE` | `/opt/percussion/perc-cms/Jetty/base` | Jetty base |
+| `JETTY_DEFAULTS` | `/opt/percussion/perc-cms/Jetty/defaults` | Jetty defaults |
+| `JETTY_RUN` | `/var/run/rxjetty/perc-cms` | Runtime dir |
+| `JETTY_CONF` | `/opt/percussion/perc-cms/Jetty/base/etc/jetty.conf` | Jetty config |
+| `JETTY_START_LOG` | `/opt/percussion/perc-cms/Jetty/base/logs/start.log` | Start log |
+| `JETTY_PID` | `/var/run/rxjetty/perc-cms/rxjetty.pid` | PID file |
+| `JAVA_HOME` | `/opt/percussion/perc-cms/JRE64` | JDK install |
+| `JAVA` | `${JAVA_HOME}/bin/java` | java binary |
+| `JAVA_OPTIONS` | `-XX:+DisableAttachMechanism -Drxdeploydir=...` | JVM options (single line, no embedded newlines) |
+| `JETTY_ARGS` | `--include-jetty-dir=...` | Jetty args |
+| `JETTY_USER` | `percussion` | Runtime user |
+| `INSTANCE_NAME` | `default` | The instance identifier |
+
+## Validation
+
+A file is "valid" when:
+
+1. Mode is exactly `0640` (verified by `stat -c '%a'`).
+2. All required keys are present.
+3. All path values resolve to existing directories or files on disk.
+4. No line contains `$(`, backticks, or `export ` (migration script defensively rejects these).
+5. `systemctl show percussioncms@<instance>.service -p Environment` shows all expected `KEY=VALUE` pairs (substituting actual env values from the file).
+
+## Security notes (SC-006)
+
+- This file MUST NOT contain DB passwords, JWT signing keys, or other secrets. Secrets belong in CMS application config under `${PERC_ROOT}/rxconfig/Server/`, which is protected by OS file permissions on the install tree (not by this file).
+- Migration from legacy `/etc/default/<name>` files: the migration script copies non-secret keys and WARNs (does not silently drop) on any key matching a known-secret pattern (`PASSWORD`, `SECRET`, `KEY`, `TOKEN` in the value).
+- The directory `/etc/percussion/` MUST be created with mode `0755 root:root`; per-file mode is `0640` as above.
+
+## Example (illustrative, not for direct copy)
+
+```ini
+PERC_ROOT=/opt/percussion/perc-cms
+JETTY_HOME=/opt/percussion/perc-cms/Jetty/upstream
+JETTY_BASE=/opt/percussion/perc-cms/Jetty/base
+JETTY_DEFAULTS=/opt/percussion/perc-cms/Jetty/defaults
+JETTY_RUN=/var/run/rxjetty/perc-cms
+JETTY_CONF=/opt/percussion/perc-cms/Jetty/base/etc/jetty.conf
+JETTY_START_LOG=/opt/percussion/perc-cms/Jetty/base/logs/start.log
+JETTY_PID=/var/run/rxjetty/perc-cms/rxjetty.pid
+JAVA_HOME=/opt/percussion/perc-cms/JRE64
+JAVA=/opt/percussion/perc-cms/JRE64/bin/java
+JAVA_OPTIONS=-XX:+DisableAttachMechanism -Drxdeploydir=/opt/percussion/perc-cms -Djetty_perc_defaults=/opt/percussion/perc-cms/Jetty/defaults
+JETTY_ARGS=--include-jetty-dir=/opt/percussion/perc-cms/Jetty/defaults
+JETTY_USER=percussion
+INSTANCE_NAME=default
+```

--- a/specs/006-systemd-linux-services/contracts/installer-script.md
+++ b/specs/006-systemd-linux-services/contracts/installer-script.md
@@ -1,0 +1,68 @@
+# Contract: install-systemd-units.sh
+
+**Date**: 2026-07-11
+
+This contract specifies the behavior of the installer script `install-systemd-units.sh` shipped in `modules/perc-distribution-tree/scripts/`. The script handles fresh install, upgrade-from-init.d, and idempotent re-run.
+
+## Synopsis
+
+```text
+install-systemd-units.sh [--perc-root PATH] [--user USER] [--instance NAME] [--dry-run] [--force] [--help]
+```
+
+- `--perc-root PATH`: install root. Default: detected from `objectstore.properties` or `/etc/default/<name>`.
+- `--user USER`: runtime user. Default: detected from `rx_user.id` or `/etc/default/<name>`.
+- `--instance NAME`: instance name. Default: `default` for a single-instance install, `instance2` for the second, etc.
+- `--dry-run`: print what would be done; do not modify the system.
+- `--force`: overwrite existing env file (default: prompt).
+- `--help`: print usage.
+
+## Phases (in order)
+
+1. **Probe**: read existing state — `/etc/init.d/*`, `/etc/rc?.d/*`, `/etc/default/*`, `/etc/systemd/system/*`, `/etc/percussion/*`.
+2. **Detect**: build the in-memory `Instance Record` list per [data-model.md](./data-model.md#entity-instance-record-in-memory-only).
+3. **Validate**: for each instance, verify `PERC_ROOT` exists, `rxconfig/Server/objectstore.properties` exists, `rx_user.id` exists (or `--user` was supplied).
+4. **Render**: write the env file (`0640 root:<group>`) and the rendered unit file (under `/etc/systemd/system/`).
+5. **Migrate (upgrade only)**: stop the legacy init.d service (`service <name> stop` or `/etc/init.d/<name> stop`), deregister (`chkconfig --del` / `update-rc.d -f remove`), remove the symlinks, remove the legacy script.
+6. **Enable**: `systemctl daemon-reload && systemctl enable percussioncms@<instance>.service`.
+7. **Start**: `systemctl start percussioncms@<instance>.service`. Wait up to `TimeoutStartSec` for `is-active` to return `active`.
+8. **Report**: print a summary table — per instance: detected source, env file path, unit path, start status.
+
+## Idempotency rules (FR-010)
+
+- Re-running with no changes: detects the existing systemd state, validates, prints "already migrated", exits 0.
+- Re-running after partial migration (init.d removed, no unit installed): re-creates the env file and unit, starts, exits 0.
+- Re-running with conflicting state (unit exists, env file missing): recreates the env file, restarts the unit, exits 0.
+- Re-running with `--force` over an existing env file: backs up the existing file to `cms-<instance>.env.bak.<timestamp>`, writes the new one, restarts the unit.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All instances migrated successfully (or already migrated). |
+| 1 | At least one instance failed migration; others may have succeeded. Summary table shows which. |
+| 2 | Invalid arguments or missing prerequisites (e.g. not running as root, systemd not PID 1, no `PERC_ROOT`). |
+| 3 | Idempotency violation: legacy init.d state and systemd state both exist for the same instance. Operator must run with `--force` to resolve. |
+
+## Pre-conditions
+
+- Must be run as root (or via `sudo`).
+- `systemctl` MUST be on `PATH`.
+- PID 1 MUST be `systemd` (verified via `pidof systemd` or `cat /proc/1/comm`).
+
+## Post-conditions
+
+- For each detected instance:
+  - Legacy init.d script and run-level symlinks: absent.
+  - `/etc/percussion/cms-<instance>.env`: present, mode `0640`.
+  - `/etc/systemd/system/percussioncms@<instance>.service`: present, passes `systemd-analyze verify`.
+  - `systemctl is-active percussioncms@<instance>.service`: `active`.
+  - `journalctl -u percussioncms@<instance>.service -n 5`: non-empty.
+
+## Failure recovery (FR-011)
+
+If the script exits non-zero partway through, the operator re-runs it (with or without `--force`). The probe phase re-derives state from disk and converges to the post-condition set.
+
+## Logging
+
+All actions are logged to `journalctl -t install-systemd-units` (using `systemd-cat` or `logger -t`). The summary table is also printed to stdout.

--- a/specs/006-systemd-linux-services/contracts/unit-template.md
+++ b/specs/006-systemd-linux-services/contracts/unit-template.md
@@ -1,0 +1,102 @@
+# Contract: percussioncms@.service Unit Template
+
+**Date**: 2026-07-11
+**Spec**: [spec.md](./spec.md)
+**Data model**: [data-model.md](./data-model.md)
+
+This contract specifies the rendered form of the systemd unit template shipped at `modules/perc-distribution-tree/src/main/resources/systemd/percussioncms@.service.template`. The template uses `${VAR}` syntax expanded at install time by the installer; the rendered file is a valid systemd unit consumable by `systemctl`.
+
+## Rendered form (per-instance `<instance>` is `%i`)
+
+```ini
+[Unit]
+Description=Percussion CMS (%i)
+Documentation=https://percussioncmshelp.intsof.com/
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/percussion/cms-%i.env
+WorkingDirectory=${PERC_ROOT}
+ExecStart=${JAVA} ${JAVA_OPTIONS} -jar ${PERC_ROOT}/Jetty/base/start.jar ${JETTY_ARGS}
+ExecStop=${PERC_ROOT}/Jetty/base/stop.sh
+PIDFile=${JETTY_PID}
+Restart=on-failure
+RestartSec=30s
+StartLimitBurst=5
+StartLimitIntervalSec=600s
+TimeoutStartSec=300
+TimeoutStopSec=120
+User=${JETTY_USER}
+Group=${JETTY_USER}
+KillMode=mixed
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+RestrictRealtime=true
+RestrictNamespaces=true
+ReadWritePaths=${PERC_ROOT} ${JETTY_RUN}
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+
+*Note: The exact `ExecStart=` will be verified against the actual Jetty 12 entry point at implementation time. Two candidates exist today: `StartJetty.sh` and `start.jar` (via `start.jar`). The tasks phase picks the working one on a clean VM and freezes the contract.*
+
+## Validation
+
+A unit is "valid" when:
+
+1. `systemd-analyze verify /etc/systemd/system/percussioncms@<instance>.service` exits 0.
+2. `systemctl daemon-reload` does not emit warnings for the unit.
+3. `systemctl start percussioncms@<instance>.service` returns 0 within `TimeoutStartSec`.
+4. `systemctl is-active percussioncms@<instance>.service` returns `active`.
+5. `journalctl -u percussioncms@<instance>.service -n 50` returns non-empty output containing CMS startup banner.
+6. `systemctl stop percussioncms@<instance>.service` returns 0 within `TimeoutStopSec`.
+7. `systemctl status percussioncms@<instance>.service` shows `enable` state set by the install (`enabled` in `systemctl is-enabled`).
+
+## Versioning
+
+- The unit template is part of the distribution; versioned with the CMS release.
+- Backward-compat rule: a unit shipped with release N MUST work with a runtime installed by release N or any later release on the supported-platform matrix.
+- Forward-compat rule: a unit shipped with release N+1 MUST NOT be installed over a release-N runtime without the operator running the upgrade installer.
+
+## Failure modes (must be diagnosable via journal)
+
+| Symptom | Likely cause | Journal hint |
+|---------|--------------|--------------|
+| `start request repeated too quickly` | JVM crash loop | `Main process exited, code=exited, status=1/FAILURE` |
+| `Failed at step GROUP spawning ...` | `User`/`Group` missing on host | `nss-systemd` / `getpwnam` errors |
+| `Failed to read environment file` | Env file missing or wrong mode | `openat(2) ... Permission denied` |
+| Unit stays `activating` past `TimeoutStartSec` | Jetty hang on startup | `Jetty server starting...` stalls at a module |
+| `Service hold-off time over, scheduling restart` | Repeated failures (expected) | `Scheduled restart job` |
+
+## Migration contract (consumed by `install-systemd-units.sh`)
+
+The migration script's input is the legacy init.d state of a host; its output is the systemd state defined by this contract. The contract is:
+
+**Input probes**:
+- `/etc/init.d/<name>` files matching the legacy patterns in [data-model.md](./data-model.md#entity-legacy-initd-script-deleted-in-this-release)
+- `/etc/rc?.d/[SK]??<name>` symlinks
+- `/etc/default/<name>` env files
+- `chkconfig --list` / `update-rc.d --list` (whichever exists)
+
+**Output guarantees**:
+- All input scripts and symlinks are removed.
+- `chkconfig --del <name>` (or `update-rc.d -f <name> remove`) has been run.
+- `/etc/systemd/system/percussioncms@<instance>.service` exists and passes `systemd-analyze verify`.
+- `/etc/percussion/cms-<instance>.env` exists with mode `0640`.
+- `systemctl daemon-reload` has been run.
+- `systemctl enable --now percussioncms@<instance>.service` has been run and returned 0.
+- `systemctl is-active percussioncms@<instance>.service` returns `active`.
+- The exit code of the migration script reflects the final state: 0 = all instances migrated, 1 = at least one instance failed (partial-migration recovery is then possible per FR-011 on the next run).

--- a/specs/006-systemd-linux-services/data-model.md
+++ b/specs/006-systemd-linux-services/data-model.md
@@ -1,0 +1,133 @@
+# Data Model: Systemd Linux Service Scripts
+
+**Date**: 2026-07-11
+**Spec**: [spec.md](./spec.md)
+
+This feature has no application data model — it is a supervision-layer change. The "entities" below describe the *artifacts* on disk and in the installer that must be tracked and validated.
+
+## Entity: Unit File Template (`*.service.template`)
+
+A Mustache-style or `${VAR}`-substituted template shipped in `modules/perc-distribution-tree/src/main/resources/systemd/`. At install time the installer substitutes paths and writes the rendered file to `/etc/systemd/system/<unit-name>.service`.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `Unit.Description` | string | yes | Human-readable description, shown by `systemctl status`. |
+| `Unit.Documentation` | URL | yes | Link to operator docs (Maven site page). |
+| `Unit.After` | list | yes | `network-online.target` (CMS depends on network). |
+| `Service.Type` | enum | yes | `simple` (per Decision 1). |
+| `Service.EnvironmentFile` | path | yes | `/etc/percussion/cms-%i.env`. |
+| `Service.ExecStart` | command | yes | `${PERC_ROOT}/Jetty/base/StartJetty.sh`. |
+| `Service.ExecStop` | command | yes | `${PERC_ROOT}/Jetty/base/StopJetty.sh`. |
+| `Service.PIDFile` | path | yes | `${JETTY_RUN}/rxjetty.pid`. |
+| `Service.Restart` | enum | yes | `on-failure`. |
+| `Service.RestartSec` | duration | yes | `30s`. |
+| `Service.TimeoutStartSec` | duration | yes | `300s` (initial; tune in `/speckit.tasks`). |
+| `Service.TimeoutStopSec` | duration | yes | `120s` (initial; tune in `/speckit.tasks`). |
+| `Service.User` | string | yes | Runtime user (extracted from `rx_user.id`). |
+| `Service.Group` | string | yes | Runtime group. |
+| `Service.KillMode` | enum | yes | `mixed`. |
+| `Service.NoNewPrivileges` | bool | yes | `true`. |
+| `Service.ProtectSystem` | enum | yes | `strict`. |
+| `Service.ProtectHome` | bool | yes | `true`. |
+| `Service.PrivateTmp` | bool | yes | `true`. |
+| `Service.ReadWritePaths` | path list | yes | `PERC_ROOT`, `JETTY_RUN`. |
+| `Service.StandardOutput` | enum | yes | `journal`. |
+| `Service.StandardError` | enum | yes | `journal`. |
+| `Install.WantedBy` | list | yes | `multi-user.target`. |
+
+**Relationships**: A template renders to N concrete unit files when N instances exist (`percussioncms@default.service`, `percussioncms@instance2.service`, …).
+
+**Validation rules**:
+- `User` and `Group` MUST exist on the target host.
+- `PERC_ROOT` and `JETTY_RUN` from `EnvironmentFile=` MUST exist on disk.
+- The rendered unit MUST pass `systemd-analyze verify`.
+
+---
+
+## Entity: Environment File (`/etc/percussion/cms-<instance>.env`)
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `PERC_ROOT` | absolute path | yes | Install root (e.g. `/opt/percussion/perc-cms`). |
+| `JETTY_HOME` | absolute path | yes | Jetty home (e.g. `${PERC_ROOT}/Jetty/upstream`). |
+| `JETTY_BASE` | absolute path | yes | Jetty base (e.g. `${PERC_ROOT}/Jetty/base`). |
+| `JETTY_DEFAULTS` | absolute path | yes | Jetty defaults (e.g. `${PERC_ROOT}/Jetty/defaults`). |
+| `JETTY_RUN` | absolute path | yes | Runtime dir (e.g. `/var/run/rxjetty/percussioncms`). |
+| `JETTY_CONF` | absolute path | yes | `jetty.conf` path. |
+| `JETTY_START_LOG` | absolute path | yes | Start log path. |
+| `JETTY_PID` | absolute path | yes | PID file path (`${JETTY_RUN}/rxjetty.pid`). |
+| `JAVA_HOME` | absolute path | yes | JDK install. |
+| `JAVA` | absolute path | yes | `java` binary. |
+| `JAVA_OPTIONS` | string | yes | JVM options (existing `DisableAttachMechanism` etc. preserved). |
+| `JETTY_ARGS` | string | yes | Jetty module include args. |
+| `JETTY_USER` | string | yes | Runtime user (mirrors `Service.User`). |
+| `INSTANCE_NAME` | string | yes | The instance identifier (`default`, `instance2`, …). |
+
+**File mode**: `0640`, owner `root:<JETTY_USER-group>`. Group MUST match `Service.Group`.
+
+**Validation rules**:
+- File MUST be syntactically valid `key=value` lines; the migration script defensively strips `$(...)`, backticks, and `export` prefixes.
+- All path values MUST exist after install; missing paths fail the install.
+- No secret material (DB passwords, JWT signing keys) MUST be in this file — those belong in CMS application config under `rxconfig/Server/`, not in the unit's env file.
+
+---
+
+## Entity: Legacy Init.d Script (deleted in this release)
+
+Files deleted:
+
+- `system/release/installer/Linux/percussion-service.sh`
+- `system/release/installer/Linux/InstallPublisherDaemon.sh`
+- `system/release/installer/Linux/InstallDaemon.sh`
+- `system/release/installer/Linux/InstallFTSDaemon.sh`
+- `system/release/installer/unix/InstallPublisherDaemon.sh`
+- `system/release/installer/unix/InstallDaemon.sh`
+- `system/release/installer/unix/InstallFTSDaemon.sh`
+- `deliverytiersuite/.../DTSStagingService.sh`
+- `deliverytiersuite/.../DTSProductionService.sh`
+
+**Lifecycle**:
+- **Pre-install**: script may exist on the target host (legacy install).
+- **Migration**: script is stopped, symlinks under `/etc/rc?.d/` are removed, the script itself is removed from `/etc/init.d/`, `chkconfig` / `update-rc.d` deregistration is run.
+- **Post-install**: script MUST NOT exist on the target host (FR-007 / SC-004).
+
+**Migration detection inputs** (read-only, used by the migration script):
+
+| Signal | Path / Pattern |
+|--------|----------------|
+| Init.d script | `/etc/init.d/{percussion,rxjetty,PercussionCMS,PercussionD,DTSStagingService,DTSProductionService}` |
+| Run-level symlinks | `/etc/rc?.d/[SK]??<name>`, `/etc/rc.d/rc?.d/[SK]??<name>` |
+| chkconfig | `chkconfig --list | grep <name>` |
+| Default config | `/etc/default/<name>` |
+| Service wrapper jar | `${PERC_ROOT}/perc-service-wrapper.jar` |
+| Install marker | `${PERC_ROOT}/rxconfig/Server/objectstore.properties` |
+
+---
+
+## Entity: Instance Record (in-memory only)
+
+The migration script builds an in-memory list of instances during detection. Not persisted.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `instance_name` | string | `default`, `instance2`, … |
+| `perc_root` | path | Detected `PERC_ROOT` |
+| `jetty_home` | path | Detected `JETTY_HOME` |
+| `jetty_base` | path | Detected `JETTY_BASE` |
+| `jetty_run` | path | Detected `JETTY_RUN` |
+| `jetty_user` | string | Detected runtime user |
+| `java_options` | string | Detected `JAVA_OPTIONS` |
+| `legacy_initd_path` | path | The legacy script path that produced this instance |
+| `state` | enum | `detected | migrating | migrated | failed` |
+
+**State transitions**:
+- `detected → migrating` when the migration script begins processing
+- `migrating → migrated` when `systemctl is-active` returns `active`
+- `migrating → failed` when `systemctl start` fails (FR-011 recovery path)
+- `failed → migrating` on retry
+
+---
+
+## Entity: Installer Manifest Reference (deleted)
+
+Files in `modules/perc-ant` and `modules/perc-distribution-tree` (Maven `xml` / `properties`) that reference the legacy init.d scripts MUST be updated to reference the new systemd unit files instead. The tasks phase enumerates these via grep before deletion.

--- a/specs/006-systemd-linux-services/plan.md
+++ b/specs/006-systemd-linux-services/plan.md
@@ -1,0 +1,167 @@
+# Implementation Plan: Systemd Linux Service Scripts (Replace init.d)
+
+**Branch**: `006-systemd-linux-services` | **Date**: 2026-07-11 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/006-systemd-linux-services/spec.md`
+**Source issue**: intersoftdatalabs-in/percussioncms#962 (migrated from percussion/percussioncms#426)
+
+## Summary
+
+Replace the legacy init.d-based service supervision of the Percussion CMS (and the Delivery Tier Suite staging/production services) with native systemd units. The change is a pure supervision-layer swap: the CMS runtime (Jetty 12 + Jakarta Servlet 6.1) is untouched; systemd just owns `start`, `stop`, `restart`, journal logging, and failure-restart semantics. The first release that ships systemd **drops init.d entirely** (per resolved clarification): existing init.d installs MUST be converted in-place by the upgrade installer (FR-003); legacy scripts and their installer-manifest references are physically deleted (FR-007). Multi-instance support on a single host is in scope via a systemd template unit `percussioncms@.service` (FR-004a). The plan covers the installer migration logic, the new unit files, an integration-test harness using a systemd-enabled container, and documentation/site updates.
+
+## Technical Context
+
+**Language/Version**: Java 21 on `development` (build/test via `./mvn-env.sh`). The actual implementation work is shell + systemd unit syntax + a small Java/Ant test harness — no new Java services are added. Jetty 12.1.7 / Jakarta Servlet 6.1 (per `modules/perc-jetty/AGENTS.md`) — unchanged.
+**Primary Dependencies**: Maven multi-module (existing); the installer (`modules/perc-ant`) and distribution tree (`modules/perc-distribution-tree`) wire the new units into the CMS installer. No new Maven dependencies needed.
+**Storage**: N/A (no schema change; no persistence).
+**Testing**: JUnit 5 + Mockito for installer-logic unit tests; a new shell-level integration test using `systemd-nspawn` or a privileged Docker container running `ubuntu:22.04` (or `debian:12`) with `/sbin/init` as PID 1 to exercise `systemctl` against the generated units. Jetty runtime is unchanged, so the existing Jetty test suites remain authoritative for runtime behavior.
+**Target Platform**: Linux distributions with systemd as PID 1 — explicitly: Ubuntu 22.04+, Debian 12+, RHEL 9+, Rocky/AlmaLinux 9+, Amazon Linux 2023+. The supported-platform matrix (FR-005) is published in `modules/perc-distribution-tree` docs. Hosts without systemd are out of support in this release (per resolved clarification Q1).
+**Project Type**: Multi-module CMS mono-repo. The work touches the installer and distribution tree (no source-code behavior changes in `system/` runtime).
+**Performance Goals**: Install/upgrade completion within +10% of the legacy init.d path (SC-001). No runtime-performance regression since the Jetty entry points are unchanged.
+**Constraints**:
+- Branch JDK 21 via `./mvn-env.sh`; not a Spring Boot app.
+- Backward compatibility: the *runtime* contract (ports, JVM options, log locations) is preserved. The *installer* contract changes (no init.d install path). Document the breaking change in the release notes and `BREAKING_CHANGES.md` if one exists.
+- Module AGENTS hierarchy: `AGENTS.md` (root), `modules/perc-jetty/AGENTS.md`, `modules/perc-distribution-tree/AGENTS.md` (if present).
+**Scale/Scope**:
+- Modules touched: `modules/perc-distribution-tree` (primary), `system/release/installer/Linux` (delete), `system/release/installer/unix` (delete), `modules/perc-jetty` (extend `install-jetty-service.sh` or add new sibling script that writes systemd unit + env file), `deliverytiersuite/delivery-tier-suite/delivery-tier-distribution` (delete init.d rootFiles, add systemd units).
+- User roles: integrator / system administrator / build & release engineer.
+- Install/upgrade impact: distribution tree content change; installer behavior change for upgrade path. `.ppkg` content changes when installer ships new unit files.
+**Owning module(s)**:
+- Primary: `modules/perc-distribution-tree`, `modules/perc-jetty`
+- Deletion-only: `system/release/installer/Linux`, `system/release/installer/unix`, `deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/DTSStagingService.sh`, `deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/DTSProductionService.sh`
+**AGENTS hierarchy applied**: `AGENTS.md` (root), `modules/perc-jetty/AGENTS.md`, `system/AGENTS.md` (sanity check — no Java service changes)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+*Source: `.specify/memory/constitution.md` (v2.1.0)*
+
+- [x] **I. Module-First Boundaries**: Owning modules identified above; Rule Discovery Protocol applied (read root + `modules/perc-jetty/AGENTS.md` + `system/AGENTS.md`); no orphan shared code — installer logic stays in `modules/perc-jetty`/`perc-distribution-tree`, not in `system/`.
+- [x] **II. Evidence Over Invention**: Approach cites existing paths: `modules/perc-jetty/src/main/jetty/service/install-jetty-service.sh` (today's init.d installer; evolved), `modules/perc-jetty/src/main/jetty/StartJetty.sh` & `StopJetty.sh` (runtime entry points we reuse as `ExecStart=`/`ExecStop=`), `system/release/installer/Linux/percussion-service.sh` (deleted in this release per FR-007), `deliverytiersuite/.../DTSStagingService.sh` & `DTSProductionService.sh` (deleted). No new third-party libraries needed; systemd is part of the OS.
+- [x] **III. Test Discipline**: Unit tests planned for installer detection/migration logic (JUnit 5 + Mockito, mirroring existing `modules/perc-jetty` test patterns); integration test against a real systemd-enabled container; tests added as first-class tasks in `/speckit.tasks`.
+- [x] **IV. Contract & Integration Integrity**: Public REST/SOAP/package contracts unchanged. Installer behavior is changing — documented as a release-note breaking change. Per-instance `cms-<instance>.env` is the new operator contract for configuration.
+- [x] **V. Safe Modernization**: No Spring Boot; no new frameworks; scope limited to the supervision-layer change. The deletion of legacy init.d scripts is a scope-clean cutover, not drive-by cleanup.
+- [x] **VI. Security by Default**: Unit file's `EnvironmentFile=` MUST be `0640 root:root` (no world-readable secret leakage); no setuid wrappers; `User=`/`Group=` set on the unit; `NoNewPrivileges=true`, `ProtectSystem=strict`, `ProtectHome=true` declared where compatible with the install path. Threat notes in this plan, abuse-case tests (env-file injection, world-writable path) added.
+- [x] **VII. Build, Platform & Dependency Hygiene**: JDK 21 via `./mvn-env.sh`; no new Maven/npm deps; Spotless not relevant for shell files. ShellCheck on new shell scripts (added to CI if not already present).
+- [x] **VIII. Documentation & Operability**: README updates in `modules/perc-distribution-tree` (supported-platform matrix), `modules/perc-jetty/README.md` (new install procedure), `deliverytiersuite/.../delivery-tier-distribution/README.md` (DTS systemd procedure). Worklog entry under `modules/perc-jetty/src/site/markdown/worklog/`. Failures diagnosable via `journalctl -u percussioncms@<instance>.service`.
+- [x] **IX. PR Review Comment Resolution**: Plan owner will follow root `AGENTS.md` "PR Review Comment Resolution" — inline reply + `resolveReviewThread` mutation — for every review thread on the resulting PR (none yet; this is a forward-looking commitment).
+- [x] **Complexity Budget**: No principle violations. Template unit (`percussioncms@.service`) is justified by FR-004a (multi-instance) and is the standard systemd idiom — not complexity bloat.
+- [x] **Governance**: Constitution list will be re-checked after Phase 1 design.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/006-systemd-linux-services/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (unit-file schemas, env-file schema)
+└── tasks.md             # Phase 2 output (NOT created by /speckit.plan)
+```
+
+### Source Code (repository modules)
+
+```text
+# Primary — installer & distribution wiring
+modules/perc-distribution-tree/
+├── src/main/resources/
+│   ├── systemd/
+│   │   ├── percussioncms@.service.template      # CMS template unit
+│   │   ├── percussiondts-staging@.service.template
+│   │   └── percussiondts-production@.service.template
+│   └── env/
+│       └── percussioncms.env.template           # Per-instance env file template
+├── scripts/
+│   ├── install-systemd-units.sh                  # NEW: install/upgrade/migrate
+│   ├── uninstall-systemd-units.sh                # NEW: clean removal
+│   └── README.md                                  # UPDATE: document new scripts
+└── src/site/markdown/systemd-linux-services.md   # NEW: operator guide
+
+# Primary — Jetty-runtime glue
+modules/perc-jetty/
+├── src/main/jetty/service/
+│   ├── install-jetty-service.sh                  # UPDATE: deprecated, dispatch to new path
+│   └── install-systemd-jetty-service.sh          # NEW: writes the systemd unit + env file
+├── README.md                                      # UPDATE
+└── src/site/markdown/worklog/
+    └── systemd-linux-services.md                 # NEW: worklog entry
+
+# Deletion-only
+system/release/installer/Linux/                   # DELETE entire directory
+system/release/installer/unix/                    # DELETE entire directory
+deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/
+└── src/main/rootFiles/
+    ├── DTSStagingService.sh                      # DELETE
+    └── DTSProductionService.sh                   # DELETE
+
+# Tests
+modules/perc-distribution-tree/src/test/
+└── java/.../systemd/
+    ├── InstallSystemdUnitsScriptTest.java        # Unit test: detection logic
+    ├── EnvFileSchemaTest.java                    # Unit test: env-file validation
+    └── MultiInstanceDetectionTest.java           # Unit test: per-instance migration
+
+modules/perc-jetty/src/test/
+└── shell/
+    └── install-systemd-jetty-service.bats        # Shell-level test (bats-core)
+
+# Integration test harness (new)
+docker/systemd-test/
+├── Dockerfile                                     # ubuntu:22.04 + systemd-nspawn
+├── run-tests.sh
+└── README.md
+```
+
+**Structure Decision**: The work is split between `modules/perc-jetty` (which already owns the Jetty-runtime install script `install-jetty-service.sh` and the `StartJetty.sh`/`StopJetty.sh` entry points the unit will call) and `modules/perc-distribution-tree` (which owns the install tree / distribution artifacts). This avoids creating a new module and respects existing ownership — constitution I.
+
+## Complexity Tracking
+
+No principle violations. No entries.
+
+## Phase 0: Outline & Research
+
+Research artifacts captured in [`research.md`](./research.md). Key resolutions:
+
+- **NEEDS CLARIFICATION → Resolved**: Unit `Type=` chosen as `simple` (Jetty doesn't `fork()`; the wrapper script blocks). `ExecStart=` invokes `StartJetty.sh`; `ExecStop=` invokes `StopJetty.sh`. `PIDFile=` not used (Jetty writes its own pid under `${JETTY_RUN}/rxjetty.pid`; unit reads it for `ExecStop` via a small wrapper or `KillMode=mixed`).
+- **NEEDS CLARIFICATION → Resolved**: Multi-instance detection enumerates `S??percussion-*` symlinks under `/etc/rc?.d/` and `/etc/init.d/percussion-*` files; each maps to one `percussioncms@<instance>.service` instantiation with its own env file.
+- **NEEDS CLARIFICATION → Resolved**: Env-file permissions `0640 root:root` with the unit's `User=`/`Group=` set to the runtime user (so the runtime can read but unprivileged users cannot exfiltrate).
+- **NEEDS CLARIFICATION → Resolved**: Idempotent installer uses "filesystem + systemd" state probes (does `/etc/systemd/system/percussioncms@<instance>.service` exist? is it `enabled`? is it `active`?) rather than relying on installer manifests.
+
+## Phase 1: Design & Contracts
+
+Artifacts produced:
+
+- [`data-model.md`](./data-model.md) — entities: Unit File, Environment File, Legacy Init.d Script, Installer Manifest, Instance Record.
+- [`contracts/`](./contracts/) — schemas for the unit template file, env file, and detection/migration contract.
+- [`quickstart.md`](./quickstart.md) — runnable validation scenarios.
+
+### Re-evaluate Constitution Check (post-Phase 1)
+
+- [x] I. Module-First Boundaries — confirmed; no new modules created.
+- [x] II. Evidence Over Invention — confirmed; all paths cited exist in tree.
+- [x] III. Test Discipline — confirmed; unit + shell + integration test tasks defined.
+- [x] IV. Contract & Integration Integrity — confirmed; runtime contract unchanged, installer behavior change documented.
+- [x] V. Safe Modernization — confirmed; no Spring Boot, no framework churn.
+- [x] VI. Security by Default — confirmed; env-file perms, `ProtectSystem=`, `NoNewPrivileges=` in unit template; abuse-case tests planned.
+- [x] VII. Build, Platform & Dependency Hygiene — confirmed; no new deps; ShellCheck in CI.
+- [x] VIII. Documentation & Operability — confirmed; README + worklog + site doc + operator quickstart planned.
+- [x] IX. PR Review Comment Resolution — confirmed; owner commits to root `AGENTS.md` procedure.
+- [x] Complexity Budget — no violations.
+- [x] Governance — done.
+
+## Mandatory Post-Execution Hooks
+
+No hooks registered (`.specify/extensions.yml` absent) — skipped.
+
+## Completion Report
+
+- **Branch**: `006-systemd-linux-services`
+- **Plan path**: `specs/006-systemd-linux-services/plan.md`
+- **Generated artifacts**:
+  - `specs/006-systemd-linux-services/research.md`
+  - `specs/006-systemd-linux-services/data-model.md`
+  - `specs/006-systemd-linux-services/contracts/` (unit template schema, env file schema, installer contract)
+  - `specs/006-systemd-linux-services/quickstart.md`
+- **Next command**: `/speckit.tasks`

--- a/specs/006-systemd-linux-services/quickstart.md
+++ b/specs/006-systemd-linux-services/quickstart.md
@@ -1,0 +1,234 @@
+# Quickstart: Systemd Linux Service Scripts (Replace init.d)
+
+**Date**: 2026-07-11
+**Spec**: [spec.md](./spec.md)
+**Plan**: [plan.md](./plan.md)
+
+This quickstart is the runnable validation guide for the feature. Each scenario is end-to-end runnable on the supported-platform matrix (Ubuntu 22.04+, Debian 12+, RHEL 9+, Rocky/AlmaLinux 9+, Amazon Linux 2023+).
+
+## Prerequisites
+
+- A clean Linux VM (or container) with systemd as PID 1, JDK 21, and the Percussion CMS distribution tree staged at `${PERC_ROOT}` (or a fresh CMS install built from this branch).
+- For container-based testing: `docker run --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -ti ubuntu:22.04 /sbin/init` then `apt-get install -y openjdk-21-jdk` and stage the CMS distribution.
+- For CI: the `docker/systemd-test/` harness (added by this feature) runs all scenarios automatically.
+
+## Scenario 1 — Fresh install on a systemd host
+
+**Goal**: Verify FR-001 / FR-002 / Story 1.
+
+```bash
+# 1. As root, run the installer
+sudo bash modules/perc-distribution-tree/scripts/install-systemd-units.sh \
+    --perc-root /opt/percussion/perc-cms \
+    --user percussion \
+    --instance default
+
+# Expected output includes a "Migrated 1 instance" summary row.
+
+# 2. Verify the unit is installed
+systemctl list-unit-files | grep percussion
+# Expected: percussioncms@.service    enabled
+
+# 3. Verify it is active
+systemctl is-active percussioncms@default
+# Expected: active
+
+# 4. Verify the CMS is responding
+curl -sf http://localhost:9992/Rhythmyx/Authentication/login.html | head -5
+# Expected: HTML output (the CMS login page)
+
+# 5. View logs via journalctl
+journalctl -u percussioncms@default -n 50 --no-pager
+# Expected: CMS startup banner visible
+
+# 6. Reboot and verify autostart
+sudo reboot
+# After reboot:
+systemctl is-active percussioncms@default
+# Expected: active
+```
+
+## Scenario 2 — Upgrade from a legacy init.d install
+
+**Goal**: Verify FR-003 / Story 2.
+
+```bash
+# 1. Seed a legacy init.d install (simulates an existing customer)
+sudo cp system/release/installer/Linux/percussion-service.sh /etc/init.d/PercussionCMS
+sudo ln -s /etc/init.d/PercussionCMS /etc/rc2.d/S99PercussionCMS
+sudo ln -s /etc/init.d/PercussionCMS /etc/rc3.d/S99PercussionCMS
+sudo service PercussionCMS start   # starts via legacy script
+
+# 2. Verify the legacy install is running
+service PercussionCMS status
+# Expected: legacy start succeeded
+
+# 3. Run the upgrade installer (the same installer used in Scenario 1)
+sudo bash modules/perc-distribution-tree/scripts/install-systemd-units.sh \
+    --perc-root /opt/percussion/perc-cms \
+    --user percussion \
+    --instance default
+
+# Expected: "Detected legacy init.d installation for instance 'default'; migrating."
+
+# 4. Verify legacy artifacts are gone
+ls /etc/init.d/ | grep -i percussion
+# Expected: empty (or no percussion-related entries)
+
+ls /etc/rc?.d/ | grep -i percussion
+# Expected: empty
+
+# 5. Verify the systemd unit is now active
+systemctl is-active percussioncms@default
+# Expected: active
+
+systemctl list-unit-files | grep percussion
+# Expected: percussioncms@.service    enabled
+```
+
+## Scenario 3 — Operator lifecycle (systemctl + journalctl)
+
+**Goal**: Verify FR-006a / Story 3.
+
+```bash
+# Stop
+sudo systemctl stop percussioncms@default
+# Expected: exits 0 within TimeoutStopSec (120s default)
+systemctl is-active percussioncms@default
+# Expected: inactive
+
+# Start
+sudo systemctl start percussioncms@default
+# Expected: exits 0 within TimeoutStartSec (300s default)
+systemctl is-active percussioncms@default
+# Expected: active
+
+# Restart
+sudo systemctl restart percussioncms@default
+# Expected: active within TimeoutStartSec + TimeoutStopSec
+
+# Status
+systemctl status percussioncms@default
+# Expected: shows active (running), recent journal entries, PID
+
+# Disable / re-enable autostart
+sudo systemctl disable percussioncms@default
+sudo systemctl is-enabled percussioncms@default
+# Expected: disabled
+sudo systemctl enable percussioncms@default
+# Expected: enabled
+
+# Crash and verify auto-restart
+sudo kill -9 $(cat /var/run/rxjetty/perc-cms/rxjetty.pid)
+# Wait 30s, then:
+systemctl is-active percussioncms@default
+# Expected: active (RestartSec=30s, Restart=on-failure)
+journalctl -u percussioncms@default -n 20
+# Expected: "Main process exited" followed by "Scheduled restart job"
+
+# Crash-loop verify
+for i in 1 2 3 4 5 6; do sudo kill -9 $(cat /var/run/rxjetty/perc-cms/rxjetty.pid); sleep 2; done
+# After StartLimitBurst=5 failures, systemd stops trying:
+systemctl is-active percussioncms@default
+# Expected: failed
+sudo systemctl reset-failed percussioncms@default
+# Now restart works again.
+```
+
+## Scenario 4 — Multi-instance (FR-004a)
+
+**Goal**: Verify two CMS instances on one host.
+
+```bash
+# 1. Stage a second instance under a different PERC_ROOT
+sudo mkdir -p /opt/percussion/perc-cms-2
+# (copy or symlink the install tree; the actual second-instance provisioning is out of scope
+# for v1 of this feature — for now, a copy of the install tree is sufficient)
+
+# 2. Register the second instance
+sudo bash modules/perc-distribution-tree/scripts/install-systemd-units.sh \
+    --perc-root /opt/percussion/perc-cms-2 \
+    --user percussion \
+    --instance instance2
+
+# 3. Start both
+sudo systemctl start percussioncms@default
+sudo systemctl start percussioncms@instance2
+
+# 4. Verify both are active and on different ports
+systemctl list-units --type=service | grep percussion
+# Expected: both percussioncms@default.service and percussioncms@instance2.service active
+```
+
+## Scenario 5 — DTS staging and production
+
+**Goal**: Verify FR-008 / Story 4.
+
+```bash
+# 1. Install DTS (separate distribution)
+sudo bash deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/scripts/install-systemd-units.sh \
+    --instance staging
+sudo bash deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/scripts/install-systemd-units.sh \
+    --instance production
+
+# 2. Verify
+systemctl list-units --type=service | grep dts
+# Expected: percussiondts-staging@staging.service and percussiondts-production@production.service active
+```
+
+## Scenario 6 — Idempotency (FR-010)
+
+**Goal**: Verify the installer is safe to re-run.
+
+```bash
+# Re-run the installer
+sudo bash modules/perc-distribution-tree/scripts/install-systemd-units.sh \
+    --perc-root /opt/percussion/perc-cms \
+    --user percussion \
+    --instance default
+# Expected: "Instance 'default' already migrated; no action taken." Exit 0.
+
+# Re-run after manually deleting the unit (simulates partial failure)
+sudo rm /etc/systemd/system/percussioncms@default.service
+sudo systemctl daemon-reload
+sudo bash modules/perc-distribution-tree/scripts/install-systemd-units.sh ...
+# Expected: re-creates the unit, restarts, exits 0.
+```
+
+## Scenario 7 — Out-of-support host (negative test)
+
+**Goal**: Verify the installer refuses non-systemd hosts with a clear error.
+
+```bash
+# In a chroot or non-systemd container:
+bash modules/perc-distribution-tree/scripts/install-systemd-units.sh ...
+# Expected: exit 2, "systemd is not PID 1; this installer does not support non-systemd hosts. Upgrade is required via a supported distribution."
+```
+
+## Validation summary (maps to Success Criteria)
+
+| Scenario | SC verified |
+|----------|-------------|
+| 1 | SC-001 (install time within 10% of baseline), SC-003 (lifecycle commands), SC-004 (no init.d artifacts) |
+| 2 | SC-002 (upgrade without intervention; init.d absent after) |
+| 3 | SC-003 (full lifecycle), SC-006 (security hardening) |
+| 4 | SC-003 (multi-instance) |
+| 5 | SC-003 (DTS coverage) |
+| 6 | SC-002 (idempotency), FR-010 / FR-011 |
+| 7 | SC-004 (supported-platform matrix enforced) |
+
+## Troubleshooting
+
+- `systemd-analyze verify` warnings — run with `--man=true` for human-readable output; check for missing `EnvironmentFile=` keys.
+- `Failed to read environment file: Permission denied` — env file mode is not `0640`, or owner group does not match the runtime group.
+- `start request repeated too quickly` — see the journal for the underlying failure; usually a bad `JAVA_OPTIONS` or a missing `JETTY_HOME`.
+- Multi-instance port conflict — the operator must configure per-instance ports via `JAVA_OPTIONS` or `rxconfig/Server/`. This feature does not auto-assign ports.
+
+## Reference
+
+- [plan.md](./plan.md) — implementation plan
+- [research.md](./research.md) — Phase 0 research
+- [data-model.md](./data-model.md) — entities
+- [contracts/unit-template.md](./contracts/unit-template.md) — unit template contract
+- [contracts/env-file.md](./contracts/env-file.md) — env file contract
+- [contracts/installer-script.md](./contracts/installer-script.md) — installer script contract

--- a/specs/006-systemd-linux-services/research.md
+++ b/specs/006-systemd-linux-services/research.md
@@ -1,0 +1,137 @@
+# Phase 0 Research: Systemd Linux Service Scripts (Replace init.d)
+
+**Date**: 2026-07-11
+**Spec**: [spec.md](./spec.md)
+**Plan**: [plan.md](./plan.md)
+
+## Decision 1 — systemd unit `Type=`
+
+**Decision**: `Type=simple`.
+
+**Rationale**: The CMS's runtime entry point is `modules/perc-jetty/src/main/jetty/StartJetty.sh`, which `exec`s the Java process and blocks until the JVM exits. systemd's `simple` type matches this exactly: systemd considers the unit "started" as soon as `ExecStart=` returns from fork, and the service stays "active" while the main PID lives. No `fork()` wrapper is involved, so `forking` would be wrong. `notify` would require Jetty to emit `sd_notify`, which it does not currently do; `Type=simple` avoids that wiring.
+
+**Alternatives considered**:
+- `Type=forking` — rejected; would require restructuring the start script to fork and detach.
+- `Type=notify` — rejected; requires Jetty support not currently present; tracked as a future enhancement, not v1.
+- `Type=oneshot` — rejected; the CMS is a long-running service, not a one-shot task.
+
+---
+
+## Decision 2 — `ExecStart=`, `ExecStop=`, and `PIDFile=`
+
+**Decision**:
+- `ExecStart=/bin/bash -c '${PERC_ROOT}/Jetty/base/StartJetty.sh'` (path resolved from `EnvironmentFile=`)
+- `ExecStop=/bin/bash -c '${PERC_ROOT}/Jetty/base/StopJetty.sh'`
+- `PIDFile=${JETTY_RUN}/rxjetty.pid` (Jetty already writes this; per `install-jetty-service.sh:194`)
+- `KillMode=mixed` — `SIGTERM` to the main PID (per PIDFile), `SIGKILL` to remaining cgroup processes after `TimeoutStopSec=`
+
+**Rationale**: Reuses the existing entry points without duplication. The env file (`EnvironmentFile=`) exposes `PERC_ROOT`, `JETTY_RUN`, etc., so the unit template is not hard-coded to a path.
+
+**Alternatives considered**:
+- A new `systemd-aware` start script that calls `sd_notify` — rejected for v1 (out of scope per Decision 1).
+
+---
+
+## Decision 3 — Restart policy (already resolved in clarification)
+
+**Decision**: `Restart=on-failure`, `RestartSec=30s`, `StartLimitBurst=5`, `StartLimitIntervalSec=600s`.
+
+**Rationale**: A hard JVM crash should bring the CMS back automatically, but a misconfigured DB / network should not produce a tight restart loop. 5 restarts in 10 minutes is enough to recover from transient failures; after that, systemd leaves the unit in `failed` state and the operator must intervene (matches Story 3 scenario 3).
+
+---
+
+## Decision 4 — Multi-instance detection algorithm
+
+**Decision**: The migration script enumerates existing init.d installations by:
+
+1. Scanning `/etc/init.d/` for entries matching `^[SK]?[0-9]{0,3}(percussion|rx|rxjetty|rhythmyx|perc)` (case-insensitive), excluding `catalina.sh` (Tomcat — not ours).
+2. For each candidate, parsing `SERVER_DIR=`, `PERC_ROOT=`, or `/etc/default/<name>` for the install path and existing JVM options.
+3. Mapping each to one `percussioncms@<instance>.service` unit, where `<instance>` defaults to `default` for the first install and `instance2`, `instance3`, … for subsequent installs.
+4. Writing `/etc/percussion/cms-<instance>.env` from the parsed values; never overwriting an existing env file without prompting (FR-010 idempotency).
+
+**Rationale**: The legacy `install-jetty-service.sh:131` already gates on `/etc/init.d/${SERVICE_NAME}`; the new migration script reuses that check and extends it to enumerate prefixes. Mapping to per-instance env files matches `EnvironmentFile=/etc/percussion/cms-%i.env` on the template unit.
+
+**Alternatives considered**:
+- A "let the operator rename" prompt at upgrade time — rejected; too fragile, breaks unattended upgrades.
+- A separate `percussioncms-instances` registry file — rejected; the unit template + env file pair is the standard systemd idiom.
+
+---
+
+## Decision 5 — Environment file format & permissions
+
+**Decision**: `/etc/percussion/cms-<instance>.env` is a `key=value` shell-sourced file with mode `0640`, owner `root:<runtime-group>`. The unit's `User=`/`Group=` are set to the same runtime user/group (extracted from the legacy `rx_user.id` or the install tree's owner).
+
+**Rationale**: SC-006 requires "no world-writable env files, no log-injection vectors via `EnvironmentFile=`". Mode `0640` with group-restricted read satisfies that. systemd's `EnvironmentFile=` reads `key=value` pairs without shell expansion, so there is no injection vector; but the file MUST not contain `export FOO=$(...)` or backticks, and the migration script strips these defensively.
+
+**Alternatives considered**:
+- Dropping the env file and hard-coding values in the unit — rejected; FR-004 forbids hard-coding.
+- systemd `LoadCredential=` (encrypted creds) — rejected; v1 only handles install paths / JVM opts, no secrets.
+
+---
+
+## Decision 6 — Hardening directives
+
+**Decision**: Ship the unit template with:
+
+```ini
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+RestrictRealtime=true
+RestrictNamespaces=true
+```
+
+**Rationale**: SC-006 (no security regressions). These directives harden the CMS process without breaking Jetty's need for network sockets (allowed by default) and read access to its install path (covered by `ReadWritePaths=` on `PERC_ROOT` and `JETTY_RUN`). Testing in CI will confirm Jetty still starts under these restrictions.
+
+**Alternatives considered**:
+- `DynamicUser=yes` — rejected; the runtime needs a fixed UID/GID to own install files.
+- `CapabilityBoundingSet=` (zero) — rejected; Jetty needs `CAP_NET_BIND_SERVICE` for privileged ports; covered separately if needed.
+
+---
+
+## Decision 7 — Supported-platform matrix (initial draft)
+
+**Decision**: Ship documentation listing:
+
+- **Supported**: Ubuntu 22.04 LTS+, Debian 12+, RHEL 9+, Rocky Linux 9+, AlmaLinux 9+, Amazon Linux 2023+.
+- **Out of support in this release**: RHEL 7 / CentOS 7 / Ubuntu 18.04 (no systemd or systemd too old).
+- **Container notes**: PID 1 must be systemd for `systemctl` to work. Standard `docker run --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro ubuntu:22.04 /sbin/init` is the documented pattern.
+
+**Rationale**: Matches modern Linux support norms and matches the JDK 21 runtime baseline. Per Q1 (clarification), legacy init.d hosts are out of support in this release.
+
+**Alternatives considered**:
+- "Best-effort" support for RHEL 7 — rejected; init.d dropped this release.
+
+---
+
+## Decision 8 — Integration test harness
+
+**Decision**: A new `docker/systemd-test/` harness using `ubuntu:22.04` with `/sbin/init` as PID 1 and the host's cgroups mounted. The test:
+
+1. Installs the distribution tree under `/opt/percussion` (simulated).
+2. Runs `install-systemd-units.sh`.
+3. Asserts `systemctl is-active percussioncms@default` returns `active` and `journalctl -u percussioncms@default` shows CMS startup logs.
+4. Restarts and verifies.
+5. For upgrade path: seeds `/etc/init.d/PercussionCMS` symlinks, runs the migration, asserts init.d scripts are gone and the systemd unit is active.
+
+**Rationale**: FR-012 requires an integration test that exercises `systemctl`. A privileged container with `/sbin/init` is the lightest-weight way to get real systemd on CI.
+
+**Alternatives considered**:
+- `systemd-nspawn` — considered; works on systemd hosts but less portable for GitHub Actions runners.
+- Mocking `systemctl` — rejected; would not exercise the actual lifecycle semantics.
+
+---
+
+## Open Implementation Notes (passed to `/speckit.tasks`)
+
+- Exact `TimeoutStartSec=` / `TimeoutStopSec=` values need empirical tuning against the actual Jetty startup time on a clean VM. Start with `TimeoutStartSec=300`, `TimeoutStopSec=120` and adjust if tests show they are too tight.
+- The `/etc/percussion/` directory mode/owner policy (`0755 root:root` for the dir, `0640 root:<group>` for env files) needs cross-check against the runtime user having read access.
+- ShellCheck on the new `install-systemd-units.sh` and `install-systemd-jetty-service.sh` scripts — add to CI if not already wired.
+- The deletion of `system/release/installer/Linux` and `system/release/installer/unix` may also require updating Maven assembly descriptors / `perc-ant` install XMLs that reference these paths; the tasks phase must grep for references before deletion.

--- a/specs/006-systemd-linux-services/spec.md
+++ b/specs/006-systemd-linux-services/spec.md
@@ -1,0 +1,198 @@
+# Feature Specification: Systemd Linux Service Scripts (Replace init.d)
+
+**Feature Branch**: `006-systemd-linux-services`
+**Created**: 2026-07-11
+**Status**: Draft  
+**Input**: User description: "Please take a look at issue https://github.com/intersoftdatalabs-in/percussioncms/issues/962 and build a feature spec for this. We will need to handle upgrade scenarios and remove the legacy init.d scripts after conversion to systemd."
+**Source issue**: intersoftdatalabs-in/percussioncms#962 (migrated from percussion/percussioncms#426)
+
+## Clarifications
+
+### Session 2026-07-11
+
+- Q: Supported-platform matrix / init.d fallback strategy (drop in same release vs. one-release fallback vs. keep indefinitely) → A: Drop init.d support in the same release that introduces systemd (cleanest cutover; existing hosts must upgrade through this release's installer to stay supported).
+- Q: Restart policy on unexpected process exit → A: `Restart=on-failure` with `RestartSec=30s` and a bounded `StartLimitBurst=` / `StartLimitIntervalSec=` cap (CMS comes back after a JVM crash but cannot spin in a tight restart loop).
+- Q: Whether to physically delete the legacy init.d scripts and installer references from the source tree, or keep them deprecated for one release → A: Physically delete in this release (no in-tree dead code; matches issue #962's wording).
+- Q: Multi-instance support on one host (in scope via template unit vs. out of scope for v1) → A: In scope — ship `percussioncms@.service` template unit with per-instance parameterisation via `EnvironmentFile=/etc/percussion/cms-%i.env`.
+
+## Module Scope *(mandatory for this mono-repo)*
+
+- **Primary module(s)**: `modules/perc-distribution-tree` (installer / distribution tree that ships Linux service scripts), `system/release/installer/Linux` (legacy init.d sources that ship with the CMS installer)
+- **Secondary / integration modules**: `modules/perc-jetty` (owns the `rxjetty.sh` service wrapper and `install-jetty-service.sh` installer), `deliverytiersuite/delivery-tier-suite/delivery-tier-distribution` (ships `DTSStagingService.sh` / `DTSProductionService.sh` for the Delivery Tier Suite)
+- **AGENTS files to apply**: root `AGENTS.md`, `system/AGENTS.md` (only as a sanity check — no new Java services are added), `modules/perc-distribution-tree/AGENTS.md` if present
+- **User roles affected**: integrator / system administrator who installs, upgrades, and operates the CMS and/or DTS on Linux servers; build/release engineer who assembles the distribution tree
+- **Install / upgrade impact**: package `.ppkg` content change (distribution tree replaces init.d templates with systemd units); install/upgrade scripts under `modules/perc-ant` and `modules/perc-distribution-tree/scripts` may need to detect existing init.d installations and migrate them
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Fresh Install on a systemd Linux Host (Priority: P1)
+
+An integrator downloads the Percussion CMS Linux installer and runs it on a modern Linux distribution (Ubuntu 22.04+, RHEL 9+, Debian 12+, or any other systemd-based distribution). After installation, the CMS processes are managed by systemd: starting the host, running `systemctl start percussioncms` brings the service up, `systemctl status percussioncms` reports health, and `journalctl -u percussioncms` shows the logs.
+
+**Why this priority**: This is the primary path for new customers and is the core value of issue #962. Without a clean systemd story on fresh installs, the feature does not exist.
+
+**Independent Test**: Perform a clean CMS install on a fresh systemd Linux VM; verify that systemd units are installed, enabled, started, and that the CMS responds on its documented ports without invoking any legacy init.d scripts.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh Linux host with systemd as PID 1 and the CMS installer, **When** the installer completes successfully, **Then** the appropriate systemd unit file(s) for the CMS are present under `/etc/systemd/system/` or `/usr/lib/systemd/system/`, are enabled to start at boot, and are running.
+2. **Given** the CMS is managed by systemd, **When** the administrator runs `systemctl restart percussioncms`, **Then** the CMS process is stopped and started cleanly and the service returns to a healthy state within a documented timeout.
+3. **Given** the CMS is managed by systemd, **When** the administrator runs `journalctl -u percussioncms -n 200`, **Then** the recent CMS server log entries are visible through the systemd journal.
+4. **Given** the CMS is managed by systemd, **When** the host reboots, **Then** the CMS service starts automatically as part of the normal boot sequence.
+
+---
+
+### User Story 2 - Existing Installation Upgrade From init.d to systemd (Priority: P2)
+
+An integrator previously installed the CMS using the legacy init.d-based installer. They upgrade to a new release that ships systemd units. The upgrade must detect the existing init.d service, stop it cleanly, install the new systemd units, transfer any custom configuration, and start the CMS under systemd — without requiring a fresh install or losing custom paths / ports.
+
+**Why this priority**: Existing customers are the largest install base. A new release that breaks upgrade in place will block adoption and force reinstalls. Issue #962 explicitly calls out upgrade scenarios.
+
+**Independent Test**: Take a CMS installed via the legacy init.d installer (symlinks under `/etc/init.d/` or `/etc/rc.d/`), run the upgrade installer, and verify that the legacy init.d scripts are removed/disabled, the systemd units are installed and active, and the CMS comes back up with the same effective configuration (ports, install path, JVM options).
+
+**Acceptance Scenarios**:
+
+1. **Given** a CMS previously installed via the legacy init.d scripts (symlinks and LSB-style scripts present), **When** the operator runs the upgrade installer, **Then** the installer detects the existing init.d installation, stops the init.d-managed process, removes the legacy init.d symlinks/scripts, installs the systemd unit(s), and starts the CMS under systemd.
+2. **Given** an existing init.d installation with custom ports or non-default install paths, **When** the upgrade completes, **Then** the new systemd unit is configured with those same custom values (no re-prompting for values the installer already knows).
+3. **Given** an upgrade that fails partway through, **When** the operator re-runs the upgrade, **Then** the installer is idempotent and does not leave the system in a half-converted state (either fully on systemd or fully on init.d).
+4. **Given** an upgrade from init.d, **When** the CMS is running under systemd, **Then** `systemctl list-unit-files | grep percussion` shows the new unit(s) installed and enabled, and `ls /etc/init.d/ | grep percussion` shows no remaining percussion init.d scripts.
+
+---
+
+### User Story 3 - Operator Lifecycle and Diagnostics (Priority: P3)
+
+A system administrator who is comfortable with systemd uses standard Linux tooling to operate the CMS service: start, stop, restart, check status, view logs, and enable/disable autostart. They do not need to learn any Percussion-proprietary commands.
+
+**Why this priority**: This is the operator-experience payoff of moving to systemd. It is lower priority than the install and upgrade paths because it is "free" once the units exist, but the spec must still cover it because the choice of unit type (`simple`, `forking`, `notify`, `oneshot`) and the unit metadata determine whether this story works.
+
+**Independent Test**: From a clean systemd-managed CMS, exercise `systemctl start|stop|restart|status|enable|disable` and `journalctl` and confirm each behaves correctly without falling back to any init.d script.
+
+**Acceptance Scenarios**:
+
+1. **Given** the CMS is running under systemd, **When** the operator runs `systemctl stop percussioncms`, **Then** the CMS process shuts down gracefully (in-flight requests complete or are timed out per documented behavior) and `systemctl is-active percussioncms` reports `inactive` within a documented timeout.
+2. **Given** the CMS is stopped, **When** the operator runs `systemctl start percussioncms`, **Then** the CMS becomes active and the documented CMS ports begin accepting traffic within a documented timeout.
+3. **Given** the CMS process dies unexpectedly, **When** systemd detects the failure, **Then** it is logged to the journal with the unit name, the unit enters `failed` state (visible via `systemctl status percussioncms`), and after `RestartSec=30s` systemd attempts one restart; after `StartLimitBurst` failures within `StartLimitIntervalSec` the unit stops auto-restarting and remains in `failed` until the operator intervenes.
+
+---
+
+### User Story 4 - Delivery Tier Suite (DTS) Services Move to systemd (Priority: P3)
+
+The DTS has its own init.d-style scripts (`DTSStagingService.sh`, `DTSProductionService.sh`) shipped via `deliverytiersuite/delivery-tier-suite/delivery-tier-distribution`. Operators who install both CMS and DTS on the same host should get a consistent systemd experience for both.
+
+**Why this priority**: DTS is a separate but co-installed product. It would be confusing to ship systemd for CMS and init.d for DTS on the same host. Lower priority because DTS upgrades follow their own cadence and the CMS install path does not strictly depend on this.
+
+**Independent Test**: On a fresh systemd host, install the DTS distribution; verify that the staging and production services are installed as systemd units and behave the same as the CMS units under `systemctl`/`journalctl`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh systemd Linux host and the DTS distribution, **When** the DTS installer completes, **Then** both the staging and production DTS services are installed as systemd units, enabled, and running.
+2. **Given** an existing DTS installation using init.d scripts, **When** the operator runs the DTS upgrade, **Then** the legacy scripts are migrated out and the new systemd units take over with the same effective configuration.
+
+### Edge Cases
+
+- **Distribution without systemd** (legacy RHEL 7, older Ubuntu LTS). **Resolved**: out of support in this release (per Q1 / FR-005); the installer refuses non-systemd hosts with exit code 2 and the message "systemd is not PID 1; this installer does not support non-systemd hosts" (see `contracts/installer-script.md`).
+- **Container hosts** where PID 1 is not systemd (Docker without `--privileged` and a systemd image). Unit files still install but `systemctl` does not work; the installer must not fail destructively.
+- **Non-root install paths** (`/opt/percussion`, `/srv/percussion`, custom user). The unit must use `EnvironmentFile=` or unit-time substitution so paths are not hard-coded into the shipped unit template.
+- **Multiple CMS instances on one host** (per FR-004a, supported via `percussioncms@<instance>.service`). The installer MUST enumerate any existing init.d-prefixed CMS instances it finds and convert each one to its own template-instantiated unit, preserving per-instance install paths and ports.
+- **Upgrades where the init.d service was disabled or already stopped.** The migration must not fail just because the legacy service is not currently running.
+- **Hostname change / IP change** between install and first systemd start. Service should start cleanly regardless of network identity.
+- **SELinux / AppArmor denying journal writes or process exec.** Unit must declare the minimum needed capabilities; failure mode should be a clear journal error, not a silent crash.
+- **Upgrade interrupted by power loss / SIGKILL mid-install.** Re-running the installer must converge to a consistent state.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The CMS Linux distribution MUST include one or more systemd unit files that start, stop, and supervise the CMS service(s) on systemd-based hosts. *(Replaces the legacy `BEGIN INIT INFO`-style init.d scripts in `system/release/installer/Linux` and `system/release/installer/unix`.)*
+- **FR-002**: The CMS Linux installer MUST install the systemd unit file(s) under the standard systemd directory (`/etc/systemd/system/` or `/usr/lib/systemd/system/`), run `systemctl daemon-reload`, `systemctl enable`, and `systemctl start` as appropriate, and report clear success/failure to the operator.
+- **FR-003**: The CMS Linux installer MUST support an upgrade-in-place path that detects a pre-existing init.d-based CMS installation, stops the legacy service, removes the init.d symlinks/scripts, and brings the CMS up under systemd without requiring a fresh install.
+- **FR-004**: The systemd unit file(s) MUST be parameterised so that custom install paths, ports, JVM options, and user/group are NOT hard-coded into the shipped file. An `EnvironmentFile=` (e.g. `/etc/percussion/cms.env`) or template-time substitution MUST be used so the same unit file ships to every customer.
+- **FR-004a**: The CMS unit MUST be shipped as a systemd template unit `percussioncms@.service` (per the resolved clarification), with per-instance configuration in `/etc/percussion/cms-<instance>.env`, so multiple CMS instances can coexist on one host as `percussioncms@<instance>.service`. Single-instance installs use the instance name `default`. The DTS units follow the same template pattern (`percussiondts-staging@.service`, `percussiondts-production@.service`).
+- **FR-005**: The project MUST publish a supported-platform matrix in `modules/perc-distribution-tree` documentation stating which Linux distributions / init systems are supported in this release. Per the resolved clarification, init.d-based hosts are NOT supported in this release: the installer is the only supported migration path, and hosts that do not run the upgrade installer are out of support.
+- **FR-006**: After a successful conversion, the legacy init.d scripts MUST NOT be required by the running CMS. The unit file MUST start the CMS via the same Jetty / service-wrapper entry points already used today (so the runtime is unchanged — only the supervision mechanism changes).
+- **FR-006a**: The CMS unit MUST declare `Restart=on-failure` with `RestartSec=30s` and a bounded `StartLimitBurst=` / `StartLimitIntervalSec=` cap (per the resolved clarification), so that a JVM crash brings the CMS back automatically but a failing service cannot spin in a tight restart loop. The DTS units follow the same policy.
+- **FR-007**: The legacy init.d scripts (`percussion-service.sh`, `InstallPublisherDaemon.sh`, `InstallDaemon.sh`, `InstallFTSDaemon.sh`, and their `unix/` counterparts) and their installer-manifest references MUST be physically deleted from the source tree in this release (per the resolved clarification). Init.d support is dropped entirely this release (no one-release overlap); the installer must convert any existing init.d installation to systemd as part of upgrade (FR-003).
+- **FR-008**: The DTS distribution (`deliverytiersuite/delivery-tier-suite/delivery-tier-distribution`) MUST include equivalent systemd units for the staging and production services, with an upgrade path from the existing `DTSStagingService.sh` / `DTSProductionService.sh` init.d scripts.
+- **FR-009**: The new systemd units MUST direct all CMS / DTS log output to the systemd journal (`StandardOutput=journal`, `StandardError=journal`) in addition to any existing log files, so operators can use `journalctl -u <unit>` without additional configuration.
+- **FR-010**: The installer MUST be idempotent: running it twice on the same host (whether mid-upgrade or to repair state) MUST converge to the same end state and MUST NOT produce duplicate or conflicting systemd units or init.d symlinks.
+- **FR-011**: The installer MUST detect a partially-completed prior conversion (init.d scripts removed but no systemd unit installed) and recover to a working systemd-managed state on the next run, rather than leaving the host unmanaged.
+- **FR-012**: All behavior changes MUST be accompanied by automated tests: unit tests for the installer's detection / migration logic and an integration test that exercises `systemctl` against the generated units in a systemd-enabled container or VM. *(Per constitution principle III.)*
+- **FR-013**: All changes MUST update module documentation (`modules/perc-distribution-tree` README, `system/release/installer/Linux` README, DTS distribution docs, and the appropriate `src/site/markdown/` pages) describing the new install / upgrade procedure and the supported-platform matrix.
+
+### Key Entities *(include if feature involves data)*
+
+- **Systemd Unit File**: A `.service` template file shipped in the distribution tree that describes how to start, stop, and supervise one CMS (or DTS) service. Identified by template name (e.g. `percussioncms@.service`) and instantiated as `percussioncms@<instance>.service`. Has `EnvironmentFile=`, `ExecStart=`, `ExecStop=`, `Restart=on-failure`, `RestartSec=30s`, `StartLimitBurst=`, `StartLimitIntervalSec=`, `User=`, `Group=`, `WantedBy=`, and LSB-equivalent metadata (`Description=`, `Documentation=`).
+- **Environment File**: A small shell-sourced file (e.g. `/etc/percussion/cms-<instance>.env`) holding install-path, port, JVM options, and user/group overrides for one instance. Referenced from the unit via `EnvironmentFile=`; the `%i` specifier expands to the instance name.
+- **Legacy Init.d Script**: An existing LSB-style init script with `BEGIN INIT INFO` headers, symlinked under `/etc/init.d/` or `/etc/rc.d/`. Identified by file presence and by `chkconfig`/`update-rc.d` registration. Tracked by the installer so it can be cleanly removed during upgrade.
+- **Installer Manifest**: The existing installer configuration (under `modules/perc-ant` and `modules/perc-distribution-tree`) that decides which files to copy and which install/upgrade actions to run. Must be updated to install the unit file, remove init.d artifacts, and run `systemctl` commands.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A clean install of the CMS on a supported systemd Linux distribution completes end-to-end (installer invoked → `systemctl is-active percussioncms@default` returns `active` and the CMS login port responds) within 90 seconds on the reference VM (Ubuntu 22.04, 4 vCPU, 8 GB RAM, 20 GB disk, no other CMS instances) — measured by the integration test harness `docker/systemd-test/`.
+- **SC-002**: An upgrade from a legacy init.d-based CMS install to the systemd-based release completes end-to-end without operator interaction beyond launching the installer (no prompts, no manual `systemctl` invocations, no `journalctl` monitoring required); afterwards `systemctl is-active percussioncms@default` returns `active`, `ls /etc/init.d/ | grep -i percussion` returns zero matches, and the CMS login port responds on the same port as before the upgrade.
+- **SC-003**: On a supported systemd host, 100% of the standard operator lifecycle commands (`systemctl start|stop|restart|status|enable|disable` and `journalctl -u percussioncms`) succeed without falling back to init.d or wrapper scripts.
+- **SC-004**: The distribution artifacts that previously included init.d scripts no longer contain them in this release (verifiable by `find modules/perc-distribution-tree -name '*.sh' | grep -i init.d` returning zero matches, and likewise for DTS distribution).
+- **SC-005**: Automated test coverage for the installer's detection / migration logic reaches at least 85% line coverage on the new code paths, and the systemd integration test passes on a clean Ubuntu 22.04 (or equivalent) container.
+- **SC-006**: Zero new high or critical security findings are introduced by the new units and install/upgrade path (no setuid wrappers, no world-writable env files, no log-injection vectors via `EnvironmentFile=`).
+
+## Assumptions
+
+- The underlying CMS runtime (Jetty-based) does not need to change. The change is purely in the *supervision* layer (how the OS starts/stops/monitors the CMS process), not in the CMS process itself.
+- The systemd unit will reuse the existing Jetty/service-wrapper entry points (`StartJetty.sh` / `StopJetty.sh` / `rxjetty.sh`) so that JVM arguments, ports, and logging paths behave exactly as they do today.
+- The repo currently builds under JDK 21 on the `development` branch (per `AGENTS.md`); the installer shell scripts and unit files are not JDK-sensitive, but the build wiring must still go through `mvn-env.sh`.
+- Linux distributions without systemd (RHEL 7 / CentOS 7 / older Ubuntu LTS) are a minority of the installed base. The exact handling of these hosts is captured as clarification Q1.
+- "Upgrade scenarios" means in-place upgrade of the CMS install — not a downgrade path from systemd back to init.d.
+- The DTS staging/production services follow the same architectural pattern as CMS services, so a single design decision applies to both. If they diverge in implementation, that is a concern for `/speckit.plan`, not for this spec.
+- An `EnvironmentFile=` per service is the accepted mechanism for parameterisation; we are not introducing a new templating system.
+- The project does not need to ship a `systemd` *generator*; we ship static unit files that are parameterised via the env file at install time.
+
+## Resolved Questions
+
+All open questions raised during `/speckit.specify` were resolved during the `/speckit.clarify` pass (see the `## Clarifications` section at the top of this file). Resolutions, with rationale and downstream impact, for the record:
+
+### Q1 — Supported-platform matrix: init.d fallback strategy
+
+- **Question**: Do we (a) drop init.d support in the same release that introduces systemd, (b) keep init.d as a one-release fallback, or (c) keep init.d indefinitely as a documented alternative?
+- **Answer**: **(a) Drop init.d support in the same release that introduces systemd.** No one-release overlap; no in-tree deprecated init.d fallback.
+- **Rationale**: Cleanest cutover. Issue #962's wording ("remove the legacy init.d scripts after conversion to systemd") supports a single cutover. A one-release overlap would perpetuate two supervision paths and complicate the upgrade installer, which already has to detect-and-migrate legacy installs (FR-003).
+- **Downstream impact**:
+  - `FR-005` (supported-platform matrix): init.d-based hosts are NOT supported in this release; the upgrade installer is the only supported migration path.
+  - `FR-007` (init.d removal): legacy scripts and installer references are physically deleted this release (no in-tree deprecated copy).
+  - `SC-004`: `find … init.d` returns zero matches in the distribution tree.
+  - The "Distribution without systemd" edge case (FR-005) is closed: non-systemd hosts are out of support; the installer refuses with exit code 2 and a clear message (covered by US1 negative-path test T013-b).
+  - The "Open Questions" section is now collapsed to this resolved record; no live ambiguity.
+
+### Q2 — Init.d removal scope: delete from source tree or keep deprecated?
+
+- **Question**: In this release (the one that introduces systemd), should the legacy init.d scripts and their installer-manifest references be physically deleted, or kept in-tree marked `@Deprecated`/commented out?
+- **Answer**: **Physically delete in this release.** No in-tree deprecated copy, no commented-out installer entries.
+- **Rationale**: Matches issue #962's "remove the legacy init.d scripts" wording. Keeping a deprecated in-tree copy would create dead code that future readers mistake for live behavior, and would invite a future re-enable in the wrong place. Constitution V (Safe Modernization) favors incremental removal over preserving unused code when the cutover is intentional.
+- **Downstream impact**:
+  - `FR-007`: physical deletion of `system/release/installer/Linux/*.sh` and `system/release/installer/unix/*.sh` and the DTS `rootFiles/DTS*Service.sh`.
+  - US2 implementation tasks T030 (CMS deletions) and T031 (DTS deletions) plus the manifest-cleanup task T032 (greps every reference before deletion).
+  - The legacy-detection logic in the upgrade installer (US2 / T024 / T025) handles the *runtime* artifacts on customer hosts (`/etc/init.d/*`, `/etc/rc?.d/*`, `chkconfig`/`update-rc.d` registrations) — those are on customer machines, not in our source tree, and are removed by the installer on upgrade, not by FR-007.
+
+### Q3 — Multi-instance support: in scope via template unit?
+
+- **Question**: Is preserving the historical "prefix symlinks allow multiple CMS instances on one host" pattern in scope for the systemd unit, or do we standardise on one instance per host for v1?
+- **Answer**: **In scope.** Ship `percussioncms@.service` as a systemd template unit with per-instance configuration at `/etc/percussion/cms-<instance>.env`. Single-instance installs use the instance name `default`. The DTS units follow the same template pattern (`percussiondts-staging@.service`, `percussiondts-production@.service`).
+- **Rationale**: Multi-instance is rare but historically supported (the legacy `install-jetty-service.sh` already gates on `/etc/init.d/${SERVICE_NAME}` and can be re-run with different names). A systemd template unit is the standard idiom for "N instances of the same service on one host" — it costs almost nothing in unit complexity and avoids designing around an edge case that hasn't been validated against current installer behavior. The DTS staging and production services have always been two instances on the same host, so a single design decision covers CMS and DTS.
+- **Downstream impact**:
+  - `FR-004a`: template unit + per-instance env file is mandatory, not optional.
+  - `FR-004` (parameterisation): the same unit file ships to every customer; per-instance values come from the env file.
+  - The unit template is named `percussioncms@.service` (no hyphens — see note in `## Clarifications` / inline renames); the env file is `cms-<instance>.env`; the service name (after `@`) is the instance identifier (`default` for single, `instance2`, `instance3`, … for multi).
+  - US2 task T028 (per-instance detection) and US1 task T016 (the template itself) reflect this.
+  - The `EnvironmentFile=` line in the template uses the `%i` specifier, which systemd expands to the instance name at `systemctl start percussioncms@default` time.
+
+### Out-of-scope clarifications deferred to planning
+
+The following items were intentionally NOT promoted to `[NEEDS CLARIFICATION]` markers because they are tuning knobs best resolved in `/speckit.tasks` or during implementation, not in the spec:
+
+- Exact `StartLimitBurst` / `StartLimitIntervalSec` numeric values (per Q3 the *policy* is fixed; the numbers are tuned against observed CMS startup behavior — currently 5 / 600s as a placeholder).
+- Exact `TimeoutStartSec` / `TimeoutStopSec` values (per Q3 the *policy* is fixed; the numbers depend on Jetty startup time on the reference VM — currently 300s / 120s as a placeholder).
+- Exact `EnvironmentFile=` directory mode/owner (per SC-006 the security property is fixed; the directory is `/etc/percussion/` with mode `0755 root:root` and per-file mode `0640 root:<group>` — see `contracts/env-file.md`).
+- `systemd-nspawn` vs. privileged-Docker for the integration test harness (per Decision 8 in `research.md`; the docker harness is the default, nspawn is an option on systemd hosts).
+
+These are recorded in `research.md` (Decisions 1, 3, 5, 8) and will be pinned as concrete values in `contracts/unit-template.md` once the integration test harness (US1 / T005) runs end-to-end on the reference VM.

--- a/specs/006-systemd-linux-services/tasks.md
+++ b/specs/006-systemd-linux-services/tasks.md
@@ -1,0 +1,272 @@
+# Tasks: Systemd Linux Service Scripts (Replace init.d)
+
+**Input**: Design documents from `/specs/006-systemd-linux-services/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+**Source issue**: intersoftdatalabs-in/percussioncms#962
+
+**Tests**: REQUIRED for every behavioral code change (Constitution III — Test Discipline). Each user story MUST include test tasks. Prefer fail-then-pass (write/adjust tests first).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- Include exact mono-repo file paths in descriptions (module + `src/main` / `src/test`)
+
+## Path Conventions
+
+- **Mono-repo modules** (Percussion CMS): use real module roots, e.g.
+  - Installer / distribution: `modules/perc-distribution-tree/`, `modules/perc-jetty/`
+  - Legacy install tree (deletion target): `system/release/installer/Linux/`, `system/release/installer/unix/`
+  - DTS distribution: `deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/`
+  - Test harness: `docker/systemd-test/`
+- Shell scripts and unit templates are not Java; do NOT run `./mvn-env.sh` against them directly. Use `shellcheck` and the integration test harness instead.
+- Build wiring changes still go through `./mvn-env.sh` for any touched module's `pom.xml`.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm ownership, AGENTS rules, and build baseline for touched modules
+
+- [ ] T001 Read `AGENTS.md` (root) and `modules/perc-jetty/AGENTS.md` and apply Rule Discovery Protocol for `modules/perc-distribution-tree` and `system/`
+- [ ] T002 Confirm branch JDK (21 on `development`) and verify `./mvn-env.sh -pl modules/perc-distribution-tree -am test` baseline passes
+- [ ] T003 [P] Confirm `modules/perc-jetty/src/main/jetty/StartJetty.sh` and `StopJetty.sh` exist and are the runtime entry points we will reference from the unit template
+- [ ] T004 [P] Confirm `shellcheck` is available in the dev environment for new shell scripts; add to CI gate if missing
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared prerequisites that MUST be complete before ANY user story can be implemented
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T005 Create the new `docker/systemd-test/` harness directory and `docker/systemd-test/Dockerfile` (Ubuntu 22.04 with `/sbin/init` as entrypoint, cgroups mounted, JDK 21 installed) so the integration test in US1 can run end-to-end
+- [ ] T006 [P] Create `docker/systemd-test/run-tests.sh` and `docker/systemd-test/README.md` documenting how to launch the harness
+- [ ] T007 Enumerate every reference to the legacy init.d scripts across the repository (grep for `percussion-service.sh`, `InstallDaemon.sh`, `InstallPublisherDaemon.sh`, `InstallFTSDaemon.sh`, `DTSStagingService.sh`, `DTSProductionService.sh`, `chkconfig`, `update-rc.d`, `/etc/rc?.d`, `/etc/init.d`); record the list in `specs/006-systemd-linux-services/checklists/legacy-initd-references.md`
+- [ ] T008 [P] Read the existing `modules/perc-jetty/src/main/jetty/service/install-jetty-service.sh` and `modules/perc-jetty/src/main/jetty/StartJetty.sh` and capture the full set of env vars the legacy installer writes to `/etc/default/<name>` (the source of truth for the env-file contract)
+- [ ] T009 [P] Update `modules/perc-distribution-tree/src/main/resources/META-INF/MANIFEST.MF` (or equivalent assembly descriptor) to include the new `systemd/` and `env/` resource directories in the install tree
+- [ ] T010 Create `modules/perc-distribution-tree/scripts/README.md` documenting the new `install-systemd-units.sh` and `uninstall-systemd-units.sh` scripts (per AGENTS rule: scripts need a README)
+- [ ] T011 [P] Add a `shellcheck` step to the CI pipeline that runs against `modules/perc-distribution-tree/scripts/*.sh` and `modules/perc-jetty/src/main/jetty/service/*.sh` (modify `.github/workflows/` or equivalent)
+
+**Checkpoint**: Foundation ready - user story implementation can now begin in parallel
+
+---
+
+## Phase 3: User Story 1 - Fresh Install on a systemd Linux Host (Priority: P1) 🎯 MVP
+
+**Goal**: A clean CMS install on a systemd Linux host ends with the CMS running under `systemd` (managed by `percussioncms@default.service`), all logs in the journal, autostart on boot enabled.
+
+**Independent Test**: Run `docker/systemd-test/run-tests.sh scenario-fresh-install` and confirm the harness asserts `systemctl is-active percussioncms@default` returns `active`, `curl` reaches the CMS port, and `journalctl -u percussioncms@default` shows startup logs.
+
+### Tests for User Story 1 (REQUIRED) ⚠️
+
+> **NOTE: Write or update these tests FIRST; ensure they FAIL before implementation, then PASS**
+
+- [ ] T012 [P] [US1] Write a shell-level bats test `modules/perc-jetty/src/test/shell/install-systemd-units.bats` covering: fresh install (no existing init.d) creates `/etc/systemd/system/percussioncms@default.service`, `/etc/percussion/cms-default.env` (mode `0640`), runs `daemon-reload`/`enable`/`start`, and `systemctl is-active` returns `active`
+- [ ] T013 [P] [US1] Add a negative-path bats test case covering FR-002's "report clear success/failure" contract: (a) env file with mode `0644` (group/world readable) → installer exits 2, unit file is NOT installed, `systemctl is-enabled percussioncms@default` returns `disabled`; (b) non-systemd PID 1 (simulated via `unshare --pid --fork` or a chroot) → installer exits 2 with the "systemd is not PID 1" message; (c) `JETTY_HOME` path missing → installer exits 2 with the missing-path message
+- [ ] T014 [P] [US1] Write a JUnit 5 test `modules/perc-distribution-tree/src/test/java/com/percussion/distribution/systemd/EnvFileSchemaTest.java` validating the env-file key set, mode `0640`, and rejection of `$(`, backticks, `export` per `specs/006-systemd-linux-services/contracts/env-file.md` (also serves as the SC-006 abuse-case test for env-file injection)
+- [ ] T015 [P] [US1] Write a JUnit 5 test `modules/perc-distribution-tree/src/test/java/com/percussion/distribution/systemd/UnitTemplateRenderTest.java` rendering the template with a sample env and asserting `systemd-analyze verify` (or static structural check) passes the contract from `specs/006-systemd-linux-services/contracts/unit-template.md`
+
+### Implementation for User Story 1
+
+- [ ] T016 [P] [US1] Create the unit template `modules/perc-distribution-tree/src/main/resources/systemd/percussioncms@.service.template` per `specs/006-systemd-linux-services/contracts/unit-template.md` (must declare `Type=simple`, `EnvironmentFile=/etc/percussion/cms-%i.env`, `Restart=on-failure`, `RestartSec=30s`, `StartLimitBurst=5`, `StartLimitIntervalSec=600s`, `NoNewPrivileges=true`, `ProtectSystem=strict`, and the rest of the hardening directives)
+- [ ] T017 [P] [US1] Create the env-file template `modules/perc-distribution-tree/src/main/resources/env/percussioncms.env.template` with all keys from `specs/006-systemd-linux-services/contracts/env-file.md` (PERC_ROOT, JETTY_HOME, JETTY_BASE, JETTY_DEFAULTS, JETTY_RUN, JETTY_CONF, JETTY_START_LOG, JETTY_PID, JAVA_HOME, JAVA, JAVA_OPTIONS, JETTY_ARGS, JETTY_USER, INSTANCE_NAME)
+- [ ] T018 [US1] Create `modules/perc-distribution-tree/scripts/install-systemd-units.sh` implementing the 8-phase flow per `specs/006-systemd-linux-services/contracts/installer-script.md` (probe → detect → validate → render → migrate (no-op on fresh install) → enable → start → report), with `--perc-root`, `--user`, `--instance`, `--dry-run`, `--force`, `--help` flags and exit codes 0/1/2/3
+- [ ] T019 [US1] Create `modules/perc-distribution-tree/scripts/uninstall-systemd-units.sh` that does the reverse: `systemctl disable --now`, `rm` the unit and env file, `systemctl daemon-reload`, `reset-failed`
+- [ ] T020 [US1] Wire the new scripts into the CMS installer pipeline (Maven assembly / `perc-ant` install XMLs) so the CMS installer invokes `install-systemd-units.sh` on a fresh install; update `modules/perc-distribution-tree/scripts/README.md` accordingly
+- [ ] T021 [US1] Run `shellcheck modules/perc-distribution-tree/scripts/install-systemd-units.sh modules/perc-distribution-tree/scripts/uninstall-systemd-units.sh`; fix every reported issue
+- [ ] T022 [US1] Run `./mvn-env.sh -pl modules/perc-distribution-tree -am test`; ensure the JUnit tests T014 / T015 pass
+- [ ] T023 [US1] Run the bats test T012 inside `docker/systemd-test/`; confirm Scenario 1 from `specs/006-systemd-linux-services/quickstart.md` passes end-to-end
+
+**Checkpoint**: At this point, User Story 1 should be fully functional and testable independently — the CMS is installable on a fresh systemd host with no init.d artifacts.
+
+---
+
+## Phase 4: User Story 2 - Existing Installation Upgrade From init.d to systemd (Priority: P2)
+
+**Goal**: An existing init.d-based CMS install is migrated in place by the upgrade installer: legacy scripts/symlinks removed, systemd units installed and active, no operator intervention beyond running the installer.
+
+**Independent Test**: Seed a legacy init.d install (Scenario 2 in `quickstart.md`), run the upgrade installer inside the `docker/systemd-test/` harness, assert legacy artifacts are gone, the systemd unit is active, and the CMS is reachable.
+
+### Tests for User Story 2 (REQUIRED) ⚠️
+
+- [ ] T024 [P] [US2] Add a bats test case to `modules/perc-jetty/src/test/shell/install-systemd-units.bats` covering: seeded `/etc/init.d/PercussionCMS` + `/etc/rc?.d/S99PercussionCMS` symlinks; after `install-systemd-units.sh`, the legacy script and symlinks are absent, `chkconfig --list | grep percussion` is empty (or the tool is missing), and the systemd unit is active
+- [ ] T025 [P] [US2] Add a JUnit 5 test `modules/perc-distribution-tree/src/test/java/com/percussion/distribution/systemd/LegacyDetectionTest.java` covering: detection of multiple init.d patterns (`percussion-service.sh`, `PercussionD`, `PercussionCMS`, `DTSStagingService`, `DTSProductionService`), rc?.d symlink enumeration, and `/etc/default/<name>` parsing
+- [ ] T026 [P] [US2] Add a JUnit 5 test `modules/perc-distribution-tree/src/test/java/com/percussion/distribution/systemd/IdempotencyTest.java` covering: re-running the installer (a) on a clean host (no-op, exit 0), (b) after manual unit deletion (recreates, starts, exit 0), (c) with conflicting init.d + systemd state (exit 3 unless `--force`)
+
+### Implementation for User Story 2
+
+- [ ] T027 [US2] Extend `modules/perc-distribution-tree/scripts/install-systemd-units.sh` with the upgrade-only migration phase 5 (legacy service stop, `chkconfig --del` / `update-rc.d -f remove`, symlink removal, legacy script removal) per Decision 4 in `specs/006-systemd-linux-services/research.md`
+- [ ] T028 [US2] Extend the same script with per-instance detection so multiple init.d-prefixed CMS instances each map to a `percussioncms@<instance>.service` (FR-004a); default instance name is `default`, additional ones are `instance2`, `instance3`, …
+- [ ] T029 [US2] Extend the same script with FR-011 recovery: detect partial-migration state (init.d removed but no systemd unit present) and re-create the unit + env file
+- [ ] T030 [P] [US2] Physically delete the legacy init.d scripts per FR-007: `system/release/installer/Linux/percussion-service.sh`, `system/release/installer/Linux/InstallPublisherDaemon.sh`, `system/release/installer/Linux/InstallDaemon.sh`, `system/release/installer/Linux/InstallFTSDaemon.sh`, and their `system/release/installer/unix/` counterparts
+- [ ] T031 [P] [US2] Physically delete the DTS init.d scripts: `deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/DTSStagingService.sh` and `DTSProductionService.sh`
+- [ ] T032 [US2] Update every installer manifest entry that referenced the deleted scripts (use the enumeration from T007); confirm `mvn -pl modules/perc-ant` validate-pom and any assembly XML still resolve
+- [ ] T033 [US2] Add a hardening note to `install-systemd-units.sh`: when parsing legacy `/etc/default/<name>`, warn (not silently drop) on values matching secret patterns (`PASSWORD`, `SECRET`, `KEY`, `TOKEN`); do NOT copy such values into the new env file
+- [ ] T034 [US2] Run `shellcheck` and `./mvn-env.sh -pl modules/perc-distribution-tree -am test`; ensure T025 / T026 pass
+- [ ] T035 [US2] Run the bats test T024 inside `docker/systemd-test/`; confirm Scenario 2 from `quickstart.md` passes
+
+**Checkpoint**: At this point, User Stories 1 AND 2 should both work independently — fresh installs and in-place upgrades both land on systemd.
+
+---
+
+## Phase 5: User Story 3 - Operator Lifecycle and Diagnostics (Priority: P3)
+
+**Goal**: An operator uses only `systemctl` and `journalctl` to manage the CMS — start, stop, restart, status, autostart toggle, and crash-recovery behavior all work via the standard systemd interface.
+
+**Independent Test**: Run Scenarios 3 and 6 from `quickstart.md` inside the `docker/systemd-test/` harness; assert each `systemctl` subcommand exits 0 and the post-conditions hold.
+
+### Tests for User Story 3 (REQUIRED) ⚠️
+
+- [ ] T036 [P] [US3] Add a bats test case to `modules/perc-jetty/src/test/shell/install-systemd-units.bats` covering: `systemctl stop` then `is-active` → `inactive`; `systemctl start` then `is-active` → `active`; `systemctl restart` exits 0; `disable`/`enable` round-trips `is-enabled`; `kill -9 <pid>` is followed by `is-active` → `active` within `RestartSec=30s`
+- [ ] T037 [P] [US3] Add a bats test case for the crash-loop guard: after `StartLimitBurst=5` crashes within `StartLimitIntervalSec=600s`, the unit enters `failed` state; `systemctl reset-failed` allows a fresh start
+
+### Implementation for User Story 3
+
+- [ ] T038 [US3] Confirm (and tune if needed) the unit template's `TimeoutStartSec`, `TimeoutStopSec`, `RestartSec`, `StartLimitBurst`, `StartLimitIntervalSec` values match the spec; record final values in `specs/006-systemd-linux-services/contracts/unit-template.md` (Decision 1 / 3 in `research.md`)
+- [ ] T039 [US3] Confirm the unit's `StandardOutput=journal` and `StandardError=journal` actually capture CMS output (not just Jetty's stdout): if CMS writes to a file only, add a `tail -F` wrapper or document the limitation in the operator guide
+- [ ] T040 [P] [US3] Add a JUnit 5 test `modules/perc-distribution-tree/src/test/java/com/percussion/distribution/systemd/RestartPolicyTest.java` asserting the rendered unit string contains `Restart=on-failure`, `RestartSec=30s`, `StartLimitBurst=5`, `StartLimitIntervalSec=600s` (per FR-006a)
+- [ ] T041 [US3] Run the bats tests T036 / T037 inside `docker/systemd-test/`; confirm Scenarios 3 and 6 from `quickstart.md` pass
+- [ ] T042 [US3] Run `./mvn-env.sh -pl modules/perc-distribution-tree -am test`; ensure T040 passes
+
+**Checkpoint**: At this point, User Stories 1, 2, and 3 should all work independently.
+
+---
+
+## Phase 6: User Story 4 - Delivery Tier Suite (DTS) Services Move to systemd (Priority: P3)
+
+**Goal**: The DTS staging and production services install as systemd units with a parallel upgrade path from the legacy `DTSStagingService.sh` / `DTSProductionService.sh` init.d scripts.
+
+**Independent Test**: Run Scenario 5 from `quickstart.md` inside the `docker/systemd-test/` harness; assert both `percussiondts-staging@<instance>.service` and `percussiondts-production@<instance>.service` are active.
+
+### Tests for User Story 4 (REQUIRED) ⚠️
+
+- [ ] T043 [P] [US4] Add a bats test case to `modules/perc-jetty/src/test/shell/install-systemd-units.bats` covering: DTS install (template + env files for staging and production) results in two active units; legacy `DTSStagingService.sh` / `DTSProductionService.sh` (seeded) are removed after upgrade
+
+### Implementation for User Story 4
+
+- [ ] T044 [P] [US4] Create the DTS unit templates `modules/perc-distribution-tree/src/main/resources/systemd/percussiondts-staging@.service.template` and `percussiondts-production@.service.template` (parallel to the CMS template, same hardening and restart policy)
+- [ ] T045 [P] [US4] Create the DTS env templates `modules/perc-distribution-tree/src/main/resources/env/percussiondts-staging.env.template` and `percussiondts-production.env.template`
+- [ ] T046 [US4] Wire the DTS templates into the DTS installer pipeline (`deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml` or its assembly); reuse the same `install-systemd-units.sh` from T018 with `--instance staging` / `--instance production`
+- [ ] T047 [P] [US4] Extend the legacy-detection test T025 to recognize `DTSStagingService` / `DTSProductionService` (already covered, but confirm per-instance mapping produces two separate units)
+- [ ] T048 [US4] Run the bats test T043 inside `docker/systemd-test/`; confirm Scenario 5 from `quickstart.md` passes
+
+**Checkpoint**: All user stories are now independently functional.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories
+
+- [ ] T049 [P] Update `modules/perc-distribution-tree/README.md` to point at the new operator guide and link to `specs/006-systemd-linux-services/quickstart.md`
+- [ ] T050 [P] Update `modules/perc-jetty/README.md` to note the deprecation of `install-jetty-service.sh` for the init.d path; keep the script as a no-op dispatcher (or delete per FR-007 if the new script fully replaces it)
+- [ ] T051 [P] Create `modules/perc-distribution-tree/src/site/markdown/systemd-linux-services.md` (operator guide, supported-platform matrix, install/upgrade procedure, troubleshooting) and add a menu item in `modules/perc-distribution-tree/src/site/site.xml`
+- [ ] T052 [P] Create `modules/perc-jetty/src/site/markdown/worklog/systemd-linux-services.md` describing the change for the next maintainer; add a worklog menu item in `modules/perc-jetty/src/site/site.xml`
+- [ ] T053 [P] Add a `BREAKING_CHANGES.md` entry (or existing release-notes file) noting: "init.d support is removed in this release. Hosts running legacy init.d installs MUST run the upgrade installer in this release to convert to systemd; out-of-support otherwise." per Q1 resolution
+- [ ] T054 Security review: confirm `EnvironmentFile=` is mode `0640`, owner `root:<group>`; confirm no secret material can land in `/etc/percussion/*.env`; confirm `ProtectSystem=strict` / `NoNewPrivileges=true` do not break Jetty (Scenarios 1–5 still pass after enabling them — they already do in T016)
+- [ ] T055 [P] Add a regression test for the edge case in `data-model.md`: multi-host, multi-instance seed (two distinct `PERC_ROOT` paths) yields two `percussioncms@<instance>.service` units with independent env files
+- [ ] T056 [P] Run Spotless (`./mvn-env.sh spotless:check`) against any module whose `pom.xml` was touched
+- [ ] T057 [P] Verify `.specify/feature.json` still points at `specs/006-systemd-linux-services` and the checklist `specs/006-systemd-linux-services/checklists/requirements.md` is up to date with all resolutions
+- [ ] T058 [P] Add a `dependabot.yml` entry or `CODEOWNERS` rule so the new `modules/perc-distribution-tree/scripts/*.sh` and `modules/perc-distribution-tree/src/main/resources/systemd/**` have an owning team
+- [ ] T059 Final end-to-end run of all 7 scenarios from `specs/006-systemd-linux-services/quickstart.md` in `docker/systemd-test/`; attach the harness output to the PR
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3+)**: All depend on Foundational phase completion
+  - User stories can then proceed in parallel (if staffed)
+  - Or sequentially in priority order (P1 → P2 → P3 → P3)
+- **Polish (Phase 7)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1) Fresh Install**: Can start after Foundational (Phase 2) - No dependencies on other stories
+- **User Story 2 (P2) Upgrade from init.d**: Depends on US1 (the systemd unit template, env-file template, and `install-systemd-units.sh` from US1 are extended in US2 with the migration phase and per-instance detection). US2 cannot ship without US1's unit + env files.
+- **User Story 3 (P3) Operator Lifecycle**: Depends on US1 (the unit template carries the restart policy and journal directives US3 tests). US3 is mostly test work plus a few template tweaks.
+- **User Story 4 (P3) DTS**: Depends on US1 (same `install-systemd-units.sh` is reused with `--instance staging|production`). The DTS-specific templates T044 / T045 are parallel to US1's templates.
+
+### Within Each User Story
+
+- Tests MUST be written/updated and FAIL before implementation, then PASS after
+- Unit files and env-file templates come first; the installer script that wires them comes second; integration tests come last
+- Deletion of legacy init.d scripts (US2) happens AFTER the new path is tested green, not before
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- All Setup tasks marked [P] can run in parallel
+- All Foundational tasks marked [P] can run in parallel (within Phase 2)
+- T012 / T013 / T014 / T015 (US1 tests) can be authored in parallel
+- T016 / T017 (US1 templates) can be authored in parallel
+- T030 / T031 (US2 deletions) can be authored in parallel
+- T044 / T045 (US4 DTS templates) can be authored in parallel
+- T049 / T050 / T051 / T052 (US7 docs) can be authored in parallel
+- Once Foundational phase completes, US1 can start; US2/US3/US4 should wait for US1's unit + env template to be frozen, then proceed in parallel by different developers (US2 = installer-logic, US3 = test work, US4 = DTS templates)
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch tests for User Story 1 together:
+Task: "Write bats test in modules/perc-jetty/src/test/shell/install-systemd-units.bats"
+Task: "Write EnvFileSchemaTest in modules/perc-distribution-tree/src/test/java/.../EnvFileSchemaTest.java"
+Task: "Write UnitTemplateRenderTest in modules/perc-distribution-tree/src/test/java/.../UnitTemplateRenderTest.java"
+
+# Independent production artifacts in parallel after tests are red:
+Task: "Create unit template in modules/perc-distribution-tree/src/main/resources/systemd/percussioncms@.service.template"
+Task: "Create env template in modules/perc-distribution-tree/src/main/resources/env/percussioncms.env.template"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL - blocks all stories)
+3. Complete Phase 3: User Story 1
+4. **STOP and VALIDATE**: Test User Story 1 independently via `docker/systemd-test/`
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Foundation ready
+2. Add User Story 1 → Test independently → Deploy/Demo (MVP!)
+3. Add User Story 2 → Test independently → Deploy/Demo
+4. Add User Story 3 → Test independently → Deploy/Demo
+5. Add User Story 4 → Test independently → Deploy/Demo
+6. Each story adds value without breaking previous stories
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. Team completes Setup + Foundational together
+2. Once US1's unit + env templates are frozen:
+   - Developer A: User Story 2 (installer migration phase + legacy deletions)
+   - Developer B: User Story 3 (operator lifecycle tests)
+   - Developer C: User Story 4 (DTS templates + installer wiring)
+3. Stories complete and integrate independently
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Verify tests fail before implementing
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Avoid: vague tasks, same file conflicts, cross-story dependencies that break independence
+- Per Constitution IX (PR Review Comment Resolution): the PR author MUST follow root `AGENTS.md` "PR Review Comment Resolution" — inline reply + `resolveReviewThread` mutation — for every review thread before considering the PR merge-ready
+- All deletion tasks (T030 / T031) MUST be paired with a `grep` verification step (T032) to catch every reference in the source tree before deletion


### PR DESCRIPTION
## Summary

- **Spec, plan, research, data model, contracts, quickstart, and tasks** for replacing the legacy init.d service scripts with native systemd units (issue #962).
- All four `/speckit.clarify` questions resolved and recorded in `spec.md` (`## Clarifications` + `## Resolved Questions`):
  - **Q1** — init.d dropped in this release (no one-release overlap).
  - **Q2** — legacy init.d scripts and installer references physically deleted in this release.
  - **Q3** — multi-instance in scope via `percussioncms@.service` template unit.
  - **Q4** — restart policy `Restart=on-failure` with `RestartSec=30s` and bounded start-limit.
- Unit naming uses the no-hyphen form per design decision: `percussioncms`, `percussiondts-staging`, `percussiondts-production`.

## Artifacts (10 files, 1424 insertions)

| File | Purpose |
|---|---|
| `specs/006-systemd-linux-services/spec.md` | Feature spec (user stories, FRs, SCs, clarifications) |
| `specs/006-systemd-linux-services/plan.md` | Implementation plan, Constitution Check (all 11 pass) |
| `specs/006-systemd-linux-services/research.md` | Phase 0: 8 design decisions |
| `specs/006-systemd-linux-services/data-model.md` | Entities (Unit File, Env File, Instance Record, …) |
| `specs/006-systemd-linux-services/contracts/unit-template.md` | Rendered unit schema + validation + failure modes |
| `specs/006-systemd-linux-services/contracts/env-file.md` | `/etc/percussion/cms-<instance>.env` schema |
| `specs/006-systemd-linux-services/contracts/installer-script.md` | `install-systemd-units.sh` 8-phase contract |
| `specs/006-systemd-linux-services/quickstart.md` | 7 runnable validation scenarios |
| `specs/006-systemd-linux-services/tasks.md` | 59 tasks organized by user story (T001–T059) |
| `specs/006-systemd-linux-services/checklists/requirements.md` | Spec quality checklist (all items pass) |

## Test plan

This PR is **spec-only** — no code, no CI changes. The next PR will be the implementation, structured per the tasks in `tasks.md` and validated against the 7 scenarios in `quickstart.md` via the `docker/systemd-test/` harness defined in the plan.

## Out of scope for this PR

- Implementation tasks (T001–T059). These will be worked in subsequent PRs against this branch, organized by user story per the dependency graph in `tasks.md`.
- Code deletions (`system/release/installer/Linux/`, `system/release/installer/unix/`, DTS `rootFiles/DTS*Service.sh`) — covered by US2 implementation tasks T030/T031, gated on the new path being tested green first.

## Constitution compliance

All 9 Percussion CMS constitution principles satisfied (per `plan.md` Constitution Check, both pre- and post-Phase 1).

Refs #962