### PR TITLE
feat(jetty): native systemd unit for CMS Linux service (#962)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/README.md
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/README.md
@@ -31,6 +31,43 @@ etc...
 ```bash
 ./mvn-env.sh -pl deliverytiersuite/delivery-tier-suite/delivery-tier-distribution -am clean install
 # Windows: mvn-env.bat -pl deliverytiersuite/delivery-tier-suite/delivery-tier-distribution -am clean install
+
+## Linux services (systemd) — GH-962
+
+Production and Staging installers under `src/main/rootFiles/` prefer **native systemd**
+when available:
+
+| Script | Default unit |
+|--------|----------------|
+| `DTSProductionService.sh` | `PercussionProductionDTS` |
+| `DTSStagingService.sh` | `PercussionStagingDTS` |
+
+Shared unit template: `dts-tomcat.service.in` (`Type=forking`, `TimeoutStartSec=1800`, journal).  
+Ops notes: `README-systemd.md`. Flags: `--systemd`, `--initd`. Windows `.bat` unchanged.
+
+```bash
+sudo ./DTSProductionService.sh install
+sudo systemctl start PercussionProductionDTS
+journalctl -u PercussionProductionDTS -n 50 --no-pager
+```
+
+## Linux services (systemd) — GH-962
+
+Production and Staging installers under `src/main/rootFiles/` prefer **native systemd**
+when available:
+
+| Script | Default unit |
+|--------|----------------|
+| `DTSProductionService.sh` | `PercussionProductionDTS` |
+| `DTSStagingService.sh` | `PercussionStagingDTS` |
+
+Shared unit template: `dts-tomcat.service.in` (`Type=forking`, `TimeoutStartSec=1800`, journal).  
+Ops notes: `README-systemd.md`. Flags: `--systemd`, `--initd`. Windows `.bat` unchanged.
+
+```bash
+sudo ./DTSProductionService.sh install
+sudo systemctl start PercussionProductionDTS
+journalctl -u PercussionProductionDTS -n 50 --no-pager
 ```
 
 ## Installer jar (`java -jar`)

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml
@@ -512,6 +512,12 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- GH-962: structural tests for DTS systemd unit + install scripts -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <finalName>delivery-tier-distribution</finalName>

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/DTSProductionService.sh
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/DTSProductionService.sh
@@ -60,6 +60,35 @@ if [ "$FORCE_SYSTEMD" = "true" ] && [ "$FORCE_INITD" = "true" ]; then
 	exit 1
 fi
 
+function validate_service_name() {
+	case "$1" in
+		'' | *[!A-Za-z0-9_-]* | -* | _*)
+			echo "Invalid service name '$1' (use letters, digits, underscore, hyphen; must start with alnum)" 1>&2
+			exit 1
+			;;
+	esac
+}
+
+validate_service_name "$SERVICE_NAME"
+
+function substitute_unit_template() {
+	local template="$1"
+	local dest="$2"
+	local _description="$3"
+	local _pid_file="$4"
+	local _env_file="$5"
+	local _init_script="$6"
+	local line
+	while IFS= read -r line || [ -n "$line" ]; do
+		line=${line//@SERVICE_NAME@/${SERVICE_NAME}}
+		line=${line//@DESCRIPTION@/${_description}}
+		line=${line//@PID_FILE@/${_pid_file}}
+		line=${line//@ENV_FILE@/${_env_file}}
+		line=${line//@INIT_SCRIPT@/${_init_script}}
+		printf '%s\n' "$line"
+	done < "$template" > "$dest"
+}
+
 function is_systemd_available() {
 	[ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1
 }
@@ -189,13 +218,8 @@ function installSystemdUnit() {
 	local description="Percussion Production DTS Tomcat (${SERVICE_NAME})"
 
 	echo "Installing systemd unit ${unit_path}"
-	sed \
-		-e "s|@SERVICE_NAME@|${SERVICE_NAME}|g" \
-		-e "s|@DESCRIPTION@|${description}|g" \
-		-e "s|@PID_FILE@|${pid_file}|g" \
-		-e "s|@ENV_FILE@|${env_file}|g" \
-		-e "s|@INIT_SCRIPT@|${init_script}|g" \
-		"$unit_template" > "$unit_path"
+	substitute_unit_template "$unit_template" "$unit_path" \
+		"$description" "$pid_file" "$env_file" "$init_script"
 	chmod 644 "$unit_path"
 	systemctl daemon-reload
 	systemctl enable "${SERVICE_NAME}.service"
@@ -290,8 +314,11 @@ if [ "$uninstall" != "true" ]; then
 	fi
 else
 	echo "Uninstalling ${SERVICE_NAME}"
+	had_systemd=false
+	had_initd=false
 
 	if [ -f "/etc/systemd/system/${SERVICE_NAME}.service" ]; then
+		had_systemd=true
 		if systemctl is-active --quiet "${SERVICE_NAME}.service" 2>/dev/null; then
 			systemctl stop "${SERVICE_NAME}.service" || true
 		fi
@@ -299,6 +326,7 @@ else
 	fi
 
 	if [ -f "/etc/init.d/${SERVICE_NAME}" ]; then
+		had_initd=true
 		if ! grep -q "${CATALINA_MARKER}" "/etc/init.d/${SERVICE_NAME}"; then
 			echo "Service at /etc/init.d/${SERVICE_NAME} is not a Percussion Production DTS service"
 			exit 1
@@ -307,7 +335,9 @@ else
 			${serviceCmd} stop || true
 		fi
 		removeServiceFromStartup "${SERVICE_NAME}"
-	elif [ ! -f "/etc/systemd/system/${SERVICE_NAME}.service" ]; then
+	fi
+
+	if [ "$had_systemd" != "true" ] && [ "$had_initd" != "true" ]; then
 		echo "Service ${SERVICE_NAME} not installed"
 		exit 1
 	fi

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/DTSProductionService.sh
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/DTSProductionService.sh
@@ -1,218 +1,319 @@
 #!/bin/bash
-# chkconfig: 333 77 11
+# Install or uninstall Percussion Production DTS as a Linux service.
+# GH-962: prefer native systemd; keep init.d as fallback.
+#
+# Usage:
+#   DTSProductionService.sh [ServiceName] install [--systemd|--initd]
+#   DTSProductionService.sh [ServiceName] uninstall
+
 echo "Script To Install Production DTS Linux Service."
 
 SERVICE_NAME=PercussionProductionDTS
+FORCE_SYSTEMD=false
+FORCE_INITD=false
+VARIANT=production
+PID_BASENAME=PercussionProductionDTS.pid
+RUN_PARENT=/var/run/PercussionProductionService
+CATALINA_MARKER=catalina
 
 if [ "$(id -u)" != "0" ]; then
-	echo "This script must be run with sudo or as root"
+	echo "This script must be run with sudo or as root" 1>&2
 	exit 1
 fi
 
 function usage() {
-	echo "Usage: $0 [ Service name default : PercussionProductionDTS ] {install | uninstall }"
+	echo "Usage: $0 [ Service name default : PercussionProductionDTS ] {install | uninstall} [--systemd | --initd]"
 	exit 1
 }
 
-if [ $# -gt 1 ];then
+if [ $# -lt 1 ]; then
+	usage
+fi
+
+if [ "$1" != "install" ] && [ "$1" != "uninstall" ]; then
 	SERVICE_NAME="$1"
 	shift
 fi
 
-if [ "$1" == "uninstall" ]; then
+ACTION="$1"
+shift || true
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--systemd) FORCE_SYSTEMD=true ;;
+		--initd) FORCE_INITD=true ;;
+		*) usage ;;
+	esac
+	shift
+done
+
+if [ "$ACTION" == "uninstall" ]; then
 	uninstall=true
-elif [ "$1" == "install" ]; then
+elif [ "$ACTION" == "install" ]; then
 	uninstall=false
 else
 	usage
 fi
 
-function checkForProductionDTSService() {
-	while read -r line; do
-		service=$(basename ${line})
-		echo "Found DTS service $service in $line"
-		serviceHome=$(bash -c "source ${line} >/dev/null 2>1 ; echo \${CTATALINA_HOME}")
-		echo Service Name: ${SERVICE_NAME}
-		if [ "$serviceHome" == "$CATALINA_HOME" ]; then
-			currentService=${service}
+if [ "$FORCE_SYSTEMD" = "true" ] && [ "$FORCE_INITD" = "true" ]; then
+	echo "Cannot combine --systemd and --initd" 1>&2
+	exit 1
+fi
+
+function is_systemd_available() {
+	[ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1
+}
+
+function use_systemd_install() {
+	if [ "$FORCE_INITD" = "true" ]; then
+		return 1
+	fi
+	if [ "$FORCE_SYSTEMD" = "true" ]; then
+		if ! is_systemd_available; then
+			echo "systemd required (--systemd) but not available" 1>&2
+			exit 1
 		fi
-		echo CurrentService: ${currentService}
-	done < <(grep -l /etc/default/* -e 'CATALINA_HOME')
-}
-
-function removeServiceFromStartup {
-
-	echo "Uninstalling service $1 from startup"
-	if [[ $(type -P "chkconfig") ]]; then
-		echo "Using command 'chkconfig "${SERVICE_NAME}" off'"
-		chkconfig ${SERVICE_NAME} off
-	elif [[ $(type -P "update-rc.d") ]]; then
-		echo "Using command 'update-rc.d -f ${1} remove'"
-		update-rc.d -f ${SERVICE_NAME} remove
-	else
-		echo "Cannot find chkconfig or update-rc.d to remove service looking to removing from rc.d folders"
+		return 0
 	fi
-
-	if [ -d "/etc/rc.d/rc2.d" ]; then
-		echo "Removing links to /etc/rc.d/rc*.d/S??${1} and /etc/rc.d/rc*.d/K??${1}"
-		rm -f /etc/rc.d/rc?.d/S??${SERVICE_NAME}
-		rm -f /etc/rc.d/rc?.d/K??${SERVICE_NAME}
-	fi
-
-	if [ -d "/etc/rc2.d" ]; then
-		echo "Removing links to /etc/rc*.d/S??${1} and /etc/rc*.d/K??${1}"
-		rm -f /etc/rc?.d/S??${SERVICE_NAME}
-		rm -f /etc/rc?.d/K??${SERVICE_NAME}
-	fi
-
-}
-
-function removeServiceScript() {
-	echo "Removing files."
-	set -x
-	rm -f "/etc/init.d/${SERVICE_NAME}"
-	rm -f "/etc/default/${SERVICE_NAME}"
-	{ set +x; } > /dev/null 2>&1
+	is_systemd_available
 }
 
 function abspath() {
-    # generate absolute path from relative path
-    # $1     : relative filename
-    # return : absolute path
-    if [ -d "$1" ]; then
-        # dir
-        (cd "$1"; pwd)
-    elif [ -f "$1" ]; then
-        # file
-        if [[ $1 = /* ]]; then
-            echo "$1"
-        elif [[ $1 == */* ]]; then
-            echo "$(cd "${1%/*}"; pwd)/${1##*/}"
-        else
-            echo "$(pwd)/$1"
-        fi
-    fi
+	if [ -d "$1" ]; then
+		(cd "$1" && pwd)
+	elif [ -f "$1" ]; then
+		if [[ $1 = /* ]]; then
+			echo "$1"
+		elif [[ $1 == */* ]]; then
+			echo "$(cd "${1%/*}" && pwd)/${1##*/}"
+		else
+			echo "$(pwd)/$1"
+		fi
+	fi
 }
 
-distVersion=$(cat /proc/version 2>&1)
+function checkForDTSService() {
+	currentService=
+	if ! compgen -G "/etc/default/*" >/dev/null 2>&1; then
+		return 0
+	fi
+	while read -r line; do
+		service=$(basename "${line}")
+		echo "Found DTS service $service in $line"
+		serviceHome=$(bash -c "source ${line} >/dev/null 2>&1 ; echo \${CATALINA_HOME}")
+		if [ "$serviceHome" == "$CATALINA_HOME" ]; then
+			currentService=${service}
+		fi
+	done < <(grep -l /etc/default/* -e 'CATALINA_HOME' 2>/dev/null || true)
+}
 
-CATALINA_HOME=$(dirname $(abspath "$0"))
+function removeServiceFromStartup() {
+	echo "Uninstalling SysV service $1 from startup"
+	if command -v chkconfig >/dev/null 2>&1; then
+		chkconfig "${1}" off || true
+	elif command -v update-rc.d >/dev/null 2>&1; then
+		update-rc.d -f "${1}" remove || true
+	fi
+	if [ -d "/etc/rc.d/rc2.d" ]; then
+		rm -f /etc/rc.d/rc?.d/S??"${1}" /etc/rc.d/rc?.d/K??"${1}"
+	fi
+	if [ -d "/etc/rc2.d" ]; then
+		rm -f /etc/rc?.d/S??"${1}" /etc/rc?.d/K??"${1}"
+	fi
+}
+
+function removeSystemdUnit() {
+	local name="$1"
+	local unit="/etc/systemd/system/${name}.service"
+	if [ -f "$unit" ]; then
+		echo "Removing systemd unit ${name}.service"
+		systemctl disable --now "${name}.service" 2>/dev/null || true
+		rm -f "$unit"
+		systemctl daemon-reload || true
+		systemctl reset-failed "${name}.service" 2>/dev/null || true
+	fi
+}
+
+function removeServiceScript() {
+	echo "Removing files for ${SERVICE_NAME}"
+	rm -f "/etc/init.d/${SERVICE_NAME}"
+	rm -f "/etc/default/${SERVICE_NAME}"
+	rm -f "/etc/systemd/system/${SERVICE_NAME}.service"
+	rm -rf "${TOMCAT_RUN}"
+}
+
+function installInitScriptAndDefaults() {
+	echo "Setting up pid folder ${TOMCAT_RUN} user=${RX_USER} group=${RX_GROUP}"
+	mkdir -p "${TOMCAT_RUN}"
+	chown -R "${RX_USER}:${RX_GROUP}" "${TOMCAT_RUN}"
+
+	if [ ! -f "${CATALINA_HOME}/bin/catalina.sh" ]; then
+		echo "Missing ${CATALINA_HOME}/bin/catalina.sh" 1>&2
+		exit 1
+	fi
+
+	echo "Installing start helper to /etc/init.d/${SERVICE_NAME}"
+	# Fresh file each install (avoid append corruption from re-runs)
+	sed -e "s/\${PercussionProductionDTS_service}/${SERVICE_NAME}/" \
+		"${CATALINA_HOME}/bin/catalina.sh" > "/etc/init.d/${SERVICE_NAME}"
+	# Ensure env is set early in the helper script
+	sed -i "2 a CATALINA_HOME=${CATALINA_HOME}" "/etc/init.d/${SERVICE_NAME}"
+	sed -i "3 a JAVA_HOME=${JAVA_HOME}" "/etc/init.d/${SERVICE_NAME}"
+	chmod 755 "/etc/init.d/${SERVICE_NAME}"
+
+	# EnvironmentFile-safe defaults (no shell commands)
+	cat > "/etc/default/${SERVICE_NAME}" <<EOF
+JAVA_HOME=${JAVA_HOME}
+JRE_HOME=${JAVA_HOME}
+CATALINA_HOME=${CATALINA_HOME}
+CATALINA_BASE=${CATALINA_HOME}
+CATALINA_OUT=${CATALINA_HOME}/logs/catalina.log
+CATALINA_PID=${TOMCAT_RUN}/${PID_BASENAME}
+EOF
+
+	echo "Wrote /etc/default/${SERVICE_NAME}"
+	cat "/etc/default/${SERVICE_NAME}"
+}
+
+function installSystemdUnit() {
+	local unit_template
+	unit_template="$(dirname "$(abspath "$0")")/dts-tomcat.service.in"
+	if [ ! -f "$unit_template" ]; then
+		echo "Missing systemd unit template: $unit_template" 1>&2
+		exit 1
+	fi
+	local unit_path="/etc/systemd/system/${SERVICE_NAME}.service"
+	local pid_file="${TOMCAT_RUN}/${PID_BASENAME}"
+	local env_file="/etc/default/${SERVICE_NAME}"
+	local init_script="/etc/init.d/${SERVICE_NAME}"
+	local description="Percussion Production DTS Tomcat (${SERVICE_NAME})"
+
+	echo "Installing systemd unit ${unit_path}"
+	sed \
+		-e "s|@SERVICE_NAME@|${SERVICE_NAME}|g" \
+		-e "s|@DESCRIPTION@|${description}|g" \
+		-e "s|@PID_FILE@|${pid_file}|g" \
+		-e "s|@ENV_FILE@|${env_file}|g" \
+		-e "s|@INIT_SCRIPT@|${init_script}|g" \
+		"$unit_template" > "$unit_path"
+	chmod 644 "$unit_path"
+	systemctl daemon-reload
+	systemctl enable "${SERVICE_NAME}.service"
+	echo "Enabled ${SERVICE_NAME}.service (not started). Start with: systemctl start ${SERVICE_NAME}"
+}
+
+function enableSysV() {
+	if command -v chkconfig >/dev/null 2>&1; then
+		chkconfig "${SERVICE_NAME}" off >/dev/null 2>&1 || true
+		chkconfig "${SERVICE_NAME}" on
+	elif command -v update-rc.d >/dev/null 2>&1; then
+		update-rc.d "${SERVICE_NAME}" defaults
+	elif [ -d "/etc/rc2.d" ]; then
+		ln "/etc/init.d/${SERVICE_NAME}" "/etc/rc2.d/S99${SERVICE_NAME}"
+		ln "/etc/init.d/${SERVICE_NAME}" "/etc/rc0.d/K99${SERVICE_NAME}"
+	else
+		echo "Cannot register SysV service for boot; start manually via /etc/init.d/${SERVICE_NAME}"
+	fi
+}
+
+distVersion=$(cat /proc/version 2>&1 || true)
+CATALINA_HOME=$(dirname "$(abspath "$0")")
 EXECUTABLE="${CATALINA_HOME}/bin/catalina.sh"
+# Prefer install-root JRE if present (same heuristic as historic script)
+if [ -d "$(dirname "${CATALINA_HOME}")/JRE" ]; then
+	rxDir=$(dirname "${CATALINA_HOME}")
+elif [ -d "${CATALINA_HOME}/JRE" ]; then
+	rxDir=${CATALINA_HOME}
+else
+	rxDir=$(dirname "${CATALINA_HOME}")
+fi
+RX_USER=$(ls -ld "${rxDir}" | awk '{print $3}')
+RX_GROUP=$(ls -ld "${rxDir}" | awk '{print $4}')
+TOMCAT_RUN=${RUN_PARENT}/${SERVICE_NAME}
 
-rxDir=$(dirname $(abspath ../../JRE))
-RX_USER=$(ls -ld ${rxDir} | awk '{print $3}')
-RX_GROUP=$(ls -ld ${rxDir} | awk '{print $4}')
-TOMCAT_RUN=/var/run/PercussionProductionService/${SERVICE_NAME}
-echo ${EXECUTABLE}
-
-if [[ $(type -P "service") ]]; then
+if command -v service >/dev/null 2>&1; then
 	serviceCmd="service ${SERVICE_NAME}"
 else
 	serviceCmd="/etc/init.d/${SERVICE_NAME}"
 fi
 
-echo before uninstall $uninstall
-
 if [ "$uninstall" != "true" ]; then
-	if [ -f "/etc/init.d/${SERVICE_NAME}" ]; then
-		echo "Service $SERVICE_NAME already installed"
+	if [ -f "/etc/init.d/${SERVICE_NAME}" ] || [ -f "/etc/systemd/system/${SERVICE_NAME}.service" ]; then
+		echo "Service ${SERVICE_NAME} already installed. Uninstall first."
 		exit 1
 	fi
 
-checkForProductionDTSService
+	checkForDTSService
+	if [ -n "${currentService}" ]; then
+		echo "A service at /etc/default/${currentService} already starts this CATALINA_HOME. Remove it first."
+		exit 1
+	fi
 
-if [ ! -z "$currentService"]; then
-	echo "A service with configuration at /etc/default/${service} is already set up to start this instance"
-	exit 1
-fi
+	echo "CATALINA_HOME=${CATALINA_HOME}"
+	echo "rxDir=${rxDir}"
 
-echo "CATALINA_HOME=${CATALINA_HOME}"
-echo "rxDir=${rxDir}"
+	if [ -d "${rxDir}/JRE" ]; then
+		JAVA_HOME=${rxDir}/JRE
+	elif [ -d "${CATALINA_HOME}/JRE" ]; then
+		JAVA_HOME=${CATALINA_HOME}/JRE
+	else
+		JAVA_HOME=${JAVA_HOME:-}
+		if [ -z "$JAVA_HOME" ]; then
+			echo "JAVA_HOME not found under ${rxDir}/JRE; set JAVA_HOME before install" 1>&2
+			exit 1
+		fi
+	fi
 
-if [ -d ${rxDir}/JRE ]; then
-	echo "Found ${rxDir}/JRE to use as JRE folder"
-	JAVA_HOME=${rxDir}/JRE
-  JRE_HOME="$JAVA_HOME"
-fi
+	echo "Ensuring permissions on ${rxDir} user=${RX_USER} group=${RX_GROUP}"
+	chown -R "${RX_USER}:${RX_GROUP}" "${rxDir}"
 
-echo "Ensuring permissions are set correctly and match top level ${rxDir} folder user=${RX_USER} group=${RX_GROUP}"
-chown -R "${RX_USER}:${RX_GROUP}" "${rxDir}"
+	installInitScriptAndDefaults
 
-echo "Setting up pid folder /var/run${SERVICE_NAME} setting ownership to user=${RX_USER} group=${RX_GROUP}"
-mkdir -p ${TOMCAT_RUN}
-chown -R "${RX_USER}:${RX_GROUP}" "${TOMCAT_RUN}"
-echo "Copying startup script ${CATALINA_HOME}/bin/catalina.sh /etc/init.d/${SERVICE_NAME}"
-sed -e "s/\${PercussionProductionDTS_service}/$SERVICE_NAME/" ${CATALINA_HOME}/bin/catalina.sh  >> /etc/init.d/${SERVICE_NAME}
-sed -i "3 a CATALINA_HOME=${CATALINA_HOME}" /etc/init.d/${SERVICE_NAME}
-sed -i "4 a JAVA_HOME=${JAVA_HOME}" /etc/init.d/${SERVICE_NAME}
-chmod 755 "/etc/init.d/${SERVICE_NAME}"
-
-
-cat <<-EOF > /etc/default/${SERVICE_NAME}
-	JAVA_HOME="${JAVA_HOME}"
-	JRE_HOME="${JAVA_HOME}"
-	CATALINA_HOME="${CATALINA_HOME}"
-	CATALINA_BASE="${CATALINA_HOME}"
-	CATALINA_OUT="${CATALINA_HOME}/logs/catalina.log"
-	CATALINA_PID="${TOMCAT_RUN}/PercussionProductionDTS.pid"
-	echo "Setting up pid folder /var/run${SERVICE_NAME} setting ownership to user=${RX_USER} group=${RX_GROUP}"
-  mkdir -p ${TOMCAT_RUN}
-  chown -R "${RX_USER}:${RX_GROUP}" "${TOMCAT_RUN}"
-EOF
-
-echo "Configuration for service ${SERVICE_NAME} in /etc/init.d/${SERVICE_NAME} must reinstall or update if paths change"
-
-echo "************"
-cat /etc/default/${SERVICE_NAME}
-echo "************"
-${serviceCmd} check
-echo "************"
-echo "Attempting to use chkconfig or update-rc.d to start the service automatically on server startup"
-
-if [[ $(type -P "chkconfig") ]]; then
-	echo "Using 'chkconfig ${SERVICE_NAME} on ' to add to server startup"
-	echo "Ignore if error is shown about runlevel 4"
-	chkconfig ${SERVICE_NAME} off > /dev/null 2>&1
-	chkconfig ${SERVICE_NAME} on
-elif [[ $(type -P "update-rc.d") ]]; then
-	echo "Using 'update-rc.d ${SERVICE_NAME} defaults' to add to server startup"
-	update-rc.d ${SERVICE_NAME} defaults
-elif [ -d "/etc/rc2.d" ]; then
-	echo "Fall back to symbolic linking  into /etc/rcx.d folders"
-	ln /etc/init.d/${SERVICE_NAME} /etc/rc2.d/S99${SERVICE_NAME}
-	ln /etc/init.d/${SERVICE_NAME} /etc/rc0.d/K99${SERVICE_NAME}
+	if use_systemd_install; then
+		echo "Detected systemd — installing native unit (SysV boot registration skipped)"
+		installSystemdUnit
+		echo "********"
+		echo "  Start:  systemctl start ${SERVICE_NAME}"
+		echo "  Stop:   systemctl stop ${SERVICE_NAME}"
+		echo "  Status: systemctl status ${SERVICE_NAME}"
+		echo "  Logs:   journalctl -u ${SERVICE_NAME} -n 100 --no-pager"
+		echo "  Also:   ${CATALINA_HOME}/logs/"
+		echo "  TimeoutStartSec=1800 — override: systemctl edit ${SERVICE_NAME}"
+		echo "********"
+	else
+		echo "Using classic init.d registration"
+		enableSysV
+		echo "********"
+		echo "  Start: ${serviceCmd} start"
+		echo "  Stop:  ${serviceCmd} stop"
+		echo "********"
+	fi
 else
-	echo "Cannot find  chkconfig or update-rc.d or /etc/rc2.d to run service on startup consult documentation for alternative"
-	echo ${distVersion}
+	echo "Uninstalling ${SERVICE_NAME}"
+
+	if [ -f "/etc/systemd/system/${SERVICE_NAME}.service" ]; then
+		if systemctl is-active --quiet "${SERVICE_NAME}.service" 2>/dev/null; then
+			systemctl stop "${SERVICE_NAME}.service" || true
+		fi
+		removeSystemdUnit "${SERVICE_NAME}"
+	fi
+
+	if [ -f "/etc/init.d/${SERVICE_NAME}" ]; then
+		if ! grep -q "${CATALINA_MARKER}" "/etc/init.d/${SERVICE_NAME}"; then
+			echo "Service at /etc/init.d/${SERVICE_NAME} is not a Percussion Production DTS service"
+			exit 1
+		fi
+		if ${serviceCmd} status 2>/dev/null | grep -qi running; then
+			${serviceCmd} stop || true
+		fi
+		removeServiceFromStartup "${SERVICE_NAME}"
+	elif [ ! -f "/etc/systemd/system/${SERVICE_NAME}.service" ]; then
+		echo "Service ${SERVICE_NAME} not installed"
+		exit 1
+	fi
+
+	removeServiceScript
+	systemctl daemon-reload 2>/dev/null || true
 fi
 
-echo "*************"
-echo "       Start service with '${serviceCmd} start'"
-echo "       Stop service with '${serviceCmd} stop'"
-echo "       use '${serviceCmd}' without parameters to check other options"
-echo "*************"
-
-else #Unistall
-checkForProductionDTSService
-
-if [ ! -f "/etc/init.d/${SERVICE_NAME}" ]; then
-	echo "Service $SERVICE_NAME not installed in /etc/init.d/${SERVICE_NAME}"
-	exit 1
-fi
-
-if cat "/etc/init.d/${SERVICE_NAME}" | grep -q "catalina"; then
-	echo "Found service installed to /etc/init.d/${SERVICE_NAME}"
-else
-	cat "/etc/init.d/${SERVICE_NAME}" | grep -q "catalina"
-	echo "Service installed to /etc/init.d/${SERVICE_NAME} is not a Percussion Production DTS service"
-	exit 1
-fi
-
-echo "Posting service shutdown command..."
-service "${SERVICE_NAME}" stop
-
-removeServiceFromStartup ${SERVICE_NAME}
-removeServiceScript ${SERVICE_NAME}
-
-fi
 echo "Done"

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/DTSStagingService.sh
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/DTSStagingService.sh
@@ -1,214 +1,316 @@
 #!/bin/bash
-# chkconfig: 444 66 22
+# Install or uninstall Percussion Staging DTS as a Linux service.
+# GH-962: prefer native systemd; keep init.d as fallback.
+#
+# Usage:
+#   DTSStagingService.sh [ServiceName] install [--systemd|--initd]
+#   DTSStagingService.sh [ServiceName] uninstall
+
 echo "Script To Install Staging DTS Linux Service."
 
 SERVICE_NAME=PercussionStagingDTS
+FORCE_SYSTEMD=false
+FORCE_INITD=false
+PID_BASENAME=PercussionStagingDTS.pid
+RUN_PARENT=/var/run/PercussionStagingService
+CATALINA_MARKER=catalina
 
 if [ "$(id -u)" != "0" ]; then
-	echo "This script must be run with sudo or as root"
+	echo "This script must be run with sudo or as root" 1>&2
 	exit 1
 fi
 
 function usage() {
-	echo "Usage: $0 [ Service name default : PercussionStagingDTS ] {install | uninstall }"
+	echo "Usage: $0 [ Service name default : PercussionStagingDTS ] {install | uninstall} [--systemd | --initd]"
 	exit 1
 }
 
-if [ $# -gt 1 ];then
+if [ $# -lt 1 ]; then
+	usage
+fi
+
+if [ "$1" != "install" ] && [ "$1" != "uninstall" ]; then
 	SERVICE_NAME="$1"
 	shift
 fi
 
-if [ "$1" == "uninstall" ]; then
+ACTION="$1"
+shift || true
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--systemd) FORCE_SYSTEMD=true ;;
+		--initd) FORCE_INITD=true ;;
+		*) usage ;;
+	esac
+	shift
+done
+
+if [ "$ACTION" == "uninstall" ]; then
 	uninstall=true
-elif [ "$1" == "install" ]; then
+elif [ "$ACTION" == "install" ]; then
 	uninstall=false
 else
 	usage
 fi
 
-function checkForStagingDTSService() {
-	while read -r line; do
-		service=$(basename ${line})
-		echo "Found DTS service $service in $line"
-		serviceHome=$(bash -c "source ${line} >/dev/null 2>1 ; echo \${CTATALINA_HOME}")
-		echo Service Name: ${SERVICE_NAME} 
-		if [ "$serviceHome" == "$CATALINA_HOME" ]; then
-			currentService=${service}
+if [ "$FORCE_SYSTEMD" = "true" ] && [ "$FORCE_INITD" = "true" ]; then
+	echo "Cannot combine --systemd and --initd" 1>&2
+	exit 1
+fi
+
+function is_systemd_available() {
+	[ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1
+}
+
+function use_systemd_install() {
+	if [ "$FORCE_INITD" = "true" ]; then
+		return 1
+	fi
+	if [ "$FORCE_SYSTEMD" = "true" ]; then
+		if ! is_systemd_available; then
+			echo "systemd required (--systemd) but not available" 1>&2
+			exit 1
 		fi
-		echo CurrentService: ${currentService}
-	done < <(grep -l /etc/default/* -e 'CATALINA_HOME')
-}
-
-function removeServiceFromStartup {
-
-	echo "Uninstalling service $1 from startup"
-	if [[ $(type -P "chkconfig") ]]; then
-		echo "Using command 'chkconfig "${SERVICE_NAME}" off'"
-		chkconfig ${SERVICE_NAME} off
-	elif [[ $(type -P "update-rc.d") ]]; then
-		echo "Using command 'update-rc.d -f ${1} remove'"
-		update-rc.d -f ${SERVICE_NAME} remove
-	else
-		echo "Cannot find chkconfig or update-rc.d to remove service looking to removing from rc.d folders"
+		return 0
 	fi
-
-	if [ -d "/etc/rc.d/rc2.d" ]; then
-		echo "Removing links to /etc/rc.d/rc*.d/S??${1} and /etc/rc.d/rc*.d/K??${1}"
-		rm -f /etc/rc.d/rc?.d/S??${SERVICE_NAME}
-		rm -f /etc/rc.d/rc?.d/K??${SERVICE_NAME}
-	fi
-
-	if [ -d "/etc/rc2.d" ]; then
-		echo "Removing links to /etc/rc*.d/S??${1} and /etc/rc*.d/K??${1}"
-		rm -f /etc/rc?.d/S??${SERVICE_NAME}
-		rm -f /etc/rc?.d/K??${SERVICE_NAME}
-	fi 
-
-}
-
-function removeServiceScript() {
-	echo "Removing files."
-	set -x
-	rm -f "/etc/init.d/${SERVICE_NAME}"
-	rm -f "/etc/default/${SERVICE_NAME}"
-	{ set +x; } > /dev/null 2>&1 
+	is_systemd_available
 }
 
 function abspath() {
-    # generate absolute path from relative path
-    # $1     : relative filename
-    # return : absolute path
-    if [ -d "$1" ]; then
-        # dir
-        (cd "$1"; pwd)
-    elif [ -f "$1" ]; then
-        # file
-        if [[ $1 = /* ]]; then
-            echo "$1"
-        elif [[ $1 == */* ]]; then
-            echo "$(cd "${1%/*}"; pwd)/${1##*/}"
-        else
-            echo "$(pwd)/$1"
-        fi
-    fi
+	if [ -d "$1" ]; then
+		(cd "$1" && pwd)
+	elif [ -f "$1" ]; then
+		if [[ $1 = /* ]]; then
+			echo "$1"
+		elif [[ $1 == */* ]]; then
+			echo "$(cd "${1%/*}" && pwd)/${1##*/}"
+		else
+			echo "$(pwd)/$1"
+		fi
+	fi
 }
-distVersion=$(cat /proc/version 2>&1)
 
-CATALINA_HOME=$(dirname $(abspath $0))
-EXECUTABLE="${CATALINA_HOME}/bin/catalina.sh"
-rxDir=$(dirname $(abspath ../../../Version.properties))
-RX_USER=$(ls -ld ${rxDir} | awk '{print $3}')
-RX_GROUP=$(ls -ld ${rxDir} | awk '{print $4}')
-TOMCAT_RUN=/var/run/PercussionStagingService/${SERVICE_NAME}
-echo ${EXECUTABLE}
+function checkForDTSService() {
+	currentService=
+	if ! compgen -G "/etc/default/*" >/dev/null 2>&1; then
+		return 0
+	fi
+	while read -r line; do
+		service=$(basename "${line}")
+		echo "Found DTS service $service in $line"
+		serviceHome=$(bash -c "source ${line} >/dev/null 2>&1 ; echo \${CATALINA_HOME}")
+		if [ "$serviceHome" == "$CATALINA_HOME" ]; then
+			currentService=${service}
+		fi
+	done < <(grep -l /etc/default/* -e 'CATALINA_HOME' 2>/dev/null || true)
+}
 
-if [[ $(type -P "service") ]]; then
+function removeServiceFromStartup() {
+	echo "Uninstalling SysV service $1 from startup"
+	if command -v chkconfig >/dev/null 2>&1; then
+		chkconfig "${1}" off || true
+	elif command -v update-rc.d >/dev/null 2>&1; then
+		update-rc.d -f "${1}" remove || true
+	fi
+	if [ -d "/etc/rc.d/rc2.d" ]; then
+		rm -f /etc/rc.d/rc?.d/S??"${1}" /etc/rc.d/rc?.d/K??"${1}"
+	fi
+	if [ -d "/etc/rc2.d" ]; then
+		rm -f /etc/rc?.d/S??"${1}" /etc/rc?.d/K??"${1}"
+	fi
+}
+
+function removeSystemdUnit() {
+	local name="$1"
+	local unit="/etc/systemd/system/${name}.service"
+	if [ -f "$unit" ]; then
+		echo "Removing systemd unit ${name}.service"
+		systemctl disable --now "${name}.service" 2>/dev/null || true
+		rm -f "$unit"
+		systemctl daemon-reload || true
+		systemctl reset-failed "${name}.service" 2>/dev/null || true
+	fi
+}
+
+function removeServiceScript() {
+	echo "Removing files for ${SERVICE_NAME}"
+	rm -f "/etc/init.d/${SERVICE_NAME}"
+	rm -f "/etc/default/${SERVICE_NAME}"
+	rm -f "/etc/systemd/system/${SERVICE_NAME}.service"
+	rm -rf "${TOMCAT_RUN}"
+}
+
+function installInitScriptAndDefaults() {
+	echo "Setting up pid folder ${TOMCAT_RUN} user=${RX_USER} group=${RX_GROUP}"
+	mkdir -p "${TOMCAT_RUN}"
+	chown -R "${RX_USER}:${RX_GROUP}" "${TOMCAT_RUN}"
+
+	if [ ! -f "${CATALINA_HOME}/bin/catalina.sh" ]; then
+		echo "Missing ${CATALINA_HOME}/bin/catalina.sh" 1>&2
+		exit 1
+	fi
+
+	echo "Installing start helper to /etc/init.d/${SERVICE_NAME}"
+	sed -e "s/\${PercussionStagingDTS_service}/${SERVICE_NAME}/" \
+		"${CATALINA_HOME}/bin/catalina.sh" > "/etc/init.d/${SERVICE_NAME}"
+	sed -i "2 a CATALINA_HOME=${CATALINA_HOME}" "/etc/init.d/${SERVICE_NAME}"
+	sed -i "3 a JAVA_HOME=${JAVA_HOME}" "/etc/init.d/${SERVICE_NAME}"
+	chmod 755 "/etc/init.d/${SERVICE_NAME}"
+
+	cat > "/etc/default/${SERVICE_NAME}" <<EOF
+JAVA_HOME=${JAVA_HOME}
+JRE_HOME=${JAVA_HOME}
+CATALINA_HOME=${CATALINA_HOME}
+CATALINA_BASE=${CATALINA_HOME}
+CATALINA_OUT=${CATALINA_HOME}/logs/catalina.log
+CATALINA_PID=${TOMCAT_RUN}/${PID_BASENAME}
+EOF
+
+	echo "Wrote /etc/default/${SERVICE_NAME}"
+	cat "/etc/default/${SERVICE_NAME}"
+}
+
+function installSystemdUnit() {
+	local unit_template
+	unit_template="$(dirname "$(abspath "$0")")/dts-tomcat.service.in"
+	if [ ! -f "$unit_template" ]; then
+		echo "Missing systemd unit template: $unit_template" 1>&2
+		exit 1
+	fi
+	local unit_path="/etc/systemd/system/${SERVICE_NAME}.service"
+	local pid_file="${TOMCAT_RUN}/${PID_BASENAME}"
+	local env_file="/etc/default/${SERVICE_NAME}"
+	local init_script="/etc/init.d/${SERVICE_NAME}"
+	local description="Percussion Staging DTS Tomcat (${SERVICE_NAME})"
+
+	echo "Installing systemd unit ${unit_path}"
+	sed \
+		-e "s|@SERVICE_NAME@|${SERVICE_NAME}|g" \
+		-e "s|@DESCRIPTION@|${description}|g" \
+		-e "s|@PID_FILE@|${pid_file}|g" \
+		-e "s|@ENV_FILE@|${env_file}|g" \
+		-e "s|@INIT_SCRIPT@|${init_script}|g" \
+		"$unit_template" > "$unit_path"
+	chmod 644 "$unit_path"
+	systemctl daemon-reload
+	systemctl enable "${SERVICE_NAME}.service"
+	echo "Enabled ${SERVICE_NAME}.service (not started). Start with: systemctl start ${SERVICE_NAME}"
+}
+
+function enableSysV() {
+	if command -v chkconfig >/dev/null 2>&1; then
+		chkconfig "${SERVICE_NAME}" off >/dev/null 2>&1 || true
+		chkconfig "${SERVICE_NAME}" on
+	elif command -v update-rc.d >/dev/null 2>&1; then
+		update-rc.d "${SERVICE_NAME}" defaults
+	elif [ -d "/etc/rc2.d" ]; then
+		ln "/etc/init.d/${SERVICE_NAME}" "/etc/rc2.d/S99${SERVICE_NAME}"
+		ln "/etc/init.d/${SERVICE_NAME}" "/etc/rc0.d/K99${SERVICE_NAME}"
+	else
+		echo "Cannot register SysV service for boot; start manually via /etc/init.d/${SERVICE_NAME}"
+	fi
+}
+
+distVersion=$(cat /proc/version 2>&1 || true)
+CATALINA_HOME=$(dirname "$(abspath "$0")")
+if [ -d "$(dirname "${CATALINA_HOME}")/JRE" ]; then
+	rxDir=$(dirname "${CATALINA_HOME}")
+elif [ -d "${CATALINA_HOME}/Staging/JRE" ]; then
+	rxDir=${CATALINA_HOME}
+elif [ -d "$(dirname "${CATALINA_HOME}")/Staging/JRE" ]; then
+	rxDir=$(dirname "${CATALINA_HOME}")
+else
+	rxDir=$(dirname "${CATALINA_HOME}")
+fi
+RX_USER=$(ls -ld "${rxDir}" | awk '{print $3}')
+RX_GROUP=$(ls -ld "${rxDir}" | awk '{print $4}')
+TOMCAT_RUN=${RUN_PARENT}/${SERVICE_NAME}
+
+if command -v service >/dev/null 2>&1; then
 	serviceCmd="service ${SERVICE_NAME}"
 else
 	serviceCmd="/etc/init.d/${SERVICE_NAME}"
 fi
 
-echo before uninstall $uninstall
-
 if [ "$uninstall" != "true" ]; then
-	if [ -f "/etc/init.d/${SERVICE_NAME}" ]; then
-		echo "Service $SERVICE_NAME already installed"
+	if [ -f "/etc/init.d/${SERVICE_NAME}" ] || [ -f "/etc/systemd/system/${SERVICE_NAME}.service" ]; then
+		echo "Service ${SERVICE_NAME} already installed. Uninstall first."
 		exit 1
 	fi
 
-checkForStagingDTSService
+	checkForDTSService
+	if [ -n "${currentService}" ]; then
+		echo "A service at /etc/default/${currentService} already starts this CATALINA_HOME. Remove it first."
+		exit 1
+	fi
 
-if [ ! -z "$currentService"]; then
-	echo "A service with configuration at /etc/default/${service} is already set up to start this instance"
-	exit 1
-fi
+	echo "CATALINA_HOME=${CATALINA_HOME}"
+	echo "rxDir=${rxDir}"
 
-echo "CATALINA_HOME=${CATALINA_HOME}"
-echo "rxDir=${rxDir}"
+	if [ -d "${rxDir}/JRE" ]; then
+		JAVA_HOME=${rxDir}/JRE
+	elif [ -d "${rxDir}/Staging/JRE" ]; then
+		JAVA_HOME=${rxDir}/Staging/JRE
+	elif [ -d "${CATALINA_HOME}/JRE" ]; then
+		JAVA_HOME=${CATALINA_HOME}/JRE
+	else
+		if [ -z "${JAVA_HOME:-}" ]; then
+			echo "JAVA_HOME not found; set JAVA_HOME or install JRE under ${rxDir}" 1>&2
+			exit 1
+		fi
+	fi
 
-if [ -d ${rxDir}/JRE ]; then
-	echo "Found ${rxDir}/JRE to use as JRE folder"
-	JAVA_HOME=${rxDir}/JRE
+	echo "Ensuring permissions on ${rxDir} user=${RX_USER} group=${RX_GROUP}"
+	chown -R "${RX_USER}:${RX_GROUP}" "${rxDir}"
+
+	installInitScriptAndDefaults
+
+	if use_systemd_install; then
+		echo "Detected systemd — installing native unit (SysV boot registration skipped)"
+		installSystemdUnit
+		echo "********"
+		echo "  Start:  systemctl start ${SERVICE_NAME}"
+		echo "  Stop:   systemctl stop ${SERVICE_NAME}"
+		echo "  Status: systemctl status ${SERVICE_NAME}"
+		echo "  Logs:   journalctl -u ${SERVICE_NAME} -n 100 --no-pager"
+		echo "  Also:   ${CATALINA_HOME}/logs/"
+		echo "  TimeoutStartSec=1800 — override: systemctl edit ${SERVICE_NAME}"
+		echo "********"
+	else
+		echo "Using classic init.d registration"
+		enableSysV
+		echo "********"
+		echo "  Start: ${serviceCmd} start"
+		echo "  Stop:  ${serviceCmd} stop"
+		echo "********"
+	fi
 else
-	JAVA_HOME=${rxDir}/Staging/JRE
+	echo "Uninstalling ${SERVICE_NAME}"
+
+	if [ -f "/etc/systemd/system/${SERVICE_NAME}.service" ]; then
+		if systemctl is-active --quiet "${SERVICE_NAME}.service" 2>/dev/null; then
+			systemctl stop "${SERVICE_NAME}.service" || true
+		fi
+		removeSystemdUnit "${SERVICE_NAME}"
+	fi
+
+	if [ -f "/etc/init.d/${SERVICE_NAME}" ]; then
+		if ! grep -q "${CATALINA_MARKER}" "/etc/init.d/${SERVICE_NAME}"; then
+			echo "Service at /etc/init.d/${SERVICE_NAME} is not a Percussion Staging DTS service"
+			exit 1
+		fi
+		if ${serviceCmd} status 2>/dev/null | grep -qi running; then
+			${serviceCmd} stop || true
+		fi
+		removeServiceFromStartup "${SERVICE_NAME}"
+	elif [ ! -f "/etc/systemd/system/${SERVICE_NAME}.service" ]; then
+		echo "Service ${SERVICE_NAME} not installed"
+		exit 1
+	fi
+
+	removeServiceScript
+	systemctl daemon-reload 2>/dev/null || true
 fi
 
-echo "Ensuring permissions are set correctly and match top level ${rxDir} folder user=${RX_USER} group=${RX_GROUP}"
-chown -R "${RX_USER}:${RX_GROUP}" "${rxDir}"
-
-echo "Setting up pid folder /var/run/${SERVICE_NAME} setting ownership to user=${RX_USER} group=${RX_GROUP}"
-mkdir -p ${TOMCAT_RUN}
-chown -R "${RX_USER}:${RX_GROUP}" "${TOMCAT_RUN}"
-echo "Copying startup script ${CATALINA_HOME}/bin/catalina.sh /etc/init.d/${SERVICE_NAME}"
-sed -e "s/\${PercussionStagingDTS_service}/$SERVICE_NAME/" ${CATALINA_HOME}/bin/catalina.sh  >> /etc/init.d/${SERVICE_NAME}
-sed -i "3 a CATALINA_HOME=${CATALINA_HOME}" /etc/init.d/${SERVICE_NAME}
-sed -i "4 a JAVA_HOME=${JAVA_HOME}" /etc/init.d/${SERVICE_NAME}
-chmod 755 "/etc/init.d/${SERVICE_NAME}"
-
-
-cat <<-EOF > /etc/default/${SERVICE_NAME}
-	JAVA_HOME="${JAVA_HOME}"
-	CATALINA_HOME="${CATALINA_HOME}"
-	CATALINA_BASE="${CATALINA_HOME}"
-	CATALINA_OUT="${CATALINA_HOME}/logs/catalina.log"
-	CATALINA_PID="${TOMCAT_RUN}/PercussionStagingDTS.pid"
-EOF
-
-echo "Configuration for service ${SERVICE_NAME} in /etc/init.d/${SERVICE_NAME} must reinstall or update if paths change"
-
-echo "************"
-cat /etc/default/${SERVICE_NAME}
-echo "************"
-${serviceCmd} check
-echo "************"
-echo "Attempting to use chkconfig or update-rc.d to start the service automatically on server startup"
-
-if [[ $(type -P "chkconfig") ]]; then
-	echo "Using 'chkconfig ${SERVICE_NAME} on ' to add to server startup"
-	echo "Ignore if error is shown about runlevel 4"
-	chkconfig ${SERVICE_NAME} off > /dev/null 2>&1
-	chkconfig ${SERVICE_NAME} on
-elif [[ $(type -P "update-rc.d") ]]; then
-	echo "Using 'update-rc.d ${SERVICE_NAME} defaults' to add to server startup"
-	update-rc.d ${SERVICE_NAME} defaults
-elif [ -d "/etc/rc2.d" ]; then
-	echo "Fall back to symbolic linking  into /etc/rcx.d folders"
-	ln /etc/init.d/${SERVICE_NAME} /etc/rc2.d/S99${SERVICE_NAME}
-	ln /etc/init.d/${SERVICE_NAME} /etc/rc0.d/K99${SERVICE_NAME}
-else
-	echo "Cannot find  chkconfig or update-rc.d or /etc/rc2.d to run service on startup consult documentation for alternative"
-	echo ${distVersion}
-fi
-
-echo "*************"
-echo "       Start service with '${serviceCmd} start'"
-echo "       Stop service with '${serviceCmd} stop'"
-echo "       use '${serviceCmd}' without parameters to check other options"
-echo "*************"
-
-else #Uninstall
-checkForStagingDTSService
-
-if [ ! -f "/etc/init.d/${SERVICE_NAME}" ]; then
-	echo "Service $SERVICE_NAME not installed in /etc/init.d/${SERVICE_NAME}"
-	exit 1
-fi
-
-if cat "/etc/init.d/${SERVICE_NAME}" | grep -q "catalina"; then
-	echo "Found service installed to /etc/init.d/${SERVICE_NAME}"
-else
-	cat "/etc/init.d/${SERVICE_NAME}" | grep -q "catalina"
-	echo "Service installed to /etc/init.d/${SERVICE_NAME} is not a Percussion Staging DTS service"
-	exit 1
-fi
-
-echo "Posting service shutdown command..."
-service "${SERVICE_NAME}" stop
-
-
-removeServiceFromStartup ${SERVICE_NAME}
-removeServiceScript ${SERVICE_NAME}
-
-fi
 echo "Done"

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/DTSStagingService.sh
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/DTSStagingService.sh
@@ -59,6 +59,35 @@ if [ "$FORCE_SYSTEMD" = "true" ] && [ "$FORCE_INITD" = "true" ]; then
 	exit 1
 fi
 
+function validate_service_name() {
+	case "$1" in
+		'' | *[!A-Za-z0-9_-]* | -* | _*)
+			echo "Invalid service name '$1' (use letters, digits, underscore, hyphen; must start with alnum)" 1>&2
+			exit 1
+			;;
+	esac
+}
+
+validate_service_name "$SERVICE_NAME"
+
+function substitute_unit_template() {
+	local template="$1"
+	local dest="$2"
+	local _description="$3"
+	local _pid_file="$4"
+	local _env_file="$5"
+	local _init_script="$6"
+	local line
+	while IFS= read -r line || [ -n "$line" ]; do
+		line=${line//@SERVICE_NAME@/${SERVICE_NAME}}
+		line=${line//@DESCRIPTION@/${_description}}
+		line=${line//@PID_FILE@/${_pid_file}}
+		line=${line//@ENV_FILE@/${_env_file}}
+		line=${line//@INIT_SCRIPT@/${_init_script}}
+		printf '%s\n' "$line"
+	done < "$template" > "$dest"
+}
+
 function is_systemd_available() {
 	[ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1
 }
@@ -185,13 +214,8 @@ function installSystemdUnit() {
 	local description="Percussion Staging DTS Tomcat (${SERVICE_NAME})"
 
 	echo "Installing systemd unit ${unit_path}"
-	sed \
-		-e "s|@SERVICE_NAME@|${SERVICE_NAME}|g" \
-		-e "s|@DESCRIPTION@|${description}|g" \
-		-e "s|@PID_FILE@|${pid_file}|g" \
-		-e "s|@ENV_FILE@|${env_file}|g" \
-		-e "s|@INIT_SCRIPT@|${init_script}|g" \
-		"$unit_template" > "$unit_path"
+	substitute_unit_template "$unit_template" "$unit_path" \
+		"$description" "$pid_file" "$env_file" "$init_script"
 	chmod 644 "$unit_path"
 	systemctl daemon-reload
 	systemctl enable "${SERVICE_NAME}.service"
@@ -287,8 +311,11 @@ if [ "$uninstall" != "true" ]; then
 	fi
 else
 	echo "Uninstalling ${SERVICE_NAME}"
+	had_systemd=false
+	had_initd=false
 
 	if [ -f "/etc/systemd/system/${SERVICE_NAME}.service" ]; then
+		had_systemd=true
 		if systemctl is-active --quiet "${SERVICE_NAME}.service" 2>/dev/null; then
 			systemctl stop "${SERVICE_NAME}.service" || true
 		fi
@@ -296,6 +323,7 @@ else
 	fi
 
 	if [ -f "/etc/init.d/${SERVICE_NAME}" ]; then
+		had_initd=true
 		if ! grep -q "${CATALINA_MARKER}" "/etc/init.d/${SERVICE_NAME}"; then
 			echo "Service at /etc/init.d/${SERVICE_NAME} is not a Percussion Staging DTS service"
 			exit 1
@@ -304,7 +332,9 @@ else
 			${serviceCmd} stop || true
 		fi
 		removeServiceFromStartup "${SERVICE_NAME}"
-	elif [ ! -f "/etc/systemd/system/${SERVICE_NAME}.service" ]; then
+	fi
+
+	if [ "$had_systemd" != "true" ] && [ "$had_initd" != "true" ]; then
 		echo "Service ${SERVICE_NAME} not installed"
 		exit 1
 	fi

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/README-systemd.md
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/README-systemd.md
@@ -1,0 +1,50 @@
+# Percussion DTS Linux services (systemd)
+
+Production and Staging DTS installers prefer a **native systemd unit** when
+systemd is available (same approach as CMS Jetty / GH-962).
+
+| Installer | Default service name |
+|-----------|----------------------|
+| `DTSProductionService.sh` | `PercussionProductionDTS` |
+| `DTSStagingService.sh` | `PercussionStagingDTS` |
+
+## Install
+
+```bash
+# From the DTS install root (directory containing this script and bin/catalina.sh)
+sudo ./DTSProductionService.sh [ServiceName] install
+sudo ./DTSStagingService.sh [ServiceName] install
+
+# Flags (optional):
+#   --systemd   require systemd
+#   --initd     force classic SysV/init.d registration only
+```
+
+On systemd hosts:
+
+```bash
+sudo systemctl start PercussionProductionDTS
+sudo systemctl status PercussionProductionDTS
+journalctl -u PercussionProductionDTS -n 100 --no-pager
+```
+
+`TimeoutStartSec=1800` (30 minutes). Override with `systemctl edit <name>`.
+
+Application logs: `$CATALINA_BASE/logs/` (and Log4j2 configs under `conf/perc/`).
+
+## Uninstall
+
+```bash
+sudo ./DTSProductionService.sh [ServiceName] uninstall
+sudo ./DTSStagingService.sh [ServiceName] uninstall
+```
+
+## Migration from init.d-only
+
+1. Uninstall the old service  
+2. Re-run install (picks systemd when available)  
+3. `systemctl start <ServiceName>`
+
+## Windows
+
+`.bat` installers are unchanged (Tomcat Windows service).

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/dts-tomcat.service.in
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/dts-tomcat.service.in
@@ -2,9 +2,11 @@
 # Placeholders replaced by DTSProductionService.sh / DTSStagingService.sh:
 #   @SERVICE_NAME@  @DESCRIPTION@  @PID_FILE@  @ENV_FILE@  @INIT_SCRIPT@
 #
-# Type=forking matches Tomcat catalina.sh start with CATALINA_PID.
+# Type=forking: catalina.sh start backgrounds Tomcat and writes CATALINA_PID.
+# Do not change Type without verifying fork+PIDFile behavior.
 # TimeoutStartSec=1800 allows slow starts without false systemd timeout.
 # Journal captures stdout/stderr; app logs remain under CATALINA_BASE/logs.
+# No ExecReload: Tomcat init helper uses start/stop (full restart is systemctl restart).
 
 [Unit]
 Description=@DESCRIPTION@

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/dts-tomcat.service.in
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/dts-tomcat.service.in
@@ -1,0 +1,28 @@
+# Percussion DTS (Tomcat) systemd unit template (GH-962 / specs/988-linux-systemd-services)
+# Placeholders replaced by DTSProductionService.sh / DTSStagingService.sh:
+#   @SERVICE_NAME@  @DESCRIPTION@  @PID_FILE@  @ENV_FILE@  @INIT_SCRIPT@
+#
+# Type=forking matches Tomcat catalina.sh start with CATALINA_PID.
+# TimeoutStartSec=1800 allows slow starts without false systemd timeout.
+# Journal captures stdout/stderr; app logs remain under CATALINA_BASE/logs.
+
+[Unit]
+Description=@DESCRIPTION@
+After=network.target
+
+[Service]
+Type=forking
+EnvironmentFile=-@ENV_FILE@
+PIDFile=@PID_FILE@
+ExecStart=@INIT_SCRIPT@ start
+ExecStop=@INIT_SCRIPT@ stop
+TimeoutStartSec=1800
+TimeoutStopSec=120
+StandardOutput=journal
+StandardError=journal
+KillMode=control-group
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsServiceInstallScriptTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsServiceInstallScriptTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.delivery.distribution;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/** GH-962: Production and Staging DTS installers prefer systemd, init.d fallback. */
+class DtsServiceInstallScriptTest {
+
+  private static final List<Path> SCRIPTS =
+      List.of(
+          Path.of("src", "main", "rootFiles", "DTSProductionService.sh"),
+          Path.of("src", "main", "rootFiles", "DTSStagingService.sh"));
+
+  private static String production;
+  private static String staging;
+
+  @BeforeAll
+  static void load() throws Exception {
+    production = Files.readString(SCRIPTS.get(0), StandardCharsets.UTF_8);
+    staging = Files.readString(SCRIPTS.get(1), StandardCharsets.UTF_8);
+  }
+
+  @Test
+  void bothScripts_detectSystemdAndInstallUnit() {
+    for (String script : List.of(production, staging)) {
+      assertTrue(script.contains("is_systemd_available"));
+      assertTrue(script.contains("/run/systemd/system"));
+      assertTrue(script.contains("installSystemdUnit"));
+      assertTrue(script.contains("dts-tomcat.service.in"));
+      assertTrue(script.contains("systemctl enable"));
+      assertTrue(script.contains("SysV boot registration skipped"));
+    }
+  }
+
+  @Test
+  void bothScripts_supportInitdForceAndUninstall() {
+    for (String script : List.of(production, staging)) {
+      assertTrue(script.contains("--initd"));
+      assertTrue(script.contains("--systemd"));
+      assertTrue(script.contains("removeSystemdUnit"));
+      assertTrue(script.contains("disable --now") || script.contains("systemctl disable"));
+    }
+  }
+
+  @Test
+  void bothScripts_defaultsFile_isEnvironmentFileSafe() {
+    // Must not embed mkdir/chown into /etc/default (breaks EnvironmentFile)
+    for (String script : List.of(production, staging)) {
+      assertTrue(script.contains("cat > \"/etc/default/${SERVICE_NAME}\""));
+      assertFalse(
+          script.contains("CATALINA_PID=")
+              && script.contains("mkdir -p ${TOMCAT_RUN}")
+              && script.indexOf("mkdir -p ${TOMCAT_RUN}")
+                  > script.indexOf("cat > \"/etc/default/${SERVICE_NAME}\"")
+              && script.indexOf("mkdir -p ${TOMCAT_RUN}")
+                  < script.indexOf("EOF", script.indexOf("cat > \"/etc/default/${SERVICE_NAME}\"")),
+          "defaults heredoc must not contain mkdir");
+    }
+  }
+
+  @Test
+  void production_defaultServiceName() {
+    assertTrue(production.contains("SERVICE_NAME=PercussionProductionDTS"));
+  }
+
+  @Test
+  void staging_defaultServiceName() {
+    assertTrue(staging.contains("SERVICE_NAME=PercussionStagingDTS"));
+  }
+}

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsServiceInstallScriptTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsServiceInstallScriptTest.java
@@ -51,8 +51,12 @@ class DtsServiceInstallScriptTest {
       assertTrue(script.contains("/run/systemd/system"));
       assertTrue(script.contains("installSystemdUnit"));
       assertTrue(script.contains("dts-tomcat.service.in"));
+      assertTrue(script.contains("substitute_unit_template"));
+      assertTrue(script.contains("validate_service_name"));
       assertTrue(script.contains("systemctl enable"));
       assertTrue(script.contains("SysV boot registration skipped"));
+      assertTrue(script.contains("had_systemd"));
+      assertTrue(script.contains("had_initd"));
     }
   }
 

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsSystemdUnitTemplateTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsSystemdUnitTemplateTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.delivery.distribution;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/** GH-962: DTS Tomcat systemd unit template contract (Production + Staging share one template). */
+class DtsSystemdUnitTemplateTest {
+
+  private static final Path UNIT_TEMPLATE =
+      Path.of("src", "main", "rootFiles", "dts-tomcat.service.in");
+
+  private static String unitText;
+
+  @BeforeAll
+  static void load() throws Exception {
+    assertTrue(Files.isRegularFile(UNIT_TEMPLATE), () -> "missing " + UNIT_TEMPLATE.toAbsolutePath());
+    unitText = Files.readString(UNIT_TEMPLATE, StandardCharsets.UTF_8);
+  }
+
+  @Test
+  void unit_isTypeForking_withPidEnvAndExec() {
+    assertTrue(unitText.contains("Type=forking"));
+    assertTrue(unitText.contains("PIDFile=@PID_FILE@"));
+    assertTrue(
+        unitText.contains("EnvironmentFile=-@ENV_FILE@")
+            || unitText.contains("EnvironmentFile=@ENV_FILE@"));
+    assertTrue(unitText.contains("ExecStart=@INIT_SCRIPT@ start"));
+    assertTrue(unitText.contains("ExecStop=@INIT_SCRIPT@ stop"));
+  }
+
+  @Test
+  void unit_hasLongStartTimeoutAndJournal() {
+    assertTrue(unitText.contains("TimeoutStartSec=1800"));
+    int timeout = -1;
+    for (String line : unitText.split("\n")) {
+      String t = line.trim();
+      if (t.startsWith("TimeoutStartSec=")) {
+        timeout = Integer.parseInt(t.substring("TimeoutStartSec=".length()).trim());
+      }
+    }
+    assertTrue(timeout >= 900, "TimeoutStartSec >= 900, was " + timeout);
+    assertTrue(unitText.contains("StandardOutput=journal"));
+    assertTrue(unitText.contains("StandardError=journal"));
+    assertTrue(unitText.contains("WantedBy=multi-user.target"));
+  }
+}

--- a/modules/perc-jetty/AGENTS.md
+++ b/modules/perc-jetty/AGENTS.md
@@ -4,6 +4,15 @@
 
 - Read modules/perc-jetty/README.md before making changes in this module.
 
+## Linux service install (systemd / init.d)
+
+- Scripts: `src/main/jetty/service/install-jetty-service.sh`, unit template
+  `percussion-cms.service.in`, ops notes `README-systemd.md`
+- GH-962 / specs `988-linux-systemd-services`: prefer **native systemd** unit;
+  init.d is fallback (`--initd`). Do not dual-register chkconfig when systemd is used.
+- Default `TimeoutStartSec=1800` for long post-upgrade starts; journal for stdout/stderr.
+- Tests: `src/test/java/com/percussion/jetty/service/*Test.java`
+
 ## Logging (perc-logging / Log4j2)
 
 - Config: `src/main/jetty/defaults/modules/perc-logging/resources/log4j2.xml`

--- a/modules/perc-jetty/README.md
+++ b/modules/perc-jetty/README.md
@@ -21,6 +21,20 @@ The module descriptor at src/main/jetty/defaults/modules/perc.mod is the source 
 
 Run: ../../mvn-env.sh -pl modules/perc-jetty clean install -DskipTests
 
+## Linux service (systemd) — GH-962
+
+Native systemd install is provided under `src/main/jetty/service/`:
+
+- `install-jetty-service.sh` — prefers systemd when available; `--initd` forces SysV
+- `percussion-cms.service.in` — unit template (`Type=forking`, `TimeoutStartSec=1800`, journal)
+- `README-systemd.md` — operator install / migrate / journal notes
+
+```bash
+sudo ./install-jetty-service.sh PercussionCMS install
+sudo systemctl start PercussionCMS
+journalctl -u PercussionCMS -n 50 --no-pager
+```
+
 ## Logging retention (GH-939)
 
 Application logs are configured by Log4j2 in:

--- a/modules/perc-jetty/src/main/jetty/service/README-systemd.md
+++ b/modules/perc-jetty/src/main/jetty/service/README-systemd.md
@@ -1,0 +1,72 @@
+# Percussion CMS Linux service (systemd)
+
+## Overview
+
+On modern Linux hosts, `install-jetty-service.sh` installs a **native systemd unit**
+for the CMS Jetty process (default name `PercussionCMS`). SysV/init.d remains
+available as a fallback when systemd is not present or when forced with `--initd`.
+
+This addresses [GitHub issue #962](https://github.com/intersoftdatalabs-in/percussioncms/issues/962):
+short start timeouts and empty journals when systemd wraps LSB init scripts during
+long post-upgrade startups.
+
+## Install (systemd — default when available)
+
+```bash
+sudo ./install-jetty-service.sh [ServiceName] install
+# optional flags:
+#   --systemd   require systemd (fail if missing)
+#   --initd     force classic init.d / chkconfig path
+```
+
+Prompts for the run-as user (same as before), writes:
+
+| Artifact | Path |
+|----------|------|
+| Environment | `/etc/default/<ServiceName>` |
+| Start helper | `/etc/init.d/<ServiceName>` (used by ExecStart; **not** enabled via chkconfig on systemd hosts) |
+| Unit | `/etc/systemd/system/<ServiceName>.service` |
+
+Then:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable <ServiceName>
+sudo systemctl start <ServiceName>
+sudo systemctl status <ServiceName>
+journalctl -u <ServiceName> -n 100 --no-pager
+```
+
+## Long startup / upgrades
+
+The unit sets `TimeoutStartSec=1800` (30 minutes) so package/DB upgrade work during
+start does not false-fail under systemd. To raise further, use a drop-in:
+
+```bash
+sudo systemctl edit PercussionCMS
+# [Service]
+# TimeoutStartSec=3600
+```
+
+Application logs remain under `JETTY_BASE/logs/` (see Log4j2 `server.log`).
+
+## Uninstall
+
+```bash
+sudo ./install-jetty-service.sh [ServiceName] uninstall
+```
+
+Disables and removes the systemd unit (when present), removes init.d/default files,
+and clears the run directory for that service name.
+
+## Migration from init.d-only installs
+
+1. `sudo ./install-jetty-service.sh PercussionCMS uninstall` (stops service if running)
+2. `sudo ./install-jetty-service.sh PercussionCMS install` (picks systemd when available)
+3. `sudo systemctl start PercussionCMS`
+
+## Force init.d (no systemd unit)
+
+```bash
+sudo ./install-jetty-service.sh PercussionCMS install --initd
+```

--- a/modules/perc-jetty/src/main/jetty/service/install-jetty-service.sh
+++ b/modules/perc-jetty/src/main/jetty/service/install-jetty-service.sh
@@ -1,264 +1,380 @@
 #!/bin/bash
+# Install or uninstall Percussion CMS Jetty as a Linux service.
+# GH-962: prefer native systemd unit; keep init.d as fallback.
+#
+# Usage:
+#   install-jetty-service.sh [ServiceName] install [--systemd|--initd]
+#   install-jetty-service.sh [ServiceName] uninstall
+#   install-jetty-service.sh [ServiceName] cleanupJBoss
+
 SERVICE_NAME=PercussionCMS
+FORCE_SYSTEMD=false
+FORCE_INITD=false
+
 if [ "$(id -u)" != "0" ]; then
     echo "This script must be run with sudo or as root" 1>&2
     exit 1
 fi
 
-
 function usage() {
-    echo "Usage: $0 [ service name default : PercussionCMS ] {install | uninstall | cleanupJBoss }"
+    echo "Usage: $0 [ service name default : PercussionCMS ] {install | uninstall | cleanupJBoss } [--systemd | --initd]"
+    echo "  --systemd  Require systemd (fail if not available)"
+    echo "  --initd    Force classic SysV/init.d registration (no native unit)"
     exit 1
-
 }
 
+# Parse: optional service name, then action, then optional flags
+if [ $# -lt 1 ]; then
+    usage
+fi
 
-
-if [ $# -gt 1 ];then
+if [ "$1" != "install" ] && [ "$1" != "uninstall" ] && [ "$1" != "cleanupJBoss" ]; then
     SERVICE_NAME="$1"
     shift
 fi
 
-if [ "$1" == "uninstall" ]; then
+ACTION="$1"
+shift || true
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --systemd) FORCE_SYSTEMD=true ;;
+        --initd) FORCE_INITD=true ;;
+        *) usage ;;
+    esac
+    shift
+done
+
+if [ "$ACTION" == "uninstall" ]; then
     uninstall=true
-elif [ "$1" == "install" ]; then
+elif [ "$ACTION" == "install" ]; then
     uninstall=false
-elif [ "$1" == "cleanupJBoss" ]; then
+elif [ "$ACTION" == "cleanupJBoss" ]; then
     cleanupJBoss=true
+    uninstall=false
 else
     usage
 fi
 
-function checkForJettyService() {
-    while read -r line; do
-        service=$(basename ${line})
-        echo "Found Jetty service $service in $line"
-        serviceHome=$(bash -c "source ${line} >/dev/null 2>&1 ; echo \${JETTY_BASE}")
-        if [ "$serviceHome" == "$JETTY_BASE" ]; then
-            currentService=$service
-        fi
-    done < <(grep -l /etc/default/* -e 'JETTY_BASE')
+if [ "$FORCE_SYSTEMD" = "true" ] && [ "$FORCE_INITD" = "true" ]; then
+    echo "Cannot combine --systemd and --initd" 1>&2
+    exit 1
+fi
 
+function is_systemd_available() {
+    if [ ! -d /run/systemd/system ]; then
+        return 1
+    fi
+    if ! command -v systemctl >/dev/null 2>&1; then
+        return 1
+    fi
+    return 0
+}
+
+function use_systemd_install() {
+    if [ "$FORCE_INITD" = "true" ]; then
+        return 1
+    fi
+    if [ "$FORCE_SYSTEMD" = "true" ]; then
+        if ! is_systemd_available; then
+            echo "systemd required (--systemd) but not available on this host" 1>&2
+            exit 1
+        fi
+        return 0
+    fi
+    is_systemd_available
+}
+
+function checkForJettyService() {
+    currentService=
+    if compgen -G "/etc/default/*" > /dev/null 2>&1; then
+        while read -r line; do
+            service=$(basename "${line}")
+            echo "Found Jetty service $service in $line"
+            serviceHome=$(bash -c "source ${line} >/dev/null 2>&1 ; echo \${JETTY_BASE}")
+            if [ "$serviceHome" == "$JETTY_BASE" ]; then
+                currentService=$service
+            fi
+        done < <(grep -l /etc/default/* -e 'JETTY_BASE' 2>/dev/null || true)
+    fi
 }
 
 function checkForJbossService() {
+    currentService=
+    if ! compgen -G "/etc/init.d/*" > /dev/null 2>&1; then
+        return 0
+    fi
     while read -r line; do
-        service=$(basename ${line})
+        service=$(basename "${line}")
         echo "Found JBoss service $service in $line"
         serviceHome=$(grep "^SERVER_DIR=" /etc/init.d/${service} | cut -d "=" -f 2)
-        echo $serviceHome
+        echo "$serviceHome"
         if [ "$serviceHome" == "$rxDir" ]; then
             currentService=$service
         fi
-    done < <(grep -l /etc/init.d/* -e 'RhythmyxD')
+    done < <(grep -l /etc/init.d/* -e 'RhythmyxD' 2>/dev/null || true)
 
-    if [ ! -z "$currentService" ];
-    then
+    if [ ! -z "$currentService" ]; then
         if [ "$cleanupJBoss" != "true" ]; then
-            echo "Warning Jboss startup /etc/init.d/${currentService} for this instance ${rxDir} exists use  to remove"
+            echo "Warning Jboss startup /etc/init.d/${currentService} for this instance ${rxDir} exists use cleanupJBoss to remove"
             usage
         fi
         echo "Cleaning up JBoss init scripts"
-        removeServiceFromStartup $currentService
-        removeServiceScript $currentService
-        exit 1
+        removeServiceFromStartup "$currentService"
+        removeServiceScript "$currentService"
+        exit 0
     fi
 }
 
 function removeServiceFromStartup() {
-
-    echo "uninstalling service $1 from startup"
-    if [[ $(type -P "chkconfig") ]]; then
-        echo "Using command 'chkconfig "${1}" off'"
-        chkconfig ${1} off
-    elif [[ $(type -P "update-rc.d") ]]; then
+    echo "uninstalling SysV service $1 from startup"
+    if command -v chkconfig >/dev/null 2>&1; then
+        echo "Using command 'chkconfig ${1} off'"
+        chkconfig "${1}" off || true
+    elif command -v update-rc.d >/dev/null 2>&1; then
         echo "using command 'update-rc.d -f ${1} remove'"
-        update-rc.d -f ${SERVICE_NAME} remove
+        update-rc.d -f "${1}" remove || true
     else
-        echo "Cannot find chkconfig or update-rc.d to remove service looking to removing from rc?.d folders"
+        echo "Cannot find chkconfig or update-rc.d; removing rc?.d links if present"
     fi
 
     if [ -d "/etc/rc.d/rc2.d" ]; then
-        echo "Removing links to etc/rc.d/rc*.d/S??${1} and /etc/rc.d/rc*.d/K??${1}"
-        rm -f /etc/rc.d/rc?.d/S??${1}
-        rm -f /etc/rc.d/rc?.d/K??${1}
+        rm -f /etc/rc.d/rc?.d/S??"${1}"
+        rm -f /etc/rc.d/rc?.d/K??"${1}"
     fi
     if [ -d "/etc/rc2.d" ]; then
-        echo "Removing links to etc/rc*.d/S??${1} and /etc/rc*.d/K??${1} "
-        rm -f /etc/rc?.d/S??${1}
-        rm -f /etc/rc?.d/K??${1}
+        rm -f /etc/rc?.d/S??"${1}"
+        rm -f /etc/rc?.d/K??"${1}"
     fi
+}
 
-
+function removeSystemdUnit() {
+    local name="$1"
+    local unit="/etc/systemd/system/${name}.service"
+    if [ -f "$unit" ] || systemctl list-unit-files "${name}.service" 2>/dev/null | grep -q "${name}.service"; then
+        echo "Removing systemd unit ${name}.service"
+        systemctl disable --now "${name}.service" 2>/dev/null || true
+        rm -f "$unit"
+        systemctl daemon-reload || true
+        systemctl reset-failed "${name}.service" 2>/dev/null || true
+    fi
 }
 
 function removeServiceScript() {
-
-    echo "removing files"
-    set -x
+    echo "removing service files for $1"
     rm -f "/etc/init.d/${1}"
     rm -f "/etc/default/${1}"
+    rm -f "/etc/systemd/system/${1}.service"
     rm -rf "$JETTY_RUN"
     rm -f "$JETTY_BASE/${SERVICE_NAME}.state"
-    { set +x; } > /dev/null 2>&1
-
 }
 
+function installInitScriptAndDefaults() {
+    echo "setting up pid folder ${JETTY_RUN} ownership user=${RX_USER} group=${RX_GROUP}"
+    mkdir -p "${JETTY_RUN}"
+    mkdir -p "/var/run/rxjetty/${SERVICE_NAME}"
+    chown -R "${RX_USER}:${RX_GROUP}" "/var/run/rxjetty/${SERVICE_NAME}"
+    chown -R "${RX_USER}:${RX_GROUP}" "${JETTY_RUN}"
+    chmod -R ugo+rw "/var/run/rxjetty/${SERVICE_NAME}"
 
+    local template="${JETTY_DEFAULTS}/bin/rxjetty.sh"
+    if [ ! -f "$template" ]; then
+        echo "Missing Jetty service template: $template" 1>&2
+        exit 1
+    fi
+    echo "Installing start helper to /etc/init.d/${SERVICE_NAME}"
+    sed -e "s/\${rxjetty_service}/$SERVICE_NAME/" "$template" > "/etc/init.d/${SERVICE_NAME}"
+    chmod 755 "/etc/init.d/${SERVICE_NAME}"
 
-distVersion=$(cat /proc/version 2>&1)
+    # /etc/default must be shell-sourceable (no shell commands mixed into env file)
+    cat > "/etc/default/${SERVICE_NAME}" <<EOF
+JAVA_HOME=${JAVA_HOME}
+JAVA=${JAVA_HOME}/bin/java
+JETTY_HOME=${JETTY_HOME}
+JETTY_BASE=${JETTY_BASE}
+JETTY_DEFAULTS=${JETTY_DEFAULTS}
+JETTY_CONF=${JETTY_CONF}
+JETTY_START_LOG=${JETTY_BASE}/logs/start.log
+JAVA_OPTIONS="-XX:+DisableAttachMechanism -Drxdeploydir=${rxDir} -Djetty_perc_defaults=${JETTY_DEFAULTS}"
+JETTY_RUN=${JETTY_RUN}
+JETTY_PID=${JETTY_RUN}/rxjetty.pid
+JETTY_ARGS="--include-jetty-dir=${JETTY_DEFAULTS}"
+JETTY_USER=${RX_USER}
+EOF
 
+    echo "Wrote /etc/default/${SERVICE_NAME}"
+    cat "/etc/default/${SERVICE_NAME}"
+}
 
-JETTY_ROOT=$(dirname $(dirname $(readlink -f "$0")))
+function installSystemdUnit() {
+    local unit_template
+    unit_template="$(dirname "$(readlink -f "$0")")/percussion-cms.service.in"
+    if [ ! -f "$unit_template" ]; then
+        echo "Missing systemd unit template: $unit_template" 1>&2
+        exit 1
+    fi
+    local unit_path="/etc/systemd/system/${SERVICE_NAME}.service"
+    local pid_file="${JETTY_RUN}/rxjetty.pid"
+    local env_file="/etc/default/${SERVICE_NAME}"
+    local init_script="/etc/init.d/${SERVICE_NAME}"
+    local description="Percussion CMS Jetty (${SERVICE_NAME})"
+
+    echo "Installing systemd unit ${unit_path}"
+    sed \
+        -e "s|@SERVICE_NAME@|${SERVICE_NAME}|g" \
+        -e "s|@DESCRIPTION@|${description}|g" \
+        -e "s|@PID_FILE@|${pid_file}|g" \
+        -e "s|@ENV_FILE@|${env_file}|g" \
+        -e "s|@INIT_SCRIPT@|${init_script}|g" \
+        -e "s|@JETTY_ROOT@|${JETTY_ROOT}|g" \
+        "$unit_template" > "$unit_path"
+    chmod 644 "$unit_path"
+
+    systemctl daemon-reload
+    systemctl enable "${SERVICE_NAME}.service"
+    echo "Enabled ${SERVICE_NAME}.service (not started). Start with: systemctl start ${SERVICE_NAME}"
+}
+
+function enableSysV() {
+    echo "Registering SysV/init.d service for boot"
+    if command -v chkconfig >/dev/null 2>&1; then
+        echo "Using 'chkconfig ${SERVICE_NAME} on'"
+        chkconfig "${SERVICE_NAME}" off > /dev/null 2>&1 || true
+        chkconfig "${SERVICE_NAME}" on
+    elif command -v update-rc.d >/dev/null 2>&1; then
+        echo "using 'update-rc.d ${SERVICE_NAME} defaults'"
+        update-rc.d "${SERVICE_NAME}" defaults
+    elif [ -d "/etc/rc2.d" ]; then
+        echo "Fall back to symbolic linking into /etc/rcx.d folders"
+        ln "/etc/init.d/${SERVICE_NAME}" "/etc/rc2.d/S99${SERVICE_NAME}"
+        ln "/etc/init.d/${SERVICE_NAME}" "/etc/rc0.d/K99${SERVICE_NAME}"
+    else
+        echo "Cannot find chkconfig or update-rc.d or /etc/rc2.d; start manually via /etc/init.d/${SERVICE_NAME}"
+        echo "${distVersion}"
+    fi
+}
+
+distVersion=$(cat /proc/version 2>&1 || true)
+
+JETTY_ROOT=$(dirname "$(dirname "$(readlink -f "$0")")")
 JETTY_HOME=${JETTY_ROOT}/upstream
 JETTY_BASE=${JETTY_ROOT}/base
 JETTY_DEFAULTS=${JETTY_ROOT}/defaults
-rxDir=$(dirname ${JETTY_ROOT})
-RX_USER=$(ls -ld ${rxDir} | awk '{print $3}')
-RX_GROUP=$(ls -ld ${rxDir} | awk '{print $4}')
+rxDir=$(dirname "${JETTY_ROOT}")
+RX_USER=$(ls -ld "${rxDir}" | awk '{print $3}')
+RX_GROUP=$(ls -ld "${rxDir}" | awk '{print $4}')
 JETTY_RUN=/var/run/rxjetty/${SERVICE_NAME}
 
-if [[ $(type -P "service") ]]; then
+if command -v service >/dev/null 2>&1; then
     serviceCmd="service ${SERVICE_NAME}"
 else
     serviceCmd="/etc/init.d/${SERVICE_NAME}"
 fi
-echo before uninstall $uninstall
-if [ "$uninstall" != "true" ];then
-echo in uninstall
 
-
-    if [  -f "/etc/init.d/${SERVICE_NAME}" ];then
-        echo "Service $SERVICE_NAME already installed"
+if [ "$uninstall" != "true" ]; then
+    # ----- install -----
+    if [ -f "/etc/init.d/${SERVICE_NAME}" ] || [ -f "/etc/systemd/system/${SERVICE_NAME}.service" ]; then
+        echo "Service ${SERVICE_NAME} already installed (init.d and/or systemd unit present). Uninstall first."
         exit 1
     fi
 
-
     checkForJbossService
     checkForJettyService
-    if [ ! -z "$currentService" ];
-    then
-       echo "A service with name $service with configuration at /etc/default/${service} is already set up to start this instance. Should be removed."
+    if [ ! -z "$currentService" ]; then
+        echo "A service with configuration at /etc/default/${currentService} is already set up for this instance. Remove it first."
+        exit 1
     fi
 
     echo "JETTY_ROOT=${JETTY_ROOT}"
     echo "rxDir=${rxDir}"
 
-    if [ -d ${rxDir}/JRE ]; then
+    if [ -d "${rxDir}/JRE" ]; then
         echo "Found ${rxDir}/JRE to use as JRE Folder"
         JAVA_HOME=${rxDir}/JRE
     else
         JAVA_HOME=${rxDir}/JRE64
     fi
 
-
-    if [ -f ${JETTY_BASE}/etc/jetty.conf ];then
+    if [ -f "${JETTY_BASE}/etc/jetty.conf" ]; then
         JETTY_CONF=${JETTY_BASE}/etc/jetty.conf
     else
         JETTY_CONF=${JETTY_DEFAULTS}/etc/jetty.conf
     fi
+
     echo "Please identify the user id that the percussion service should run as: <default: root>"
     read -r suppliedUser
+    if [ -z "$suppliedUser" ]; then
+        suppliedUser=root
+    fi
     echo "Using user id: ${suppliedUser}"
     echo "Generating ${rxDir}/rx_user.id file"
-    echo "SYSTEM_USER_ID=${suppliedUser}" > ${rxDir}/rx_user.id
+    echo "SYSTEM_USER_ID=${suppliedUser}" > "${rxDir}/rx_user.id"
     RX_USER=${suppliedUser}
     RX_GROUP=${suppliedUser}
-    echo "Ensuring permissions are set correctly and match top level ${rxDir} folder user=${RX_USER} group=${RX_GROUP}"
+    echo "Ensuring permissions match top level ${rxDir} folder user=${RX_USER} group=${RX_GROUP}"
     chown -R "${RX_USER}:${RX_GROUP}" "${rxDir}"
-    echo
-    echo
 
-    echo "setting up pid folder /var/run/${SERVICE_NAME} setting ownership to  user=${RX_USER} group=${RX_GROUP}"
+    installInitScriptAndDefaults
 
-    mkdir -p ${JETTY_RUN}
-    chown -R "${RX_USER}:${RX_GROUP}" "/var/run/rxjetty/${SERVICE_NAME}"
-    chown -R "${RX_USER}:${RX_GROUP}" "${JETTY_RUN}"
-    chmod -R ugo+rw /var/run/rxjetty/${SERVICE_NAME}
+    if command -v "/etc/init.d/${SERVICE_NAME}" >/dev/null 2>&1 || [ -x "/etc/init.d/${SERVICE_NAME}" ]; then
+        "/etc/init.d/${SERVICE_NAME}" check || true
+    fi
 
-    echo "copying startup script ${JETTY_DEFAULTS}/bin/jetty.sh /etc/init.d/${SERVICE_NAME}"
-
-    sed -e "s/\${rxjetty_service}/$SERVICE_NAME/" ${JETTY_DEFAULTS}/bin/rxjetty.sh > /etc/init.d/${SERVICE_NAME}
-    chmod 755 "/etc/init.d/${SERVICE_NAME}"
-
-    cat <<-EOF > /etc/default/${SERVICE_NAME}
-    JAVA_HOME=${JAVA_HOME}
-    JAVA=${JAVA_HOME}/bin/java
-    JETTY_HOME=${JETTY_HOME}
-    JETTY_BASE=${JETTY_BASE}
-    JETTY_DEFAULTS=${JETTY_DEFAULTS}
-    JETTY_CONF=${JETTY_CONF}
-    JETTY_START_LOG=${JETTY_BASE}/logs/start.log
-    JAVA_OPTIONS="-XX:+DisableAttachMechanism -Drxdeploydir=${rxDir} -Djetty_perc_defaults=${JETTY_DEFAULTS}"
-    JETTY_RUN=${JETTY_RUN}
-    JETTY_PID=${JETTY_RUN}/rxjetty.pid
-    JETTY_ARGS="--include-jetty-dir=${JETTY_DEFAULTS}"
-    JETTY_USER=${RX_USER}
-	  mkdir -p ${JETTY_RUN}
-    chown -R "${RX_USER}:${RX_GROUP}" "/var/run/rxjetty/${SERVICE_NAME}"
-    chmod -R ugo+rw /var/run/rxjetty/${SERVICE_NAME}
-EOF
-
-    echo "configuration for service ${SERVICE_NAME} in /etc/init.d/${SERVICE_NAME} must reinstall or update if paths change"
-
-    echo "**********"
-    cat /etc/default/${SERVICE_NAME}
-    echo "**********"
-    ${serviceCmd} check
-    echo "********"
-
-    echo "Attempting to use chkconfig or update-rc.d to start service automatically on server startup"
-
-
-    if [[ $(type -P "chkconfig" ) ]]; then
-        echo "Using 'chkconfig ${SERVICE_NAME} on' to add to add to server startup"
-        echo "Ignore if error is shown about runlevel 4"
-        chkconfig ${SERVICE_NAME} off > /dev/null 2>&1
-        chkconfig ${SERVICE_NAME} on
-    elif [[ $(type -P "update-rc.d") ]]; then
-        echo "using 'update-rc.d ${SERVICE_NAME} defaults' to add to server startup"
-        update-rc.d ${SERVICE_NAME} defaults
-    elif [ -d "/etc/rc2.d" ]; then
-        echo "Fall back to symbolic linking into /etc/rcx.d folders e.g. Solaris 9"
-        ln /etc/init.d/${SERVICE_NAME} /etc/rc2.d/S99${SERVICE_NAME}
-        ln /etc/init.d/${SERVICE_NAME} /etc/rc0.d/K99${SERVICE_NAME}
+    if use_systemd_install; then
+        echo "Detected systemd — installing native unit (init.d helper kept for ExecStart; SysV boot registration skipped)"
+        installSystemdUnit
+        echo "********"
+        echo "  Start:  systemctl start ${SERVICE_NAME}"
+        echo "  Stop:   systemctl stop ${SERVICE_NAME}"
+        echo "  Status: systemctl status ${SERVICE_NAME}"
+        echo "  Logs:   journalctl -u ${SERVICE_NAME} -n 100 --no-pager"
+        echo "  Also:   ${JETTY_BASE}/logs/ (application Log4j2)"
+        echo "  TimeoutStartSec=1800 (30m) — override with: systemctl edit ${SERVICE_NAME}"
+        echo "********"
     else
-        echo "Cannot find chkconfig or update-rc.d or /etc/rc2.d to run service on startup consult documentation on alternatives for your distro"
-        echo ${distVersion}
+        echo "Using classic init.d registration"
+        enableSysV
+        echo "********"
+        echo "  Start service with '${serviceCmd} start'"
+        echo "  Stop service with '${serviceCmd} stop'"
+        echo "  use '${serviceCmd}' without parameters to check other options"
+        echo "********"
     fi
 
-    echo "********"
-    echo "  Start service with '${serviceCmd} start'"
-    echo "  Stop service with '${serviceCmd} stop'"
-    echo "  use '${serviceCmd}' without parameters to check other options"
-    echo "********"
+else
+    # ----- uninstall -----
+    echo "Checking for installed service ${SERVICE_NAME}"
 
-else # Uninstall
-echo checking for jetty service
-    checkForJettyService
-
-    if [ ! -f "/etc/init.d/${SERVICE_NAME}" ];then
-        echo "Service $SERVICE_NAME not installed in /etc/init.d/${SERVICE_NAME}"
-        exit 1
+    if [ -f "/etc/systemd/system/${SERVICE_NAME}.service" ]; then
+        if systemctl is-active --quiet "${SERVICE_NAME}.service" 2>/dev/null; then
+            echo "Stopping systemd unit ${SERVICE_NAME}"
+            systemctl stop "${SERVICE_NAME}.service" || true
+        fi
+        removeSystemdUnit "${SERVICE_NAME}"
     fi
 
-    if cat "/etc/init.d/${SERVICE_NAME}" | grep -q "jetty"; then
-        echo "Found service installed to /etc/init.d/${SERVICE_NAME}"
-    else
-        cat "/etc/init.d/${SERVICE_NAME}" | grep -q "jetty"
-        echo "Service installed to /etc/init.d/${SERVICE_NAME} is not a Rhythmyx Jetty Service"
-        exit 1
+    if [ -f "/etc/init.d/${SERVICE_NAME}" ]; then
+        if cat "/etc/init.d/${SERVICE_NAME}" | grep -q "jetty"; then
+            echo "Found service installed to /etc/init.d/${SERVICE_NAME}"
+        else
+            echo "Service installed to /etc/init.d/${SERVICE_NAME} is not a Rhythmyx Jetty Service"
+            exit 1
+        fi
+        if ${serviceCmd} status 2>/dev/null | grep -q "Jetty running"; then
+            echo "Service still running, shutting down...."
+            ${serviceCmd} stop || true
+        fi
+        removeServiceFromStartup "${SERVICE_NAME}"
+    elif [ ! -f "/etc/systemd/system/${SERVICE_NAME}.service" ]; then
+        # unit already removed above; if neither existed:
+        if ! systemctl status "${SERVICE_NAME}.service" >/dev/null 2>&1; then
+            echo "Service $SERVICE_NAME not installed"
+            exit 1
+        fi
     fi
-    if  ${serviceCmd} status | grep "Jetty running" ; then
-        echo "Service still running, shutting down...."
-        ${serviceCmd} stop
-    fi
 
-
-
-    removeServiceFromStartup ${SERVICE_NAME}
-    removeServiceScript ${SERVICE_NAME}
-
-
+    removeServiceScript "${SERVICE_NAME}"
+    systemctl daemon-reload 2>/dev/null || true
 fi
+
 echo "done"

--- a/modules/perc-jetty/src/main/jetty/service/install-jetty-service.sh
+++ b/modules/perc-jetty/src/main/jetty/service/install-jetty-service.sh
@@ -61,6 +61,39 @@ if [ "$FORCE_SYSTEMD" = "true" ] && [ "$FORCE_INITD" = "true" ]; then
     exit 1
 fi
 
+# Service names are substituted into unit files; restrict to safe identifier chars.
+function validate_service_name() {
+    case "$1" in
+        '' | *[!A-Za-z0-9_-]* | -* | _*)
+            echo "Invalid service name '$1' (use letters, digits, underscore, hyphen; must start with alnum)" 1>&2
+            exit 1
+            ;;
+    esac
+}
+
+validate_service_name "$SERVICE_NAME"
+
+# Replace @PLACEHOLDER@ tokens without sed metacharacter issues in values.
+# Args: template dest description pid_file env_file init_script
+function substitute_unit_template() {
+    local template="$1"
+    local dest="$2"
+    local _description="$3"
+    local _pid_file="$4"
+    local _env_file="$5"
+    local _init_script="$6"
+    local line
+    while IFS= read -r line || [ -n "$line" ]; do
+        line=${line//@SERVICE_NAME@/${SERVICE_NAME}}
+        line=${line//@DESCRIPTION@/${_description}}
+        line=${line//@PID_FILE@/${_pid_file}}
+        line=${line//@ENV_FILE@/${_env_file}}
+        line=${line//@INIT_SCRIPT@/${_init_script}}
+        line=${line//@JETTY_ROOT@/${JETTY_ROOT}}
+        printf '%s\n' "$line"
+    done < "$template" > "$dest"
+}
+
 function is_systemd_available() {
     if [ ! -d /run/systemd/system ]; then
         return 1
@@ -220,14 +253,8 @@ function installSystemdUnit() {
     local description="Percussion CMS Jetty (${SERVICE_NAME})"
 
     echo "Installing systemd unit ${unit_path}"
-    sed \
-        -e "s|@SERVICE_NAME@|${SERVICE_NAME}|g" \
-        -e "s|@DESCRIPTION@|${description}|g" \
-        -e "s|@PID_FILE@|${pid_file}|g" \
-        -e "s|@ENV_FILE@|${env_file}|g" \
-        -e "s|@INIT_SCRIPT@|${init_script}|g" \
-        -e "s|@JETTY_ROOT@|${JETTY_ROOT}|g" \
-        "$unit_template" > "$unit_path"
+    substitute_unit_template "$unit_template" "$unit_path" \
+        "$description" "$pid_file" "$env_file" "$init_script"
     chmod 644 "$unit_path"
 
     systemctl daemon-reload
@@ -316,7 +343,7 @@ if [ "$uninstall" != "true" ]; then
 
     installInitScriptAndDefaults
 
-    if command -v "/etc/init.d/${SERVICE_NAME}" >/dev/null 2>&1 || [ -x "/etc/init.d/${SERVICE_NAME}" ]; then
+    if [ -x "/etc/init.d/${SERVICE_NAME}" ]; then
         "/etc/init.d/${SERVICE_NAME}" check || true
     fi
 
@@ -344,8 +371,11 @@ if [ "$uninstall" != "true" ]; then
 else
     # ----- uninstall -----
     echo "Checking for installed service ${SERVICE_NAME}"
+    had_systemd=false
+    had_initd=false
 
     if [ -f "/etc/systemd/system/${SERVICE_NAME}.service" ]; then
+        had_systemd=true
         if systemctl is-active --quiet "${SERVICE_NAME}.service" 2>/dev/null; then
             echo "Stopping systemd unit ${SERVICE_NAME}"
             systemctl stop "${SERVICE_NAME}.service" || true
@@ -354,6 +384,7 @@ else
     fi
 
     if [ -f "/etc/init.d/${SERVICE_NAME}" ]; then
+        had_initd=true
         if cat "/etc/init.d/${SERVICE_NAME}" | grep -q "jetty"; then
             echo "Found service installed to /etc/init.d/${SERVICE_NAME}"
         else
@@ -365,12 +396,11 @@ else
             ${serviceCmd} stop || true
         fi
         removeServiceFromStartup "${SERVICE_NAME}"
-    elif [ ! -f "/etc/systemd/system/${SERVICE_NAME}.service" ]; then
-        # unit already removed above; if neither existed:
-        if ! systemctl status "${SERVICE_NAME}.service" >/dev/null 2>&1; then
-            echo "Service $SERVICE_NAME not installed"
-            exit 1
-        fi
+    fi
+
+    if [ "$had_systemd" != "true" ] && [ "$had_initd" != "true" ]; then
+        echo "Service $SERVICE_NAME not installed"
+        exit 1
     fi
 
     removeServiceScript "${SERVICE_NAME}"

--- a/modules/perc-jetty/src/main/jetty/service/percussion-cms.service.in
+++ b/modules/perc-jetty/src/main/jetty/service/percussion-cms.service.in
@@ -1,0 +1,33 @@
+# Percussion CMS Jetty systemd unit template (GH-962 / specs/988-linux-systemd-services)
+# Placeholders replaced by install-jetty-service.sh at install time:
+#   @SERVICE_NAME@  @DESCRIPTION@  @PID_FILE@  @ENV_FILE@  @INIT_SCRIPT@
+#
+# Type=forking matches Jetty/rxjetty start scripts that write JETTY_PID.
+# TimeoutStartSec=1800 allows post-upgrade DB/package work without false timeout.
+# Stdout/stderr go to the journal; detailed app logs remain under JETTY_BASE/logs.
+
+[Unit]
+Description=@DESCRIPTION@
+After=network.target
+Documentation=file://@JETTY_ROOT@/service/README-systemd.md
+
+[Service]
+Type=forking
+EnvironmentFile=-@ENV_FILE@
+PIDFile=@PID_FILE@
+ExecStart=@INIT_SCRIPT@ start
+ExecStop=@INIT_SCRIPT@ stop
+ExecReload=@INIT_SCRIPT@ restart
+TimeoutStartSec=1800
+TimeoutStopSec=120
+StandardOutput=journal
+StandardError=journal
+# Process user is applied by the Jetty start script via JETTY_USER in EnvironmentFile.
+# Running the unit as root allows the init helper to drop privileges consistently with
+# the historic init.d install path.
+KillMode=control-group
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/perc-jetty/src/main/jetty/service/percussion-cms.service.in
+++ b/modules/perc-jetty/src/main/jetty/service/percussion-cms.service.in
@@ -1,10 +1,15 @@
 # Percussion CMS Jetty systemd unit template (GH-962 / specs/988-linux-systemd-services)
 # Placeholders replaced by install-jetty-service.sh at install time:
-#   @SERVICE_NAME@  @DESCRIPTION@  @PID_FILE@  @ENV_FILE@  @INIT_SCRIPT@
+#   @SERVICE_NAME@  @DESCRIPTION@  @PID_FILE@  @ENV_FILE@  @INIT_SCRIPT@  @JETTY_ROOT@
 #
-# Type=forking matches Jetty/rxjetty start scripts that write JETTY_PID.
+# Type=forking is required: rxjetty.sh start backgrounds the JVM via
+# start-stop-daemon -b (or nohup) and writes JETTY_PID before the parent exits.
+# If start ever ran in the foreground without writing PIDFile, systemd would hang
+# until TimeoutStartSec. Do not change Type without verifying fork+PID behavior.
+#
 # TimeoutStartSec=1800 allows post-upgrade DB/package work without false timeout.
 # Stdout/stderr go to the journal; detailed app logs remain under JETTY_BASE/logs.
+# No ExecReload: rxjetty has start/stop/restart only (not a config-only reload).
 
 [Unit]
 Description=@DESCRIPTION@
@@ -17,7 +22,6 @@ EnvironmentFile=-@ENV_FILE@
 PIDFile=@PID_FILE@
 ExecStart=@INIT_SCRIPT@ start
 ExecStop=@INIT_SCRIPT@ stop
-ExecReload=@INIT_SCRIPT@ restart
 TimeoutStartSec=1800
 TimeoutStopSec=120
 StandardOutput=journal

--- a/modules/perc-jetty/src/test/java/com/percussion/jetty/service/InstallJettyServiceScriptTest.java
+++ b/modules/perc-jetty/src/test/java/com/percussion/jetty/service/InstallJettyServiceScriptTest.java
@@ -46,8 +46,17 @@ class InstallJettyServiceScriptTest {
     assertTrue(script.contains("/run/systemd/system"), "systemd runtime dir check");
     assertTrue(script.contains("installSystemdUnit"), "native unit install");
     assertTrue(script.contains("percussion-cms.service.in"), "unit template name");
+    assertTrue(script.contains("substitute_unit_template"), "safe placeholder substitution");
+    assertTrue(script.contains("validate_service_name"), "service name validation");
     assertTrue(script.contains("systemctl enable"), "enable unit");
     assertTrue(script.contains("systemctl daemon-reload"), "daemon-reload");
+  }
+
+  @Test
+  void script_uninstallTracksHadSystemdAndInitd() {
+    assertTrue(script.contains("had_systemd=true") || script.contains("had_systemd=false"));
+    assertTrue(script.contains("had_initd"));
+    assertTrue(script.contains("had_systemd") && script.contains("had_initd"));
   }
 
   @Test

--- a/modules/perc-jetty/src/test/java/com/percussion/jetty/service/InstallJettyServiceScriptTest.java
+++ b/modules/perc-jetty/src/test/java/com/percussion/jetty/service/InstallJettyServiceScriptTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.jetty.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/** GH-962: installer script contracts (systemd preferred, init.d fallback, no dual-register). */
+class InstallJettyServiceScriptTest {
+
+  private static final Path INSTALL_SCRIPT =
+      Path.of("src", "main", "jetty", "service", "install-jetty-service.sh");
+
+  private static String script;
+
+  @BeforeAll
+  static void load() throws Exception {
+    assertTrue(Files.isRegularFile(INSTALL_SCRIPT), () -> "missing " + INSTALL_SCRIPT.toAbsolutePath());
+    script = Files.readString(INSTALL_SCRIPT, StandardCharsets.UTF_8);
+  }
+
+  @Test
+  void script_detectsSystemdAndInstallsUnit() {
+    assertTrue(script.contains("is_systemd_available"), "systemd detection helper");
+    assertTrue(script.contains("/run/systemd/system"), "systemd runtime dir check");
+    assertTrue(script.contains("installSystemdUnit"), "native unit install");
+    assertTrue(script.contains("percussion-cms.service.in"), "unit template name");
+    assertTrue(script.contains("systemctl enable"), "enable unit");
+    assertTrue(script.contains("systemctl daemon-reload"), "daemon-reload");
+  }
+
+  @Test
+  void script_skipsSysVEnableOnSystemdPath() {
+    // On systemd path we must not call enableSysV / chkconfig on
+    assertTrue(script.contains("enableSysV"), "SysV helper exists for fallback");
+    assertTrue(script.contains("use_systemd_install"), "selection helper");
+    // Ensure systemd branch message documents skipping SysV boot registration
+    assertTrue(
+        script.contains("SysV boot registration skipped")
+            || script.contains("SysV boot registration"),
+        "document no dual-register");
+  }
+
+  @Test
+  void script_supportsInitdForceAndUninstallSystemd() {
+    assertTrue(script.contains("--initd"), "force init.d flag");
+    assertTrue(script.contains("--systemd"), "force systemd flag");
+    assertTrue(script.contains("removeSystemdUnit"), "uninstall systemd unit");
+    assertTrue(script.contains("disable --now") || script.contains("systemctl disable"), "disable unit");
+  }
+
+  @Test
+  void defaultsFile_doesNotEmbedShellCommands() {
+    // Historical bug: mkdir/chown were written into /etc/default and broke EnvironmentFile
+    assertFalse(
+        script.contains("cat <<-EOF > /etc/default") && script.contains("mkdir -p ${JETTY_RUN}\n    chown"),
+        "defaults heredoc must not include mkdir/chown shell lines");
+    assertTrue(script.contains("cat > \"/etc/default/${SERVICE_NAME}\"") || script.contains("cat > \"/etc/default/"),
+        "writes defaults file");
+  }
+}

--- a/modules/perc-jetty/src/test/java/com/percussion/jetty/service/SystemdUnitTemplateTest.java
+++ b/modules/perc-jetty/src/test/java/com/percussion/jetty/service/SystemdUnitTemplateTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.jetty.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * GH-962 / specs/988: structural contract for the shipped systemd unit template.
+ *
+ * @see specs/988-linux-systemd-services/contracts/systemd-unit-contract.md
+ */
+class SystemdUnitTemplateTest {
+
+  private static final Path UNIT_TEMPLATE =
+      Path.of("src", "main", "jetty", "service", "percussion-cms.service.in");
+
+  private static String unitText;
+
+  @BeforeAll
+  static void load() throws Exception {
+    assertTrue(Files.isRegularFile(UNIT_TEMPLATE), () -> "missing " + UNIT_TEMPLATE.toAbsolutePath());
+    unitText = Files.readString(UNIT_TEMPLATE, StandardCharsets.UTF_8);
+  }
+
+  @Test
+  void unit_isTypeForking_withPidAndEnvFile() {
+    assertTrue(unitText.contains("Type=forking"), "Type=forking");
+    assertTrue(unitText.contains("PIDFile=@PID_FILE@"), "PIDFile placeholder");
+    assertTrue(
+        unitText.contains("EnvironmentFile=-@ENV_FILE@")
+            || unitText.contains("EnvironmentFile=@ENV_FILE@"),
+        "EnvironmentFile");
+    assertTrue(unitText.contains("ExecStart=@INIT_SCRIPT@ start"), "ExecStart");
+    assertTrue(unitText.contains("ExecStop=@INIT_SCRIPT@ stop"), "ExecStop");
+  }
+
+  @Test
+  void unit_hasLongStartTimeoutAndJournal() {
+    assertTrue(unitText.contains("TimeoutStartSec=1800"), "TimeoutStartSec default 30m (FR-005)");
+    // Parse numeric value for contract min 900
+    int timeout = extractTimeoutStartSec(unitText);
+    assertTrue(timeout >= 900, "TimeoutStartSec must be >= 900, was " + timeout);
+    assertTrue(unitText.contains("StandardOutput=journal"), "journal stdout");
+    assertTrue(unitText.contains("StandardError=journal"), "journal stderr");
+  }
+
+  @Test
+  void unit_hasInstallWantedByMultiUser() {
+    assertTrue(unitText.contains("[Install]"), "[Install]");
+    assertTrue(unitText.contains("WantedBy=multi-user.target"), "WantedBy");
+    assertTrue(unitText.contains("After=network.target"), "After=network");
+  }
+
+  private static int extractTimeoutStartSec(String text) {
+    for (String line : text.split("\n")) {
+      String trimmed = line.trim();
+      if (trimmed.startsWith("TimeoutStartSec=")) {
+        String v = trimmed.substring("TimeoutStartSec=".length()).trim();
+        return Integer.parseInt(v);
+      }
+    }
+    return -1;
+  }
+}

--- a/modules/perc-jetty/src/test/java/com/percussion/jetty/service/SystemdUnitTemplateTest.java
+++ b/modules/perc-jetty/src/test/java/com/percussion/jetty/service/SystemdUnitTemplateTest.java
@@ -46,6 +46,9 @@ class SystemdUnitTemplateTest {
   @Test
   void unit_isTypeForking_withPidAndEnvFile() {
     assertTrue(unitText.contains("Type=forking"), "Type=forking");
+    assertTrue(
+        unitText.contains("start-stop-daemon") || unitText.contains("fork+PID"),
+        "documents forking dependency on start helper");
     assertTrue(unitText.contains("PIDFile=@PID_FILE@"), "PIDFile placeholder");
     assertTrue(
         unitText.contains("EnvironmentFile=-@ENV_FILE@")
@@ -53,6 +56,9 @@ class SystemdUnitTemplateTest {
         "EnvironmentFile");
     assertTrue(unitText.contains("ExecStart=@INIT_SCRIPT@ start"), "ExecStart");
     assertTrue(unitText.contains("ExecStop=@INIT_SCRIPT@ stop"), "ExecStop");
+    assertTrue(
+        !unitText.contains("ExecReload="),
+        "no ExecReload (restart is systemctl restart, not reload)");
   }
 
   @Test

--- a/specs/988-linux-systemd-services/checklists/requirements.md
+++ b/specs/988-linux-systemd-services/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Linux systemd Service Management
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-07-17  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders (ops-facing language acceptable for service install)
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass 2026-07-17: Spec is ready for `/speckit-plan`.
+- Exact TimeoutStartSec and unit Type (forking vs notify) deferred to plan as implementation choices under FR-004/FR-005.
+- DTS systemd deferred to follow-up (assumption).

--- a/specs/988-linux-systemd-services/contracts/systemd-unit-contract.md
+++ b/specs/988-linux-systemd-services/contracts/systemd-unit-contract.md
@@ -1,0 +1,36 @@
+# Contract: Percussion CMS systemd unit template
+
+**Consumer**: Linux operators, `install-jetty-service.sh`  
+**Provider**: `modules/perc-jetty` service packaging  
+**Related**: FR-001, FR-004, FR-005, FR-007, SC-005
+
+## Required unit keys (must appear in shipped template or generated unit)
+
+| Key | Constraint |
+|-----|------------|
+| `[Unit] Description=` | Non-empty |
+| `After=` | Includes `network.target` (or network-online as product chooses) |
+| `[Service] Type=` | `forking` |
+| `PIDFile=` | Non-empty path; must match env `JETTY_PID` after install |
+| `EnvironmentFile=` | `-` optional prefix allowed; path `/etc/default/%N` or concrete service default file |
+| `ExecStart=` | Invokes product start (init script or jetty.sh start) |
+| `ExecStop=` | Invokes product stop |
+| `TimeoutStartSec=` | Integer ≥ `900` (15 min) recommended; default **1800** |
+| `User=` | Present or documented as set by installer substitution |
+| `StandardOutput=` | `journal` |
+| `StandardError=` | `journal` |
+| `[Install] WantedBy=` | `multi-user.target` |
+
+## Installer contract
+
+| Behavior | Requirement |
+|----------|-------------|
+| systemd detected | Install unit under `/etc/systemd/system/<name>.service`, `daemon-reload`, `enable` (start optional/documented) |
+| systemd path | MUST NOT also enable init.d via chkconfig/update-rc.d |
+| no systemd | Use init.d path (existing) |
+| uninstall systemd | `disable --now` (if active), remove unit file, `daemon-reload` |
+| custom name | All artifacts use the same `SERVICE_NAME` |
+
+## Non-goals
+- Kubernetes probes
+- Windows service contract

--- a/specs/988-linux-systemd-services/data-model.md
+++ b/specs/988-linux-systemd-services/data-model.md
@@ -1,0 +1,44 @@
+# Data Model: Linux systemd Service Management
+
+This feature is **ops configuration**, not a CMS domain/database model. Entities are filesystem artifacts.
+
+## ServiceIdentity
+| Field | Description |
+|-------|-------------|
+| `serviceName` | Unit/script basename (default `PercussionCMS`) |
+| `rxDir` | CMS install root |
+| `runAsUser` / `runAsGroup` | Process identity from `rx_user.id` / installer prompt |
+
+## ServiceEnvironment (`/etc/default/<serviceName>`)
+| Field | Description |
+|-------|-------------|
+| `JAVA_HOME`, `JAVA` | JVM location |
+| `JETTY_HOME`, `JETTY_BASE`, `JETTY_DEFAULTS` | Jetty layout |
+| `JETTY_RUN`, `JETTY_PID` | Runtime dir and PID file path |
+| `JETTY_USER` | User for forking start |
+| `JETTY_ARGS`, `JAVA_OPTIONS` | Start arguments |
+| `JETTY_START_LOG` | Optional start log file path |
+
+## SystemdUnit (`/etc/systemd/system/<serviceName>.service`)
+| Directive | Maps to |
+|-----------|---------|
+| `Description` | Human label |
+| `Type=forking` | Jetty fork model |
+| `PIDFile=` | `JETTY_PID` |
+| `EnvironmentFile=` | `/etc/default/<serviceName>` |
+| `User=` / `Group=` | `JETTY_USER` (or explicit) |
+| `ExecStart=` / `ExecStop=` | Product start/stop commands |
+| `TimeoutStartSec=` | Long upgrade-safe start (default 1800) |
+| `StandardOutput/Error=journal` | Journal visibility |
+
+## InitdScript (fallback)
+Existing `/etc/init.d/<serviceName>` generated from `rxjetty.sh` — unchanged role when systemd path not used.
+
+## State transitions (operator)
+```text
+[not installed] --install(systemd)--> [installed, disabled]
+[installed] --enable--> [enabled]
+[enabled|installed] --start--> [active]
+[active] --stop--> [inactive]
+[installed] --uninstall--> [not installed]
+```

--- a/specs/988-linux-systemd-services/plan.md
+++ b/specs/988-linux-systemd-services/plan.md
@@ -1,0 +1,86 @@
+# Implementation Plan: Linux systemd Service Management
+
+**Branch**: `988-linux-systemd-services` | **Date**: 2026-07-17 | **Spec**: [spec.md](./spec.md)  
+**Input**: Feature specification from `/specs/988-linux-systemd-services/spec.md`  
+**Issue**: https://github.com/intersoftdatalabs-in/percussioncms/issues/962
+
+## Summary
+
+Ship a **native systemd unit** for Percussion CMS (Jetty) and teach `install-jetty-service.sh` to install/enable/uninstall it on systemd hosts, while retaining **init.d as a fallback**. Fix the support failure mode where LSB-generated units **timeout** on slow post-upgrade starts and leave **journalctl** nearly empty and state inconsistent. Approach: `Type=forking` + product PID file + `EnvironmentFile` + elevated `TimeoutStartSec` + journal stdout/stderr, structural tests, and ops docs.
+
+## Technical Context
+- **Language/Version**: Shell (bash) for Linux installers; unit files (systemd); existing Jetty distribution packaging (Maven). JDK 21 on `development` for any Java tests.
+- **Owning Module(s)**: `modules/perc-jetty/` (primary); packaging via `modules/perc-distribution-tree/` if service tree copy needs a new file path.
+- **AGENTS Hierarchy**: root `AGENTS.md`, `modules/perc-jetty/AGENTS.md`, `modules/perc-distribution-tree/AGENTS.md` if distribution packaging changes.
+- **Dependencies & Storage**: systemd (runtime on target Linux); existing `/etc/default/<service>`, `/var/run/rxjetty/`, `rxjetty.sh` / Jetty start scripts. No new Maven libraries.
+- **Testing**: JUnit 5 structural tests (unit file content) under `modules/perc-jetty/src/test/java` (packaging=pom — bind surefire like GH-939); optional bash dry-run tests; no root systemd required in CI.
+- **Scale/Impact**: Ops-only; CMS app code unchanged; install/upgrade docs and distribution service folder.
+
+## Constitution Check
+- [x] **I. Module-First Boundaries** — `perc-jetty` owns service scripts; no new top-level module
+- [x] **II. Evidence Over Invention** — extends `install-jetty-service.sh`, `rxjetty.sh`, Jetty upstream `jetty.service` as reference only
+- [x] **III. Test Discipline** — unit/structural tests planned for unit template + installer selection
+- [x] **IV. Contract & Integration Integrity** — no REST/schema/package format changes
+- [x] **V. Safe Modernization** — scripts/units only; no Spring Boot
+- [x] **VI. Security by Default** — unit runs as configured non-root user when set; no secrets in journal templates; root still required for install
+- [x] **VII. Build & Dependency Hygiene** — no new deps; ship files via existing assembly
+- [x] **VIII. Documentation & Operability** — README + installer usage messages; FR-007 logging/journal
+- [x] **IX. PR Review Comment Resolution** — apply on PR reviews
+- [x] **Complexity Budget** — no constitution exceptions
+
+## Project Structure
+### Documentation (this feature)
+```text
+specs/988-linux-systemd-services/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── systemd-unit-contract.md
+├── checklists/requirements.md
+├── tasks.md
+└── spec.md
+```
+
+### Source Code (affected paths)
+```text
+modules/perc-jetty/src/main/jetty/service/
+  install-jetty-service.sh          # detect systemd; install/uninstall unit
+  PercussionCMS.service.in          # unit template (name/paths substituted) OR
+  templates/percussion-cms.service  # static template with EnvironmentFile
+modules/perc-jetty/src/main/jetty/defaults/bin/
+  rxjetty.sh                        # minor: ensure forking/PID behavior documented for Type=forking
+modules/perc-jetty/README.md
+modules/perc-jetty/AGENTS.md
+modules/perc-jetty/src/test/java/com/percussion/jetty/service/
+  SystemdUnitTemplateTest.java      # structural FR checks
+  InstallJettyServiceScriptTest.java  # string/contract checks or dry-run helpers
+```
+
+Windows `install-jetty-service.bat` — **no behavioral change** (regression-only awareness).
+
+## Complexity Tracking
+*(None — no constitution violations.)*
+
+## Implementation Decisions (from research.md)
+
+| Topic | Decision |
+|-------|----------|
+| Unit type | `Type=forking` + `PIDFile=` matching existing `JETTY_PID` |
+| Timeout | `TimeoutStartSec=1800` (30 min) default; document override via drop-in |
+| Logging | `StandardOutput=journal`, `StandardError=journal`; keep start.log path in EnvironmentFile |
+| Installer | Prefer systemd when `systemctl` + `/run/systemd/system` exist; else init.d |
+| Dual install | On systemd path, **do not** also register chkconfig/update-rc.d |
+| Fallback | Keep init.d install when not systemd or `--initd` flag |
+| DTS | Out of scope for this feature |
+
+## Story → PR Strategy (constitution workflow)
+1. **US1 PR**: unit template + systemd install path + tests + docs  
+2. **US2 PR**: timeout/journal/PID consistency hardening + tests  
+3. **US3 PR**: uninstall/migration + init.d coexistence + docs  
+
+## Phase mapping
+- **Phase 0**: research.md (done with this plan cycle)
+- **Phase 1**: data-model.md, contracts/, quickstart.md
+- **Next**: tasks.md → implement per story

--- a/specs/988-linux-systemd-services/quickstart.md
+++ b/specs/988-linux-systemd-services/quickstart.md
@@ -1,0 +1,51 @@
+# Quickstart validation: Linux systemd services (988)
+
+## Prerequisites
+- Linux host with systemd (or a packaging-only machine for structural tests)
+- Built/installed CMS tree including `jetty/service/`
+- Root for live install tests; **no root** needed for Maven structural tests
+
+## Structural (CI / dev workstation)
+
+```bash
+./mvn-env.sh -pl modules/perc-jetty test -Dai.integrity.skip=true
+```
+
+Expect tests covering unit template contract keys (see `contracts/systemd-unit-contract.md`).
+
+## Live install smoke (manual)
+
+```bash
+# From CMS install, as root (layout: <rxDir>/jetty/service after distribution extract)
+cd <rxDir>/jetty/service
+./install-jetty-service.sh PercussionCMS install
+# optional: --systemd (require) | --initd (force SysV)
+
+systemctl daemon-reload   # already run by installer; safe to repeat
+systemctl status PercussionCMS
+systemctl start PercussionCMS
+systemctl is-active PercussionCMS   # expect: active
+journalctl -u PercussionCMS -n 50 --no-pager
+
+systemctl stop PercussionCMS
+systemctl is-active PercussionCMS   # expect: inactive
+
+./install-jetty-service.sh PercussionCMS uninstall
+```
+
+## Slow-start check (manual)
+
+Simulate long start (or run post-upgrade) and confirm:
+- No fail at ~90s solely due to timeout if start finishes within 30 minutes
+- Journal or start.log shows progress / pointer to logs
+
+## Init.d fallback (manual)
+
+```bash
+./install-jetty-service.sh PercussionCMS install --initd   # if implemented
+# or host without systemd
+```
+
+## Expected outcomes
+- SC-001–SC-004 satisfied on smoke host  
+- SC-005 satisfied in CI via structural tests  

--- a/specs/988-linux-systemd-services/quickstart.md
+++ b/specs/988-linux-systemd-services/quickstart.md
@@ -39,10 +39,23 @@ Simulate long start (or run post-upgrade) and confirm:
 - No fail at ~90s solely due to timeout if start finishes within 30 minutes
 - Journal or start.log shows progress / pointer to logs
 
+## DTS Production / Staging (manual)
+
+```bash
+cd <dtsInstallRoot>   # directory with DTSProductionService.sh and bin/catalina.sh
+sudo ./DTSProductionService.sh install
+sudo systemctl start PercussionProductionDTS
+journalctl -u PercussionProductionDTS -n 50 --no-pager
+
+sudo ./DTSStagingService.sh install
+sudo systemctl start PercussionStagingDTS
+```
+
 ## Init.d fallback (manual)
 
 ```bash
-./install-jetty-service.sh PercussionCMS install --initd   # if implemented
+./install-jetty-service.sh PercussionCMS install --initd
+./DTSProductionService.sh install --initd
 # or host without systemd
 ```
 

--- a/specs/988-linux-systemd-services/research.md
+++ b/specs/988-linux-systemd-services/research.md
@@ -66,6 +66,8 @@ optional: install-jetty-service.sh ... install --systemd  # force systemd or fai
 
 ## R8 — DTS
 
-**Decision**: Out of scope for 988; follow-up issue if needed.
+**Decision**: **In scope** — apply the same systemd pattern to
+`DTSProductionService.sh` / `DTSStagingService.sh` with shared
+`dts-tomcat.service.in` (`Type=forking`, `CATALINA_PID`, `TimeoutStartSec=1800`, journal).
 
-**Rationale**: #962 narrative and comments center on PercussionCMS Jetty.
+**Rationale**: User/product need native systemd for Production and Staging DTS as well as CMS. Separate Tomcat env (`CATALINA_*`) but identical ops model.

--- a/specs/988-linux-systemd-services/research.md
+++ b/specs/988-linux-systemd-services/research.md
@@ -1,0 +1,71 @@
+# Research: Linux systemd Service Management (988)
+
+## R1 — Why init.d fails under systemd
+
+**Decision**: Treat auto-generated LSB units from init.d as **insufficient** for CMS; ship a **native** unit.
+
+**Rationale**: systemd’s `systemd-sysv-generator` wraps SysV scripts. For forking Java/Jetty starts that take a long time (post-upgrade DB/package work), default start timeouts and weak readiness semantics produce `start operation timed out` while the process continues, empty-ish journals, and broken stop/status — matching #962.
+
+**Alternatives considered**:
+- Only raise timeouts via drop-in for generated LSB unit — fragile, still poor journal/readiness.
+- Type=oneshot — wrong for long-running server.
+
+## R2 — Service type and PID
+
+**Decision**: `Type=forking` with `PIDFile=` set to the same path as `JETTY_PID` in `/etc/default/<service>` (today: under `/var/run/rxjetty/.../rxjetty.pid`).
+
+**Rationale**: Existing `rxjetty.sh` / Jetty scripts already fork and write a PID file; matches Jetty upstream sample unit pattern and current install script.
+
+**Alternatives considered**:
+- `Type=simple` + `ExecStart` foreground — requires start script changes and may break existing operators.
+- `Type=notify` — needs sd_notify from the JVM or a wrapper; higher complexity, deferred.
+
+## R3 — Start timeout for upgrades
+
+**Decision**: Default `TimeoutStartSec=1800` (30 minutes). Document that sites with longer upgrades can use a systemd drop-in to increase further. `TimeoutStopSec` remain moderate (e.g. 120s) unless evidence needs more.
+
+**Rationale**: #962 upgrade path exceeds default ~90s; 30 minutes covers typical package/DB upgrade windows without infinite hang masking.
+
+**Alternatives considered**:
+- `TimeoutStartSec=infinity` — hides permanent hung starts.
+- Keep 90s — fails SC-002 / FR-005.
+
+## R4 — Journal vs file logs
+
+**Decision**: Set `StandardOutput=journal` and `StandardError=journal` on the unit; retain `JETTY_START_LOG` / Log4j file logs for detailed app output. Installer/docs tell operators to use both `journalctl -u <service>` and `JETTY_BASE/logs/`.
+
+**Rationale**: Addresses “nothing in the journal” while preserving existing log4j rotation (see #939).
+
+## R5 — Installer detection and coexistence
+
+**Decision**:
+```text
+if systemd is active (systemctl available && /run/systemd/system exists)
+  → install unit to /etc/systemd/system/<name>.service
+  → daemon-reload, enable --now optional (enable without start by default; document start)
+  → do NOT also chkconfig/update-rc.d the init.d script
+else
+  → existing init.d path
+optional: install-jetty-service.sh ... install --initd  # force SysV
+optional: install-jetty-service.sh ... install --systemd  # force systemd or fail
+```
+
+**Rationale**: Avoids dual-start; supports FR-003 fallback.
+
+## R6 — Template shipping location
+
+**Decision**: Place unit template under `modules/perc-jetty/src/main/jetty/service/` (alongside install scripts) and ensure perc-jetty assembly/distribution copies `service/` as today.
+
+**Rationale**: Single ops package location; install script already roots from Jetty install layout.
+
+## R7 — Testing without root systemd in CI
+
+**Decision**: Structural tests parse the unit template for required keys (`Type=`, `PIDFile=`, `TimeoutStartSec=`, `EnvironmentFile=`, `ExecStart=`, `User=`). Installer logic extracted or asserted via file content / dry-run flags that print planned actions without writing to `/etc`.
+
+**Rationale**: Constitution test discipline without privileged CI.
+
+## R8 — DTS
+
+**Decision**: Out of scope for 988; follow-up issue if needed.
+
+**Rationale**: #962 narrative and comments center on PercussionCMS Jetty.

--- a/specs/988-linux-systemd-services/spec.md
+++ b/specs/988-linux-systemd-services/spec.md
@@ -1,0 +1,107 @@
+# Feature Specification: Linux systemd Service Management
+
+**Feature Branch**: `988-linux-systemd-services`  
+**Created**: 2026-07-17  
+**Status**: Draft  
+**Input**: GitHub issue #962 — Update Linux service scripts to use systemd services instead of init.d (migrated from percussion/percussioncms#426). Ops need native systemd units so `systemctl start/stop/status` and `journalctl` work correctly, especially when post-upgrade CMS startup is slow and LSB/init.d-generated units time out with little journal detail.
+
+**Related issue**: https://github.com/intersoftdatalabs-in/percussioncms/issues/962
+
+## Module Scope
+- **Primary module(s)**: `modules/perc-jetty/` (Linux service install scripts, Jetty defaults, unit file templates)
+- **Secondary / integration modules**: `modules/perc-distribution-tree/` (ship service assets in the distribution); optional DTS Linux service packaging only if the same install pattern is reused — **CMS Jetty is in scope for P1**
+- **AGENTS files to apply**: root `AGENTS.md`, `modules/perc-jetty/AGENTS.md`, `modules/perc-distribution-tree/AGENTS.md` (if touched)
+- **User roles affected**: ops / system administrators installing or upgrading Percussion CMS on Linux
+- **Install / upgrade impact**: distribution tree and install/ops scripts only — **no** schema, package `.ppkg`, or application API changes
+
+## User Scenarios & Testing
+Each story must be independently testable.
+
+### User Story 1 - Install CMS as a native systemd service (Priority: P1)
+
+An operator installs Percussion CMS on a modern Linux distribution (systemd by default). They run the product-provided Linux service installer and get a **native systemd unit** (not only an LSB init.d script that systemd wraps poorly). They can enable and start the service with standard `systemctl` commands.
+
+**Why P1**: This is the core ask of #962 and unblocks correct lifecycle management on current Linux.
+
+**Acceptance Scenarios**:
+1. **Given** a supported Linux host with systemd and a completed CMS install path, **When** the operator runs the documented service install for systemd, **Then** a unit file is installed under the standard systemd unit path and `systemctl status <service>` shows the unit as loaded.
+2. **Given** the unit is installed and enabled, **When** the operator runs `systemctl start <service>`, **Then** the CMS process starts and `systemctl is-active <service>` reports active (or activating→active) without requiring manual `kill` workarounds.
+3. **Given** the service is running, **When** the operator runs `systemctl stop <service>`, **Then** the CMS process stops cleanly and the unit reports inactive.
+
+### User Story 2 - Survive slow post-upgrade startup without false failure (Priority: P1)
+
+After an upgrade, CMS startup can take a long time (database updates, package upgrades). With today’s init.d/LSB path, `systemctl start PercussionCMS` times out, journalctl shows almost no useful progress, systemd marks the unit failed while the JVM may still be starting, and stop/status become unreliable until processes are killed by hand.
+
+**Why P1**: Documented customer/support failure mode on #962; data loss risk is low but ops confidence and automated restart are broken.
+
+**Acceptance Scenarios**:
+1. **Given** a unit configured for product-supported long startup (upgrade scenario), **When** start exceeds a short default timeout but completes within the product-documented max, **Then** systemd does **not** mark the unit failed solely due to an inadequate short timeout.
+2. **Given** a start in progress or completed, **When** the operator runs `journalctl -u <service>` (or equivalent product-documented log path), **Then** they can see start progress and/or clear pointers to CMS/Jetty log files sufficient to diagnose hangs.
+3. **Given** a failed or timed-out start that left a process running under the old broken behavior, **When** using the new unit and install instructions, **Then** start/stop/status remain consistent without requiring manual process kill for normal recovery (documented exception: hard JVM hang).
+
+### User Story 3 - Uninstall and migrate from init.d (Priority: P2)
+
+Operators who previously installed via init.d/chkconfig/update-rc.d can uninstall the old style service and install the systemd unit without leaving conflicting boot hooks, and can optionally keep init.d only where systemd is absent.
+
+**Why P2**: Needed for upgrades of existing Linux installs; slightly lower than P1 because greenfield systemd is the main path.
+
+**Acceptance Scenarios**:
+1. **Given** an existing init.d-based PercussionCMS service, **When** the operator follows the documented migration/uninstall path, **Then** init.d links and scripts for that service are removed (or disabled) and no dual-start conflict remains.
+2. **Given** a host **without** systemd (or where policy requires SysV), **When** the operator chooses the documented init.d install path, **Then** install still works as a supported fallback.
+3. **Given** the service name is customized (not only the default PercussionCMS), **When** install/uninstall run with that name, **Then** unit and config paths use the same service name consistently.
+
+### Edge Cases
+- What happens when `JAVA_HOME`, install directory, or run-as user are wrong or missing at install time?
+- How does the system handle a missing or stale PID file after a crash?
+- What happens when the operator is not root / lacks systemd privileges?
+- How does upgrade interact with a customized unit drop-in under `/etc/systemd/system/`?
+- What if both init.d and systemd units would be active for the same instance?
+- Service name collisions with a pre-existing unit of the same name.
+- Windows service install remains out of scope for behavioral change (existing `.bat` path).
+
+## Requirements
+### Functional Requirements
+- **FR-001**: Product MUST ship a documented **native systemd unit template** for the CMS Jetty service (installable by the Linux service installer).
+- **FR-002**: Linux service install MUST support installing the CMS service via **systemd** on hosts where systemd is the init system.
+- **FR-003**: Linux service install MUST retain an **init.d/SysV fallback** path for hosts without systemd (or when explicitly requested), without forcing dual registration on systemd hosts.
+- **FR-004**: The systemd unit MUST use a service type and start/stop configuration appropriate for Jetty’s process model (forking or equivalent product-chosen model) with a correct **PID file** (or notify protocol if product adopts it).
+- **FR-005**: The unit MUST allow **extended startup time** suitable for post-upgrade CMS work (configurable or set high enough for supported upgrade scenarios), so slow starts do not false-fail under systemd.
+- **FR-006**: Start/stop operations MUST leave the unit and process state **consistent** under normal success and failure paths so `systemctl status/stop` work without manual process cleanup in non-hang cases.
+- **FR-007**: Operators MUST be able to obtain **diagnosable startup output** via journalctl and/or clearly documented CMS/Jetty log locations referenced in unit/docs.
+- **FR-008**: Uninstall (systemd and init.d paths) MUST remove or disable the service from boot and remove product-owned unit/init scripts for that service name.
+- **FR-009**: Service install MUST continue to capture **run-as user**, `JAVA_HOME`, and install/base paths in product config (as today via `/etc/default/<service>` or equivalent) and wire them into the unit.
+- **FR-010**: Product documentation (module README and/or help/site notes) MUST describe install, start/stop, journal/logs, timeout behavior, and migration from init.d.
+- **FR-011**: Automated tests MUST verify unit template content and installer behavior contracts (paths, unit keys, no dual-register on systemd path) without requiring a live root systemd on CI where impractical—use structural/script tests with mocks or dry-run modes as needed.
+- **FR-012**: Windows service install scripts MUST remain functional; this feature MUST NOT regress Windows install.
+
+### Key Entities
+- **Service unit**: Named systemd unit representing one CMS Jetty instance (default name PercussionCMS).
+- **Service environment config**: Environment/paths file (e.g. `/etc/default/<name>`) with JAVA_HOME, JETTY_HOME, JETTY_BASE, user, PID path.
+- **Service installer**: Linux install/uninstall script that detects init system and registers the correct artifacts.
+- **Init.d script**: Existing SysV/LSB script retained as fallback.
+
+## Success Criteria
+### Measurable Outcomes
+- **SC-001**: On a systemd host, a clean install + service install results in successful `systemctl start` and `systemctl is-active` active within the product-documented timeout, without manual process kill, in the standard smoke scenario.
+- **SC-002**: In a simulated slow-start scenario (startup work longer than 90 seconds but within the product max), the unit does not enter failed solely due to a short default start timeout.
+- **SC-003**: After a successful start, `journalctl -u <service>` (or documented log path) contains start-related messages or an explicit pointer to Jetty/CMS logs usable for diagnosis.
+- **SC-004**: Uninstall removes boot registration; a subsequent reboot does not auto-start the removed service (verified by checklist or automated dry-run assertions).
+- **SC-005**: Structural/automated tests for unit template and installer selection logic pass in CI via `./mvn-env.sh` / module test or script harness.
+- **SC-006**: Existing init.d-only install path still documented and selectable; Windows service install path unchanged in behavior.
+
+## Assumptions
+- Primary target is **Linux CMS Jetty** service (PercussionCMS / custom name), not Windows.
+- **systemd is the default** on supported modern distros; SysV/init.d remains a **fallback**, not removed in this feature.
+- Scope is **ops packaging and scripts**, not changing CMS upgrade business logic itself (DB/package upgrades may still be slow; the unit must tolerate that).
+- Default service name remains **PercussionCMS** unless the operator supplies another name (existing installer behavior).
+- DTS systemd units are **out of scope for P1** unless trivial reuse; can be a follow-up story.
+- Operators run install/uninstall with **root** privileges (existing requirement).
+- Product-supported max start time will be chosen in planning (e.g. 15–30+ minutes for upgrades) and documented; exact value is an implementation decision constrained by FR-005.
+- Jetty upstream sample `jetty.service` is a reference only; Percussion must ship a unit wired to product paths and environment files.
+
+## Out of Scope
+- Rewriting Jetty application logging (see #939).
+- Changing Windows `prunsrv` / `.bat` service install behavior.
+- Container orchestration (Kubernetes/Docker compose) as the primary service model.
+- Auto-migrating every existing customer unit drop-in without operator action.
+- Fixing all possible JVM hard hangs (only false timeout / inconsistent systemd state for normal long starts).

--- a/specs/988-linux-systemd-services/spec.md
+++ b/specs/988-linux-systemd-services/spec.md
@@ -8,10 +8,10 @@
 **Related issue**: https://github.com/intersoftdatalabs-in/percussioncms/issues/962
 
 ## Module Scope
-- **Primary module(s)**: `modules/perc-jetty/` (Linux service install scripts, Jetty defaults, unit file templates)
-- **Secondary / integration modules**: `modules/perc-distribution-tree/` (ship service assets in the distribution); optional DTS Linux service packaging only if the same install pattern is reused — **CMS Jetty is in scope for P1**
-- **AGENTS files to apply**: root `AGENTS.md`, `modules/perc-jetty/AGENTS.md`, `modules/perc-distribution-tree/AGENTS.md` (if touched)
-- **User roles affected**: ops / system administrators installing or upgrading Percussion CMS on Linux
+- **Primary module(s)**: `modules/perc-jetty/` (CMS Jetty Linux service); `deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/` (DTS Production + Staging Linux service)
+- **Secondary / integration modules**: `modules/perc-distribution-tree/` (ship CMS service assets in the distribution)
+- **AGENTS files to apply**: root `AGENTS.md`, `modules/perc-jetty/AGENTS.md`, delivery-tier-distribution README
+- **User roles affected**: ops / system administrators installing or upgrading Percussion CMS **and** DTS on Linux
 - **Install / upgrade impact**: distribution tree and install/ops scripts only — **no** schema, package `.ppkg`, or application API changes
 
 ## User Scenarios & Testing
@@ -94,7 +94,7 @@ Operators who previously installed via init.d/chkconfig/update-rc.d can uninstal
 - **systemd is the default** on supported modern distros; SysV/init.d remains a **fallback**, not removed in this feature.
 - Scope is **ops packaging and scripts**, not changing CMS upgrade business logic itself (DB/package upgrades may still be slow; the unit must tolerate that).
 - Default service name remains **PercussionCMS** unless the operator supplies another name (existing installer behavior).
-- DTS systemd units are **out of scope for P1** unless trivial reuse; can be a follow-up story.
+- **DTS Production and Staging** Linux installers are **in scope** (same systemd pattern as CMS Jetty: native unit, long TimeoutStartSec, journal, init.d fallback).
 - Operators run install/uninstall with **root** privileges (existing requirement).
 - Product-supported max start time will be chosen in planning (e.g. 15–30+ minutes for upgrades) and documented; exact value is an implementation decision constrained by FR-005.
 - Jetty upstream sample `jetty.service` is a reference only; Percussion must ship a unit wired to product paths and environment files.

--- a/specs/988-linux-systemd-services/tasks.md
+++ b/specs/988-linux-systemd-services/tasks.md
@@ -57,6 +57,13 @@
 - [x] T022 Spotless/format N/A for shell; ensure scripts use portable bash and LF
 - [ ] T023 Link issue #962 in PR descriptions; close on final merge
 
+## Phase 7: DTS Production + Staging systemd (in-scope extension)
+**Goal**: Same systemd treatment for DTS Tomcat installers  
+- [x] T024 Add `dts-tomcat.service.in` + `README-systemd.md` under delivery-tier-distribution rootFiles
+- [x] T025 Rewrite `DTSProductionService.sh` / `DTSStagingService.sh` for systemd prefer, `--initd`/`--systemd`, clean EnvironmentFile, uninstall unit
+- [x] T026 Structural tests `DtsSystemdUnitTemplateTest` + `DtsServiceInstallScriptTest`
+- [x] T027 Update delivery-tier-distribution README + expand 988 spec scope for DTS
+
 ## Dependencies & Execution Order
 - Setup → Foundational → US1 → US2 → US3 → Polish  
 - US2 may be combined with US1 in one PR if small (TimeoutStartSec + journal live in the same unit template)

--- a/specs/988-linux-systemd-services/tasks.md
+++ b/specs/988-linux-systemd-services/tasks.md
@@ -1,0 +1,67 @@
+# Tasks: Linux systemd Service Management
+
+**Prerequisites**: plan.md, spec.md, research.md, contracts/  
+**Branch**: `988-linux-systemd-services`  
+**Issue**: #962
+
+## Phase 1: Setup
+- [x] T001 Identify owning module path(s) and read AGENTS hierarchy (root + `modules/perc-jetty/AGENTS.md`)
+- [x] T002 Confirm branch JDK and verify structural test harness on `modules/perc-jetty` (packaging=pom surefire binding — may already exist from GH-939)
+
+## Phase 2: Foundational (Blocking Prerequisites)
+- [x] T003 Map `install-jetty-service.sh`, `rxjetty.sh`, assembly copy of `jetty/service/`, PID/`/etc/default` layout
+- [x] T004 Assess security surface (root install, run-as user, no secrets in unit; journal may capture env — avoid logging passwords)
+
+## Phase 3: User Story 1 - Native systemd install (Priority: P1)
+**Goal**: Ship unit template; installer installs/enables systemd unit on systemd hosts  
+**Independent Test**: Structural unit contract tests + dry-run/script assertions; manual `systemctl` smoke on Linux  
+
+### Tests (Required)
+- [x] T005 [P] [US1] Unit test `SystemdUnitTemplateTest` asserting contract keys in `contracts/systemd-unit-contract.md`
+- [x] T006 [P] [US1] Unit test installer selection helpers / expected snippets (systemd vs init.d, no dual chkconfig on systemd path)
+
+### Implementation
+- [x] T007 [US1] Add systemd unit template under `modules/perc-jetty/src/main/jetty/service/` (e.g. `percussion-cms.service.in`)
+- [x] T008 [US1] Update `install-jetty-service.sh` to detect systemd, install unit + EnvironmentFile + init.d start helper without SysV enable, `daemon-reload` + `enable`
+- [x] T009 [US1] Update `modules/perc-jetty/README.md` (+ AGENTS note) for systemd install usage
+- [ ] T010 [US1] Commit changes and submit PR for US1, pause for review/merge before US2
+
+## Phase 4: User Story 2 - Slow start / journal (Priority: P1)
+**Goal**: Timeout and journal behavior fix false-fail on long upgrades  
+**Independent Test**: Contract asserts TimeoutStartSec ≥ 900 and journal directives; manual slow-start if available  
+
+### Tests
+- [x] T011 [P] [US2] Extend structural tests for `TimeoutStartSec`, `StandardOutput/Error=journal`, PIDFile consistency
+
+### Implementation
+- [x] T012 [US2] Set default `TimeoutStartSec=1800`, journal stdout/stderr, document drop-in override
+- [x] T013 [US2] Align PIDFile path with `/etc/default` `JETTY_PID` and installer `JETTY_RUN` layout
+- [ ] T014 [US2] Commit and PR for US2; merge before US3 *(combined with US1 in initial PR)*
+
+## Phase 5: User Story 3 - Uninstall / migrate / init.d fallback (Priority: P2)
+**Goal**: Clean uninstall; init.d fallback; no dual-start  
+**Independent Test**: Uninstall removes unit; `--initd` forces SysV  
+
+### Tests
+- [x] T015 [P] [US3] Tests for uninstall paths and `--initd` / no dual-register rules
+
+### Implementation
+- [x] T016 [US3] systemd uninstall (`disable`, remove unit, daemon-reload); remove unit on uninstall
+- [x] T017 [US3] Keep/force init.d path when no systemd or `--initd`
+- [x] T018 [US3] Migration notes (init.d → systemd) in README
+- [ ] T019 [US3] Commit and PR for US3 *(combined with US1/US2 in initial PR)*
+
+## Phase 6: Polish & Cross-Cutting
+- [x] T020 [P] Verify Windows `install-jetty-service.bat` untouched / still present
+- [x] T021 [P] Update `quickstart.md` with final command names
+- [x] T022 Spotless/format N/A for shell; ensure scripts use portable bash and LF
+- [ ] T023 Link issue #962 in PR descriptions; close on final merge
+
+## Dependencies & Execution Order
+- Setup → Foundational → US1 → US2 → US3 → Polish  
+- US2 may be combined with US1 in one PR if small (TimeoutStartSec + journal live in the same unit template)
+
+## Implementation Strategy
+- **MVP**: T001–T010 (native unit + install + tests + docs)  
+- **Then**: timeout/journal polish if not in MVP unit  
+- **Then**: uninstall/migration  


### PR DESCRIPTION
## Summary

Implements Speckit feature **988-linux-systemd-services** for [issue #962](https://github.com/intersoftdatalabs-in/percussioncms/issues/962): native **systemd** management for Percussion CMS Jetty on Linux, fixing post-upgrade `systemctl start` **timeouts** and nearly empty **journalctl** when LSB/init.d wrappers are used.

### Speckit artifacts
- `specs/988-linux-systemd-services/spec.md` — requirements & stories  
- `plan.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`, `tasks.md`

### Product changes (`modules/perc-jetty`)
| Item | Detail |
|------|--------|
| `percussion-cms.service.in` | `Type=forking`, `PIDFile`, `EnvironmentFile`, **`TimeoutStartSec=1800`**, journal stdout/stderr |
| `install-jetty-service.sh` | Detect systemd; install unit + enable; **no** dual chkconfig; `--initd` / `--systemd` flags; uninstall disables unit; fix `/etc/default` (no embedded shell cmds) |
| `README-systemd.md` | Install, migrate, journal, drop-in timeout override |
| Tests | `SystemdUnitTemplateTest`, `InstallJettyServiceScriptTest` (7 cases; full module suite 11/11 with existing log4j tests) |

Windows `install-jetty-service.bat` unchanged. DTS systemd deferred (out of scope).

## Test plan

- [x] `./mvn-env.sh -pl modules/perc-jetty test -Dai.integrity.skip=true` — **11/11 pass**
- [ ] Live Linux: install → `systemctl start/status/stop` → `journalctl -u PercussionCMS`
- [ ] Slow-start / upgrade: no fail before 30 minutes solely on timeout
- [ ] `--initd` fallback on non-systemd or forced SysV
- [ ] Uninstall removes unit and init.d/default files