### PR TITLE
docs(agents): require portable file I/O; hard-gate in Erlang review

### DIFF
--- a/.github/agents/erlang.agent.md
+++ b/.github/agents/erlang.agent.md
@@ -2,7 +2,8 @@
 name: erlang
 description: >-
   Strict independent code review for Percussion CMS before commit or PR.
-  Blocks on bugs and missing behavioral tests. Prefer for pre-merge review.
+  Blocks on bugs, missing behavioral tests, and non-portable Windows/Unix
+  path handling. Prefer for pre-merge review.
 ---
 
 # Erlang — Percussion CMS (GitHub Copilot agent mirror)
@@ -13,15 +14,19 @@ This file is a **discovery mirror** for GitHub Copilot custom agents.
 
 `modules/ai-shared-develop/src/main/resources/agents/erlang-code-review.md`
 
+Product cross-platform path rules: root `AGENTS.md` → **Cross-Platform File I/O & Paths**.
+
 ## Quick start
 
 1. Open that canonical agent file and follow it exactly.
 2. Review uncommitted changes and `origin/development...HEAD` unless the user
    specifies a PR or other base.
-3. Strict gate: any bug or missing behavioral tests for non-trivial logic →
-   `request-changes` and **May commit/push: no**.
-4. Do not implement fixes unless the user asks after the report.
-5. Optional artifact: `tmp/reviews/YYYYMMDD-HHMM-<topic>-erlang.md`.
+3. Strict gate: any bug, missing behavioral tests for non-trivial logic, or
+   non-portable path/file I/O → `request-changes` and **May commit/push: no**.
+4. When the diff touches file I/O or path assertions, apply the Erlang
+   cross-platform checklist and state the outcome in the report.
+5. Do not implement fixes unless the user asks after the report.
+6. Optional artifact: `tmp/reviews/YYYYMMDD-HHMM-<topic>-erlang.md`.
 
 One-shot prompt (any tool):
 

--- a/.kilocode/rules/pre-commit-review.md
+++ b/.kilocode/rules/pre-commit-review.md
@@ -16,7 +16,8 @@ authored in this session:
 
 3. Prefer the skill `erlang-review` or Kilo workflow `/erlang-review`.
 4. If the recommendation is `request-changes` or Gate says **May commit/push: no**:
-   - Fix all **bug** findings (including missing behavioral tests)
+   - Fix all **bug** findings (including missing behavioral tests and
+     non-portable path/file I/O — see root `AGENTS.md` **Cross-Platform File I/O & Paths**)
    - Re-run Erlang on the fix pack
    - Only then commit / push / open PR
 5. Do not treat CI or GitHub bot review as a substitute for this pre-commit pass.
@@ -30,4 +31,5 @@ in the commit message or PR body.
 ## Why
 
 Unreviewed commits create long GitHub review cycles (human + bots). Catching
-defects and weak tests locally is mandatory team practice for Percussion CMS.
+defects, weak tests, and Unix-only path bugs that fail on Windows (and the
+reverse) locally is mandatory team practice for Percussion CMS.

--- a/.kilocode/workflows/erlang-review.md
+++ b/.kilocode/workflows/erlang-review.md
@@ -1,7 +1,8 @@
 ---
 description: >-
   Strict Erlang pre-commit / pre-PR code review for Percussion CMS. Reviews
-  uncommitted and branch diffs vs development; blocks on bugs and missing tests.
+  uncommitted and branch diffs vs development; blocks on bugs, missing tests,
+  and non-portable (Windows/Unix) path/file I/O.
 ---
 
 ## User Input
@@ -43,10 +44,14 @@ If `$ARGUMENTS` names a branch or path, limit the review accordingly.
 1. Collect the diff and changed-file list. If empty → report nothing to review and stop.
 2. Read surrounding context for non-trivial changes.
 3. Apply Percussion checks from the Erlang agent (tests, silent catches, security,
-   multi-copy lockstep, JDK/branch, secrets).
+   multi-copy lockstep, JDK/branch, secrets, **cross-platform path/file I/O**).
+   Load root `AGENTS.md` section **Cross-Platform File I/O & Paths** when the
+   diff touches paths, files, installers, packaging, or path assertions in tests.
 4. Emit the required report structure (Summary, Scope, Recommendation, Gate, Issues).
