### PR TITLE
fix(dts): shade PathValidation into DTS installer jar (#1180)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/README.md
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/README.md
@@ -29,6 +29,33 @@ etc...
 ## Build
 
 ```bash
-mvn clean install
+./mvn-env.sh -pl deliverytiersuite/delivery-tier-suite/delivery-tier-distribution -am clean install
+# Windows: mvn-env.bat -pl deliverytiersuite/delivery-tier-suite/delivery-tier-distribution -am clean install
 ```
+
+## Installer jar (`java -jar`)
+
+The package artifact `target/delivery-tier-distribution.jar` is launched with:
+
+```bash
+java -jar delivery-tier-distribution.jar <install-or-upgrade-folder>
+```
+
+`MainDTSPreInstall` validates Zip entry paths with
+`com.percussion.security.validation.PathValidation` (CWE-22 / ZipSlip). That class
+lives in `perc-security-utils` and is **not** on a thin jar classpath when using
+`java -jar`.
+
+**GH-1180:** package runs a **minimal** `maven-shade-plugin` step that merges only:
+
+| Artifact | What is included |
+|----------|------------------|
+| `com.percussion:perc-security-utils` | `PathValidation` + nested types only |
+| `org.apache.logging.log4j:log4j-api` | Required by `PathValidation`'s logger |
+
+This is intentionally **not** a full `jar-with-dependencies` (unlike
+`perc-distribution-tree`), so wars/Tomcat/Spring stay out of the installer jar.
+
+Verify phase fails the build if `PathValidation.class` or `LogManager.class` is
+missing from the packaged jar (`verify-pathvalidation-shaded` antrun).
 

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml
@@ -502,6 +502,16 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <finalName>delivery-tier-distribution</finalName>
@@ -855,6 +865,65 @@
                     </archive>
                 </configuration>
             </plugin>
+            <!--
+              GH-1180: MainDTSPreInstall uses PathValidation (ZipSlip) but java -jar runs
+              a thin jar with no Class-Path. Shade only the preinstall runtime types needed
+              for extractArchive — not a full jar-with-dependencies (wars/Tomcat/Spring).
+              CMS installer (perc-distribution-tree) uses fat jar-with-dependencies instead.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-preinstall-security</id>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <promoteTransitiveDependencies>false</promoteTransitiveDependencies>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                    </excludes>
+                                </filter>
+                                <!--
+                                  Only PathValidation (+ nested types) is required at preinstall
+                                  runtime today. Keep the filter tight so future bloat in
+                                  perc-security-utils is not pulled into the DTS installer jar.
+                                -->
+                                <filter>
+                                    <artifact>com.percussion:perc-security-utils</artifact>
+                                    <includes>
+                                        <include>com/percussion/security/validation/PathValidation.class</include>
+                                        <include>com/percussion/security/validation/PathValidation$*.class</include>
+                                    </includes>
+                                </filter>
+                            </filters>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.percussion:perc-security-utils</include>
+                                    <!-- PathValidation static logger uses LogManager -->
+                                    <include>org.apache.logging.log4j:log4j-api</include>
+                                </includes>
+                            </artifactSet>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.percussion.preinstall.MainDTSPreInstall</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
@@ -892,6 +961,39 @@
                                 <delete dir="${assembly-directory}/Deployment/Server/webapps/manager"/>
                                 <delete dir="${assembly-directory}/Deployment/Server/webapps/host-manager"/>
                                 <delete file="${assembly-directory}/Deployment/Server/conf/logging.properties"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <!--
+                      GH-1180 regression gate: the packaged installer jar must contain
+                      PathValidation after the minimal shade. Runs on every verify so a
+                      future pom change cannot drop the shade without failing the build.
+                    -->
+                    <execution>
+                        <id>verify-pathvalidation-shaded</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>verify</phase>
+                        <configuration>
+                            <target>
+                                <property name="dts.installer.jar" location="${project.build.directory}/${project.build.finalName}.jar"/>
+                                <available file="${dts.installer.jar}" property="dts.installer.jar.exists"/>
+                                <fail unless="dts.installer.jar.exists" message="DTS installer jar missing: ${dts.installer.jar}"/>
+                                <!-- Portable: jar tool is on the JDK used by Maven; works on Windows/Linux/macOS -->
+                                <exec executable="jar" outputproperty="dts.installer.listing" failonerror="true">
+                                    <arg value="tf"/>
+                                    <arg file="${dts.installer.jar}"/>
+                                </exec>
+                                <condition property="dts.has.pathvalidation">
+                                    <contains string="${dts.installer.listing}" substring="com/percussion/security/validation/PathValidation.class"/>
+                                </condition>
+                                <fail unless="dts.has.pathvalidation" message="GH-1180: ${dts.installer.jar} is missing PathValidation.class — minimal shade of perc-security-utils failed or was removed."/>
+                                <condition property="dts.has.log4j.api">
+                                    <contains string="${dts.installer.listing}" substring="org/apache/logging/log4j/LogManager.class"/>
+                                </condition>
+                                <fail unless="dts.has.log4j.api" message="GH-1180: ${dts.installer.jar} is missing log4j-api (LogManager) required by PathValidation."/>
+                                <echo message="GH-1180: PathValidation + log4j-api present in ${dts.installer.jar}"/>
                             </target>
                         </configuration>
                     </execution>

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
@@ -223,8 +223,10 @@ public class MainDTSPreInstall {
               System.out.println("Warning: could not set executable bit on " + entryDest);
             }
           }
