### PR TITLE
fix(system-tests): canonicalize both sides in ZipSlip valid-relative assertion

### DIFF
--- a/system/src/test/java/com/percussion/system/utils/PSArchiveFilesZipSlipTest.java
+++ b/system/src/test/java/com/percussion/system/utils/PSArchiveFilesZipSlipTest.java
@@ -144,19 +144,23 @@ class PSArchiveFilesZipSlipTest {
 
   @Test
   @DisplayName("PathValidation.constructSafePath returns a path under baseDir for a valid relative path")
-  void testConstructSafePathAcceptsValidRelative() {
+  void testConstructSafePathAcceptsValidRelative() throws IOException {
     File base = extractDir;
     File safe = PathValidation.constructSafePath(base, "subdir/file.txt");
     assertNotNull(safe);
-    // Use java.nio.file.Path.startsWith(Path) which is case-insensitive on Windows
-    // (java.nio.file.WindowsPath) and case-sensitive on Unix, handling both the
-    // case-folding on Windows and the path-separator difference (/ vs \\) in a
-    // single platform-aware call. The previous String.startsWith was
-    // case-sensitive on all platforms, which produced a Windows-only
-    // regression (CI on dev laptops) when the JUnit TempDir path and the
-    // resolved child path differed only in drive letter casing.
-    Path basePath = base.getAbsoluteFile().toPath().toAbsolutePath().normalize();
-    Path safePath = safe.getAbsoluteFile().toPath().toAbsolutePath().normalize();
+    // Canonicalize both sides before comparing. PathValidation.constructSafePath
+    // returns the canonical form of the resolved path (long-form on Windows),
+    // but base.getAbsoluteFile() returns the path with whatever the JVM cached
+    // for the original constructor - on Windows that can be the 8.3 short form
+    // (e.g. C:\Users\VIJAYA~1.BOD\...) even when the OS still resolves the long
+    // name. The two forms are NOT equal path-by-path, so Path#startsWith sees
+    // different first components (VIJAYA~1.BOD vs vijaya.boddipudi) and
+    // returns false even though both addresses point at the same directory.
+    // Forcing both sides through getCanonicalFile() puts them in the same
+    // canonical long-form, after which Path#startsWith (which is case-insensitive
+    // on Windows) reports containment correctly.
+    Path basePath = base.getCanonicalFile().toPath();
+    Path safePath = safe.getCanonicalFile().toPath();
     assertTrue(safePath.startsWith(basePath),
         "safe path must be under baseDir, got: " + safe);
   }


### PR DESCRIPTION
## Summary

Fixes the Windows failure of PSArchiveFilesZipSlipTest.testConstructSafePathAcceptsValidRelative (expected: <true> but was: <false>).

## Root cause

The test compared ase.getAbsoluteFile() against safe.getAbsoluteFile() where:
- safe is the canonical File returned by PathValidation.constructSafePath (line 299: combinedPath.getCanonicalFile()) — long form on Windows.
- ase is the raw File built from Files.createTempDirectory().toFile() — the JVM caches the 8.3 short form (C:\Users\VIJAYA~1.BOD\...) even though the OS resolves the long name (C:\Users\vijaya.boddipudi\...).

The two addresses point at the same physical directory, but Path#startsWith(Path) compares path name-by-name and is only case-insensitive on Windows — it does **not** resolve 8.3 short names. First components (VIJAYA~1.BOD vs ijaya.boddipudi) differ, so startsWith returned alse even though containment was correct.

This is a regression introduced when constructSafePath was changed to return getCanonicalFile() in PR #1265.

## Fix

Route both sides through getCanonicalFile() so they share the same canonical long-form before Path#startsWith. safe already came back canonical; ase now is too.

## Verification

- mvn test -pl system → Tests run: 712, Failures: 0, Errors: 0, Skipped: 246
- Hash integrity check → 15011 verified, 0 failed

## Cross-platform

Both Windows and Linux are covered: getCanonicalFile() resolves .. and . on every platform; on Windows it also resolves 8.3 short names to the canonical long form. No production code change — test-only.