### PR TITLE
fix(webui): remove discontinued Redirect Management gadget (#715)

### DIFF
--- a/WebUI/src/main/resources/com/percussion/webui/gadget/servlets/GadgetRegistry.xml
+++ b/WebUI/src/main/resources/com/percussion/webui/gadget/servlets/GadgetRegistry.xml
@@ -23,7 +23,8 @@
         <gadget name="Activity" baseuri="/cm/gadgets/repository/perc_activity_gadget" file="perc_activity_gadget.xml"/>
         <gadget name="Siteimprove" baseuri="/cm/gadgets/repository/perc_site_improve_gadget" file="perc_site_improve_gadget.xml"/>
         <gadget name="Membership" baseuri="/cm/gadgets/repository/perc_membership_gadget" file="perc_membership_gadget.xml"/>
-        <gadget name="Redirect Management" baseuri="/cm/gadgets/repository/perc_website_config_gadget" file="perc_website_config_gadget.xml"/>
+        <!-- Redirect Management removed entirely (issue #715): product discontinued;
+             legacy perc_website_config_gadget assets are no longer shipped. -->
         <gadget name="Widget Configuration" baseuri="/cm/gadgets/repository/PercWidgetConfigGadget" file="PercWidgetConfigGadget.xml"/>
     </group>
 </gadgets>

--- a/WebUI/src/test/java/com/percussion/webui/gadget/servlets/GadgetRegistryTest.java
+++ b/WebUI/src/test/java/com/percussion/webui/gadget/servlets/GadgetRegistryTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 /**
  * Regression for v8.1.7 PR #722 / #885: GadgetRegistry.xml on classpath with Percussion +
- * Deprecated groups.
+ * Deprecated groups. Also covers issue #715 (Redirect Management gadget removed).
  */
 public class GadgetRegistryTest {
 
@@ -37,7 +37,6 @@ public class GadgetRegistryTest {
     assertEquals("Deprecated", map.get("Activity"));
     assertEquals("Deprecated", map.get("Siteimprove"));
     assertEquals("Deprecated", map.get("Membership"));
-    assertEquals("Deprecated", map.get("Redirect Management"));
     assertEquals("Deprecated", map.get("Widget Configuration"));
 
     // #885 undeprecated these back to Percussion
@@ -47,6 +46,19 @@ public class GadgetRegistryTest {
 
     assertEquals("Percussion", map.get("Welcome"));
     assertEquals("Percussion", map.get("Bulk Upload"));
+  }
+
+  /**
+   * Issue #715: Redirect Management gadget is discontinued and must not appear in the registry
+   * (neither Percussion nor Deprecated). Unknown names resolve to Custom.
+   */
+  @Test
+  public void redirectManagementGadgetIsRemoved() {
+    Map<String, String> map = GadgetRegistry.loadGadgetTypeMap();
+    assertFalse(
+        "Redirect Management must not be registered after issue #715",
+        map.containsKey("Redirect Management"));
+    assertEquals("Custom", GadgetRegistry.getGadgetType("Redirect Management"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes #715 — completely removes the discontinued **Redirect Management** dashboard gadget from product configuration.

### Context
- On 8.1.7 the gadget was only moved to the **Deprecated** group (#793 / #794).
- Issue #715 requires full removal: the feature is unsupported and remaining references produce blank/broken dashboard components.
- Legacy `perc_website_config_gadget` repository assets are already absent from the source tree; the remaining registration lived in `GadgetRegistry.xml`.

### Changes
- Remove `Redirect Management` from `GadgetRegistry.xml` (Deprecated group).
- Update `GadgetRegistryTest`: assert the name is **not** registered (resolves as `Custom` via unknown-name path).
- Leave redirect **service** paths (`/redirectmanagement`, `PercRedirectHandler`, `IPSRedirectService`) intact — those support page-move redirect rules, not the dashboard gadget.

### Erlang review
Strict pre-PR review: **approve** (0 blocking bugs).  
Report: `tmp/reviews/2026-07-16-715-remove-redirect-management-gadget-erlang.md`.

## Test plan

- [x] `./mvn-env.sh -pl WebUI -Dtest=GadgetRegistryTest test` (4 tests, pass)
- [ ] Dashboard → Add Gadgets: Redirect Management does not appear under Percussion, Deprecated, Custom, or All
- [ ] Existing non-Redirect gadgets still load and group as before