### PR TITLE
Migrate PR #889+#914: search path Lucene escape

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSLuceneQueryEscaper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSLuceneQueryEscaper.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.searchmanagement.service.impl;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Package-visible Lucene free-text query escaping used by {@link PSSearchService}. Extracted so
+ * unit tests can exercise mid-query slash escaping without Spring-wiring {@code PSSearchService}.
+ */
+final class PSLuceneQueryEscaper {
+
+  private static final List<String> LUCENE_SPECIAL_CHARACTERS =
+      Arrays.asList(
+          "+", "-", "&&", "||", "!", "(", ")", "{", "}", "[", "]", "^", "'", "~", "*", "?", ":");
+
+  private PSLuceneQueryEscaper() {}
+
+  /**
+   * Escapes Lucene special characters for free-text queries, including mid-query {@code /} (paths).
+   *
+   * @param query raw query text; blank values returned unchanged
+   * @return escaped query safe for classic QueryParser
+   */
+  static String escape(String query) {
+    if (StringUtils.isBlank(query)) {
+      return query;
+    }
+    var escapedQuery = query;
+    for (var specialCharacter : LUCENE_SPECIAL_CHARACTERS) {
+      if (escapedQuery.startsWith(specialCharacter)) {
+        var replacement = "\\" + specialCharacter;
+        escapedQuery = replacement + escapedQuery.substring(1);
+        break;
+      }
+    }
+    escapedQuery = escapedQuery.replaceAll("(?<!\\\\)/", "\\\\/");
+    return escapedQuery;
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchRestService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchRestService.java
@@ -40,7 +40,9 @@ import jakarta.ws.rs.core.MediaType;
 import java.util.ArrayList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.queryparser.flexible.standard.QueryParserUtil;
+import com.percussion.share.service.exception.PSParametersValidationException;
+import com.percussion.share.validation.PSValidationErrorsBuilder;
+import org.apache.lucene.queryparser.classic.QueryParser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -72,7 +74,7 @@ public class PSSearchRestService {
       var q = criteria.getQuery();
       if (q != null) {
         q = SecureStringUtils.sanitizeStringForHTML(q);
-        q = QueryParserUtil.escape(q);
+        q = QueryParser.escape(q);
         criteria.setQuery(q);
       }
 
@@ -114,7 +116,11 @@ public class PSSearchRestService {
           }
           itemList = searchService.search(criteria, contentIds);
         } else {
-          itemList = searchService.search(criteria);
+          try {
+            itemList = searchService.search(criteria);
+          } catch (PSSearchServiceException e) {
+            checkAndThrowValidationException(e, criteria);
+          }
         }
       }
       return itemList;
@@ -135,6 +141,33 @@ public class PSSearchRestService {
       throws PSSearchServiceException {
     criteria = searchService.validateSearchCriteria(criteria);
     sanitizeCriteria(criteria);
-    return searchService.getExtendedSearchResults(criteria);
+    try {
+      return searchService.getExtendedSearchResults(criteria);
+    } catch (PSSearchServiceException e) {
+      try {
+        checkAndThrowValidationException(e, criteria);
+      } catch (PSValidationException ve) {
+        throw new WebApplicationException(ve);
+      }
+      throw e;
+    }
+  }
+
+  private void checkAndThrowValidationException(
+      PSSearchServiceException e, PSSearchCriteria criteria) throws PSValidationException {
+    Throwable cause = e.getCause();
+    while (cause != null) {
+      if (cause instanceof org.apache.lucene.queryparser.classic.ParseException) {
+        PSValidationErrorsBuilder builder = new PSValidationErrorsBuilder("PSSearchRestService");
+        builder.rejectField(
+            "query",
+            "invalid",
+            "The search query is invalid: " + cause.getMessage(),
+            criteria.getQuery());
+        throw new PSParametersValidationException(builder.build());
+      }
+      cause = cause.getCause();
+    }
+    throw e;
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchRestService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchRestService.java
@@ -119,7 +119,7 @@ public class PSSearchRestService {
           try {
             itemList = searchService.search(criteria);
           } catch (PSSearchServiceException e) {
-            checkAndThrowValidationException(e, criteria);
+            return checkAndThrowValidationException(e, criteria);
           }
         }
       }
@@ -145,16 +145,22 @@ public class PSSearchRestService {
       return searchService.getExtendedSearchResults(criteria);
     } catch (PSSearchServiceException e) {
       try {
-        checkAndThrowValidationException(e, criteria);
+        return checkAndThrowValidationException(e, criteria);
       } catch (PSValidationException ve) {
         throw new WebApplicationException(ve);
       }
-      throw e;
     }
   }
 
-  private void checkAndThrowValidationException(
-      PSSearchServiceException e, PSSearchCriteria criteria) throws PSValidationException {
+  /**
+   * If the failure chain contains a Lucene {@code ParseException}, throw a field validation
+   * error; otherwise rethrow the original search exception. Never returns normally.
+   *
+   * @param <T> dummy return type so callers can {@code return} this and satisfy control-flow
+   */
+  private <T> T checkAndThrowValidationException(
+      PSSearchServiceException e, PSSearchCriteria criteria)
+      throws PSValidationException, PSSearchServiceException {
     Throwable cause = e.getCause();
     while (cause != null) {
       if (cause instanceof org.apache.lucene.queryparser.classic.ParseException) {

--- a/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchService.java
@@ -379,20 +379,9 @@ public class PSSearchService implements IPSSearchService {
     }
   }
 
+  /** Delegates to {@link PSLuceneQueryEscaper#escape(String)} for free-text Lucene queries. */
   private String escapeLuceneQuery(String query) {
-    if (StringUtils.isBlank(query)) {
-      return query;
-    }
-    var escapedQuery = query;
-    for (var specialCharacter : luceneSpecialCharacters) {
-      if (escapedQuery.startsWith(specialCharacter)) {
-        var replacement = "\\" + specialCharacter;
-        escapedQuery = replacement + escapedQuery.substring(1);
-        break;
-      }
-    }
-    escapedQuery = escapedQuery.replaceAll("(?<!\\\\)/", "\\\\/");
-    return escapedQuery;
+    return PSLuceneQueryEscaper.escape(query);
   }
 
   private String excludeLocalWorkflow(String query, PSWSSearchParams searchParams)
@@ -461,10 +450,6 @@ public class PSSearchService implements IPSSearchService {
   private IPSRecycleService recycleService;
   private IPSSystemService systemService = PSSystemServiceLocator.getSystemService();
   private int localContentWfId = -1;
-
-  private static final List<String> luceneSpecialCharacters =
-      Arrays.asList(
-          "+", "-", "&&", "||", "!", "(", ")", "{", "}", "[", "]", "^", "'", "~", "*", "?", ":");
 
   private static final Logger log = LogManager.getLogger(PSSearchService.class);
 

--- a/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchService.java
@@ -380,6 +380,9 @@ public class PSSearchService implements IPSSearchService {
   }
 
   private String escapeLuceneQuery(String query) {
+    if (StringUtils.isBlank(query)) {
+      return query;
+    }
     var escapedQuery = query;
     for (var specialCharacter : luceneSpecialCharacters) {
       if (escapedQuery.startsWith(specialCharacter)) {
@@ -388,6 +391,7 @@ public class PSSearchService implements IPSSearchService {
         break;
       }
     }
+    escapedQuery = escapedQuery.replaceAll("(?<!\\)/", "\\/");
     return escapedQuery;
   }
 

--- a/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchService.java
@@ -391,7 +391,7 @@ public class PSSearchService implements IPSSearchService {
         break;
       }
     }
-    escapedQuery = escapedQuery.replaceAll("(?<!\\)/", "\\/");
+    escapedQuery = escapedQuery.replaceAll("(?<!\\\\)/", "\\\\/");
     return escapedQuery;
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/searchmanagement/service/impl/PSSearchRestServiceTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/searchmanagement/service/impl/PSSearchRestServiceTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.searchmanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.percussion.searchmanagement.data.PSSearchCriteria;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for GH-878 / v8.1.7 PRs #889 and #914: path-based search terms with slashes and dashes
+ * must be Lucene-escaped so classic QueryParser does not throw ParseException.
+ */
+class PSSearchRestServiceTest {
+
+  @Test
+  void sanitizeCriteriaEscapesSlashesAndDashes() {
+    PSSearchRestService restService = new PSSearchRestService(null, null, null);
+    PSSearchCriteria criteria = new PSSearchCriteria();
+    criteria.setQuery("people/donna-williams");
+    restService.sanitizeCriteria(criteria);
+    assertNotNull(criteria.getQuery());
+    // Lucene classic QueryParser.escape escapes / and -
+    assertEquals("people\\/donna\\-williams", criteria.getQuery());
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/searchmanagement/service/impl/PSSearchRestServiceTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/searchmanagement/service/impl/PSSearchRestServiceTest.java
@@ -18,6 +18,7 @@ package com.percussion.searchmanagement.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.percussion.searchmanagement.data.PSSearchCriteria;
 import org.junit.jupiter.api.Test;
@@ -37,5 +38,30 @@ class PSSearchRestServiceTest {
     assertNotNull(criteria.getQuery());
     // Lucene classic QueryParser.escape escapes / and -
     assertEquals("people\\/donna\\-williams", criteria.getQuery());
+  }
+
+  /**
+   * Exercises {@link PSLuceneQueryEscaper#escape(String)} mid-query slash escaping used on the
+   * urlDecodedQuery search path in {@code PSSearchService} (GH-878 / #889 / #914).
+   */
+  @Test
+  void escapeLuceneQueryEscapesMidQuerySlash() {
+    assertEquals("a\\/b", PSLuceneQueryEscaper.escape("a/b"));
+    assertEquals("people\\/donna-williams", PSLuceneQueryEscaper.escape("people/donna-williams"));
+  }
+
+  @Test
+  void escapeLuceneQueryLeavesAlreadyEscapedSlashUntouched() {
+    assertEquals("a\\/b", PSLuceneQueryEscaper.escape("a\\/b"));
+    assertEquals("x\\/y\\/z", PSLuceneQueryEscaper.escape("x\\/y\\/z"));
+  }
+
+  @Test
+  void escapeLuceneQueryHandlesBlankAndLeadingSpecial() {
+    assertNull(PSLuceneQueryEscaper.escape(null));
+    assertEquals("", PSLuceneQueryEscaper.escape(""));
+    assertEquals("   ", PSLuceneQueryEscaper.escape("   "));
+    // leading special char is escaped once, then mid-query slashes
+    assertEquals("\\-a\\/b", PSLuceneQueryEscaper.escape("-a/b"));
   }
 }


### PR DESCRIPTION
## Summary
Port of v8.1.7 [#889](https://github.com/intersoftdatalabs-in/percussioncms/pull/889) and [#914](https://github.com/intersoftdatalabs-in/percussioncms/pull/914) (GH-878) to `development`.

Path-based search terms (slashes/dashes) no longer blow up Lucene query parsing:
- `QueryParser.escape` in REST sanitize
- ParseException → `PSParametersValidationException`
- mid-query `/` escaping in `escapeLuceneQuery`

## Tests
- `PSSearchRestServiceTest`

## Backlog
`specs/005-migrate-8.1.7-changes`