+   Include "Cross-platform path review: …" when I/O or paths are in scope.
 5. **Strict gate:**
-   - Any **bug**, or missing **behavioral** tests for new/changed non-trivial logic
+   - Any **bug**, missing **behavioral** tests for new/changed non-trivial logic,
+     or **non-portable path/file I/O** (Windows vs Unix)
      → Recommendation `request-changes`, Gate **May commit/push: no**
    - Tell the author not to commit or open/update a PR until bugs are fixed
 6. Write a durable copy when practical:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ This repository is a large mono-repo with many modules.  This code base has a lo
 - **Repo Script Dir:** `./scripts`
 - **Repo Skills Dir:** `./modules/ai-shared-develop/src/main/resources/skills`
 - **Stack**: Java 21, Spring, Hibernate, Artemis, React, JSP, jQuery, XML, XSL, JUnit 5, Mockito
+- **Platforms**: Cross-platform product — builds, tests, installs, and runs on **Windows**, **Linux**, and **macOS**. All file I/O and path handling MUST be portable (see **Cross-Platform File I/O & Paths** below).
 
 ## Key Terms
 - **DTS**" `Delivery Tier Service` means `./deliverytiersuite/delivery-tier-suite`
@@ -50,7 +51,7 @@ Before `git commit`, `git push`, or opening/updating a GitHub PR for changes you
 2. Canonical agent: `modules/ai-shared-develop/src/main/resources/agents/erlang-code-review.md`
 3. Skill: `modules/ai-shared-develop/src/main/resources/skills/erlang-review/SKILL.md`
 4. **Kilo (preferred):** workflow `/erlang-review` (`.kilocode/workflows/erlang-review.md`); project rule `.kilocode/rules/pre-commit-review.md` also applies.
-5. Any **bug** finding, or missing **behavioral** unit tests for new/changed non-trivial logic, is a **hard gate** — do not commit or open the PR until fixed and re-reviewed.
+5. Any **bug** finding, missing **behavioral** unit tests for new/changed non-trivial logic, or **non-portable path/file I/O** (Windows/Unix — see **Cross-Platform File I/O & Paths**), is a **hard gate** — do not commit or open the PR until fixed and re-reviewed. Erlang must apply the cross-platform path checklist when the diff touches file I/O, paths, installers, packaging, or path assertions.
 6. Optional report path: `tmp/reviews/` (repo temp dir).
 
 Tool-agnostic one-shot prompt: `modules/ai-shared-develop/src/main/resources/prompts/erlang-review-uncommitted.md`.
