### PR TITLE
Migrate PR #771: auto-list PercServiceUtils delivery/CSRF fix

### DIFF
--- a/WebUI/src/main/webapp/cm/app/js/legacy/services/PercServiceUtils.js
+++ b/WebUI/src/main/webapp/cm/app/js/legacy/services/PercServiceUtils.js
@@ -19,6 +19,16 @@
  * Utility functions and constants for use with client services.
  */
 (function ($) {
+
+    if (typeof jQuery !== 'undefined') {
+        if (typeof jQuery.getDeliveryServiceBase !== 'function' && typeof window.percDeliveryServiceBase !== 'undefined') {
+            jQuery.getDeliveryServiceBase = function() { return window.percDeliveryServiceBase; };
+        }
+        if (typeof jQuery.getCMSVersion !== 'function' && typeof window.percCMSVersion !== 'undefined') {
+            jQuery.getCMSVersion = function() { return window.percCMSVersion; };
+        }
+    }
+
   /**
    * Constant indicating a successful request.
    */
@@ -133,16 +143,9 @@
         if (typeof response !== "undefined" && response != null) {
           var tokenHeader = response.getResponseHeader("X-CSRF-HEADER");
           if (typeof tokenHeader === "undefined" || tokenHeader === null) {
-            if (
-              typeof callback.callcount !== "undefined" &&
-              callback.callcount === 1
-            ) {
-              callback.callcount = 2;
-            } else {
-              callback.callcount = 1;
-            }
-            csrfGetToken(url, callback);
-            return;
+            // The header might be missing due to CORS Access-Control-Expose-Headers.
+            // Instead of retrying and silently dropping the request, proceed with the callback.
+            callback(response);
           } else {
             callback(response);
           }

--- a/WebUI/src/main/webapp/cm/services/PercServiceUtils.js
+++ b/WebUI/src/main/webapp/cm/services/PercServiceUtils.js
@@ -19,6 +19,16 @@
  * Utility functions and constants for use with client services.
  */
 (function ($) {
+
+    if (typeof jQuery !== 'undefined') {
+        if (typeof jQuery.getDeliveryServiceBase !== 'function' && typeof window.percDeliveryServiceBase !== 'undefined') {
+            jQuery.getDeliveryServiceBase = function() { return window.percDeliveryServiceBase; };
+        }
+        if (typeof jQuery.getCMSVersion !== 'function' && typeof window.percCMSVersion !== 'undefined') {
+            jQuery.getCMSVersion = function() { return window.percCMSVersion; };
+        }
+    }
+
   /**
    * Constant indicating a successful request.
    */
@@ -133,16 +143,9 @@
         if (typeof response !== "undefined" && response != null) {
           var tokenHeader = response.getResponseHeader("X-CSRF-HEADER");
           if (typeof tokenHeader === "undefined" || tokenHeader === null) {
-            if (
-              typeof callback.callcount !== "undefined" &&
-              callback.callcount === 1
-            ) {
-              callback.callcount = 2;
-            } else {
-              callback.callcount = 1;
-            }
-            csrfGetToken(url, callback);
-            return;
+            // The header might be missing due to CORS Access-Control-Expose-Headers.
+            // Instead of retrying and silently dropping the request, proceed with the callback.
+            callback(response);
           } else {
             callback(response);
           }

--- a/WebUI/war/services/PercServiceUtils.js
+++ b/WebUI/war/services/PercServiceUtils.js
@@ -20,6 +20,16 @@
  */
 (function ($) {
 
+
+    if (typeof jQuery !== 'undefined') {
+        if (typeof jQuery.getDeliveryServiceBase !== 'function' && typeof window.percDeliveryServiceBase !== 'undefined') {
+            jQuery.getDeliveryServiceBase = function() { return window.percDeliveryServiceBase; };
+        }
+        if (typeof jQuery.getCMSVersion !== 'function' && typeof window.percCMSVersion !== 'undefined') {
+            jQuery.getCMSVersion = function() { return window.percCMSVersion; };
+        }
+    }
+
     /**
      * Constant indicating a successful request.
      */
@@ -140,14 +150,10 @@
                 if (typeof response !== 'undefined' && response != null) {
                     var tokenHeader = response.getResponseHeader("X-CSRF-HEADER");
                     if (typeof tokenHeader === "undefined" || tokenHeader === null) {
-                        if (typeof callback.callcount !== 'undefined' && callback.callcount === 1) {
-                            callback.callcount = 2;
-                        }else{
-                            callback.callcount = 1;
-                        }
-                        csrfGetToken(url,callback);
-                        return;
-                    }else{
+                        // The header might be missing due to CORS Access-Control-Expose-Headers.
+                        // Instead of retrying and silently dropping the request, proceed with the callback.
+                        callback(response);
+                    } else {
                         callback(response);
                     }
                 }

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/AutoListServiceUtilsPortTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/AutoListServiceUtilsPortTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/** Regression for GH-749 / v8.1.7 PR #771: auto-list delivery path + CSRF header handling. */
+class AutoListServiceUtilsPortTest {
+
+  @Test
+  void percServiceUtilsFallsBackToGlobalDeliveryPath() throws Exception {
+    Path root = resolveRoot();
+    Path war = root.resolve("WebUI/war/services/PercServiceUtils.js");
+    if (!Files.isRegularFile(war)) fail(war.toString());
+    String js = Files.readString(war, StandardCharsets.UTF_8);
+    assertTrue(js.contains("percDeliveryServiceBase"));
+    assertTrue(js.contains("percCMSVersion"));
+    assertTrue(js.contains("Access-Control-Expose-Headers"));
+  }
+
+  private static Path resolveRoot() {
+    Path cwd = Path.of("").toAbsolutePath().normalize();
+    Path up = cwd.resolve("../..").normalize();
+    if (Files.isDirectory(up.resolve("WebUI"))) return up;
+    if (Files.isDirectory(cwd.resolve("WebUI"))) return cwd;
+    fail("could not resolve monorepo root");
+    return cwd;
+  }
+}


### PR DESCRIPTION
## Summary
Port of v8.1.7 [#771](https://github.com/intersoftdatalabs-in/percussioncms/pull/771) (GH-749).

Fixes auto-list widgets on published sites by providing global-var fallbacks for delivery service base/CMS version and by not silently dropping requests when CSRF headers are not exposed (CORS).

## Tests
- \`AutoListServiceUtilsPortTest\`

## Backlog
\`specs/005-migrate-8.1.7-changes\`