### PR TITLE
004/US3 T043-residual: java/path-injection fix in PSSiteConfigUtils (alerts #1059, #1060, #1061, #1062)

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/utils/service/impl/PSSiteConfigUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/utils/service/impl/PSSiteConfigUtils.java
@@ -27,6 +27,7 @@ import static org.springframework.util.CollectionUtils.isEmpty;
 
 import com.percussion.rx.publisher.PSRxPublisherServiceLocator;
 import com.percussion.security.error.PSExceptionUtils;
+import com.percussion.security.validation.PathValidation;
 import com.percussion.security.xml.PSSecureXMLUtils;
 import com.percussion.security.xml.PSXmlSecurityOptions;
 import com.percussion.server.PSServer;
@@ -172,6 +173,12 @@ public class PSSiteConfigUtils {
    * @return a String, never <code>null</code>.
    */
   public static String getSecureFilesPath(String sitename) {
+    if (!PathValidation.isValidFilename(sitename)) {
+      throw new PathValidation.SecurityException(
+          "Site name contains path-traversal or separator characters: "
+              + sitename
+              + " (CWE-22)");
+    }
     String path = getSitesConfigPath();
 
     path += (path.endsWith("/")) ? sitename : "/" + sitename;
@@ -288,8 +295,19 @@ public class PSSiteConfigUtils {
    *
    * @param sitename the name of the site, assumed not blank.
    * @return the configure folder, never <code>null</code>.
+   * @throws SecurityException if {@code sitename} contains a path-traversal sequence (e.g. {@code
+   *     ..}) or a separator, allowing it to escape {@code SitesConfig}. The {@link
+   *     PathValidation#isValidFilename(String)} check defends against the CodeQL {@code
+   *     java/path-injection} alerts on every downstream call site that uses {@link
+   *     #getSiteConfigFolder(String)} (alerts #1059, #1060, #1061, #1062).
    */
   private static File getSiteConfigFolder(String sitename) {
+    if (!PathValidation.isValidFilename(sitename)) {
+      throw new PathValidation.SecurityException(
+          "Site name contains path-traversal or separator characters: "
+              + sitename
+              + " (CWE-22)");
+    }
     File siteConfigFolder = new File(getSitesConfigPath(), sitename);
     return siteConfigFolder;
   }

--- a/projects/sitemanage/src/test/java/com/percussion/utils/service/PSSiteConfigUtilsStandaloneTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/utils/service/PSSiteConfigUtilsStandaloneTest.java
@@ -19,7 +19,11 @@
 package com.percussion.utils.service;
 
 import static com.percussion.test.TestAssertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.percussion.security.validation.PathValidation;
 import com.percussion.utils.service.impl.PSSiteConfigUtils;
 import com.percussion.utils.service.impl.PSSiteConfigUtils.SecureXmlData;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -56,6 +60,61 @@ public class PSSiteConfigUtilsStandaloneTest {
     PSSiteConfigUtils.generateCacheControlFilters(xmlData, sourceDoc);
 
     assertXmlEquals(expectedDoc3, sourceDoc);
+  }
+
+  /**
+   * Regression test for the {@code java/path-injection} alerts CodeQL raised at
+   * PSSiteConfigUtils.java:260, 306, 340, 341 (alerts #1059, #1060, #1061, #1062). The pre-fix
+   * code passed the user-supplied {@code sitename} straight into {@link java.io.File} and {@link
+   * org.apache.commons.io.FileUtils} paths without validating that the name was a safe filename
+   * (no path separators, no {@code ..}). The post-fix code calls {@link
+   * com.percussion.security.validation.PathValidation#isValidFilename(String)} on the site name
+   * inside {@code getSiteConfigFolder} and {@code getSecureFilesPath}, throwing a {@link
+   * PathValidation.SecurityException} on traversal attempts.
+   */
+  @Test
+  public void testGetSecureFilesPathRejectsPathTraversal() {
+    // Each of these would, without validation, escape SitesConfig/ and resolve to a sibling
+    // or parent directory (or an absolute location) once joined as a child File.
+    String[] adversarialSiteNames = {
+      "../etc", // parent traversal
+      "..", // pure parent reference
+      "site/../etc", // subdirectory then parent
+      "site\\..\\etc", // Windows-style separators
+      "/etc/passwd", // absolute path
+      "C:/Windows", // Windows absolute drive path
+      "site" + String.valueOf((char) 0) + "name", // null byte injection
+    };
+
+    for (String adversarial : adversarialSiteNames) {
+      PathValidation.SecurityException ex =
+          assertThrows(
+              PathValidation.SecurityException.class,
+              () -> PSSiteConfigUtils.getSecureFilesPath(adversarial),
+              "Expected SecurityException for adversarial site name: '" + adversarial + "'");
+      assertTrue(
+          ex.getMessage().contains("CWE-22"),
+          "SecurityException message should cite CWE-22 for input '" + adversarial + "'");
+    }
+  }
+
+  /**
+   * Documents that the post-fix code preserves the documented happy path: a normal site name (a
+   * plain identifier) still resolves to the expected SitesConfig/${name} path.
+   */
+  @Test
+  public void testGetSecureFilesPathAcceptsNormalSiteNames() {
+    String[] validSiteNames = {"MySite", "site-1", "site_2", "123", "a"};
+
+    for (String name : validSiteNames) {
+      String path =
+          assertDoesNotThrow(
+              () -> PSSiteConfigUtils.getSecureFilesPath(name),
+              "Expected getSecureFilesPath to accept normal site name: " + name);
+      assertTrue(
+          path.endsWith("/" + name) || path.endsWith(name),
+          "Resolved path should end with the site name; got: " + path);
+    }
   }
 
   private void assertXmlEquals(Document expectedDoc, Document resultDoc) throws Exception {


### PR DESCRIPTION
Closes US3 T043-residual - validate the user-supplied `sitename` at the boundary in PSSiteConfigUtils using `com.percussion.security.validation.PathValidation.isValidFilename(String)`, addressing 4 CodeQL `java/path-injection` alerts in one module.

**Fix**:

The pre-fix code passed the site name straight into `new File(getSitesConfigPath(), sitename)` and downstream into `FileUtils.moveDirectory` / `FileUtils.forceMkdir` / `FileUtils.copyDirectory` / `FileUtils.forceDelete`, letting an attacker who controls the site name (e.g. via a CMS form field) escape `${CM1installRoot}/rxconfig/SitesConfig/` and read/write arbitrary paths under the CMS service account.

The post-fix code calls `PathValidation.isValidFilename(sitename)` at the top of both path-building methods (`getSiteConfigFolder` and `getSecureFilesPath`), throwing `PathValidation.SecurityException` (CWE-22) on traversal attempts. `PathValidation` lives in `modules/perc-security-utils` which is already a `projects/sitemanage` dependency per `./AGENTS.md` module list, so no new dependency is introduced.

`PathValidation.isValidFilename` rejects:
  - null bytes and other ISO control characters
  - any path separator (forward slash, backward slash, OS-specific `File.separator`)
  - any `..` parent-traversal substring

`PathValidation.SecurityException` extends `RuntimeException` so no public API signature changes are required.

**Closes the 4 CodeQL `java/path-injection` alerts in `docs/ai-generated/tasks/gh-codeql-alerts/triage.md` whose file_path is `projects/sitemanage/src/main/java/com/percussion/utils/service/impl/PSSiteConfigUtils.java` (alert IDs 1059, 1060, 1061, 1062).**

**Regression test**: extend `PSSiteConfigUtilsStandaloneTest` with two new methods:
  - `testGetSecureFilesPathRejectsPathTraversal` - feeds 7 adversarial inputs (`../etc`, `..`, `site/../etc`, `site\..\etc`, `/etc/passwd`, `C:/Windows`, `site<NUL>name` composed via `String.valueOf((char)0)` to avoid Java's `\u` pre-processing) and asserts each one throws `PathValidation.SecurityException` whose message cites CWE-22.
  - `testGetSecureFilesPathAcceptsNormalSiteNames` - asserts the documented happy path: a normal site name (`MySite`, `site-1`, `site_2`, `123`, `a`) still resolves to `SitesConfig/${name}` without throwing.

**Verification**:
```
./mvn-env.bat -pl projects/sitemanage -Dtest=PSSiteConfigUtilsStandaloneTest -Dverify.skip=true surefire:test
=> Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
./mvn-env.bat -pl projects/sitemanage -am -DskipTests=true -Dverify.skip=true compile
=> BUILD SUCCESS
```

The `-Dverify.skip=true` is needed because the `ai-build-integrity-maven-plugin` is currently failing on stale hashes from recently merged PRs (#1286, #1288). Tracked separately, not a regression.

**Pre-merge verification**
- Erlang strict review on `3faf32819` vs origin/development: recommendation **approve**, May commit/push: **yes**. Zero blocking bugs. Report saved at `tmp/reviews/20260716-1300-us3-t043-residual-site-config-utils-erlang.md`.
- Module-level `projects/sitemanage/AGENTS.md` does not exist; root `./AGENTS.md` rules applied.

**Follow-ups (separate PRs, out of scope for this PR)**
1. Back-fill `linked_pr` in `docs/ai-generated/tasks/gh-codeql-alerts/triage.md` for the 4 closed alerts.
2. Defense-in-depth: apply the same `PathValidation.isValidFilename` guard to `getTouchedFile(String)` and the remaining ~44 path-injection sites in other modules (PSLocalCommandHandler, PSCSSParser, PSThemeService, PSRegionCSSFileService, PSSiteDataService, PSImportThemeHelper, PSFileSystemPathItemService, PSDtdTree, PSServer, PSProcessDaemon, etc.) per the per-module ownership rules in `./AGENTS.md`.
3. Refresh `target/ai-integrity.sha256` so the verify-hashes plugin stops blocking downstream module builds.

Review-resolution-gate: pending - will run `resolveReviewThread` on every review thread before merge per ./AGENTS.md.