### PR TITLE
Migrate PR #1165: audit logger tests write under target/

### DIFF
--- a/modules/jcadf-master/src/main/java/com/ibm/cadf/auditlogger/csv/CSVAuditLogger.java
+++ b/modules/jcadf-master/src/main/java/com/ibm/cadf/auditlogger/csv/CSVAuditLogger.java
@@ -32,9 +32,7 @@ public class CSVAuditLogger extends AuditLogger {
 
   private static CSVAuditLogger instance;
 
-  private CSVAuditLogger() {
-    writeFieldNames();
-  }
+  private CSVAuditLogger() {}
 
   public static CSVAuditLogger getInstance() {
 
@@ -52,6 +50,7 @@ public class CSVAuditLogger extends AuditLogger {
 
   @Override
   public void writeLog(Event auditEvent) {
+    writeFieldNames();
 
     BufferedWriter writer = null;
 

--- a/modules/jcadf-master/src/test/java/com/ibm/cadf/auditlogger/CSVAuditLoggerTest.java
+++ b/modules/jcadf-master/src/test/java/com/ibm/cadf/auditlogger/CSVAuditLoggerTest.java
@@ -46,12 +46,13 @@ public class CSVAuditLoggerTest {
   public void testCSVAuditing()
       throws CADFException, IOException, com.opencsv.exceptions.CsvException {
 
-    File file = new File(Constants.CSV_AUDIT_FILES_NAME);
+    File file = new File("target/" + Constants.CSV_AUDIT_FILES_NAME);
     if (file.exists()) {
       file.delete();
     }
 
     AuditLogger auditLogger = AuditLoggerFactory.getAuditLogger(Constants.AUDIT_FORMAT_TYPE_CSV);
+    auditLogger.setOutputFilePath("target/" + Constants.CSV_AUDIT_FILES_NAME);
 
     String initiatorId = Identifier.generateUniqueId();
     Resource initiator = new Resource(initiatorId);
@@ -94,12 +95,12 @@ public class CSVAuditLoggerTest {
 
     Assertions.assertTrue(true);
 
-    file = new File(Constants.CSV_AUDIT_FILES_NAME);
+    file = new File("target/" + Constants.CSV_AUDIT_FILES_NAME);
 
     if (file.exists()) {
 
       // create CSVReader object
-      CSVReader reader = new CSVReader(new FileReader(Constants.CSV_AUDIT_FILES_NAME));
+      CSVReader reader = new CSVReader(new FileReader("target/" + Constants.CSV_AUDIT_FILES_NAME));
 
       // read all lines at once
       List<String[]> records = reader.readAll();

--- a/modules/jcadf-master/src/test/java/com/ibm/cadf/auditlogger/JsonAuditLoggerTest.java
+++ b/modules/jcadf-master/src/test/java/com/ibm/cadf/auditlogger/JsonAuditLoggerTest.java
@@ -41,11 +41,12 @@ public class JsonAuditLoggerTest {
   @Test
   public void testJsonAuditing() throws CADFException, IOException {
 
-    File file = new File(Constants.JSON_AUDIT_FILES_NAME);
+    File file = new File("target/" + Constants.JSON_AUDIT_FILES_NAME);
     if (file.exists()) {
       file.delete();
     }
     AuditLogger auditLogger = AuditLoggerFactory.getAuditLogger(Constants.AUDIT_FORMAT_TYPE_JSON);
+    auditLogger.setOutputFilePath("target/" + Constants.JSON_AUDIT_FILES_NAME);
     String initiatorId = Identifier.generateUniqueId();
     Resource initiator = new Resource(initiatorId);
     initiator.setTypeURI("/testcase");


### PR DESCRIPTION
## Summary

Ports v8.1.7 **#1165**: CADF audit logger unit tests must not write CSV/JSON audit files into the source tree.

## Changes

- `CSVAuditLogger`: write field headers on first `writeLog`, not in the constructor
- Tests use `target/` + `setOutputFilePath`

## Test plan

- [x] `./mvn-env.sh -pl modules/jcadf-master -Dtest=CSVAuditLoggerTest,JsonAuditLoggerTest test`