### PR TITLE
004/tests: make path-traversal + zip-slip security tests platform-portable (Windows CI fix)

### DIFF
--- a/system/src/test/java/com/percussion/process/PSLocalCommandHandlerSecurityTest.java
+++ b/system/src/test/java/com/percussion/process/PSLocalCommandHandlerSecurityTest.java
@@ -23,6 +23,8 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -82,6 +84,7 @@ class PSLocalCommandHandlerSecurityTest {
 
     @Test
     @DisplayName("Should reject absolute paths like /etc/passwd")
+    @EnabledOnOs({OS.LINUX, OS.MAC})
     void shouldRejectAbsoluteEtcPasswd() {
       File absolutePath = new File("/etc/passwd");
 
@@ -93,6 +96,7 @@ class PSLocalCommandHandlerSecurityTest {
 
     @Test
     @DisplayName("Should reject absolute system paths")
+    @EnabledOnOs({OS.LINUX, OS.MAC})
     void shouldRejectAbsoluteSystemPath() {
       File absolutePath = new File("/usr/bin/bash");
 
@@ -121,6 +125,7 @@ class PSLocalCommandHandlerSecurityTest {
 
     @Test
     @DisplayName("Should prevent /etc/passwd access attempt")
+    @EnabledOnOs({OS.LINUX, OS.MAC})
     void shouldPreventEtcPasswdAccess() {
       File etcPasswd = new File("/etc/passwd");
 

--- a/system/src/test/java/com/percussion/system/utils/PSArchiveFilesZipSlipTest.java
+++ b/system/src/test/java/com/percussion/system/utils/PSArchiveFilesZipSlipTest.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
@@ -147,7 +148,16 @@ class PSArchiveFilesZipSlipTest {
     File base = extractDir;
     File safe = PathValidation.constructSafePath(base, "subdir/file.txt");
     assertNotNull(safe);
-    assertTrue(safe.getAbsolutePath().startsWith(base.getAbsolutePath()),
+    // Use java.nio.file.Path.startsWith(Path) which is case-insensitive on Windows
+    // (java.nio.file.WindowsPath) and case-sensitive on Unix, handling both the
+    // case-folding on Windows and the path-separator difference (/ vs \\) in a
+    // single platform-aware call. The previous String.startsWith was
+    // case-sensitive on all platforms, which produced a Windows-only
+    // regression (CI on dev laptops) when the JUnit TempDir path and the
+    // resolved child path differed only in drive letter casing.
+    Path basePath = base.getAbsoluteFile().toPath().toAbsolutePath().normalize();
+    Path safePath = safe.getAbsoluteFile().toPath().toAbsolutePath().normalize();
+    assertTrue(safePath.startsWith(basePath),
         "safe path must be under baseDir, got: " + safe);
   }
 


### PR DESCRIPTION
## Summary

Fixes 4 pre-existing platform-portability failures in two test files. Not introduced by any session PR; surfaced because this session's dev environment is Windows.

### Failures

| Test | Platform | Root cause |
|------|----------|------------|
| `PSLocalCommandHandlerSecurityTest.shouldPreventEtcPasswdAccess` | Windows | Hardcoded `/etc/absent` path triggers `FileNotFoundException` from JVM filesystem layer BEFORE production security check runs |
| `PSLocalCommandHandlerSecurityTest.shouldRejectAbsoluteEtcPasswd` | Windows | Same — `/etc/passwd` |
| `PSLocalCommandHandlerSecurityTest.shouldRejectAbsoluteSystemPath` | Windows | Same — `/usr/bin/bash` |
| `PSArchiveFilesZipSlipTest.testConstructSafePathAcceptsValidRelative` | Windows | `String#startsWith` is case-sensitive on Windows; JUnit `@TempDir` path case (`C:\Users\...`) differs from `File#getAbsolutePath` resolved path |

### Fix 1 — `PSLocalCommandHandlerSecurityTest.java`

Added `@EnabledOnOs({OS.LINUX, OS.MAC})` to the 3 Unix-path-only tests. JUnit 5 disables them on non-POSIX hosts; the other 11 tests (using `..` or null) continue to run cross-platform. Imports: `org.junit.jupiter.api.condition.EnabledOnOs`, `org.junit.jupiter.api.condition.OS`.

### Fix 2 — `PSArchiveFilesZipSlipTest.java`

Replaced the `String#startsWith` containment check with `java.nio.file.Path#startsWith(Path)`, which:
- Is case-insensitive on Windows (`WindowsPath` provider)
- Is case-sensitive on Unix (`UnixPath` provider)
- Normalizes path-separator difference (`/` vs `\`) and drive-letter-case differences in one platform-aware call
- Normalizes both paths before comparison (relative segments, dot-segments)

Imports: `java.nio.file.Path`.

### Files

- `system/src/test/java/com/percussion/process/PSLocalCommandHandlerSecurityTest.java`
- `system/src/test/java/com/percussion/system/utils/PSArchiveFilesZipSlipTest.java`

(No spec/plan artifact updates per user directive on this branch type.)

### Constitution compliance

- **III. Test Discipline**: test-only changes; no production code touched.
- **V. Safe Modernization**: no drive-by refactoring; only 2 JUnit annotations + 1 import + 5-line assertion change.
- **VIII. Documentation & Operability**: comment in `testConstructSafePathAcceptsValidRelative` explains the failure mode and why `Path#startsWith(Path)` is the correct cross-platform check.

### Verification

- The 3 `should*Absolute*` tests will be skipped on Windows (`@EnabledOnOs(LINUX, MAC)`) and pass on the canonical Linux runner.
- The 11 other `PSLocalCommandHandlerSecurityTest` tests and all `PSArchiveFilesZipSlipTest` tests run on every platform.
- CI on `ubuntu-latest` (GitHub's default runner) runs the full test matrix; Windows runner (if added) runs the cross-platform subset.