### PR TITLE
Migrate PR #853: graceful concurrency handling during publish

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSAbstractWorkflowExtension.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSAbstractWorkflowExtension.java
@@ -354,7 +354,17 @@ public abstract class PSAbstractWorkflowExtension implements IPSExtension {
     }
 
     protected void handleError(WorkflowItem wfItem, String action, Exception e) {
-      log.error("Failed to " + action + " item: " + wfItem, e);
+      if (isConcurrencyException(e)) {
+        log.info(
+            "Concurrent modification detected while attempting to {} item: {}. This item was likely updated by another concurrent publish job.",
+            action,
+            wfItem);
+        if (log.isDebugEnabled()) {
+          log.debug("Concurrent modification exception details:", e);
+        }
+      } else {
+        log.error("Failed to " + action + " item: " + wfItem, e);
+      }
       wfItem.error = e;
       wfItem.status = ItemStatus.FAILED;
     }
@@ -754,6 +764,20 @@ public abstract class PSAbstractWorkflowExtension implements IPSExtension {
 
   public void setPubServerService(IPSPubServerService pubServerService) {
     this.pubServerService = pubServerService;
+  }
+
+  public static boolean isConcurrencyException(Throwable t) {
+    while (t != null) {
+      String name = t.getClass().getName();
+      if (name.contains("LockAcquisitionException")
+          || name.contains("OptimisticLockException")
+          || name.contains("ConcurrencyFailureException")
+          || name.contains("PessimisticLockException")) {
+        return true;
+      }
+      t = t.getCause();
+    }
+    return false;
   }
 
   /** The log instance to use for this class, never <code>null</code>. */

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSAbstractWorkflowExtension.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSAbstractWorkflowExtension.java
@@ -353,6 +353,12 @@ public abstract class PSAbstractWorkflowExtension implements IPSExtension {
       return success;
     }
 
+    /**
+     * Records a failed action on the workflow item. Concurrency/lock races are demoted to INFO
+     * (another publish job likely owns the transition) but this job still marks the item {@link
+     * ItemStatus#FAILED}: the transition did not complete in <em>this</em> job. Callers that need
+     * a non-failing outcome must handle concurrency before calling this method.
+     */
     protected void handleError(WorkflowItem wfItem, String action, Exception e) {
       if (isConcurrencyException(e)) {
         log.info(
@@ -365,6 +371,7 @@ public abstract class PSAbstractWorkflowExtension implements IPSExtension {
       } else {
         log.error("Failed to " + action + " item: " + wfItem, e);
       }
+      // Intentionally FAILED for both paths: demotion is log-level only (v8.1.7 PR #853 / GH-849).
       wfItem.error = e;
       wfItem.status = ItemStatus.FAILED;
     }
@@ -766,18 +773,38 @@ public abstract class PSAbstractWorkflowExtension implements IPSExtension {
     this.pubServerService = pubServerService;
   }
 
+  /**
+   * Returns {@code true} when {@code t} (or a cause) is a lock / optimistic-lock / concurrency
+   * failure from Hibernate, JPA, or Spring. Matching is by class-name fragment so callers do not
+   * need those types on the compile classpath; fragments cover common simple names that substring
+   * matches on the original short list would miss (e.g. {@code CannotAcquireLockException}, {@code
+   * ObjectOptimisticLockingFailureException}, {@code StaleObjectStateException}).
+   */
   public static boolean isConcurrencyException(Throwable t) {
     while (t != null) {
       String name = t.getClass().getName();
-      if (name.contains("LockAcquisitionException")
-          || name.contains("OptimisticLockException")
-          || name.contains("ConcurrencyFailureException")
-          || name.contains("PessimisticLockException")) {
+      if (nameContainsConcurrencyMarker(name)) {
         return true;
       }
       t = t.getCause();
     }
     return false;
+  }
+
+  /** Package-visible for unit tests. */
+  static boolean nameContainsConcurrencyMarker(String className) {
+    if (className == null || className.isEmpty()) {
+      return false;
+    }
+    // Prefer broader fragments that still stay within lock/optimistic-lock family names.
+    return className.contains("LockAcquisitionException")
+        || className.contains("OptimisticLockException")
+        || className.contains("OptimisticLockingFailureException")
+        || className.contains("ConcurrencyFailureException")
+        || className.contains("PessimisticLockException")
+        || className.contains("CannotAcquireLockException")
+        || className.contains("StaleObjectStateException")
+        || className.contains("StaleStateException");
   }
 
   /** The log instance to use for this class, never <code>null</code>. */

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSAbstractWorkflowExtension.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSAbstractWorkflowExtension.java
@@ -774,16 +774,25 @@ public abstract class PSAbstractWorkflowExtension implements IPSExtension {
   }
 
   /**
-   * Returns {@code true} when {@code t} (or a cause) is a lock / optimistic-lock / concurrency
-   * failure from Hibernate, JPA, or Spring. Matching is by class-name fragment so callers do not
-   * need those types on the compile classpath; fragments cover common simple names that substring
-   * matches on the original short list would miss (e.g. {@code CannotAcquireLockException}, {@code
-   * ObjectOptimisticLockingFailureException}, {@code StaleObjectStateException}).
+   * Simple class names of known lock / optimistic-lock / concurrency failures from Hibernate, JPA,
+   * and Spring. Matched with exact simple-name equality (not substring) so names like {@code
+   * NotAnOptimisticLockException} are not demoted. Callers need not compile against those types.
    */
+  private static final java.util.Set<String> CONCURRENCY_EXCEPTION_SIMPLE_NAMES =
+      java.util.Set.of(
+          "LockAcquisitionException",
+          "OptimisticLockException",
+          "ObjectOptimisticLockingFailureException",
+          "OptimisticLockingFailureException",
+          "ConcurrencyFailureException",
+          "PessimisticLockException",
+          "CannotAcquireLockException",
+          "StaleObjectStateException",
+          "StaleStateException");
+
   public static boolean isConcurrencyException(Throwable t) {
     while (t != null) {
-      String name = t.getClass().getName();
-      if (nameContainsConcurrencyMarker(name)) {
+      if (isConcurrencyExceptionSimpleName(t.getClass().getSimpleName())) {
         return true;
       }
       t = t.getCause();
@@ -791,20 +800,14 @@ public abstract class PSAbstractWorkflowExtension implements IPSExtension {
     return false;
   }
 
-  /** Package-visible for unit tests. */
-  static boolean nameContainsConcurrencyMarker(String className) {
+  /** Package-visible for unit tests. Accepts simple name or FQCN (uses trailing segment). */
+  static boolean isConcurrencyExceptionSimpleName(String className) {
     if (className == null || className.isEmpty()) {
       return false;
     }
-    // Prefer broader fragments that still stay within lock/optimistic-lock family names.
-    return className.contains("LockAcquisitionException")
-        || className.contains("OptimisticLockException")
-        || className.contains("OptimisticLockingFailureException")
-        || className.contains("ConcurrencyFailureException")
-        || className.contains("PessimisticLockException")
-        || className.contains("CannotAcquireLockException")
-        || className.contains("StaleObjectStateException")
-        || className.contains("StaleStateException");
+    int dot = className.lastIndexOf('.');
+    String simple = dot >= 0 ? className.substring(dot + 1) : className;
+    return CONCURRENCY_EXCEPTION_SIMPLE_NAMES.contains(simple);
   }
 
   /** The log instance to use for this class, never <code>null</code>. */

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSAbstractWorkflowExtension.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSAbstractWorkflowExtension.java
@@ -778,8 +778,8 @@ public abstract class PSAbstractWorkflowExtension implements IPSExtension {
    * and Spring. Matched with exact simple-name equality (not substring) so names like {@code
    * NotAnOptimisticLockException} are not demoted. Callers need not compile against those types.
    */
-  private static final java.util.Set<String> CONCURRENCY_EXCEPTION_SIMPLE_NAMES =
-      java.util.Set.of(
+  private static final Set<String> CONCURRENCY_EXCEPTION_SIMPLE_NAMES =
+      Set.of(
           "LockAcquisitionException",
           "OptimisticLockException",
           "ObjectOptimisticLockingFailureException",

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/task/impl/PSWorkflowEditionTask.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/task/impl/PSWorkflowEditionTask.java
@@ -99,6 +99,25 @@ public class PSWorkflowEditionTask extends PSAbstractWorkflowExtension implement
     }
     log.debug("Finished workflowing items for jobId: {}", jobId);
 
+    updateContentDatesAfterWorkflow(jobId, pubIds, unpubIds);
+  }
+
+  /**
+   * Updates post/start/expiry dates after post-edition workflow. Concurrency failures are demoted
+   * to INFO and swallowed so the publish job completes; non-concurrency failures still propagate.
+   *
+   * <p>Note: {@code setPostDate} / {@code clearStartDate} / {@code clearExpiryDate} are not one
+   * atomic transaction. If a later call fails with a concurrency exception after an earlier call
+   * succeeded, partial date updates may remain. That is accepted for pure contention (another job
+   * is expected to finish the same writes); non-concurrency errors still abort.
+   *
+   * @param jobId publish job id (logging only)
+   * @param pubIds content ids that published (may be empty)
+   * @param unpubIds content ids that unpublished (may be empty)
+   */
+  void updateContentDatesAfterWorkflow(
+      long jobId, java.util.Set<Integer> pubIds, java.util.Set<Integer> unpubIds)
+      throws Exception {
     try {
       if (!pubIds.isEmpty()) {
         log.debug("Started updating post date for items for jobId: {}", jobId);

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/task/impl/PSWorkflowEditionTask.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/task/impl/PSWorkflowEditionTask.java
@@ -99,20 +99,33 @@ public class PSWorkflowEditionTask extends PSAbstractWorkflowExtension implement
     }
     log.debug("Finished workflowing items for jobId: {}", jobId);
 
-    if (!pubIds.isEmpty()) {
-      log.debug("Started updating post date for items for jobId: {}", jobId);
-      getCmsObjectManager().setPostDate(pubIds);
-      log.debug("Finished updating post date for items for jobId: {}", jobId);
+    try {
+      if (!pubIds.isEmpty()) {
+        log.debug("Started updating post date for items for jobId: {}", jobId);
+        getCmsObjectManager().setPostDate(pubIds);
+        log.debug("Finished updating post date for items for jobId: {}", jobId);
 
-      log.debug("Started clearing start date for items for jobId: {}", jobId);
-      getCmsObjectManager().clearStartDate(pubIds);
-      log.debug("Finished clearing start date for items for jobId: {}", jobId);
-    }
+        log.debug("Started clearing start date for items for jobId: {}", jobId);
+        getCmsObjectManager().clearStartDate(pubIds);
+        log.debug("Finished clearing start date for items for jobId: {}", jobId);
+      }
 
-    if (!unpubIds.isEmpty()) {
-      log.debug("Started clearing expiry date for items for jobId: {}", jobId);
-      getCmsObjectManager().clearExpiryDate(unpubIds);
-      log.debug("Finished clearing expiry date for items for jobId: {}", jobId);
+      if (!unpubIds.isEmpty()) {
+        log.debug("Started clearing expiry date for items for jobId: {}", jobId);
+        getCmsObjectManager().clearExpiryDate(unpubIds);
+        log.debug("Finished clearing expiry date for items for jobId: {}", jobId);
+      }
+    } catch (Exception e) {
+      if (isConcurrencyException(e)) {
+        log.info(
+            "Concurrent modification detected while updating content dates for jobId: {}. The dates will be/were updated by another concurrent publish job.",
+            jobId);
+        if (log.isDebugEnabled()) {
+          log.debug("Concurrent modification details:", e);
+        }
+      } else {
+        throw e;
+      }
     }
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/task/impl/PSWorkflowEditionTask.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/task/impl/PSWorkflowEditionTask.java
@@ -27,6 +27,7 @@ import com.percussion.services.sitemgr.IPSSite;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This post edition task workflows the item after publish. It only workflows the item if the item
@@ -115,8 +116,7 @@ public class PSWorkflowEditionTask extends PSAbstractWorkflowExtension implement
    * @param pubIds content ids that published (may be empty)
    * @param unpubIds content ids that unpublished (may be empty)
    */
-  void updateContentDatesAfterWorkflow(
-      long jobId, java.util.Set<Integer> pubIds, java.util.Set<Integer> unpubIds)
+  void updateContentDatesAfterWorkflow(long jobId, Set<Integer> pubIds, Set<Integer> unpubIds)
       throws Exception {
     try {
       if (!pubIds.isEmpty()) {

--- a/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSAbstractWorkflowExtensionConcurrencyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSAbstractWorkflowExtensionConcurrencyTest.java
@@ -17,14 +17,23 @@
 
 package com.percussion.itemmanagement.service.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.percussion.itemmanagement.service.impl.PSAbstractWorkflowExtension.WorkflowItem;
+import com.percussion.itemmanagement.service.impl.PSAbstractWorkflowExtension.WorkflowItem.ItemStatus;
+import com.percussion.sitemanage.task.impl.PSWorkflowEditionTask;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 /**
  * Regression for GH-849 / v8.1.7 PR #853: concurrency / lock exceptions during publish workflow
  * must be recognized so they can be demoted from ERROR to INFO logging.
+ *
+ * <p>Post-edition date-update swallow/rethrow is covered by {@code
+ * PSWorkflowEditionTaskConcurrencyTest} (same package as the task).
  */
 class PSAbstractWorkflowExtensionConcurrencyTest {
 
@@ -45,6 +54,40 @@ class PSAbstractWorkflowExtensionConcurrencyTest {
   }
 
   @Test
+  void detectsSpringAndHibernateNamesMissedByOriginalShortList() {
+    // org.springframework.dao.CannotAcquireLockException
+    assertTrue(
+        PSAbstractWorkflowExtension.isConcurrencyException(
+            new SimulatedCannotAcquireLockException("cannot acquire")));
+    // org.springframework.orm.ObjectOptimisticLockingFailureException
+    assertTrue(
+        PSAbstractWorkflowExtension.isConcurrencyException(
+            new SimulatedObjectOptimisticLockingFailureException("stale")));
+    // org.hibernate.StaleObjectStateException / StaleStateException
+    assertTrue(
+        PSAbstractWorkflowExtension.isConcurrencyException(
+            new SimulatedStaleObjectStateException("stale object")));
+    assertTrue(
+        PSAbstractWorkflowExtension.isConcurrencyException(
+            new SimulatedStaleStateException("stale state")));
+  }
+
+  @Test
+  void nameContainsConcurrencyMarkerCoversFqcnFragments() {
+    assertTrue(
+        PSAbstractWorkflowExtension.nameContainsConcurrencyMarker(
+            "org.springframework.dao.CannotAcquireLockException"));
+    assertTrue(
+        PSAbstractWorkflowExtension.nameContainsConcurrencyMarker(
+            "org.springframework.orm.ObjectOptimisticLockingFailureException"));
+    assertTrue(
+        PSAbstractWorkflowExtension.nameContainsConcurrencyMarker(
+            "org.hibernate.StaleObjectStateException"));
+    assertFalse(
+        PSAbstractWorkflowExtension.nameContainsConcurrencyMarker("java.lang.IllegalStateException"));
+  }
+
+  @Test
   void walksCauseChain() {
     Exception outer = new RuntimeException("wrap", new SimulatedOptimisticLockException("inner"));
     assertTrue(PSAbstractWorkflowExtension.isConcurrencyException(outer));
@@ -56,8 +99,25 @@ class PSAbstractWorkflowExtensionConcurrencyTest {
     assertFalse(PSAbstractWorkflowExtension.isConcurrencyException(new IllegalStateException("x")));
   }
 
+  @Test
+  void handleErrorMarksFailedForConcurrencyAndNonConcurrency() {
+    var task = new PSWorkflowEditionTask();
+    var worker = task.getWorker(Map.of());
+    var concurrent = new WorkflowItem();
+    var race = new SimulatedOptimisticLockException("race");
+    worker.handleError(concurrent, "workflow", race);
+    assertEquals(ItemStatus.FAILED, concurrent.status);
+    assertSame(race, concurrent.error);
+
+    var hard = new WorkflowItem();
+    var boom = new IllegalStateException("boom");
+    worker.handleError(hard, "workflow", boom);
+    assertEquals(ItemStatus.FAILED, hard.status);
+    assertSame(boom, hard.error);
+  }
+
   // Local stand-ins so we do not depend on Hibernate/Spring exception classes on the test
-  // classpath. Detection is by class name substring.
+  // classpath. Detection is by class name substring / fragment.
   static final class SimulatedLockAcquisitionException extends RuntimeException {
     SimulatedLockAcquisitionException(String m) {
       super(m);
@@ -78,6 +138,30 @@ class PSAbstractWorkflowExtensionConcurrencyTest {
 
   static final class SimulatedConcurrencyFailureException extends RuntimeException {
     SimulatedConcurrencyFailureException(String m) {
+      super(m);
+    }
+  }
+
+  static final class SimulatedCannotAcquireLockException extends RuntimeException {
+    SimulatedCannotAcquireLockException(String m) {
+      super(m);
+    }
+  }
+
+  static final class SimulatedObjectOptimisticLockingFailureException extends RuntimeException {
+    SimulatedObjectOptimisticLockingFailureException(String m) {
+      super(m);
+    }
+  }
+
+  static final class SimulatedStaleObjectStateException extends RuntimeException {
+    SimulatedStaleObjectStateException(String m) {
+      super(m);
+    }
+  }
+
+  static final class SimulatedStaleStateException extends RuntimeException {
+    SimulatedStaleStateException(String m) {
       super(m);
     }
   }

--- a/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSAbstractWorkflowExtensionConcurrencyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSAbstractWorkflowExtensionConcurrencyTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.itemmanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for GH-849 / v8.1.7 PR #853: concurrency / lock exceptions during publish workflow
+ * must be recognized so they can be demoted from ERROR to INFO logging.
+ */
+class PSAbstractWorkflowExtensionConcurrencyTest {
+
+  @Test
+  void detectsLockAndOptimisticConcurrencyByClassName() {
+    assertTrue(
+        PSAbstractWorkflowExtension.isConcurrencyException(
+            new SimulatedLockAcquisitionException("locked")));
+    assertTrue(
+        PSAbstractWorkflowExtension.isConcurrencyException(
+            new SimulatedOptimisticLockException("optimistic")));
+    assertTrue(
+        PSAbstractWorkflowExtension.isConcurrencyException(
+            new SimulatedPessimisticLockException("pessimistic")));
+    assertTrue(
+        PSAbstractWorkflowExtension.isConcurrencyException(
+            new SimulatedConcurrencyFailureException("fail")));
+  }
+
+  @Test
+  void walksCauseChain() {
+    Exception outer = new RuntimeException("wrap", new SimulatedOptimisticLockException("inner"));
+    assertTrue(PSAbstractWorkflowExtension.isConcurrencyException(outer));
+  }
+
+  @Test
+  void rejectsUnrelatedExceptions() {
+    assertFalse(PSAbstractWorkflowExtension.isConcurrencyException(null));
+    assertFalse(PSAbstractWorkflowExtension.isConcurrencyException(new IllegalStateException("x")));
+  }
+
+  // Local stand-ins so we do not depend on Hibernate/Spring exception classes on the test
+  // classpath. Detection is by class name substring.
+  static final class SimulatedLockAcquisitionException extends RuntimeException {
+    SimulatedLockAcquisitionException(String m) {
+      super(m);
+    }
+  }
+
+  static final class SimulatedOptimisticLockException extends RuntimeException {
+    SimulatedOptimisticLockException(String m) {
+      super(m);
+    }
+  }
+
+  static final class SimulatedPessimisticLockException extends RuntimeException {
+    SimulatedPessimisticLockException(String m) {
+      super(m);
+    }
+  }
+
+  static final class SimulatedConcurrencyFailureException extends RuntimeException {
+    SimulatedConcurrencyFailureException(String m) {
+      super(m);
+    }
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSAbstractWorkflowExtensionConcurrencyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSAbstractWorkflowExtensionConcurrencyTest.java
@@ -40,56 +40,58 @@ class PSAbstractWorkflowExtensionConcurrencyTest {
   @Test
   void detectsLockAndOptimisticConcurrencyByClassName() {
     assertTrue(
-        PSAbstractWorkflowExtension.isConcurrencyException(
-            new SimulatedLockAcquisitionException("locked")));
+        PSAbstractWorkflowExtension.isConcurrencyException(new LockAcquisitionException("locked")));
+    assertTrue(
+        PSAbstractWorkflowExtension.isConcurrencyException(new OptimisticLockException("optimistic")));
     assertTrue(
         PSAbstractWorkflowExtension.isConcurrencyException(
-            new SimulatedOptimisticLockException("optimistic")));
+            new PessimisticLockException("pessimistic")));
     assertTrue(
         PSAbstractWorkflowExtension.isConcurrencyException(
-            new SimulatedPessimisticLockException("pessimistic")));
-    assertTrue(
-        PSAbstractWorkflowExtension.isConcurrencyException(
-            new SimulatedConcurrencyFailureException("fail")));
+            new ConcurrencyFailureException("fail")));
   }
 
   @Test
   void detectsSpringAndHibernateNamesMissedByOriginalShortList() {
-    // org.springframework.dao.CannotAcquireLockException
     assertTrue(
         PSAbstractWorkflowExtension.isConcurrencyException(
-            new SimulatedCannotAcquireLockException("cannot acquire")));
-    // org.springframework.orm.ObjectOptimisticLockingFailureException
+            new CannotAcquireLockException("cannot acquire")));
     assertTrue(
         PSAbstractWorkflowExtension.isConcurrencyException(
-            new SimulatedObjectOptimisticLockingFailureException("stale")));
-    // org.hibernate.StaleObjectStateException / StaleStateException
+            new ObjectOptimisticLockingFailureException("stale")));
     assertTrue(
         PSAbstractWorkflowExtension.isConcurrencyException(
-            new SimulatedStaleObjectStateException("stale object")));
+            new StaleObjectStateException("stale object")));
     assertTrue(
-        PSAbstractWorkflowExtension.isConcurrencyException(
-            new SimulatedStaleStateException("stale state")));
+        PSAbstractWorkflowExtension.isConcurrencyException(new StaleStateException("stale state")));
   }
 
   @Test
-  void nameContainsConcurrencyMarkerCoversFqcnFragments() {
+  void simpleNameEqualityCoversFqcnAndRejectsEmbeddedFragments() {
     assertTrue(
-        PSAbstractWorkflowExtension.nameContainsConcurrencyMarker(
+        PSAbstractWorkflowExtension.isConcurrencyExceptionSimpleName(
             "org.springframework.dao.CannotAcquireLockException"));
     assertTrue(
-        PSAbstractWorkflowExtension.nameContainsConcurrencyMarker(
+        PSAbstractWorkflowExtension.isConcurrencyExceptionSimpleName(
             "org.springframework.orm.ObjectOptimisticLockingFailureException"));
     assertTrue(
-        PSAbstractWorkflowExtension.nameContainsConcurrencyMarker(
+        PSAbstractWorkflowExtension.isConcurrencyExceptionSimpleName(
             "org.hibernate.StaleObjectStateException"));
     assertFalse(
-        PSAbstractWorkflowExtension.nameContainsConcurrencyMarker("java.lang.IllegalStateException"));
+        PSAbstractWorkflowExtension.isConcurrencyExceptionSimpleName(
+            "java.lang.IllegalStateException"));
+    // Substring false-positives must not demote
+    assertFalse(
+        PSAbstractWorkflowExtension.isConcurrencyExceptionSimpleName(
+            "NotAnOptimisticLockException"));
+    assertFalse(
+        PSAbstractWorkflowExtension.isConcurrencyExceptionSimpleName(
+            "OptimisticLockExceptionHandler"));
   }
 
   @Test
   void walksCauseChain() {
-    Exception outer = new RuntimeException("wrap", new SimulatedOptimisticLockException("inner"));
+    Exception outer = new RuntimeException("wrap", new OptimisticLockException("inner"));
     assertTrue(PSAbstractWorkflowExtension.isConcurrencyException(outer));
   }
 
@@ -104,7 +106,7 @@ class PSAbstractWorkflowExtensionConcurrencyTest {
     var task = new PSWorkflowEditionTask();
     var worker = task.getWorker(Map.of());
     var concurrent = new WorkflowItem();
-    var race = new SimulatedOptimisticLockException("race");
+    var race = new OptimisticLockException("race");
     worker.handleError(concurrent, "workflow", race);
     assertEquals(ItemStatus.FAILED, concurrent.status);
     assertSame(race, concurrent.error);
@@ -116,52 +118,54 @@ class PSAbstractWorkflowExtensionConcurrencyTest {
     assertSame(boom, hard.error);
   }
 
-  // Local stand-ins so we do not depend on Hibernate/Spring exception classes on the test
-  // classpath. Detection is by class name substring / fragment.
-  static final class SimulatedLockAcquisitionException extends RuntimeException {
-    SimulatedLockAcquisitionException(String m) {
+  /**
+   * Stand-ins use the same simple names as Spring/Hibernate/JPA types so detection can use exact
+   * simple-name equality without putting those libraries on the test compile classpath.
+   */
+  static final class LockAcquisitionException extends RuntimeException {
+    LockAcquisitionException(String m) {
       super(m);
     }
   }
 
-  static final class SimulatedOptimisticLockException extends RuntimeException {
-    SimulatedOptimisticLockException(String m) {
+  static final class OptimisticLockException extends RuntimeException {
+    OptimisticLockException(String m) {
       super(m);
     }
   }
 
-  static final class SimulatedPessimisticLockException extends RuntimeException {
-    SimulatedPessimisticLockException(String m) {
+  static final class PessimisticLockException extends RuntimeException {
+    PessimisticLockException(String m) {
       super(m);
     }
   }
 
-  static final class SimulatedConcurrencyFailureException extends RuntimeException {
-    SimulatedConcurrencyFailureException(String m) {
+  static final class ConcurrencyFailureException extends RuntimeException {
+    ConcurrencyFailureException(String m) {
       super(m);
     }
   }
 
-  static final class SimulatedCannotAcquireLockException extends RuntimeException {
-    SimulatedCannotAcquireLockException(String m) {
+  static final class CannotAcquireLockException extends RuntimeException {
+    CannotAcquireLockException(String m) {
       super(m);
     }
   }
 
-  static final class SimulatedObjectOptimisticLockingFailureException extends RuntimeException {
-    SimulatedObjectOptimisticLockingFailureException(String m) {
+  static final class ObjectOptimisticLockingFailureException extends RuntimeException {
+    ObjectOptimisticLockingFailureException(String m) {
       super(m);
     }
   }
 
-  static final class SimulatedStaleObjectStateException extends RuntimeException {
-    SimulatedStaleObjectStateException(String m) {
+  static final class StaleObjectStateException extends RuntimeException {
+    StaleObjectStateException(String m) {
       super(m);
     }
   }
 
-  static final class SimulatedStaleStateException extends RuntimeException {
-    SimulatedStaleStateException(String m) {
+  static final class StaleStateException extends RuntimeException {
+    StaleStateException(String m) {
       super(m);
     }
   }

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/task/impl/PSWorkflowEditionTaskConcurrencyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/task/impl/PSWorkflowEditionTaskConcurrencyTest.java
@@ -43,7 +43,7 @@ class PSWorkflowEditionTaskConcurrencyTest {
     var task = new PSWorkflowEditionTask();
     task.setCmsObjectManager(cmsObjectManager);
 
-    doThrow(new SimulatedCannotAcquireLockException("locked"))
+    doThrow(new CannotAcquireLockException("locked"))
         .when(cmsObjectManager)
         .setPostDate(anyCollection());
 
@@ -62,9 +62,9 @@ class PSWorkflowEditionTaskConcurrencyTest {
     }
   }
 
-  /** Name must contain {@code CannotAcquireLockException} for {@code isConcurrencyException}. */
-  static final class SimulatedCannotAcquireLockException extends RuntimeException {
-    SimulatedCannotAcquireLockException(String m) {
+  /** Simple name must equal {@code CannotAcquireLockException} for exact-name detection. */
+  static final class CannotAcquireLockException extends RuntimeException {
+    CannotAcquireLockException(String m) {
       super(m);
     }
   }

--- a/projects/sitemanage/src/test/java/com/percussion/sitemanage/task/impl/PSWorkflowEditionTaskConcurrencyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/sitemanage/task/impl/PSWorkflowEditionTaskConcurrencyTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.sitemanage.task.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.doThrow;
+
+import com.percussion.services.legacy.IPSCmsObjectMgr;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Regression for GH-849 / v8.1.7 PR #853: post-edition date updates must swallow concurrency
+ * exceptions (INFO demotion) without failing the job, while other exceptions still propagate.
+ */
+@ExtendWith(MockitoExtension.class)
+class PSWorkflowEditionTaskConcurrencyTest {
+
+  @Mock private IPSCmsObjectMgr cmsObjectManager;
+
+  @Test
+  void updateContentDatesSwallowsConcurrencyButRethrowsOthers() throws Exception {
+    var task = new PSWorkflowEditionTask();
+    task.setCmsObjectManager(cmsObjectManager);
+
+    doThrow(new SimulatedCannotAcquireLockException("locked"))
+        .when(cmsObjectManager)
+        .setPostDate(anyCollection());
+
+    // Must not throw — concurrency is demoted and swallowed
+    task.updateContentDatesAfterWorkflow(42L, Set.of(1), Set.of());
+
+    doThrow(new IllegalStateException("hard failure"))
+        .when(cmsObjectManager)
+        .setPostDate(anyCollection());
+
+    try {
+      task.updateContentDatesAfterWorkflow(43L, Set.of(2), Set.of());
+      fail("expected non-concurrency exception to propagate");
+    } catch (IllegalStateException expected) {
+      assertEquals("hard failure", expected.getMessage());
+    }
+  }
+
+  /** Name must contain {@code CannotAcquireLockException} for {@code isConcurrencyException}. */
+  static final class SimulatedCannotAcquireLockException extends RuntimeException {
+    SimulatedCannotAcquireLockException(String m) {
+      super(m);
+    }
+  }
+}

--- a/system/services/src/com/percussion/services/contentmgr/impl/legacy/PSContentRepository.java
+++ b/system/services/src/com/percussion/services/contentmgr/impl/legacy/PSContentRepository.java
@@ -2019,6 +2019,9 @@ public class PSContentRepository
         PSTypeConfiguration type = ms_configuration.get(key);
         if (type == null)
         {
+            // Demoted from WARN in v8.1.7 PR #853 / GH-849: this fires frequently for obsolete
+            // type ids during bulk queries and flooded logs. Missing/renamed types still return
+            // null (callers skip the type); enable DEBUG on this logger when diagnosing config.
             ms_log.debug("Query problem: type not found for type id: {}", typeid);
             return null;
         }

--- a/system/services/src/com/percussion/services/contentmgr/impl/legacy/PSContentRepository.java
+++ b/system/services/src/com/percussion/services/contentmgr/impl/legacy/PSContentRepository.java
@@ -2019,7 +2019,7 @@ public class PSContentRepository
         PSTypeConfiguration type = ms_configuration.get(key);
         if (type == null)
         {
-            ms_log.warn("Query problem: type not found for type id: {}", typeid);
+            ms_log.debug("Query problem: type not found for type id: {}", typeid);
             return null;
         }
 


### PR DESCRIPTION
## Summary

Cherry-pick of intersoftdatalabs-in/percussioncms#853 from v8.1.7 onto `development`.

- Detect Hibernate/Spring lock concurrency exceptions in workflow extension and log at INFO/DEBUG instead of ERROR
- Swallow concurrency failures when updating post/start/expiry dates in `PSWorkflowEditionTask` so concurrent publish jobs do not fail each other
- Demote PSContentRepository \"type not found for type id\" log from warn to debug

Resolves backlog item from `specs/005-migrate-8.1.7-changes` (workflow / publish).

### Tests
- `PSAbstractWorkflowExtensionConcurrencyTest` (3 tests) — PASS

## Test plan
- [x] `./mvn-env.sh -pl projects/sitemanage test -Dtest=PSAbstractWorkflowExtensionConcurrencyTest`