@@ -70,6 +71,73 @@ Tool-agnostic one-shot prompt: `modules/ai-shared-develop/src/main/resources/pro
 * Always use the #codebase or root `./` context when resolving missing interfaces or classes.
 * You MUST respect rate limits when calling 3rd party API's. All 3rd party API integrations must be implemented with rate limit detection and exponential backoff logic.
 * You MUST NOT share or leak secrets, tokens, or keys over the wire, in logs, or in LLM sessions.  If you see MKD-REDACTED in a session, that means you leaked a secret.
+* **Cross-platform is mandatory.** Percussion CMS is a cross-platform build, test, and deploy product (Windows, Linux, macOS). Any production code, unit/integration test, script, or path assertion that works only on Unix-style paths is a defect. Follow **Cross-Platform File I/O & Paths** below.
+
+## Cross-Platform File I/O & Paths
+
+Percussion CMS is built, tested, installed, and deployed on **Windows, Linux, and macOS**. Agents MUST write portable file and path code. Failures that appear only on Windows (or only on Unix) from non-portable path handling are preventable defects — treat them as hard bugs, not environment quirks.
+
+### Non-negotiable rules
+
+1. **Never hardcode OS path separators in filesystem paths.** Do not concatenate paths with `"/"`, `"\\"`, or mixed literals for local files. Hardcoded `/` is correct only for **URL, URI, classpath, and ZIP entry** paths (those always use `/`).
+2. **Prefer portable Java NIO path APIs** for all filesystem work:
+   * `java.nio.file.Path`, `Paths.get(...)`, `Path.of(...)` (JDK 11+)
+   * `path.resolve("child")`, `path.resolveSibling(...)`, `path.getParent()`, `path.normalize()`, `path.toAbsolutePath()`
+   * `Files.*` (`Files.readString`, `Files.write`, `Files.createDirectories`, `Files.exists`, `Files.walk`, etc.) instead of ad-hoc `File` + string ops when practical
+3. **When a separator character is required**, use the platform constants — do not invent them:
+   * `File.separator` / `File.separatorChar` — path element separator (`\` on Windows, `/` on Unix)
+   * `File.pathSeparator` / `File.pathSeparatorChar` — multi-path list separator (`;` on Windows, `:` on Unix)
+   * Prefer `Path` resolve/join over manually inserting separators
+4. **Do not assume a case-sensitive filesystem.** Windows (default) and some macOS volumes are case-insensitive. Avoid tests or logic that require `Foo.txt` and `foo.txt` as distinct files in the same directory. Prefer exact canonical names and case-insensitive comparisons only when the product domain requires them.
+5. **Do not assume Unix-only roots or temp locations.** Avoid hardcoding `/tmp`, `/var`, `/home`, or drive-letter-free absolute paths. Use `System.getProperty("java.io.tmpdir")`, `Files.createTempFile` / `Files.createTempDirectory`, or the repo temp dir (`./tmp`) as appropriate. On Windows, absolute paths include a drive letter or UNC prefix (`C:\...`, `\\server\share\...`).
+6. **Normalize before comparing paths as strings.** Prefer `Path` equality (`path1.normalize().toAbsolutePath().equals(...)`) or `Files.isSameFile` over string equality of raw path text. If string form is unavoidable, normalize separators first (e.g. via `Path` then `toString()`, or consistent use of `File.separator`).
+7. **Line endings differ by platform.** Do not assert exact multi-line file contents with only `\n` when the runtime or Git may produce `\r\n` on Windows. Normalize line endings in tests (`replace("\r\n", "\n")`) or compare logical lines / use platform-agnostic matchers.
+8. **Shell scripts are not portable by themselves.** Repo automation that must run on Windows needs a `.bat`/`.cmd` counterpart (or a documented Java/Maven entry point). Existing pattern: `./mvn-env.sh` and `./mvn-env.bat`. Do not land Unix-only scripts as the sole way to run a required workflow.
+9. **Unit and integration tests must be cross-platform.** Tests that construct paths, write files, parse absolute paths, or assert path strings MUST pass on Windows. Common failure modes to avoid:
+   * Expected path strings built with `/` when the OS returns `\`
+   * Splitting `PATH` / classpath with `:` only
+   * Regexes that only match Unix paths (`^/.*`) and reject `C:\...`
+   * Commands invoked via `/bin/sh` without a Windows alternative in product code paths
+   * Assuming executable bits / POSIX permissions semantics
+
+### Preferred patterns (Java)
+
+```java
+// GOOD: portable join and resolve
+Path base = Path.of(System.getProperty("java.io.tmpdir"), "percussion-test");
+Path out = base.resolve("reports").resolve("result.xml");
+Files.createDirectories(out.getParent());
+Files.writeString(out, content);
+
+// GOOD: when a File is required by a legacy API
+File f = out.toFile();
+
+// GOOD: multi-entry path lists (classpath, PATH)
+String joined = String.join(File.pathSeparator, entry1, entry2);
+
+// BAD: hardcoded separators for filesystem paths
+String bad1 = base + "/reports/result.xml";
+String bad2 = "C:\\temp\\reports\\result.xml";
+String bad3 = dir + "\\" + name;
+
+// GOOD: URLs / classpath / zip always use '/'
+String resource = "com/percussion/config/defaults.xml";
+URI uri = URI.create("file:///some/logical/url"); // URL path form, not OS file join
+```
+
+### Review checklist (agents)
+
+Before finishing any change that touches file I/O, paths, installers, packaging, or tests:
+
+* [ ] No new `".../" +` or `"...\\" +` filesystem path construction
+* [ ] New path logic uses `Path` / `Paths.get` / `Path.of` / `Files`
+* [ ] Separators from `File.separator` / `File.pathSeparator` only when a char/string is truly needed
+* [ ] Tests do not assert Unix-only absolute path shapes or raw `/` path strings from the OS
+* [ ] Temp files use portable APIs or the repo `./tmp` convention — not OS-specific temp hardcodes
+* [ ] Line-ending sensitive assertions are normalized
+* [ ] Required scripts have Windows counterparts or a cross-platform runner where operators need them
+
+**Linux/macOS-only developer machines are not an excuse.** Code and tests must still be written as if the next CI agent or customer install is Windows.
 
 ## PR Review Comment Resolution
 

--- a/modules/ai-shared-develop/README.md
+++ b/modules/ai-shared-develop/README.md
@@ -63,6 +63,9 @@ Paste `prompts/erlang-review-uncommitted.md` or attach `agents/erlang-code-revie
 ### Strictness
 
 - **Block** on any bug and on missing behavioral tests for new/changed non-trivial logic.
