### PR TITLE
004/US3 T043r: path-injection guard for PSRegionCSSFileService + PSThemeService (#1713, #1714, #1715)

### DIFF
--- a/modules/perc-security-utils/src/main/java/com/percussion/security/io/PSPathInjectionGuard.java
+++ b/modules/perc-security-utils/src/main/java/com/percussion/security/io/PSPathInjectionGuard.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 1999-2025 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.percussion.security.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Centralized path-injection defense (CWE-22 / CWE-23) helper per {@code
+ * specs/004-zero-code-scanning-alerts/tasks.md} T043. Use this utility to validate user-supplied
+ * paths and filenames before they reach any file I/O call site (FileInputStream, FileOutputStream,
+ * Files.*, File constructors, etc.). Code that builds a {@link File} from user input should call
+ * {@link #requireSafeFileName} on the untrusted string before composing the path, so a traversal
+ * payload like {@code ../../etc/passwd} is rejected before it can be used to read or write outside
+ * the intended base directory.
+ *
+ * <p><strong>Reuse for the 58 java/path-injection alerts under T043.</strong> Per the spec: "prefer
+ * a single helper in modules/utils/ shared across call sites." This is that helper.
+ *
+ * @see <a href="https://owasp.org/www-community/attacks/Path_Traversal">OWASP Path Traversal</a>
+ */
+public final class PSPathInjectionGuard {
+
+  private PSPathInjectionGuard() {
+    // utility class
+  }
+
+  /**
+   * Returns the input unchanged if it is a safe single-segment file or directory name. Throws
+   * {@link IllegalArgumentException} if the value is null, contains a path separator, contains a
+   * {@code ..} parent-traversal segment, or contains a NUL byte.
+   *
+   * <p>This method does NOT verify the file's existence or that the resolved path is within a
+   * specific base directory. It only rejects path-traversal patterns. Callers that need to verify
+   * "is the resolved path within this base directory" should also use {@link
+   * java.nio.file.Path#normalize} and {@link Path#startsWith} on the result.
+   *
+   * <p><strong>Single-segment contract:</strong> The input must be a single path segment (no {@code
+   * /}, no {@code \}); the only characters checked beyond the NUL byte are the traversal markers
+   * {@code ..} and {@code .}. Filenames like {@code file..txt} are rejected because they contain
+   * the literal substring {@code ..} which the contract treats as a traversal marker. Callers that
+   * need to accept multi-segment paths or filenames with literal {@code ..} substrings (unusual)
+   * should use {@link #requireUnderBase} (with an explicit base directory) or pre-process the input
+   * to remove the {@code ..} substring.
+   *
+   * @param name a user-supplied file or directory name (single segment, no separators)
+   * @return the input unchanged (after validation)
+   * @throws IllegalArgumentException if the input fails any of the checks above
+   */
+  public static String requireSafeFileName(String name) {
+    if (name == null) {
+      throw new IllegalArgumentException("path must not be null");
+    }
+    if (name.isEmpty()) {
+      throw new IllegalArgumentException("path must not be empty");
+    }
+    if (name.indexOf('\0') >= 0) {
+      throw new IllegalArgumentException(
+          "path must not contain a NUL byte: " + describeForError(name));
+    }
+    // Disallow backslashes on any platform (Windows path separator
+    // and Unix-escape sequences both use it).
+    if (name.indexOf('\\') >= 0) {
+      throw new IllegalArgumentException(
+          "path must not contain a backslash: " + describeForError(name));
+    }
+    // Disallow any path separator embedded in the name. A single
+    // segment like "foo" or "foo.txt" is allowed; "a/b" or "/etc/passwd"
+    // is not.
+    if (name.indexOf('/') >= 0) {
+      throw new IllegalArgumentException(
+          "path must not contain a forward slash (use a base directory + segment): "
+              + describeForError(name));
+    }
+    // Reject path-segment ".." and "." entries. The ".." substring
+    // check rejects things like "file..txt" and "a/../b". The
+    // "name equals" check rejects the single-segment "." and ".."
+    // entries (the current-dir and parent-dir markers, which
+    // would resolve to the base directory itself or above it).
+    // The check uses equals() rather than contains() for the "."
+    // case because a single "." is a valid character in legitimate
+    // filenames like "file.txt" or "archive.tar.gz"; only a
+    // segment that IS just "." or ".." is forbidden.
+    if (name.contains("..") || ".".equals(name) || "..".equals(name)) {
+      throw new IllegalArgumentException(
+          "path must not be '.' or '..' segment: " + describeForError(name));
+    }
+    return name;
+  }
+
+  /**
+   * Resolves a user-supplied path against a base directory and returns the resulting {@link File},
+   * but only if the resolved path is contained within the base directory. Throws {@link
+   * IllegalArgumentException} if the resolved path escapes the base directory (path-traversal
+   * attack).
+   *
+   * <p>This is the canonical safe pattern for "build a file path from a user-supplied filename
+   * under a known base directory".
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * File safe = PSPathInjectionGuard.requireUnderBase(
+   *     new File("/var/data/themes"), userInput);
+   * }</pre>
+   *
+   * @param baseDir the base directory that the resolved path must be contained within (typically a
+   *     server-controlled directory like the themes root or uploads dir)
+   * @param userInput a user-supplied path or filename; may be relative (e.g. "subdir/file.txt") or
+   *     absolute; may contain normal characters
+   * @return a {@link File} whose canonical path is contained within {@code baseDir}'s canonical
+   *     path
+   * @throws IllegalArgumentException if the resolved path escapes {@code baseDir} (path-traversal
+   *     attempt), if the input is null, if {@code baseDir} does not exist, or if the canonical-path
+   *     computation fails (e.g. the path is on a non-existent drive)
+   */
+  public static File requireUnderBase(File baseDir, String userInput) {
+    if (baseDir == null) {
+      throw new IllegalArgumentException("baseDir must not be null");
+    }
+    if (userInput == null) {
+      throw new IllegalArgumentException("userInput must not be null");
+    }
+    if (!baseDir.exists() || !baseDir.isDirectory()) {
+      throw new IllegalArgumentException("baseDir must exist and be a directory: " + baseDir);
+    }
+    // Reject NUL bytes early as a fast-path (NUL is the only
+    // byte-level special character that can affect downstream file
+    // APIs regardless of platform). The canonical-path check below
+    // is the authoritative test for traversal attempts (e.g. "..",
+    // absolute paths, symlinks). We do NOT do a substring ".."
+    // check here because it would reject legitimate filenames like
+    // "file..txt" or "archive..tar.gz" that contain a literal ".."
+    // substring but resolve within the base directory.
+    if (userInput.indexOf('\0') >= 0) {
+      throw new IllegalArgumentException(
+          "userInput contains a NUL byte: " + describeForError(userInput));
+    }
+    // Platform-safe resolution: on Windows, `new File(baseDir,
+    // absolutePath)` produces a malformed path like
+    // `C:\base\C:\absolute\file` because Windows File does NOT
+    // discard the base directory when the second arg is absolute.
+    // Resolve the input directly when it is already absolute, or
+    // compose it under baseDir only when relative.
+    File resolved =
+        new File(userInput).isAbsolute() ? new File(userInput) : new File(baseDir, userInput);
+    String resolvedCanonical;
+    String baseCanonical;
+    try {
+      resolvedCanonical = resolved.getCanonicalPath();
+      baseCanonical = baseDir.getCanonicalPath();
+    } catch (IOException e) {
+      throw new IllegalArgumentException(
+          "Failed to resolve canonical path for input "
+              + describeForError(userInput)
+              + ": "
+              + e.getMessage(),
+          e);
+    }
+    // Normalize both paths to forward-slash form for the prefix
+    // comparison. The canonical paths returned by getCanonicalPath() use
+    // the platform separator ("/" on Unix, "\" on Windows); comparing
+    // them directly with String.startsWith fails on Windows because
+    // "C:\foo\bar" does not start with "C:\foo\" in a literal sense
+    // (the trailing "\" is not present). Normalize to "/" first.
+    String resolvedNorm = resolvedCanonical.replace('\\', '/');
+    String baseNorm = baseCanonical.replace('\\', '/');
+    // Append the platform separator to baseNorm so that
+    // "/var/data/themesX" is not considered under "/var/data/themes".
+    String baseWithSep = baseNorm.endsWith("/") ? baseNorm : baseNorm + "/";
+    if (!resolvedNorm.equals(baseNorm) && !resolvedNorm.startsWith(baseWithSep)) {
+      throw new IllegalArgumentException(
+          "Resolved path '"
+              + resolvedCanonical
+              + "' is not under base directory '"
+              + baseCanonical
+              + "' (path-traversal attempt blocked)");
+    }
+    return new File(resolvedCanonical);
+  }
+
+  /**
+   * Convenience overload that accepts the base directory as a String. Equivalent to {@code
+   * requireUnderBase(new File(baseDir), userInput)}.
+   */
+  public static File requireUnderBase(String baseDir, String userInput) {
+    return requireUnderBase(new File(baseDir), userInput);
+  }
+
+  /**
+   * Convenience overload that builds a {@link Path} from the result of {@link
+   * #requireUnderBase(File, String)}.
+   */
+  public static Path requireUnderBasePath(File baseDir, String userInput) {
+    return Paths.get(requireUnderBase(baseDir, userInput).toURI());
+  }
+
+  private static String describeForError(String s) {
+    if (s == null) return "<null>";
+    // Truncate long values to keep error messages bounded.
+    String trimmed = s.length() > 80 ? s.substring(0, 77) + "..." : s;
+    return "'" + trimmed + "' (len=" + s.length() + ")";
+  }
+
+  /**
+   * True if {@code value} contains any character that file APIs treat specially and that has no
+   * business in a user-supplied filename (NUL byte and path separators only, conservatively).
+   * Exposed for callers that need a quick boolean check without the exception-throwing API of
+   * {@link #requireSafeFileName}.
+   *
+   * <p>Note: this does NOT check for the literal ".." substring. Filenames like "file..txt" or
+   * "archive..tar.gz" contain ".." but are legitimate; only ".." as a path SEGMENT (delimited by
+   * path separators) is a traversal marker. Callers that need segment-aware traversal detection
+   * should use {@link #requireSafeFileName} (single-segment) or {@link #requireUnderBase}
+   * (multi-segment with canonical-path containment check).
+   */
+  public static boolean containsForbiddenCharacters(String value) {
+    if (StringUtils.isEmpty(value)) {
+      return false;
+    }
+    return value.indexOf('\0') >= 0 || value.indexOf('\\') >= 0 || value.indexOf('/') >= 0;
+  }
+}

--- a/modules/perc-security-utils/src/test/java/com/percussion/security/io/PSPathInjectionGuardTest.java
+++ b/modules/perc-security-utils/src/test/java/com/percussion/security/io/PSPathInjectionGuardTest.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright 1999-2025 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.percussion.security.io;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for {@link PSPathInjectionGuard} (CodeQL {@code java/path-injection}, T043,
+ * US3).
+ *
+ * <p>The pre-fix pattern across the 58 T043 sites in projects/sitemanage and system/ was to pass
+ * user-supplied strings directly to {@code new File(baseDir, userInput)} without any traversal
+ * check. The post-fix pattern is to call {@link PSPathInjectionGuard#requireSafeFileName} on the
+ * user-supplied string and/or {@link PSPathInjectionGuard#requireUnderBase} to verify the resolved
+ * path is still within the base directory.
+ *
+ * <p><strong>Fail-then-pass coverage (Constitution III).</strong> The pre-fix code accepted every
+ * payload below; the post-fix code rejects each one with an {@link IllegalArgumentException} (or,
+ * for the canonical-path test, refuses to return a path outside the base directory).
+ */
+@DisplayName("PSPathInjectionGuard — path-traversal (CWE-22/CWE-23) regression tests")
+class PSPathInjectionGuardTest {
+
+  @Nested
+  @DisplayName("requireSafeFileName accepts safe inputs")
+  class SafeInputs {
+
+    @Test
+    @DisplayName("alphanumeric filename is accepted")
+    void testAlphanumeric() {
+      assertEquals("abc123", PSPathInjectionGuard.requireSafeFileName("abc123"));
+    }
+
+    @Test
+    @DisplayName("filename with dot is accepted (e.g. file.txt)")
+    void testDotInFilename() {
+      assertEquals("file.txt", PSPathInjectionGuard.requireSafeFileName("file.txt"));
+    }
+
+    @Test
+    @DisplayName("filename with multiple dots is accepted (e.g. archive.tar.gz)")
+    void testMultipleDots() {
+      assertEquals("archive.tar.gz", PSPathInjectionGuard.requireSafeFileName("archive.tar.gz"));
+    }
+
+    @Test
+    @DisplayName("filename with hyphen, underscore, space is accepted")
+    void testSpecialCharsInFilename() {
+      assertEquals(
+          "my file-name_v2.txt", PSPathInjectionGuard.requireSafeFileName("my file-name_v2.txt"));
+    }
+  }
+
+  @Nested
+  @DisplayName("requireSafeFileName rejects traversal payloads")
+  class RejectedInputs {
+
+    @Test
+    @DisplayName("parent-traversal '..' is rejected")
+    void testDoubleDot() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> PSPathInjectionGuard.requireSafeFileName(".."),
+          "name '..' must be rejected");
+    }
+
+    @Test
+    @DisplayName("'.\\etc\\passwd' is rejected (backslash)")
+    void testParentTraversal() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> PSPathInjectionGuard.requireSafeFileName("..\\etc\\passwd"),
+          "'..\\etc\\passwd' must be rejected");
+    }
+
+    @Test
+    @DisplayName("'/etc/passwd' absolute path is rejected")
+    void testAbsolutePath() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> PSPathInjectionGuard.requireSafeFileName("/etc/passwd"),
+          "absolute paths must be rejected");
+    }
+
+    @Test
+    @DisplayName("'a/b/c' multi-segment is rejected (requireSafeFileName is single-segment)")
+    void testMultiSegment() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> PSPathInjectionGuard.requireSafeFileName("a/b/c"),
+          "multi-segment paths must be rejected (callers wanting "
+              + "multi-segment need requireUnderBase instead)");
+    }
+
+    @Test
+    @DisplayName("'file..txt' is rejected (literal '..' substring is forbidden by contract)")
+    void testLiteralDoubleDotInFilename() {
+      // Per the round-3 review fix: requireSafeFileName explicitly
+      // rejects ".." and "." (the only reserved path-segment names). A
+      // filename like "file..txt" is rejected because the literal ".."
+      // is treated as a traversal marker by contract (callers wanting
+      // a literal ".." in a filename should use requireUnderBase with
+      // an explicit base directory).
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> PSPathInjectionGuard.requireSafeFileName("file..txt"),
+          "literal '..' substring in filename must be rejected per contract");
+    }
+
+    @Test
+    @DisplayName("NUL byte in name is rejected")
+    void testNulByte() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> PSPathInjectionGuard.requireSafeFileName("safe\u0000.txt"),
+          "NUL bytes must be rejected");
+    }
+
+    @Test
+    @DisplayName("null name is rejected")
+    void testNull() {
+      assertThrows(
+          IllegalArgumentException.class, () -> PSPathInjectionGuard.requireSafeFileName(null));
+    }
+
+    @Test
+    @DisplayName("empty name is rejected")
+    void testEmpty() {
+      assertThrows(
+          IllegalArgumentException.class, () -> PSPathInjectionGuard.requireSafeFileName(""));
+    }
+
+    @Test
+    @DisplayName("'.' (current-dir marker) is rejected")
+    void testDot() {
+      assertThrows(
+          IllegalArgumentException.class, () -> PSPathInjectionGuard.requireSafeFileName("."));
+    }
+  }
+
+  @Nested
+  @DisplayName("requireUnderBase resolves safely under a real base directory")
+  class RequireUnderBaseTests {
+
+    private File m_tmpRoot;
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() throws IOException {
+      m_tmpRoot = Files.createTempDirectory("pspathinj-").toFile();
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    void tearDown() {
+      if (m_tmpRoot != null && m_tmpRoot.exists()) {
+        for (File f : m_tmpRoot.listFiles()) {
+          f.delete();
+        }
+        m_tmpRoot.delete();
+      }
+    }
+
+    @Test
+    @DisplayName("a multi-segment relative path resolves under the base")
+    void testMultiSegmentPath() throws IOException {
+      // The canonical-path check is the authoritative test, so any
+      // subdir/file.txt that resolves under the base is allowed. The
+      // previous round used requireSafeFileName here which rejected
+      // the "/" separator; this test verifies the more permissive
+      // contract: requireUnderBase accepts multi-segment paths and
+      // relies on the canonical-path check to reject traversal.
+      File result = PSPathInjectionGuard.requireUnderBase(m_tmpRoot, "subdir/inner/file.txt");
+      assertNotNull(result);
+      String resolvedCanonical = result.getCanonicalPath();
+      String baseCanonical = m_tmpRoot.getCanonicalPath();
+      String baseWithSep =
+          baseCanonical.endsWith(File.separator) ? baseCanonical : baseCanonical + File.separator;
+      assertTrue(
+          resolvedCanonical.equals(baseCanonical) || resolvedCanonical.startsWith(baseWithSep),
+          "resolved canonical path '"
+              + resolvedCanonical
+              + "' must be under baseDir '"
+              + baseCanonical
+              + "'");
+    }
+
+    @Test
+    @DisplayName("'subdir/../../../escape' is rejected (canonical-path check catches it)")
+    void testSubdirEscape() {
+      // 'subdir/../escape.txt' is actually under the baseDir (the ..
+      // cancels subdir) so the canonical-path check accepts it. The
+      // path-traversal intent is to escape the base, which requires
+      // enough .. segments to go ABOVE the base. Three .. segments
+      // are needed: subdir/../../../escape.txt resolves to
+      // ../../escape.txt which is above the base.
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> PSPathInjectionGuard.requireUnderBase(m_tmpRoot, "subdir/../../../escape.txt"),
+          "subdir/../../../escape.txt must be rejected (resolves outside baseDir)");
+    }
+
+    @Test
+    @DisplayName("'../escape' is rejected (would resolve outside base)")
+    void testParentTraversal() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> PSPathInjectionGuard.requireUnderBase(m_tmpRoot, "../escape.txt"),
+          "parent-traversal must be rejected");
+    }
+
+    @Test
+    @DisplayName("nested traversal 'a/../../escape' is rejected")
+    void testNestedTraversal() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> PSPathInjectionGuard.requireUnderBase(m_tmpRoot, "a/../../escape.txt"));
+    }
+
+    @Test
+    @DisplayName("absolute path is rejected")
+    void testAbsoluteEscape() {
+      // On Unix, "/etc/passwd" is a traversal target. On Windows,
+      // "C:\\Windows\\System32\\config\\SAM" is the classic equivalent.
+      // We test with the actual platform's "forbidden outside the
+      // tempdir" path so the canonical-path check is meaningful on
+      // every OS.
+      String os = System.getProperty("os.name").toLowerCase();
+      String traversal = os.contains("win") ? "C:\\Windows\\System32\\config\\SAM" : "/etc/passwd";
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> PSPathInjectionGuard.requireUnderBase(m_tmpRoot, traversal),
+          "absolute path '" + traversal + "' must be rejected");
+    }
+
+    @Test
+    @DisplayName("baseDir must exist")
+    void testNonExistentBase() {
+      File nonExistent = new File(m_tmpRoot, "does-not-exist");
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> PSPathInjectionGuard.requireUnderBase(nonExistent, "file.txt"));
+    }
+
+    @Test
+    @DisplayName("null baseDir is rejected")
+    void testNullBase() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> PSPathInjectionGuard.requireUnderBase((File) null, "file.txt"));
+    }
+  }
+
+  @Nested
+  @DisplayName("containsForbiddenCharacters boolean helper")
+  class BooleanHelper {
+
+    @Test
+    @DisplayName("safe inputs return false")
+    void testSafeInputs() {
+      assertFalse(PSPathInjectionGuard.containsForbiddenCharacters("file.txt"));
+      assertFalse(PSPathInjectionGuard.containsForbiddenCharacters(""));
+      assertFalse(PSPathInjectionGuard.containsForbiddenCharacters(null));
+      assertFalse(PSPathInjectionGuard.containsForbiddenCharacters("a.b.c"));
+      // Literal ".." in a filename (e.g. "file..txt") is no longer
+      // flagged by the boolean helper per the round-3 review. Only
+      // separator and NUL-byte checks are done at the boolean level;
+      // the segment-aware check is in requireSafeFileName.
+      assertFalse(PSPathInjectionGuard.containsForbiddenCharacters("file..txt"));
+      assertFalse(PSPathInjectionGuard.containsForbiddenCharacters("archive..tar.gz"));
+    }
+
+    @Test
+    @DisplayName("traversal payloads return true")
+    void testForbiddenInputs() {
+      assertTrue(PSPathInjectionGuard.containsForbiddenCharacters("/etc/passwd"));
+      assertTrue(PSPathInjectionGuard.containsForbiddenCharacters("../etc/passwd"));
+      assertTrue(PSPathInjectionGuard.containsForbiddenCharacters("a\\b"));
+      assertTrue(PSPathInjectionGuard.containsForbiddenCharacters("a/b"));
+      assertTrue(PSPathInjectionGuard.containsForbiddenCharacters("safe\u0000.txt"));
+    }
+  }
+
+  @Test
+  @DisplayName("Smoke: requireSafeFileName is a no-op on a clean input (no throw)")
+  void testSmokeNoThrow() {
+    assertDoesNotThrow(() -> PSPathInjectionGuard.requireSafeFileName("clean-input.txt"));
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/theme/service/impl/PSRegionCSSFileService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/theme/service/impl/PSRegionCSSFileService.java
@@ -24,6 +24,7 @@ import static org.apache.commons.lang3.Validate.notEmpty;
 import static org.apache.commons.lang3.Validate.notNull;
 
 import com.percussion.pagemanagement.data.PSRegionTree;
+import com.percussion.security.io.PSPathInjectionGuard;
 import com.percussion.share.service.IPSDataService.PSThemeNotFoundException;
 import com.percussion.theme.data.PSRegionCSS;
 import com.phloc.css.ECSSVersion;
@@ -52,6 +53,21 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
 public class PSRegionCSSFileService {
+  private File themesRoot;
+
+  /**
+   * Sets the themes root directory used to validate path arguments. When set, public methods that
+   * accept a file path MUST validate that the path resolves under this directory before performing
+   * any file I/O. When unset (legacy/test usage), the methods fall back to single-segment
+   * validation via {@code PSPathInjectionGuard.requireSafeFileName}.
+   *
+   * @param themesRoot the themes root directory, may be {@code null} for single-segment-only
+   *     validation.
+   */
+  public void setThemesRoot(File themesRoot) {
+    this.themesRoot = themesRoot;
+  }
+
   /**
    * Finds the specified region CSS from a file.
    *
@@ -64,7 +80,7 @@ public class PSRegionCSSFileService {
       throws PSThemeNotFoundException {
     notEmpty(outerRegion);
     notEmpty(region);
-    notEmpty(filePath);
+    validatePath(filePath);
 
     List<PSRegionCSS> regions = read(filePath);
     return findRegionCSS(outerRegion, region, regions);
@@ -90,6 +106,7 @@ public class PSRegionCSSFileService {
   public void save(PSRegionCSS regionCSS, String filePath) throws PSThemeNotFoundException {
     notNull(regionCSS);
     notEmpty(filePath);
+    validatePath(filePath);
 
     List<PSRegionCSS> regions = read(filePath);
     PSRegionCSS r =
@@ -115,6 +132,7 @@ public class PSRegionCSSFileService {
     notEmpty(outerRegion);
     notEmpty(region);
     notEmpty(filePath);
+    validatePath(filePath);
 
     List<PSRegionCSS> regions = read(filePath);
     PSRegionCSS r = findRegionCSS(outerRegion, region, regions);
@@ -133,6 +151,7 @@ public class PSRegionCSSFileService {
    */
   public List<PSRegionCSS> read(String filePath) throws PSThemeNotFoundException {
     notEmpty(filePath);
+    validatePath(filePath);
 
     String contents = getContentFromFile(filePath);
     if (contents == null) return new ArrayList<>();
@@ -166,6 +185,9 @@ public class PSRegionCSSFileService {
    * @param cssList the list of region CSS, not <code>null</code>, may be empty.
    */
   public void write(String filePath, List<PSRegionCSS> cssList) throws PSThemeNotFoundException {
+    notEmpty(filePath);
+    validatePath(filePath);
+
     Collections.sort(cssList);
 
     StringBuilder buffer = new StringBuilder();
@@ -189,6 +211,8 @@ public class PSRegionCSSFileService {
     notNull(tree);
     notEmpty(srcPath);
     notEmpty(targetPath);
+    validatePath(srcPath);
+    validatePath(targetPath);
 
     List<PSRegionCSS> regions = getRegionCssFromTreeAndSource(tree, srcPath);
     if (regions == null || regions.isEmpty()) return;
@@ -272,6 +296,8 @@ public class PSRegionCSSFileService {
    */
   public void copyFile(String srcPath, String targetPath) throws PSThemeNotFoundException {
     notEmpty(targetPath);
+    if (srcPath != null) validatePath(srcPath);
+    validatePath(targetPath);
 
     File srcFile = getSourceFile(srcPath);
     File target = getTargetFile(targetPath);
@@ -433,5 +459,34 @@ public class PSRegionCSSFileService {
 
     ECSSSelectorCombinator combinator = (ECSSSelectorCombinator) member;
     return (combinator == ECSSSelectorCombinator.BLANK);
+  }
+
+  /**
+   * Validates that {@code filePath} is a safe path argument for the public methods on this class.
+   * When {@link #themesRoot} is set, the resolved canonical path MUST be contained within {@code
+   * themesRoot}; otherwise, the path is treated as a single-segment name and validated via {@link
+   * PSPathInjectionGuard#requireSafeFileName}.
+   *
+   * @param filePath a user-supplied file path argument; never {@code null} (callers MUST validate
+   *     non-empty before calling).
+   * @throws IllegalArgumentException if {@code filePath} contains a path-traversal payload or
+   *     resolves outside {@code themesRoot}.
+   */
+  private void validatePath(String filePath) {
+    if (filePath == null) {
+      throw new IllegalArgumentException("filePath must not be null");
+    }
+    if (themesRoot != null) {
+      // Canonical-path containment check against the configured
+      // themes root. Rejects any path that resolves outside the
+      // themes root, including "../escape" payloads.
+      PSPathInjectionGuard.requireUnderBase(themesRoot, filePath);
+    } else {
+      // No themesRoot configured (legacy/test usage). Fall back to
+      // single-segment validation: reject path separators, NUL
+      // bytes, and ".." / "." segment markers. Callers that pass
+      // absolute paths in this mode are out of contract.
+      PSPathInjectionGuard.requireSafeFileName(new File(filePath).getName());
+    }
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/theme/service/impl/PSThemeService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/theme/service/impl/PSThemeService.java
@@ -24,6 +24,7 @@ import static org.apache.commons.lang3.Validate.notNull;
 import com.percussion.pagemanagement.data.PSTemplate;
 import com.percussion.pagemanagement.service.IPSTemplateService;
 import com.percussion.security.error.PSExceptionUtils;
+import com.percussion.security.io.PSPathInjectionGuard;
 import com.percussion.server.PSRequest;
 import com.percussion.share.service.IPSDataService.DataServiceDeleteException;
 import com.percussion.share.service.IPSDataService.DataServiceLoadException;
@@ -68,6 +69,11 @@ public class PSThemeService implements IPSThemeService {
     String tempThemeDir = getThemesTempRootDirectory();
     File tempDir = new File(tempThemeDir);
     FileUtils.deleteQuietly(tempDir);
+    // Wire the themes root into the region-CSS file service so that
+    // PSRegionCSSFileService validates every public-method path
+    // argument against the configured themes root (CWE-22 defense
+    // per tasks.md T043).
+    cssFileService.setThemesRoot(getThemesRoot());
   }
 
   /*
@@ -177,7 +183,8 @@ public class PSThemeService implements IPSThemeService {
   }
 
   /**
-   * Calculates the newThemeName if the folder already exists in {@code <INSTALL_DIR>}/web_resources/themes.
+   * Calculates the newThemeName if the folder already exists in {@code
+   * <INSTALL_DIR>}/web_resources/themes.
    *
    * <p>The new name is the first available folder (non existing one) using the following pattern:
    * {@code <themeName>-#} (where # starts with 1)
@@ -199,6 +206,11 @@ public class PSThemeService implements IPSThemeService {
   }
 
   protected File getThemeFolder(String themeName) throws PSThemeNotFoundException {
+    // CWE-22 / CWE-23 defense (tasks.md T043): validate the theme name
+    // before composing any File path. Rejects "../escape" payloads,
+    // path separators, NUL bytes, and ".." / "." segment markers.
+    PSPathInjectionGuard.requireSafeFileName(themeName);
+
     File root = getThemesRoot();
     File themeFolder = new File(root, themeName);
     if (!themeFolder.isDirectory())

--- a/projects/sitemanage/src/test/java/com/percussion/theme/PSRegionCSSFileServiceSecurityTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/theme/PSRegionCSSFileServiceSecurityTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 1999-2025 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.theme;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.percussion.share.service.IPSDataService.PSThemeNotFoundException;
+import com.percussion.theme.service.impl.PSRegionCSSFileService;
+import java.io.File;
+import java.nio.file.Files;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for the CWE-22 / CWE-23 path-injection alerts on {@link PSRegionCSSFileService}.
+ * Covers GitHub code-scanning alerts #1714 and #1715 (java/path-injection, error severity,
+ * projects/sitemanage/).
+ *
+ * <p>Pre-fix behavior: the public methods accepted any string as a file path and resolved it
+ * against the JVM working directory. A payload like {@code ../../tmp/outside.css} would have
+ * allowed read/write of files outside the themes root.
+ *
+ * <p>Post-fix behavior: the public methods validate the input via {@code
+ * PSPathInjectionGuard.requireUnderBase} when the {@code themesRoot} is configured, rejecting any
+ * path that does not resolve under the configured themes root. Tests MUST fail on the pre-fix code
+ * (no validation, payload is accepted) and pass on the post-fix code (validation throws {@link
+ * IllegalArgumentException}).
+ */
+public class PSRegionCSSFileServiceSecurityTest {
+
+  private File themesRoot;
+  private PSRegionCSSFileService service;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    // Use a short prefix so the resulting temp dir name does not
+    // exceed Windows' 260-char MAX_PATH limit when combined with the
+    // JVM's user.home + Local\Temp prefix (which on this machine is
+    // C:\Users\VIJAYA~1.BOD\... — already 50+ chars).
+    themesRoot = Files.createTempDirectory("psc-").toFile();
+    themesRoot.mkdirs();
+    service = new PSRegionCSSFileService();
+    service.setThemesRoot(themesRoot);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    deleteRecursively(themesRoot);
+  }
+
+  /** Closes alert #1714: read() with traversal payload rejected. */
+  @Test
+  public void read_rejectsTraversalAboveThemesRoot() {
+    String payload = themesRoot.getAbsolutePath() + "/../../../etc/passwd";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> service.read(payload),
+        "read() must reject a path that escapes themesRoot");
+  }
+
+  /** Closes alert #1715: save() with traversal payload rejected. */
+  @Test
+  public void save_rejectsTraversalAboveThemesRoot() {
+    String payload = themesRoot.getAbsolutePath() + "/../../escape.css";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try {
+            service.save(new com.percussion.theme.data.PSRegionCSS("o", "r"), payload);
+          } catch (PSThemeNotFoundException e) {
+            throw new RuntimeException(e);
+          }
+        },
+        "save() must reject a path that escapes themesRoot");
+  }
+
+  /** Same defense for delete(). */
+  @Test
+  public void delete_rejectsTraversalAboveThemesRoot() {
+    String payload = themesRoot.getAbsolutePath() + "/../delete-target.css";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try {
+            service.delete("o", "r", payload);
+          } catch (PSThemeNotFoundException e) {
+            throw new RuntimeException(e);
+          }
+        },
+        "delete() must reject a path that escapes themesRoot");
+  }
+
+  /** write() with traversal payload rejected. */
+  @Test
+  public void write_rejectsTraversalAboveThemesRoot() {
+    String payload = themesRoot.getAbsolutePath() + "/../write-target.css";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try {
+            service.write(payload, new java.util.ArrayList<>());
+          } catch (PSThemeNotFoundException e) {
+            throw new RuntimeException(e);
+          }
+        },
+        "write() must reject a path that escapes themesRoot");
+  }
+
+  /** mergeFile() with traversal target rejected. */
+  @Test
+  public void mergeFile_rejectsTraversalTargetPath() {
+    String src = new File(themesRoot, "safe-src.css").getAbsolutePath();
+    String target = themesRoot.getAbsolutePath() + "/../merge-target.css";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try {
+            service.mergeFile(new com.percussion.pagemanagement.data.PSRegionTree(), src, target);
+          } catch (PSThemeNotFoundException e) {
+            throw new RuntimeException(e);
+          }
+        },
+        "mergeFile() must reject a target path that escapes themesRoot");
+  }
+
+  /** copyFile() with traversal target rejected. */
+  @Test
+  public void copyFile_rejectsTraversalTargetPath() throws Exception {
+    // Create the source file inside themesRoot so that copyFile()
+    // reaches the target-path validation step (not the source
+    // existence check, which would mask the traversal).
+    File src = new File(themesRoot, "safe.css");
+    Files.write(src.toPath(), "/* safe */".getBytes());
+    String target = themesRoot.getAbsolutePath() + "/../copy-target.css";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try {
+            service.copyFile(src.getAbsolutePath(), target);
+          } catch (PSThemeNotFoundException e) {
+            throw new RuntimeException(e);
+          }
+        },
+        "copyFile() must reject a target path that escapes themesRoot");
+  }
+
+  /** Sanity check: a path inside themesRoot is accepted (does NOT throw). */
+  @Test
+  public void read_acceptsPathInsideThemesRoot() throws Exception {
+    File insideFile = new File(themesRoot, "inside.css");
+    Files.write(insideFile.toPath(), "/* safe */".getBytes());
+    // Should NOT throw IAE - validates that the fix doesn't over-reject
+    // legitimate use cases. The read() may throw PSThemeNotFoundException
+    // if the CSS is malformed, but it must NOT throw IAE because the
+    // path is under themesRoot.
+    String absPath = insideFile.getAbsolutePath();
+    try {
+      service.read(absPath);
+    } catch (PSThemeNotFoundException expected) {
+      // Parse failure is fine - what matters is that validation
+      // doesn't reject the path itself.
+    } catch (IllegalArgumentException unexpected) {
+      throw new AssertionError(
+          "read() must accept a path inside themesRoot, but threw IAE: " + unexpected.getMessage(),
+          unexpected);
+    }
+  }
+
+  private static void deleteRecursively(File f) {
+    if (f == null || !f.exists()) return;
+    if (f.isDirectory()) {
+      File[] children = f.listFiles();
+      if (children != null) {
+        for (File c : children) deleteRecursively(c);
+      }
+    }
+    f.delete();
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/theme/PSThemeServiceSecurityTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/theme/PSThemeServiceSecurityTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 1999-2025 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.theme;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.percussion.share.service.IPSDataService.DataServiceLoadException;
+import com.percussion.share.service.IPSDataService.DataServiceNotFoundException;
+import com.percussion.share.service.exception.PSValidationException;
+import com.percussion.theme.service.impl.PSThemeService;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for the CWE-22 / CWE-23 path-injection alert on {@link PSThemeService}. Covers
+ * GitHub code-scanning alert #1713 (java/path-injection, error severity, projects/sitemanage/).
+ *
+ * <p>Pre-fix behavior: {@code getThemeFolder(String themeName)} accepted any string and built
+ * {@code new File(themesRoot, themeName)} without validation. A payload like {@code ../../etc}
+ * would have resolved to a path outside the themes root.
+ *
+ * <p>Post-fix behavior: the theme name is validated via {@code
+ * PSPathInjectionGuard.requireSafeFileName} at the trust boundary, rejecting null/empty, NUL bytes,
+ * path separators, and {@code ..} segment markers.
+ */
+public class PSThemeServiceSecurityTest {
+
+  /**
+   * Closes alert #1713: a theme name with a parent-traversal payload must be rejected before it
+   * reaches {@code new File(themesRoot, themeName)}.
+   */
+  @Test
+  public void getThemeFolder_rejectsParentTraversalInThemeName() {
+    PSThemeService svc = new PSThemeService();
+    String payload = "../escape";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try {
+            svc.find(payload);
+          } catch (DataServiceLoadException
+              | DataServiceNotFoundException
+              | PSValidationException e) {
+            // Expected: the lookup itself may fail with a
+            // service-level exception (folder does not exist).
+            // The point of this test is that the validation
+            // layer rejects the name FIRST, before the lookup.
+            throw new AssertionError(
+                "find() must reject traversal payload at validation, not at lookup: " + e, e);
+          }
+        },
+        "find() must reject a theme name that escapes themesRoot via parent traversal");
+  }
+
+  /** Sanity: a single-segment, safe theme name is accepted (does NOT throw IAE). */
+  @Test
+  public void getThemeFolder_acceptsSafeSingleSegmentName() {
+    PSThemeService svc = new PSThemeService();
+    String safe = "mytheme";
+    try {
+      svc.find(safe);
+    } catch (IllegalArgumentException e) {
+      throw new AssertionError("Safe single-segment name must not be rejected", e);
+    } catch (Exception expected) {
+      // DataServiceNotFoundException or similar for a non-existent
+      // theme is fine - what matters is that the validation layer
+      // does NOT throw IAE on a safe name.
+    }
+  }
+
+  /** A theme name containing a forward slash is rejected (path separator). */
+  @Test
+  public void find_rejectsThemeNameWithForwardSlash() {
+    PSThemeService svc = new PSThemeService();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try {
+            svc.find("foo/bar");
+          } catch (DataServiceLoadException
+              | DataServiceNotFoundException
+              | PSValidationException e) {
+            throw new AssertionError(
+                "find() must reject forward slash at validation, not at lookup: " + e, e);
+          }
+        },
+        "find() must reject a theme name containing '/'");
+  }
+
+  /** A theme name containing a backslash is rejected (Windows separator). */
+  @Test
+  public void find_rejectsThemeNameWithBackslash() {
+    PSThemeService svc = new PSThemeService();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try {
+            svc.find("foo\\bar");
+          } catch (DataServiceLoadException
+              | DataServiceNotFoundException
+              | PSValidationException e) {
+            throw new AssertionError(
+                "find() must reject backslash at validation, not at lookup: " + e, e);
+          }
+        },
+        "find() must reject a theme name containing '\\'");
+  }
+
+  /** A theme name containing a NUL byte is rejected. */
+  @Test
+  public void find_rejectsThemeNameWithNulByte() {
+    PSThemeService svc = new PSThemeService();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          try {
+            svc.find("foo\0bar");
+          } catch (DataServiceLoadException
+              | DataServiceNotFoundException
+              | PSValidationException e) {
+            throw new AssertionError(
+                "find() must reject NUL byte at validation, not at lookup: " + e, e);
+          }
+        },
+        "find() must reject a theme name containing a NUL byte");
+  }
+}


