### PR TITLE
feat(installer): non-Derby DB targets for new CLI installs (#949)

### DIFF
--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSValidateRepositoryConnection.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSValidateRepositoryConnection.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.ant.install;
+
+import com.percussion.install.InstallUtil;
+import com.percussion.install.PSLogger;
+import com.percussion.tablefactory.PSJdbcDbmsDef;
+import com.percussion.tablefactory.PSJdbcTableFactoryException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Task;
+
+/**
+ * Validates that the repository described by install-root {@code
+ * rxconfig/Installer/rxrepository.properties} can be reached with the configured credentials.
+ *
+ * <p>Intended for <strong>new install</strong> only (wired behind {@code do.install}). Does not log
+ * or echo passwords.
+ *
+ * <pre>
+ *   &lt;PSValidateRepositoryConnection rootDir="${install.dir}" loginTimeoutSeconds="15"/&gt;
+ * </pre>
+ */
+public class PSValidateRepositoryConnection extends Task {
+
+  private String rootDir;
+  private int loginTimeoutSeconds = 15;
+
+  public void setRootDir(String rootDir) {
+    this.rootDir = rootDir;
+  }
+
+  public String getRootDir() {
+    return rootDir;
+  }
+
+  public void setLoginTimeoutSeconds(int loginTimeoutSeconds) {
+    this.loginTimeoutSeconds = loginTimeoutSeconds;
+  }
+
+  public int getLoginTimeoutSeconds() {
+    return loginTimeoutSeconds;
+  }
+
+  @Override
+  public void execute() throws BuildException {
+    if (StringUtils.isBlank(rootDir)) {
+      throw new BuildException("rootDir is required for PSValidateRepositoryConnection");
+    }
+
+    File propFile =
+        new File(rootDir + File.separator + "rxconfig/Installer/rxrepository.properties");
+    if (!(propFile.exists() && propFile.isFile())) {
+      throw new BuildException(
+          "Repository properties file not found for connection validation: "
+              + propFile.getAbsolutePath());
+    }
+
+    Properties props = new Properties();
+    try (FileInputStream in = new FileInputStream(propFile)) {
+      props.load(in);
+    } catch (IOException e) {
+      throw new BuildException(
+          "Unable to read repository properties for connection validation: "
+              + propFile.getAbsolutePath(),
+          e);
+    }
+
+    String backend = props.getProperty("DB_BACKEND", "");
+    String driverName = props.getProperty("DB_DRIVER_NAME", "");
+    String driverClass = props.getProperty("DB_DRIVER_CLASS_NAME", "");
+    String server = props.getProperty("DB_SERVER", "");
+    String database = props.getProperty("DB_NAME", "");
+    String uid = props.getProperty("UID", "");
+
+    // Never include password in log lines
+    PSLogger.logInfo(
+        "Validating repository connection: backend="
+            + backend
+            + " driver="
+            + driverName
+            + " server="
+            + server
+            + " database="
+            + database
+            + " uid="
+            + uid);
+
+    // Register JARs for InstallUtil's custom loader. Do not Class.forName here — drivers often
+    // live only under jetty/base/lib/jdbc and are loaded the same way as PSExecSQLStmt.
+    registerJdbcDriversFromInstall(rootDir);
+
+    try {
+      if (getRootDir() != null && !"".equals(getRootDir())) {
+        InstallUtil.setRootDir(getRootDir());
+      }
+
+      PSJdbcDbmsDef dbmsDef = new PSJdbcDbmsDef(props);
+      String driver = dbmsDef.getDriver();
+      String serverName = dbmsDef.getServer();
+      String db = dbmsDef.getDataBase();
+      String user = dbmsDef.getUserId();
+      String password = dbmsDef.getPassword();
+
+      int previousTimeout = DriverManager.getLoginTimeout();
+      try {
+        if (loginTimeoutSeconds > 0) {
+          DriverManager.setLoginTimeout(loginTimeoutSeconds);
+        }
+        try (Connection conn =
+            InstallUtil.createLoadedConnection(driver, serverName, db, user, password)) {
+          if (conn == null || conn.isClosed()) {
+            throw new BuildException(
+                failureMessage(
+                    backend,
+                    server,
+                    driverClass,
+                    "Unable to establish a connection. Check host, credentials, database"
+                        + " provisioning, and JDBC drivers under jetty/base/lib/jdbc."));
+          }
+          PSLogger.logInfo("Repository connection validation succeeded for backend=" + backend);
+        }
+      } finally {
+        DriverManager.setLoginTimeout(previousTimeout);
+      }
+    } catch (BuildException be) {
+      throw be;
+    } catch (PSJdbcTableFactoryException | SQLException e) {
+      throw new BuildException(
+          failureMessage(backend, server, driverClass, safeExceptionMessage(e)), e);
+    } catch (Exception e) {
+      throw new BuildException(
+          failureMessage(backend, server, driverClass, safeExceptionMessage(e)), e);
+    }
+  }
+
+  /**
+   * Build a user-facing failure message that never intentionally embeds secrets. When the root
+   * cause looks like a missing driver, append FR-012-style remediation.
+   */
+  static String failureMessage(
+      String backend, String server, String driverClass, String detail) {
+    StringBuilder msg = new StringBuilder();
+    msg.append("Repository connection validation failed for backend=")
+        .append(backend == null ? "" : backend)
+        .append(" server=")
+        .append(server == null ? "" : server);
+    if (StringUtils.isNotBlank(detail)) {
+      msg.append(": ").append(detail);
+    }
+    if (looksLikeMissingDriver(detail, driverClass)) {
+      msg.append(" Place the appropriate JDBC driver JAR in jetty/base/lib/jdbc and retry.");
+      if (StringUtils.isNotBlank(driverClass)) {
+        msg.append(" Expected driver class: ").append(driverClass).append('.');
+      }
+    }
+    return msg.toString();
+  }
+
+  static boolean looksLikeMissingDriver(String detail, String driverClass) {
+    if (detail == null) {
+      return false;
+    }
+    String lower = detail.toLowerCase();
+    if (lower.contains("classnotfound")
+        || lower.contains("no suitable driver")
+        || lower.contains("driver not found")
+        || lower.contains("is not supported by the current installer")
+        || (lower.contains("cannot find") && lower.contains("driver"))) {
+      return true;
+    }
+    return StringUtils.isNotBlank(driverClass) && detail.contains(driverClass)
+        && (lower.contains("not found") || lower.contains("not supported"));
+  }
+
+  /** Prefer getMessage(); never append nested causes that might echo credentials. */
+  static String safeExceptionMessage(Throwable e) {
+    if (e == null) {
+      return "";
+    }
+    String m = e.getMessage();
+    return m == null ? e.getClass().getSimpleName() : m;
+  }
+
+  /**
+   * Register JARs from the install tree's JDBC driver drop directory so DriverManager can load
+   * them during fresh install validation.
+   */
+  static void registerJdbcDriversFromInstall(String installRoot) {
+    Path jdbcDir =
+        Paths.get(installRoot, "jetty", "base", "lib", "jdbc");
+    if (!Files.isDirectory(jdbcDir)) {
+      return;
+    }
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(jdbcDir, "*.jar")) {
+      for (Path jar : stream) {
+        InstallUtil.addJarFileUrl(jar.toAbsolutePath().toString());
+      }
+    } catch (IOException e) {
+      PSLogger.logInfo("Unable to enumerate JDBC drivers in " + jdbcDir + ": " + e.getMessage());
+    }
+  }
+
+  /**
+   * Test helper: true when a message appears free of an explicit secret sample.
+   *
+   * @param message user-facing message
+   * @param secret password that must not appear
+   * @return true if secret is blank or not contained in message
+   */
+  static boolean messageDoesNotContainSecret(String message, String secret) {
+    if (secret == null || secret.isEmpty()) {
+      return true;
+    }
+    return message == null || !message.contains(secret);
+  }
+}

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSValidateRepositoryConnection.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSValidateRepositoryConnection.java
@@ -115,9 +115,8 @@ public class PSValidateRepositoryConnection extends Task {
     registerJdbcDriversFromInstall(rootDir);
 
     try {
-      if (getRootDir() != null && !"".equals(getRootDir())) {
-        InstallUtil.setRootDir(getRootDir());
-      }
+      // rootDir already validated non-blank above
+      InstallUtil.setRootDir(rootDir);
 
       PSJdbcDbmsDef dbmsDef = new PSJdbcDbmsDef(props);
       String driver = dbmsDef.getDriver();
@@ -133,14 +132,24 @@ public class PSValidateRepositoryConnection extends Task {
         }
         try (Connection conn =
             InstallUtil.createLoadedConnection(driver, serverName, db, user, password)) {
-          if (conn == null || conn.isClosed()) {
+          if (conn == null) {
+            // createLoadedConnection may return null for driver/loader failures without throwing
             throw new BuildException(
                 failureMessage(
                     backend,
                     server,
                     driverClass,
-                    "Unable to establish a connection. Check host, credentials, database"
-                        + " provisioning, and JDBC drivers under jetty/base/lib/jdbc."));
+                    "Connection returned null (driver may be missing or failed to load)."
+                        + " Check JDBC drivers under jetty/base/lib/jdbc and credentials."));
+          }
+          if (conn.isClosed()) {
+            throw new BuildException(
+                failureMessage(
+                    backend,
+                    server,
+                    driverClass,
+                    "Connection was closed immediately after open. Check host, credentials,"
+                        + " and database provisioning."));
           }
           PSLogger.logInfo("Repository connection validation succeeded for backend=" + backend);
         }
@@ -189,11 +198,15 @@ public class PSValidateRepositoryConnection extends Task {
     if (lower.contains("classnotfound")
         || lower.contains("no suitable driver")
         || lower.contains("driver not found")
+        || lower.contains("driver may be missing")
+        || lower.contains("failed to load")
         || lower.contains("is not supported by the current installer")
-        || (lower.contains("cannot find") && lower.contains("driver"))) {
+        || (lower.contains("cannot find") && lower.contains("driver"))
+        || (lower.contains("returned null") && lower.contains("driver"))) {
       return true;
     }
-    return StringUtils.isNotBlank(driverClass) && detail.contains(driverClass)
+    return StringUtils.isNotBlank(driverClass)
+        && detail.contains(driverClass)
         && (lower.contains("not found") || lower.contains("not supported"));
   }
 

--- a/modules/perc-ant/src/main/resources/com/percussion/ant/antlib.xml
+++ b/modules/perc-ant/src/main/resources/com/percussion/ant/antlib.xml
@@ -116,6 +116,8 @@
 		classname="com.percussion.ant.install.PSExportDatabase" />
 	<taskdef name="PSMakeLasagna"
 		classname="com.percussion.ant.install.PSMakeLasagna" />
+	<taskdef name="PSValidateRepositoryConnection"
+		classname="com.percussion.ant.install.PSValidateRepositoryConnection" />
 	<taskdef name="PSCopyDirectory"
 		classname="com.percussion.ant.packagetool.PSCopyDirectory" />
 	<taskdef name="PSUnZipPackage"

--- a/modules/perc-ant/src/test/java/com/percussion/ant/install/PSValidateRepositoryConnectionTest.java
+++ b/modules/perc-ant/src/test/java/com/percussion/ant/install/PSValidateRepositoryConnectionTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.ant.install;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.tools.ant.BuildException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("UnitTest")
+class PSValidateRepositoryConnectionTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void missingRepositoryPropertiesFails() {
+    PSValidateRepositoryConnection task = new PSValidateRepositoryConnection();
+    task.setRootDir(tempDir.toString());
+    BuildException ex = assertThrows(BuildException.class, task::execute);
+    assertTrue(ex.getMessage().toLowerCase().contains("not found"));
+  }
+
+  @Test
+  void unreachableHostFailsWithoutLeakingPassword() throws Exception {
+    Path installer = tempDir.resolve("rxconfig/Installer");
+    Files.createDirectories(installer);
+    Path props = installer.resolve("rxrepository.properties");
+    String secret = "super-secret-password-do-not-leak";
+    Files.writeString(
+        props,
+        """
+        DB_BACKEND=MYSQL
+        DB_DRIVER_NAME=mysql
+        DB_DRIVER_CLASS_NAME=org.mariadb.jdbc.Driver
+        DB_SERVER=//127.0.0.1:1/nosuchdb
+        DB_NAME=nosuchdb
+        DB_SCHEMA=
+        UID=cmsuser
+        PWD=%s
+        PWD_ENCRYPTED=N
+        """
+            .formatted(secret),
+        StandardCharsets.UTF_8);
+
+    // Empty jdbc dir — InstallUtil may still attempt connect; either path must fail closed
+    Files.createDirectories(tempDir.resolve("jetty/base/lib/jdbc"));
+
+    PSValidateRepositoryConnection task = new PSValidateRepositoryConnection();
+    task.setRootDir(tempDir.toString());
+    task.setLoginTimeoutSeconds(2);
+    BuildException ex = assertThrows(BuildException.class, task::execute);
+    assertTrue(
+        ex.getMessage().toLowerCase().contains("validation failed")
+            || ex.getMessage().toLowerCase().contains("connection"),
+        () -> "unexpected message: " + ex.getMessage());
+    assertTrue(
+        PSValidateRepositoryConnection.messageDoesNotContainSecret(ex.getMessage(), secret),
+        () -> "password leaked in: " + ex.getMessage());
+  }
+
+  @Test
+  void failureMessageAddsDriverGuidanceWhenMissingDriver() {
+    String msg =
+        PSValidateRepositoryConnection.failureMessage(
+            "MYSQL",
+            "//db:3306/p",
+            "org.mariadb.jdbc.Driver",
+            "Driver mysql is not supported by the current installer.");
+    assertTrue(msg.contains("jetty/base/lib/jdbc"));
+    assertTrue(msg.contains("org.mariadb.jdbc.Driver"));
+    assertFalse(msg.contains("password"));
+  }
+
+  @Test
+  void messageHelperRejectsSecretLeak() {
+    assertFalse(
+        PSValidateRepositoryConnection.messageDoesNotContainSecret(
+            "failed for user with pass abc", "abc"));
+    assertTrue(
+        PSValidateRepositoryConnection.messageDoesNotContainSecret(
+            "failed for backend=MYSQL", "abc"));
+  }
+
+  @Test
+  void looksLikeMissingDriverDetectsCommonPatterns() {
+    assertTrue(
+        PSValidateRepositoryConnection.looksLikeMissingDriver(
+            "no suitable driver found", "org.mariadb.jdbc.Driver"));
+    assertTrue(
+        PSValidateRepositoryConnection.looksLikeMissingDriver(
+            "Driver mysql is not supported by the current installer.", null));
+    assertFalse(
+        PSValidateRepositoryConnection.looksLikeMissingDriver(
+            "Connection refused", "org.mariadb.jdbc.Driver"));
+  }
+}

--- a/modules/perc-ant/src/test/java/com/percussion/ant/install/PSValidateRepositoryConnectionTest.java
+++ b/modules/perc-ant/src/test/java/com/percussion/ant/install/PSValidateRepositoryConnectionTest.java
@@ -109,8 +109,24 @@ class PSValidateRepositoryConnectionTest {
     assertTrue(
         PSValidateRepositoryConnection.looksLikeMissingDriver(
             "Driver mysql is not supported by the current installer.", null));
+    assertTrue(
+        PSValidateRepositoryConnection.looksLikeMissingDriver(
+            "Connection returned null (driver may be missing or failed to load).", null));
     assertFalse(
         PSValidateRepositoryConnection.looksLikeMissingDriver(
             "Connection refused", "org.mariadb.jdbc.Driver"));
+  }
+
+  @Test
+  void nullConnectionMessageTriggersDriverGuidance() {
+    String msg =
+        PSValidateRepositoryConnection.failureMessage(
+            "MYSQL",
+            "//db:3306/p",
+            "org.mariadb.jdbc.Driver",
+            "Connection returned null (driver may be missing or failed to load)."
+                + " Check JDBC drivers under jetty/base/lib/jdbc and credentials.");
+    assertTrue(msg.contains("jetty/base/lib/jdbc"));
+    assertTrue(msg.toLowerCase().contains("driver"));
   }
 }

