### PR TITLE
Migrate PR #872: folder path parse after create/rename

### DIFF
--- a/WebUI/src/main/webapp/cm/plugins/perc_utils.js
+++ b/WebUI/src/main/webapp/cm/plugins/perc_utils.js
@@ -1619,14 +1619,10 @@
             value,
             function (status, result, code) {
               if (status === $.PercServiceUtils.STATUS_SUCCESS) {
-                var pth = $.perc_finder().lastClickPath;
-                if (
-                  $.perc_finder().lastClickPath === null ||
-                  typeof $.perc_finder().lastClickPath === "undefined"
-                ) {
-                  pth = result.PathItem.path.split("/");
-                  pth.push(value);
-                }
+                                                var pth = result.PathItem.path.split("/");
+                                if (pth[pth.length - 1] === "") {
+                                    pth.pop();
+                                }
                 $.perc_finder().lastClickPath = null;
                 $.perc_finder().open(pth);
                 $.unblockUI();

--- a/WebUI/src/main/webapp/cm/plugins/perc_utils.js
+++ b/WebUI/src/main/webapp/cm/plugins/perc_utils.js
@@ -1619,12 +1619,20 @@
             value,
             function (status, result, code) {
               if (status === $.PercServiceUtils.STATUS_SUCCESS) {
+                // Guard the new path-parse against a SUCCESS payload that lacks
+                // a PathItem (e.g. partial server response or unexpected shape).
+                // Without this guard, `result.PathItem.path.split(...)` would
+                // throw TypeError on a missing `PathItem` and the finder would
+                // never re-open. Skip the open() call -- the finder is already
+                // showing the pre-rename view.
+                if (result && result.PathItem && result.PathItem.path) {
                                                 var pth = result.PathItem.path.split("/");
                                 if (pth[pth.length - 1] === "") {
                                     pth.pop();
                                 }
-                $.perc_finder().lastClickPath = null;
-                $.perc_finder().open(pth);
+                  $.perc_finder().lastClickPath = null;
+                  $.perc_finder().open(pth);
+                }
                 $.unblockUI();
               } else {
                 $nameEl.text(oldName); // Reset back to old name

--- a/WebUI/war/plugins/perc_utils.js
+++ b/WebUI/war/plugins/perc_utils.js
@@ -1525,11 +1525,9 @@
                         function(status, result, code){
                             if(status === $.PercServiceUtils.STATUS_SUCCESS)
                             {
-                                var pth = $.perc_finder().lastClickPath;
-                                if($.perc_finder().lastClickPath === null ||  typeof $.perc_finder().lastClickPath === "undefined")
-                                {
-                                    pth = result.PathItem.path.split("/");
-                                    pth.push(value);
+                                                                var pth = result.PathItem.path.split("/");
+                                if (pth[pth.length - 1] === "") {
+                                    pth.pop();
                                 }
                                 $.perc_finder().lastClickPath = null;
                                 $.perc_finder().open(pth);

--- a/WebUI/war/plugins/perc_utils.js
+++ b/WebUI/war/plugins/perc_utils.js
@@ -1525,12 +1525,23 @@
                         function(status, result, code){
                             if(status === $.PercServiceUtils.STATUS_SUCCESS)
                             {
+                                // Guard the new path-parse against a SUCCESS
+                                // payload that lacks a PathItem (e.g. partial
+                                // server response or unexpected shape).
+                                // Without this guard, `result.PathItem.path.split(...)`
+                                // would throw TypeError on a missing `PathItem`
+                                // and the finder would never re-open. Skip the
+                                // open() call -- the finder is already showing
+                                // the pre-rename view.
+                                if (result && result.PathItem && result.PathItem.path)
+                                {
                                                                 var pth = result.PathItem.path.split("/");
-                                if (pth[pth.length - 1] === "") {
-                                    pth.pop();
+                                    if (pth[pth.length - 1] === "") {
+                                        pth.pop();
+                                    }
+                                    $.perc_finder().lastClickPath = null;
+                                    $.perc_finder().open(pth);
                                 }
-                                $.perc_finder().lastClickPath = null;
-                                $.perc_finder().open(pth);
                                 $.unblockUI();
                             }
                             else

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PercUtilsFolderPathParseTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PercUtilsFolderPathParseTest.java
@@ -1,0 +1,42 @@
+package com.percussion.pagemanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Regression for GH-867 / v8.1.7 PR #872: folder open path uses PathItem, not lastClickPath. */
+class PercUtilsFolderPathParseTest {
+  @Test
+  void openUsesPathItemNotLastClickPath() throws Exception {
+    Path root = resolve();
+    for (String rel :
+        List.of(
+            "WebUI/war/plugins/perc_utils.js",
+            "WebUI/src/main/webapp/cm/plugins/perc_utils.js")) {
+      Path p = root.resolve(rel);
+      if (!Files.isRegularFile(p)) fail(p.toString());
+      String js = Files.readString(p, StandardCharsets.UTF_8);
+      assertTrue(js.contains("result.PathItem.path.split"), rel);
+      assertTrue(js.contains("pth[pth.length - 1] === \"\""), rel + " trims trailing empty segment");
+      // Should not prefer lastClickPath for the new folder path
+      assertFalse(
+          js.contains("var pth = $.perc_finder().lastClickPath;"),
+          rel + " must not seed path from lastClickPath");
+    }
+  }
+
+  private static Path resolve() {
+    Path cwd = Path.of("").toAbsolutePath().normalize();
+    Path up = cwd.resolve("../..").normalize();
+    if (Files.isDirectory(up.resolve("WebUI"))) return up;
+    if (Files.isDirectory(cwd.resolve("WebUI"))) return cwd;
+    fail("root");
+    return cwd;
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PercUtilsFolderPathParseTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PercUtilsFolderPathParseTest.java
@@ -24,6 +24,11 @@ class PercUtilsFolderPathParseTest {
       String js = Files.readString(p, StandardCharsets.UTF_8);
       assertTrue(js.contains("result.PathItem.path.split"), rel);
       assertTrue(js.contains("pth[pth.length - 1] === \"\""), rel + " trims trailing empty segment");
+      // Defensive guard against a SUCCESS payload that lacks a PathItem
+      // (kilo-code-bot WARNING on PR #1246).
+      assertTrue(
+          js.contains("result && result.PathItem && result.PathItem.path"),
+          rel + " must guard the result.PathItem dereference");
       // Should not prefer lastClickPath for the new folder path
       assertFalse(
           js.contains("var pth = $.perc_finder().lastClickPath;"),
@@ -32,11 +37,32 @@ class PercUtilsFolderPathParseTest {
   }
 
   private static Path resolve() {
+    // Prefer Surefire's `basedir` system property -- it points at this
+    // module's directory (`projects/sitemanage`) regardless of the host CWD,
+    // so the test resolves the same monorepo root on every runner (CLI,
+    // CI, IDE). Fall back to relative CWD traversal for `mvn test` invocations
+    // outside Surefire where `basedir` is not set.
+    String basedir = System.getProperty("basedir");
+    if (basedir != null && !basedir.isEmpty()) {
+      Path fromSurefire = Path.of(basedir).resolve("../..").normalize();
+      if (isMonorepoRoot(fromSurefire)) {
+        return fromSurefire;
+      }
+    }
     Path cwd = Path.of("").toAbsolutePath().normalize();
     Path up = cwd.resolve("../..").normalize();
-    if (Files.isDirectory(up.resolve("WebUI"))) return up;
-    if (Files.isDirectory(cwd.resolve("WebUI"))) return cwd;
-    fail("root");
+    if (isMonorepoRoot(up)) return up;
+    if (isMonorepoRoot(cwd)) return cwd;
+    fail(
+        "could not resolve monorepo root (Surefire basedir="
+            + basedir
+            + ", cwd="
+            + cwd
+            + ") -- expected a directory containing both WebUI/ and system/");
     return cwd;
+  }
+
+  private static boolean isMonorepoRoot(Path p) {
+    return Files.isDirectory(p.resolve("WebUI")) && Files.isDirectory(p.resolve("system"));
   }
 }


### PR DESCRIPTION
## Summary
- Port of v8.1.7 [#872](https://github.com/intersoftdatalabs-in/percussioncms/pull/872) (GH-867).
- \`perc_utils.js\`: open path from \`result.PathItem.path\` after folder create.
- Regression: \`PercUtilsFolderPathParseTest\`.

## Test plan
- [x] unit test
- [ ] Create/rename folder in finder: no false Path not found