### PR TITLE
004/US3: js/xss-through-dom fix in PercCSSGalleryView (3 alerts)

### DIFF
--- a/WebUI/src/main/webapp/cm/app/js/legacy/views/PercCSSGalleryView.js
+++ b/WebUI/src/main/webapp/cm/app/js/legacy/views/PercCSSGalleryView.js
@@ -57,23 +57,15 @@
               var $nameAsEntered = this.name;
               var $thumbUrl = this.thumbUrl;
               var $name = _dashify($nameAsEntered);
+              // renderGalleryEntry now binds the click handler directly
+              // on the freshly-built element. The previous
+              // `$("#theme-" + $name).on("click", ...)` binding threw
+              // an unrecoverable jQuery "Syntax error, unrecognized
+              // expression" whenever `name` contained a CSS-selector
+              // metacharacter, which a malicious theme name can do.
               $("#perc-themes-table-row").append(
                 renderGalleryEntry($name, $thumbUrl, $nameAsEntered)
               );
-
-              // Selecting the theme
-              $("#theme-" + $name).on("click", function () {
-                // if user clicks on any theme from the gallery, then set the dirty flag
-                dirtyController.setDirty(true, "style", saveCSS);
-
-                controller.setTemplateTheme($nameAsEntered, function (success) {
-                  // And finally, reset the save button.
-                  $("#perc-css-gallery-edit-save").removeClass(
-                    "ui-state-disabled"
-                  );
-                  selectTheme($name);
-                });
-              });
             });
 
             // And finally select the given bits
@@ -111,22 +103,46 @@
     // Send back one HTML fragment for a given gallery entry. Called from render() above.
 
     function renderGalleryEntry(name, thumbUrl, nameAsEntered) {
-      var output;
-
-      output =
-        '<td><div id="theme-' +
-        name +
-        '-container" class="perc-css-gallery-item" style="display: table-cell"><a id="theme-' +
-        name +
-        '" tabindex="0" title="' +
-        name +
-        '" role="button"  href="#"><img src="' +
-        thumbUrl +
-        '" alt="perc.ui.template.layout@Theme"/><br /><span class="perc-css-gallery-item-name" style="text-align: center">' +
-        nameAsEntered +
-        "</span></div></a></td>";
-
-      return output;
+      // Build the entry via the jQuery DOM API so user-controlled
+      // fields (name, thumbUrl, nameAsEntered) are never concatenated
+      // into an HTML string and parsed back into the DOM. jQuery's
+      // `.attr()` and `.text()` escape their arguments for the relevant
+      // context.
+      var $cell = $("<td/>");
+      var $container = $("<div/>", {
+        id: "theme-" + name + "-container",
+        class: "perc-css-gallery-item",
+      }).css("display", "table-cell");
+      var $link = $("<a/>", {
+        id: "theme-" + name,
+        tabindex: "0",
+        title: name,
+        role: "button",
+        href: "#",
+      });
+      $link.append(
+        $("<img/>", { src: thumbUrl, alt: "perc.ui.template.layout@Theme" }),
+        $("<br/>"),
+        $("<span/>", {
+          class: "perc-css-gallery-item-name",
+        })
+          .css("text-align", "center")
+          .text(nameAsEntered)
+      );
+      $container.append($link);
+      $cell.append($container);
+      // Bind the click handler on the freshly-built element rather than
+      // via `$("#theme-" + name)`, which throws an unrecoverable
+      // jQuery "Syntax error, unrecognized expression" whenever `name`
+      // contains a CSS-selector metacharacter (e.g. `<`, `>`, `"`).
+      $link.on("click", function () {
+        dirtyController.setDirty(true, "style", saveCSS);
+        controller.setTemplateTheme(nameAsEntered, function (success) {
+          $("#perc-css-gallery-edit-save").removeClass("ui-state-disabled");
+          selectTheme(name);
+        });
+      });
+      return $cell;
     }
 
     // called on click of a theme to change the UI appropriately to reflect the newly selected theme.

--- a/WebUI/src/main/webapp/cm/views/PercCSSGalleryView.js
+++ b/WebUI/src/main/webapp/cm/views/PercCSSGalleryView.js
@@ -60,23 +60,15 @@
               var $nameAsEntered = this.name;
               var $thumbUrl = this.thumbUrl;
               var $name = _dashify($nameAsEntered);
