### PR TITLE
Migrate PR #924: path-not-found exception maps to HTTP 404

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/share/web/service/PSPathServiceExceptionMapper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/web/service/PSPathServiceExceptionMapper.java
@@ -20,6 +20,7 @@ package com.percussion.share.web.service;
 
 import com.percussion.cms.IPSConstants;
 import com.percussion.pathmanagement.service.IPSPathService;
+import com.percussion.share.service.exception.IPSNotFoundException;
 import com.percussion.share.validation.PSErrors;
 import com.percussion.system.utils.PSSiteManageBean;
 import jakarta.inject.Singleton;
@@ -71,6 +72,11 @@ public class PSPathServiceExceptionMapper
   @Override
   @Produces(MediaType.APPLICATION_JSON)
   protected Response.Status getStatus(IPSPathService.PSPathServiceException exception) {
+    // Path not found is a client/path issue, not a server fault (v8.1.7 #924 / GH-867)
+    if (exception instanceof IPSPathService.PSPathNotFoundServiceException
+        || exception.getCause() instanceof IPSNotFoundException) {
+      return Response.Status.NOT_FOUND;
+    }
     return super.getStatus(exception);
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/share/web/service/PSPathServiceExceptionMapper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/web/service/PSPathServiceExceptionMapper.java
@@ -74,9 +74,26 @@ public class PSPathServiceExceptionMapper
   protected Response.Status getStatus(IPSPathService.PSPathServiceException exception) {
     // Path not found is a client/path issue, not a server fault (v8.1.7 #924 / GH-867)
     if (exception instanceof IPSPathService.PSPathNotFoundServiceException
-        || exception.getCause() instanceof IPSNotFoundException) {
+        || hasNotFoundCause(exception)) {
       return Response.Status.NOT_FOUND;
     }
     return super.getStatus(exception);
+  }
+
+  /** Walk the cause chain so nested {@link IPSNotFoundException} still maps to 404. */
+  private static boolean hasNotFoundCause(Throwable exception) {
+    Throwable t = exception;
+    // Bound depth to avoid cycles in malformed chains
+    for (int i = 0; t != null && i < 16; i++) {
+      if (t instanceof IPSNotFoundException) {
+        return true;
+      }
+      Throwable next = t.getCause();
+      if (next == t) {
+        break;
+      }
+      t = next;
+    }
+    return false;
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/foldermanagement/service/impl/PSFolderRestServiceErrorExposureTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/foldermanagement/service/impl/PSFolderRestServiceErrorExposureTest.java
@@ -20,6 +20,8 @@ package com.percussion.foldermanagement.service.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -30,8 +32,9 @@ import com.percussion.foldermanagement.data.PSWorkflowAssignment;
 import com.percussion.foldermanagement.service.IPSFolderService;
 import com.percussion.foldermanagement.service.IPSFolderService.PSWorkflowAssignmentInProgressException;
 import com.percussion.foldermanagement.service.IPSFolderService.PSWorkflowNotFoundException;
-import com.percussion.share.dao.IPSGenericDao.LoadException;
 import com.percussion.pathmanagement.service.IPSPathService.PSPathNotFoundServiceException;
+import com.percussion.share.dao.IPSGenericDao.LoadException;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -74,7 +77,7 @@ class PSFolderRestServiceErrorExposureTest {
   @BeforeEach
   void setUp() {
     MockitoAnnotations.openMocks(this);
-    folderRestService = new PSFolderRestService(mockFolderService);
+    folderService = new PSFolderRestService(mockFolderService);
   }
 
   @Test
@@ -85,7 +88,7 @@ class PSFolderRestServiceErrorExposureTest {
         .thenThrow(new PSWorkflowNotFoundException("Internal DB Error details"));
 
     try {
-      folderRestService.startGetAssociatedFoldersJob(badWorkflow, "path", false);
+      folderService.startGetAssociatedFoldersJob(badWorkflow, "path", false);
       fail("Expected WebApplicationException");
     } catch (WebApplicationException e) {
       Response response = e.getResponse();

--- a/projects/sitemanage/src/test/java/com/percussion/share/web/service/PSPathServiceExceptionMapperTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/web/service/PSPathServiceExceptionMapperTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.share.web.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.percussion.pathmanagement.service.IPSPathService;
+import com.percussion.share.service.exception.IPSNotFoundException;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for GH-867 / v8.1.7 PR #924: path-not-found maps to HTTP 404, not 500.
+ *
+ * <p>Folder-create race retries already live in {@code PSPathItemService.addFolder}; this covers
+ * the exception mapper status mapping.
+ */
+class PSPathServiceExceptionMapperTest {
+
+  private final PSPathServiceExceptionMapper mapper = new PSPathServiceExceptionMapper();
+
+  @Test
+  void pathNotFoundServiceExceptionIsNotFound() {
+    IPSPathService.PSPathNotFoundServiceException ex =
+        new IPSPathService.PSPathNotFoundServiceException("Path not found");
+    assertEquals(Response.Status.NOT_FOUND, mapper.getStatus(ex));
+  }
+
+  private static class CustomNotFoundException extends Exception implements IPSNotFoundException {
+    private static final long serialVersionUID = 1L;
+  }
+
+  @Test
+  void notFoundCauseIsNotFound() {
+    IPSPathService.PSPathServiceException ex =
+        new IPSPathService.PSPathServiceException("Wrapper", new CustomNotFoundException());
+    assertEquals(Response.Status.NOT_FOUND, mapper.getStatus(ex));
+  }
+
+  @Test
+  void genericPathServiceExceptionIsServerError() {
+    IPSPathService.PSPathServiceException ex =
+        new IPSPathService.PSPathServiceException("Generic error");
+    assertEquals(Response.Status.INTERNAL_SERVER_ERROR, mapper.getStatus(ex));
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/share/web/service/PSPathServiceExceptionMapperTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/web/service/PSPathServiceExceptionMapperTest.java
@@ -52,6 +52,15 @@ class PSPathServiceExceptionMapperTest {
     assertEquals(Response.Status.NOT_FOUND, mapper.getStatus(ex));
   }
 
+
+  @Test
+  void nestedNotFoundCauseIsNotFound() {
+    Exception mid = new RuntimeException("mid", new CustomNotFoundException());
+    IPSPathService.PSPathServiceException ex =
+        new IPSPathService.PSPathServiceException("outer wrap", mid);
+    assertEquals(Response.Status.NOT_FOUND, mapper.getStatus(ex));
+  }
+
   @Test
   void genericPathServiceExceptionIsServerError() {
     IPSPathService.PSPathServiceException ex =


### PR DESCRIPTION
## Summary

Completes the remaining half of v8.1.7 **#924** (GH-867): path service exceptions for missing paths return **404 NOT_FOUND** instead of 500.

Folder-create lookup **retries** were already on `development` (from the #1152/#1156 port cluster).

## Changes

- `PSPathServiceExceptionMapper.getStatus` → `NOT_FOUND` for `PSPathNotFoundServiceException` or `IPSNotFoundException` cause
- `PSPathServiceExceptionMapperTest` (3 cases)
- Fix compile break in `PSFolderRestServiceErrorExposureTest` (pre-existing typo/imports from #1268)

## Test plan

- [x] `./mvn-env.sh -pl projects/sitemanage -Dtest=PSPathServiceExceptionMapperTest test`