### PR TITLE
Migrate PR #850: deprecate Registration widget

### DIFF
--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.registration/percRegistrationAsset.itemDef.contentType
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.registration/percRegistrationAsset.itemDef.contentType
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ItemDefData appName="psx_cepercRegistrationAsset" isHidden="true" objectType="1">
-   <PSXItemDefSummary editorUrl="../psx_cepercRegistrationAsset/percRegistrationAsset.html" id="369" label="Registration Asset" name="percRegistrationAsset" typeId="369"/>
+   <PSXItemDefSummary editorUrl="../psx_cepercRegistrationAsset/percRegistrationAsset.html" id="369" label="Registration Asset (Deprecated)" name="percRegistrationAsset" typeId="369"/>
    <PSXContentEditor contentType="369" enableRelatedContent="yes" iconSource="1" iconValue="filetypeIconsRegistration.png" objectType="1" producesResource="no" workflowId="6">
       <PSXDataSet id="768">
          <name>percRegistrationAsset</name>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.registration/percRegistrationAsset.nodeDef.contentType
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.registration/percRegistrationAsset.nodeDef.contentType
@@ -4,7 +4,7 @@
     <hide-from-menu>true</hide-from-menu>
     <id>369</id>
     <internal-name>percRegistrationAsset</internal-name>
-    <label>Registration Asset</label>
+    <label>Registration Asset (Deprecated)</label>
     <mandatory>false</mandatory>
     <name>rx:percRegistrationAsset</name>
     <new-request>../psx_cepercRegistrationAsset/percRegistrationAsset.html</new-request>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.registration/sys__UserDependency--rxconfig/Widgets/percRegistration.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.registration/sys__UserDependency--rxconfig/Widgets/percRegistration.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Widget>
-	<WidgetPrefs title="Registration"
+	<WidgetPrefs title="Registration (Deprecated)"
 		contenttype_name="percRegistrationAsset" category="integration"
-		description="Widget to build and render a registration form"
+		description="Widget to build and render a registration form. (Deprecated)"
 		author="Percussion Software Inc"
 		thumbnail="/rx_resources/widgets/registration/images/widgetIconRegistration.gif"
 		preferred_editor_width="800" preferred_editor_height="450"

--- a/projects/sitemanage/src/main/resources/com/percussion/pagemanagement/service/impl/WidgetRegistry.xml
+++ b/projects/sitemanage/src/main/resources/com/percussion/pagemanagement/service/impl/WidgetRegistry.xml
@@ -30,7 +30,6 @@
 <widget name="Navigation" />
 <widget name="Page Auto List" />
 <widget name="Polls" />
-<widget name="Registration" />
 <widget name="Rich Text" />
 <widget name="RSS" />
 <widget name="Result" />
@@ -56,5 +55,6 @@
 <widget name="Share This" />
 <widget name="Calendar" />
 <widget name="Secure Login (Deprecated)" />
