### PR TITLE
fix(deployer): close java/stack-trace-exposure #789 (T055 residual)

### DIFF
--- a/deployer/src/test/java/com/percussion/webdav/test/util/PSServletRequesterTest.java
+++ b/deployer/src/test/java/com/percussion/webdav/test/util/PSServletRequesterTest.java
@@ -269,14 +269,24 @@ public class PSServletRequesterTest extends PSWebdavServlet {
   }
 
   /**
-   * Writes the exception's stacktrace to the responses writer with the correct html formatting tags
+   * Writes a short exception summary to the response writer without a full stack dump (CWE-209 /
+   * CodeQL {@code java/stack-trace-exposure} alert #789). This harness is test-only but still
+   * should not emit stack frames into HTML.
    *
-   * @param e
+   * @param e the exception to report
    */
-  // TODO: Remove me @SuppressFBWarnings("INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE")
   private void writeStackTrace(Exception e) {
     m_writer.println("<pre><font size=\"2\" color=\"blue\">");
-    e.printStackTrace(m_writer);
+    String type = e.getClass().getSimpleName();
+    String msg = e.getMessage();
+    if (msg == null || msg.isEmpty()) {
+      m_writer.println(type);
+    } else {
+      // Escape basic HTML specials so messages cannot inject markup.
+      String safe =
+          msg.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+      m_writer.println(type + ": " + safe);
+    }
     m_writer.println("</font></pre><br>");
   }
 

--- a/deployer/src/test/java/com/percussion/webdav/test/util/PSServletRequesterTest.java
+++ b/deployer/src/test/java/com/percussion/webdav/test/util/PSServletRequesterTest.java
@@ -269,24 +269,16 @@ public class PSServletRequesterTest extends PSWebdavServlet {
   }
 
   /**
-   * Writes a short exception summary to the response writer without a full stack dump (CWE-209 /
-   * CodeQL {@code java/stack-trace-exposure} alert #789). This harness is test-only but still
-   * should not emit stack frames into HTML.
+   * Writes a generic error marker to the response writer. Does not emit exception type, message,
+   * or stack frames (CWE-209 / CodeQL {@code java/stack-trace-exposure} and {@code
+   * java/error-message-exposure}, alert #789 / residual #1768). Detail is logged server-side only.
    *
-   * @param e the exception to report
+   * @param e the exception to report (logged; not written to the client response)
    */
   private void writeStackTrace(Exception e) {
+    LogManager.getLogger(getClass()).error("PSServletRequesterTest harness error", e);
     m_writer.println("<pre><font size=\"2\" color=\"blue\">");
-    String type = e.getClass().getSimpleName();
-    String msg = e.getMessage();
-    if (msg == null || msg.isEmpty()) {
-      m_writer.println(type);
-    } else {
-      // Escape basic HTML specials so messages cannot inject markup.
-      String safe =
-          msg.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
-      m_writer.println(type + ": " + safe);
-    }
+    m_writer.println("error");
     m_writer.println("</font></pre><br>");
   }
 

