### PR TITLE
Migrate PR #775+#776: bulk upload empty-file errors

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetService.java
@@ -1961,11 +1961,8 @@ public class PSAssetService extends PSAbstractFullDataService<PSAsset, PSAssetSu
     String content = IOUtils.toString(request.getFileContents(), StandardCharsets.UTF_8);
     String fileName = request.getFileName();
 
-    if (isBlank(content)) {
-      throw new PSExtractHTMLException(
-          "The uploaded file '"
-              + (fileName != null ? fileName : "")
-              + "' is empty (0 bytes). Cannot create a text-based asset from an empty file.");
+    if (PSEmptyUploadContent.isEmptyOrWhitespaceOnly(content)) {
+      throw new PSExtractHTMLException(PSEmptyUploadContent.rejectionMessage(fileName));
     }
 
     String selector = request.getSelector();

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetService.java
@@ -1959,19 +1959,26 @@ public class PSAssetService extends PSAbstractFullDataService<PSAsset, PSAssetSu
    */
   private String extractContent(PSExtractedAssetRequest request) throws IOException {
     String content = IOUtils.toString(request.getFileContents(), StandardCharsets.UTF_8);
-    String selector = request.getSelector();
-    String extractedContent = null;
+    String fileName = request.getFileName();
 
-    extractedContent =
+    if (isBlank(content)) {
+      throw new PSExtractHTMLException(
+          "The uploaded file '"
+              + (fileName != null ? fileName : "")
+              + "' is empty (0 bytes). Cannot create a text-based asset from an empty file.");
+    }
+
+    String selector = request.getSelector();
+    String extractedContent =
         PSHtmlUtils.extractHtml(
-            selector, content, request.getFileName(), request.shouldIncludeOuterHtml());
+            selector, content, fileName, request.shouldIncludeOuterHtml());
 
     if (isBlank(extractedContent)) {
       String warning =
           "CSS Selector \""
               + selector
               + "\" does not exist in file '"
-              + request.getFileName()
+              + fileName
               + ".'";
       throw new PSExtractHTMLException(warning);
     }

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetUploadServlet.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetUploadServlet.java
@@ -101,17 +101,36 @@ public class PSAssetUploadServlet extends HttpServlet {
           out.flush();
         }
       } else {
-        writeErrorResponse(response, fileName, "No valid file was provided for upload.", 400);
+        safeWriteErrorResponse(
+            response, fileName, "No valid file was provided for upload.", 400);
       }
     } catch (PSExtractHTMLException caE) {
       handleExtractionError(caE, response, fileName);
     } catch (Exception e) {
+      // Log full detail server-side; never return raw e.getMessage() (info disclosure).
       logger.error(PSExceptionUtils.getMessageForLog(e));
-      String msg = e.getMessage();
-      if (msg == null || msg.trim().isEmpty()) {
-        msg = "Upload failed due to an unexpected server error.";
+      logger.debug(PSExceptionUtils.getDebugMessageForLog(e));
+      safeWriteErrorResponse(
+          response,
+          fileName,
+          "Upload failed due to an unexpected server error.",
+          HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /**
+   * Best-effort error write: if the response is already committed or the write fails, only set
+   * status 500 without attempting a second body write.
+   */
+  private void safeWriteErrorResponse(
+      HttpServletResponse response, String fileName, String message, int statusCode) {
+    try {
+      writeErrorResponse(response, fileName, message, statusCode);
+    } catch (IOException | IllegalStateException ex) {
+      logger.error("Failed to write upload error response", ex);
+      if (!response.isCommitted()) {
+        response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
       }
-      writeErrorResponse(response, fileName, msg, 500);
     }
   }
 
@@ -119,6 +138,10 @@ public class PSAssetUploadServlet extends HttpServlet {
   private void writeErrorResponse(
       HttpServletResponse response, String fileName, String message, int statusCode)
       throws IOException {
+    if (response.isCommitted()) {
+      logger.warn("Response already committed; cannot write upload error: {}", message);
+      return;
+    }
     response.setStatus(statusCode);
     response.setContentType("application/json");
     response.setCharacterEncoding("UTF-8");
@@ -141,7 +164,8 @@ public class PSAssetUploadServlet extends HttpServlet {
   }
 
   /**
-   * Handles extraction errors.
+   * Handles extraction errors. {@link PSExtractHTMLException} messages are curated product text
+   * (e.g. empty/whitespace-only file) and are intentionally returned to the client.
    *
    * @param e the extraction error / exception, assumed not {@code null}.
    * @param response the HTTP response, assumed not {@code null}.
@@ -155,11 +179,7 @@ public class PSAssetUploadServlet extends HttpServlet {
     if (msg == null || msg.trim().isEmpty()) {
       msg = "Failed to extract content from the uploaded file.";
     }
-    try {
-      writeErrorResponse(response, fileName, msg, HttpServletResponse.SC_BAD_REQUEST);
-    } catch (IOException ex) {
-      response.setStatus(500);
-    }
+    safeWriteErrorResponse(response, fileName, msg, HttpServletResponse.SC_BAD_REQUEST);
   }
 
   private static final Logger logger = LogManager.getLogger("PSAssetUploadServlet");

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetUploadServlet.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetUploadServlet.java
@@ -74,8 +74,8 @@ public class PSAssetUploadServlet extends HttpServlet {
     var approve = request.getParameter("approveOnUpload");
     var approveOnUpload = approve != null && approve.equalsIgnoreCase("true");
 
+    String fileName = null;
     try {
-      String fileName = null;
       PSAsset newAsset = null;
       for (var part : request.getParts()) {
         fileName = SecureStringUtils.sanitizeFileName(getFileName(part));
@@ -100,12 +100,43 @@ public class PSAssetUploadServlet extends HttpServlet {
           out.print(jsonObject.toString());
           out.flush();
         }
+      } else {
+        writeErrorResponse(response, fileName, "No valid file was provided for upload.", 400);
       }
     } catch (PSExtractHTMLException caE) {
-      handleExtractionError(caE, response);
+      handleExtractionError(caE, response, fileName);
     } catch (Exception e) {
       logger.error(PSExceptionUtils.getMessageForLog(e));
-      response.setStatus(500);
+      String msg = e.getMessage();
+      if (msg == null || msg.trim().isEmpty()) {
+        msg = "Upload failed due to an unexpected server error.";
+      }
+      writeErrorResponse(response, fileName, msg, 500);
+    }
+  }
+
+  /** Writes a JSON error response for upload failures. */
+  private void writeErrorResponse(
+      HttpServletResponse response, String fileName, String message, int statusCode)
+      throws IOException {
+    response.setStatus(statusCode);
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
+    try (PrintWriter w = response.getWriter()) {
+      var err = new JSONObject();
+      try {
+        err.put("error", message != null ? message : "Upload failed.");
+        if (fileName != null && !fileName.isEmpty()) {
+          err.put("name", fileName);
+        }
+      } catch (org.codehaus.jettison.json.JSONException je) {
+        // Fallback plain text if JSON construction fails
+        w.print("{\"error\":\"Upload failed.\"}");
+        w.flush();
+        return;
+      }
+      w.print(err.toString());
+      w.flush();
     }
   }
 
@@ -114,12 +145,18 @@ public class PSAssetUploadServlet extends HttpServlet {
    *
    * @param e the extraction error / exception, assumed not {@code null}.
    * @param response the HTTP response, assumed not {@code null}.
+   * @param fileName the name of the file being uploaded (may be null).
    */
-  private void handleExtractionError(PSExtractHTMLException e, HttpServletResponse response) {
+  private void handleExtractionError(
+      PSExtractHTMLException e, HttpServletResponse response, String fileName) {
     logger.error(PSExceptionUtils.getMessageForLog(e));
     logger.debug(PSExceptionUtils.getDebugMessageForLog(e));
+    String msg = e.getMessage();
+    if (msg == null || msg.trim().isEmpty()) {
+      msg = "Failed to extract content from the uploaded file.";
+    }
     try {
-      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      writeErrorResponse(response, fileName, msg, HttpServletResponse.SC_BAD_REQUEST);
     } catch (IOException ex) {
       response.setStatus(500);
     }

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSEmptyUploadContent.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSEmptyUploadContent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.assetmanagement.service.impl;
+
+/**
+ * Package-visible helpers for rejecting empty / whitespace-only text asset uploads (GH-728 /
+ * #775+#776). Extracted for pure unit tests without Spring-wiring {@code PSAssetService}.
+ */
+final class PSEmptyUploadContent {
+
+  private PSEmptyUploadContent() {}
+
+  /** True when content is null, empty, or whitespace-only ({@link String#isBlank()}). */
+  static boolean isEmptyOrWhitespaceOnly(String content) {
+    return content == null || content.isBlank();
+  }
+
+  /**
+   * User-facing rejection message. Uses "empty or whitespace-only" (not "0 bytes") because the
+   * guard rejects both zero-length and blank content.
+   */
+  static String rejectionMessage(String fileName) {
+    return "The uploaded file '"
+        + (fileName != null ? fileName : "")
+        + "' is empty or whitespace-only. Cannot create a text-based asset from an empty file.";
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/assetmanagement/service/impl/BulkUploadEmptyFileTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/assetmanagement/service/impl/BulkUploadEmptyFileTest.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.assetmanagement.service.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -30,6 +32,10 @@ import org.junit.jupiter.api.Test;
  *
  * <p>Note: development replaced the legacy bulk upload gadget UI; server-side servlet + extraction
  * messaging is still the product path for empty uploads.
+ *
+ * <p>Path-based source assertions are the established 005 migrate regression pattern for
+ * package/servlet surface code that cannot be driven without a full container. Pure helpers used by
+ * that surface are covered behaviorally below.
  */
 class BulkUploadEmptyFileTest {
 
@@ -43,8 +49,8 @@ class BulkUploadEmptyFileTest {
       fail(svc.toString());
     }
     String text = Files.readString(svc, StandardCharsets.UTF_8);
-    assertTrue(text.contains("is empty (0 bytes)"));
-    assertTrue(text.contains("Cannot create a text-based asset from an empty file"));
+    assertTrue(text.contains("PSEmptyUploadContent.isEmptyOrWhitespaceOnly"));
+    assertTrue(text.contains("PSEmptyUploadContent.rejectionMessage"));
   }
 
   @Test
@@ -58,10 +64,29 @@ class BulkUploadEmptyFileTest {
     }
     String text = Files.readString(servlet, StandardCharsets.UTF_8);
     assertTrue(text.contains("writeErrorResponse"));
+    assertTrue(text.contains("safeWriteErrorResponse"));
     assertTrue(text.contains("No valid file was provided for upload."));
     assertTrue(text.contains("handleExtractionError"));
     assertTrue(text.contains("SC_BAD_REQUEST"));
     assertTrue(text.contains("err.put(\"error\""));
+    // Generic Exception path must not surface raw e.getMessage() to the client
+    assertTrue(text.contains("Upload failed due to an unexpected server error."));
+  }
+
+  /** Pure-function coverage of empty/whitespace guard + message (GH-728 / #775). */
+  @Test
+  void emptyOrWhitespaceHelperRejectsBlankAndWordingAvoidsZeroBytesClaim() {
+    assertTrue(PSEmptyUploadContent.isEmptyOrWhitespaceOnly(null));
+    assertTrue(PSEmptyUploadContent.isEmptyOrWhitespaceOnly(""));
+    assertTrue(PSEmptyUploadContent.isEmptyOrWhitespaceOnly("   \n\t"));
+    assertFalse(PSEmptyUploadContent.isEmptyOrWhitespaceOnly("x"));
+
+    String msg = PSEmptyUploadContent.rejectionMessage("blank.txt");
+    assertTrue(msg.contains("blank.txt"));
+    assertTrue(msg.contains("empty or whitespace-only"));
+    assertTrue(msg.contains("Cannot create a text-based asset from an empty file"));
+    assertFalse(msg.contains("(0 bytes)"));
+    assertEquals(PSEmptyUploadContent.rejectionMessage(null), PSEmptyUploadContent.rejectionMessage(""));
   }
 
   private static Path resolveRepoRoot() {

--- a/projects/sitemanage/src/test/java/com/percussion/assetmanagement/service/impl/BulkUploadEmptyFileTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/assetmanagement/service/impl/BulkUploadEmptyFileTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.assetmanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for GH-728 / v8.1.7 PRs #775+#776: empty file uploads must return clear JSON errors
+ * instead of silent failures / opaque 500s.
+ *
+ * <p>Note: development replaced the legacy bulk upload gadget UI; server-side servlet + extraction
+ * messaging is still the product path for empty uploads.
+ */
+class BulkUploadEmptyFileTest {
+
+  @Test
+  void assetServiceRejectsEmptyExtractedContent() throws Exception {
+    Path root = resolveRepoRoot();
+    Path svc =
+        root.resolve(
+            "projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetService.java");
+    if (!Files.isRegularFile(svc)) {
+      fail(svc.toString());
+    }
+    String text = Files.readString(svc, StandardCharsets.UTF_8);
+    assertTrue(text.contains("is empty (0 bytes)"));
+    assertTrue(text.contains("Cannot create a text-based asset from an empty file"));
+  }
+
+  @Test
+  void uploadServletWritesJsonErrorResponses() throws Exception {
+    Path root = resolveRepoRoot();
+    Path servlet =
+        root.resolve(
+            "projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSAssetUploadServlet.java");
+    if (!Files.isRegularFile(servlet)) {
+      fail(servlet.toString());
+    }
+    String text = Files.readString(servlet, StandardCharsets.UTF_8);
+    assertTrue(text.contains("writeErrorResponse"));
+    assertTrue(text.contains("No valid file was provided for upload."));
+    assertTrue(text.contains("handleExtractionError"));
+    assertTrue(text.contains("SC_BAD_REQUEST"));
+    assertTrue(text.contains("err.put(\"error\""));
+  }
+
+  private static Path resolveRepoRoot() {
+    Path cwd = Path.of("").toAbsolutePath().normalize();
+    Path candidate = cwd.resolve("../..").normalize();
+    if (Files.isDirectory(candidate.resolve("projects/sitemanage"))) {
+      return candidate;
+    }
+    if (Files.isDirectory(cwd.resolve("projects/sitemanage"))) {
+      return cwd;
+    }
+    fail("could not resolve monorepo root");
+    return cwd;
+  }
+}


### PR DESCRIPTION
## Summary
Port of v8.1.7 [#775](https://github.com/intersoftdatalabs-in/percussioncms/pull/775) / [#776](https://github.com/intersoftdatalabs-in/percussioncms/pull/776) (GH-728) to `development`.

Server-side empty upload handling:
- `PSAssetService.extractContent` rejects 0-byte text assets with a clear message
- `PSAssetUploadServlet` returns JSON error bodies (including no-file and extraction failures)

**Note:** the legacy bulk-file-upload gadget JS is gone on development (React status widget). Client early-reject from 8.1.7 was not ported.

## Tests
- `BulkUploadEmptyFileTest`

## Backlog
`specs/005-migrate-8.1.7-changes`