### PR TITLE
Migrate PR #1152+#1156: folder path retries

### DIFF
--- a/WebUI/src/main/webapp/cm/app/js/legacy/plugins/perc_path_manager.js
+++ b/WebUI/src/main/webapp/cm/app/js/legacy/plugins/perc_path_manager.js
@@ -197,25 +197,49 @@
     }
 
     if (!$.perc_fakes.path_service) {
-      if (folder) {
-        $.ajax({
-          type: "GET",
-          success: callback,
-          error: err,
-          url: serviceUrl,
-          dataType: "json",
-          cache: false,
-        });
-      } else {
-        $.ajax({
-          type: "GET",
-          success: callback,
-          error: err,
-          url: $.perc_paths.PATH_ITEM + path_str,
-          dataType: "json",
-          cache: false,
-        });
+      var maxRetries = 6;
+      var retryDelay = 300;
+      var retryCount = 0;
+
+      function doOpen() {
+        if (folder) {
+          $.ajax({
+            type: "GET",
+            success: callback,
+            error: function (xhr, status, error) {
+              if ((xhr.status === 500 || xhr.status === 404) && retryCount < maxRetries) {
+                retryCount++;
+                console.log("open_path retry " + retryCount + " of " + maxRetries + " for path: " + path_str);
+                setTimeout(doOpen, retryDelay);
+              } else {
+                err(xhr, status, error);
+              }
+            },
+            url: serviceUrl,
+            dataType: "json",
+            cache: false,
+          });
+        } else {
+          $.ajax({
+            type: "GET",
+            success: callback,
+            error: function (xhr, status, error) {
+              if ((xhr.status === 500 || xhr.status === 404) && retryCount < maxRetries) {
+                retryCount++;
+                console.log("open_path retry " + retryCount + " of " + maxRetries + " for path: " + path_str);
+                setTimeout(doOpen, retryDelay);
+              } else {
+                err(xhr, status, error);
+              }
+            },
+            url: $.perc_paths.PATH_ITEM + path_str,
+            dataType: "json",
+            cache: false,
+          });
+        }
       }
+
+      doOpen();
     } else {
       var fakes = {
         "/": { PathItem: [{ name: "Sites", leaf: "false", path: "/Sites/" }] },

--- a/WebUI/src/main/webapp/cm/app/js/legacy/plugins/perc_utils.js
+++ b/WebUI/src/main/webapp/cm/app/js/legacy/plugins/perc_utils.js
@@ -1613,6 +1613,10 @@
         var oldName = $nameEl.parent().attr("title");
         if (value.length === 0) return oldName;
         if (value.toLowerCase() !== oldName.toLowerCase()) {
+          if (isRenamingFolder) {
+            return oldName;
+          }
+          isRenamingFolder = true;
           $.PercBlockUI($.PercBlockUIMode.CURSORONLY);
           $.PercPathService.renameFolder(
             pathItem.path,
@@ -1630,9 +1634,11 @@
                 $.perc_finder().lastClickPath = null;
                 $.perc_finder().open(pth);
                 $.unblockUI();
+                isRenamingFolder = false;
               } else {
                 $nameEl.text(oldName); // Reset back to old name
                 $.unblockUI();
+                isRenamingFolder = false;
                 var errorMsg = "";
                 if (
                   code === "renameFolderItem.reservedName" ||

--- a/WebUI/src/main/webapp/cm/plugins/perc_path_manager.js
+++ b/WebUI/src/main/webapp/cm/plugins/perc_path_manager.js
@@ -197,25 +197,49 @@
     }
 
     if (!$.perc_fakes.path_service) {
-      if (folder) {
-        $.ajax({
-          type: "GET",
-          success: callback,
-          error: err,
-          url: serviceUrl,
-          dataType: "json",
-          cache: false,
-        });
-      } else {
-        $.ajax({
-          type: "GET",
-          success: callback,
-          error: err,
-          url: $.perc_paths.PATH_ITEM + path_str,
-          dataType: "json",
-          cache: false,
-        });
+      var maxRetries = 6;
+      var retryDelay = 300;
+      var retryCount = 0;
+
+      function doOpen() {
+        if (folder) {
+          $.ajax({
+            type: "GET",
+            success: callback,
+            error: function (xhr, status, error) {
+              if ((xhr.status === 500 || xhr.status === 404) && retryCount < maxRetries) {
+                retryCount++;
+                console.log("open_path retry " + retryCount + " of " + maxRetries + " for path: " + path_str);
+                setTimeout(doOpen, retryDelay);
+              } else {
+                err(xhr, status, error);
+              }
+            },
+            url: serviceUrl,
+            dataType: "json",
+            cache: false,
+          });
+        } else {
+          $.ajax({
+            type: "GET",
+            success: callback,
+            error: function (xhr, status, error) {
+              if ((xhr.status === 500 || xhr.status === 404) && retryCount < maxRetries) {
+                retryCount++;
+                console.log("open_path retry " + retryCount + " of " + maxRetries + " for path: " + path_str);
+                setTimeout(doOpen, retryDelay);
+              } else {
+                err(xhr, status, error);
+              }
+            },
+            url: $.perc_paths.PATH_ITEM + path_str,
+            dataType: "json",
+            cache: false,
+          });
+        }
       }
+
+      doOpen();
     } else {
       var fakes = {
         "/": { PathItem: [{ name: "Sites", leaf: "false", path: "/Sites/" }] },

--- a/WebUI/src/main/webapp/cm/plugins/perc_utils.js
+++ b/WebUI/src/main/webapp/cm/plugins/perc_utils.js
@@ -1613,6 +1613,10 @@
         var oldName = $nameEl.parent().attr("title");
         if (value.length === 0) return oldName;
         if (value.toLowerCase() !== oldName.toLowerCase()) {
+          if (isRenamingFolder) {
+            return oldName;
+          }
+          isRenamingFolder = true;
           $.PercBlockUI($.PercBlockUIMode.CURSORONLY);
           $.PercPathService.renameFolder(
             pathItem.path,
@@ -1630,9 +1634,11 @@
                 $.perc_finder().lastClickPath = null;
                 $.perc_finder().open(pth);
                 $.unblockUI();
+                isRenamingFolder = false;
               } else {
                 $nameEl.text(oldName); // Reset back to old name
                 $.unblockUI();
+                isRenamingFolder = false;
                 var errorMsg = "";
                 if (
                   code === "renameFolderItem.reservedName" ||

--- a/WebUI/src/main/webapp/cm/widgets/perc_delete_page_button.js
+++ b/WebUI/src/main/webapp/cm/widgets/perc_delete_page_button.js
@@ -709,11 +709,11 @@
           }
         },
         function (request) {
-          var msg = $.PercServiceUtils.extractDefaultErrorMessage(request);
-          $.perc_utils.alert_dialog({
-            title: I18N.message("perc.ui.publish.title@Error"),
-            content: msg,
-          });
+          // Silently disable delete button on transient path lookup failure after create/rename.
+          $(".perc-finder-menu #perc-finder-delete")
+            .removeClass("ui-enabled")
+            .addClass("ui-disabled")
+            .off("click");
         }
       );
     }

--- a/WebUI/war/plugins/perc_path_manager.js
+++ b/WebUI/war/plugins/perc_path_manager.js
@@ -172,26 +172,52 @@
         }
 
         if (!$.perc_fakes.path_service) {
-            if (folder) {
-                $.ajax({
-                    type: 'GET',
-                    success: callback,
-                    error: err,
-                    url: serviceUrl,
-                    dataType: 'json',
-                    cache: false
-                });
+            var maxRetries = 6;
+            var retryDelay = 300;
+            var retryCount = 0;
+
+            function doOpen() {
+                if (folder) {
+                    $.ajax({
+                        type: 'GET',
+                        success: callback,
+                        error: function(xhr, status, error) {
+                            // Retry on server errors (500) AND path-not-found (404) since folder may not be indexed yet
+                            if ((xhr.status === 500 || xhr.status === 404) && retryCount < maxRetries) {
+                                retryCount++;
+                                console.log("open_path retry " + retryCount + " of " + maxRetries + " for path: " + path_str);
+                                setTimeout(doOpen, retryDelay);
+                            } else {
+                                err(xhr, status, error);
+                            }
+                        },
+                        url: serviceUrl,
+                        dataType: 'json',
+                        cache: false
+                    });
+                }
+                else {
+                    $.ajax({
+                        type: 'GET',
+                        success: callback,
+                        error: function(xhr, status, error) {
+                            // Retry on server errors (500) AND path-not-found (404) since folder may not be indexed yet
+                            if ((xhr.status === 500 || xhr.status === 404) && retryCount < maxRetries) {
+                                retryCount++;
+                                console.log("open_path retry " + retryCount + " of " + maxRetries + " for path: " + path_str);
+                                setTimeout(doOpen, retryDelay);
+                            } else {
+                                err(xhr, status, error);
+                            }
+                        },
+                        url: $.perc_paths.PATH_ITEM + path_str,
+                        dataType: 'json',
+                        cache: false
+                    });
+                }
             }
-            else {
-                $.ajax({
-                    type: 'GET',
-                    success: callback,
-                    error: err,
-                    url: $.perc_paths.PATH_ITEM + path_str,
-                    dataType: 'json',
-                    cache: false
-                });
-            }
+
+            doOpen();
         }
         else {
             var fakes = {

--- a/WebUI/war/plugins/perc_utils.js
+++ b/WebUI/war/plugins/perc_utils.js
@@ -35,6 +35,8 @@
     $.ajaxSetup( { cache: false } );
     $.Percussion = $.Percussion || {};
 
+    var isRenamingFolder = false;
+
 
     $.perc_fakes = {
         path_service: false,
@@ -1518,6 +1520,10 @@
                     return oldName;
                 if(value.toLowerCase() !== oldName.toLowerCase())
                 {
+                    if(isRenamingFolder){
+                        return oldName;
+                    }
+                    isRenamingFolder = true;
                     $.PercBlockUI($.PercBlockUIMode.CURSORONLY);
                     $.PercPathService.renameFolder(
                         pathItem.path,

--- a/WebUI/war/widgets/perc_delete_page_button.js
+++ b/WebUI/war/widgets/perc_delete_page_button.js
@@ -572,8 +572,12 @@
                     }
                 },
                 function (request) {
-                    var msg = $.PercServiceUtils.extractDefaultErrorMessage(request);
-                    $.perc_utils.alert_dialog({ title: I18N.message("perc.ui.publish.title@Error"), content: msg });
+                    // The path was just navigated to in the finder (e.g. immediately
+                    // after folder create/rename), so it must exist. The lookup can
+                    // transiently fail with a 404/500 while the JCR finishes indexing
+                    // the new/renamed path - silently disable the delete button
+                    // rather than showing a misleading "Path not found" error dialog.
+                    $(".perc-finder-menu #perc-finder-delete").removeClass('ui-enabled').addClass('ui-disabled').off('click');
                 }
             );
 

--- a/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSPathItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSPathItemService.java
@@ -357,6 +357,30 @@ public abstract class PSPathItemService implements IPSPathService {
     } catch (Exception e) {
       throw new PSPathServiceException("Failed to add folder: " + path, e);
     }
+
+    int retryCount = 5;
+    int retryDelayMs = 200;
+    PSPathNotFoundServiceException lastException = null;
+    for (int i = 0; i < retryCount; i++) {
+      try {
+        return find(path);
+      } catch (PSPathNotFoundServiceException e) {
+        lastException = e;
+        log.warn(
+            "Folder added but path not found, retrying lookup. Attempt {} of {}",
+            i + 1,
+            retryCount);
+        try {
+          Thread.sleep(retryDelayMs);
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          break;
+        }
+      }
+    }
+    if (lastException != null) {
+      throw lastException;
+    }
     return find(path);
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/pathmanagement/service/impl/FolderPathRetryPortTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pathmanagement/service/impl/FolderPathRetryPortTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pathmanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/** Regression for GH-867 / v8.1.7 PRs #1152+#1156. */
+class FolderPathRetryPortTest {
+
+  @Test
+  void addFolderRetriesLookup() throws Exception {
+    Path root = resolveRepoRoot();
+    Path svc =
+        root.resolve(
+            "projects/sitemanage/src/main/java/com/percussion/pathmanagement/service/impl/PSPathItemService.java");
+    String text = Files.readString(svc, StandardCharsets.UTF_8);
+    assertTrue(text.contains("int retryCount = 5;"));
+    assertTrue(text.contains("int retryDelayMs = 200;"));
+    assertTrue(text.contains("Folder added but path not found, retrying lookup"));
+  }
+
+  @Test
+  void openPathRetriesAndDeleteSilentOnMiss() throws Exception {
+    Path root = resolveRepoRoot();
+    Path pathMgr = root.resolve("WebUI/war/plugins/perc_path_manager.js");
+    Path del = root.resolve("WebUI/war/widgets/perc_delete_page_button.js");
+    Path utils = root.resolve("WebUI/war/plugins/perc_utils.js");
+    for (Path p : new Path[] {pathMgr, del, utils}) {
+      if (!Files.isRegularFile(p)) {
+        fail(p.toString());
+      }
+    }
+    String pm = Files.readString(pathMgr, StandardCharsets.UTF_8);
+    assertTrue(pm.contains("maxRetries = 6"));
+    assertTrue(pm.contains("retryDelay = 300"));
+    assertTrue(pm.contains("xhr.status === 404"));
+
+    String d = Files.readString(del, StandardCharsets.UTF_8);
+    assertTrue(d.toLowerCase().contains("silently disable"));
+
+    String u = Files.readString(utils, StandardCharsets.UTF_8);
+    assertTrue(u.contains("isRenamingFolder"));
+  }
+
+  private static Path resolveRepoRoot() {
+    Path cwd = Path.of("").toAbsolutePath().normalize();
+    Path candidate = cwd.resolve("../..").normalize();
+    if (Files.isDirectory(candidate.resolve("WebUI"))) {
+      return candidate;
+    }
+    if (Files.isDirectory(cwd.resolve("WebUI"))) {
+      return cwd;
+    }
+    fail("could not resolve monorepo root");
+    return cwd;
+  }
+}


### PR DESCRIPTION
## Summary
Port of v8.1.7 [#1152](https://github.com/intersoftdatalabs-in/percussioncms/pull/1152) and [#1156](https://github.com/intersoftdatalabs-in/percussioncms/pull/1156) (GH-867) to `development`.

Reduces false **Path not found** dialogs after folder create/rename:
- Backend `addFolder` retries `find()` 5×200ms
- Client `open_path` retries 6×300ms on 404/500
- Delete button update fails silently on transient lookup miss
- Rename re-entry guard (`isRenamingFolder`)

Related open port: #1246 (PR #872 PathItem path parse).

## Tests
- `FolderPathRetryPortTest`

## Backlog
`specs/005-migrate-8.1.7-changes`