### PR TITLE
004/US3: js/xss-through-dom fix in PercChangeTemplateDialog (3 alerts)

### DIFF
--- a/WebUI/src/main/webapp/cm/app/js/legacy/views/PercChangeTemplateDialog.js
+++ b/WebUI/src/main/webapp/cm/app/js/legacy/views/PercChangeTemplateDialog.js
@@ -183,7 +183,7 @@
             var itemId = $(this).find(".item-id").text();
             var itemName = $(this).find(".perc-text-overflow").text();
             $("#perc-select-template").val(itemId);
-            $(".perc-label-right").html("Selected Template:&nbsp;" + itemName);
+            $(".perc-label-right").text("Selected Template: " + itemName);
             $(".perc-items .item").removeClass("perc-selected-item");
             $(this).addClass("perc-selected-item");
           });
@@ -205,11 +205,11 @@
           sourceType = "TEMPLATE";
         }
 
-        $(".perc-label-left").html(
-          "Current Template:&nbsp;" + currentTemplateName
+        $(".perc-label-left").text(
+          "Current Template: " + currentTemplateName
         );
-        $(".perc-label-right").html(
-          "Selected Template:&nbsp;" + selectedTemplateName
+        $(".perc-label-right").text(
+          "Selected Template: " + selectedTemplateName
         );
         $("#perc-select-template").val(currentTemplateName);
 
@@ -220,28 +220,42 @@
          * Creates and returns an entry for the template selection field.
          */
         function createTemplateEntry(data, templateId) {
-          var tempDiv = '<div class="item">';
+          // Build the entry via the jQuery DOM API so user-controlled
+          // fields (data.imageThumbPath, data.id, data.name) are never
+          // concatenated into an HTML string and parsed back into the
+          // DOM. jQuery's `.attr()` and `.text()` escape their
+          // arguments for the relevant context.
+          var $entry = $("<div/>", { class: "item" });
           if (data.id === templateId) {
-            tempDiv = '<div class="item perc-selected-item">';
+            $entry.addClass("perc-selected-item");
           }
-          var temp =
-            tempDiv +
-            '<div class="item-id">@ITEM_ID@</div>' +
-            "    <table>" +
-            "        <tr><td align='left'>" +
-            "            <img style='border:1px solid #E6E6E9' height = '86px' width = '122px' src=\"@IMG_SRC@\"/>" +
-            "        </td></tr>" +
-            "        <tr><td>" +
-            "            <div class='perc-text-overflow-container' style='text-overflow:ellipsis;width:122px;overflow:hidden;white-space:nowrap'>" +
-            "                <div class='perc-text-overflow' style='float:none' title='@ITEM_TT@' alt='@ITEM_TT@'>@ITEM_LABEL@</div>" +
-            "        </td></tr>" +
-            "    </table>" +
-            "</div>";
-          return temp
-            .replace(/@IMG_SRC@/, data.imageThumbPath)
-            .replace(/@ITEM_ID@/, data.id)
-            .replace(/@ITEM_LABEL@/, data.name)
-            .replace(/@ITEM_TT@/g, data.name);
+          var $itemId = $("<div/>", { class: "item-id" }).text(data.id);
+          var $img = $("<img/>", {
+            style: "border:1px solid #E6E6E9",
+            height: "86px",
+            width: "122px",
+          }).attr("src", data.imageThumbPath);
+          var $overflowContainer = $("<div/>", {
+            class: "perc-text-overflow-container",
+            style:
+              "text-overflow:ellipsis;width:122px;overflow:hidden;white-space:nowrap",
+          });
+          var $overflow = $("<div/>", { class: "perc-text-overflow", style: "float:none" })
+            .attr("title", data.name)
+            .attr("alt", data.name)
+            .text(data.name);
+          $overflowContainer.append($overflow);
+          $entry
+            .append($itemId)
+            .append(
+              $("<table/>").append(
+                $("<tbody/>").append(
+                  $("<tr/>").append($("<td/>", { align: "left" }).append($img)),
+                  $("<tr/>").append($("<td/>").append($overflowContainer))
+                )
+              )
+            );
+          return $entry;
         }
       }
     } // End open dialog

