### PR TITLE
Migrate PR #762: auto-list scripts on published pages

### DIFF
--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/SysAssemblyPublishedScriptsGuardTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/SysAssemblyPublishedScriptsGuardTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.pagemanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for GH-749 / v8.1.7 PR #762: global {@code includeOnPublishedPage != "no"} guards
+ * around shared page scripts (jquery-ui path selection, non-jquery script links, delivery service
+ * helpers, mobile preview, cataloged-link suppress, print_jqueryUI wrapper) must not gate published
+ * pages. Widget-level {@code includeOnPublishedPage} property usage remains valid elsewhere.
+ */
+class SysAssemblyPublishedScriptsGuardTest {
+
+  private static final Path REL =
+      Path.of(
+          "system/cms/content/applications/sys_resources/ApplicationFiles/vm/sys_assembly.vm");
+
+  @Test
+  void bodyCloseAndDeliveryScriptsNotGatedByIncludeOnPublishedPage() throws Exception {
+    String vm = readAssemblyVm();
+
+    // jquery-ui edit/preview branches must not require includeOnPublishedPage
+    assertFalse(
+        Pattern.compile(
+                "isEditMode\\(\\)\\s*&&\\s*\\(\\$includeOnPublishedPage\\s*!=\\s*\"no\"\\)")
+            .matcher(vm)
+            .find(),
+        "edit-mode jquery-ui branch must not gate on includeOnPublishedPage");
+    assertFalse(
+        Pattern.compile(
+                "isPreviewMode\\(\\)\\s*&&\\s*\\(\\$includeOnPublishedPage\\s*!=\\s*\"no\"\\)")
+            .matcher(vm)
+            .find(),
+        "preview-mode jquery-ui branch must not gate on includeOnPublishedPage");
+
+    // non-jquery/jquery-ui script emission must not require includeOnPublishedPage
+    assertFalse(
+        Pattern.compile(
+                "endsWith\\(\"/jquery-ui\\.js\"\\)\\)\\s*&&\\s*\\(\\$includeOnPublishedPage")
+            .matcher(vm)
+            .find(),
+        "generic script loop must not gate on includeOnPublishedPage");
+
+    // delivery helpers always emit with jQuery guard
+    assertTrue(
+        vm.contains("if (typeof jQuery !== 'undefined') { jQuery.getDeliveryServiceBase"),
+        "perc_addDeliveryJSFunctions must guard jQuery and always emit");
+    assertFalse(
+        Pattern.compile(
+                "#macro\\(perc_addDeliveryJSFunctions\\)[\\s\\S]*?#if\\(\\$includeOnPublishedPage\\s*!=\\s*\"no\"\\)")
+            .matcher(vm)
+            .find(),
+        "perc_addDeliveryJSFunctions must not wrap in includeOnPublishedPage");
+  }
+
+  @Test
+  void printJqueryUiMacroNotWrappedByIncludeOnPublishedPage() throws Exception {
+    String vm = readAssemblyVm();
+    // Macro body must start processing instances without an outer includeOnPublishedPage if
+    assertTrue(
+        Pattern.compile(
+                "#macro\\(print_jqueryUI\\s+\\$location_name\\)##\\s*#set\\(\\$instances")
+            .matcher(vm)
+            .find(),
+        "print_jqueryUI must not open with includeOnPublishedPage guard");
+  }
+
+  @Test
+  void widgetLevelIncludeOnPublishedPageStillPresent() throws Exception {
+    String vm = readAssemblyVm();
+    // Widget property plumbing must remain (auto-list / jquery widgets still honor per-widget flag)
+    assertTrue(
+        vm.contains("$widgetitem.getProperties().get(\"includeOnPublishedPage\")"),
+        "widget-level includeOnPublishedPage property still required");
+  }
+
+  private static String readAssemblyVm() throws Exception {
+    Path root = resolveRepoRoot();
+    Path vm = root.resolve(REL);
+    if (!Files.isRegularFile(vm)) {
+      fail("expected sys_assembly.vm at " + vm.toAbsolutePath());
+    }
+    return Files.readString(vm, StandardCharsets.UTF_8);
+  }
+
+  private static Path resolveRepoRoot() {
+    Path cwd = Path.of("").toAbsolutePath().normalize();
+    Path candidate = cwd.resolve("../..").normalize();
+    if (Files.isDirectory(candidate.resolve("system"))
+        && Files.isDirectory(candidate.resolve("WebUI"))) {
+      return candidate;
+    }
+    if (Files.isDirectory(cwd.resolve("system")) && Files.isDirectory(cwd.resolve("WebUI"))) {
+      return cwd;
+    }
+    fail("could not resolve monorepo root; tried " + candidate + " and " + cwd);
+    return cwd;
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/SysAssemblyPublishedScriptsGuardTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/SysAssemblyPublishedScriptsGuardTest.java
@@ -87,6 +87,27 @@ class SysAssemblyPublishedScriptsGuardTest {
             .matcher(vm)
             .find(),
         "print_jqueryUI must not open with includeOnPublishedPage guard");
+    // Widget-level UI flag must remain the control for published jquery-ui
+    assertTrue(
+        vm.contains("includeUIOnPublishedPage"),
+        "print_jqueryUI must still honor includeUIOnPublishedPage widget property");
+  }
+
+  @Test
+  void previewOnlyMacrosNotGatedByIncludeOnPublishedPage() throws Exception {
+    String vm = readAssemblyVm();
+    assertFalse(
+        Pattern.compile(
+                "#macro\\(suppressCatalogedLinks\\)##[\\s\\S]*?#if\\(\\$includeOnPublishedPage\\s*!=\\s*\"no\"\\)")
+            .matcher(vm)
+            .find(),
+        "suppressCatalogedLinks must not gate on includeOnPublishedPage");
+    assertFalse(
+        Pattern.compile(
+                "#macro\\(addMobilePreviewToolbar\\)##[\\s\\S]*?#if\\(\\$includeOnPublishedPage\\s*!=\\s*\"no\"\\)")
+            .matcher(vm)
+            .find(),
+        "addMobilePreviewToolbar must not gate on includeOnPublishedPage");
   }
 
   @Test

--- a/system/cms/content/applications/sys_resources/ApplicationFiles/vm/sys_assembly.vm
+++ b/system/cms/content/applications/sys_resources/ApplicationFiles/vm/sys_assembly.vm
@@ -672,9 +672,9 @@ display:none;
 #set($jqueryUIwidget = $rx.pageutils.findWidgetInstances($sys.assemblyItem, $NULL, "percJQueryUIWidget"))##
 #foreach($js_link in $rx.pageutils.javascriptLinks($perc.linkContext, $sys.assemblyItem))##
 #if($js_link.getUrl().endsWith("/jquery-ui.js"))##
-#if($perc.isEditMode() && ($includeOnPublishedPage != "no"))##
+#if($perc.isEditMode())##
 <script src='/cm/jslib/profiles/3x/jquery/libraries/jquery-ui/jquery-ui.js'></script>
-#elseif ($perc.isPreviewMode() && ($includeOnPublishedPage != "no") && ($perc.linkContext.site.overrideSystemJQueryUI==false) && ($jqueryUIwidget.size()==0) )##
+#elseif ($perc.isPreviewMode() && ($perc.linkContext.site.overrideSystemJQueryUI==false) && ($jqueryUIwidget.size()==0) )##
 <script src='/cm/jslib/profiles/3x/jquery/libraries/jquery-ui/jquery-ui.js'></script>
 #else##
 #print_jqueryUI("additionalHeadContent")##
@@ -683,7 +683,7 @@ display:none;
 #end##
 #perc_addDeliveryJSFunctions()##
 #foreach($js_link in $rx.pageutils.javascriptLinks($perc.linkContext, $sys.assemblyItem))##
-#if(! $js_link.getUrl().endsWith("/jquery.js") && !($js_link.getUrl().endsWith("/jquery-ui.js")) && ($includeOnPublishedPage != "no"))##
+#if(! $js_link.getUrl().endsWith("/jquery.js") && !($js_link.getUrl().endsWith("/jquery-ui.js")))##
 <script src="$js_link"></script>
 #end##
 #end##
@@ -745,13 +745,13 @@ ga('send', 'pageview');
 #if ($perc.isPreviewMode())##
 #if($perc.isEditMode())##
 #else##
-#if($includeOnPublishedPage != "no")
 <script>
 document.addEventListener("DOMContentLoaded", function(event) {
-(function($){$(document).ready(function(){$('a[href*="/.system/PageCatalog"]').attr('cataloged', 'true' );$('a[href*="/.system/PageCatalog"]').on("click",function(e) {alert('This page has not yet been imported. It will be available for preview after import is complete.');e.preventDefault();});})    })(jQuery);
+    if (typeof jQuery !== 'undefined') {
+        (function($){$(document).ready(function(){$('a[href*="/.system/PageCatalog"]').attr('cataloged', 'true' );$('a[href*="/.system/PageCatalog"]').on("click",function(e) {alert('This page has not yet been imported. It will be available for preview after import is complete.');e.preventDefault();});})    })(jQuery);
+    }
 });
 </script>
-#end##
 #end##
 #end##
 #end##
@@ -761,9 +761,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
 #if ($perc.isPreviewMode())##
 #if($perc.isEditMode())##
 #else##
-#if($includeOnPublishedPage != "no")
 <script src="/Rhythmyx/sys_resources/mobilepreview/js/PercMobilePreview.js" defer></script>
-#end##
 #end##
 #end##
 #end##
@@ -792,9 +790,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
 #if(! $cm1Version )##
 #set($cm1Version = "")##
 #end##
-#if($includeOnPublishedPage != "no")
-<script>(function() { jQuery.getDeliveryServiceBase = function(){ return '$dServiceBase';};jQuery.getCMSVersion = function(){ return '$!{cm1Version}';};})();</script>
-#end##
+<script>(function() { if (typeof jQuery !== 'undefined') { jQuery.getDeliveryServiceBase = function(){ return '$dServiceBase';};jQuery.getCMSVersion = function(){ return '$!{cm1Version}';}; } })();</script>
 #end##
 ##
 ##
@@ -1041,7 +1037,6 @@ crossorigin="$!{jQueryMigrateCrossOrigin}"
 ## $location_name is a reference to additionalHeadContent, beforeBodyClose,
 ## or afterBodyStart, etc.
 #macro(print_jqueryUI $location_name)##
-#if($includeOnPublishedPage != "no")
 #set($instances = $rx.pageutils.findWidgetInstances($sys.assemblyItem, $NULL, "percJQueryUIWidget"))##
 #if($instances.size() > 0)##
 #set($instance = $instances.get(0))##
@@ -1104,7 +1099,6 @@ crossorigin="$!{jQueryCrossOrigin}"
 #end##
 #else##
 <script src="$js_link"></script>
-#end##
 #end##
 #end##
 #end##


### PR DESCRIPTION
## Summary
- Port of v8.1.7 [#762](https://github.com/intersoftdatalabs-in/percussioncms/pull/762) (GH-749) onto `development`.
- Removes erroneous global `$includeOnPublishedPage != \"no\"` guards from shared assembly scripts in `sys_assembly.vm` so auto-list (and related) JS still load on published pages.
- Keeps widget-level `includeOnPublishedPage` / `includeUIOnPublishedPage` property handling.
- Adds `typeof jQuery` guards for inline snippets that depend on jQuery.
- Regression: `SysAssemblyPublishedScriptsGuardTest`.

## Erlang pre-PR review
- Recommendation: **approve** (no bugs).
- Incorporated: stronger test coverage for suppress/mobile macros and `includeUIOnPublishedPage`.

## Test plan
- [x] `./mvn-env.sh -pl projects/sitemanage -Dtest=SysAssemblyPublishedScriptsGuardTest test`
- [ ] Publish a page with auto-list widgets; confirm list JS/data loads on public site
- [ ] Preview/edit still behave for mobile preview toolbar and cataloged-link suppress