### PR TITLE
004/US3 T054-followup: fix java/error-message-exposure in PSPageBaseTag.getUrlContent (alert #1728, CWE-209)

### DIFF
--- a/system/src/main/java/com/percussion/servlets/taglib/PSPageBaseTag.java
+++ b/system/src/main/java/com/percussion/servlets/taglib/PSPageBaseTag.java
@@ -35,6 +35,8 @@ import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * This base tag implements behavior used by the header and sidenav tags
@@ -42,6 +44,8 @@ import java.util.Set;
  * @author dougrand
  */
 public abstract class PSPageBaseTag implements Tag {
+  private static final Logger log = LogManager.getLogger(PSPageBaseTag.class);
+
   protected PSComponentUrls m_urls = null;
 
   protected PageContext m_context = null;
@@ -83,30 +87,30 @@ public abstract class PSPageBaseTag implements Tag {
         requestparams.put(name, extra.get(name));
       }
     }
-    String url = m_urls.getComponentUrl(componentname);
-    // Remove parameters that are overridden
-    Set<String> keys = requestparams.keySet();
-    if (keys.size() > 0 && url.contains("?")) {
-      String parts[] = url.split("\\u003f");
-      StringBuilder b = new StringBuilder(parts[0]);
-      String params[] = parts[1].split("&");
-      boolean first = true;
-      for (int i = 0; i < params.length; i++) {
-        parts = params[i].split("=");
-        if (!keys.contains(parts[0])) {
-          if (first) {
-            b.append('?');
-            first = false;
-          } else {
-            b.append('&');
-          }
-          b.append(params[i]);
-        }
-      }
-      url = b.toString();
-    }
-
     try {
+      String url = m_urls.getComponentUrl(componentname);
+      // Remove parameters that are overridden
+      Set<String> keys = requestparams.keySet();
+      if (keys.size() > 0 && url.contains("?")) {
+        String parts[] = url.split("\\u003f");
+        StringBuilder b = new StringBuilder(parts[0]);
+        String params[] = parts[1].split("&");
+        boolean first = true;
+        for (int i = 0; i < params.length; i++) {
+          parts = params[i].split("=");
+          if (!keys.contains(parts[0])) {
+            if (first) {
+              b.append('?');
+              first = false;
+            } else {
+              b.append('&');
+            }
+            b.append(params[i]);
+          }
+        }
+        url = b.toString();
+      }
+
       PSRequest req = (PSRequest) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_PSREQUEST);
       PSInternalRequest ireq = PSServer.getInternalRequest(url, req, requestparams, false, null);
       ByteArrayOutputStream os = ireq.getMergedResult();
@@ -123,7 +127,19 @@ public abstract class PSPageBaseTag implements Tag {
       }
       return (String) enc.encode(b.toString());
     } catch (Exception e) {
-      return e.getLocalizedMessage();
+      // CodeQL java/error-message-exposure (alert #1728): the previous implementation
+      // returned e.getLocalizedMessage() to the caller, which PSPageSidenavTag then wrote
+      // to the JSP output via out.print(...), exposing internal exception details to the
+      // end user (CWE-209). Log the detail server-side and return a generic empty string;
+      // the JSP layer (PSPageSidenavTag.doStartTag) already converts any failure into a
+      // generic JspException message, so dropping the body here keeps the user-visible
+      // surface free of internal exception text.
+      log.error(
+          "Problem while loading component URL content for component={}: {}",
+          componentname,
+          e.getMessage(),
+          e);
+      return "";
     }
   }
 

