### PR TITLE
004/US3 T044: fix js/xss-through-dom in PercUserView (2 alerts, high, 8.2-must-fix)

### DIFF
--- a/WebUI/src/main/webapp/cm/views/PercUserView.js
+++ b/WebUI/src/main/webapp/cm/views/PercUserView.js
@@ -738,7 +738,7 @@
       // add role to available role list
       var availableRole = $("<option/>")
         .val(selectedAssignedRoleValue)
-        .html(selectedAssignedRoleValue);
+        .text(selectedAssignedRoleValue);
       var availableRoles = $("#perc-users-available-roles > select").append(
         availableRole
       );
@@ -762,7 +762,7 @@
       // add role to available role list
       var assignedRole = $("<option/>")
         .val(selectedAvailableRoleValue)
-        .html(selectedAvailableRoleValue);
+        .text(selectedAvailableRoleValue);
       var assignedRoles = $("#perc-users-assigned-roles > select").append(
         assignedRole
       );

--- a/docs/ai-generated/tasks/gh-codeql-alerts/triage.md
+++ b/docs/ai-generated/tasks/gh-codeql-alerts/triage.md
@@ -108,8 +108,8 @@ Candidate disposition heuristics applied (final disposition assigned by module o
 | 87 | 1622 | `js/xss-through-dom` | high | `WebUI/src/main/webapp/cm/widgets/PercInlineEditDataTable.js` | `WebUI/` | `valid` | fix per rule guidance | `8.2-must-fix` | — | — |
 | 88 | 1621 | `js/xss-through-dom` | high | `WebUI/src/main/webapp/cm/widgetbuilder/js/views/PercWidgetFieldsViews.js` | `WebUI/` | `valid` | fix per rule guidance | `8.2-must-fix` | — | — |
 | 89 | 1620 | `js/xss-through-dom` | high | `WebUI/src/main/webapp/cm/widgetbuilder/js/views/PercWidgetBuilderDefinitionView.js` | `WebUI/` | `valid` | fix per rule guidance | `8.2-must-fix` | — | — |
-| 90 | 1619 | `js/xss-through-dom` | high | `WebUI/src/main/webapp/cm/views/PercUserView.js` | `WebUI/` | `valid` | fix per rule guidance | `8.2-must-fix` | — | — |
-| 91 | 1618 | `js/xss-through-dom` | high | `WebUI/src/main/webapp/cm/views/PercUserView.js` | `WebUI/` | `valid` | fix per rule guidance | `8.2-must-fix` | — | — |
+| 90 | 1619 | `js/xss-through-dom` | high | `WebUI/src/main/webapp/cm/views/PercUserView.js` | `WebUI/` | `valid` | fix per rule guidance | `8.2-must-fix` | #1220 | Secure option tag building using .text instead of .html |
+| 91 | 1618 | `js/xss-through-dom` | high | `WebUI/src/main/webapp/cm/views/PercUserView.js` | `WebUI/` | `valid` | fix per rule guidance | `8.2-must-fix` | #1220 | Secure option tag building using .text instead of .html |
 | 92 | 1617 | `js/xss-through-dom` | high | `WebUI/src/main/webapp/cm/views/PercChangeTemplateDialog.js` | `WebUI/` | `valid` | fix per rule guidance | `8.2-must-fix` | — | — |
 | 93 | 1616 | `js/xss-through-dom` | high | `WebUI/src/main/webapp/cm/views/PercCSSGalleryView.js` | `WebUI/` | `valid` | fix per rule guidance | `8.2-must-fix` | — | — |
 | 94 | 1615 | `js/xss-through-dom` | high | `WebUI/src/main/webapp/cm/shared-common-minuet.js` | `WebUI/` | `obsolete` | remove vendored 3rd-party file (verify not referenced by build/runtime) | `8.2-must-fix` | — | — |


### PR DESCRIPTION
Fixes DOM XSS vulnerabilities in PercUserView.js by using .text() instead of .html() when building drop-down option elements.