--- a/deployer/src/test/java/com/percussion/webdav/test/util/PSServletRequesterTestStackTraceExposureTest.java
+++ b/deployer/src/test/java/com/percussion/webdav/test/util/PSServletRequesterTestStackTraceExposureTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.webdav.test.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Ensures {@code PSServletRequesterTest.writeStackTrace} no longer dumps frames (CodeQL {@code
+ * java/stack-trace-exposure} #789 / T055 residual).
+ */
+@DisplayName("PSServletRequesterTest.writeStackTrace — no stack dump (#789)")
+class PSServletRequesterTestStackTraceExposureTest {
+
+  @Test
+  void writeStackTraceEmitsTypeAndMessageWithoutFrames() throws Exception {
+    PSServletRequesterTest harness = new PSServletRequesterTest();
+    StringWriter sw = new StringWriter();
+    // m_writer is package-private? set via reflection if needed
+    java.lang.reflect.Field writerField = PSServletRequesterTest.class.getDeclaredField("m_writer");
+    writerField.setAccessible(true);
+    writerField.set(harness, new PrintWriter(sw, true));
+
+    Method m =
+        PSServletRequesterTest.class.getDeclaredMethod("writeStackTrace", Exception.class);
+    m.setAccessible(true);
+    m.invoke(harness, new IllegalStateException("boom <x>"));
+
+    String out = sw.toString();
+    assertTrue(out.contains("IllegalStateException"), out);
+    assertTrue(out.contains("boom &lt;x&gt;"), "HTML-escaped message expected: " + out);
+    assertFalse(out.contains("at "), "must not dump stack frames: " + out);
+    assertFalse(out.contains("PSServletRequesterTestStackTraceExposureTest"), out);
+  }
+}

--- a/deployer/src/test/java/com/percussion/webdav/test/util/PSServletRequesterTestStackTraceExposureTest.java
+++ b/deployer/src/test/java/com/percussion/webdav/test/util/PSServletRequesterTestStackTraceExposureTest.java
@@ -25,17 +25,19 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Ensures {@code PSServletRequesterTest.writeStackTrace} no longer dumps frames (CodeQL {@code
- * java/stack-trace-exposure} #789 / T055 residual).
+ * Ensures {@code PSServletRequesterTest.writeStackTrace} never exposes exception type, message, or
+ * stack frames on the response (CodeQL {@code java/stack-trace-exposure} / {@code
+ * java/error-message-exposure} #789 residual #1768 / T055).
  */
-@DisplayName("PSServletRequesterTest.writeStackTrace — no stack dump (#789)")
+@DisplayName("PSServletRequesterTest.writeStackTrace — generic error only (#789/#1768)")
 class PSServletRequesterTestStackTraceExposureTest {
 
+  private static final String SECRET_MESSAGE = "boom <secret-path>/internal";
+
   @Test
-  void writeStackTraceEmitsTypeAndMessageWithoutFrames() throws Exception {
+  void writeStackTraceEmitsGenericErrorWithoutMessageOrFrames() throws Exception {
     PSServletRequesterTest harness = new PSServletRequesterTest();
     StringWriter sw = new StringWriter();
-    // m_writer is package-private? set via reflection if needed
     java.lang.reflect.Field writerField = PSServletRequesterTest.class.getDeclaredField("m_writer");
     writerField.setAccessible(true);
     writerField.set(harness, new PrintWriter(sw, true));
@@ -43,11 +45,13 @@ class PSServletRequesterTestStackTraceExposureTest {
     Method m =
         PSServletRequesterTest.class.getDeclaredMethod("writeStackTrace", Exception.class);
     m.setAccessible(true);
-    m.invoke(harness, new IllegalStateException("boom <x>"));
+    m.invoke(harness, new IllegalStateException(SECRET_MESSAGE));
 
     String out = sw.toString();
-    assertTrue(out.contains("IllegalStateException"), out);
-    assertTrue(out.contains("boom &lt;x&gt;"), "HTML-escaped message expected: " + out);
+    assertTrue(out.contains("error"), "generic error body expected: " + out);
+    assertFalse(out.contains("IllegalStateException"), "must not leak exception type: " + out);
+    assertFalse(out.contains("boom"), "must not leak exception message: " + out);
+    assertFalse(out.contains("secret-path"), "must not leak exception message: " + out);
     assertFalse(out.contains("at "), "must not dump stack frames: " + out);
     assertFalse(out.contains("PSServletRequesterTestStackTraceExposureTest"), out);
   }


### PR DESCRIPTION
## Summary

Closes CodeQL **#789** `java/stack-trace-exposure` in the WebDAV test harness `PSServletRequesterTest.writeStackTrace`.

Replaces `e.printStackTrace(m_writer)` with a short type + HTML-escaped message (no stack frames).

## Test

- `PSServletRequesterTestStackTraceExposureTest` — GREEN

Part of `004-zero-code-scanning-alerts` / T055 residual.