### PR DESCRIPTION
## 004/US3 T043r: path-injection guard for PSRegionCSSFileService + PSThemeService (alerts #1713, #1714, #1715)

Closes the 3 remaining `java/path-injection` (error severity, projects/sitemanage/) alerts on `development` after the prior T043 PRs (#1207–#1210, #1222–#1224) closed the other 55 of the original 58-alert cluster.

### Why this PR exists

The previous T043 PRs guarded the *file-I/O helpers* (`getContentFromFile`, `writeContent`, `getTargetFile`, `getSourceFile`) but did not guard the *public trust boundary* — the methods that accept a user-supplied `filePath` or `themeName` and pass it to those helpers. CodeQL's inter-procedural analysis correctly flagged the trust-boundary gap:

| GitHub alert # | File | Sink |
|---|---|---|
| #1713 | `PSThemeService.java` | `new File(root, themeName)` at `getThemeFolder(String)` |
| #1714 | `PSRegionCSSFileService.java` | `new File(filePath)` at `getContentFromFile(filePath)` (called from `read`, `findRegionCSS`, `mergeFile`) |
| #1715 | `PSRegionCSSFileService.java` | `new FileOutputStream(filePath)` at `writeContent(filePath, content)` (called from `save`, `delete`, `write`) |

### Changes

* **`modules/perc-security-utils/src/main/java/com/percussion/security/io/PSPathInjectionGuard.java`** — new helper (cherry-pick of the final state from side-branch commit `78f0cca57` approved in PR #1207, plus a Windows-specific bug fix):
  - `requireSafeFileName(String)` — single-segment validation; rejects NUL bytes, `\`, `/`, `..`, and `.`
  - `requireUnderBase(File baseDir, String userInput)` — canonical-path containment against a base directory
  - **Windows fix in `requireUnderBase`**: when `userInput` is already absolute, resolve via `new File(userInput)` directly instead of `new File(baseDir, userInput)`. The latter produces malformed paths like `C:\base\C:\absolute\file` on Windows when both arguments are absolute, which `getCanonicalPath()` then rejects with "filename ... syntax is incorrect". Verified with a probe test during development.

* **`projects/sitemanage/src/main/java/com/percussion/theme/service/impl/PSRegionCSSFileService.java`** — added `setThemesRoot(File)` and `validatePath(String)`. The latter is invoked at every public method entry (`findRegionCSS`, `save`, `delete`, `read`, `write`, `mergeFile`, `copyFile`) and delegates to `PSPathInjectionGuard.requireUnderBase(themesRoot, filePath)` when `themesRoot` is configured. Falls back to `requireSafeFileName(name-only)` when `themesRoot` is unset (legacy/test usage).

* **`projects/sitemanage/src/main/java/com/percussion/theme/service/impl/PSThemeService.java`** — `getThemeFolder(String themeName)` now calls `PSPathInjectionGuard.requireSafeFileName(themeName)` as the first statement (single-segment contract). The `@PostConstruct init()` method wires `cssFileService.setThemesRoot(getThemesRoot())` so the region-CSS service gets its base directory at startup.

### Tests (Constitution III fail-then-pass)

* **`projects/sitemanage/src/test/java/com/percussion/theme/PSRegionCSSFileServiceSecurityTest.java`** (new, 7 cases):
  - `read_rejectsTraversalAboveThemesRoot`
  - `save_rejectsTraversalAboveThemesRoot`
  - `delete_rejectsTraversalAboveThemesRoot`
  - `write_rejectsTraversalAboveThemesRoot`
  - `mergeFile_rejectsTraversalTargetPath`
  - `copyFile_rejectsTraversalTargetPath`
  - `read_acceptsPathInsideThemesRoot` (positive control — proves the fix doesn't over-reject)

* **`projects/sitemanage/src/test/java/com/percussion/theme/PSThemeServiceSecurityTest.java`** (new, 5 cases):
  - `getThemeFolder_rejectsParentTraversalInThemeName`
  - `getThemeFolder_acceptsSafeSingleSegmentName` (positive control)
  - `find_rejectsThemeNameWithForwardSlash`
  - `find_rejectsThemeNameWithBackslash`
  - `find_rejectsThemeNameWithNulByte`

* **`modules/perc-security-utils/src/test/java/com/percussion/security/io/PSPathInjectionGuardTest.java`** — 23 cases (cherry-picked from the side-branch PR #1207), unchanged except for Spotless formatting.

**Fail-then-pass loop (per Constitution III / T019b):**
- Pre-fix baseline log: `tmp/baselines/sitemanage-pre-fix-7fe67d0fe.log` — **10 of 12 new tests FAIL** with "Expected IllegalArgumentException to be thrown, but nothing was thrown" (pre-fix code accepted the traversal payloads).
- Post-fix log: `tmp/baselines/sitemanage-post-fix-7fe67d0fe.log` — **12 of 12 new tests PASS**.
- Helper test isolated: 23/23 pass.
- Full `projects/sitemanage` suite: 338 tests run, 10 pre-existing failures + 6 pre-existing errors, **0 new failures or regressions introduced by these changes**.

### Dispositions

- **3 alerts closed** by this PR: #1713, #1714, #1715 (all `java/path-injection`, error severity, projects/sitemanage/).
- **55 alerts closed** by prior T043 PRs (#1207–#1210, #1222–#1224) — reflected in the live GitHub dashboard but not yet backfilled into `triage.md` linked_pr column (separate bookkeeping PR, out of scope for this fix).
- Live alert count: 100 open (down from 759 in `release-readiness-8.2.md` Section 1, which was last refreshed 2026-07-14 before the merged T043 PRs landed).

### Spotless

Spotless clean on the 6 changed files. 36 unrelated files in `projects/sitemanage` had whitespace-only Spotless noise from my first `spotless:apply` run; those changes were reverted before commit to keep this PR scoped.

### Review-resolution gate (T078b / Constitution IX NON-NEGOTIABLE)

`Review-resolution-gate: pending`

This will be marked `passed` after any review comments on this PR receive (1) an inline reply citing the commit hash and a short mitigation statement, AND (2) the corresponding `resolveReviewThread` GraphQL mutation per the procedure in `./AGENTS.md`.

### Files changed

```
modules/perc-security-utils/src/main/java/com/percussion/security/io/PSPathInjectionGuard.java    (new, +246)
modules/perc-security-utils/src/test/java/com/percussion/security/io/PSPathInjectionGuardTest.java (new, +318)
projects/sitemanage/src/main/java/com/percussion/theme/service/impl/PSRegionCSSFileService.java   (+55)
projects/sitemanage/src/main/java/com/percussion/theme/service/impl/PSThemeService.java           (+14)
projects/sitemanage/src/test/java/com/percussion/theme/PSRegionCSSFileServiceSecurityTest.java   (new, +154)
projects/sitemanage/src/test/java/com/percussion/theme/PSThemeServiceSecurityTest.java           (new, +153)
```

Review-resolution-gate: pending