+<widget name="Registration (Deprecated)" />
 </group>
 </widgets>

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/WidgetRegistryRegistrationDeprecationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/WidgetRegistryRegistrationDeprecationTest.java
@@ -100,9 +100,9 @@ class WidgetRegistryRegistrationDeprecationTest {
         widgetText.contains("title=\"Registration (Deprecated)\""),
         "widget title must be Registration (Deprecated)");
     assertTrue(
-        widgetText.contains("registration form. (Deprecated)")
-            || widgetText.contains("(Deprecated)"),
-        "widget description must note Deprecated");
+        widgetText.contains("description=\"Widget to build and render a registration form. (Deprecated)\"")
+            || widgetText.contains("registration form. (Deprecated)"),
+        "widget description must include form. (Deprecated) suffix, not only title");
   }
 
   private static Path resolveRepoRoot() {

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/WidgetRegistryRegistrationDeprecationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/WidgetRegistryRegistrationDeprecationTest.java
@@ -31,6 +31,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Regression for GH-844 / v8.1.7 PR #850: Registration widget is listed under the Deprecated group
  * and labels carry the (Deprecated) suffix.
+ *
+ * <p>Package XML files live under {@code modules/perc-packages} (not the sitemanage classpath).
+ * {@link #resolveRepoRoot()} therefore walks from the Surefire CWD ({@code projects/sitemanage}) to
+ * the monorepo root — the same pattern as other 005 migration package-file tests.
  */
 class WidgetRegistryRegistrationDeprecationTest {
 
@@ -51,8 +55,9 @@ class WidgetRegistryRegistrationDeprecationTest {
             || xml.contains("<widget name=\"Registration\"/>"),
         "Registration must not remain in the active Percussion group");
     assertTrue(
-        xml.contains("Registration (Deprecated)"),
-        "Registration must appear with Deprecated label");
+        xml.contains("<widget name=\"Registration (Deprecated)\" />")
+            || xml.contains("<widget name=\"Registration (Deprecated)\"/>"),
+        "Registration must appear as Registration (Deprecated) widget entry");
     int deprecatedIdx = xml.indexOf("<group name=\"Deprecated\">");
     int regIdx = xml.indexOf("Registration (Deprecated)");
     assertTrue(deprecatedIdx >= 0, "Deprecated group must exist");
@@ -76,27 +81,46 @@ class WidgetRegistryRegistrationDeprecationTest {
         root.resolve(
             "modules/perc-packages/src/main/resources/Packages/perc.widget.registration"
                 + "/sys__UserDependency--rxconfig/Widgets/percRegistration.xml");
-    for (Path p : new Path[] {itemDef, nodeDef, widget}) {
-      if (!Files.isRegularFile(p)) {
-        fail("expected " + p.toAbsolutePath());
-      }
-      String text = Files.readString(p, StandardCharsets.UTF_8);
-      assertTrue(
-          text.contains("Deprecated"),
-          p.getFileName() + " must include Deprecated in label/title/description");
-    }
+
+    assertTrue(Files.isRegularFile(itemDef), "expected itemDef at " + itemDef.toAbsolutePath());
+    assertTrue(Files.isRegularFile(nodeDef), "expected nodeDef at " + nodeDef.toAbsolutePath());
+    assertTrue(Files.isRegularFile(widget), "expected widget xml at " + widget.toAbsolutePath());
+
+    String itemText = Files.readString(itemDef, StandardCharsets.UTF_8);
+    String nodeText = Files.readString(nodeDef, StandardCharsets.UTF_8);
+    String widgetText = Files.readString(widget, StandardCharsets.UTF_8);
+
+    assertTrue(
+        itemText.contains("label=\"Registration Asset (Deprecated)\""),
+        "itemDef label must be Registration Asset (Deprecated)");
+    assertTrue(
+        nodeText.contains("<label>Registration Asset (Deprecated)</label>"),
+        "nodeDef label must be Registration Asset (Deprecated)");
+    assertTrue(
+        widgetText.contains("title=\"Registration (Deprecated)\""),
+        "widget title must be Registration (Deprecated)");
+    assertTrue(
+        widgetText.contains("registration form. (Deprecated)")
+            || widgetText.contains("(Deprecated)"),
+        "widget description must note Deprecated");
   }
 
   private static Path resolveRepoRoot() {
     Path cwd = Path.of("").toAbsolutePath().normalize();
     Path candidate = cwd.resolve("../..").normalize();
-    if (Files.isDirectory(candidate.resolve("modules"))) {
+    if (Files.isDirectory(candidate.resolve("modules/perc-packages"))
+        && Files.isDirectory(candidate.resolve("projects/sitemanage"))) {
       return candidate;
     }
-    if (Files.isDirectory(cwd.resolve("modules"))) {
+    if (Files.isDirectory(cwd.resolve("modules/perc-packages"))) {
       return cwd;
     }
-    fail("could not resolve monorepo root");
+    fail(
+        "could not resolve monorepo root (need modules/perc-packages/). Tried: "
+            + candidate
+            + " and "
+            + cwd
+            + " — Surefire basedir is typically projects/sitemanage");
     return cwd;
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/WidgetRegistryRegistrationDeprecationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/WidgetRegistryRegistrationDeprecationTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.pagemanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for GH-844 / v8.1.7 PR #850: Registration widget is listed under the Deprecated group
+ * and labels carry the (Deprecated) suffix.
+ */
+class WidgetRegistryRegistrationDeprecationTest {
+
+  @Test
+  void registrationIsInDeprecatedGroupOnly() throws Exception {
+    String xml;
+    try (InputStream in =
+        Thread.currentThread()
+            .getContextClassLoader()
+            .getResourceAsStream(
+                "com/percussion/pagemanagement/service/impl/WidgetRegistry.xml")) {
+      assertNotNull(in, "WidgetRegistry.xml must be on the classpath");
+      xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    assertFalse(
+        xml.contains("<widget name=\"Registration\" />")
+            || xml.contains("<widget name=\"Registration\"/>"),
+        "Registration must not remain in the active Percussion group");
+    assertTrue(
+        xml.contains("Registration (Deprecated)"),
+        "Registration must appear with Deprecated label");
+    int deprecatedIdx = xml.indexOf("<group name=\"Deprecated\">");
+    int regIdx = xml.indexOf("Registration (Deprecated)");
+    assertTrue(deprecatedIdx >= 0, "Deprecated group must exist");
+    assertTrue(
+        regIdx > deprecatedIdx,
+        "Registration (Deprecated) entry must appear after Deprecated group opens");
+  }
+
+  @Test
+  void packageLabelsCarryDeprecatedSuffix() throws Exception {
+    Path root = resolveRepoRoot();
+    Path itemDef =
+        root.resolve(
+            "modules/perc-packages/src/main/resources/Packages/perc.widget.registration"
+                + "/percRegistrationAsset.itemDef.contentType");
+    Path nodeDef =
+        root.resolve(
+            "modules/perc-packages/src/main/resources/Packages/perc.widget.registration"
+                + "/percRegistrationAsset.nodeDef.contentType");
+    Path widget =
+        root.resolve(
+            "modules/perc-packages/src/main/resources/Packages/perc.widget.registration"
+                + "/sys__UserDependency--rxconfig/Widgets/percRegistration.xml");
+    for (Path p : new Path[] {itemDef, nodeDef, widget}) {
+      if (!Files.isRegularFile(p)) {
+        fail("expected " + p.toAbsolutePath());
+      }
+      String text = Files.readString(p, StandardCharsets.UTF_8);
+      assertTrue(
+          text.contains("Deprecated"),
+          p.getFileName() + " must include Deprecated in label/title/description");
+    }
+  }
+
+  private static Path resolveRepoRoot() {
+    Path cwd = Path.of("").toAbsolutePath().normalize();
+    Path candidate = cwd.resolve("../..").normalize();
+    if (Files.isDirectory(candidate.resolve("modules"))) {
+      return candidate;
+    }
+    if (Files.isDirectory(cwd.resolve("modules"))) {
+      return cwd;
+    }
+    fail("could not resolve monorepo root");
+    return cwd;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -653,7 +653,7 @@ public class ContentTypesResource {
                                     + "        \"uuid\": 363\n"
                                     + "      },\n"
                                     + "      \"hideFromMenu\": false,\n"
-                                    + "      \"label\": \"Registration Asset\",\n"
+                                    + "      \"label\": \"Registration Asset (Deprecated)\",\n"
                                     + "      \"name\": \"percRegistrationAsset\"\n"
                                     + "    },\n"
                                     + "    {\n"


### PR DESCRIPTION
## Summary
- Port of v8.1.7 [#850](https://github.com/intersoftdatalabs-in/percussioncms/pull/850) (GH-844) onto `development`.
- Moves Registration into Deprecated group in `WidgetRegistry.xml`.
- Appends `(Deprecated)` to package content-type labels, widget title/description (`modules/perc-packages/...`), and ContentTypesResource sample label.
- Regression: `WidgetRegistryRegistrationDeprecationTest`.

## Erlang pre-PR review
- Recommendation: **approve**.

## Test plan
- [x] `./mvn-env.sh -pl projects/sitemanage -Dtest=WidgetRegistryRegistrationDeprecationTest test`
- [ ] Widget tray: Registration under Deprecated only