### PR TITLE
fix(webui): PercSimpleMenu + categoryDropDown medium JS sinks

### DIFF
--- a/WebUI/src/main/webapp/cm/widgets/PercSimpleMenu.js
+++ b/WebUI/src/main/webapp/cm/widgets/PercSimpleMenu.js
@@ -89,12 +89,22 @@
       return $("<span>").text(String(label));
     }
     var trimmed = label.trim();
+    // First-party "<a>label</a>" only: parse with DOMParser and take textContent.
+    // Do NOT regex-strip tags (CodeQL js/incomplete-multi-character-sanitization #1780).
     if (/^<a[\s>]/i.test(trimmed) && /<\/a>\s*$/i.test(trimmed)) {
-      var text = trimmed
-        .replace(/^<a[^>]*>/i, "")
-        .replace(/<\/a>\s*$/i, "")
-        .replace(/<[^>]+>/g, "");
-      return $("<a>").text(text);
+      try {
+        var doc = new DOMParser().parseFromString(trimmed, "text/html");
+        var anchors = doc.body ? doc.body.getElementsByTagName("a") : [];
+        if (
+          anchors.length === 1 &&
+          doc.body.children.length === 1 &&
+          anchors[0].tagName === "A"
+        ) {
+          return $("<a>").text(anchors[0].textContent || "");
+        }
+      } catch (e) {
+        // fall through to plain text
+      }
     }
     // Plain text or any other string — never pass to $() HTML constructor
     return $("<span>").text(label);

--- a/WebUI/src/main/webapp/cm/widgets/PercSimpleMenu.js
+++ b/WebUI/src/main/webapp/cm/widgets/PercSimpleMenu.js
@@ -66,6 +66,77 @@
   };
 
   /**
+   * Resolve a menu label without ever passing an untrusted string to $().
+   * CodeQL js/unsafe-jquery-plugin (#1681): pre-fix used $(menuLabels[ml]), which
+   * HTML-parses strings that look like markup.
+   *
+   * - jQuery / DOM nodes pass through
+   * - plain strings become text in a &lt;span&gt;
+   * - simple first-party "&lt;a&gt;...&lt;/a&gt;" becomes a real &lt;a&gt; with text only
+   *   (href/target applied later from trusted callbackData)
+   */
+  function resolveMenuLabel(label) {
+    if (label == null || label === "") {
+      return $("<span>");
+    }
+    if (label.jquery) {
+      return label;
+    }
+    if (typeof label === "object" && label.nodeType) {
+      return $(label);
+    }
+    if (typeof label !== "string") {
+      return $("<span>").text(String(label));
+    }
+    var trimmed = label.trim();
+    if (/^<a[\s>]/i.test(trimmed) && /<\/a>\s*$/i.test(trimmed)) {
+      var text = trimmed
+        .replace(/^<a[^>]*>/i, "")
+        .replace(/<\/a>\s*$/i, "")
+        .replace(/<[^>]+>/g, "");
+      return $("<a>").text(text);
+    }
+    // Plain text or any other string — never pass to $() HTML constructor
+    return $("<span>").text(label);
+  }
+
+  /**
+   * Set title content without .html(string) for plain labels; allow jQuery/DOM.
+   */
+  function setTitleContent($el, content) {
+    $el.empty();
+    if (content == null) {
+      return;
+    }
+    if (content.jquery || (typeof content === "object" && content.nodeType)) {
+      $el.append(content);
+      return;
+    }
+    if (typeof content === "string" && content.trim().charAt(0) === "<") {
+      // First-party icon markup (e.g. &lt;img&gt;): parse via DOMParser, allow only img
+      try {
+        var doc = new DOMParser().parseFromString(content, "text/html");
+        var imgs = doc.body.querySelectorAll("img");
+        if (imgs.length === 1 && doc.body.children.length === 1) {
+          var src = imgs[0].getAttribute("src") || "";
+          if (!/^\s*javascript:/i.test(src) && !/^\s*data:text\/html/i.test(src)) {
+            var img = document.createElement("img");
+            img.setAttribute("src", src);
+            if (imgs[0].getAttribute("alt") != null) {
+              img.setAttribute("alt", imgs[0].getAttribute("alt"));
+            }
+            $el.append(img);
+            return;
+          }
+        }
+      } catch (e) {
+        // fall through to text
+      }
+    }
+    $el.text(String(content));
+  }
+
+  /**
    *  percSimpleMenu()
    *  plugin implementation
    */
@@ -82,20 +153,24 @@
 
     // create menu dynamically
     // create menu container, add title
-    var $menu = $("<div class='perc-simplemenu-menu'>");
-    var $menuTitle = $("<div class='perc-simplemenu-title'>");
-    $menuTitle.append(menuTitleCollapsed);
+    var $menu = $("<div>").addClass("perc-simplemenu-menu");
+    var $menuTitle = $("<div>").addClass("perc-simplemenu-title");
+    setTitleContent($menuTitle, menuTitleCollapsed);
 
     // add menu items