+- **Block** on non-portable path/file I/O (hardcoded separators, Unix-only or Windows-only
+  absolute paths in shared code/tests, etc.). See root `AGENTS.md` → **Cross-Platform File I/O & Paths**
+  and the checklist in `agents/erlang-code-review.md`.
 - Recommendation `request-changes` ⇒ do not commit or open/update a PR yet.
 - Optional durable reports go under repo `tmp/reviews/` (gitignored via `tmp/`).
 

--- a/modules/ai-shared-develop/src/main/resources/agents/erlang-code-review.md
+++ b/modules/ai-shared-develop/src/main/resources/agents/erlang-code-review.md
@@ -3,9 +3,10 @@ name: erlang
 description: >-
   Erlang — strict independent code review for Percussion CMS. Use before commit
   or PR when reviewing uncommitted changes, a branch vs development, or a GitHub
-  PR. Catches correctness bugs, missing tests, and convention violations early.
-  Read-only review persona; does not implement fixes unless the human asks after
-  the review. Tool-agnostic (Kilo, Copilot, Claude, Cursor, CLI agents).
+  PR. Catches correctness bugs, missing tests, non-portable Windows/Unix path
+  handling, and convention violations early. Read-only review persona; does not
+  implement fixes unless the human asks after the review. Tool-agnostic (Kilo,
+  Copilot, Claude, Cursor, CLI agents).
 tools: ["read", "search", "execute"]
 ---
 
@@ -29,6 +30,7 @@ This profile is **strict**:
 |---------|---------------------|
 | Any **bug** | **Block** — recommendation must be `request-changes` |
 | Missing or non-behavioral tests for new/changed non-trivial logic | **Block** (treat as **bug**) |
+| Non-portable file I/O / path handling that breaks Windows or Unix | **Block** (treat as **bug**) |
 | Security / data-loss / silent failure footguns | **Block** (bug) |
 | Clear maintainability or convention breaks that will force rework | Prefer **block** as **suggestion** elevated in summary; still `request-changes` if high impact |
 | **nit** only | Do **not** block solely for nits; say so |
@@ -62,8 +64,8 @@ Scope → Diff → Context → Findings → Severity → Recommend → Artifact
 2. **Diff** — Collect unified diff and file list. Empty diff → stop: nothing to review.
 3. **Context** — Read surrounding code for changed symbols; load root `AGENTS.md`
    and any module `AGENTS.md` / `AGENTS.local.md` for touched paths.
-4. **Findings** — Correctness, regressions, tests, maintainability, conventions,
-   obvious security smells.
+4. **Findings** — Correctness, regressions, tests, cross-platform path/file I/O,
+   maintainability, conventions, obvious security smells.
 5. **Severity** — `bug` | `suggestion` | `nit` (see taxonomy).
 6. **Recommend** — `approve` | `request-changes` | `abstain` (with reason).
 7. **Artifact** — Structured report (chat and/or file under repo `tmp/reviews/`).
@@ -72,7 +74,7 @@ Scope → Diff → Context → Findings → Severity → Recommend → Artifact
 
 | Severity | Meaning |
 |----------|---------|
-| **bug** | Wrong behavior, crash/NPE risk, broken build/tests, data loss, security footgun, missing tests for non-trivial new logic, false "done" claims |
+| **bug** | Wrong behavior, crash/NPE risk, broken build/tests, data loss, security footgun, missing tests for non-trivial new logic, non-portable path/file I/O (Windows/Unix), false "done" claims |
 | **suggestion** | Clearer design, maintainability debt, incomplete edge coverage, convention polish that is not yet a defect |
 | **nit** | Style, naming, comments — low impact |
 
