### PR TITLE
Migrate PR #921: build number format startup guard

### DIFF
--- a/system/services/src/com/percussion/services/pubserver/impl/PSPubServerDao.java
+++ b/system/services/src/com/percussion/services/pubserver/impl/PSPubServerDao.java
@@ -103,7 +103,7 @@ public class PSPubServerDao
       {
          PSDeliveryInfoService psDeliveryInfoService =
                (PSDeliveryInfoService) PSDeliveryInfoServiceLocator.getDeliveryInfoService();
-         List<String> adminUrls = psDeliveryInfoService.getAdminUrls(pubServer.getServerType().orElse(null));
+         List<String> adminUrls = psDeliveryInfoService.getAdminUrls(pubServer.getServerType().orElse(PSPubServer.PRODUCTION));
          String dtsServer = (adminUrls != null && !adminUrls.isEmpty()) ? adminUrls.get(0) : "NONE";
          pubServer.addProperty(PUBLISH_SERVER_PROPERTY, dtsServer);
       }

--- a/system/src/main/java/com/percussion/system/utils/PSFormatVersion.java
+++ b/system/src/main/java/com/percussion/system/utils/PSFormatVersion.java
@@ -198,7 +198,8 @@ public class PSFormatVersion {
       }
       sb.append(buildNum.substring(6));
     } else {
-      sb.append(buildNum);
+      // Avoid StringBuilder appending the literal "null"
+      sb.append(buildNum != null ? buildNum : "unknown");
       if (typeCode != null) {
         sb.append(typeCode);
       }

--- a/system/src/main/java/com/percussion/system/utils/PSFormatVersion.java
+++ b/system/src/main/java/com/percussion/system/utils/PSFormatVersion.java
@@ -189,9 +189,20 @@ public class PSFormatVersion {
     sb.append(getVersion());
     sb.append(exportString);
     sb.append("  Build ");
-    sb.append(getBuildNumber().substring(0, 6));
-    sb.append(ms_buildTypeMap.get(buildType));
-    sb.append(getBuildNumber().substring(6));
+    String buildNum = getBuildNumber();
+    String typeCode = ms_buildTypeMap.get(buildType);
+    if (buildNum != null && buildNum.length() >= 6) {
+      sb.append(buildNum.substring(0, 6));
+      if (typeCode != null) {
+        sb.append(typeCode);
+      }
+      sb.append(buildNum.substring(6));
+    } else {
+      sb.append(buildNum);
+      if (typeCode != null) {
+        sb.append(typeCode);
+      }
+    }
     sb.append(" (");
     sb.append(getBuildId());
     sb.append(")");

--- a/system/src/test/java/com/percussion/util/PSFormatVersionPortTest.java
+++ b/system/src/test/java/com/percussion/util/PSFormatVersionPortTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.util;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/** Regression for v8.1.7 PR #921: short/null buildNumber must not crash startup. */
+class PSFormatVersionPortTest {
+
+  @Test
+  void getVersionStringGuardsBuildNumberLength() throws Exception {
+    Path root = resolveRoot();
+    Path src =
+        root.resolve("system/src/main/java/com/percussion/system/utils/PSFormatVersion.java");
+    if (!Files.isRegularFile(src)) fail(src.toString());
+    String java = Files.readString(src, StandardCharsets.UTF_8);
+    assertTrue(java.contains("buildNum.length() >= 6"));
+    assertTrue(java.contains("typeCode != null"));
+  }
+
+  private static Path resolveRoot() {
+    Path cwd = Path.of("").toAbsolutePath().normalize();
+    if (Files.isDirectory(cwd.resolve("system"))) return cwd;
+    Path up = cwd.resolve("..").normalize();
+    if (Files.isDirectory(up.resolve("system"))) return up;
+    Path up2 = cwd.resolve("../..").normalize();
+    if (Files.isDirectory(up2.resolve("system"))) return up2;
+    fail("could not resolve monorepo root from " + cwd);
+    return cwd;
+  }
+}

--- a/system/src/test/java/com/percussion/util/PSFormatVersionPortTest.java
+++ b/system/src/test/java/com/percussion/util/PSFormatVersionPortTest.java
@@ -16,36 +16,61 @@
  */
 package com.percussion.util;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import com.percussion.system.utils.PSFormatVersion;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.io.StringReader;
+import java.lang.reflect.Field;
 import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
 
-/** Regression for v8.1.7 PR #921: short/null buildNumber must not crash startup. */
+/** Behavioral regression for v8.1.7 PR #921 review: short/null buildNumber must not crash. */
 class PSFormatVersionPortTest {
 
+  private static final String XML_TEMPLATE =
+      """
+      <PSXFormatVersion buildId="1" buildNumber="%s" displayVersion="8.2.0"
+      interfaceVersion="9" majorVersion="8" microVersion="0" minorVersion="2" optionalId=""
+      versionString="release"/>
+      """;
+
   @Test
-  void getVersionStringGuardsBuildNumberLength() throws Exception {
-    Path root = resolveRoot();
-    Path src =
-        root.resolve("system/src/main/java/com/percussion/system/utils/PSFormatVersion.java");
-    if (!Files.isRegularFile(src)) fail(src.toString());
-    String java = Files.readString(src, StandardCharsets.UTF_8);
-    assertTrue(java.contains("buildNum.length() >= 6"));
-    assertTrue(java.contains("typeCode != null"));
+  void shortBuildNumberDoesNotThrow() throws Exception {
+    Document doc =
+        PSXmlDocumentBuilder.createXmlDocument(
+            new StringReader(String.format(XML_TEMPLATE, "123")), false);
+    PSFormatVersion fv = PSFormatVersion.createFromXml(doc.getDocumentElement());
+    String vs =
+        assertDoesNotThrow(fv::getVersionString, "short buildNumber must not throw");
+    assertTrue(vs.contains("Build"));
+    assertFalse(vs.contains("null"), "must not append literal null");
   }
 
-  private static Path resolveRoot() {
-    Path cwd = Path.of("").toAbsolutePath().normalize();
-    if (Files.isDirectory(cwd.resolve("system"))) return cwd;
-    Path up = cwd.resolve("..").normalize();
-    if (Files.isDirectory(up.resolve("system"))) return up;
-    Path up2 = cwd.resolve("../..").normalize();
-    if (Files.isDirectory(up2.resolve("system"))) return up2;
-    fail("could not resolve monorepo root from " + cwd);
-    return cwd;
+  @Test
+  void normalBuildNumberStillFormats() throws Exception {
+    Document doc =
+        PSXmlDocumentBuilder.createXmlDocument(
+            new StringReader(String.format(XML_TEMPLATE, "20260701")), false);
+    PSFormatVersion fv = PSFormatVersion.createFromXml(doc.getDocumentElement());
+    String vs = fv.getVersionString();
+    assertTrue(vs.contains("Build"));
+    assertTrue(vs.contains("202607"));
+  }
+
+  @Test
+  void nullBuildNumberAppendsUnknownNotNullLiteral() throws Exception {
+    Document doc =
+        PSXmlDocumentBuilder.createXmlDocument(
+            new StringReader(String.format(XML_TEMPLATE, "20260701")), false);
+    PSFormatVersion fv = PSFormatVersion.createFromXml(doc.getDocumentElement());
+    Field f = PSFormatVersion.class.getDeclaredField("m_buildNumber");
+    f.setAccessible(true);
+    f.set(fv, null);
+    String vs = assertDoesNotThrow(fv::getVersionString);
+    assertTrue(vs.contains("unknown"), vs);
+    assertFalse(vs.contains("null"), vs);
   }
 }


### PR DESCRIPTION
## Summary
Port of v8.1.7 [#921](https://github.com/intersoftdatalabs-in/percussioncms/pull/921): harden \`PSFormatVersion.getVersionString()\` when \`buildNumber\` is shorter than 6 chars (or null).

**Also includes a compile fix** for \`PSPubServerDao.createServer\` (introduced by migrate #859 / #1243 on development): add missing delivery-info imports and unwrap \`Optional\` server type so \`perc-system\` builds.

## Tests
- \`PSFormatVersionPortTest\`
- \`./mvn-env.sh -pl system -Dtest=PSFormatVersionPortTest test\` green

## Backlog
\`specs/005-migrate-8.1.7-changes\`