### PR TITLE
Migrate PR #722: restore GadgetRegistry.xml and Deprecated grouping

### DIFF
--- a/WebUI/src/main/java/com/percussion/webui/gadget/servlets/GadgetRegistry.java
+++ b/WebUI/src/main/java/com/percussion/webui/gadget/servlets/GadgetRegistry.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.webui.gadget.servlets;
+
+import com.percussion.security.error.PSExceptionUtils;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/**
+ * Loads {@code GadgetRegistry.xml} from the classpath. Restored for v8.1.7 PR #722 / #885 grouping
+ * (Percussion vs Deprecated). The registry was removed with Shindig cleanup but remains the
+ * canonical grouping for dashboard gadget types.
+ */
+public final class GadgetRegistry {
+
+  private static final Logger log = LogManager.getLogger(GadgetRegistry.class);
+
+  /** Classpath location of the registry resource. */
+  public static final String REGISTRY_RESOURCE =
+      "com/percussion/webui/gadget/servlets/GadgetRegistry.xml";
+
+  private GadgetRegistry() {}
+
+  /**
+   * Loads gadget name → group name map from the classpath registry.
+   *
+   * @return unmodifiable map; empty if the resource is missing or unreadable
+   */
+  public static Map<String, String> loadGadgetTypeMap() {
+    Map<String, String> gadTypeMap = new LinkedHashMap<>();
+    try (InputStream in =
+        GadgetRegistry.class.getClassLoader().getResourceAsStream(REGISTRY_RESOURCE)) {
+      if (in == null) {
+        log.error("Gadget registry file is missing from classpath: {}", REGISTRY_RESOURCE);
+        return Collections.emptyMap();
+      }
+
+      Document doc = PSXmlDocumentBuilder.createXmlDocument(in, false);
+      NodeList groupElems = doc.getElementsByTagName("group");
+      for (int i = 0; i < groupElems.getLength(); i++) {
+        Element groupElem = (Element) groupElems.item(i);
+        String groupName = groupElem.getAttribute("name");
+        NodeList gadgetElems = groupElem.getElementsByTagName("gadget");
+        for (int j = 0; j < gadgetElems.getLength(); j++) {
+          Element gadgetElem = (Element) gadgetElems.item(j);
+          String gdgName = gadgetElem.getAttribute("name");
+          if (gdgName != null && !gdgName.isBlank()) {
+            gadTypeMap.put(gdgName, groupName);
+          }
+        }
+      }
+    } catch (Exception e) {
+      log.error("Failed to load {}: {}", REGISTRY_RESOURCE, PSExceptionUtils.getMessageForLog(e));
+      log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+      return Collections.emptyMap();
+    }
+    return Collections.unmodifiableMap(gadTypeMap);
+  }
+
+  /**
+   * @param gadgetName display name from registry (e.g. "Activity")
+   * @return group name, or {@code "Custom"} if unknown
+   */
+  public static String getGadgetType(String gadgetName) {
+    if (gadgetName == null || gadgetName.isBlank()) {
+      return "Custom";
+    }
+    String type = loadGadgetTypeMap().get(gadgetName);
+    return type != null ? type : "Custom";
+  }
+}

