### PR TITLE
fix(webui): PercDataTable safe DOM construction (js/html-constructed-from-input)

### DIFF
--- a/WebUI/src/main/webapp/cm/widgets/PercDataTable/PercDataTable.js
+++ b/WebUI/src/main/webapp/cm/widgets/PercDataTable/PercDataTable.js
@@ -158,13 +158,13 @@
 
       var pInfo = $(".perc-datatables-info");
       if (pInfo.length > 0) {
-        pInfo.html(pageOfPages);
+        // Page numbers only — use text(), not html() (js/html-constructed-from-input)
+        pInfo.text(pageOfPages);
       } else {
-        $(
-          "<div class='datatables_info perc-datatables-info'>" +
-            pageOfPages +
-            "</div>"
-        ).appendTo("body");
+        $("<div>")
+          .addClass("datatables_info perc-datatables-info")
+          .text(pageOfPages)
+          .appendTo("body");
       }
 
       var gFooterBar = $(".perc-footer-bar");
@@ -347,38 +347,18 @@
             config.percHeaders[colIndex].replace(/ /g, "-").toLowerCase();
         }
 
-        // create the table data
-        var columnTd = $(
-          "<td class='" +
-            percType +
-            " " +
-            headerClass +
-            " perc-datatable-column perc-ellipsis perc-index-" +
-            colIndex +
-            " perc-cell-" +
-            colIndex +
-            "-" +
-            rowIndex +
-            " " +
-            firstLast +
-            "' valign='top'>"
-        );
+        // Build <td> via jQuery APIs — never interpolate untrusted tokens into HTML
+        // (CodeQL js/html-constructed-from-input #1575–#1578).
+        var columnTd = $("<td>")
+          .attr("valign", "top")
+          .addClass(percType)
+          .addClass(headerClass)
+          .addClass("perc-datatable-column perc-ellipsis")
+          .addClass("perc-index-" + colIndex)
+          .addClass("perc-cell-" + colIndex + "-" + rowIndex)
+          .addClass(firstLast);
         if (aoIndex == 1) {
-          columnTd = $(
-            "<td scope = row' class='" +
-              percType +
-              " " +
-              headerClass +
-              " perc-datatable-column perc-ellipsis perc-index-" +
-              colIndex +
-              " perc-cell-" +
-              colIndex +
-              "-" +
-              rowIndex +
-              " " +
-              firstLast +
-              "' valign='top'>"
-          );
+          columnTd.attr("scope", "row");
         }
         var columnRow;
         if (typeof column === "object") {
@@ -388,7 +368,7 @@
           // iterate over the rows within a table cell
           if (Array.isArray(column)) {
             $.each(column, function (colRowIndex, element) {
-              if (!element) element = "&nbsp;";
+              if (!element) element = "\u00a0";
               var columnRowData = element;
               var firstLast = "";
               if (colRowIndex === 0) firstLast = "perc-first";
@@ -407,16 +387,14 @@
                 title = columnRowData.title;
               }
 
-              if (title === "&nbsp;") title = "";
+              if (title === "&nbsp;" || title === "\u00a0") title = "";
 
               // finally, wrap the content in a div and then add it to the table data
-              columnRow = $(
-                "<div style='width:100%' class='perc-datatable-columnrow perc-ellipsis perc-index-" +
-                  colRowIndex +
-                  " " +
-                  firstLast +
-                  "'>"
-              );
+              columnRow = $("<div>")
+                .css("width", "100%")
+                .addClass("perc-datatable-columnrow perc-ellipsis")
+                .addClass("perc-index-" + colRowIndex)
+                .addClass(firstLast);
               if (columnRowData.callback) {
                 var cBack = $("<span>").attr("title", title).append(content);
                 cBack.css("cursor", "pointer").addClass("perc-callback");
@@ -438,17 +416,20 @@
           } else {
             let title = element.title;
             let content = element.content;
-            columnRow = $(
-              "<div title='" +
-                title +
-                "' class='perc-datatable-columnrow perc-ellipsis perc-index-0 perc-first'>"
-            ).append(content);
+            columnRow = $("<div>")
+              .attr("title", title == null ? "" : String(title))
+              .addClass(
+                "perc-datatable-columnrow perc-ellipsis perc-index-0 perc-first"
+              )
+              .append(content);
             columnTd.append(columnRow);
           }
         } else {
-          columnRow = $(
-            "<div class='perc-datatable-columnrow perc-ellipsis perc-index-0 perc-first'>"
-          ).append(element);
+          columnRow = $("<div>")
+            .addClass(
+              "perc-datatable-columnrow perc-ellipsis perc-index-0 perc-first"
+            )
+            .append(element);
           columnTd.append(columnRow);
         }
         // add the table data to the row
@@ -506,17 +487,14 @@
         if (index === 0) firstLast = "perc-first";
         else if (index === headers.length - 1) firstLast = "perc-last";
         else firstLast = "perc-middle";
-        var head = $(
-          "<th scope='col' class='" +
-            percType +
-            " " +
-            headerClass +
-            " perc-datatable-head-column perc-index-" +
-            index +
-            " " +
-            firstLast +
-            "'>"
-        );
+        // Build <th> via jQuery APIs (CodeQL js/html-constructed-from-input #1579–#1580)
+        var head = $("<th>")
+          .attr("scope", "col")
+          .addClass(percType)
+          .addClass(headerClass)
+          .addClass("perc-datatable-head-column")
+          .addClass("perc-index-" + index)
+          .addClass(firstLast);
 
         head.width(columnWidth);
 

--- a/WebUI/src/main/webapp/cm/widgets/PercDataTableWrong/PercDataTable.js
+++ b/WebUI/src/main/webapp/cm/widgets/PercDataTableWrong/PercDataTable.js
@@ -135,20 +135,17 @@
         headerClass = headerClasses[h];
       if (columnWidths && columnWidths.length > 0)
         headerWidth = columnWidths[i];
-      // put header text in a SPAN so we move the sorting arrow with the header
-      tableHeaderRow.append(
-        "<th class='perc-datatable-header perc-col-" +
-          i +
-          " " +
-          headerClass +
-          "' style='width:" +
-          headerWidth +
-          "; max-width:" +
-          headerWidth +
-          "'><span>" +
-          header +
-          "</span></th>"
-      );
+      // Build header via jQuery APIs — never interpolate into HTML strings
+      // (CodeQL js/html-constructed-from-input #1571–#1574).
+      var th = $("<th>")
+        .addClass("perc-datatable-header")
+        .addClass("perc-col-" + i)
+        .addClass(headerClass || "");
+      if (headerWidth) {
+        th.css({ width: headerWidth, maxWidth: headerWidth });
+      }
+      th.append($("<span>").text(header == null ? "" : String(header)));
+      tableHeaderRow.append(th);
     }
 
     // create rows
@@ -161,10 +158,15 @@
       var percRow = percRows[r];
       for (let i = 0; i < indices.length; i++) {
         var d = indices[i];
-        var tableData = $("<td class='perc-cell-" + r + "-" + i + "'>");
+        var tableData = $("<td>").addClass("perc-cell-" + r + "-" + i);
         var data = percRow[d];
-        if (data === "" || data === undefined) data = "&nbsp;";
-        tableData.append(data);
+        if (data === "" || data === undefined) {
+          tableData.text("\u00a0");
+        } else if (typeof data === "string") {
+          tableData.text(data);
+        } else {
+          tableData.append(data);
+        }
         tableRow.append(tableData);
       }
       tableBody.append(tableRow);

--- a/WebUI/src/test/js/percDataTableDomSafety.test.js
+++ b/WebUI/src/test/js/percDataTableDomSafety.test.js
@@ -1,0 +1,169 @@
+/**
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regression tests for PercDataTable DOM construction (js/html-constructed-from-input).
+ *
+ * Pre-fix code built &lt;td&gt;/&lt;th&gt; via HTML string concatenation of header
+ * classes and cell indices (CodeQL #1575–#1580). Post-fix uses jQuery
+ * element constructors + .addClass()/.attr()/.text() only.
+ *
+ * Strategy: load the real source with jQuery + a minimal DataTables stub so
+ * $.fn.PercDataTable can run without the full plugin.
+ */
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import jquery from "jquery";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(
+  __dirname,
+  "../../main/webapp/cm/widgets/PercDataTable/PercDataTable.js"
+);
+const WRONG_SRC = resolve(
+  __dirname,
+  "../../main/webapp/cm/widgets/PercDataTableWrong/PercDataTable.js"
+);
+
+function loadPercDataTable($) {
+  // Minimal DataTables stub — PercDataTable only needs .DataTable(config)
+  $.fn.DataTable = function () {
+    return this;
+  };
+  $.fn.dataTable = function () {
+    return this;
+  };
+  const src = readFileSync(SRC, "utf8");
+  // File is an IIFE that expects global jQuery as $
+  // eslint-disable-next-line no-new-func
+  const run = new Function("jQuery", "window", "document", src + "\n; return jQuery.fn.PercDataTable;");
+  run($, globalThis, globalThis.document);
+  return $.fn.PercDataTable;
+}
+
+function loadPercDataTableWrong($) {
+  $.fn.dataTable = function () {
+    return this;
+  };
+  $.fn.dataTableExt = $.fn.dataTableExt || {};
+  $.fn.dataTableExt.afnSortData = $.fn.dataTableExt.afnSortData || {};
+  $.browser = $.browser || { msie: false, mozilla: false };
+  const src = readFileSync(WRONG_SRC, "utf8");
+  // eslint-disable-next-line no-new-func
+  const run = new Function(
+    "jQuery",
+    "window",
+    "document",
+    "gadgets",
+    src + "\n; return jQuery.fn.percDataTable;"
+  );
+  run($, globalThis, globalThis.document, undefined);
+  return $.fn.percDataTable;
+}
+
+describe("PercDataTable DOM construction safety", () => {
+  let $;
+  let host;
+
+  beforeEach(() => {
+    let jq = jquery(globalThis.window);
+    if (typeof jq !== "function") {
+      jq = typeof jquery === "function" ? jquery : jquery.fn || jquery;
+    }
+    $ = jq;
+    globalThis.jQuery = $;
+    globalThis.$ = $;
+    host = $("<div id='perc-dt-host'>").appendTo(document.body);
+  });
+
+  afterEach(() => {
+    host.remove();
+    delete globalThis.jQuery;
+    delete globalThis.$;
+  });
+
+  it("builds cells without interpreting hostile class tokens as HTML", () => {
+    loadPercDataTable($);
+    const hostileHeader = "x\" onclick=alert(1) x=\"";
+    const config = {
+      percExpandParentFrameVertically: false,
+      bPaginate: false,
+      bSort: false,
+      percHeaders: [hostileHeader, "Col2"],
+      aoColumns: [{ sType: "string" }, { sType: "string" }],
+      percData: [
+        {
+          rowContent: ["safe-a", "safe-b"],
+          rowData: {},
+        },
+      ],
+    };
+
+    host.PercDataTable(config);
+
+    // No injected attributes from class string breakout
+    const tds = host.find("td");
+    expect(tds.length).toBeGreaterThan(0);
+    tds.each(function () {
+      expect(this.getAttribute("onclick")).toBeNull();
+    });
+    // Cell text still present
+    expect(host.text()).toContain("safe-a");
+    expect(host.text()).toContain("safe-b");
+  });
+
+  it("sets title attributes via DOM API rather than attribute HTML concat", () => {
+    loadPercDataTable($);
+    const config = {
+      percExpandParentFrameVertically: false,
+      bPaginate: false,
+      bSort: false,
+      percHeaders: ["H1"],
+      aoColumns: [{ sType: "string" }],
+      percData: [
+        {
+          rowContent: [{ content: "Body", title: "Title with 'quotes\" & more" }],
+          rowData: {},
+        },
+      ],
+    };
+    host.PercDataTable(config);
+    const titled = host.find("[title]").filter(function () {
+      return $(this).attr("title") && $(this).attr("title").indexOf("Title with") === 0;
+    });
+    expect(titled.length).toBeGreaterThan(0);
+    expect(titled.first().attr("title")).toContain("Title with");
+  });
+
+  it("PercDataTableWrong headers use text nodes for labels", () => {
+    loadPercDataTableWrong($);
+    const config = {
+      percHeaders: ["<img src=x onerror=alert(1)>", "OK"],
+      percColsLeft: [0, 1],
+      percColsRight: [0, 1],
+      percData: [["a", "b"]],
+      percHeaderClasses: ["h0", "h1"],
+      oLanguage: {},
+    };
+    host.percDataTable(config);
+    // Header label must be text, not a live img element
+    expect(host.find("th img").length).toBe(0);
+    expect(host.find("th").first().text()).toContain("<img");
+  });
+});

--- a/WebUI/war/widgets/PercDataTable/PercDataTable.js
+++ b/WebUI/war/widgets/PercDataTable/PercDataTable.js
@@ -20,15 +20,14 @@
  *  @author Jose Annunziato
  *
  */
-(function($) {
+(function ($) {
+  var MARGIN_PX = 16;
+  var PADDING_BOTTOM_PX = 5;
+  var tableDom;
+  var configo;
+  var totalPages = 0;
 
-    var MARGIN_PX = 16;
-    var PADDING_BOTTOM_PX = 5;
-    var tableDom;
-    var configo;
-    var totalPages = 0;
-
-    /**
+  /**
      *  PercDataTable(config)
      *  @param config
         { percData:
@@ -46,536 +45,575 @@
                     rowData : {commentId : 21123, pageId : 2123, pagePath : "/sewq/dsa/cxz"}},...
          *
      */
-    $.fn.PercDataTable = function(config) {
-        // fix aoColumns config based on percVisibleColumns
-        // throw out column configs that are not visible
-        if(config.percVisibleColumns && config.aoColumns) {
-            var newAoColumns = [];
-            $.each(config.percVisibleColumns, function(index, visibleColumnIndex){
-                newAoColumns.push(config.aoColumns[visibleColumnIndex]);
-            });
-            config.aoColumns = newAoColumns;
-        }
-
-        for(let c=0; c<config.aoColumns.length; c++){
-            var aoColumn = config.aoColumns[c];
-            aoColumn.sSortDataType = "perc-type-"+aoColumn.sType;
-        }
-
-        // build the HTML table and convert it to a dataTable
-        config = $.extend(true, {}, defaultConfig, config);
-        configo = config;
-        tableDom = buildTableDomFromData(config);
-        $(this).append(tableDom);
-        tableDom.DataTable(config);
-
-        // resize parent iframe's height to fit the table
-        if(config.percExpandParentFrameVertically) {
-            var height = tableDom.parents(".dataTables_wrapper").outerHeight() + MARGIN_PX;
-            var width  = tableDom.parents(".dataTables_wrapper").outerWidth()  + MARGIN_PX;
-            var parentFrame = getParentFrame();
-            var frameHeight = height;
-            var additionalHt = config.additionalIframeHeight?config.additionalIframeHeight:0;
-            if(config.iDisplayLength) {
-                var headHeight = tableDom.find("thead").height();
-                var oneRowHeight = $(tableDom.find("tbody tr")[0]).height();
-                var paginatorHeight = $(".dataTables_paginate").height();
-                var frameMinHeight = headHeight + oneRowHeight * config.iDisplayLength + paginatorHeight + additionalHt;
-                frameHeight = frameMinHeight;
-            }
-            if(config.percStayBelow) {
-                var belowElement = $(config.percStayBelow);
-                frameHeight += belowElement.offset().top + belowElement.outerHeight() + MARGIN_PX;
-            }
-            $(parentFrame).height(frameHeight + PADDING_BOTTOM_PX);
-        }
-
-        return tableDom;
-    };
-
-    function tableRedrawCallback() {
-        var dataTable = $(this);
-        var config = dataTable.data("config");
-
-        if(config && config.percTableRedrawCallback)
-        {
-            if(typeof(config.percTableRedrawCallback) === "object")
-            {
-                $.each(config.percTableRedrawCallback, function(index, value){
-                    this(dataTable);
-                });
-            }
-            else if(typeof(config.percTableRedrawCallback) === "function")
-            {
-                config.percTableRedrawCallback(dataTable);
-            }
-        }
-        setTimeout(function(){
-            // prepend Pages label before page numbers
-            var paginator = dataTable.parent().children(".dataTables_paginate.paging_full_numbers");
-            paginator.find('.perc-datatable-paginator-pages-label').removeClass('paginate_button');
-            // add page number attribute to each page for QA
-            var pageNumbers = paginator.find("span span.paginate_button, span span.paginate_active");
-
-            $.each(pageNumbers, function(index, element){
-                $(element).attr("perc-page", index + 1 );
-            });
-            if(!totalPages || totalPages < 2)
-                paginator.hide();
-            else
-                paginator.show();
-            paginator.css("position","absolute");
-        }, 1);
-
+  $.fn.PercDataTable = function (config) {
+    // fix aoColumns config based on percVisibleColumns
+    // throw out column configs that are not visible
+    if (config.percVisibleColumns && config.aoColumns) {
+      var newAoColumns = [];
+      $.each(config.percVisibleColumns, function (index, visibleColumnIndex) {
+        newAoColumns.push(config.aoColumns[visibleColumnIndex]);
+      });
+      config.aoColumns = newAoColumns;
     }
 
-    function getParentFrame() {
-        var arrFrames = parent.document.getElementsByTagName("IFRAME");
-        for (var i = 0; i < arrFrames.length; i++) {
-            if (arrFrames[i].contentWindow === window)
-                return arrFrames[i];
-        }
+    for (let c = 0; c < config.aoColumns.length; c++) {
+      var aoColumn = config.aoColumns[c];
+      aoColumn.sSortDataType = "perc-type-" + aoColumn.sType;
     }
 
-    function footerRedrawCallback( nFoot, aasData, iStart, iEnd, aiDisplay ) {
-        if (configo.bPaginate){
-            var config = configo;
+    // build the HTML table and convert it to a dataTable
+    config = $.extend(true, {}, defaultConfig, config);
+    configo = config;
+    tableDom = buildTableDomFromData(config);
+    $(this).append(tableDom);
+    tableDom.DataTable(config);
 
-            var itemsPerPage = config.iDisplayLength;
-            var totalItemsCount = aiDisplay.length;
-            var pages = Math.ceil(totalItemsCount / itemsPerPage);
-            var currentPageNumber = Math.ceil(iEnd / itemsPerPage);
-            var pageOfPages = currentPageNumber + " of " + pages + (pages === 1 ? " Page" : " Pages");
-            totalPages = pages;
-            if(pages === 0 || config.singlePage)
-                pageOfPages = "";
-
-            var pInfo = $(".perc-datatables-info");
-            if(pInfo.length > 0){
-                pInfo.html(pageOfPages);
-            } else {
-                $("<div class='datatables_info perc-datatables-info'>"+pageOfPages+"</div>")
-                    .appendTo("body");
-            }
-
-            var gFooterBar = $(".perc-footer-bar");
-            if(gFooterBar.length === 0){
-                $("<div class='perc-footer-bar'>&nbsp;</div>")
-                    .appendTo("body");
-            }
-        }
+    // resize parent iframe's height to fit the table
+    if (config.percExpandParentFrameVertically) {
+      var height =
+        tableDom.parents(".dataTables_wrapper").outerHeight() + MARGIN_PX;
+      var width =
+        tableDom.parents(".dataTables_wrapper").outerWidth() + MARGIN_PX;
+      var parentFrame = getParentFrame();
+      var frameHeight = height;
+      var additionalHt = config.additionalIframeHeight
+        ? config.additionalIframeHeight
+        : 0;
+      if (config.iDisplayLength) {
+        var headHeight = tableDom.find("thead").height();
+        var oneRowHeight = $(tableDom.find("tbody tr")[0]).height();
+        var paginatorHeight = $(".dataTables_paginate").height();
+        var frameMinHeight =
+          headHeight +
+          oneRowHeight * config.iDisplayLength +
+          paginatorHeight +
+          additionalHt;
+        frameHeight = frameMinHeight;
+      }
+      if (config.percStayBelow) {
+        var belowElement = $(config.percStayBelow);
+        frameHeight +=
+          belowElement.offset().top + belowElement.outerHeight() + MARGIN_PX;
+      }
+      $(parentFrame).height(frameHeight + PADDING_BOTTOM_PX);
     }
 
-    var defaultConfig = {
-        percExpandParentFrameVertically : true,
-        additionalIframeHeight : 0, //The Iframe height is calculated based on the rows and other things, if a gadget requires additional height they can specify by this property
-        percColumnWidths : ["*","123"],
-        percRowDblclickCallback : $.PercOpenPage,
-        showPreviewBtnOnHover: false,
-        iDisplayLength : 5,
-        bFilter: false,
-        bAutoWidth : false,
-        bPaginate : true,
-        bSort: true,
-        sPaginationType : "full_numbers",
-        bLengthChange : false,
-        bInfo : true,
-        fnDrawCallback : tableRedrawCallback,
-        fnFooterCallback: footerRedrawCallback,
-        oLanguage : {sZeroRecords: typeof I18N === "undefined" ? "No Pages Found" : I18N.message("perc.ui.workflow.status.gadget@No Pages Found"), oPaginate : {sFirst : "&lt;&lt;", sPrevious : "&lt;", sNext : "&gt;", sLast : "&gt;&gt;"}, sInfo : " ", sInfoEmpty : " "}
-    };
+    return tableDom;
+  };
 
-    /**
-     *  Builds a Table DOM from the array of arrays in the percData configuration
-     *  @param config table configuration containing percData and percHeaders
-     *
-     *  Generates the following DOM
-     *
-     *  <pre>
-     *  <table cellspacing="0" cellpadding="0" class="perc-datatable">
-     *      <thead>
-     *          <tr class="perc-datatable-head-row">
-     *              <th class="perc-datatable-head-column perc-index-0 perc-first sorting_asc">Page</th>
-     *              <th class="perc-datatable-head-column perc-index-1 sorting">Heading 2</th>
-     *          </tr>
-     *      </thead>
-     *      <tbody>
-     *          <tr class="perc-datatable-row perc-index-0 perc-first odd">
-     *              <td valign="top" class="perc-datatable-column perc-index-0 perc-first sorting_1">
-     *                  <div class="perc-datatable-columnrow perc-index-0 perc-first" title="">Comment 11</div>
-     *                  <div class="perc-datatable-columnrow perc-index-1 perc-last" title="">/Site/Site22</div>
-     *              </td>
-     *              <td valign="top" class="perc-datatable-column perc-index-1 ">
-     *                  <div class="perc-datatable-columnrow perc-index-0 perc-first" title="">12/22/33</div>
-     *                  <div class="perc-datatable-columnrow perc-index-1 perc-last" title="">22:44:55 PM</div>
-     *              </td>
-     *           </tr>
-     *           <tr class="perc-datatable-row perc-index-1 per-last even">
-     *              <td valign="top" class="perc-datatable-column perc-index-0 perc-first sorting_1">
-     *                  <div class="perc-datatable-columnrow perc-index-0 perc-first" title="">Comment 22</div>
-     *                  <div class="perc-datatable-columnrow perc-index-1 perc-last" title="">/Site/Site33</div>
-     *               </td>
-     *               <td valign="top" class="perc-datatable-column perc-index-1 ">
-     *                   <div class="perc-datatable-columnrow perc-index-0 perc-first" title="">13/22/33</div>
-     *                   <div class="perc-datatable-columnrow perc-index-1 perc-last" title="">22:44:55 PM</div>
-     *              </td>
-     *          </tr>
-     *      </tbody>
-     *  </table>
-     *  </pre>
-     *
-     */
-    function buildTableDomFromData(config) {
-        var data = config.percData;
-        var headers = config.percHeaders;
+  function tableRedrawCallback() {
+    var dataTable = $(this);
+    var config = dataTable.data("config");
 
-        // create the table and body
-        var table = $("<table class='perc-datatable' style='table-layout : fixed' cellpadding='0' cellspacing='0'>");
-        var tbody = $("<tbody>");
-
-        var aoColumns = config.aoColumns;
-
-        // iterate over the data containing rows
-        $.each(data, function(rowIndex, element){
-            var row = element;
-
-            // mark the first and last table rows
-            var firstLast = "";
-            if(rowIndex === 0)
-                firstLast = "perc-first";
-            else if(rowIndex === data.length-1)
-                firstLast = "perc-last";
-
-            // create the table row
-            var rowTr = $("<tr class='perc-datatable-row perc-index-"+rowIndex+" "+firstLast+"'>");
-
-            if(row.rowData)
-                rowTr.data("percRowData", row.rowData);
-
-            // bind click event callbacks
-            if(config.percRowClickCallback)
-            {
-                if(row.rowData)
-                {
-                    rowTr.on("click",null,row.rowData,
-                        function(evt){
-                            config.percRowClickCallback(evt);
-                        });
-                }
-                else
-                {
-                    rowTr.on("click",function(e){
-                        config.percRowClickCallback(e);
-                    });
-                }
-            }
-
-            // bind mouseover event callbacks
-            if(config.showPreviewBtnOnHover)
-            {
-
-                rowTr.on("mouseover",function() {
-                    $(this).css('background-color', '#CAF589');
-                    $(this).find('.perc-preview-col').show();
-
-                }).on("mouseout",function(){
-                    $(this).css('background-color', 'white');
-                    $(this).find('.perc-preview-col').hide();
-                });
-            }
-
-            if(config.percRowDblclickCallback)
-            {
-                if(row.rowData)
-                {
-                    rowTr.on("dblclick",row.rowData, function(e){
-                        config.percRowDblclickCallback(e);
-                    });
-                }
-                else
-                {
-                    rowTr.on("dblclick",function(e){
-                        config.percRowDblclickCallback(e);
-                    });
-                }
-            }
-
-            // iterate over the columns in each row
-            var aoIndex = 0;
-            $.each(row.rowContent, function(colIndex, element){
-
-                // skip over non visible columns
-                if(config.percVisibleColumns)
-                    if($.inArray(colIndex, config.percVisibleColumns)==-1)
-                        return true;
-
-                var aoColumn = aoColumns[aoIndex++];
-                var sType = aoColumn.sType;
-                var percType = "perc-type-"+sType;
-
-                var column = element;
-                // mark the first and last column
-                var firstLast = "";
-                if(colIndex == 0)
-                    firstLast = "perc-first";
-                else if(colIndex == row.rowContent.length-1)
-                    firstLast = "perc-last";
-                else
-                    firstLast = "perc-middle";
-
-                var headerClass = "";
-                //Header classes are auto generated by the element text, if the element text happens to be invalid for a class name,
-                //users of this table can pass another array from which the header classes can be created
-                if(config.percHeaderClasses && config.percHeaderClasses[colIndex])
-                {
-                    headerClass = "perc-"+config.percHeaderClasses[colIndex].replace(/ /g,"-").toLowerCase();
-                }
-                else
-                {
-                    headerClass = "perc-"+config.percHeaders[colIndex].replace(/ /g,"-").toLowerCase();
-                }
-
-                // create the table data
-                var columnTd = $("<td class='"+percType+" "+headerClass+" perc-datatable-column perc-ellipsis perc-index-"+colIndex+" perc-cell-"+colIndex+"-"+rowIndex+" "+firstLast+"' valign='top'>");
-                if(aoIndex ==1){
-                    columnTd = $("<td scope = row' class='"+percType+" "+headerClass+" perc-datatable-column perc-ellipsis perc-index-"+colIndex+" perc-cell-"+colIndex+"-"+rowIndex+" "+firstLast+"' valign='top'>");
-                }
-                var columnRow;
-                if(typeof column === "object") {
-                    var content = "";
-                    var title = "";
-
-                    // iterate over the rows within a table cell
-                    if(Array.isArray(column)) {
-                        $.each(column, function(colRowIndex, element){
-                            if(!element)
-                                element = "&nbsp;";
-                            var columnRowData = element;
-                            var firstLast = "";
-                            if(colRowIndex === 0)
-                                firstLast = "perc-first";
-                            else if(colRowIndex === column.length-1)
-                                firstLast = "perc-last";
-                            else
-                                firstLast = "perc-middle";
-                            // if it's just a string, then that's the content, otherwise it's an object with content and maybe a title
-                            if(typeof columnRowData == "string") {
-                                content = columnRowData;
-                            } else {
-                                columnRowData = $.extend({ "content" : "", "title" : "" }, columnRowData);
-                                content = columnRowData.content;
-                                title = columnRowData.title;
-                            }
-
-                            if(title === "&nbsp;")
-                                title = "";
-
-                            // finally, wrap the content in a div and then add it to the table data
-                            columnRow = $("<div style='width:100%' class='perc-datatable-columnrow perc-ellipsis perc-index-"+colRowIndex+" "+firstLast+"'>");
-                            if(columnRowData.callback) {
-                                var cBack = $("<span>")
-                                    .attr("title", title)
-                                    .append(content);
-                                cBack
-                                    .css("cursor", "pointer")
-                                    .addClass("perc-callback");
-                                columnRow.append(cBack);
-                                if(row.rowData)
-                                    cBack.on("click",null, row.rowData, function(e){
-                                        columnRowData.callback(e);
-                                    });
-                                else
-                                    cBack.on("click",function(e){
-                                        columnRowData.callback(e);
-                                    });
-                            }
-                            else {
-                                columnRow
-                                    .attr("title", title)
-                                    .append(content);
-                            }
-
-                            columnTd.append(columnRow);
-                        });
-                    } else {
-                        let title = element.title;
-                        let content = element.content;
-                        columnRow = $("<div title='"+title+"' class='perc-datatable-columnrow perc-ellipsis perc-index-0 perc-first'>")
-                            .append(content);
-                        columnTd.append(columnRow);
-                    }
-                } else {
-                    columnRow = $("<div class='perc-datatable-columnrow perc-ellipsis perc-index-0 perc-first'>")
-                        .append(element);
-                    columnTd.append(columnRow);
-                }
-                // add the table data to the row
-                rowTr.append(columnTd);
-            });
-            // add the row to the table body
-            tbody.append(rowTr);
+    if (config && config.percTableRedrawCallback) {
+      if (typeof config.percTableRedrawCallback === "object") {
+        $.each(config.percTableRedrawCallback, function (index, value) {
+          this(dataTable);
         });
-        // add the table body to the table
-        table.append(tbody);
+      } else if (typeof config.percTableRedrawCallback === "function") {
+        config.percTableRedrawCallback(dataTable);
+      }
+    }
+    setTimeout(function () {
+      // prepend Pages label before page numbers
+      var paginator = dataTable
+        .parent()
+        .children(".dataTables_paginate.paging_full_numbers");
+      paginator
+        .find(".perc-datatable-paginator-pages-label")
+        .removeClass("paginate_button");
+      // add page number attribute to each page for QA
+      var pageNumbers = paginator.find(
+        "span span.paginate_button, span span.paginate_active"
+      );
 
-        if(headers) {
-            var thead = $("<thead>");
-            var row = $("<tr class='perc-datatable-head-row'>");
-            var aoIndex = 0;
-            $.each(headers, function(index, element){
-                // skip over non visible columns
-                if(config.percVisibleColumns)
-                    if($.inArray(index, config.percVisibleColumns)===-1)
-                        return true;
+      $.each(pageNumbers, function (index, element) {
+        $(element).attr("perc-page", index + 1);
+      });
+      if (!totalPages || totalPages < 2) paginator.hide();
+      else paginator.show();
+      paginator.css("position", "absolute");
+    }, 1);
+  }
 
-                var aoColumn = aoColumns[aoIndex++];
-                var sType = aoColumn.sType;
-                var percType = "perc-type-"+sType;
+  function getParentFrame() {
+    var arrFrames = parent.document.getElementsByTagName("IFRAME");
+    for (var i = 0; i < arrFrames.length; i++) {
+      if (arrFrames[i].contentWindow === window) return arrFrames[i];
+    }
+  }
 
-                var columnWidth = "";
-                if(config.percColumnWidths) {
-                    if(index < config.percColumnWidths.length-1) {
-                        columnWidth = config.percColumnWidths[index];
-                        if(columnWidth === "*")
-                            columnWidth = "";
-                    } else {
-                        columnWidth = config.percColumnWidths[config.percColumnWidths.length-1];
-                    }
-                }
+  function footerRedrawCallback(nFoot, aasData, iStart, iEnd, aiDisplay) {
+    if (configo.bPaginate) {
+      var config = configo;
 
+      var itemsPerPage = config.iDisplayLength;
+      var totalItemsCount = aiDisplay.length;
+      var pages = Math.ceil(totalItemsCount / itemsPerPage);
+      var currentPageNumber = Math.ceil(iEnd / itemsPerPage);
+      var pageOfPages =
+        currentPageNumber + " of " + pages + (pages === 1 ? " Page" : " Pages");
+      totalPages = pages;
+      if (pages === 0 || config.singlePage) pageOfPages = "";
 
-                // if($.browser.browser.msie || $.browser.webkit)
-                //     columnWidth = parseInt(columnWidth) + 20;
+      var pInfo = $(".perc-datatables-info");
+      if (pInfo.length > 0) {
+        // Page numbers only — use text(), not html() (js/html-constructed-from-input)
+        pInfo.text(pageOfPages);
+      } else {
+        $("<div>")
+          .addClass("datatables_info perc-datatables-info")
+          .text(pageOfPages)
+          .appendTo("body");
+      }
 
+      var gFooterBar = $(".perc-footer-bar");
+      if (gFooterBar.length === 0) {
+        $("<div class='perc-footer-bar'>&nbsp;</div>").appendTo("body");
+      }
+    }
+  }
 
-                if(columnWidth[columnWidth.length - 1] !== '%') {
-                    columnWidth += "px";
-                }
+  var defaultConfig = {
+    percExpandParentFrameVertically: true,
+    additionalIframeHeight: 0, //The Iframe height is calculated based on the rows and other things, if a gadget requires additional height they can specify by this property
+    percColumnWidths: ["*", "123"],
+    percRowDblclickCallback: $.PercOpenPage,
+    showPreviewBtnOnHover: false,
+    iDisplayLength: 5,
+    bFilter: false,
+    bAutoWidth: false,
+    bPaginate: true,
+    bSort: true,
+    sPaginationType: "full_numbers",
+    bLengthChange: false,
+    bInfo: true,
+    fnDrawCallback: tableRedrawCallback,
+    fnFooterCallback: footerRedrawCallback,
+    oLanguage: {
+      sZeroRecords:
+        typeof I18N === "undefined"
+          ? "No Pages Found"
+          : I18N.message("perc.ui.workflow.status.gadget@No Pages Found"),
+      oPaginate: {
+        sFirst: "&lt;&lt;",
+        sPrevious: "&lt;",
+        sNext: "&gt;",
+        sLast: "&gt;&gt;",
+      },
+      sInfo: " ",
+      sInfoEmpty: " ",
+    },
+  };
 
-                var headerClass = "";
-                if(config.percHeaderClasses && config.percHeaderClasses[index])
-                {
-                    headerClass = "perc-"+config.percHeaderClasses[index].replace(/ /g,"-").toLowerCase();
-                }
-                else
-                {
-                    headerClass = "perc-"+config.percHeaders[index].replace(/ /g,"-").toLowerCase();
-                }
+  /**
+   *  Builds a Table DOM from the array of arrays in the percData configuration
+   *  @param config table configuration containing percData and percHeaders
+   *
+   *  Generates the following DOM
+   *
+   *  <pre>
+   *  <table cellspacing="0" cellpadding="0" class="perc-datatable">
+   *      <thead>
+   *          <tr class="perc-datatable-head-row">
+   *              <th class="perc-datatable-head-column perc-index-0 perc-first sorting_asc">Page</th>
+   *              <th class="perc-datatable-head-column perc-index-1 sorting">Heading 2</th>
+   *          </tr>
+   *      </thead>
+   *      <tbody>
+   *          <tr class="perc-datatable-row perc-index-0 perc-first odd">
+   *              <td valign="top" class="perc-datatable-column perc-index-0 perc-first sorting_1">
+   *                  <div class="perc-datatable-columnrow perc-index-0 perc-first" title="">Comment 11</div>
+   *                  <div class="perc-datatable-columnrow perc-index-1 perc-last" title="">/Site/Site22</div>
+   *              </td>
+   *              <td valign="top" class="perc-datatable-column perc-index-1 ">
+   *                  <div class="perc-datatable-columnrow perc-index-0 perc-first" title="">12/22/33</div>
+   *                  <div class="perc-datatable-columnrow perc-index-1 perc-last" title="">22:44:55 PM</div>
+   *              </td>
+   *           </tr>
+   *           <tr class="perc-datatable-row perc-index-1 per-last even">
+   *              <td valign="top" class="perc-datatable-column perc-index-0 perc-first sorting_1">
+   *                  <div class="perc-datatable-columnrow perc-index-0 perc-first" title="">Comment 22</div>
+   *                  <div class="perc-datatable-columnrow perc-index-1 perc-last" title="">/Site/Site33</div>
+   *               </td>
+   *               <td valign="top" class="perc-datatable-column perc-index-1 ">
+   *                   <div class="perc-datatable-columnrow perc-index-0 perc-first" title="">13/22/33</div>
+   *                   <div class="perc-datatable-columnrow perc-index-1 perc-last" title="">22:44:55 PM</div>
+   *              </td>
+   *          </tr>
+   *      </tbody>
+   *  </table>
+   *  </pre>
+   *
+   */
+  function buildTableDomFromData(config) {
+    var data = config.percData;
+    var headers = config.percHeaders;
 
+    // create the table and body
+    var table = $(
+      "<table class='perc-datatable' style='table-layout : fixed' cellpadding='0' cellspacing='0'>"
+    );
+    var tbody = $("<tbody>");
 
-                var firstLast = "";
-                if(index === 0)
-                    firstLast = "perc-first";
-                else if(index === headers.length-1)
-                    firstLast = "perc-last";
-                else
-                    firstLast = "perc-middle";
-                var head = $("<th scope='col' class='"+percType+" "+headerClass+" perc-datatable-head-column perc-index-"+index+" "+firstLast+"'>");
+    var aoColumns = config.aoColumns;
 
-                head.width(columnWidth);
+    // iterate over the data containing rows
+    $.each(data, function (rowIndex, element) {
+      var row = element;
 
-                var sortingDirection = $("<span class='perc-sort' style='padding: 0px 10px 0px 0px; border-bottom:none'>&nbsp;</span>");
+      // mark the first and last table rows
+      var firstLast = "";
+      if (rowIndex === 0) firstLast = "perc-first";
+      else if (rowIndex === data.length - 1) firstLast = "perc-last";
 
-                //Asign external sort function.
-                if (typeof(config.sortFunction) !== "undefined" && !config.bSort){
-                    var colName = config.percColNames[index];
-                    var data = {};
-                    data.colName = colName;
-                    data.sortFunction = config.sortFunction;
-                    head.on("click",function(e){
-                        e.data = data;
-                        sortingHandler(e,$(this));
-                    });
+      // create the table row
+      var rowTr = $(
+        "<tr class='perc-datatable-row perc-index-" +
+          rowIndex +
+          " " +
+          firstLast +
+          "'>"
+      );
 
-                    //Avoid select text on double click in the headers.
-                    if($.browser.mozilla)
-                        head.css('MozUserSelect','none');
-                    else if($.browser.msie)
-                        head.on('selectstart',function(){return false;});
+      if (row.rowData) rowTr.data("percRowData", row.rowData);
 
-                    //SortOrder == asc or desc
-                    if (colName === config.sortColumn){
-                        head.addClass("sorting_" + config.sortOrder);
-                    }
-                }
-
-                head.append(element);
-                head.append(sortingDirection);
-                row.append(head);
-            });
-            thead.append(row);
-            table.append(thead);
+      // bind click event callbacks
+      if (config.percRowClickCallback) {
+        if (row.rowData) {
+          rowTr.on("click", null, row.rowData, function (evt) {
+            config.percRowClickCallback(evt);
+          });
+        } else {
+          rowTr.on("click", function (e) {
+            config.percRowClickCallback(e);
+          });
         }
-        if(config.bSort)
-            declareCustomSortingFunctions();
+      }
 
-        return table;
-    }
+      // bind mouseover event callbacks
+      if (config.showPreviewBtnOnHover) {
+        rowTr
+          .on("mouseover", function () {
+            $(this).css("background-color", "#CAF589");
+            $(this).find(".perc-preview-col").show();
+          })
+          .on("mouseout", function () {
+            $(this).css("background-color", "white");
+            $(this).find(".perc-preview-col").hide();
+          });
+      }
 
-    function sortingHandler(event,head){
-        var element = event.data.colName;
-        var callback = event.data.sortFunction;
-        head.siblings().removeClass("sorting_asc").removeClass("sorting_desc");
-        var order = "asc";
-        if (head.is(".sorting_asc")){
-            head.removeClass("sorting_asc").addClass("sorting_desc");
-            order = "desc";
-        }else if (head.is(".sorting_desc")){
-            head.removeClass("sorting_desc").addClass("sorting_asc");
-        }else{
-            head.addClass("sorting_asc");
+      if (config.percRowDblclickCallback) {
+        if (row.rowData) {
+          rowTr.on("dblclick", row.rowData, function (e) {
+            config.percRowDblclickCallback(e);
+          });
+        } else {
+          rowTr.on("dblclick", function (e) {
+            config.percRowDblclickCallback(e);
+          });
         }
-        callback(element, order);
-    }
+      }
 
-    function declareCustomSortingFunctions() {
-        // custom column sorting for Change, Views, and Template column
-        // checks to see if all data is the same and if so it changes it
-        // so that it is unique to force it to sort in reverse order
-        $.fn.dataTableExt.afnSortData['perc-type-string'] = function  ( oSettings, iColumn ) {
-            var aData = [];
-            var data;
-            this.api().column( iColumn, {order:'index'} ).nodes().map( function ( td, iColumn ) {
-                var inText = $(td)[0].innerText;
-                //CMS-8495 : Activity gadget sorting issue as the values 1, 11, 12 etc were being treated as string rather than numerals.
-                if(isNumericValue(inText)){
-                    inText = parseInt(inText);
-                }
-                aData.push(inText);
-            } );
+      // iterate over the columns in each row
+      var aoIndex = 0;
+      $.each(row.rowContent, function (colIndex, element) {
+        // skip over non visible columns
+        if (config.percVisibleColumns)
+          if ($.inArray(colIndex, config.percVisibleColumns) == -1) return true;
 
-            return aData;
-        };
+        var aoColumn = aoColumns[aoIndex++];
+        var sType = aoColumn.sType;
+        var percType = "perc-type-" + sType;
 
-        $.fn.dataTableExt.afnSortData['perc-type-numeric'] = $.fn.dataTableExt.afnSortData['perc-type-string'];
+        var column = element;
+        // mark the first and last column
+        var firstLast = "";
+        if (colIndex == 0) firstLast = "perc-first";
+        else if (colIndex == row.rowContent.length - 1) firstLast = "perc-last";
+        else firstLast = "perc-middle";
 
-        // custom column sorting for date columns
-        // changes the seconds so that if the date, minutes and hours are the same
-        // it will be forced to sort in reverse order
-        $.fn.dataTableExt.afnSortData['perc-type-date'] = function  ( oSettings, iColumn ) {
-            var aData = [];
-            this.api().column( iColumn, {order:'index'} ).nodes().map( function ( td, iColumn ) {
-                var dateTimeArray = Array("", "");
-                var date;
-                var divs = $($(td)[0]).find('div');
-                if(divs.length>1){
-                    //blogs gadget has dates in two divs one for date and other for time.
-                    dateTimeArray[0] = $(divs[0]).text();
-                    dateTimeArray[1] = $(divs[1]).text();
-                    var dateString = dateTimeArray.join(' ');
-                    date = new Date(dateString);
-                }else{
-                    date = new Date($(td)[0].innerText);
-                }
-                aData.push(date);
+        var headerClass = "";
+        //Header classes are auto generated by the element text, if the element text happens to be invalid for a class name,
+        //users of this table can pass another array from which the header classes can be created
+        if (config.percHeaderClasses && config.percHeaderClasses[colIndex]) {
+          headerClass =
+            "perc-" +
+            config.percHeaderClasses[colIndex].replace(/ /g, "-").toLowerCase();
+        } else {
+          headerClass =
+            "perc-" +
+            config.percHeaders[colIndex].replace(/ /g, "-").toLowerCase();
+        }
+
+        // Build <td> via jQuery APIs — never interpolate untrusted tokens into HTML
+        // (CodeQL js/html-constructed-from-input #1575–#1578).
+        var columnTd = $("<td>")
+          .attr("valign", "top")
+          .addClass(percType)
+          .addClass(headerClass)
+          .addClass("perc-datatable-column perc-ellipsis")
+          .addClass("perc-index-" + colIndex)
+          .addClass("perc-cell-" + colIndex + "-" + rowIndex)
+          .addClass(firstLast);
+        if (aoIndex == 1) {
+          columnTd.attr("scope", "row");
+        }
+        var columnRow;
+        if (typeof column === "object") {
+          var content = "";
+          var title = "";
+
+          // iterate over the rows within a table cell
+          if (Array.isArray(column)) {
+            $.each(column, function (colRowIndex, element) {
+              if (!element) element = "\u00a0";
+              var columnRowData = element;
+              var firstLast = "";
+              if (colRowIndex === 0) firstLast = "perc-first";
+              else if (colRowIndex === column.length - 1)
+                firstLast = "perc-last";
+              else firstLast = "perc-middle";
+              // if it's just a string, then that's the content, otherwise it's an object with content and maybe a title
+              if (typeof columnRowData == "string") {
+                content = columnRowData;
+              } else {
+                columnRowData = $.extend(
+                  { content: "", title: "" },
+                  columnRowData
+                );
+                content = columnRowData.content;
+                title = columnRowData.title;
+              }
+
+              if (title === "&nbsp;" || title === "\u00a0") title = "";
+
+              // finally, wrap the content in a div and then add it to the table data
+              columnRow = $("<div>")
+                .css("width", "100%")
+                .addClass("perc-datatable-columnrow perc-ellipsis")
+                .addClass("perc-index-" + colRowIndex)
+                .addClass(firstLast);
+              if (columnRowData.callback) {
+                var cBack = $("<span>").attr("title", title).append(content);
+                cBack.css("cursor", "pointer").addClass("perc-callback");
+                columnRow.append(cBack);
+                if (row.rowData)
+                  cBack.on("click", null, row.rowData, function (e) {
+                    columnRowData.callback(e);
+                  });
+                else
+                  cBack.on("click", function (e) {
+                    columnRowData.callback(e);
+                  });
+              } else {
+                columnRow.attr("title", title).append(content);
+              }
+
+              columnTd.append(columnRow);
             });
-            return aData;
-        };
-    }
+          } else {
+            let title = element.title;
+            let content = element.content;
+            columnRow = $("<div>")
+              .attr("title", title == null ? "" : String(title))
+              .addClass(
+                "perc-datatable-columnrow perc-ellipsis perc-index-0 perc-first"
+              )
+              .append(content);
+            columnTd.append(columnRow);
+          }
+        } else {
+          columnRow = $("<div>")
+            .addClass(
+              "perc-datatable-columnrow perc-ellipsis perc-index-0 perc-first"
+            )
+            .append(element);
+          columnTd.append(columnRow);
+        }
+        // add the table data to the row
+        rowTr.append(columnTd);
+      });
+      // add the row to the table body
+      tbody.append(rowTr);
+    });
+    // add the table body to the table
+    table.append(tbody);
 
-    //To check if the column value is numeric for sorting.
-    function isNumericValue(str){
-        return !isNaN(parseFloat(str)) && isFinite(str);
-    }
+    if (headers) {
+      var thead = $("<thead>");
+      var row = $("<tr class='perc-datatable-head-row'>");
+      var aoIndex = 0;
+      $.each(headers, function (index, element) {
+        // skip over non visible columns
+        if (config.percVisibleColumns)
+          if ($.inArray(index, config.percVisibleColumns) === -1) return true;
 
-})(jQuery); 
+        var aoColumn = aoColumns[aoIndex++];
+        var sType = aoColumn.sType;
+        var percType = "perc-type-" + sType;
+
+        var columnWidth = "";
+        if (config.percColumnWidths) {
+          if (index < config.percColumnWidths.length - 1) {
+            columnWidth = config.percColumnWidths[index];
+            if (columnWidth === "*") columnWidth = "";
+          } else {
+            columnWidth =
+              config.percColumnWidths[config.percColumnWidths.length - 1];
+          }
+        }
+
+        // if($.browser.browser.msie || $.browser.webkit)
+        //     columnWidth = parseInt(columnWidth) + 20;
+
+        if (columnWidth[columnWidth.length - 1] !== "%") {
+          columnWidth += "px";
+        }
+
+        var headerClass = "";
+        if (config.percHeaderClasses && config.percHeaderClasses[index]) {
+          headerClass =
+            "perc-" +
+            config.percHeaderClasses[index].replace(/ /g, "-").toLowerCase();
+        } else {
+          headerClass =
+            "perc-" +
+            config.percHeaders[index].replace(/ /g, "-").toLowerCase();
+        }
+
+        var firstLast = "";
+        if (index === 0) firstLast = "perc-first";
+        else if (index === headers.length - 1) firstLast = "perc-last";
+        else firstLast = "perc-middle";
+        // Build <th> via jQuery APIs (CodeQL js/html-constructed-from-input #1579–#1580)
+        var head = $("<th>")
+          .attr("scope", "col")
+          .addClass(percType)
+          .addClass(headerClass)
+          .addClass("perc-datatable-head-column")
+          .addClass("perc-index-" + index)
+          .addClass(firstLast);
+
+        head.width(columnWidth);
+
+        var sortingDirection = $(
+          "<span class='perc-sort' style='padding: 0px 10px 0px 0px; border-bottom:none'>&nbsp;</span>"
+        );
+
+        //Asign external sort function.
+        if (typeof config.sortFunction !== "undefined" && !config.bSort) {
+          var colName = config.percColNames[index];
+          var data = {};
+          data.colName = colName;
+          data.sortFunction = config.sortFunction;
+          head.on("click", function (e) {
+            e.data = data;
+            sortingHandler(e, $(this));
+          });
+
+          //Avoid select text on double click in the headers.
+          if ($.browser.mozilla) head.css("MozUserSelect", "none");
+          else if ($.browser.msie)
+            head.on("selectstart", function () {
+              return false;
+            });
+
+          //SortOrder == asc or desc
+          if (colName === config.sortColumn) {
+            head.addClass("sorting_" + config.sortOrder);
+          }
+        }
+
+        head.append(element);
+        head.append(sortingDirection);
+        row.append(head);
+      });
+      thead.append(row);
+      table.append(thead);
+    }
+    if (config.bSort) declareCustomSortingFunctions();
+
+    return table;
+  }
+
+  function sortingHandler(event, head) {
+    var element = event.data.colName;
+    var callback = event.data.sortFunction;
+    head.siblings().removeClass("sorting_asc").removeClass("sorting_desc");
+    var order = "asc";
+    if (head.is(".sorting_asc")) {
+      head.removeClass("sorting_asc").addClass("sorting_desc");
+      order = "desc";
+    } else if (head.is(".sorting_desc")) {
+      head.removeClass("sorting_desc").addClass("sorting_asc");
+    } else {
+      head.addClass("sorting_asc");
+    }
+    callback(element, order);
+  }
+
+  function declareCustomSortingFunctions() {
+    // custom column sorting for Change, Views, and Template column
+    // checks to see if all data is the same and if so it changes it
+    // so that it is unique to force it to sort in reverse order
+    $.fn.dataTableExt.afnSortData["perc-type-string"] = function (
+      oSettings,
+      iColumn
+    ) {
+      var aData = [];
+      var data;
+      this.api()
+        .column(iColumn, { order: "index" })
+        .nodes()
+        .map(function (td, iColumn) {
+          var inText = $(td)[0].innerText;
+          //CMS-8495 : Activity gadget sorting issue as the values 1, 11, 12 etc were being treated as string rather than numerals.
+          if (isNumericValue(inText)) {
+            inText = parseInt(inText);
+          }
+          aData.push(inText);
+        });
+
+      return aData;
+    };
+
+    $.fn.dataTableExt.afnSortData["perc-type-numeric"] =
+      $.fn.dataTableExt.afnSortData["perc-type-string"];
+
+    // custom column sorting for date columns
+    // changes the seconds so that if the date, minutes and hours are the same
+    // it will be forced to sort in reverse order
+    $.fn.dataTableExt.afnSortData["perc-type-date"] = function (
+      oSettings,
+      iColumn
+    ) {
+      var aData = [];
+      this.api()
+        .column(iColumn, { order: "index" })
+        .nodes()
+        .map(function (td, iColumn) {
+          var dateTimeArray = Array("", "");
+          var date;
+          var divs = $($(td)[0]).find("div");
+          if (divs.length > 1) {
+            //blogs gadget has dates in two divs one for date and other for time.
+            dateTimeArray[0] = $(divs[0]).text();
+            dateTimeArray[1] = $(divs[1]).text();
+            var dateString = dateTimeArray.join(" ");
+            date = new Date(dateString);
+          } else {
+            date = new Date($(td)[0].innerText);
+          }
+          aData.push(date);
+        });
+      return aData;
+    };
+  }
+
+  //To check if the column value is numeric for sorting.
+  function isNumericValue(str) {
+    return !isNaN(parseFloat(str)) && isFinite(str);
+  }
+})(jQuery);

--- a/WebUI/war/widgets/PercDataTableWrong/PercDataTable.js
+++ b/WebUI/war/widgets/PercDataTableWrong/PercDataTable.js
@@ -22,7 +22,7 @@
  *  Description:
  *  Thin plugin layer over jQuery's datatable plugin http://www.datatables.net/
  *  to implement Percussion specific custom behavior.
- *  
+ *
  *  @param percHeaders   (string[]) Labels for the headers
  *  @param percColsLeft  (int[]) indices of columns to show if gadget is on the left
  *  @param percColsRight (int[]) indices of columns to show if gadget is on the right
@@ -30,223 +30,258 @@
  *  @param percHeaderClasses (string[]) classes to add to each of the headers
  *
  */
-(function($) {
-    
-    // constants
-    var S_INFO_LEFT  = "_START_ to _END_ of _TOTAL_";
-    var S_INFO_RIGHT = "Showing _START_ to _END_ of _TOTAL_ total results";
-    
-    var defaultConfig = {
-        percHeaderClasses : [],
-        iDisplayLength : 5,
-        bFilter: false,
-        bAutoWidth : false,
-        bPaginate : true,
-        sPaginationType : "full_numbers",
-        bLengthChange : false,
-        bInfo : true,
-        fnDrawCallback  : function() {
-            // fix the ellipsis on every draw
-            if ($.browser.msie) {
-                $(".perc-ellipsis").each(function(){
-                    handleOverflow($(this));
-                });
-            }
-        },
-        // if on first or last page, update the disabled color of the sequential pagination controls
-        fnFooterCallback: function( nFoot, aasData, iStart, iEnd, aiDisplay ) {
-            // set them all to their default active color
-            $(".first").addClass("perc-percdatatable-active").removeClass("perc-percdatatable-disabled");
-            $(".previous").addClass("perc-percdatatable-active").removeClass("perc-percdatatable-disabled");
-            $(".next").addClass("perc-percdatatable-active").removeClass("perc-percdatatable-disabled");
-            $(".last").addClass("perc-percdatatable-active").removeClass("perc-percdatatable-disabled");
-            // if on the first page disable First and Previous controls
-            if(iStart === 0) {
-                $(".first").addClass("perc-percdatatable-disabled").removeClass("perc-percdatatable-active");
-                $(".previous").addClass("perc-percdatatable-disabled").removeClass("perc-percdatatable-active");
-            }
-            // if on the last page disable Last and Next controls
-            if(iEnd === aasData.length) {
-                $(".next").addClass("perc-percdatatable-disabled").removeClass("perc-percdatatable-active");
-                $(".last").addClass("perc-percdatatable-disabled").removeClass("perc-percdatatable-active");
-            }
+(function ($) {
+  // constants
+  var S_INFO_LEFT = "_START_ to _END_ of _TOTAL_";
+  var S_INFO_RIGHT = "Showing _START_ to _END_ of _TOTAL_ total results";
+
+  var defaultConfig = {
+    percHeaderClasses: [],
+    iDisplayLength: 5,
+    bFilter: false,
+    bAutoWidth: false,
+    bPaginate: true,
+    sPaginationType: "full_numbers",
+    bLengthChange: false,
+    bInfo: true,
+    fnDrawCallback: function () {
+      // fix the ellipsis on every draw
+      if ($.browser.msie) {
+        $(".perc-ellipsis").each(function () {
+          handleOverflow($(this));
+        });
+      }
+    },
+    // if on first or last page, update the disabled color of the sequential pagination controls
+    fnFooterCallback: function (nFoot, aasData, iStart, iEnd, aiDisplay) {
+      // set them all to their default active color
+      $(".first")
+        .addClass("perc-percdatatable-active")
+        .removeClass("perc-percdatatable-disabled");
+      $(".previous")
+        .addClass("perc-percdatatable-active")
+        .removeClass("perc-percdatatable-disabled");
+      $(".next")
+        .addClass("perc-percdatatable-active")
+        .removeClass("perc-percdatatable-disabled");
+      $(".last")
+        .addClass("perc-percdatatable-active")
+        .removeClass("perc-percdatatable-disabled");
+      // if on the first page disable First and Previous controls
+      if (iStart === 0) {
+        $(".first")
+          .addClass("perc-percdatatable-disabled")
+          .removeClass("perc-percdatatable-active");
+        $(".previous")
+          .addClass("perc-percdatatable-disabled")
+          .removeClass("perc-percdatatable-active");
+      }
+      // if on the last page disable Last and Next controls
+      if (iEnd === aasData.length) {
+        $(".next")
+          .addClass("perc-percdatatable-disabled")
+          .removeClass("perc-percdatatable-active");
+        $(".last")
+          .addClass("perc-percdatatable-disabled")
+          .removeClass("perc-percdatatable-active");
+      }
+    },
+  };
+
+  $.fn.percDataTable = function (config) {
+    var sInfo = S_INFO_RIGHT;
+    var columnWidths = [];
+    if (config.percColumnWidths && config.percColumnWidths.length > 0)
+      columnWidths = config.percColumnWidths[0];
+
+    // TODO: do we really need this dependency with gadgets? could be a configuration
+    var isRightColumn = true;
+    if (gadgets) {
+      // if the gadget is in first column then we have to render it as large
+      isRightColumn = gadgets.window.getDashboardColumn() === 1;
+      sInfo = isRightColumn ? S_INFO_RIGHT : S_INFO_LEFT;
+      if (columnWidths.length > 1)
+        columnWidths = isRightColumn
+          ? config.percColumnWidths[0]
+          : config.percColumnWidths[1];
+    }
+
+    fixPercColsLeftAndRightIfUndefined(config);
+
+    // merge and override default and custom configurations
+    config = $.extend({}, defaultConfig, config);
+
+    config.oLanguage.sInfo = sInfo;
+
+    var table = $(this);
+
+    table.addClass("perc-datatable");
+
+    // create headers
+    var headers = config.percHeaders;
+    table.append("<thead><tr>");
+    var tableHeaderRow = table.find("thead tr");
+
+    var indices = config.percColsLeft;
+    if (isRightColumn) indices = config.percColsRight;
+
+    var headerClasses = config.percHeaderClasses;
+    for (let i = 0; i < indices.length; i++) {
+      var h = indices[i];
+      var header = headers[h];
+      var headerClass = "";
+      var headerWidth = "";
+      if (headerClasses && headerClasses.length > 0)
+        headerClass = headerClasses[h];
+      if (columnWidths && columnWidths.length > 0)
+        headerWidth = columnWidths[i];
+      // Build header via jQuery APIs — never interpolate into HTML strings
+      // (CodeQL js/html-constructed-from-input #1571–#1574).
+      var th = $("<th>")
+        .addClass("perc-datatable-header")
+        .addClass("perc-col-" + i)
+        .addClass(headerClass || "");
+      if (headerWidth) {
+        th.css({ width: headerWidth, maxWidth: headerWidth });
+      }
+      th.append($("<span>").text(header == null ? "" : String(header)));
+      tableHeaderRow.append(th);
+    }
+
+    // create rows
+    table.append("<tbody>");
+    var percRows = config.percData;
+    var tableBody = table.find("tbody");
+    tableBody.html("");
+    for (let r = 0; r < percRows.length; r++) {
+      var tableRow = $("<tr class='perc-row-" + r + "'>");
+      var percRow = percRows[r];
+      for (let i = 0; i < indices.length; i++) {
+        var d = indices[i];
+        var tableData = $("<td>").addClass("perc-cell-" + r + "-" + i);
+        var data = percRow[d];
+        if (data === "" || data === undefined) {
+          tableData.text("\u00a0");
+        } else if (typeof data === "string") {
+          tableData.text(data);
+        } else {
+          tableData.append(data);
         }
+        tableRow.append(tableData);
+      }
+      tableBody.append(tableRow);
+    }
+
+    declareCustomSortingFunctions();
+
+    var oTable = table.dataTable(config);
+
+    // only fix ellipsis in IE
+    if ($.browser.msie) {
+      // fix text overflow at first
+      $(".perc-ellipsis").each(function () {
+        handleOverflow($(this));
+      });
+
+      // fix text overflow when window resizes
+      $(window).on("resize", function () {
+        $(".perc-ellipsis").each(function () {
+          handleOverflow($(this));
+        });
+      });
+    }
+
+    return oTable;
+  };
+
+  function handleOverflow(element) {
+    var title = element.attr("title");
+    if (title === "") return true;
+    var width = element.parents("td").width();
+    element.css("width", width);
+  }
+
+  /**
+   *  if percColsLeft is undefined then we want all columns to show on the left column
+   *  same for percColsRight for the right column
+   */
+  function fixPercColsLeftAndRightIfUndefined(config) {
+    var headers;
+    if (typeof config.percColsLeft === "undefined") {
+      config.percColsLeft = [];
+      headers = config.percHeaders;
+      for (let h = 0; h < headers.length; h++) {
+        config.percColsLeft.push(h);
+      }
+    }
+    if (typeof config.percColsRight === "undefined") {
+      config.percColsRight = [];
+      headers = config.percHeaders;
+      for (let h = 0; h < headers.length; h++) {
+        config.percColsRight.push(h);
+      }
+    }
+  }
+
+  function declareCustomSortingFunctions() {
+    // custom column sorting for Change, Views, and Template column
+    // checks to see if all data is the same and if so it changes it
+    // so that it is unique to force it to sort in reverse order
+    $.fn.dataTableExt.afnSortData["dom-ptext"] = function (oSettings, iColumn) {
+      var aData = [];
+      var different = false;
+      var previous = null;
+      var data;
+      $("td:eq(" + iColumn + ")", oSettings.oApi.rows().nodes()).each(
+        function () {
+          data = $(this).text();
+          if (previous != null && previous !== data) different = true;
+          previous = data;
+          aData.push(data);
+        }
+      );
+      if (!different) {
+        for (let i = 0; i < aData.length; i++) {
+          aData[i] = aData[i] + i;
+        }
+      }
+      return aData;
     };
-    
-    $.fn.percDataTable = function (config) {
-        
-        var sInfo = S_INFO_RIGHT;
-        var columnWidths = [];
-        if(config.percColumnWidths && config.percColumnWidths.length > 0)
-            columnWidths = config.percColumnWidths[0];
-        
-        // TODO: do we really need this dependency with gadgets? could be a configuration
-        var isRightColumn = true;
-        if(gadgets) {
-            // if the gadget is in first column then we have to render it as large 
-            isRightColumn = gadgets.window.getDashboardColumn() === 1;
-            sInfo = isRightColumn ? S_INFO_RIGHT : S_INFO_LEFT;
-            if(columnWidths.length > 1)
-                columnWidths = isRightColumn ? config.percColumnWidths[0] : config.percColumnWidths[1];
-        }
-        
-        fixPercColsLeftAndRightIfUndefined(config);
-        
-        // merge and override default and custom configurations
-        config = $.extend({}, defaultConfig, config);
 
-        config.oLanguage.sInfo = sInfo;
-
-        var table = $(this);
-        
-        table.addClass("perc-datatable");
-        
-        // create headers
-        var headers = config.percHeaders;
-        table.append("<thead><tr>");
-        var tableHeaderRow = table.find("thead tr");
-            
-        var indices = config.percColsLeft;
-        if(isRightColumn)
-            indices = config.percColsRight;
-            
-        var headerClasses = config.percHeaderClasses;
-        for(let i=0; i<(indices.length); i++) {
-            var h = indices[i];
-            var header = headers[h];
-            var headerClass = "";
-            var headerWidth = "";
-            if(headerClasses && headerClasses.length > 0)
-                headerClass = headerClasses[h];
-            if(columnWidths && columnWidths.length > 0)
-                headerWidth = columnWidths[i];
-            // put header text in a SPAN so we move the sorting arrow with the header
-            tableHeaderRow.append("<th class='perc-datatable-header perc-col-" + i + " " + headerClass + "' style='width:"+headerWidth+"; max-width:"+headerWidth+"'><span>"+header+"</span></th>");
+    // custom column sorting for Page Link column
+    $.fn.dataTableExt.afnSortData["dom-page"] = function (oSettings, iColumn) {
+      var aData = [];
+      $("td:eq(" + iColumn + ")", oSettings.oApi.rows(oSettings).nodes()).each(
+        function () {
+          var data = $(this).text();
+          data = data.substring(0, data.indexOf("/"));
+          aData.push(data);
         }
-
-        // create rows
-        table.append("<tbody>");
-        var percRows  = config.percData;
-        var tableBody = table.find("tbody");
-        tableBody.html("");
-        for(let r=0; r<percRows.length; r++) {
-            var tableRow = $("<tr class='perc-row-"+r+"'>");
-            var percRow = percRows[r];
-            for(let i=0; i<indices.length; i++) {
-                var d = indices[i];
-                var tableData = $("<td class='perc-cell-"+r+"-"+i+"'>");
-                var data = percRow[d];
-                if(data==="" || data===undefined)
-                    data = "&nbsp;";
-                tableData.append(data);
-                tableRow.append(tableData);
-            }
-            tableBody.append(tableRow);
-        }
-
-        declareCustomSortingFunctions();
-        
-        var oTable = table.dataTable(config);
-            
-        // only fix ellipsis in IE
-        if ($.browser.msie) {
-            // fix text overflow at first
-            $(".perc-ellipsis").each(function() {
-                handleOverflow($(this));
-            });
-            
-            // fix text overflow when window resizes
-            $(window).on('resize', function(){
-                $(".perc-ellipsis").each(function(){
-                    handleOverflow($(this));
-                });
-            });
-        }
-                
-        return oTable;
+      );
+      return aData;
     };
 
-    function handleOverflow(element) {
-        var title = element.attr("title");
-        if(title === '')
-            return true;
-        var width = element.parents("td").width();
-        element.css("width",width);
-    }
-
-    /**
-     *  if percColsLeft is undefined then we want all columns to show on the left column
-     *  same for percColsRight for the right column
-     */
-    function fixPercColsLeftAndRightIfUndefined(config) {
-        var headers;
-        if(typeof config.percColsLeft === "undefined") {
-            config.percColsLeft = [];
-            headers = config.percHeaders;
-            for(let h=0;h<headers.length;h++) {
-                config.percColsLeft.push(h);
-            }
+    // custom column sorting for date columns
+    // changes the seconds so that if the date, minutes and hours are the same
+    // it will be forced to sort in reverse order
+    $.fn.dataTableExt.afnSortData["dom-date"] = function (oSettings, iColumn) {
+      var aData = [];
+      var seconds = 0;
+      $("td:eq(" + iColumn + ")", oSettings.oApi.rows(oSettings).nodes()).each(
+        function () {
+          var dateTimeArray = Array("", "");
+          dateTimeArray[0] = $(this).find(".top-line").text();
+          dateTimeArray[1] = ("" + $(this).find(".bottom-line").text()).replace(
+            /^(.*?)\s*\(.+$/,
+            "$1"
+          ); // Get rid of username.
+          var dateString = dateTimeArray.join(" ");
+          var date = new Date(dateString);
+          aData.push(new Date(date.setSeconds(seconds)));
+          seconds++;
         }
-        if(typeof config.percColsRight === "undefined") {
-            config.percColsRight = [];
-            headers = config.percHeaders;
-            for(let h=0;h<headers.length;h++) {
-                config.percColsRight.push(h);
-            }
-        }
-    }
-
-    function declareCustomSortingFunctions() {
-        // custom column sorting for Change, Views, and Template column
-        // checks to see if all data is the same and if so it changes it
-        // so that it is unique to force it to sort in reverse order
-        $.fn.dataTableExt.afnSortData['dom-ptext'] = function  ( oSettings, iColumn ) {
-            var aData = [];
-            var different = false;
-            var previous = null;
-            var data;
-            $( 'td:eq('+iColumn+')', oSettings.oApi.rows().nodes()).each( function () {
-                data = $(this).text();
-                if(previous != null && previous !== data)
-                    different = true;
-                previous = data;
-                aData.push( data );
-            });
-            if(!different) {
-                for(let i=0; i<aData.length; i++) {
-                    aData[i] = aData[i] + i;
-                }
-            }
-            return aData;
-        };
-
-        // custom column sorting for Page Link column
-        $.fn.dataTableExt.afnSortData['dom-page'] = function  ( oSettings, iColumn ) {
-            var aData = [];
-            $( 'td:eq('+iColumn+')', oSettings.oApi.rows(oSettings).nodes() ).each( function () {
-                var data = $(this).text();
-                data = data.substring(0,data.indexOf("/"));
-                aData.push( data );
-            });
-            return aData;
-        };
-
-        // custom column sorting for date columns
-        // changes the seconds so that if the date, minutes and hours are the same
-        // it will be forced to sort in reverse order
-        $.fn.dataTableExt.afnSortData['dom-date'] = function  ( oSettings, iColumn ) {
-            var aData = [];
-            var seconds = 0;
-            $( 'td:eq('+iColumn+')', oSettings.oApi.rows(oSettings).nodes() ).each( function () {
-                var dateTimeArray = Array("", "");
-                dateTimeArray[0] = $(this).find('.top-line').text();
-                dateTimeArray[1] = (""+$(this).find('.bottom-line').text()).replace(/^(.*?)\s*\(.+$/, "$1"); // Get rid of username.
-                var dateString = dateTimeArray.join(' ');
-                var date = new Date(dateString);
-                aData.push(new Date(date.setSeconds(seconds)));
-                seconds++;
-            });
-            return aData;
-        };
-    }
-})(jQuery); 
+      );
+      return aData;
+    };
+  }
+})(jQuery);


### PR DESCRIPTION
## Summary

Closes product **medium** `js/html-constructed-from-input` alerts on **PercDataTable** (#1575–#1580) and the unused **PercDataTableWrong** copy (#1571–#1574). WAR mirrors updated the same way (#297–#306 when not already excluded by vendor paths-ignore).

### Root cause
`<td>` / `<th>` markup was built by concatenating header class names and indices into HTML strings. CodeQL correctly flags that as constructing HTML from input.

### Fix
- Build cells/headers with `$(\"<td>\")` / `$(\"<th>\")` + `.addClass()` / `.attr()` / `.text()`
- Page footer uses `.text()` for page numbers
- Wrong variant: header labels via `$(\"<span>\").text(header)`; cell text via `.text()` when string
- Fixed pre-existing typo `scope = row'` → `scope=\"row\"`

### Tests
```
npx vitest run src/test/js/percDataTableDomSafety.test.js
# 3 passed
```

## Test plan
- [x] Unit tests green under vitest/jsdom
- [ ] CodeQL Advanced on PR should clear #1571–#1580 on product paths
- [ ] Smoke: dashboard/gadget tables still render if exercised manually