### PR TITLE
Migrate PR #812+#821: Social Buttons X rebrand

### DIFF
--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/SupportFile-rx_resources/stylesheets/controls/percSocialButtonsControl.xsl
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/SupportFile-rx_resources/stylesheets/controls/percSocialButtonsControl.xsl
@@ -229,7 +229,8 @@
 							</td>
 							<td class="perc-social-button-td perc-platform-name">
 								<div class="perc-social-button-ui">
-									<i class="fab fa-fw fa-twitter" aria-hidden="true"
+									<!-- aria-hidden omitted so aria-label is exposed to AT -->
+									<i class="fab fa-fw fa-twitter"
 										aria-label="X (Twitter)"></i>
 								</div>
 							</td>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/SupportFile-rx_resources/stylesheets/controls/percSocialButtonsControl.xsl
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/SupportFile-rx_resources/stylesheets/controls/percSocialButtonsControl.xsl
@@ -230,7 +230,7 @@
 							<td class="perc-social-button-td perc-platform-name">
 								<div class="perc-social-button-ui">
 									<i class="fab fa-fw fa-twitter" aria-hidden="true"
-										aria-label="Twitter"></i>
+										aria-label="X (Twitter)"></i>
 								</div>
 							</td>
 							<td class="perc-input-td perc-social-button-td">
@@ -248,7 +248,7 @@
 								<input name="socialLink"
 									class="datadisplay perc-social-button-input perc-social-page-link"
 									style="height: 15px;padding-top: 3px;padding-bottom: 5px;"
