### PR TITLE
Migrate PR #491: JEXL hardening and script engine compatibility

### DIFF
--- a/modules/utils/src/main/java/com/percussion/utils/jexl/PSScript.java
+++ b/modules/utils/src/main/java/com/percussion/utils/jexl/PSScript.java
@@ -52,8 +52,13 @@ public class PSScript implements IPSScript {
   // Control JEXL debug
   private static boolean jexlUseDebug = false;
 
-  // Explicit feature toggles for backward-compatibility control (legacy defaults: off)
+  /**
+   * Optional JexlFeatures toggles (legacy defaults: off). Loaded from server.properties only when
+   * {@link #reinit(boolean)} is called with {@code reloadOptionsFromConfig=true}; there is no
+   * automatic startup reload today (same as jexlUseStrict/silent/debug/cache).
+   */
   private static boolean jexlLexical = false;
+
   private static boolean jexlLexicalShade = false;
   private static boolean jexlConstCapture = false;
 

--- a/modules/utils/src/main/java/com/percussion/utils/jexl/PSScript.java
+++ b/modules/utils/src/main/java/com/percussion/utils/jexl/PSScript.java
@@ -27,8 +27,10 @@ import org.apache.commons.jexl3.JexlBuilder;
 import org.apache.commons.jexl3.JexlContext;
 import org.apache.commons.jexl3.JexlEngine;
 import org.apache.commons.jexl3.JexlException;
+import org.apache.commons.jexl3.JexlFeatures;
 import org.apache.commons.jexl3.JexlScript;
 import org.apache.commons.jexl3.MapContext;
+import org.apache.commons.jexl3.introspection.JexlPermissions;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -50,10 +52,19 @@ public class PSScript implements IPSScript {
   // Control JEXL debug
   private static boolean jexlUseDebug = false;
 
+  // Explicit feature toggles for backward-compatibility control (legacy defaults: off)
+  private static boolean jexlLexical = false;
+  private static boolean jexlLexicalShade = false;
+  private static boolean jexlConstCapture = false;
+
   private boolean compilable = false;
 
-  private JexlScript compiledScript = null;
-  private String fixedScriptText = null;
+  /** Compiled script; volatile for safe publication under concurrent first eval. */
+  private volatile JexlScript compiledScript = null;
+
+  /** Script text after legacy syntax fixes; volatile for concurrent first compile. */
+  private volatile String fixedScriptText = null;
+
   // Per-instance JEXL mode flags to avoid cross-test/global state pollution
   private boolean useStrictMode = jexlUseStrict;
   private boolean useDebugMode = jexlUseDebug;
@@ -126,46 +137,92 @@ public class PSScript implements IPSScript {
   public Object eval(Map<String, Object> bindingsMap) throws JexlException {
     JexlContext context = new MapContext(bindingsMap);
 
-    if (compiledScript == null) {
-      this.fixedScriptText = JexlScriptFixes.fixScript(scriptText, ownerType, ownerName);
+    try {
+      // Double-checked locking: safe publication of compiled script under concurrent first eval
+      JexlScript local = compiledScript;
+      if (local == null) {
+        synchronized (this) {
+          local = compiledScript;
+          if (local == null) {
+            if (fixedScriptText == null) {
+              this.fixedScriptText = JexlScriptFixes.fixScript(scriptText, ownerType, ownerName);
+            }
 
-      // Use the shared engine if instance flags match defaults; otherwise create an
-      // engine configured for this instance so mode changes don't affect other instances/tests.
-      if (useStrictMode == jexlUseStrict
-          && useDebugMode == jexlUseDebug
-          && useSilentMode == jexlUseSilent) {
-        compiledScript = EngineSingletonHolder.DEFAULT_ENGINE.createScript(this.fixedScriptText);
+            // Use the shared engine if instance flags match defaults; otherwise create an
+            // engine configured for this instance so mode changes don't affect other
+            // instances/tests.
+            if (useStrictMode == jexlUseStrict
+                && useDebugMode == jexlUseDebug
+                && useSilentMode == jexlUseSilent) {
+              local = EngineSingletonHolder.DEFAULT_ENGINE.createScript(this.fixedScriptText);
+            } else {
+              JexlEngine engine =
+                  newBuilder(useStrictMode, useSilentMode, useDebugMode).create();
+              local = engine.createScript(this.fixedScriptText);
+            }
+            compiledScript = local;
+          }
+        }
+      }
+
+      if (ownerName == null) {
+        this.ownerName = "";
       } else {
-        JexlEngine engine =
-            new JexlBuilder()
-                .strict(useStrictMode)
-                .silent(useSilentMode)
-                .debug(useDebugMode)
-                .logger(LOG)
-                .cache(CACHE_SIZE)
-                .create();
-        compiledScript = engine.createScript(this.fixedScriptText);
+        this.ownerName = ownerName.trim();
       }
-    }
-    if (ownerName == null) {
-      this.ownerName = "";
-    } else {
+
+      Object result = local.execute(context);
+
+      // Enforce strict-mode behavior: if strict is enabled and silent is disabled,
+      // a top-level $ expression that evaluates to null should throw an exception
+      // (matches legacy expectations/tests).
+      if (useStrictMode && !useSilentMode) {
+        String src = this.fixedScriptText != null ? this.fixedScriptText : this.scriptText;
+        if (src != null && src.trim().startsWith("$") && result == null) {
+          throw new RuntimeException("JEXL evaluation returned null in strict mode for: " + src);
+        }
+      }
       this.ownerName = ownerName.trim();
-    }
-
-    Object result = compiledScript.execute(context);
-
-    // Enforce strict-mode behavior: if strict is enabled and silent is disabled,
-    // a top-level $ expression that evaluates to null should throw an exception
-    // (matches legacy expectations/tests).
-    if (useStrictMode && !useSilentMode) {
-      String src = this.fixedScriptText != null ? this.fixedScriptText : this.scriptText;
-      if (src != null && src.trim().startsWith("$") && result == null) {
-        throw new RuntimeException("JEXL evaluation returned null in strict mode for: " + src);
+      return result;
+    } catch (JexlException x) {
+      // Add owner context for faster diagnosis while preserving original exception type
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(
+            "JEXL error in script. Type: "
+                + ownerType
+                + " Name: "
+                + ownerName
+                + " Script: "
+                + scriptText);
       }
+      throw x;
     }
-    this.ownerName = ownerName.trim();
-    return result;
+  }
+
+  /**
+   * Builds a {@link JexlBuilder} with product defaults: unrestricted permissions (JEXL 2.x / legacy
+   * 3.x compatibility), safe navigation when not strict, and optional lexical feature flags from
+   * server.properties.
+   *
+   * @param strict whether strict mode is enabled
+   * @param silent whether silent mode is enabled
+   * @param debug whether debug mode is enabled
+   * @return a configured builder (not yet created)
+   */
+  private static JexlBuilder newBuilder(boolean strict, boolean silent, boolean debug) {
+    return new JexlBuilder()
+        .strict(strict)
+        .safe(!strict)
+        .silent(silent)
+        .permissions(JexlPermissions.UNRESTRICTED)
+        .debug(debug)
+        .logger(LOG)
+        .cache(CACHE_SIZE)
+        .features(
+            new JexlFeatures()
+                .lexical(jexlLexical)
+                .lexicalShade(jexlLexicalShade)
+                .constCapture(jexlConstCapture));
   }
 
   @Override
@@ -220,13 +277,7 @@ public class PSScript implements IPSScript {
 
     /** The JEXL engine singleton instance. */
     private static JexlEngine DEFAULT_ENGINE =
-        new JexlBuilder()
-            .strict(jexlUseStrict)
-            .silent(jexlUseSilent)
-            .debug(jexlUseDebug)
-            .logger(LOG)
-            .cache(CACHE_SIZE)
-            .create();
+        newBuilder(jexlUseStrict, jexlUseSilent, jexlUseDebug).create();
 
     private static void initConfig() {
       DefaultConfigurationContextImpl config =
@@ -257,6 +308,11 @@ public class PSScript implements IPSScript {
         jexlUseDebug = Boolean.parseBoolean(props.getProperty("jexlUseDebug", "false"));
 
         CACHE_SIZE = Integer.parseInt(props.getProperty("jexlCacheSize", "512"));
+
+        // Feature flags default to false for legacy semantics; can be enabled via config
+        jexlLexical = Boolean.parseBoolean(props.getProperty("jexlLexical", "false"));
+        jexlLexicalShade = Boolean.parseBoolean(props.getProperty("jexlLexicalShade", "false"));
+        jexlConstCapture = Boolean.parseBoolean(props.getProperty("jexlConstCapture", "false"));
       }
     }
 
@@ -266,14 +322,7 @@ public class PSScript implements IPSScript {
 
       if (DEFAULT_ENGINE != null) DEFAULT_ENGINE.clearCache();
 
-      DEFAULT_ENGINE =
-          new JexlBuilder()
-              .strict(jexlUseStrict)
-              .silent(jexlUseSilent)
-              .debug(jexlUseDebug)
-              .logger(LOG)
-              .cache(CACHE_SIZE)
-              .create();
+      DEFAULT_ENGINE = newBuilder(jexlUseStrict, jexlUseSilent, jexlUseDebug).create();
     }
   }
 

--- a/modules/utils/src/test/java/com/percussion/utils/jexl/PSScriptTest.java
+++ b/modules/utils/src/test/java/com/percussion/utils/jexl/PSScriptTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2023 Percussion Software, Inc.
+ * Copyright 1999-2025 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,7 +16,9 @@
 package com.percussion.utils.jexl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
@@ -25,6 +27,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.jexl3.JexlBuilder;
+import org.apache.commons.jexl3.JexlEngine;
+import org.apache.commons.jexl3.MapContext;
+import org.apache.commons.jexl3.introspection.JexlPermissions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,6 +42,21 @@ import org.junit.jupiter.api.Test;
  * @author percussion
  */
 public class PSScriptTest {
+
+  /**
+   * Product-like domain type outside JEXL 3.x RESTRICTED allowlists ({@code java.lang.*}, {@code
+   * java.util.*}, etc.). Methods on this type succeed only when the engine uses {@link
+   * JexlPermissions#UNRESTRICTED} (or an equivalent custom allowlist).
+   */
+  public static class DomainWidget {
+    public String echo(String value) {
+      return value;
+    }
+
+    public String getToken() {
+      return "widget-token";
+    }
+  }
 
   @BeforeEach
   public void setUp() {
@@ -602,11 +623,54 @@ public class PSScriptTest {
   }
 
   /**
-   * Unrestricted permissions must allow legacy method patterns that restricted JEXL 3.x defaults
-   * can block (product scripts invoke ordinary Java methods on domain objects).
+   * Core hardening proof: product domain types are outside JEXL RESTRICTED allowlists. {@link
+   * PSScript} must use {@link JexlPermissions#UNRESTRICTED} so CMS template/widget scripts can call
+   * ordinary methods on domain objects (as they did under JEXL 2.x / early 3.x).
+   *
+   * <p>Control: the same script against a RESTRICTED engine does not return the domain result
+   * (returns null under non-strict silent-ish evaluation). If {@code UNRESTRICTED} were dropped
+   * from {@code PSScript}, this test would fail.
    */
   @Test
-  public void testUnrestrictedPermissionsAllowMethodCalls() {
+  public void testUnrestrictedPermissionsAllowDomainTypeMethods() {
+    DomainWidget widget = new DomainWidget();
+    Map<String, Object> bindings = new HashMap<>();
+    bindings.put("$widget", widget);
+
+    PSScript echoScript = new PSScript("$widget.echo('ok')");
+    assertEquals(
+        "ok",
+        echoScript.eval(bindings),
+        "Domain method echo must work under PSScript (UNRESTRICTED)");
+
+    PSScript tokenScript = new PSScript("$widget.getToken()");
+    assertEquals(
+        "widget-token",
+        tokenScript.eval(bindings),
+        "Domain method getToken must work under PSScript (UNRESTRICTED)");
+
+    // Control: RESTRICTED blocks non-allowlisted domain types (returns null, not the method result)
+    JexlEngine restricted =
+        new JexlBuilder()
+            .permissions(JexlPermissions.RESTRICTED)
+            .strict(false)
+            .safe(true)
+            .create();
+    MapContext restrictedCtx = new MapContext(bindings);
+    Object restrictedResult =
+        restricted.createScript("$widget.echo('ok')").execute(restrictedCtx);
+    assertNotEquals(
+        "ok",
+        restrictedResult,
+        "RESTRICTED must not expose DomainWidget methods — proves the UNRESTRICTED requirement");
+  }
+
+  /**
+   * JDK types remain usable (sanity for common template patterns). Alone these do not prove
+   * UNRESTRICTED; see {@link #testUnrestrictedPermissionsAllowDomainTypeMethods()}.
+   */
+  @Test
+  public void testJdkMethodCallsStillWork() {
     Map<String, Object> bindings = new HashMap<>();
     bindings.put("$text", "percussion");
     bindings.put("$list", new java.util.ArrayList<>(java.util.Arrays.asList("a", "b", "c")));
@@ -614,19 +678,13 @@ public class PSScriptTest {
     PSScript lengthScript = new PSScript("$text.length()");
     assertEquals(10, lengthScript.eval(bindings), "String.length should be allowed");
 
-    PSScript substringScript = new PSScript("$text.substring(0, 4)");
-    assertEquals("perc", substringScript.eval(bindings), "String.substring should be allowed");
-
     PSScript sizeScript = new PSScript("$list.size()");
     assertEquals(3, sizeScript.eval(bindings), "List.size should be allowed");
-
-    PSScript getScript = new PSScript("$list.get(1)");
-    assertEquals("b", getScript.eval(bindings), "List.get should be allowed");
   }
 
   /**
    * When strict is off, safe navigation should return null for missing intermediate properties
-   * rather than throwing (legacy template behavior).
+   * rather than throwing (legacy template behavior; {@code .safe(true)} when not strict).
    */
   @Test
   public void testSafeModeNullPropertyNavigation() {
@@ -638,6 +696,28 @@ public class PSScriptTest {
 
     Object result = ps.eval(bindings);
     assertEquals(null, result, "Null intermediate property should yield null when not strict/safe");
+  }
+
+  /**
+   * When strict is on, {@code .safe(false)} is wired: null intermediate property navigation must
+   * fail rather than return null. Uses per-instance mode so a dedicated engine is built with
+   * strict=true.
+   */
+  @Test
+  public void testStrictModeRejectsNullPropertyNavigation() {
+    PSScript ps = new PSScript("$obj.missing.prop");
+    ps.setUseStrictMode(true);
+    ps.setUseSilentMode(false);
+
+    Map<String, Object> bindings = new HashMap<>();
+    bindings.put("$obj", new HashMap<String, Object>());
+
+    // PSScript also throws RuntimeException for top-level $expr that returns null in strict mode;
+    // either JexlException or that wrapper proves safe/strict pairing is active.
+    assertThrows(
+        RuntimeException.class,
+        () -> ps.eval(bindings),
+        "Strict mode with safe=false must not silently return null for missing intermediate props");
   }
 
   /**
@@ -653,17 +733,23 @@ public class PSScriptTest {
     assertTrue(result instanceof java.util.ArrayList, "Result should be an ArrayList instance");
   }
 
-  /** Per-instance engine path (strict differs from global default) must also use unrestricted perms. */
+  /**
+   * Per-instance engine path (modes diverge from global defaults) must also use UNRESTRICTED so
+   * domain methods work — not only JDK String methods.
+   */
   @Test
-  public void testPerInstanceEngineAllowsMethodCalls() {
-    PSScript ps = new PSScript("$obj.toUpperCase()");
-    // Force per-instance builder (defaults are non-strict; enable silent to diverge further)
+  public void testPerInstanceEngineAllowsDomainTypeMethods() {
+    PSScript ps = new PSScript("$widget.echo('per-instance')");
+    // Force per-instance builder (defaults are non-strict; enable silent to diverge)
     ps.setUseSilentMode(true);
 
     Map<String, Object> bindings = new HashMap<>();
-    bindings.put("$obj", "hello");
+    bindings.put("$widget", new DomainWidget());
 
     Object result = ps.eval(bindings);
-    assertEquals("HELLO", result, "Per-instance engine must allow method invocation");
+    assertEquals(
+        "per-instance",
+        result,
+        "Per-instance engine must allow domain method invocation via UNRESTRICTED");
   }
 }

--- a/modules/utils/src/test/java/com/percussion/utils/jexl/PSScriptTest.java
+++ b/modules/utils/src/test/java/com/percussion/utils/jexl/PSScriptTest.java
@@ -554,4 +554,116 @@ public class PSScriptTest {
     PSScript script4 = new PSScript("empty $notEmpty");
     assertEquals(false, script4.eval(bindings), "Non-empty string should not be empty");
   }
+
+  /**
+   * Concurrent first-compile smoke: many threads hit an uncompiled instance together. Double-checked
+   * locking must publish a single usable compiled script without races.
+   */
+  @Test
+  public void testConcurrentFirstCompile() throws Exception {
+    String script = "$x + 1";
+    PSScript ps = new PSScript(script);
+
+    int threadCount = 16;
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch start = new CountDownLatch(1);
+    CountDownLatch done = new CountDownLatch(threadCount);
+    java.util.concurrent.atomic.AtomicReference<Throwable> error =
+        new java.util.concurrent.atomic.AtomicReference<>();
+
+    for (int i = 0; i < threadCount; i++) {
+      final int threadId = i;
+      executor.submit(
+          () -> {
+            try {
+              start.await();
+              Map<String, Object> bindings = new HashMap<>();
+              bindings.put("$x", threadId);
+              Object result = ps.eval(bindings);
+              assertEquals(threadId + 1, result, "Concurrent first compile must eval correctly");
+            } catch (Throwable t) {
+              error.compareAndSet(null, t);
+            } finally {
+              done.countDown();
+            }
+          });
+    }
+
+    start.countDown();
+    assertTrue(done.await(15, TimeUnit.SECONDS), "All concurrent first-compile threads should finish");
+    executor.shutdownNow();
+    if (error.get() != null) {
+      throw new AssertionError("Concurrent first compile failed", error.get());
+    }
+
+    java.lang.reflect.Field compiledScriptField = PSScript.class.getDeclaredField("compiledScript");
+    compiledScriptField.setAccessible(true);
+    assertNotNull(compiledScriptField.get(ps), "Compiled script should be published after concurrent eval");
+  }
+
+  /**
+   * Unrestricted permissions must allow legacy method patterns that restricted JEXL 3.x defaults
+   * can block (product scripts invoke ordinary Java methods on domain objects).
+   */
+  @Test
+  public void testUnrestrictedPermissionsAllowMethodCalls() {
+    Map<String, Object> bindings = new HashMap<>();
+    bindings.put("$text", "percussion");
+    bindings.put("$list", new java.util.ArrayList<>(java.util.Arrays.asList("a", "b", "c")));
+
+    PSScript lengthScript = new PSScript("$text.length()");
+    assertEquals(10, lengthScript.eval(bindings), "String.length should be allowed");
+
+    PSScript substringScript = new PSScript("$text.substring(0, 4)");
+    assertEquals("perc", substringScript.eval(bindings), "String.substring should be allowed");
+
+    PSScript sizeScript = new PSScript("$list.size()");
+    assertEquals(3, sizeScript.eval(bindings), "List.size should be allowed");
+
+    PSScript getScript = new PSScript("$list.get(1)");
+    assertEquals("b", getScript.eval(bindings), "List.get should be allowed");
+  }
+
+  /**
+   * When strict is off, safe navigation should return null for missing intermediate properties
+   * rather than throwing (legacy template behavior).
+   */
+  @Test
+  public void testSafeModeNullPropertyNavigation() {
+    PSScript ps = new PSScript("$obj.missing.prop");
+    ps.setUseStrictMode(false);
+
+    Map<String, Object> bindings = new HashMap<>();
+    bindings.put("$obj", new HashMap<String, Object>());
+
+    Object result = ps.eval(bindings);
+    assertEquals(null, result, "Null intermediate property should yield null when not strict/safe");
+  }
+
+  /**
+   * new(...) construction used by some legacy extension scripts must remain available under
+   * unrestricted permissions.
+   */
+  @Test
+  public void testNewInstanceConstructionAllowed() {
+    PSScript ps = new PSScript("new('java.util.ArrayList')");
+    Map<String, Object> bindings = new HashMap<>();
+    Object result = ps.eval(bindings);
+    assertNotNull(result, "new(ArrayList) should succeed with unrestricted permissions");
+    assertTrue(result instanceof java.util.ArrayList, "Result should be an ArrayList instance");
+  }
+
+  /** Per-instance engine path (strict differs from global default) must also use unrestricted perms. */
+  @Test
+  public void testPerInstanceEngineAllowsMethodCalls() {
+    PSScript ps = new PSScript("$obj.toUpperCase()");
+    // Force per-instance builder (defaults are non-strict; enable silent to diverge further)
+    ps.setUseSilentMode(true);
+
+    Map<String, Object> bindings = new HashMap<>();
+    bindings.put("$obj", "hello");
+
+    Object result = ps.eval(bindings);
+    assertEquals("HELLO", result, "Per-instance engine must allow method invocation");
+  }
 }


### PR DESCRIPTION
## Summary

Ports **JEXL product hardening** from v8.1.7 [#491](https://github.com/intersoftdatalabs-in/percussioncms/pull/491) (plus [#716](https://github.com/intersoftdatalabs-in/percussioncms/pull/716) permissions bits). Spec 005 migration backlog.

### Changes (`modules/utils` … `PSScript`)

- Thread-safe first compile (`volatile` + double-checked locking)
- Shared `JexlBuilder` helper: `JexlPermissions.UNRESTRICTED`, `.safe(!strict)`, legacy-off `JexlFeatures` (lexical / lexicalShade / constCapture)
- Optional `server.properties` feature toggles (loaded on `reinit(true)`)
- Debug logging of owner type/name on `JexlException`

### Intentionally not ported

- myfaces 1.8 downgrade (development is Jakarta / myfaces 4.1.2)
- Deployer jexl visitor / `PSMenuItemTag` (already modernized on development)
- README / copilot-instructions noise

### Tests

- Extended `PSScriptTest` including **domain type outside RESTRICTED allowlists** + RESTRICTED control + concurrent compile + strict null navigation
- `./mvn-env.sh -pl modules/utils -Dtest=PSScriptTest,PSJexlEvaluatorTest,JexlScriptFixesTest test` — 42/42 green

### Review

Erlang pre-PR review: **approve** after fix round (`tmp/reviews/005-migrate-491-jexl-hardening.md`)

## Test plan

- [x] Focused unit tests green
- [ ] CI on PR