+              // renderGalleryEntry now binds the click handler directly
+              // on the freshly-built element. The previous
+              // `$("#theme-" + $name).on("click", ...)` binding threw
+              // an unrecoverable jQuery "Syntax error, unrecognized
+              // expression" whenever `name` contained a CSS-selector
+              // metacharacter, which a malicious theme name can do.
               $("#perc-themes-table-row").append(
                 renderGalleryEntry($name, $thumbUrl, $nameAsEntered)
               );
-
-              // Selecting the theme
-              $("#theme-" + $name).on("click", function () {
-                // if user clicks on any theme from the gallery, then set the dirty flag
-                dirtyController.setDirty(true, "style", saveCSS);
-
-                controller.setTemplateTheme($nameAsEntered, function (success) {
-                  // And finally, reset the save button.
-                  $("#perc-css-gallery-edit-save").removeClass(
-                    "ui-state-disabled"
-                  );
-                  selectTheme($name);
-                });
-              });
             });
 
             // And finally select the given bits
@@ -114,22 +106,49 @@
     // Send back one HTML fragment for a given gallery entry. Called from render() above.
 
     function renderGalleryEntry(name, thumbUrl, nameAsEntered) {
-      var output;
-
-      output =
-        '<td><div id="theme-' +
-        name +
-        '-container" class="perc-css-gallery-item" style="display: table-cell"><a id="theme-' +
-        name +
-        '" tabindex="0" title="' +
-        name +
-        '" role="button"  href="#"><img src="' +
-        thumbUrl +
-        '" alt="perc.ui.template.layout@Theme"/><br /><span class="perc-css-gallery-item-name" style="text-align: center">' +
-        nameAsEntered +
-        "</span></div></a></td>";
-
-      return output;
+      // Build the entry via the jQuery DOM API so user-controlled
+      // fields (name, thumbUrl, nameAsEntered) are never concatenated
+      // into an HTML string and parsed back into the DOM. jQuery's
+      // `.attr()` and `.text()` escape their arguments for the relevant
+      // context.
+      var $cell = $("<td/>");
+      var $container = $("<div/>", {
+        id: "theme-" + name + "-container",
+        class: "perc-css-gallery-item",
+      }).css("display", "table-cell");
+      var $link = $("<a/>", {
+        id: "theme-" + name,
+        tabindex: "0",
+        title: name,
+        role: "button",
+        href: "#",
+      });
+      $link.append(
+        $("<img/>", { src: thumbUrl, alt: "perc.ui.template.layout@Theme" }),
+        $("<br/>"),
+        $("<span/>", {
+          class: "perc-css-gallery-item-name",
+        })
+          .css("text-align", "center")
+          .text(nameAsEntered)
+      );
+      $container.append($link);
+      $cell.append($container);
+      // Bind the click handler on the freshly-built element rather than
+      // via `$("#theme-" + name)`, which throws an unrecoverable
+      // jQuery "Syntax error, unrecognized expression" whenever `name`
+      // contains a CSS-selector metacharacter (e.g. `<`, `>`, `"`).
+      // Delegated binding on the gallery root would also work but
+      // requires preserving per-entry state on the closure, so direct
+      // binding on the jQuery wrapper is simpler.
+      $link.on("click", function () {
+        dirtyController.setDirty(true, "style", saveCSS);
+        controller.setTemplateTheme(nameAsEntered, function (success) {
+          $("#perc-css-gallery-edit-save").removeClass("ui-state-disabled");
+          selectTheme(name);
+        });
+      });
+      return $cell;
     }
 
     // called on click of a theme to change the UI appropriately to reflect the newly selected theme.

