### PR TITLE
fix(security): close java/zipslip #720/#722/#723 (T041, 8.2-must-fix)

### DIFF
--- a/docs/ai-generated/code-reviews/004-us3-t041-java-zipslip-erlang.md
+++ b/docs/ai-generated/code-reviews/004-us3-t041-java-zipslip-erlang.md
@@ -1,0 +1,59 @@
+# Erlang Review — 004/us3-t041-java-zipslip
+
+**Date**: 2026-07-17  
+**Reviewer**: Erlang (strict independent pre-PR)  
+**Scope**: Uncommitted ZipSlip fixes on `004/us3-t041-java-zipslip` vs `origin/development`
+
+## Summary
+
+Closes the three open `java/zipslip` code-scanning alerts (#720, #722, #723) by routing archive entry names through `PathValidation.constructSafePath` **before** any `mkdirs` / `FileOutputStream`. Prior partial fix on `PSArchiveFiles` still created parent dirs from the raw entry name; that gap is closed. Behavioral unit tests cover reject-and-no-escape for all three modules.
+
+## Scope
+
+- Base: `origin/development`
+- Head: uncommitted working tree on `004/us3-t041-java-zipslip`
+- Files: 3 production + 2 new tests (+ this review doc)
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Blocking bugs: **0**
+- May commit/push: **yes**
+
+## Cross-platform path checklist
+
+- [x] No hardcoded filesystem separators for local path construction in production code (uses `PathValidation` / `File` APIs)
+- [x] Tests use `Files.createTempDirectory` / `File` and `File.separatorChar` when building expected paths
+- [x] Zip entry names remain `/`-separated (ZIP/URL convention) — correct
+- [x] Containment checks rely on `PathValidation` canonicalization (Windows-safe)
+
+## Issues
+
+### Issue 1 — Severity: nit
+- File: `system/.../PSArchiveFiles.java`
+- Description: Zip directory entries that use a trailing backslash (non-standard; ZIP always uses `/`) are not stripped before validation. Harmless on real archives.
+- Suggestion: Optional follow-up only if non-conformant archives appear in the wild.
+
+### Issue 2 — Severity: suggestion
+- File: `projects/sitemanage/.../PSWidgetPackageBuilder.java`
+- Description: After `xform.transformPath`, re-validation uses `validatePathWithinDirectory` on the absolute `File`. Correct, but transformers that return paths outside `rootDir` now fail closed (good). Document that transformers must stay under `rootDir`.
+- Suggestion: Optional one-line javadoc on `setFileTransformers` — not blocking.
+
+## Positive notes
+
+- Validation happens before any filesystem mutation (fixes residual CodeQL flow on #723).
+- `PSExtractJarFiles` skips bad entries and continues with safe ones (installer resilience).
+- Fail-then-pass tests assert the escape file is absent outside the extract root.
+
+## Tests run
+
+- `./mvn-env.sh -pl system -am -Dtest=PSArchiveFilesZipSlipTest -Dsurefire.failIfNoSpecifiedTests=false test` — 4 tests GREEN
+- `./mvn-env.sh -pl modules/perc-ant -Dtest=PSExtractJarFilesZipSlipTest test` — 1 test GREEN
+- `./mvn-env.sh -pl projects/sitemanage -am -Dtest=PSWidgetPackageBuilderZipSlipTest -Dsurefire.failIfNoSpecifiedTests=false test` — 1 test GREEN
+
+## Handoff
+
+Safe to commit and open PR against `development`.

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSExtractJarFiles.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSExtractJarFiles.java
@@ -90,9 +90,20 @@ public class PSExtractJarFiles extends PSAction {
         final File fJarFile;
         try {
           fJarFile = PathValidation.constructSafePath(fDest, entryName);
-        } catch (PathValidation.SecurityException | IllegalArgumentException se) {
+        } catch (PathValidation.SecurityException se) {
           PSLogger.logError(
-              "PSExtractJarFiles rejecting unsafe jar entry (ZipSlip): " + entryName + " — " + se.getMessage());
+              "PSExtractJarFiles rejecting unsafe jar entry (ZipSlip): "
+                  + entryName
+                  + " — "
+                  + se.getMessage());
+          continue;
+        } catch (IllegalArgumentException iae) {
+          // Config / precondition error (null/empty entry, baseDir missing) — not an attack.
+          PSLogger.logError(
+              "PSExtractJarFiles skipping entry due to invalid path arguments: "
+                  + entryName
+                  + " — "
+                  + iae.getMessage());
           continue;
         }
 

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSExtractJarFiles.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSExtractJarFiles.java
@@ -18,6 +18,7 @@
 package com.percussion.ant.install;
 
 import com.percussion.install.PSLogger;
+import com.percussion.security.validation.PathValidation;
 import com.percussion.utils.tools.PSPatternMatcher;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -83,11 +84,23 @@ public class PSExtractJarFiles extends PSAction {
       int bytesRead;
 
       for (int k = 0; k < fileList.size(); k++) {
-        String jarFileLoc = destinationDir + File.separator + fileList.get(k);
-        File makeLocation = new File(jarFileLoc).getParentFile();
-        makeLocation.mkdirs();
+        String entryName = (String) fileList.get(k);
+        // CWE-22 / java/zipslip #720: never concatenate destinationDir with a raw jar entry
+        // name. PathValidation.constructSafePath rejects absolute paths and .. traversal.
+        final File fJarFile;
+        try {
+          fJarFile = PathValidation.constructSafePath(fDest, entryName);
+        } catch (PathValidation.SecurityException | IllegalArgumentException se) {
+          PSLogger.logError(
+              "PSExtractJarFiles rejecting unsafe jar entry (ZipSlip): " + entryName + " — " + se.getMessage());
+          continue;
+        }
+
+        File makeLocation = fJarFile.getParentFile();
+        if (makeLocation != null) {
+          makeLocation.mkdirs();
+        }
         try (JarFile jf = new JarFile(jarFile)) {
-          File fJarFile = new File(jarFileLoc);
 
           if (fJarFile.exists() && fJarFile.isFile()) {
             // see if we can replace this file?
@@ -118,7 +131,7 @@ public class PSExtractJarFiles extends PSAction {
 
           if (!fJarFile.createNewFile()) throw new IOException("Unable to create file.");
 
-          try (InputStream is = jf.getInputStream(jf.getEntry((String) fileList.get(k)))) {
+          try (InputStream is = jf.getInputStream(jf.getEntry(entryName))) {
             try (FileOutputStream fos = new FileOutputStream(fJarFile)) {
               while ((bytesRead = is.read(buffer)) != -1) {
                 fos.write(buffer, 0, bytesRead);

--- a/modules/perc-ant/src/test/java/com/percussion/ant/install/PSExtractJarFilesZipSlipTest.java
+++ b/modules/perc-ant/src/test/java/com/percussion/ant/install/PSExtractJarFilesZipSlipTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.ant.install;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for {@link PSExtractJarFiles} ZipSlip defense (CodeQL {@code java/zipslip}
+ * alert #720, T041).
+ *
+ * <p>Pre-fix code concatenated {@code destinationDir + File.separator + entryName} and wrote
+ * the result with {@link FileOutputStream}, which is the classic ZipSlip vector (CWE-22). The fix
+ * routes every entry name through {@code PathValidation.constructSafePath} and skips unsafe
+ * entries.
+ */
+@Tag("UnitTest")
+@DisplayName("PSExtractJarFiles — ZipSlip (CWE-22) regression tests")
+class PSExtractJarFilesZipSlipTest {
+
+  private File parentDir;
+  private File destDir;
+  private File escapeFile;
+  private File jarFile;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    parentDir = Files.createTempDirectory("extract-jar-zipslip-parent").toFile();
+    destDir = new File(parentDir, "dest");
+    assertTrue(destDir.mkdirs());
+    escapeFile = new File(parentDir, "escape.txt");
+    jarFile = new File(parentDir, "payload.jar");
+
+    try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarFile))) {
+      // Traversal entry that would escape destDir if not validated.
+      jos.putNextEntry(new JarEntry("../escape.txt"));
+      jos.write("escaped".getBytes(StandardCharsets.UTF_8));
+      jos.closeEntry();
+      // Safe entry that must still extract after the bad entry is skipped.
+      jos.putNextEntry(new JarEntry("safe/ok.txt"));
+      jos.write("ok".getBytes(StandardCharsets.UTF_8));
+      jos.closeEntry();
+    }
+  }
+
+  @AfterEach
+  void tearDown() {
+    deleteRecursive(parentDir);
+  }
+
+  @Test
+  @DisplayName("execute skips zip-slip entries and still extracts safe ones")
+  void executeRejectsZipSlipAndExtractsSafeEntry() {
+    PSExtractJarFiles task = new PSExtractJarFiles();
+    task.setJarFile(jarFile.getAbsolutePath());
+    task.setDestinationDir(destDir.getAbsolutePath());
+    task.execute();
+
+    assertFalse(
+        escapeFile.exists(),
+        "ZipSlip entry ../escape.txt must not create a file outside destinationDir");
+    File safe = new File(destDir, "safe/ok.txt".replace('/', File.separatorChar));
+    assertTrue(safe.isFile(), "safe/ok.txt must still be extracted under destinationDir");
+  }
+
+  private static void deleteRecursive(File f) {
+    if (f == null || !f.exists()) {
+      return;
+    }
+    File[] children = f.listFiles();
+    if (children != null) {
+      for (File c : children) {
+        deleteRecursive(c);
+      }
+    }
+    f.delete();
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/widgetbuilder/utils/PSWidgetPackageBuilder.java
+++ b/projects/sitemanage/src/main/java/com/percussion/widgetbuilder/utils/PSWidgetPackageBuilder.java
@@ -17,6 +17,7 @@
  */
 package com.percussion.widgetbuilder.utils;
 
+import com.percussion.security.validation.PathValidation;
 import com.percussion.utils.PSTokenReplacingReader;
 import com.percussion.widgetbuilder.utils.xform.PSAclFileTransformer;
 import com.percussion.widgetbuilder.utils.xform.PSContentTypeFileTransformer;
@@ -112,6 +113,10 @@ public class PSWidgetPackageBuilder {
       if (rootDir.exists()) {
         FileUtils.deleteDirectory(rootDir);
       }
+      // PathValidation.constructSafePath requires baseDir to exist.
+      if (!rootDir.mkdirs() && !rootDir.isDirectory()) {
+        throw new IOException("Could not create package extract directory: " + rootDir);
+      }
 
       try (var in = new FileInputStream(srcFile);
           var zin = new ZipInputStream(in)) {
@@ -119,13 +124,21 @@ public class PSWidgetPackageBuilder {
         ZipEntry entry = zin.getNextEntry();
         while (entry != null) {
           if (!entry.isDirectory()) {
+            // CWE-22 / java/zipslip #722: validate resolved entry path under rootDir before any
+            // FileOutputStream / mkdirs. resolvePath may rewrite template tokens but must still
+            // stay relative; PathValidation rejects absolute paths and .. traversal.
             var resolvePath = resolvePath(entry.getName(), packageSpec);
-            var file = new File(rootDir, resolvePath);
+            var file = PathValidation.constructSafePath(rootDir, resolvePath);
             var xform = getFileTransformer(file);
             if (xform != null) {
               file = xform.transformPath(file, packageSpec);
+              // Re-check after transform so a transformer cannot re-introduce ZipSlip.
+              PathValidation.validatePathWithinDirectory(file, rootDir);
             }
-            file.getParentFile().mkdirs();
+            File parent = file.getParentFile();
+            if (parent != null) {
+              parent.mkdirs();
+            }
 
             try (var fout = new FileOutputStream(file)) {
               if (isTextFile(file)) {

--- a/projects/sitemanage/src/main/java/com/percussion/widgetbuilder/utils/PSWidgetPackageBuilder.java
+++ b/projects/sitemanage/src/main/java/com/percussion/widgetbuilder/utils/PSWidgetPackageBuilder.java
@@ -193,7 +193,18 @@ public class PSWidgetPackageBuilder {
    * @return The resolved path.
    */
   private String resolvePath(String path, PSWidgetPackageSpec packageSpec) {
-    return StringUtils.replace(path, WIDGET_TEMPLATE_NAME, packageSpec.getFullWidgetName());
+    // Defense-in-depth: token substitution must not inject path segments. constructSafePath
+    // still rejects .. / absolute paths at the sink (java/zipslip #722); this fails earlier
+    // with a clearer message if a package spec ever carries separators or traversal.
+    String fullWidgetName = packageSpec.getFullWidgetName();
+    if (fullWidgetName == null
+        || fullWidgetName.contains("..")
+        || fullWidgetName.indexOf('/') >= 0
+        || fullWidgetName.indexOf('\\') >= 0) {
+      throw new IllegalArgumentException(
+          "Widget full name must not contain path segments or traversal: " + fullWidgetName);
+    }
+    return StringUtils.replace(path, WIDGET_TEMPLATE_NAME, fullWidgetName);
   }
 
   /**

--- a/projects/sitemanage/src/test/java/com/percussion/widgetbuilder/utils/PSWidgetPackageBuilderZipSlipTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/widgetbuilder/utils/PSWidgetPackageBuilderZipSlipTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.widgetbuilder.utils;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for {@link PSWidgetPackageBuilder} ZipSlip defense (CodeQL {@code
+ * java/zipslip} alert #722, T041).
+ *
+ * <p>Pre-fix code used {@code new File(rootDir, resolvePath)} with the raw zip entry name, which
+ * is the classic ZipSlip vector (CWE-22). The fix routes the resolved path through {@code
+ * PathValidation.constructSafePath} before any {@code FileOutputStream} / {@code mkdirs}.
+ */
+@DisplayName("PSWidgetPackageBuilder — ZipSlip (CWE-22) regression tests")
+class PSWidgetPackageBuilderZipSlipTest {
+
+  private File parentDir;
+  private File tmpDir;
+  private File tgtDir;
+  private File escapeFile;
+  private File srcZip;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    parentDir = Files.createTempDirectory("widget-pkg-zipslip-parent").toFile();
+    tmpDir = new File(parentDir, "tmp");
+    tgtDir = new File(parentDir, "tgt");
+    assertTrue(tmpDir.mkdirs());
+    assertTrue(tgtDir.mkdirs());
+    escapeFile = new File(parentDir, "escape.txt");
+    srcZip = new File(parentDir, "template.zip");
+
+    try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(srcZip))) {
+      zos.putNextEntry(new ZipEntry("../escape.txt"));
+      zos.write("escaped".getBytes(StandardCharsets.UTF_8));
+      zos.closeEntry();
+    }
+  }
+
+  @AfterEach
+  void tearDown() {
+    deleteRecursive(parentDir);
+  }
+
+  @Test
+  @DisplayName("generatePackage rejects zip-slip entries and does not write outside tmpDir")
+  void generatePackageRejectsZipSlip() {
+    PSWidgetPackageBuilder builder = new PSWidgetPackageBuilder(srcZip, tmpDir);
+    // No transformers — keep the path as resolved from the zip entry only.
+    builder.setFileTransformers(Collections.emptyList());
+
+    PSWidgetPackageSpec spec =
+        new PSWidgetPackageSpec(
+            "test", "www.test.com", "ZipSlip Widget", "zipslip test", "1.0.0", "8.2.0");
+
+    assertThrows(
+        PSWidgetPackageBuilderException.class,
+        () -> builder.generatePackage(tgtDir, spec),
+        "generatePackage must fail closed when the template zip contains a traversal entry");
+
+    assertFalse(
+        escapeFile.exists(),
+        "../escape.txt must not be created outside the package extract directory");
+  }
+
+  private static void deleteRecursive(File f) {
+    if (f == null || !f.exists()) {
+      return;
+    }
+    File[] children = f.listFiles();
+    if (children != null) {
+      for (File c : children) {
+        deleteRecursive(c);
+      }
+    }
+    f.delete();
+  }
+}

--- a/system/src/main/java/com/percussion/system/utils/PSArchiveFiles.java
+++ b/system/src/main/java/com/percussion/system/utils/PSArchiveFiles.java
@@ -334,49 +334,50 @@ public class PSArchiveFiles {
       pw.println("Extracting files from archive");
     }
 
+    // Resolve once; all entry paths are validated against this base (CWE-22 / java/zipslip #723).
+    File baseDir = directory;
+
     for (Enumeration<? extends ZipEntry> files = archiveFile.entries(); files.hasMoreElements(); ) {
       ZipEntry entry = files.nextElement();
-      StringBuilder errorBuf = new StringBuilder();
 
-      // Check whether the directory exists for this file. If not, create it.
-      String dir = "";
       String name = entry.getName();
       // don't extract manifest file
       if (name.equals(JarFile.MANIFEST_NAME)) continue;
 
       if (pw != null) pw.println(name);
 
+      // Strip trailing slash for directory entries so constructSafePath sees a clean relative path.
+      String relativeName = name;
+      if (entry.isDirectory() && relativeName.endsWith("/")) {
+        relativeName = relativeName.substring(0, relativeName.length() - 1);
+      }
+      if (relativeName.isEmpty() || ".".equals(relativeName)) {
+        continue;
+      }
+
+      // Validate BEFORE any mkdirs / open: prior code used new File(extractDir, dir) for
+      // parent creation with the raw entry name (CodeQL java/zipslip #723 on entry.getName()).
+      // PathValidation.constructSafePath rejects absolute paths and .. traversal (CWE-22).
+      File safeFile = PathValidation.constructSafePath(baseDir, relativeName);
+
       if (entry.isDirectory()) {
-        // As directory entry ends with forward slash remove that
-        dir = name.substring(0, name.length() - 1);
-      } else {
-        int index = -1;
-        if ((index = name.lastIndexOf(File.separator)) != -1) dir = name.substring(0, index);
-        else dir = "."; // to indicate extract to the extract base directory
-      }
-
-      if (!dir.equals(".")) {
-        File file = new File(extractDir, dir);
-        if (!file.exists()) {
-          if (!file.mkdirs()) return "Could not make directory " + file.getCanonicalPath();
+        if (!safeFile.exists() && !safeFile.mkdirs()) {
+          return "Could not make directory " + safeFile.getCanonicalPath();
         }
+        continue;
       }
 
-      // Since entry is directory, just return
-      if (entry.isDirectory()) continue;
+      File parent = safeFile.getParentFile();
+      if (parent != null && !parent.exists() && !parent.mkdirs()) {
+        return "Could not make directory " + parent.getCanonicalPath();
+      }
 
       InputStream in = null;
       FileOutputStream out = null;
 
       try {
         in = archiveFile.getInputStream(entry);
-
-        if (!extractDir.endsWith(File.separator)) extractDir += File.separator;
-
-        // CWE-22: Prevent ZipSlip attacks by validating the extracted path
-        File baseDir = new File(extractDir);
-        File file = PathValidation.constructSafePath(baseDir, entry.getName());
-        out = new FileOutputStream(file);
+        out = new FileOutputStream(safeFile);
 
         byte[] buf = new byte[1024];
         int len;

--- a/system/src/main/java/com/percussion/system/utils/PSArchiveFiles.java
+++ b/system/src/main/java/com/percussion/system/utils/PSArchiveFiles.java
@@ -335,6 +335,9 @@ public class PSArchiveFiles {
     }
 
     // Resolve once; all entry paths are validated against this base (CWE-22 / java/zipslip #723).
+    // baseDir is the pre-checked extract directory. extractDir is a method-local String
+    // parameter — the former loop mutation "extractDir += File.separator" was only used
+    // when building File paths inside this method and was never visible to callers.
     File baseDir = directory;
 
     for (Enumeration<? extends ZipEntry> files = archiveFile.entries(); files.hasMoreElements(); ) {
@@ -346,10 +349,13 @@ public class PSArchiveFiles {
 
       if (pw != null) pw.println(name);
 
-      // Strip trailing slash for directory entries so constructSafePath sees a clean relative path.
+      // Strip trailing directory separator for directory entries so constructSafePath sees
+      // a clean relative path. ZIP entries use '/'; also strip '\\' for non-standard archives.
       String relativeName = name;
-      if (entry.isDirectory() && relativeName.endsWith("/")) {
-        relativeName = relativeName.substring(0, relativeName.length() - 1);
+      if (entry.isDirectory()) {
+        while (relativeName.endsWith("/") || relativeName.endsWith("\\")) {
+          relativeName = relativeName.substring(0, relativeName.length() - 1);
+        }
       }
       if (relativeName.isEmpty() || ".".equals(relativeName)) {
         continue;


### PR DESCRIPTION
## Summary

Closes the three open CodeQL `java/zipslip` alerts by validating every archive entry name with `PathValidation.constructSafePath` **before** any `mkdirs` / `FileOutputStream`:

| Alert | File | Fix |
|-------|------|-----|
| #720 | `modules/perc-ant/.../PSExtractJarFiles.java` | Safe path for jar extract; skip + log unsafe entries |
| #722 | `projects/sitemanage/.../PSWidgetPackageBuilder.java` | Safe path for template zip extract; re-check after transformers |
| #723 | `system/.../PSArchiveFiles.java` | Close residual: parent-dir creation previously used raw `entry.getName()` |

## Tests

- `PSArchiveFilesZipSlipTest` (4) — GREEN
- `PSExtractJarFilesZipSlipTest` (1) — GREEN
- `PSWidgetPackageBuilderZipSlipTest` (1) — GREEN

## Erlang review

Approve — `docs/ai-generated/code-reviews/004-us3-t041-java-zipslip-erlang.md`

## Checklist

- [x] Runtime fix + regression tests
- [x] Sink uses validated path only
- [x] Cross-platform path APIs via `PathValidation`
- [ ] CodeQL Advanced re-scan after merge (alerts should close as fixed)

Part of `004-zero-code-scanning-alerts` / T041.