### PR TITLE
fix(sitemanage): close java/xss #750/#1063/#751/#752 via suppression format fix (T044)

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteDataRestService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteDataRestService.java
@@ -160,7 +160,12 @@ public class PSSiteDataRestService {
   public PSSite save(PSSite site) throws PSParametersValidationException {
     // Typed PSSite JAXB/JSON bean; service validates. Client HTML-encodes before DOM insert.
     try {
-      // codeql[java/xss] T044 #750: JSON/XML DTO via Jackson/JAXB; not an HTML response body
+      // codeql[java/xss] justification: JSON/XML DTO via Jackson/JAXB; not an HTML
+      // response body. The input is the typed `site` JAXB/JSON bean (not a raw
+      // string), and the response is rendered through the standard REST contract
+      // where the client is responsible for HTML-encoding before DOM insert.
+      // CodeQL does not model JAXB/Jackson structural encoding as a sanitizer,
+      // but the data flow is JSON/XML, not HTML. See T044 / alert #750.
       return siteDataService.save(site);
     } catch (PSParametersValidationException pve) {
       throw pve;
@@ -178,7 +183,12 @@ public class PSSiteDataRestService {
   public PSSite createSiteFromUrl(@Context HttpServletRequest request, PSSite site)
       throws PSSiteImportException {
     try {
-      // codeql[java/xss] T044 #1063: JSON/XML DTO via Jackson/JAXB; not an HTML response body
+      // codeql[java/xss] justification: JSON/XML DTO via Jackson/JAXB; not an HTML
+      // response body. The input is the typed `site` JAXB/JSON bean (not a raw
+      // string), and the response is rendered through the standard REST contract
+      // where the client is responsible for HTML-encoding before DOM insert.
+      // CodeQL does not model JAXB/Jackson structural encoding as a sanitizer,
+      // but the data flow is JSON/XML, not HTML. See T044 / alert #1063.
       return siteDataService.createSiteFromUrl(request, site);
     } catch (PSValidationException e) {
       throw new WebApplicationException(jakarta.ws.rs.core.Response.Status.BAD_REQUEST);
@@ -250,7 +260,12 @@ public class PSSiteDataRestService {
   @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
   public PSSiteProperties updateSiteProperties(PSSiteProperties props) {
     try {
-      // codeql[java/xss] T044 #751: JSON/XML DTO via Jackson/JAXB; not an HTML response body
+      // codeql[java/xss] justification: JSON/XML DTO via Jackson/JAXB; not an HTML
+      // response body. The input is the typed `props` JAXB/JSON bean (not a raw
+      // string), and the response is rendered through the standard REST contract
+      // where the client is responsible for HTML-encoding before DOM insert.
+      // CodeQL does not model JAXB/Jackson structural encoding as a sanitizer,
+      // but the data flow is JSON/XML, not HTML. See T044 / alert #751.
       return siteDataService.updateSiteProperties(props);
     } catch (PSNotFoundException | PSDataServiceException e) {
       throw new WebApplicationException(jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR);
@@ -277,7 +292,12 @@ public class PSSiteDataRestService {
   @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
   public PSSitePublishProperties updateSitePublishProperties(PSSitePublishProperties publishProps) {
     try {
-      // codeql[java/xss] T044 #752: JSON/XML DTO via Jackson/JAXB; not an HTML response body
+      // codeql[java/xss] justification: JSON/XML DTO via Jackson/JAXB; not an HTML
+      // response body. The input is the typed `publishProps` JAXB/JSON bean (not
+      // a raw string), and the response is rendered through the standard REST
+      // contract where the client is responsible for HTML-encoding before DOM
+      // insert. CodeQL does not model JAXB/Jackson structural encoding as a
+      // sanitizer, but the data flow is JSON/XML, not HTML. See T044 / alert #752.
       return siteDataService.updateSitePublishProperties(publishProps);
     } catch (IPSDataService.DataServiceSaveException | PSNotFoundException e) {
       throw new WebApplicationException(jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
## Summary

Closes CodeQL alerts **#750, #1063, #751, #752 (`java/xss`)** in `PSSiteDataRestService.java:164, 182, 254, 281` by fixing the inline suppression format.

## Pre-fix state

The runtime defense was already in place (`requireSafeId` validator at the API boundary, JAXB/Jackson JSON/XML serialization on the response side, 16 regression tests in `PSSiteDataRestServiceXssTest`). However, a prior PR added inline suppressions using the format `// codeql[java/xss] T044 #XXX: ...` — a custom prefix that CodeQL does NOT recognize. CodeQL's suppression parser only honors the keyword `justification:` after the rule id. The four alerts (#750, #1063, #751, #752) stayed open because the suppressions were silently ignored.

## Fix

Replace each `// codeql[java/xss] T044 #XXX: ...` comment with the canonical `// codeql[java/xss] justification: ...` form (matching the working suppressions already in the file at lines 97, 122, 142, 194, 219, 235, 264, 305, 331, 349, 365). The justification text documents:
- Data flow is JSON/XML via Jackson/JAXB, not an HTML response body
- Client is responsible for HTML-encoding before DOM insertion (standard REST contract)
- CodeQL does not model JAXB/Jackson structural encoding as a sanitizer

Affected alerts:
- **#750** — `save(PSSite site)` line 164 (return statement)
- **#1063** — `createSiteFromUrl(...)` line 182 (return statement)
- **#751** — `updateSiteProperties(...)` line 254 (return statement)
- **#752** — `updateSitePublishProperties(...)` line 281 (return statement)

## Runtime defense (unchanged, already in place)

- `requireSafeId(String id, String paramName)` validates path parameters against `SAFE_ID_PATTERN` (`[A-Za-z0-9._:\\-]{1,100}`), rejecting XSS payloads with HTTP 400. Pinned by `PSSiteDataRestServiceXssTest` (16 cases).
- JAXB/Jackson JSON/XML serialization for response bodies — not HTML.
- Tests: `PSSiteDataRestServiceXssTest` (16 cases) continues to pass; module test suite = 452 tests, 0 failures, 129 pre-existing skips.

## Erlang review

`docs/ai-generated/code-reviews/2026-07-18-004-t044-pssitedatdarservice-erlang.md` — verdict **pass**. Erlang confirmed the canonical format is correct, the placement is right (one line above each sink), the justification text is accurate, and no production logic changed. Erlang also appended a new principle to the `erlang-review/patterns.md` file under `Security / config`:

> Inline CodeQL suppressions must use the canonical `// codeql[<query-id>] justification: <reason>` form; any custom prefix (e.g. `T044 #123:`) is silently ignored and the alert stays open — verify the `justification:` keyword before trusting that an inline suppression closes an alert.

(The patterns.md change is preserved in the working tree per the project's branch policy — patterns file changes are not committed to PRs.)

## Files

- `projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteDataRestService.java` — 4 inline suppressions reformatted (no logic change).

## Out of scope

- Spec-tracking files (`specs/004-zero-code-scanning-alerts/tasks.md`, `plan.md`, `spec.md`) are intentionally excluded from this PR per the feature's branch policy.

Refs specs/004-zero-code-scanning-alerts T044.

## Review-resolution-gate

All review threads on this PR will be resolved inline per `AGENTS.md` Constitution IX (`SC-007`).