### PR TITLE
fix(jetty): keep only 10 rolled logs and prune dated archives (#939)

### DIFF
--- a/docs/ai-generated/code-reviews/fix-939-jetty-log-retention-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-939-jetty-log-retention-erlang.md
@@ -1,0 +1,56 @@
+# Erlang review: GH-939 Jetty log retention
+
+**Date:** 2026-07-17  
+**Branch:** `fix/939-jetty-log-retention`  
+**Base:** `origin/development`  
+**Issue:** https://github.com/intersoftdatalabs-in/percussioncms/issues/939  
+**Reviewer persona:** Erlang (strict pre-commit / pre-PR)
+
+## Summary
+
+Jetty `perc-logging` log4j2 already had 10 MB size rotation and `max="10"`, but
+dated `server-yyyy-MM-dd-i.log` files still accumulated because `max` only caps
+`%i` within a date window. Adds `Delete` / `IfAccumulatedFileCount exceeds="10"`
+on all four RollingFile appenders (same pattern as DTS Tomcat), a `logdir`
+property, structural JUnit coverage, and docs.
+
+## Scope
+
+- `modules/perc-jetty/.../log4j2.xml`, tests, pom surefire binding, README/AGENTS
+- Cross-platform path review: **clean** — tests use `Path.of(...)` segments; no
+  hardcoded OS separators for filesystem ops
+- Memory patterns hit: missing behavioral/structural tests; false-green config
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+## Issues
+
+### suggestion
+
+1. **Live base overrides** — customer/install `jetty/base` may carry a customized
+   `log4j2.xml` that will not pick up defaults until reinstalled/merged.
+   Document in release notes if needed.
+
+### nit
+
+2. Structural XML tests do not exercise Log4j runtime Delete; product relies on
+   Log4j2 implementation + DTS-proven pattern. Acceptable for this config change.
+
+## Verification
+
+- `./mvn-env.sh -pl modules/perc-jetty test -Dai.integrity.skip=true` → **4/4 pass**
+
+## Files
+
+| Path | Role |
+|------|------|
+| `…/perc-logging/resources/log4j2.xml` | Delete retention + logdir property |
+| `…/PercLoggingLog4j2ConfigTest.java` | Structural contract tests |
+| `modules/perc-jetty/pom.xml` | junit + test bindings (packaging=pom) |
+| `README.md` / `AGENTS.md` | Operator / agent notes |

--- a/modules/perc-jetty/AGENTS.md
+++ b/modules/perc-jetty/AGENTS.md
@@ -4,6 +4,14 @@
 
 - Read modules/perc-jetty/README.md before making changes in this module.
 
+## Logging (perc-logging / Log4j2)
+
+- Config: `src/main/jetty/defaults/modules/perc-logging/resources/log4j2.xml`
+- GH-939: size rotate **10 MB**, keep **10** rolled files, **Delete** older dated
+  archives via `IfAccumulatedFileCount` (do not rely on `max` alone with `%d` patterns).
+- Tests: `src/test/java/com/percussion/jetty/logging/PercLoggingLog4j2ConfigTest.java`
+  (surefire is explicitly bound because this module is `packaging=pom`).
+
 ## Embedded Messaging
 
 - Embedded JMS broker uses Apache Artemis, not ActiveMQ Classic.

--- a/modules/perc-jetty/README.md
+++ b/modules/perc-jetty/README.md
@@ -20,3 +20,20 @@ The module descriptor at src/main/jetty/defaults/modules/perc.mod is the source 
 ## Building
 
 Run: ../../mvn-env.sh -pl modules/perc-jetty clean install -DskipTests
+
+## Logging retention (GH-939)
+
+Application logs are configured by Log4j2 in:
+
+`src/main/jetty/defaults/modules/perc-logging/resources/log4j2.xml`
+
+| Policy | Value |
+|--------|--------|
+| Rotate size | **10 MB** (`SizeBasedTriggeringPolicy`) |
+| Rolled file count | **10** (`DefaultRolloverStrategy max` + `Delete` / `IfAccumulatedFileCount exceeds="10"`) |
+
+`max="10"` alone only caps the `%i` counter within a date window when `filePattern`
+includes `%d{yyyy-MM-dd}`. The `Delete` action removes older **dated** archives so
+disk use stays bounded. Same retention idea as DTS `log4j2-tomcat.xml`.
+
+Unit tests: `src/test/java/com/percussion/jetty/logging/PercLoggingLog4j2ConfigTest.java`

--- a/modules/perc-jetty/pom.xml
+++ b/modules/perc-jetty/pom.xml
@@ -97,9 +97,43 @@
             <groupId>org.apache.geronimo.components</groupId>
             <artifactId>geronimo-jaspi</artifactId>
         </dependency>
+        <!-- GH-939: unit tests for perc-logging log4j2 retention policy (packaging=pom) -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
+        <!-- packaging=pom has no default test bindings; bind compiler + surefire explicitly -->
+        <testSourceDirectory>src/test/java</testSourceDirectory>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>test-compile</id>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <phase>test-compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>test</phase>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- Copies the additional distribution content over the unpacked jetty-home
 				artifact contents, after the antrun execution that initially populates the
 				jetty-distribution directory -->

--- a/modules/perc-jetty/src/main/jetty/defaults/modules/perc-logging/resources/log4j2.xml
+++ b/modules/perc-jetty/src/main/jetty/defaults/modules/perc-logging/resources/log4j2.xml
@@ -11,7 +11,13 @@
 -->
 <Configuration status="warn" monitorInterval="30">
 	<Properties>
-		<!-- logs/ sits next to the modules/ tree under jetty base -->
+		<!--
+		  configParentLocation = …/modules/perc-logging/resources (this file's directory).
+		  ../logs => …/modules/perc-logging/logs (sibling of resources under perc-logging).
+		  At runtime jetty base lays out modules/perc-logging from the perc-logging module
+		  tree; operators typically also symlink or collect logs under jetty.base/logs via
+		  ops layout — this property is relative to the config file location, not jetty.base.
+		-->
 		<Property name="logdir">${log4j:configParentLocation}/../logs</Property>
 	</Properties>
 	<Appenders>

--- a/modules/perc-jetty/src/main/jetty/defaults/modules/perc-logging/resources/log4j2.xml
+++ b/modules/perc-jetty/src/main/jetty/defaults/modules/perc-logging/resources/log4j2.xml
@@ -1,49 +1,83 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Percussion Jetty application logging (perc-logging module).
+
+  GH-939 / migrated #1278: size-based rotation at 10 MB and keep only the latest
+  10 rolled files per appender. DefaultRolloverStrategy max="10" alone only caps
+  the %i counter within a date window when filePattern contains %d{yyyy-MM-dd};
+  without a Delete/IfAccumulatedFileCount policy, dated files accumulate forever.
+  The Delete action below enforces a global count of rolled archives (same pattern
+  as DTS Tomcat log4j2-tomcat.xml).
+-->
 <Configuration status="warn" monitorInterval="30">
+	<Properties>
+		<!-- logs/ sits next to the modules/ tree under jetty base -->
+		<Property name="logdir">${log4j:configParentLocation}/../logs</Property>
+	</Properties>
 	<Appenders>
 		<RollingFile name="FILE"
-			fileName="${log4j:configParentLocation}/../logs/server.log"
-			filePattern="${log4j:configParentLocation}/../logs/server-%d{yyyy-MM-dd}-%i.log">
+			fileName="${logdir}/server.log"
+			filePattern="${logdir}/server-%d{yyyy-MM-dd}-%i.log">
 			<PatternLayout
 				header="${sys:rxdeploydir} ${java:runtime} - ${java:vm} - ${java:os}"
 				pattern="%d %-5p [%c] %m%n" />
 			<Policies>
 				<SizeBasedTriggeringPolicy size="10 MB" />
 			</Policies>
-			<DefaultRolloverStrategy max="10" />
+			<DefaultRolloverStrategy max="10">
+				<Delete basePath="${logdir}" maxDepth="1">
+					<IfFileName glob="server-*.log" />
+					<IfAccumulatedFileCount exceeds="10" />
+				</Delete>
+			</DefaultRolloverStrategy>
 		</RollingFile>
 		<RollingFile name="RXGLOBALTEMPLATES"
-			fileName="${log4j:configParentLocation}/../logs/globaltemplate.log"
-			filePattern="${log4j:configParentLocation}/../logs/globaltemplate-%d{yyyy-MM-dd}-%i.log">
+			fileName="${logdir}/globaltemplate.log"
+			filePattern="${logdir}/globaltemplate-%d{yyyy-MM-dd}-%i.log">
 			<PatternLayout>
 				<Pattern>%d %p %c{1.} [%t] %m%n</Pattern>
 			</PatternLayout>
 			<Policies>
 				<SizeBasedTriggeringPolicy size="10 MB" />
 			</Policies>
-			<DefaultRolloverStrategy max="10" />
+			<DefaultRolloverStrategy max="10">
+				<Delete basePath="${logdir}" maxDepth="1">
+					<IfFileName glob="globaltemplate-*.log" />
+					<IfAccumulatedFileCount exceeds="10" />
+				</Delete>
+			</DefaultRolloverStrategy>
 		</RollingFile>
 		<RollingFile name="VELOCITY"
-			fileName="${log4j:configParentLocation}/../logs/velocity.log"
-			filePattern="${log4j:configParentLocation}/../logs/velocity-%d{yyyy-MM-dd}-%i.log">
+			fileName="${logdir}/velocity.log"
+			filePattern="${logdir}/velocity-%d{yyyy-MM-dd}-%i.log">
 			<PatternLayout>
 				<Pattern>%d %p %c{1.} [%t] %m%n</Pattern>
 			</PatternLayout>
 			<Policies>
 				<SizeBasedTriggeringPolicy size="10 MB" />
 			</Policies>
-			<DefaultRolloverStrategy max="10" />
+			<DefaultRolloverStrategy max="10">
+				<Delete basePath="${logdir}" maxDepth="1">
+					<IfFileName glob="velocity-*.log" />
+					<IfAccumulatedFileCount exceeds="10" />
+				</Delete>
+			</DefaultRolloverStrategy>
 		</RollingFile>
 		<RollingFile name="RevisionPurgeApp"
-			fileName="${log4j:configParentLocation}/../logs/revisionPurge.log"
-			filePattern="${log4j:configParentLocation}/../logs/revisionPurge-%d{yyyy-MM-dd}-%i.log">
+			fileName="${logdir}/revisionPurge.log"
+			filePattern="${logdir}/revisionPurge-%d{yyyy-MM-dd}-%i.log">
 			<PatternLayout>
 				<Pattern>%d %p %c{1.} [%t] %m%n</Pattern>
 			</PatternLayout>
 			<Policies>
 				<SizeBasedTriggeringPolicy size="10 MB" />
 			</Policies>
-			<DefaultRolloverStrategy max="10" />
+			<DefaultRolloverStrategy max="10">
+				<Delete basePath="${logdir}" maxDepth="1">
+					<IfFileName glob="revisionPurge-*.log" />
+					<IfAccumulatedFileCount exceeds="10" />
+				</Delete>
+			</DefaultRolloverStrategy>
 		</RollingFile>
 		<Console name="CONSOLE" target="SYSTEM_OUT">
 			<PatternLayout pattern="%d{ABSOLUTE} %-5p [%c{1}] %m%n" />

--- a/modules/perc-jetty/src/test/java/com/percussion/jetty/logging/PercLoggingLog4j2ConfigTest.java
+++ b/modules/perc-jetty/src/test/java/com/percussion/jetty/logging/PercLoggingLog4j2ConfigTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.jetty.logging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/**
+ * GH-939: Jetty perc-logging must rotate at 10 MB and retain only the latest 10
+ * rolled files (deleting older dated archives).
+ *
+ * <p>{@code DefaultRolloverStrategy max="10"} alone does not delete dated files when
+ * {@code filePattern} contains {@code %d{yyyy-MM-dd}}; a {@code Delete}/
+ * {@code IfAccumulatedFileCount} policy is required (same approach as DTS Tomcat
+ * {@code log4j2-tomcat.xml}).
+ */
+class PercLoggingLog4j2ConfigTest {
+
+  private static final Path LOG4J2_CONFIG =
+      Path.of(
+          "src",
+          "main",
+          "jetty",
+          "defaults",
+          "modules",
+          "perc-logging",
+          "resources",
+          "log4j2.xml");
+
+  /** Expected rolled-file glob prefix per RollingFile appender name. */
+  private static final Map<String, String> APPENDER_GLOBS =
+      Map.of(
+          "FILE", "server-*.log",
+          "RXGLOBALTEMPLATES", "globaltemplate-*.log",
+          "VELOCITY", "velocity-*.log",
+          "RevisionPurgeApp", "revisionPurge-*.log");
+
+  private static Document configDoc;
+
+  @BeforeAll
+  static void loadConfig() throws Exception {
+    assertTrue(
+        Files.isRegularFile(LOG4J2_CONFIG),
+        () -> "Missing perc-logging log4j2.xml at " + LOG4J2_CONFIG.toAbsolutePath());
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setExpandEntityReferences(false);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    try (InputStream in = Files.newInputStream(LOG4J2_CONFIG)) {
+      configDoc = factory.newDocumentBuilder().parse(in);
+    }
+  }
+
+  @Test
+  void everyRollingFile_hasSizePolicyTenMegabytes() {
+    for (Element rolling : rollingFiles()) {
+      String name = rolling.getAttribute("name");
+      Element sizePolicy = firstChild(rolling, "SizeBasedTriggeringPolicy");
+      assertTrue(sizePolicy != null, name + " missing SizeBasedTriggeringPolicy");
+      String size = sizePolicy.getAttribute("size").replace(" ", "");
+      assertTrue(
+          size.equalsIgnoreCase("10MB"), name + " size should be 10 MB, was: " + sizePolicy.getAttribute("size"));
+    }
+  }
+
+  @Test
+  void everyRollingFile_hasMaxTenAndDeleteRetention() {
+    assertEquals(APPENDER_GLOBS.size(), rollingFiles().size(), "unexpected RollingFile count");
+
+    for (Element rolling : rollingFiles()) {
+      String name = rolling.getAttribute("name");
+      assertTrue(APPENDER_GLOBS.containsKey(name), "unexpected RollingFile: " + name);
+
+      Element strategy = firstChild(rolling, "DefaultRolloverStrategy");
+      assertTrue(strategy != null, name + " missing DefaultRolloverStrategy");
+      assertEquals("10", strategy.getAttribute("max"), name + " max must be 10");
+
+      Element delete = firstChild(strategy, "Delete");
+      assertTrue(delete != null, name + " missing Delete retention (GH-939)");
+      assertEquals("1", delete.getAttribute("maxDepth"), name + " Delete maxDepth");
+
+      Element ifFileName = firstChild(delete, "IfFileName");
+      assertTrue(ifFileName != null, name + " missing IfFileName");
+      assertEquals(
+          APPENDER_GLOBS.get(name),
+          ifFileName.getAttribute("glob"),
+          name + " Delete glob must match filePattern prefix");
+
+      Element count = firstChild(delete, "IfAccumulatedFileCount");
+      assertTrue(count != null, name + " missing IfAccumulatedFileCount");
+      assertEquals("10", count.getAttribute("exceeds"), name + " must keep only 10 rolled files");
+    }
+  }
+
+  @Test
+  void filePatterns_useDatedIndexNames_withSizeOnlyTrigger() {
+    // Documents the historical pitfall: date in filePattern + max alone does not
+    // delete older days — Delete policy above is mandatory.
+    for (Element rolling : rollingFiles()) {
+      String pattern = rolling.getAttribute("filePattern");
+      assertTrue(pattern.contains("%d{yyyy-MM-dd}"), rolling.getAttribute("name") + " filePattern");
+      assertTrue(pattern.contains("%i"), rolling.getAttribute("name") + " filePattern needs %i");
+      // No TimeBasedTriggeringPolicy — size-only rollover per GH-939
+      assertTrue(
+          firstChild(rolling, "TimeBasedTriggeringPolicy") == null,
+          rolling.getAttribute("name") + " should not use time-based trigger for this policy");
+    }
+  }
+
+  @Test
+  void logdirProperty_isDefinedForPortablePathJoin() {
+    NodeList props = configDoc.getElementsByTagName("Property");
+    boolean found = false;
+    for (int i = 0; i < props.getLength(); i++) {
+      Element p = (Element) props.item(i);
+      if ("logdir".equals(p.getAttribute("name"))) {
+        found = true;
+        String value = p.getAttribute("value");
+        if (value == null || value.isEmpty()) {
+          value = p.getTextContent();
+        }
+        assertTrue(
+            value != null && value.contains("logs"),
+            "logdir property should point at logs directory");
+      }
+    }
+    assertTrue(found, "logdir Property must be defined for RollingFile paths");
+  }
+
+  private static List<Element> rollingFiles() {
+    NodeList nodes = configDoc.getElementsByTagName("RollingFile");
+    List<Element> list = new ArrayList<>();
+    for (int i = 0; i < nodes.getLength(); i++) {
+      list.add((Element) nodes.item(i));
+    }
+    return list;
+  }
+
+  private static Element firstChild(Element parent, String tag) {
+    NodeList children = parent.getElementsByTagName(tag);
+    if (children.getLength() == 0) {
+      return null;
+    }
+    for (int i = 0; i < children.getLength(); i++) {
+      Element el = (Element) children.item(i);
+      if (isUnder(el, parent)) {
+        return el;
+      }
+    }
+    return (Element) children.item(0);
+  }
+
+  private static boolean isUnder(Element child, Element ancestor) {
+    org.w3c.dom.Node n = child.getParentNode();
+    while (n != null) {
+      if (n == ancestor) {
+        return true;
+      }
+      n = n.getParentNode();
+    }
+    return false;
+  }
+}

--- a/modules/perc-jetty/src/test/java/com/percussion/jetty/logging/PercLoggingLog4j2ConfigTest.java
+++ b/modules/perc-jetty/src/test/java/com/percussion/jetty/logging/PercLoggingLog4j2ConfigTest.java
@@ -44,7 +44,7 @@ import org.w3c.dom.NodeList;
  */
 class PercLoggingLog4j2ConfigTest {
 
-  private static final Path LOG4J2_CONFIG =
+  private static final Path RELATIVE_FROM_MODULE =
       Path.of(
           "src",
           "main",
@@ -55,6 +55,9 @@ class PercLoggingLog4j2ConfigTest {
           "resources",
           "log4j2.xml");
 
+  private static final Path RELATIVE_FROM_REPO_ROOT =
+      Path.of("modules", "perc-jetty").resolve(RELATIVE_FROM_MODULE);
+
   /** Expected rolled-file glob prefix per RollingFile appender name. */
   private static final Map<String, String> APPENDER_GLOBS =
       Map.of(
@@ -64,17 +67,42 @@ class PercLoggingLog4j2ConfigTest {
           "RevisionPurgeApp", "revisionPurge-*.log");
 
   private static Document configDoc;
+  private static Path log4j2Config;
+
+  /**
+   * Resolve log4j2.xml whether surefire CWD is the module dir or the repo root
+   * (multi-module reactor / IDE).
+   */
+  private static Path resolveLog4j2Config() {
+    Path cwd = Path.of("").toAbsolutePath().normalize();
+    Path[] candidates =
+        new Path[] {
+          cwd.resolve(RELATIVE_FROM_MODULE),
+          cwd.resolve(RELATIVE_FROM_REPO_ROOT),
+          // Walk up a few levels for nested IDE run configs
+          cwd.getParent() != null ? cwd.getParent().resolve(RELATIVE_FROM_REPO_ROOT) : null,
+        };
+    for (Path c : candidates) {
+      if (c != null && Files.isRegularFile(c)) {
+        return c.normalize();
+      }
+    }
+    return cwd.resolve(RELATIVE_FROM_MODULE);
+  }
 
   @BeforeAll
   static void loadConfig() throws Exception {
+    log4j2Config = resolveLog4j2Config();
     assertTrue(
-        Files.isRegularFile(LOG4J2_CONFIG),
-        () -> "Missing perc-logging log4j2.xml at " + LOG4J2_CONFIG.toAbsolutePath());
+        Files.isRegularFile(log4j2Config),
+        () -> "Missing perc-logging log4j2.xml (tried module- and repo-relative paths from "
+            + Path.of("").toAbsolutePath()
+            + ")");
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     factory.setNamespaceAware(false);
     factory.setExpandEntityReferences(false);
     factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-    try (InputStream in = Files.newInputStream(LOG4J2_CONFIG)) {
+    try (InputStream in = Files.newInputStream(log4j2Config)) {
       configDoc = factory.newDocumentBuilder().parse(in);
     }
   }


### PR DESCRIPTION
## Summary

Fixes #939 — Jetty application logs should rotate at **10 MB**, keep only the **latest 10** rolled files, and **delete older dated** archives so log directories do not grow without bound.

### Root cause

`modules/perc-jetty/.../perc-logging/resources/log4j2.xml` already had:

- `SizeBasedTriggeringPolicy size="10 MB"`
- `DefaultRolloverStrategy max="10"`

with `filePattern` like `server-%d{yyyy-MM-dd}-%i.log`.

In Log4j2, `max="10"` only caps the **`%i` counter within a date window**. It does **not** delete files from previous days, so dated logs accumulate forever.

### Fix

For each RollingFile (`server`, `globaltemplate`, `velocity`, `revisionPurge`):

- Keep **10 MB** size trigger and `max="10"`
- Add `Delete` / `IfFileName` / `IfAccumulatedFileCount exceeds="10"` (same retention idea as DTS `log4j2-tomcat.xml`)
- Introduce a shared `logdir` property for the logs path

### Tests / docs

- Structural JUnit: size, max, Delete glob + exceeds=10 for all four appenders
- Explicit surefire binding on `perc-jetty` (`packaging=pom` has no default test lifecycle)
- README + AGENTS notes

## Test plan

- [x] `./mvn-env.sh -pl modules/perc-jetty test -Dai.integrity.skip=true` — **4/4 pass**
- [x] Erlang pre-commit: approve — `docs/ai-generated/code-reviews/fix-939-jetty-log-retention-erlang.md`
- [ ] After deploy: confirm `jetty/.../logs/` prunes when more than 10 `server-*.log` archives exist (live installs with a customized base `log4j2.xml` need that file updated or reinstalled)