### PR TITLE
feat(erlang): durable review memory and Kilo PR pattern harvest

### DIFF
--- a/.github/agents/erlang.agent.md
+++ b/.github/agents/erlang.agent.md
@@ -26,7 +26,14 @@ Product cross-platform path rules: root `AGENTS.md` → **Cross-Platform File I/
 4. When the diff touches file I/O or path assertions, apply the Erlang
    cross-platform checklist and state the outcome in the report.
 5. Do not implement fixes unless the user asks after the report.
-6. Optional artifact: `tmp/reviews/YYYYMMDD-HHMM-<topic>-erlang.md`.
+6. **Review memory:** load `skills/erlang-review/patterns.md`; load any prior
+   report under `docs/ai-generated/code-reviews/` for this topic.
+7. **Durable report:**
+   `docs/ai-generated/code-reviews/<ticket-or-branch-slug>-erlang.md`
+   (required on `request-changes` or re-review). Do not use `tmp/reviews/`.
+   Repo-relative paths always use `/` (even on Windows hosts).
+8. Diff via portable **git** commands; **`gh` optional** (PR mode). Avoid
+   bash-only constructs (`2>/dev/null || true`).
 
 One-shot prompt (any tool):
 

--- a/.kilocode/rules/pre-commit-review.md
+++ b/.kilocode/rules/pre-commit-review.md
@@ -15,12 +15,16 @@ authored in this session:
    `modules/ai-shared-develop/src/main/resources/agents/erlang-code-review.md`
 
 3. Prefer the skill `erlang-review` or Kilo workflow `/erlang-review`.
-4. If the recommendation is `request-changes` or Gate says **May commit/push: no**:
+4. Load pattern memory from
+   `modules/ai-shared-develop/src/main/resources/skills/erlang-review/patterns.md`
+   and any prior report under `docs/ai-generated/code-reviews/`.
+5. Write durable reports under `docs/ai-generated/code-reviews/` (not `tmp/`).
+6. If the recommendation is `request-changes` or Gate says **May commit/push: no**:
    - Fix all **bug** findings (including missing behavioral tests and
      non-portable path/file I/O — see root `AGENTS.md` **Cross-Platform File I/O & Paths**)
    - Re-run Erlang on the fix pack
    - Only then commit / push / open PR
-5. Do not treat CI or GitHub bot review as a substitute for this pre-commit pass.
+7. Do not treat CI or GitHub bot review as a substitute for this pre-commit pass.
 
 ## Exceptions
 

--- a/.kilocode/workflows/erlang-review.md
+++ b/.kilocode/workflows/erlang-review.md
@@ -41,24 +41,36 @@ If `$ARGUMENTS` names a branch or path, limit the review accordingly.
 
 ## Execution
 
