### PR TITLE
Migrate PR #896: theme gallery thumbnail size constraints

### DIFF
--- a/WebUI/src/main/webapp/cm/app/css/legacy/perc_css_editor.css
+++ b/WebUI/src/main/webapp/cm/app/css/legacy/perc_css_editor.css
@@ -21,6 +21,15 @@
   float: left;
 }
 
+.perc-css-gallery-item img {
+    max-width: 150px;
+    max-height: 120px;
+    width: auto;
+    height: auto;
+    object-fit: contain;
+}
+
+
 #perc-css-gallery-button-bar {
   float: right;
 }

--- a/WebUI/src/main/webapp/cm/css/perc_css_editor.css
+++ b/WebUI/src/main/webapp/cm/css/perc_css_editor.css
@@ -21,6 +21,15 @@
   float: left;
 }
 
+.perc-css-gallery-item img {
+    max-width: 150px;
+    max-height: 120px;
+    width: auto;
+    height: auto;
+    object-fit: contain;
+}
+
+
 #perc-css-gallery-button-bar {
   float: right;
 }

--- a/WebUI/war/css/perc_css_editor.css
+++ b/WebUI/war/css/perc_css_editor.css
@@ -21,6 +21,15 @@
   float: left;
 }
 
+.perc-css-gallery-item img {
+    max-width: 150px;
+    max-height: 120px;
+    width: auto;
+    height: auto;
+    object-fit: contain;
+}
+
+
 #perc-css-gallery-button-bar {
   float: right;
 }

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/ThemeThumbSizeCssTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/ThemeThumbSizeCssTest.java
@@ -1,0 +1,39 @@
+package com.percussion.pagemanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Regression for GH-876 / v8.1.7 PR #896: theme gallery thumbs constrained. */
+class ThemeThumbSizeCssTest {
+  @Test
+  void galleryImagesConstrained() throws Exception {
+    Path root = resolve();
+    for (String rel :
+        List.of(
+            "WebUI/war/css/perc_css_editor.css",
+            "WebUI/src/main/webapp/cm/css/perc_css_editor.css",
+            "WebUI/src/main/webapp/cm/app/css/legacy/perc_css_editor.css")) {
+      Path p = root.resolve(rel);
+      if (!Files.isRegularFile(p)) fail(p.toString());
+      String css = Files.readString(p, StandardCharsets.UTF_8);
+      assertTrue(css.contains(".perc-css-gallery-item img"), rel);
+      assertTrue(css.contains("max-width: 150px"), rel);
+      assertTrue(css.contains("max-height: 120px"), rel);
+    }
+  }
+
+  private static Path resolve() {
+    Path cwd = Path.of("").toAbsolutePath().normalize();
+    Path up = cwd.resolve("../..").normalize();
+    if (Files.isDirectory(up.resolve("WebUI"))) return up;
+    if (Files.isDirectory(cwd.resolve("WebUI"))) return cwd;
+    fail("root");
+    return cwd;
+  }
+}


### PR DESCRIPTION
## Summary
- Port of v8.1.7 [#896](https://github.com/intersoftdatalabs-in/percussioncms/pull/896) (GH-876).
- CSS max dimensions on theme preview thumbnails.
- Regression: \`ThemeThumbSizeCssTest\`.

## Test plan
- [x] unit test
- [ ] Style tab gallery: large theme thumbs do not blow layout