-									placeholder="http://www.twitter.com/percussion"></input>
+									placeholder="https://x.com/percussion"></input>
 							</td>
 							<td class="perc-move-button-container">
 								<div role="button" tabindex="0" id="move-up"

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/SupportFile-rx_resources/widgets/percSocialButtons/css/percSocialButtons.css
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/SupportFile-rx_resources/widgets/percSocialButtons/css/percSocialButtons.css
@@ -29,7 +29,21 @@ div.perc-social-button-ui {
 }
 
 .perc-social-button-ui .fa-twitter {
-  background-color: #00a9f1;
+  background-color: #111111;
+}
+
+.perc-social-button-ui .fa-twitter::before,
+.perc-social-button .fa-twitter::before {
+  content: "" !important;
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  background-color: currentColor;
+  vertical-align: -0.125em;
+  mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><path d='M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z'/></svg>") no-repeat center;
+  mask-size: contain;
+  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><path d='M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z'/></svg>") no-repeat center;
+  -webkit-mask-size: contain;
 }
 
 .perc-social-button-ui .fa-linkedin {

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/SupportFile-rx_resources/widgets/percSocialButtons/css/percSocialButtons.css
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/SupportFile-rx_resources/widgets/percSocialButtons/css/percSocialButtons.css
@@ -32,6 +32,14 @@ div.perc-social-button-ui {
   background-color: #111111;
 }
 
+/* X glyph mask URI is intentionally duplicated in:
+ * - SupportFile-rx_resources/.../percSocialButtons.css (editor assets)
+ * - sys__UserDependency--rx_resources/.../percSocialButtons.css (runtime)
+ * - sys__UserDependency--rxconfig/Widgets/percSocialButtons.xml (velocity CSS)
+ * Package packaging keeps SupportFile vs UserDependency copies in sync;
+ * there is no shared CSS variable across package zip boundaries without redesign.
+ * Keep the three SVG path data values identical when editing the X icon.
+ */
 .perc-social-button-ui .fa-twitter::before,
 .perc-social-button .fa-twitter::before {
   content: "" !important;

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/psx_archiveInfo.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/psx_archiveInfo.xml
@@ -23,7 +23,7 @@
 				<Publisher name="https://www.percussion.com"
 					url="https://www.percussion.com" />
 				<CmsVersion max="9.0.0" min="5.3.15" />
-				<Version>1.2.3</Version>
+				<Version>1.2.4</Version>
 				<ImplConfigFile />
 				<LocalConfigFile />
 				<PKGDependencies>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/sys__UserDependency--rx_resources/widgets/percSocialButtons/css/percSocialButtons.css
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/sys__UserDependency--rx_resources/widgets/percSocialButtons/css/percSocialButtons.css
@@ -29,7 +29,21 @@ div.perc-social-button-ui {
 }
 
 .perc-social-button-ui .fa-twitter {
-  background-color: #00a9f1;
+  background-color: #111111;
+}
+
+.perc-social-button-ui .fa-twitter::before,
+.perc-social-button .fa-twitter::before {
+  content: "" !important;
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  background-color: currentColor;
+  vertical-align: -0.125em;
+  mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><path d='M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z'/></svg>") no-repeat center;
+  mask-size: contain;
+  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><path d='M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z'/></svg>") no-repeat center;
+  -webkit-mask-size: contain;
 }
 
 .perc-social-button-ui .fa-linkedin {

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/sys__UserDependency--rx_resources/widgets/percSocialButtons/css/percSocialButtons.css
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/sys__UserDependency--rx_resources/widgets/percSocialButtons/css/percSocialButtons.css
@@ -32,6 +32,8 @@ div.perc-social-button-ui {
   background-color: #111111;
 }
 
+/* X glyph mask URI intentionally duplicated — keep in sync with SupportFile CSS
+ * and velocity-inlined CSS in percSocialButtons.xml (package zip boundaries). */
 .perc-social-button-ui .fa-twitter::before,
 .perc-social-button .fa-twitter::before {
   content: "" !important;

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/sys__UserDependency--rxconfig/Widgets/percSocialButtons.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/sys__UserDependency--rxconfig/Widgets/percSocialButtons.xml
@@ -218,6 +218,7 @@
             color: #$outputColor.text;
           }
 
+          /* X glyph mask URI intentionally inlined here (and in SupportFile + UserDependency CSS). Keep path data in sync. */
           .perc-twitter-social-button i::before {
             content: "" !important;
             display: inline-block;

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/sys__UserDependency--rxconfig/Widgets/percSocialButtons.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons/sys__UserDependency--rxconfig/Widgets/percSocialButtons.xml
@@ -88,7 +88,7 @@
            ## assign standard colors
            $standardColor = $rx.string.stringToMap(null);
            $standardColor.put('facebook', '3b5998');
-           $standardColor.put('twitter', '00a9f1');
+           $standardColor.put('twitter', '111111');
            $standardColor.put('linkedIn', '0077b5');
            $standardColor.put('pinterest', 'c92228');
            $standardColor.put('youtube', 'cd201f');
@@ -216,6 +216,19 @@
           .perc-twitter-social-button {
             background-color: #$outputColor.twitter;
             color: #$outputColor.text;
+          }
+
+          .perc-twitter-social-button i::before {
+            content: "" !important;
+            display: inline-block;
+            width: 1em;
+            height: 1em;
+            background-color: currentColor;
+            vertical-align: -0.125em;
+            mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><path d='M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z'/></svg>") no-repeat center;
+            mask-size: contain;
+            -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><path d='M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z'/></svg>") no-repeat center;
+            -webkit-mask-size: contain;
           }
 
           .perc-linkedin-social-button {
@@ -433,7 +446,7 @@
                   percSocial[platform]['iconClass'] = 'fa-facebook';
                   break;
                 case 'twitter':
-                  percSocial[platform]['shareLink'] = 'https://twitter.com/intent/tweet?text=' + percEncodedPageSummary + '&url=' + percEncodedCurrentUrl;
+                  percSocial[platform]['shareLink'] = 'https://x.com/intent/tweet?text=' + percEncodedPageSummary + '&url=' + percEncodedCurrentUrl;
                   percSocial[platform]['buttonClass'] = 'perc-twitter-social-button';
                   percSocial[platform]['iconClass'] = 'fa-twitter';
                   break;

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/SocialButtonsXRebrandTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/SocialButtonsXRebrandTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.pagemanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for GH-809 / v8.1.7 PRs #812 and #821: Social Buttons widget rebrands Twitter to X
+ * (color, SVG mask icon, share URL, labels, version).
+ */
+class SocialButtonsXRebrandTest {
+
+  private static final Path PKG =
+      Path.of("modules/perc-packages/src/main/resources/Packages/perc.widget.socialButtons");
+
+  @Test
+  void socialButtonsUsesXBranding() throws Exception {
+    Path root = resolveRepoRoot();
+    Path css =
+        root.resolve(
+            PKG.resolve(
+                "sys__UserDependency--rx_resources/widgets/percSocialButtons/css/percSocialButtons.css"));
+    Path supportCss =
+        root.resolve(
+            PKG.resolve(
+                "SupportFile-rx_resources/widgets/percSocialButtons/css/percSocialButtons.css"));
+    Path widget =
+        root.resolve(PKG.resolve("sys__UserDependency--rxconfig/Widgets/percSocialButtons.xml"));
+    Path xsl =
+        root.resolve(
+            PKG.resolve(
+                "SupportFile-rx_resources/stylesheets/controls/percSocialButtonsControl.xsl"));
+    Path archive = root.resolve(PKG.resolve("psx_archiveInfo.xml"));
+
+    for (Path p : new Path[] {css, supportCss, widget, xsl, archive}) {
+      if (!Files.isRegularFile(p)) {
+        fail("expected " + p.toAbsolutePath());
+      }
+    }
+
+    String cssText = Files.readString(css, StandardCharsets.UTF_8);
+    assertTrue(cssText.contains("#111111"), "twitter brand color must be X black");
+    assertFalse(cssText.contains("#00a9f1"), "legacy Twitter blue must be gone");
+    assertTrue(cssText.contains("mask-size: contain"), "X icon sizing from #821");
+    assertTrue(cssText.contains("vertical-align: -0.125em"), "X icon alignment from #821");
+
+    String support = Files.readString(supportCss, StandardCharsets.UTF_8);
+    assertTrue(support.contains("#111111") && support.contains("mask-size: contain"));
+
+    String widgetXml = Files.readString(widget, StandardCharsets.UTF_8);
+    assertTrue(widgetXml.contains("https://x.com/intent/tweet"), "share link must use x.com");
+    assertFalse(
+        widgetXml.contains("https://twitter.com/intent/tweet"), "legacy twitter.com share gone");
+    assertTrue(widgetXml.contains("put('twitter', '111111')"), "velocity standard color");
+    assertTrue(widgetXml.contains(".perc-twitter-social-button i::before"));
+
+    String xslText = Files.readString(xsl, StandardCharsets.UTF_8);
+    assertTrue(xslText.contains("aria-label=\"X (Twitter)\""));
+    assertTrue(xslText.contains("placeholder=\"https://x.com/percussion\""));
+
+    String arch = Files.readString(archive, StandardCharsets.UTF_8);
+    assertTrue(arch.contains("<Version>1.2.4</Version>"), "package version bump");
+  }
+
+  private static Path resolveRepoRoot() {
+    Path cwd = Path.of("").toAbsolutePath().normalize();
+    Path candidate = cwd.resolve("../..").normalize();
+    if (Files.isDirectory(candidate.resolve("modules/perc-packages"))) {
+      return candidate;
+    }
+    if (Files.isDirectory(cwd.resolve("modules/perc-packages"))) {
+      return cwd;
+    }
+    fail("could not resolve monorepo root");
+    return cwd;
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/SocialButtonsXRebrandTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/SocialButtonsXRebrandTest.java
@@ -78,22 +78,30 @@ class SocialButtonsXRebrandTest {
 
     String xslText = Files.readString(xsl, StandardCharsets.UTF_8);
     assertTrue(xslText.contains("aria-label=\"X (Twitter)\""));
+    // Rebrand label must be exposed: fa-twitter must not carry aria-hidden
+    assertFalse(
+        xslText.matches("(?s).*fa-twitter\"[^>]*aria-hidden=\"true\".*"),
+        "fa-twitter must not use aria-hidden so aria-label is announced");
     assertTrue(xslText.contains("placeholder=\"https://x.com/percussion\""));
 
     String arch = Files.readString(archive, StandardCharsets.UTF_8);
     assertTrue(arch.contains("<Version>1.2.4</Version>"), "package version bump");
   }
 
+  /**
+   * Walk parent directories from the process working directory until {@code
+   * modules/perc-packages} is found. Works whether Surefire runs from the
+   * monorepo root or from {@code projects/sitemanage}.
+   */
   private static Path resolveRepoRoot() {
-    Path cwd = Path.of("").toAbsolutePath().normalize();
-    Path candidate = cwd.resolve("../..").normalize();
-    if (Files.isDirectory(candidate.resolve("modules/perc-packages"))) {
-      return candidate;
+    Path dir = Path.of("").toAbsolutePath().normalize();
+    while (dir != null) {
+      if (Files.isDirectory(dir.resolve("modules/perc-packages"))) {
+        return dir;
+      }
+      dir = dir.getParent();
     }
-    if (Files.isDirectory(cwd.resolve("modules/perc-packages"))) {
-      return cwd;
-    }
-    fail("could not resolve monorepo root");
-    return cwd;
+    fail("could not resolve monorepo root (no modules/perc-packages ancestor)");
+    return Path.of("").toAbsolutePath();
   }
 }


### PR DESCRIPTION
## Summary
Port of v8.1.7 [#812](https://github.com/intersoftdatalabs-in/percussioncms/pull/812) and [#821](https://github.com/intersoftdatalabs-in/percussioncms/pull/821) (GH-809) to `development`.

Rebrands the Social Buttons widget Twitter platform to X:
- Brand color `#111111` and SVG mask icon (with #821 alignment/sizing)
- Share URL `https://x.com/intent/tweet`
- Editor aria-label / placeholder updates
- Package version `1.2.4`

Paths translated: `system/Packages/...` → `modules/perc-packages/src/main/resources/Packages/...`.

## Tests
- `SocialButtonsXRebrandTest` (path-based)

## Backlog
`specs/005-migrate-8.1.7-changes` / migration-backlog.md