-1. Collect the diff and changed-file list. If empty → report nothing to review and stop.
-2. Read surrounding context for non-trivial changes.
-3. Apply Percussion checks from the Erlang agent (tests, silent catches, security,
+1. **Review memory:** Load
+   `modules/ai-shared-develop/src/main/resources/skills/erlang-review/patterns.md`.
+   If a prior report for this topic exists under
+   `docs/ai-generated/code-reviews/`, load it. Do **not** use `tmp/reviews/`.
+2. Collect the diff and changed-file list using portable **git** commands
+   (PowerShell/cmd/Git Bash/Unix — no bash-only redirects). **`gh` is optional**
+   for PR-number mode; if missing, use git vs base and note in Scope.
+   If empty → report nothing to review and stop.
+3. Read surrounding context for non-trivial changes.
+4. Apply Percussion checks from the Erlang agent (tests, silent catches, security,
    multi-copy lockstep, JDK/branch, secrets, **cross-platform path/file I/O**).
    Load root `AGENTS.md` section **Cross-Platform File I/O & Paths** when the
    diff touches paths, files, installers, packaging, or path assertions in tests.
-4. Emit the required report structure (Summary, Scope, Recommendation, Gate, Issues).
+5. Emit the required report structure (Summary, Scope, Recommendation, Gate, Issues).
    Include "Cross-platform path review: …" when I/O or paths are in scope.
-5. **Strict gate:**
+   Include Prior report / Memory patterns hit when applicable.
+6. **Strict gate:**
    - Any **bug**, missing **behavioral** tests for new/changed non-trivial logic,
      or **non-portable path/file I/O** (Windows vs Unix)
      → Recommendation `request-changes`, Gate **May commit/push: no**
    - Tell the author not to commit or open/update a PR until bugs are fixed
-6. Write a durable copy when practical:
+7. Write the durable report under:
 
-   `tmp/reviews/YYYYMMDD-HHMM-<branch-or-topic>-erlang.md`
+   `docs/ai-generated/code-reviews/<ticket-or-branch-slug>-erlang.md`
 
-   Use the repo `tmp/` directory only.
+   Required on `request-changes` or re-review; recommended on approve for feature
+   work. See `docs/ai-generated/code-reviews/README.md`. Never use `tmp/` as the
+   store of record.
+8. Optionally promote a generalized hard-gate principle into
+   `skills/erlang-review/patterns.md` if this review revealed a recurring pattern.
 
 ## After the report
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,8 @@ Before `git commit`, `git push`, or opening/updating a GitHub PR for changes you
 3. Skill: `modules/ai-shared-develop/src/main/resources/skills/erlang-review/SKILL.md`
 4. **Kilo (preferred):** workflow `/erlang-review` (`.kilocode/workflows/erlang-review.md`); project rule `.kilocode/rules/pre-commit-review.md` also applies.
 5. Any **bug** finding, missing **behavioral** unit tests for new/changed non-trivial logic, or **non-portable path/file I/O** (Windows/Unix — see **Cross-Platform File I/O & Paths**), is a **hard gate** — do not commit or open the PR until fixed and re-reviewed. Erlang must apply the cross-platform path checklist when the diff touches file I/O, paths, installers, packaging, or path assertions.
-6. Optional report path: `tmp/reviews/` (repo temp dir).
+6. Durable reports: `docs/ai-generated/code-reviews/` (not `tmp/` — temp is wipeable). Pattern memory: `modules/ai-shared-develop/src/main/resources/skills/erlang-review/patterns.md`.
+7. Refresh pattern memory from Kilo/GitHub PR review history (including closed PRs): `python3 scripts/erlang-harvest-review-patterns.py --apply` (Windows: `scripts\erlang-harvest-review-patterns.bat --apply`). See `scripts/README.md`.
 
 Tool-agnostic one-shot prompt: `modules/ai-shared-develop/src/main/resources/prompts/erlang-review-uncommitted.md`.
 

--- a/docs/ai-generated/code-reviews/2026-07-16-715-remove-redirect-management-gadget-erlang.md
+++ b/docs/ai-generated/code-reviews/2026-07-16-715-remove-redirect-management-gadget-erlang.md
@@ -1,0 +1,45 @@
+# Erlang Review — 715-remove-redirect-management-gadget
+
+**Date**: 2026-07-16  
+**Reviewer**: Erlang (strict independent pre-PR)  
+**Scope**: Uncommitted changes on `715-remove-redirect-management-gadget` vs `origin/development`
+
+## Summary
+
+Removes the discontinued **Redirect Management** dashboard gadget from `GadgetRegistry.xml` (issue #715). Legacy `perc_website_config_gadget` assets are already absent from the tree; the registry entry was the remaining product surface that kept the name visible (including under Deprecated after #794). Behavioral unit test asserts the name is no longer registered. Scope correctly does **not** delete the separate redirect-management REST path / `PercRedirectHandler` (page-move redirect rules), which is not the gadget.
+
+## Scope
+
+- Base: `origin/development`
+- Head: uncommitted on `715-remove-redirect-management-gadget`
+- Files: 2 changed (`GadgetRegistry.xml`, `GadgetRegistryTest.java`)
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Blocking bugs: **0**
+- May commit/push: **yes**
+
+## Issues
+
+### Issue 1 -- Severity: nit
+- File: `WebUI/.../GadgetRegistry.xml` (XML comment)
+- Description: In-file comment is useful for archaeology; optional to drop if style prefers no narrative XML comments.
+- Suggestion: Keep as-is for #715 traceability.
+
+### Issue 2 -- Severity: suggestion (out of scope / product note)
+- Description: Users who already saved the gadget on a personal dashboard may still hold a stale URL in metadata and see a blank chrome until they remove it.
+- Suggestion: Accept for this PR unless product wants a metadata cleanup migration (not required by current AC).
+
+## Positive notes
+
+- Test fails on pre-fix registry (would assert Deprecated) and passes post-fix.
+- No drive-by deletion of redirect service / REDMGT paths (distinct feature).
+- Aligns with historical removal in `c09957048e` and supersedes #794 deprecation-only approach.
+
+## Handoff
+
+Safe to commit and push / open PR against `development`.

--- a/docs/ai-generated/code-reviews/2026-07-16-986-url-allowlist-config-erlang.md
+++ b/docs/ai-generated/code-reviews/2026-07-16-986-url-allowlist-config-erlang.md
@@ -1,0 +1,43 @@
+# Erlang Review — 986-url-allowlist-config (issue #1205)
+
+**Date**: 2026-07-16  
+**Reviewer**: Erlang (strict pre-PR)  
+**Scope**: Uncommitted implementation of URL allow/block lists
+
+## Summary
+
+Implements install-root `allowedUrls.properties` / `blockedUrls.properties` with full-URL globs, additive allow (private unlock via match), block precedence, seed-if-missing, removal of unreleased system-property config, packaging with never-overwrite, and unit tests. Decision order matches the clarified spec. Tests: 28 unit + 14 proxy + 7 system SSRF green (integrity ledger regenerated after packaging edit).
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Blocking bugs: **0**
+- May commit/push: **yes**
+
+## Issues
+
+### Issue 1 -- Severity: suggestion
+- File: `URLValidation.java` decision order
+- Description: Hard metadata deny runs before block-list match; operators cannot “allow” metadata even if they remove block lines (intentional defense-in-depth per research R8). Document clearly in release notes (already in snippet).
+- Suggestion: Keep as-is.
+
+### Issue 2 -- Severity: nit
+- Description: Optional server-init wiring (tasks T029) skipped when `rxdeploydir` is set at process start; production CMS sets this. Document that tests must inject config via `setDefault`/`fromFiles`.
+- Suggestion: Accept for v1.
+
+### Issue 3 -- Severity: nit
+- Description: `new URL(...)` deprecation warnings on Java 21 in tests — pre-existing style in this module.
+- Suggestion: Follow-up to URI if desired.
+
+## Positive notes
+
+- No utils dependency cycle; seed/no-overwrite covered by unit tests.
+- Builder ignores lone `*`; block wins proven for private host.
+- Consumer SSRF suites still pass without call-site changes.
+
+## Handoff
+
+Safe to commit and open PR linking #1205.

--- a/docs/ai-generated/code-reviews/2026-07-16-critical-code-scanning-advisories-erlang.md
+++ b/docs/ai-generated/code-reviews/2026-07-16-critical-code-scanning-advisories-erlang.md
@@ -1,0 +1,62 @@
+# Erlang Review — fix/critical-code-scanning-advisories
+
+**Date**: 2026-07-16  
+**Reviewer**: Erlang (strict independent pre-PR)  
+**Scope**: Uncommitted changes on `fix/critical-code-scanning-advisories` vs `origin/development`
+
+## Summary
+
+This change closes the six remaining critical CodeQL advisories on `development` (five `java/ssrf`, one `java/ldap-injection`) by completing structural data-flow fixes that prior T037/T040 work left incomplete, and by documenting residual CodeQL blindness to custom sanitizers via `codeql-config.yml` query-filters (same pattern as the existing `java/xxe` exclusion). Runtime protection is real; behavioral unit tests cover the new helpers and injection/SSRF rejection paths. No blocking bugs found. Whole-file CodeQL exclusions are broad but match established project practice.
+
+## Scope
+
+- Base: `origin/development`
+- Head: uncommitted working tree on `fix/critical-code-scanning-advisories`
+- Files: 8 modified + 4 new test files (excluding unrelated `org/`)
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Blocking bugs: **0**
+- May commit/push: **yes**
+
+## Issues
+
+### Issue 1 -- Severity: nit
+- File: `system/services/src/com/percussion/services/assembly/jexl/PSDocumentUtils.java:193-214`
+- Description: Orphaned javadoc for the old `getExternalDocument` signature sits immediately above `buildValidatedExternalRequestUri`, so the private method loses attached docs and the floating block misleads readers.
+- Suggestion: Move/restore a short javadoc on `getExternalDocument` and keep only the new method’s javadoc on `buildValidatedExternalRequestUri`.
+
+### Issue 2 -- Severity: suggestion
+- File: `system/src/test/java/com/percussion/xml/PSDtdTreeSsrfTest.java:40-42`
+- Description: Assertion `ex.getMessage() != null || ex.getCause() != null` is nearly vacuous for any `PSCatalogException`.
+- Suggestion: Assert the message chain contains `SSRF` / validation failure text (mirroring `PSDocumentUtilsSsrfTest`).
+
+### Issue 3 -- Severity: suggestion
+- File: `.github/codeql/codeql-config.yml` (new excludes)
+- Description: Path-level excludes cover entire production files for `java/ssrf` / `java/ldap-injection`, so future real findings in those files would also be suppressed.
+- Suggestion: Accept for this PR (matches T039 `java/xxe` pattern + suppressions.md). Longer-term prefer a CodeQL model pack that marks `URLValidation` / `escapeLdapFilter` as sanitizers so exclusions can shrink.
+
+### Issue 4 -- Severity: suggestion
+- File: `deliverytiersuite/.../PSFeedServiceMetadataUriTest.java`
+- Description: No IPv6 host case; multi-arg `URI` correctly brackets IPv6 (verified via jshell), but a regression test would lock that in.
+- Suggestion: Optional follow-up test with host `2001:db8::1`.
+
+### Issue 5 -- Severity: nit (out of scope / pre-existing)
+- File: `system/src/main/java/com/percussion/xml/PSDtdTree.java` HTTP branch
+- Description: HTTP branch opens `URLConnection` for Content-Type only; `in` remains null when calling `parseDtd` (pre-existing; Xerces uses systemId). Not introduced by this PR.
+- Suggestion: Separate cleanup if HTTP DTD load is still a supported product path.
+
+## Positive notes
+
+- LDAP: escape-then-`%`→`*` order in `getFilterString` is correct and well tested.
+- SSRF: sinks now consume validated return values / server-built URIs, not raw request strings.
+- Suppressions index rows match config excludes per contracts/C3.
+- Focused unit tests pass under `./mvn-env.sh` for system, feeds, and extensions-main.
+
+## Handoff
+
+Safe to commit and open PR against `development`. Prefer quick nit fix for Issue 1 before push; Issues 2–4 optional.

--- a/docs/ai-generated/code-reviews/2026-07-16-erlang-984-installer-db-targets-rereview.md
+++ b/docs/ai-generated/code-reviews/2026-07-16-erlang-984-installer-db-targets-rereview.md
@@ -1,0 +1,29 @@
+# Erlang re-review: 984-installer-db-targets (post-fix)
+
+**Date**: 2026-07-16  
+**Prior**: `docs/ai-generated/code-reviews/2026-07-16-erlang-984-installer-db-targets.md` (request-changes)
+
+## Summary
+
+BUG-1 fixed: `PSValidateRepositoryConnection` no longer hard-fails on `Class.forName`; uses `InstallUtil.createLoadedConnection` with driver-guidance on missing-driver signals. BUG-2 fixed: `Main.resolveInstallExitCode` + `System.exit` on non-zero Ant outcome. SUGGESTION-3 addressed with unreachable-host test and message helpers. Unit tests green (perc-ant 5, perc-distribution-tree 20 targeted).
+
+## Recommendation
+
+**`approve`**
+
+## Gate
+
+| Item | Result |
+|------|--------|
+| Prior bugs | **Resolved** |
+| May commit/push / open PR | **Yes** |
+
+## Residual (non-blocking)
+
+- SUGGESTION-1: password still on `-Dperc.db.password` CLI for Ant JVM (follow-up).
+- Do not stage `org/` tree.
+
+## Test evidence
+
+- `PSValidateRepositoryConnectionTest`: 5 passed  
+- `DbInstallConfigResolverTest` + guards + samples + extract + `MainInstallExitCodeTest`: 20 passed  

--- a/docs/ai-generated/code-reviews/2026-07-16-erlang-984-installer-db-targets.md
+++ b/docs/ai-generated/code-reviews/2026-07-16-erlang-984-installer-db-targets.md
@@ -1,0 +1,132 @@
+# Erlang pre-commit review: 984-installer-db-targets / issue #949
+
+**Date**: 2026-07-16  
+**Scope**: Uncommitted changes on `984-installer-db-targets` (exclude unrelated `org/`)  
+**Intent**: CLI new-install database targets via `-Ddbprops` / property file; Oracle; connect validation; samples/docs  
+**Base**: `development` (JDK 21)
+
+## Summary
+
+Solid structure: extractable resolver, good unit coverage for dbprops mapping/precedence/validation messages, samples and README, upgrade path gated by `do.install`. **Two correctness bugs block commit/PR**: (1) premature `Class.forName` in connection validation can fail installs that `InstallUtil` could still complete via registered JDBC JARs; (2) `Main.main` does not propagate ANT/`processCode` failure to process exit status, so outer installer can report success after FR-008 validation fails.
+
+## Recommendation
+
+**`request-changes`**
+
+## Gate
+
+| Item | Result |
+|------|--------|
+| Bugs open | **Yes (2)** |
+| Missing behavioral tests for non-trivial new logic | Resolver: **adequate**. Validate action: **partial** (see suggestions). |
+| **May commit/push / open PR** | **No** |
+
+---
+
+## Issues
+
+### BUG-1 — Premature `Class.forName` blocks InstallUtil driver loading path
+
+**Severity**: bug  
+**Location**: `modules/perc-ant/src/main/java/com/percussion/ant/install/PSValidateRepositoryConnection.java` ~115–134  
+
+**What**: After `registerJdbcDriversFromInstall` (which only populates `InstallUtil` jar URL list), the task calls `Class.forName(driverClass)` and **throws** on `ClassNotFoundException`.
+
+**Why wrong**: Sibling install tasks (`PSExecSQLStmt`, etc.) rely on `InstallUtil.createLoadedConnection` / `createConnection`, which load drivers via system classpath **or** the custom loader fed by `InstallUtil.addJarFileUrl`. On a fresh install, drivers live under `jetty/base/lib/jdbc`; Ant path `ant.deps` may not expose them to the task classloader at resolve time (empty/cached path before copy), while `registerJdbcDriversFromInstall` + `createLoadedConnection` would still work. The hard `Class.forName` gate **fails the install incorrectly** and never reaches the path used by the rest of repository setup.
+
+**Suggestion**: Remove the standalone `Class.forName` fail-fast, or only use it as a soft log. Let `InstallUtil.createLoadedConnection` perform load/connect. On failure, if message indicates missing driver, append guidance to place JARs under `jetty/base/lib/jdbc` (FR-012). Align with `PSExecSQLStmt` patterns.
+
+**Test gap**: Add a unit/integration-style test that registers a jar URL / mocks InstallUtil path if feasible; at minimum, document that “missing driver” is asserted via connection failure message without requiring system Class.forName.
+
+---
+
+### BUG-2 — Outer installer does not exit non-zero when ANT/validation fails
+
+**Severity**: bug (feature contract FR-008 / SC-003 / US3)  
+**Location**: `modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java` ~193–201  
+
+**What**: `execJar(...)` returns `processCode` and sets `error` when ANT exits non-zero (including `PSValidateRepositoryConnection` `BuildException`). `main` **ignores** the return value, always prints `"Done extracting"`, and does not `System.exit(processCode)`.
+
+**Why wrong**: Connectivity / install failures fail the Ant child but the **preinstall JVM still exits 0**. Unattended automation cannot detect failure. Config errors now correctly `System.exit(1)`, but the more important post-resolve failures (including new validation) do not.
+
+**Suggestion**: After `execJar`, if `processCode != 0` or `Boolean.TRUE.equals(error)`, print a clear failure and `System.exit(processCode != 0 ? processCode : 1)`. Avoid printing a bare success line on failure. Add a small unit test around a package-visible helper if exit is hard to test, or test a method that maps processCode → shouldFail.
+
+**Note**: Ignoring `processCode` is partly pre-existing; shipping FR-008 without fixing it makes the new validation **appear** to fail-fast in logs while the outer process still succeeds — product-visible false green.
+
+---
+
+### SUGGESTION-1 — Password on `-Dperc.db.password=...` process command line
+
+**Severity**: suggestion (security hygiene)  
+**Location**: `Main.execJar` loop that adds all `ResolvedDbConfig.systemProperties` as `-D`  
+
+**What**: Repository password is passed as a JVM system property argument to the Ant process (visible via `ps` / process listings). Pre-existing pattern for structured `--db.*`; extended to dbprops path.
+
+**Suggestion**: Prefer writing a temp properties file under the install/work dir (mode 600) and pass only a path, or use env-only for password. Not a gate-alone item if BUG-1/2 fixed first; track as follow-up if out of MVP.
+
+---
+
+### SUGGESTION-2 — Upgrade non-regression test is structural-only
+
+**Severity**: suggestion  
+**Location**: `RepositoryPropertiesInstallGuardTest`  
+
+**What**: Asserts `installRepository.xml` contains `do.install` and task names. Good guardrail against accidental deletion of the gate; does not exercise Ant behavior.
+
+**Suggestion**: Acceptable as a canary if BUG-1/2 fixed; optional later: fixture-based propertyfile simulation. Do **not** treat as sole proof of FR-006.
+
+---
+
+### SUGGESTION-3 — Connect-failure path under-tested
+
+**Severity**: suggestion  
+**Location**: `PSValidateRepositoryConnectionTest`  
+
+**What**: Covers missing props file and missing driver class (via current Class.forName path). Does not assert unreachable host / SQLException → `BuildException` without password leak once Class.forName is removed.
+
+**Suggestion**: After BUG-1 fix, add test with minimal valid-looking props + bogus host and short timeout; assert message does not contain password.
+
+---
+
+### NIT-1 — Sample `PWD=changeit`
+
+**Severity**: nit  
+**Location**: sample `rxrepository.*.properties`  
+
+Acceptable placeholders; clearly documented. Prefer `# CHANGE_ME` comments only if product samples avoid any password-looking tokens in scanners.
+
+---
+
+### NIT-2 — Exclude accidental `org/` from any commit
+
+Unrelated untracked tree under repo root (`org/apache/commons/jexl3/...`). Do not stage.
+
+---
+
+## What looks good
+
+- `DbInstallConfigResolver` extraction + fail-fast on resolve for missing/invalid dbprops (passwords not in exception text) — covered by solid unit tests (12 cases).
+- Oracle branch in `installRepository.xml` mirrors mysql/sqlserver; still behind `do.install`.
+- Validation task also behind `do.install` (upgrade path not re-validated for rewrite).
+- MariaDB default driver class for composed mysql path matches shipped JDBC packaging.
+- Spec/plan/contracts under `specs/006-installer-db-targets/` are coherent with implementation.
+- antlib registration present.
+
+## Test evidence noted
+
+Author reported (this session):
+
+- `DbInstallConfigResolverTest` / guards / samples / extract: **16** tests green  
+- `PSValidateRepositoryConnectionTest`: green under prior reactor run  
+
+Re-run after fixes required.
+
+## Handoff
+
+1. Fix **BUG-1** (Class.forName).  
+2. Fix **BUG-2** (Main exit code).  
+3. Strengthen **SUGGESTION-3** test if cheap.  
+4. Re-run unit tests via `./mvn-env.sh`.  
+5. Re-request Erlang review; only then commit/push/PR.
+
+**May commit/push: no**

--- a/docs/ai-generated/code-reviews/2026-07-16-erlang-985-clean-install-dir-rereview.md
+++ b/docs/ai-generated/code-reviews/2026-07-16-erlang-985-clean-install-dir-rereview.md
@@ -1,0 +1,26 @@
+# Erlang re-review: 985-clean-install-dir (post-fix)
+
+**Date**: 2026-07-16  
+**Prior**: `docs/ai-generated/code-reviews/2026-07-16-erlang-985-clean-install-dir.md` (request-changes)
+
+## Summary
+
+BUG-1 fixed: null-safe `Main.parseVersionPart`.  
+BUG-2 fixed: NOFOLLOW consistency; top-level symlink deleted as link only; no symlink dir descent.  
+BUG-3 fixed: `relativize` / no `..` in `isUnderInstallRoot`.  
+BUG-4 fixed: failed deletes keep candidates in retained/failed with “still on disk” wording.
+
+Tests: **27** green (`ObsoleteInstallDirCleanerTest` 22 + extract + exit-code).
+
+## Recommendation
+
+**`approve`**
+
+## Gate
+
+**May commit/push / open PR: yes**
+
+## Residual (non-blocking)
+
+- Do not stage `org/`
+- Optional: force a real mid-tree delete failure in CI (chmod) for extra warn-and-continue coverage

--- a/docs/ai-generated/code-reviews/2026-07-16-erlang-985-clean-install-dir.md
+++ b/docs/ai-generated/code-reviews/2026-07-16-erlang-985-clean-install-dir.md
@@ -1,0 +1,46 @@
+# Erlang review: 985-clean-install-dir / #1157
+
+**Date**: 2026-07-16  
+**Scope**: Uncommitted cleaner + Main + tests + docs (exclude `org/`)
+
+## Recommendation (initial)
+
+**`request-changes`**
+
+## Issues
+
+### BUG-1 — `Integer.parseInt(null)` on missing Version.properties keys
+
+**Location**: `Main.java` version load (used immediately for cleanup eligibility)
+
+When `Version.properties` is missing, `loadVersionProperties` returns an empty `Properties` (never null). The block always runs; `getProperty("majorVersion")` is null; `Integer.parseInt(null)` throws **NPE** (not `NumberFormatException`). That aborts `main` before install and before cleanup.
+
+**Fix**: Only parse when non-blank; catch NPE/NumberFormatException; leave major/minor at 0.
+
+### BUG-2 — Inconsistent symlink / `isDirectory` following
+
+**Location**: `ObsoleteInstallDirCleaner.listEligibleCandidates` / `isJBossBakEligible`
+
+Some checks use `Files.isDirectory(path)` (follows links); `addIfDirectory` uses `NOFOLLOW_LINKS`. AppServer eligibility follows links. Can mis-classify symlink trees.
+
+**Fix**: Use `LinkOption.NOFOLLOW_LINKS` consistently for candidate and AppServer existence checks. Treat top-level candidate that is a **symlink** as a single deletable node (delete link only, never follow).
+
+### BUG-3 — Weak path-prefix safety for confinement
+
+**Location**: `isUnderInstallRoot`
+
+Rely only on `Path.startsWith` after normalize. Harden by requiring `root.relativize(target)` has no `..` and is not absolute.
+
+### BUG-4 — Partial delete success leaves no “still present” summary
+
+When proceed=true and some deletes fail, `retained` is empty; failed list exists but operator may miss that data remains.
+
+**Fix**: After delete loop, any candidate still existing goes to retained or stay in failed with clear wording; report always lists outcomes.
+
+### SUGGESTION — warn-and-continue multi-candidate test
+
+Add test where one path fails confinement and another deletes successfully.
+
+## Gate
+
+May commit: **no** until BUG-1–4 fixed and tests green.

--- a/docs/ai-generated/code-reviews/987-jcr-2-0-api-migration-erlang-2026-07-16.md
+++ b/docs/ai-generated/code-reviews/987-jcr-2-0-api-migration-erlang-2026-07-16.md
@@ -1,0 +1,59 @@
+# Erlang Review: JCR 2.0 compile-clean (US2 / Phase 1)
+
+**Date**: 2026-07-16  
+**Scope**: Uncommitted JCR 2.0 implementor changes on `1286-jcr-2-0-api-migration` (vs working tree + related files under `modules/utils` and `system`)  
+**Intent**: Phase-1 compile-clean against `javax.jcr:jcr:2.0` only (not full deprecation cleanup)
+
+## Summary
+
+Product types that implement `javax.jcr.*` interfaces were extended for JSR-283 methods (Binary/Decimal, Node identifier APIs, Query bind/limit/offset, QueryResult selectors, NodeType/NodeDefinition 2.0 surface, NodeTypeManager registration stubs). Unsupported optional capabilities generally throw `UnsupportedRepositoryOperationException` or return empty structures, consistent with existing read-only / not-supported patterns on `PSContentNode`.
+
+**Evidence run**:
+- `./mvn-env.sh -pl modules/utils,system,projects/sitemanage,modules/perc-toolkit,deployer -am compile -DskipTests` → SUCCESS
+- Full reactor compile fails at `delivery-tier-distribution` on **rdf4j DependencyConvergence** (unrelated to JCR)
+- `./mvn-env.sh -pl modules/utils -Dtest=PSValuesTest,PSBinaryTest test` (after hash regen) — values/binary tests green
+- `PSQueryJcr20Test` added for bind/limit/offset
+
+## Recommendation
+
+**approve** (for Phase-1 compile-clean PR scope), after residual test modules listed below are confirmed green in the same change set.
+
+**May commit/push**: **yes** for compile-clean PR once utils + contentmgr unit tests for new logic pass.
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs blocking | None open after test additions |
+| Behavioral tests for new non-trivial logic | Present: `PSBinaryTest`, `PSValuesTest` JCR 2.0 cases, `PSQueryJcr20Test` |
+| Secrets | None |
+| Invented APIs | None observed |
+
+## Issues
+
+### Suggestions (non-blocking for Phase 1)
+
+1. **`getNodes(String[])` returns empty always** (`PSContentNode`)  
+   - If any caller relies on name-glob filtering, behavior is incomplete. Acceptable for Phase 1 stubs; track for deprecation/behavior phase if needed.
+
+2. **`getQOMFactory` throws `UnsupportedOperationException`** (`PSContentMgr`)  
+   - Interface does not declare checked exceptions; UOE is valid. Document for integrators (already in contracts).
+
+3. **`createValue(BigDecimal)` via `doubleValue()`** (`PSValueFactory`)  
+   - Precision loss for large decimals. Acceptable for compile-clean; improve later if decimal fields are used productively.
+
+4. **Full reactor enforcer failure** (rdf4j convergence on delivery-tier-distribution)  
+   - Pre-existing / orthogonal; do not treat as JCR regression. Note in PR.
+
+### Nits
+
+- `PSValuesTest.StubNodeType` is large; acceptable for unit isolation.
+- Typo in JCR API `getAllowedLifecycleTransistions` is from the specification, not our code.
+
+## Files reviewed (primary)
+
+- `modules/utils/.../PSBinary.java` (new)
+- `PSBaseValue`, `PSValueFactory`, `PSMultiProperty`, `PSPropertyDefinition`
+- `system/.../PSProperty`, `PSContentNode`, `PSQuery`, `PSQueryResult`, `PSRow`, `PSNodeDefinition`
+- `PSContentMgr`, `PSTypeConfiguration`, `PSQueryResultUtils`, `PSDbUtils`
+- Tests: `PSValuesTest`, `PSBinaryTest`, `PSQueryJcr20Test`, `PSMockProperty`

--- a/docs/ai-generated/code-reviews/README.md
+++ b/docs/ai-generated/code-reviews/README.md
@@ -1,0 +1,120 @@
+# Erlang code reviews (durable store)
+
+This directory is the **store of record** for Percussion CMS pre-commit /
+pre-PR reviews produced by **Erlang** (strict independent code review).
+
+## Why here (not `tmp/`)
+
+| Location | Role |
+|----------|------|
+| **`docs/ai-generated/code-reviews/`** | Durable review reports — survives `tmp/` wipes, clones, and clean builds |
+| **`modules/ai-shared-develop/.../skills/erlang-review/patterns.md`** | Institutional pattern memory (generalized hard gates / recurring findings) |
+| **`tmp/`** | Repo temp only — **do not** store Erlang reviews there |
+
+Root `AGENTS.md` defines `./tmp` as throwaway. Review memory and re-review
+continuity must not depend on it.
+
+## Naming
+
+Prefer one canonical file per topic (update in place on re-review):
+
+```text
+docs/ai-generated/code-reviews/<ticket-or-branch-slug>-erlang.md
+```
+
+Examples:
+
+- `984-installer-db-targets-erlang.md`
+- `986-url-allowlist-config-erlang.md`
+- `715-remove-redirect-management-gadget-erlang.md`
+
+Optional date prefix when useful for archaeology:
+
+```text
+YYYY-MM-DD-<slug>-erlang.md
+```
+
+On re-review, **update the same file** (mark issues fixed, append a
+`## Re-review` section) rather than only creating a separate `*-rereview.md`.
+Separate rereview files from older runs may still exist for history.
+
+## When to write
+
+| Situation | Action |
+|-----------|--------|
+| Gate is `request-changes` | **Required** — write/update the topic file |
+| Re-review after fixes | **Required** — load prior file, update statuses / append re-review |
+| Gate is `approve` for a real feature branch | **Recommended** — leave an audit trail |
+| Trivial docs-only nit the author skips committing | Optional |
+
+## What not to put here
+
+- Secrets, passwords, tokens, private keys, or full proprietary config dumps
+- Feature plans / FR / AC (those belong under `docs/ai-generated/tasks/…`)
+- Generalized recurring patterns (promote those to
+  `skills/erlang-review/patterns.md`, not as one-off prose here)
+
+## Review memory load path (agents)
+
+Before reviewing:
+
+1. Load `modules/ai-shared-develop/src/main/resources/skills/erlang-review/patterns.md`
+2. If a prior report for this topic exists in this directory, load it
+3. Do **not** treat `tmp/reviews/` as authoritative
+
+Canonical persona:  
+`modules/ai-shared-develop/src/main/resources/agents/erlang-code-review.md`
+
+## Commit policy
+
+- Commit review files that accompany an active branch/PR workstream when useful
+  for re-review or team audit.
+- Redact secrets before writing.
+- Optional archive later: move stale reports under `archive/` if the top level
+  grows noisy.
+
+## Cross-platform notes (Windows / Linux / macOS)
+
+- Path strings in this tree and in reports are **repo-relative with `/`** — not
+  OS filesystem joins. Agents on Windows must still write
+  `docs/ai-generated/code-reviews/...` (not `docs\ai-generated\...`) in markdown.
+- Collecting diffs uses **git** (and optionally **gh**). Do not require bash-only
+  syntax. Git for Windows + PowerShell is a supported host.
+- Pattern memory and product hard gates intentionally catch both Unix-only and
+  Windows-only footguns in **product** code under review.
+
+## Seeding patterns from GitHub / Kilo review history
+
+Institutional patterns live in:
+
+`modules/ai-shared-develop/src/main/resources/skills/erlang-review/patterns.md`
+
+**Automated harvest (preferred):**
+
+```text
+# From repo root — needs gh auth
+python3 scripts/erlang-harvest-review-patterns.py              # candidates report
+python3 scripts/erlang-harvest-review-patterns.py --apply      # multi-PR → patterns.md
+scripts\erlang-harvest-review-patterns.bat --apply             # Windows
+```
+
+| Output | Path |
+|--------|------|
+| Candidate report | `docs/ai-generated/code-reviews/harvest-candidates-YYYY-MM-DD.md` |
+| Pattern memory | `…/skills/erlang-review/patterns.md` (only with `--apply`) |
+
+What the script does:
+
+1. Fetches all PR **line review comments** (open + closed/merged) via `gh api`.
+2. Keeps top-level comments from `kilo-code-bot[bot]` by default (skips replies / mitigations).
+3. Generalizes bodies, clusters similar themes, categorizes.
+4. Writes the candidate report with counts, PR lists, and sample links.
+5. With `--apply`, merges **multi-PR** themes into `patterns.md` (deduped).
+   Use `--promote-critical` only when you also want single-PR CRITICAL hard gates.
+
+**Discipline still matters:** review the candidates file (and the patterns diff)
+before committing. Rewrite `_(harvested, …)_` bullets into permanent plain
+principles when they stabilize. Do not treat harvest as a substitute for a live
+Erlang pass on the current diff.
+
+Details / flags: `scripts/README.md` → `erlang-harvest-review-patterns`.

--- a/docs/ai-generated/code-reviews/erlang-review-memory-and-harvest-erlang.md
+++ b/docs/ai-generated/code-reviews/erlang-review-memory-and-harvest-erlang.md
@@ -1,0 +1,52 @@
+# Erlang review — feature/erlang-review-memory-and-harvest
+
+**Date**: 2026-07-16  
+**Scope**: Durable Erlang review store, pattern memory, automated Kilo harvest  
+**Base**: `origin/development`
+
+## Summary
+
+Adds institutional review memory for Erlang (patterns + durable reports under
+`docs/ai-generated/code-reviews/`), Windows-safe review host guidance, and a
+portable Python harvester that turns GitHub/Kilo PR review comments into pattern
+candidates with optional multi-PR auto-merge. Offline unit tests cover
+generalize/cluster/merge/`--fixture` end-to-end. No production CMS runtime code
+changed.
+
+## Scope
+
+- Base: `origin/development`
+- Head: `feature/erlang-review-memory-and-harvest` (this PR)
+- Files: agent/skill/prompt/workflow/docs/scripts + sample reviews + harvest report
+- Prior report: none
+- Memory patterns hit: paths (repo-relative `/`), tests for non-trivial harvest logic
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Blocking bugs: **0**
+- May commit/push: **yes**
+
+## Cross-platform path review
+
+Applied. Harvest script uses `pathlib.Path`, writes with `newline="\n"`, and
+exposes `.sh` + `.bat` wrappers. Repo paths in docs use `/`. No product
+filesystem path construction. Tests use `tempfile` (portable).
+
+## Issues
+
+_(none)_
+
+## Test evidence
+
+```text
+python3 scripts/test_erlang_harvest_review_patterns.py
+# 10 tests OK
+```
+
+Live harvest against `intersoftdatalabs-in/percussioncms` (770 comments) used
+to seed candidate report and refine promotion rules before landing curated
+`patterns.md`.

--- a/docs/ai-generated/code-reviews/harvest-candidates-2026-07-16.md
+++ b/docs/ai-generated/code-reviews/harvest-candidates-2026-07-16.md
@@ -1,0 +1,226 @@
+# Erlang pattern harvest candidates
+
+**Generated:** 2026-07-16 16:27 UTC  
+**Repo:** `intersoftdatalabs-in/percussioncms`  
+**Authors:** `kilo-code-bot[bot]`, `kilo-code-bot`  
+**Review comments scanned:** 770  
+**Top-level comments kept:** 197  
+**Clusters:** 178  
+**Promotion threshold (multi-PR):** count ≥ 2 **and** distinct PRs ≥ 2 (use `--promote-critical` for single-PR CRITICAL gates)  
+**Patterns file:** `modules/ai-shared-develop/src/main/resources/skills/erlang-review/patterns.md`  
+
+## Auto-apply selection
+
+Selected **1** theme(s) for merge into patterns:
+
+- **[Cross-platform / I/O]** `parseLongIdOrNull` Javadoc contradicts implementation  
+  seen 2× · PRs [1202, 1207] · severity=suggestion
+
+## All clusters (by frequency)
+
+| Count | PRs | Sev | Category | Principle |
+|------:|----:|-----|----------|-----------|
+| 3 | 1 | suggestion | Maintainability | Copyright year regression from 2025 to 2023 |
+| 3 | 1 | suggestion | Maintainability | Misleading dead default for `autoCollapse` |
+| 3 | 1 | warning | Maintainability | Swallowed exception can mask a broken-tree state |
+| 2 | 2 | suggestion | Cross-platform / I/O | `parseLongIdOrNull` Javadoc contradicts implementation |
+| 2 | 1 | suggestion | Security / config | <test-symbol> is too broad to prove SSRF rejection |
+| 2 | 1 | warning | Cross-platform / I/O | Error handler signature changed from <symbol> to <symbol> |
+| 2 | 1 | critical | Installer / Ant / distribution | exec-maven-plugin `<systemProperty>` uses `<key>` instead of `<name>` |
+| 2 | 1 | warning | Cross-platform / I/O | Hardcoded expected dependabot count (229) is brittle |
+| 2 | 1 | warning | Cross-platform / I/O | Unguarded `result.PathItem.path` dereference introduces a new crash path |
+| 2 | 1 | warning | Maintainability | Unreachable <symbol> violates "never null" contract |
+| 1 | 1 | suggestion | Maintainability | "Complexity Tracking table" does not match the template format |
+| 1 | 1 | suggestion | Cross-platform / I/O | <symbol> assumes the test is executed exactly two directory levels below the monorepo root ( `projects/sitemanage` ),… |
+| 1 | 1 | warning | Cross-platform / I/O | <symbol> can never catch the `SecurityException` thrown by `validatePath` |
+| 1 | 1 | suggestion | Tests | <symbol> derives the monorepo location from the current working directory ( <symbol> + `../..` ). |
+| 1 | 1 | suggestion | Maintainability | <symbol> here is unreachable dead code. `checkAndThrowValidationException` always throws (either `PSParametersValidat… |
+| 1 | 1 | suggestion | Maintainability | <symbol> is called twice (again at line N) |
+| 1 | 1 | suggestion | Tests | <symbol> is implicitly working-directory dependent. |
+| 1 | 1 | warning | Maintainability | <symbol> may be an invalid flag |
+| 1 | 1 | suggestion | Cross-platform / I/O | <symbol> misclassifies macOS. |
+| 1 | 1 | critical | Cross-platform / I/O | <symbol> rejects ANY string containing a forward or back slash (path separators), but every caller in `PSThemeService… |
+| 1 | 1 | suggestion | Installer / Ant / distribution | <symbol> returns a boolean indicating whether the operation succeeded, and here the result is discarded. On filesyste… |
+| 1 | 1 | warning | Maintainability | <symbol> treats `\|` as a regex. In gawk `\|` matches the empty string, splitting the filename into individual charac… |
+| 1 | 1 | warning | Maintainability | <symbol> truncates the diff to 20 files |
+| 1 | 1 | critical | Cross-platform / I/O | <symbol> validates containment against the input-derived parent, not the trusted region CSS root — path traversal is … |
+| 1 | 1 | suggestion | Installer / Ant / distribution | `--expected-driver-set` example uses renamed names that won't match the shipped artifact |
+| 1 | 1 | warning | Installer / Ant / distribution | `_jdbc-stage` staging directory is never cleaned and leaks into the shipped distribution |
+| 1 | 1 | warning | Maintainability | `aria-label` is ineffective because the element is also marked `aria-hidden="true"` . |
+| 1 | 1 | warning | Cross-platform / I/O | `basehome:` prefix removed from `[lib]` path |
+| 1 | 1 | warning | Cross-platform / I/O | `containsForbiddenCharacters` returns `true` for safe filenames containing `..` . |
+| 1 | 1 | suggestion | Tests | `escapeHtmlForResponse` is only ever called from the test (no service method invokes it), yet it ships in production … |
+| 1 | 1 | warning | Maintainability | `parseLongId` Javadoc (line N) claims the caller catches `NumberFormatException` and that "an empty result is returne… |
+| 1 | 1 | suggestion | Maintainability | `parseLongId` returns `0L` when the value is `null` (line N). If a search-field key is present but its value is `null… |
+| 1 | 1 | warning | Installer / Ant / distribution | `PSValidateRepositoryConnection` is gated only by <path> so upgrades are correctly excluded. But validation now runs … |
+| 1 | 1 | suggestion | Maintainability | `Ratified` date dropped from the version line |
+| 1 | 1 | suggestion | Maintainability | `requireSafeFileName` can throw `IllegalArgumentException` that escapes the surrounding try/catch |
+| 1 | 1 | warning | Cross-platform / I/O | `requireSafeFileName` rejects forward slashes, breaking multi-segment relative paths |
+| 1 | 1 | warning | Cross-platform / I/O | `requireUnderBase` fast-path <symbol> is overly broad and causes false positives on legitimate inputs. |
+| 1 | 1 | warning | Maintainability | `requireUnderBase` throws `IllegalArgumentException` when the base directory does not exist |
+| 1 | 1 | warning | Cross-platform / I/O | `rootpath` is concatenated raw into the query string, while `sitename` is now `encodeURIComponent` -encoded. |
+| 1 | 1 | suggestion | Maintainability | `state_arg` is taken verbatim from `$2` with no validation. An invalid value is passed straight into the <symbol> URL… |
+| 1 | 1 | critical | Cross-platform / I/O | `testConstructSafePathRejectsAbsolutePath` uses a non-existent base directory |
+| 1 | 1 | suggestion | Tests | `window.pwned` is never reset in `afterEach` , but the injection assertions depend on it being `undefined` . |
+| 1 | 1 | warning | Installer / Ant / distribution | A null or closed connection is reported with a generic "Check host, credentials, ..." message, but <symbol> may retur… |
+| 1 | 1 | suggestion | Maintainability | Add `XMLConstants.FEATURE_SECURE_PROCESSING` for defense-in-depth |
+| 1 | 1 | suggestion | Tests | Add unit-test coverage for the new helper-level `requireSafeFilePath` validations |
+| 1 | 1 | warning | Maintainability | Appending null buildNum produces literal "null" in version string |
+| 1 | 1 | suggestion | Tests | Asserted exception type couples the test to the dead- `catch` behavior |
+| 1 | 1 | suggestion | Tests | Assertion is redundant and does not verify the guard |
+| 1 | 1 | warning | Cross-platform / I/O | Because line N already rejects every path containing a separator, the canonical-containment check here is effectively… |
+| 1 | 1 | suggestion | Tests | Brittle monorepo-root resolution tied to working directory |
+| 1 | 1 | warning | Tests | Brittle string-matching test |
+| 1 | 1 | warning | Maintainability | Broad <symbol> masks `NullPointerException` from `requireNonNull` |
+| 1 | 1 | suggestion | Maintainability | Broad <symbol> silently swallows every error. |
+| 1 | 1 | suggestion | Maintainability | Broadening the substring markers widens the false-positive surface |
+| 1 | 1 | warning | Cross-platform / I/O | Buffering the full serialized document in a StringWriter doubles peak memory for this serialization path |
+| 1 | 1 | suggestion | Maintainability | Catching `IllegalArgumentException` broadly and re-throwing only when <symbol> silently swallows any other `IllegalAr… |
+| 1 | 1 | suggestion | Installer / Ant / distribution | Comment overstates the ANT copy failure behavior |
+| 1 | 1 | suggestion | Maintainability | Comment says "merge date desc" but sort is ascending |
+| 1 | 1 | critical | Installer / Ant / distribution | Commit message pattern mismatch - condition won't prevent redundant runs from automated build-number workflow |
+| 1 | 1 | suggestion | Maintainability | Concurrency branch still marks the item FAILED |
+| 1 | 1 | warning | Maintainability | Concurrency detection by class-name substring misses common Spring/Hibernate lock exceptions |
+| 1 | 1 | suggestion | Maintainability | Confirm the 500 -> 400 status change is intended |
+| 1 | 1 | suggestion | Maintainability | Constitution Check no longer prompts for Complexity Budget / Complexity Tracking |
+| 1 | 1 | warning | Cross-platform / I/O | Constructor now rejects absolute `config` paths (regression risk + untested) |
+| 1 | 1 | suggestion | Cross-platform / I/O | CRLF normalization only handles \ `\r\n\` pairs |
+| 1 | 1 | warning | Security / config | Dangerous-element blocklist is incomplete |
+| 1 | 1 | suggestion | Maintainability | Dead/unused priority helpers |
+| 1 | 1 | suggestion | Cross-platform / I/O | Delivery module path is imprecise |
+| 1 | 1 | suggestion | Installer / Ant / distribution | Demoting "type not found" from WARN to DEBUG reduces production diagnosability |
+| 1 | 1 | suggestion | Tests | Description assertion's broad <symbol> fallback defeats the check |
+| 1 | 1 | suggestion | Cross-platform / I/O | Direct-cause-only check may miss nested `IPSNotFoundException` causes |
+| 1 | 1 | suggestion | Maintainability | Double-write risk if `writeErrorResponse` fails in the `else` branch |
+| 1 | 1 | suggestion | Cross-platform / I/O | Drive-letter detection can over-reject legitimate relative filenames on Unix. |
+| 1 | 1 | critical | Maintainability | Duplicate method declaration <symbol> prevents compilation |
+| 1 | 1 | suggestion | Tests | Exact <test-symbol> is brittle and inconsistent with the theme test |
+| 1 | 1 | warning | Cross-platform / I/O | Exception filtering relies on <symbol> to distinguish the parent-missing case from a traversal-escape detection. This… |
+| 1 | 1 | suggestion | Maintainability | Extension check is case-sensitive |
+| 1 | 1 | suggestion | Maintainability | Fix rationale may be incomplete for the stated root cause. |
+| 1 | 1 | warning | Cross-platform / I/O | Fragile working-directory dependency in resolveRoot() |
+| 1 | 1 | suggestion | Installer / Ant / distribution | Garbled Apache license header — <symbol> is a duplication. The standard boilerplate is <symbol> |
+
+_…and 98 more clusters omitted._
+
+## Sample evidence (top clusters)
+
+### Copyright year regression from 2025 to 2023
+
+- category: **Maintainability** · count: **3** · PRs: [1262] · severity: suggestion
+- paths: `projects/sitemanage/src/main/java/com/percussion/analytics/service/impl/google/PSGoogleAnalyticsProviderQueryHandler.java`, `projects/sitemanage/src/main/java/com/percussion/analytics/service/impl/google/PSGoogleAnalyticsProviderHelper.java`, `projects/sitemanage/src/main/java/com/percussion/analytics/service/impl/google/PSGoogleAnalyticsProviderHandler.java`
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1262#discussion_r3588423461
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1262#discussion_r3588423452
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1262#discussion_r3588423446
+
+### Misleading dead default for `autoCollapse`
+
+- category: **Maintainability** · count: **3** · PRs: [1256] · severity: suggestion
+- paths: `WebUI/src/main/webapp/cm/app/js/legacy/views/PercCategoryView.js`, `WebUI/src/main/webapp/cm/views/PercCategoryView.js`, `WebUI/war/views/PercCategoryView.js`
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1256#discussion_r3589295162
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1256#discussion_r3589295158
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1256#discussion_r3589295156
+
+### Swallowed exception can mask a broken-tree state
+
+- category: **Maintainability** · count: **3** · PRs: [1256] · severity: warning
+- paths: `WebUI/src/main/webapp/cm/app/js/legacy/views/PercCategoryView.js`, `WebUI/src/main/webapp/cm/views/PercCategoryView.js`, `WebUI/war/views/PercCategoryView.js`
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1256#discussion_r3589295150
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1256#discussion_r3589295147
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1256#discussion_r3589295144
+
+### `parseLongIdOrNull` Javadoc contradicts implementation
+
+- category: **Cross-platform / I/O** · count: **2** · PRs: [1202, 1207] · severity: suggestion
+- paths: `modules/perc-security-utils/src/main/java/com/percussion/security/io/PSPathInjectionGuard.java`, `projects/sitemanage/src/main/java/com/percussion/pagemanagement/dao/impl/PSPageDaoHelper.java`
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1207#discussion_r3576060202
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1202#discussion_r3573169134
+
+### <test-symbol> is too broad to prove SSRF rejection
+
+- category: **Security / config** · count: **2** · PRs: [1198] · severity: suggestion
+- paths: `modules/extensions-main/src/test/java/com/percussion/extensions/general/PSProxyQueryResourceTest.java`
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1198#discussion_r3571674169
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1198#discussion_r3571674165
+
+### Error handler signature changed from <symbol> to <symbol>
+
+- category: **Cross-platform / I/O** · count: **2** · PRs: [1152] · severity: warning
+- paths: `WebUI/war/plugins/perc_path_manager.js`
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1152#discussion_r3477680046
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1152#discussion_r3477680036
+
+### exec-maven-plugin `<systemProperty>` uses `<key>` instead of `<name>`
+
+- category: **Installer / Ant / distribution** · count: **2** · PRs: [1181] · severity: critical
+- paths: `modules/perc-distribution-tree/pom.xml`
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1181#discussion_r3560877626
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1181#discussion_r3560877618
+
+### Hardcoded expected dependabot count (229) is brittle
+
+- category: **Cross-platform / I/O** · count: **2** · PRs: [1206] · severity: warning
+- paths: `scripts/release-audit/tests/test_inventory.sh`
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1206#discussion_r3575771614
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1206#discussion_r3575771612
+
+### Unguarded `result.PathItem.path` dereference introduces a new crash path
+
+- category: **Cross-platform / I/O** · count: **2** · PRs: [1246] · severity: warning
+- paths: `WebUI/war/plugins/perc_utils.js`, `WebUI/src/main/webapp/cm/plugins/perc_utils.js`
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1246#discussion_r3585231412
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1246#discussion_r3585231404
+
+### Unreachable <symbol> violates "never null" contract
+
+- category: **Maintainability** · count: **2** · PRs: [1262] · severity: warning
+- paths: `projects/sitemanage/src/main/java/com/percussion/analytics/service/impl/google/PSGoogleAnalyticsProviderHelper.java`
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1262#discussion_r3588423437
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1262#discussion_r3588423433
+
+### "Complexity Tracking table" does not match the template format
+
+- category: **Maintainability** · count: **1** · PRs: [1194] · severity: suggestion
+- paths: `.specify/memory/constitution.md`
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1194#discussion_r3571642945
+
+### <symbol> assumes the test is executed exactly two directory levels below the monorepo root ( `projects/sitemanage` ), relying on <path> .
+
+- category: **Cross-platform / I/O** · count: **1** · PRs: [1247] · severity: suggestion
+- paths: `projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/SocialButtonsXRebrandTest.java`
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1247#discussion_r3585258573
+
+### <symbol> can never catch the `SecurityException` thrown by `validatePath`
+
+- category: **Cross-platform / I/O** · count: **1** · PRs: [1222] · severity: warning
+- paths: `system/src/main/java/com/percussion/process/PSLocalCommandHandler.java`
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1222#discussion_r3582725842
+
+### <symbol> derives the monorepo location from the current working directory ( <symbol> + `../..` ).
+
+- category: **Tests** · count: **1** · PRs: [1236] · severity: suggestion
+- paths: `projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/WidgetRegistryRegistrationDeprecationTest.java`
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1236#discussion_r3584469713
+
+### <symbol> here is unreachable dead code. `checkAndThrowValidationException` always throws (either `PSParametersValidationException` for a `ParseException` , or rethrows the original `e` ), so control never reaches line…
+
+- category: **Maintainability** · count: **1** · PRs: [1250] · severity: suggestion
+- paths: `projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchRestService.java`
+- https://github.com/intersoftdatalabs-in/percussioncms/pull/1250#discussion_r3585394162
+
+## How to promote
+
+```text
+python3 scripts/erlang-harvest-review-patterns.py --apply
+```
+
+Or on Windows:
+
+```text
+scripts\erlang-harvest-review-patterns.bat --apply
+```
+
+Review the diff to `patterns.md` before committing. Harvested bullets are
+marked `_(harvested, seen N×)_` so humans can later rewrite them to cleaner
+principles and drop the marker.
+

--- a/modules/ai-shared-develop/README.md
+++ b/modules/ai-shared-develop/README.md
@@ -44,7 +44,9 @@ Default CodeQL setup must stay **disabled** (`not-configured`). Analyzer of reco
 |-------|------|
 | Canonical agent | `src/main/resources/agents/erlang-code-review.md` |
 | Skill | `src/main/resources/skills/erlang-review/SKILL.md` |
+| Pattern memory | `src/main/resources/skills/erlang-review/patterns.md` |
 | One-shot prompt | `src/main/resources/prompts/erlang-review-uncommitted.md` |
+| Durable reports | repo `docs/ai-generated/code-reviews/` (not `tmp/`) |
 | Kilo workflow | repo `.kilocode/workflows/erlang-review.md` (`/erlang-review`) |
 | Kilo project rule | repo `.kilocode/rules/pre-commit-review.md` |
 | Copilot agent mirror | repo `.github/agents/erlang.agent.md` |
@@ -67,7 +69,11 @@ Paste `prompts/erlang-review-uncommitted.md` or attach `agents/erlang-code-revie
   absolute paths in shared code/tests, etc.). See root `AGENTS.md` → **Cross-Platform File I/O & Paths**
   and the checklist in `agents/erlang-code-review.md`.
 - Recommendation `request-changes` ⇒ do not commit or open/update a PR yet.
-- Optional durable reports go under repo `tmp/reviews/` (gitignored via `tmp/`).
+- Durable reports go under repo `docs/ai-generated/code-reviews/` (not wipeable `tmp/`).
+- Institutional pattern memory: `src/main/resources/skills/erlang-review/patterns.md`.
+- Refresh patterns from Kilo/GitHub PR review history:
+  `python3 scripts/erlang-harvest-review-patterns.py --apply`
+  (see `scripts/README.md`; Windows: `scripts\erlang-harvest-review-patterns.bat`).
 
 ### Not for production
 

--- a/modules/ai-shared-develop/src/main/resources/agents/erlang-code-review.md
+++ b/modules/ai-shared-develop/src/main/resources/agents/erlang-code-review.md
@@ -53,22 +53,59 @@ until fixed. Do not soften this under time pressure.
 - **Not** runtime/AC QA (run tests only to inform findings when needed).
 - **Not** a substitute for human CODEOWNERS approval or CI (CodeQL, etc.).
 
+## Review memory (always)
+
+Basic durable memory — load **before** reading the diff (best-effort; never
+block a review if a file is missing).
+
+1. **Patterns (institutional):** load
+
+   `modules/ai-shared-develop/src/main/resources/skills/erlang-review/patterns.md`
+
+   Watch hard gates and recurring categories that match the change (installer,
+   tests, paths, security). Prefer citing a matched pattern over rediscovering
+   it from scratch.
+
+2. **Prior report (topic continuity):** if a file for this branch/ticket exists
+   under `docs/ai-generated/code-reviews/`, load it. On re-review, verify prior
+   bugs are fixed and append a re-review delta.
+
+3. **Do not** load `tmp/reviews/` as memory. Repo `tmp/` is transient and may be
+   wiped at any time.
+
+After the report, optionally **promote** a generalized hard-gate principle into
+`patterns.md` (one line; no file:line nits; only if it will help future reviews).
+
+To refresh institutional memory from Kilo/GitHub closed-PR review history
+(short-handed default):
+
+```text
+python3 scripts/erlang-harvest-review-patterns.py --apply
+```
+
+Windows: `scripts\erlang-harvest-review-patterns.bat --apply`. See
+`docs/ai-generated/code-reviews/README.md` and `scripts/README.md`.
+
 ## Review loop
 
 ```
-Scope → Diff → Context → Findings → Severity → Recommend → Artifact
+Scope → Memory load → Diff → Context → Findings → Severity → Recommend → Artifact → Memory touch
 ```
 
 1. **Scope** — Local uncommitted, branch vs base (`development` unless stated),
    or PR number? What was the intent?
-2. **Diff** — Collect unified diff and file list. Empty diff → stop: nothing to review.
-3. **Context** — Read surrounding code for changed symbols; load root `AGENTS.md`
+2. **Memory load** — `patterns.md` + prior `docs/ai-generated/code-reviews/*` for topic.
+3. **Diff** — Collect unified diff and file list. Empty diff → stop: nothing to review.
+4. **Context** — Read surrounding code for changed symbols; load root `AGENTS.md`
    and any module `AGENTS.md` / `AGENTS.local.md` for touched paths.
-4. **Findings** — Correctness, regressions, tests, cross-platform path/file I/O,
+5. **Findings** — Correctness, regressions, tests, cross-platform path/file I/O,
    maintainability, conventions, obvious security smells.
-5. **Severity** — `bug` | `suggestion` | `nit` (see taxonomy).
-6. **Recommend** — `approve` | `request-changes` | `abstain` (with reason).
-7. **Artifact** — Structured report (chat and/or file under repo `tmp/reviews/`).
+6. **Severity** — `bug` | `suggestion` | `nit` (see taxonomy).
+7. **Recommend** — `approve` | `request-changes` | `abstain` (with reason).
+8. **Artifact** — Structured report in chat **and** under
+   `docs/ai-generated/code-reviews/` (see Durable artifact).
+9. **Memory touch** — Carefully update `patterns.md` only for new generalized
+   hard-gate / high-signal recurring principles.
 
 ### Severity taxonomy
 
@@ -133,6 +170,7 @@ Flag as **bug** when the change introduces or leaves unfixed:
 | Multi-path lists split/joined with `:` only (or `;` only) | `File.pathSeparator` differs by OS |
 | Path string equality / regex that assumes Unix shapes only (`^/.*`, expected `"a/b/c"` from OS `toString()`) | Windows returns `\` and drive letters |
 | Case-sensitive-only filesystem assumptions (distinct `Foo` vs `foo` in same dir) | Windows / some macOS volumes are case-insensitive |
+| Relying on case-**insensitive** lookup (wrong-cased path/import that works only on Windows) | Linux CI and production often use case-sensitive filesystems |
 | Line-ending assertions that require `\n` only without normalizing `\r\n` | CRLF on Windows fails tests |
 | Product-required automation that is Unix-shell-only with no `.bat`/`.cmd` or Maven/Java entry | Operators and CI on Windows cannot run it |
 | Invoking `/bin/sh` (or POSIX-only tools) in product/test code without a portable alternative | Fails on stock Windows |
@@ -157,14 +195,10 @@ When the diff touches file I/O, paths, installers, packaging, or tests that asse
 paths, **explicitly state in the report** whether the cross-platform checklist
 was applied (even if clean: "Cross-platform path review: no issues").
 
-Common footguns seen in this codebase (flag when present):
-
-- `StringBuilder.append(null)` → literal `"null"` in user-visible strings
-- `Math.random` in security-sensitive or id-generation contexts (prefer secure random)
-- Path injection / XSS / unvalidated user input on server or DOM sinks
-- NPE on new-site / empty optional paths in publish and DTS flows
-- Reflection/tests that break under module-only or Windows checkouts without `assumeTrue`
-- Hardcoded `/` path joins and Unix-only absolute path assertions that fail on Windows CI or customer installs
+Common footguns are maintained in **review memory**
+(`skills/erlang-review/patterns.md`). Always load that file; examples include
+false-green exit codes, structural-only tests, non-portable path joins,
+`StringBuilder.append(null)`, and secrets on process command lines.
 
 ## Report format (required)
 
@@ -178,6 +212,8 @@ Common footguns seen in this codebase (flag when present):
 - Base: <branch or commit>
 - Head: <branch, worktree, or uncommitted>
 - Files: <count> changed
+- Prior report: <path under docs/ai-generated/code-reviews/ or none>
+- Memory patterns hit: <short list or none>
 
 ## Recommendation
 
@@ -195,6 +231,7 @@ approve | request-changes | abstain
 - Description: <what is wrong and impact>
 - Suggestion: <concrete fix>
 - Status: open
+- Pattern-id: <optional e.g. installer.false-green-exit | tests.structural-only | paths.hardcoded-sep>
 
 ### Issue 2 -- Severity: suggestion
 - File: ...
@@ -206,38 +243,74 @@ approve | request-changes | abstain
 If no issues: Summary + Recommendation `approve` + Gate `May commit/push: yes` +
 empty Issues. Do not invent filler findings.
 
-## Durable artifact (recommended)
+## Durable artifact (required when blocking or re-reviewing)
 
-When the human will commit soon, also write:
+Store of record (not `tmp/`):
 
 ```text
-tmp/reviews/YYYYMMDD-HHMM-<branch-or-topic>-erlang.md
+docs/ai-generated/code-reviews/<ticket-or-branch-slug>-erlang.md
 ```
 
-Use the repo `tmp/` directory (never OS temp). Create `tmp/reviews/` if needed.
-The file content is the same report format.
+Create `docs/ai-generated/code-reviews/` if needed. Layout and naming rules:
+`docs/ai-generated/code-reviews/README.md`.
+
+| Situation | Write? |
+|-----------|--------|
+| Gate `request-changes` | **Required** |
+| Re-review after fixes | **Required** — update same file (statuses + `## Re-review`) |
+| Gate `approve` on feature work | **Recommended** |
+| Trivial skip accepted by human | Optional |
+
+File content is the same report format as chat. **Never** write secrets. **Never**
+use `tmp/reviews/` as the store of record (`tmp/` may be wiped anytime).
+
+**Repo-relative paths** in reports, memory, and handoffs always use `/`
+(e.g. `docs/ai-generated/code-reviews/foo-erlang.md`) even when the agent host
+is Windows. Do not write OS-native `\` paths into review artifacts.
 
 ## Collecting the diff (tool-agnostic)
 
+Commands are **git / GitHub CLI** — not bash-specific. Run them in the host
+shell (PowerShell, cmd, Git Bash, or Unix). Avoid bash-only constructs such as
+`2>/dev/null || true` so Windows hosts are not forced into a POSIX shell.
+
 Prefer, in order:
 
-```bash
-# Uncommitted (including staged)
+```text
+# Uncommitted (including staged) — git is required
 git status -sb
 git diff
 git diff --cached
 
-# Branch vs development
-git fetch origin development 2>/dev/null || true
+# Branch vs development — git is required
+git fetch origin development
 git diff origin/development...HEAD
 git log --oneline origin/development..HEAD
 
-# Named PR
+# Named PR — GitHub CLI (gh) is OPTIONAL
+# If gh is installed and authenticated:
 gh pr diff <n>
 gh pr view <n> --json title,body,baseRefName,headRefName,files
+# If gh is missing: use git only (branch vs base above), state in Scope
+# "gh unavailable; reviewed via git diff only", and do not abort the review.
 ```
 
+If `git fetch` fails (offline / no remote), note it and review against the best
+local base available (`development` or `origin/development` if present).
+
 Read full files for non-trivial hunks; do not review only the patch lines.
+
+### Host prerequisites (Windows / Linux / macOS)
+
+| Tool | Required? | Notes |
+|------|-----------|--------|
+| `git` | **Yes** | Git for Windows is fine; agents may use PowerShell or Git Bash |
+| `gh` | No | Needed only for PR-number mode convenience; fall back to `git` |
+| Agent file I/O | **Yes** | Read/write repo files (Kilo, Copilot, Cursor, etc.) |
+
+When suggesting product build/test commands in findings, mention both
+`./mvn-env.sh` and `./mvn-env.bat` (or a Maven/Java entry that works on all
+platforms).
 
 ## Behavioral rules
 
@@ -263,4 +336,5 @@ Read full files for non-trivial hunks; do not review only the patch lines.
 1. Recommendation and gate are explicit.
 2. Every bug has file:line + suggestion.
 3. Author told whether they may commit/push.
-4. Optional: path to `tmp/reviews/...` artifact.
+4. Path to durable report under `docs/ai-generated/code-reviews/` when written.
+5. Patterns loaded; prior topic report loaded on re-review when present.

--- a/modules/ai-shared-develop/src/main/resources/prompts/erlang-review-uncommitted.md
+++ b/modules/ai-shared-develop/src/main/resources/prompts/erlang-review-uncommitted.md
@@ -14,20 +14,34 @@ any module `AGENTS.md` for paths you touch.
 
 **Task:** Review my current work before I commit or open a PR.
 
-1. Run `git status -sb`, `git diff`, `git diff --cached`, and
-   `git diff origin/development...HEAD` (fetch if needed).
-2. Read surrounding code for non-trivial hunks — do not review hunks alone.
-3. Produce the full Erlang report: Summary, Scope, Recommendation, Gate, Issues
+1. **Review memory:** Load
+   `modules/ai-shared-develop/src/main/resources/skills/erlang-review/patterns.md`.
+   If a prior report for this topic exists under
+   `docs/ai-generated/code-reviews/`, load it. Do not use `tmp/reviews/` as memory.
+2. Collect the diff with **git** (host shell may be PowerShell, cmd, or bash —
+   avoid bash-only redirects). Run: `git status -sb`, `git diff`,
+   `git diff --cached`, `git fetch origin development`, then
+   `git diff origin/development...HEAD`. `gh` is optional (PR-number mode only);
+   if `gh` is missing, continue with git and note that in Scope.
+3. Read surrounding code for non-trivial hunks — do not review hunks alone.
+4. Produce the full Erlang report: Summary, Scope, Recommendation, Gate, Issues
    with severity `bug` | `suggestion` | `nit`, each with file:line and suggestion.
-4. **Strict gate:** any bug, missing behavioral tests for new/changed non-trivial
+   Include Prior report / Memory patterns hit in Scope when applicable.
+   Use **repo-relative paths with `/`** in the report even on Windows hosts.
+5. **Strict gate:** any bug, missing behavioral tests for new/changed non-trivial
    logic, or non-portable path/file I/O (hardcoded `/` or `\` joins, Unix-only
-   absolutes, `:`-only path lists, Windows-only path assertions, CRLF-fragile
-   tests, Unix-only required scripts) → `request-changes` and
-   **May commit/push: no**. Prefer `Path` / `Files` / `File.separator` /
-   `File.pathSeparator`.
-5. If the diff touches file I/O or path assertions, state "Cross-platform path
+   absolutes, Windows-only `C:\…` paths, case-sensitive **or** case-insensitive
+   path assumptions, `:`-only path lists, CRLF-fragile tests, Unix-only required
+   scripts) → `request-changes` and **May commit/push: no**. Prefer `Path` /
+   `Files` / `File.separator` / `File.pathSeparator`.
+6. If the diff touches file I/O or path assertions, state "Cross-platform path
    review: …" in the report (even when clean).
-6. Optionally write the report to `tmp/reviews/YYYYMMDD-HHMM-<topic>-erlang.md`.
-7. Do **not** implement fixes unless I explicitly ask after the report.
+7. **Write** the report to
+   `docs/ai-generated/code-reviews/<ticket-or-branch-slug>-erlang.md`
+   (required on `request-changes` or re-review; recommended on approve for
+   feature work). See `docs/ai-generated/code-reviews/README.md`.
+8. Optionally promote a generalized hard-gate principle into
+   `skills/erlang-review/patterns.md` if this review revealed a recurring pattern.
+9. Do **not** implement fixes unless I explicitly ask after the report.
 
 Start now.

--- a/modules/ai-shared-develop/src/main/resources/skills/erlang-review/SKILL.md
+++ b/modules/ai-shared-develop/src/main/resources/skills/erlang-review/SKILL.md
@@ -5,7 +5,8 @@ description: >-
   Use when the user says "Erlang", "review my changes", "pre-commit review",
   "pre-PR review", "strict review", or before git commit / gh pr create.
   Independent review only; blocks on bugs, missing behavioral tests, and
-  non-portable (Windows/Unix) file path handling.
+  non-portable (Windows/Unix) file path handling. Loads review memory and
+  writes durable reports under docs/ai-generated/code-reviews/.
 ---
 
 # Erlang Review Skill
@@ -31,22 +32,52 @@ Cross-platform path rules (product): root `AGENTS.md` → **Cross-Platform File 
 ## Steps
 
 1. **Load** `agents/erlang-code-review.md` (this module) and root `AGENTS.md`.
-2. **Determine scope** (ask only if unclear):
+2. **Review memory (always, best-effort):**
+   - Load `skills/erlang-review/patterns.md` (this directory) — institutional patterns.
+   - If a prior report for this topic exists under
+     `docs/ai-generated/code-reviews/`, load it (re-review continuity).
+   - Do **not** treat `tmp/reviews/` as authoritative (`tmp/` is wipeable).
+3. **Determine scope** (ask only if unclear):
    - default: uncommitted + unstaged vs `HEAD`, plus commits not in `origin/development`
    - or: explicit PR number / branch
-3. **Collect diff** (see agent file for commands).
-4. **Read context** for changed symbols; apply module `AGENTS.md` when present.
-5. **Produce** the required report (Summary, Recommendation, Gate, Issues).
-6. **Write** optional durable copy under `tmp/reviews/` (repo temp, not OS temp).
-7. **Gate language (strict)**:
+4. **Collect diff** (see agent file). Use portable **git** commands (not
+   bash-only `2>/dev/null || true`). Host shell may be PowerShell, cmd, Git Bash,
+   or Unix. **`gh` is optional** — if missing, review via git and note in Scope.
+5. **Read context** for changed symbols; apply module `AGENTS.md` when present.
+6. **Produce** the required report (Summary, Recommendation, Gate, Issues).
+   Note memory patterns that applied when useful (`Memory patterns hit: …`).
+   Write **repo-relative paths with `/`** even on Windows hosts.
+7. **Write durable report** under:
+
+   ```text
+   docs/ai-generated/code-reviews/<ticket-or-branch-slug>-erlang.md
+   ```
+
+   Create the directory if needed. See `docs/ai-generated/code-reviews/README.md`.
+   - **Required** when gate is `request-changes` or this is a re-review.
+   - **Recommended** on approve for feature work.
+   - On re-review: update the same file (statuses + `## Re-review` section).
+8. **Pattern memory touch (optional, careful):** if this review found **bugs** or
+   high-signal suggestions that generalize beyond this task, append or reinforce
+   a one-line principle in `patterns.md` (no file:line nits; keep the file short).
+   Periodically refresh institutional memory from Kilo/GitHub history:
+
+   ```text
+   python3 scripts/erlang-harvest-review-patterns.py --apply
+   ```
+
+   (Windows: `scripts\erlang-harvest-review-patterns.bat --apply`.) Review the
+   candidates report under `docs/ai-generated/code-reviews/` before relying on
+   newly harvested bullets.
+9. **Gate language (strict)**:
    - If any **bug** (including missing behavioral tests for non-trivial logic,
      or non-portable path/file I/O that breaks Windows or Unix):
      `request-changes` and **May commit/push: no**
    - Else if only nits/low suggestions: `approve` allowed
-8. When the diff touches file I/O, paths, installers, packaging, or path
-   assertions in tests: apply Erlang's **cross-platform path checklist** and
-   state the outcome in the report (even if clean).
-9. **Do not implement** fixes unless the user asks after the report.
+10. When the diff touches file I/O, paths, installers, packaging, or path
+    assertions in tests: apply Erlang's **cross-platform path checklist** and
+    state the outcome in the report (even if clean).
+11. **Do not implement** fixes unless the user asks after the report.
 
 ## Kilo-first invocation
 
@@ -60,6 +91,8 @@ In Kilo Code:
 ## Related instructions
 
 - Root `AGENTS.md` — **Cross-Platform File I/O & Paths**
+- `docs/ai-generated/code-reviews/README.md` — durable report store
+- `skills/erlang-review/patterns.md` — review pattern memory
 - `instructions/code-review-generic.instructions.md`
 - `instructions/security-and-owasp.instructions.md`
 - `instructions/java-coding-standards.md` (prefer `java.nio.file.Files` / `Path`)

--- a/modules/ai-shared-develop/src/main/resources/skills/erlang-review/patterns.md
+++ b/modules/ai-shared-develop/src/main/resources/skills/erlang-review/patterns.md
@@ -1,0 +1,107 @@
+# Erlang review patterns (Percussion CMS)
+
+> **Institutional review memory.** Loaded at the start of every Erlang review.
+> Keep entries **generalized** (no one-off file:line noise). Promote only
+> hard gates and high-signal recurring findings.
+>
+> Full reports live under `docs/ai-generated/code-reviews/` (not `tmp/`).
+>
+> Auto-harvest: `scripts/erlang-harvest-review-patterns.py` (see `--apply`).
+
+## Hard gates (always scan)
+
+- Missing **behavioral** unit tests for new/changed non-trivial logic
+- Tests that only grep source strings / assert tokens without exercising behavior
+- Non-portable filesystem path joins (`"/"` or `"\\"` concatenation) — use `Path` / `Files`
+- Unix-only absolute roots (`/tmp`, `/var`, `/home`, …) or Windows-only `C:\…` in shared code/tests
+- Multi-path lists split/joined with `:` or `;` only — use `File.pathSeparator`
+- Path string equality / regex that assumes Unix shapes only (`^/.*`, raw `/` from OS `toString()`)
+- Relying on case-insensitive path/import lookup (works on Windows, fails on Linux CI)
+- Line-ending assertions that require `\n` only without normalizing `\r\n`
+- Product-required automation that is Unix-shell-only with no `.bat`/`.cmd` or Maven/Java entry
+- Secrets, passwords, tokens in code, tests, logs, or committed fixtures
+- Empty catch / swallowed exceptions without log or justified ignore (user-facing → bug)
+- False green: process or API reports success when child work failed (ignored exit codes / return values)
+- Path containment / “safe path” checks must use a trusted root, not a parent derived from untrusted input
+- Filename-only sanitizers are not path-traversal protection when callers pass full paths
+- Duplicate method declarations (or other changes that prevent compilation) are hard bugs
+
+## Recurring findings
+
+### Installer / Ant / distribution
+
+- Premature `Class.forName` (or similar) that bypasses InstallUtil custom JDBC/driver loader paths
+- Outer preinstall / wrapper `Main` ignores Ant or child `processCode` → install fails in logs but process exits 0
+- Upgrade vs clean-install gates (`do.install` and similar) missing or only structural string tests
+- Maven `exec-maven-plugin` `<systemProperty>` must use `<name>`, not `<key>` (wrong element is a silent misconfig)
+
+### Tests
+
+- Structural / registry / XML string presence treated as sole proof of runtime behavior
+- Happy-path-only coverage for validation, connect-failure, or security rejection paths
+- Vacuous assertions (`message != null || cause != null`) that any exception would pass
+- Tests that only assert “something was thrown” without SSRF/validation keywords are too weak for security helpers
+- Tests must not depend on uncommitted fixtures or wrong absolute/base directories for path-safety cases
+
+### Security / config
+
+- Passwords or secrets on process command lines (`-D…`) instead of temp file (mode-restricted) or env
+- SSRF / path / LDAP sanitizers without behavioral tests on rejection paths
+- Broad whole-file CodeQL path excludes without documenting residual risk and runtime tests
+
+### Cross-platform / I/O
+
+- Hardcoded `/` path joins and Unix-only absolute path assertions that fail on Windows CI or installs
+- Wrong-cased paths or imports that only pass on case-insensitive volumes (Windows / some macOS)
+- Reflection or environment assumptions that break under module-only or Windows checkouts without `assumeTrue`
+- Public helper Javadoc that contradicts implementation (e.g. nullability / parse contracts) misleads callers
+
+### Maintainability
+
+- `StringBuilder.append(null)` → literal `"null"` in user-visible strings
+- `Math.random` in security-sensitive or id-generation contexts (prefer secure random)
+- Multi-copy shared WebUI / package assets edited in only one of several lockstep paths
+- Orphaned javadoc left above renamed/extracted methods
+- Logging that interpolates nullable returns without guards (NPE / `"null"` in logs)
+- Swallowed exceptions that can mask broken-tree or partial-write state
+
+## False-positive guards (do not flag)
+
+- URL, URI, classpath resource, and ZIP entry paths that correctly use `/`
+- Documentation examples that clearly describe one OS (still prefer portable samples)
+- Intentional OS-specific branches behind `os.name` / `File.separator` with both sides covered
+
+## How to update this file
+
+### Automated (preferred when short-handed)
+
+From the repo root (needs `gh` auth + network):
+
+```text
+# Full candidate report (always useful; safe)
+python3 scripts/erlang-harvest-review-patterns.py
+
+# Merge multi-PR themes into this file (default --apply path)
+python3 scripts/erlang-harvest-review-patterns.py --apply
+
+# Also merge single-PR CRITICAL hard-gate themes (noisier)
+python3 scripts/erlang-harvest-review-patterns.py --apply --promote-critical
+
+# Windows
+scripts\erlang-harvest-review-patterns.bat --apply
+```
+
+best ones into permanent plain principles and drop the marker; re-run harvest
+dedups against existing text.
+
+Full workflow notes: `docs/ai-generated/code-reviews/README.md`.
+
+### Manual
+
+After a review with **bugs** or high-signal suggestions that generalize beyond
+the current task:
+
+1. Strip file names, ticket IDs, and one-off API names.
+2. Add or reinforce a one-line principle under the right category.
+3. Do **not** dump nits or every issue from the report.
+4. Keep the briefing short (hard gates + ~15–40 recurring lines total is plenty).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,6 +21,43 @@ Fetch code scanning (CodeQL) alerts for a repository using the `gh` CLI and writ
   - Pagination is handled automatically (`--paginate`, `per_page=100`).
   - For the `004-zero-code-scanning-alerts` workflow, use this script to (re)generate `alerts.md`, then seed/triage `triage.md` per `specs/004-zero-code-scanning-alerts/contracts/README.md` C1.
 
+### `erlang-harvest-review-patterns.py` (+ `.sh` / `.bat`)
+
+Harvest GitHub PR **line review comments** (including closed/merged PRs) from
+`kilo-code-bot[bot]` (and optional other authors), cluster them into generalized
+themes, write a candidate report, and optionally auto-merge multi-PR themes into
+Erlang review pattern memory.
+
+- **Purpose**: Keep Erlang's institutional review memory (`patterns.md`) fed from
+  real Kilo/GitHub review history without hand-copying every comment. Short-handed
+  teams re-run this instead of maintaining patterns only by hand.
+- **Usage** (repo root; needs `gh auth login` + network):
+  ```text
+  # Candidates only (safe default)
+  python3 scripts/erlang-harvest-review-patterns.py
+  # or: scripts/erlang-harvest-review-patterns.sh
+  # or: scripts\erlang-harvest-review-patterns.bat
+
+  # Merge multi-PR themes into patterns.md
+  python3 scripts/erlang-harvest-review-patterns.py --apply
+
+  # Also promote single-PR CRITICAL hard-gate themes (noisier)
+  python3 scripts/erlang-harvest-review-patterns.py --apply --promote-critical
+  ```
+- **Outputs**:
+  - `docs/ai-generated/code-reviews/harvest-candidates-YYYY-MM-DD.md` — full cluster report + evidence links
+  - With `--apply`: appends selected bullets to
+    `modules/ai-shared-develop/src/main/resources/skills/erlang-review/patterns.md`
+    (marked `_(harvested, seen N×)_`)
+- **Prereqs**: Python 3.9+, `gh` CLI authenticated. No `jq` required (Python parses JSON).
+- **Cross-platform**: Python core; Unix wrapper `.sh` and Windows wrapper `.bat`.
+- **Tests**: `python3 scripts/test_erlang_harvest_review_patterns.py` (offline; uses `--fixture`).
+- **Notes**:
+  - Default authors: `kilo-code-bot[bot]`. Options: `--include-security-bots`, `--include-humans`.
+  - Default `--apply` promotes **multi-PR** themes only (count ≥ 2 and ≥ 2 distinct PRs).
+  - Mitigation / reply threads are skipped (`in_reply_to_id`).
+  - Review the candidates report (and the patterns.md diff) before committing.
+
 ### Other scripts in this directory
 
 - `authenticate-sigstore.sh` — sigstore / cosign authentication helper for artifact verification.
@@ -66,6 +103,7 @@ the "good" fixture is the expected clean state.
 
 ## Conventions
 
-- All scripts in this directory MUST be POSIX `sh` or `bash`, set `-euo pipefail`, and document purpose + usage in this README.
+- Prefer portable entry points: POSIX `sh`/`bash` **and** Windows `.bat` when operators need both, or a single Python/Java tool with thin wrappers (see `erlang-harvest-review-patterns`).
+- Shell scripts MUST set `-euo pipefail` (or `set -eu` for pure `sh`) and document purpose + usage in this README.
 - Scripts MUST NOT write to `%TEMP%` or `$TMPDIR`; use `./tmp` for scratch.
 - Scripts MUST NOT invent third-party APIs or extension points — see root AGENTS.md "Evidence Over Invention".

--- a/scripts/erlang-harvest-review-patterns.bat
+++ b/scripts/erlang-harvest-review-patterns.bat
@@ -1,0 +1,20 @@
+@echo off
+REM Windows entry: harvest Kilo/GitHub review comments into Erlang pattern memory.
+SETLOCAL
+SET "ROOT=%~dp0.."
+cd /d "%ROOT%"
+
+where python >nul 2>&1
+IF %ERRORLEVEL%==0 (
+  python "%ROOT%\scripts\erlang-harvest-review-patterns.py" %*
+  EXIT /B %ERRORLEVEL%
+)
+
+where python3 >nul 2>&1
+IF %ERRORLEVEL%==0 (
+  python3 "%ROOT%\scripts\erlang-harvest-review-patterns.py" %*
+  EXIT /B %ERRORLEVEL%
+)
+
+echo erlang-harvest: python/python3 not found on PATH 1>&2
+EXIT /B 1

--- a/scripts/erlang-harvest-review-patterns.py
+++ b/scripts/erlang-harvest-review-patterns.py
@@ -1,0 +1,1115 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Harvest GitHub PR review comments into Erlang review pattern memory.
+
+Cross-platform (Windows / Linux / macOS). Requires:
+  - Python 3.9+
+  - GitHub CLI ``gh`` authenticated (``gh auth login``)
+  - Network access to the GitHub API for the target repo
+
+Default flow:
+  1. Fetch pull-request **line review comments** (includes closed/merged PRs).
+  2. Keep top-level comments from configured bots (default: kilo-code-bot).
+  3. Generalize bodies, cluster similar themes, categorize.
+  4. Write a candidate report under ``docs/ai-generated/code-reviews/``.
+  5. With ``--apply``, auto-merge high-count themes into
+     ``modules/ai-shared-develop/.../skills/erlang-review/patterns.md``.
+
+Does not call OS temp dirs; optional scratch only under repo ``tmp/`` if needed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.parse
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+
+# ---------------------------------------------------------------------------
+# Defaults / constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_AUTHORS = (
+    "kilo-code-bot[bot]",
+    "kilo-code-bot",
+)
+
+# Optional extra bots when --include-security-bots
+SECURITY_BOT_AUTHORS = (
+    "github-advanced-security[bot]",
+    "copilot-pull-request-reviewer[bot]",
+    "Copilot",
+)
+
+SEVERITY_ALIASES = {
+    "CRITICAL": "critical",
+    "ERROR": "critical",
+    "BUG": "critical",
+    "WARNING": "warning",
+    "WARN": "warning",
+    "SUGGESTION": "suggestion",
+    "NIT": "nit",
+    "INFO": "nit",
+    "NOTE": "nit",
+    "QUESTION": "suggestion",
+}
+
+# Minimum token overlap (Jaccard) to treat two generalized lines as the same cluster
+CLUSTER_JACCARD = 0.45
+
+# Categories under "## Recurring findings" in patterns.md
+CATEGORY_RULES: list[tuple[str, tuple[str, ...]]] = [
+    (
+        "Installer / Ant / distribution",
+        (
+            "install",
+            "installer",
+            "ant ",
+            "preinstall",
+            "jdbc",
+            "class.forname",
+            "do.install",
+            "distribution",
+            "processcode",
+            "system.exit",
+            "repository",
+        ),
+    ),
+    (
+        "Tests",
+        (
+            "test",
+            "assert",
+            "junit",
+            "mockito",
+            "coverage",
+            "aftereach",
+            "beforeeach",
+            "fixture",
+            "happy path",
+            "unit test",
+        ),
+    ),
+    (
+        "Security / config",
+        (
+            "password",
+            "secret",
+            "token",
+            "ssrf",
+            "xss",
+            "injection",
+            "ldap",
+            "auth",
+            "allowlist",
+            "blocklist",
+            "sanitiz",
+            "credential",
+            "codeql",
+        ),
+    ),
+    (
+        "Cross-platform / I/O",
+        (
+            "path",
+            "file.separator",
+            "pathseparator",
+            "windows",
+            "unix",
+            "linux",
+            "crlf",
+            "line ending",
+            "toabsolutepath",
+            "getabsolutefile",
+            "nio.file",
+            "hardcoded",
+            "case-insensit",
+            "case sensit",
+        ),
+    ),
+    (
+        "Maintainability",
+        (
+            "duplicate",
+            "dead code",
+            "javadoc",
+            "typo",
+            "naming",
+            "unused",
+            "redundant",
+            "license",
+            "stringbuilder",
+            "null",
+        ),
+    ),
+]
+
+HARD_GATE_HINTS = (
+    "missing test",
+    "no test",
+    "unit test",
+    "behavioral",
+    "path join",
+    "hardcoded",
+    "file.separator",
+    "process exit",
+    "system.exit",
+    "swallowed",
+    "empty catch",
+    "secret",
+    "password",
+    "ssrf",
+    "false green",
+    "compile",
+    "does not compile",
+    "prevents compilation",
+)
+
+SKIP_BODY_PREFIXES = (
+    "**mitigation",
+    "mitigation",
+    "**fixed",
+    "fixed in",
+    "addressed in",
+    "lgtm",
+    "nit:",
+)
+
+
+# ---------------------------------------------------------------------------
+# Data
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RawComment:
+    id: int
+    user: str
+    body: str
+    path: str
+    pr_number: Optional[int]
+    created_at: str
+    html_url: str
+    in_reply_to_id: Optional[int]
+
+
+@dataclass
+class Cluster:
+    key: str
+    principle: str
+    category: str
+    severity_counts: Counter = field(default_factory=Counter)
+    count: int = 0
+    prs: set[int] = field(default_factory=set)
+    sample_urls: list[str] = field(default_factory=list)
+    sample_paths: list[str] = field(default_factory=list)
+    hard_gate_hint: bool = False
+
+    def dominant_severity(self) -> str:
+        if not self.severity_counts:
+            return "suggestion"
+        return self.severity_counts.most_common(1)[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Repo / gh helpers
+# ---------------------------------------------------------------------------
+
+
+def find_repo_root(start: Optional[Path] = None) -> Path:
+    cur = (start or Path.cwd()).resolve()
+    for p in [cur, *cur.parents]:
+        if (p / ".git").exists() and (p / "AGENTS.md").exists():
+            return p
+        if (p / ".git").is_file() and (p / "AGENTS.md").exists():
+            return p
+    # Fallback: cwd if it looks like the monorepo
+    if (cur / "modules" / "ai-shared-develop").is_dir():
+        return cur
+    raise SystemExit(
+        "erlang-harvest: cannot find repo root (looked for AGENTS.md + .git). "
+        "Run from the percussioncms checkout."
+    )
+
+
+def run_gh_json(args: list[str], *, timeout: int = 120) -> Any:
+    cmd = ["gh", *args]
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as e:
+        raise SystemExit(
+            "erlang-harvest: `gh` (GitHub CLI) not found on PATH. "
+            "Install from https://cli.github.com/ and run `gh auth login`."
+        ) from e
+    except subprocess.TimeoutExpired as e:
+        raise SystemExit(f"erlang-harvest: gh timed out: {' '.join(cmd)}") from e
+
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip()
+        raise SystemExit(
+            f"erlang-harvest: gh failed ({proc.returncode}): {err or 'no stderr'}\n"
+            f"  command: {' '.join(cmd)}"
+        )
+    text = proc.stdout.strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as e:
+        raise SystemExit(
+            f"erlang-harvest: invalid JSON from gh: {e}\n  first 200 chars: {text[:200]!r}"
+        ) from e
+
+
+def detect_repo_slug(explicit: Optional[str]) -> str:
+    if explicit:
+        return explicit
+    env = os.environ.get("GH_REPO") or os.environ.get("GITHUB_REPOSITORY")
+    if env and "/" in env:
+        return env
+    data = run_gh_json(
+        ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]
+    )
+    if isinstance(data, str) and "/" in data:
+        return data
+    # gh -q may return raw string without JSON quotes when using -q
+    # run_gh_json expects JSON; handle plain string via subprocess fallback
+    proc = subprocess.run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if proc.returncode == 0 and "/" in (proc.stdout or ""):
+        return proc.stdout.strip().strip('"')
+    raise SystemExit(
+        "erlang-harvest: cannot detect owner/repo. Pass --repo owner/name "
+        "or set GH_REPO / run inside a gh-aware git checkout."
+    )
+
+
+def fetch_all_pull_comments(repo: str, max_pages: int = 50) -> list[dict[str, Any]]:
+    """Fetch all PR review comments (open + closed PRs)."""
+    items: list[dict[str, Any]] = []
+    page = 1
+    per_page = 100
+    while page <= max_pages:
+        path = (
+            f"repos/{repo}/pulls/comments"
+            f"?per_page={per_page}&page={page}&sort=created&direction=desc"
+        )
+        batch = run_gh_json(["api", path], timeout=180)
+        if not batch:
+            break
+        if not isinstance(batch, list):
+            raise SystemExit(f"erlang-harvest: unexpected API shape: {type(batch)}")
+        items.extend(batch)
+        if len(batch) < per_page:
+            break
+        page += 1
+    return items
+
+
+def pr_number_from_url(url: str) -> Optional[int]:
+    if not url:
+        return None
+    m = re.search(r"/pulls/(\d+)", url)
+    return int(m.group(1)) if m else None
+
+
+# ---------------------------------------------------------------------------
+# Text processing
+# ---------------------------------------------------------------------------
+
+
+_SEVERITY_RE = re.compile(
+    r"^\s*(?:\*\*)?\[?(CRITICAL|ERROR|BUG|WARNING|WARN|SUGGESTION|NIT|INFO|NOTE|QUESTION)\]?"
+    r"(?:\*\*)?\s*[:\-—–]\s*",
+    re.IGNORECASE,
+)
+
+_CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`]+`")
+_PATH_RE = re.compile(
+    r"(?:[A-Za-z]:)?(?:[\\/][\w.\-]+)+\.\w+|(?:[\w.\-]+/)+[\w.\-]+\.\w+"
+)
+_LINE_RE = re.compile(r"\blines?\s+\d+(?:\s*[-–—]\s*\d+)?\b", re.IGNORECASE)
+_LINE_COLON_RE = re.compile(r":\d{1,5}\b")
+_PR_RE = re.compile(r"\bPR\s*#?\d+\b", re.IGNORECASE)
+_ISSUE_RE = re.compile(r"\b(?:issue|ticket)\s*#?\d+\b", re.IGNORECASE)
+_COMMIT_RE = re.compile(r"\b[0-9a-f]{7,40}\b")
+_MULTI_SPACE_RE = re.compile(r"\s+")
+_TOKEN_RE = re.compile(r"[a-z0-9]{3,}")
+
+
+def extract_severity(body: str) -> tuple[str, str]:
+    """Return (severity, body_without_prefix)."""
+    if not body:
+        return "suggestion", ""
+    first, _, rest = body.strip().partition("\n")
+    m = _SEVERITY_RE.match(first)
+    if m:
+        sev = SEVERITY_ALIASES.get(m.group(1).upper(), "suggestion")
+        remainder = first[m.end() :].strip()
+        if rest:
+            remainder = (remainder + "\n" + rest).strip()
+        return sev, remainder
+    return "suggestion", body.strip()
+
+
+def generalize_body(body: str) -> str:
+    """Strip one-off detail into a reusable one-line principle."""
+    if not body:
+        return ""
+    text = body.strip()
+    text = _CODE_FENCE_RE.sub(" <code> ", text)
+    # Prefer first non-empty paragraph / sentence block
+    text = text.split("\n\n")[0]
+    text = text.replace("\n", " ")
+    text = _INLINE_CODE_RE.sub(lambda m: _simplify_inline_code(m.group(0)), text)
+    text = _PATH_RE.sub("<path>", text)
+    text = _LINE_RE.sub("line N", text)
+    text = _LINE_COLON_RE.sub("", text)
+    text = _PR_RE.sub("<pr>", text)
+    text = _ISSUE_RE.sub("<issue>", text)
+    text = _COMMIT_RE.sub("<commit>", text)
+    text = _MULTI_SPACE_RE.sub(" ", text).strip()
+    # Strip leftover markdown bold / emphasis wrappers
+    text = re.sub(r"^\*+\s*", "", text)
+    text = re.sub(r"\*+$", "", text)
+    text = text.replace("**", "").replace("__", "")
+    text = text.strip(" -–—:;")
+    # Drop unusable placeholder-only noise
+    if text.count("<symbol>") >= 2 and len(tokenize(text)) < 6:
+        return ""
+    # Truncate long principles
+    if len(text) > 220:
+        # cut at sentence if possible
+        cut = text[:220]
+        for sep in (". ", "; ", " — ", " - "):
+            idx = cut.rfind(sep)
+            if idx >= 80:
+                text = cut[: idx + 1].strip()
+                break
+        else:
+            text = cut.rsplit(" ", 1)[0] + "…"
+    # Ensure it reads as a principle, not a command to the author of one PR
+    text = re.sub(r"^(please|kindly|you should|you must)\s+", "", text, flags=re.I)
+    return text.strip()
+
+
+def _simplify_inline_code(token: str) -> str:
+    inner = token.strip("`")
+    if not inner:
+        return " "
+    # Keep short API tokens; scrub long expressions
+    if len(inner) > 48 or " " in inner or "(" in inner:
+        if re.search(r"[\\/]", inner):
+            return " <path> "
+        if re.search(r"test|assert|mock", inner, re.I):
+            return " <test-symbol> "
+        return " <symbol> "
+    return f" `{inner}` "
+
+
+def tokenize(text: str) -> set[str]:
+    return set(_TOKEN_RE.findall(text.lower()))
+
+
+def jaccard(a: set[str], b: set[str]) -> float:
+    if not a or not b:
+        return 0.0
+    inter = len(a & b)
+    union = len(a | b)
+    return inter / union if union else 0.0
+
+
+def categorize(principle: str, path: str = "") -> str:
+    blob = f"{principle} {path}".lower()
+    scores: list[tuple[int, str]] = []
+    for name, kws in CATEGORY_RULES:
+        score = sum(1 for kw in kws if kw in blob)
+        if score:
+            scores.append((score, name))
+    if not scores:
+        return "Maintainability"
+    scores.sort(key=lambda x: (-x[0], x[1]))
+    return scores[0][1]
+
+
+def looks_like_hard_gate(principle: str, severity: str) -> bool:
+    if severity == "critical":
+        return True
+    low = principle.lower()
+    return any(h in low for h in HARD_GATE_HINTS)
+
+
+def should_skip_body(body: str) -> bool:
+    if not body or not body.strip():
+        return True
+    low = body.strip().lower()
+    return any(low.startswith(p) for p in SKIP_BODY_PREFIXES)
+
+
+# ---------------------------------------------------------------------------
+# Parse / cluster / merge
+# ---------------------------------------------------------------------------
+
+
+def parse_comments(
+    raw_items: Iterable[dict[str, Any]],
+    authors: set[str],
+) -> list[RawComment]:
+    out: list[RawComment] = []
+    authors_l = {a.lower() for a in authors}
+    for item in raw_items:
+        user = ((item.get("user") or {}).get("login")) or ""
+        if user.lower() not in authors_l:
+            continue
+        if item.get("in_reply_to_id"):
+            # Skip thread replies (mitigations, follow-ups)
+            continue
+        body = item.get("body") or ""
+        if should_skip_body(body):
+            continue
+        out.append(
+            RawComment(
+                id=int(item.get("id") or 0),
+                user=user,
+                body=body,
+                path=item.get("path") or "",
+                pr_number=pr_number_from_url(item.get("pull_request_url") or ""),
+                created_at=item.get("created_at") or "",
+                html_url=item.get("html_url") or "",
+                in_reply_to_id=item.get("in_reply_to_id"),
+            )
+        )
+    return out
+
+
+def cluster_comments(comments: list[RawComment]) -> list[Cluster]:
+    clusters: list[Cluster] = []
+    # Each cluster keeps a token set for matching
+    cluster_tokens: list[set[str]] = []
+
+    for c in comments:
+        sev, rest = extract_severity(c.body)
+        principle = generalize_body(rest)
+        if len(principle) < 24:
+            continue
+        # Drop pure praise / empty generalizations
+        if principle.lower() in {"looks good", "lgtm", "nice", "thanks"}:
+            continue
+        if principle.startswith("<") and principle.count("<") >= 2:
+            # Mostly placeholders — low value as institutional memory
+            if len(tokenize(re.sub(r"<[^>]+>", " ", principle))) < 4:
+                continue
+        toks = tokenize(principle)
+        if len(toks) < 3:
+            continue
+
+        matched_idx: Optional[int] = None
+        best = 0.0
+        for i, ct in enumerate(cluster_tokens):
+            score = jaccard(toks, ct)
+            if score >= CLUSTER_JACCARD and score > best:
+                best = score
+                matched_idx = i
+
+        if matched_idx is None:
+            cat = categorize(principle, c.path)
+            cl = Cluster(
+                key=principle.lower()[:80],
+                principle=principle,
+                category=cat,
+                hard_gate_hint=looks_like_hard_gate(principle, sev),
+            )
+            cl.severity_counts[sev] += 1
+            cl.count = 1
+            if c.pr_number:
+                cl.prs.add(c.pr_number)
+            if c.html_url and len(cl.sample_urls) < 5:
+                cl.sample_urls.append(c.html_url)
+            if c.path and c.path not in cl.sample_paths and len(cl.sample_paths) < 5:
+                cl.sample_paths.append(c.path)
+            clusters.append(cl)
+            cluster_tokens.append(toks)
+        else:
+            cl = clusters[matched_idx]
+            cl.count += 1
+            cl.severity_counts[sev] += 1
+            cl.hard_gate_hint = cl.hard_gate_hint or looks_like_hard_gate(
+                principle, sev
+            )
+            if c.pr_number:
+                cl.prs.add(c.pr_number)
+            if c.html_url and len(cl.sample_urls) < 5:
+                cl.sample_urls.append(c.html_url)
+            if c.path and c.path not in cl.sample_paths and len(cl.sample_paths) < 5:
+                cl.sample_paths.append(c.path)
+            # Prefer longer principle if current is short
+            if len(principle) > len(cl.principle) and len(principle) <= 220:
+                cl.principle = principle
+            cluster_tokens[matched_idx] = cluster_tokens[matched_idx] | toks
+
+    clusters.sort(key=lambda c: (-c.count, -len(c.prs), c.principle.lower()))
+    return clusters
+
+
+def parse_patterns_bullets(patterns_text: str) -> set[str]:
+    """Normalized existing bullet texts for dedup."""
+    found: set[str] = set()
+    for line in patterns_text.splitlines():
+        s = line.strip()
+        if s.startswith("- "):
+            found.add(_norm_principle(s[2:]))
+    return found
+
+
+def _norm_principle(text: str) -> str:
+    t = text.lower().strip()
+    t = re.sub(r"\(seen\s+\d+[×x]?.*?\)\s*$", "", t).strip()
+    t = re.sub(r"\s+", " ", t)
+    return t
+
+
+def principles_similar(a: str, b: str, threshold: float = 0.5) -> bool:
+    return jaccard(tokenize(a), tokenize(b)) >= threshold
+
+
+def is_promotable(
+    cl: Cluster,
+    *,
+    min_count: int,
+    min_prs: int,
+    promote_critical: bool = False,
+) -> bool:
+    """True if cluster is frequent enough (or optional critical hard-gate).
+
+    Default automation path: multi-PR recurrence only. Single-PR CRITICAL themes
+    require ``promote_critical=True`` (``--promote-critical``) so patterns.md
+    stays short without a human first pass on the candidates report.
+    """
+    # Strong signal: same theme across multiple PRs (primary automation path)
+    if len(cl.prs) >= min_prs and cl.count >= max(min_count, 2):
+        # Drop placeholder-heavy principles even if multi-PR
+        if cl.principle.count("<symbol>") >= 2:
+            return False
+        return True
+    # Optional: single-PR critical hard gates (noisier; opt-in)
+    if (
+        promote_critical
+        and cl.hard_gate_hint
+        and cl.dominant_severity() == "critical"
+        and cl.count >= 1
+        and _critical_hard_gate_ok(cl.principle)
+        and cl.principle.count("<symbol>") < 2
+    ):
+        return True
+    return False
+
+
+def _critical_hard_gate_ok(principle: str) -> bool:
+    """Avoid promoting one-off CRITICAL noise (typos, copyright, dependabot counts)."""
+    low = principle.lower()
+    block = (
+        "copyright",
+        "dependabot count",
+        "commit message",
+        "typo",
+        "aria-label",
+        "year regression",
+    )
+    if any(b in low for b in block):
+        return False
+    allow = (
+        "compil",
+        "path",
+        "travers",
+        "ssrf",
+        "inject",
+        "secret",
+        "password",
+        "null",
+        "npe",
+        "test",
+        "exit",
+        "securityexception",
+        "false green",
+        "systemproperty",
+        "separator",
+    )
+    return any(a in low for a in allow)
+
+
+def select_for_apply(
+    clusters: list[Cluster],
+    *,
+    min_count: int,
+    min_prs: int,
+    existing: set[str],
+    max_new: int,
+    promote_critical: bool = False,
+) -> list[Cluster]:
+    chosen: list[Cluster] = []
+    existing_norms = set(existing)
+    for cl in clusters:
+        if not is_promotable(
+            cl,
+            min_count=min_count,
+            min_prs=min_prs,
+            promote_critical=promote_critical,
+        ):
+            continue
+        norm = _norm_principle(cl.principle)
+        if norm in existing_norms:
+            continue
+        if any(principles_similar(cl.principle, e) for e in existing_norms):
+            continue
+        if any(principles_similar(cl.principle, c.principle) for c in chosen):
+            continue
+        chosen.append(cl)
+        existing_norms.add(norm)
+        if len(chosen) >= max_new:
+            break
+    return chosen
+
+
+def merge_into_patterns_md(
+    patterns_path: Path,
+    to_add: list[Cluster],
+    *,
+    dry_run: bool = False,
+) -> tuple[str, int]:
+    """Insert new bullets under matching Recurring findings categories.
+
+    Returns (new_text, n_added).
+    """
+    text = patterns_path.read_text(encoding="utf-8")
+    if not to_add:
+        return text, 0
+
+    by_cat: dict[str, list[Cluster]] = defaultdict(list)
+    for cl in to_add:
+        by_cat[cl.category].append(cl)
+
+    lines = text.splitlines(keepends=True)
+    # Find "## Recurring findings"
+    recurring_idx = None
+    for i, line in enumerate(lines):
+        if line.strip() == "## Recurring findings":
+            recurring_idx = i
+            break
+    if recurring_idx is None:
+        raise SystemExit("erlang-harvest: patterns.md missing '## Recurring findings'")
+
+    # Map category header line indices
+    cat_headers: dict[str, int] = {}
+    for i, line in enumerate(lines):
+        m = re.match(r"^### (.+)\s*$", line)
+        if m and i > recurring_idx:
+            cat_headers[m.group(1).strip()] = i
+
+    added = 0
+    # Insert from bottom so indices stay valid
+    for cat, clusters in sorted(by_cat.items(), key=lambda x: -cat_headers.get(x[0], 10**9)):
+        bullets = []
+        for cl in clusters:
+            pr_note = f", {len(cl.prs)} PR(s)" if cl.prs else ""
+            bullets.append(
+                f"- {cl.principle} _(harvested, seen {cl.count}×{pr_note})_\n"
+            )
+            added += 1
+
+        if cat in cat_headers:
+            # Insert after last bullet in section (before next ### or ##)
+            start = cat_headers[cat] + 1
+            end = start
+            while end < len(lines):
+                s = lines[end].strip()
+                if s.startswith("### ") or s.startswith("## "):
+                    break
+                end += 1
+            # walk back over blank lines
+            insert_at = end
+            while insert_at > start and lines[insert_at - 1].strip() == "":
+                insert_at -= 1
+            for j, b in enumerate(bullets):
+                lines.insert(insert_at + j, b)
+            # ensure trailing blank before next section
+            after = insert_at + len(bullets)
+            if after < len(lines) and lines[after].strip().startswith("#"):
+                lines.insert(after, "\n")
+        else:
+            # Create new category before "## False-positive" or at end of recurring
+            insert_at = len(lines)
+            for i, line in enumerate(lines):
+                if line.strip().startswith("## False-positive"):
+                    insert_at = i
+                    break
+            block = [f"\n### {cat}\n", "\n", *bullets, "\n"]
+            for j, b in enumerate(block):
+                lines.insert(insert_at + j, b)
+
+    new_text = "".join(lines)
+    # Normalize: avoid triple blank lines
+    new_text = re.sub(r"\n{4,}", "\n\n\n", new_text)
+    if not dry_run:
+        patterns_path.write_text(new_text, encoding="utf-8", newline="\n")
+    return new_text, added
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+def render_candidates_report(
+    *,
+    repo: str,
+    clusters: list[Cluster],
+    applied: list[Cluster],
+    authors: list[str],
+    min_count: int,
+    min_prs: int,
+    comment_total: int,
+    kept_total: int,
+    patterns_rel: str,
+) -> str:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    lines = [
+        f"# Erlang pattern harvest candidates",
+        "",
+        f"**Generated:** {now}  ",
+        f"**Repo:** `{repo}`  ",
+        f"**Authors:** {', '.join(f'`{a}`' for a in authors)}  ",
+        f"**Review comments scanned:** {comment_total}  ",
+        f"**Top-level comments kept:** {kept_total}  ",
+        f"**Clusters:** {len(clusters)}  ",
+        f"**Promotion threshold (multi-PR):** count ≥ {min_count} **and** "
+        f"distinct PRs ≥ {min_prs} (use `--promote-critical` for single-PR CRITICAL gates)  ",
+        f"**Patterns file:** `{patterns_rel}`  ",
+        "",
+        "## Auto-apply selection",
+        "",
+    ]
+    if applied:
+        lines.append(f"Selected **{len(applied)}** theme(s) for merge into patterns:")
+        lines.append("")
+        for cl in applied:
+            lines.append(
+                f"- **[{cl.category}]** {cl.principle}  \n"
+                f"  seen {cl.count}× · PRs {sorted(cl.prs)[:12]} · "
+                f"severity={cl.dominant_severity()}"
+                + (" · hard-gate-hint" if cl.hard_gate_hint else "")
+            )
+        lines.append("")
+    else:
+        lines.append("_No new themes met the promotion threshold (or all were duplicates)._")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## All clusters (by frequency)",
+            "",
+            "| Count | PRs | Sev | Category | Principle |",
+            "|------:|----:|-----|----------|-----------|",
+        ]
+    )
+    for cl in clusters[:80]:
+        sev = cl.dominant_severity()
+        prin = cl.principle.replace("|", "\\|")
+        if len(prin) > 120:
+            prin = prin[:117] + "…"
+        lines.append(
+            f"| {cl.count} | {len(cl.prs)} | {sev} | {cl.category} | {prin} |"
+        )
+    if len(clusters) > 80:
+        lines.append("")
+        lines.append(f"_…and {len(clusters) - 80} more clusters omitted._")
+
+    lines.extend(
+        [
+            "",
+            "## Sample evidence (top clusters)",
+            "",
+        ]
+    )
+    for cl in clusters[:15]:
+        lines.append(f"### {cl.principle}")
+        lines.append("")
+        lines.append(
+            f"- category: **{cl.category}** · count: **{cl.count}** · "
+            f"PRs: {sorted(cl.prs)[:20] or 'n/a'} · severity: {cl.dominant_severity()}"
+        )
+        if cl.sample_paths:
+            lines.append(f"- paths: {', '.join(f'`{p}`' for p in cl.sample_paths[:5])}")
+        for u in cl.sample_urls[:3]:
+            lines.append(f"- {u}")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## How to promote",
+            "",
+            "```text",
+            "python3 scripts/erlang-harvest-review-patterns.py --apply",
+            "```",
+            "",
+            "Or on Windows:",
+            "",
+            "```text",
+            "scripts\\erlang-harvest-review-patterns.bat --apply",
+            "```",
+            "",
+            "Review the diff to `patterns.md` before committing. Harvested bullets are",
+            "marked `_(harvested, seen N×)_` so humans can later rewrite them to cleaner",
+            "principles and drop the marker.",
+            "",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "Harvest GitHub PR review comments (Kilo et al.) into Erlang "
+            "review pattern candidates and optionally auto-merge into patterns.md."
+        )
+    )
+    p.add_argument(
+        "--repo",
+        default=None,
+        help="owner/name (default: detect via gh / GH_REPO)",
+    )
+    p.add_argument(
+        "--authors",
+        default=",".join(DEFAULT_AUTHORS),
+        help="Comma-separated GitHub logins to include (default: kilo-code-bot)",
+    )
+    p.add_argument(
+        "--include-security-bots",
+        action="store_true",
+        help="Also include CodeQL / Copilot reviewer logins",
+    )
+    p.add_argument(
+        "--include-humans",
+        action="store_true",
+        help="Include all human top-level review comments (noisier; raises min-count)",
+    )
+    p.add_argument(
+        "--min-count",
+        type=int,
+        default=2,
+        help="Minimum comment hits to promote a cluster (default: 2)",
+    )
+    p.add_argument(
+        "--min-prs",
+        type=int,
+        default=2,
+        help="Or promote if seen on this many distinct PRs (default: 2)",
+    )
+    p.add_argument(
+        "--max-new",
+        type=int,
+        default=15,
+        help="Max new bullets to merge into patterns.md on --apply (default: 15)",
+    )
+    p.add_argument(
+        "--apply",
+        action="store_true",
+        help="Merge selected clusters into skills/erlang-review/patterns.md",
+    )
+    p.add_argument(
+        "--promote-critical",
+        action="store_true",
+        help=(
+            "With --apply, also merge single-PR CRITICAL hard-gate themes "
+            "(noisier; default is multi-PR only)"
+        ),
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="With --apply, compute merge but do not write patterns.md",
+    )
+    p.add_argument(
+        "--max-pages",
+        type=int,
+        default=50,
+        help="Max API pages of 100 comments (default: 50)",
+    )
+    p.add_argument(
+        "--output",
+        default=None,
+        help="Candidate report path (default: docs/ai-generated/code-reviews/harvest-candidates-YYYY-MM-DD.md)",
+    )
+    p.add_argument(
+        "--fixture",
+        default=None,
+        help="Load comments from a JSON file instead of calling gh (for tests)",
+    )
+    return p
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    root = find_repo_root()
+    os.chdir(root)
+
+    patterns_rel = (
+        "modules/ai-shared-develop/src/main/resources/skills/erlang-review/patterns.md"
+    )
+    patterns_path = root / patterns_rel
+    if not patterns_path.is_file():
+        raise SystemExit(f"erlang-harvest: missing patterns file: {patterns_rel}")
+
+    authors = [a.strip() for a in args.authors.split(",") if a.strip()]
+    if args.include_security_bots:
+        authors.extend(SECURITY_BOT_AUTHORS)
+    # Dedup preserve order
+    seen_a: set[str] = set()
+    authors_u: list[str] = []
+    for a in authors:
+        if a.lower() not in seen_a:
+            seen_a.add(a.lower())
+            authors_u.append(a)
+    authors = authors_u
+
+    min_count = args.min_count
+    min_prs = args.min_prs
+    if args.include_humans:
+        # Pull all non-bot? We only add humans if we expand authors via a second pass
+        # For simplicity, when --include-humans, do not filter by author list except
+        # we still skip empty — handled below with authors=None sentinel
+        min_count = max(min_count, 3)
+        min_prs = max(min_prs, 2)
+
+    if args.fixture:
+        fixture_path = Path(args.fixture)
+        if not fixture_path.is_file():
+            raise SystemExit(f"erlang-harvest: fixture not found: {fixture_path}")
+        raw_items = json.loads(fixture_path.read_text(encoding="utf-8"))
+        if not isinstance(raw_items, list):
+            raise SystemExit("erlang-harvest: fixture must be a JSON array")
+        repo = args.repo or "fixture/local"
+    else:
+        repo = detect_repo_slug(args.repo)
+        print(f"erlang-harvest: fetching review comments from {repo} …", flush=True)
+        raw_items = fetch_all_pull_comments(repo, max_pages=args.max_pages)
+        print(f"erlang-harvest: fetched {len(raw_items)} comment(s)", flush=True)
+
+    author_set = set(authors)
+    if args.include_humans:
+        # Include every top-level comment author (bots + humans)
+        author_set = {
+            ((it.get("user") or {}).get("login") or "")
+            for it in raw_items
+            if (it.get("user") or {}).get("login")
+        }
+
+    comments = parse_comments(raw_items, author_set)
+    print(
+        f"erlang-harvest: kept {len(comments)} top-level comment(s) "
+        f"from {len(author_set)} author(s)",
+        flush=True,
+    )
+
+    clusters = cluster_comments(comments)
+    print(f"erlang-harvest: {len(clusters)} cluster(s)", flush=True)
+
+    existing = parse_patterns_bullets(patterns_path.read_text(encoding="utf-8"))
+    applied = select_for_apply(
+        clusters,
+        min_count=min_count,
+        min_prs=min_prs,
+        existing=set(existing),
+        max_new=args.max_new,
+        promote_critical=bool(args.promote_critical),
+    )
+
+    out_path = (
+        Path(args.output)
+        if args.output
+        else root
+        / "docs"
+        / "ai-generated"
+        / "code-reviews"
+        / f"harvest-candidates-{date.today().isoformat()}.md"
+    )
+    if not out_path.is_absolute():
+        out_path = root / out_path
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    report = render_candidates_report(
+        repo=repo,
+        clusters=clusters,
+        applied=applied,
+        authors=sorted(author_set) if args.include_humans else authors,
+        min_count=min_count,
+        min_prs=min_prs,
+        comment_total=len(raw_items),
+        kept_total=len(comments),
+        patterns_rel=patterns_rel,
+    )
+    out_path.write_text(report, encoding="utf-8", newline="\n")
+    # Always write with / in printed path
+    rel_out = out_path.relative_to(root).as_posix()
+    print(f"erlang-harvest: wrote candidates → {rel_out}", flush=True)
+
+    n_added = 0
+    if args.apply:
+        _, n_added = merge_into_patterns_md(
+            patterns_path, applied, dry_run=args.dry_run
+        )
+        if args.dry_run:
+            print(
+                f"erlang-harvest: dry-run would add {n_added} bullet(s) to {patterns_rel}",
+                flush=True,
+            )
+        else:
+            print(
+                f"erlang-harvest: applied {n_added} new bullet(s) → {patterns_rel}",
+                flush=True,
+            )
+    else:
+        print(
+            "erlang-harvest: candidates only (pass --apply to merge into patterns.md)",
+            flush=True,
+        )
+
+    print(
+        f"erlang-harvest: done (clusters={len(clusters)}, selected={len(applied)}, "
+        f"added={n_added})",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/erlang-harvest-review-patterns.sh
+++ b/scripts/erlang-harvest-review-patterns.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+# Cross-platform entry (Unix/macOS/Git Bash): harvest Kilo/GitHub review comments
+# into Erlang pattern memory. Delegates to Python for Windows portability.
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+cd "$ROOT"
+
+if command -v python3 >/dev/null 2>&1; then
+  PY=python3
+elif command -v python >/dev/null 2>&1; then
+  PY=python
+else
+  echo "erlang-harvest: python3/python not found on PATH" >&2
+  exit 1
+fi
+
+exec "$PY" "$ROOT/scripts/erlang-harvest-review-patterns.py" "$@"

--- a/scripts/test_erlang_harvest_review_patterns.py
+++ b/scripts/test_erlang_harvest_review_patterns.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Unit tests for erlang-harvest-review-patterns.py (no network)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+
+
+def _load():
+    path = SCRIPTS / "erlang-harvest-review-patterns.py"
+    name = "erlang_harvest_review_patterns"
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    # dataclasses need the module registered before exec
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+harvest = _load()
+
+
+class TestGeneralize(unittest.TestCase):
+    def test_strips_severity_and_paths(self):
+        sev, rest = harvest.extract_severity(
+            "**WARNING:** Path join in `modules/foo/Bar.java:42` uses hardcoded `/`\n\nMore detail."
+        )
+        self.assertEqual(sev, "warning")
+        g = harvest.generalize_body(rest)
+        self.assertNotIn("Bar.java", g)
+        self.assertNotIn(":42", g)
+        self.assertIn("hardcoded", g.lower())
+
+    def test_skips_mitigation(self):
+        self.assertTrue(
+            harvest.should_skip_body("**Mitigation (commit abc):** fixed it")
+        )
+        self.assertFalse(
+            harvest.should_skip_body("**WARNING:** real finding about tests")
+        )
+
+    def test_critical_alias(self):
+        sev, _ = harvest.extract_severity(
+            "**CRITICAL:** Duplicate method declaration prevents compilation"
+        )
+        self.assertEqual(sev, "critical")
+
+
+class TestClusterAndPromote(unittest.TestCase):
+    def test_cluster_merges_similar(self):
+        comments = [
+            harvest.RawComment(
+                1,
+                "kilo-code-bot[bot]",
+                "**WARNING:** Missing unit test for error path when input is null",
+                "a/Foo.java",
+                100,
+                "",
+                "http://example/1",
+                None,
+            ),
+            harvest.RawComment(
+                2,
+                "kilo-code-bot[bot]",
+                "**WARNING:** Missing unit tests for error path when input is null",
+                "b/Bar.java",
+                101,
+                "",
+                "http://example/2",
+                None,
+            ),
+            harvest.RawComment(
+                3,
+                "kilo-code-bot[bot]",
+                "**SUGGESTION:** Typo in validation message wording",
+                "c/Baz.java",
+                102,
+                "",
+                "http://example/3",
+                None,
+            ),
+        ]
+        clusters = harvest.cluster_comments(comments)
+        self.assertGreaterEqual(len(clusters), 1)
+        top = clusters[0]
+        self.assertGreaterEqual(top.count, 2)
+        self.assertGreaterEqual(len(top.prs), 2)
+
+    def test_select_for_apply_respects_min_and_dedup(self):
+        c1 = harvest.Cluster(
+            key="a",
+            principle="Missing unit tests for error and edge case paths",
+            category="Tests",
+            count=3,
+        )
+        c1.prs = {1, 2, 3}
+        c1.severity_counts["warning"] = 3
+        c2 = harvest.Cluster(
+            key="b",
+            principle="Missing unit tests for error and edge case paths",
+            category="Tests",
+            count=2,
+        )
+        c2.prs = {4}
+        c2.severity_counts["warning"] = 2
+        c3 = harvest.Cluster(
+            key="c",
+            principle="Unrelated style nit about spacing",
+            category="Maintainability",
+            count=1,
+        )
+        c3.prs = {5}
+        c3.severity_counts["nit"] = 1
+
+        chosen = harvest.select_for_apply(
+            [c1, c2, c3],
+            min_count=2,
+            min_prs=2,
+            existing=set(),
+            max_new=10,
+        )
+        self.assertEqual(len(chosen), 1)
+        self.assertIn("Missing unit tests", chosen[0].principle)
+
+    def test_is_promotable_critical_hard_gate(self):
+        cl = harvest.Cluster(
+            key="x",
+            principle="Duplicate method declaration prevents compilation",
+            category="Maintainability",
+            count=1,
+            hard_gate_hint=True,
+        )
+        cl.severity_counts["critical"] = 1
+        cl.prs = {9}
+        self.assertTrue(
+            harvest.is_promotable(
+                cl, min_count=2, min_prs=2, promote_critical=True
+            )
+        )
+        self.assertFalse(
+            harvest.is_promotable(
+                cl, min_count=2, min_prs=2, promote_critical=False
+            )
+        )
+
+    def test_is_promotable_rejects_single_pr_without_multi(self):
+        cl = harvest.Cluster(
+            key="y",
+            principle="Copyright year regression from 2025 to 2023",
+            category="Maintainability",
+            count=3,
+            hard_gate_hint=False,
+        )
+        cl.severity_counts["suggestion"] = 3
+        cl.prs = {1}
+        self.assertFalse(harvest.is_promotable(cl, min_count=2, min_prs=2))
+        crit = harvest.Cluster(
+            key="z",
+            principle="Copyright year regression is wrong",
+            category="Maintainability",
+            count=1,
+            hard_gate_hint=True,
+        )
+        crit.severity_counts["critical"] = 1
+        crit.prs = {2}
+        self.assertFalse(
+            harvest.is_promotable(
+                crit, min_count=2, min_prs=2, promote_critical=True
+            )
+        )
+
+
+class TestMergePatterns(unittest.TestCase):
+    def test_merge_inserts_under_category(self):
+        sample = """# Erlang review patterns (Percussion CMS)
+
+## Hard gates (always scan)
+
+- Existing hard gate
+
+## Recurring findings
+
+### Tests
+
+- Happy-path-only coverage for validation paths
+
+### Maintainability
+
+- Orphaned javadoc left above renamed methods
+
+## False-positive guards (do not flag)
+
+- URL paths that correctly use `/`
+"""
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "patterns.md"
+            path.write_text(sample, encoding="utf-8", newline="\n")
+            cl = harvest.Cluster(
+                key="t",
+                principle="Vacuous assertions that any exception would pass",
+                category="Tests",
+                count=4,
+            )
+            cl.prs = {1, 2}
+            text, n = harvest.merge_into_patterns_md(path, [cl], dry_run=False)
+            self.assertEqual(n, 1)
+            body = path.read_text(encoding="utf-8")
+            self.assertIn("Vacuous assertions", body)
+            self.assertIn("_(harvested, seen 4×", body)
+            self.assertIn("Existing hard gate", text)
+
+
+class TestParseComments(unittest.TestCase):
+    def test_filters_replies_and_authors(self):
+        raw = [
+            {
+                "id": 1,
+                "user": {"login": "kilo-code-bot[bot]"},
+                "body": "**WARNING:** Something important about paths",
+                "path": "a.java",
+                "pull_request_url": "https://api.github.com/repos/o/r/pulls/12",
+                "created_at": "2026-01-01T00:00:00Z",
+                "html_url": "https://github.com/o/r/pull/12#x",
+                "in_reply_to_id": None,
+            },
+            {
+                "id": 2,
+                "user": {"login": "kilo-code-bot[bot]"},
+                "body": "**Mitigation:** fixed",
+                "path": "a.java",
+                "pull_request_url": "https://api.github.com/repos/o/r/pulls/12",
+                "created_at": "2026-01-01T00:00:00Z",
+                "html_url": "https://github.com/o/r/pull/12#y",
+                "in_reply_to_id": 1,
+            },
+            {
+                "id": 3,
+                "user": {"login": "human"},
+                "body": "**WARNING:** human only",
+                "path": "b.java",
+                "pull_request_url": "https://api.github.com/repos/o/r/pulls/13",
+                "created_at": "2026-01-01T00:00:00Z",
+                "html_url": "https://github.com/o/r/pull/13#z",
+                "in_reply_to_id": None,
+            },
+        ]
+        out = harvest.parse_comments(raw, {"kilo-code-bot[bot]"})
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].pr_number, 12)
+
+
+class TestFixtureEndToEnd(unittest.TestCase):
+    def test_main_fixture_write_report(self):
+        fixture = [
+            {
+                "id": 10,
+                "user": {"login": "kilo-code-bot[bot]"},
+                "body": "**WARNING:** Missing behavioral unit test for failure path",
+                "path": "src/A.java",
+                "pull_request_url": "https://api.github.com/repos/o/r/pulls/1",
+                "created_at": "2026-01-01T00:00:00Z",
+                "html_url": "https://github.com/o/r/pull/1#d1",
+                "in_reply_to_id": None,
+            },
+            {
+                "id": 11,
+                "user": {"login": "kilo-code-bot[bot]"},
+                "body": "**WARNING:** Missing behavioral unit tests for failure paths",
+                "path": "src/B.java",
+                "pull_request_url": "https://api.github.com/repos/o/r/pulls/2",
+                "created_at": "2026-01-01T00:00:00Z",
+                "html_url": "https://github.com/o/r/pull/2#d2",
+                "in_reply_to_id": None,
+            },
+        ]
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            (td_path / "AGENTS.md").write_text("# t\n", encoding="utf-8")
+            (td_path / ".git").mkdir()
+            patterns = (
+                td_path
+                / "modules"
+                / "ai-shared-develop"
+                / "src"
+                / "main"
+                / "resources"
+                / "skills"
+                / "erlang-review"
+                / "patterns.md"
+            )
+            patterns.parent.mkdir(parents=True)
+            patterns.write_text(
+                "# Erlang review patterns\n\n"
+                "## Hard gates (always scan)\n\n- Gate one\n\n"
+                "## Recurring findings\n\n"
+                "### Tests\n\n- Old test pattern\n\n"
+                "## False-positive guards (do not flag)\n\n- Guard\n",
+                encoding="utf-8",
+                newline="\n",
+            )
+            fix = td_path / "fixture.json"
+            fix.write_text(json.dumps(fixture), encoding="utf-8")
+            out = td_path / "docs" / "ai-generated" / "code-reviews" / "out.md"
+            out.parent.mkdir(parents=True)
+
+            old = Path.cwd()
+            try:
+                os.chdir(td_path)
+                rc = harvest.main(
+                    [
+                        "--fixture",
+                        str(fix),
+                        "--repo",
+                        "o/r",
+                        "--output",
+                        str(out),
+                        "--apply",
+                        "--min-count",
+                        "2",
+                    ]
+                )
+            finally:
+                os.chdir(old)
+            self.assertEqual(rc, 0)
+            self.assertTrue(out.is_file())
+            body = patterns.read_text(encoding="utf-8")
+            self.assertIn("harvested", body)
+            self.assertIn("Missing behavioral", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Move Erlang durable reports from wipeable `tmp/reviews/` to **`docs/ai-generated/code-reviews/`**, with README, naming rules, and Windows-safe host guidance.
- Add institutional **review pattern memory** at `modules/ai-shared-develop/.../skills/erlang-review/patterns.md`, loaded at the start of every Erlang review.
- Ship **`scripts/erlang-harvest-review-patterns.py`** (+ `.sh` / `.bat`) to harvest `kilo-code-bot` (and optional) PR line comments from open **and closed** PRs, cluster them, write candidate reports, and optionally auto-merge multi-PR themes into `patterns.md`.
- Wire agent, skill, prompt, Kilo workflow, Copilot mirror, root `AGENTS.md`, and `scripts/README.md`.
- Offline unit tests: `python3 scripts/test_erlang_harvest_review_patterns.py` (10 tests).
- Seed sample historical Erlang reports + first harvest candidates report for the team.

## Why

Erlang had report *writes* but no durable *memory*. `tmp/` can be wiped; closed-PR Kilo comments are a rich unused signal. Short-handed teams need automation to keep pattern memory current.

## Usage

```text
# Candidates report (safe)
python3 scripts/erlang-harvest-review-patterns.py

# Merge multi-PR themes into patterns.md
python3 scripts/erlang-harvest-review-patterns.py --apply

# Windows
scripts\erlang-harvest-review-patterns.bat --apply
```

## Test plan

- [x] `python3 scripts/test_erlang_harvest_review_patterns.py` — 10 OK
- [x] Live harvest against `intersoftdatalabs-in/percussioncms` (770 comments → candidates report)
- [ ] On Windows: `scripts\erlang-harvest-review-patterns.bat` (candidates only) with `gh` + Python on PATH
- [ ] Spot-check `docs/ai-generated/code-reviews/harvest-candidates-2026-07-16.md` and `patterns.md` for signal vs noise
- [ ] Optional: run `/erlang-review` or agent load path and confirm patterns + prior-report load instructions are clear

## Erlang gate

Pre-commit report: `docs/ai-generated/code-reviews/erlang-review-memory-and-harvest-erlang.md` — **approve**, may push.