### PR TITLE
004/US3 T044: fix js/xss-through-dom in PercInlineEditDataTable (2 alerts, high, 8.2-must-fix)

### DIFF
--- a/WebUI/src/main/webapp/cm/widgets/PercInlineEditDataTable.js
+++ b/WebUI/src/main/webapp/cm/widgets/PercInlineEditDataTable.js
@@ -218,39 +218,28 @@
         placeHolderValue = config.percPlaceHolderValues[rowNumber][colNumber];
       }
 
-      var value = "";
-
       if ($(aData[colNumber]).length > 0) {
         value = $(aData[colNumber]).text().trim();
         if (config.percShowValuesPlaceholders && value === placeHolderValue)
           value = "";
-        nCol.innerHTML =
-          '<input id="inputEdition' +
-          colNumber +
-          '" placeholder="' +
-          placeHolderValue +
-          '" type="text" value="' +
-          value +
-          '" />';
       } else {
         value = aData[colNumber].trim();
         if (config.percShowValuesPlaceholders && value === placeHolderValue)
           value = "";
-        nCol.innerHTML =
-          '<input id="inputEdition' +
-          colNumber +
-          '" placeholder="' +
-          placeHolderValue +
-          '" type="text" value="' +
-          value +
-          '" />';
       }
+      $(nCol).empty().append(
+        $("<input/>")
+          .attr("id", "inputEdition" + colNumber)
+          .attr("placeholder", placeHolderValue)
+          .attr("type", "text")
+          .val(value)
+      );
       $(table).find("td input").on("focusout", tableCellFocusOut);
-      var labelHtml =
-        '<label class="visuallyhidden" for="inputEdition' +
-        colNumber +
-        '">Search:</label>';
-      table.parent().append(labelHtml);
+      var label = $("<label/>")
+        .addClass("visuallyhidden")
+        .attr("for", "inputEdition" + colNumber)
+        .text("Search:");
+      table.parent().append(label);
       addPlaceHolder();
 
       $(nCol).find("input").trigger("focus");
@@ -276,24 +265,16 @@
         $(table)
           .parent()
           .append(
-            '<label class="visuallyhidden" for="inputEdition' +
-              i +
-              '">Search:</label>'
+            $("<label/>")
+              .addClass("visuallyhidden")
+              .attr("for", "inputEdition" + i)
+              .text("Search:")
           );
         var value = "";
         if ($(aData[i]).length > 0) {
           value = $(aData[i]).text().trim();
           if (config.percShowValuesPlaceholders && value === placeHolderValue)
             value = "";
-
-          jqTds[i].innerHTML =
-            '<input id="inputEdition' +
-            i +
-            '" placeholder="' +
-            placeHolderValue +
-            '" type="text" value="' +
-            value +
-            '" />';
         } else {
           value = "";
           if (typeof aData[i] != "undefined") {
@@ -302,15 +283,14 @@
 
           if (config.percShowValuesPlaceholders && value === placeHolderValue)
             value = "";
-          jqTds[i].innerHTML =
-            '<input id="inputEdition' +
-            i +
-            '" placeholder="' +
-            placeHolderValue +
-            '" type="text" value="' +
-            value +
-            '" />';
         }
+        $(jqTds[i]).empty().append(
+          $("<input/>")
+            .attr("id", "inputEdition" + i)
+            .attr("placeholder", placeHolderValue)
+            .attr("type", "text")
+            .val(value)
+        );
       }
       addPlaceHolder();
 

--- a/WebUI/src/main/webapp/cm/widgets/PercInlineEditDataTable.js
+++ b/WebUI/src/main/webapp/cm/widgets/PercInlineEditDataTable.js
@@ -218,6 +218,8 @@
         placeHolderValue = config.percPlaceHolderValues[rowNumber][colNumber];
       }
 
+      var value = "";
+
       if ($(aData[colNumber]).length > 0) {
         value = $(aData[colNumber]).text().trim();
         if (config.percShowValuesPlaceholders && value === placeHolderValue)

--- a/docs/ai-generated/tasks/gh-codeql-alerts/triage.md
+++ b/docs/ai-generated/tasks/gh-codeql-alerts/triage.md
@@ -104,8 +104,8 @@ Candidate disposition heuristics applied (final disposition assigned by module o
 | 83 | 1626 | `js/unsafe-jquery-plugin` | medium | `WebUI/src/main/webapp/cm/app/js/legacy/plugins/perc_utils.js` | `WebUI/` | `obsolete` | remove vendored 3rd-party file (verify not referenced by build/runtime) | `8.2-must-fix` | — | — |
 | 84 | 1625 | `js/unsafe-jquery-plugin` | medium | `WebUI/src/main/webapp/cm/app/js/legacy/plugins/perc_utils.js` | `WebUI/` | `obsolete` | remove vendored 3rd-party file (verify not referenced by build/runtime) | `8.2-must-fix` | — | — |
 | 85 | 1624 | `js/xss-through-dom` | high | `WebUI/src/main/webapp/cm/widgets/perc_page_edit_dialog.js` | `WebUI/` | `valid` | fix per rule guidance | `8.2-must-fix` | — | — |
-| 86 | 1623 | `js/xss-through-dom` | high | `WebUI/src/main/webapp/cm/widgets/PercInlineEditDataTable.js` | `WebUI/` | `valid` | fix per rule guidance | `8.2-must-fix` | — | — |
-| 87 | 1622 | `js/xss-through-dom` | high | `WebUI/src/main/webapp/cm/widgets/PercInlineEditDataTable.js` | `WebUI/` | `valid` | fix per rule guidance | `8.2-must-fix` | — | — |
+| 86 | 1623 | `js/xss-through-dom` | high | `WebUI/src/main/webapp/cm/widgets/PercInlineEditDataTable.js` | `WebUI/` | `valid` | fix per rule guidance | `8.2-must-fix` | #1217 | Secure innerHTML with safe jQuery element creation |
+| 87 | 1622 | `js/xss-through-dom` | high | `WebUI/src/main/webapp/cm/widgets/PercInlineEditDataTable.js` | `WebUI/` | `valid` | fix per rule guidance | `8.2-must-fix` | #1217 | Secure innerHTML with safe jQuery element creation |
 | 88 | 1621 | `js/xss-through-dom` | high | `WebUI/src/main/webapp/cm/widgetbuilder/js/views/PercWidgetFieldsViews.js` | `WebUI/` | `valid` | fix per rule guidance | `8.2-must-fix` | — | — |
 | 89 | 1620 | `js/xss-through-dom` | high | `WebUI/src/main/webapp/cm/widgetbuilder/js/views/PercWidgetBuilderDefinitionView.js` | `WebUI/` | `valid` | fix per rule guidance | `8.2-must-fix` | — | — |
 | 90 | 1619 | `js/xss-through-dom` | high | `WebUI/src/main/webapp/cm/views/PercUserView.js` | `WebUI/` | `valid` | fix per rule guidance | `8.2-must-fix` | — | — |


### PR DESCRIPTION
Fixes the DOM XSS vulnerabilities in PercInlineEditDataTable by building elements safely using jQuery rather than raw HTML innerHTML string concatenation.