### PR TITLE
docs(test): document entity-test.html fixture for RDFa regression (#1286 follow-up)

### DIFF
--- a/system/src/test/resources/com/percussion/delivery/entity-test.html
+++ b/system/src/test/resources/com/percussion/delivery/entity-test.html
@@ -1,4 +1,9 @@
 <!DOCTYPE html>
+<!--
+  Fixture for PSMetadataExtractorServiceTests#testEntityAndScriptHandling
+  (v8.1.7 PR #107 / migrate PR #1286): HTML entities in meta/body and
+  script/JSON-LD that must not leak into extracted RDFa properties.
+-->
 <html prefix="dcterms: http://purl.org/dc/terms/">
   <head>
     <title>Comprehensive Test</title>


### PR DESCRIPTION
## Summary

Follow-up to review on merged [#1286](https://github.com/intersoftdatalabs-in/percussioncms/pull/1286).

Kilo flagged that `entity-test.html` was not in that PR's diff. The fixture was already on `development` (so CI was fine); this PR documents the fixture purpose with a header comment so the resource is explicitly associated with `testEntityAndScriptHandling`.

## Test plan
- [x] Fixture content unchanged except HTML comment header
- [ ] CI green