--- a/WebUI/src/main/resources/com/percussion/webui/gadget/servlets/GadgetRegistry.xml
+++ b/WebUI/src/main/resources/com/percussion/webui/gadget/servlets/GadgetRegistry.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gadgets>
+    <group name="Percussion">
+        <gadget name="Assets By Status"  baseuri="/cm/gadgets/repository/PercAssetStatusGadget" file="PercAssetStatusGadget.xml" />
+        <gadget name="Blogs" baseuri="/cm/gadgets/repository/PercBlogsGadget" file="PercBlogsGadget.xml"/>
+        <gadget name="Bulk Upload" baseuri="/cm/gadgets/repository/perc_bulk_file_upload_gadget" file="perc_bulk_file_upload_gadget.xml"/>
+        <gadget name="Comments" baseuri="/cm/gadgets/repository/perc_comments_gadget" file="perc_comments_gadget.xml"/>
+        <gadget name="Cookie Consent" baseuri="/cm/gadgets/repository/perc_cookie_consent_gadget" file="perc_cookie_consent_gadget.xml"/>
+        <gadget name="Forms Tracker" baseuri="/cm/gadgets/repository/PercFormTrackerGadget" file="PercFormTrackerGadget.xml"/>
+        <gadget name="Global Variables" baseuri="/cm/gadgets/repository/PercGlobalVariablesGadget" file="PercGlobalVariablesGadget.xml"/>
+        <gadget name="Google Setup" baseuri="/cm/gadgets/repository/perc_google_setup_gadget" file="perc_google_setup_gadget.xml"/>
+        <gadget name="Iframe" baseuri="/cm/gadgets/repository/perc_iframe_gadget" file="perc_iframe_gadget.xml"/>
+        <gadget name="Pages By Status" baseuri="/cm/gadgets/repository/perc_workflow_status_gadget" file="perc_workflow_status_gadget.xml"/>
+        <gadget name="Process Monitor" baseuri="/cm/gadgets/repository/PercProcessorMonitorGadget" file="PercProcessorMonitorGadget.xml"/>
+        <gadget name="Reports" baseuri="/cm/gadgets/repository/perc_reports_gadget" file="perc_reports_gadget.xml"/>
+        <gadget name="SEO Audit" baseuri="/cm/gadgets/repository/perc_seo_gadget" file="perc_seo_status_gadget.xml"/>
+        <gadget name="Sitewide Framework"  baseuri="/cm/gadgets/repository/PercSiteFrameworkGadget" file="perc_sitewide_framework_gadget.xml"/>
+        <gadget name="Traffic" baseuri="/cm/gadgets/repository/perc_traffic_gadget" file="perc_traffic_gadget.xml"/>
+        <gadget name="Welcome" baseuri="/cm/gadgets/repository/cm1_welcome_gadget" file="perc_welcome_gadget.xml"/>
+        <gadget name="What's Working" baseuri="/cm/gadgets/repository/perc_effectiveness_gadget" file="perc_effectiveness_gadget.xml"/>
+    </group>
+    <group name="Deprecated">
+        <gadget name="Activity" baseuri="/cm/gadgets/repository/perc_activity_gadget" file="perc_activity_gadget.xml"/>
+        <gadget name="Siteimprove" baseuri="/cm/gadgets/repository/perc_site_improve_gadget" file="perc_site_improve_gadget.xml"/>
+        <gadget name="Membership" baseuri="/cm/gadgets/repository/perc_membership_gadget" file="perc_membership_gadget.xml"/>
+        <gadget name="Redirect Management" baseuri="/cm/gadgets/repository/perc_website_config_gadget" file="perc_website_config_gadget.xml"/>
+        <gadget name="Widget Configuration" baseuri="/cm/gadgets/repository/PercWidgetConfigGadget" file="PercWidgetConfigGadget.xml"/>
+    </group>
+</gadgets>

