### PR TITLE
Migrate PR #824: jQuery load order and defer dependents

### DIFF
--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/JQueryLoadOrderDeferTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/JQueryLoadOrderDeferTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for GH-819 / v8.1.7 PR #824: when the jQuery widget is deferred, dependent scripts
+ * (jQuery UI and other catalogued JS) must also defer outside edit mode.
+ */
+class JQueryLoadOrderDeferTest {
+
+  private static final Path VM =
+      Path.of(
+          "system/cms/content/applications/sys_resources/ApplicationFiles/vm/sys_assembly.vm");
+
+  @Test
+  void assemblyDefersDependentsWhenJqueryDeferred() throws Exception {
+    Path root = resolveRepoRoot();
+    Path vm = root.resolve(VM);
+    if (!Files.isRegularFile(vm)) {
+      fail("expected " + vm.toAbsolutePath());
+    }
+    String text = Files.readString(vm, StandardCharsets.UTF_8);
+    assertTrue(text.contains("#set($deferDependents = false)##"));
+    assertTrue(text.contains("#set($jqueryIsDeferred = \"no\")##")
+        || text.contains("#set($jqueryIsDeferred = \"no\")##".replace("\\\"", "\"")));
+    assertTrue(text.contains("$jqueryIsDeferred == \"yes\""));
+    assertTrue(text.contains("#if($deferDependents) defer#end"));
+    assertTrue(text.contains("#if($jqueryWidgetInstances.size() > 0)##"));
+    // force UI deferred when dependents deferred
+    assertTrue(text.contains("#if($deferDependents)##"));
+    assertTrue(text.contains("#set($isDeferred = \"yes\")##"));
+  }
+
+  private static Path resolveRepoRoot() {
+    Path cwd = Path.of("").toAbsolutePath().normalize();
+    Path candidate = cwd.resolve("../..").normalize();
+    if (Files.isDirectory(candidate.resolve("system"))) {
+      return candidate;
+    }
+    if (Files.isDirectory(cwd.resolve("system"))) {
+      return cwd;
+    }
+    fail("could not resolve monorepo root");
+    return cwd;
+  }
+}

