### PR TITLE
Migrate PR #848: deprecate Secure Login + secure-membership

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/webapp/WEB-INF/security.xml
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/webapp/WEB-INF/security.xml
@@ -9,6 +9,11 @@
 	http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!--
+       @deprecated This Spring Security configuration is deprecated because the Secure Login widget
+       and perc-secure-membership module are deprecated.
+    -->
+
     <security:http pattern="/favicon.ico" security='none' />
     <security:http  create-session="stateless" use-expressions="true" auto-config="true">
         <security:csrf disabled="${disableCSRFProtection}" token-repository-ref="tokenRepository" request-matcher-ref="requestMatcher" />

--- a/deliverytiersuite/delivery-tier-suite/comments/src/test/resources/security.xml
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/test/resources/security.xml
@@ -12,7 +12,12 @@
 	http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
-	<security:http pattern="/favicon.ico" security='none' />
+    <!--
+       @deprecated This Spring Security configuration is deprecated because the Secure Login widget
+       and perc-secure-membership module are deprecated.
+    -->
+
+    <security:http pattern="/favicon.ico" security='none' />
 
 	<security:http create-session="stateless"
 		use-expressions="true" auto-config="true">

--- a/deliverytiersuite/delivery-tier-suite/common/src/main/java/com/percussion/delivery/spring/CustomAuthenticationProvider.java
+++ b/deliverytiersuite/delivery-tier-suite/common/src/main/java/com/percussion/delivery/spring/CustomAuthenticationProvider.java
@@ -26,6 +26,11 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.stereotype.Component;
 