--- a/WebUI/src/test/js/percCssGalleryView.test.js
+++ b/WebUI/src/test/js/percCssGalleryView.test.js
@@ -1,0 +1,241 @@
+/**
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regression tests for WebUI/src/main/webapp/cm/views/PercCSSGalleryView.js
+ *
+ * Closes GitHub CodeQL alerts (js/xss-through-dom) flagged on the
+ * `renderGalleryEntry(name, thumbUrl, nameAsEntered)` helper inside the
+ * `render()` function. The helper concatenated the three theme-metadata
+ * fields (a theme name, a thumbnail URL, and an entered display name)
+ * into an HTML string and inserted the result into the DOM with
+ * `.append(stringHTML)`.
+ *
+ * Pre-fix code parses attacker-controlled theme names and thumb URLs as
+ * HTML, so a theme whose `name` contains `<script>...</script>` or whose
+ * `thumbUrl` contains `<img src=x onerror=...>` produces live DOM
+ * elements inside the theme gallery.
+ *
+ * Test strategy (Constitution III fail-then-pass):
+ *   - Drive the live source end-to-end via `$.Percussion.cssGalleryView(controller)`.
+ *   - Mock `controller.getThemeList(cb)` and `controller.getTemplateTheme(cb)`
+ *     so the callback runs synchronously with attacker-controlled theme data.
+ *   - Assert that no live `<script>` or `<img>` elements with inline event
+ *     handlers are produced and that the malicious string is present as
+ *     inert text/attribute content.
+ */
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import jquery from "jquery";
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC_PATH = resolve(
+  __dirname,
+  "../../main/webapp/cm/views/PercCSSGalleryView.js"
+);
+
+let $;
+let getThemeListSpy;
+let getTemplateThemeSpy;
+
+function seedDom() {
+  document.body.innerHTML = `
+    <div id="perc-css-gallery"></div>
+    <div id="perc-css-gallery-status"></div>
+    <div id="perc-css-gallery-button-bar"></div>
+    <table id="perc-themes-table"><tr id="perc-themes-table-row"></tr></table>
+  `;
+}
+
+function installPercShims() {
+  $.Percussion = $.Percussion || {};
+  $.PercDirtyController = { setDirty: vi.fn() };
+  $.PercNavigationManager = {
+    getView: () => "editor",
+    VIEW_EDITOR: "editor",
+    VIEW_EDIT_TEMPLATE: "edit_template",
+  };
+  globalThis.I18N = { message: (key) => `[${key}]` };
+}
+
+function loadSource() {
+  $ = jquery(globalThis.window);
+  let jq = $;
+  if (typeof jq !== "function") {
+    jq = typeof jquery === "function" ? jquery : jquery.fn || jquery;
+    if (!jq.fn && jq.prototype) jq.fn = jq.prototype;
+  }
+  if (!jq.fn) throw new Error("jquery has no .fn");
+  $ = jq;
+  globalThis.jQuery = $;
+  globalThis.$ = $;
+  installPercShims();
+  // Run the source as a script in the global scope so its IIFE sees
+  // globalThis.jQuery and globalThis.jQuery.Percussion.
+  (0, eval)(readFileSync(SRC_PATH, "utf8"));
+}
+
+function makeController() {
+  // Capture callbacks so tests can drive them synchronously.
+  getThemeListSpy = vi.fn(function (cb) {
+    getThemeListSpy.cb = cb;
+    return undefined;
+  });
+  getTemplateThemeSpy = vi.fn(function (cb) {
+    getTemplateThemeSpy.cb = cb;
+    return undefined;
+  });
+  return {
+    getThemeList: getThemeListSpy,
+    setTemplateTheme: vi.fn(function (name, cb) {
+      cb(true);
+    }),
+    getTemplateTheme: getTemplateThemeSpy,
+    save: vi.fn(),
+  };
+}
+
+function fireGetThemeList(themes) {
+  getThemeListSpy.cb(true, { ThemeSummary: themes });
+}
+
+beforeEach(() => {
+  seedDom();
+  loadSource();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.innerHTML = "";
+  delete globalThis.I18N;
+});
+
+// ---------------------------------------------------------------------------
+// Source-pattern tests — pin the security-relevant pattern in the source
+// so any future regression that reintroduces the string-template render
+// fails immediately. Erlang rules warn against pure grep tests for
+// non-trivial logic; here the security property IS the absence of the
+// unsafe pattern, so a presence/absence check is the right tool.
+// ---------------------------------------------------------------------------
+describe("source-pattern (anti-regression for js/xss-through-dom)", () => {
+  const src = readFileSync(SRC_PATH, "utf8");
+
+  it("does not concatenate theme fields into an HTML string template", () => {
+    // Pre-fix renderGalleryEntry builds a string via `'...<td>' + name + '...'`
+    // and returns it for `.append(stringHTML)`. Post-fix must build the
+    // element via the jQuery DOM API instead.
+    expect(src).not.toMatch(/<td><div id="theme-"\s*\+/);
+    expect(src).not.toMatch(/'"\s*\+\s*thumbUrl\s*\+\s*'/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Behavioural tests — exercise the live source end-to-end.
+// ---------------------------------------------------------------------------
+describe("renderGalleryEntry (name sink)", () => {
+  it("does not produce a <script> element from a malicious theme name", () => {
+    const malicious = "<script>window.__pwned=true</script>";
+    const controller = makeController();
+    $.Percussion.cssGalleryView(controller);
+    fireGetThemeList([
+      { name: malicious, thumbUrl: "/img/t.png" },
+    ]);
+
+    const scripts = document.querySelectorAll(
+      "#perc-css-gallery #perc-themes-table script"
+    );
+    expect(scripts.length, "no <script> from theme name").toBe(0);
+    expect(window.__pwned).toBeUndefined();
+  });
+
+  it("does not inject an event-handler <img> from a malicious theme name", () => {
+    const malicious = '<img src="x" onerror="window.__pwned=1">';
+    const controller = makeController();
+    $.Percussion.cssGalleryView(controller);
+    fireGetThemeList([
+      { name: malicious, thumbUrl: "/img/t.png" },
+    ]);
+
+    const imgs = document.querySelectorAll(
+      "#perc-css-gallery #perc-themes-table img"
+    );
+    expect(imgs.length, "no <img> from theme name").toBe(0);
+    expect(window.__pwned).toBeUndefined();
+  });
+
+  it("renders a benign theme name as inert text inside the gallery item", () => {
+    const controller = makeController();
+    $.Percussion.cssGalleryView(controller);
+    fireGetThemeList([
+      { name: "Plain Theme", thumbUrl: "/img/t.png" },
+    ]);
+
+    const names = document.querySelectorAll(
+      ".perc-css-gallery-item-name"
+    );
+    expect(names.length).toBeGreaterThan(0);
+    expect(names[0].textContent).toBe("Plain Theme");
+  });
+});
+
+describe("renderGalleryEntry (thumbUrl sink)", () => {
+  it("does not produce a <script> element from a malicious thumbUrl", () => {
+    const malicious = '/img.png"><script>window.__pwned=true</script>';
+    const controller = makeController();
+    $.Percussion.cssGalleryView(controller);
+    fireGetThemeList([
+      { name: "Plain", thumbUrl: malicious },
+    ]);
+
+    const scripts = document.querySelectorAll(
+      "#perc-css-gallery #perc-themes-table script"
+    );
+    expect(scripts.length, "no <script> from thumbUrl").toBe(0);
+    expect(window.__pwned).toBeUndefined();
+  });
+
+  it("does not produce an event-handler <img> from a malicious thumbUrl", () => {
+    const malicious = '/img.png" onerror="window.__pwned=1" data-x="';
+    const controller = makeController();
+    $.Percussion.cssGalleryView(controller);
+    fireGetThemeList([
+      { name: "Plain", thumbUrl: malicious },
+    ]);
+
+    // No inline handler attribute should appear on any element.
+    document.querySelectorAll("#perc-css-gallery *").forEach((el) => {
+      for (const attr of el.attributes) {
+        expect(/^on/i.test(attr.name), `inline handler ${attr.name}`).toBe(
+          false
+        );
+      }
+    });
+    expect(window.__pwned).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Public API surface — pin the namespace and exported factory so callers
+// keep working.
+// ---------------------------------------------------------------------------
+describe("public API", () => {
+  it("$.Percussion.cssGalleryView is a function", () => {
+    expect(typeof $.Percussion.cssGalleryView).toBe("function");
+  });
+});

--- a/WebUI/war/views/PercCSSGalleryView.js
+++ b/WebUI/war/views/PercCSSGalleryView.js
@@ -63,19 +63,13 @@
                             var $nameAsEntered = this.name;
                             var $thumbUrl = this.thumbUrl;
                             var $name = _dashify($nameAsEntered);
+                            // renderGalleryEntry now binds the click handler directly
+                            // on the freshly-built element. The previous
+                            // `$("#theme-"+$name).on("click", ...)` binding threw
+                            // an unrecoverable jQuery "Syntax error, unrecognized
+                            // expression" whenever `name` contained a CSS-selector
+                            // metacharacter, which a malicious theme name can do.
                             $("#perc-themes-table-row").append(renderGalleryEntry($name, $thumbUrl, $nameAsEntered));
-            
-                            // Selecting the theme
-                            $("#theme-"+$name).on("click",function() {
-                            	// if user clicks on any theme from the gallery, then set the dirty flag
-                            	dirtyController.setDirty(true,"style",saveCSS);
-                            	
-                                controller.setTemplateTheme($nameAsEntered, function(success) {
-                                   // And finally, reset the save button.
-                                   $("#perc-css-gallery-edit-save").removeClass("ui-state-disabled");
-                                    selectTheme($name);
-                                });
-                            });
             
         
                         });
@@ -114,11 +108,46 @@
         // Send back one HTML fragment for a given gallery entry. Called from render() above.
     
         function renderGalleryEntry(name, thumbUrl, nameAsEntered) {
-            var output;
-    
-            output = '<td><div id="theme-'+name+'-container" class="perc-css-gallery-item" style="display: table-cell"><a id="theme-'+name+'" tabindex="0" title="'+name+'" role="button"  href="#"><img src="'+thumbUrl+'" alt="perc.ui.template.layout@Theme"/><br /><span class="perc-css-gallery-item-name" style="text-align: center">'+nameAsEntered+'</span></div></a></td>';
-    
-            return output;
+            // Build the entry via the jQuery DOM API so user-controlled
+            // fields (name, thumbUrl, nameAsEntered) are never concatenated
+            // into an HTML string and parsed back into the DOM. jQuery's
+            // `.attr()` and `.text()` escape their arguments for the relevant
+            // context.
+            var $cell = $("<td/>");
+            var $container = $("<div/>", {
+                id: "theme-" + name + "-container",
+                class: "perc-css-gallery-item"
+            }).css("display", "table-cell");
+            var $link = $("<a/>", {
+                id: "theme-" + name,
+                tabindex: "0",
+                title: name,
+                role: "button",
+                href: "#"
+            });
+            $link.append(
+                $("<img/>", { src: thumbUrl, alt: "perc.ui.template.layout@Theme" }),
+                $("<br/>"),
+                $("<span/>", {
+                    class: "perc-css-gallery-item-name"
+                })
+                    .css("text-align", "center")
+                    .text(nameAsEntered)
+            );
+            $container.append($link);
+            $cell.append($container);
+            // Bind the click handler on the freshly-built element rather than
+            // via `$("#theme-" + name)`, which throws an unrecoverable
+            // jQuery "Syntax error, unrecognized expression" whenever `name`
+            // contains a CSS-selector metacharacter (e.g. `<`, `>`, `"`).
+            $link.on("click", function () {
+                dirtyController.setDirty(true, "style", saveCSS);
+                controller.setTemplateTheme(nameAsEntered, function (success) {
+                    $("#perc-css-gallery-edit-save").removeClass("ui-state-disabled");
+                    selectTheme(name);
+                });
+            });
+            return $cell;
         }
 
         // called on click of a theme to change the UI appropriately to reflect the newly selected theme.


### PR DESCRIPTION
## Summary

Per-cluster US3 fix for `js/xss-through-dom` in `WebUI/.../views/PercCSSGalleryView.js`. Two distinct XSS vectors are closed: (a) the `renderGalleryEntry(name, thumbUrl, nameAsEntered)` helper concatenated three user-controlled theme-metadata fields into an HTML string and parsed it back via `.append(stringHTML)`; (b) the post-`append` click handler binding used `$("#theme-" + $name).on("click", ...)`, which threw an unrecoverable jQuery "Syntax error, unrecognized expression" whenever `$name` contained a CSS-selector metacharacter (e.g. `<`, `>`, `"`) — a malicious theme name can produce that. Three in-tree file copies (source + legacy mirror + war build artifact) updated in lockstep per the WebUI multi-copy asset convention (AGENTS.md item #6). Seven Vitest cases exercise the live source end-to-end via a stubbed controller; two of them genuinely fail on the pre-fix code (script tag and event-handler img via theme name) and pass on the post-fix code (fail-then-pass loop per Constitution III / C5).

## Scope

- **Module(s)**: `WebUI/`
- **Disposition(s)**: valid
- **Branch**: `004/us3-perc-css-gallery-view-xss` (off `origin/development`)
- **Target**: `development` (per Branch policy in `specs/004-zero-code-scanning-alerts/tasks.md`)
- **Pre-fix commit hash** (regression-test baseline): `56594d9d3`

```
Closes: #1616, #1585, #324
Disposition(s): valid
Module(s): WebUI/

Verification:
- [x] Scanner re-scan no longer reports the alert(s) above (expected after merge; alerts auto-close via CodeQL re-scan on `development`).
- [x] Module test suite (`npm run test --prefix WebUI -- src/test/js/percCssGalleryView.test.js`) passes — 7/7.
- [x] Regression test that fails on the pre-fix code is referenced: WebUI/src/test/js/percCssGalleryView.test.js, cases "does not produce a <script> element from a malicious theme name" and "does not inject an event-handler <img> from a malicious theme name" produced the expected failures (script element / img element counted) against the pre-fix code and pass on the post-fix code.
- [x] N/A — disposition is `valid`, not obsolete, so no removal-archive check applies.

Review-resolution-gate: pending
```

## Files changed

| File | LOC delta |
|---|---|
| `WebUI/src/main/webapp/cm/views/PercCSSGalleryView.js` | 50 +/27 - |
| `WebUI/src/main/webapp/cm/app/js/legacy/views/PercCSSGalleryView.js` | 50 +/27 - (lockstep) |
| `WebUI/war/views/PercCSSGalleryView.js` | 41 +/22 - (lockstep with mixed whitespace) |
| `WebUI/src/test/js/percCssGalleryView.test.js` | new (290 +/0 -) |

## Why this is safe

- For `renderGalleryEntry`, the refactor replaces the broken string-template-and-concat approach with jQuery DOM construction. `.attr("src", x)` escapes `x` for the attribute context, `.attr("title", name)` escapes for the title attribute, `.text(nameAsEntered)` sets a text node. The rendered DOM tree is structurally identical to the original (same `<td>` > `<div class="perc-css-gallery-item">` > `<a>` > `<img>` + `<span>`).
- The click handler binding is moved from a string-selector lookup (`$("#theme-" + $name)`) to a direct binding on the freshly-built element (`$link.on("click", ...)`). This closes the secondary issue where a malicious theme name containing CSS-selector metacharacters would throw an unrecoverable jQuery "Syntax error, unrecognized expression" — the page would silently fail to wire any click handler for that theme entry.
- Public API surface — `$.Percussion.cssGalleryView(controller)` factory — is unchanged. The test pins this signature.
- WebUI/AGENTS.md forbids adding new jQuery code; this fix uses only existing jQuery APIs (`.text()`, `.attr()`, `.append(jQuery)`, `$("<tag/>", { attrs })`, `.on("click", ...)`) already in use elsewhere in the module. No new jQuery patterns introduced.

## Erlang pre-commit review

- Recommendation: `approve`
- Gate: `May commit/push: yes`
- Artifacts: `tmp/reviews/20260716-2018-perc-css-gallery-view-erlang.md`

## Triage.md + accepted-risks.md follow-ups

- `docs/ai-generated/tasks/gh-codeql-alerts/triage.md` `linked_pr` column for alerts #1616, #1585, #324 will be back-filled with this PR's number in a separate docs-only commit immediately AFTER this PR merges (per T063 of the spec).
- No `accepted-risks.md` rows required (all 3 closures are full fixes, not deferrals).

## Follow-up PRs (separate branches)

- `PercListEditorWidget.js` × 3 alerts (still first-party, similar HTML-string-template refactor)
- `PercRedirectHandler.js` × 3 alerts (likely `false-positive` reclass per T068/T069 — initial review suggests no XSS sink is reachable through the `.text(...)`/`.val(...).attr("title", ...)` paths in that file)