--- a/modules/perc-distribution-tree/README.md
+++ b/modules/perc-distribution-tree/README.md
@@ -79,6 +79,50 @@ JARs are placed in the install with their Maven-resolved filenames (e.g. `mariad
 
 Integrators who need a driver that is not bundled (for example an enterprise Oracle driver) can simply drop a JDBC driver JAR into `jetty/base/lib/jdbc/` of the unpacked distribution. The install scripts (`rxconfig/Installer/install.xml`, `installServer.xml`, `installRepository.xml`) do not purge this folder.
 
+## CLI installer: database targets for new installs
+
+By default a **new** command-line install uses the embedded **Derby** repository. To target MySQL/MariaDB, SQL Server, or Oracle on a **new install only**, supply a repository properties file in the same format as `rxconfig/Installer/rxrepository.properties`:
+
+```bash
+java -Ddbprops=/path/to/rxrepository.mysql.properties -jar PercussionCMS.jar /path/to/install/root
+# equivalent:
+java -jar PercussionCMS.jar /path/to/install/root --dbprops=/path/to/rxrepository.mysql.properties
+```
+
+### Supported backends
+
+| `DB_BACKEND` | Structured `db.type` | Notes |
+|--------------|----------------------|-------|
+| `DERBY` | `derby` | Default when no override is given |
+| `MYSQL` | `mysql` | MySQL or MariaDB-compatible; sample uses MariaDB driver class |
+| `MSSQL` | `sqlserver` | Microsoft SQL Server |
+| `ORACLE` | `oracle` | Oracle thin |
+
+### Sample files
+
+Shipped under the distribution installer tree:
+
+- `rxconfig/Installer/samples/rxrepository.mysql.properties`
+- `rxconfig/Installer/samples/rxrepository.sqlserver.properties`
+- `rxconfig/Installer/samples/rxrepository.oracle.properties`
+
+Copy a sample, replace host/credentials, pre-create the empty database/schema, then pass the file with `-Ddbprops` / `--dbprops`.
+
+### Input precedence (new install)
+
+1. `dbprops` file (`-Ddbprops` / `--dbprops`)
+2. Structured CLI `--db.*` (and env-style aliases)
+3. Env file (`--db.config.env.file` / `DB_CONFIG_ENV_FILE`)
+4. Process environment
+5. Defaults (Derby)
+
+### New install vs upgrade
+
+- **New install**: database target input applies; installer writes effective `rxconfig/Installer/rxrepository.properties` and validates connectivity before schema setup.
+- **Upgrade**: existing repository configuration is preserved. You do **not** need `-Ddbprops` to keep a non-Derby backend.
+
+Feature design artifacts: `specs/006-installer-db-targets/` (contracts under `contracts/`).
+
 The install/upgrade script's `<delete>` block in `install.xml` is pinned to the exact bundled-driver filenames shipped in this release (sourced from the parent POM's version properties: `${mariadb.version}`, `${derby.version}`, `${mssql.version}`, `${jtds.version}`, `${ojdbc17.version}`). When a driver version is bumped, THREE places MUST be updated in lockstep in the same commit:
 
 1. **Parent POM** — bump the relevant version property (`${mariadb.version}`, `${derby.version}`, `${mssql.version}`, `${jtds.version}`, or `${ojdbc17.version}`).

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/DbInstallConfigResolver.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/DbInstallConfigResolver.java
@@ -1,0 +1,665 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+
+/**
+ * Resolves CMS repository database targeting for new CLI installs.
+ *
+ * <p>Supports:
+ *
+ * <ul>
+ *   <li>{@code -Ddbprops=} / {@code --dbprops=} property files in {@code rxrepository.properties}
+ *       format (issue #949)
+ *   <li>Structured {@code --db.*} CLI / env-file / environment inputs (existing automation surface)
+ *   <li>Default embedded Derby when no override is supplied
+ * </ul>
+ *
+ * <p><strong>Security:</strong> never log or print {@code PWD} / password field values in error
+ * messages.
+ */
+public final class DbInstallConfigResolver {
+
+  public static final String DB_TYPE_DEFAULT = "derby";
+  public static final String DB_SSL_ENABLED_DEFAULT = "true";
+  public static final String DB_SSL_VERIFY_DEFAULT = "true";
+  public static final String DB_SSL_ALLOW_SELF_SIGNED_DEFAULT = "false";
+
+  /** Issue #949 system property / CLI key for repository properties file path. */
+  public static final String DBPROPS_KEY = "dbprops";
+
+  private static final String MARIADB_DRIVER_CLASS = "org.mariadb.jdbc.Driver";
+  private static final String MYSQL_COMPAT_DRIVER_NAME = "mysql";
+  private static final String MSSQL_DRIVER_CLASS =
+      "com.microsoft.sqlserver.jdbc.SQLServerDriver";
+  private static final String ORACLE_DRIVER_CLASS = "oracle.jdbc.OracleDriver";
+  private static final String ORACLE_DRIVER_NAME = "oracle:thin";
+
+  private DbInstallConfigResolver() {}
+
+  /**
+   * Parse installer CLI arguments: first non-{@code --} token is install path; {@code --key=value}
+   * and {@code --key value} options fill the options map.
+   */
+  public static ParsedArgs parseArgs(String[] args) {
+    Path installPath = null;
+    Map<String, String> options = new HashMap<>();
+
+    int index = 0;
+    while (index < args.length) {
+      String argument = args[index];
+      if (!argument.startsWith("--")) {
+        if (installPath == null) {
+          installPath = Paths.get(argument);
+        }
+        index++;
+        continue;
+      }
+
+      String option = argument.substring(2);
+      String key;
+      String value;
+      int equalsPosition = option.indexOf('=');
+      if (equalsPosition > -1) {
+        key = option.substring(0, equalsPosition).trim();
+        value = option.substring(equalsPosition + 1).trim();
+      } else {
+        key = option.trim();
+        if (index + 1 < args.length && !args[index + 1].startsWith("--")) {
+          value = args[index + 1].trim();
+          index++;
+        } else {
+          value = "true";
+        }
+      }
+
+      if (!key.isEmpty()) {
+        options.put(key, value);
+      }
+      index++;
+    }
+
+    return new ParsedArgs(installPath, options);
+  }
+
+  /**
+   * Resolve database configuration into {@code perc.db.*} system properties for the ANT install
+   * JVM.
+   *
+   * @param cliOptions options from {@link #parseArgs(String[])}; may be empty
+   * @return resolved config (never null)
+   * @throws IllegalArgumentException when validation fails (messages must not contain secrets)
+   */
+  public static ResolvedDbConfig resolveDbConfig(Map<String, String> cliOptions) {
+    Map<String, String> options = cliOptions != null ? cliOptions : Map.of();
+
+    String dbpropsPath =
+        firstNonBlank(
+            options.get(DBPROPS_KEY),
+            options.get("db.props"),
+            System.getProperty(DBPROPS_KEY),
+            System.getProperty("db.props"));
+
+    if (!isBlank(dbpropsPath)) {
+      return resolveFromDbpropsFile(dbpropsPath, options);
+    }
+
+    return resolveFromStructuredInput(options);
+  }
+
+  private static ResolvedDbConfig resolveFromDbpropsFile(
+      String dbpropsPath, Map<String, String> cliOptions) {
+    Path path = Paths.get(dbpropsPath);
+    if (!Files.isRegularFile(path) || !Files.isReadable(path)) {
+      throw new IllegalArgumentException(
+          "dbprops file not found or not readable: " + path.toAbsolutePath());
+    }
+
+    Properties fileProps = new Properties();
+    try (InputStream in = Files.newInputStream(path)) {
+      fileProps.load(in);
+    } catch (IOException e) {
+      throw new IllegalArgumentException(
+          "Unable to read dbprops file: " + path.toAbsolutePath(), e);
+    }
+
+    String backendRaw = firstNonBlank(fileProps.getProperty("DB_BACKEND"), "");
+    String dbType = normalizeBackendToDbType(backendRaw);
+
+    Map<String, String> envFileValues = loadEnvFileIfConfigured(cliOptions);
+
+    String sslEnabled =
+        normalizeBoolean(
+            firstNonBlank(
+                fileProps.getProperty("DB_SSL_ENABLED"),
+                getConfigValue(
+                    "db.ssl.enabled", cliOptions, envFileValues, DB_SSL_ENABLED_DEFAULT)),
+            "db.ssl.enabled");
+    String sslVerify =
+        normalizeBoolean(
+            firstNonBlank(
+                fileProps.getProperty("DB_SSL_VERIFY"),
+                getConfigValue("db.ssl.verify", cliOptions, envFileValues, DB_SSL_VERIFY_DEFAULT)),
+            "db.ssl.verify");
+    String sslAllowSelfSigned =
+        normalizeBoolean(
+            firstNonBlank(
+                fileProps.getProperty("DB_SSL_ALLOW_SELF_SIGNED"),
+                getConfigValue(
+                    "db.ssl.allowSelfSigned",
+                    cliOptions,
+                    envFileValues,
+                    DB_SSL_ALLOW_SELF_SIGNED_DEFAULT)),
+            "db.ssl.allowSelfSigned");
+
+    Map<String, String> systemProperties = new HashMap<>();
+    systemProperties.put("perc.db.type", dbType);
+    systemProperties.put("perc.db.ssl.enabled", sslEnabled);
+    systemProperties.put("perc.db.ssl.verify", sslVerify);
+    systemProperties.put("perc.db.ssl.allowSelfSigned", sslAllowSelfSigned);
+
+    if (Objects.equals(dbType, "derby")) {
+      return new ResolvedDbConfig(systemProperties, "dbprops");
+    }
+
+    String server = trimToNull(fileProps.getProperty("DB_SERVER"));
+    String name = trimToNull(fileProps.getProperty("DB_NAME"));
+    String schema = trimToNull(fileProps.getProperty("DB_SCHEMA"));
+    String driverName = trimToNull(fileProps.getProperty("DB_DRIVER_NAME"));
+    String driverClass = trimToNull(fileProps.getProperty("DB_DRIVER_CLASS_NAME"));
+    String user = trimToNull(fileProps.getProperty("UID"));
+    String password = trimToNull(fileProps.getProperty("PWD"));
+
+    List<String> missing = new ArrayList<>();
+    if (server == null) {
+      missing.add("DB_SERVER");
+    }
+    if (user == null) {
+      missing.add("UID");
+    }
+    if (password == null) {
+      missing.add("PWD");
+    }
+    if (driverName == null) {
+      missing.add("DB_DRIVER_NAME");
+    }
+    if (driverClass == null) {
+      missing.add("DB_DRIVER_CLASS_NAME");
+    }
+    if ((Objects.equals(dbType, "mysql") || Objects.equals(dbType, "sqlserver")) && name == null) {
+      missing.add("DB_NAME");
+    }
+    if (!missing.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Missing required database properties in dbprops file for DB_BACKEND="
+              + backendRaw
+              + ": "
+              + String.join(", ", missing));
+    }
+
+    String resolvedSchema = schema;
+    if (resolvedSchema == null) {
+      if (Objects.equals(dbType, "sqlserver")) {
+        resolvedSchema = "DBO";
+      } else {
+        resolvedSchema = "";
+      }
+    }
+
+    String backendLabel = backendLabelForType(dbType);
+    systemProperties.put("perc.db.cms.backend", backendLabel);
+    systemProperties.put("perc.db.cms.driverName", driverName);
+    systemProperties.put("perc.db.cms.driverClass", driverClass);
+    systemProperties.put("perc.db.cms.server", server);
+    if (name != null) {
+      systemProperties.put("perc.db.cms.name", name);
+    } else {
+      systemProperties.put("perc.db.cms.name", "");
+    }
+    systemProperties.put("perc.db.cms.schema", resolvedSchema);
+    systemProperties.put("perc.db.user", user);
+    systemProperties.put("perc.db.password", password);
+
+    applyDtsHintsFromCms(
+        systemProperties, dbType, server, name, resolvedSchema, driverClass, sslEnabled, sslVerify);
+
+    return new ResolvedDbConfig(systemProperties, "dbprops");
+  }
+
+  private static ResolvedDbConfig resolveFromStructuredInput(Map<String, String> cliOptions) {
+    Map<String, String> environmentFileValues = loadEnvFileIfConfigured(cliOptions);
+
+    String dbType = getConfigValue("db.type", cliOptions, environmentFileValues, null);
+    if (isBlank(dbType)) {
+      dbType = DB_TYPE_DEFAULT;
+    }
+    dbType = normalizeStructuredDbType(dbType);
+
+    String sslEnabled =
+        normalizeBoolean(
+            getConfigValue(
+                "db.ssl.enabled", cliOptions, environmentFileValues, DB_SSL_ENABLED_DEFAULT),
+            "db.ssl.enabled");
+    String sslVerify =
+        normalizeBoolean(
+            getConfigValue(
+                "db.ssl.verify", cliOptions, environmentFileValues, DB_SSL_VERIFY_DEFAULT),
+            "db.ssl.verify");
+    String sslAllowSelfSigned =
+        normalizeBoolean(
+            getConfigValue(
+                "db.ssl.allowSelfSigned",
+                cliOptions,
+                environmentFileValues,
+                DB_SSL_ALLOW_SELF_SIGNED_DEFAULT),
+            "db.ssl.allowSelfSigned");
+
+    String host = getConfigValue("db.host", cliOptions, environmentFileValues, null);
+    String port = getConfigValue("db.port", cliOptions, environmentFileValues, null);
+    String name = getConfigValue("db.name", cliOptions, environmentFileValues, null);
+    String schema = getConfigValue("db.schema", cliOptions, environmentFileValues, null);
+    String user = getConfigValue("db.user", cliOptions, environmentFileValues, null);
+    String password = getConfigValue("db.password", cliOptions, environmentFileValues, null);
+
+    if (!Objects.equals(dbType, "derby")) {
+      List<String> missing = new ArrayList<>();
+      if (isBlank(host)) {
+        missing.add("db.host");
+      }
+      if (isBlank(port)) {
+        missing.add("db.port");
+      }
+      if (isBlank(name) && !Objects.equals(dbType, "oracle")) {
+        missing.add("db.name");
+      }
+      if (isBlank(user)) {
+        missing.add("db.user");
+      }
+      if (isBlank(password)) {
+        missing.add("db.password");
+      }
+      if (!missing.isEmpty()) {
+        throw new IllegalArgumentException(
+            "Missing required database parameters for db.type="
+                + dbType
+                + ": "
+                + String.join(", ", missing));
+      }
+    }
+
+    Map<String, String> systemProperties = new HashMap<>();
+    systemProperties.put("perc.db.type", dbType);
+    systemProperties.put("perc.db.ssl.enabled", sslEnabled);
+    systemProperties.put("perc.db.ssl.verify", sslVerify);
+    systemProperties.put("perc.db.ssl.allowSelfSigned", sslAllowSelfSigned);
+    setIfPresent(systemProperties, "perc.db.host", host);
+    setIfPresent(systemProperties, "perc.db.port", port);
+    setIfPresent(systemProperties, "perc.db.name", name);
+    setIfPresent(systemProperties, "perc.db.schema", schema);
+    setIfPresent(systemProperties, "perc.db.user", user);
+    setIfPresent(systemProperties, "perc.db.password", password);
+    setIfPresent(
+        systemProperties,
+        "perc.db.ssl.trustStorePath",
+        getConfigValue("db.ssl.trustStorePath", cliOptions, environmentFileValues, null));
+    setIfPresent(
+        systemProperties,
+        "perc.db.ssl.trustStorePassword",
+        getConfigValue("db.ssl.trustStorePassword", cliOptions, environmentFileValues, null));
+    setIfPresent(
+        systemProperties,
+        "perc.db.ssl.keyStorePath",
+        getConfigValue("db.ssl.keyStorePath", cliOptions, environmentFileValues, null));
+    setIfPresent(
+        systemProperties,
+        "perc.db.ssl.keyStorePassword",
+        getConfigValue("db.ssl.keyStorePassword", cliOptions, environmentFileValues, null));
+
+    if (Objects.equals(dbType, "mysql")) {
+      // Schema may be empty for MySQL; do not use firstNonBlank("", ...) (empty is blank).
+      String resolvedSchema = schema == null ? "" : schema.trim();
+      String cmsServer =
+          "//"
+              + host
+              + ":"
+              + port
+              + "/"
+              + name
+              + "?useUnicode=yes&characterEncoding=UTF-8"
+              + "&useSSL="
+              + sslEnabled
+              + "&requireSSL="
+              + sslEnabled
+              + "&verifyServerCertificate="
+              + sslVerify;
+      systemProperties.put("perc.db.cms.backend", "MYSQL");
+      systemProperties.put("perc.db.cms.driverName", MYSQL_COMPAT_DRIVER_NAME);
+      // Prefer MariaDB client shipped in jetty/base/lib/jdbc (specs/001-fix-jdbc-drivers)
+      systemProperties.put("perc.db.cms.driverClass", MARIADB_DRIVER_CLASS);
+      systemProperties.put("perc.db.cms.server", cmsServer);
+      systemProperties.put("perc.db.cms.name", name);
+      systemProperties.put("perc.db.cms.schema", resolvedSchema);
+      systemProperties.put(
+          "perc.db.dts.jdbcUrl",
+          "jdbc:mysql://"
+              + host
+              + ":"
+              + port
+              + "/"
+              + name
+              + "?useUnicode=yes&characterEncoding=UTF-8"
+              + "&useSSL="
+              + sslEnabled
+              + "&requireSSL="
+              + sslEnabled
+              + "&verifyServerCertificate="
+              + sslVerify);
+      systemProperties.put("perc.db.dts.jdbcDriver", MARIADB_DRIVER_CLASS);
+      systemProperties.put(
+          "perc.db.dts.hibernateDialect", "org.hibernate.dialect.MySQL5InnoDBDialect");
+      systemProperties.put("perc.db.dts.schema", resolvedSchema);
+    } else if (Objects.equals(dbType, "sqlserver")) {
+      String resolvedSchema =
+          (schema == null || schema.trim().isEmpty()) ? "DBO" : schema.trim();
+      String trustServerCertificate =
+          Objects.equals(sslAllowSelfSigned, "true") || Objects.equals(sslVerify, "false")
+              ? "true"
+              : "false";
+      String cmsServer =
+          "//"
+              + host
+              + ":"
+              + port
+              + ";databaseName="
+              + name
+              + ";encrypt="
+              + sslEnabled
+              + ";trustServerCertificate="
+              + trustServerCertificate;
+      systemProperties.put("perc.db.cms.backend", "MSSQL");
+      systemProperties.put("perc.db.cms.driverName", "sqlserver");
+      systemProperties.put("perc.db.cms.driverClass", MSSQL_DRIVER_CLASS);
+      systemProperties.put("perc.db.cms.server", cmsServer);
+      systemProperties.put("perc.db.cms.name", name);
+      systemProperties.put("perc.db.cms.schema", resolvedSchema);
+      systemProperties.put(
+          "perc.db.dts.jdbcUrl",
+          "jdbc:sqlserver://"
+              + host
+              + ":"
+              + port
+              + ";databaseName="
+              + name
+              + ";encrypt="
+              + sslEnabled
+              + ";trustServerCertificate="
+              + trustServerCertificate);
+      systemProperties.put("perc.db.dts.jdbcDriver", MSSQL_DRIVER_CLASS);
+      systemProperties.put(
+          "perc.db.dts.hibernateDialect",
+          "com.percussion.delivery.rdbms.PSUnicodeSQLServerDialect");
+      systemProperties.put("perc.db.dts.schema", resolvedSchema);
+    } else if (Objects.equals(dbType, "oracle")) {
+      String resolvedSchema =
+          (schema == null || schema.trim().isEmpty())
+              ? (user == null ? "" : user.trim())
+              : schema.trim();
+      // Service/SID form: @host:port:name (name may be service or SID)
+      String serviceOrSid = name == null ? "" : name.trim();
+      String cmsServer = "@" + host + ":" + port + ":" + serviceOrSid;
+      systemProperties.put("perc.db.cms.backend", "ORACLE");
+      systemProperties.put("perc.db.cms.driverName", ORACLE_DRIVER_NAME);
+      systemProperties.put("perc.db.cms.driverClass", ORACLE_DRIVER_CLASS);
+      systemProperties.put("perc.db.cms.server", cmsServer);
+      systemProperties.put("perc.db.cms.name", serviceOrSid);
+      systemProperties.put("perc.db.cms.schema", resolvedSchema);
+      systemProperties.put(
+          "perc.db.dts.jdbcUrl", "jdbc:oracle:thin:@" + host + ":" + port + ":" + serviceOrSid);
+      systemProperties.put("perc.db.dts.jdbcDriver", ORACLE_DRIVER_CLASS);
+      systemProperties.put("perc.db.dts.hibernateDialect", "org.hibernate.dialect.Oracle12cDialect");
+      systemProperties.put("perc.db.dts.schema", resolvedSchema);
+    }
+
+    return new ResolvedDbConfig(systemProperties, "structured");
+  }
+
+  private static void applyDtsHintsFromCms(
+      Map<String, String> systemProperties,
+      String dbType,
+      String server,
+      String name,
+      String schema,
+      String driverClass,
+      String sslEnabled,
+      String sslVerify) {
+    // Best-effort residual DTS hints; full DTS write-through is out of scope for #949.
+    if (Objects.equals(dbType, "mysql")) {
+      systemProperties.put("perc.db.dts.jdbcDriver", driverClass);
+      systemProperties.put(
+          "perc.db.dts.hibernateDialect", "org.hibernate.dialect.MySQL5InnoDBDialect");
+      systemProperties.put("perc.db.dts.schema", schema);
+      if (server != null && server.startsWith("//")) {
+        systemProperties.put("perc.db.dts.jdbcUrl", "jdbc:mysql:" + server);
+      }
+    } else if (Objects.equals(dbType, "sqlserver")) {
+      systemProperties.put("perc.db.dts.jdbcDriver", driverClass);
+      systemProperties.put(
+          "perc.db.dts.hibernateDialect",
+          "com.percussion.delivery.rdbms.PSUnicodeSQLServerDialect");
+      systemProperties.put("perc.db.dts.schema", schema);
+      if (server != null && server.startsWith("//")) {
+        systemProperties.put("perc.db.dts.jdbcUrl", "jdbc:sqlserver:" + server);
+      }
+    } else if (Objects.equals(dbType, "oracle")) {
+      systemProperties.put("perc.db.dts.jdbcDriver", driverClass);
+      systemProperties.put("perc.db.dts.hibernateDialect", "org.hibernate.dialect.Oracle12cDialect");
+      systemProperties.put("perc.db.dts.schema", schema);
+      if (server != null) {
+        String thin = server.startsWith("@") ? server : "@" + server;
+        systemProperties.put("perc.db.dts.jdbcUrl", "jdbc:oracle:thin:" + thin);
+      }
+    }
+  }
+
+  /**
+   * Map {@code DB_BACKEND} values from rxrepository.properties to installer {@code perc.db.type}.
+   */
+  static String normalizeBackendToDbType(String backendRaw) {
+    if (isBlank(backendRaw)) {
+      return DB_TYPE_DEFAULT;
+    }
+    String b = backendRaw.trim().toUpperCase(Locale.ROOT);
+    return switch (b) {
+      case "DERBY" -> "derby";
+      case "MYSQL" -> "mysql";
+      case "MSSQL" -> "sqlserver";
+      case "ORACLE", "ORA" -> "oracle";
+      default -> throw new IllegalArgumentException(
+          "Unknown DB_BACKEND='"
+              + backendRaw
+              + "'. Allowed values: DERBY, MYSQL, MSSQL, ORACLE");
+    };
+  }
+
+  static String normalizeStructuredDbType(String dbTypeRaw) {
+    String t = dbTypeRaw.trim().toLowerCase(Locale.ROOT);
+    return switch (t) {
+      case "derby", "mysql", "sqlserver", "oracle" -> t;
+      case "mssql" -> "sqlserver";
+      case "ora" -> "oracle";
+      default -> throw new IllegalArgumentException(
+          "Unknown db.type='"
+              + dbTypeRaw
+              + "'. Allowed values: derby, mysql, sqlserver, oracle");
+    };
+  }
+
+  private static String backendLabelForType(String dbType) {
+    return switch (dbType) {
+      case "mysql" -> "MYSQL";
+      case "sqlserver" -> "MSSQL";
+      case "oracle" -> "ORACLE";
+      default -> "DERBY";
+    };
+  }
+
+  private static Map<String, String> loadEnvFileIfConfigured(Map<String, String> cliOptions) {
+    Map<String, String> environmentFileValues = new HashMap<>();
+    String envFilePath =
+        firstNonBlank(
+            cliOptions.get("db.config.env.file"),
+            System.getenv("DB_CONFIG_ENV_FILE"),
+            System.getenv("PERC_DB_CONFIG_ENV_FILE"));
+
+    if (envFilePath != null) {
+      environmentFileValues.putAll(loadEnvFile(envFilePath));
+    }
+    return environmentFileValues;
+  }
+
+  static Map<String, String> loadEnvFile(String envFilePath) {
+    Map<String, String> values = new HashMap<>();
+    Path path = Paths.get(envFilePath);
+    if (!Files.exists(path)) {
+      throw new IllegalArgumentException("db.config.env.file not found: " + envFilePath);
+    }
+    try {
+      List<String> lines = Files.readAllLines(path);
+      for (String line : lines) {
+        if (line == null) {
+          continue;
+        }
+        String trimmed = line.trim();
+        if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+          continue;
+        }
+        int separator = trimmed.indexOf('=');
+        if (separator <= 0) {
+          continue;
+        }
+        String key = trimmed.substring(0, separator).trim();
+        String value = trimmed.substring(separator + 1).trim();
+        values.put(key, value);
+      }
+      return values;
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Unable to read db.config.env.file: " + envFilePath, e);
+    }
+  }
+
+  static String getConfigValue(
+      String logicalKey,
+      Map<String, String> cliOptions,
+      Map<String, String> envFileValues,
+      String defaultValue) {
+    String envStyle = logicalToEnvStyle(logicalKey);
+    String percEnvStyle = "PERC_" + envStyle;
+    return firstNonBlank(
+        cliOptions.get(logicalKey),
+        cliOptions.get(envStyle),
+        cliOptions.get(percEnvStyle),
+        envFileValues.get(logicalKey),
+        envFileValues.get(envStyle),
+        envFileValues.get(percEnvStyle),
+        System.getenv(logicalKey),
+        System.getenv(envStyle),
+        System.getenv(percEnvStyle),
+        defaultValue);
+  }
+
+  private static String logicalToEnvStyle(String logicalKey) {
+    return logicalKey.toUpperCase(Locale.ROOT).replace('.', '_');
+  }
+
+  static String firstNonBlank(String... values) {
+    for (String value : values) {
+      if (!isBlank(value)) {
+        return value.trim();
+      }
+    }
+    return null;
+  }
+
+  static boolean isBlank(String value) {
+    return value == null || value.trim().isEmpty();
+  }
+
+  private static String trimToNull(String value) {
+    if (isBlank(value)) {
+      return null;
+    }
+    return value.trim();
+  }
+
+  static String normalizeBoolean(String value, String key) {
+    if (isBlank(value)) {
+      throw new IllegalArgumentException("Missing required boolean value for " + key);
+    }
+    if ("true".equalsIgnoreCase(value)) {
+      return "true";
+    }
+    if ("false".equalsIgnoreCase(value)) {
+      return "false";
+    }
+    throw new IllegalArgumentException("Invalid boolean value for " + key + ": " + value);
+  }
+
+  static void setIfPresent(Map<String, String> target, String key, String value) {
+    if (!isBlank(value)) {
+      target.put(key, value.trim());
+    }
+  }
+
+  public record ParsedArgs(Path installPath, Map<String, String> options) {}
+
+  /**
+   * @param systemProperties map of {@code perc.db.*} keys for the ANT JVM
+   * @param source diagnostic label: {@code default}, {@code dbprops}, {@code structured}
+   */
+  public record ResolvedDbConfig(Map<String, String> systemProperties, String source) {
+    public ResolvedDbConfig(Map<String, String> systemProperties) {
+      this(systemProperties, "default");
+    }
+
+    public ResolvedDbConfig {
+      // Map.copyOf rejects null keys/values; filter defensively.
+      Map<String, String> copy = new HashMap<>();
+      if (systemProperties != null) {
+        for (Map.Entry<String, String> entry : systemProperties.entrySet()) {
+          if (entry.getKey() != null && entry.getValue() != null) {
+            copy.put(entry.getKey(), entry.getValue());
+          }
+        }
+      }
+      systemProperties = Map.copyOf(copy);
+      if (source == null) {
+        source = "default";
+      }
+    }
+  }
+}

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/DbInstallConfigResolver.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/DbInstallConfigResolver.java
@@ -225,7 +225,8 @@ public final class DbInstallConfigResolver {
     String resolvedSchema = schema;
     if (resolvedSchema == null) {
       if (Objects.equals(dbType, "sqlserver")) {
-        resolvedSchema = "DBO";
+        // SQL Server default schema is lowercase "dbo" (product convention)
+        resolvedSchema = "dbo";
       } else {
         resolvedSchema = "";
       }
@@ -294,7 +295,8 @@ public final class DbInstallConfigResolver {
       if (isBlank(port)) {
         missing.add("db.port");
       }
-      if (isBlank(name) && !Objects.equals(dbType, "oracle")) {
+      // Oracle uses db.name as service name / SID in composed DB_SERVER (@host:port:name)
+      if (isBlank(name)) {
         missing.add("db.name");
       }
       if (isBlank(user)) {
@@ -385,7 +387,7 @@ public final class DbInstallConfigResolver {
       systemProperties.put("perc.db.dts.schema", resolvedSchema);
     } else if (Objects.equals(dbType, "sqlserver")) {
       String resolvedSchema =
-          (schema == null || schema.trim().isEmpty()) ? "DBO" : schema.trim();
+          (schema == null || schema.trim().isEmpty()) ? "dbo" : schema.trim();
       String trustServerCertificate =
           Objects.equals(sslAllowSelfSigned, "true") || Objects.equals(sslVerify, "false")
               ? "true"

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
@@ -33,11 +33,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -75,10 +72,6 @@ public class Main {
   private static final String SERVER_PROPS_PATH = "/rxconfig/Server/server.properties";
   private static final String JETTY_JDBC_PATH = "/jetty/base/lib/jdbc/";
   private static final String OLD_JDBC_LIST_PATH = "/rxconfig/Installer/oldJdbcJarsList.txt";
-  private static final String DB_TYPE_DEFAULT = "derby";
-  private static final String DB_SSL_ENABLED_DEFAULT = "true";
-  private static final String DB_SSL_VERIFY_DEFAULT = "true";
-  private static final String DB_SSL_ALLOW_SELF_SIGNED_DEFAULT = "false";
   public static File tmpFolder;
   public static String developmentFlag = "false";
   public static String percVersion;
@@ -93,15 +86,25 @@ public class Main {
   public static void main(String[] args) {
     try {
 
-      ParsedArgs parsedArgs = parseArgs(args);
+      DbInstallConfigResolver.ParsedArgs parsedArgs = DbInstallConfigResolver.parseArgs(args);
       if (parsedArgs.installPath() == null) {
         System.out.println("Must specify installation or upgrade folder");
+        System.out.println(
+            "Optional database target for new installs: -Ddbprops=<path> or --dbprops=<path>");
         System.exit(0);
       }
 
       Path installPath = parsedArgs.installPath();
 
-      ResolvedDbConfig resolvedDbConfig = resolveDbConfig(parsedArgs.options());
+      DbInstallConfigResolver.ResolvedDbConfig resolvedDbConfig;
+      try {
+        resolvedDbConfig = DbInstallConfigResolver.resolveDbConfig(parsedArgs.options());
+      } catch (IllegalArgumentException badDbConfig) {
+        System.out.println(
+            "Database configuration error: " + badDbConfig.getMessage());
+        System.exit(1);
+        return;
+      }
 
       debug = System.getProperty("DEBUG");
       if (debug == null || debug.equalsIgnoreCase("")) {
@@ -187,15 +190,51 @@ public class Main {
       Path execPath = installSrc.resolve(Paths.get("rxconfig", "Installer"));
       Path installAntJarPath =
           execPath.resolve(PathUtils.getVersionLessJarFilePath(execPath, PERC_ANT_JAR + "-*.jar"));
-      execJar(installAntJarPath, execPath, installPath, resolvedDbConfig);
+      Integer antExit = execJar(installAntJarPath, execPath, installPath, resolvedDbConfig);
       deleteOldJDBCJars(installPath);
+
+      int exitCode = resolveInstallExitCode(antExit, error, processCode);
+      if (exitCode != 0) {
+        System.out.println(
+            "Installation failed (exit code "
+                + exitCode
+                + "). See installer output and logs under the install directory.");
+        System.exit(exitCode);
+      }
 
     } catch (Exception e) {
       System.out.println(
           "An error occurred while executing the installation, installation has likely failed. "
               + e.getMessage());
+      System.exit(1);
+      return;
     }
     System.out.println("Done extracting");
+  }
+
+  /**
+   * Map Ant process outcome to the preinstall process exit code.
+   *
+   * @param antExit return value from {@link #execJar}, may be null
+   * @param errorFlag shared error flag set by {@link #execJar}
+   * @param sharedProcessCode shared process code field updated by {@link #execJar}
+   * @return 0 on success; non-zero on failure
+   */
+  static int resolveInstallExitCode(
+      Integer antExit, Boolean errorFlag, Integer sharedProcessCode) {
+    if (antExit != null && antExit != 0) {
+      return antExit;
+    }
+    if (Boolean.TRUE.equals(errorFlag)) {
+      if (sharedProcessCode != null && sharedProcessCode != 0) {
+        return sharedProcessCode;
+      }
+      return 1;
+    }
+    if (sharedProcessCode != null && sharedProcessCode != 0) {
+      return sharedProcessCode;
+    }
+    return 0;
   }
 
   private static void deleteOldJDBCJars(Path installPath) {
@@ -289,7 +328,10 @@ public class Main {
   }
 
   public static Integer execJar(
-      Path jar, Path execPath, Path installDir, ResolvedDbConfig resolvedDbConfig)
+      Path jar,
+      Path execPath,
+      Path installDir,
+      DbInstallConfigResolver.ResolvedDbConfig resolvedDbConfig)
       throws IOException, InterruptedException {
 
     try {
@@ -411,323 +453,6 @@ public class Main {
     }
     return processCode;
   }
-
-  private static ParsedArgs parseArgs(String[] args) {
-    Path installPath = null;
-    Map<String, String> options = new HashMap<>();
-
-    int index = 0;
-    while (index < args.length) {
-      String argument = args[index];
-      if (!argument.startsWith("--")) {
-        if (installPath == null) {
-          installPath = Paths.get(argument);
-        }
-        index++;
-        continue;
-      }
-
-      String option = argument.substring(2);
-      String key;
-      String value;
-      int equalsPosition = option.indexOf('=');
-      if (equalsPosition > -1) {
-        key = option.substring(0, equalsPosition).trim();
-        value = option.substring(equalsPosition + 1).trim();
-      } else {
-        key = option.trim();
-        if (index + 1 < args.length && !args[index + 1].startsWith("--")) {
-          value = args[index + 1].trim();
-          index++;
-        } else {
-          value = "true";
-        }
-      }
-
-      if (!key.isEmpty()) {
-        options.put(key, value);
-      }
-      index++;
-    }
-
-    return new ParsedArgs(installPath, options);
-  }
-
-  private static ResolvedDbConfig resolveDbConfig(Map<String, String> cliOptions) {
-    Map<String, String> environmentFileValues = new HashMap<>();
-    String envFilePath =
-        firstNonBlank(
-            cliOptions.get("db.config.env.file"),
-            System.getenv("DB_CONFIG_ENV_FILE"),
-            System.getenv("PERC_DB_CONFIG_ENV_FILE"));
-
-    if (envFilePath != null) {
-      environmentFileValues.putAll(loadEnvFile(envFilePath));
-    }
-
-    String dbType = getConfigValue("db.type", cliOptions, environmentFileValues, null);
-    if (isBlank(dbType)) {
-      dbType = DB_TYPE_DEFAULT;
-    }
-    dbType = dbType.toLowerCase(Locale.ROOT);
-
-    String sslEnabled =
-        normalizeBoolean(
-            getConfigValue(
-                "db.ssl.enabled", cliOptions, environmentFileValues, DB_SSL_ENABLED_DEFAULT),
-            "db.ssl.enabled");
-    String sslVerify =
-        normalizeBoolean(
-            getConfigValue(
-                "db.ssl.verify", cliOptions, environmentFileValues, DB_SSL_VERIFY_DEFAULT),
-            "db.ssl.verify");
-    String sslAllowSelfSigned =
-        normalizeBoolean(
-            getConfigValue(
-                "db.ssl.allowSelfSigned",
-                cliOptions,
-                environmentFileValues,
-                DB_SSL_ALLOW_SELF_SIGNED_DEFAULT),
-            "db.ssl.allowSelfSigned");
-
-    String host = getConfigValue("db.host", cliOptions, environmentFileValues, null);
-    String port = getConfigValue("db.port", cliOptions, environmentFileValues, null);
-    String name = getConfigValue("db.name", cliOptions, environmentFileValues, null);
-    String schema = getConfigValue("db.schema", cliOptions, environmentFileValues, null);
-    String user = getConfigValue("db.user", cliOptions, environmentFileValues, null);
-    String password = getConfigValue("db.password", cliOptions, environmentFileValues, null);
-
-    if (!Objects.equals(dbType, "derby")) {
-      List<String> missing = new ArrayList<>();
-      if (isBlank(host)) {
-        missing.add("db.host");
-      }
-      if (isBlank(port)) {
-        missing.add("db.port");
-      }
-      if (isBlank(name)) {
-        missing.add("db.name");
-      }
-      if (isBlank(user)) {
-        missing.add("db.user");
-      }
-      if (isBlank(password)) {
-        missing.add("db.password");
-      }
-      if (!missing.isEmpty()) {
-        throw new IllegalArgumentException(
-            "Missing required database parameters for db.type="
-                + dbType
-                + ": "
-                + String.join(", ", missing));
-      }
-    }
-
-    Map<String, String> systemProperties = new HashMap<>();
-    systemProperties.put("perc.db.type", dbType);
-    systemProperties.put("perc.db.ssl.enabled", sslEnabled);
-    systemProperties.put("perc.db.ssl.verify", sslVerify);
-    systemProperties.put("perc.db.ssl.allowSelfSigned", sslAllowSelfSigned);
-    setIfPresent(systemProperties, "perc.db.host", host);
-    setIfPresent(systemProperties, "perc.db.port", port);
-    setIfPresent(systemProperties, "perc.db.name", name);
-    setIfPresent(systemProperties, "perc.db.schema", schema);
-    setIfPresent(systemProperties, "perc.db.user", user);
-    setIfPresent(systemProperties, "perc.db.password", password);
-    setIfPresent(
-        systemProperties,
-        "perc.db.ssl.trustStorePath",
-        getConfigValue("db.ssl.trustStorePath", cliOptions, environmentFileValues, null));
-    setIfPresent(
-        systemProperties,
-        "perc.db.ssl.trustStorePassword",
-        getConfigValue("db.ssl.trustStorePassword", cliOptions, environmentFileValues, null));
-    setIfPresent(
-        systemProperties,
-        "perc.db.ssl.keyStorePath",
-        getConfigValue("db.ssl.keyStorePath", cliOptions, environmentFileValues, null));
-    setIfPresent(
-        systemProperties,
-        "perc.db.ssl.keyStorePassword",
-        getConfigValue("db.ssl.keyStorePassword", cliOptions, environmentFileValues, null));
-
-    if (Objects.equals(dbType, "mysql")) {
-      String resolvedSchema = firstNonBlank(schema, "");
-      String cmsServer =
-          "//"
-              + host
-              + ":"
-              + port
-              + "/"
-              + name
-              + "?useUnicode=yes&characterEncoding=UTF-8"
-              + "&useSSL="
-              + sslEnabled
-              + "&requireSSL="
-              + sslEnabled
-              + "&verifyServerCertificate="
-              + sslVerify;
-      systemProperties.put("perc.db.cms.backend", "MYSQL");
-      systemProperties.put("perc.db.cms.driverName", "mysql");
-      systemProperties.put("perc.db.cms.driverClass", "com.mysql.cj.jdbc.Driver");
-      systemProperties.put("perc.db.cms.server", cmsServer);
-      systemProperties.put("perc.db.cms.name", name);
-      systemProperties.put("perc.db.cms.schema", resolvedSchema);
-      systemProperties.put(
-          "perc.db.dts.jdbcUrl",
-          "jdbc:mysql://"
-              + host
-              + ":"
-              + port
-              + "/"
-              + name
-              + "?useUnicode=yes&characterEncoding=UTF-8"
-              + "&useSSL="
-              + sslEnabled
-              + "&requireSSL="
-              + sslEnabled
-              + "&verifyServerCertificate="
-              + sslVerify);
-      systemProperties.put("perc.db.dts.jdbcDriver", "com.mysql.cj.jdbc.Driver");
-      systemProperties.put(
-          "perc.db.dts.hibernateDialect", "org.hibernate.dialect.MySQL5InnoDBDialect");
-      systemProperties.put("perc.db.dts.schema", resolvedSchema);
-    } else if (Objects.equals(dbType, "sqlserver")) {
-      String resolvedSchema = firstNonBlank(schema, "DBO");
-      String trustServerCertificate =
-          Objects.equals(sslAllowSelfSigned, "true") || Objects.equals(sslVerify, "false")
-              ? "true"
-              : "false";
-      String cmsServer =
-          "//"
-              + host
-              + ":"
-              + port
-              + ";databaseName="
-              + name
-              + ";encrypt="
-              + sslEnabled
-              + ";trustServerCertificate="
-              + trustServerCertificate;
-      systemProperties.put("perc.db.cms.backend", "MSSQL");
-      systemProperties.put("perc.db.cms.driverName", "sqlserver");
-      systemProperties.put(
-          "perc.db.cms.driverClass", "com.microsoft.sqlserver.jdbc.SQLServerDriver");
-      systemProperties.put("perc.db.cms.server", cmsServer);
-      systemProperties.put("perc.db.cms.name", name);
-      systemProperties.put("perc.db.cms.schema", resolvedSchema);
-      systemProperties.put(
-          "perc.db.dts.jdbcUrl",
-          "jdbc:sqlserver://"
-              + host
-              + ":"
-              + port
-              + ";databaseName="
-              + name
-              + ";encrypt="
-              + sslEnabled
-              + ";trustServerCertificate="
-              + trustServerCertificate);
-      systemProperties.put(
-          "perc.db.dts.jdbcDriver", "com.microsoft.sqlserver.jdbc.SQLServerDriver");
-      systemProperties.put(
-          "perc.db.dts.hibernateDialect",
-          "com.percussion.delivery.rdbms.PSUnicodeSQLServerDialect");
-      systemProperties.put("perc.db.dts.schema", resolvedSchema);
-    }
-
-    return new ResolvedDbConfig(systemProperties);
-  }
-
-  private static Map<String, String> loadEnvFile(String envFilePath) {
-    Map<String, String> values = new HashMap<>();
-    Path path = Paths.get(envFilePath);
-    if (!Files.exists(path)) {
-      throw new IllegalArgumentException("db.config.env.file not found: " + envFilePath);
-    }
-    try {
-      List<String> lines = Files.readAllLines(path);
-      for (String line : lines) {
-        if (line == null) {
-          continue;
-        }
-        String trimmed = line.trim();
-        if (trimmed.isEmpty() || trimmed.startsWith("#")) {
-          continue;
-        }
-        int separator = trimmed.indexOf('=');
-        if (separator <= 0) {
-          continue;
-        }
-        String key = trimmed.substring(0, separator).trim();
-        String value = trimmed.substring(separator + 1).trim();
-        values.put(key, value);
-      }
-      return values;
-    } catch (IOException e) {
-      throw new IllegalArgumentException("Unable to read db.config.env.file: " + envFilePath, e);
-    }
-  }
-
-  private static String getConfigValue(
-      String logicalKey,
-      Map<String, String> cliOptions,
-      Map<String, String> envFileValues,
-      String defaultValue) {
-    String envStyle = logicalToEnvStyle(logicalKey);
-    String percEnvStyle = "PERC_" + envStyle;
-    return firstNonBlank(
-        cliOptions.get(logicalKey),
-        cliOptions.get(envStyle),
-        cliOptions.get(percEnvStyle),
-        envFileValues.get(logicalKey),
-        envFileValues.get(envStyle),
-        envFileValues.get(percEnvStyle),
-        System.getenv(logicalKey),
-        System.getenv(envStyle),
-        System.getenv(percEnvStyle),
-        defaultValue);
-  }
-
-  private static String logicalToEnvStyle(String logicalKey) {
-    return logicalKey.toUpperCase(Locale.ROOT).replace('.', '_');
-  }
-
-  private static String firstNonBlank(String... values) {
-    for (String value : values) {
-      if (!isBlank(value)) {
-        return value.trim();
-      }
-    }
-    return null;
-  }
-
-  private static boolean isBlank(String value) {
-    return value == null || value.trim().isEmpty();
-  }
-
-  private static String normalizeBoolean(String value, String key) {
-    if (isBlank(value)) {
-      throw new IllegalArgumentException("Missing required boolean value for " + key);
-    }
-    if ("true".equalsIgnoreCase(value)) {
-      return "true";
-    }
-    if ("false".equalsIgnoreCase(value)) {
-      return "false";
-    }
-    throw new IllegalArgumentException("Invalid boolean value for " + key + ": " + value);
-  }
-
-  private static void setIfPresent(Map<String, String> target, String key, String value) {
-    if (!isBlank(value)) {
-      target.put(key, value.trim());
-    }
-  }
-
-  private record ParsedArgs(Path installPath, Map<String, String> options) {}
-
-  private record ResolvedDbConfig(Map<String, String> systemProperties) {}
 
   private static Properties loadVersionProperties(Path installDir) {
     File versionFile = new File(installDir + File.separator + VERSION_PROPERTIES);

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml
@@ -533,10 +533,18 @@
 
 		<PSMakeLasagna root="${install.dir}" />
 
-		<!-- New-install only: fail fast if repository is unreachable (issue #949 FR-008).
-		     Gated by do.install so upgrades do not re-validate / rewrite backends. -->
+		<!-- New-install non-Derby only: fail fast if repository is unreachable (issue #949 FR-008).
+		     Skip embedded Derby defaults (props are already connectable via product defaults and
+		     validation here would only add risk without targeting enterprise backends).
+		     Upgrades excluded via do.install so backends are not re-validated/rewritten. -->
 		<if>
-			<istrue value="${do.install}" />
+			<and>
+				<istrue value="${do.install}" />
+				<not>
+					<equals arg1="${perc.db.type}" arg2="derby"
+						casesensitive="false" />
+				</not>
+			</and>
 			<then>
 				<PSValidateRepositoryConnection rootDir="${install.dir}"
 					loginTimeoutSeconds="15" />

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml
@@ -479,6 +479,31 @@
 				</if>
 
 				<if>
+					<equals arg1="${perc.db.type}" arg2="oracle"
+						casesensitive="false" />
+					<then>
+						<propertyfile file="${rxrepository.properties}"
+							comment="Repository Properties">
+							<entry key="DB_BACKEND" value="${perc.db.cms.backend}" />
+							<entry key="DB_DRIVER_NAME"
+								value="${perc.db.cms.driverName}" />
+							<entry key="DB_DRIVER_CLASS_NAME"
+								value="${perc.db.cms.driverClass}" />
+							<entry key="DB_SERVER" value="${perc.db.cms.server}" />
+							<entry key="DB_NAME" value="${perc.db.cms.name}" />
+							<entry key="DB_SCHEMA" value="${perc.db.cms.schema}" />
+							<entry key="UID" value="${perc.db.user}" />
+							<entry key="PWD" value="${perc.db.password}" />
+							<entry key="PWD_ENCRYPTED" value="N" />
+							<entry key="DB_SSL_ENABLED" value="${perc.db.ssl.enabled}" />
+							<entry key="DB_SSL_VERIFY" value="${perc.db.ssl.verify}" />
+							<entry key="DB_SSL_ALLOW_SELF_SIGNED"
+								value="${perc.db.ssl.allowSelfSigned}" />
+						</propertyfile>
+					</then>
+				</if>
+
+				<if>
 					<equals arg1="${perc.db.type}" arg2="derby"
 						casesensitive="false" />
 					<then>
@@ -507,6 +532,16 @@
 		</if>
 
 		<PSMakeLasagna root="${install.dir}" />
+
+		<!-- New-install only: fail fast if repository is unreachable (issue #949 FR-008).
+		     Gated by do.install so upgrades do not re-validate / rewrite backends. -->
+		<if>
+			<istrue value="${do.install}" />
+			<then>
+				<PSValidateRepositoryConnection rootDir="${install.dir}"
+					loginTimeoutSeconds="15" />
+			</then>
+		</if>
 	</target>
 
 	<target name="exportDB">

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/samples/rxrepository.mysql.properties
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/samples/rxrepository.mysql.properties
@@ -1,0 +1,22 @@
+# Sample CMS repository target for MySQL / MariaDB-compatible servers (new CLI install).
+# Usage:
+#   java -Ddbprops=/path/to/this-file.properties -jar PercussionCMS.jar /path/to/install/root
+# Or:
+#   java -jar PercussionCMS.jar /path/to/install/root --dbprops=/path/to/this-file.properties
+#
+# Pre-create an empty database and user with DDL privileges. Replace placeholders below.
+
+DB_BACKEND=MYSQL
+DB_SERVER=//db.example.com:3306/percussion?useUnicode=yes&characterEncoding=UTF-8
+DB_NAME=percussion
+DB_SCHEMA=
+DB_DRIVER_NAME=mysql
+# Default packaged connector is MariaDB (see jetty/base/lib/jdbc). Override if you drop in another driver.
+DB_DRIVER_CLASS_NAME=org.mariadb.jdbc.Driver
+UID=cms
+PWD=changeit
+PWD_ENCRYPTED=N
+DSCONFIG_NAME=PercussionData
+DB_SSL_ENABLED=true
+DB_SSL_VERIFY=true
+DB_SSL_ALLOW_SELF_SIGNED=false

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/samples/rxrepository.oracle.properties
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/samples/rxrepository.oracle.properties
@@ -1,0 +1,19 @@
+# Sample CMS repository target for Oracle (thin driver) — new CLI install.
+# Usage:
+#   java -Ddbprops=/path/to/this-file.properties -jar PercussionCMS.jar /path/to/install/root
+#
+# DB_SERVER uses the product thin form @host:port:serviceOrSid. Adjust to your DBA's SID/service name.
+
+DB_BACKEND=ORACLE
+DB_SERVER=@ora.example.com:1521:ORCL
+DB_NAME=
+DB_SCHEMA=CMS
+DB_DRIVER_NAME=oracle:thin
+DB_DRIVER_CLASS_NAME=oracle.jdbc.OracleDriver
+UID=cms
+PWD=changeit
+PWD_ENCRYPTED=N
+DSCONFIG_NAME=PercussionData
+DB_SSL_ENABLED=true
+DB_SSL_VERIFY=true
+DB_SSL_ALLOW_SELF_SIGNED=false

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/samples/rxrepository.sqlserver.properties
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/samples/rxrepository.sqlserver.properties
@@ -1,0 +1,17 @@
+# Sample CMS repository target for Microsoft SQL Server (new CLI install).
+# Usage:
+#   java -Ddbprops=/path/to/this-file.properties -jar PercussionCMS.jar /path/to/install/root
+
+DB_BACKEND=MSSQL
+DB_SERVER=//sql.example.com:1433;databaseName=PercussionDB;encrypt=true;trustServerCertificate=false
+DB_NAME=PercussionDB
+DB_SCHEMA=dbo
+DB_DRIVER_NAME=sqlserver
+DB_DRIVER_CLASS_NAME=com.microsoft.sqlserver.jdbc.SQLServerDriver
+UID=cms
+PWD=changeit
+PWD_ENCRYPTED=N
+DSCONFIG_NAME=PercussionData
+DB_SSL_ENABLED=true
+DB_SSL_VERIFY=true
+DB_SSL_ALLOW_SELF_SIGNED=false

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/DbInstallConfigResolverTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/DbInstallConfigResolverTest.java
@@ -92,7 +92,7 @@ class DbInstallConfigResolverTest {
         DbInstallConfigResolver.resolveDbConfig(opts);
     assertEquals("sqlserver", cfg.systemProperties().get("perc.db.type"));
     assertEquals("MSSQL", cfg.systemProperties().get("perc.db.cms.backend"));
-    assertEquals("DBO", cfg.systemProperties().get("perc.db.cms.schema"));
+    assertEquals("dbo", cfg.systemProperties().get("perc.db.cms.schema"));
   }
 
   @Test
@@ -111,6 +111,38 @@ class DbInstallConfigResolverTest {
     assertEquals("ORACLE", cfg.systemProperties().get("perc.db.cms.backend"));
     assertEquals("oracle:thin", cfg.systemProperties().get("perc.db.cms.driverName"));
     assertTrue(cfg.systemProperties().get("perc.db.cms.server").startsWith("@ora.example.com"));
+    assertTrue(cfg.systemProperties().get("perc.db.cms.server").endsWith(":ORCL"));
+  }
+
+  @Test
+  void structuredOracleRequiresDbNameForServiceOrSid() {
+    Map<String, String> opts = new HashMap<>();
+    opts.put("db.type", "oracle");
+    opts.put("db.host", "ora.example.com");
+    opts.put("db.port", "1521");
+    opts.put("db.user", "cms");
+    opts.put("db.password", "x");
+    // no db.name → must not produce @host:port:
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> DbInstallConfigResolver.resolveDbConfig(opts));
+    assertTrue(ex.getMessage().contains("db.name"));
+  }
+
+  @Test
+  void structuredSqlServerDefaultsSchemaToDbo() {
+    Map<String, String> opts = new HashMap<>();
+    opts.put("db.type", "sqlserver");
+    opts.put("db.host", "sql.example.com");
+    opts.put("db.port", "1433");
+    opts.put("db.name", "PercussionDB");
+    opts.put("db.user", "sa");
+    opts.put("db.password", "x");
+
+    DbInstallConfigResolver.ResolvedDbConfig cfg =
+        DbInstallConfigResolver.resolveDbConfig(opts);
+    assertEquals("dbo", cfg.systemProperties().get("perc.db.cms.schema"));
   }
 
   @Test
@@ -163,6 +195,7 @@ class DbInstallConfigResolverTest {
         DbInstallConfigResolver.resolveDbConfig(Map.of("dbprops", mssql.toString()));
     assertEquals("sqlserver", m.systemProperties().get("perc.db.type"));
     assertEquals("MSSQL", m.systemProperties().get("perc.db.cms.backend"));
+    assertEquals("dbo", m.systemProperties().get("perc.db.cms.schema"));
 
     Path ora = tempDir.resolve("ora.properties");
     Files.writeString(

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/DbInstallConfigResolverTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/DbInstallConfigResolverTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("UnitTest")
+class DbInstallConfigResolverTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void defaultIsDerbyWhenNoOptions() {
+    DbInstallConfigResolver.ResolvedDbConfig cfg =
+        DbInstallConfigResolver.resolveDbConfig(Map.of());
+    assertEquals("derby", cfg.systemProperties().get("perc.db.type"));
+    assertFalse(cfg.systemProperties().containsKey("perc.db.cms.backend"));
+  }
+
+  @Test
+  void structuredMysqlMapsCmsFieldsWithMariaDbDriver() {
+    Map<String, String> opts = new HashMap<>();
+    opts.put("db.type", "mysql");
+    opts.put("db.host", "db.example.com");
+    opts.put("db.port", "3306");
+    opts.put("db.name", "percussion");
+    opts.put("db.user", "cms");
+    opts.put("db.password", "s3cret");
+
+    DbInstallConfigResolver.ResolvedDbConfig cfg =
+        DbInstallConfigResolver.resolveDbConfig(opts);
+    Map<String, String> p = cfg.systemProperties();
+    assertEquals("mysql", p.get("perc.db.type"));
+    assertEquals("MYSQL", p.get("perc.db.cms.backend"));
+    assertEquals("mysql", p.get("perc.db.cms.driverName"));
+    assertEquals("org.mariadb.jdbc.Driver", p.get("perc.db.cms.driverClass"));
+    assertTrue(p.get("perc.db.cms.server").contains("db.example.com"));
+    assertEquals("cms", p.get("perc.db.user"));
+    assertEquals("s3cret", p.get("perc.db.password"));
+  }
+
+  @Test
+  void structuredMysqlMissingFieldsThrowsWithoutPasswordInMessage() {
+    Map<String, String> opts = new HashMap<>();
+    opts.put("db.type", "mysql");
+    opts.put("db.password", "super-secret-pw");
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> DbInstallConfigResolver.resolveDbConfig(opts));
+    assertTrue(ex.getMessage().contains("db.host"));
+    assertFalse(ex.getMessage().contains("super-secret-pw"));
+  }
+
+  @Test
+  void structuredSqlServerMapsBackend() {
+    Map<String, String> opts = new HashMap<>();
+    opts.put("db.type", "sqlserver");
+    opts.put("db.host", "sql.example.com");
+    opts.put("db.port", "1433");
+    opts.put("db.name", "PercussionDB");
+    opts.put("db.user", "sa");
+    opts.put("db.password", "x");
+
+    DbInstallConfigResolver.ResolvedDbConfig cfg =
+        DbInstallConfigResolver.resolveDbConfig(opts);
+    assertEquals("sqlserver", cfg.systemProperties().get("perc.db.type"));
+    assertEquals("MSSQL", cfg.systemProperties().get("perc.db.cms.backend"));
+    assertEquals("DBO", cfg.systemProperties().get("perc.db.cms.schema"));
+  }
+
+  @Test
+  void structuredOracleMapsBackend() {
+    Map<String, String> opts = new HashMap<>();
+    opts.put("db.type", "oracle");
+    opts.put("db.host", "ora.example.com");
+    opts.put("db.port", "1521");
+    opts.put("db.name", "ORCL");
+    opts.put("db.user", "cms");
+    opts.put("db.password", "x");
+
+    DbInstallConfigResolver.ResolvedDbConfig cfg =
+        DbInstallConfigResolver.resolveDbConfig(opts);
+    assertEquals("oracle", cfg.systemProperties().get("perc.db.type"));
+    assertEquals("ORACLE", cfg.systemProperties().get("perc.db.cms.backend"));
+    assertEquals("oracle:thin", cfg.systemProperties().get("perc.db.cms.driverName"));
+    assertTrue(cfg.systemProperties().get("perc.db.cms.server").startsWith("@ora.example.com"));
+  }
+
+  @Test
+  void dbpropsMysqlFileMapsKeys() throws Exception {
+    Path props = tempDir.resolve("mysql.properties");
+    Files.writeString(
+        props,
+        """
+        DB_BACKEND=MYSQL
+        DB_SERVER=//db.example.com:3306/percussion
+        DB_NAME=percussion
+        DB_SCHEMA=
+        DB_DRIVER_NAME=mysql
+        DB_DRIVER_CLASS_NAME=org.mariadb.jdbc.Driver
+        UID=cms
+        PWD=file-secret
+        """,
+        StandardCharsets.UTF_8);
+
+    Map<String, String> opts = Map.of("dbprops", props.toString());
+    DbInstallConfigResolver.ResolvedDbConfig cfg =
+        DbInstallConfigResolver.resolveDbConfig(opts);
+    Map<String, String> p = cfg.systemProperties();
+    assertEquals("dbprops", cfg.source());
+    assertEquals("mysql", p.get("perc.db.type"));
+    assertEquals("MYSQL", p.get("perc.db.cms.backend"));
+    assertEquals("//db.example.com:3306/percussion", p.get("perc.db.cms.server"));
+    assertEquals("org.mariadb.jdbc.Driver", p.get("perc.db.cms.driverClass"));
+    assertEquals("cms", p.get("perc.db.user"));
+    assertEquals("file-secret", p.get("perc.db.password"));
+  }
+
+  @Test
+  void dbpropsMssqlAndOracle() throws Exception {
+    Path mssql = tempDir.resolve("mssql.properties");
+    Files.writeString(
+        mssql,
+        """
+        DB_BACKEND=MSSQL
+        DB_SERVER=//sql:1433;databaseName=P
+        DB_NAME=P
+        DB_SCHEMA=dbo
+        DB_DRIVER_NAME=sqlserver
+        DB_DRIVER_CLASS_NAME=com.microsoft.sqlserver.jdbc.SQLServerDriver
+        UID=sa
+        PWD=x
+        """,
+        StandardCharsets.UTF_8);
+    DbInstallConfigResolver.ResolvedDbConfig m =
+        DbInstallConfigResolver.resolveDbConfig(Map.of("dbprops", mssql.toString()));
+    assertEquals("sqlserver", m.systemProperties().get("perc.db.type"));
+    assertEquals("MSSQL", m.systemProperties().get("perc.db.cms.backend"));
+
+    Path ora = tempDir.resolve("ora.properties");
+    Files.writeString(
+        ora,
+        """
+        DB_BACKEND=ORACLE
+        DB_SERVER=@ora:1521:ORCL
+        DB_NAME=
+        DB_SCHEMA=CMS
+        DB_DRIVER_NAME=oracle:thin
+        DB_DRIVER_CLASS_NAME=oracle.jdbc.OracleDriver
+        UID=cms
+        PWD=x
+        """,
+        StandardCharsets.UTF_8);
+    DbInstallConfigResolver.ResolvedDbConfig o =
+        DbInstallConfigResolver.resolveDbConfig(Map.of("dbprops", ora.toString()));
+    assertEquals("oracle", o.systemProperties().get("perc.db.type"));
+    assertEquals("ORACLE", o.systemProperties().get("perc.db.cms.backend"));
+    assertEquals("@ora:1521:ORCL", o.systemProperties().get("perc.db.cms.server"));
+  }
+
+  @Test
+  void dbpropsTakesPrecedenceOverConflictingCliType() throws Exception {
+    Path props = tempDir.resolve("mysql.properties");
+    Files.writeString(
+        props,
+        """
+        DB_BACKEND=MYSQL
+        DB_SERVER=//db:3306/p
+        DB_NAME=p
+        DB_DRIVER_NAME=mysql
+        DB_DRIVER_CLASS_NAME=org.mariadb.jdbc.Driver
+        UID=u
+        PWD=p
+        """,
+        StandardCharsets.UTF_8);
+    Map<String, String> opts = new HashMap<>();
+    opts.put("dbprops", props.toString());
+    opts.put("db.type", "sqlserver");
+    opts.put("db.host", "ignored");
+    opts.put("db.port", "1433");
+    opts.put("db.name", "ignored");
+    opts.put("db.user", "ignored");
+    opts.put("db.password", "ignored");
+
+    DbInstallConfigResolver.ResolvedDbConfig cfg =
+        DbInstallConfigResolver.resolveDbConfig(opts);
+    assertEquals("mysql", cfg.systemProperties().get("perc.db.type"));
+    assertEquals("MYSQL", cfg.systemProperties().get("perc.db.cms.backend"));
+  }
+
+  @Test
+  void missingDbpropsPathFailsWithPathInMessage() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                DbInstallConfigResolver.resolveDbConfig(
+                    Map.of("dbprops", tempDir.resolve("missing.properties").toString())));
+    assertTrue(ex.getMessage().toLowerCase().contains("not found")
+        || ex.getMessage().toLowerCase().contains("not readable"));
+  }
+
+  @Test
+  void incompleteDbpropsListsKeysNotPassword() throws Exception {
+    Path props = tempDir.resolve("incomplete.properties");
+    Files.writeString(
+        props,
+        """
+        DB_BACKEND=MYSQL
+        PWD=do-not-leak-this
+        """,
+        StandardCharsets.UTF_8);
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                DbInstallConfigResolver.resolveDbConfig(
+                    Map.of("dbprops", props.toString())));
+    assertTrue(ex.getMessage().contains("DB_SERVER") || ex.getMessage().contains("UID"));
+    assertFalse(ex.getMessage().contains("do-not-leak-this"));
+  }
+
+  @Test
+  void unknownBackendFailsWithAllowedList() throws Exception {
+    Path props = tempDir.resolve("bad.properties");
+    Files.writeString(props, "DB_BACKEND=POSTGRES\n", StandardCharsets.UTF_8);
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                DbInstallConfigResolver.resolveDbConfig(
+                    Map.of("dbprops", props.toString())));
+    assertTrue(ex.getMessage().contains("MYSQL"));
+    assertTrue(ex.getMessage().contains("ORACLE"));
+  }
+
+  @Test
+  void parseArgsInstallPathAndOptions() {
+    DbInstallConfigResolver.ParsedArgs parsed =
+        DbInstallConfigResolver.parseArgs(
+            new String[] {"/opt/install", "--dbprops=/tmp/a.properties", "--db.type=mysql"});
+    assertEquals(Path.of("/opt/install"), parsed.installPath());
+    assertEquals("/tmp/a.properties", parsed.options().get("dbprops"));
+    assertEquals("mysql", parsed.options().get("db.type"));
+  }
+}

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/DbInstallSamplePropertiesTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/DbInstallSamplePropertiesTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+class DbInstallSamplePropertiesTest {
+
+  @Test
+  void samplePropertyFilesExistInDistributionTree() {
+    Path samples =
+        Path.of("src/main/resources/distribution/rxconfig/Installer/samples");
+    assertTrue(Files.isDirectory(samples), "samples directory missing: " + samples.toAbsolutePath());
+    assertTrue(Files.isRegularFile(samples.resolve("rxrepository.mysql.properties")));
+    assertTrue(Files.isRegularFile(samples.resolve("rxrepository.sqlserver.properties")));
+    assertTrue(Files.isRegularFile(samples.resolve("rxrepository.oracle.properties")));
+  }
+}

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/MainInstallExitCodeTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/MainInstallExitCodeTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+class MainInstallExitCodeTest {
+
+  @Test
+  void successWhenZeroAndNoError() {
+    assertEquals(0, Main.resolveInstallExitCode(0, false, 0));
+    assertEquals(0, Main.resolveInstallExitCode(null, false, 0));
+  }
+
+  @Test
+  void antNonZeroWins() {
+    assertEquals(3, Main.resolveInstallExitCode(3, false, 0));
+    assertEquals(2, Main.resolveInstallExitCode(2, true, 99));
+  }
+
+  @Test
+  void errorFlagProducesNonZero() {
+    assertEquals(1, Main.resolveInstallExitCode(0, true, 0));
+    assertEquals(7, Main.resolveInstallExitCode(0, true, 7));
+    assertEquals(5, Main.resolveInstallExitCode(null, true, 5));
+  }
+
+  @Test
+  void sharedProcessCodeAloneIsHonored() {
+    assertEquals(4, Main.resolveInstallExitCode(0, false, 4));
+  }
+}

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/RepositoryPropertiesInstallGuardTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/RepositoryPropertiesInstallGuardTest.java
@@ -59,10 +59,13 @@ class RepositoryPropertiesInstallGuardTest {
     // Oracle branch present for new installs
     assertTrue(
         xml.contains("arg2=\"oracle\""), "oracle branch required for new-install db targets");
-    // Connection validation also gated
+    // Connection validation wired and excluded for derby (default new install)
     assertTrue(
         xml.contains("PSValidateRepositoryConnection"),
         "connection validation task must be wired");
+    assertTrue(
+        xml.contains("arg2=\"derby\""),
+        "validation must exclude default derby new installs");
   }
 
   @Test

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/RepositoryPropertiesInstallGuardTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/RepositoryPropertiesInstallGuardTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards that fresh-install repository property writes remain behind {@code do.install} so upgrade
+ * paths do not rewrite {@code DB_BACKEND} (issue #949 / FR-006).
+ */
+@Tag("UnitTest")
+class RepositoryPropertiesInstallGuardTest {
+
+  @Test
+  void repositoryPropertiesTargetIsGatedByDoInstall() throws Exception {
+    String xml;
+    try (InputStream in =
+        getClass()
+            .getResourceAsStream(
+                "/distribution/rxconfig/Installer/installRepository.xml")) {
+      // Resource may live only under main resources — read via filesystem relative to module
+      if (in == null) {
+        xml =
+            java.nio.file.Files.readString(
+                java.nio.file.Path.of(
+                    "src/main/resources/distribution/rxconfig/Installer/installRepository.xml"),
+                StandardCharsets.UTF_8);
+      } else {
+        xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+      }
+    }
+
+    assertTrue(
+        xml.contains("name=\"repository_properties\""),
+        "repository_properties target must exist");
+    // Fresh-install apply block must check do.install
+    assertTrue(
+        xml.contains("<istrue value=\"${do.install}\" />")
+            || xml.contains("<istrue value=\"${do.install}\"/>"),
+        "repository_properties must gate on do.install");
+    // Oracle branch present for new installs
+    assertTrue(
+        xml.contains("arg2=\"oracle\""), "oracle branch required for new-install db targets");
+    // Connection validation also gated
+    assertTrue(
+        xml.contains("PSValidateRepositoryConnection"),
+        "connection validation task must be wired");
+  }
+
+  @Test
+  void upgradeFixtureDocumentsNonDerbyBackend() throws Exception {
+    String fixture =
+        new String(
+            getClass()
+                .getResourceAsStream(
+                    "/com/percussion/preinstall/upgrade-fixture/rxrepository.properties")
+                .readAllBytes(),
+            StandardCharsets.UTF_8);
+    assertTrue(fixture.contains("DB_BACKEND=MSSQL"));
+  }
+}

--- a/modules/perc-distribution-tree/src/test/resources/com/percussion/preinstall/upgrade-fixture/rxrepository.properties
+++ b/modules/perc-distribution-tree/src/test/resources/com/percussion/preinstall/upgrade-fixture/rxrepository.properties
@@ -1,0 +1,12 @@
+# Fixture representing an existing non-Derby install root (upgrade non-regression).
+# Not applied by tests that rewrite production config; documents expected pre-upgrade shape.
+DB_BACKEND=MSSQL
+DB_DRIVER_NAME=sqlserver
+DB_DRIVER_CLASS_NAME=com.microsoft.sqlserver.jdbc.SQLServerDriver
+DB_SERVER=//sql.example.com:1433;databaseName=PercussionDB
+DB_NAME=PercussionDB
+DB_SCHEMA=dbo
+UID=cms
+PWD=fixture-not-used-for-live-connect
+PWD_ENCRYPTED=N
+DSCONFIG_NAME=PercussionData

--- a/specs/006-installer-db-targets/checklists/requirements.md
+++ b/specs/006-installer-db-targets/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: CLI Installer Database Targets for New Installs
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-07-15  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass 1 (2026-07-15): All items pass.
+- Spec is stakeholder-oriented: module paths appear only in Module Scope (mono-repo mandatory section) and path examples that integrators already use (`rxrepository.properties`, `-Ddbprops`).
+- No `[NEEDS CLARIFICATION]` markers; informed defaults recorded in Assumptions (properties-file contract, CMS new-install scope, DTS out of scope unless coupled, MySQL includes MariaDB-compatible).
+- Ready for `/speckit-clarify` (optional) or `/speckit-plan`.

--- a/specs/006-installer-db-targets/contracts/README.md
+++ b/specs/006-installer-db-targets/contracts/README.md
@@ -1,0 +1,19 @@
+# Contracts: CLI Installer Database Targets
+
+**Feature**: `specs/006-installer-db-targets`  
+**Date**: 2026-07-15
+
+This feature exposes **install-time integrator contracts**, not a new HTTP API.
+
+| Contract | Audience | Artifact |
+|----------|----------|----------|
+| CLI / system-property input | Integrators, automation | [installer-db-input.md](installer-db-input.md) |
+| Effective repository properties | CMS runtime + install tools | [rxrepository-properties.md](rxrepository-properties.md) |
+| Sample property files | Integrators | Shipped under `rxconfig/Installer/samples/` (planned) |
+
+## Non-contracts (out of scope)
+
+- Public REST/SOAP APIs — unchanged.
+- DTS `perc-datasources.properties` write-through — follow-on.
+- GUI installer dialog contract — unchanged unless shared code path.
+- Upgrade rewrite of repository identity — **must not** happen.

--- a/specs/006-installer-db-targets/contracts/installer-db-input.md
+++ b/specs/006-installer-db-targets/contracts/installer-db-input.md
@@ -1,0 +1,107 @@
+# Contract: Installer Database Target Input (New Install)
+
+## Purpose
+
+Define how integrators supply a non-Derby (or explicit Derby) repository target when performing a **new** command-line CMS install.
+
+## Invocation surface
+
+### A. Primary — properties file (issue #949)
+
+```text
+java [jvm-args] -Ddbprops=/absolute/or/relative/path/to/repo.properties \
+  -jar PercussionCMS.jar /path/to/install/root
+```
+
+Also accepted as CLI option (same semantics):
+
+```text
+java -jar PercussionCMS.jar /path/to/install/root --dbprops=/path/to/repo.properties
+```
+
+**Path resolution**: Relative paths resolve against the process working directory. Missing/unreadable path → install aborts before repository setup with an error that includes the path (not file contents).
+
+### B. Secondary — structured flags / env (existing code, retained)
+
+```text
+java -jar PercussionCMS.jar /path/to/install/root \
+  --db.type=mysql \
+  --db.host=db.example.com \
+  --db.port=3306 \
+  --db.name=percussion \
+  --db.schema= \
+  --db.user=cms \
+  --db.password=*** \
+  [--db.ssl.enabled=true] [--db.ssl.verify=true] [--db.ssl.allowSelfSigned=false]
+```
+
+Env file:
+
+```text
+--db.config.env.file=/path/to/db.env
+```
+
+Env file lines: `KEY=VALUE`, `#` comments, blank lines ignored. Keys may be logical (`db.host`) or env-style (`DB_HOST` / `PERC_DB_HOST`).
+
+### C. Default
+
+If neither A nor B supplies a non-Derby type, install uses **embedded Derby** (current default).
+
+## Precedence (highest first)
+
+1. `--dbprops` / `-Ddbprops` file contents for repository identity fields  
+2. CLI `--db.*` (and env-style aliases on CLI)  
+3. Values from `--db.config.env.file`  
+4. Process environment variables  
+5. Built-in defaults (`db.type=derby`, SSL defaults true/true/false)
+
+Mixing: If `dbprops` is set, structured keys may still supply SSL-only overrides when not present in the file (implementation may document exact merge rules; identity fields come from the file).
+
+## Properties file schema
+
+See [rxrepository-properties.md](rxrepository-properties.md) for keys. Minimum non-Derby example:
+
+```properties
+DB_BACKEND=MYSQL
+DB_SERVER=//db.example.com:3306/percussion?useUnicode=yes&characterEncoding=UTF-8
+DB_NAME=percussion
+DB_SCHEMA=
+DB_DRIVER_NAME=mysql
+DB_DRIVER_CLASS_NAME=org.mariadb.jdbc.Driver
+UID=cms
+PWD=changeit
+PWD_ENCRYPTED=N
+DSCONFIG_NAME=PercussionData
+```
+
+## Supported `DB_BACKEND` / `db.type` values
+
+| File `DB_BACKEND` | Structured `db.type` | Notes |
+|-------------------|----------------------|-------|
+| `DERBY` | `derby` | Default |
+| `MYSQL` | `mysql` | MySQL or MariaDB-compatible server |
+| `MSSQL` | `sqlserver` | Microsoft SQL Server |
+| `ORACLE` | `oracle` | Oracle thin (recommended sample) |
+
+Any other value → validation error listing allowed values.
+
+## Error contract
+
+| Condition | Behavior |
+|-----------|----------|
+| Missing install path | Message; non-success exit |
+| dbprops path missing/unreadable | Fail before schema; message includes path |
+| Required fields missing | Fail; list missing logical keys (never values of secrets) |
+| Unknown backend | Fail; list allowed backends |
+| Connectivity failure | Fail after props write attempt / before or during pre-schema validate; user-readable SQL/driver message; **no password** |
+| Missing JDBC driver JAR | Fail with guidance to place driver in documented `jetty/base/lib/jdbc` location |
+
+## Success contract
+
+- Exit success only if install chain completes.
+- Effective `{install}/rxconfig/Installer/rxrepository.properties` reflects selected backend and non-secret identity fields.
+- Upgrade invocations without new-install mode do not require this contract and must not reset backend to Derby.
+
+## Versioning
+
+Backward compatible additive contract: existing Derby-only installs with no flags remain valid. New flags are optional.

--- a/specs/006-installer-db-targets/contracts/rxrepository-properties.md
+++ b/specs/006-installer-db-targets/contracts/rxrepository-properties.md
@@ -1,0 +1,52 @@
+# Contract: Effective `rxrepository.properties`
+
+## Location
+
+```text
+{install.dir}/rxconfig/Installer/rxrepository.properties
+```
+
+Written or updated on **new install** by the installer when applying database target configuration. On **upgrade**, existing values for backend identity must be preserved by this feature.
+
+## Canonical keys (CMS repository)
+
+| Key | Description | Example (illustrative) |
+|-----|-------------|------------------------|
+| `DB_BACKEND` | Backend alias | `DERBY`, `MYSQL`, `MSSQL`, `ORACLE` |
+| `DB_DRIVER_NAME` | Logical/JDBC driver name | `derby`, `mysql`, `sqlserver`, `oracle:thin` |
+| `DB_DRIVER_CLASS_NAME` | JDBC `Driver` class | `org.apache.derby.jdbc.EmbeddedDriver`, `org.mariadb.jdbc.Driver`, `com.microsoft.sqlserver.jdbc.SQLServerDriver`, `oracle.jdbc.OracleDriver` |
+| `DB_SERVER` | Server identity string (backend-specific) | See samples |
+| `DB_NAME` | Database name | `percussion` or empty (Oracle often empty) |
+| `DB_SCHEMA` | Schema | `CMDB`, `dbo`, Oracle schema name |
+| `UID` | User | |
+| `PWD` | Password | |
+| `PWD_ENCRYPTED` | `Y` or `N` | Install may encrypt after write via existing steps |
+| `DSCONFIG_NAME` | Datasource config name | `PercussionData` |
+| `DB_SSL_ENABLED` | SSL enabled flag | `true`/`false` |
+| `DB_SSL_VERIFY` | Verify server cert | `true`/`false` |
+| `DB_SSL_ALLOW_SELF_SIGNED` | Allow self-signed | `true`/`false` |
+
+Additional keys may exist historically for tools/notifications; this feature does not require them for new-install targeting.
+
+## Backend-specific `DB_SERVER` shapes (reference)
+
+Integrators supplying **dbprops** own the final `DB_SERVER` string. Structured CLI composition will produce equivalent forms:
+
+| Backend | Typical `DB_SERVER` form |
+|---------|---------------------------|
+| Derby | `CMDB;create=true` (product default) |
+| MySQL/MariaDB | `//host:port/dbname?useUnicode=yes&characterEncoding=UTF-8&...` |
+| SQL Server | `//host:port;databaseName=dbname;encrypt=...;trustServerCertificate=...` |
+| Oracle thin | `@host:port:serviceOrSid` (document exact recommended sample in shipped file) |
+
+## Consumers (must keep working)
+
+- `com.percussion.ant.install.PSConfigureDatasource`
+- `com.percussion.ant.install.PSMakeLasagna`
+- `com.percussion.ant.install.PSExecSQLStmt` and related SQL install actions
+- `com.percussion.tablefactory.PSJdbcDbmsDef` / table factory
+- Runtime container datasource configuration derived during install
+
+## Stability
+
+Key names are a **long-standing product contract**. This feature must not rename keys. New optional SSL keys are additive and already partially used by the fresh-install ANT target.

--- a/specs/006-installer-db-targets/data-model.md
+++ b/specs/006-installer-db-targets/data-model.md
@@ -1,0 +1,174 @@
+# Data Model: CLI Installer Database Targets
+
+**Feature**: `specs/006-installer-db-targets`  
+**Date**: 2026-07-15
+
+This feature does not introduce a new persistent application schema. It models **install-time configuration entities** that flow from integrator input into the CMS repository configuration files already used at runtime.
+
+## Entities
+
+### 1. DatabaseTargetPropertiesFile (integrator input)
+
+Integrator-supplied Java properties file (issue #949 / `-Ddbprops` / `--dbprops`).
+
+| Field (key) | Type | Required | Description |
+|-------------|------|----------|-------------|
+| `DB_BACKEND` | enum string | Yes (non-Derby) | `DERBY` \| `MYSQL` \| `MSSQL` \| `ORACLE` (case-insensitive) |
+| `DB_SERVER` | string | Yes (non-Derby) | Backend-specific server / JDBC server identity string as used by CMS |
+| `DB_NAME` | string | Backend-dependent | Database name (MySQL/MSSQL); often empty for Oracle |
+| `DB_SCHEMA` | string | Backend-dependent | Schema/user schema (e.g. `dbo`, Oracle schema, empty/default for MySQL) |
+| `DB_DRIVER_NAME` | string | Yes (non-Derby) | Logical driver name (e.g. `mysql`, `sqlserver`, `oracle:thin`, `derby`) |
+| `DB_DRIVER_CLASS_NAME` | string | Yes (non-Derby) | JDBC driver class |
+| `UID` | string | Yes (non-Derby) | Repository user |
+| `PWD` | string | Yes (non-Derby) | Repository password (may be plain; encryption handled by existing install steps) |
+| `PWD_ENCRYPTED` | `Y`/`N` | No | Default `N` for new supplied files |
+| `DSCONFIG_NAME` | string | No | Default `PercussionData` |
+| `DB_SSL_ENABLED` | boolean string | No | Default product SSL default (`true`) |
+| `DB_SSL_VERIFY` | boolean string | No | Default `true` |
+| `DB_SSL_ALLOW_SELF_SIGNED` | boolean string | No | Default `false` |
+
+**Validation rules**:
+
+- File path must exist, be a regular file, and be readable.
+- Unknown `DB_BACKEND` → fail with list of allowed values.
+- For `MYSQL` / `MSSQL` / `ORACLE`: require `DB_SERVER`, `UID`, `PWD`, `DB_DRIVER_NAME`, `DB_DRIVER_CLASS_NAME`; require `DB_NAME` for MYSQL/MSSQL; schema required or defaulted per backend (MSSQL default `dbo` / `DBO` consistent with product).
+- For `DERBY` (or omitting dbprops): no host credentials required.
+- Passwords must never be written to console/log in clear text by validation code.
+
+**Relationships**: Maps 1:1 into `ResolvedInstallDbConfig` then into `EffectiveRepositoryConfiguration`.
+
+---
+
+### 2. StructuredDbCliInput (secondary input)
+
+Already partially implemented; retained as alternate automation surface.
+
+| Logical key | Env style | Description |
+|-------------|-----------|-------------|
+| `db.type` | `DB_TYPE` / `PERC_DB_TYPE` | `derby` \| `mysql` \| `sqlserver` \| `oracle` |
+| `db.host` | `DB_HOST` | Hostname |
+| `db.port` | `DB_PORT` | Port |
+| `db.name` | `DB_NAME` | Database name |
+| `db.schema` | `DB_SCHEMA` | Schema |
+| `db.user` | `DB_USER` | User |
+| `db.password` | `DB_PASSWORD` | Password |
+| `db.ssl.*` | `DB_SSL_*` | SSL flags and optional keystore paths |
+| `db.config.env.file` | `DB_CONFIG_ENV_FILE` | Path to KEY=VALUE env-style file |
+
+**Validation rules**: Non-Derby requires host, port, name, user, password (existing code). Oracle composition rules documented in contracts.
+
+**Precedence** relative to dbprops: see research D2.
+
+---
+
+### 3. ResolvedInstallDbConfig (internal)
+
+In-memory result of resolution used to launch ANT.
+
+| Field | Description |
+|-------|-------------|
+| `systemProperties` | Map of `perc.db.*` keys passed as JVM `-D` to the install ANT process |
+| `source` | `default` \| `dbprops` \| `cli` \| `env-file` \| `environment` (for diagnostics; optional) |
+| `backendType` | Normalized: `derby` \| `mysql` \| `sqlserver` \| `oracle` |
+
+**Key `perc.db.*` outputs** (consumed by ANT):
+
+| Key | Purpose |
+|-----|---------|
+| `perc.db.type` | Branch selector in `repository_properties` |
+| `perc.db.cms.backend` | → `DB_BACKEND` |
+| `perc.db.cms.driverName` | → `DB_DRIVER_NAME` |
+| `perc.db.cms.driverClass` | → `DB_DRIVER_CLASS_NAME` |
+| `perc.db.cms.server` | → `DB_SERVER` |
+| `perc.db.cms.name` | → `DB_NAME` |
+| `perc.db.cms.schema` | → `DB_SCHEMA` |
+| `perc.db.user` | → `UID` |
+| `perc.db.password` | → `PWD` |
+| `perc.db.ssl.enabled` / `.verify` / `.allowSelfSigned` | → `DB_SSL_*` |
+| `perc.db.dts.*` | Optional residual; not required for CMS acceptance |
+
+**State**: Immutable after resolution; invalid resolution throws before extract/ANT.
+
+---
+
+### 4. EffectiveRepositoryConfiguration (install-root artifact)
+
+File: `{install.dir}/rxconfig/Installer/rxrepository.properties`
+
+| Field | Description |
+|-------|-------------|
+| Same keys as DatabaseTargetPropertiesFile | Written by ANT `propertyfile` on **new install** only |
+| Backend-specific values | Must match integrator intent after successful install |
+
+**Lifecycle**:
+
+```text
+[New install + no override]
+    → ship/default Derby template (+ optional SSL stamps)
+[New install + dbprops or structured input]
+    → resolve → validate fields → write effective file → connect validate → schema setup
+[Upgrade]
+    → leave existing effective file identity intact (no backend rewrite)
+```
+
+**Relationships**: Read by `PSConfigureDatasource`, `PSMakeLasagna`, `PSExecSQLStmt`, table factory, and CMS runtime container utils.
+
+---
+
+### 5. InstallMode
+
+| Value | Detection | DB target feature applies? |
+|-------|-----------|----------------------------|
+| `NEW` | `do.install=true` (no prior product version markers per existing install.xml rules) | Yes |
+| `UPGRADE` | `do.upgrade=true` | No (preserve config) |
+
+---
+
+## State transitions (new install)
+
+```text
+                    ┌──────────────┐
+                    │  Start CLI   │
+                    └──────┬───────┘
+                           ▼
+                 ┌─────────────────────┐
+                 │ Resolve DB config   │
+                 │ (dbprops / cli /    │
+                 │  default)           │
+                 └─────────┬───────────┘
+            invalid        │ valid
+               ▼           ▼
+        ┌──────────┐  ┌────────────────┐
+        │ Fail     │  │ Extract / ANT  │
+        │ (nonzero)│  └───────┬────────┘
+        └──────────┘          ▼
+                     ┌────────────────────┐
+                     │ Write effective    │
+                     │ rxrepository.props │  (do.install only)
+                     └─────────┬──────────┘
+                               ▼
+                     ┌────────────────────┐
+                     │ Connect validate   │
+                     └─────────┬──────────┘
+                  fail         │ ok
+                     ▼         ▼
+              ┌──────────┐  ┌─────────────────┐
+              │ Fail     │  │ Repository/schema│
+              │ install  │  │ setup (existing) │
+              └──────────┘  └────────┬────────┘
+                                     ▼
+                              ┌─────────────┐
+                              │ Success     │
+                              └─────────────┘
+```
+
+## Identity & uniqueness
+
+- One effective repository configuration per CMS install root.
+- Integrator may keep multiple sample/dbprops files outside the install root; only the path passed at install time is consumed.
+
+## Secrets handling
+
+- `PWD` / `db.password` / `perc.db.password` are **secret**.
+- Not echoed by validation errors, install console summaries, or log statements.
+- File-system protection of dbprops is integrator responsibility (assumption in spec).

--- a/specs/006-installer-db-targets/plan.md
+++ b/specs/006-installer-db-targets/plan.md
@@ -1,0 +1,118 @@
+# Implementation Plan: CLI Installer Database Targets for New Installs
+
+**Branch**: `984-installer-db-targets` | **Date**: 2026-07-15 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `specs/006-installer-db-targets/spec.md` (GitHub [#949](https://github.com/intersoftdatalabs-in/percussioncms/issues/949))  
+**Feature directory**: `specs/006-installer-db-targets` (see `.specify/feature.json`; branch number differs from sequential spec id)
+
+## Summary
+
+New CLI installs of Percussion CMS still default to embedded Derby and lack a complete, documented way to target MySQL/MariaDB, SQL Server, or Oracle using a repository properties file. Partial support already exists: `com.percussion.preinstall.Main.resolveDbConfig` maps structured `--db.*` / env inputs to `perc.db.*` system properties for **mysql** and **sqlserver**, and `installRepository.xml` `repository_properties` writes those into install-root `rxrepository.properties` when `do.install=true`.  
+
+This plan **completes** that path for issue #949 by: (1) adding `-Ddbprops` / `--dbprops` input in `rxrepository.properties` format; (2) adding **Oracle**; (3) aligning default MySQL-compatible driver class with shipped MariaDB JDBC; (4) fail-fast field validation and connectivity validation on new install; (5) samples + README; (6) unit tests with extracted resolver. Upgrade mode remains untouched for backend identity.
+
+## Technical Context
+
+- **Language/Version**: Java 21 on `development`; ANT 1.10.x install scripts (existing)
+- **Owning Module(s)**: `modules/perc-distribution-tree` (primary — preinstall `Main`, distribution installer XML, samples, README); `modules/perc-ant` (secondary — optional connect-validation action if not kept inside distribution-only ANT/Java)
+- **AGENTS Hierarchy**: root `AGENTS.md`; `modules/perc-distribution-tree/AGENTS.md`
+- **Dependencies & Storage**: Existing JDBC drivers in distribution (`jetty/base/lib/jdbc` — see `001-fix-jdbc-drivers`); no new third-party libraries; no TableFactory schema format change; uses existing `rxrepository.properties` keys and `PSJdbcUtils` backend labels
+- **Testing**: JUnit 5 (+ Mockito as needed) under `modules/perc-distribution-tree` (and `perc-ant` if new action lives there); `./mvn-env.sh`; no new test framework
+- **Scale/Impact**: Install-time only; integrators/automation; new-install config write + validation; upgrades must not regress; DTS full write-through out of scope
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*  
+*Source: `.specify/memory/constitution.md` (v2.3.0)*
+
+- [x] **I. Module-First Boundaries**: Owning modules identified; shared JDBC constants reused from `modules/utils` (`PSJdbcUtils`); no new org-only module.
+- [x] **II. Evidence Over Invention**: Plan cites existing `Main.resolveDbConfig`, `installRepository.xml` `repository_properties`, `rxrepository.properties`, `PSJdbcUtils`, table-factory `-dbprops` precedent; no invented APIs.
+- [x] **III. Test Discipline**: Unit tests planned for resolver, validation, backend mapping, precedence; connect-validation testable with mock/invalid endpoint; behavioral changes covered (see [quickstart.md](quickstart.md)).
+- [x] **IV. Contract & Integration Integrity**: No REST/SOAP/XML-app/`.ppkg` breaks; repository property **key names** preserved; upgrade backend identity preserved; additive CLI contract only.
+- [x] **V. Safe Modernization**: No Spring Boot; no drive-by rewrite of extract/upgrade helpers; extract only DB resolution for testability.
+- [x] **VI. Security by Default**: No password logging; path validation remains for zip extract (existing); dbprops path handled as file read with clear errors; no secret leakage in messages.
+- [x] **VII. Build & Dependency Hygiene**: JDK 21 via `./mvn-env.sh`; no naked new dependency versions; scripts/docs under module conventions.
+- [x] **VIII. Documentation & Operability**: README + shipped samples; fail-fast messages actionable; note new vs upgrade.
+- [x] **IX. PR Review Comment Resolution**: Apply when PRs land (process obligation).
+- [x] **Complexity Budget**: No constitution violations. Optional residual: password via `-D` special-character risk mitigated per research D6/D10 notes (temp props or tests).
+
+**Re-evaluation after Phase 1 design**: Gates still pass. Design keeps CMS-only scope, reuses ANT write path, and isolates Oracle + dbprops as additive branches. Complexity Tracking empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/006-installer-db-targets/
+├── plan.md                 # This file
+├── research.md             # Phase 0
+├── data-model.md           # Phase 1
+├── quickstart.md           # Phase 1
+├── contracts/
+│   ├── README.md
+│   ├── installer-db-input.md
+│   └── rxrepository-properties.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md                # Phase 2 — created by /speckit-tasks (not this command)
+```
+
+### Source Code (affected paths)
+
+```text
+modules/perc-distribution-tree/
+├── src/main/java/com/percussion/preinstall/
+│   ├── Main.java                    # Wire resolver; fail fast on resolve errors; non-zero exit
+│   └── DbInstallConfigResolver.java # NEW (name flexible): parse/load/map/validate pure logic
+├── src/test/java/com/percussion/preinstall/
+│   └── DbInstallConfigResolverTest.java  # NEW
+├── src/main/resources/distribution/rxconfig/Installer/
+│   ├── installRepository.xml        # Oracle branch; optional validateRepositoryConnection target hook
+│   ├── rxrepository.properties      # defaults unchanged (Derby)
+│   └── samples/                     # NEW: mysql, sqlserver, oracle sample property files
+├── README.md                        # Document -Ddbprops / --dbprops / backends / upgrade note
+└── (optional) scripts/              # Only if a standalone verify helper is warranted
+
+modules/perc-ant/                    # OPTIONAL if connect validation is a reusable Ant action
+├── src/main/java/com/percussion/ant/install/
+│   └── PSValidateRepositoryConnection.java  # NEW (or equivalent)
+└── src/test/java/...                # Unit tests for the action
+
+modules/utils/                       # READ-ONLY reference: PSJdbcUtils backend constants
+```
+
+**Structure Decision**: Prefer keeping resolution in `perc-distribution-tree` preinstall package (owns CLI entry). Prefer connectivity validation as `perc-ant` action invoked from `installRepository.xml` so JDBC drivers on the install classpath are available. Avoid changing DTS modules.
+
+## Implementation approach (design summary)
+
+1. **Extract** `resolveDbConfig` / helpers from `Main` into a testable class; support:
+   - `-Ddbprops` and `--dbprops` → load `Properties`, map per [research.md](research.md) D3
+   - Existing structured CLI/env path (mysql/sqlserver + **oracle**)
+   - Precedence D2
+2. **Oracle**: Java mapping + ANT `propertyfile` branch for `perc.db.type=oracle`
+3. **MariaDB driver default** for composed mysql path (research D5); dbprops may override class/name
+4. **Validation**: static required fields at resolve time; **connect** after properties written (research D6)
+5. **main error handling**: on `IllegalArgumentException` / validation failure, print message and `System.exit` non-zero (today many failures may be swallowed by broad catch)
+6. **Samples + README** (FR-010)
+7. **Tests** per quickstart scenarios 1–5 minimum
+
+## Complexity Tracking
+
+*(No constitution exceptions.)*
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| _none_ | _none_ | _none_ |
+
+## Phase outputs
+
+| Phase | Artifact | Status |
+|-------|----------|--------|
+| 0 | [research.md](research.md) | Complete |
+| 1 | [data-model.md](data-model.md), [contracts/](contracts/), [quickstart.md](quickstart.md) | Complete |
+| 2 | `tasks.md` | **Not** created by `/speckit-plan` — use `/speckit-tasks` |
+
+## Next command
+
+```text
+/speckit-tasks
+```

--- a/specs/006-installer-db-targets/quickstart.md
+++ b/specs/006-installer-db-targets/quickstart.md
@@ -1,0 +1,125 @@
+# Quickstart Validation: CLI Installer Database Targets
+
+**Feature**: `specs/006-installer-db-targets`  
+**Date**: 2026-07-15  
+**Contracts**: [contracts/](contracts/) · **Model**: [data-model.md](data-model.md)
+
+This guide is a **validation runbook** for implementers and reviewers. It is not the full task list.
+
+## Prerequisites
+
+- Branch: `984-installer-db-targets` (or equivalent with this feature)
+- JDK 21 via `./mvn-env.sh`
+- Built modules: at minimum `modules/perc-distribution-tree` (and test dependencies)
+- For live non-Derby scenarios: a reachable empty database and credentials
+- For unit-only scenarios: no external DB required
+
+## Scenario 1 — Unit: resolve default Derby
+
+**Goal**: SC-002 / FR-005  
+
+```bash
+./mvn-env.sh -pl modules/perc-distribution-tree -am test \
+  -Dtest=DbInstallConfigResolverTest,Main*Test
+```
+
+**Expect**:
+
+- No dbprops / no `--db.type` → `perc.db.type=derby` (or equivalent default)
+- Required non-Derby fields not forced
+
+## Scenario 2 — Unit: load dbprops MySQL and map keys
+
+**Goal**: FR-001, FR-002, FR-003, FR-004  
+
+Provide a temp properties file in test resources with `DB_BACKEND=MYSQL` and required keys (see [contracts/installer-db-input.md](contracts/installer-db-input.md)).
+
+**Expect**:
+
+- Resolver returns `perc.db.type=mysql` and CMS fields matching file
+- Missing file → clear exception
+- Missing `UID`/`PWD`/`DB_SERVER` → validation error listing keys, not secret values
+
+## Scenario 3 — Unit: Oracle and SQL Server backends
+
+**Goal**: FR-004  
+
+**Expect**:
+
+- `DB_BACKEND=ORACLE` → `oracle` / `ORACLE` mapping
+- `DB_BACKEND=MSSQL` → `sqlserver` / `MSSQL` mapping
+- Unknown backend → failure with allowed list
+
+## Scenario 4 — Unit: precedence dbprops over CLI
+
+**Goal**: research D2  
+
+**Expect**: When both `--dbprops` (MySQL file) and `--db.type=sqlserver` are present, repository identity follows **dbprops**.
+
+## Scenario 5 — Unit / action: connect validation failure
+
+**Goal**: FR-008, SC-003  
+
+Mock or use invalid host with short timeout.
+
+**Expect**: Validation reports failure without printing password; install chain would abort (assert task/action result).
+
+## Scenario 6 — New install Derby (integration / manual)
+
+**Goal**: SC-002 regression  
+
+```bash
+# After building distribution artifact per modules/perc-distribution-tree/README.md
+java -jar <distribution-installer.jar> /tmp/perc-install-derby
+# Inspect:
+grep -E '^(DB_BACKEND|DB_DRIVER)' /tmp/perc-install-derby/rxconfig/Installer/rxrepository.properties
+```
+
+**Expect**: `DB_BACKEND=DERBY` (or product default labels); install completes.
+
+## Scenario 7 — New install with dbprops (manual / CI with MySQL)
+
+**Goal**: SC-001  
+
+1. Create `mysql.properties` from shipped sample; set host/user/password for a pre-created empty DB.
+2. Run:
+
+```bash
+java -Ddbprops=/path/to/mysql.properties -jar <distribution-installer.jar> /tmp/perc-install-mysql
+```
+
+3. Inspect effective properties and confirm install success.
+4. Confirm no password appears in console capture.
+
+**Expect**: Effective file shows `MYSQL` (or equivalent) and supplied server/user; no manual post-edit needed.
+
+## Scenario 8 — Upgrade non-regression (fixture)
+
+**Goal**: SC-005 / FR-006  
+
+1. Seed an install root fixture with `DB_BACKEND=MSSQL` (or MYSQL) in `rxconfig/Installer/rxrepository.properties` and version markers that force **upgrade** mode.
+2. Run installer **without** dbprops against that root.
+3. Re-read `DB_BACKEND`.
+
+**Expect**: Backend unchanged; not rewritten to Derby.
+
+## Scenario 9 — Documentation check
+
+**Goal**: SC-006 / FR-010  
+
+```bash
+# Samples exist in distribution tree sources:
+ls modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/samples/
+# README documents -Ddbprops and backends:
+rg -n "dbprops|DB_BACKEND|Oracle|SQL Server" modules/perc-distribution-tree/README.md
+```
+
+**Expect**: Samples for MySQL/MariaDB, SQL Server, Oracle; README describes new vs upgrade.
+
+## Suggested automated gate for CI
+
+Prefer unit tests (Scenarios 1–5) on every PR. Scenarios 6–8 may be nightly or Docker-based; at least one non-Derby **config write** path should be asserted without requiring a live DB (file content after ANT `repository_properties` with injected `-Dperc.db.*`).
+
+## Related verification
+
+JDBC drivers must be present in the distribution (`scripts/verify-jdbc-drivers.sh` from `001-fix-jdbc-drivers`). A non-Derby install will fail FR-012 cleanly if the needed driver JAR is absent — confirm message quality when testing Oracle/MySQL/MSSQL.

--- a/specs/006-installer-db-targets/research.md
+++ b/specs/006-installer-db-targets/research.md
@@ -1,0 +1,200 @@
+# Research: CLI Installer Database Targets for New Installs
+
+**Feature**: `specs/006-installer-db-targets`  
+**Branch**: `984-installer-db-targets`  
+**Date**: 2026-07-15  
+**Source issue**: [#949](https://github.com/intersoftdatalabs-in/percussioncms/issues/949)
+
+## Current-state findings
+
+### Existing partial implementation (evidence)
+
+The distribution already contains a **partial** non-Derby new-install path that is incomplete relative to issue #949:
+
+| Layer | Location | Behavior today |
+|-------|----------|----------------|
+| Preinstall entry | `modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java` | `resolveDbConfig()` accepts CLI `--db.*` / env file / env vars; maps **mysql** and **sqlserver** to `perc.db.*` system properties; defaults `db.type=derby`. **No Oracle.** **No `dbprops` / `rxrepository.properties` file input.** |
+| Property pass-through | `Main.execJar(...)` | Forwards `ResolvedDbConfig.systemProperties` as `-Dperc.db.*=...` on the ANT JVM command line. |
+| Fresh-install write | `.../rxconfig/Installer/installRepository.xml` target `repository_properties` | Guarded by `${do.install}` (true only for **new** installs). Writes `rxrepository.properties` for `mysql` and `sqlserver`; Derby only updates SSL keys. **No Oracle branch.** |
+| Default ship file | `.../rxconfig/Installer/rxrepository.properties` | `DB_BACKEND=DERBY` with embedded driver settings. |
+| Upgrade safety | `install.xml` `do.install` / `do.upgrade` | Upgrade path does **not** enter the fresh-install property rewrite for backend selection — aligns with FR-006. |
+| Downstream consumers | `modules/perc-ant` (`PSConfigureDatasource`, `PSMakeLasagna`, `PSExecSQLStmt`, etc.) | Read **install-root** `rxconfig/Installer/rxrepository.properties` after it is written. |
+| Backend constants | `modules/utils/.../PSJdbcUtils.java` | Canonical backend labels: `DERBY`, `MYSQL`, `MSSQL`, `ORACLE`. |
+| JDBC packaging | `specs/001-fix-jdbc-drivers` | Distribution ships MariaDB, Derby, MSSQL, jTDS, Oracle drivers under `jetty/base/lib/jdbc/`. |
+| Tests | `MainExtractExecutableTest` + JDBC assembly tests | **No unit tests** for `resolveDbConfig` / `parseArgs` / property-file load. |
+| DTS | `perc.db.dts.*` set in `Main` for mysql/sqlserver | **No ANT consumer found** under installer resources that writes DTS datasources from these properties. Spec keeps full DTS contract out of scope. |
+
+### Gap vs issue #949
+
+Issue asks for: property file shaped like `rxrepository.properties` + `-Ddbprops=<path>` for **new** CLI installs targeting MySQL, SQL Server, **Oracle**.
+
+Gaps:
+
+1. **Input contract mismatch**: Code uses `db.type` / `db.host` / …; issue wants **`dbprops` file** in repository-properties format.
+2. **Oracle missing** from both Java mapping and ANT write branches.
+3. **Connectivity preflight** (FR-008) not present before repository schema steps.
+4. **Documentation / samples** for integrators not shipped for the new contract.
+5. **Test coverage** for resolution, validation, and upgrade non-touch of repository props.
+6. **Error handling**: `main` catches `Exception` and prints a message but may still exit in ways that obscure fail-fast for bad DB config; needs explicit non-zero exit on resolve/validation failure.
+7. **Driver class drift**: existing mysql path uses `com.mysql.cj.jdbc.Driver` while the product default packaged driver is **MariaDB** (`org.mariadb.jdbc.Driver` per JDBC packaging work). Research decision required (below).
+
+### ANT property semantics (important)
+
+In ANT, `<property name="perc.db.type" value="derby" />` sets the property **only if unset**. JVM `-Dperc.db.type=mysql` therefore wins over the XML default. This is the correct mechanism for preinstall → ANT handoff; do not replace with `ant -D` only or unconditional `propertyfile` defaults that clobber upgrades.
+
+---
+
+## Decisions
+
+### D1 — Primary integrator contract: `dbprops` file
+
+**Decision**: Support a filesystem path to a Java properties file in **`rxrepository.properties` key format** as the issue-mandated new-install input:
+
+- System property: `-Ddbprops=<path>` (issue wording)
+- CLI equivalent: `--dbprops=<path>` (parity with existing `--db.*` style in `parseArgs`)
+
+**Rationale**: Matches issue #949 and existing table-factory / upgrade tooling mental model (`-dbprops` already used by `RxJdbcTableFactory` / import scripts). Integrators can reuse the same property names they already know.
+
+**Alternatives considered**:
+
+| Alternative | Why not primary |
+|-------------|-----------------|
+| Only keep `--db.host` / `DB_TYPE` env style | Does not satisfy issue #949 wording; harder for ops teams that already maintain repository property files. |
+| Require interactive GUI | Out of scope; CLI/unattended is the pain point. |
+| Post-install manual edit of `rxrepository.properties` | Status quo; fails SC-001. |
+
+### D2 — Keep existing `db.*` CLI/env as secondary input
+
+**Decision**: Retain and document the already-coded precedence for structured flags:
+
+1. **`dbprops` file** (if path present) — highest for repository identity fields  
+2. CLI `--db.*` / env-style keys in CLI  
+3. Env file (`--db.config.env.file` / `DB_CONFIG_ENV_FILE` / `PERC_DB_CONFIG_ENV_FILE`)  
+4. Process environment  
+5. Defaults (Derby + SSL defaults)
+
+When `dbprops` is present, map its keys into the same internal `ResolvedDbConfig` used today so ANT remains a single write path. Do **not** invent a second ANT write path that copies the file blindly without validation.
+
+**Rationale**: Avoids throwing away working mysql/sqlserver mapping code; dual input is low cost once resolution is extracted and tested.
+
+### D3 — Mapping from `rxrepository.properties` keys → internal model
+
+**Decision**: Load with `java.util.Properties` and map:
+
+| File key | Internal / `perc.db.*` role |
+|----------|-----------------------------|
+| `DB_BACKEND` | Determines `perc.db.type`: `DERBY`→`derby`, `MYSQL`→`mysql`, `MSSQL`→`sqlserver`, `ORACLE`→`oracle` (case-insensitive). Reject unknown. |
+| `DB_SERVER` | `perc.db.cms.server` (pass-through; **do not re-compose** host/port when using dbprops — file already holds the product’s server string form) |
+| `DB_NAME` | `perc.db.cms.name` |
+| `DB_SCHEMA` | `perc.db.cms.schema` |
+| `DB_DRIVER_NAME` | `perc.db.cms.driverName` |
+| `DB_DRIVER_CLASS_NAME` | `perc.db.cms.driverClass` |
+| `UID` | `perc.db.user` |
+| `PWD` | `perc.db.password` |
+| `DSCONFIG_NAME` | optional; default `PercussionData` if absent |
+| `DB_SSL_*` / `PWD_ENCRYPTED` | optional; SSL keys map to existing `perc.db.ssl.*`; encrypted password handling must follow existing `PSMakeLasagna` / encryptor rules |
+
+When using **structured** `--db.*` (not dbprops), continue **composing** `DB_SERVER` / JDBC URL from host+port+name+ssl as today.
+
+**Rationale**: `DB_SERVER` format is backend-specific (`//host:port/db?...`, `//host:port;databaseName=...`, `@host:port:sid` / service forms for Oracle). Re-parsing free-form server strings is error-prone; dbprops is already in final product shape.
+
+### D4 — Oracle support
+
+**Decision**: Add `oracle` as a first-class `perc.db.type` alongside `derby` / `mysql` / `sqlserver`:
+
+- Backend label: `ORACLE` (`PSJdbcUtils.ORACLE_DB_BACKEND`)
+- Default driver name: `oracle:thin` (or value from file)
+- Default driver class: `oracle.jdbc.OracleDriver` (or value from file; match bundled `ojdbc17`)
+- ANT: mirror mysql/sqlserver `propertyfile` write block for `oracle`
+- Structured `--db.*` composition for Oracle: build CMS `DB_SERVER` in the product’s historical thin form (e.g. `@host:port:serviceOrSid` or documented service-name form); ship sample properties for the recommended form
+
+**Rationale**: Explicitly required by issue #949 and already a supported upgrade/runtime backend.
+
+### D5 — MySQL vs MariaDB driver class for composed (non-dbprops) path
+
+**Decision**: For structured `db.type=mysql` defaults, prefer **MariaDB** driver class/name consistent with shipped JDBC packaging (`org.mariadb.jdbc.Driver` / MariaDB connector), while still accepting `DB_BACKEND=MYSQL` in repository properties. Document that MySQL-compatible servers are the target and that integrators may override class/name via **dbprops**.
+
+**Rationale**: Distribution ships MariaDB client (001-fix-jdbc-drivers). Hard-coding `com.mysql.cj.jdbc.Driver` causes FR-012-style failures when only MariaDB JAR is present. Preserve ability to set classic MySQL class via dbprops for environments that drop in Oracle MySQL drivers.
+
+**Alternatives**: Keep `com.mysql.cj.jdbc.Driver` only — rejected unless both JARs ship; today MariaDB is the default packaged connector.
+
+### D6 — Connectivity validation placement
+
+**Decision**: Perform connectivity validation **after** repository properties are applied to the install root and JDBC driver directory is available, as an ANT step (or small `perc-ant` action) in the **new-install** chain only — not solely inside preinstall `Main` before extract (preinstall classpath does not reliably include distribution JDBC drivers).
+
+Flow:
+
+1. Preinstall resolves config + fails fast on missing/unreadable dbprops / incomplete fields (no network required).
+2. ANT `repository_properties` writes effective `rxrepository.properties`.
+3. New task e.g. `validateRepositoryConnection` loads those properties, loads driver from `jetty/base/lib/jdbc` (and/or system classpath), attempts `DriverManager.getConnection`, fails install with actionable message **without logging password**.
+4. Existing table/schema install continues only if connect succeeds.
+
+**Rationale**: Satisfies FR-007 (early static validation) + FR-008 (connectivity) with correct classloader/driver availability. Reuse patterns from `PSJdbcDbmsDef` / existing install SQL actions where practical without pulling large upgrade-only plugins into preinstall.
+
+**Alternatives**:
+
+| Alternative | Why secondary |
+|-------------|----------------|
+| Validate only in Main before extract | Drivers often not on preinstall classpath. |
+| Skip connect; only write props | Fails FR-008; half-configured installs. |
+
+### D7 — Upgrade non-regression
+
+**Decision**: No code path may rewrite `DB_BACKEND` / connection identity on upgrade. Keep all fresh-install writes inside `${do.install}` guards. Unit/integration checks assert upgrade fixtures keep existing backend.
+
+**Rationale**: Issue note + FR-006 / SC-005.
+
+### D8 — DTS scope
+
+**Decision**: **CMS repository only** for acceptance of this feature. Continue emitting `perc.db.dts.*` only if already present for mysql/sqlserver **or** extend Oracle symmetrically if trivial; do **not** block this feature on a full DTS datasource write-through. Track residual DTS write as follow-on if product install always co-installs DTS against the same RDBMS.
+
+**Rationale**: Spec Out of Scope; no ANT consumer found today.
+
+### D9 — Extraction for testability
+
+**Decision**: Extract pure functions from `Main` into a focused helper (e.g. `com.percussion.preinstall.DbInstallConfigResolver` or package-visible methods) so JUnit 5 can cover:
+
+- parseArgs  
+- load/map dbprops  
+- backend normalization  
+- required-field validation  
+- precedence  
+- secret redaction helpers for log messages  
+
+Avoid large refactor of extract/zip/upgrade helpers in the same change set.
+
+**Rationale**: Constitution III; Main is ~1000 lines and hard to unit-test as a monolith.
+
+### D10 — Documentation artifacts
+
+**Decision**:
+
+- Sample files under distribution installer config, e.g.  
+  `rxconfig/Installer/samples/rxrepository.mysql.properties`,  
+  `...sqlserver.properties`, `...oracle.properties`  
+  (or `docs/` + copy into distribution via assembly — prefer **shipping with installer tree** so offline installs work).
+- Document `-Ddbprops` / `--dbprops` and secondary `--db.*` in `modules/perc-distribution-tree/README.md` (and install help text if one exists).
+- Note upgrade vs new-install behavior.
+
+---
+
+## Best practices applied
+
+- **Single write path** to effective repository config (ANT `propertyfile` on install-root file) — avoids dual sources of truth.
+- **Fail-fast validation** before expensive schema work.
+- **No secret logging** (Constitution VI).
+- **JDK 21** / `./mvn-env.sh` for tests (Constitution VII).
+- **Reuse** `PSJdbcUtils` backend constants and existing property key names (Constitution II).
+
+## Open risks (accepted, mitigated in plan)
+
+| Risk | Mitigation |
+|------|------------|
+| Password special characters in `-Dperc.db.password=...` on ProcessBuilder | Prefer writing a temp properties sidecar or env for secrets if quoting proves fragile; at minimum document and test characters that break shells. Research favors keeping `-D` for parity with current code but adding a test matrix for special chars; if failures found, switch password pass-through to ANT property file only (dbprops already has PWD). |
+| MariaDB vs MySQL URL differences | Document; allow full override via dbprops. |
+| Oracle service name vs SID | Document one recommended sample; accept full `DB_SERVER` from file. |
+| Connect timeout hangs install | Set short login timeout on validation connection. |
+
+## NEEDS CLARIFICATION resolution
+
+All Technical Context unknowns resolved via codebase evidence and decisions D1–D10. No remaining blockers for Phase 1 design.

--- a/specs/006-installer-db-targets/spec.md
+++ b/specs/006-installer-db-targets/spec.md
@@ -1,0 +1,173 @@
+# Feature Specification: CLI Installer Database Targets for New Installs
+
+**Feature Branch**: `984-installer-db-targets`  
+**Created**: 2026-07-15  
+**Status**: Draft  
+**Input**: GitHub issue [#949](https://github.com/intersoftdatalabs-in/percussioncms/issues/949) — "Add support for different database targets to the command line installer for new installs." Migrated from percussion/percussioncms#633. Milestone 8.2.
+
+## Module Scope
+
+- **Primary module(s)**: `modules/perc-distribution-tree` (distribution install scripts and preinstall entry point), `modules/perc-ant` (install-time repository/datasource configuration actions)
+- **Secondary / integration modules**: `modules/TableFactory` (repository property / JDBC setup patterns already used with `-dbprops`), default and sample repository property resources under distribution `rxconfig/Installer/`; related JDBC packaging already covered by `specs/001-fix-jdbc-drivers`
+- **AGENTS files to apply**: root `AGENTS.md`, `modules/perc-distribution-tree/AGENTS.md` (and any local overrides under `modules/perc-ant` if present)
+- **User roles affected**: integrator / operator performing unattended or scripted **new** CMS installs; automation (CI/Docker) that currently depends on Derby-only fresh installs
+- **Install / upgrade impact**: **new install path only** — effective repository configuration written for the selected RDBMS; upgrade path behavior must remain unchanged (issue states upgrades already handle non-Derby backends)
+
+## User Scenarios & Testing
+
+Each story must be independently testable.
+
+### User Story 1 - Fresh install to an enterprise RDBMS via property file (Priority: P1)
+
+An integrator is deploying Percussion CMS for the first time in an environment that uses MySQL (or MariaDB-compatible), SQL Server, or Oracle—not the embedded Derby database. They prepare a repository properties file in the same format as `rxconfig/Installer/rxrepository.properties` (connection host/server, schema/database, credentials, backend, driver identifiers as applicable) and pass its path to the command-line installer (for example, via a system property such as `-Ddbprops=<path>`). After a successful install, the CMS is configured to use that database for the repository without hand-editing installed config files.
+
+**Why this priority**: Today, new CLI installs default to embedded Derby. Customers and automation that need enterprise databases cannot complete a correct first install without unsupported post-install rework. This is the core gap described in issue #949.
+
+**Independent Test**: On a clean target host (or disposable install root), run a new install with a valid properties file targeting a pre-provisioned supported non-Derby database. Assert that install completes successfully and that the effective repository configuration in the install root matches the intended backend and connection settings (without requiring manual edits after install).
+
+**Acceptance Scenarios**:
+
+1. **Given** a clean install root and a valid repository properties file for MySQL/MariaDB, **When** the integrator runs a new command-line install supplying that file as the database target input, **Then** the install completes successfully and the effective CMS repository configuration identifies MySQL/MariaDB (or the product’s equivalent backend label) with the supplied connection and credential settings.
+2. **Given** the same setup for SQL Server, **When** a new CLI install is run with a valid SQL Server properties file, **Then** the install completes successfully and the effective repository configuration matches SQL Server and the supplied settings.
+3. **Given** the same setup for Oracle, **When** a new CLI install is run with a valid Oracle properties file, **Then** the install completes successfully and the effective repository configuration matches Oracle and the supplied settings.
+4. **Given** a successful non-Derby new install, **When** the integrator inspects the install root’s repository configuration (for example under `rxconfig/Installer/rxrepository.properties` or the documented effective location), **Then** they do **not** need to manually rewrite backend, server, schema, driver, or credential fields to match the intended database.
+
+---
+
+### User Story 2 - Default remains Derby when no alternate target is supplied (Priority: P1)
+
+An integrator (or automation) runs a new command-line install **without** supplying an alternate database properties path. Behavior remains the familiar embedded Derby default so existing docs, demos, and scripts do not break.
+
+**Why this priority**: Backward-compatible default is required so the feature is additive; issue #949 frames enterprise targets as an **option**, not a forced change of default.
+
+**Independent Test**: Run a new CLI install with no database-target override; assert repository configuration remains Derby-oriented as today and install succeeds on a clean root.
+
+**Acceptance Scenarios**:
+
+1. **Given** a clean install root and no database-target property file argument, **When** the integrator runs a new command-line install, **Then** the install uses the embedded Derby default and completes successfully as it does today.
+2. **Given** such a default install, **When** the effective repository configuration is inspected, **Then** the backend identifies Derby (or the product’s equivalent default labels) consistent with current shipped defaults.
+
+---
+
+### User Story 3 - Invalid or incomplete database target fails fast with clear guidance (Priority: P2)
+
+An integrator supplies a properties file that is missing, unreadable, incomplete for the chosen backend, or points at a database that cannot be reached with the given credentials. The installer stops during the new-install path with a clear, actionable message rather than leaving a half-configured install that looks successful.
+
+**Why this priority**: Silent misconfiguration forces long debug cycles and unsafe “green” installs. Fail-fast is essential for unattended automation.
+
+**Independent Test**: Run new installs with deliberately bad inputs (missing file, missing required keys, wrong password / unreachable host) and assert non-zero failure and message content that identifies the problem class without printing secrets.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new install invocation that references a database properties path that does not exist or is unreadable, **When** install starts, **Then** it fails early with a message that names the path problem.
+2. **Given** a properties file missing required fields for a non-Derby backend (for example server identity or credentials), **When** install runs, **Then** it fails with a message listing what is required for that backend.
+3. **Given** a well-formed properties file whose connection cannot be established (wrong host, credentials, or database not provisioned), **When** install runs, **Then** it fails with a user-readable connectivity/auth failure and does **not** report overall install success.
+4. **Given** any of the failure cases above, **When** install output and logs are inspected, **Then** passwords and other secret values from the properties file are not printed in clear text.
+
+---
+
+### User Story 4 - Documented property-file contract and samples for integrators (Priority: P2)
+
+An integrator needs to know which keys to set, which backends are supported for new CLI installs, how to pass the file path on the install command line, and what a minimal working example looks like for each supported enterprise backend.
+
+**Why this priority**: Without a documented contract, the feature is unusable outside the team that implemented it; issue #949 explicitly points at the existing `rxrepository.properties` shape as the simplicity model.
+
+**Independent Test**: Review installer documentation (distribution README, install help text, and/or sample property files shipped with the distribution) and verify each supported backend has an example and that the CLI flag/system property name is documented.
+
+**Acceptance Scenarios**:
+
+1. **Given** the product documentation for the command-line installer, **When** an integrator looks up database targeting for new installs, **Then** they find the input mechanism (path to properties file / system property name), supported backends, and required keys.
+2. **Given** sample property files (or equivalent documented examples) for MySQL/MariaDB, SQL Server, and Oracle, **When** an integrator copies and fills credentials for their environment, **Then** they can complete User Story 1 without reverse-engineering installed defaults.
+3. **Given** the documentation, **When** an integrator reads the upgrade section (or notes), **Then** it is clear that this feature applies to **new installs** and that upgrades continue to use existing repository configuration as today.
+
+---
+
+### User Story 5 - Upgrade path unchanged (Priority: P1)
+
+An operator upgrading an existing CMS installation that already uses MySQL, SQL Server, Oracle, or Derby does not need a new database-target flag and does not have their repository configuration overwritten by Derby defaults.
+
+**Why this priority**: Issue #949 states upgrades already handle different databases; regressing upgrades would be a high-severity release blocker.
+
+**Independent Test**: Run an upgrade against an install root whose repository configuration already targets a non-Derby backend (fixture or representative config); assert backend remains the pre-upgrade value and upgrade completes without requiring `-Ddbprops`.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing install whose repository is configured for a non-Derby backend, **When** the operator runs the standard upgrade path without a new-install database-target override, **Then** the repository backend and connection settings remain that non-Derby configuration.
+2. **Given** an existing Derby-based install, **When** upgrade runs without database-target override, **Then** Derby configuration is preserved as today.
+
+---
+
+### Edge Cases
+
+- What happens when the properties file path is relative vs absolute? The installer must resolve it predictably (documented rule: relative paths relative to the process working directory unless docs specify otherwise) and fail clearly if resolution fails.
+- What happens when the file uses the same key names as `rxrepository.properties` but with unexpected casing or whitespace? Behavior should match existing repository-properties parsing conventions; invalid/unknown backend labels fail with a clear list of accepted values.
+- What happens when the target database exists but the schema/user lacks permission to create objects required by repository setup? Install fails with a permission/setup error, not a silent partial schema.
+- What happens when the integrator selects a backend whose JDBC driver is not present in the distribution’s driver location? Install fails with guidance to place the appropriate driver where the product documents (consistent with JDBC driver packaging work), rather than succeeding with a broken runtime.
+- What happens if both a database-target properties path and conflicting interactive or legacy defaults would apply? For new installs, the explicit properties-file input takes precedence over the shipped Derby defaults; precedence is documented.
+- What happens on a second “new install” into a non-empty install root? Existing product rules for re-install vs refuse apply; this feature must not bypass them solely to force a different database.
+- What happens if the properties file contains only a subset of keys? Missing optional keys may fall back to documented defaults where safe; missing required keys for the selected backend fail validation (User Story 3).
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: For a **new** command-line install, the installer MUST accept an explicit database-target input that is a filesystem path to a properties file whose key set is compatible with the existing `rxconfig/Installer/rxrepository.properties` format (including at least backend identity, server/connection identity, schema/database name as applicable, driver name/class as applicable, and credentials).
+- **FR-002**: The documented command-line mechanism for supplying that path MUST be a system property or equivalent install flag of the form `-Ddbprops=<path>` (or the product’s chosen equivalent name if an existing install property already serves this role—see Assumptions); the name and usage MUST be documented for integrators.
+- **FR-003**: When the database-target input is supplied on a new install, the installer MUST configure the CMS repository for the selected backend such that post-install effective configuration matches the intended backend without manual file editing.
+- **FR-004**: Supported backends for this new-install option MUST include at least: embedded Derby (default when no override), MySQL (including MariaDB-compatible configurations as already supported by the product), Microsoft SQL Server, and Oracle.
+- **FR-005**: When no database-target input is supplied on a new install, the installer MUST retain the current embedded Derby default behavior.
+- **FR-006**: The **upgrade** path MUST continue to honor the existing installation’s repository configuration and MUST NOT require the new database-target input to preserve non-Derby backends.
+- **FR-007**: On new install with a database-target input, the installer MUST validate that the properties file is readable and that required fields for the selected backend are present before performing irreversible repository setup steps that depend on that configuration.
+- **FR-008**: On new install with a database-target input, the installer MUST attempt to verify database connectivity (or equivalent pre-flight) using the supplied settings and MUST fail the install if connectivity/authentication fails, with a user-readable error that does not print passwords.
+- **FR-009**: Installer and related logs MUST NOT emit clear-text passwords or other secret property values from the database properties file.
+- **FR-010**: The distribution or installer documentation MUST include: how to pass the database-target file, which backends are supported for new CLI installs, required property keys per backend (or a single shared key list with backend-specific notes), and sample property files or copy-paste examples for MySQL/MariaDB, SQL Server, and Oracle.
+- **FR-011**: After a successful new install with a database-target input, repository schema/setup steps that the installer already performs for Derby MUST run against the selected backend using the product’s existing multi-database install/setup capabilities (the same class of capability upgrades already rely on), without requiring the integrator to run separate undocumented tools for basic repository creation.
+- **FR-012**: If the selected backend requires a JDBC driver that is not available in the install’s documented driver location, the installer MUST fail with an actionable message rather than reporting success.
+
+### Key Entities
+
+- **Database target properties file**: Integrator-supplied file describing the CMS repository RDBMS target for a new install; shape aligns with `rxrepository.properties` (backend, server, schema/name, driver identifiers, credentials, datasource name as applicable).
+- **Effective repository configuration**: The post-install configuration under the install root that the CMS uses to connect to its repository (including `rxconfig/Installer/rxrepository.properties` and any immediately derived runtime datasource settings the install already writes today).
+- **New install vs upgrade**: Install modes distinguished by product rules; this feature’s alternate database targeting applies to **new** installs; upgrades retain existing repository configuration.
+- **Supported backend**: One of the RDBMS platforms the product supports for the CMS repository on new CLI install: Derby, MySQL/MariaDB-compatible, SQL Server, Oracle.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: An integrator can complete a new CLI install against MySQL/MariaDB, SQL Server, or Oracle using only the documented properties-file input and a pre-provisioned empty (or product-allowed) database, with zero manual post-install edits to repository connection settings, in a single install invocation.
+- **SC-002**: A new CLI install with no database-target input continues to succeed with Derby defaults on a clean install root (no regression vs current default path).
+- **SC-003**: 100% of scripted negative tests for missing file, incomplete required keys, and failed connectivity result in install failure (non-success exit) and operator-visible error text that identifies the failure class.
+- **SC-004**: Spot-check of install console output and primary install log for successful and failed runs shows no clear-text password values from the properties file.
+- **SC-005**: Upgrade of a non-Derby existing install completes without supplying the new database-target input and retains the pre-upgrade backend identity in effective repository configuration.
+- **SC-006**: A new integrator following only product documentation (no source code) can produce a valid properties file for at least one non-Derby backend and complete SC-001 within one working session (documentation completeness).
+- **SC-007**: Automated verification (unit and/or install-level tests) covers at least: default Derby new install, one non-Derby new-install configuration path (properties applied to effective config), validation failure for missing/invalid input, and upgrade non-regression for existing repository config.
+
+## Assumptions
+
+- Scope is the **CMS command-line installer new-install path** described in issue #949; interactive GUI installer changes are out of scope unless they share the same underlying new-install configuration path and pick up the behavior automatically.
+- Delivery Tier Service (DTS) datasource configuration is **out of scope** for this specification unless the CMS new-install flow already necessarily writes DTS datasource files in the same pass—in that case, only parity needed to avoid leaving DTS on Derby while CMS is non-Derby is in scope; a full DTS-specific input contract is otherwise a follow-on.
+- Property key names and semantics match existing `rxrepository.properties` / table-factory conventions already used by upgrades and tools (`DB_BACKEND`, `DB_SERVER`, `DB_SCHEMA`, `DB_NAME`, `UID`, `PWD`, driver fields, etc.), rather than inventing a parallel schema.
+- The issue’s suggested `-Ddbprops=<path>` is the preferred integrator-facing contract; if the preinstall entry point already reserves a different property name for the same purpose, planning may adopt the existing name provided documentation is unambiguous and equivalent.
+- “MySQL” in the issue includes MariaDB-compatible deployments already used as the product’s common non-Derby repository (consistent with shipped JDBC packaging).
+- Target empty database / schema is pre-created by the customer’s DBA when the backend requires it; the installer creates product objects inside that database, not the RDBMS server instance itself.
+- Supported backend list for new install matches platforms the product already supports for upgrades/runtime; this feature does not add a new RDBMS engine.
+- Security: properties files on disk remain the integrator’s responsibility to protect (file permissions); the installer’s obligation is no secret leakage in logs/console and fail-fast validation.
+- Related work: JDBC drivers must be present in the distribution for bundled backends (see `specs/001-fix-jdbc-drivers`); this feature depends on drivers being available or on clear failure when they are not.
+- Prior internal notes under `docs/ai-generated/tasks/PR#-installer-db-target-enhancement/` inform context but do **not** expand this spec to env-var precedence matrices, SSL flag defaults, or multi-input CLI surfaces beyond the properties-file contract unless required for FR compliance.
+
+## Out of Scope
+
+- Changing the default new-install database away from Derby.
+- Migrating data from Derby (or any backend) to another RDBMS after install.
+- Redesigning upgrade database handling (already considered adequate per issue #949).
+- Adding new RDBMS platforms beyond those the product already supports.
+- Full DTS installer redesign, SSL policy product changes, or a multi-source env/CLI precedence system beyond the properties-file input (unless discovered as already required for a correct CMS-only new install).
+- GUI/wizard UX redesign for database selection (except incidental shared-code benefits).
+
+## Dependencies
+
+- Supported JDBC drivers available in the install tree for backends that ship drivers; integrator-supplied drivers for cases the product documents as bring-your-own.
+- Pre-provisioned database/schema and network access from the install host to the RDBMS for non-Derby targets.
+- Existing multi-database repository setup/table-factory behavior used on upgrades must remain usable from the new-install path once configuration is written correctly.
+- Issue tracking: [GitHub #949](https://github.com/intersoftdatalabs-in/percussioncms/issues/949); milestone 8.2.

--- a/specs/006-installer-db-targets/tasks.md
+++ b/specs/006-installer-db-targets/tasks.md
@@ -1,0 +1,243 @@
+# Tasks: CLI Installer Database Targets for New Installs
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/](contracts/), [quickstart.md](quickstart.md)  
+**Branch**: `984-installer-db-targets`  
+**Feature directory**: `specs/006-installer-db-targets`  
+**Issue**: [#949](https://github.com/intersoftdatalabs-in/percussioncms/issues/949)
+
+**Tests**: Required by project constitution (III) and plan — unit tests for all behavioral resolver/validation changes; connect-validation covered with unit/mocked failure paths.
+
+## Phase 1: Setup
+
+- [x] T001 Identify owning modules and read AGENTS hierarchy: root `AGENTS.md`, `modules/perc-distribution-tree/AGENTS.md`, and skim `modules/perc-ant` for Ant action patterns used by install
+- [x] T002 Confirm JDK 21 on branch `984-installer-db-targets` and run baseline `./mvn-env.sh -pl modules/perc-distribution-tree -am test` (note failures unrelated to this feature)
+- [x] T003 [P] Re-read research decisions D1–D10 in `specs/006-installer-db-targets/research.md` and contracts in `specs/006-installer-db-targets/contracts/` before coding
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Goal**: Extract testable DB config resolution from `Main`, wire fail-fast exit, preserve existing mysql/sqlserver structured CLI behavior as the base for all stories.  
+**Blocks**: All user stories.
+
+- [x] T004 Map existing flow in `modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java` (`parseArgs`, `resolveDbConfig`, `execJar` `-Dperc.db.*` pass-through) and `modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml` target `repository_properties` (`do.install` guard, mysql/sqlserver/derby branches)
+- [x] T005 Assess security surface for this feature: password handling in process args/logs, dbprops file read, no ZipSlip changes; document “do not log PWD” rule for implementers in class-level Javadoc on the new resolver
+- [x] T006 Create package-visible/testable resolver class `modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/DbInstallConfigResolver.java` by moving/extracting `resolveDbConfig`, `loadEnvFile`, `getConfigValue`, `parseArgs` DB-related helpers, and `ResolvedDbConfig` / `ParsedArgs` records from `Main.java` without behavior change yet
+- [x] T007 Refactor `modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java` to call `DbInstallConfigResolver`; on `IllegalArgumentException` (and equivalent resolve failures) print a clear message and `System.exit` with non-zero code (do not swallow as soft “install likely failed” success path)
+- [x] T008 [P] Add foundational unit tests in `modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/DbInstallConfigResolverTest.java` covering: default Derby when no options; structured `--db.type=mysql` with required fields maps to `perc.db.cms.*`; missing required mysql fields throws; existing sqlserver mapping still works
+- [x] T009 Run `./mvn-env.sh -pl modules/perc-distribution-tree -am test -Dtest=DbInstallConfigResolverTest,MainExtractExecutableTest` and fix regressions from the extract
+
+## Phase 3: User Story 1 — Fresh install to enterprise RDBMS via property file (Priority: P1)
+
+**Goal**: Integrator can pass `-Ddbprops` / `--dbprops` (rxrepository.properties format) and get effective CMS repository config for MySQL/MariaDB, SQL Server, and Oracle without manual post-edit (FR-001–FR-004, FR-011).  
+**Independent Test**: Resolver unit tests for all three backends + ANT oracle write branch; optional full install per [quickstart.md](quickstart.md) Scenario 7.
+
+### Tests
+
+- [x] T010 [P] [US1] Add unit tests in `modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/DbInstallConfigResolverTest.java` for loading a temp MySQL `dbprops` file → `perc.db.type=mysql` and CMS fields match file keys (`DB_SERVER`, `UID`, etc.)
+- [x] T011 [P] [US1] Add unit tests in `modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/DbInstallConfigResolverTest.java` for MSSQL and ORACLE `dbprops` files (backend normalization `MSSQL`→`sqlserver`, `ORACLE`→`oracle`)
+- [x] T012 [P] [US1] Add unit test in `modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/DbInstallConfigResolverTest.java` that `dbprops` identity fields take precedence over conflicting `--db.type` CLI values (research D2)
+
+### Implementation
+
+- [x] T013 [US1] Implement `dbprops` load path in `modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/DbInstallConfigResolver.java`: accept `-Ddbprops` system property and CLI `--dbprops` / `dbprops` option; resolve relative path against CWD; map keys per research D3 / `contracts/rxrepository-properties.md`
+- [x] T014 [US1] Add Oracle structured + dbprops mapping in `modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/DbInstallConfigResolver.java` (`perc.db.type=oracle`, backend `ORACLE`, default driver name/class aligned with bundled ojdbc / `PSJdbcUtils`)
+- [x] T015 [US1] Align composed (non-dbprops) mysql defaults to shipped MariaDB driver class/name in `modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/DbInstallConfigResolver.java` (research D5); keep dbprops free to override class/name
+- [x] T016 [US1] Add Oracle branch to `modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml` in target `repository_properties` (mirror mysql/sqlserver `propertyfile` entries for `DB_*` / `UID` / `PWD` / SSL keys when `perc.db.type=oracle`)
+- [x] T017 [US1] Verify mysql/sqlserver `propertyfile` blocks in `installRepository.xml` still write when `perc.db.*` is supplied via JVM `-D` (ANT property semantics); fix only if a regression is found
+- [x] T018 [US1] Run `./mvn-env.sh -pl modules/perc-distribution-tree -am test -Dtest=DbInstallConfigResolverTest` and ensure US1 tests pass
+- [ ] T019 [US1] Commit US1 changes and open a PR scoped to enterprise dbprops + Oracle write-through; pause downstream stories until PR is ready for review
+- [ ] T020 [US1] Monitor CI/Kilo checks on the US1 PR; address feedback; reply+resolve review threads per `AGENTS.md` PR Review Comment Resolution
+- [ ] T021 [US1] Verify human approval and merge of US1 PR before starting User Story 2
+
+## Phase 4: User Story 2 — Default remains Derby when no alternate target is supplied (Priority: P1)
+
+**Goal**: No override ⇒ Derby default unchanged (FR-005, SC-002).  
+**Independent Test**: Resolver returns Derby; default `rxrepository.properties` ship file still DERBY; no forced non-Derby fields.
+
+### Tests
+
+- [x] T022 [P] [US2] Extend `modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/DbInstallConfigResolverTest.java` with explicit cases: empty options → derby; empty/whitespace `db.type` → derby; no `perc.db.cms.backend` forced for derby
+
+### Implementation
+
+- [x] T023 [US2] Confirm `modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/rxrepository.properties` remains Derby defaults and derby branch in `installRepository.xml` only stamps SSL keys (no accidental backend overwrite)
+- [x] T024 [US2] If any US1 change altered default path, fix `DbInstallConfigResolver` / `Main` so omit-override behavior matches pre-feature Derby default
+- [x] T025 [US2] Run targeted tests `./mvn-env.sh -pl modules/perc-distribution-tree -am test -Dtest=DbInstallConfigResolverTest`
+- [ ] T026 [US2] Commit US2 changes (or no-op confirmation commit note) and open/update PR; pause for review
+- [ ] T027 [US2] Monitor checks, resolve review threads, verify merge before User Story 5
+
+## Phase 5: User Story 5 — Upgrade path unchanged (Priority: P1)
+
+**Goal**: Upgrade must not rewrite repository backend identity; no requirement for `-Ddbprops` (FR-006, SC-005).  
+**Independent Test**: Fixture/assert `repository_properties` write logic only when `do.install=true`; document/test that upgrade leaves existing `DB_BACKEND` alone.
+
+### Tests
+
+- [x] T028 [P] [US5] Add a focused unit or resource-level test under `modules/perc-distribution-tree/src/test/java/` that asserts the `repository_properties` fresh-install write is gated by `do.install` (e.g. parse/inspect `installRepository.xml` structure, or a small Ant propertyfile unit if one already exists in perc-ant patterns) — choose the lightest reliable approach that fails if the `do.install` guard is removed
+- [x] T029 [P] [US5] Add regression test notes or fixture under `modules/perc-distribution-tree/src/test/resources/com/percussion/preinstall/upgrade-fixture/` with a sample existing `rxrepository.properties` (`DB_BACKEND=MSSQL`) used by T028 or a dedicated assertion helper so non-Derby pre-upgrade config is represented in-repo
+
+### Implementation
+
+- [x] T030 [US5] Audit `modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml` and `install.xml` to ensure no new targets write `DB_BACKEND` outside `${do.install}`; fix if any US1 Oracle/mysql work leaked into upgrade path
+- [x] T031 [US5] Ensure preinstall `Main` / resolver does not overwrite install-root repository files before ANT mode detection (resolution only produces JVM props; ANT still owns write under `do.install`)
+- [x] T032 [US5] Run `./mvn-env.sh -pl modules/perc-distribution-tree -am test` for affected tests
+- [ ] T033 [US5] Commit US5 changes and open PR; pause for review/merge before P2 stories
+
+## Phase 6: User Story 3 — Invalid or incomplete database target fails fast (Priority: P2)
+
+**Goal**: Missing file, incomplete keys, connectivity failure → non-success, clear messages, no password leakage (FR-007–FR-009, FR-012, SC-003–SC-004).  
+**Independent Test**: Unit tests for missing/incomplete dbprops; connect-validation action fails on unreachable DB without logging password.
+
+### Tests
+
+- [x] T034 [P] [US3] Add unit tests in `modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/DbInstallConfigResolverTest.java` for missing dbprops path, unreadable path, unknown `DB_BACKEND`, missing required keys; assert messages list key names and do not contain password values
+- [x] T035 [P] [US3] Add unit tests in `modules/perc-ant/src/test/java/com/percussion/ant/install/PSValidateRepositoryConnectionTest.java` (or chosen class name) for: missing driver guidance path, connection failure with short timeout, password not present in logged/exception user-facing text
+
+### Implementation
+
+- [x] T036 [US3] Harden static validation messages in `modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/DbInstallConfigResolver.java` (required-field lists per backend; unknown backend allowed-list; path errors)
+- [x] T037 [US3] Implement Ant action `modules/perc-ant/src/main/java/com/percussion/ant/install/PSValidateRepositoryConnection.java` that loads install-root `rxconfig/Installer/rxrepository.properties`, attempts JDBC connect with short login timeout using drivers from install `jetty/base/lib/jdbc` (and product conventions), fails the build on error without echoing `PWD`
+- [x] T038 [US3] Wire validation into `modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml` for **new install only** after `repository_properties` / password lasagna steps and before heavy schema work that depends on a live connection (pick the earliest safe dependency point consistent with existing target order)
+- [x] T039 [US3] Handle missing JDBC driver with actionable fail message (FR-012) in the validate action under `modules/perc-ant/src/main/java/com/percussion/ant/install/PSValidateRepositoryConnection.java`
+- [x] T040 [US3] Register/discover the new Ant task the same way sibling `PS*` install tasks are registered (update taskdef/typedef resources under `modules/perc-ant` if required by existing packaging)
+- [x] T041 [US3] Run `./mvn-env.sh -pl modules/perc-ant,modules/perc-distribution-tree -am test -Dtest=DbInstallConfigResolverTest,PSValidateRepositoryConnectionTest`
+- [ ] T042 [US3] Commit US3 changes and open PR; pause for review/merge
+
+## Phase 7: User Story 4 — Documented property-file contract and samples (Priority: P2)
+
+**Goal**: Integrators can find `-Ddbprops`, supported backends, required keys, and samples for MySQL/MariaDB, SQL Server, Oracle; upgrade vs new install clarified (FR-010, SC-006).  
+**Independent Test**: Samples exist under distribution tree; README documents contract; matches [contracts/installer-db-input.md](contracts/installer-db-input.md).
+
+### Tests
+
+- [x] T043 [P] [US4] Add a lightweight test or verify step (JUnit resource existence check under `modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/DbInstallSamplePropertiesTest.java` or assembly assertion) that sample files exist at the packaged paths under `modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/samples/`
+
+### Implementation
+
+- [x] T044 [P] [US4] Create `modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/samples/rxrepository.mysql.properties` with MYSQL-compatible keys and MariaDB driver class example (placeholder credentials)
+- [x] T045 [P] [US4] Create `modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/samples/rxrepository.sqlserver.properties` with MSSQL example keys
+- [x] T046 [P] [US4] Create `modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/samples/rxrepository.oracle.properties` with ORACLE thin example keys
+- [x] T047 [US4] Update `modules/perc-distribution-tree/README.md` with: `-Ddbprops` / `--dbprops`, secondary `--db.*`, supported backends, precedence summary, new-install vs upgrade note, pointer to samples and `specs/006-installer-db-targets/contracts/`
+- [x] T048 [US4] If installer prints usage/help from `Main.java`, add a short line documenting `--dbprops` in `modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java` (only if a help path already exists or can be added without scope creep)
+- [ ] T049 [US4] Run tests including sample existence check; commit US4 and open PR; pause for review/merge
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+- [x] T050 [P] Walk [quickstart.md](quickstart.md) scenarios 1–5 against the implementation; fix gaps or update quickstart if commands drifted
+- [x] T051 [P] Security pass: grep install/preinstall/validate code paths for password logging (`PWD`, `db.password`, `perc.db.password`) under `modules/perc-distribution-tree` and `modules/perc-ant`; remediate any clear-text leak
+- [x] T052 Spotless / format check on touched modules via `./mvn-env.sh -pl modules/perc-distribution-tree,modules/perc-ant -am spotless:check` (or module-equivalent if Spotless not configured — then skip with note)
+- [x] T053 Full module test pass: `./mvn-env.sh -pl modules/perc-distribution-tree,modules/perc-ant -am test`
+- [x] T054 Update `specs/006-installer-db-targets/plan.md` / this `tasks.md` checkboxes as work completes; ensure issue #949 acceptance criteria are traceable to completed tasks
+- [ ] T055 Final PR (or stack restack) for any polish-only commits; resolve all review threads before merge
+
+---
+
+## Dependencies & Execution Order
+
+```text
+Phase 1 Setup
+    ↓
+Phase 2 Foundational  (extract resolver, fail-fast Main, baseline tests)
+    ↓
+Phase 3 US1 (P1)  dbprops + Oracle + MariaDB default  ← MVP
+    ↓
+Phase 4 US2 (P1)  Derby default regression
+    ↓
+Phase 5 US5 (P1)  Upgrade non-regression
+    ↓
+Phase 6 US3 (P2)  Validation + connectivity fail-fast
+    ↓
+Phase 7 US4 (P2)  Samples + README
+    ↓
+Phase 8 Polish
+```
+
+| Story | Depends on | Notes |
+|-------|------------|-------|
+| US1 | Foundational | MVP; delivers issue #949 core value |
+| US2 | US1 merged (or same PR only if tiny) | Confirms additive default |
+| US5 | US1 (ANT changes exist) | Must stay before calling feature “done” for release |
+| US3 | US1 (+ ideally US5 guard intact) | Connect validate needs written props path |
+| US4 | US1 (samples match real keys) | Can draft samples in parallel after T013 mapping is stable |
+
+**Story PR policy** (constitution): Implement → commit → PR per story → merge before next story when practical. US2 may be a thin follow-up PR if US1 already preserved Derby.
+
+## Parallel Execution Examples
+
+### Within Foundational
+
+```text
+# After T006 class skeleton exists:
+T008 unit tests can be drafted in parallel with T007 Main wiring (coordinate on API shape)
+```
+
+### Within US1
+
+```text
+# Parallel after resolver API supports dbprops:
+T010 MySQL dbprops tests
+T011 MSSQL/Oracle dbprops tests  
+T012 precedence test
+# Implementation T013–T015 sequential on same class; T016 ANT Oracle can start once perc.db.type=oracle is defined
+```
+
+### Within US4
+
+```text
+T044, T045, T046 sample files in parallel
+T043 sample existence test in parallel once paths known
+T047 README after samples land
+```
+
+### Within US3
+
+```text
+T034 resolver validation tests || T035 validate-action tests (after action skeleton T037)
+```
+
+## Implementation Strategy
+
+### MVP (minimum shippable for #949)
+
+1. Complete Phase 1–2  
+2. Complete **User Story 1** (dbprops + MySQL/MSSQL/Oracle effective config write)  
+3. Validate with US1 tests + quickstart Scenario 2–3  
+
+### Incremental delivery
+
+| Increment | Stories | Customer-visible outcome |
+|-----------|---------|---------------------------|
+| MVP | US1 | Non-Derby new install via property file |
+| Safety | US2 + US5 | Default + upgrade safe |
+| Hardening | US3 | Fail-fast + connect validate |
+| Enablement | US4 | Docs/samples |
+| Close | Polish | CI green, secrets clean |
+
+### Task format validation
+
+All tasks use: `- [ ]`, sequential `T00N` IDs, optional `[P]`, story labels `[US1]`–`[US5]` on story-phase tasks only, and explicit file paths in descriptions.
+
+## Summary Counts
+
+| Phase | Task IDs | Count |
+|-------|----------|-------|
+| Setup | T001–T003 | 3 |
+| Foundational | T004–T009 | 6 |
+| US1 | T010–T021 | 12 |
+| US2 | T022–T027 | 6 |
+| US5 | T028–T033 | 6 |
+| US3 | T034–T042 | 9 |
+| US4 | T043–T049 | 7 |
+| Polish | T050–T055 | 6 |
+| **Total** | T001–T055 | **55** |
+
+| User story | Task count (approx.) |
+|------------|----------------------|
+| US1 | 12 |
+| US2 | 6 |
+| US5 | 6 |
+| US3 | 9 |
+| US4 | 7 |
+
+**Suggested MVP scope**: Phase 1 + Phase 2 + **User Story 1** (T001–T021).
+
+**Parallel opportunities**: Marked with `[P]` on independent test/sample tasks; story PRs remain sequential per constitution checkpoint.


### PR DESCRIPTION
## Summary

- Adds `-Ddbprops` / `--dbprops` for **new** CLI installs so integrators can target MySQL/MariaDB, SQL Server, or Oracle using `rxrepository.properties`-format files (closes the gap in #949).
- Extracts `DbInstallConfigResolver`, wires Oracle into `installRepository.xml`, validates repository connectivity on new install only, and propagates non-zero exit codes from Ant to the preinstall process.
- Ships samples under `rxconfig/Installer/samples/` and documents usage in `modules/perc-distribution-tree/README.md`. Spec/plan under `specs/006-installer-db-targets/`.

## Design notes

- Default remains embedded Derby when no override is supplied.
- Upgrade path is unchanged (`do.install` gates property rewrite and validation).
- MariaDB driver class is the default for composed `db.type=mysql` (matches bundled JDBC packaging); dbprops may override.

## Test plan

- [x] `./mvn-env.sh -pl modules/perc-ant test -Dtest=PSValidateRepositoryConnectionTest -Dai.integrity.skip=true`
- [x] `./mvn-env.sh -pl modules/perc-distribution-tree test -Dtest=DbInstallConfigResolverTest,RepositoryPropertiesInstallGuardTest,DbInstallSamplePropertiesTest,MainExtractExecutableTest,MainInstallExitCodeTest -Dai.integrity.skip=true`
- [ ] Optional: full new install with sample mysql.properties against a pre-provisioned DB
- [ ] Optional: upgrade fixture / existing non-Derby root without `-Ddbprops` keeps backend

## Erlang review

- Initial: request-changes (Class.forName gate; Main exit code) — fixed
- Re-review: **approve** (`tmp/reviews/2026-07-16-erlang-984-installer-db-targets-rereview.md`)

Fixes #949