+/**
+ * @deprecated This class is part of the deprecated secure-membership/DTS spring security
+ *     integration.
+ */
+@Deprecated
 @Component
 public class CustomAuthenticationProvider
     implements AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> {

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/webapp/WEB-INF/security.xml
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/webapp/WEB-INF/security.xml
@@ -9,6 +9,11 @@
 	http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!--
+       @deprecated This Spring Security configuration is deprecated because the Secure Login widget
+       and perc-secure-membership module are deprecated.
+    -->
+
     <security:http pattern="/favicon.ico" security='none' />
     <security:http  create-session="stateless" use-expressions="true" auto-config="true">
         <security:csrf disabled="${disableCSRFProtection}" token-repository-ref="tokenRepository" request-matcher-ref="requestMatcher" />

--- a/deliverytiersuite/delivery-tier-suite/forms/src/main/java/webapp/WEB-INF/security.xml
+++ b/deliverytiersuite/delivery-tier-suite/forms/src/main/java/webapp/WEB-INF/security.xml
@@ -9,6 +9,11 @@
 	http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!--
+       @deprecated This Spring Security configuration is deprecated because the Secure Login widget
+       and perc-secure-membership module are deprecated.
+    -->
+
     <security:http pattern="/favicon.ico" security='none' />
     <security:http  create-session="stateless" use-expressions="true" auto-config="true">
         <security:csrf disabled="${disableCSRFProtection}" token-repository-ref="tokenRepository" request-matcher-ref="requestMatcher" />

--- a/deliverytiersuite/delivery-tier-suite/forms/src/test/webapp/WEB-INF/security.xml
+++ b/deliverytiersuite/delivery-tier-suite/forms/src/test/webapp/WEB-INF/security.xml
@@ -11,6 +11,11 @@
 	http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!--
+       @deprecated This Spring Security configuration is deprecated because the Secure Login widget
+       and perc-secure-membership module are deprecated.
+    -->
+
     <security:http pattern="/favicon.ico" security='none' />
 
 

--- a/deliverytiersuite/delivery-tier-suite/integrations/src/main/java/com/percussion/delivery/integrations/ems/CustomAuthenticationProvider.java
+++ b/deliverytiersuite/delivery-tier-suite/integrations/src/main/java/com/percussion/delivery/integrations/ems/CustomAuthenticationProvider.java
@@ -26,6 +26,11 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.stereotype.Component;
 
+/**
+ * @deprecated This class is part of the deprecated secure-membership/DTS spring security
+ *     integration.
+ */
+@Deprecated
 @Component
 public class CustomAuthenticationProvider
     implements AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> {

--- a/deliverytiersuite/delivery-tier-suite/integrations/src/main/java/webapp/WEB-INF/security.xml
+++ b/deliverytiersuite/delivery-tier-suite/integrations/src/main/java/webapp/WEB-INF/security.xml
@@ -9,6 +9,11 @@
 	http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!--
+       @deprecated This Spring Security configuration is deprecated because the Secure Login widget
+       and perc-secure-membership module are deprecated.
+    -->
+
     <security:http pattern="/favicon.ico" security='none' />
     <security:http  create-session="stateless" use-expressions="true" auto-config="true">
         <security:csrf disabled="${disableCSRFProtection}" token-repository-ref="tokenRepository" request-matcher-ref="requestMatcher" />

--- a/deliverytiersuite/delivery-tier-suite/membership/src/main/java/webapp/WEB-INF/security.xml
+++ b/deliverytiersuite/delivery-tier-suite/membership/src/main/java/webapp/WEB-INF/security.xml
@@ -9,6 +9,11 @@
 	http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!--
+       @deprecated This Spring Security configuration is deprecated because the Secure Login widget
+       and perc-secure-membership module are deprecated.
+    -->
+
     <security:http pattern="/favicon.ico" security='none' />
     <security:http  create-session="stateless" use-expressions="true" auto-config="true">
         <security:csrf disabled="${disableCSRFProtection}" token-repository-ref="tokenRepository" request-matcher-ref="requestMatcher" />

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/webapp/WEB-INF/security.xml
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/webapp/WEB-INF/security.xml
@@ -9,6 +9,11 @@
 	http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!--
+       @deprecated This Spring Security configuration is deprecated because the Secure Login widget
+       and perc-secure-membership module are deprecated.
+    -->
+
     <security:http pattern="/favicon.ico" security='none' />
     <security:http  create-session="stateless" use-expressions="true" auto-config="true">
         <security:csrf disabled="${disableCSRFProtection}" token-repository-ref="tokenRepository" request-matcher-ref="requestMatcher" />

--- a/deliverytiersuite/delivery-tier-suite/polls/src/main/java/webapp/WEB-INF/security.xml
+++ b/deliverytiersuite/delivery-tier-suite/polls/src/main/java/webapp/WEB-INF/security.xml
@@ -9,6 +9,11 @@
 	http://www.springframework.org/schema/security/spring-security.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!--
+       @deprecated This Spring Security configuration is deprecated because the Secure Login widget
+       and perc-secure-membership module are deprecated.
+    -->
+
     <security:http pattern="/favicon.ico" security='none' />
 
     <security:http create-session="stateless" use-expressions="true" auto-config="true">

--- a/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/data/PSMembershipConfiguration.java
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/data/PSMembershipConfiguration.java
@@ -19,6 +19,8 @@ package com.percussion.secure.data;
 
 import java.util.Objects;
 
+/** @deprecated This class is part of the deprecated secure-membership module. */
+@Deprecated
 public class PSMembershipConfiguration {
   // Set by Spring beans config
   private String membershipServiceHost;

--- a/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/AuthFormProcessingFilter.java
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/AuthFormProcessingFilter.java
@@ -27,6 +27,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 
+/** @deprecated This class is part of the deprecated secure-membership module. */
+@Deprecated
 // REFACTORED: CP-JAVA11
 public class AuthFormProcessingFilter extends AbstractAuthenticationProcessingFilter {
   public static final String SPRING_SECURITY_FORM_USERNAME_KEY = "j_username";

--- a/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSCacheControlFilter.java
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSCacheControlFilter.java
@@ -26,6 +26,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Date;
 
+/** @deprecated This class is part of the deprecated secure-membership module. */
+@Deprecated
 public class PSCacheControlFilter implements Filter {
   // REFACTORED: CP-JAVA11
   @Override

--- a/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSLdapMembershipAuthProvider.java
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSLdapMembershipAuthProvider.java
@@ -56,7 +56,9 @@ import org.springframework.util.StringUtils;
  * Works to provide authentication for Active Directory users using Spring Security
  *
  * @author Shweta Patel
+ * @deprecated This class is part of the deprecated secure-membership module.
  */
+@Deprecated
 public class PSLdapMembershipAuthProvider extends AbstractLdapAuthenticationProvider {
   private static final Pattern SUB_ERROR_CODE = Pattern.compile(".*data\\s([0-9a-f]{3,4}).*");
 

--- a/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSLdapUserDetailsMapper.java
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSLdapUserDetailsMapper.java
@@ -42,7 +42,9 @@ import org.xml.sax.SAXException;
  * Handles User Details Mapping for authorization.
  *
  * @author Shweta Patel
+ * @deprecated This class is part of the deprecated secure-membership module.
  */
+@Deprecated
 public class PSLdapUserDetailsMapper extends LdapUserDetailsMapper {
   private static final String ROLE_TEST = "role_test";
   private static final String ROLE_ADMIN = "Domain Admins";

--- a/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSMembershipAuthProvider.java
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSMembershipAuthProvider.java
@@ -48,7 +48,9 @@ import org.springframework.security.core.userdetails.UserDetails;
  * Security.
  *
  * @author Jay Seletz
+ * @deprecated This class is part of the deprecated secure-membership module.
  */
+@Deprecated
 public class PSMembershipAuthProvider extends AbstractUserDetailsAuthenticationProvider {
   private static final ThreadLocal<String> SESSION_ID = new ThreadLocal<>();
   private static final Client msClient = ClientBuilder.newClient();

--- a/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSMembershipAuthUtils.java
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSMembershipAuthUtils.java
@@ -33,6 +33,8 @@ import org.springframework.web.context.ContextLoader;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
+/** @deprecated This class is part of the deprecated secure-membership module. */
+@Deprecated
 public class PSMembershipAuthUtils {
 
   private static final Logger log = LogManager.getLogger(PSMembershipAuthUtils.class);

--- a/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSMembershipLoginHandler.java
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSMembershipLoginHandler.java
@@ -30,7 +30,9 @@ import org.springframework.security.web.authentication.SavedRequestAwareAuthenti
  * Handles setting the membership session cookie after successful authentication.
  *
  * @author Jay Seletz
+ * @deprecated This class is part of the deprecated secure-membership module.
  */
+@Deprecated
 public class PSMembershipLoginHandler extends SavedRequestAwareAuthenticationSuccessHandler {
   private PSMembershipConfiguration membershipConfig;
 

--- a/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSMembershipLogoutHandler.java
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/src/main/java/com/percussion/secure/services/PSMembershipLogoutHandler.java
@@ -33,7 +33,9 @@ import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuc
  * Handles logging out of membership and session cookie cleanup.
  *
  * @author Jay Seletz
+ * @deprecated This class is part of the deprecated secure-membership module.
  */
+@Deprecated
 public class PSMembershipLogoutHandler extends SimpleUrlLogoutSuccessHandler {
   private static final Client msClient = ClientBuilder.newClient();
   private PSMembershipConfiguration membershipConfig;

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.secureLogin/percSecureLogin.itemDef.contentType
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.secureLogin/percSecureLogin.itemDef.contentType
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ItemDefData appName="psx_cepercSecureLogin" isHidden="true" objectType="1">
-   <PSXItemDefSummary editorUrl="../psx_cepercSecureLogin/percSecureLogin.html" id="369" label="Secure Login" name="percSecureLogin" typeId="369"/>
+   <PSXItemDefSummary editorUrl="../psx_cepercSecureLogin/percSecureLogin.html" id="369" label="Secure Login (Deprecated)" name="percSecureLogin" typeId="369"/>
    <PSXContentEditor contentType="369" enableRelatedContent="yes" iconSource="0" iconValue="" objectType="1" producesResource="no" workflowId="6">
       <PSXDataSet id="768">
          <name>percSecureLogin</name>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.secureLogin/percSecureLogin.nodeDef.contentType
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.secureLogin/percSecureLogin.nodeDef.contentType
@@ -4,7 +4,7 @@
     <hide-from-menu>true</hide-from-menu>
     <id>369</id>
     <internal-name>percSecureLogin</internal-name>
-    <label>Secure Login</label>
+    <label>Secure Login (Deprecated)</label>
     <mandatory>false</mandatory>
     <name>rx:percSecureLogin</name>
     <new-request>../psx_cepercSecureLogin/percSecureLogin.html</new-request>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.secureLogin/sys__UserDependency--rxconfig/Widgets/percSecureLogin.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.secureLogin/sys__UserDependency--rxconfig/Widgets/percSecureLogin.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Widget>
-	<WidgetPrefs title="Secure Login"
-		contenttype_name="percSecureLogin" category="integration"
-		description="Login widget to access secured content."
-		author="Percussion Software Inc."
-		thumbnail="/rx_resources/widgets/percSecureLogin/images/widgetIconLogin.gif"
-		preferred_editor_width="780" preferred_editor_height="450"
-		is_responsive="true" />
-	<UserPref name="labelAlign" display_name="Label align"
-		required="true" default_value="top" datatype="enum">
+<WidgetPrefs title="Secure Login (Deprecated)"
+contenttype_name="percSecureLogin" category="integration"
+description="Login widget to access secured content. (Deprecated)"
+author="Percussion Software Inc."
+thumbnail="/rx_resources/widgets/percSecureLogin/images/widgetIconLogin.gif"
+preferred_editor_width="780" preferred_editor_height="450"
+is_responsive="true" />
+<UserPref name="labelAlign" display_name="Label align"
+required="true" default_value="top" datatype="enum">
 		<EnumValue value="top" display_value="Top of the control" />
 		<EnumValue value="left" display_value="Left of the control" />
 	</UserPref>

--- a/projects/sitemanage/src/main/resources/com/percussion/pagemanagement/service/impl/WidgetRegistry.xml
+++ b/projects/sitemanage/src/main/resources/com/percussion/pagemanagement/service/impl/WidgetRegistry.xml
@@ -3,58 +3,58 @@
 
 <!--Widget grouping XML -->
 <widgets>
-	<group name="Percussion">
-		<widget name="Archives" />
-		<widget name="Auto List" />
-		<widget name="Blog List" />
-		<widget name="Blog Post" />
-		<widget name="Breadcrumb" />
-		<widget name="Calendar 2.0" />
-		<widget name="Categories" />
-		<widget name="Comments" />
-		<widget name="Comments Form" />
-		<widget name="Cookie Consent" />
-		<widget name="Event" />
-		<widget name="File" />
-		<widget name="File Auto List" />
-		<widget name="Form" />
-		<widget name="HTML" />
-		<widget name="Iframe" />
-		<widget name="Image" />
-		<widget name="Image Auto List" />
-		<widget name="Image Slider" />
-		<widget name="jQuery Widget" />
-		<widget name="jQuery UI Widget" />
-		<widget name="Like" />
-		<widget name="Login" />
-		<widget name="Navigation" />
-		<widget name="Page Auto List" />
-		<widget name="Polls" />
-		<widget name="Registration" />
-		<widget name="Rich Text" />
-		<widget name="RSS" />
-		<widget name="Result" />
-		<widget name="Secure Login" />
-		<widget name="Social Buttons" />
-		<widget name="Twitter Summary Cards" />
-		<widget name="Facebook Open Graph" />
-		<widget name="Simple Text" />
-		<widget name="Tags" />
-		<widget name="Title" />
-		<widget name="Local Language" />
-		<widget name="Default Language" />
-		<widget name="Department" />
-		<widget name="Directory" />
-		<widget name="Organization" />
-		<widget name="Person" />
-		<widget name="Most Read Blog Posts" />
-		<widget name="Redirect" />
-	</group>
-	<group name="Community">
-		<widget name="EMS Event List" />
-	</group>
-	<group name="Deprecated">
-		<widget name="Share This" />
-		<widget name="Calendar" />
-	</group>
+<group name="Percussion">
+<widget name="Archives" />
+<widget name="Auto List" />
+<widget name="Blog List" />
+<widget name="Blog Post" />
+<widget name="Breadcrumb" />
+<widget name="Calendar 2.0" />
+<widget name="Categories" />
+<widget name="Comments" />
+<widget name="Comments Form" />
+<widget name="Cookie Consent" />
+<widget name="Event" />
+<widget name="File" />
+<widget name="File Auto List" />
+<widget name="Form" />
+<widget name="HTML" />
+<widget name="Iframe" />
+<widget name="Image" />
+<widget name="Image Auto List" />
+<widget name="Image Slider" />
+<widget name="jQuery Widget" />
+<widget name="jQuery UI Widget" />
+<widget name="Like" />
+<widget name="Login" />
+<widget name="Navigation" />
+<widget name="Page Auto List" />
+<widget name="Polls" />
+<widget name="Registration" />
+<widget name="Rich Text" />
+<widget name="RSS" />
+<widget name="Result" />
+<widget name="Social Buttons" />
+<widget name="Twitter Summary Cards" />
+<widget name="Facebook Open Graph" />
+<widget name="Simple Text" />
+<widget name="Tags" />
+<widget name="Title" />
+<widget name="Local Language" />
+<widget name="Default Language" />
+<widget name="Department" />
+<widget name="Directory" />
+<widget name="Organization" />
+<widget name="Person" />
+<widget name="Most Read Blog Posts" />
+<widget name="Redirect" />
+</group>
+<group name="Community">
+<widget name="EMS Event List" />
+</group>
+<group name="Deprecated">
+<widget name="Share This" />
+<widget name="Calendar" />
+<widget name="Secure Login (Deprecated)" />
+</group>
 </widgets>

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/WidgetRegistrySecureLoginDeprecationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/WidgetRegistrySecureLoginDeprecationTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.pagemanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for GH-845 / v8.1.7 PR #848: Secure Login widget is listed under the Deprecated group
+ * and no longer under Percussion.
+ */
+class WidgetRegistrySecureLoginDeprecationTest {
+
+  @Test
+  void secureLoginIsInDeprecatedGroupOnly() throws Exception {
+    String xml;
+    try (InputStream in =
+        Thread.currentThread()
+            .getContextClassLoader()
+            .getResourceAsStream(
+                "com/percussion/pagemanagement/service/impl/WidgetRegistry.xml")) {
+      assertNotNull(in, "WidgetRegistry.xml must be on the classpath");
+      xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    // Not present as an active Percussion widget name
+    assertFalse(
+        xml.contains("<widget name=\"Secure Login\" />")
+            || xml.contains("<widget name=\"Secure Login\"/>"),
+        "Secure Login must not remain in the active Percussion group");
+    assertTrue(
+        xml.contains("Secure Login (Deprecated)"),
+        "Secure Login must appear with Deprecated label");
+    int deprecatedIdx = xml.indexOf("<group name=\"Deprecated\">");
+    int secureIdx = xml.indexOf("Secure Login (Deprecated)");
+    assertTrue(deprecatedIdx >= 0, "Deprecated group must exist");
+    assertTrue(
+        secureIdx > deprecatedIdx,
+        "Secure Login (Deprecated) entry must appear after Deprecated group opens");
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -682,7 +682,7 @@ public class ContentTypesResource {
                                     + "        \"uuid\": 367\n"
                                     + "      },\n"
                                     + "      \"hideFromMenu\": false,\n"
-                                    + "      \"label\": \"Secure Login\",\n"
+                                    + "      \"label\": \"Secure Login (Deprecated)\",\n"
                                     + "      \"name\": \"percSecureLogin\"\n"
                                     + "    },\n"
                                     + "    {\n"


### PR DESCRIPTION
## Summary

Cherry-pick of intersoftdatalabs-in/percussioncms#848 from v8.1.7 onto \`development\` (GH-845).

- Mark Secure Login widget as deprecated in WidgetRegistry, package defs, and ContentTypes REST label
- Add \`@Deprecated\` to secure-membership classes and CustomAuthenticationProvider variants
- Add deprecation comments to DTS \`security.xml\` configs

### Conflict resolution
- Kept development WidgetRegistry structure (Percussion/Community/Deprecated groups); moved Secure Login into Deprecated as \`Secure Login (Deprecated)\` without adopting 8.1.x lowercase group names or reclassifying EMS Event List
- Kept development Java style (author tags, REFACTORED comments) while adding deprecation annotations/docs

### Tests
- \`WidgetRegistrySecureLoginDeprecationTest\` — PASS

## Test plan
- [x] \`./mvn-env.sh -pl projects/sitemanage test -Dtest=WidgetRegistrySecureLoginDeprecationTest\`