-    var $menuItems = $("<div class='perc-simplemenu-menuitems'>");
-    for (ml = 0; ml < menuLabels.length; ml++) {
-      var $menuItem = $("<div class='perc-simplemenu-menuitem'>");
-      var $menuLabel = $(menuLabels[ml]);
+    var $menuItems = $("<div>").addClass("perc-simplemenu-menuitems");
+    for (var ml = 0; ml < menuLabels.length; ml++) {
+      var $menuItem = $("<div>").addClass("perc-simplemenu-menuitem");
+      var $menuLabel = resolveMenuLabel(menuLabels[ml]);
 
       if ($menuLabel.is("a")) {
         $menuItem.css("padding", "0");
 
-        if (callbackData[ml].formSummary.totalSubmissions > 0) {
+        if (
+          callbackData[ml] &&
+          callbackData[ml].formSummary &&
+          callbackData[ml].formSummary.totalSubmissions > 0
+        ) {
           $menuLabel.attr(
             "href",
             escape(
@@ -108,17 +183,20 @@
           $menuLabel.attr("target", "_blank");
         }
 
-        $menuLabel.attr(
-          "style",
-          "text-decoration: none; padding: 0; " +
-            "font-family: Verdana; font-size: 11px; " +
-            "color: white; display: block; width: 100%; padding: 5px"
-        );
-      } else {
-        $menuLabel = menuLabels[ml];
+        $menuLabel.css({
+          "text-decoration": "none",
+          padding: "5px",
+          "font-family": "Verdana",
+          "font-size": "11px",
+          color: "white",
+          display: "block",
+          width: "100%",
+        });
       }
       // add the new class, use with identifier unique
-      $menuItem.addClass(optionClasses[ml]);
+      if (optionClasses[ml]) {
+        $menuItem.addClass(optionClasses[ml]);
+      }
       // configure each menu item
       $menuItem
         .data("callbackData", callbackData[ml])
@@ -222,7 +300,7 @@
     var menuTitleCollapsed = config.menuTitleCollapsed;
     var menuTitle = menu.find(".perc-simplemenu-title");
 
-    menuTitle.html(menuTitleExpanded);
+    setTitleContent(menuTitle, menuTitleExpanded);
     menuItems.css("position", "absolute");
     // Get pagination control as a reference to calculate menu's position (upwards or downwards)
     var oPaginate = $("#" + menu.parents("table").attr("id") + "_paginate");
@@ -257,7 +335,7 @@
     var menuTitleCollapsed = config.menuTitleCollapsed;
     var menuTitle = menu.find(".perc-simplemenu-title");
 
-    menuTitle.html(menuTitleCollapsed);
+    setTitleContent(menuTitle, menuTitleCollapsed);
     menuItems.hide();
   }
 })(jQuery);

--- a/WebUI/src/main/webapp/cm/widgets/PercSimpleMenu/PercSimpleMenu.js
+++ b/WebUI/src/main/webapp/cm/widgets/PercSimpleMenu/PercSimpleMenu.js
@@ -84,10 +84,18 @@
       var callback = menuItem.callback;
       var data = menuItem.data;
 
-      var menuItemDom = $(
-        "<div class='perc-simplemenu-menuitem perc-index-" + index + "'>"
-      )
-        .append(label)
+      // Build menu item without HTML string interpolation of index
+      var menuItemDom = $("<div>")
+        .addClass("perc-simplemenu-menuitem")
+        .addClass("perc-index-" + index)
+        .append(
+          // Labels that are plain strings must not go through $() HTML parse
+          label && label.jquery
+            ? label
+            : typeof label === "object" && label && label.nodeType
+              ? label
+              : $("<span>").text(label == null ? "" : String(label))
+        )
         .addClass(menuItemClass)
         .data("callback", callback)
         .on("click", function (event) {

--- a/WebUI/src/test/js/categoryDropdownSafety.test.js
+++ b/WebUI/src/test/js/categoryDropdownSafety.test.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regression for categoryDropdown createSubCategorySelect
+ * (js/html-constructed-from-input #1408/#1409).
+ *
+ * Pre-fix: $('<select id="' + id + '" name="' + name + '" />')
+ * Post-fix: $("<select>").attr("id", id).attr("name", name)
+ */
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import jquery from "jquery";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(
+  __dirname,
+  "../../../../modules/perc-packages/src/main/resources/Packages/perc.CategoryDropDownControl/SupportFile-rx_resources/widgets/categoryDropDown/js/categoryDropdown.js"
+);
+
+describe("categoryDropdown createSubCategorySelect", () => {
+  let $;
+
+  beforeEach(() => {
+    let jq = jquery(globalThis.window);
+    if (typeof jq !== "function") {
+      jq = typeof jquery === "function" ? jquery : jquery.fn || jquery;
+    }
+    $ = jq;
+    globalThis.jQuery = $;
+    globalThis.$ = $;
+    document.body.innerHTML =
+      '<div id="maindiv-testParam"></div><div id="datadisplay-testParam"></div>';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete globalThis.jQuery;
+    delete globalThis.$;
+  });
+
+  it("source no longer concatenates id/name into an HTML select string", () => {
+    const src = readFileSync(SRC, "utf8");
+    expect(src).not.toMatch(/\$\(\s*['"]<select id=['"]\s*\+/);
+    expect(src).toMatch(/\$\(["']<select>["']\)/);
+    expect(src).toMatch(/\.attr\(\s*["']id["']/);
+    expect(src).toMatch(/\.attr\(\s*["']name["']/);
+  });
+
+  it("jQuery .attr API places hostile id/name into attributes, not markup injection", () => {
+    const id = 'x"><img src=x onerror=alert(1)>';
+    const name = 'n"><script>alert(1)</script>';
+    const sel = $("<select>").attr("id", id).attr("name", name);
+    $("#maindiv-testParam").append(sel);
+    expect(document.querySelectorAll("img").length).toBe(0);
+    expect(document.querySelectorAll("script").length).toBe(0);
+    const el = $("#maindiv-testParam select")[0];
+    expect(el.getAttribute("id")).toBe(id);
+    expect(el.getAttribute("name")).toBe(name);
+  });
+});

--- a/WebUI/src/test/js/percSimpleMenuSafety.test.js
+++ b/WebUI/src/test/js/percSimpleMenuSafety.test.js
@@ -1,0 +1,126 @@
+/**
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regression for PercSimpleMenu js/unsafe-jquery-plugin (#1681 / #434).
+ *
+ * Pre-fix: $(menuLabels[ml]) passed label strings into jQuery's HTML-sniffing
+ * constructor. Post-fix: resolveMenuLabel never does that for plain/hostile
+ * strings.
+ */
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import jquery from "jquery";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(
+  __dirname,
+  "../../main/webapp/cm/widgets/PercSimpleMenu.js"
+);
+
+function loadPlugin($) {
+  $.browser = $.browser || { msie: false, mozilla: false };
+  const src = readFileSync(SRC, "utf8");
+  // eslint-disable-next-line no-new-func
+  const run = new Function("jQuery", "window", "document", src);
+  run($, globalThis, globalThis.document);
+  return $.fn.percSimpleMenu;
+}
+
+describe("percSimpleMenu label resolution (js/unsafe-jquery-plugin)", () => {
+  let $;
+  let host;
+  let rawCalls;
+
+  beforeEach(() => {
+    let jq = jquery(globalThis.window);
+    if (typeof jq !== "function") {
+      jq = typeof jquery === "function" ? jquery : jquery.fn || jquery;
+    }
+    rawCalls = [];
+    function spy(arg) {
+      rawCalls.push(arg);
+      return jq.apply(this, arguments);
+    }
+    Object.assign(spy, jq);
+    spy.fn = jq.fn;
+    $ = spy;
+    globalThis.jQuery = spy;
+    globalThis.$ = spy;
+    host = $("<div id='menu-host'>").appendTo(document.body);
+    loadPlugin($);
+  });
+
+  afterEach(() => {
+    if (host) host.remove();
+    delete globalThis.jQuery;
+    delete globalThis.$;
+  });
+
+  it("never hands a hostile HTML string to the jQuery constructor", () => {
+    const payload = '<img src=x onerror="window.__menu_pwned=1">';
+    host.percSimpleMenu({
+      menuLabels: [payload, "Edit"],
+      callbacks: [function () {}, function () {}],
+      callbackData: [{}, {}],
+      menuTitleCollapsed: "[+]",
+      menuTitleExpanded: "[-]",
+    });
+
+    // Hostile markup must not become a live img
+    expect(host.find("img").length).toBe(0);
+    expect(globalThis.__menu_pwned).toBeUndefined();
+    // Label text is still visible (escaped as text)
+    expect(host.text()).toContain("img");
+    // $() was never called with the raw payload string as sole argument
+    const hostileCtor = rawCalls.filter(
+      (a) => typeof a === "string" && a.indexOf("onerror") !== -1
+    );
+    expect(hostileCtor.length).toBe(0);
+  });
+
+  it("builds plain text labels as text nodes", () => {
+    host.percSimpleMenu({
+      menuLabels: ["Preview", "Delete"],
+      callbacks: [function () {}, function () {}],
+      callbackData: ["a", "b"],
+      menuTitleCollapsed: "Menu",
+      menuTitleExpanded: "Menu",
+    });
+    expect(host.text()).toContain("Preview");
+    expect(host.text()).toContain("Delete");
+    expect(host.find(".perc-simplemenu-menuitem").length).toBe(2);
+  });
+
+  it("creates a real anchor for simple first-party <a> labels without $(html)", () => {
+    host.percSimpleMenu({
+      menuLabels: ["<a>Export</a>"],
+      callbacks: [function () {}],
+      callbackData: [
+        { formSummary: { totalSubmissions: 0, name: "f1" } },
+      ],
+      menuTitleCollapsed: "[+]",
+      menuTitleExpanded: "[-]",
+    });
+    const a = host.find("a");
+    expect(a.length).toBe(1);
+    expect(a.text()).toBe("Export");
+    expect(host.find("a img").length).toBe(0);
+  });
+});

--- a/WebUI/src/test/js/percSimpleMenuSafety.test.js
+++ b/WebUI/src/test/js/percSimpleMenuSafety.test.js
@@ -123,4 +123,22 @@ describe("percSimpleMenu label resolution (js/unsafe-jquery-plugin)", () => {
     expect(a.text()).toBe("Export");
     expect(host.find("a img").length).toBe(0);
   });
+
+  it("anchor labels never leave executable markup (no regex tag-strip residual)", () => {
+    // Nested/odd markup must not produce live script/img; only text of the <a>
+    host.percSimpleMenu({
+      menuLabels: ['<a><img src=x onerror="window.__menu_pwned=1">Export</a>'],
+      callbacks: [function () {}],
+      callbackData: [{ formSummary: { totalSubmissions: 0, name: "f1" } }],
+      menuTitleCollapsed: "[+]",
+      menuTitleExpanded: "[-]",
+    });
+    expect(host.find("a").length).toBe(1);
+    expect(host.find("img").length).toBe(0);
+    expect(host.find("script").length).toBe(0);
+    expect(globalThis.__menu_pwned).toBeUndefined();
+    // textContent includes Export (img alt empty)
+    expect(host.find("a").text()).toMatch(/Export/);
+  });
+
 });

--- a/WebUI/war/widgets/PercSimpleMenu.js
+++ b/WebUI/war/widgets/PercSimpleMenu.js
@@ -56,198 +56,286 @@
  *  body.append(menuContainer);
  *
  */
-(function($) {
+(function ($) {
+  var defaultConfig = {
+    menuTitle: "Menu!!!",
+    menuTitleExpanded: "[-]",
+    menuTitleCollapsed: "[+]",
+    optionClasses: [],
+    menuWidth: 65, // IE has issues with width, supply an explicit value here to force it.
+  };
 
-    var defaultConfig = {
-        menuTitle : "Menu!!!",
-        menuTitleExpanded : "[-]",
-        menuTitleCollapsed : "[+]",
-        optionClasses : [],
-		menuWidth : 65 // IE has issues with width, supply an explicit value here to force it.
-    };
- 
-    /**
-     *  percSimpleMenu()
-     *  plugin implementation
-     */
-    $.fn.percSimpleMenu = function(config) {
-        config = $.extend({}, defaultConfig, config);
+  /**
+   * Resolve a menu label without ever passing an untrusted string to $().
+   * CodeQL js/unsafe-jquery-plugin (#1681): pre-fix used $(menuLabels[ml]), which
+   * HTML-parses strings that look like markup.
+   *
+   * - jQuery / DOM nodes pass through
+   * - plain strings become text in a &lt;span&gt;
+   * - simple first-party "&lt;a&gt;...&lt;/a&gt;" becomes a real &lt;a&gt; with text only
+   *   (href/target applied later from trusted callbackData)
+   */
+  function resolveMenuLabel(label) {
+    if (label == null || label === "") {
+      return $("<span>");
+    }
+    if (label.jquery) {
+      return label;
+    }
+    if (typeof label === "object" && label.nodeType) {
+      return $(label);
+    }
+    if (typeof label !== "string") {
+      return $("<span>").text(String(label));
+    }
+    var trimmed = label.trim();
+    if (/^<a[\s>]/i.test(trimmed) && /<\/a>\s*$/i.test(trimmed)) {
+      var text = trimmed
+        .replace(/^<a[^>]*>/i, "")
+        .replace(/<\/a>\s*$/i, "")
+        .replace(/<[^>]+>/g, "");
+      return $("<a>").text(text);
+    }
+    // Plain text or any other string — never pass to $() HTML constructor
+    return $("<span>").text(label);
+  }
 
-        var callbacks = config.callbacks;
-        var callbackData = config.callbackData;
-        var menuTitle = config.menuTitle;
-        var menuTitleExpanded  = config.menuTitleExpanded;
-        var menuTitleCollapsed = config.menuTitleCollapsed;
-        var menuLabels = config.menuLabels;
-		var optionClasses = config.optionClasses?config.optionClasses:[];
-        
-        // create menu dynamically
-        // create menu container, add title
-        var $menu      = $("<div class='perc-simplemenu-menu'>");
-        var $menuTitle = $("<div class='perc-simplemenu-title'>");
-        $menuTitle.append(menuTitleCollapsed);
-
-        // add menu items
-        var $menuItems = $("<div class='perc-simplemenu-menuitems'>");
-        for(ml=0; ml<menuLabels.length; ml++) {
-            var $menuItem = $("<div class='perc-simplemenu-menuitem'>");
-			var $menuLabel = $(menuLabels[ml]);
-            
-			if ($menuLabel.is("a")) {
-				$menuItem.css("padding", "0");
-				
-				if (callbackData[ml].formSummary.totalSubmissions > 0) {
-					$menuLabel.attr("href", escape(percJQuery.perc_paths.ASSET_FORMS_EXPORT + "/" +
-						callbackData[ml].formSummary.name + ".csv"));
-					$menuLabel.attr("target", "_blank");
-				}
-				
-				$menuLabel.attr("style", "text-decoration: none; padding: 0; " +
-					"font-family: Verdana; font-size: 11px; " +
-					"color: white; display: block; width: 100%; padding: 5px");
-			}
-			else {
-				$menuLabel = menuLabels[ml];
-			}
-			// add the new class, use with identifier unique
-            $menuItem.addClass(optionClasses[ml]);
-            // configure each menu item
-            $menuItem
-                .data("callbackData", callbackData[ml])
-                .data("callback", callbacks[ml])
-                .append($menuLabel)
-                // on click event
-                .on("click",function(evt) {
-                    let menuItem = $(this);
-                    var data = menuItem.data("callbackData");
-                    var callback = menuItem.data("callback");
-                    var menuItems = menuItem.parent();
-                    menuItems.hide();
-                    callback(data);
-                })
-                .on("mouseenter",function(e) {
-                    let menuItem = $(this);
-                    menuItem.addClass("perc-simplemenu-menuitem-hover");
-                }).on("mouseleave",function(e) {
-                    let menuItem = $(this);
-                    menuItem.removeClass("perc-simplemenu-menuitem-hover");
-                });
-            $menuItems.append($menuItem);
-        }
-        $menu.append($menuTitle)
-             .append($menuItems);
-        this.append($menu);
-        
-        // event handling
-        $menu.data("config", config);
-        $menuItems.hide();
-        
-        $menuTitle.find("*").on("click",
-            function(e){
-                menuTitleClick(e);
-            });
-        
-        $menuTitle.on("click",
-            function(e){
-                menuTitleClick(e);
-            });
-
-        $menuTitle.on("mouseenter",(
-                function() {
-                    var menuItem = $(this);
-                    menuItem.addClass("perc-simplemenu-title-hover");
-                }));
-
-        $menuTitle.on("mouseleave", (function() {
-                    var menuItem = $(this);
-                    menuItem.removeClass("perc-simplemenu-title-hover");
-                }));
-
-        // hide all menus if you exit the containing document
-        // useful if used inside an iframe like a gadget
-        $(document).on("mouseenter",null).on("mouseleave",
-            function() {
-                hideAllMenus();
+  /**
+   * Set title content without .html(string) for plain labels; allow jQuery/DOM.
+   */
+  function setTitleContent($el, content) {
+    $el.empty();
+    if (content == null) {
+      return;
+    }
+    if (content.jquery || (typeof content === "object" && content.nodeType)) {
+      $el.append(content);
+      return;
+    }
+    if (typeof content === "string" && content.trim().charAt(0) === "<") {
+      // First-party icon markup (e.g. &lt;img&gt;): parse via DOMParser, allow only img
+      try {
+        var doc = new DOMParser().parseFromString(content, "text/html");
+        var imgs = doc.body.querySelectorAll("img");
+        if (imgs.length === 1 && doc.body.children.length === 1) {
+          var src = imgs[0].getAttribute("src") || "";
+          if (!/^\s*javascript:/i.test(src) && !/^\s*data:text\/html/i.test(src)) {
+            var img = document.createElement("img");
+            img.setAttribute("src", src);
+            if (imgs[0].getAttribute("alt") != null) {
+              img.setAttribute("alt", imgs[0].getAttribute("alt"));
             }
-        );
-        
-        // hide all menus when clicking on body
-        $("body").on("click",function(event){
-            var target = $(event.target);
-            var noParents = target.parents().length === 0;
-            var menuParent = target.parent().hasClass("perc-simplemenu-menu");
-            if(!noParents && !menuParent)
-                hideAllMenus();
-        });
-    };
-    
-    function hideAllMenus() {
-        var allMenus = $(".perc-simplemenu-menu");
-        
-        $.each(allMenus, function() {
-            var menu = $(this);
-            collapseMenu(menu);
-        });
-    }
-    
-    // show the menu when you click on the title
-    function menuTitleClick(event) {
-        var menu = $($(event.target).parents(".perc-simplemenu-menu")[0]);
-        var config = menu.data("config");
-        if(config === undefined)
+            $el.append(img);
             return;
-        var menuItems = menu.find(".perc-simplemenu-menuitems");
-        var menuTitleExpanded  = config.menuTitleExpanded;
-        var menuTitleCollapsed = config.menuTitleCollapsed;
-        var menuTitle = menu.find(".perc-simplemenu-title");
-        
-        var visible = menuItems.css("display") === "block";
-        
-        hideAllMenus();
-        
-        if(visible) {
-            collapseMenu(menu);
-        } else {
-            expandMenu(menu);
+          }
         }
+      } catch (e) {
+        // fall through to text
+      }
     }
-    
-    function expandMenu(menu) {
-        var config = menu.data("config");
-        var menuItems = menu.find(".perc-simplemenu-menuitems");
-        var menuTitleExpanded  = config.menuTitleExpanded;
-        var menuTitleCollapsed = config.menuTitleCollapsed;
-        var menuTitle = menu.find(".perc-simplemenu-title");
-        
-        menuTitle.html(menuTitleExpanded);
-        menuItems.css("position","absolute");
-		// Get pagination control as a reference to calculate menu's position (upwards or downwards)
-		var oPaginate = $('#' + menu.parents('table').attr('id') + '_paginate');
-		if (oPaginate){
-			// Recalculate the position of Action menu when this appears behind the paging controls 
-			// fix: 5 pixel of diference between IE and FF
-			if (menu.position()['top'] + menu.outerHeight() + menuItems.outerHeight() + 5 > oPaginate.position()['top'] ){
-				menuItems.css("margin-top",(menu.outerHeight() + menuItems.outerHeight()) * -1);
-			}else
-			{
-				menuItems.css("margin-top", 0);
-			}
-		}
-        menuItems.show();
-        
-        // TODO: make this a configuration. for some reason in IE it loses the width of the menu and it shrinks.
-        if($.browser.msie)
-            menuItems.width(config.menuWidth);
+    $el.text(String(content));
+  }
+
+  /**
+   *  percSimpleMenu()
+   *  plugin implementation
+   */
+  $.fn.percSimpleMenu = function (config) {
+    config = $.extend({}, defaultConfig, config);
+
+    var callbacks = config.callbacks;
+    var callbackData = config.callbackData;
+    var menuTitle = config.menuTitle;
+    var menuTitleExpanded = config.menuTitleExpanded;
+    var menuTitleCollapsed = config.menuTitleCollapsed;
+    var menuLabels = config.menuLabels;
+    var optionClasses = config.optionClasses ? config.optionClasses : [];
+
+    // create menu dynamically
+    // create menu container, add title
+    var $menu = $("<div>").addClass("perc-simplemenu-menu");
+    var $menuTitle = $("<div>").addClass("perc-simplemenu-title");
+    setTitleContent($menuTitle, menuTitleCollapsed);
+
+    // add menu items
+    var $menuItems = $("<div>").addClass("perc-simplemenu-menuitems");
+    for (var ml = 0; ml < menuLabels.length; ml++) {
+      var $menuItem = $("<div>").addClass("perc-simplemenu-menuitem");
+      var $menuLabel = resolveMenuLabel(menuLabels[ml]);
+
+      if ($menuLabel.is("a")) {
+        $menuItem.css("padding", "0");
+
+        if (
+          callbackData[ml] &&
+          callbackData[ml].formSummary &&
+          callbackData[ml].formSummary.totalSubmissions > 0
+        ) {
+          $menuLabel.attr(
+            "href",
+            escape(
+              percJQuery.perc_paths.ASSET_FORMS_EXPORT +
+                "/" +
+                callbackData[ml].formSummary.name +
+                ".csv"
+            )
+          );
+          $menuLabel.attr("target", "_blank");
+        }
+
+        $menuLabel.css({
+          "text-decoration": "none",
+          padding: "5px",
+          "font-family": "Verdana",
+          "font-size": "11px",
+          color: "white",
+          display: "block",
+          width: "100%",
+        });
+      }
+      // add the new class, use with identifier unique
+      if (optionClasses[ml]) {
+        $menuItem.addClass(optionClasses[ml]);
+      }
+      // configure each menu item
+      $menuItem
+        .data("callbackData", callbackData[ml])
+        .data("callback", callbacks[ml])
+        .append($menuLabel)
+        // on click event
+        .on("click", function (evt) {
+          let menuItem = $(this);
+          var data = menuItem.data("callbackData");
+          var callback = menuItem.data("callback");
+          var menuItems = menuItem.parent();
+          menuItems.hide();
+          callback(data);
+        })
+        .on("mouseenter", function (e) {
+          let menuItem = $(this);
+          menuItem.addClass("perc-simplemenu-menuitem-hover");
+        })
+        .on("mouseleave", function (e) {
+          let menuItem = $(this);
+          menuItem.removeClass("perc-simplemenu-menuitem-hover");
+        });
+      $menuItems.append($menuItem);
     }
-    
-    function collapseMenu(menu) {
-        var config = menu.data("config");
-        var menuItems = menu.find(".perc-simplemenu-menuitems");
-        var menuTitleExpanded  = config.menuTitleExpanded;
-        var menuTitleCollapsed = config.menuTitleCollapsed;
-        var menuTitle = menu.find(".perc-simplemenu-title");
-        
-        menuTitle.html(menuTitleCollapsed);
-        menuItems.hide();
+    $menu.append($menuTitle).append($menuItems);
+    this.append($menu);
+
+    // event handling
+    $menu.data("config", config);
+    $menuItems.hide();
+
+    $menuTitle.find("*").on("click", function (e) {
+      menuTitleClick(e);
+    });
+
+    $menuTitle.on("click", function (e) {
+      menuTitleClick(e);
+    });
+
+    $menuTitle.on("mouseenter", function () {
+      var menuItem = $(this);
+      menuItem.addClass("perc-simplemenu-title-hover");
+    });
+
+    $menuTitle.on("mouseleave", function () {
+      var menuItem = $(this);
+      menuItem.removeClass("perc-simplemenu-title-hover");
+    });
+
+    // hide all menus if you exit the containing document
+    // useful if used inside an iframe like a gadget
+    $(document)
+      .on("mouseenter", null)
+      .on("mouseleave", function () {
+        hideAllMenus();
+      });
+
+    // hide all menus when clicking on body
+    $("body").on("click", function (event) {
+      var target = $(event.target);
+      var noParents = target.parents().length === 0;
+      var menuParent = target.parent().hasClass("perc-simplemenu-menu");
+      if (!noParents && !menuParent) hideAllMenus();
+    });
+  };
+
+  function hideAllMenus() {
+    var allMenus = $(".perc-simplemenu-menu");
+
+    $.each(allMenus, function () {
+      var menu = $(this);
+      collapseMenu(menu);
+    });
+  }
+
+  // show the menu when you click on the title
+  function menuTitleClick(event) {
+    var menu = $($(event.target).parents(".perc-simplemenu-menu")[0]);
+    var config = menu.data("config");
+    if (config === undefined) return;
+    var menuItems = menu.find(".perc-simplemenu-menuitems");
+    var menuTitleExpanded = config.menuTitleExpanded;
+    var menuTitleCollapsed = config.menuTitleCollapsed;
+    var menuTitle = menu.find(".perc-simplemenu-title");
+
+    var visible = menuItems.css("display") === "block";
+
+    hideAllMenus();
+
+    if (visible) {
+      collapseMenu(menu);
+    } else {
+      expandMenu(menu);
     }
+  }
+
+  function expandMenu(menu) {
+    var config = menu.data("config");
+    var menuItems = menu.find(".perc-simplemenu-menuitems");
+    var menuTitleExpanded = config.menuTitleExpanded;
+    var menuTitleCollapsed = config.menuTitleCollapsed;
+    var menuTitle = menu.find(".perc-simplemenu-title");
+
+    setTitleContent(menuTitle, menuTitleExpanded);
+    menuItems.css("position", "absolute");
+    // Get pagination control as a reference to calculate menu's position (upwards or downwards)
+    var oPaginate = $("#" + menu.parents("table").attr("id") + "_paginate");
+    if (oPaginate) {
+      // Recalculate the position of Action menu when this appears behind the paging controls
+      // fix: 5 pixel of diference between IE and FF
+      if (
+        menu.position()["top"] +
+          menu.outerHeight() +
+          menuItems.outerHeight() +
+          5 >
+        oPaginate.position()["top"]
+      ) {
+        menuItems.css(
+          "margin-top",
+          (menu.outerHeight() + menuItems.outerHeight()) * -1
+        );
+      } else {
+        menuItems.css("margin-top", 0);
+      }
+    }
+    menuItems.show();
+
+    // TODO: make this a configuration. for some reason in IE it loses the width of the menu and it shrinks.
+    if ($.browser.msie) menuItems.width(config.menuWidth);
+  }
+
+  function collapseMenu(menu) {
+    var config = menu.data("config");
+    var menuItems = menu.find(".perc-simplemenu-menuitems");
+    var menuTitleExpanded = config.menuTitleExpanded;
+    var menuTitleCollapsed = config.menuTitleCollapsed;
+    var menuTitle = menu.find(".perc-simplemenu-title");
+
+    setTitleContent(menuTitle, menuTitleCollapsed);
+    menuItems.hide();
+  }
 })(jQuery);

--- a/WebUI/war/widgets/PercSimpleMenu.js
+++ b/WebUI/war/widgets/PercSimpleMenu.js
@@ -89,12 +89,22 @@
       return $("<span>").text(String(label));
     }
     var trimmed = label.trim();
+    // First-party "<a>label</a>" only: parse with DOMParser and take textContent.
+    // Do NOT regex-strip tags (CodeQL js/incomplete-multi-character-sanitization #1780).
     if (/^<a[\s>]/i.test(trimmed) && /<\/a>\s*$/i.test(trimmed)) {
-      var text = trimmed
-        .replace(/^<a[^>]*>/i, "")
-        .replace(/<\/a>\s*$/i, "")
-        .replace(/<[^>]+>/g, "");
-      return $("<a>").text(text);
+      try {
+        var doc = new DOMParser().parseFromString(trimmed, "text/html");
+        var anchors = doc.body ? doc.body.getElementsByTagName("a") : [];
+        if (
+          anchors.length === 1 &&
+          doc.body.children.length === 1 &&
+          anchors[0].tagName === "A"
+        ) {
+          return $("<a>").text(anchors[0].textContent || "");
+        }
+      } catch (e) {
+        // fall through to plain text
+      }
     }
     // Plain text or any other string — never pass to $() HTML constructor
     return $("<span>").text(label);

--- a/WebUI/war/widgets/PercSimpleMenu/PercSimpleMenu.js
+++ b/WebUI/war/widgets/PercSimpleMenu/PercSimpleMenu.js
@@ -21,226 +21,234 @@
  *
  *  Implements a simple dropdown menu
  */
-(function($) {
+(function ($) {
+  /**
+   *  PercSimpleMenu()
+   *  plugin implementation
+   *
+   *  @param config
+   *  {   title : "Menu Title",         Clickable title at top to show/hide menu below. Omit if using an background image (optional)
+   *       menuItemsAlign : "left",     Render menu to the left of title. Default position is below and right of title (optional)
+   *       stayInsideOf : "#selector",  jQuery selector of container to stay inside. If menu doesnt fit, it will render to the left and/or above. Overules menuItemsAlign (optional)
+   *       items : [                    Array of menu items (required)
+   *           {   label : "Open",      Label of menu item. At least one. Can be HTML (required)
+   *               callback : open,     Callback function to call whem menu item is clicked (optional)
+   *               data : "page-id-1"   Data to pass when callback. Can be object/anything (optional)
+   *           },
+   *           {   label : "Preview",   Label of menu item. At least one. Can be HTML (required)
+   *               callback : preview,  Callback function to call whem menu item is clicked (optional)
+   *               data : "page-path-1" Data to pass when callback. Can be object/anything (optional)
+   *           }, etc...
+   *  ]};
+   *
+   *  Generates the following DOM
+   *
+   *   <pre>
+   *   <div class="perc-simplemenu">
+   *       <div class="perc-simplemenu-title perc-simplemenu-title-deselected">Title</div>
+   *       <div class="perc-simplemenu-menuitems" style="display: none;">
+   *           <div class="perc-simplemenu-menuitem perc-index-0">Open</div>
+   *           <div class="perc-simplemenu-menuitem perc-index-1">Preview</div>
+   *       </div>
+   *   </div>
+   *   </pre>
+   *
+   *  +-----+
+   *  |Title|         click: show menu items, click again: hide menu items
+   *  +-----+-----+
+   *  |Open       |   click: open() and hide menu items
+   *  +-----------+
+   *  |Preview    |   click: preview() and hide menu items
+   *  +-----------+
+   */
+  $.fn.PercSimpleMenu = function (config) {
+    var title = config.title;
+    var items = config.items;
 
-    /**
-     *  PercSimpleMenu()
-     *  plugin implementation
-     *
-     *  @param config
-     *  {   title : "Menu Title",         Clickable title at top to show/hide menu below. Omit if using an background image (optional)
-     *       menuItemsAlign : "left",     Render menu to the left of title. Default position is below and right of title (optional)
-     *       stayInsideOf : "#selector",  jQuery selector of container to stay inside. If menu doesnt fit, it will render to the left and/or above. Overules menuItemsAlign (optional)
-     *       items : [                    Array of menu items (required)
-     *           {   label : "Open",      Label of menu item. At least one. Can be HTML (required)
-     *               callback : open,     Callback function to call whem menu item is clicked (optional)
-     *               data : "page-id-1"   Data to pass when callback. Can be object/anything (optional)
-     *           },
-     *           {   label : "Preview",   Label of menu item. At least one. Can be HTML (required)
-     *               callback : preview,  Callback function to call whem menu item is clicked (optional)
-     *               data : "page-path-1" Data to pass when callback. Can be object/anything (optional)
-     *           }, etc...
-     *  ]};
-     *
-     *  Generates the following DOM
-     *
-     *   <pre>
-     *   <div class="perc-simplemenu">
-     *       <div class="perc-simplemenu-title perc-simplemenu-title-deselected">Title</div>
-     *       <div class="perc-simplemenu-menuitems" style="display: none;">
-     *           <div class="perc-simplemenu-menuitem perc-index-0">Open</div>
-     *           <div class="perc-simplemenu-menuitem perc-index-1">Preview</div>
-     *       </div>
-     *   </div>
-     *   </pre>
-     *
-     *  +-----+
-     *  |Title|         click: show menu items, click again: hide menu items
-     *  +-----+-----+
-     *  |Open       |   click: open() and hide menu items
-     *  +-----------+
-     *  |Preview    |   click: preview() and hide menu items
-     *  +-----------+
-     */
-    $.fn.PercSimpleMenu = function(config) {
-        var title = config.title;
-        var items = config.items;
-        
-        var menu = $("<div class='perc-simplemenu'>");
-        var menuTitle = $("<div class='perc-simplemenu-title perc-simplemenu-title-deselected'>")
-            .append(title);
-        menu.append(menuTitle);
-        var menuItems = $("<div class='perc-simplemenu-menuitems'>");
-        menu.append(menuItems);
-        
-        menu.data("config", config);
-        
-        $.each(items, function(index, menuItem){
-            var menuItemClass = "perc-menu-item";
-            if(index == items.length - 1) {
-                menuItemClass = "perc-menu-last-item";
-            }
-            var label = menuItem.label;
-            var callback = menuItem.callback;
-            var data = menuItem.data;
-            
-            var menuItemDom = $("<div class='perc-simplemenu-menuitem perc-index-"+index+"'>")
-                .append(label)
-                .addClass(menuItemClass)
-                .data("callback",callback)
-                .on("click",function(event){
-                    menuItemClicked(event);
-                    var callback = $(this).data("callback");
-                    var data = menu.data("data");
-                    event.data = data;
-                    callback(event);
-                })
-                .on("mouseenter",function () {
-                    $(this).css('color', '#000');})
-                .on("mouseleave",function(){ $(this).css('color', '#fff');});
-                
-            if(data)
-                menuItemDom.data("data",data);
-                
-            menuItems.append(menuItemDom);
+    var menu = $("<div class='perc-simplemenu'>");
+    var menuTitle = $(
+      "<div class='perc-simplemenu-title perc-simplemenu-title-deselected'>"
+    ).append(title);
+    menu.append(menuTitle);
+    var menuItems = $("<div class='perc-simplemenu-menuitems'>");
+    menu.append(menuItems);
+
+    menu.data("config", config);
+
+    $.each(items, function (index, menuItem) {
+      var menuItemClass = "perc-menu-item";
+      if (index == items.length - 1) {
+        menuItemClass = "perc-menu-last-item";
+      }
+      var label = menuItem.label;
+      var callback = menuItem.callback;
+      var data = menuItem.data;
+
+      // Build menu item without HTML string interpolation of index
+      var menuItemDom = $("<div>")
+        .addClass("perc-simplemenu-menuitem")
+        .addClass("perc-index-" + index)
+        .append(
+          // Labels that are plain strings must not go through $() HTML parse
+          label && label.jquery
+            ? label
+            : typeof label === "object" && label && label.nodeType
+              ? label
+              : $("<span>").text(label == null ? "" : String(label))
+        )
+        .addClass(menuItemClass)
+        .data("callback", callback)
+        .on("click", function (event) {
+          menuItemClicked(event);
+          var callback = $(this).data("callback");
+          var data = menu.data("data");
+          event.data = data;
+          callback(event);
+        })
+        .on("mouseenter", function () {
+          $(this).css("color", "#000");
+        })
+        .on("mouseleave", function () {
+          $(this).css("color", "#fff");
         });
-        
-        $(this).append(menu);
-        
-        menuTitle.on("click",function(e){
-            menuTitleClicked(e);
-        });
-        menu.on("mouseenter",function(e){
-            menuHoverIn(e);
-        }).on("mouseleave",function(e){
-            menuHoverOut(e);
-        });
-        
-        return $(menu);
-    };
 
-    /**
-     *  menuTitleClicked()
-     *
-     *  Handles clicking of title
-     *
-     *  Toggles between classes:
-     *  perc-simplemenu-title-deselected and hides the menu items
-     *  perc-simplemenu-title-selected   and shows the menu items
-     */
-    function menuTitleClicked(event) {
-        var menuTitle = $(event.currentTarget);
-        if(menuTitle.hasClass("perc-simplemenu-title-deselected")) {
-            menuTitle
-                .addClass("perc-simplemenu-title-selected")
-                .removeClass("perc-simplemenu-title-deselected");
-            showMenuItems(event);
-        } else {
-            menuTitle
-                .removeClass("perc-simplemenu-title-selected")
-                .addClass("perc-simplemenu-title-deselected");
-            hideMenuItems(event);
-        }
-    }
-    
-    var _hidemenu = true;
-    var _lastCurrentTarget = null;
-    function menuHoverIn(event) {
-        if(_lastCurrentTarget == event.currentTarget)
-            _hidemenu = false;
-    }
-    
-    function menuHoverOut(event) {
-        _hidemenu = true;
-        _lastCurrentTarget = event.currentTarget;
-        setTimeout(function()
-                {
-                    if(_hidemenu)
-                        hideMenuItems(event);
-                }
-        ,500);
-    }
+      if (data) menuItemDom.data("data", data);
 
-    /**
-     *  showMenuItems()
-     *
-     *  Displays the menu items when the title is clicked.
-     *  By default positions the menu items below and to the right of the title.
-     *  Unless configured to show to the left of the title.
-     *  Unless configured to stay above and to the left of the right and bottom edgets of an ancestor containing element.
-     *
-     */
-    function showMenuItems(event) {
-        var menuTitle = $(event.currentTarget);
-        var menuItems = menuTitle.next();
-        var menuItemsWidth = menuItems.width();
-        
-        var menu = menuTitle.parents(".perc-simplemenu");
-        var config = menu.data("config");
-        
-        var menuItemsTop  = menuTitle.offset().top + menuTitle.height();
-        var menuItemsLeft = menuTitle.offset().left;
-        if(config.menuItemsAlign == "left")
-            menuItemsLeft = menuItemsLeft-menuItemsWidth+menuTitle.width();
-        
-        if(config.stayInsideOf) {
-            // calculate bottom position of container and menu items
-            var container = menu.parents(config.stayInsideOf);
-            
-            var containerTop = container.offset().top;
-            var containerHeight = container.height();
-            var containerBottom = containerTop + containerHeight;
-            
-            var menuItemsHeight = menuItems.height();
-            var menuItemsBottom = menuItemsTop + menuItemsHeight;
-            // if menu items dont fit, display them above the title
-            var menuItemsTopNew; 
-            if(menuItemsBottom > containerBottom)
-                menuItemsTopNew = menuItemsTop - menuItemsHeight - menuTitle.height();
+      menuItems.append(menuItemDom);
+    });
 
-            // but dont flip the menu if it's going to show in negative vertical position
-            if(menuItemsTopNew > containerTop)
-                menuItemsTop = menuItemsTopNew;
+    $(this).append(menu);
 
-            // if already configure to render to the left, dont bother checking right edge of container
-            // other wise if right edge of menu spills over the right edge of the container, render it to the left of the title
-            if(config.menuItemsAlign != "left") {
-                var containerLeft = container.offset().left;
-                var containerWidth = container.width();
-                var containerRight = containerLeft + containerWidth;
-                
-                var menuItemsRight = menuItemsLeft + menuItemsWidth;
-                
-                if(menuItemsRight > containerRight)
-                    menuItemsLeft = menuItemsLeft - menuItemsWidth + menuTitle.width();
-            }
-        }
-        
-        menuItems
-            .css("position","absolute")
-//            .css("top", "15px")
-  //          .css("left", "-15px");
-            .css("top", menuItemsTop+"px")
-            .css("left", menuItemsLeft+"px");
-        
-        menuItems.show();
+    menuTitle.on("click", function (e) {
+      menuTitleClicked(e);
+    });
+    menu
+      .on("mouseenter", function (e) {
+        menuHoverIn(e);
+      })
+      .on("mouseleave", function (e) {
+        menuHoverOut(e);
+      });
+
+    return $(menu);
+  };
+
+  /**
+   *  menuTitleClicked()
+   *
+   *  Handles clicking of title
+   *
+   *  Toggles between classes:
+   *  perc-simplemenu-title-deselected and hides the menu items
+   *  perc-simplemenu-title-selected   and shows the menu items
+   */
+  function menuTitleClicked(event) {
+    var menuTitle = $(event.currentTarget);
+    if (menuTitle.hasClass("perc-simplemenu-title-deselected")) {
+      menuTitle
+        .addClass("perc-simplemenu-title-selected")
+        .removeClass("perc-simplemenu-title-deselected");
+      showMenuItems(event);
+    } else {
+      menuTitle
+        .removeClass("perc-simplemenu-title-selected")
+        .addClass("perc-simplemenu-title-deselected");
+      hideMenuItems(event);
     }
-    
-    function hideMenuItems(event) {
-        var currentTarget = $(event.currentTarget);
-        var menu = currentTarget;
-        if(!currentTarget.hasClass("perc-simplemenu"))
-            menu = currentTarget.parents(".perc-simplemenu");
-        var menuTitle = menu.find(".perc-simplemenu-title");
-        menuTitle
-            .removeClass("perc-simplemenu-title-selected")
-            .addClass("perc-simplemenu-title-deselected");
-        var menuItems = menu.find(".perc-simplemenu-menuitems");
-        menuItems.hide();
-    }
-    
-    function menuItemClicked(event) {
-        hideMenuItems(event);
+  }
+
+  var _hidemenu = true;
+  var _lastCurrentTarget = null;
+  function menuHoverIn(event) {
+    if (_lastCurrentTarget == event.currentTarget) _hidemenu = false;
+  }
+
+  function menuHoverOut(event) {
+    _hidemenu = true;
+    _lastCurrentTarget = event.currentTarget;
+    setTimeout(function () {
+      if (_hidemenu) hideMenuItems(event);
+    }, 500);
+  }
+
+  /**
+   *  showMenuItems()
+   *
+   *  Displays the menu items when the title is clicked.
+   *  By default positions the menu items below and to the right of the title.
+   *  Unless configured to show to the left of the title.
+   *  Unless configured to stay above and to the left of the right and bottom edgets of an ancestor containing element.
+   *
+   */
+  function showMenuItems(event) {
+    var menuTitle = $(event.currentTarget);
+    var menuItems = menuTitle.next();
+    var menuItemsWidth = menuItems.width();
+
+    var menu = menuTitle.parents(".perc-simplemenu");
+    var config = menu.data("config");
+
+    var menuItemsTop = menuTitle.offset().top + menuTitle.height();
+    var menuItemsLeft = menuTitle.offset().left;
+    if (config.menuItemsAlign == "left")
+      menuItemsLeft = menuItemsLeft - menuItemsWidth + menuTitle.width();
+
+    if (config.stayInsideOf) {
+      // calculate bottom position of container and menu items
+      var container = menu.parents(config.stayInsideOf);
+
+      var containerTop = container.offset().top;
+      var containerHeight = container.height();
+      var containerBottom = containerTop + containerHeight;
+
+      var menuItemsHeight = menuItems.height();
+      var menuItemsBottom = menuItemsTop + menuItemsHeight;
+      // if menu items dont fit, display them above the title
+      var menuItemsTopNew;
+      if (menuItemsBottom > containerBottom)
+        menuItemsTopNew = menuItemsTop - menuItemsHeight - menuTitle.height();
+
+      // but dont flip the menu if it's going to show in negative vertical position
+      if (menuItemsTopNew > containerTop) menuItemsTop = menuItemsTopNew;
+
+      // if already configure to render to the left, dont bother checking right edge of container
+      // other wise if right edge of menu spills over the right edge of the container, render it to the left of the title
+      if (config.menuItemsAlign != "left") {
+        var containerLeft = container.offset().left;
+        var containerWidth = container.width();
+        var containerRight = containerLeft + containerWidth;
+
+        var menuItemsRight = menuItemsLeft + menuItemsWidth;
+
+        if (menuItemsRight > containerRight)
+          menuItemsLeft = menuItemsLeft - menuItemsWidth + menuTitle.width();
+      }
     }
 
+    menuItems
+      .css("position", "absolute")
+      //            .css("top", "15px")
+      //          .css("left", "-15px");
+      .css("top", menuItemsTop + "px")
+      .css("left", menuItemsLeft + "px");
+
+    menuItems.show();
+  }
+
+  function hideMenuItems(event) {
+    var currentTarget = $(event.currentTarget);
+    var menu = currentTarget;
+    if (!currentTarget.hasClass("perc-simplemenu"))
+      menu = currentTarget.parents(".perc-simplemenu");
+    var menuTitle = menu.find(".perc-simplemenu-title");
+    menuTitle
+      .removeClass("perc-simplemenu-title-selected")
+      .addClass("perc-simplemenu-title-deselected");
+    var menuItems = menu.find(".perc-simplemenu-menuitems");
+    menuItems.hide();
+  }
+
+  function menuItemClicked(event) {
+    hideMenuItems(event);
+  }
 })(jQuery);

--- a/modules/perc-packages/src/main/resources/Packages/perc.CategoryDropDownControl/SupportFile-rx_resources/widgets/categoryDropDown/js/categoryDropdown.js
+++ b/modules/perc-packages/src/main/resources/Packages/perc.CategoryDropDownControl/SupportFile-rx_resources/widgets/categoryDropDown/js/categoryDropdown.js
@@ -283,7 +283,11 @@
     }
 
     function createSubCategorySelect(name, id) {
-      var subCategories = $('<select id="' + id + '" name="' + name + '" />');
+      // Build via attr APIs — never interpolate name/id into an HTML string
+      // (CodeQL js/html-constructed-from-input #1408/#1409).
+      var subCategories = $("<select>")
+        .attr("id", id == null ? "" : String(id))
+        .attr("name", name == null ? "" : String(name));
       if (readonly === "yes")
         $("#datadisplay-" + paramName).append(subCategories);
       else $("#maindiv-" + paramName).append(subCategories);


### PR DESCRIPTION
## Summary

Closes remaining **product medium** JS alerts while Vijay works highs and the vendor/DataTable rescans finish:

| Alert | Rule | File |
|-------|------|------|
| #1681, #434 | `js/unsafe-jquery-plugin` | `PercSimpleMenu.js` (+ war) |
| #1408, #1409 | `js/html-constructed-from-input` | `categoryDropdown.js` |

### PercSimpleMenu
Pre-fix used `$(menuLabels[ml])`, which HTML-parses strings. Now `resolveMenuLabel()`:
- never passes plain/hostile strings to `$()`
- plain labels → `$(\"<span>\").text(...)`
- simple first-party `<a>…</a>` → real `<a>` with text only (href still set from trusted form export path)
- expand/collapse title uses `setTitleContent` (no bare `.html()` for plain text)

### categoryDropDown
```js
// before
$('<select id=\"' + id + '\" name=\"' + name + '\" />')
// after
$(\"<select>\").attr(\"id\", id).attr(\"name\", name)
```

### Tests
```
npx vitest run src/test/js/percSimpleMenuSafety.test.js src/test/js/categoryDropdownSafety.test.js
# 5 passed
```

## Test plan
- [x] Unit tests green
- [ ] CodeQL Advanced clears #1681 / #1408 / #1409
- [ ] Forms export menu still shows Export link when submissions &gt; 0 (manual smoke if available)