--- a/WebUI/src/main/ts/dashboard/Dashboard.tsx
+++ b/WebUI/src/main/ts/dashboard/Dashboard.tsx
@@ -85,7 +85,8 @@ const AVAILABLE_GADGETS: GadgetInfo[] = [
     name: "Activity",
     component: ActivityWidget,
     description: "Recent content activity timeline",
-    category: "Content Management",
+    // GadgetRegistry.xml group "Deprecated" (v8.1.7 #722 / #885)
+    category: "Deprecated",
   },
   {
     id: "process-monitor",
@@ -176,7 +177,8 @@ const AVAILABLE_GADGETS: GadgetInfo[] = [
     name: "Membership",
     component: MembershipWidget,
     description: "User membership information and statistics",
-    category: "System",
+    // GadgetRegistry.xml group "Deprecated" (v8.1.7 #722 / #885)
+    category: "Deprecated",
   },
   {
     id: "sitewide-framework",
@@ -190,7 +192,8 @@ const AVAILABLE_GADGETS: GadgetInfo[] = [
     name: "Siteimprove",
     component: SiteimproveWidget,
     description: "Accessibility and quality metrics from Siteimprove",
-    category: "Analytics",
+    // GadgetRegistry.xml group "Deprecated" (v8.1.7 #722 / #885)
+    category: "Deprecated",
   },
   {
     id: "iframe",
@@ -211,9 +214,11 @@ const AVAILABLE_GADGETS: GadgetInfo[] = [
     name: "Dashboard Configuration",
     component: WidgetConfigurationWidget,
     description: "Manage dashboard widgets and configuration",
-    category: "System",
+    // GadgetRegistry.xml group "Deprecated" (v8.1.7 #722 / #885)
+    category: "Deprecated",
   },
 ];
+
 const DEFAULT_GADGETS: DashboardWidget[] = [
   {
     id: "welcome",

--- a/WebUI/src/main/webapp/cm/app/dashboard.jsp
+++ b/WebUI/src/main/webapp/cm/app/dashboard.jsp
@@ -249,6 +249,7 @@
                     <option value="all"><i18n:message key = "perc.ui.dashboard@View All"/></option>
                     <option selected="true" value="percussion">Percussion</option>
                     <option value="custom"><i18n:message key = "perc.ui.dashboard@Custom"/></option>
+                    <option value="deprecated"><i18n:message key = "perc.ui.dashboard@Deprecated" /></option>
                 </select>
                 <label><i18n:message key = "perc.ui.dashboard@Category"/></label>
                 <select class="perc-gadget-category" tabindex="0">

--- a/WebUI/src/main/webapp/cm/pages/app/dashboard.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/dashboard.jsp
@@ -249,6 +249,7 @@
                     <option value="all"><i18n:message key = "perc.ui.dashboard@View All"/></option>
                     <option selected="true" value="percussion">Percussion</option>
                     <option value="custom"><i18n:message key = "perc.ui.dashboard@Custom"/></option>
+                    <option value="deprecated"><i18n:message key = "perc.ui.dashboard@Deprecated" /></option>
                 </select>
                 <label><i18n:message key = "perc.ui.dashboard@Category"/></label>
                 <select class="perc-gadget-category" tabindex="0">

--- a/WebUI/src/test/java/com/percussion/webui/gadget/servlets/GadgetRegistryTest.java
+++ b/WebUI/src/test/java/com/percussion/webui/gadget/servlets/GadgetRegistryTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.webui.gadget.servlets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * Regression for v8.1.7 PR #722 / #885: GadgetRegistry.xml on classpath with Percussion +
+ * Deprecated groups.
+ */
+public class GadgetRegistryTest {
+
+  @Test
+  public void registryLoadsWithPercussionAndDeprecatedGroups() {
+    Map<String, String> map = GadgetRegistry.loadGadgetTypeMap();
+    assertFalse("GadgetRegistry.xml must be on the classpath", map.isEmpty());
+
+    assertEquals("Deprecated", map.get("Activity"));
+    assertEquals("Deprecated", map.get("Siteimprove"));
+    assertEquals("Deprecated", map.get("Membership"));
+    assertEquals("Deprecated", map.get("Redirect Management"));
+    assertEquals("Deprecated", map.get("Widget Configuration"));
+
+    // #885 undeprecated these back to Percussion
+    assertEquals("Percussion", map.get("Google Setup"));
+    assertEquals("Percussion", map.get("Traffic"));
+    assertEquals("Percussion", map.get("What's Working"));
+
+    assertEquals("Percussion", map.get("Welcome"));
+    assertEquals("Percussion", map.get("Bulk Upload"));
+  }
+
+  @Test
+  public void unknownGadgetIsCustom() {
+    assertEquals("Custom", GadgetRegistry.getGadgetType("Not A Real Gadget"));
+  }
+
+  @Test
+  public void deprecatedTypeLookup() {
+    assertTrue("Deprecated".equals(GadgetRegistry.getGadgetType("Activity")));
+  }
+}

--- a/WebUI/war/app/dashboard.jsp
+++ b/WebUI/war/app/dashboard.jsp
@@ -249,6 +249,7 @@
                     <option value="all"><i18n:message key = "perc.ui.dashboard@View All"/></option>
                     <option selected="true" value="percussion">Percussion</option>
                     <option value="custom"><i18n:message key = "perc.ui.dashboard@Custom"/></option>
+                    <option value="deprecated"><i18n:message key = "perc.ui.dashboard@Deprecated" /></option>
                 </select>
                 <label><i18n:message key = "perc.ui.dashboard@Category"/></label>
                 <select class="perc-gadget-category" tabindex="0">

--- a/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
@@ -14111,6 +14111,16 @@ Documentación' href='https://percussioncmshelp.intsof.com/'&gt;percussioncmshel
 	        <seg>Personalizado</seg>
 	    </tuv>
 	 </tu>
+  <tu tuid="perc.ui.dashboard@Deprecated">
+         <prop type="sectionname" xml:lang="en-us">Dashboard</prop>
+         <note xml:lang="en-us"></note>
+         <tuv xml:lang="en-us">
+             <seg>Deprecated (Pending Removal)</seg>
+         </tuv>
+           <tuv xml:lang="es">
+             <seg>En desuso (eliminación pendiente)</seg>
+         </tuv>
+      </tu>
 	 <tu tuid="perc.ui.dashboard@Type">
 	    <prop type="sectionname" xml:lang="en-us">Dashboard</prop>
 	    <note xml:lang="en-us"></note>


### PR DESCRIPTION
## Summary

Restores **`GadgetRegistry.xml`**, which was removed during Shindig cleanup (`13710b70a9`) but remains the canonical Percussion vs **Deprecated** gadget grouping from v8.1.7 (**#722** + later **#885** undeprecations).

The new React dashboard hardcodes widgets; this does **not** bring Shindig back. It restores the registry resource, a small loader, legacy tray filter UI, and aligns React categories for deprecated gadgets.

## Changes

| Area | Change |
|------|--------|
| `WebUI/.../GadgetRegistry.xml` | Restored from `development-8.1.x` tip (Percussion + Deprecated groups) |
| `GadgetRegistry.java` | Classpath loader → name→group map |
| `GadgetRegistryTest` | Asserts Deprecated vs Percussion membership (#722/#885) |
| Legacy `dashboard.jsp` (×3) | Type filter option `deprecated` |
| `CmsUi.tmx` | `perc.ui.dashboard@Deprecated` |
| React `Dashboard.tsx` | Activity, Membership, Siteimprove, Widget Configuration → category `Deprecated` |

## Test plan

- [x] `./mvn-env.sh -pl WebUI -Dtest=GadgetRegistryTest test`
- [ ] Spot-check legacy tray type filter shows “Deprecated (Pending Removal)”
- [ ] Spot-check React add-gadget modal categories for deprecated widgets