### PR TITLE
Migrate PR #786: View Metadata tags and categories rendering

### DIFF
--- a/modules/perc-packages/src/main/resources/Packages/perc.Baseline/SupportFile-rx_resources/stylesheets/controls/percTagListControl.xsl
+++ b/modules/perc-packages/src/main/resources/Packages/perc.Baseline/SupportFile-rx_resources/stylesheets/controls/percTagListControl.xsl
@@ -101,54 +101,16 @@
 		</select>
 	</xsl:template>
 
+	<!-- Read-only (View Metadata): plain comma-separated text, not editable inputs. -->
 	<xsl:template
 		match="Control[@name='percTagListControl' and @isReadOnly='yes']"
 		priority="10" mode="psxcontrol">
 		<div class="datadisplay">
 			<xsl:for-each
 				select="DisplayChoices/DisplayEntry[@selected='yes']">
-				<input type="text" name="{concat(@paramName,'-display')}"
-					id="{concat(@paramName,'-display')}" class="percTagListControl">
-					<xsl:value-of select="Value" />
-					<xsl:if test="not(position()=last())">
-						,
-					</xsl:if>
-				</input>
+				<xsl:value-of select="Value" />
+				<xsl:if test="not(position()=last())">, </xsl:if>
 			</xsl:for-each>