-        } catch (SecurityException se) {
-          // ZipSlip attack detected - skip malicious entry
+        } catch (PathValidation.SecurityException | SecurityException se) {
+          // ZipSlip / path traversal rejected by PathValidation (CWE-22).
+          // PathValidation throws its nested SecurityException (RuntimeException),
+          // not java.lang.SecurityException — catch both so either form is skipped.
           System.out.println("Security: Rejected malicious zip entry: " + entryName);
         }
       }

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/MainDTSPreInstallExtractArchiveTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/MainDTSPreInstallExtractArchiveTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.preinstall;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Behavioral tests for {@link MainDTSPreInstall#extractArchive(Path, Path, String)}.
+ *
+ * <p>Covers GH-1180: extract must use {@code PathValidation} on the runtime classpath (shaded into
+ * the installer jar) and reject ZipSlip entries without aborting the whole extraction.
+ */
+class MainDTSPreInstallExtractArchiveTest {
+
+  private static final String PREFIX = "distribution";
+
+  @TempDir Path tempDir;
+
+  @Test
+  void extractArchive_writesSafeEntriesUnderPrefix() throws Exception {
+    Path archive = tempDir.resolve("safe.zip");
+    // Flat file only: extractArchive does not create parent dirs for nested
+    // file entries unless the zip also contains directory ZipEntry records
+    // (cargo/rootFiles packaging includes those). GH-1180 scope is classpath.
+    writeZip(archive, entry(PREFIX + "/ok.txt", "hello"));
+
+    Path dest = tempDir.resolve("out");
+    MainDTSPreInstall.extractArchive(archive, dest, PREFIX);
+
+    assertTrue(Files.isRegularFile(dest.resolve("ok.txt")));
+    assertTrue(
+        new String(Files.readAllBytes(dest.resolve("ok.txt")), StandardCharsets.UTF_8)
+            .contains("hello"));
+  }
+
+  @Test
+  void extractArchive_skipsEntriesOutsidePrefix() throws Exception {
+    Path archive = tempDir.resolve("prefix.zip");
+    writeZip(
+        archive,
+        entry("other/ignore.txt", "nope"),
+        entry(PREFIX + "/keep.txt", "yes"));
+
+    Path dest = tempDir.resolve("out");
+    MainDTSPreInstall.extractArchive(archive, dest, PREFIX);
+
+    assertTrue(Files.isRegularFile(dest.resolve("keep.txt")));
+    assertFalse(Files.exists(dest.resolve("ignore.txt")));
+    assertFalse(Files.exists(dest.resolve("other")));
+  }
+
+  @Test
+  void extractArchive_rejectsZipSlipAndContinues() throws Exception {
+    Path archive = tempDir.resolve("slip.zip");
+    // Classic ZipSlip: entry name walks above the extract root
+    writeZip(
+        archive,
+        entry(PREFIX + "/good.txt", "safe"),
+        entry(PREFIX + "/../../zipslip-outside.txt", "evil"));
+
+    Path dest = tempDir.resolve("extract");
+    Files.createDirectories(dest);
+    Path siblingProbe = tempDir.resolve("zipslip-outside.txt");
+
+    MainDTSPreInstall.extractArchive(archive, dest, PREFIX);
+
+    assertTrue(Files.isRegularFile(dest.resolve("good.txt")), "safe entry must extract");
+    assertFalse(
+        Files.exists(siblingProbe),
+        "ZipSlip entry must not be written outside the extract directory");
+  }
+
+  @Test
+  void extractArchive_rejectsAbsoluteStyleUserPathComponents() throws Exception {
+    Path archive = tempDir.resolve("abs.zip");
+    // PathValidation.looksAbsolute rejects leading / or \ in the relative component
+    writeZip(archive, entry(PREFIX + "/good2.txt", "ok"), entry(PREFIX + "/../escape.txt", "bad"));
+
+    Path dest = tempDir.resolve("extract2");
+    MainDTSPreInstall.extractArchive(archive, dest, PREFIX);
+
+    assertTrue(Files.isRegularFile(dest.resolve("good2.txt")));
+    assertFalse(Files.exists(tempDir.resolve("escape.txt")));
+  }
+
+  private static ZipEntrySpec entry(String name, String content) {
+    return new ZipEntrySpec(name, content.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static void writeZip(Path zipFile, ZipEntrySpec... entries) throws IOException {
+    try (OutputStream fos = Files.newOutputStream(zipFile);
+        ZipOutputStream zos = new ZipOutputStream(fos)) {
+      for (ZipEntrySpec e : entries) {
+        ZipEntry ze = new ZipEntry(e.name);
+        zos.putNextEntry(ze);
+        zos.write(e.bytes);
+        zos.closeEntry();
+      }
+    }
+  }
+
+  private static final class ZipEntrySpec {
+    final String name;
+    final byte[] bytes;
+
+    ZipEntrySpec(String name, byte[] bytes) {
+      this.name = name;
+      this.bytes = bytes;
+    }
+  }
+}

--- a/docs/ai-generated/code-reviews/fix-1180-dts-installer-pathvalidation-shade-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-1180-dts-installer-pathvalidation-shade-erlang.md
@@ -1,0 +1,68 @@
+# Erlang review: GH-1180 DTS installer PathValidation minimal shade
+
+**Date:** 2026-07-17  
+**Branch:** `fix/1180-dts-installer-pathvalidation-shade`  
+**Base:** `origin/development`  
+**Issue:** https://github.com/intersoftdatalabs-in/percussioncms/issues/1180  
+**Reviewer persona:** Erlang (strict pre-commit / pre-PR)
+
+## Summary
+
+Fixes `NoClassDefFoundError: PathValidation` when running
+`java -jar delivery-tier-distribution.jar` by minimally shading
+`PathValidation` (+ nested types) and `log4j-api` into the installer jar.
+Also corrects ZipSlip catch to handle `PathValidation.SecurityException`
+(nested `RuntimeException`, not `java.lang.SecurityException`). Adds
+behavioral extractArchive tests and a package `verify` antrun gate.
+
+## Scope
+
+- Uncommitted / staged module work under
+  `deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/`
+- Memory patterns hit: missing behavioral tests; false-green packaging;
+  non-portable path I/O (not introduced — NIO `Path` / Ant `file=` used)
+- Cross-platform path review: **clean** for new code (tests use
+  `Files`/`Path`/`@TempDir`; verify uses JDK `jar tf`)
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+## Issues
+
+### suggestion
+
+1. **Log4j "no logging provider" at preinstall runtime**  
+   Shading only `log4j-api` is enough for classloading; StatusLogger prints
+   an ERROR once. Optional later: add a tiny `log4j2-simple` config or
+   `log4j-core` if installer diagnostics need real log files. Not a gate.
+
+2. **Nested extract parent dirs**  
+   `extractArchive` does not `createDirectories` for nested file entries
+   without directory ZipEntries. Pre-existing; not GH-1180. Optional fix.
+
+### nit
+
+3. Shade overlap warnings (log4j-api already present via other paths on
+   rebuild) are noisy but harmless.
+
+## Verification
+
+- Unit tests: `MainDTSPreInstallExtractArchiveTest` — 4 tests (safe extract,
+  prefix filter, ZipSlip reject, `../` reject)
+- `verify-pathvalidation-shaded` antrun: PathValidation + LogManager in jar
+- Smoke: `Class.forName("…PathValidation")` with only the installer jar on
+  classpath → OK
+
+## Files
+
+| Path | Role |
+|------|------|
+| `…/pom.xml` | shade + junit test deps + verify antrun |
+| `…/MainDTSPreInstall.java` | catch PathValidation.SecurityException |
+| `…/MainDTSPreInstallExtractArchiveTest.java` | behavioral tests |
+| `…/README.md` | packaging contract docs |


### PR DESCRIPTION
## Summary

Fixes #1180 — `java -jar delivery-tier-distribution.jar` aborted with:

```text
NoClassDefFoundError: com/percussion/security/validation/PathValidation
```

`MainDTSPreInstall.extractArchive` uses `PathValidation` for ZipSlip, but the packaged installer was a **thin** jar (`Main-Class` only, no `Class-Path`). Compile still worked because `perc-security-utils` is a Maven dependency; runtime under `java -jar` did not.

### Approach (minimal shade)

- `maven-shade-plugin` at package merges **only**:
  - `perc-security-utils` → `PathValidation` + nested types (filter)
  - `log4j-api` → required by `PathValidation` static logger
- **Not** full `jar-with-dependencies` (keeps wars/Tomcat/Spring out of the installer entry jar; CMS uses fat jar for `perc-distribution-tree` instead)
- Catch `PathValidation.SecurityException` (nested `RuntimeException`) so ZipSlip skips entries instead of crashing
- Unit tests for safe extract + ZipSlip rejection
- Verify-phase antrun fails the build if `PathValidation.class` / `LogManager.class` is missing from the jar

## Test plan

- [x] `./mvn-env.sh -pl deliverytiersuite/delivery-tier-suite/delivery-tier-distribution test package verify -Dai.integrity.skip=true` — 4/4 tests, BUILD SUCCESS, shade verify echo
- [x] `Class.forName("com.percussion.security.validation.PathValidation")` with only the installer jar on classpath
- [x] Erlang pre-commit: approve — `docs/ai-generated/code-reviews/fix-1180-dts-installer-pathvalidation-shade-erlang.md`
- [ ] Manual: `java -jar target/delivery-tier-distribution.jar <install-dir>` on a clean machine proceeds past extract (no NCDFE)