--- a/system/src/test/java/com/percussion/servlets/taglib/PSPageBaseTagErrorMessageExposureTest.java
+++ b/system/src/test/java/com/percussion/servlets/taglib/PSPageBaseTagErrorMessageExposureTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.servlets.taglib;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.percussion.data.PSInternalRequestCallException;
+import com.percussion.servlets.utils.PSComponentUrls;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.jsp.PageContext;
+import java.util.HashMap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for CodeQL {@code java/error-message-exposure} (alert #1728, CWE-209) on {@link
+ * PSPageBaseTag#getUrlContent(String, java.util.Map)}.
+ *
+ * <p><strong>Background.</strong> The pre-fix implementation returned {@code
+ * e.getLocalizedMessage()} from the {@code catch (Exception e)} block. The caller {@link
+ * PSPageSidenavTag#doStartTag()} writes the returned string to the JSP output via {@code
+ * out.print(...)}. If an exception occurred while loading the component URL, the JSP page would
+ * render the internal exception message to the end user, potentially leaking class names, paths,
+ * host information, or other details useful to an attacker (CWE-209: Information Exposure Through
+ * an Error Message).
+ *
+ * <p>The fix logs the exception detail server-side and returns an empty string, keeping the
+ * user-visible surface free of internal exception text. These tests exercise the catch path
+ * directly: when {@code PSComponentUrls#getComponentUrl} throws, the returned string must not
+ * contain any portion of the exception message.
+ */
+@DisplayName("PSPageBaseTag.getUrlContent - error-message-exposure (CWE-209) regression tests")
+class PSPageBaseTagErrorMessageExposureTest {
+
+  /**
+   * Concrete subclass used to instantiate the abstract {@link PSPageBaseTag}. Only {@link
+   * PSPageBaseTag#getUrlContent} is exercised; {@code doStartTag} / {@code doEndTag} are not
+   * called.
+   */
+  private static final class TestPageBaseTag extends PSPageBaseTag {
+    @Override
+    public int doStartTag() {
+      return 0;
+    }
+
+    @Override
+    public int doEndTag() {
+      return 0;
+    }
+  }
+
+  /**
+   * When the component-URL fetch throws, getUrlContent must not return the exception message. The
+   * pre-fix code returned {@code e.getLocalizedMessage()}, which CodeQL flagged as an
+   * error-message-exposure sink flowing into the JSP response body.
+   */
+  @Test
+  @DisplayName("getUrlContent returns empty string (not the exception message) on internal failure")
+  void testGetUrlContentDoesNotLeakExceptionMessage() throws PSInternalRequestCallException {
+    PageContext pageContext = mock(PageContext.class);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    PSComponentUrls componentUrls = mock(PSComponentUrls.class);
+
+    when(pageContext.getRequest()).thenReturn(request);
+    when(request.getParameterMap()).thenReturn(new HashMap<>());
+    when(componentUrls.getComponentUrl("flaky-component"))
+        .thenThrow(
+            new RuntimeException(
+                "INTERNAL-DETAIL: /secret/path/to/resource.xml (do-not-leak-this-token-91827)"));
+
+    TestPageBaseTag tag = new TestPageBaseTag();
+    // Inject mocked state directly; the production setPageContext creates a
+    // real PSComponentUrls (which does an internal HTTP request to load
+    // sys_ComponentSupport/componentsupport.xml) and that is not feasible in a
+    // unit test. m_context and m_urls are protected, so this works in the same
+    // package as PSPageBaseTag.
+    tag.m_context = pageContext;
+    tag.m_urls = componentUrls;
+
+    String result = tag.getUrlContent("flaky-component", null);
+
+    assertNotNull(result, "getUrlContent must return a value, never null");
+    assertEquals(
+        "",
+        result,
+        "getUrlContent must return an empty string on internal failure rather than the"
+            + " exception message; the JSP layer renders this value verbatim to the"
+            + " browser, so any non-empty content is an error-message-exposure (CWE-209)"
+            + " leak. Got: "
+            + result);
+    // Belt-and-braces: explicitly check the leak tokens are not in the response.
+    assertFalse(
+        result.contains("INTERNAL-DETAIL"),
+        "internal exception prefix must not appear in JSP response body, got: " + result);
+    assertFalse(
+        result.contains("do-not-leak-this-token"),
+        "internal exception body must not appear in JSP response body, got: " + result);
+  }
+
+  /**
+   * Sanity check: the contract is "empty string on failure", not null. The JSP {@code
+   * out.print(...)} would render the literal text "null" if we returned null, which is still better
+   * than the exception message but worse than the empty string. Pin the contract.
+   */
+  @Test
+  @DisplayName("getUrlContent contract: empty string on failure, never null")
+  void testGetUrlContentContractIsEmptyStringNotNull() throws PSInternalRequestCallException {
+    PageContext pageContext = mock(PageContext.class);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    PSComponentUrls componentUrls = mock(PSComponentUrls.class);
+
+    when(pageContext.getRequest()).thenReturn(request);
+    when(request.getParameterMap()).thenReturn(new HashMap<>());
+    when(componentUrls.getComponentUrl(any()))
+        .thenThrow(new IllegalStateException("upstream is down"));
+
+    TestPageBaseTag tag = new TestPageBaseTag();
+    tag.m_context = pageContext;
+    tag.m_urls = componentUrls;
+
+    String result = tag.getUrlContent("any-component", null);
+
+    assertNotNull(result, "must be non-null");
+    assertTrue(result.isEmpty(), "must be empty, got: [" + result + "]");
+  }
+
+  // Avoid an extra import: org.mockito.ArgumentMatchers.any
+  private static <T> T any() {
+    return org.mockito.ArgumentMatchers.any();
+  }
+}


### PR DESCRIPTION
## Summary

Closes CodeQL alert #1728 (java/error-message-exposure, medium, system/) - a residual leak from the T054 cluster after PR #1268.

## Root cause

PSPageSidenavTag.doStartTag() writes the return value of PSPageBaseTag.getUrlContent(...) to the JSP output via out.print(...). The pre-fix getUrlContent returned e.getLocalizedMessage() from its catch (Exception e) block. When the internal component-URL fetch failed, the JSP page rendered the internal exception message verbatim to the end user, potentially leaking class names, file paths, or other internal details (CWE-209).

PR #1268 (T054 cluster) closed the original alert #788 in PSPageSidenavTag.doStartTag directly (which now throws a generic JspException) but did not cover this exception path inside the parent class PSPageBaseTag, which is why CodeQL re-flagged the same vulnerability at #1728.

A second contributing defect: the pre-fix 	ry { ... } catch (Exception e) block started **after** the m_urls.getComponentUrl(componentname) call (line 90). An exception from getComponentUrl itself was not caught at all and propagated up.

## Fix

system/src/main/java/com/percussion/servlets/taglib/PSPageBaseTag.java:
- Widen the 	ry block to cover both getComponentUrl(...) AND the downstream PSServer.getInternalRequest(...) path.
- Replace the leaked return value (e.getLocalizedMessage()) with a generic empty string.
- Log the exception detail server-side at ERROR level (with full stack trace) so operators retain diagnostic visibility.

## Regression test

New system/src/test/java/com/percussion/servlets/taglib/PSPageBaseTagErrorMessageExposureTest.java:
- Mocks PSComponentUrls to throw an exception containing sentinel leak tokens.
- Asserts the returned string is empty and contains no portion of the exception message.
- Pins the contract: empty string on failure, not 
ull (avoids JSP rendering literal 
ull).

## Verification

\\\
mvn test -pl system
[INFO] Tests run: 714, Failures: 0, Errors: 0, Skipped: 246
[INFO] BUILD SUCCESS
Hash integrity: 15030 verified, 0 failed
\\\

(Was 712 tests; +2 from the new test class.)

Closes: #1728
Disposition: valid
Module: system/

Verification:
- [x] Scanner re-scan will not report alert #1728.
- [x] Module test suite (mvn test -pl system) passes.
- [x] Regression test fails on pre-fix code and passes on post-fix code (verified by reverting the catch-block change and observing the test fail with RuntimeException: INTERNAL-DETAIL: ... (do-not-leak-this-token-91827)).
- [x] Module is not in perc-distribution-tree / perc-packages, so erify-distribution-archive.sh is N/A.