### PR TITLE
004/US3 T037-residual: close java/ssrf alert #1067 in PSDocumentUtils via inline suppression

### DIFF
--- a/system/services/src/com/percussion/services/assembly/jexl/PSDocumentUtils.java
+++ b/system/services/src/com/percussion/services/assembly/jexl/PSDocumentUtils.java
@@ -266,7 +266,14 @@ public class PSDocumentUtils extends PSJexlUtilBase
       {
          String token = Base64.getEncoder().encodeToString(
                (user + ":" + password).getBytes(StandardCharsets.UTF_8));
-         requestBuilder.header("Authorization", "Basic " + token);
+         // CodeQL java/ssrf (alert #1067): the Authorization header carries
+         // only user-supplied username/password for Basic auth; the destination
+         // URL has already been validated against the allow-list by
+         // buildValidatedExternalRequestUri() above. SSRF is not possible from
+         // the Authorization header value (the request URL is fixed for the
+         // lifetime of this builder). Suppression is on the sink line per the
+         // pattern documented at line 257-259.
+         requestBuilder.header("Authorization", "Basic " + token); // codeql[java/ssrf]
       }
 
       try


### PR DESCRIPTION
## Summary

Closes CodeQL alert #1067 (`java/ssrf`, critical, system/) — a residual finding in `PSDocumentUtils.getExternalDocument` not addressed by PR #1300.

## Root cause

PR #1300 closed the sibling alert #1066 (also in `PSDocumentUtils.java`) by hardening the URL validation path. Alert #1067 points at the `Authorization` header sink on line 270:

```
requestBuilder.header("Authorization", "Basic " + token);
```

CodeQL's data-flow analysis tracks the user-supplied username/password through the header value and flags this as SSRF because the header is part of the outbound `HttpRequest`. However, the destination URL has already been validated against the allow-list by `buildValidatedExternalRequestUri()` (line 213, `URLValidation.validateURLString`), so SSRF is not possible from the header value.

## Fix

Inline `// codeql[java/ssrf]` suppression on the sink line per the same pattern used for the two existing suppressions on lines 261 and 275. Per the existing comment at lines 257–259, CodeQL only honors inline suppressions on the alert line or the line immediately above it.

The justification cites:
- Upstream `URLValidation` call (line 213) validates the destination against the configured allow-list.
- The `Authorization` header carries only the Basic-auth token; the request URL is set once at line 261 and never re-derived from user input.

## Verification

```
mvn test -pl system -Dtest=PSDocumentUtilsSsrfTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
```

Closes: #1067
Disposition: false-positive (inline suppression per contract C2)
Module: system/

Verification:
- [x] CodeQL re-scan will no longer report alert #1067.
- [x] Module test suite (`mvn test -pl system -Dtest=PSDocumentUtilsSsrfTest`) passes.
- [x] Justification cites concrete controls (URLValidation upstream + URL fixed in builder).
- [x] Module is not in `perc-distribution-tree` / `perc-packages`, so `verify-distribution-archive.sh` is N/A.