--- a/WebUI/src/main/webapp/cm/views/PercChangeTemplateDialog.js
+++ b/WebUI/src/main/webapp/cm/views/PercChangeTemplateDialog.js
@@ -183,7 +183,7 @@
             var itemId = $(this).find(".item-id").text();
             var itemName = $(this).find(".perc-text-overflow").text();
             $("#perc-select-template").val(itemId);
-            $(".perc-label-right").html("Selected Template:&nbsp;" + itemName);
+            $(".perc-label-right").text("Selected Template: " + itemName);
             $(".perc-items .item").removeClass("perc-selected-item");
             $(this).addClass("perc-selected-item");
           });
@@ -205,11 +205,11 @@
           sourceType = "TEMPLATE";
         }
 
-        $(".perc-label-left").html(
-          "Current Template:&nbsp;" + currentTemplateName
+        $(".perc-label-left").text(
+          "Current Template: " + currentTemplateName
         );
-        $(".perc-label-right").html(
-          "Selected Template:&nbsp;" + selectedTemplateName
+        $(".perc-label-right").text(
+          "Selected Template: " + selectedTemplateName
         );
         $("#perc-select-template").val(currentTemplateName);
 
@@ -220,28 +220,42 @@
          * Creates and returns an entry for the template selection field.
          */
         function createTemplateEntry(data, templateId) {
-          var tempDiv = '<div class="item">';
+          // Build the entry via the jQuery DOM API so user-controlled
+          // fields (data.imageThumbPath, data.id, data.name) are never
+          // concatenated into an HTML string and parsed back into the
+          // DOM. jQuery's `.attr()` and `.text()` escape their
+          // arguments for the relevant context.
+          var $entry = $("<div/>", { class: "item" });
           if (data.id === templateId) {
-            tempDiv = '<div class="item perc-selected-item">';
+            $entry.addClass("perc-selected-item");
           }
-          var temp =
-            tempDiv +
-            '<div class="item-id">@ITEM_ID@</div>' +
-            "    <table>" +
-            "        <tr><td align='left'>" +
-            "            <img style='border:1px solid #E6E6E9' height = '86px' width = '122px' src=\"@IMG_SRC@\"/>" +
-            "        </td></tr>" +
-            "        <tr><td>" +
-            "            <div class='perc-text-overflow-container' style='text-overflow:ellipsis;width:122px;overflow:hidden;white-space:nowrap'>" +
-            "                <div class='perc-text-overflow' style='float:none' title='@ITEM_TT@' alt='@ITEM_TT@'>@ITEM_LABEL@</div>" +
-            "        </td></tr>" +
-            "    </table>" +
-            "</div>";
-          return temp
-            .replace(/@IMG_SRC@/, data.imageThumbPath)
-            .replace(/@ITEM_ID@/, data.id)
-            .replace(/@ITEM_LABEL@/, data.name)
-            .replace(/@ITEM_TT@/g, data.name);
+          var $itemId = $("<div/>", { class: "item-id" }).text(data.id);
+          var $img = $("<img/>", {
+            style: "border:1px solid #E6E6E9",
+            height: "86px",
+            width: "122px",
+          }).attr("src", data.imageThumbPath);
+          var $overflowContainer = $("<div/>", {
+            class: "perc-text-overflow-container",
+            style:
+              "text-overflow:ellipsis;width:122px;overflow:hidden;white-space:nowrap",
+          });
+          var $overflow = $("<div/>", { class: "perc-text-overflow", style: "float:none" })
+            .attr("title", data.name)
+            .attr("alt", data.name)
+            .text(data.name);
+          $overflowContainer.append($overflow);
+          $entry
+            .append($itemId)
+            .append(
+              $("<table/>").append(
+                $("<tbody/>").append(
+                  $("<tr/>").append($("<td/>", { align: "left" }).append($img)),
+                  $("<tr/>").append($("<td/>").append($overflowContainer))
+                )
+              )
+            );
+          return $entry;
         }
       }
     } // End open dialog

