### PR TITLE
Migrate PR #716: PSPageUtils html defaults and target=_blank selector

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/PSPageUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/PSPageUtils.java
@@ -2269,8 +2269,12 @@ public class PSPageUtils extends PSJexlUtilBase {
    * @return never <code>null</code>.
    */
   public String html(Object item, String fields, Object defaultValue) {
-    notNull(item, "item cannot be null");
-    notEmpty(fields, "field cannot be empty.");
+    // Graceful defaults for template use: null/empty item or fields must not throw
+    // (ported from v8.1.7 PR #716 release-testing fixes).
+    if (item == null || fields == null || fields.trim().isEmpty()) {
+      return defaultValue == null ? "" : StringEscapeUtils.escapeHtml4(defaultValue.toString());
+    }
+
     try {
       Node node = null;
       if (item instanceof Node) {
@@ -2281,10 +2285,14 @@ public class PSPageUtils extends PSJexlUtilBase {
         node = ((PSRenderAsset) item).getNode();
       } else if (item instanceof Map<?, ?>) {
         NameAndValue nv = getProperty((Map<?, ?>) item, fields);
-        if (nv == null && defaultValue == null) {
-          handleNoFieldFound(item, fields);
+        if (nv == null) {
+          if (defaultValue == null) {
+            handleNoFieldFound(item, fields);
+          } else {
+            return StringEscapeUtils.escapeHtml4(defaultValue.toString());
+          }
         }
-        return nv == null ? null : StringEscapeUtils.escapeHtml4(nv.value);
+        return StringEscapeUtils.escapeHtml4(nv.value);
       } else {
         throw new IllegalArgumentException("Item must be either a map, assembly item, or node");
       }

--- a/projects/sitemanage/src/main/java/com/percussion/patch/PSSaveAssetsMaintenanceProcess.java
+++ b/projects/sitemanage/src/main/java/com/percussion/patch/PSSaveAssetsMaintenanceProcess.java
@@ -458,11 +458,14 @@ public class PSSaveAssetsMaintenanceProcess
                 + ":not(img["
                 + IPSManagedLinkService.PERC_LINKID_ATTR
                 + "])");
+    // get all anchor links with an href attr and target="_blank" but without the rel attr.
+    // A_HREF is already "a[href]", so append attribute filters only (not another "a[...]").
+    // Fix ported from v8.1.7 PR #716.
     var targetAnchors =
         doc.select(
             IPSManagedLinkService.A_HREF
-                + "a[target=\"_blank\"]"
-                + ":not(a[rel=\"noopener noreferrer\"])");
+                + "[target=\"_blank\"]"
+                + ":not([rel=\"noopener noreferrer\"])");
     if (anchors.isEmpty() && imgs.isEmpty() && targetAnchors.isEmpty()) {
       hasUnmanagedLinks = false;
     } else {

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/assembler/PSPageUtilsHtmlTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/assembler/PSPageUtilsHtmlTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.assembler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral unit tests for {@link PSPageUtils#html(Object, String, Object)}.
+ *
+ * <p>Covers graceful default handling for null/empty item or fields and Map-path missing property
+ * defaults. Ported product fix from v8.1.7 PR #716 (Bugfix/8.1.7 release testing).
+ */
+class PSPageUtilsHtmlTest {
+
+  private PSPageUtils utils;
+
+  @BeforeEach
+  void setUp() {
+    utils = new PSPageUtils();
+  }
+
+  @Test
+  void nullItemWithDefaultReturnsEscapedDefault() {
+    assertEquals("fallback", utils.html(null, "title", "fallback"));
+  }
+
+  @Test
+  void nullItemWithNullDefaultReturnsEmptyString() {
+    assertEquals("", utils.html(null, "title", null));
+  }
+
+  @Test
+  void nullFieldsWithDefaultReturnsEscapedDefault() {
+    Map<String, String> item = Map.of("title", "Hello");
+    assertEquals("fallback", utils.html(item, null, "fallback"));
+  }
+
+  @Test
+  void emptyFieldsWithDefaultReturnsEscapedDefault() {
+    Map<String, String> item = Map.of("title", "Hello");
+    assertEquals("fallback", utils.html(item, "", "fallback"));
+    assertEquals("fallback", utils.html(item, "   ", "fallback"));
+  }
+
+  @Test
+  void emptyFieldsWithNullDefaultReturnsEmptyString() {
+    Map<String, String> item = Map.of("title", "Hello");
+    assertEquals("", utils.html(item, "", null));
+  }
+
+  @Test
+  void nullItemAndFieldsDoNotThrow() {
+    assertDoesNotThrow(() -> utils.html(null, null, "x"));
+    assertDoesNotThrow(() -> utils.html(null, null, null));
+    assertDoesNotThrow(() -> utils.html(null, "", "x"));
+  }
+
+  @Test
+  void mapMissingPropertyWithDefaultReturnsEscapedDefault() {
+    Map<String, String> item = new HashMap<>();
+    item.put("other", "value");
+    assertEquals("default-val", utils.html(item, "missing", "default-val"));
+  }
+
+  @Test
+  void mapMissingPropertyWithDefaultEscapesHtml() {
+    Map<String, String> item = Map.of("other", "value");
+    assertEquals(
+        "&lt;b&gt;safe&lt;/b&gt;", utils.html(item, "missing", "<b>safe</b>"));
+  }
+
+  @Test
+  void mapPresentPropertyReturnsEscapedValue() {
+    Map<String, String> item = Map.of("title", "Hello & World");
+    assertEquals("Hello &amp; World", utils.html(item, "title", "unused-default"));
+  }
+
+  @Test
+  void mapMissingPropertyWithNullDefaultReturnsEmptyWithoutThrowing() {
+    // handleNoFieldFound throws RepositoryException; outer catch returns ""
+    Map<String, String> item = Map.of("other", "value");
+    assertEquals("", assertDoesNotThrow(() -> utils.html(item, "missing", null)));
+  }
+
+  @Test
+  void mapCommaSeparatedFieldsUsesFirstPresent() {
+    Map<String, String> item = Map.of("b", "second");
+    assertEquals("second", utils.html(item, "a,b,c", "default"));
+  }
+
+  @Test
+  void twoArgHtmlDelegatesAndHandlesNullItem() {
+    // two-arg form uses null default → empty string for null item
+    assertEquals("", utils.html(null, "title"));
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/patch/test/PSSaveAssetsMainetanceProcessUT.java
+++ b/projects/sitemanage/src/test/java/com/percussion/patch/test/PSSaveAssetsMainetanceProcessUT.java
@@ -20,37 +20,62 @@
 package com.percussion.patch.test;
 
 import static com.percussion.test.TestAssertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.percussion.linkmanagement.service.IPSManagedLinkService;
 import org.jsoup.Jsoup;
+import org.jsoup.select.Selector;
 import org.junit.jupiter.api.Test;
 
 /**
- * Unit test for verifying anchor tag rel attributes for managed links. Sunny Sal says: "Testing
- * links is like checking pizza toppings—don't let anything suspicious slip through!"
+ * Unit test for verifying anchor tag rel attributes for managed links.
+ *
+ * <p>Selector construction must append attribute filters to {@link
+ * IPSManagedLinkService#A_HREF} ({@code "a[href]"}), not another {@code a[...]} segment. Broken
+ * concatenation {@code a[href]a[target=...]} is not a valid jsoup query. Fix ported from v8.1.7
+ * PR #716.
  */
 public class PSSaveAssetsMainetanceProcessUT {
+
+  /**
+   * Selector used by {@code PSSaveAssetsMaintenanceProcess#processLinks} for target=_blank
+   * anchors missing the safe rel attribute. Kept in lockstep with production code.
+   */
+  static final String TARGET_BLANK_UNSAFE_REL_SELECTOR =
+      IPSManagedLinkService.A_HREF
+          + "[target=\"_blank\"]"
+          + ":not([rel=\"noopener noreferrer\"])";
 
   @Test
   void testTarget() {
     var doc = Jsoup.parseBodyFragment("<p>This is <a href=\"#\" target=\"_blank\"/>");
-    var targetAnchors =
-        doc.select(
-            IPSManagedLinkService.A_HREF
-                + "a[target=\"_blank\"]"
-                + ":not(a[rel=\"noopener noreferrer\"])");
+    var targetAnchors = doc.select(TARGET_BLANK_UNSAFE_REL_SELECTOR);
 
     assertFalse(targetAnchors.isEmpty());
 
     doc =
         Jsoup.parseBodyFragment(
             "<p>This is <a href=\"#\" target=\"_blank\" rel=\"noopener noreferrer\" />");
-    targetAnchors =
-        doc.select(
-            IPSManagedLinkService.A_HREF
-                + "a[target=\"_blank\"]"
-                + ":not(a[rel=\"noopener noreferrer\"])");
+    targetAnchors = doc.select(TARGET_BLANK_UNSAFE_REL_SELECTOR);
 
     assertTrue(targetAnchors.isEmpty());
+  }
+
+  @Test
+  void brokenConcatenatedSelectorIsInvalid() {
+    // Regression: old code used A_HREF + "a[target=...]" producing "a[href]a[target=...]"
+    // which jsoup rejects (SelectorParseException) rather than matching anchors.
+    var broken =
+        IPSManagedLinkService.A_HREF
+            + "a[target=\"_blank\"]"
+            + ":not(a[rel=\"noopener noreferrer\"])";
+    var doc = Jsoup.parseBodyFragment("<p><a href=\"#\" target=\"_blank\">x</a></p>");
+    assertThrows(
+        Selector.SelectorParseException.class,
+        () -> doc.select(broken),
+        "Broken concatenated selector must not be a valid jsoup query");
+    assertFalse(
+        doc.select(TARGET_BLANK_UNSAFE_REL_SELECTOR).isEmpty(),
+        "Correct selector must match target=_blank anchors without safe rel");
   }
 }


### PR DESCRIPTION
## Summary

Ports the **product-relevant** fixes from v8.1.7 [#716](https://github.com/intersoftdatalabs-in/percussioncms/pull/716) (release testing mega-PR). Spec 005 migration backlog.

### Changes

1. **`PSPageUtils.html(item, fields, defaultValue)`** — null/empty item or fields return escaped default (or `""`) instead of hard `Validate.notNull`/`notEmpty`. Map missing-property path returns escaped default when provided (previously could return `null`).
2. **`PSSaveAssetsMaintenanceProcess.processLinks`** — fix broken jsoup selector: `a[href]a[target=_blank]` → `a[href][target=_blank]:not([rel=noopener noreferrer])`. Old form throws `SelectorParseException` on current jsoup.

### Tests

- New `PSPageUtilsHtmlTest` (12 cases)
- Updated `PSSaveAssetsMainetanceProcessUT` (selector + broken-selector regression)
- `./mvn-env.sh -pl projects/sitemanage -Dtest=PSPageUtilsHtmlTest,PSSaveAssetsMainetanceProcessUT test` — 14/14 green

### Out of scope (intentionally not ported)

- Jackson `FAIL_ON_UNKNOWN_PROPERTIES` flip
- PSScript JexlPermissions
- QA automation / AGENTS.md / .idea / package-lock
- Title widget package bumps

### Review

Erlang pre-PR review: **approve** (`tmp/reviews/005-migrate-716-pageutils-assets.md`)

## Test plan

- [x] Focused unit tests green
- [ ] CI on PR