### PR TITLE
Migrate PR #676: Jackson null-handling and BAD_REQUEST mapping

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/analytics/service/impl/PSAnalyticsProviderService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/analytics/service/impl/PSAnalyticsProviderService.java
@@ -114,6 +114,7 @@ public class PSAnalyticsProviderService implements IPSAnalyticsProviderService {
     String userID;
     if (metadata == null) return null;
     var json = metadata.getData();
+    if (StringUtils.isBlank(json)) return null;
     var objectMapper = new com.fasterxml.jackson.databind.ObjectMapper();
     try {
       config = objectMapper.readValue(json, PSAnalyticsProviderConfig.class);

--- a/projects/sitemanage/src/main/java/com/percussion/category/marshaller/PSCategoryUnMarshaller.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/marshaller/PSCategoryUnMarshaller.java
@@ -104,6 +104,9 @@ public class PSCategoryUnMarshaller {
   }
 
   public static PSCategory unMarshalFromString(String categoryJson) {
+    if (StringUtils.isBlank(categoryJson)) {
+      return null;
+    }
     try (Reader reader = new StringReader(categoryJson)) {
       var mapper = new ObjectMapper();
       mapper.registerModule(new JavaTimeModule());

--- a/projects/sitemanage/src/main/java/com/percussion/category/service/impl/PSCategoryService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/service/impl/PSCategoryService.java
@@ -216,6 +216,9 @@ public class PSCategoryService implements IPSCategoryService {
   public String updateCategoriesWithString(
       @RequestParam("categorystring") String categoryString, @PathParam("sitename") String sitename)
       throws PSDataServiceException {
+    if (StringUtils.isBlank(categoryString)) {
+      throw new IllegalArgumentException("categorystring parameter must not be null or empty");
+    }
     PSCategory categoryWithJson = null;
     try {
       var mapper = new ObjectMapper();
@@ -233,6 +236,9 @@ public class PSCategoryService implements IPSCategoryService {
   @Consumes({MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN, MediaType.APPLICATION_XML})
   public String updateCategoriesWithString(@RequestParam("categorystring") String categoryString)
       throws PSDataServiceException {
+    if (StringUtils.isBlank(categoryString)) {
+      throw new IllegalArgumentException("categorystring parameter must not be null or empty");
+    }
     PSCategory categoryWithJson = null;
     try {
       var mapper = new ObjectMapper();

--- a/projects/sitemanage/src/main/java/com/percussion/licensemanagement/service/impl/PSLicenseService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/licensemanagement/service/impl/PSLicenseService.java
@@ -204,6 +204,10 @@ public class PSLicenseService implements IPSLicenseService {
    * @return PSModuleLicenses corresponding to the supplied string
    */
   private PSModuleLicenses mapToModuleLicenses(String jsonStr) {
+    if (StringUtils.isBlank(jsonStr)) {
+      log.warn("Module license string is null or empty, returning null.");
+      return null;
+    }
     PSModuleLicenses mls;
     var mapper = new ObjectMapper();
     try {

--- a/projects/sitemanage/src/main/java/com/percussion/share/web/service/PSRuntimeExceptionMapper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/web/service/PSRuntimeExceptionMapper.java
@@ -17,6 +17,7 @@
  */
 package com.percussion.share.web.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.percussion.cms.IPSConstants;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.share.service.exception.IPSValidationException;
@@ -72,6 +73,16 @@ public class PSRuntimeExceptionMapper extends PSAbstractExceptionMapper<RuntimeE
   @Produces(MediaType.APPLICATION_JSON)
   protected Status getStatus(RuntimeException exception) {
     if (exception instanceof IPSValidationException) {
+      return Status.BAD_REQUEST;
+    }
+    // Jackson null/parse footguns and bad client args map to 400 (v8.1.7 #676)
+    if (exception instanceof NullPointerException) {
+      return Status.BAD_REQUEST;
+    }
+    if (exception instanceof IllegalArgumentException) {
+      return Status.BAD_REQUEST;
+    }
+    if (exception.getCause() instanceof JsonProcessingException) {
       return Status.BAD_REQUEST;
     }
     return super.getStatus(exception);

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteDataService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteDataService.java
@@ -367,20 +367,23 @@ public class PSSiteDataService extends PSAbstractDataService<PSSite, PSSiteSumma
     props.setMobilePreviewEnabled(site.isMobilePreviewEnabled());
     props.setGenerateSiteMap(site.isGenerateSitemap());
 
-    ObjectMapper mapper = new ObjectMapper();
     String jsonString = site.getGenerateSiteMapOptions();
-    if (jsonString != null) {
-      PSGenerateSiteMapOptions psGenerateSiteMapOptions = null;
+    PSGenerateSiteMapOptions psGenerateSiteMapOptions = null;
+    if (StringUtils.isNotBlank(jsonString)) {
+      ObjectMapper mapper = new ObjectMapper();
       try {
         psGenerateSiteMapOptions = mapper.readValue(jsonString, PSGenerateSiteMapOptions.class);
       } catch (JsonProcessingException e) {
-        log.error(
-            "Error in json String for site {} and the error is: {} ",
+        log.warn(
+            "Failed to parse generateSiteMapOptions JSON for site {}, using defaults. Error: {}",
             site.getName(),
             PSExceptionUtils.getMessageForLog(e));
       }
-      props.setGenerateSiteMapOptions(psGenerateSiteMapOptions);
     }
+    if (psGenerateSiteMapOptions == null) {
+      psGenerateSiteMapOptions = new PSGenerateSiteMapOptions();
+    }
+    props.setGenerateSiteMapOptions(psGenerateSiteMapOptions);
   }
 
   public PSSitePublishProperties getSitePublishProperties(String siteName)

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/task/impl/PSSiteMapGeneratorTask.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/task/impl/PSSiteMapGeneratorTask.java
@@ -106,14 +106,20 @@ public class PSSiteMapGeneratorTask implements IPSEditionTask {
 
     if (site.isGenerateSitemap()) {
 
-      var mapper = new ObjectMapper();
       var jsonString = site.getGenerateSiteMapOptions();
       PSGenerateSiteMapOptions psGenerateSiteMapOptions = null;
-      try {
-        psGenerateSiteMapOptions = mapper.readValue(jsonString, PSGenerateSiteMapOptions.class);
-      } catch (JsonProcessingException e) {
-        log.error(PSExceptionUtils.getMessageForLog(e));
-        throw new PSExtensionException(e);
+      if (jsonString != null && !jsonString.trim().isEmpty()) {
+        var mapper = new ObjectMapper();
+        try {
+          psGenerateSiteMapOptions = mapper.readValue(jsonString, PSGenerateSiteMapOptions.class);
+        } catch (JsonProcessingException e) {
+          log.warn(
+              "Failed to parse generateSiteMapOptions JSON, using defaults. Error: {}",
+              PSExceptionUtils.getMessageForLog(e));
+        }
+      }
+      if (psGenerateSiteMapOptions == null) {
+        psGenerateSiteMapOptions = new PSGenerateSiteMapOptions();
       }
 
       long count = 0;

--- a/projects/sitemanage/src/test/java/com/percussion/category/marshaller/PSCategoryUnMarshallerNullJsonTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/category/marshaller/PSCategoryUnMarshallerNullJsonTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.category.marshaller;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+/** Regression for GH-675 / v8.1.7 PR #676: blank category JSON must not throw. */
+class PSCategoryUnMarshallerNullJsonTest {
+
+  @Test
+  void blankJsonReturnsNull() {
+    assertNull(PSCategoryUnMarshaller.unMarshalFromString(null));
+    assertNull(PSCategoryUnMarshaller.unMarshalFromString(""));
+    assertNull(PSCategoryUnMarshaller.unMarshalFromString("   "));
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/share/web/service/PSRuntimeExceptionMapperJacksonNullTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/web/service/PSRuntimeExceptionMapperJacksonNullTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.share.web.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.ws.rs.core.Response;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for GH-675 / v8.1.7 PR #676: map Jackson/null-style runtime failures to BAD_REQUEST.
+ */
+class PSRuntimeExceptionMapperJacksonNullTest {
+
+  private final PSRuntimeExceptionMapper mapper = new PSRuntimeExceptionMapper();
+
+  private Response.Status statusOf(RuntimeException ex) throws Exception {
+    Method m =
+        PSRuntimeExceptionMapper.class.getDeclaredMethod("getStatus", RuntimeException.class);
+    m.setAccessible(true);
+    return (Response.Status) m.invoke(mapper, ex);
+  }
+
+  @Test
+  void nullPointerIsBadRequest() throws Exception {
+    assertEquals(Response.Status.BAD_REQUEST, statusOf(new NullPointerException("npe")));
+  }
+
+  @Test
+  void illegalArgumentIsBadRequest() throws Exception {
+    assertEquals(Response.Status.BAD_REQUEST, statusOf(new IllegalArgumentException("bad")));
+  }
+
+  @Test
+  void jacksonCauseIsBadRequest() throws Exception {
+    RuntimeException wrap =
+        new RuntimeException("wrap", new JsonProcessingException("bad json") {});
+    assertEquals(Response.Status.BAD_REQUEST, statusOf(wrap));
+  }
+}


### PR DESCRIPTION
## Summary

Ports v8.1.7 **#676** (GH-675): defensive null/blank handling around Jackson JSON use, and map client-side parse/null runtime failures to **400 BAD_REQUEST**.

## Changes

- Blank category JSON → `null` (unmarshal); blank update payload → `IllegalArgumentException`
- Blank analytics config data → `null`; blank module license string → `null` + warn
- Sitemap options: blank/invalid JSON → defaults (no hard fail on parse)
- `PSRuntimeExceptionMapper`: NPE, `IllegalArgumentException`, Jackson cause → `BAD_REQUEST`
- Unit tests for mapper status codes and blank category unmarshal

GA key blank checks were already present on `development` (GA4 port).

## Test plan

- [x] `PSRuntimeExceptionMapperJacksonNullTest` (3)
- [x] `PSCategoryUnMarshallerNullJsonTest` (1)