--- a/WebUI/src/test/js/percChangeTemplateDialog.test.js
+++ b/WebUI/src/test/js/percChangeTemplateDialog.test.js
@@ -1,0 +1,331 @@
+/**
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regression tests for WebUI/src/main/webapp/cm/views/PercChangeTemplateDialog.js
+ *
+ * Closes GitHub CodeQL alerts (js/xss-through-dom) flagged on three
+ * `.html("...&nbsp;" + name)` sinks inside `scrollableTemplateSelector`
+ * (the "Selected Template" / "Current Template" labels) and the
+ * template-entry HTML builder `createTemplateEntry(...)` that substitutes
+ * user-controlled template metadata (`data.name`, `data.imageThumbPath`)
+ * into a string template that is then appended to the DOM.
+ *
+ * Pre-fix code parses template names and thumb paths as HTML, so a
+ * template whose name contains `<script>...</script>` or
+ * `<img onerror=...>` produces live DOM elements inside the dialog.
+ *
+ * Test strategy (Constitution III fail-then-pass):
+ *   - Drive `$.PercChangeTemplateDialog().openDialog(...)` against a
+ *     stubbed `$.getJSON` so the JSON callback runs synchronously.
+ *   - Seed the response with template summaries whose `name` field
+ *     contains attacker-controlled HTML.
+ *   - Assert that no live `<script>` / `<img>` elements with inline
+ *     event handlers are produced and that the malicious template
+ *     string is present as inert text.
+ */
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import jquery from "jquery";
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC_PATH = resolve(
+  __dirname,
+  "../../main/webapp/cm/views/PercChangeTemplateDialog.js"
+);
+
+let $;
+let api;
+let getJsonSpy;
+
+function seedDom() {
+  document.body.innerHTML = `
+    <div class="perc-scrollable"></div>
+    <div class="perc-items"></div>
+    <div id="perc-select-template_perc_is"></div>
+    <span class="perc-label-left"></span>
+    <span class="perc-label-right"></span>
+    <input id="perc-select-template" />
+    <div id="perc-change-template-dialog"></div>
+  `;
+}
+
+function installPercShims() {
+  $.perc_paths = { TEMPLATES_BY_SITE: "/Rhythmyx/services/templates/bysite" };
+  $.perc_utils = { alert_dialog: vi.fn() };
+  $.PercServiceUtils = {
+    STATUS_SUCCESS: "success",
+    STATUS_ERROR: "error",
+    extractDefaultErrorMessage: () => "",
+    extractFieldErrorCode: () => "",
+  };
+  $.PercTextOverflow = vi.fn();
+  // capture getJSON so the test can drive its callback synchronously.
+  getJsonSpy = vi.fn(function (_url, cb) {
+    getJsonSpy.cb = cb;
+    return { done: () => ({}) };
+  });
+  $.getJSON = getJsonSpy;
+  $.fn.perc_dialog = function () {
+    if (this[0] && this[0].nodeType === 1) {
+      document.body.appendChild(this[0]);
+    }
+    return this;
+  };
+  $.fn.scrollable = function () {
+    return this;
+  };
+  globalThis.I18N = {
+    message: (key) => `[${key}]`,
+  };
+}
+
+function loadFactory() {
+  let jq = jquery(globalThis.window);
+  if (typeof jq !== "function") {
+    jq = typeof jquery === "function" ? jquery : (jquery.fn || jquery);
+    if (!jq.fn && jq.prototype) jq.fn = jq.prototype;
+  }
+  if (!jq.fn) throw new Error("jquery has neither .fn nor .prototype");
+  $ = jq;
+  globalThis.jQuery = $;
+  globalThis.$ = $;
+  // Plugin stubs must exist before the IIFE runs, since the source
+  // calls $(...).perc_dialog() / $(...).scrollable() inside
+  // _openTemplateDialog().
+  $.fn.perc_dialog = function () {
+    if (this[0] && this[0].nodeType === 1) {
+      document.body.appendChild(this[0]);
+    }
+    return this;
+  };
+  $.fn.scrollable = function () {
+    return this;
+  };
+  // Install shims BEFORE wrapping with counters so the wrap survives.
+  installPercShims();
+  // eslint-disable-next-line no-console
+  console.log("DEBUG stub perc_dialog typeof:", typeof $.fn.perc_dialog, "globalThis.jQuery.fn.perc_dialog typeof:", typeof globalThis.jQuery.fn.perc_dialog);
+  installPercShims();
+  // Wrap with counters AFTER installPercShims so they survive.
+  globalThis.__percDialogCalls__ = { n: 0 };
+  globalThis.__scrollableCalls__ = { n: 0 };
+  const realPercDialog = $.fn.perc_dialog;
+  $.fn.perc_dialog = function (...a) {
+    globalThis.__percDialogCalls__.n++;
+    return realPercDialog.apply(this, a);
+  };
+  const realScrollable = $.fn.scrollable;
+  $.fn.scrollable = function (...a) {
+    globalThis.__scrollableCalls__.n++;
+    return realScrollable.apply(this, a);
+  };
+  // Sanity: assert the wrap points at the append-to-body stub.
+  // eslint-disable-next-line no-console
+  console.log("DEBUG wrap typeof realPercDialog===", typeof realPercDialog, "outerHTML len=", realPercDialog.toString().length);
+  // Run the source as a script in the global scope so its IIFE sees
+  // globalThis.jQuery.
+  (0, eval)(readFileSync(SRC_PATH, "utf8"));
+  api = globalThis.$.PercChangeTemplateDialog();
+}
+
+function fireGetJson(templateSummaries) {
+  // The factory calls $.getJSON(url, callback). Run the captured
+  // callback with the test-controlled templateSummaries.
+  getJsonSpy.cb({ TemplateSummary: templateSummaries });
+}
+
+beforeEach(() => {
+  seedDom();
+  loadFactory();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.innerHTML = "";
+  delete globalThis.I18N;
+});
+
+// ---------------------------------------------------------------------------
+// Source-pattern tests — pin the security-relevant pattern in the source
+// so any future regression that reintroduces `.html(prefix + name)` fails
+// immediately. Erlang rules warn against pure grep tests for non-trivial
+// logic; here the security property IS the absence of the unsafe pattern,
+// so a presence/absence check is the right tool.
+// ---------------------------------------------------------------------------
+describe("source-pattern (anti-regression for js/xss-through-dom)", () => {
+  const src = readFileSync(SRC_PATH, "utf8");
+
+  it("does not call .html(prefix + name) for the label sinks", () => {
+    expect(src).not.toMatch(/\.html\("Selected Template:[^"]*"\s*\+\s*itemName/);
+    expect(src).not.toMatch(/\.html\("Current Template:[^"]*"\s*\+\s*\w+/);
+  });
+
+  it("does not build the template-entry HTML via string concatenation of data fields", () => {
+    // The pre-fix createTemplateEntry uses .replace(/@ITEM_LABEL@/, data.name).
+    // Post-fix must not substitute user-controlled strings into HTML.
+    expect(src).not.toMatch(/\.replace\(\s*\/@ITEM_LABEL@\/,\s*data\.name\s*\)/);
+    expect(src).not.toMatch(/\.replace\(\s*\/@ITEM_TT@\/g,\s*data\.name\s*\)/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Behavioural tests — exercise the live source against a stubbed $.getJSON.
+// ---------------------------------------------------------------------------
+describe("openDialog (Selected Template label sink)", () => {
+  it("does not produce a <script> element from a malicious template name", () => {
+    const malicious = "<script>window.__pwned=true</script>";
+    api.openDialog("page-1", "tmpl-2", "SiteA", () => {});
+    // 2 templates so the dialog branch (not the alert branch) runs.
+    fireGetJson([
+      { id: "t1", name: "Plain", imageThumbPath: "/img/t1.png" },
+      { id: "t2", name: malicious, imageThumbPath: "/img/t2.png" },
+    ]);
+
+    const labelRight = document.querySelector(".perc-label-right");
+    expect(labelRight).toBeTruthy();
+    expect(labelRight.querySelectorAll("script").length).toBe(0);
+    expect(window.__pwned).toBeUndefined();
+  });
+
+  it("does not inject an event-handler <img> from a malicious template name", () => {
+    const malicious = '<img src="x" onerror="window.__pwned=1">';
+    api.openDialog("page-1", "tmpl-2", "SiteA", () => {});
+    fireGetJson([
+      { id: "t1", name: "Plain", imageThumbPath: "/img/t1.png" },
+      { id: "t2", name: malicious, imageThumbPath: "/img/t2.png" },
+    ]);
+
+    const labelRight = document.querySelector(".perc-label-right");
+    expect(labelRight.querySelectorAll("img").length).toBe(0);
+    expect(window.__pwned).toBeUndefined();
+  });
+});
+
+describe("openDialog (Current Template label sink)", () => {
+  it("does not produce a <script> element when the currentTemplateName is malicious", () => {
+    const malicious = "<script>window.__pwned=true</script>";
+    // If templateId is empty AND templateSummaries[0].id !== "" the
+    // initialTemplateName stays "Unassigned". To exercise the sink we
+    // pass an empty templateId and a templates list whose first id is
+    // non-empty so the loop does NOT set currentTemplateName; this
+    // means the malicious string must come from a different path:
+    // we instead exercise it through the createTemplateEntry sink by
+    // ensuring item name is malicious and the dialog click handler
+    // is wired. (Current Template label is set inside the loop too;
+    // see "the loop assigns currentTemplateName" below.)
+    api.openDialog("page-1", "", "SiteA", () => {});
+    fireGetJson([{ id: malicious, name: "Plain", imageThumbPath: "/x.png" }]);
+
+    // The current-template label was set via .html(...) pre-fix.
+    const labelLeft = document.querySelector(".perc-label-left");
+    expect(labelLeft).toBeTruthy();
+    expect(labelLeft.querySelectorAll("script").length).toBe(0);
+    expect(window.__pwned).toBeUndefined();
+  });
+});
+
+describe("openDialog (createTemplateEntry sink — imageThumbPath)", () => {
+  it("does not produce a <script> element from a malicious imageThumbPath", () => {
+    const malicious = "/x.png\"><script>window.__pwned=true</script>";
+    api.openDialog("page-1", "tmpl-x", "SiteA", () => {});
+    fireGetJson([
+      { id: "t1", name: "Plain", imageThumbPath: malicious },
+      { id: "t2", name: "Other", imageThumbPath: "/img/t2.png" },
+    ]);
+
+    const items = document.querySelectorAll(".perc-items");
+    expect(items.length).toBeGreaterThan(0);
+    const allScripts = document.querySelectorAll(".perc-items script");
+    expect(allScripts.length).toBe(0);
+    expect(window.__pwned).toBeUndefined();
+  });
+
+  it("does not produce an event-handler element from a malicious imageThumbPath", () => {
+    const malicious = '/x.png" onerror="window.__pwned=1" data-x="';
+    api.openDialog("page-1", "tmpl-x", "SiteA", () => {});
+    fireGetJson([
+      { id: "t1", name: "Plain", imageThumbPath: malicious },
+      { id: "t2", name: "Other", imageThumbPath: "/img/t2.png" },
+    ]);
+
+    document.querySelectorAll(".perc-items *").forEach((el) => {
+      for (const attr of el.attributes) {
+        expect(/^on/i.test(attr.name), `inline handler ${attr.name}`).toBe(
+          false
+        );
+      }
+    });
+    expect(window.__pwned).toBeUndefined();
+  });
+});
+
+describe("openDialog (createTemplateEntry sink — name)", () => {
+  it("renders a benign template name as inert text inside .perc-text-overflow", () => {
+    api.openDialog("page-1", "tmpl-x", "SiteA", () => {});
+    fireGetJson([
+      { id: "t1", name: "Plain Theme", imageThumbPath: "/x.png" },
+      { id: "t2", name: "Other", imageThumbPath: "/y.png" },
+    ]);
+    // eslint-disable-next-line no-console
+    console.log(
+      "DEBUG body items:",
+      [...document.querySelectorAll(".perc-items")].map(
+        (n) => `len=${n.children.length}`
+      ),
+      "dialog outerHTML:",
+      document.querySelector("#perc-change-template-dialog")?.outerHTML?.slice(0, 600),
+      "dialog items:",
+      [...document.querySelectorAll("#perc-change-template-dialog .perc-items")].map(
+        (n) => `len=${n.children.length}`
+      )
+    );
+    const texts = document.querySelectorAll(".perc-text-overflow");
+    expect(texts.length).toBeGreaterThan(0);
+    const labels = Array.from(texts).map((n) => n.textContent);
+    expect(labels).toContain("Plain Theme");
+  });
+
+  it("does not produce an <img> with an onerror handler from a malicious template name", () => {
+    const malicious = '<img src=x onerror="window.__pwned=1">';
+    api.openDialog("page-1", "tmpl-x", "SiteA", () => {});
+    fireGetJson([
+      { id: "t1", name: malicious, imageThumbPath: "/x.png" },
+      { id: "t2", name: "Other", imageThumbPath: "/y.png" },
+    ]);
+    document.querySelectorAll(".perc-items *").forEach((el) => {
+      for (const attr of el.attributes) {
+        expect(/^on/i.test(attr.name), `inline handler ${attr.name}`).toBe(
+          false
+        );
+      }
+    });
+    expect(window.__pwned).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Public API surface — pin the factory's exported method name so callers
+// keep working.
+// ---------------------------------------------------------------------------
+describe("public API", () => {
+  it("$.PercChangeTemplateDialog() returns { openDialog }", () => {
+    expect(typeof api.openDialog).toBe("function");
+  });
+});

--- a/WebUI/war/views/PercChangeTemplateDialog.js
+++ b/WebUI/war/views/PercChangeTemplateDialog.js
@@ -196,7 +196,7 @@
                         var itemId = $(this).find(".item-id").text();
                         var itemName = $(this).find(".perc-text-overflow").text();
                         $("#perc-select-template").val(itemId);
-                        $(".perc-label-right").html("Selected Template:&nbsp;" + itemName);
+                        $(".perc-label-right").text("Selected Template: " + itemName);
                         $(".perc-items .item").removeClass("perc-selected-item");
                         $(this).addClass("perc-selected-item");
                     });
@@ -223,8 +223,8 @@
                     sourceType = "TEMPLATE";
                 }
                 
-                $(".perc-label-left").html("Current Template:&nbsp;" + currentTemplateName);
-                $(".perc-label-right").html("Selected Template:&nbsp;" + selectedTemplateName);
+                $(".perc-label-left").text("Current Template: " + currentTemplateName);
+                $(".perc-label-right").text("Selected Template: " + selectedTemplateName);
                 $("#perc-select-template").val(currentTemplateName);
                 
                 // after adding all the template entries, truncate the labels if they dont fit
@@ -236,23 +236,42 @@
                  */
                 function createTemplateEntry(data, templateId)
                 {
-                    var tempDiv = "<div class=\"item\">";
-                    if(data.id === templateId) {
-                        tempDiv = "<div class=\"item perc-selected-item\">";
+                    // Build the entry via the jQuery DOM API so user-controlled
+                    // fields (data.imageThumbPath, data.id, data.name) are never
+                    // concatenated into an HTML string and parsed back into the
+                    // DOM. jQuery's `.attr()` and `.text()` escape their
+                    // arguments for the relevant context.
+                    var $entry = $("<div/>", { class: "item" });
+                    if (data.id === templateId) {
+                        $entry.addClass("perc-selected-item");
                     }
-                    var temp = tempDiv +
-                    "<div class=\"item-id\">@ITEM_ID@</div>" +
-                    "    <table>" +
-                    "        <tr><td align='left'>" +
-                    "            <img style='border:1px solid #E6E6E9' height = '86px' width = '122px' src=\"@IMG_SRC@\"/>" +
-                    "        </td></tr>" +
-                    "        <tr><td>" +
-                    "            <div class='perc-text-overflow-container' style='text-overflow:ellipsis;width:122px;overflow:hidden;white-space:nowrap'>" +
-                    "                <div class='perc-text-overflow' style='float:none' title='@ITEM_TT@' alt='@ITEM_TT@'>@ITEM_LABEL@</div>" +
-                    "        </td></tr>" +
-                    "    </table>" +
-                    "</div>";
-                    return temp.replace(/@IMG_SRC@/, data.imageThumbPath).replace(/@ITEM_ID@/, data.id).replace(/@ITEM_LABEL@/, data.name).replace(/@ITEM_TT@/g, data.name);
+                    var $itemId = $("<div/>", { class: "item-id" }).text(data.id);
+                    var $img = $("<img/>", {
+                        style: "border:1px solid #E6E6E9",
+                        height: "86px",
+                        width: "122px",
+                    }).attr("src", data.imageThumbPath);
+                    var $overflowContainer = $("<div/>", {
+                        class: "perc-text-overflow-container",
+                        style:
+                            "text-overflow:ellipsis;width:122px;overflow:hidden;white-space:nowrap",
+                    });
+                    var $overflow = $("<div/>", { class: "perc-text-overflow", style: "float:none" })
+                        .attr("title", data.name)
+                        .attr("alt", data.name)
+                        .text(data.name);
+                    $overflowContainer.append($overflow);
+                    $entry
+                        .append($itemId)
+                        .append(
+                            $("<table/>").append(
+                                $("<tbody/>").append(
+                                    $("<tr/>").append($("<td/>", { align: "left" }).append($img)),
+                                    $("<tr/>").append($("<td/>").append($overflowContainer))
+                                )
+                            )
+                        );
+                    return $entry;
                 }
                 
             }


### PR DESCRIPTION
## Summary

Per-cluster US3 fix for `js/xss-through-dom` in `WebUI/.../views/PercChangeTemplateDialog.js`. Two distinct XSS sinks are closed: (a) three `.html("...&nbsp;" + name)` label sinks in the click handler and the open-dialog setup; (b) `createTemplateEntry(data, templateId)` which concatenated user-controlled template metadata (`data.imageThumbPath`, `data.id`, `data.name`) into an HTML string template and parsed it back via `.append(stringHTML)`. Three in-tree file copies (source + legacy mirror + war build artifact) updated in lockstep per the WebUI multi-copy asset convention (AGENTS.md item #6). Ten Vitest cases exercise the live source end-to-end via a stubbed `$.getJSON`; five of them genuinely fail on the pre-fix code (two source-pattern presence/absence checks + three behavioural tests for the `createTemplateEntry` sink) and pass on the post-fix code (fail-then-pass loop per Constitution III / C5).

## Scope

- **Module(s)**: `WebUI/`
- **Disposition(s)**: valid
- **Branch**: `004/us3-views-plugins-xss-through-dom` (off `origin/development`)
- **Target**: `development` (per Branch policy in `specs/004-zero-code-scanning-alerts/tasks.md`)
- **Pre-fix commit hash** (regression-test baseline): `56594d9d3`

```
Closes: #1617, #1586, #325
Disposition(s): valid
Module(s): WebUI/

Verification:
- [x] Scanner re-scan no longer reports the alert(s) above (expected after merge; alerts auto-close via CodeQL re-scan on `development`).
- [x] Module test suite (`npm run test --prefix WebUI -- src/test/js/percChangeTemplateDialog.test.js`) passes — 10/10.
- [x] Regression test that fails on the pre-fix code is referenced: WebUI/src/test/js/percChangeTemplateDialog.test.js — five of the ten cases (2 source-pattern + 3 behavioural for the `createTemplateEntry` sink) produce the expected failures against the pre-fix code and pass on the post-fix code.
- [x] N/A — disposition is `valid`, not obsolete, so no removal-archive check applies.

Review-resolution-gate: pending
```

## Files changed

| File | LOC delta |
|---|---|
| `WebUI/src/main/webapp/cm/views/PercChangeTemplateDialog.js` | 32 +/32 - (lockstep) |
| `WebUI/src/main/webapp/cm/app/js/legacy/views/PercChangeTemplateDialog.js` | 32 +/32 - (lockstep) |
| `WebUI/war/views/PercChangeTemplateDialog.js` | 25 +/32 - (lockstep with mixed tabs/spaces per original style) |
| `WebUI/src/test/js/percChangeTemplateDialog.test.js` | new (354 +/0 -) |

## Why this is safe

- `$(...).text(s)` writes a text node; HTML markup in `s` is rendered literally, never parsed. Closes the `<script>` / `<img onerror=...>` injection vector for both the label sinks and the i18n `createTemplateEntry` sink.
- For `createTemplateEntry`, the refactor replaces the broken string-template-and-replace approach with jQuery DOM construction. `.attr("src", x)` escapes `x` for the attribute context, `.attr("title", x)` and `.attr("alt", x)` do the same, and `.text(x)` sets a text node. The rendered DOM tree is structurally identical to the original (same `div.item` > `table` > rows of `img` + label).
- Public API surface — `$.PercChangeTemplateDialog()` factory and its `openDialog(finderPath, templateId, sitename, successCallback)` method — is unchanged. The test pins this signature.
- WebUI/AGENTS.md forbids adding new jQuery code; this fix uses only existing jQuery APIs (`.text()`, `.attr()`, `.append(jQuery)`, `$("<tag/>", { attrs })`) already in use elsewhere in the module. No new jQuery patterns introduced.

## Erlang pre-commit review

- Recommendation: `approve`
- Gate: `May commit/push: yes`
- Artifacts: `tmp/reviews/20260716-2011-perc-change-template-dialog-erlang.md`

## Triage.md + accepted-risks.md follow-ups

- `docs/ai-generated/tasks/gh-codeql-alerts/triage.md` `linked_pr` column for alerts #1617, #1586, #325 will be back-filled with this PR's number in a separate docs-only commit immediately AFTER this PR merges (per T063 of the spec).
- No `accepted-risks.md` rows required (all 3 closures are full fixes, not deferrals).

## Follow-up PRs (separate branches)

This branch only closes 3 of the 12 `js/xss-through-dom` WebUI valid alerts in the `004/us3-views-plugins-xss-through-dom` cluster. The remaining 9 are tracked as separate per-cluster PRs:

- `PercCSSGalleryView.js` × 3 alerts (file-copies in `views/`, `app/js/legacy/views/`, `war/views/`)
- `PercListEditorWidget.js` × 3 alerts (file-copies in `plugins/`, `app/js/legacy/plugins/`, `war/plugins/`)
- `PercRedirectHandler.js` × 3 alerts (likely `false-positive` reclass per T068/T069 — initial review suggests no XSS sink is reachable through the `.text(...)`/`.val(...).attr("title", ...)` paths in that file)