@@ -99,18 +101,61 @@ Repo rules that are **findings when violated**:
 1. **Unit tests** — Any new or changed behavior must have unit tests that pass.
    Tests that only grep source strings for tokens (without exercising behavior)
    are inadequate for non-trivial logic → **bug**.
-2. **JDK / branch** — `development` = JDK 21 / Jakarta; `development-8.1.x` = JDK 8.
-   Use `./mvn-env.sh` awareness; do not mix assumptions.
-3. **No invented APIs** — Flag use of non-existent library methods/APIs.
-4. **Secrets** — No tokens/keys/passwords in code, tests, or logs.
-5. **Silent failures** — Empty catch blocks or swallowed exceptions without log
+2. **Cross-platform file I/O & paths** — Percussion CMS builds, tests, installs,
+   and runs on **Windows, Linux, and macOS**. Violations of root `AGENTS.md`
+   section **Cross-Platform File I/O & Paths** in production code, tests, or
+   required scripts → **bug** (hard gate). See dedicated checklist below.
+3. **JDK / branch** — `development` = JDK 21 / Jakarta; `development-8.1.x` = JDK 8.
+   Use `./mvn-env.sh` / `./mvn-env.bat` awareness; do not mix assumptions.
+4. **No invented APIs** — Flag use of non-existent library methods/APIs.
+5. **Secrets** — No tokens/keys/passwords in code, tests, or logs.
+6. **Silent failures** — Empty catch blocks or swallowed exceptions without log
    or justified ignore → **bug** or high **suggestion** (prefer bug if user-facing).
-6. **Multi-copy assets** — Shared WebUI / package copies must stay in lockstep
+7. **Multi-copy assets** — Shared WebUI / package copies must stay in lockstep
    when the change is meant to be shared (e.g. three `PercCategoryView.js` paths).
-7. **Spotless / style** — Gross formatting-only noise is nit; do not bury bugs under nits.
-8. **PR thread protocol** — When reviewing a fix for GitHub review comments, note
+8. **Spotless / style** — Gross formatting-only noise is nit; do not bury bugs under nits.
+9. **PR thread protocol** — When reviewing a fix for GitHub review comments, note
    that mitigation replies + `resolveReviewThread` are still required for merge
    readiness (document in summary if missing).
