### PR TITLE
Migrate PR #931: curly apostrophe in path error messages

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSSitePathItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSSitePathItemService.java
@@ -116,10 +116,10 @@ public class PSSitePathItemService extends PSPathItemService {
         // Site not found, assume orphaned path
         var msg =
             sfp.isOnlySiteId()
-                ? "Oops.  We can't find the site "
+                ? "Oops.  We can’t find the site "
                     + sfp.getSiteId()
                     + ".  It may have been deleted."
-                : "Oops. We're sorry. The requested page is no longer available.";
+                : "Oops. We’re sorry. The requested page is no longer available.";
         throw new PSPathNotFoundServiceException(msg);
       }
     }

--- a/projects/sitemanage/src/test/java/com/percussion/pathmanagement/service/PSSitePathItemServiceCurlyApostropheTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pathmanagement/service/PSSitePathItemServiceCurlyApostropheTest.java
@@ -1,0 +1,35 @@
+package com.percussion.pathmanagement.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/** Regression for GH-879 / v8.1.7 PR #931: path error messages use curly apostrophes. */
+class PSSitePathItemServiceCurlyApostropheTest {
+  @Test
+  void sitePathMessagesUseCurlyApostrophe() throws Exception {
+    Path root = resolveRoot();
+    Path java =
+        root.resolve(
+            "projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSSitePathItemService.java");
+    if (!Files.isRegularFile(java)) fail(java.toString());
+    String src = Files.readString(java, StandardCharsets.UTF_8);
+    assertTrue(src.contains("\u2019"), "must use U+2019 curly apostrophe in error messages");
+    assertFalse(src.contains("can't find the site"), "must not use straight apostrophe in can't");
+    assertFalse(src.contains("We're sorry"), "must not use straight apostrophe in We're");
+  }
+
+  private static Path resolveRoot() {
+    Path cwd = Path.of("").toAbsolutePath().normalize();
+    Path up = cwd.resolve("../..").normalize();
+    if (Files.isDirectory(up.resolve("projects/sitemanage"))) return up;
+    if (Files.isDirectory(cwd.resolve("projects/sitemanage"))) return cwd;
+    fail("no root");
+    return cwd;
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/pathmanagement/service/PSSitePathItemServiceCurlyApostropheTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pathmanagement/service/PSSitePathItemServiceCurlyApostropheTest.java
@@ -29,7 +29,7 @@ class PSSitePathItemServiceCurlyApostropheTest {
     Path up = cwd.resolve("../..").normalize();
     if (Files.isDirectory(up.resolve("projects/sitemanage"))) return up;
     if (Files.isDirectory(cwd.resolve("projects/sitemanage"))) return cwd;
-    fail("no root");
+    fail("could not resolve monorepo root (Surefire basedir projects/sitemanage expected)");
     return cwd;
   }
 }


### PR DESCRIPTION
## Summary
- Port of v8.1.7 [#931](https://github.com/intersoftdatalabs-in/percussioncms/pull/931) (GH-879).
- \`PSSitePathItemService\` site/page not-found messages use curly apostrophe (U+2019).
- Regression: \`PSSitePathItemServiceCurlyApostropheTest\`.

## Erlang pre-PR review
- Trivial string-only port; static test locks curly apostrophe.

## Test plan
- [x] unit test
- [ ] UI: orphaned page/site error shows real apostrophe not &#39;