### PR TITLE
Migrate PR #782: DTS JUL noise + category query empty-criteria fix

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/resources/log4j2.component.properties
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/resources/log4j2.component.properties
@@ -1,0 +1,6 @@
+# Log4j2 component properties loaded very early.
+# Suppresses StatusLogger noise from the log4j-jul bridge (the "setUseParentHandlers" warnings).
+log4j2.statusLoggerLevel=ERROR
+
+# Silence early "setUseParentHandlers" warnings from the Log4j JUL bridge.
+org.apache.logging.log4j.jul.Log4jLogger.level=OFF

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/conf/perc/metadata-log4j2.xml
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/conf/perc/metadata-log4j2.xml
@@ -23,13 +23,12 @@
 		<Logger name="com.percussion.delivery.metadata" level="info"
 			additivity="false">
 			<AppenderRef ref="RollingRandomAccessFile" />
-		
-    <!-- Silence Log4j JUL bridge noise during startup (v8.1.7 #782). -->
-    <Logger name="org.apache.logging.log4j.jul" level="error" additivity="false">
-      <AppenderRef ref="RollingRandomAccessFile"/>
-    </Logger>
+		</Logger>
 
-</Logger>
+		<!-- Silence Log4j JUL bridge noise during startup (v8.1.7 #782). Sibling Logger under Loggers. -->
+		<Logger name="org.apache.logging.log4j.jul" level="error" additivity="false">
+			<AppenderRef ref="RollingRandomAccessFile"/>
+		</Logger>
 		<!-- Uncomment for MSSQL Driver Debugging <Logger name="com.microsoft.sqlserver.jdbc"
 			level="SEVERE" additivity="true"> <AppenderRef ref="RollingRandomAccessFile"/>
 			</Logger> -->

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/conf/perc/metadata-log4j2.xml
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/conf/perc/metadata-log4j2.xml
@@ -23,7 +23,13 @@
 		<Logger name="com.percussion.delivery.metadata" level="info"
 			additivity="false">
 			<AppenderRef ref="RollingRandomAccessFile" />
-		</Logger>
+		
+    <!-- Silence Log4j JUL bridge noise during startup (v8.1.7 #782). -->
+    <Logger name="org.apache.logging.log4j.jul" level="error" additivity="false">
+      <AppenderRef ref="RollingRandomAccessFile"/>
+    </Logger>
+
+</Logger>
 		<!-- Uncomment for MSSQL Driver Debugging <Logger name="com.microsoft.sqlserver.jdbc"
 			level="SEVERE" additivity="true"> <AppenderRef ref="RollingRandomAccessFile"/>
 			</Logger> -->

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/tomcat10/bin/setenv.bat
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/tomcat10/bin/setenv.bat
@@ -1,5 +1,7 @@
 SET JAVA_OPTS=%JAVA_OPTS% -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager @JAVA_OPTS@
 SET CLASSPATH=%CATALINA_BASE%/log4j2/lib/*;%CATALINA_BASE%/log4j2/conf;%CLASSPATH%
 
+REM Suppress noisy JUL bridge warnings during early Tomcat startup.
+SET JAVA_OPTS=%JAVA_OPTS% -Dorg.apache.logging.log4j.jul.Log4jLogger.level=OFF
 
 

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/tomcat10/bin/setenv.sh
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/tomcat10/bin/setenv.sh
@@ -2,4 +2,7 @@
 
 CLASSPATH=$CATALINA_BASE/log4j2/lib/*:$CATALINA_BASE/log4j2/conf
 LOGGING_MANAGER="-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"
-JAVA_OPTS="$JAVA_OPTS @JAVA_OPTS@"
+
+# Suppress noisy "Ignoring call to j.u.l.Logger.setUseParentHandlers(true)" warnings
+# from the Log4j JUL bridge during early Tomcat startup.
+JAVA_OPTS="$JAVA_OPTS -Dorg.apache.logging.log4j.jul.Log4jLogger.level=OFF @JAVA_OPTS@"

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/tomcat10/conf/log4j2-tomcat.xml
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/tomcat10/conf/log4j2-tomcat.xml
@@ -51,5 +51,14 @@
 			<AppenderRef ref="CONSOLE" />
 		</Logger>
 
-	</Loggers>
+	
+        <!-- Expected Tomcat exploded-webapp cache warning noise (v8.1.7 #782). -->
+        <Logger name="org.apache.catalina.webresources.DirResourceSet"
+                level="error"
+                additivity="false">
+            <AppenderRef ref="CATALINA"/>
+            <AppenderRef ref="CONSOLE" />
+        </Logger>
+
+    </Loggers>
 </Configuration>

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/tomcat9/bin/setenv.bat
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/tomcat9/bin/setenv.bat
@@ -1,5 +1,7 @@
 SET JAVA_OPTS=%JAVA_OPTS% -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager @JAVA_OPTS@
 SET CLASSPATH=%CATALINA_BASE%/log4j2/lib/*;%CATALINA_BASE%/log4j2/conf;%CLASSPATH%
 
+REM Suppress noisy JUL bridge warnings during early Tomcat startup.
+SET JAVA_OPTS=%JAVA_OPTS% -Dorg.apache.logging.log4j.jul.Log4jLogger.level=OFF
 
 

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/tomcat9/bin/setenv.sh
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/tomcat9/bin/setenv.sh
@@ -2,4 +2,7 @@
 
 CLASSPATH=$CATALINA_BASE/log4j2/lib/*:$CATALINA_BASE/log4j2/conf
 LOGGING_MANAGER="-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"
-JAVA_OPTS="$JAVA_OPTS @JAVA_OPTS@"
+
+# Suppress noisy "Ignoring call to j.u.l.Logger.setUseParentHandlers(true)" warnings
+# from the Log4j JUL bridge during early Tomcat startup.
+JAVA_OPTS="$JAVA_OPTS -Dorg.apache.logging.log4j.jul.Log4jLogger.level=OFF @JAVA_OPTS@"

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/tomcat9/conf/log4j2-tomcat.xml
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/tomcat9/conf/log4j2-tomcat.xml
@@ -51,5 +51,14 @@
 			<AppenderRef ref="CONSOLE" />
 		</Logger>
 
-	</Loggers>
+	
+        <!-- Expected Tomcat exploded-webapp cache warning noise (v8.1.7 #782). -->
+        <Logger name="org.apache.catalina.webresources.DirResourceSet"
+                level="error"
+                additivity="false">
+            <AppenderRef ref="CATALINA"/>
+            <AppenderRef ref="CONSOLE" />
+        </Logger>
+
+    </Loggers>
 </Configuration>

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/resources/log4j2.component.properties
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/resources/log4j2.component.properties
@@ -1,0 +1,6 @@
+# Log4j2 component properties loaded very early.
+# Suppresses StatusLogger noise from the log4j-jul bridge (the "setUseParentHandlers" warnings).
+log4j2.statusLoggerLevel=ERROR
+
+# Silence early "setUseParentHandlers" warnings from the Log4j JUL bridge.
+org.apache.logging.log4j.jul.Log4jLogger.level=OFF

--- a/deliverytiersuite/delivery-tier-suite/forms/src/main/resources/log4j2.component.properties
+++ b/deliverytiersuite/delivery-tier-suite/forms/src/main/resources/log4j2.component.properties
@@ -1,0 +1,6 @@
+# Log4j2 component properties loaded very early.
+# Suppresses StatusLogger noise from the log4j-jul bridge (the "setUseParentHandlers" warnings).
+log4j2.statusLoggerLevel=ERROR
+
+# Silence early "setUseParentHandlers" warnings from the Log4j JUL bridge.
+org.apache.logging.log4j.jul.Log4jLogger.level=OFF

--- a/deliverytiersuite/delivery-tier-suite/integrations/src/main/resources/log4j2.component.properties
+++ b/deliverytiersuite/delivery-tier-suite/integrations/src/main/resources/log4j2.component.properties
@@ -1,0 +1,6 @@
+# Log4j2 component properties loaded very early.
+# Suppresses StatusLogger noise from the log4j-jul bridge (the "setUseParentHandlers" warnings).
+log4j2.statusLoggerLevel=ERROR
+
+# Silence early "setUseParentHandlers" warnings from the Log4j JUL bridge.
+org.apache.logging.log4j.jul.Log4jLogger.level=OFF

--- a/deliverytiersuite/delivery-tier-suite/membership/src/main/resources/log4j2.component.properties
+++ b/deliverytiersuite/delivery-tier-suite/membership/src/main/resources/log4j2.component.properties
@@ -1,0 +1,6 @@
+# Log4j2 component properties loaded very early.
+# Suppresses StatusLogger noise from the log4j-jul bridge (the "setUseParentHandlers" warnings).
+log4j2.statusLoggerLevel=ERROR
+
+# Silence early "setUseParentHandlers" warnings from the Log4j JUL bridge.
+org.apache.logging.log4j.jul.Log4jLogger.level=OFF

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSMetadataQueryService.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSMetadataQueryService.java
@@ -240,6 +240,7 @@ public class PSMetadataQueryService implements IPSMetadataQueryService {
       }
     }
 
+    // After empty-criteria fast path return, at least one of Q3/Q4 is non-null.
     StringBuilder Q2;
     if (Q3 != null) {
       Q2 =
@@ -247,15 +248,12 @@ public class PSMetadataQueryService implements IPSMetadataQueryService {
                   "select distinct p2.entry.id from PSDbMetadataProperty p2 where p2.entry.id in( ")
               .append(Q3)
               .append(" )");
-    } else if (Q4 != null) {
+    } else {
       Q2 =
           new StringBuilder(
                   "select distinct p2.entry.id from PSDbMetadataProperty p2 where p2.entry.id in( ")
               .append(Q4)
               .append(" )");
-    } else {
-      // Defense-in-depth if fast path was skipped
-      Q2 = new StringBuilder("select distinct p2.entry.id from PSDbMetadataProperty p2");
     }
 
     StringBuilder Q1 =

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSMetadataQueryService.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSMetadataQueryService.java
@@ -134,6 +134,27 @@ public class PSMetadataQueryService implements IPSMetadataQueryService {
       }
     }
 
+    // Fast path: no criteria (common for global category trees). Complex Q1–Q4
+    // builder assumes at least one filter and produces invalid HQL when empty
+    // (v8.1.7 #782 / GH-748).
+    if (entryCrit.isEmpty() && propsCrit.isEmpty()) {
+      String hql =
+          "SELECT distinct count(p.entry.id), p.name, p.stringvalue "
+              + "FROM PSDbMetadataProperty p "
+              + "WHERE p.name = 'perc:category' "
+              + "GROUP BY p.name, p.stringvalue "
+              + "ORDER BY p.stringvalue";
+      log.debug("{}", hql);
+      try (Session session = getSession()) {
+        Query hq = session.createQuery(hql);
+        cats = hq.getResultList();
+      } catch (Exception e) {
+        log.error("Simple category query failed: {}", e.getMessage());
+        log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+      }
+      return cats;
+    }
+
     StringBuilder Q4WhereClause = null;
     String clauseTemplate = " e.{0} {1} :{2}";
     int paramIndex = 0;
@@ -219,13 +240,22 @@ public class PSMetadataQueryService implements IPSMetadataQueryService {
       }
     }
 
-    StringBuilder Q2 =
-        new StringBuilder(
-            "select distinct p2.entry.id from PSDbMetadataProperty p2 where p2.entry.id in( ");
+    StringBuilder Q2;
     if (Q3 != null) {
-      Q2.append(Q3).append(" )");
+      Q2 =
+          new StringBuilder(
+                  "select distinct p2.entry.id from PSDbMetadataProperty p2 where p2.entry.id in( ")
+              .append(Q3)
+              .append(" )");
     } else if (Q4 != null) {
-      Q2.append(Q4).append(" )");
+      Q2 =
+          new StringBuilder(
+                  "select distinct p2.entry.id from PSDbMetadataProperty p2 where p2.entry.id in( ")
+              .append(Q4)
+              .append(" )");
+    } else {
+      // Defense-in-depth if fast path was skipped
+      Q2 = new StringBuilder("select distinct p2.entry.id from PSDbMetadataProperty p2");
     }
 
     StringBuilder Q1 =

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/resources/log4j2.component.properties
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/resources/log4j2.component.properties
@@ -1,0 +1,6 @@
+# Log4j2 component properties loaded very early.
+# Suppresses StatusLogger noise from the log4j-jul bridge (the "setUseParentHandlers" warnings).
+log4j2.statusLoggerLevel=ERROR
+
+# Silence early "setUseParentHandlers" warnings from the Log4j JUL bridge.
+org.apache.logging.log4j.jul.Log4jLogger.level=OFF

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/PSMetadataQueryServiceTest.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/PSMetadataQueryServiceTest.java
@@ -477,7 +477,12 @@ public class PSMetadataQueryServiceTest {
     q.setTotalMaxResults(10);
     try {
       List<Object[]> cats = service.executeCategoryQuery(q);
-
+      assertNotNull(cats, "category results should not be null (even if empty)");
+      // Unfiltered query with seeded test data should yield at least one category row
+      // (v8.1.7 #782 empty-criteria fast path).
+      assertFalse(
+          cats.isEmpty(),
+          "expected at least one category row for unfiltered query with seeded test data");
     } catch (PSMalformedMetadataQueryException e) {
       fail(e.getMessage());
     }

--- a/deliverytiersuite/delivery-tier-suite/polls/src/main/resources/log4j2.component.properties
+++ b/deliverytiersuite/delivery-tier-suite/polls/src/main/resources/log4j2.component.properties
@@ -1,0 +1,6 @@
+# Log4j2 component properties loaded very early.
+# Suppresses StatusLogger noise from the log4j-jul bridge (the "setUseParentHandlers" warnings).
+log4j2.statusLoggerLevel=ERROR
+
+# Silence early "setUseParentHandlers" warnings from the Log4j JUL bridge.
+org.apache.logging.log4j.jul.Log4jLogger.level=OFF


### PR DESCRIPTION
## Summary

Ports the **product-safe** parts of v8.1.7 **#782** (GH-748) onto `development` (JDK 21).

### Included
- Suppress Log4j JUL bridge / StatusLogger noise (`log4j2.component.properties`, `setenv.sh`/`.bat`, logger configs)
- Tomcat `DirResourceSet` expected-warning level
- **Metadata** `executeCategoryQuery` empty-criteria fast path (fixes invalid HQL `in(  )` when no filters)

### Intentionally **not** ported
- Forcing TLS **1.2-only** / stripping TLS 1.3 ciphers (Java 8 JSSE workaround) — would regress JDK 21 DTS TLS support

## Test plan

- [x] `./mvn-env.sh -pl deliverytiersuite/delivery-tier-suite/metadata -Dtest=PSMetadataQueryServiceTest#testCategoryQuery test`