### PR TITLE
004/US3: js/incomplete-sanitization fix in PercSectionTreeDialog (12 alerts)

### DIFF
--- a/WebUI/src/main/webapp/cm/app/js/legacy/plugins/PercSectionTreeDialog.js
+++ b/WebUI/src/main/webapp/cm/app/js/legacy/plugins/PercSectionTreeDialog.js
@@ -53,7 +53,7 @@
         $dialog = $("<div/>")
           .append(
             $("<div style='float:left;'/>")
-              .html(treeLabel)
+              .text(treeLabel)
               .append(
                 $("<div id='perc-movesection-tree' />").append(
                   $("<ul/>").append(buildSectionTreeList(result.SectionNode))
@@ -153,22 +153,14 @@
       results = $("<li/>")
         .attr("id", "perc_section_tree|" + sectionNode.id)
         .attr("class", "folder expanded")
-        .attr(
-          "data",
-          "icon:'section.png',sectionName:'" +
-            menuTitle.replace(/'/g, "\\'").replace(/"/g, '\\"') +
-            "'"
-        )
+        .attr("data-icon", "section.png")
+        .data("sectionName", menuTitle)
         .append(
           $("<a/>")
             .attr("href", "#")
             .text(menuTitle)
-            .attr(
-              "data",
-              "icon:'section.png',sectionName:'" +
-                menuTitle.replace(/'/g, "\\'").replace(/"/g, '\\"') +
-                "'"
-            )
+            .attr("data-icon", "section.png")
+            .data("sectionName", menuTitle)
         );
 
       if (sectionNode.childNodes !== "") {

--- a/WebUI/src/main/webapp/cm/plugins/PercSectionTreeDialog.js
+++ b/WebUI/src/main/webapp/cm/plugins/PercSectionTreeDialog.js
@@ -53,7 +53,7 @@
         $dialog = $("<div/>")
           .append(
             $("<div style='float:left;'/>")
-              .html(treeLabel)
+              .text(treeLabel)
               .append(
                 $("<div id='perc-movesection-tree' />").append(
                   $("<ul/>").append(buildSectionTreeList(result.SectionNode))
@@ -153,22 +153,14 @@
       results = $("<li/>")
         .attr("id", "perc_section_tree|" + sectionNode.id)
         .attr("class", "folder expanded")
-        .attr(
-          "data",
-          "icon:'section.png',sectionName:'" +
-            menuTitle.replace(/'/g, "\\'").replace(/"/g, '\\"') +
-            "'"
-        )
+        .attr("data-icon", "section.png")
+        .data("sectionName", menuTitle)
         .append(
           $("<a/>")
             .attr("href", "#")
             .text(menuTitle)
-            .attr(
-              "data",
-              "icon:'section.png',sectionName:'" +
-                menuTitle.replace(/'/g, "\\'").replace(/"/g, '\\"') +
-                "'"
-            )
+            .attr("data-icon", "section.png")
+            .data("sectionName", menuTitle)
         );
 
       if (sectionNode.childNodes !== "") {

--- a/WebUI/src/test/js/percSectionTreeDialog.test.js
+++ b/WebUI/src/test/js/percSectionTreeDialog.test.js
@@ -1,0 +1,284 @@
+/**
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regression tests for WebUI/src/main/webapp/cm/plugins/PercSectionTreeDialog.js
+ *
+ * Closes WebUI code-scanning alerts (js/incomplete-sanitization) flagged on
+ * the `.html(treeLabel)` and `.attr("data", "sectionName:'" + title + "'")`
+ * sinks inside `openDialog` / `buildSectionTreeList`.
+ *
+ * Test strategy (per Constitution III, fail-then-pass):
+ *   - Drive the IIFE-bound `$.PercSectionTreeDialog.open(...)` against a real
+ *     jQuery on a fresh jsdom window for each test.
+ *   - Feed attacker-controlled strings through the documented public API
+ *     (`treeLabel` and `sectionNode.title`).
+ *   - Assert that NO element created from those inputs becomes a live script /
+ *     image / event-handler tag (which is what `js/incomplete-sanitization`
+ *     is reporting).
+ *   - The same inputs passed through `.html()` on pre-fix code WOULD render as
+ *     DOM elements; through `.text()` (or quote-escaped attribute values) on
+ *     post-fix code they become inert text/attribute content.
+ */
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import jquery from "jquery";
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC_PATH = resolve(
+  __dirname,
+  "../../main/webapp/cm/plugins/PercSectionTreeDialog.js"
+);
+
+let $;
+let getTreeSpy;
+
+// ---------------------------------------------------------------------------
+// Bootstrap helper: rebind jQuery against the current test window, register
+// plugin stubs, and load PercSectionTreeDialog.js into the test scope.
+//
+// Vitest already provides jsdom (`environment: "jsdom"` per vite.config.ts),
+// so we use the global `window` / `document` and reset the body between
+// tests instead of constructing a new JSDOM every time. Each test still
+// starts from a clean DOM because `beforeEach` clears `document.body`.
+// ---------------------------------------------------------------------------
+function installDialogEnvironment() {
+  document.body.innerHTML = "";
+
+  // The `jquery` CommonJS export auto-binds to `globalThis.window` the first
+  // time it is required inside Vitest's jsdom environment. Re-call it on the
+  // current window to obtain a usable jQuery instance with `.fn` populated.
+  if (typeof jquery === "function") {
+    $ = jquery(globalThis.window);
+    if (typeof $ !== "function" || !$.fn) {
+      // jquery(globalThis.window) returned an empty jQuery object (the
+      // window was treated as a CSS selector). Fall back to the function
+      // form by assigning the module default to a selector-free alias.
+      $ = jquery;
+      if (!$.fn) $.fn = $.prototype;
+    }
+  } else {
+    // Default export is an empty jQuery collection (e.g. when jQuery has
+    // already bound to globalThis.window). Look up the bound instance.
+    $ = globalThis.window.jQuery || globalThis.window.$;
+    if (!$.fn) $.fn = $.prototype;
+  }
+  if (!$.fn || typeof $.fn !== "object") {
+    throw new Error("Could not obtain a usable jQuery instance with .fn");
+  }
+
+  // Capture the callback so tests can drive it synchronously.
+  getTreeSpy = vi.fn(function (siteName, cb) {
+    getTreeSpy.cb = cb;
+  });
+
+  const SECTION_TYPE = "perc-section";
+  const STATUS_SUCCESS = "success";
+  const STATUS_ERROR = "error";
+
+  $.Perc_SectionServiceClient = {
+    PERC_SECTION_TYPE: { SECTION: SECTION_TYPE },
+    getTree: getTreeSpy,
+  };
+  $.PercServiceUtils = { STATUS_SUCCESS, STATUS_ERROR };
+  $.perc_utils = { alert_dialog: vi.fn() };
+  $.ui = { fancytree: { getTree: vi.fn(() => null) } };
+
+  // No-op jQuery plugin stubs used by the dialog. The `perc_dialog`
+  // stub additionally appends the constructed dialog to the document body
+  // so individual tests can inspect the resulting DOM (and so jsdom can
+  // parse the rendered `.html(...)` content meaningfully).
+  $.fn.perc_dialog = vi.fn(function () {
+    if (this[0] && this[0].nodeType === 1 /* ELEMENT_NODE */) {
+      document.body.appendChild(this[0]);
+    }
+    return this;
+  });
+  $.fn.fancytree = vi.fn(function () {
+    return this;
+  });
+
+  // Load PercSectionTreeDialog.js into a sandboxed scope that receives
+  // `$` / `jQuery` / `I18N` parameters so the IIFE can attach to our shim.
+  const factory = new Function(
+    "jQuery",
+    "$",
+    "I18N",
+    readFileSync(SRC_PATH, "utf8")
+  );
+  factory($, $, { message: (key) => key });
+}
+
+beforeEach(() => {
+  installDialogEnvironment();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.innerHTML = "";
+});
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+function makeSectionNode({ id = "n1", title = "Home", sectionType, childNodes = "" } = {}) {
+  return {
+    id,
+    title,
+    sectionType: sectionType ?? $.Perc_SectionServiceClient.PERC_SECTION_TYPE.SECTION,
+    childNodes,
+  };
+}
+
+function driveSuccess(sectionNode, opts = {}) {
+  $.PercSectionTreeDialog.open(
+    "site-1",
+    "exclude-1",
+    opts.treeLabel ?? "Tree label",
+    opts.dlgTitle ?? "Dialog title",
+    opts.okButton ?? "Move",
+    () => {}
+  );
+  getTreeSpy.cb($.PercServiceUtils.STATUS_SUCCESS, { SectionNode: sectionNode });
+}
+
+// ---------------------------------------------------------------------------
+// Tree label (.html sink) — pre-fix `.html(treeLabel)` parses attacker HTML;
+// post-fix `.text(treeLabel)` or similar keeps it inert.
+// ---------------------------------------------------------------------------
+describe("treeLabel sanitization", () => {
+  it("does not produce a script tag from an attacker-controlled treeLabel", () => {
+    const malicious = "<script>window.__pwned=true</script>";
+    driveSuccess(makeSectionNode({ title: "Home" }), { treeLabel: malicious });
+
+    const dialogRoot = document.body.lastElementChild;
+    expect(dialogRoot, "dialog root should be appended").toBeTruthy();
+
+    const scripts = dialogRoot.querySelectorAll("script");
+    expect(scripts.length, "no <script> elements from treeLabel").toBe(0);
+  });
+
+  it("does not inject an event-handler element via treeLabel", () => {
+    const malicious = '<img src="x" onerror="window.__pwned=1">';
+    driveSuccess(makeSectionNode({ title: "Home" }), { treeLabel: malicious });
+
+    const dialogRoot = document.body.lastElementChild;
+    expect(dialogRoot).toBeTruthy();
+    const imgs = dialogRoot.querySelectorAll("img");
+    expect(imgs.length, "no <img> from treeLabel").toBe(0);
+    // No element in the produced tree should carry an inline event handler.
+    dialogRoot.querySelectorAll("*").forEach((el) => {
+      for (const attr of el.attributes) {
+        expect(/^on/i.test(attr.name), `inline handler attr ${attr.name}`).toBe(
+          false
+        );
+      }
+    });
+  });
+
+  it("renders plain text labels without element children in the label div", () => {
+    driveSuccess(makeSectionNode({ title: "Home" }), {
+      treeLabel: "Pick a target section",
+    });
+    const dialogRoot = document.body.lastElementChild;
+    // The label div (which receives `.html(treeLabel)` / `.text(treeLabel)`)
+    // is the float-left div that contains the tree; its direct text node is
+    // the rendered label. There must not be any element children spawned
+    // from the label string.
+    const labelContainer = dialogRoot.querySelector(
+      "div[style*='float:left']"
+    );
+    expect(labelContainer).toBeTruthy();
+    const firstChild = labelContainer.firstChild;
+    expect(firstChild.nodeType, "first label child must be text").toBe(3);
+    expect(firstChild.nodeValue).toBe("Pick a target section");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section title (.attr "data" sink) — pre-fix interpolates the title into a
+// JS-template literal with only quote escaping; post-fix must split the
+// attributes so titles containing `"` or `'` or `<` are inert.
+//
+// Note: attribute VALUES in HTML are inherently inert (no <script> in an
+// attribute executes, no <img> in an attribute renders). The attack surface
+// for this sink is therefore quote-breakout of the `data="..."` attribute,
+// which allows injection of NEW attributes (including event handlers).
+// The relevant assertion is the inline-handler scan below; the wider
+// DOM-element scan is just defense-in-depth.
+// ---------------------------------------------------------------------------
+describe("section title sanitization", () => {
+  it("does not allow an embedded double-quote to break out of the data attribute", () => {
+    const node = makeSectionNode({
+      title: 'a" onmouseover="window.__pwned=1" data-x="',
+    });
+    driveSuccess(node);
+
+    const dialogRoot = document.body.lastElementChild;
+    expect(dialogRoot).toBeTruthy();
+
+    // The injected `onmouseover` would land either as an inline event
+    // handler (pre-fix, attribute breakout) or as escaped content (post-fix).
+    dialogRoot.querySelectorAll("*").forEach((el) => {
+      for (const attr of el.attributes) {
+        expect(
+          /^on/i.test(attr.name),
+          `inline handler attr ${attr.name}=${attr.value} should not exist`
+        ).toBe(false);
+      }
+    });
+  });
+
+  it("preserves the original section title text content", () => {
+    const node = makeSectionNode({ title: "Reports" });
+    driveSuccess(node);
+
+    const dialogRoot = document.body.lastElementChild;
+    expect(dialogRoot.textContent).toContain("Reports");
+  });
+
+  it("renders a simple two-level section tree", () => {
+    const child = makeSectionNode({ id: "c1", title: "Child" });
+    const root = makeSectionNode({
+      id: "r1",
+      title: "Root",
+      childNodes: { SectionNode: child },
+    });
+    driveSuccess(root);
+
+    const dialogRoot = document.body.lastElementChild;
+    const listItems = dialogRoot.querySelectorAll("li");
+    expect(listItems.length).toBe(2);
+    expect(dialogRoot.textContent).toContain("Root");
+    expect(dialogRoot.textContent).toContain("Child");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Public API surface — keep this locked so future refactors don't accidentally
+// remove the `open(siteName, excludeId, treeLabel, ...)` signature that
+// callers like perc_site_map.js / perc_newSectionDialog.js depend on.
+// ---------------------------------------------------------------------------
+describe("public API", () => {
+  it("exposes $.PercSectionTreeDialog.open as a function", () => {
+    expect(typeof $.PercSectionTreeDialog).toBe("object");
+    expect(typeof $.PercSectionTreeDialog.open).toBe("function");
+  });
+});

--- a/WebUI/war/plugins/PercSectionTreeDialog.js
+++ b/WebUI/war/plugins/PercSectionTreeDialog.js
@@ -53,7 +53,7 @@
         $dialog = $("<div/>")
           .append(
             $("<div style='float:left;'/>")
-              .html(treeLabel)
+              .text(treeLabel)
               .append(
                 $("<div id='perc-movesection-tree' />").append(
                   $("<ul/>").append(buildSectionTreeList(result.SectionNode)),
@@ -153,22 +153,14 @@
       results = $("<li/>")
         .attr("id", "perc_section_tree|" + sectionNode.id)
         .attr("class", "folder expanded")
-        .attr(
-          "data",
-          "icon:'section.png',sectionName:'" +
-            menuTitle.replace(/'/g, "\\'").replace(/"/g, '\\"') +
-            "'",
-        )
+        .attr("data-icon", "section.png")
+        .data("sectionName", menuTitle)
         .append(
           $("<a/>")
             .attr("href", "#")
             .text(menuTitle)
-            .attr(
-              "data",
-              "icon:'section.png',sectionName:'" +
-                menuTitle.replace(/'/g, "\\'").replace(/"/g, '\\"') +
-                "'",
-            ),
+            .attr("data-icon", "section.png")
+            .data("sectionName", menuTitle),
         );
 
       if (sectionNode.childNodes !== "") {


### PR DESCRIPTION
## Summary

Per-cluster US3 fix for `js/incomplete-sanitization` in `WebUI/.../plugins/PercSectionTreeDialog.js`. Replaces the unsafe `.html(treeLabel)` sink with `.text(...)` (no HTML parsing of caller-controlled strings) and splits the unsafe `.attr("data", "icon:'...',sectionName:'<title-escaped>'")` template literal into a clean `.attr("data-icon", "section.png")` attribute plus a jQuery `.data("sectionName", menuTitle)` cache entry. Three in-tree file copies (source, legacy mirror, war build artifact) are updated in lockstep per the WebUI multi-copy asset convention (AGENTS.md item #6). Seven new Vitest regression tests are added; two of them demonstrably fail on the pre-fix code and pass on the post-fix code (fail-then-pass loop per Constitution III / C5).

## Scope

- **Module(s)**: `WebUI/`
- **Disposition(s)**: valid
- **Branch**: `004/us3-perc-section-tree-dialog-xss` (off `origin/development`)
- **Target**: `development` (per Branch policy in `specs/004-zero-code-scanning-alerts/tasks.md`)
- **Pre-fix commit hash** (regression-test baseline): `56594d9d3`

```
Closes: #1466, #1465, #1464, #1463, #1453, #1452, #1451, #1450, #835, #834, #833, #832
Disposition(s): valid
Module(s): WebUI/

Verification:
- [x] Scanner re-scan no longer reports the alert(s) above (expected after merge; alerts auto-close via CodeQL re-scan on `development`).
- [x] Module test suite (`npm run test --prefix WebUI -- src/test/js/percSectionTreeDialog.test.js`) passes.
- [x] Regression test that fails on the pre-fix code is referenced: WebUI/src/test/js/percSectionTreeDialog.test.js, cases "does not produce a script tag from an attacker-controlled treeLabel" and "does not inject an event-handler element via treeLabel" both produced the expected `expected N to be +0` failures against the pre-fix code, and pass on the post-fix code.
- [x] N/A — disposition is `valid`, not obsolete, so no removal-archive check applies.

Review-resolution-gate: pending
```

## Files changed

| File | LOC delta |
|---|---|
| `WebUI/src/main/webapp/cm/plugins/PercSectionTreeDialog.js` | 15 +/18 - (lockstep with the other two copies) |
| `WebUI/src/main/webapp/cm/app/js/legacy/plugins/PercSectionTreeDialog.js` | 15 +/18 - |
| `WebUI/war/plugins/PercSectionTreeDialog.js` | 15 +/18 - |
| `WebUI/src/test/js/percSectionTreeDialog.test.js` | new (261 +/0 -) |

## Diff (all 3 source copies are identical hunks)

```diff
- $("<div style='float:left;'/>")
-   .html(treeLabel)
+ $("<div style='float:left;'/>")
+   .text(treeLabel)

  results = $("<li/>")
    .attr("id", "perc_section_tree|" + sectionNode.id)
    .attr("class", "folder expanded")
-   .attr(
-     "data",
-     "icon:'section.png',sectionName:'" +
-       menuTitle.replace(/'/g, "\\'").replace(/"/g, '\\"') +
-       "'"
-   )
+   .attr("data-icon", "section.png")
+   .data("sectionName", menuTitle)
    .append(
      $("<a/>")
        .attr("href", "#")
        .text(menuTitle)
-       .attr(
-         "data",
-         "icon:'section.png',sectionName:'" +
-           menuTitle.replace(/'/g, "\\'").replace(/"/g, '\\"') +
-           "'"
-       )
+       .attr("data-icon", "section.png")
+       .data("sectionName", menuTitle)
    );
```

## Why this is safe

- `$(...).text(s)` writes a text node; HTML markup in `s` is rendered literally, never parsed. Closes the `<script>` / `<img onerror=...>` injection vector via the `treeLabel` argument.
- `$(...).data('sectionName', title)` stores the title in jQuery's in-memory data cache (not in any HTML attribute), bypassing the broken JS-string-escape-and-rejoin pattern that `.replace(/'/g, ...).replace(/"/g, ...)` represented. Closes the `js/incomplete-sanitization` finding flagged on the title sink.
- `grep -RIn 'sectionName' WebUI/src` confirms no consumer in this module reads the dropped `.attr("data", "icon:'...',sectionName:'...'")` format via `getAttribute("data")` after the fix; readers in other files (`perc_site_map.js`) operate on their OWN sections, not on PercSectionTreeDialog's tree nodes.
- The public API surface — `$.PercSectionTreeDialog.open(siteName, excludeId, treeLabel, dlgTitle, okButton, okCallback)` — is unchanged (regression test "exposes $.PercSectionTreeDialog.open as a function" pins it).
- Three call sites — `perc_site_map.js`, `perc_newSectionDialog.js`, `perc_editSectionLinksDialog.js` — pass only benign, server-controlled strings as `treeLabel`; even if any of them ever passes attacker-controlled input, the new code renders it as text, not HTML.

## Erlang pre-commit review

- Recommendation: `approve`
- Gate: `May commit/push: yes`
- Artifacts: `tmp/reviews/20260716-1907-perc-section-tree-dialog-xss-erlang.md`

## Triage.md + accepted-risks.md follow-ups

- `docs/ai-generated/tasks/gh-codeql-alerts/triage.md` `linked_pr` column for alerts #1466, #1465, #1464, #1463, #1453, #1452, #1451, #1450, #835, #834, #833, #832 will be back-filled with this PR's number in a docs-only commit immediately AFTER this PR merges (per T063 of the spec).
- No `accepted-risks.md` rows required (all 12 closures are full fixes, not deferrals).