-			<xsl:if test="@accessKey!=''">
-				<xsl:attribute name="accesskey"><xsl:call-template
-					name="getaccesskey"><xsl:with-param name="label"
-					select="preceding-sibling::DisplayLabel" /><xsl:with-param
-					name="sourceType"
-					select="preceding-sibling::DisplayLabel/@sourceType" /><xsl:with-param
-					name="paramName" select="@paramName" /><xsl:with-param
-					name="accessKey" select="@accessKey" /></xsl:call-template></xsl:attribute>
-			</xsl:if>
-			<xsl:call-template name="parametersToAttributes">
-				<xsl:with-param name="controlClassName"
-					select="'sys_EditBox'" />
-				<xsl:with-param name="controlNode" select="." />
-			</xsl:call-template>
-			<input type="hidden" name="{concat(@paramName,'-display')}"
-				id="{concat(@paramName,'-display')}" class="percTagListControl">
-				<xsl:attribute name="value"><xsl:for-each
-					select="DisplayChoices/DisplayEntry[@selected='yes']"><xsl:value-of select="Value" /><xsl:if
-					test="not(position()=last())">, </xsl:if></xsl:for-each></xsl:attribute>
-				<xsl:if test="@accessKey!=''">
-					<xsl:attribute name="accesskey"><xsl:call-template
-						name="getaccesskey"><xsl:with-param name="label"
-						select="preceding-sibling::DisplayLabel" /><xsl:with-param
-						name="sourceType"
-						select="preceding-sibling::DisplayLabel/@sourceType" /><xsl:with-param
-						name="paramName" select="@paramName" /><xsl:with-param
-						name="accessKey" select="@accessKey" /></xsl:call-template></xsl:attribute>
-				</xsl:if>
-				<xsl:call-template name="parametersToAttributes">
-					<xsl:with-param name="controlClassName"
-						select="'sys_EditBox'" />
-					<xsl:with-param name="controlNode" select="." />
-				</xsl:call-template>
-			</input>
 		</div>
 	</xsl:template>
 </xsl:stylesheet>

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/ViewMetadataTagListControlTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/ViewMetadataTagListControlTest.java
@@ -47,41 +47,56 @@ class ViewMetadataTagListControlTest {
   @Test
   void readOnlyTagListRendersPlainTextNotInputs() throws Exception {
     String xsl = read(TAG_XSL);
-    // Isolate the isReadOnly template body
+    // Isolate the isReadOnly template body (non-greedy so nested templates do not over-match)
     Matcher m =
         Pattern.compile(
-                "match=\"Control\\[@name='percTagListControl' and @isReadOnly='yes'\\]\"[\\s\\S]*?</xsl:template>",
+                "match\\s*=\\s*\"Control\\[@name='percTagListControl' and @isReadOnly='yes'\\]\""
+                    + "[\\s\\S]*?</xsl:template>",
                 Pattern.MULTILINE)
             .matcher(xsl);
     assertTrue(m.find(), "expected isReadOnly percTagListControl template");
     String body = m.group();
+    // Collapse whitespace so cosmetic reformatting does not break the guard
+    String compact = body.replaceAll("\\s+", " ");
     assertFalse(
-        body.contains("<input"),
+        Pattern.compile("<input\\b", Pattern.CASE_INSENSITIVE).matcher(compact).find(),
         "read-only tags must not emit <input> (View Metadata should show plain text)");
-    assertTrue(body.contains("datadisplay"), "read-only tags must use datadisplay wrapper");
     assertTrue(
-        body.contains("xsl:value-of") || body.contains("<xsl:value-of"),
+        compact.contains("datadisplay"), "read-only tags must use datadisplay wrapper");
+    assertTrue(
+        Pattern.compile("xsl:value-of").matcher(compact).find(),
         "read-only tags must output Value text");
     assertTrue(
-        body.contains("not(position()=last())\">, </xsl:if>")
-            || body.contains("not(position()=last())\">, "),
-        "selected tags must be joined with comma+space");
+        Pattern.compile("not\\s*\\(\\s*position\\s*\\(\\s*\\)\\s*=\\s*last\\s*\\(\\s*\\)\\s*\\)")
+            .matcher(compact)
+            .find(),
+        "selected tags must join with a position()!=last separator");
+    assertTrue(
+        compact.contains(", ") || compact.contains("\",\""),
+        "selected tags must be joined with a comma separator");
   }
 
   @Test
   void checkBoxTreeJsAlwaysInitializesWithSafeSiteName() throws Exception {
     String xsl = read(SYS_TEMPLATES);
-    // The CDATA block for sys_CheckBoxTreeJS must always call perc_checkboxTree
+    String compact = xsl.replaceAll("\\s+", " ");
     assertTrue(
-        xsl.contains("encodeURIComponent(siteName)"),
+        compact.contains("encodeURIComponent(siteName)"),
         "siteName must be encodeURIComponent'd for query string safety");
     assertTrue(
-        xsl.contains("parent.$.PercNavigationManager"),
+        compact.contains("encodeURIComponent(rootpath")
+            || compact.contains("encodeURIComponent(rootpath ||")
+            || compact.contains("encodeURIComponent(rootpath||"),
+        "rootpath must be encodeURIComponent'd for query string safety");
+    assertTrue(
+        compact.contains("parent.$.PercNavigationManager"),
         "must still attempt PercNavigationManager when present");
     assertTrue(
-        xsl.contains("try {") && xsl.contains("} catch (e) {"),
+        compact.contains("try {") && compact.contains("} catch (e) {"),
         "PercNavigationManager access must be try/catch guarded for iframe contexts");
-    // Must not gate tree init solely on parent.$ being defined
+    assertTrue(
+        compact.contains("console.debug"),
+        "catch path should log at debug for diagnosability");
     assertFalse(
         Pattern.compile(
                 "if\\s*\\(\\s*typeof\\s+parent\\.\\$\\s*!==\\s*'undefined'\\s*\\)\\s*\\{\\s*"
@@ -90,7 +105,7 @@ class ViewMetadataTagListControlTest {
             .find(),
         "must not use the old pattern that only inits the tree when parent.$ is defined");
     assertTrue(
-        xsl.contains("$('#' + paramName + '-tree').perc_checkboxTree(opts)"),
+        compact.contains("$('#' + paramName + '-tree').perc_checkboxTree(opts)"),
         "perc_checkboxTree must always be invoked");
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/ViewMetadataTagListControlTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/ViewMetadataTagListControlTest.java
@@ -62,6 +62,10 @@ class ViewMetadataTagListControlTest {
     assertTrue(
         body.contains("xsl:value-of") || body.contains("<xsl:value-of"),
         "read-only tags must output Value text");
+    assertTrue(
+        body.contains("not(position()=last())\">, </xsl:if>")
+            || body.contains("not(position()=last())\">, "),
+        "selected tags must be joined with comma+space");
   }
 
   @Test
@@ -74,6 +78,9 @@ class ViewMetadataTagListControlTest {
     assertTrue(
         xsl.contains("parent.$.PercNavigationManager"),
         "must still attempt PercNavigationManager when present");
+    assertTrue(
+        xsl.contains("try {") && xsl.contains("} catch (e) {"),
+        "PercNavigationManager access must be try/catch guarded for iframe contexts");
     // Must not gate tree init solely on parent.$ being defined
     assertFalse(
         Pattern.compile(

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/ViewMetadataTagListControlTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/ViewMetadataTagListControlTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.pagemanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for GH-785 / v8.1.7 PR #786: View Metadata dialog must render tags as plain text and
+ * always initialize the category checkbox tree (even when PercNavigationManager is unavailable in
+ * the metadata iframe).
+ */
+class ViewMetadataTagListControlTest {
+
+  private static final Path TAG_XSL =
+      Path.of(
+          "modules/perc-packages/src/main/resources/Packages/perc.Baseline"
+              + "/SupportFile-rx_resources/stylesheets/controls/percTagListControl.xsl");
+
+  private static final Path SYS_TEMPLATES =
+      Path.of(
+          "system/cms/content/applications/sys_resources/ApplicationFiles/stylesheets/sys_Templates.xsl");
+
+  @Test
+  void readOnlyTagListRendersPlainTextNotInputs() throws Exception {
+    String xsl = read(TAG_XSL);
+    // Isolate the isReadOnly template body
+    Matcher m =
+        Pattern.compile(
+                "match=\"Control\\[@name='percTagListControl' and @isReadOnly='yes'\\]\"[\\s\\S]*?</xsl:template>",
+                Pattern.MULTILINE)
+            .matcher(xsl);
+    assertTrue(m.find(), "expected isReadOnly percTagListControl template");
+    String body = m.group();
+    assertFalse(
+        body.contains("<input"),
+        "read-only tags must not emit <input> (View Metadata should show plain text)");
+    assertTrue(body.contains("datadisplay"), "read-only tags must use datadisplay wrapper");
+    assertTrue(
+        body.contains("xsl:value-of") || body.contains("<xsl:value-of"),
+        "read-only tags must output Value text");
+  }
+
+  @Test
+  void checkBoxTreeJsAlwaysInitializesWithSafeSiteName() throws Exception {
+    String xsl = read(SYS_TEMPLATES);
+    // The CDATA block for sys_CheckBoxTreeJS must always call perc_checkboxTree
+    assertTrue(
+        xsl.contains("encodeURIComponent(siteName)"),
+        "siteName must be encodeURIComponent'd for query string safety");
+    assertTrue(
+        xsl.contains("parent.$.PercNavigationManager"),
+        "must still attempt PercNavigationManager when present");
+    // Must not gate tree init solely on parent.$ being defined
+    assertFalse(
+        Pattern.compile(
+                "if\\s*\\(\\s*typeof\\s+parent\\.\\$\\s*!==\\s*'undefined'\\s*\\)\\s*\\{\\s*"
+                    + "var\\s+siteName\\s*=\\s*parent\\.\\$\\.PercNavigationManager\\.getSiteName\\s*\\(\\s*\\)\\s*;")
+            .matcher(xsl)
+            .find(),
+        "must not use the old pattern that only inits the tree when parent.$ is defined");
+    assertTrue(
+        xsl.contains("$('#' + paramName + '-tree').perc_checkboxTree(opts)"),
+        "perc_checkboxTree must always be invoked");
+  }
+
+  private static String read(Path rel) throws Exception {
+    Path p = resolveRepoRoot().resolve(rel);
+    if (!Files.isRegularFile(p)) {
+      fail("expected file at " + p.toAbsolutePath());
+    }
+    return Files.readString(p, StandardCharsets.UTF_8);
+  }
+
+  private static Path resolveRepoRoot() {
+    Path cwd = Path.of("").toAbsolutePath().normalize();
+    Path candidate = cwd.resolve("../..").normalize();
+    if (Files.isDirectory(candidate.resolve("system"))
+        && Files.isDirectory(candidate.resolve("modules"))) {
+      return candidate;
+    }
+    if (Files.isDirectory(cwd.resolve("system")) && Files.isDirectory(cwd.resolve("modules"))) {
+      return cwd;
+    }
+    fail("could not resolve monorepo root; tried " + candidate + " and " + cwd);
+    return cwd;
+  }
+}

--- a/system/cms/content/applications/sys_resources/ApplicationFiles/stylesheets/sys_Templates.xsl
+++ b/system/cms/content/applications/sys_resources/ApplicationFiles/stylesheets/sys_Templates.xsl
@@ -3165,13 +3165,18 @@ onchange    %Script;       #IMPLIED
          </xsl:call-template>
          // <![CDATA[
             readonly = readonly == 'true' ? true : false;
-            if(typeof parent.$ !== 'undefined'){
-               var siteName = parent.$.PercNavigationManager.getSiteName();
-               siteurl = treeSrcUrl + "?" + "sitename="+ siteName + "&rootpath="+rootpath;
-
-               var opts = {url : siteurl, selected : selectedValues, paramName : paramName, readonly : readonly};
-               $('#' + paramName + '-tree').perc_checkboxTree(opts);
+            var siteName = '';
+            try {
+               if (typeof parent.$ !== 'undefined' && parent.$.PercNavigationManager) {
+                  siteName = parent.$.PercNavigationManager.getSiteName() || '';
+               }
+            } catch (e) {
+               // ignore, use empty siteName (metadata dialog iframe has no navigation manager)
             }
+            var siteurl = treeSrcUrl + "?" + "sitename=" + encodeURIComponent(siteName) + "&rootpath=" + (rootpath || '');
+
+            var opts = {url : siteurl, selected : selectedValues, paramName : paramName, readonly : readonly};
+            $('#' + paramName + '-tree').perc_checkboxTree(opts);
         });
         })(jQuery);
         // ]]>

--- a/system/cms/content/applications/sys_resources/ApplicationFiles/stylesheets/sys_Templates.xsl
+++ b/system/cms/content/applications/sys_resources/ApplicationFiles/stylesheets/sys_Templates.xsl
@@ -3171,9 +3171,13 @@ onchange    %Script;       #IMPLIED
                   siteName = parent.$.PercNavigationManager.getSiteName() || '';
                }
             } catch (e) {
-               // ignore, use empty siteName (metadata dialog iframe has no navigation manager)
+               // metadata dialog iframe has no navigation manager; keep diagnosable
+               if (typeof console !== 'undefined' && console.debug) {
+                  console.debug('PercNavigationManager siteName unavailable; using empty sitename', e);
+               }
             }
-            var siteurl = treeSrcUrl + "?" + "sitename=" + encodeURIComponent(siteName) + "&rootpath=" + (rootpath || '');
+            var siteurl = treeSrcUrl + "?" + "sitename=" + encodeURIComponent(siteName)
+                  + "&rootpath=" + encodeURIComponent(rootpath || '');
 
             var opts = {url : siteurl, selected : selectedValues, paramName : paramName, readonly : readonly};
             $('#' + paramName + '-tree').perc_checkboxTree(opts);


### PR DESCRIPTION
## Summary
- Port of v8.1.7 [#786](https://github.com/intersoftdatalabs-in/percussioncms/pull/786) (GH-785) onto `development`.
- `percTagListControl.xsl` (under `modules/perc-packages/...`): read-only template emits plain comma-separated tag text instead of broken inputs.
- `sys_Templates.xsl` `sys_CheckBoxTreeJS`: always initializes `perc_checkboxTree` with try/catch around `PercNavigationManager` and `encodeURIComponent(siteName)`.
- Regression: `ViewMetadataTagListControlTest`.

## Erlang pre-PR review
- Recommendation: **approve**. Incorporated try/catch + comma-join test assertions.

## Test plan
- [x] `./mvn-env.sh -pl projects/sitemanage -Dtest=ViewMetadataTagListControlTest test`
- [ ] View Metadata dialog: tags as plain text; categories tree renders