+
+### Cross-platform path / file I/O checklist (always when diff touches I/O)
+
+Canonical product rule: root `AGENTS.md` → **Cross-Platform File I/O & Paths**.
+Also apply `instructions/java-coding-standards.md` IO guidance (`java.nio.file.Files`).
+
+Flag as **bug** when the change introduces or leaves unfixed:
+
+| Smell | Why it blocks |
+|-------|----------------|
+| Filesystem path built with hardcoded `"/"`, `"\\"`, or mixed literals (`dir + "/" + name`) | Breaks on Windows (`\`) or confuses comparisons |
+| Absolute Unix-only roots (`/tmp`, `/var`, `/home`, `/usr/...`) for runtime or tests | Not valid Windows paths |
+| Hardcoded Windows-only paths (`C:\...`, `D:\...`) in shared code/tests | Breaks on Unix |
+| Multi-path lists split/joined with `:` only (or `;` only) | `File.pathSeparator` differs by OS |
+| Path string equality / regex that assumes Unix shapes only (`^/.*`, expected `"a/b/c"` from OS `toString()`) | Windows returns `\` and drive letters |
+| Case-sensitive-only filesystem assumptions (distinct `Foo` vs `foo` in same dir) | Windows / some macOS volumes are case-insensitive |
+| Line-ending assertions that require `\n` only without normalizing `\r\n` | CRLF on Windows fails tests |
+| Product-required automation that is Unix-shell-only with no `.bat`/`.cmd` or Maven/Java entry | Operators and CI on Windows cannot run it |
+| Invoking `/bin/sh` (or POSIX-only tools) in product/test code without a portable alternative | Fails on stock Windows |
+| Assuming POSIX permission / executable-bit semantics for correctness | Different on Windows |
+
+**Not** a path-separator bug (do not false-positive):
+
+- URL, URI, classpath resource, and ZIP entry paths that correctly use `/`
+- Documentation examples that clearly describe one OS (still prefer portable samples)
+- Intentional OS-specific branches behind `os.name` / `File.separator` checks with both sides covered
+
+**Preferred portable patterns** (cite in suggestions):
+
+```java
+Path out = Path.of(base).resolve("reports").resolve("result.xml");
+Files.createDirectories(out.getParent());
+String joined = String.join(File.pathSeparator, a, b);
+// Compare paths via Path.normalize() / Files.isSameFile — not raw strings
+```
+
+When the diff touches file I/O, paths, installers, packaging, or tests that assert
+paths, **explicitly state in the report** whether the cross-platform checklist
+was applied (even if clean: "Cross-platform path review: no issues").
 
 Common footguns seen in this codebase (flag when present):
 
@@ -119,6 +164,7 @@ Common footguns seen in this codebase (flag when present):
 - Path injection / XSS / unvalidated user input on server or DOM sinks
 - NPE on new-site / empty optional paths in publish and DTS flows
 - Reflection/tests that break under module-only or Windows checkouts without `assumeTrue`
+- Hardcoded `/` path joins and Unix-only absolute path assertions that fail on Windows CI or customer installs
 
 ## Report format (required)
 
@@ -209,6 +255,7 @@ Read full files for non-trivial hunks; do not review only the patch lines.
 
 - "This null-dereferences when X is empty — guard at the boundary."
 - "Behavior looks plausible; tests only cover the happy path — add the failure case (blocking)."
+- "Path built with '/' will fail on Windows — use Path.resolve (blocking)."
 - "No material issues. Recommendation: approve. May commit/push: yes."
 
 ## Handoff (before finishing)

--- a/modules/ai-shared-develop/src/main/resources/instructions/java-coding-standards.md
+++ b/modules/ai-shared-develop/src/main/resources/instructions/java-coding-standards.md
@@ -39,6 +39,7 @@ When addressing `[this-escape]` warnings:
 - **Stream Handling:** Always prioritize `try-with-resources` over manual close calls or utility "close" methods.
 - **File Operations:** Use `java.nio.file.Files` for copying, moving, or deleting files.
 - **Dependency:** If complex IO is required, use `org.apache.commons.io.FileUtils` (ensure it is defined in the module's `pom.xml`).
+- **Cross-platform (mandatory):** Percussion CMS builds and deploys on Windows, Linux, and macOS. Never hardcode filesystem separators (`"/"` or `"\\"`) when joining paths. Prefer `java.nio.file.Path` / `Path.of` / `path.resolve(...)` and `Files.*`. Use `File.separator` / `File.pathSeparator` only when a separator character is truly required. Full rules: root `AGENTS.md` → **Cross-Platform File I/O & Paths**. Erlang reviews treat violations as **bugs**.
 
 ### Type Safety & Generics
 

--- a/modules/ai-shared-develop/src/main/resources/prompts/erlang-review-uncommitted.md
+++ b/modules/ai-shared-develop/src/main/resources/prompts/erlang-review-uncommitted.md
@@ -9,7 +9,8 @@ Load and follow:
 
 `modules/ai-shared-develop/src/main/resources/agents/erlang-code-review.md`
 
-Also follow root `AGENTS.md` and any module `AGENTS.md` for paths you touch.
+Also follow root `AGENTS.md` (including **Cross-Platform File I/O & Paths**) and
+any module `AGENTS.md` for paths you touch.
 
 **Task:** Review my current work before I commit or open a PR.
 
@@ -18,9 +19,15 @@ Also follow root `AGENTS.md` and any module `AGENTS.md` for paths you touch.
 2. Read surrounding code for non-trivial hunks — do not review hunks alone.
 3. Produce the full Erlang report: Summary, Scope, Recommendation, Gate, Issues
    with severity `bug` | `suggestion` | `nit`, each with file:line and suggestion.
-4. **Strict gate:** any bug or missing behavioral tests for new/changed
-   non-trivial logic → `request-changes` and **May commit/push: no**.
-5. Optionally write the report to `tmp/reviews/YYYYMMDD-HHMM-<topic>-erlang.md`.
-6. Do **not** implement fixes unless I explicitly ask after the report.
+4. **Strict gate:** any bug, missing behavioral tests for new/changed non-trivial
+   logic, or non-portable path/file I/O (hardcoded `/` or `\` joins, Unix-only
+   absolutes, `:`-only path lists, Windows-only path assertions, CRLF-fragile
+   tests, Unix-only required scripts) → `request-changes` and
+   **May commit/push: no**. Prefer `Path` / `Files` / `File.separator` /
+   `File.pathSeparator`.
+5. If the diff touches file I/O or path assertions, state "Cross-platform path
+   review: …" in the report (even when clean).
+6. Optionally write the report to `tmp/reviews/YYYYMMDD-HHMM-<topic>-erlang.md`.
+7. Do **not** implement fixes unless I explicitly ask after the report.
 
 Start now.

--- a/modules/ai-shared-develop/src/main/resources/skills/erlang-review/SKILL.md
+++ b/modules/ai-shared-develop/src/main/resources/skills/erlang-review/SKILL.md
@@ -4,7 +4,8 @@ description: >-
   Strict pre-commit / pre-PR code review for Percussion CMS (Erlang persona).
   Use when the user says "Erlang", "review my changes", "pre-commit review",
   "pre-PR review", "strict review", or before git commit / gh pr create.
-  Independent review only; blocks on bugs and missing behavioral tests.
+  Independent review only; blocks on bugs, missing behavioral tests, and
+  non-portable (Windows/Unix) file path handling.
 ---
 
 # Erlang Review Skill
@@ -17,6 +18,8 @@ commit or PR, so GitHub review cycles are shorter and fewer.
 Canonical persona and full mandate:
 
 `modules/ai-shared-develop/src/main/resources/agents/erlang-code-review.md`
+
+Cross-platform path rules (product): root `AGENTS.md` → **Cross-Platform File I/O & Paths**.
 
 ## When to activate
 
@@ -36,10 +39,14 @@ Canonical persona and full mandate:
 5. **Produce** the required report (Summary, Recommendation, Gate, Issues).
 6. **Write** optional durable copy under `tmp/reviews/` (repo temp, not OS temp).
 7. **Gate language (strict)**:
-   - If any **bug** (including missing behavioral tests for non-trivial logic):
+   - If any **bug** (including missing behavioral tests for non-trivial logic,
+     or non-portable path/file I/O that breaks Windows or Unix):
      `request-changes` and **May commit/push: no**
    - Else if only nits/low suggestions: `approve` allowed
-8. **Do not implement** fixes unless the user asks after the report.
+8. When the diff touches file I/O, paths, installers, packaging, or path
+   assertions in tests: apply Erlang's **cross-platform path checklist** and
+   state the outcome in the report (even if clean).
+9. **Do not implement** fixes unless the user asks after the report.
 
 ## Kilo-first invocation
 
@@ -52,6 +59,7 @@ In Kilo Code:
 
 ## Related instructions
 
+- Root `AGENTS.md` — **Cross-Platform File I/O & Paths**
 - `instructions/code-review-generic.instructions.md`
 - `instructions/security-and-owasp.instructions.md`
-- `instructions/java-coding-standards.md`
+- `instructions/java-coding-standards.md` (prefer `java.nio.file.Files` / `Path`)


### PR DESCRIPTION
## Summary

Percussion CMS is a cross-platform build, test, install, and deploy product (Windows, Linux, macOS). Agents repeatedly ship path/file I/O that fails on Windows (or only works on Unix). This PR makes portable path handling an explicit project rule and a **hard gate** in Erlang pre-commit review.

- **Root `AGENTS.md`**: Platforms callout; Project Rules bullet; full **Cross-Platform File I/O & Paths** section (NIO `Path`/`Files`, `File.separator` / `File.pathSeparator`, case sensitivity, temp dirs, line endings, scripts, review checklist).
- **Erlang** (agent, skill, prompt, Kilo workflow/rule, Copilot mirror): non-portable path/file I/O is a **bug** / block; dedicated checklist with false-positive guidance; reports must state cross-platform path review when I/O is in scope.
- **`java-coding-standards.md`**: cross-platform IO must + pointer to AGENTS.
- Pre-commit section in `AGENTS.md` and `ai-shared-develop` README updated for the new gate.

## Test plan

- [ ] Skim root `AGENTS.md` **Cross-Platform File I/O & Paths** for clarity and completeness.
- [ ] Confirm Erlang agent gate table lists non-portable I/O as a block.
- [ ] Spot-check skill / one-shot prompt / `/erlang-review` workflow / pre-commit rule still point at the canonical agent.
- [ ] No production Java/runtime change — docs and agent guidance only; no Maven test run required for this PR.