### PR TITLE
Migrate PR #515: restore executable bit on extracted shell scripts

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
@@ -216,6 +216,10 @@ public class MainDTSPreInstall {
           }
           System.out.println("Creating file " + entryDest);
           Files.copy(archive.getInputStream(entry), entryDest);
+          // Preserve executable permissions for shell scripts (v8.1.7 #515 / GH-510)
+          if (entryName.endsWith(".sh")) {
+            entryDest.toFile().setExecutable(true, false);
+          }
         } catch (SecurityException se) {
           // ZipSlip attack detected - skip malicious entry
           System.out.println("Security: Rejected malicious zip entry: " + entryName);

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
@@ -218,7 +218,10 @@ public class MainDTSPreInstall {
           Files.copy(archive.getInputStream(entry), entryDest);
           // Preserve executable permissions for shell scripts (v8.1.7 #515 / GH-510)
           if (entryName.endsWith(".sh")) {
-            entryDest.toFile().setExecutable(true, false);
+            File sh = entryDest.toFile();
+            if (!sh.setExecutable(true, false)) {
+              System.out.println("Warning: could not set executable bit on " + entryDest);
+            }
           }
         } catch (SecurityException se) {
           // ZipSlip attack detected - skip malicious entry

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/rxconfig/Installer/installDts.xml
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/rxconfig/Installer/installDts.xml
@@ -102,7 +102,7 @@
 					<isset property="isLinux" />
 					<then>
 						<echo>Setting executable Permissions</echo>
-						<chmod perm="o+x" failifexecutionfails="false"
+						<chmod perm="ugo+x" failifexecutionfails="false"
 							failonerror="false" includes="**/*.sh" dir="${install.dir}" />
 					</then>
 				</if>

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
@@ -271,7 +271,10 @@ public class Main {
           Files.copy(archive.getInputStream(entry), entryDest);
           // Preserve executable permissions for shell scripts (v8.1.7 #515 / GH-510)
           if (entryName.endsWith(".sh")) {
-            entryDest.toFile().setExecutable(true, false);
+            File sh = entryDest.toFile();
+            if (!sh.setExecutable(true, false)) {
+              log.warn("Could not set executable bit on extracted script: {}", entryDest);
+            }
           }
         } catch (SecurityException se) {
           // ZipSlip or path traversal attack detected

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
@@ -269,6 +269,10 @@ public class Main {
           }
           System.out.println("Creating file " + entryDest);
           Files.copy(archive.getInputStream(entry), entryDest);
+          // Preserve executable permissions for shell scripts (v8.1.7 #515 / GH-510)
+          if (entryName.endsWith(".sh")) {
+            entryDest.toFile().setExecutable(true, false);
+          }
         } catch (SecurityException se) {
           // ZipSlip or path traversal attack detected
           log.warn("Rejected malicious zip entry: {} - {}", entryName, se.getMessage());

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/MainExtractExecutableTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/MainExtractExecutableTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.preinstall;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression for GH-510 / v8.1.7 PR #515: extracted {@code .sh} entries must be marked executable.
+ */
+class MainExtractExecutableTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void extractedShellScriptsAreExecutable() throws Exception {
+    assumeTrue(
+        !System.getProperty("os.name", "").toLowerCase().contains("win"),
+        "executable bit not meaningful on Windows");
+
+    Path zip = tempDir.resolve("dist.zip");
+    try (OutputStream fos = Files.newOutputStream(zip);
+        ZipOutputStream zos = new ZipOutputStream(fos)) {
+      zos.putNextEntry(new ZipEntry("distribution/"));
+      zos.closeEntry();
+      zos.putNextEntry(new ZipEntry("distribution/bin/hello.sh"));
+      zos.write("#!/bin/sh\necho hi\n".getBytes(StandardCharsets.UTF_8));
+      zos.closeEntry();
+      zos.putNextEntry(new ZipEntry("distribution/readme.txt"));
+      zos.write("text\n".getBytes(StandardCharsets.UTF_8));
+      zos.closeEntry();
+    }
+
+    Path dest = tempDir.resolve("out");
+    Files.createDirectories(dest);
+    Main.extractArchive(zip, dest, "distribution");
+
+    Path script = dest.resolve("bin/hello.sh");
+    assertTrue(Files.isRegularFile(script), "script extracted");
+    assertTrue(Files.isExecutable(script), "script must be executable after extract");
+  }
+}


### PR DESCRIPTION
## Summary

Ports the **executable-bit** core of v8.1.7 **#515** (GH-510). Zip-based install/extract often drops Unix mode bits; extracted \`*.sh\` must be re-marked executable.

## Changes

- \`Main.extractArchive\` / \`MainDTSPreInstall.extractArchive\`: \`setExecutable(true, false)\` for \`.sh\` entries
- \`installDts.xml\`: early chmod \`o+x\` → \`ugo+x\`
- \`MainExtractExecutableTest\` (skipped on Windows)

## Not in this PR (already on development or out of scope)

- Jetty \`StartJetty\`/\`StopJetty\` / log4j \`rxdeploydir\` (#509) — already present under \`modules/perc-jetty\`
- Broad CSRF / Jackson / package-list noise from the original #515 mega-diff

## Test plan

- [x] \`./mvn-env.sh -pl modules/perc-distribution-tree -Dtest=MainExtractExecutableTest test\`