### PR TITLE
Migrate PR #814: prevent duplicate Facebook Open Graph tags

### DIFF
--- a/docs/ai-generated/tasks/811-facebook-open-graph-duplicate-tags/README.md
+++ b/docs/ai-generated/tasks/811-facebook-open-graph-duplicate-tags/README.md
@@ -1,0 +1,20 @@
+# Bug Fix #811 – Facebook Open Graph Meta Tags Rendered Twice in Page Source
+
+## Problem Summary
+
+- When a page contains the **Facebook Open Graph** widget, all generated Open Graph meta tags (`og:site_name`, `og:title`, `og:description`, `og:url`, `og:type`, `og:image`, `og:image:width`, `og:image:height`, `og:locale`, `og:fb_app_id`) are rendered twice in the HTML source head section.
+
+## Root Cause
+
+- The JEXL code block in the Facebook Open Graph widget [percOpenGraph.xml](file:///home/nate/projects/java8/percussioncms/system/Packages/perc.openGraphWidget/sys__UserDependency--rxconfig/Widgets/percOpenGraph.xml) appends the meta tags directly to the page's `AdditionalHeadContent` variable.
+- During page assembly, JEXL code of widgets on the template/page is evaluated twice (or inherited from template assembly context).
+- Because the JEXL code did not check if the tags were already present in `AdditionalHeadContent`, it unconditionally appended them again, creating exact duplicates.
+
+## Solution
+
+- Modified the JEXL code inside [percOpenGraph.xml](file:///home/nate/projects/java8/percussioncms/system/Packages/perc.openGraphWidget/sys__UserDependency--rxconfig/Widgets/percOpenGraph.xml) to check if the specific Open Graph properties (e.g., `property="og:site_name"`) are already present in `AdditionalHeadContent` before appending them.
+
+## Files Changed
+
+- [percOpenGraph.xml](file:///home/nate/projects/java8/percussioncms/system/Packages/perc.openGraphWidget/sys__UserDependency--rxconfig/Widgets/percOpenGraph.xml)
+

--- a/modules/perc-packages/src/main/resources/Packages/perc.openGraphWidget/sys__UserDependency--rxconfig/Widgets/percOpenGraph.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.openGraphWidget/sys__UserDependency--rxconfig/Widgets/percOpenGraph.xml
@@ -443,49 +443,70 @@
 	}
 	$nl="";
 	if(!empty($use_site_name)){
-		$perc.page.setAdditionalHeadContent($addlHead + $meta_sitename);
+		$addlHead = $perc.page.getAdditionalHeadContent();
+		if (! $addlHead.contains("property=\"og:site_name\"")) {
+			$perc.page.setAdditionalHeadContent($addlHead + $meta_sitename);
+		}
 	}
 
 	if(!empty($use_title)){
 		$addlHead = $perc.page.getAdditionalHeadContent();
-		$perc.page.setAdditionalHeadContent($nl.format("%s%n%s", $addlHead,$meta_title));
+		if (! $addlHead.contains("property=\"og:title\"")) {
+			$perc.page.setAdditionalHeadContent($nl.format("%s%n%s", $addlHead,$meta_title));
+		}
 	}
 
 	if(!empty($use_description)){
 		$addlHead = $perc.page.getAdditionalHeadContent();
-		$perc.page.setAdditionalHeadContent($nl.format("%s%n%s", $addlHead,$meta_description));
+		if (! $addlHead.contains("property=\"og:description\"")) {
+			$perc.page.setAdditionalHeadContent($nl.format("%s%n%s", $addlHead,$meta_description));
+		}
 	}
 	if(!empty($use_url)){
 		$addlHead = $perc.page.getAdditionalHeadContent();
-		$perc.page.setAdditionalHeadContent($nl.format("%s%n%s", $addlHead,$meta_url));
+		if (! $addlHead.contains("property=\"og:url\"")) {
+			$perc.page.setAdditionalHeadContent($nl.format("%s%n%s", $addlHead,$meta_url));
+		}
 	}
 
 	if(!empty($use_type)){
 		$addlHead = $perc.page.getAdditionalHeadContent();
-		$perc.page.setAdditionalHeadContent($nl.format("%s%n%s", $addlHead,$meta_type));
+		if (! $addlHead.contains("property=\"og:type\"")) {
+			$perc.page.setAdditionalHeadContent($nl.format("%s%n%s", $addlHead,$meta_type));
+		}
 	}
 
 	if(!empty($use_image)){
 		$addlHead = $perc.page.getAdditionalHeadContent();
-		$perc.page.setAdditionalHeadContent($nl.format("%s%n%s", $addlHead,$meta_image));
-			if(!empty($use_image_width)){
+		if (! $addlHead.contains("property=\"og:image\"")) {
+			$perc.page.setAdditionalHeadContent($nl.format("%s%n%s", $addlHead,$meta_image));
+		}
+		if(!empty($use_image_width)){
 			$addlHead = $perc.page.getAdditionalHeadContent();
-			$perc.page.setAdditionalHeadContent($nl.format("%s%n%s", $addlHead,$meta_image_width));
+			if (! $addlHead.contains("property=\"og:image:width\"")) {
+				$perc.page.setAdditionalHeadContent($nl.format("%s%n%s", $addlHead,$meta_image_width));
+			}
 		}
 		if(!empty($use_image_height)){
 			$addlHead = $perc.page.getAdditionalHeadContent();
-			$perc.page.setAdditionalHeadContent($nl.format("%s%n%s", $addlHead,$meta_image_height));
+			if (! $addlHead.contains("property=\"og:image:height\"")) {
+				$perc.page.setAdditionalHeadContent($nl.format("%s%n%s", $addlHead,$meta_image_height));
+			}
 		}
 	}
 
 	if(!empty($use_locale)){
 		$addlHead = $perc.page.getAdditionalHeadContent();
-		$perc.page.setAdditionalHeadContent($nl.format("%s%n%s", $addlHead, $meta_locale));
+		if (! $addlHead.contains("property=\"og:locale\"")) {
+			$perc.page.setAdditionalHeadContent($nl.format("%s%n%s", $addlHead, $meta_locale));
+		}
 	}
 
 	if(!empty($use_fb_app_id)){
 		$addlHead = $perc.page.getAdditionalHeadContent();
-		$perc.page.setAdditionalHeadContent($nl.format("%s%n%s", $addlHead,$meta_fb_app_id));
+		if (! $addlHead.contains("property=\"og:fb_app_id\"")) {
+			$perc.page.setAdditionalHeadContent($nl.format("%s%n%s", $addlHead,$meta_fb_app_id));
+		}
 	}
 
 	]]>

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PercOpenGraphDedupeGuardTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PercOpenGraphDedupeGuardTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.pagemanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for GH-811 / v8.1.7 PR #814: Open Graph widget Jexl must guard each {@code og:*} meta
+ * tag so assembly does not append duplicates into AdditionalHeadContent.
+ */
+class PercOpenGraphDedupeGuardTest {
+
+  private static final String[] OG_PROPS = {
+    "og:site_name",
+    "og:title",
+    "og:description",
+    "og:url",
+    "og:type",
+    "og:image",
+    "og:image:width",
+    "og:image:height",
+    "og:locale",
+    "og:fb_app_id"
+  };
+
+  @Test
+  void openGraphWidgetGuardsEachPropertyBeforeAppend() throws Exception {
+    Path widget =
+        resolveRepoRoot()
+            .resolve(
+                "modules/perc-packages/src/main/resources/Packages/perc.openGraphWidget"
+                    + "/sys__UserDependency--rxconfig/Widgets/percOpenGraph.xml");
+    if (!Files.isRegularFile(widget)) {
+      fail("expected Open Graph widget at " + widget.toAbsolutePath());
+    }
+    String xml = Files.readString(widget, StandardCharsets.UTF_8);
+    for (String prop : OG_PROPS) {
+      String guard = "contains(\"property=\\\"" + prop + "\\\"\")";
+      assertTrue(xml.contains(guard), "missing contains() guard for " + prop);
+    }
+  }
+
+  private static Path resolveRepoRoot() {
+    Path cwd = Path.of("").toAbsolutePath().normalize();
+    // Surefire basedir is projects/sitemanage when -pl projects/sitemanage
+    Path candidate = cwd.resolve("../..").normalize();
+    if (Files.isDirectory(candidate.resolve("modules/perc-packages"))) {
+      return candidate;
+    }
+    if (Files.isDirectory(cwd.resolve("modules/perc-packages"))) {
+      return cwd;
+    }
+    return cwd;
+  }
+}


### PR DESCRIPTION
## Summary

Port of intersoftdatalabs-in/percussioncms#814 from v8.1.7 onto \`development\` (GH-811).

On development the Open Graph widget lives under \`modules/perc-packages/\` (not \`system/Packages/\`), so this is a path-translated port rather than a clean cherry-pick.

Each \`setAdditionalHeadContent\` append is gated with \`contains("property=\"og:...\")\` so template/page double-evaluation does not emit duplicate OG meta tags.

### Tests
- \`PercOpenGraphDedupeGuardTest\` — PASS

## Test plan
- [x] \`./mvn-env.sh -pl projects/sitemanage test -Dtest=PercOpenGraphDedupeGuardTest\`