### PR TITLE
fix(webui): close remaining js/incomplete-sanitization CodeQL alerts (14)

### DIFF
--- a/WebUI/src/main/webapp/WEB-INF/classes/features/perc/getDashboardColumn/perc_getDashboardColumn.js
+++ b/WebUI/src/main/webapp/WEB-INF/classes/features/perc/getDashboardColumn/perc_getDashboardColumn.js
@@ -15,13 +15,21 @@ gadgets.window = gadgets.window || {};
  * Sanitisation rationale: the raw regex capture from `RegExp.exec` is
  * never safe to flow into a downstream string context (selector, URL,
  * data-context attribute). This helper was flagged by GitHub CodeQL as
- * `js/incomplete-sanitization`; the fix URL-decodes the captured value
- * and reduces it to an allow-listed character set so callers can
- * concatenate the result without a second pass of escaping.
+ * `js/incomplete-sanitization`; the fix (1) allow-lists the parameter
+ * *name* before building the RegExp (no incomplete `[` / `]` first-only
+ * escape), (2) URL-decodes the captured value, and (3) reduces it to a
+ * safe character set so callers can concatenate the result without a
+ * second pass of escaping.
  */
 function __gup( name )
 {
-  name = name.replace(/[\[]/,"\\\[").replace(/[\]]/,"\\\]");
+  // Parameter names are fixed gadget identifiers (e.g. "mid"). Reject
+  // anything outside a safe identifier set so we never build a RegExp from
+  // untrusted text. (Closes js/incomplete-sanitization on the previous
+  // non-global [ / ] escape.)
+  if (typeof name !== "string" || !/^[A-Za-z0-9._-]+$/.test(name)) {
+    return "";
+  }
   var regexS = "[\\?&]"+name+"=([^&#]*)";
   var regex = new RegExp( regexS );
   var results = regex.exec( window.location.href );

--- a/WebUI/src/main/webapp/cm/WEB-INF/classes/features/perc/getDashboardColumn/perc_getDashboardColumn.js
+++ b/WebUI/src/main/webapp/cm/WEB-INF/classes/features/perc/getDashboardColumn/perc_getDashboardColumn.js
@@ -15,13 +15,21 @@ gadgets.window = gadgets.window || {};
  * Sanitisation rationale: the raw regex capture from `RegExp.exec` is
  * never safe to flow into a downstream string context (selector, URL,
  * data-context attribute). This helper was flagged by GitHub CodeQL as
- * `js/incomplete-sanitization`; the fix URL-decodes the captured value
- * and reduces it to an allow-listed character set so callers can
- * concatenate the result without a second pass of escaping.
+ * `js/incomplete-sanitization`; the fix (1) allow-lists the parameter
+ * *name* before building the RegExp (no incomplete `[` / `]` first-only
+ * escape), (2) URL-decodes the captured value, and (3) reduces it to a
+ * safe character set so callers can concatenate the result without a
+ * second pass of escaping.
  */
 function __gup( name )
 {
-  name = name.replace(/[\[]/,"\\\[").replace(/[\]]/,"\\\]");
+  // Parameter names are fixed gadget identifiers (e.g. "mid"). Reject
+  // anything outside a safe identifier set so we never build a RegExp from
+  // untrusted text. (Closes js/incomplete-sanitization on the previous
+  // non-global [ / ] escape.)
+  if (typeof name !== "string" || !/^[A-Za-z0-9._-]+$/.test(name)) {
+    return "";
+  }
   var regexS = "[\\?&]"+name+"=([^&#]*)";
   var regex = new RegExp( regexS );
   var results = regex.exec( window.location.href );

--- a/WebUI/src/main/webapp/cm/app/includes/siteimprove_integration.html
+++ b/WebUI/src/main/webapp/cm/app/includes/siteimprove_integration.html
@@ -166,7 +166,7 @@
             return;
           } else {
             var dataStr = results.metadata.data;
-            dataStr = dataStr.replace("\\", "");
+            dataStr = dataStr.replace(/\\/g, "");
             //get our site info from the meta data
             var parsedMetadata = JSON.parse(dataStr);
 
@@ -186,7 +186,7 @@
 
     function getParameterByName(name) {
       url = window.location.href;
-      name = name.replace(/[\[\]]/g, "\\$&");
+      name = String(name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
         results = regex.exec(url);
       if (!results) return null;

--- a/WebUI/src/main/webapp/cm/app/js/legacy/plugins/perc_css_utils.js
+++ b/WebUI/src/main/webapp/cm/app/js/legacy/plugins/perc_css_utils.js
@@ -104,7 +104,7 @@
     // all selectors are IDs (looking for #), and that the resulting properties
     // are properly terminated.
 
-    cssString = cssString.replace('"', ""); // HACK!
+    cssString = cssString.replace(/"/g, ""); // HACK! strip all double-quotes
 
     var cssSelectors = getRegionSelectorsFrom(cssString);
     var regionCSS = {};

--- a/WebUI/src/main/webapp/cm/app/js/legacy/services/PercUserService.js
+++ b/WebUI/src/main/webapp/cm/app/js/legacy/services/PercUserService.js
@@ -173,7 +173,7 @@
       );
       return;
     }
-    usernameStartsWith = usernameStartsWith.replace("%", "*");
+    usernameStartsWith = usernameStartsWith.replace(/%/g, "*");
     if (!usernameStartsWith.endsWith("*"))
       usernameStartsWith = usernameStartsWith + "*";
     var urlfindExternalUsernamesThatStartwith =

--- a/WebUI/src/main/webapp/cm/pages/app/includes/siteimprove_integration.html
+++ b/WebUI/src/main/webapp/cm/pages/app/includes/siteimprove_integration.html
@@ -166,7 +166,7 @@
             return;
           } else {
             var dataStr = results.metadata.data;
-            dataStr = dataStr.replace("\\", "");
+            dataStr = dataStr.replace(/\\/g, "");
             //get our site info from the meta data
             var parsedMetadata = JSON.parse(dataStr);
 
@@ -186,7 +186,7 @@
 
     function getParameterByName(name) {
       url = window.location.href;
-      name = name.replace(/[\[\]]/g, "\\$&");
+      name = String(name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
         results = regex.exec(url);
       if (!results) return null;

--- a/WebUI/src/main/webapp/cm/perc_common_ui.js
+++ b/WebUI/src/main/webapp/cm/perc_common_ui.js
@@ -1678,7 +1678,7 @@ var SimpleDateFormat;
   function unescapeFormat(s) {
     return regexEscape(
       s
-        .replace("\\", "")
+        .replace(/\\/g, "")
         .replace(
           /\\(\[)|\\(\])|\[([^\]\[]*)\]|\\(.)/g,
           function (matched, p1, p2, p3, p4) {

--- a/WebUI/src/main/webapp/cm/plugins/perc_css_utils.js
+++ b/WebUI/src/main/webapp/cm/plugins/perc_css_utils.js
@@ -104,7 +104,7 @@
     // all selectors are IDs (looking for #), and that the resulting properties
     // are properly terminated.
 
-    cssString = cssString.replace('"', ""); // HACK!
+    cssString = cssString.replace(/"/g, ""); // HACK! strip all double-quotes
 
     var cssSelectors = getRegionSelectorsFrom(cssString);
     var regionCSS = {};

--- a/WebUI/src/main/webapp/cm/services/PercUserService.js
+++ b/WebUI/src/main/webapp/cm/services/PercUserService.js
@@ -173,7 +173,7 @@
       );
       return;
     }
-    usernameStartsWith = usernameStartsWith.replace("%", "*");
+    usernameStartsWith = usernameStartsWith.replace(/%/g, "*");
     if (!usernameStartsWith.endsWith("*"))
       usernameStartsWith = usernameStartsWith + "*";
     var urlfindExternalUsernamesThatStartwith =

--- a/WebUI/src/main/webapp/cm/widgets/perc_site_map.js
+++ b/WebUI/src/main/webapp/cm/widgets/perc_site_map.js
@@ -2402,7 +2402,7 @@
       for (var i = 0; i < attributeValue_array.length; i++) {
         var tempArrayData = attributeValue_array[i];
         var tempArrayData_arr = tempArrayData.split(":");
-        tempArrayData_arr = tempArrayData_arr[0].replace("{", "");
+        tempArrayData_arr = tempArrayData_arr[0].replace(/\{/g, "");
         Ids_arr.push(tempArrayData_arr.trim());
       }
       for (var j = 0; j < Ids_arr.length; j++) {

--- a/WebUI/src/test/js/percGetDashboardColumn.test.js
+++ b/WebUI/src/test/js/percGetDashboardColumn.test.js
@@ -121,6 +121,15 @@ describe("source-pattern (anti-regression for js/incomplete-sanitization)", () =
     // must exist on the return path.
     expect(src).toMatch(/\.replace\s*\(\s*\/\[\^A-Za-z0-9\._-\]\/g/);
   });
+
+  it("does not use non-global [ / ] first-occurrence replaces for param names", () => {
+    // Pre-residual: name = name.replace(/[\[]/,"\\[").replace(/[\]]/,"\\]");
+    // CodeQL js/incomplete-sanitization (alerts #1110-#1113). Replaced by
+    // an allow-list check on the parameter name before building the RegExp.
+    expect(src).not.toMatch(/name\.replace\s*\(\s*\/\[\\?\[\]\//);
+    expect(src).toMatch(/\[\^A-Za-z0-9\._-\]/);
+    expect(src).toMatch(/typeof name !== "string"/);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -168,6 +177,20 @@ describe("__gup() sanitisation", () => {
       globalThis.percJQuery = () => ({ parent: () => ({ attr: () => null }) });
       loadSource();
       expect(globalThis.__gup("missing")).toBe("");
+    });
+  });
+
+  it("rejects parameter names outside the identifier allow-list", () => {
+    withFreshWindow("http://localhost/?mid=abc&x[0]=evil", () => {
+      globalThis.gadgets = { window: {} };
+      globalThis.percJQuery = () => ({ parent: () => ({ attr: () => null }) });
+      loadSource();
+      expect(globalThis.__gup("x[0]")).toBe("");
+      expect(globalThis.__gup("mid.*")).toBe("");
+      expect(globalThis.__gup("")).toBe("");
+      expect(globalThis.__gup(null)).toBe("");
+      // Normal identifier still works.
+      expect(globalThis.__gup("mid")).toBe("abc");
     });
   });
 

--- a/WebUI/src/test/js/percIncompleteSanitization.test.js
+++ b/WebUI/src/test/js/percIncompleteSanitization.test.js
@@ -1,0 +1,267 @@
+/**
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regression tests for remaining js/incomplete-sanitization CodeQL alerts.
+ *
+ * Closes GitHub CodeQL alerts:
+ *   #1485  perc_site_map.js           — non-global "{" strip
+ *   #1470  PercUserService.js         — non-global "%" → "*"
+ *   #1468  perc_css_utils.js          — non-global '"' strip
+ *   #1467  perc_common_ui.js          — non-global "\\" strip (moment unescapeFormat)
+ *   #1456  legacy PercUserService.js  — lockstep of #1470
+ *   #1454  legacy perc_css_utils.js   — lockstep of #1468
+ *   #1135/#1134  siteimprove pages    — incomplete regex escape + non-global "\\"
+ *   #1116/#1115  siteimprove app      — lockstep of #1135/#1134
+ *
+ * (getDashboardColumn #1110-#1113 residuals covered by percGetDashboardColumn.test.js)
+ *
+ * Pattern: CodeQL flags `.replace(string, ...)` / non-global regex replaces
+ * that only touch the first occurrence of a metacharacter used for
+ * sanitisation. Fix is always a global regex (`/g` flag) or a full
+ * allow-list / full RegExp-escape.
+ */
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { describe, it, expect } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const webapp = (...parts) =>
+  resolve(__dirname, "../../main/webapp", ...parts);
+
+function read(rel) {
+  return readFileSync(webapp(rel), "utf8");
+}
+
+// ---------------------------------------------------------------------------
+// PercUserService — directory-user wildcard: % → * for every occurrence
+// ---------------------------------------------------------------------------
+describe("PercUserService findDirectoryUsers wildcard (alerts #1470/#1456)", () => {
+  const copies = [
+    "cm/services/PercUserService.js",
+    "cm/app/js/legacy/services/PercUserService.js",
+  ];
+
+  for (const rel of copies) {
+    describe(rel, () => {
+      const src = read(rel);
+
+      it("uses a global regex for % → * conversion", () => {
+        expect(src).toMatch(
+          /usernameStartsWith\s*=\s*usernameStartsWith\.replace\s*\(\s*\/%\/g\s*,\s*["']\*["']\s*\)/
+        );
+      });
+
+      it("does not use a first-only string replace for %", () => {
+        expect(src).not.toMatch(
+          /usernameStartsWith\.replace\s*\(\s*["']%["']\s*,/
+        );
+      });
+    });
+  }
+
+  it("behaviourally converts every % to *", () => {
+    // Mirror of the production expression.
+    const convert = (s) => s.replace(/%/g, "*");
+    expect(convert("a%b%c")).toBe("a*b*c");
+    expect(convert("%admin%")).toBe("*admin*");
+    expect(convert("plain")).toBe("plain");
+  });
+
+  it("pre-fix first-only replace leaves trailing % characters", () => {
+    // Documents why the /g flag is load-bearing.
+    const preFix = (s) => s.replace("%", "*");
+    expect(preFix("a%b%c")).toBe("a*b%c");
+    expect(preFix("a%b%c")).not.toBe("a*b*c");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// perc_css_utils — strip every double-quote before domain CSS parse
+// ---------------------------------------------------------------------------
+describe("perc_css_utils parse_region_css quote strip (alerts #1468/#1454)", () => {
+  const copies = [
+    "cm/plugins/perc_css_utils.js",
+    "cm/app/js/legacy/plugins/perc_css_utils.js",
+  ];
+
+  for (const rel of copies) {
+    describe(rel, () => {
+      const src = read(rel);
+
+      it("uses a global regex to strip double-quotes", () => {
+        expect(src).toMatch(
+          /cssString\s*=\s*cssString\.replace\s*\(\s*\/"\/g\s*,\s*["']{2}\s*\)/
+        );
+      });
+
+      it("does not use a first-only string replace for quotes", () => {
+        // Pre-fix: cssString.replace('"', "") or cssString.replace('"', "")
+        expect(src).not.toMatch(
+          /cssString\.replace\s*\(\s*['"]\"['"]\s*,\s*["']{2}\s*\)/
+        );
+      });
+    });
+  }
+
+  it("behaviourally strips every double-quote", () => {
+    const strip = (s) => s.replace(/"/g, "");
+    expect(strip('#r1{color:"red";font:"Arial"}')).toBe(
+      "#r1{color:red;font:Arial}"
+    );
+    expect(strip('a"b"c"d')).toBe("abcd");
+  });
+
+  it("pre-fix first-only replace leaves remaining quotes", () => {
+    const preFix = (s) => s.replace('"', "");
+    expect(preFix('a"b"c')).toBe('ab"c');
+    expect(preFix('a"b"c')).not.toBe("abc");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// perc_site_map getJsonObj — strip every "{" when normalising unquoted JSON
+// ---------------------------------------------------------------------------
+describe("perc_site_map getJsonObj brace strip (alert #1485)", () => {
+  const src = read("cm/widgets/perc_site_map.js");
+
+  it("uses a global regex to strip opening braces", () => {
+    // tempArrayData_arr = tempArrayData_arr[0].replace(/\{/g, "");
+    expect(src).toMatch(
+      /tempArrayData_arr\[0\]\.replace\s*\(\s*\/\\\{\/g\s*,\s*["']{2}\s*\)/
+    );
+  });
+
+  it("does not use a first-only string replace for {", () => {
+    expect(src).not.toMatch(
+      /tempArrayData_arr\[0\]\.replace\s*\(\s*["']\{["']\s*,/
+    );
+  });
+
+  it("behaviourally strips every opening brace", () => {
+    const strip = (s) => s.replace(/\{/g, "");
+    expect(strip("{{foo:1},{bar:2}")).toBe("foo:1},bar:2}");
+    expect(strip("{a:{b:1}}")).toBe("a:b:1}}");
+  });
+
+  it("pre-fix first-only replace leaves remaining braces", () => {
+    const preFix = (s) => s.replace("{", "");
+    expect(preFix("{{a:1}")).toBe("{a:1}");
+    expect(preFix("{{a:1}")).not.toBe("a:1}");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// siteimprove_integration — backslash strip + full RegExp escape
+// ---------------------------------------------------------------------------
+describe("siteimprove_integration.html (alerts #1134/#1135/#1115/#1116)", () => {
+  const copies = [
+    "cm/app/includes/siteimprove_integration.html",
+    "cm/pages/app/includes/siteimprove_integration.html",
+  ];
+
+  for (const rel of copies) {
+    describe(rel, () => {
+      const src = read(rel);
+
+      it("strips every backslash from metadata with a global regex", () => {
+        // dataStr = dataStr.replace(/\\/g, "");
+        expect(src).toMatch(
+          /dataStr\s*=\s*dataStr\.replace\s*\(\s*\/\\\\\/g\s*,\s*["']{2}\s*\)/
+        );
+      });
+
+      it("does not use a first-only string replace for backslash", () => {
+        // Pre-fix: dataStr.replace("\\", "")
+        expect(src).not.toMatch(
+          /dataStr\.replace\s*\(\s*["']\\\\["']\s*,\s*["']{2}\s*\)/
+        );
+      });
+
+      it("uses a full RegExp-escape for query-param names (incl. backslash)", () => {
+        // name = String(name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        expect(src).toMatch(/String\s*\(\s*name\s*\)\.replace\s*\(/);
+        // Character class must include backslash and common metacharacters;
+        // replacement must use $& (whole match) with a leading escape.
+        expect(src).toContain("[.*+?^${}()|[\\]\\\\]");
+        expect(src).toContain("$&");
+      });
+
+      it("does not use the incomplete [ / ] only escape", () => {
+        // Pre-fix: name.replace(/[\[\]]/g, "\\$&") — no backslash escape
+        expect(src).not.toMatch(
+          /name\s*=\s*name\.replace\s*\(\s*\/\[\\\[\\\]\]\/g/
+        );
+      });
+    });
+  }
+
+  it("behaviourally strips every backslash from metadata", () => {
+    const strip = (s) => s.replace(/\\/g, "");
+    expect(strip('{\\"a\\":1}')).toBe('{"a":1}');
+    expect(strip("a\\b\\c")).toBe("abc");
+  });
+
+  it("pre-fix first-only backslash strip leaves remaining escapes", () => {
+    const preFix = (s) => s.replace("\\", "");
+    expect(preFix("a\\b\\c")).toBe("ab\\c");
+    expect(preFix("a\\b\\c")).not.toBe("abc");
+  });
+
+  it("behaviourally escapes all RegExp metacharacters including backslash", () => {
+    const escape = (s) =>
+      String(s).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    expect(escape("id")).toBe("id");
+    expect(escape("a.b")).toBe("a\\.b");
+    expect(escape("x[0]")).toBe("x\\[0\\]");
+    expect(escape("a\\b")).toBe("a\\\\b");
+    // Incomplete pre-fix only handled [ and ]:
+    const preFix = (s) => s.replace(/[\[\]]/g, "\\$&");
+    expect(preFix("a.b")).toBe("a.b"); // still special in RegExp
+    expect(preFix("a\\b")).toBe("a\\b"); // backslash not escaped
+  });
+});
+
+// ---------------------------------------------------------------------------
+// perc_common_ui.js — moment.js unescapeFormat non-global backslash strip
+// ---------------------------------------------------------------------------
+describe("perc_common_ui.js moment unescapeFormat (alert #1467)", () => {
+  const src = read("cm/perc_common_ui.js");
+
+  it("uses a global regex to strip backslashes inside unescapeFormat", () => {
+    // .replace(/\\/g, "") in the unescapeFormat body
+    const fnStart = src.indexOf("function unescapeFormat");
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnBody = src.slice(fnStart, fnStart + 400);
+    expect(fnBody).toMatch(/\.replace\s*\(\s*\/\\\\\/g\s*,\s*["']{2}\s*\)/);
+  });
+
+  it("does not use a first-only string replace for backslash in unescapeFormat", () => {
+    const fnStart = src.indexOf("function unescapeFormat");
+    const fnBody = src.slice(fnStart, fnStart + 400);
+    expect(fnBody).not.toMatch(
+      /\.replace\s*\(\s*["']\\\\["']\s*,\s*["']{2}\s*\)/
+    );
+  });
+
+  it("behaviourally strips every backslash", () => {
+    const strip = (s) => s.replace(/\\/g, "");
+    expect(strip("\\[\\]\\\\")).toBe("[]");
+    expect(strip("a\\b\\c")).toBe("abc");
+  });
+});

--- a/WebUI/war/WEB-INF/classes/features/perc/getDashboardColumn/perc_getDashboardColumn.js
+++ b/WebUI/war/WEB-INF/classes/features/perc/getDashboardColumn/perc_getDashboardColumn.js
@@ -15,13 +15,21 @@ gadgets.window = gadgets.window || {};
  * Sanitisation rationale: the raw regex capture from `RegExp.exec` is
  * never safe to flow into a downstream string context (selector, URL,
  * data-context attribute). This helper was flagged by GitHub CodeQL as
- * `js/incomplete-sanitization`; the fix URL-decodes the captured value
- * and reduces it to an allow-listed character set so callers can
- * concatenate the result without a second pass of escaping.
+ * `js/incomplete-sanitization`; the fix (1) allow-lists the parameter
+ * *name* before building the RegExp (no incomplete `[` / `]` first-only
+ * escape), (2) URL-decodes the captured value, and (3) reduces it to a
+ * safe character set so callers can concatenate the result without a
+ * second pass of escaping.
  */
 function __gup( name )
 {
-  name = name.replace(/[\[]/,"\\\[").replace(/[\]]/,"\\\]");
+  // Parameter names are fixed gadget identifiers (e.g. "mid"). Reject
+  // anything outside a safe identifier set so we never build a RegExp from
+  // untrusted text. (Closes js/incomplete-sanitization on the previous
+  // non-global [ / ] escape.)
+  if (typeof name !== "string" || !/^[A-Za-z0-9._-]+$/.test(name)) {
+    return "";
+  }
   var regexS = "[\\?&]"+name+"=([^&#]*)";
   var regex = new RegExp( regexS );
   var results = regex.exec( window.location.href );

--- a/WebUI/war/app/includes/siteimprove_integration.html
+++ b/WebUI/war/app/includes/siteimprove_integration.html
@@ -166,7 +166,7 @@
             return;
           } else {
             var dataStr = results.metadata.data;
-            dataStr = dataStr.replace("\\", "");
+            dataStr = dataStr.replace(/\\/g, "");
             //get our site info from the meta data
             var parsedMetadata = JSON.parse(dataStr);
 
@@ -186,7 +186,7 @@
 
     function getParameterByName(name) {
       url = window.location.href;
-      name = name.replace(/[\[\]]/g, "\\$&");
+      name = String(name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
         results = regex.exec(url);
       if (!results) return null;

--- a/WebUI/war/perc_common_ui.js
+++ b/WebUI/war/perc_common_ui.js
@@ -1614,7 +1614,7 @@ var SimpleDateFormat;
     function unescapeFormat(s) {
         return regexEscape(
             s
-                .replace('\\', '')
+                .replace(/\\/g, '')
                 .replace(
                     /\\(\[)|\\(\])|\[([^\]\[]*)\]|\\(.)/g,
                     function (matched, p1, p2, p3, p4) {

--- a/WebUI/war/plugins/perc_css_utils.js
+++ b/WebUI/war/plugins/perc_css_utils.js
@@ -115,7 +115,7 @@
 	// all selectors are IDs (looking for #), and that the resulting properties
 	// are properly terminated.
 
-	cssString = cssString.replace("\"",""); // HACK!
+	cssString = cssString.replace(/"/g,""); // HACK! strip all double-quotes
 
 	var cssSelectors = getRegionSelectorsFrom(cssString);
 	var regionCSS = {};

--- a/WebUI/war/services/PercUserService.js
+++ b/WebUI/war/services/PercUserService.js
@@ -166,7 +166,7 @@
             callback($.PercServiceUtils.STATUS_ERROR, I18N.message("perc.ui.user.service@Null String"));
             return;
         }
-        usernameStartsWith = usernameStartsWith.replace("%", "*");
+        usernameStartsWith = usernameStartsWith.replace(/%/g, "*");
         if(!usernameStartsWith.endsWith("*"))
             usernameStartsWith = usernameStartsWith + "*";
         var urlfindExternalUsernamesThatStartwith = $.perc_paths.USER_EXTERNAL_FIND + "/" + encodeURIComponent(usernameStartsWith);

--- a/WebUI/war/widgets/perc_site_map.js
+++ b/WebUI/war/widgets/perc_site_map.js
@@ -2190,7 +2190,7 @@
 			for(var i = 0; i < attributeValue_array.length; i++) {
 				var tempArrayData = attributeValue_array[i];
 				var tempArrayData_arr = tempArrayData.split(':');
-				tempArrayData_arr = tempArrayData_arr[0].replace("{","");
+				tempArrayData_arr = tempArrayData_arr[0].replace(/\{/g, "");
 				Ids_arr.push(tempArrayData_arr.trim());
 
 			}

--- a/docs/ai-generated/code-reviews/004-us3-incomplete-sanitization-residuals-erlang.md
+++ b/docs/ai-generated/code-reviews/004-us3-incomplete-sanitization-residuals-erlang.md
@@ -1,0 +1,50 @@
+# Erlang review — 004/us3-incomplete-sanitization-residuals
+
+**Date:** 2026-07-18  
+**Branch:** `004/us3-incomplete-sanitization-residuals`  
+**Scope:** uncommitted WebUI JS fixes for remaining open `js/incomplete-sanitization` CodeQL alerts (#1110–#1113, #1115–#1116, #1134–#1135, #1454, #1456, #1467–#1468, #1470, #1485)  
+**Reviewer:** Erlang (independent pre-commit)
+
+## Summary
+
+Closes all 14 remaining open GitHub CodeQL `js/incomplete-sanitization` alerts by converting first-only `.replace(string, …)` / incomplete regex-escape patterns to global regex replaces, full RegExp-escape, or identifier allow-lists. Lockstep product copies under `cm/`, `cm/app/…/legacy/`, `cm/pages/…`, and `WebUI/war/**` are updated together. Regression coverage: `percGetDashboardColumn.test.js` (extended) + new `percIncompleteSanitization.test.js` (43 tests, all green).
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs | none |
+| Behavioral unit tests for non-trivial logic | present |
+| Cross-platform path/file I/O | N/A (string sanitisation only; test paths use `path.resolve` / `fileURLToPath`) |
+| May commit/push | **yes** |
+
+## Issues
+
+None (blocking).
+
+### Nits (non-blocking)
+
+1. **perc_common_ui.js is a committed concatenation** that includes vendored moment `unescapeFormat`. The one-line global-replace fix is correct for the open alert; a longer-term paths-ignore or regenerate-from-source path (similar to `shared-common.js`) would reduce residual risk if more moment alerts appear. Out of scope for this residual close.
+2. **siteimprove `dataStr.replace(/\\/g, "")`** preserves the historical intent (strip backslashes before `JSON.parse`) and only makes it complete. If metadata ever contains legitimate escaped JSON, this strip is still lossy — pre-existing design, not introduced here.
+3. **Unrelated untracked** `docs/ai-generated/code-reviews/pr-1356-…` and `pr-1358-…` were left out of this commit (belong to other work).
+
+## Memory patterns hit
+
+- Prefer runtime global replace / allow-list over dismiss-only for `js/incomplete-sanitization` (prior PRs #1307, #1323).
+- Lockstep all product copies that CodeQL still scans (`cm/` + legacy + war mirrors where present).
+- Source-pattern + behavioral tests that fail on pre-fix first-only replace.
+
+## Cross-platform path checklist
+
+Not applicable — no filesystem path construction, no OS temp hardcodes, no path string assertions against OS separators.
+
+## Tests run
+
+```text
+cd WebUI && npm test -- --run src/test/js/percGetDashboardColumn.test.js src/test/js/percIncompleteSanitization.test.js
+# 43 passed
+```


### PR DESCRIPTION
## Summary

Closes **all 14 remaining open** GitHub CodeQL `js/incomplete-sanitization` alerts by fixing first-only `.replace(string, …)` / incomplete regex-escape sanitizers in Perc-written (and lockstep) WebUI sources.

| Alert(s) | File | Fix |
|----------|------|-----|
| #1485 | `perc_site_map.js` | `{` strip → `/\{/g` |
| #1470, #1456 | `PercUserService.js` (+ legacy) | `%` → `*` → `/%/g` |
| #1468, #1454 | `perc_css_utils.js` (+ legacy) | `"` strip → `/"/g` |
| #1467 | `perc_common_ui.js` (moment `unescapeFormat`) | `"\\"` → `/\\/g` |
| #1134/#1135, #1115/#1116 | `siteimprove_integration.html` (app + pages) | metadata `/\\/g`; full RegExp-escape for param names |
| #1110–#1113 | `perc_getDashboardColumn.js` (×3 copies) | residual: allow-list param **name** before building `RegExp` |

War packaging mirrors updated lockstep where present (`WebUI/war/**` is paths-ignored for CodeQL but kept consistent for deploy).

## Disposition (playbook ladder)

- **Step 1 runtime fix** — global replace / allow-list / full escape (no dismiss-only).
- No model pack / path exclude / sink-line suppression required for these JS sinks.

## Test plan

- [x] `cd WebUI && npm test -- --run src/test/js/percGetDashboardColumn.test.js src/test/js/percIncompleteSanitization.test.js` → **43 passed**
- [x] Erlang pre-commit: **approve** (`docs/ai-generated/code-reviews/004-us3-incomplete-sanitization-residuals-erlang.md`)
- [ ] CodeQL Advanced on PR re-scan: expect open `js/incomplete-sanitization` count → 0 (for these paths)
- [ ] Spot-check directory-user search still wildcards multi-`%` prefixes
- [ ] Spot-check Siteimprove param parsing for `id` / `view`

## CodeQL PR checklist

- [x] Runtime fix + tests green
- [x] No path query-filters / dismiss-only for these alerts
- [x] Default setup remains `not-configured` (not re-enabled)
- [ ] After merge / re-scan: dismiss only if residual thrash with new IDs on already-fixed sinks (not expected)