--- a/system/cms/content/applications/sys_resources/ApplicationFiles/vm/sys_assembly.vm
+++ b/system/cms/content/applications/sys_resources/ApplicationFiles/vm/sys_assembly.vm
@@ -433,6 +433,17 @@ $perc.setWidgetContents($rx.pageutils.widgetContents($sys.assemblyItem, $perc.wi
 ## Common header for all base templates
 #macro(perc_templateHeader)##
 #set($selectedDoctype = $perc.template.docType.selected)##
+#set($jqueryWidgetInstances = $rx.pageutils.findWidgetInstances($sys.assemblyItem, $NULL, "percJQueryWidget"))##
+#set($jqueryIsDeferred = "no")##
+#if($jqueryWidgetInstances.size() > 0)##
+#set($jqueryWidgetInstance = $jqueryWidgetInstances.get(0))##
+#set($jqueryWidgetItem = $jqueryWidgetInstance.getItem())##
+#set($jqueryIsDeferred = $jqueryWidgetItem.getProperties().get("isDeferred"))##
+#end##
+#set($deferDependents = false)##
+#if($jqueryIsDeferred == "yes" && !$perc.isEditMode())##
+#set($deferDependents = true)##
+#end##
 #foreach($option in $perc.template.docType.options)##
 #if($option.option.equals($selectedDoctype))##
 #perc_displayText("$!option.value")##
@@ -592,11 +603,17 @@ $__style
 
 ##Print JQuery and JQuery-UI scripts on top and rest below them##
 #perc_displayText("$!perc.linkContext.site.siteAdditionalHeadContent")##
+#if($jqueryWidgetInstances.size() > 0)##
+#if($perc.isEditMode())##
+<script src="/cm/jslib/profiles/3x/jquery/jquery-3.6.0.js"></script>
+<script src="/cm/jslib/profiles/3x/jquery/jquery-migrate-3.3.2.js"></script>
+#else##
+#print_jquery("additionalHeadContent")##
+#end##
+#else##
 #foreach($js_link in $rx.pageutils.javascriptLinks($perc.linkContext, $sys.assemblyItem))##
 #if($js_link.getUrl().endsWith("/jquery.js"))##
-#set($jqueryWidgetInstances = $rx.pageutils.findWidgetInstances($sys.assemblyItem, $NULL, "percJQueryWidget"))##
-    ##Need preview check as on page content view, it shows preview unless on edit mode
-#if($perc.isEditMode() || ($perc.isPreviewMode() && $jqueryWidgetInstances.size()==0))##
+#if($perc.isEditMode() || $perc.isPreviewMode())##
 <script src="/cm/jslib/profiles/3x/jquery/jquery-3.6.0.js"></script>
 <script src="/cm/jslib/profiles/3x/jquery/jquery-migrate-3.3.2.js"></script>
 #else##
@@ -604,6 +621,7 @@ $__style
 #print_jquery("additionalHeadContent")##
 #else##
 <script src="/web_resources/cm/jslib/jquery.js"></script>
+#end##
 #end##
 #end##
 #end##
@@ -675,7 +693,7 @@ display:none;
 #if($perc.isEditMode())##
 <script src='/cm/jslib/profiles/3x/jquery/libraries/jquery-ui/jquery-ui.js'></script>
 #elseif ($perc.isPreviewMode() && ($perc.linkContext.site.overrideSystemJQueryUI==false) && ($jqueryUIwidget.size()==0) )##
-<script src='/cm/jslib/profiles/3x/jquery/libraries/jquery-ui/jquery-ui.js'></script>
+<script src='/cm/jslib/profiles/3x/jquery/libraries/jquery-ui/jquery-ui.js'#if($deferDependents) defer#end></script>
 #else##
 #print_jqueryUI("additionalHeadContent")##
 #end##
@@ -684,7 +702,7 @@ display:none;
 #perc_addDeliveryJSFunctions()##
 #foreach($js_link in $rx.pageutils.javascriptLinks($perc.linkContext, $sys.assemblyItem))##
 #if(! $js_link.getUrl().endsWith("/jquery.js") && !($js_link.getUrl().endsWith("/jquery-ui.js")))##
-<script src="$js_link"></script>
+<script src="$js_link"#if($deferDependents) defer#end></script>
 #end##
 #end##
 </body>
@@ -1047,6 +1065,9 @@ crossorigin="$!{jQueryMigrateCrossOrigin}"
 #set($includeUIOnPublishedPage = "yes")## Default to publishing
 #end##
 #set($isDeferred = $widgetitem.getProperties().get("isUIDeferred"))##
+#if($deferDependents)##
+#set($isDeferred = "yes")##
+#end##
 #set($jQueryLocation = $widgetitem.getProperties().get("jQueryUILocation"))##
 #if("${jQueryLocation}"  ==  "" )##
 #if($perc.linkContext.mode == "PUBLISH")##
@@ -1095,10 +1116,10 @@ crossorigin="$!{jQueryCrossOrigin}"
 #elseif($perc.linkContext.mode.toString() == "PUBLISH" && $location_name == "additionalHeadContent")##
 #if($js_link.getUrl().endsWith("/jquery-ui.js"))##
 #if ($perc.linkContext.site.overrideSystemJQueryUI==false)##
-<script src="/web_resources/cm/jslib/jquery-ui.js"></script>
+<script src="/web_resources/cm/jslib/jquery-ui.js"#if($deferDependents) defer#end></script>
 #end##
 #else##
-<script src="$js_link"></script>
+<script src="$js_link"#if($deferDependents) defer#end></script>
 #end##
 #end##
 #end##


### PR DESCRIPTION
## Summary
Port of v8.1.7 [#824](https://github.com/intersoftdatalabs-in/percussioncms/pull/824) (GH-819) to `development`.

When the jQuery widget is deferred outside edit mode, dependent scripts (jQuery UI and other catalogued JS) also receive `defer`, and jQuery injection prefers the widget instance path.

## Tests
- `JQueryLoadOrderDeferTest`

## Backlog
`specs/005-migrate-8.1.7-changes`