### PR TITLE
Migrate PR #107: wire Semargl RDFa parser and entity/script regression test

### DIFF
--- a/system/pom.xml
+++ b/system/pom.xml
@@ -250,15 +250,32 @@
 			<artifactId>jakarta.mail</artifactId>
 			<version>1.6.8</version>
 		</dependency>
+		<!--
+		  RDF4J 4.x (not 5.x): Semargl 0.7 RDFa parser SPI is binary-incompatible with
+		  RDF4J 5 (RDFaParserSettings field types → NoSuchFieldError). 4.3.16 keeps the
+		  RioSetting types Semargl expects. Required for PSMetadataExtractorService
+		  (any23 → rdfa migration from v8.1.7 PR #107).
+		-->
 		<dependency>
 			<groupId>org.eclipse.rdf4j</groupId>
 			<artifactId>rdf4j-rio-api</artifactId>
-			<version>5.0.2</version>
+			<version>4.3.16</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.rdf4j</groupId>
 			<artifactId>rdf4j-model-api</artifactId>
-			<version>5.0.2</version>
+			<version>4.3.16</version>
+		</dependency>
+		<!-- Registers RDFFormat.RDFA via META-INF/services RDFParserFactory -->
+		<dependency>
+			<groupId>org.semarglproject</groupId>
+			<artifactId>semargl-rdfa</artifactId>
+			<version>0.7</version>
+		</dependency>
+		<dependency>
+			<groupId>org.semarglproject</groupId>
+			<artifactId>semargl-rdf4j</artifactId>
+			<version>0.7</version>
 		</dependency>
 		<dependency>
 			<groupId>io.swagger.core.v3</groupId>

--- a/system/src/test/java/com/percussion/delivery/PSMetadataExtractorServiceTests.java
+++ b/system/src/test/java/com/percussion/delivery/PSMetadataExtractorServiceTests.java
@@ -18,6 +18,7 @@
 package com.percussion.delivery;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.percussion.delivery.metadata.IPSMetadataProperty;
@@ -133,6 +134,59 @@ public class PSMetadataExtractorServiceTests {
               + "</div>",
           map.get("dcterms:abstract"));
       assertEquals("article", map.get("og:type"));
+    }
+  }
+
+  /**
+   * Regression for HTML entity decoding and script stripping in the RDFa metadata extractor
+   * (v8.1.7 PR #107 / DTS platform track residue).
+   *
+   * <p>Fixture {@code /com/percussion/delivery/entity-test.html} includes encoded entities in meta
+   * content and body abstract, plus {@code <script>} / JSON-LD that must not pollute extracted
+   * properties.
+   */
+  @Test
+  public void testEntityAndScriptHandling() throws IOException {
+    InputStream is =
+        PSMetadataExtractorServiceTests.class.getResourceAsStream(
+            "/com/percussion/delivery/entity-test.html");
+    assertNotNull(is, "entity-test.html fixture must be on the test classpath");
+
+    try (InputStreamReader inputStreamReader = new InputStreamReader(is)) {
+      PSMetadataExtractorService svc = new PSMetadataExtractorService();
+      PSMetadataEntry entry =
+          svc.process(inputStreamReader, "text/html", "/Sites/test/entity-test.html", null);
+
+      assertNotNull(entry);
+      HashMap<String, String> map = new HashMap<>();
+      for (IPSMetadataProperty prop : entry.getProperties()) {
+        map.put(prop.getName(), prop.getValue());
+      }
+
+      // Title meta uses &amp; which should be decoded to a bare ampersand
+      assertEquals("Comprehensive Test Title & More", map.get("dcterms:title"));
+
+      String description = map.get("dcterms:description");
+      assertNotNull(description, "dcterms:description should be extracted");
+
+      String abstractText = map.get("dcterms:abstract");
+      assertNotNull(abstractText, "dcterms:abstract should be extracted");
+
+      // Script bodies (including JSON-LD and inline JS) must not appear in property values
+      for (String value : map.values()) {
+        if (value == null) {
+          continue;
+        }
+        assertFalse(
+            value.contains("console.log"),
+            "script text must be stripped from metadata properties: " + value);
+        assertFalse(
+            value.contains("@context"),
+            "JSON-LD script must be stripped from metadata properties: " + value);
+        assertFalse(
+            value.contains("var x = 10"),
+            "inline script must be stripped from metadata properties: " + value);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

DTS **platform track** residue from v8.1.7 [#107](https://github.com/intersoftdatalabs-in/percussioncms/pull/107) (with triage of sibling [#504](https://github.com/intersoftdatalabs-in/percussioncms/pull/504) / [#138](https://github.com/intersoftdatalabs-in/percussioncms/pull/138)). Spec 005.

### Why this PR

`PSMetadataExtractorService` already calls `Rio.createParser(RDFFormat.RDFA)` after the any23 → RDFa migration, but:

1. **Semargl** (the RDFa parser SPI) was **not** on the `perc-system` classpath
2. **RDF4J 5.x** is binary-incompatible with Semargl **0.7** (`RDFaParserSettings` field types → `NoSuchFieldError`)

### Changes

- Pin `rdf4j-rio-api` / `rdf4j-model-api` to **4.3.16**
- Add `semargl-rdfa` + `semargl-rdf4j` **0.7**
- Add `testEntityAndScriptHandling` (entity decode + script non-leak)

### Sibling PR disposition (no further product ports)

| Source | Disposition |
|-------:|-------------|
| #504 | already-present / N/A (ICU downgrade must **not** apply; xml-apis managed; audit tests via #1277) |
| #138 | already-present / N/A (DTS version table superseded by Tomcat 11 / Spring 7 stack; ImageReaderTest already fixed) |
| #107 remainder | any23→rdfa, ojdbc17, IA removal already on development |

Details: `tmp/migrate-005/platform-track-504-138-107.md`

### Tests

```text
./mvn-env.sh -pl system -Dtest=PSMetadataExtractorServiceTests -Dai.integrity.skip=true test
# Tests run: 5, Failures: 0
```

### Review

Erlang pre-PR: **approve** (`tmp/reviews/005-migrate-107-metadata-entity-test.md`)

## Test plan

- [x] Focused unit tests green
- [ ] CI on PR