### PR TITLE
feat(992): content explorer phase 1+2 — setup, planning, and foundational scaffolding

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Typed client for the sitemanage path management REST surface used by the
+ * modern React Content Explorer (feature 992-react-content-explorer) and the
+ * reusable Content Browser (US2).
+ *
+ * <p>Contracts: see {@code specs/992-react-content-explorer/contracts/path-api.md}.
+ * Server provider: {@code projects/sitemanage} {@code PSPathService}.</p>
+ *
+ * <p>This module is intentionally thin: it maps the documented contract to a
+ * typed TS surface and delegates transport to {@link apiFetch} (CSRF + JSON +
+ * error normalization). It does <em>not</em> invent fields — when a new server
+ * field is required, align types to the live {@code PSPathItem} /
+ * {@code PSPagedItemList} / {@code PSFolderProperties} DTOs per constitution
+ * II (Evidence Over Invention).</p>
+ */
+
+import { apiFetch } from "../client";
+import { PATHS } from "../paths";
+import type {
+  PSPathItem,
+  PSPagedItemList,
+  PSFolderProperties,
+  PSRenameFolderItem,
+  PSMoveFolderItem,
+} from "./types";
+
+export interface PaginatedFolderParams {
+  startIndex: number;
+  maxResults: number;
+  sortColumn?: string;
+  sortOrder?: "asc" | "desc";
+  child?: boolean;
+  displayFormatId?: string;
+  category?: string;
+  type?: string;
+}
+
+/**
+ * List folder children (small folders). For large folders use
+ * {@link paginatedFolder}.
+ */
+export function findChildren(path: string): Promise<PSPathItem[]> {
+  const safe = encodePath(path);
+  return apiFetch<PSPathItem[]>(`${PATHS.PATH_FOLDER}/${safe}`);
+}
+
+/**
+ * Paged children loader — required for SC-005 large-folder performance gate.
+ * Server-side pagination avoids loading the full child set; the client
+ * applies virtualization on top (see plan.md Performance Goals).
+ */
+export function paginatedFolder(
+  path: string,
+  params: PaginatedFolderParams,
+): Promise<PSPagedItemList> {
+  const safe = encodePath(path);
+  const q = new URLSearchParams();
+  q.set("startIndex", String(params.startIndex));
+  q.set("maxResults", String(params.maxResults));
+  if (params.sortColumn) q.set("sortColumn", params.sortColumn);
+  if (params.sortOrder) q.set("sortOrder", params.sortOrder);
+  if (params.child !== undefined) q.set("child", String(params.child));
+  if (params.displayFormatId) q.set("displayFormatId", params.displayFormatId);
+  if (params.category) q.set("category", params.category);
+  if (params.type) q.set("type", params.type);
+  return apiFetch<PSPagedItemList>(
+    `${PATHS.PATH_PAGINATED_FOLDER}/${safe}?${q.toString()}`,
+  );
+}
+
+export function findItemByPath(path: string): Promise<PSPathItem> {
+  const safe = encodePath(path);
+  return apiFetch<PSPathItem>(`${PATHS.PATH_ITEM}/${safe}`);
+}
+
+export function findItemById(id: string): Promise<PSPathItem> {
+  return apiFetch<PSPathItem>(`${PATHS.PATH_ITEM_ID}/${encodeURIComponent(id)}`);
+}
+
+export function addNewFolder(path: string, name: string): Promise<PSPathItem> {
+  const safe = encodePath(path);
+  return apiFetch<PSPathItem>(
+    `${PATHS.PATH_ADD_NEW_FOLDER}/${safe}?name=${encodeURIComponent(name)}`,
+  );
+}
+
+export function renameFolder(body: PSRenameFolderItem): Promise<PSPathItem> {
+  return apiFetch<PSPathItem>(PATHS.PATH_RENAME_FOLDER, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export function moveItem(body: PSMoveFolderItem): Promise<void> {
+  return apiFetch<void>(PATHS.PATH_MOVE_ITEM, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export function deleteItem(path: string): Promise<void> {
+  const safe = encodePath(path);
+  return apiFetch<void>(`${PATHS.PATH_DELETE_ITEM}/${safe}`, {
+    method: "POST",
+  });
+}
+
+export function folderProperties(id: string): Promise<PSFolderProperties> {
+  return apiFetch<PSFolderProperties>(
+    `${PATHS.PATH_FOLDER_PROPERTIES}/${encodeURIComponent(id)}`,
+  );
+}
+
+export function saveFolderProperties(
+  props: PSFolderProperties,
+): Promise<void> {
+  return apiFetch<void>(PATHS.PATH_SAVE_FOLDER_PROPERTIES, {
+    method: "POST",
+    body: JSON.stringify(props),
+  });
+}
+
+export function validatePath(path: string): Promise<string> {
+  const safe = encodePath(path);
+  return apiFetch<string>(`${PATHS.PATH_VALIDATE}/${safe}`);
+}
+
+export function lastExisting(path: string): Promise<string> {
+  const safe = encodePath(path);
+  return apiFetch<string>(`${PATHS.PATH_LAST_EXISTING}/${safe}`);
+}
+
+function encodePath(path: string): string {
+  // CMS paths use '/' as separator; only encode each segment to keep the
+  // multi-segment URL intact (server JAX-RS expects {path:.*}).
+  return path
+    .split("/")
+    .map((seg) => encodeURIComponent(seg))
+    .join("/");
+}

--- a/WebUI/src/main/ts/api/contentExplorer/types.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/types.ts
@@ -120,9 +120,22 @@ export interface SelectionItem {
   name?: string;
   type?: string;
   category?: string;
+  /** Content-type ids the item is associated with; preview selector uses these. */
+  contentTypeIds?: string[];
 }
 
 export interface SelectionResult {
   /** Single-select returns one-element array; multi-select returns full set. */
   items: SelectionItem[];
+}
+
+/**
+ * Preview information for the currently-focused item in ContentBrowser.
+ * Surface added per PR review on `specs/992-react-content-explorer/contracts/content-browser-host.md`.
+ */
+export interface PreviewInfo {
+  item: SelectionItem;
+  templateId: string;
+  /** Server-rendered preview URL or rendered HTML — implementation-defined. */
+  url: string;
 }

--- a/WebUI/src/main/ts/api/contentExplorer/types.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/types.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Client-side TypeScript types mirroring sitemanage server DTOs.
+ *
+ * <p>Align to live {@code PSPathItem}, {@code PSPagedItemList},
+ * {@code PSFolderProperties}, {@code PSRenameFolderItem},
+ * {@code PSMoveFolderItem}, {@code PSFolderPermission} per constitution II
+ * (Evidence Over Invention). Do not invent fields; if a field is missing on
+ * the server, add it via a sitemanage change with a service-contract test
+ * (T052a) and threat-model note (T052b).</p>
+ *
+ * <p>Mirror of {@code specs/992-react-content-explorer/data-model.md}.</p>
+ */
+
+export type FolderAccessLevel = "ADMIN" | "WRITE" | "READ" | "VIEW";
+
+export interface PSPathItem {
+  id?: string;
+  name: string;
+  title?: string;
+  path: string;
+  /** Item type / category (e.g. "folder", "page", "asset"). */
+  type?: string;
+  /** CMS-side category discriminator; broader than {@link type}. */
+  category?: string;
+  leaf?: boolean;
+  /** Hint flags for tree expansion; may be false on paginated children. */
+  hasFolderChildren?: boolean;
+  hasItemChildren?: boolean;
+  hasSectionChildren?: boolean;
+  accessLevel?: FolderAccessLevel;
+  displayProperties?: Record<string, unknown>;
+  folderPath?: string;
+  folderPaths?: string[];
+}
+
+export interface PSPagedItemList {
+  startIndex: number;
+  maxResults: number;
+  totalCount?: number;
+  /** paged children; field name follows server contract. */
+  children?: PSPathItem[];
+  /** Some server versions return `items` instead of `children`. */
+  items?: PSPathItem[];
+}
+
+export interface PSFolderPermission {
+  accessLevel: FolderAccessLevel;
+  adminPrincipals?: PSPrincipal[];
+  writePrincipals?: PSPrincipal[];
+  readPrincipals?: PSPrincipal[];
+  viewPrincipals?: PSPrincipal[];
+}
+
+export interface PSPrincipal {
+  /** "USER" or "ROLE". */
+  type: "USER" | "ROLE";
+  name: string;
+}
+
+export interface PSFolderProperties {
+  id: string;
+  name: string;
+  permission?: PSFolderPermission;
+  acl?: unknown;
+  communityId?: string;
+  communityName?: string;
+  locale?: string;
+  displayFormatName?: string;
+  workflowId?: string;
+  allowedSites?: string[];
+}
+
+export interface PSRenameFolderItem {
+  path: string;
+  newName: string;
+}
+
+export interface PSMoveFolderItem {
+  sourcePath: string;
+  targetPath: string;
+  /** When true, server performs copy rather than move. */
+  copy?: boolean;
+}
+
+/**
+ * ReducedAction enum (FR-010a, data-model.md). The intermediate hard-cut set
+ * for the Finder / Desktop CE retirement; expanded (not redefined) by the
+ * full P-Menu phase in US3.
+ */
+export enum ReducedAction {
+  Open = "open",
+  Preview = "preview",
+  CreateFolder = "createFolder",
+  Rename = "rename",
+  Move = "move",
+  Copy = "copy",
+  Delete = "delete",
+}
+
+/** Selection payload returned from ContentBrowser to its host (US2). */
+export interface SelectionItem {
+  id: string;
+  path: string;
+  name?: string;
+  type?: string;
+  category?: string;
+}
+
+export interface SelectionResult {
+  /** Single-select returns one-element array; multi-select returns full set. */
+  items: SelectionItem[];
+}

--- a/WebUI/src/main/ts/api/paths.ts
+++ b/WebUI/src/main/ts/api/paths.ts
@@ -77,4 +77,42 @@ export const PATHS = {
   get WIDGET_BUILDER() {
     return `${SERVICES_ROOT}/widgetmanagement/widgetbuilder`;
   },
+  // --- Content Explorer (992-react-content-explorer) ---
+  get PATH_PAGINATED_FOLDER() {
+    return `${SERVICES_ROOT}/pathmanagement/path/paginatedFolder`;
+  },
+  get PATH_ITEM() {
+    return `${SERVICES_ROOT}/pathmanagement/path/item`;
+  },
+  get PATH_ITEM_ID() {
+    return `${SERVICES_ROOT}/pathmanagement/path/item/id`;
+  },
+  get PATH_ADD_NEW_FOLDER() {
+    return `${SERVICES_ROOT}/pathmanagement/path/addNewFolder`;
+  },
+  get PATH_RENAME_FOLDER() {
+    return `${SERVICES_ROOT}/pathmanagement/path/renameFolder`;
+  },
+  get PATH_MOVE_ITEM() {
+    return `${SERVICES_ROOT}/pathmanagement/path/moveItem`;
+  },
+  get PATH_DELETE_ITEM() {
+    return `${SERVICES_ROOT}/pathmanagement/path/delete`;
+  },
+  get PATH_FOLDER_PROPERTIES() {
+    return `${SERVICES_ROOT}/pathmanagement/path/folderProperties`;
+  },
+  get PATH_SAVE_FOLDER_PROPERTIES() {
+    return `${SERVICES_ROOT}/pathmanagement/path/saveFolderProperties`;
+  },
+  get PATH_VALIDATE() {
+    return `${SERVICES_ROOT}/pathmanagement/path/validate`;
+  },
+  get PATH_LAST_EXISTING() {
+    return `${SERVICES_ROOT}/pathmanagement/path/lastExisting`;
+  },
+  // --- Actions (US3) ---
+  get ACTIONS_ROOT() {
+    return `${SERVICES_ROOT}/actions`;
+  },
 } as const;

--- a/WebUI/src/main/ts/contentBrowser/ContentBrowser.tsx
+++ b/WebUI/src/main/ts/contentBrowser/ContentBrowser.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * ContentBrowser placeholder component for feature 992-react-content-explorer.
+ *
+ * <p>Registered in {@code registry.ts} so the bridge can resolve the name
+ * {@code "ContentBrowser"} for {@code window.PercModernUI.mount(...)} from
+ * legacy JSP / dialog hosts. The full embeddable navigate/search/select UI
+ * lands in US2 (tasks.md T037–T047).</p>
+ */
+
+import * as React from "react";
+import type { ContentBrowserProps } from "./types";
+
+export const ContentBrowser: React.FC<ContentBrowserProps> = (props) => {
+  return React.createElement(
+    "div",
+    {
+      "data-component": "ContentBrowser",
+      "data-feature": "992-react-content-explorer",
+      "data-status": "placeholder",
+      role: "dialog",
+      "aria-label": "Content Browser (placeholder — US2 implementation pending)",
+    },
+    `ContentBrowser placeholder — mode=${props.mode ?? "select"}, roots=${JSON.stringify(props.roots ?? "all")}. Implementer: replace with full component in tasks.md US2 (T037–T047).`,
+  );
+};
+
+export default ContentBrowser;

--- a/WebUI/src/main/ts/contentBrowser/types.ts
+++ b/WebUI/src/main/ts/contentBrowser/types.ts
@@ -23,7 +23,11 @@
  * picker, optional Home Library consumer from 989-react-cui-widget-builder).</p>
  */
 
-import type { SelectionResult, SelectionItem } from "../api/contentExplorer/types";
+import type {
+  SelectionResult,
+  SelectionItem,
+  PreviewInfo,
+} from "../api/contentExplorer/types";
 
 export type ContentBrowserMode = "select" | "browse";
 export type ContentBrowserRoots = "sites" | "assets" | "all" | string[];
@@ -47,12 +51,18 @@ export interface ContentBrowserProps {
   roots?: ContentBrowserRoots;
   /** Show search pane when API is available (US5). */
   enableSearch?: boolean;
+  /** Show preview pane for the focused item (default true). */
+  enablePreview?: boolean;
+  /** Explicit template/content-type id to render preview with; null = first associated template. */
+  previewTemplate?: string | null;
   /** Dialog title; TMX key preferred. */
   title?: string | null;
   /** Required in select mode. */
   onConfirm?: (selection: SelectionResult) => void;
+  /** Browser tells host which item is currently being previewed (drives host UI like Insert-button hint). */
+  onPreviewChange?: (preview: PreviewInfo | null) => void;
   onCancel?: () => void;
   onError?: (message: string) => void;
 }
 
-export type { SelectionItem, SelectionResult };
+export type { SelectionItem, SelectionResult, PreviewInfo };

--- a/WebUI/src/main/ts/contentBrowser/types.ts
+++ b/WebUI/src/main/ts/contentBrowser/types.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * ContentBrowser host integration types (US2 — feature 992-react-content-explorer).
+ *
+ * <p>Mirror of {@code specs/992-react-content-explorer/contracts/content-browser-host.md}.
+ * Imported by both the {@code ContentBrowser} component and any host that
+ * embeds it (asset picker, page picker, AA ContentBrowserDialog, folder
+ * picker, optional Home Library consumer from 989-react-cui-widget-builder).</p>
+ */
+
+import type { SelectionResult, SelectionItem } from "../api/contentExplorer/types";
+
+export type ContentBrowserMode = "select" | "browse";
+export type ContentBrowserRoots = "sites" | "assets" | "all" | string[];
+
+export interface ContentBrowserProps {
+  /** "select" requires user confirmation; "browse" may omit. */
+  mode?: ContentBrowserMode;
+  /** Allow multiple items. */
+  multiSelect?: boolean;
+  /** Folders selectable. */
+  allowFolderSelect?: boolean;
+  /** Items (non-folder) selectable. */
+  allowItemSelect?: boolean;
+  /** If set, only items whose type/category is in this list are confirmable. */
+  allowedTypes?: string[] | null;
+  /** Optional category filter. */
+  allowedCategories?: string[] | null;
+  /** Starting folder path; defaults to product root. */
+  initialPath?: string | null;
+  /** Root set; "all" matches path services default. */
+  roots?: ContentBrowserRoots;
+  /** Show search pane when API is available (US5). */
+  enableSearch?: boolean;
+  /** Dialog title; TMX key preferred. */
+  title?: string | null;
+  /** Required in select mode. */
+  onConfirm?: (selection: SelectionResult) => void;
+  onCancel?: () => void;
+  onError?: (message: string) => void;
+}
+
+export type { SelectionItem, SelectionResult };

--- a/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * ContentExplorerShell placeholder component for feature 992-react-content-explorer.
+ *
+ * <p>Registered in {@code registry.ts} so the bridge can resolve the name
+ * {@code "ContentExplorerShell"} for {@code window.PercModernUI.mount(...)},
+ * and so Vite's bundler pulls the module in. The full tree + detail-list +
+ * ReducedAction set implementation lands in US1 (tasks.md T017–T027).</p>
+ */
+
+import * as React from "react";
+
+export interface ContentExplorerShellProps {
+  initialPath?: string;
+}
+
+export const ContentExplorerShell: React.FC<ContentExplorerShellProps> = (props) => {
+  return React.createElement(
+    "div",
+    {
+      "data-component": "ContentExplorerShell",
+      "data-feature": "992-react-content-explorer",
+      "data-status": "placeholder",
+      role: "region",
+      "aria-label": "Content Explorer (placeholder — US1 implementation pending)",
+    },
+    `ContentExplorerShell placeholder — initialPath=${props.initialPath ?? "<root>"}. Implementer: replace with full shell in tasks.md US1 (T017–T027).`,
+  );
+};
+
+export default ContentExplorerShell;

--- a/WebUI/src/main/ts/registry.ts
+++ b/WebUI/src/main/ts/registry.ts
@@ -29,6 +29,8 @@ import { Dashboard, WorkflowStatusWidget, ActivityWidget, ProcessMonitorWidget, 
 import { HomeShell } from "./home";
 import { UnavailableView } from "./home/UnavailableView";
 import { WidgetBuilderApp } from "./widgetbuilder/WidgetBuilderApp";
+import { ContentExplorerShell } from "./contentExplorer/ContentExplorerShell";
+import { ContentBrowser } from "./contentBrowser/ContentBrowser";
 
 /** Map of component names to their React component types. */
 export const componentRegistry = new Map<string, ComponentType<any>>();
@@ -47,3 +49,5 @@ componentRegistry.set("TrafficWidget", TrafficWidget);
 componentRegistry.set("HomeShell", HomeShell);
 componentRegistry.set("WidgetBuilderApp", WidgetBuilderApp);
 componentRegistry.set("UnavailableView", UnavailableView);
+componentRegistry.set("ContentExplorerShell", ContentExplorerShell);
+componentRegistry.set("ContentBrowser", ContentBrowser);

--- a/WebUI/src/test/ts/contentBrowser/index.ts
+++ b/WebUI/src/test/ts/contentBrowser/index.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Vitest scaffold for the reusable Content Browser (feature 992-react-content-explorer US2).
+ *
+ * <p>Tasks.md T012/T037–T039: per-story test coverage under
+ * {@code WebUI/src/test/ts/contentBrowser/} for selection filters (type,
+ * folder, multi), navigate→confirm payload, and cancel / empty-selection
+ * disabled confirm.</p>
+ *
+ * <p>Add per-host migration tests under {@code WebUI/src/test/ts/contentBrowser/hosts/}
+ * for T045a–T045e (asset picker, page picker, AA dialog, folder picker, optional
+ * Home Library).</p>
+ */
+
+export {};

--- a/WebUI/src/test/ts/contentExplorer/index.ts
+++ b/WebUI/src/test/ts/contentExplorer/index.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Vitest scaffold for the modern Content Explorer (feature 992-react-content-explorer).
+ *
+ * <p>Tasks.md T012/T012b/T015a: per-story test coverage under
+ * {@code WebUI/src/test/ts/contentExplorer/} for the tree, detail list,
+ * ReducedAction set, and the SC-005 perf regression guard.</p>
+ *
+ * <p>Add the following per-US test files (implementer):</p>
+ * <ul>
+ *   <li>US1: {@code pathApi.test.ts}, {@code ExplorerTree.test.tsx}, {@code DetailList.test.tsx}, {@code reducedActions.test.tsx}, {@code sc005-perf-regression.test.tsx}</li>
+ *   <li>US3: {@code actionMenuMapper.test.ts}, {@code ContextMenu.test.tsx}, {@code ContextMenu.a11y.test.tsx}</li>
+ *   <li>US4: {@code aclLockout.test.ts}, {@code FolderSecurityPanel.test.tsx}</li>
+ *   <li>US5: {@code searchApi.test.ts}, {@code SearchPanel.test.tsx}</li>
+ *   <li>US7: {@code clipboard.test.ts}, {@code wizards/}, {@code views/}</li>
+ * </ul>
+ *
+ * <p>Vitest setup is inherited from {@code WebUI/src/main/frontend/vitest.setup.ts}.</p>
+ */
+
+export {};

--- a/docs/ai-generated/code-reviews/992-react-content-explorer-phase1plus2-erlang.md
+++ b/docs/ai-generated/code-reviews/992-react-content-explorer-phase1plus2-erlang.md
@@ -1,0 +1,102 @@
+# Erlang review — 992-react-content-explorer — Phase 1+2 commit
+
+**Branch**: `992-react-content-explorer`
+**Date**: 2026-07-19
+**Scope**: uncommitted + unstaged code in `WebUI/src/main/ts/`, `WebUI/src/test/ts/`, `scripts/` (planning artifacts under `specs/992-react-content-explorer/` are out of Erlang scope — they are spec/plan docs, not code).
+
+## Files reviewed
+
+- `WebUI/src/main/ts/api/paths.ts` (extended; 12 new URL constants)
+- `WebUI/src/main/ts/registry.ts` (extended; 2 new registry entries)
+- `WebUI/src/main/ts/api/contentExplorer/pathApi.ts` (new; typed REST client)
+- `WebUI/src/main/ts/api/contentExplorer/types.ts` (new; DTO mirrors)
+- `WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx` (new; placeholder)
+- `WebUI/src/main/ts/contentBrowser/ContentBrowser.tsx` (new; placeholder)
+- `WebUI/src/main/ts/contentBrowser/types.ts` (new; host contract types)
+- `WebUI/src/test/ts/contentExplorer/index.ts` (new; scaffold)
+- `WebUI/src/test/ts/contentBrowser/index.ts` (new; scaffold)
+- `scripts/create-large-folder-fixture.sh` (new; perf fixture seed)
+- `scripts/README.md` (extended; fixture script doc)
+
+## Summary
+
+Phase 1+2 setup and foundational scaffolding for the 992-react-content-explorer feature. The new TS/TSX code is type-only (placeholder components + typed REST client + URL constants + Vitest directory scaffolds). No runtime behavior changes for existing production paths. **Two HARD gates found** in the shell script (`scripts/create-large-folder-fixture.sh`):
+
+- **H1 — False green on child-creation failures** (Erlang hard gate "process or API reports success when child work failed"). `set -euo pipefail` is set, but every `curl` invocation has `|| true`, so the script always exits 0 even when every child creation 4xx's. A 500-iteration run could report success with zero folders created.
+- **H2 — Secret on command line** (Erlang hard gate "Passwords or secrets on process command lines"). `curl -u "${CMS_USER}:${CMS_PASS}"` puts the password on the process command line, visible to `ps` on Linux/macOS during the run.
+
+Both fixed in this commit (see Diff below).
+
+LOW / style findings (not blocking, intentional placeholders will be rewritten in US1/US2/T017/T040):
+
+- **`ContentExplorerShell.tsx` / `ContentBrowser.tsx`** use `import * as React` + `React.createElement(...)` instead of the project's `import React, { ... } from "react"` + JSX pattern. Intentional: these are placeholder components scheduled for full JSX rewrite in US1 (T017) and US2 (T040). Adding style churn now would be thrown away. Worth a follow-up note in US1 to use the project's `import React, { useState, ... } from "react"` pattern.
+- **`encodePath` in `pathApi.ts`** correctly splits on `/` before `encodeURIComponent` so the multi-segment URL pattern is preserved for the JAX-RS `{path:.*}` route. Verified: `encodeURIComponent("/")` would be `%2F`, but `["a","b"].map(encodeURIComponent).join("/")` returns `"a/b"`. No bug.
+- **No behavioral tests in this commit.** The Vitest scaffolds (`contentExplorer/index.ts`, `contentBrowser/index.ts`) are directory + JSDoc placeholders only. **Acceptable** because (a) the new TS code in this commit is itself placeholder/scaffold code (no runtime logic), (b) behavioral tests are explicitly scheduled per US in `tasks.md` (T013–T016, T037–T039, T048–T050, T058–T059, T065–T066, T071–T073), (c) `pathApi.ts` is a thin transport wrapper around `apiFetch` whose behavior is covered by the existing `apiFetch` tests in `WebUI/src/test/ts/`. The behavioral test gate applies to non-trivial logic in each US PR, not to scaffolding.
+
+## Cross-platform path checklist
+
+Erlang requires applying this checklist whenever the diff touches file I/O, paths, installers, packaging, or path assertions in tests.
+
+- **TS code (pathApi.ts, paths.ts, registry.ts)**: uses `/` for URL paths only. URL/URI/ZIP entry paths correctly use `/` (patterns.md false-positive guard applies). ✓
+- **Shell script (`create-large-folder-fixture.sh`)**: uses `/Rhythmyx/services/...` for HTTP URLs (URL paths, correctly `/`). No filesystem path joins. The script targets Linux/macOS; README documents a Windows `.cmd` counterpart as future work. **Note**: per root `AGENTS.md` **Cross-Platform File I/O & Paths**, repo automation that must run on Windows needs a `.bat`/`.cmd` counterpart. The script is **explicitly opt-in** for UAT perf runs by an implementer, not a CI-required workflow — a Windows `.cmd` is a follow-up. **No cross-platform violation in this commit.**
+- **No new Java I/O or path code.** Server-side work explicitly evaluated to "none added for 8.2" in `cutover-inventory.md` §C (system/ decision table).
+- **No tests added in this commit** that assert path strings.
+
+## Recommendation
+
+**Approve after fixes below are committed.**
+
+## Diff (fixes in this commit)
+
+### `scripts/create-large-folder-fixture.sh`
+
+Replace `|| true` swallowing with explicit failure tracking, and use a netrc-style credential file to keep `${CMS_PASS}` off the process command line:
+
+```diff
+-  curl -sS -k -u "${CMS_USER}:${CMS_PASS}" \
+-    -X GET "${CMS_BASE_URL}/Rhythmyx/services/pathmanagement/path/addNewFolder/${FIXTURE_PATH}?name=PerfFixtureRoot" \
+-    -o /dev/null -w "createRoot=%{http_code}\n" || true
++  curl -sS -k \
++    -X GET "${CMS_BASE_URL}/Rhythmyx/services/pathmanagement/path/addNewFolder/${FIXTURE_PATH}?name=PerfFixtureRoot" \
++    -o /dev/null -w "createRoot=%{http_code}\n"
+```
+
+```diff
+-  for i in $(seq 1 "${FIXTURE_COUNT}"); do
+-    child="child_$(printf '%04d' "$i")"
+-    curl -sS -k -u "${CMS_USER}:${CMS_PASS}" \
+-      -X GET "${CMS_BASE_URL}/Rhythmyx/services/pathmanagement/path/addNewFolder/${FIXTURE_PATH}/PerfFixtureRoot?name=${child}" \
+-      -o /dev/null -w "${child}=%{http_code}\n" || true
+-  done
++  netrc_file="$(mktemp)"
++  printf 'machine %s login %s password %s\n' "${CMS_HOST}" "${CMS_USER}" "${CMS_PASS}" > "${netrc_file}"
++  chmod 600 "${netrc_file}"
++  trap 'rm -f "${netrc_file}"' EXIT
++
++  failures=0
++  for i in $(seq 1 "${FIXTURE_COUNT}"); do
++    child="child_$(printf '%04d' "$i")"
++    code="$(curl -sS -k --netrc-file "${netrc_file}" \
++      -X GET "${CMS_BASE_URL}/Rhythmyx/services/pathmanagement/path/addNewFolder/${FIXTURE_PATH}/PerfFixtureRoot?name=${child}" \
++      -o /dev/null -w '%{http_code}')"
++    printf '%s=%s\n' "${child}" "${code}"
++    case "${code}" in
++      2*) ;;  # 2xx — created
++      409) ;; # 409 — already exists (idempotent re-run)
++      *)   failures=$((failures + 1)) ;;
++    esac
++  done
++
++  if [ "${failures}" -gt 0 ]; then
++    echo "[$ts] FAILED: ${failures}/${FIXTURE_COUNT} child creations did not return 2xx or 409. See above." >&2
++    exit 1
++  fi
+```
+
+Both fixes are applied in the committed version of the file.
+
+## Gate
+
+**May commit/push: yes** (after fixes above).
+
+**Memory patterns hit**: false-green-on-ignored-exit-codes, secrets-on-process-command-line.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,6 +21,23 @@ Fetch code scanning (CodeQL) alerts for a repository using the `gh` CLI and writ
   - Pagination is handled automatically (`--paginate`, `per_page=100`).
   - For the `004-zero-code-scanning-alerts` workflow, use this script to (re)generate `alerts.md`, then seed/triage `triage.md` per `specs/004-zero-code-scanning-alerts/contracts/README.md` C1.
 
+### `create-large-folder-fixture.sh`
+
+Create a single CMS folder with ≥500 children for the SC-005 perf UAT scenario of feature `992-react-content-explorer` (`quickstart.md` Scenario B).
+
+- **Purpose**: Tasks.md T012b perf fixture scaffolding. Run on a test CMS instance to seed the fixture used for the SC-005 pass criterion (`p95 ≤ 10 s` on standard office network) and the T015a Vitest regression guard.
+- **Usage**:
+  ```bash
+  CMS_BASE_URL=https://cms.local:8443 \
+  CMS_USER=admin1 CMS_PASS=<redacted> \
+  FIXTURE_PATH=/Sites/PerfFixture FIXTURE_COUNT=500 \
+  ./scripts/create-large-folder-fixture.sh
+  ```
+- **Output**: A folder `FIXTURE_PATH/PerfFixtureRoot` with `FIXTURE_COUNT` children (default `/Sites/PerfFixture/PerfFixtureRoot` × 500).
+- **Cross-platform**: Windows users run the `.cmd` counterpart (add when needed; the `.sh` is portable to Linux/macOS). Default count + path match the SC-005 fixture in `quickstart.md`.
+- **Evidence**: After UAT, append a row to `specs/992-react-content-explorer/checklists/sc005-perf-evidence.md` with run name, git SHA, fixture size, network profile, p50/p95/max times, pass/fail.
+- **Prereqs**: `curl`, network reachability to a running CMS instance with admin credentials; idempotent (re-running will create additional children under the same parent — clean up between runs as needed).
+
 ### `erlang-harvest-review-patterns.py` (+ `.sh` / `.bat`)
 
 Harvest GitHub PR **line review comments** (including closed/merged PRs) from

--- a/scripts/create-large-folder-fixture.sh
+++ b/scripts/create-large-folder-fixture.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# scripts/create-large-folder-fixture.sh
+#
+# Feature: 992-react-content-explorer — SC-005 perf fixture (tasks.md T012b).
+# Creates a single CMS folder with >=500 children for the UAT perf scenario
+# (quickstart.md Scenario B).
+#
+# Cross-platform: Windows users should run the .cmd counterpart
+# `scripts/create-large-folder-fixture.cmd` (add when needed; this .sh is
+# portable to Linux/macOS). The script is opt-in UAT scaffolding, not a
+# CI-required workflow.
+#
+# Usage:
+#   CMS_BASE_URL=https://cms.local:8443 \
+#   CMS_USER=admin1 CMS_PASS=<redacted> \
+#   FIXTURE_PATH=/Sites/PerfFixture FIXTURE_COUNT=500 \
+#   ./scripts/create-large-folder-fixture.sh
+#
+# Security:
+#   Uses a temporary netrc file (mode 0600) for curl credentials so the
+#   password is NOT placed on the process command line (Erlang hard gate).
+#   The netrc file is removed on EXIT via trap.
+#
+# Failure tracking:
+#   Each child creation is checked against the returned HTTP status. A run
+#   with any non-2xx / non-409 status exits non-zero (Erlang hard gate:
+#   no false-green on ignored child failures).
+#
+# Records evidence in:
+#   specs/992-react-content-explorer/checklists/sc005-perf-evidence.md
+#   (append a row per run with: fixture size, p50/p95/max ms, pass/fail)
+
+set -euo pipefail
+
+CMS_BASE_URL="${CMS_BASE_URL:-http://localhost:8080}"
+CMS_USER="${CMS_USER:?CMS_USER is required}"
+CMS_PASS="${CMS_PASS:?CMS_PASS is required}"
+FIXTURE_PATH="${FIXTURE_PATH:-/Sites/PerfFixture}"
+FIXTURE_COUNT="${FIXTURE_COUNT:-500}"
+
+# Parse host out of CMS_BASE_URL for the netrc "machine" field.
+CMS_HOST="${CMS_BASE_URL#*://}"
+CMS_HOST="${CMS_HOST%%/*}"
+CMS_HOST="${CMS_HOST%%:*}"
+
+# Portable date (Linux + macOS); Windows users should use the .cmd counterpart.
+ts="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+echo "[$ts] Creating fixture folder ${FIXTURE_PATH} with ${FIXTURE_COUNT} children at ${CMS_BASE_URL}"
+
+# Temporary netrc keeps the password off the process command line.
+netrc_file="$(mktemp)"
+printf 'machine %s login %s password %s\n' "${CMS_HOST}" "${CMS_USER}" "${CMS_PASS}" > "${netrc_file}"
+chmod 600 "${netrc_file}"
+trap 'rm -f "${netrc_file}"' EXIT
+
+# 1. Create the parent folder. 2xx or 409 (already exists) are both acceptable.
+create_code="$(curl -sS -k --netrc-file "${netrc_file}" \
+  -X GET "${CMS_BASE_URL}/Rhythmyx/services/pathmanagement/path/addNewFolder/${FIXTURE_PATH}?name=PerfFixtureRoot" \
+  -o /dev/null -w '%{http_code}')"
+printf 'createRoot=%s\n' "${create_code}"
+case "${create_code}" in
+  2*|409) ;;
+  *) echo "[$ts] FAILED: parent folder creation returned ${create_code}" >&2; exit 1 ;;
+esac
+
+# 2. Create N children using pathmanagement addFolder. Track failures; exit non-zero on any.
+failures=0
+for i in $(seq 1 "${FIXTURE_COUNT}"); do
+  child="child_$(printf '%04d' "$i")"
+  code="$(curl -sS -k --netrc-file "${netrc_file}" \
+    -X GET "${CMS_BASE_URL}/Rhythmyx/services/pathmanagement/path/addNewFolder/${FIXTURE_PATH}/PerfFixtureRoot?name=${child}" \
+    -o /dev/null -w '%{http_code}')"
+  printf '%s=%s\n' "${child}" "${code}"
+  case "${code}" in
+    2*) ;;   # 2xx — created
+    409) ;;  # 409 — already exists (idempotent re-run)
+    *)   failures=$((failures + 1)) ;;
+  esac
+done
+
+if [ "${failures}" -gt 0 ]; then
+  echo "[$ts] FAILED: ${failures}/${FIXTURE_COUNT} child creations did not return 2xx or 409. See above." >&2
+  exit 1
+fi
+
+echo "[$ts] Done. Verify with:"
+echo "  curl -sS -k --netrc-file <creds> \"${CMS_BASE_URL}/Rhythmyx/services/pathmanagement/path/folder/${FIXTURE_PATH}/PerfFixtureRoot\" | jq 'length'"
+echo "Then run quickstart.md Scenario B and append results to"
+echo "  specs/992-react-content-explorer/checklists/sc005-perf-evidence.md"

--- a/specs/992-react-content-explorer/checklists/cutover-inventory.md
+++ b/specs/992-react-content-explorer/checklists/cutover-inventory.md
@@ -1,0 +1,201 @@
+# Cutover inventory: Finder + Desktop Content Explorer
+
+**Feature**: [spec.md](../spec.md)  
+**Purpose**: FR-022 durable inventory — PR/release sign-off per hard-cut phase  
+**Target product release**: **8.2** (FR-029 / SC-012 — functional parity blocks 8.2 GA)  
+**Status**: Seed (expand as work proceeds)
+
+## Phase sign-off log
+
+| Phase | Description | PR / release | Reviewer | Date | Result |
+|-------|-------------|--------------|----------|------|--------|
+| P0-Core Finder | Primary nav hard cut | TBD per phase PR (T031–T036) | TBD — module owner + QA/UAT per §E sign-off rule | TBD per phase PR | Pending (T035 signs off this row) |
+| P0-Core Desktop CE | CE not required for core admin | TBD per phase PR (T034) | TBD — module owner + QA/UAT per §E sign-off rule | TBD per phase PR | Pending (T035 signs off this row) |
+| P-Host (per host) | Per-host browser hard cuts | TBD per phase PR (T045a–T045f) | TBD — module owner + QA/UAT per §E sign-off rule | TBD per phase PR | Pending (T045f verifies all in-scope hosts; per-host reviewers in §C rows) |
+| Phase 0 — Planning inventory seed | §A–§D inventory rows populated | n/a | Analyzer session (Kilo) | 2026-07-19 | §A–§D populated; §E gate rules established |
+
+**Sign-off rule** (per `quickstart.md` Scenario C, per implementation phase): at minimum **two roles** must sign each phase row — module owner (e.g. `WebUI` lead for Finder primary-nav) and QA/UAT owner (runs Scenario A/B/C against the candidate build); optional release manager for release-train readiness. Evidence per row = sign-off name + date + linked PR / commit hash + Scenario result. Per-host reviewers for P-Host are recorded in the §C rows.
+
+**§E checklist items are ticked per phase at ship time, not at planning time.** This inventory's §A/§B/§C/§D rows below are the **pre-implementation evidence** required before §E gates can fire.
+
+---
+
+## A. Finder primary navigation (hard cut)
+
+### Entry points
+
+| Location | Role | Action at hard cut | Status |
+|----------|------|--------------------|--------|
+| `WebUI/src/main/webapp/cm/app/webmgt.jsp` (lines 303, 325) | Editor shell mounts Finder (`$.Percussion.PercFinderView()` + `<jsp:include finder.jsp>`) | Replace with modern `ContentExplorerShell` mount via `PercModernUI`; **do not include** `finder.jsp` / `finder_js.jsp` (T031, T032) | Inventory populated — pending hard cut |
+| `WebUI/src/main/webapp/cm/app/dashboard.jsp` (lines 185, 229) | Dashboard shell mounts Finder | Remove Finder mount + include at hard cut | Inventory populated — pending hard cut |
+| `WebUI/src/main/webapp/cm/app/admin.jsp` (lines 146, 189) | Admin shell mounts Finder | Remove Finder mount + include | Inventory populated — pending hard cut |
+| `WebUI/src/main/webapp/cm/app/editAsset.jsp` (lines 179, 205) | Edit-asset shell mounts Finder | Remove Finder mount + include | Inventory populated — pending hard cut |
+| `WebUI/src/main/webapp/cm/app/editTemplate.jsp` (lines 111, 175) | Edit-template shell mounts Finder | Remove Finder mount + include | Inventory populated — pending hard cut |
+| `WebUI/src/main/webapp/cm/app/adminWorkflow.jsp` (line 108) | Admin-workflow shell mounts Finder | Remove Finder mount (no include) | Inventory populated — pending hard cut |
+| `WebUI/src/main/webapp/cm/app/users.jsp` (lines 100, 149) | Users shell mounts Finder | Remove Finder mount + include | Inventory populated — pending hard cut |
+| `WebUI/src/main/webapp/cm/app/siteArchitecture.jsp` (lines 109, 115, 128) | Site-architecture shell mounts Finder **and** calls `$.perc_finder().refresh()` from `siteArchitecture.jsp` | Remove mount + include; audit inline `refresh()` for adapter (T052/T012d) | Inventory populated — pending hard cut + adapter decision |
+| `WebUI/src/main/webapp/cm/pages/app/*` (mirrored JSPs) | Mirrored copy of `cm/app/` JSPs in `cm/pages/app/` (legacy pre-Track B staging path per WebUI AGENTS §Build Outputs) | Confirm `cm/pages/app/` is build-output, not source-of-truth; if mirrored, apply same Finder removals or document deletion of the mirror | Inventory populated — pending verification |
+| `WebUI/war/app/*` | Legacy WAR-root JSPs (pre-Vite migration) | Same removals as `cm/app/`; these are the legacy tree migrated to `src/main/webapp/cm/app/` per WebUI AGENTS §Track B | Inventory populated — pending verification that `war/app/` is build-output |
+| `WebUI/src/main/webapp/cm/app/includes/finder.jsp` | Finder chrome include | Stop including at hard cut; verify no other consumers (T032) | Inventory populated — pending hard cut |
+| `WebUI/src/main/webapp/cm/app/includes/finder_js.jsp` (lines 34, 35, 43) | Finder scripts include (`perc_finder.js`, `perc_finder_buttons.js`, `PercFinderView.js`) | Stop including at hard cut | Inventory populated — pending hard cut |
+| `WebUI/src/main/webapp/cm/app/includes/common_js.jsp` / `common_css.jsp` | Finder deps (timepicker, jquery-ui) | Audit for exclusive Finder refs; remove if unused post-hard-cut (T032 follow-on) | Inventory populated — pending audit |
+
+### Runtime clients (exclusive candidates)
+
+| Path | Notes | Keep / Drop | Status |
+|------|-------|-------------|--------|
+| `WebUI/src/main/webapp/cm/widgets/perc_finder.js` (and `WebUI/war/widgets/perc_finder.js` mirror) | Miller-column core (`$.perc_finder` jQuery plugin) | Drop from prod entry; keep file in repo until all `$.perc_finder()` consumers migrated to adapters (T012d / T045 host tasks) | Inventory populated — pending drop |
+| `WebUI/src/main/webapp/cm/widgets/perc_finder_buttons.js` (mirror) | Finder action button bar | Drop after inventory proves no non-Finder consumer | Inventory populated — pending drop |
+| `WebUI/src/main/webapp/cm/widgets/PercFinderListView/PercFinderListView.js` (mirror) | Finder list-view pane | Drop after consumer audit | Inventory populated — pending drop |
+| `WebUI/src/main/webapp/cm/views/PercFinderView.js` (mirror) | Finder container view | Drop after consumer audit | Inventory populated — pending drop |
+| `WebUI/src/main/webapp/cm/css/percFinder.css`, `perc_mcol.css`, `styles.css` (`#perc_finder_*` selectors) | Finder styles | Remove `#perc_finder_*` selectors after consumers cleared; keep file if non-Finder consumers remain | Inventory populated — pending audit |
+| `WebUI/src/main/resources/minify/common-bundles.json` (lines 94–103) | Minify pipeline includes Finder widgets/views | Remove Finder entries from bundle list at hard cut | Inventory populated — pending edit |
+| FancyTree only for Finder | May still be used elsewhere (e.g. AA tree) | Inventory consumers; migrate if exclusive to Finder | Inventory populated — pending audit |
+
+### `$.perc_finder()` call sites (rg `perc_finder|PercFinderView|finder\.jsp` WebUI, 2026-07-19)
+
+**Counts**: 284 matches across 91 files. The pattern below groups by directory tree (per WebUI AGENTS §Build Outputs, `WebUI/src/main/webapp/cm/` is source-of-truth; `WebUI/war/` is the legacy mirror being phased out).
+
+#### JSP entry-point consumers (must remove at P0-Core hard cut)
+
+| Consumer | Lines | Usage | Phase | Status |
+|----------|------:|-------|-------|--------|
+| `WebUI/src/main/webapp/cm/app/webmgt.jsp` | 303, 325 | `$.Percussion.PercFinderView()` + include | P0-Core | Pending — T031, T032 |
+| `WebUI/src/main/webapp/cm/app/dashboard.jsp` | 185, 229 | Mount + include | P0-Core | Pending — T031, T032 |
+| `WebUI/src/main/webapp/cm/app/admin.jsp` | 146, 189 | Mount + include | P0-Core | Pending — T031, T032 |
+| `WebUI/src/main/webapp/cm/app/editAsset.jsp` | 179, 205 | Mount + include | P0-Core | Pending — T031, T032 |
+| `WebUI/src/main/webapp/cm/app/editTemplate.jsp` | 111, 175 | Mount + include | P0-Core | Pending — T031, T032 |
+| `WebUI/src/main/webapp/cm/app/adminWorkflow.jsp` | 108 | Mount | P0-Core | Pending — T031 |
+| `WebUI/src/main/webapp/cm/app/users.jsp` | 100, 149 | Mount + include | P0-Core | Pending — T031, T032 |
+| `WebUI/src/main/webapp/cm/app/siteArchitecture.jsp` | 109, 115, 128 | Mount + `$.perc_finder().refresh()` | P0-Core | Pending — T031, T032 + adapter (T012d) |
+| `WebUI/src/main/webapp/cm/pages/app/*` | mirrors of `cm/app/` | (per WebUI AGENTS §Build Outputs: build-output / mirror) | P0-Core | Pending verification |
+| `WebUI/war/app/*` | legacy WAR-root mirror | Per WebUI AGENTS §Track B: legacy tree; same removals apply | P0-Core | Pending verification |
+
+#### View consumers (non-entry-point; require adapter or migration)
+
+| Consumer | Lines | Usage | Phase | Status |
+|----------|------:|-------|-------|--------|
+| `WebUI/src/main/webapp/cm/views/PercSiteImpactView.js` | 58, 173, 187 | `launchPagePreview`, `open`, `launchPagePreviewByPath` | P-Host-2 (AA-adjacent) | Pending adapter or host migration |
+| `WebUI/src/main/webapp/cm/views/PercCSSPreviewView.js` | 57, 60 | `addActionListener`, `ACTIONS.DELETE` | P-Host-2 | Pending |
+| `WebUI/src/main/webapp/cm/views/PercContentView.js` | 194, 196 | `addActionListener`, `ACTIONS.DELETE` | P-Host-2 | Pending |
+| `WebUI/src/main/webapp/cm/views/PercPageView.js` | 151, 167, 182, 200, 1049, 1222 | `$.perc_page_edit_dialog($,...)`, `getPathItemById`, `launchPagePreview` | P-Host-2 | Pending |
+| `WebUI/src/main/webapp/cm/views/PercLayoutView.js` | 419, 422 | `addActionListener`, `ACTIONS.DELETE` | P-Host-2 | Pending |
+| `WebUI/war/views/*` | mirrors | (legacy mirror) | Same as `cm/views/*` | Pending verification |
+
+#### Plugin consumers (use `$.perc_finder()` for path/refresh/preview helpers)
+
+| Consumer | Lines | Usage | Phase | Status |
+|----------|------:|-------|-------|--------|
+| `WebUI/src/main/webapp/cm/plugins/PercContributorUiAdaptor.js` | 41, 44 | `launchPagePreviewByPath`, `launchAssetPreview` | P-Host (Home Library 989 consumer) | Pending adapter or `host-home-library` migration |
+| `WebUI/src/main/webapp/cm/plugins/perc_newsitedialog.js` | 347 | `$.perc_finderInstance.refresh()` | P-Host-2 (AA new-site) | Pending adapter |
+| `WebUI/src/main/webapp/cm/plugins/PercFolderPropertiesDialog.js` | 73 | `FOLDER_PERMISSIONS.PERMISSION_ADMIN` reference | P-ACL (US4) | Pending — US4 must own dialog or refactor |
+| `WebUI/src/main/webapp/cm/plugins/PercNavigationManager.js` | 245, 473 | `refresh()` after nav | P-Host-2 / adapter | Pending |
+| `WebUI/src/main/webapp/cm/plugins/PercRevisionDialog.js` | 183, 190, 194 | `launchPageCompareView`, `launchPagePreview`, `launchAssetPreview` | P-Host-2 | Pending adapter |
+| `WebUI/src/main/webapp/cm/plugins/perc_utils.js` | 1658, 1659, 1688, 1701, 1703 | `open`, `refresh`, `perc_finder_inline_field_edit` (in-place rename) | P-Host-2 / shared util | Pending adapter — rename-in-place needs new UX path |
+| `WebUI/src/main/webapp/cm/plugins/PercFolderHelper.js` | 74, 94 | `getPathItemByPath`, `getPathItemById` | P-Host-2 (used by AA / dialogs) | Pending adapter |
+
+#### Widget consumers
+
+| Consumer | Lines | Usage | Phase | Status |
+|----------|------:|-------|-------|--------|
+| `WebUI/src/main/webapp/cm/widgets/perc_folderproperties_button.js` | 157, 161 | `open(newPath)`, `refresh()` after folder property change | P-ACL (US4) | Pending |
+| `WebUI/src/main/webapp/cm/widgets/perc_delete_page_button.js` | 21 | `var finder = $.perc_finder();` | P-Host-2 | Pending |
+| `WebUI/src/main/webapp/cm/widgets/PercActionDataTable/PercActionDataTable.js` | 121, 131 | `launchAssetPreview`, `launchPagePreviewByPath` | P-Host-2 | Pending |
+| `WebUI/src/main/webapp/cm/widgets/perc_site_map.js` | 2214 | `var finder = $.perc_finder();` | P-Host-2 | Pending |
+| `WebUI/src/main/webapp/cm/widgets/PercFinderListView/PercFinderListView.js` | 107–143 | `onDragStart/Stop/dragDelay`, `setCurrentItem`, `executePathChangedListeners` | P0-Core (file deleted with Finder) | Pending — file deleted as part of T032 |
+
+#### CSS consumers (selectors referencing Finder internals)
+
+| File | Lines | Notes |
+|------|------:|-------|
+| `WebUI/src/main/webapp/cm/css/percFinder.css` | 249, 514 | `perc_finder_inline_field_edit` etc. |
+| `WebUI/src/main/webapp/cm/css/perc_mcol.css` | 25 | `.perc_finder` class |
+| `WebUI/src/main/webapp/cm/css/styles.css` | 1672 | `#perc_finder_details_name` etc. |
+| `WebUI/src/main/webapp/cm/app/css/legacy/*` | mirrors | (legacy mirror) |
+
+#### Build pipeline consumers
+
+| File | Lines | Notes |
+|------|------:|-------|
+| `WebUI/src/main/resources/minify/common-bundles.json` | 94, 95, 103 | Bundle entries for `perc_finder.js`, `perc_finder_buttons.js`, `PercFinderView.js` |
+
+### Deep links
+
+| Legacy URL / param | Modern destination | Status |
+|--------------------|--------------------|--------|
+| Editor view with finder path state | Explorer path query/state — record concrete mapping in `contracts/path-api.md` or implementer note | Pending — T033 |
+| Unknown retired Finder URLs | Moved/unavailable message (T033 deep-link helper under `WebUI/src/main/ts/contentExplorer/` and/or JSP routing) | Pending — T033 |
+
+---
+
+## B. Desktop Content Explorer
+
+**Note**: spec.md problem statement describes Desktop CE as "Swing/AWT + JavaFX WebView, SOAP + HTTP." The actual module (`modules/DesktopContentExplorer/`) is **pure JavaFX 21** per its `README.md` (Java 17+, JavaFX controls/fxml/web, shaded JAR `perc-content-explorer-8.1.6-SNAPSHOT.jar`, entrypoint `com.percussion.cx.PSContentExplorerApplication`). Update spec.md problem statement in a follow-up clarification pass — non-blocking for this inventory.
+
+| Item | Action | Status |
+|------|--------|--------|
+| `modules/DesktopContentExplorer/README.md` | Add deprecation banner: "Deprecated for ordinary content admin; use modern web explorer. See feature 992." | Pending — T034 |
+| `modules/DesktopContentExplorer/pom.xml` | Mark `<description>` deprecated; flip `<distribution>` flag off so 8.2 installer does not include the CE distribution | Pending — T034 |
+| `modules/DesktopContentExplorer/dependency-reduced-pom.xml` | Mirror pom change after rebuild | Pending — T034 |
+| Install/upgrade docs (`docs/`, installer README) | Update "Desktop Content Explorer" sections to point to modern web explorer; mark CE optional → removed for ordinary admin | Pending — T034 |
+| Installer packaging (`modules/perc-distribution-tree` / `modules/perc-jetty` / installer scripts) | Verify CE distribution is optional; remove from default install profile at 8.2 GA | Pending — T034 |
+| Launch URLs / shortcuts (`cm/dce/*` pages in WebUI WAR; DCE launcher script in installer) | Map `cm/dce/*` to "moved/unavailable" message per T033 deep-link helper; remove launcher from installer | Pending — T034 |
+| Support runbooks | Update to point to modern web explorer | Pending — T034 |
+| `modules/DesktopContentExplorer/src/` | **No feature work** per spec.md Assumptions; optional later packaging cleanup only (do **not** rewrite as new desktop app per Out-of-Scope) | Pending — T034 confirms; later cleanup optional |
+| CE SOAP/HTTP endpoints used by Desktop CE | Server-side CE endpoints remain **available** for any remaining consumers until CE retirement story completes (spec.md Edge Case §152); verify no 8.2 server removal breaks Desktop CE prior to its retirement | Pending verification — T034 |
+
+**Gate**: Same as Finder P0-Core (core navigate only) — SC-007.
+
+---
+
+## C. Content browser hosts (independent hard cuts)
+
+**In-scope hosts for 8.2** (per `contracts/capability-matrix.md` P-Host, host-id table; one task ID per host):
+
+| Host id | Legacy surface | Current call sites (rg) | Modern target | Hard-cut phase | Per-host task | Status |
+|---------|----------------|--------------------------|---------------|----------------|---------------|--------|
+| `host-asset-picker` | Finder asset picker (uses `$.perc_finder().launchAssetPreview` and `perc_finder().refresh()`) | `WebUI/src/main/webapp/cm/widgets/perc_delete_page_button.js:21`, `…/widgets/PercActionDataTable/PercActionDataTable.js:121,131`, `…/views/PercPageView.js:1222` | `ContentBrowser` (P-Adv-1) | P-Host-1 | T045a | Pending — T045a |
+| `host-page-picker` | Finder page picker (`launchPagePreview`, `launchPagePreviewByPath`) | `…/views/PercSiteImpactView.js:58,173,187`, `…/widgets/PercActionDataTable/PercActionDataTable.js:131`, `…/views/PercPageView.js:1222` | `ContentBrowser` | P-Host-1 | T045b | Pending — T045b |
+| `host-aa-contentbrowser-dialog` | Dojo 0.4.3 Content Browser Dialog (Track A migration in flight per WebUI AGENTS §Track A) | `WebUI/src/main/webapp/cm/widgets/PercContentBrowserWidget.js` (and `…/cm/widgets/PercContentBrowserWidget.js`), `WebUI/src/main/webapp/cm/pages/testing/test_PercAssetBrowserWidget.jsp` (test entry) | `ContentBrowser` (Track A coordination) | P-Host-2 | T045c | Pending — T045c |
+| `host-folder-picker` | Folder picker dialog (`$.perc_finder().open(newPath.split('/'))` from folder properties button, `getPathItemByPath`/`ById` helpers) | `…/widgets/perc_folderproperties_button.js:157,161`, `…/plugins/PercFolderHelper.js:74,94` | `ContentBrowser` (folder-only mode) | P-Host-2 | T045d | Pending — T045d |
+| `host-home-library` *(optional, non-blocking)* | Home Library browse (989 consumer; `PercContributorUiAdaptor.js`) | `…/plugins/PercContributorUiAdaptor.js:41,44` | `ContentBrowser` (if 989 ready) | P-Host-3 optional | T045e | Pending — T045e (Mark OUT for 8.2 if 989 not ready) |
+| `host-perc-finder-inline-edit` *(implied by §A plugins/perc_utils.js L1701-1703)* | Inline rename field via `perc_finder_inline_field_edit` | `…/plugins/perc_utils.js:1701,1703` | Modern explorer in-place rename (P0-Core T020) | P0-Core | (covered by T020 + T045f verify) | Pending — T020 in-place rename + T045f |
+
+**`system/` wiring decisions** (per T012d evaluation; recorded per host):
+
+| Host id | Web-only? | `system/` task needed? | Decision evidence |
+|---------|-----------|------------------------|-------------------|
+| `host-asset-picker` | Yes — replaces `$.perc_finder().launchAssetPreview` with ContentBrowser confirm + sitemanage preview | No | Web-only |
+| `host-page-picker` | Yes | No | Web-only |
+| `host-aa-contentbrowser-dialog` | Yes — Dojo widget replaced by React ContentBrowser via Track A coordination | No | Web-only |
+| `host-folder-picker` | Yes | No | Web-only |
+| `host-home-library` | Yes — consumer-only adoption | No | Web-only |
+
+**No `system/` tasks are created** for 8.2 host migrations (T012e evaluates to "no task added").
+
+---
+
+## D. Tests
+
+**Legacy-only tests** (FR-024 — must be **replaced, not permanently skipped**, when surfaces retire):
+
+| Legacy test / surface | Location (rg) | Replacement | Phase | Status |
+|-----------------------|---------------|-------------|-------|--------|
+| `PercFinderView` UI automation | `WebUI/src/test/ts` (no Finder-specific Vitest found on 2026-07-19; legacy UI automation lives in manual UAT scripts) | Vitest suite under `WebUI/src/test/ts/contentExplorer/` (T013–T016, T015a) + manual UAT SC-001 | P0-Core | Pending — T013–T016, T015a, T025, T087 |
+| `PercContentBrowserWidget` UI test (Dojo/jQuery asset browser) | `WebUI/src/main/webapp/cm/pages/testing/test_PercAssetBrowserWidget.jsp` (and `cm/testing/`, `war/testing/` mirrors — manual JSP-based test entry) | Vitest component test for `ContentBrowser` (T037–T039) + UAT SC-002 | P-Host | Pending — T037–T039, T046, T087 |
+| `perc_finder_inline_field_edit` rename UI test | Implicit in `…/plugins/perc_utils.js:1701,1703` (no dedicated test) | T016 reduced-actions test covers in-place rename; T013 path API test covers `renameFolder` server call | P0-Core | Pending — T016, T013 |
+| Desktop CE UI automation | `modules/DesktopContentExplorer/` (no automated test suite — manual launch via `mvn javafx:run` per README) | **No automated CE tests to replace**; UAT SC-007 + retirement sign-off | P0-Core Desktop CE | Pending — T087, T035 |
+| Service-contract tests for finder-only REST shapes (if any) | (no finder-only REST endpoints; Finder is a jQuery UI layer over sitemanage path/search REST) | T052a service-contract test for **new** sitemanage / `rest` façades only (none added in 8.2 if T012d evaluates to web-only) | US3 | Pending — T052a (gated) |
+| CI-gate for replaced legacy tests | (new) | T029: Vitest count comparison / test-report check proving replaced tests are **running** in CI on the target JDK (not silently zero) | P0-Core | Pending — T029 |
+
+---
+
+## E. Sign-off checklist (per phase)
+
+**These boxes represent per-phase PR gates fired at ship time** (not planning time). The §A/§B/§C/§D inventory rows above are the **pre-implementation evidence** required before each §E item can be certified for a given phase. Tick boxes here mark the **gate rule itself as established**; the per-phase reviewer / date / PR-hash / Scenario result go in the Phase sign-off log above.
+
+- [x] Inventory rows for phase updated (no TBD-critical) — gate rule established; §A–§D populated 2026-07-19 by analyzer session. Per-phase reviewer / date / PR-hash recorded in Phase sign-off log above (P0-Core Finder, P0-Core Desktop CE, P-Host).
+- [x] Production path has no classic fallback for that surface — gate rule established (FR-019a, FR-020, FR-021); per-phase verification happens at phase PR per the Phase sign-off log above.
+- [x] SC for phase pass (see [quickstart.md](../quickstart.md)) — gate rule established (SC-001..SC-012); per-phase Scenario A–I results recorded in Phase sign-off log above with the relevant SC IDs.
+- [x] Legacy-only tests removed/replaced (not permanent skip) — gate rule established (FR-024 + T029 CI-gate + §D rows); per-phase CI evidence recorded in Phase sign-off log above.
+- [x] PR review thread resolution complete (constitution IX) — gate rule established (constitution IX + per-PR subtasks T027, T029a, T045a–T045f, T047, T057, T064, T070, T081, T089a); per-phase PR-hash + review-thread resolution evidence recorded in Phase sign-off log above.

--- a/specs/992-react-content-explorer/checklists/requirements.md
+++ b/specs/992-react-content-explorer/checklists/requirements.md
@@ -1,0 +1,70 @@
+# Specification Quality Checklist: Unified React Content Explorer
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-07-19  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+### Validation iteration 1 (2026-07-19)
+
+| Checklist item | Result | Notes |
+|----------------|--------|-------|
+| No implementation details | Pass with caveat | Module Scope and Assumptions name product modules and strategic stack (React/WebUI) for mono-repo navigation, matching other Percussion specs (e.g. 989). Functional requirements and success criteria stay outcome-focused (explorer layout, menus, ACLs, retirement)—no component APIs or class names in FRs/SCs. |
+| Stakeholder focus | Pass | Problem statement and stories explain user value (CE model vs miller columns). |
+| Mandatory sections | Pass | Module Scope, User Scenarios, Requirements, Success Criteria, Assumptions, Out of Scope present. |
+| NEEDS CLARIFICATION | Pass | None; phased cutover, explorer-not-miller default, and CE action/ACL reuse documented as assumptions. |
+| Testable FRs | Pass | FR-001–027 are verifiable via UAT or inventory sign-off. |
+| Measurable SCs | Pass | SC-001–010 include checklist %, action counts, timing, and sign-off gates. |
+| Technology-agnostic SCs | Pass | Outcomes refer to modern web explorer / browser / retirement—not frameworks in SC text. |
+| Acceptance scenarios | Pass | US1–US6 each have Given/When/Then scenarios. |
+| Edge cases | Pass | Large folders, ACL lockout, multi-select, session, a11y, concurrent edit. |
+| Scope bounded | Pass | Out of Scope lists editor/AA/JSF/GWT/Eclipse/desktop rewrite. |
+| Dependencies | Pass | Shell, path/ACL services, 989 coordination, API gap analysis. |
+
+### Validation iteration 2 (2026-07-19) — after `/speckit-clarify`
+
+Clarifications locked: hard cut per phase; Finder + Desktop CE hard cut = core navigate only (intermediate); independent host phases; advanced CE tools in-matrix (US7, FR-028, SC-011).
+
+### Validation iteration 3 (2026-07-19) — 8.2 release lock
+
+- Target product release **8.2**; all in-scope work is 8.2 scope.
+- **Functional parity blocks 8.2 GA** (FR-029, SC-012).
+- Phasing is within the 8.2 train only—not multi-product-release deferral.
+
+| Checklist item | Result | Notes |
+|----------------|--------|-------|
+| All content quality + completeness items | Pass | Clarifications section + US7/FR-019b/FR-028/SC phase gates; no NEEDS CLARIFICATION markers. |
+| Testable FRs | Pass | FR-001–028 (incl. 008a, 010a, 019a/b, 028). |
+| Measurable SCs | Pass | SC-001–011 with phase-specific gates. |
+| Acceptance scenarios | Pass | US1–US7. |
+| Scope bounded | Pass | Retirement gates vs post-cutover matrix explicit. |
+
+**Ready for**: `/speckit-plan`.
+
+Deferred to planning (low impact for clarify): concurrent-edit conflict policy detail; exact matrix phase ordering for advanced tools; Home Library adoption timing vs 989.

--- a/specs/992-react-content-explorer/contracts/action-menu-api.md
+++ b/specs/992-react-content-explorer/contracts/action-menu-api.md
@@ -3,6 +3,16 @@
 **Provider**: `rest` module — `com.percussion.rest.actions.ActionMenuResource` (`@Path("/actions")`)  
 **Purpose**: Configuration-driven menus for modern Content Explorer (CE model), replacing the **ReducedAction set** (FR-010a) long-term.
 
+## Maturity note (added per PR review)
+
+The public REST surface under `/actions` is **not feature-complete** today. It exposes only a subset of the menu-finding and visibility machinery that the legacy **XML action manager** (`sys_ActionPage`, `ActionMenu` configuration) provides to Desktop Content Explorer. The long-term intent is for `/actions` (and any thin sitemanage façade needed for **execution**) to fully replace the XML action manager so the modern explorer can render the same configurable menu tree CE does today. Until that parity lands:
+
+- The **ReducedAction set** (FR-010a; see [../data-model.md](../data-model.md) § *ReducedAction*) ships at the Finder / Desktop CE intermediate hard cut to keep the intermediate bar achievable without the full action manager.
+- The full configuration-driven menu phase (US3, FR-010) **requires** either `/actions` reaching feature parity with the XML action manager, **or** a thin sitemanage façade in front of the XML action manager exposing its data over web (see `plan.md` Complexity Tracking and `tasks.md` T052).
+- Capability matrix rows marked **P-Menu** track each CE menu capability against the source-of-truth (XML action manager vs REST). See [./capability-matrix.md](./capability-matrix.md) P-Menu rows + Translation (P-Trans) row.
+
+This note was added per PR review on `specs/992-react-content-explorer/contracts/action-menu-api.md` line 8.
+
 ## Discovery (expected surface)
 
 Public REST exposes action menu finders via adaptor (`IActionMenuAdaptor`), including approximately:
@@ -11,7 +21,7 @@ Public REST exposes action menu finders via adaptor (`IActionMenuAdaptor`), incl
 - Allowed transitions for content id(s)
 - Allowed content types / templates
 
-Exact query parameters and payload fields: implementers MUST align TypeScript types to live OpenAPI/Javadoc of `ActionMenuResource` and related DTOs (`ActionMenu`, `ActionMenuVisibilityContext`, `ActionMenuModeUIContext`, `ActionMenuParameter`) at implementation time—**do not invent fields**.
+Exact query parameters and payload fields: implementers MUST align TypeScript types to live OpenAPI/Javadoc of `ActionMenuResource` and related DTOs (`ActionMenu`, `ActionMenuVisibilityContext`, `ActionMenuModeUIContext`, `ActionMenuParameter`) at implementation time—**do not invent fields**. When a row in the capability matrix P-Menu or P-Trans lists cannot be served by `/actions` at US3 implementation, follow the gap policy at the bottom of this file.
 
 ## Client responsibilities
 

--- a/specs/992-react-content-explorer/contracts/action-menu-api.md
+++ b/specs/992-react-content-explorer/contracts/action-menu-api.md
@@ -1,0 +1,48 @@
+# Contract: Action menu API (US3 — post-cutover)
+
+**Provider**: `rest` module — `com.percussion.rest.actions.ActionMenuResource` (`@Path("/actions")`)  
+**Purpose**: Configuration-driven menus for modern Content Explorer (CE model), replacing the **ReducedAction set** (FR-010a) long-term.
+
+## Discovery (expected surface)
+
+Public REST exposes action menu finders via adaptor (`IActionMenuAdaptor`), including approximately:
+
+- Find menus for UI context / visibility
+- Allowed transitions for content id(s)
+- Allowed content types / templates
+
+Exact query parameters and payload fields: implementers MUST align TypeScript types to live OpenAPI/Javadoc of `ActionMenuResource` and related DTOs (`ActionMenu`, `ActionMenuVisibilityContext`, `ActionMenuModeUIContext`, `ActionMenuParameter`) at implementation time—**do not invent fields**.
+
+## Client responsibilities
+
+1. On selection change, request allowed actions for current context (folder vs item, multi-select rules).
+2. Render context menu + optional toolbar from server list (labels: TMX when keys exist; else server label).
+3. Hide or disable actions not returned / not permitted (FR-011).
+4. On invoke:
+   - Prefer documented REST/itemmanagement/path endpoints mapped from action.
+   - Or navigate to server-provided URL in product-safe frame/dialog pattern used by CM.
+5. Refresh tree/list after successful mutating actions (FR-012).
+6. Keyboard: open menu, focus items, activate (FR-013).
+
+## AuthZ
+
+- Server is authoritative; never enable an action solely because the client cached it.
+- CSRF on any POST execution paths.
+
+## Gap policy
+
+If menu **listing** works but **execution** has no safe web path for a high-value CE action:
+
+1. Record gap in [capability-matrix.md](./capability-matrix.md).
+2. Prefer existing sitemanage/itemmanagement services.
+3. Only then add a thin authenticated façade (plan Complexity Tracking).
+
+## Hard-cut relationship
+
+- **Not required** for Finder or Desktop CE hard cut (FR-010a ReducedAction set).
+- Required for SC-003 full-menu phase and long-term FR-010.
+
+## Out of scope here
+
+- Redesigning action configuration admin UI (Eclipse/workbench).
+- Desktop CE action manager port.

--- a/specs/992-react-content-explorer/contracts/capability-matrix.md
+++ b/specs/992-react-content-explorer/contracts/capability-matrix.md
@@ -1,0 +1,166 @@
+# Capability matrix: Finder + Desktop CE → modern Content Explorer
+
+**Feature**: `992-react-content-explorer`  
+**Normative** for phase gating (FR-022, FR-028, FR-029, SC-011, SC-012)  
+**Target product release**: **8.2** — all in-scope rows required for **8.2 GA**; **functional parity blocks 8.2**  
+**Status**: Seed — expand during implementation; every advanced CE row must be labeled (no silent omit); **post-8.2 “scheduled” is not allowed** for in-scope rows
+
+## Phase legend
+
+| Phase | Meaning | Intermediate hard-cut gate? | 8.2 GA required? |
+|-------|---------|----------------------------|------------------|
+| **P0-Core** | US1 core navigate — tree/list, open, create/rename/move/copy/delete, reduced actions | **Yes** — Finder primary nav + Desktop CE (same bar) | **Yes** |
+| **P-Host** | US2 content browser + per-host migration | Per-host hard cut (independent within train) | **Yes** (all in-scope hosts) |
+| **P-Menu** | US3 full action-configuration menus | No (after intermediate hard cut OK) | **Yes** |
+| **P-ACL** | US4 folder permissions/ACL UI | No | **Yes** |
+| **P-Search** | US5 full search/locate | No | **Yes** |
+| **P-Adv** | US7 advanced CE tools | No | **Yes** (SC-011 / SC-012) |
+| **OUT** | Explicitly not this feature | — | — |
+
+---
+
+## Core navigate (P0-Core) — hard-cut bar
+
+| Capability | Legacy source | Target | Phase | Acceptance |
+|------------|---------------|--------|-------|------------|
+| Explorer tree of sites/folders | CE tree / Finder columns | React tree | P0-Core | Expand/select loads children |
+| Detail list of children | CE list / Finder list view | React list + pagination | P0-Core | Columns: name, type at min; SC-005 |
+| Open item edit/preview | Both | Existing editor navigation | P0-Core | Path/id open works |
+| Create folder | Both | path addFolder APIs | P0-Core | Appears after refresh |
+| Rename | Both | renameFolder | P0-Core | Name updates |
+| Move | Both | moveItem | P0-Core | Tree/list refresh |
+| Copy (single item) | Both | path/item copy as today | P0-Core | Reduced action |
+| Delete + confirm | Both | delete APIs | P0-Core | Destructive confirm |
+| Permission denied / session errors | Both | Clear messaging | P0-Core | No blank hang |
+| ReducedAction set | Finder buttons subset | Product fixed set (ReducedAction enum) | P0-Core | FR-010a; entries enumerated in `data-model.md` |
+| Miller-column primary UX | Finder | **Removed** at hard cut | P0-Core | SC-006 |
+| Desktop CE required for core admin | CE app | **Not required** at hard cut | P0-Core | SC-007 |
+
+---
+
+## Content browser hosts (P-Host)
+
+| Capability | Legacy source | Target | Phase | Acceptance |
+|------------|---------------|--------|-------|------------|
+| Reusable browser component | ContentBrowserDialog / Finder pickers | `ContentBrowser` | P-Host | Host contract |
+| Single/multi select + filters | Dialogs | props | P-Host | US2 scenarios |
+| Pilot host hard cut | — | inventory row | P-Host | Per host |
+| AA / editor dialogs | Dojo/JSP browser | React host phases | P-Host | Independent hard cuts |
+| Home Library browse | Finder library / 989 | Optional consumer | P-Host | Non-blocking for P0 |
+
+**In-scope hosts for 8.2** (each row produces one task ID and one SC-002 evidence entry in `tasks.md` US2; see `checklists/cutover-inventory.md` §C for current call-site rows):
+
+| Host id | Legacy surface | Hard-cut phase | Acceptance evidence |
+|---------|----------------|----------------|---------------------|
+| `host-asset-picker` | Finder asset picker widgets | P-Host-1 | SC-002 checklist + Vitest |
+| `host-page-picker` | Finder page picker | P-Host-1 | SC-002 checklist + Vitest |
+| `host-aa-contentbrowser-dialog` | AA Dojo/JSP dialog | P-Host-2 | SC-002 checklist + Vitest |
+| `host-folder-picker` | Folder picker dialog | P-Host-2 | SC-002 checklist + Vitest |
+| `host-home-library` | Home Library browse (989 consumer) | P-Host-3 (optional, non-blocking) | SC-002 if adopted |
+
+Each host row is **not complete** until its individual SC-002 evidence is recorded.
+
+---
+
+## Menus (P-Menu)
+
+| Capability | Legacy source | Target | Phase | Acceptance |
+|------------|---------------|--------|-------|------------|
+| Context menu by selection | CE action menus | REST `/actions` + UI | P-Menu | SC-003 ≥10 actions (enumerated below) |
+| Toolbar/menu bar actions | CE | Same | P-Menu | FR-010 |
+| Workflow transitions | CE | Allowed transitions API | P-Menu | Authorized only |
+| Keyboard menu access | CE | a11y | P-Menu | FR-013 |
+
+**SC-003 high-value action enumeration (≥10; gate for full-menu P-Menu phase, not for intermediate hard cut)**:
+
+| # | Action category | Example | Selection |
+|---|------------------|---------|-----------|
+| 1 | Open | Open in editor | Item / Folder |
+| 2 | Edit | Edit item | Item |
+| 3 | Preview | Preview | Item / Folder |
+| 4 | Folder ops — create | Create folder | Folder |
+| 5 | Folder ops — rename | Rename | Folder / Item |
+| 6 | Folder ops — move | Move | Folder / Item |
+| 7 | Folder ops — copy | Copy | Folder / Item |
+| 8 | Folder ops — delete | Delete with confirm | Folder / Item |
+| 9 | Properties | Open folder properties | Folder / Item |
+| 10 | Workflow — check in/out | Force check-in | Item (checked out) |
+| 11 | Workflow — transition | Transition (allowed) | Item (workflow state) |
+| 12 | Workflow — history | View transitions | Item |
+
+Two or more of #10–#12 satisfy the SC-003 "workflow or properties" clause.
+
+## Advanced CE (P-Adv) — relationship / IA entity dimensions
+
+The dependency viewer and IA/relationship views surface the following entities/dimensions (defined in `data-model.md`):
+
+| Dimension | Source entity | Notes |
+|-----------|---------------|-------|
+| Outgoing relationships | `PSRelationship` (parent→child, AA link, etc.) | Filter by relationship type |
+| Incoming relationships | `PSRelationship` reverse | Symmetric view |
+| Active Assembly links | AA cross-reference | Type filter `aa` |
+| Site/taxonomy edges | `PSNode` taxonomy | IA traversal |
+| Local dependency | Item-local references (template, image) | Per-item graph |
+| Reverse dependency | Inbound local references | Per-item graph |
+
+**Acceptance per row**: at least the dimension above renders for the selected node, with permission filtering matching `PSFolderPermission`.
+
+---
+
+## Folder security (P-ACL)
+
+| Capability | Legacy source | Target | Phase | Acceptance |
+|------------|---------------|--------|-------|------------|
+| View folder permission levels | CE `PSFolderSecurityPanel` | folderProperties UI | P-ACL | SC-004 |
+| Edit ACL principals | CE ACL editor | saveFolderProperties | P-ACL | SC-004 |
+| Lockout self warning | CE | Client warn + server | P-ACL | FR-015 |
+| Read-only without rights | CE | Hide/disable | P-ACL | FR-016 |
+
+---
+
+## Search (P-Search)
+
+| Capability | Legacy source | Target | Phase | Acceptance |
+|------------|---------------|--------|-------|------------|
+| Simple/extended search | CE / Finder search | searchmanagement | P-Search | US5 |
+| Open/reveal from results | Both | Explorer | P-Search | US5 |
+| Search in content browser | Dialogs | enableSearch prop | P-Search | US2/US5 |
+| Saved searches catalog | CE | Matrix detail / REST gap | P-Search | Spike if missing |
+
+---
+
+## Advanced CE (P-Adv) — after intermediate hard cut; **required for 8.2** (FR-028, FR-029)
+
+| Capability | Legacy source | Target | Phase | Acceptance |
+|------------|---------------|--------|-------|------------|
+| Multi-item clipboard copy/paste | CE `PSClipBoard` | Explorer clipboard | P-Adv | US7 |
+| Site copy wizard | CE wizards + sitemanage copy | React wizard | P-Adv | Matrix row UAT |
+| Subfolder copy wizard | CE wizards | React wizard | P-Adv | Matrix row UAT |
+| Dependency viewer | CE `PSDependencyViewer` | React view | P-Adv | US7 |
+| IA / relationship views | CE managers | React views | P-Adv | US7 |
+| Display format full columns | CE display formats | List columns | P-Adv or P0 partial | FR-027 |
+| Relationships manager deep tools | CE | React | P-Adv | Inventory |
+
+**SC-011 / SC-012**: Before **8.2 GA**, every in-scope matrix row (including P-Adv) is **Done** with acceptance met—not unlabeled, not “post-8.2.”
+
+---
+
+## Explicit OUT (this feature)
+
+| Capability | Rationale |
+|------------|-----------|
+| Content editor field forms / AA canvas | Separate tracks |
+| JSF Admin / Publishing screens | Track B other features |
+| GWT Package Manager | Separate |
+| Eclipse Workbench | Separate |
+| Offline desktop CE rewrite | Spec out of scope |
+| Permanent dual Finder+Explorer production path | Clarification hard cut |
+| Shipping 8.2 without full matrix parity | FR-029 / SC-012 release gate |
+
+---
+
+## Maintenance
+
+- Update phase column when PRs land.
+- Cutover inventory cross-links Finder call sites and CE packaging rows.
+- New CE capabilities discovered in code review → add row; never silent drop.

--- a/specs/992-react-content-explorer/contracts/capability-matrix.md
+++ b/specs/992-react-content-explorer/contracts/capability-matrix.md
@@ -129,6 +129,21 @@ The dependency viewer and IA/relationship views surface the following entities/d
 
 ---
 
+## Translation (P-Trans) — required for 8.2 parity
+
+**Status**: Translation was missing from the initial capability matrix seed and is added per PR review. Content Explorer exposes a translation workflow (locale variants, in-flight translations, source-vs-target status) that Finder did not surface; parity requires it on the modern explorer.
+
+| Capability | Legacy source | Target | Phase | Acceptance |
+|------------|---------------|--------|-------|------------|
+| Show item locales (current + available) | CE translation panel | Explorer item detail | P-Trans | Each item row shows current locale + available locale list |
+| Translate (create new locale variant) | CE translation action | action-menu integration (`/actions` + itemmanagement) | P-Trans | Authorized user can request a new locale for an item |
+| In-flight translation status | CE translation queue | Explorer / search filter | P-Trans | List filter `translationState=inFlight`; result shows state |
+| Switch source/target locale session context | CE locale toggle | Modern shell locale switcher | P-Trans | Selecting a locale re-issues path API calls under that locale |
+
+**Open question for follow-up** (non-blocking for plan): exact REST surface for translation queue — investigate whether existing `rest` or `sitemanage` endpoints cover in-flight status, or whether a thin façade is required (T052a/T052b pattern).
+
+---
+
 ## Advanced CE (P-Adv) — after intermediate hard cut; **required for 8.2** (FR-028, FR-029)
 
 | Capability | Legacy source | Target | Phase | Acceptance |

--- a/specs/992-react-content-explorer/contracts/content-browser-host.md
+++ b/specs/992-react-content-explorer/contracts/content-browser-host.md
@@ -1,0 +1,72 @@
+# Contract: Content Browser host integration (US2)
+
+**Component name (registry)**: `ContentBrowser` (proposed)  
+**Mount**: `window.PercModernUI.mount(elementId, 'ContentBrowser', props)`  
+**Also**: importable React component for pure React hosts (Home Library, future shells)
+
+## Purpose
+
+Embeddable navigate / search / locate UI that returns a **SelectionResult** to the host without miller-column Finder or Desktop CE.
+
+## Props (host → browser)
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| mode | `'select' \| 'browse'` | `'select'` | select requires confirm; browse may omit confirm |
+| multiSelect | boolean | `false` | Allow multiple items |
+| allowFolderSelect | boolean | `true` | Folders selectable |
+| allowItemSelect | boolean | `true` | Items selectable |
+| allowedTypes | string[] \| null | `null` | If set, only these type/category values confirmable |
+| allowedCategories | string[] \| null | `null` | Optional category filter |
+| initialPath | string \| null | product root | Starting folder path |
+| roots | `'sites' \| 'assets' \| 'all' \| string[]` | `'all'` | Root set (align with path services) |
+| enableSearch | boolean | `true` | Show search when API available |
+| title | string \| null | TMX default | Dialog title |
+| onConfirm | `(selection: SelectionResult) => void` | required in select mode | Host receives selection |
+| onCancel | `() => void` | optional | User cancelled |
+| onError | `(message: string) => void` | optional | Load/action errors |
+
+## SelectionResult (browser → host)
+
+```ts
+interface SelectionItem {
+  id: string;
+  path: string;
+  name?: string;
+  type?: string;
+  category?: string;
+}
+
+interface SelectionResult {
+  items: SelectionItem[]; // length 1 if !multiSelect
+}
+```
+
+## Behavioral rules
+
+1. **Same visibility rules** as Content Explorer for the same session (FR-009).
+2. Confirm **disabled** when selection empty or fails filters (US2).
+3. Multi-select returns full set; single-select returns one-element `items`.
+4. Independent selection state from main explorer instance (edge case).
+5. CSRF/session errors call `onError` or host-visible message; do not hang.
+6. User-visible chrome strings via TMX keys.
+
+## Hard-cut per host (FR-008a)
+
+When a host is declared ready:
+
+- Production MUST mount modern ContentBrowser (or React import)—**no** classic Finder miller picker and **no** Desktop CE for that host.
+- Other hosts may remain on legacy until their phase.
+- Inventory each host in [../checklists/cutover-inventory.md](../checklists/cutover-inventory.md).
+
+## Pilot hosts (recommended order)
+
+1. Low-risk internal dialog or modern Home Library (if 989 available).
+2. Asset/page pickers in WebUI plugins that call Finder today.
+3. AA / `ContentBrowserDialog.jsp` (coordinate with Track A Dojo work—prefer not to invest in Dojo browser if Track A/B can jump to React).
+
+## Non-goals
+
+- Full admin action menus inside the picker (optional later).
+- Editing ACL inside the browser dialog.
+- Replacing the full explorer workspace.

--- a/specs/992-react-content-explorer/contracts/content-browser-host.md
+++ b/specs/992-react-content-explorer/contracts/content-browser-host.md
@@ -21,8 +21,11 @@ Embeddable navigate / search / locate UI that returns a **SelectionResult** to t
 | initialPath | string \| null | product root | Starting folder path |
 | roots | `'sites' \| 'assets' \| 'all' \| string[]` | `'all'` | Root set (align with path services) |
 | enableSearch | boolean | `true` | Show search when API available |
+| enablePreview | boolean | `true` | Show preview pane for the currently-focused item using one (or most) templates associated with the item's content type — e.g. image preview for asset items, page preview for page items. Hosts (e.g. dialogs that pick an asset to insert) can disable it when they only need selection identity. |
+| previewTemplate | string \| null | `null` | Optional explicit template/content-type id to render the preview with. When `null`, the browser picks the default (or first) template associated with the item's content type. |
 | title | string \| null | TMX default | Dialog title |
 | onConfirm | `(selection: SelectionResult) => void` | required in select mode | Host receives selection |
+| onPreviewChange | `(preview: PreviewInfo | null) => void` | optional | Browser tells host which item is currently being previewed (drives host-side UI like an Insert-button hint). |
 | onCancel | `() => void` | optional | User cancelled |
 | onError | `(message: string) => void` | optional | Load/action errors |
 
@@ -35,10 +38,19 @@ interface SelectionItem {
   name?: string;
   type?: string;
   category?: string;
+  /** Content-type id(s) the item is associated with; preview selector uses these. */
+  contentTypeIds?: string[];
 }
 
 interface SelectionResult {
   items: SelectionItem[]; // length 1 if !multiSelect
+}
+
+interface PreviewInfo {
+  item: SelectionItem;
+  templateId: string;
+  /** Server-rendered preview URL or rendered HTML — implementation-defined; see previewUrl helper. */
+  url: string;
 }
 ```
 

--- a/specs/992-react-content-explorer/contracts/path-api.md
+++ b/specs/992-react-content-explorer/contracts/path-api.md
@@ -1,0 +1,55 @@
+# Contract: Path Management API (explorer core)
+
+**Consumers**: React Content Explorer, Content Browser, (legacy Finder until hard cut)  
+**Provider**: `projects/sitemanage` — `PSPathService` (`@Path("/path")` under pathmanagement service root)  
+**Base (typical)**: `{SERVICES_ROOT}/pathmanagement/path` where `SERVICES_ROOT` is `/services` or `/Rhythmyx/services` per `WebUI/src/main/ts/api/paths.ts`
+
+## AuthN/Z
+
+- Same-origin session cookie as CM UI.
+- Mutating calls MUST include product CSRF token (modern client pattern).
+- Server enforces folder permissions; 403/validation errors returned as service faults—UI MUST surface messages.
+
+## Core operations (hard-cut / US1)
+
+| Operation | Method | Path / body | Response | Notes |
+|-----------|--------|-------------|----------|--------|
+| Find children | GET | `/folder/{path:.*}` | `PSPathItem[]` | Full list when small |
+| Paginated children | GET | `/paginatedFolder/{path:.*}?startIndex&maxResults&sortColumn&sortOrder&child&displayFormatId&category&type` | `PSPagedItemList` | **Required** for SC-005 large folders |
+| Find item by path | GET | `/item/{path:.*}` | `PSPathItem` | Open / resolve |
+| Find item by id | GET | `/item/id/{id}` | `PSPathItem` | Open by id |
+| Add folder | GET | `/addNewFolder/{path:.*}` or `/addFolder/{path:.*}` | `PSPathItem` | Match existing Finder usage |
+| Rename folder | POST | `/renameFolder` body `PSRenameFolderItem` | path item / status | |
+| Move item | POST | `/moveItem` body `PSMoveFolderItem` | status | Move/copy semantics as today |
+| Delete | (existing delete folder/item endpoints used by `PercPathService.js`) | | | Confirm in UI first |
+| Validate path | GET | `/validate/{path:.*}`, `/lastExisting/{path:.*}` | string/path | Deep link / goto |
+
+## Folder properties / ACL (US4)
+
+| Operation | Method | Path | Body / response |
+|-----------|--------|------|-----------------|
+| Get properties | GET | `/folderProperties/{id}` | `PSFolderProperties` |
+| Save properties | POST | `/saveFolderProperties` | `PSFolderProperties` → `PSNoContent` |
+
+**Rules**:
+- `id` must be valid guid string (server validates).
+- Save may reject during site-copy locks (`PSSiteCopyUtils`)—surface server message.
+- Client SHOULD warn before save if current user loses access (FR-015); server remains authoritative.
+
+## Error model
+
+- Path not found → service exception / 4xx with message.
+- Validation → `PSValidationException` style messages.
+- Client treats empty body / network failure as recoverable error state (not blank tree).
+
+## Compatibility
+
+- **No breaking change** to existing JSON field names for core ops without versioned dual support.
+- New query params only if backward compatible defaults.
+- Modern TS clients type against current DTO shapes (`PathItem`, `FolderProperties`, paged list).
+
+## Out of contract
+
+- Desktop CE SOAP `FindFolderChildren`.
+- Action menu listing (see [action-menu-api.md](./action-menu-api.md)).
+- Full text search body (searchmanagement separate service).

--- a/specs/992-react-content-explorer/data-model.md
+++ b/specs/992-react-content-explorer/data-model.md
@@ -1,0 +1,177 @@
+# Data Model: Unified React Content Explorer
+
+**Feature**: `992-react-content-explorer`  
+**Date**: 2026-07-19  
+**Scope**: Conceptual entities for modern explorer/browser clients and existing server DTOs. No new persistence schema for core navigate / ACL phases.
+
+## Entity overview
+
+```text
+PathNode (folder or item summary)
+    ├── accessLevel
+    ├── children[] (lazy)
+    └── displayProperties{}
+
+FolderProperties
+    ├── permission (accessLevel + principal lists)
+    └── acl (object ACL if present)
+
+Selection (client)
+    └── items[] → SelectionResult (host)
+
+ActionDefinition (post-cutover)
+    └── parameters[]
+
+SearchQuery / SearchResult
+ClipboardEntry (post-cutover advanced)
+```
+
+---
+
+## PathNode (server: `PSPathItem` / list helpers)
+
+| Field | Source / notes | Validation |
+|-------|----------------|------------|
+| id | Content/folder guid string | Required for open/ops when known |
+| name / title | Display name | Non-empty for create/rename |
+| path | Logical CMS path | Path encoding per existing `perc_utils` / server rules |
+| type / category | Item type / folder vs page/asset | Filters in browser host |
+| leaf | Tree leaf flag | — |
+| hasFolderChildren / hasItemChildren / hasSectionChildren | Expandability hints | May be false on paginated children (server doc) |
+| accessLevel | `PSFolderPermission.Access` | ADMIN, WRITE, READ, VIEW |
+| displayProperties / columnData | Map for list columns | Optional; display-format phase |
+| folderPath / folderPaths | Parent context | — |
+
+**Relationships**: Hierarchical via path; children loaded on demand (`folder` / `paginatedFolder`).
+
+**Client state**: Expanded path set, selected node id(s), loaded page cursors (`startIndex`, `maxResults`, sort).
+
+---
+
+## FolderProperties (server: `PSFolderProperties`)
+
+| Field | Notes |
+|-------|--------|
+| id, name | Folder identity |
+| permission | `PSFolderPermission` |
+| acl | `PSObjectAcl` when present |
+| communityId / communityName | Community context |
+| locale | Folder locale |
+| displayFormatName | List formatting |
+| workflowId | Default workflow |
+| allowedSites | Asset publish constraint |
+
+**Mutations**: `POST saveFolderProperties` — server validates; UI warns if current user would lose access (FR-015).
+
+---
+
+## PSFolderPermission
+
+| Field | Notes |
+|-------|--------|
+| accessLevel | Default for unspecified principals |
+| adminPrincipals / writePrincipals / readPrincipals / viewPrincipals | Lists of `{ type: USER\|ROLE, name }` |
+
+**Rules**: Only users with folder admin rights may edit (FR-016); server enforces.
+
+---
+
+## Selection / SelectionResult (client + host contract)
+
+| Field | Required | Notes |
+|-------|----------|--------|
+| id | Yes (when item known) | Stable content/folder id |
+| path | Preferred | For hosts that open by path |
+| type / category | When filtering | Reject disallowed types (FR-006) |
+| name | Optional | Display |
+| multi | Host flag | Array of items when multi-select |
+
+**Validation**: Host filters (folder-only, type allow-list); confirm disabled when invalid (US2).
+
+---
+
+## ReducedAction (hard-cut client enum)
+
+Product-fixed set for FR-010a (not full action config). Enumerated entries:
+
+| Action | Phase availability | Typical server call |
+|--------|--------------------|---------------------|
+| open / preview | P0-Core (intermediate hard cut) | Navigation to editor/preview by path/id |
+| createFolder | P0-Core | addNewFolder / addFolder |
+| rename | P0-Core | renameFolder |
+| move | P0-Core | moveItem |
+| copy | P0-Core | moveItem copy semantics or item copy service (inventory) |
+| delete | P0-Core | delete folder/item endpoints with confirm |
+| edit | P-Menu (FR-010 expansion) | existing itemmanagement update endpoints |
+| properties | P-Menu | folderProperties / item properties |
+| workflow transitions | P-Menu (FR-010 expansion) | Allowed transitions API |
+| workflow check-in/out | P-Menu (FR-010 expansion) | Force check-in / check-out endpoints |
+| workflow history | P-Menu (FR-010 expansion) | transitions audit endpoint |
+
+P0-Core entries are the **intermediate subset** of the full set above and are required at the Finder/Desktop CE intermediate hard cut. The P-Menu entries ship with the full configuration-driven menus (FR-010) — they expand, not redefine, the ReducedAction set.
+
+## ActionDefinition — SC-003 enumeration mapping
+
+The ≥10 high-value actions enumerated in `contracts/capability-matrix.md` P-Menu (open, edit, preview, create folder, rename, move, copy, delete, properties, force check-in, transition, history) map to existing server actions on `rest` `ActionMenuResource` and sitemanage itemmanagement. The ReducedAction set above is the **intermediate subset** of those same actions available at the intermediate hard cut. When full action menus ship (FR-010), the full enumeration expands the ReducedAction set rather than redefining the actions.
+
+---
+
+## ActionDefinition (post-cutover US3)
+
+Aligned with `rest` ActionMenu models:
+
+| Field | Notes |
+|-------|--------|
+| name / label | Display (prefer TMX when product keys exist) |
+| url / handler key | Execution target |
+| visibility context | Selection type, workflow, UI context |
+| parameters | ActionMenuParameter list |
+| enabled | From server allow-list |
+
+**State**: Built per selection change; hide/disable unauthorized (FR-011).
+
+---
+
+## SearchQuery / SearchResult
+
+| Field | Notes |
+|-------|--------|
+| criteria | Simple/extended fields per searchmanagement API |
+| results[] | PathNode-like summaries |
+| totalCount | If provided by API |
+
+**Transitions**: idle → searching → results | empty | error; open/reveal maps result → tree path.
+
+---
+
+## ClipboardEntry (US7 advanced)
+
+| Field | Notes |
+|-------|--------|
+| itemIds / paths | Multi-select payload |
+| operation | copy \| cut |
+| sourceFolder | Origin path |
+| pasted | Cleared or retained per CE-like rules after paste |
+
+---
+
+## Lifecycle notes
+
+| Event | Behavior |
+|-------|----------|
+| Expand folder | Fetch children; cache by path; invalidate on mutate |
+| Mutate (rename/move/delete) | Optimistic optional; always reconcile from server refresh |
+| ACL save | Full replace of editable permission fields; error keeps prior UI state until success |
+| Session expiry | Clear sensitive client state; re-login messaging (US1) |
+| Host dialog open/close | Independent selection from main explorer (edge case) |
+
+## Identity & uniqueness
+
+- Prefer **content/folder id** as stable key; **path** as navigation key (paths can change on rename/move).
+- After rename/move, refresh parent and update selection to new path/id from server response.
+
+## Out of model (this feature)
+
+- Full content item field schema (editors own that).
+- Desktop CE SOAP DTOs as runtime model (reference only).
+- New tables for menus/ACL (existing CMS config/storage).

--- a/specs/992-react-content-explorer/plan.md
+++ b/specs/992-react-content-explorer/plan.md
@@ -1,0 +1,179 @@
+# Implementation Plan: Unified React Content Explorer
+
+**Branch**: `992-react-content-explorer` | **Date**: 2026-07-19 | **Spec**: [spec.md](./spec.md)  
+**Input**: Feature specification from `/specs/992-react-content-explorer/spec.md`
+
+## Summary
+
+Replace the Web Management **miller-column Finder** (`perc_finder` / FancyTree columns embedded in `webmgt.jsp`) and retire **Desktop Content Explorer** for ordinary content admin. Ship a **Track B React** explorer (tree + detail list) plus a **reusable content browser** mountable from dialogs/hosts. Use existing **sitemanage path/search REST** for navigation and folder ops; extend or adapt **public REST action menus** and folder properties for full CE-depth menus/ACL. **Hard cut per phase** within the train (no production classic fallback). Finder and Desktop CE share the **same intermediate core-navigate gate**; menus, ACL UI, search, host migrations, and advanced CE tools (clipboard, site-copy wizards, dependency/IA views) complete as ordered phases **inside this feature**.
+
+**Release constraint (locked):** Target product release is **8.2**. **Everything in scope for this feature is 8.2 scope.** **Functional parity** (capability matrix in-scope rows Done + SC-012) **blocks 8.2 GA**. Work MUST NOT be deferred to a post-8.2 product release.
+
+## Technical Context
+
+- **Language/Version**: Java 21 (branch `development` / feature off development); TypeScript + React 19 (WebUI Vite pipeline)
+- **Owning Module(s)**:
+  - `WebUI/` — primary UI (explorer shell, content browser component, Finder hard-cut wiring)
+  - `projects/sitemanage/` — path management, folder properties/permissions, search (reuse first; small REST gaps only if proven)
+  - `rest/` — `ActionMenuResource` (`/actions`) for configuration-driven menus (post-cutover US3)
+  - `modules/DesktopContentExplorer/` — capability source + distribution retirement (no new Swing work)
+  - `modules/perc-i18n/` — TMX keys for explorer/browser chrome
+  - `system/` — **NOT a default touched module**. In scope **only when a specific in-scope host hard-cut proves it needs server-side wiring** (e.g. an action-page / content-browser dialog JSP that cannot be replaced via WebUI + sitemanage + REST). Each such case adds a per-host task in `tasks.md` US2; otherwise `system/` is untouched.
+- **AGENTS Hierarchy**: root `AGENTS.md`, `WebUI/AGENTS.md` (Track B bridge, Vite, tests); module AGENTS when touching sitemanage/rest
+- **Dependencies & Storage**:
+  - Path REST: `/services/pathmanagement/path/*` (`PSPathService`) — folder children, paginatedFolder, move, rename, add, delete, folderProperties, saveFolderProperties
+  - Search REST: `/services/searchmanagement/search/*`
+  - Public actions REST: `/actions` (`rest` module `ActionMenuResource`) for later menu phase
+  - Session cookies + CSRF via `WebUI/src/main/ts/api/client.ts` / existing OWASP token pattern
+  - **No new DB schema** for core navigate or ACL (reuse `PSFolderProperties` / `PSFolderPermission` / `PSObjectAcl`)
+- **Testing**: Vitest + Testing Library (`WebUI/src/test/ts`); service contract tests only if REST shapes change; `./mvn-env.sh` / frontend Maven goals; cross-platform path rules for any Java/scripts
+- **Target Platform**: Windows, Linux, macOS product builds
+- **Project Type**: Hybrid J2EE WAR + modern frontend (island mount via `PercModernUI`)
+- **Performance Goals**: SC-005 — folder with ≥500 children: select folder → list usable and open item within **10s** on standard office network. Strategy: use `paginatedFolder` for **server-side pagination** (avoid loading full child set); apply **client-side virtualization** for the rendered list. The fixture (≥500 children, single folder, content type) and measurement method (p95 from folder-select → first item open) are defined in `quickstart.md` Scenario B.
+- **Constraints**:
+  - Constitution: no Spring Boot; safe modernization; TMX for user chrome
+  - Spec clarifications: hard cut per phase; core-navigate **intermediate** gate for Finder **and** Desktop CE; independent host hard-cuts; advanced CE **in-matrix**; **8.2 GA blocked by functional parity** (FR-029 / SC-012)
+  - Do not introduce browser→SOAP permanent dependency; CE SOAP is reference-only
+  - Full jQuery WebUI retirement out of scope except Finder exclusive surface after hard cut
+- **Scale/Impact**: All Web Management content editors; Desktop CE users; dialog hosts (AA, editors) over independent phases **all before 8.2 GA**; install/upgrade primarily web UI + docs/distribution for CE client
+- **Target release**: **8.2** — incomplete functional parity **blocks** the release
+
+## Constitution Check
+
+*Gate evaluation before research / after design.*
+
+- [x] **I. Module-First Boundaries** — WebUI + sitemanage (+ rest for menus later); AGENTS applied
+- [x] **II. Evidence Over Invention** — Cites `PSPathService`, `PSFolderProperties`, `PercPathService.js`, `webmgt.jsp` Finder include, `ActionMenuResource`, `PercModernUI` / `registry.ts`, Desktop CE classes as UX inventory only
+- [x] **III. Test Discipline** — Vitest for explorer/browser; replace legacy-only Finder automation when hard-cut; expand as phases land. Any new sitemanage / `rest` façade must add a service-contract integration test (T052a) runnable via `./mvn-env.sh` on JDK 21.
+- [x] **VI. Security by Default** — Server-side folder permission enforcement remains authoritative; UI hides/disables; ACL save reuses `saveFolderProperties`; CSRF on mutating calls. Any new endpoint must add a threat-model note (T052b) covering zip-slip / XXE / CSRF / server-side AuthZ, and no secrets logged.
+- [x] **IV. Contract & Integration Integrity** — Prefer existing path/search/folder property REST; document gaps before new endpoints; no `.ppkg`/schema break for core
+- [x] **V. Safe Modernization** — Track B React islands; no Spring Boot; no full SPA rewrite of all WebUI
+- [x] **VI. Security by Default** — Server-side folder permission enforcement remains authoritative; UI hides/disables; ACL save reuses `saveFolderProperties`; CSRF on mutating calls
+- [x] **VII. Build & Dependency Hygiene** — Vite + Maven frontend; JDK 21 via mvn-env
+- [x] **VIII. Documentation & Operability** — Feature contracts, cutover inventory, capability matrix, TMX keys
+- [x] **IX. PR Review Comment Resolution** — Applies to each story PR; explicit per-PR subtasks (T027, T029a, T045a–T045f, T047, T057, T064, T070, T081) require inline reply with mitigation commit hash AND `gh api graphql resolveReviewThread` for every review thread
+- [x] **Complexity Budget** — No new top-level product module; optional thin REST adapters justified only by proven gaps (Complexity Tracking)
+
+**Post-design re-check**: Pass. Prefer **one PR train per phase/story** on the feature branch (US1 core explorer → US6 hard cut → US2 browser → hosts → US3/4/5 → US7 matrix rows). US6 intermediate hard cut only after SC-001/SC-005/SC-006 (and SC-007 when CE retired). **8.2 GA** requires full matrix Done and SC-012 (functional parity blocks release).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/992-react-content-explorer/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── path-api.md                 # sitemanage path REST used by explorer
+│   ├── content-browser-host.md     # host integration contract (US2)
+│   ├── action-menu-api.md          # public REST actions (US3)
+│   └── capability-matrix.md        # CE/Finder capability phases (normative inventory)
+├── checklists/
+│   ├── requirements.md
+│   └── cutover-inventory.md        # Finder touchpoints + CE retirement (FR-022)
+├── spec.md
+└── tasks.md                        # produced by /speckit-tasks
+```
+
+### Source Code (affected paths)
+
+```text
+WebUI/
+├── src/main/ts/
+│   ├── api/
+│   │   ├── paths.ts                # EXTEND: pathmanagement + search URLs
+│   │   ├── client.ts               # REUSE CSRF fetch
+│   │   └── contentExplorer/        # NEW: typed path/folder/browser API wrappers
+│   ├── i18n/                       # REUSE thin I18N.message wrapper
+│   ├── bridge.ts / registry.ts     # register ContentExplorerShell, ContentBrowser
+│   ├── contentExplorer/            # NEW: shell, tree, detail list, reduced actions
+│   └── contentBrowser/             # NEW: embeddable navigate/search/select
+├── src/main/webapp/cm/app/
+│   ├── webmgt.jsp                  # hard-cut: replace Finder include with modern mount / layout
+│   ├── includes/finder.jsp         # DELETE or stop including after Finder hard cut
+│   ├── includes/finder_js.jsp      # DELETE or stop including after Finder hard cut
+│   └── <optional explorer shell>.jsp  # if explorer is a dedicated view vs panel in editor
+├── war/widgets/perc_finder*.js     # retire from production entry after hard cut (inventory)
+└── src/test/ts/contentExplorer/    # NEW Vitest
+    contentBrowser/
+
+projects/sitemanage/
+└── pathmanagement/…                # REUSE; only change if contract gaps proven
+
+rest/
+└── actions/ActionMenuResource.java # REUSE for US3; verify authz + payload fit
+
+modules/DesktopContentExplorer/     # no feature work; distribution/docs retirement in US6
+modules/perc-i18n/…/CmsUi.tmx       # add perc.ui.explorer.* / browser keys
+```
+
+**Structure decision**: Track B **island pattern** — React apps registered in `registry.ts`, mounted via `PercModernUI.mount` from Web Management shell. Explorer replaces the Finder panel region in `webmgt.jsp` (or successor layout) rather than a second desktop runtime. Content browser is a **second registered component** with a documented host props contract (open as dialog or inline). Shared path API module feeds both explorer and browser (FR-009).
+
+## Implementation Phases (design → tasks)
+
+### Phase A — Foundations
+
+1. Seed [capability-matrix.md](./contracts/capability-matrix.md) and [cutover-inventory.md](./checklists/cutover-inventory.md) from Finder + CE inventory.
+2. Extend `api/paths.ts` + `api/contentExplorer/*` for path/folder/paginated/move/rename/delete/create typed clients.
+3. Register `ContentExplorerShell` and `ContentBrowser` in `registry.ts`.
+4. TMX key plan for chrome (tree, list, reduced actions, errors).
+5. Vitest harness patterns aligned with Home/Dashboard tests.
+
+### Phase B — US1 Core explorer (P1) — **hard-cut gate**
+
+1. Tree + detail list UI; load roots/children via `findChildren` / `paginatedFolder`.
+2. Open/preview using existing product navigation patterns (path/id → editor).
+3. **ReducedAction set** (FR-010a): create folder, rename, copy/move (via `moveItem` + server semantics), delete with confirm.
+4. Permission-aware empty/error states; session/CSRF handling.
+5. Performance: pagination + virtualization for SC-005.
+6. Vitest: tree navigation, list load, action happy/error paths (mocked API).
+
+### Phase C — US6 Finder (+ optional Desktop CE) hard cut (P3)
+
+1. Complete cutover inventory for Finder production entry points (`webmgt.jsp`, includes, `$.perc_finder` callers for **primary nav only**).
+2. Hard-cut primary nav: no miller-column Finder as supported production path.
+3. Desktop CE: docs/distribution deprecate/remove for ordinary admin when same bar met (same or sequential release).
+4. Deep-link map known URLs → modern explorer; unavailable message for unknown.
+5. Replace legacy-only tests for retired surfaces.
+
+### Phase D — US2 Reusable content browser (P1, independent of hard cut)
+
+1. Embeddable component: navigate, optional search, single/multi select, filters, confirm/cancel.
+2. Host contract doc + TypeScript props; pilot one host (prefer a low-risk dialog or Home Library if 989 ready).
+3. Host hard-cuts **independently** (FR-008a).
+
+### Phase E — US3 Menus, US4 ACL, US5 Search (P2, post-cutover capability)
+
+1. US3: consume `ActionMenuResource` / adaptor; context menu + toolbar; keyboard access.
+2. US4: folder properties/security UI on `folderProperties` + `saveFolderProperties`; lockout warning.
+3. US5: explorer + browser search via searchmanagement; open/reveal in tree.
+
+### Phase F — US7 Advanced CE matrix (P3, post-cutover)
+
+1. Clipboard multi-item copy/paste.
+2. Site/subfolder copy wizards (reuse sitemanage site copy services where present).
+3. Dependency viewer + IA/relationship views.
+4. SC-011: all matrix rows Done or scheduled with owners.
+
+## Complexity Tracking
+
+| Violation / stretch | Justification & alternatives |
+|---------------------|------------------------------|
+| Possible new REST for action **execution** (not only menu listing) if public `/actions` only returns definitions | Prefer wrapping existing itemmanagement/content endpoints first; add thin sitemanage façade only if CE action URLs cannot be invoked safely from browser. **Any new REST or façade endpoint must come with (a) a service-contract test under `rest/src/test/java` (REST resource) or `projects/sitemanage/src/test/java` (façade) per constitution III/IV, runnable via `./mvn-env.sh -pl <module> -am test` on JDK 21; (b) a threat-model note (zip-slip, XXE, CSRF, server-side AuthZ) per constitution VI, recorded in PR evidence under `docs/ai-generated/release/992-8.2-parity-evidence.md` (or PR description).** |
+| Finder embedded deeply via `$.perc_finder()` | Hard cut is **primary nav** first; remaining callers inventoried and migrated in host phases or temporary adapters—do not expand dual UI. |
+
+## Artifacts
+
+| Artifact | Purpose |
+|----------|---------|
+| [research.md](./research.md) | Decisions: stack, APIs, cutover, gaps |
+| [data-model.md](./data-model.md) | Client/server entities |
+| [contracts/path-api.md](./contracts/path-api.md) | Path REST contract |
+| [contracts/content-browser-host.md](./contracts/content-browser-host.md) | Host embed contract |
+| [contracts/action-menu-api.md](./contracts/action-menu-api.md) | Menu REST for US3 |
+| [contracts/capability-matrix.md](./contracts/capability-matrix.md) | Phased CE/Finder capabilities |
+| [quickstart.md](./quickstart.md) | Validation scenarios |
+| [checklists/cutover-inventory.md](./checklists/cutover-inventory.md) | FR-022 inventory seed |

--- a/specs/992-react-content-explorer/quickstart.md
+++ b/specs/992-react-content-explorer/quickstart.md
@@ -1,0 +1,132 @@
+# Quickstart validation: Unified React Content Explorer
+
+**Feature**: `992-react-content-explorer`  
+**Purpose**: Runnable validation scenarios for implementers and UAT—not a full test suite.
+
+## Prerequisites
+
+- Branch `992-react-content-explorer` (or merge target with this feature).
+- **Product release target: 8.2** — full functional parity (SC-012) is required before labeling/shipping 8.2 GA.
+- JDK 21 via `./mvn-env.sh` / `./mvn-env.bat`.
+- Running CMS instance with at least one site, nested folders, and a user with content rights; admin user for ACL phase.
+- Node/npm as required by WebUI Vite pipeline (see `WebUI/AGENTS.md` / `WebUI/README.md`).
+- Contracts: [path-api.md](./contracts/path-api.md), [content-browser-host.md](./contracts/content-browser-host.md), [capability-matrix.md](./contracts/capability-matrix.md).
+
+## Build / unit tests (dev)
+
+```bash
+# From repo root — adjust module goals per WebUI README if needed
+./mvn-env.sh -pl WebUI -am test
+# Frontend-focused (example; use project-standard WebUI frontend test goal)
+cd WebUI && npm test -- --run src/test/ts/contentExplorer src/test/ts/contentBrowser
+```
+
+**Expected**: Vitest coverage for tree navigation, list pagination hooks, reduced actions, and browser selection filters is green for implemented phases.
+
+## Scenario A — Core navigate (P0-Core / SC-001)
+
+1. Sign in as content user.
+2. Open Web Management content exploration (editor/explorer entry after rewire).
+3. Confirm **tree + detail list** (not miller columns as primary).
+4. Expand folders; select folder; verify children list.
+5. Open a page/asset; verify editor/preview path works.
+6. Create folder; rename; move or copy; delete with confirm.
+7. Force permission error or session timeout (or mock); verify clear message.
+
+**Pass**: 100% of steps without miller-column Finder or Desktop CE.
+
+## Scenario B — Large folder (SC-005)
+
+**Fixture**:
+- Single folder with **≥500 children** (mixed page/asset type). Create once per test environment via scripted content seed (`scripts/create-large-folder-fixture.sh` — added in `tasks.md` Phase 2).
+- Standard office network: wired or 802.11ac, <50 ms RTT to CMS host, no proxy throttle. Record network profile in test evidence.
+
+**Steps**:
+1. Sign in; navigate to fixture folder via modern explorer.
+2. Select folder → list loads first page.
+3. Scroll/page list.
+4. Open one item.
+
+**Pass criterion (SC-005)**:
+- **p95** time from "select folder" → "selected item open in editor" **≤ 10 seconds** on the standard office network above.
+- Recorded in `checklists/sc005-perf-evidence.md` (created in `tasks.md` Phase 2): run name, git SHA, fixture size, network profile, p50/p95/max times, pass/fail.
+- Implementer Vitest gate: a separate Vitest perf test asserts that a mocked `paginatedFolder` for a 500-child fixture renders the first page and opens a selected item within the same 10 s budget on the dev machine, to catch regressions pre-CI.
+
+## Scenario C — Finder hard cut (SC-006)
+
+1. Production-like build after US6 Finder phase.
+2. Open primary content exploration.
+3. Confirm zero miller-column Finder chrome; no production fallback toggle/URL to classic Finder.
+4. Sign off [cutover-inventory.md](./checklists/cutover-inventory.md) rows for primary nav.
+
+**Sign-off reviewers (per `cutover-inventory.md` §E)**: at minimum, **two roles** must sign each row:
+- Engineering owner of the touched module (e.g. `WebUI` lead for Finder primary-nav; sitemanage lead for path API gaps).
+- QA/UAT owner (runs Scenario A/B/C against the candidate build).
+- Optional: release manager (signs release-train readiness).
+
+Evidence per row = sign-off name + date + linked PR / commit hash + Scenario result.
+
+## Scenario D — Desktop CE retirement (SC-007)
+
+1. Same core-navigate bar as Scenario A.
+2. Complete ordinary content admin without launching Desktop CE.
+3. Docs/distribution no longer require CE for those workflows.
+
+## Scenario E — Content browser host (SC-002 / US2)
+
+1. Open pilot host dialog that mounts `ContentBrowser`.
+2. Navigate or search; select allowed item; confirm.
+3. Verify host receives `SelectionResult` (id/path).
+4. Try disallowed type; confirm blocked.
+5. If multi-select host: select multiple; confirm set.
+
+## Scenario F — ACL (SC-004 / US4) — post-cutover
+
+1. Admin: open folder properties/security; change ACL; save.
+2. Second user session: refresh; verify access change.
+3. Attempt self-lockout change; expect warning.
+
+## Scenario G — Menus (SC-003 / US3) — post-cutover
+
+1. Authorized user: context menu on folder and on item.
+2. Execute checklist of ≥10 high-value actions (matrix); all succeed.
+
+## Scenario H — Advanced matrix (SC-011 / US7)
+
+1. Review capability matrix P-Adv rows.
+2. For each in-scope row, run row-specific UAT until **Done** (post-8.2 “scheduled” is not allowed).
+
+## Scenario I — 8.2 release gate (SC-012)
+
+1. Confirm Scenarios A–H pass on the 8.2 candidate build.
+2. Confirm capability matrix in-scope rows are all Done.
+3. Confirm no production classic Finder/CE fallback for in-scope surfaces.
+4. **Do not** label or ship as 8.2 GA if any SC-012 clause fails.
+
+## Accessibility spot-check (SC-009)
+
+- Keyboard: tree expand/select, list focus, reduced actions or context menu, browser dialog confirm/cancel.
+
+## Usability survey (SC-010)
+
+**Rubric**: each of ≥5 internal users familiar with both UIs rates **five** daily folder-navigation tasks on a 1–5 Likert scale for **modern explorer** vs **miller-column Finder**. Tasks:
+1. Find a folder by name.
+2. Open a specific item from a known parent.
+3. Create a new folder and rename it.
+4. Move an item between folders.
+5. Recover from a permission-denied state.
+
+**Pass**: majority of raters (≥3 of 5) score modern explorer **higher** than miller-column Finder on the sum across tasks. Recorded in `checklists/sc010-usability-notes.md` (created in `tasks.md` T084) with raw scores per rater.
+
+## i18n spot-check
+
+- Non-default locale session: primary chrome resolves via TMX (not English-only hardcode).
+
+## Troubleshooting
+
+| Symptom | Check |
+|---------|--------|
+| 404 on `/Rhythmyx/services/...` | Use `detectServicesRoot()` / context path (`api/paths.ts`) |
+| CSRF failures | Token header on POST; shell includes CSRF like other modern pages |
+| Empty tree | User community/permissions; path roots; network tab path API |
+| Hard cut still shows Finder | `webmgt.jsp` includes and nav wiring; cutover inventory |

--- a/specs/992-react-content-explorer/research.md
+++ b/specs/992-react-content-explorer/research.md
@@ -1,0 +1,149 @@
+# Research: Unified React Content Explorer
+
+**Feature**: `992-react-content-explorer`  
+**Date**: 2026-07-19  
+**Status**: Phase 0 complete — open questions resolved for planning
+
+## R1 — UI stack and mount pattern
+
+**Decision**: Track B React 19 + TypeScript via existing Vite bundle and `window.PercModernUI.mount` / `registry.ts` (same as Dashboard, HomeShell, WidgetBuilderApp).
+
+**Rationale**: Constitution and `WebUI/AGENTS.md` mandate Track B for strategic UI; bridge pattern already ships; avoids second SPA framework.
+
+**Alternatives considered**:
+- Rewrite Finder in jQuery only — does not meet CE-model or long-term consolidation goals.
+- Full SPA replacement of all Web Management — out of scope; island mount is incremental and safer.
+- JavaFX/web dual shell — rejected by spec (web replacement only).
+
+## R2 — Navigation paradigm
+
+**Decision**: Explorer-style **tree + detail list** as default; miller columns not retained as primary UX.
+
+**Rationale**: Spec problem statement and clarifications; CE mental model preferred by users.
+
+**Alternatives considered**: Keep miller columns as optional mode — deferred indefinitely; not in MVP or hard-cut bar.
+
+## R3 — Server APIs for core navigate (hard-cut bar)
+
+**Decision**: Reuse **sitemanage path management REST** as system of record for core navigate:
+
+| Capability | Evidence |
+|------------|----------|
+| Children / list | `GET …/pathmanagement/path/folder/{path}`, `GET …/paginatedFolder/{path}` |
+| Item by path/id | `GET …/item/{path}`, `GET …/item/id/{id}` |
+| Add folder | `GET …/addFolder|addNewFolder/{path}` |
+| Rename | `POST …/renameFolder` |
+| Move | `POST …/moveItem` |
+| Delete | path delete endpoints used by `PercPathService.js` |
+| Folder props / ACL | `GET …/folderProperties/{id}`, `POST …/saveFolderProperties` |
+| Search | `…/searchmanagement/search/get` and `/get/extendedresults` |
+
+Client reference: `WebUI/war/services/PercPathService.js`, modern roots in `WebUI/src/main/ts/api/paths.ts`.
+
+**Rationale**: Finder already uses these contracts; sufficient for US1 reduced actions without SOAP.
+
+**Alternatives considered**:
+- Browser → Desktop CE SOAP (`FindFolderChildren`, etc.) — rejected (not web-native; dual protocol).
+- New parallel path API — unnecessary for core; only if proven gap.
+
+## R4 — Folder ACL / permissions
+
+**Decision**: US4 (post-cutover) uses `PSFolderProperties` + `PSFolderPermission` (+ ACL object) via existing save/find folder properties; UI mirrors CE security panel behavior (lockout warning client-side + server enforcement).
+
+**Rationale**: Data model already on REST; CE Swing (`PSFolderSecurityPanel`) is UX reference only.
+
+**Alternatives considered**: Redesign permission schema — out of scope per spec.
+
+## R5 — Action menus (US3)
+
+**Decision**: Prefer public REST `ActionMenuResource` (`@Path("/actions")` in `rest` module) for **menu discovery** (allowed actions/transitions/types). **Execute** actions via existing item/content/path REST or documented action URLs—not raw CE applet code. If execution gap remains after inventory, add thin sitemanage façade (Complexity Tracking).
+
+**Rationale**: Product already exposes action menu REST; CE loads menus from server action config (`sys_ActionPage`, action manager)—web must not hardcode only Finder buttons long-term.
+
+**Alternatives considered**:
+- Fixed button set forever — fails FR-010 long-term.
+- Port CE Swing menu builder to browser as-is — high cost; REST adaptor is cleaner.
+
+**Hard-cut note**: At Finder hard cut, **ReducedAction set** only (FR-010a); full menus post-cutover.
+
+## R6 — Cutover strategy
+
+**Decision** (from clarify + release lock):
+1. **Hard cut per phase** — no production dual primary path once phase ships.
+2. **Finder + Desktop CE intermediate gate** = core navigate only (same bar) — for ordered work *within* the train.
+3. **Host browser migrations** independent hard-cuts within the train.
+4. Advanced CE tools **in this feature** as matrix phases after intermediate retirement.
+5. **Target product release = 8.2.** All in-scope work is 8.2 scope. **Functional parity blocks 8.2 GA** (spec FR-029 / SC-012). Phases are **not** deferred to post-8.2 product releases.
+
+**Rationale**: User-locked clarifications plus product release constraint; ordered engineering without shipping incomplete 8.2.
+
+**Alternatives considered**: Time-boxed dual path; CE retirement only after full menus/ACL as *intermediate* gate — rejected in clarify. Multi-release deferral of parity — **rejected** by 8.2 lock.
+
+## R7 — Where Finder lives today
+
+**Decision**: Primary hard-cut surface is Web Management editor shell:
+
+- `WebUI/.../webmgt.jsp` includes `finder.jsp` / `finder_js.jsp`, initializes `$.Percussion.PercFinderView()`
+- Widgets: `perc_finder.js`, `PercFinderTree.js`, `PercFinderListView`, `PercFinderView.js`
+- Many plugins call `$.perc_finder()` — inventory in cutover checklist; primary nav hard cut ≠ instant deletion of every call site if hosts still need adapters until their phase
+
+**Rationale**: Evidence from source; inventory-driven retirement avoids big-bang of entire jQuery WebUI.
+
+## R8 — Content browser hosts
+
+**Decision**: Ship reusable React `ContentBrowser` with typed host contract; migrate hosts independently. Known legacy: Dojo/AA `ContentBrowserDialog.jsp`, Finder-based pickers, asset browser widgets. Prefer modern mount or temporary adapter that does not reintroduce miller columns for hard-cut hosts.
+
+**Rationale**: Spec US2 + FR-008a; Track A Dojo work is separate but hosts may dual-track carefully.
+
+## R9 — i18n
+
+**Decision**: TMX via existing `tmx.jsp` + `I18N.message` (or Home’s thin TS wrapper); new keys under `perc.ui.explorer.*` / `perc.ui.contentBrowser.*` in `CmsUi.tmx` with structural locale parity.
+
+**Rationale**: Matches 989 and constitution VIII.
+
+## R10 — Testing strategy
+
+**Decision**:
+- Vitest unit/component tests for tree/list/actions/browser selection (mocked fetch).
+- Manual UAT scripts for SC-001, SC-005, SC-006/007 hard cuts.
+- Expand FR-023 automated coverage as phases land; no permanent skip of replaced Finder-only tests after hard cut.
+- Service contract tests only if REST contracts change.
+
+## R11 — Desktop CE module fate
+
+**Decision**: No feature development in Swing/JavaFX. After hard cut, update install docs/distribution so ordinary content admin does not require CE; module may remain in repo until packaging cleanup task (matrix row).
+
+**Rationale**: Spec retirement = web replacement; avoiding large binary delete in first hard-cut PR reduces risk—inventory tracks packaging.
+
+## Open items deferred to implementation (not blocking plan)
+
+| Item | Handling |
+|------|----------|
+| Exact action **execution** map (action id → REST/URL) | Inventory during US3; gap → façade |
+| Concurrent ACL save policy | Server last-write / validation; surface server errors |
+| Home Library adoption of ContentBrowser | Coordinate with 989; non-blocking for US1 |
+| Display format full column parity | FR-027 matrix follow-on |
+| Site copy wizard REST completeness | US7 matrix research spike |
+
+## R12 — Security surface (T011 — implementer note, 2026-07-19)
+
+Findings from the analyzer session while scaffolding Phase 2. Carry into US1 implementation and per-PR threat-model notes:
+
+- **CSRF**: All mutating path calls go through `api/client.ts` `apiFetch`, which already attaches the OWASP CSRFGuard token header. **No secret, password, or token may be logged.** (Constitution VI.)
+- **Session expiry**: `apiFetch` should treat 401 as re-login UX (TMX key `perc.ui.explorer.sessionExpired` — add in T023). Avoid blank panels.
+- **Folder AuthZ**: Server is authoritative. UI MUST NOT enable actions the server will reject. The ReducedAction set (FR-010a) calls `delete` / `move` / `rename` / `copy` which require folder WRITE or ADMIN — gate visibility on `PSPathItem.accessLevel`.
+- **ACL save**: `saveFolderProperties` (FR-014 / FR-015 / FR-016) — UI warns before save if current user would lose access; server remains authoritative. Lockout-self detection belongs in client (`aclLockout.test.ts`, T058).
+- **No new REST / façade needed for core navigate or ACL** — reusing `PSPathService` + `PSFolderProperties` is sufficient. T052a/T052b only fire if US3 / US7 action execution proves a gap.
+- **Path encoding**: `pathApi.ts` `encodePath` encodes each `/`-separated segment to keep the JAX-RS `{path:.*}` pattern intact and to avoid path-traversal mistakes on multi-segment paths.
+- **Cross-platform**: No new Java I/O or shell-only paths in this feature. Server-side work only if T012d evaluates a `system/` task (none added for 8.2).
+
+## References (repo)
+
+- `projects/sitemanage/.../PSPathService.java`
+- `projects/sitemanage/.../PSFolderProperties.java`, `PSFolderPermission.java`, `PSPathItem.java`
+- `WebUI/war/services/PercPathService.js`
+- `WebUI/src/main/ts/api/paths.ts`, `registry.ts`, `bridge.ts`
+- `WebUI/src/main/webapp/cm/app/webmgt.jsp`, `includes/finder*.jsp`
+- `rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java`
+- `modules/DesktopContentExplorer/...` (UX inventory)
+- `docs/ai-generated/tasks/#000-unified-ui-plan/`

--- a/specs/992-react-content-explorer/spec.md
+++ b/specs/992-react-content-explorer/spec.md
@@ -1,0 +1,276 @@
+# Feature Specification: Unified React Content Explorer
+
+**Feature Branch**: `992-react-content-explorer`  
+**Created**: 2026-07-19  
+**Status**: Draft  
+**Input**: Consolidate the main Finder UI (dynatree/fancytree miller-column navigation, heavy iframe usage) and the Desktop Content Explorer UI (Java applet / Swing / AWT / JavaFX) into a single modern React UI that adopts the Content Explorer interaction model. Close capability gaps (folder permissions, ACLs, customizable action menus). Provide a reusable content browser component for dialogs and other features that need navigate / search / locate content.
+
+## Module Scope
+- **Primary module(s)**: `WebUI/` (Finder includes, Web Management shell, modern React/TypeScript frontend under `WebUI/src/main/ts` and `WebUI/src/main/frontend`); `modules/DesktopContentExplorer/` (source of UX and capability requirements; retirement target)
+- **Secondary / integration modules**: `projects/sitemanage/` (path management, folder helpers, permissions); `system/` (action menus, folder ACLs, content services, content browser dialog JSPs); `rest/` (public REST where applicable); related content browser consumers (Active Assembly / editors that open browse/locate dialogs)
+  - **`system/` scope clarification**: `system/` is in scope **only when host server-side wiring is required** to replace a legacy dialog/action JSP. The default modern path is browser-to-REST via `WebUI` + `projects/sitemanage` + `rest`. A `system/` task is added **only when an individual host hard-cut proves a need** (see `tasks.md` US2 per-host tasks). Otherwise `system/` is not touched by this feature.
+- **AGENTS files to apply**: root `AGENTS.md`, `WebUI/AGENTS.md` (if present), module AGENTS under Desktop Content Explorer / sitemanage when changing those modules
+- **User roles affected**: content contributors and editors (browse, open, create, search, basic folder ops); publishers and site admins (folder security, bulk/content ops); system admins (action menu configuration, ACL/community rules); integrators embedding content pickers in dialogs
+- **Install / upgrade impact**: web UI distribution and navigation entry points; possible new or extended REST contracts for actions/ACLs if gaps exist; **no** required DB schema change for first ship if existing folder ACL and action configuration storage is reused. Desktop Content Explorer client distribution becomes optional then removed after cutover. Coordinate with Home Library work in `989-react-cui-widget-builder` (shared browse component).
+- **Target product release**: **8.2** — full feature scope (all capability-matrix in-scope rows) is required for 8.2 GA; **functional parity blocks the 8.2 release** (FR-029, SC-012).
+
+## Related work
+- **Unified UI Plan** (`docs/ai-generated/tasks/#000-unified-ui-plan/`): Track B strategic React consolidation; Desktop CE listed as web-based replacement; Finder lives in WebUI Legacy layer.
+- **989 Home / Widget Builder**: Home **Library** is contributor browse/open only; this feature owns **full** content exploration for Web Management and admin content work, plus a **reusable** browser that Home Library and dialogs can adopt.
+- **FancyTree migration** (completed tactical work): does not fix miller-column UX, iframe coupling, or missing CE capabilities—this feature supersedes Finder as the long-term surface.
+
+## Clarifications
+### Session 2026-07-19
+- Q: How should production handle Finder vs modern explorer during transition? → A: **Hard cut per phase** — when a surface is declared ready, that release ships modern-only for it; no classic Finder fallback in production for that surface.
+- Q: What MUST be complete before the primary-navigation hard cut (Finder retired)? → A: **Core navigate only** — tree + list, open/create/move/copy/delete; menus may be a **ReducedAction set** (see FR-010a); ACL and full search may ship after Finder hard cut.
+- Q: When must dialog/host content-browser migrations hard-cut relative to Finder primary-nav hard cut? → A: **Independent host phases** — reusable browser can land before/with/after Finder hard cut; each host hard-cuts when migrated; not all hosts required with Finder.
+- Q: Minimum bar before Desktop Content Explorer hard cut? → A: **Same as Finder hard cut** — core navigate only; Desktop CE may retire as soon as modern explorer replaces Finder primary nav (menus/ACL/full search not required for CE retirement).
+- Q: How should advanced CE-only capabilities be scoped? → A: **All in-matrix post-cutover** — clipboard, site-copy wizards, dependency/IA views are phased work **inside** this feature after retirement (not retirement gates).
+- Q: Target product release and release gate? → A: **Everything in this feature is in scope for product release 8.2.** Engineering phases (hard cuts, PR trains) may be ordered within the 8.2 train, but **functional parity** against the capability matrix (core navigate, reusable browser + in-scope hosts, full action menus, folder ACL UI, search, and advanced CE matrix rows) **blocks 8.2 GA**. Incomplete parity MUST NOT ship as 8.2. Work MUST NOT be deferred to a post-8.2 product release.
+
+## Problem statement
+Today content exploration is split across two incompatible UIs:
+
+| Surface | Stack | Strengths | Weaknesses |
+|---------|--------|-----------|------------|
+| **Finder** (Web Management / Home library mode) | jQuery + FancyTree, miller columns, deep iframe coupling | In-browser, no desktop install | Mac-like column navigation confuses many users; limited admin actions; weak/missing folder permission & ACL UX; hard to embed cleanly; maintenance cost |
+| **Desktop Content Explorer** | Swing/AWT + JavaFX WebView, SOAP + HTTP | Explorer tree + detail list; powerful **server-driven action menus**; folder properties/security (ACL); search; clipboard; mature content admin workflows | Desktop/JavaFX runtime; separate from modern web shell; hard to support; not usable inside web dialogs |
+
+Users and support staff repeatedly prefer the Content Explorer **mental model** (tree + list, rich context actions) over Finder’s miller columns. The product needs **one** modern web surface that preserves CE’s strengths and kills both legacy stacks over time.
+
+## User Scenarios & Testing
+Each story must be independently testable.
+
+### User Story 1 - Explorer-style content workspace (Priority: P1)
+
+Content managers open the product’s primary content navigation surface and work in an **explorer-style** layout: a navigable folder/site tree on one side and a detail list (or equivalent multi-column list) of the selected folder’s children on the other—not miller-column “Mac Finder” columns as the primary paradigm. They expand folders, select items, open content for edit/preview, create folders/items where permitted, and move/copy/delete with clear feedback. The workspace is a first-class modern web view in the CM shell (same session, chrome, and visual language as Dashboard / modern Home), without embedding the legacy Finder column chrome or the desktop Content Explorer application.
+
+**Why P1**: Replaces the primary pain of Finder UX and establishes the interaction model for all later stories.
+
+**Acceptance Scenarios**:
+1. **Given** a signed-in user with content access, **When** they open the primary content exploration entry (Web Management content area / successor of Finder), **Then** they see an explorer layout (tree + detail list) with sites/folders they are allowed to see—not miller-column navigation as the only/default mode.
+2. **Given** the user expands folders in the tree and selects a folder, **When** the detail pane loads, **Then** they see that folder’s children with identity and key metadata (name, type, and other columns appropriate to display format), and can open an item for edit or preview consistent with product rules.
+3. **Given** the user has create rights in a folder, **When** they create a folder or supported content type via the workspace actions, **Then** the new item appears after refresh/navigation without requiring the desktop CE client.
+4. **Given** the user moves, copies, or deletes an item they are allowed to change, **When** the action completes, **Then** the tree and list reflect the result; on failure they see a clear, non-blank error.
+5. **Given** a deep or large folder, **When** they navigate, **Then** the UI remains usable (pagination or virtualization as needed; no unresponsive blank iframe state characteristic of legacy Finder edge cases).
+6. **Given** session timeout or insufficient permission, **When** the user attempts navigation or an action, **Then** they receive re-login or access-denied messaging without a hung embedded frame.
+
+### User Story 2 - Reusable content browser component (Priority: P1)
+
+Authors and editors invoke a **content browser** from dialogs and other features (for example: pick a page/asset/folder, locate content for linking, choose a target folder) and complete navigate / search / select / confirm without leaving the host dialog flow. The same browser capability is available as an embeddable component (not a one-off page), so product features share one navigate-and-locate experience instead of forking Finder miller columns, Dojo/legacy content browser dialogs, or desktop CE.
+
+Host migrations are **independent phases**: the browser capability may ship before, with, or after the Finder primary-nav hard cut. Each host (or host group) hard-cuts when it is migrated—**not** all hosts need to move in the same release as Finder.
+
+**Why P1**: Unblocks editors and AA/dialog flows incrementally; prevents a third parallel browser design as hosts modernize.
+
+**Acceptance Scenarios**:
+1. **Given** a host feature opens the content browser in select mode, **When** the user navigates or searches and confirms a selection, **Then** the host receives the selected item identity (and path or other agreed selection payload) and the dialog closes or returns focus cleanly.
+2. **Given** the browser is configured for folder-only or type-filtered selection, **When** the user tries to select a disallowed type, **Then** confirm is disabled or rejected with a clear message.
+3. **Given** multi-select is enabled by the host, **When** the user selects multiple allowed items and confirms, **Then** the host receives the full selection set.
+4. **Given** the same user opens the full Content Explorer workspace and a dialog browser, **When** they navigate, **Then** both use the same navigation/search behaviors and permission rules (single product model).
+5. **Given** a specific host is declared ready for hard cut, **When** that release ships, **Then** that host uses the modern browser (not miller-column Finder and not desktop CE) with **no** production classic fallback for that host; other unmigrated hosts MAY still use their prior mechanism until their own hard-cut phase.
+
+### User Story 3 - Context actions and customizable menus (Priority: P2)
+
+Users act on folders and items through **context menus and menu bars** driven by the product’s action configuration (the Content Explorer model): available actions depend on selection type, permissions, and workflow state. Menus are richer and more consistent than Finder’s limited button set. Administrators continue to configure or extend actions using existing product action configuration capabilities where those already control CE; the modern UI consumes those definitions rather than hard-coding a tiny fixed set of buttons only.
+
+**Why P2**: CE’s action system is a primary reason to prefer CE over Finder. Full menus are **not** required for an intermediate Finder/CE hard-cut commit *within* the 8.2 train, but they **are** required for **8.2 GA functional parity** (FR-029).
+
+**Acceptance Scenarios**:
+1. **Given** a user right-clicks (or uses the keyboard menu equivalent) on a folder or content item, **When** the menu opens, **Then** they see actions appropriate to that selection and their rights (including open, edit, workflow-related actions where applicable—not a generic empty menu).
+2. **Given** an action that CE exposes for the same selection today (e.g. open properties, force check-in, transition), **When** that action is in the modern menu configuration for the user’s role, **Then** invoking it performs the equivalent server-backed operation and refreshes the view.
+3. **Given** the user has no permission for an action, **When** the menu is built, **Then** that action is hidden or disabled consistently with security rules (not merely failing after click without explanation).
+4. **Given** product action configuration already customizes menus for CE, **When** an administrator relies on that configuration, **Then** the modern explorer reflects those customizations for equivalent contexts without a separate parallel menu product.
+5. **Given** keyboard-only use, **When** the user opens the context menu and chooses an action, **Then** the flow is operable without a mouse (accessibility bar aligned with other modern CM UI).
+
+### User Story 4 - Folder permissions and ACLs (Priority: P2)
+
+Site admins and content admins manage **folder security** from the modern explorer: view and edit folder permission levels and ACL entries (users/roles/communities as supported by the product today in Content Explorer), including warnings when a change would lock the current user out. Contributors without security rights can still see that they lack permission when an action is denied; they do not need the desktop CE security dialogs.
+
+**Why P2**: Explicit gap vs Finder; required for CE replacement credibility for admin users.
+
+**Acceptance Scenarios**:
+1. **Given** a user with folder admin rights, **When** they open folder properties/security for a folder, **Then** they can view current permission/ACL configuration and save allowed changes.
+2. **Given** a change that would remove the current user’s own access, **When** they attempt to save, **Then** the product warns before applying (CE-equivalent safeguard).
+3. **Given** a user without security rights, **When** they open folder properties, **Then** security editing controls are absent or read-only per product rules.
+4. **Given** ACL/permission changes are saved, **When** another user session refreshes navigation, **Then** visible folders and allowed actions match the new rules.
+5. **Given** invalid or conflicting ACL input, **When** save is attempted, **Then** the user sees a clear validation or server error and the previous configuration remains until a successful save.
+
+### User Story 5 - Search and locate at scale (Priority: P2)
+
+Users search for content from the explorer workspace and from the reusable browser (simple and advanced criteria consistent with product search capabilities used by CE/Finder for content locate), open results, and navigate to an item’s folder location. Saved or catalogued searches that CE exposes for everyday content work remain available or have a documented modern equivalent for the same user roles.
+
+**Why P2**: Locate-by-search is essential when trees are large; both legacy UIs offer search. Post-cutover relative to Finder/CE retirement hard cuts.
+
+**Acceptance Scenarios**:
+1. **Given** the user runs a content search from the explorer, **When** results return, **Then** they can open an item or reveal it in the tree/list.
+2. **Given** the reusable browser is in search-capable mode, **When** the user searches and selects a result, **Then** the host receives the selection as in US2.
+3. **Given** no results or a server error, **When** search completes, **Then** empty and error states are explicit (not a blank panel).
+4. **Given** the user lacks rights to an item in results, **When** they try to open it, **Then** access is denied cleanly.
+
+### User Story 6 - Retire Finder and Desktop Content Explorer (Priority: P3)
+
+After each surface’s readiness bar is met, operators ship a product release with a **hard cut** for that surface: **no classic production fallback**.
+
+**Shared minimum bar for Finder primary-nav and Desktop CE retirement *within the 8.2 train*:** modern explorer **core navigate** only—tree + detail list; open/preview; create/rename/copy/move/delete where permitted; session/permission errors handled. A **ReducedAction set** (FR-010a) is acceptable for that intermediate hard cut. **Full** server-driven action menus (US3), folder ACL UI (US4), full search parity (US5), advanced CE tools (US7), and in-scope host browser migrations (US2) remain **required before 8.2 GA** as functional parity (FR-029)—they may complete after intermediate hard cuts but **must** complete in the same product release train (8.2).
+
+Finder and Desktop CE hard cuts MAY land in the same or sequential **feature-branch / integration** drops within 8.2 once the shared core bar is met. Dialog browse hosts hard-cut **independently** when migrated (FR-008a), still all before 8.2 GA. Known entry points and deep links are rewired or redirected; docs stop presenting retired surfaces as supported.
+
+**Why P3**: Intermediate retirement can proceed on core navigate to kill classic UI early in the train; **8.2 customer release** still requires full functional parity. Permanent dual primary UIs and production classic fallbacks are forbidden once a surface hard-cuts.
+
+**Acceptance Scenarios**:
+1. **Given** the release that declares Finder retired for primary navigation, **When** users open Web Management content exploration, **Then** they land on the modern explorer only—**no** miller-column Finder chrome and **no** production fallback toggle/URL to classic Finder for that surface.
+2. **Given** that release, **When** a removal/cutover inventory is reviewed, **Then** production navigation for that phase does not ship classic Finder as a supported alternate; dialog hosts migrate under their own hard-cut phase(s).
+3. **Given** desktop CE is retired for in-scope workflows (same core-navigate bar; may be same or later release than Finder hard cut), **When** install/upgrade docs and distribution are checked, **Then** CE is marked deprecated/removed for those workflows and support points users to the modern web explorer—without requiring full menus/ACL/search first.
+4. **Given** bookmarks to old Finder-centric or CE launch URLs, **When** opened after the relevant hard cut, **Then** known URLs map to modern destinations; unknown ones show a clear moved/unavailable message (not classic UI).
+5. **Given** automated tests that only exercised miller-column Finder or desktop CE UI automation for in-scope flows, **When** that surface’s hard cut lands, **Then** they are replaced by modern UI and/or service-contract coverage (not permanently skipped).
+
+### User Story 7 - Advanced CE capabilities (Priority: P3) — required for 8.2 parity
+
+After core-navigate retirement of Finder and/or Desktop CE *within the train*, implementers deliver remaining Content Explorer–grade capabilities tracked in the capability matrix, including at minimum: multi-item **clipboard** (copy/paste across folders), multi-step **site and subfolder copy wizards**, **dependency viewer**, and **IA/relationship** views beyond basic open/edit. Ordering is defined in the matrix; these do not block intermediate US6 hard cuts, but **incomplete rows block 8.2 GA** (FR-029, SC-012).
+
+**Why P3**: Full CE depth stays inside this feature and inside **8.2**; matrix-driven delivery prevents silent scope loss while allowing ordered implementation.
+
+**Acceptance Scenarios**:
+1. **Given** the capability matrix after planning, **When** reviewed for advanced CE rows, **Then** clipboard, site/subfolder copy wizards, dependency viewer, and IA/relationship views each have a phase label and acceptance criteria (no unlabeled omit).
+2. **Given** a post-cutover phase for clipboard is delivered, **When** a user copies items and pastes into an allowed folder, **Then** the operation completes under permission rules without desktop CE.
+3. **Given** a post-cutover phase for a site/subfolder copy wizard is delivered, **When** an authorized user completes the wizard, **Then** the copy outcome matches product rules documented for that matrix row.
+4. **Given** dependency or IA/relationship views are delivered for their phase, **When** a user opens them from a selection, **Then** they can inspect relationships/dependencies without desktop CE.
+5. **Given** this feature is proposed as complete, **When** SC-011 is checked, **Then** all advanced matrix rows are Done or explicitly scheduled with owners (not silently dropped).
+
+### Edge Cases
+- Multi-site repositories and empty site lists (admin vs contributor messaging).
+- Folders with thousands of children (performance, pagination, sort).
+- Concurrent rename/move of the same folder by two users.
+- Mixed selection (folder + item) and multi-select action availability.
+- Items checked out by another user; workflow state blocking transitions.
+- Community filtering and folder ACLs combining to hide nodes.
+- Iframe-heavy legacy editor still open beside modern explorer (session/CSRF shared; no cross-frame Finder assumptions).
+- Dialog browser opened while full explorer is also open (independent selection state).
+- Keyboard and screen-reader paths for tree, list, menus, and security forms.
+- Locale/TMX: UI chrome follows product localization patterns used by other modern CM surfaces.
+- Network failure mid-action: partial failure messaging and safe refresh.
+- Upgrade with users still running desktop CE against a server that prefers modern UI (server remains compatible until CE retirement story completes; no silent data corruption).
+
+## Requirements
+### Functional Requirements
+
+#### Navigation & workspace
+- **FR-001**: Product MUST provide a primary **web** content exploration workspace whose default navigation paradigm is **explorer-style** (hierarchical tree + detail list of children), not miller-column folder navigation.
+- **FR-002**: The workspace MUST allow users to expand/collapse folders, select folders and items, and open items for edit/preview according to existing content rules and permissions.
+- **FR-003**: The workspace MUST support create, rename, copy, move, and delete for folders and content items where the user has rights, with confirmation for destructive actions.
+- **FR-004**: The workspace MUST honor session authentication, CSRF, community context, and folder permission checks already enforced by the CMS; UI MUST NOT show actions the server will always reject without a product reason.
+- **FR-005**: The workspace MUST integrate with the modern CM navigation shell (reachable from main product navigation alongside Dashboard/Home as appropriate) and MUST NOT require the Desktop Content Explorer runtime for in-scope web workflows. Shell-mount integration (entry-point registration, chrome consistency, no Finder-only assumptions) MUST be verified as part of US1 acceptance evidence — see `tasks.md` US1 shell-mount task.
+
+#### Reusable content browser
+- **FR-006**: Product MUST provide a reusable **content browser** capability for embed/host use in dialogs and other features supporting at least: navigate hierarchy, search/locate, single-select, optional multi-select, type/folder filters, cancel/confirm.
+- **FR-007**: The content browser MUST return a stable selection result to the host (item id and path or equivalent product identifiers already used by CMS integrations).
+- **FR-008**: Host features that today open legacy content browser or Finder-based pickers for in-scope locate flows MUST be migratable to the reusable browser; the feature MUST document the host integration contract for implementers. The concrete **in-scope host IDs** for 8.2 (`host-asset-picker`, `host-page-picker`, `host-aa-contentbrowser-dialog`, `host-folder-picker`, optional `host-home-library`) are enumerated in `contracts/capability-matrix.md` P-Host rows; per-host implementation tasks are T045a–T045f.
+- **FR-008a**: Host migrations are **independent hard-cut phases within the 8.2 train**. The reusable browser MAY land before, with, or after Finder primary-nav hard cut in the development/integration sequence. Product MUST NOT require all in-scope hosts to migrate in the same intermediate drop as Finder. When a host is declared ready, that drop hard-cuts **that host only** (no production classic fallback for that host). **All in-scope hosts MUST be hard-cut before 8.2 GA** (FR-029).
+- **FR-009**: The full explorer workspace and the reusable browser MUST share the same permission and visibility rules for nodes (no “see in dialog but not in explorer” inconsistency for the same user/session).
+
+#### Actions & menus
+- **FR-010**: Product MUST eventually present **context menus** (and primary menu/toolbar actions where applicable) for the current selection, driven by the CMS **action configuration** model used by Content Explorer—not a Finder-only fixed button strip as the **long-term** sole action surface. Full action-configuration-driven menus (US3) are a **post-retirement capability phase**, not a gate for Finder or Desktop CE hard cut.
+- **FR-010a (ReducedAction set at intermediate hard cut)**: At Finder primary-nav hard cut, product MUST expose a **ReducedAction set** sufficient for open/preview and create/rename/copy/move/delete (and related confirms). That set MAY be product-defined rather than fully configuration-driven. The ReducedAction set is the **intermediate** action surface for FR-019b and is **superseded** (not duplicated) by FR-010 once full configuration-driven menus ship. The concrete ReducedAction entries are enumerated in `data-model.md` § *ReducedAction* and the ≥10 high-value full-action list for FR-010 is enumerated in `contracts/capability-matrix.md` P-Menu rows.
+- **FR-011**: When full action menus are enabled, available actions MUST vary by object type, selection, workflow state, and user authorization consistent with server rules.
+- **FR-012**: Invoking a supported action MUST execute the corresponding CMS operation and refresh affected tree/list state (or open the appropriate editor/dialog).
+- **FR-013**: Product MUST support keyboard access to open context actions and activate menu items on the primary explorer surfaces for actions that are present in the current phase.
+
+#### Folder permissions & ACLs
+- **FR-014**: Product MUST allow authorized users to view and edit **folder permissions and ACL entries** from the modern explorer (parity with Content Explorer folder security capabilities for the permission model the product already stores).
+- **FR-015**: Product MUST warn before saving ACL changes that would remove the current user’s access to that folder.
+- **FR-016**: Users without folder security rights MUST NOT be able to modify ACLs via the modern UI.
+
+#### Search
+- **FR-017**: Product MUST provide content search from the explorer workspace sufficient to locate items by criteria comparable to everyday CE/Finder content search usage, and to open or reveal results in context. Full search is a post-retirement capability phase relative to Finder/CE hard cuts unless delivered earlier.
+- **FR-018**: The reusable browser MUST support search-based locate when the host enables it.
+
+#### Advanced CE (matrix; 8.2 parity)
+- **FR-028**: Advanced Content Explorer capabilities—including multi-item **clipboard** (copy/paste), multi-step **site/subfolder copy wizards**, **dependency viewer**, and **IA/relationship** views beyond basic open/edit—MUST be inventoried in the capability matrix and delivered as ordered phases **within this feature and within 8.2**. Product MUST NOT treat them as permanent drops or post-8.2 deferrals solely because they are not intermediate retirement gates. Phase ordering and acceptance for each advanced capability are defined in the matrix during planning.
+
+#### Cutover & retirement
+- **FR-019**: Product MUST plan work in phases **within the 8.2 release train**, for example: (1) modern explorer **core navigate** ready → Finder primary-nav hard cut and/or Desktop CE hard cut (same intermediate bar), (2) dialog/browser **host hard cut(s)** on independent schedules (FR-008a), (3) full action menus / ACL / search, (4) advanced CE tools (FR-028). Phases MAY land in sequential PRs/merges **inside 8.2** and need not be strictly ordered beyond documented dependencies (e.g. a host needs the browser capability). Phases MUST **not** be deferred to a product release after 8.2. For each **retirement/host hard-cut** phase, the integration drop that declares that surface ready MUST apply a **hard cut**: production MUST NOT ship a classic fallback (toggle, alternate URL, or dual primary path) for that surface. The detailed no-fallback-in-shipped-builds policy and the intermediate core-navigate bar are stated in FR-019a and FR-019b respectively (no duplication here).
+- **FR-019a (no classic fallback in shipped builds)**: Feature-branch and pre-release QA MAY exercise modern and classic side by side. **Shipped customer builds** (including 8.2 GA) for a completed hard-cut surface MUST be modern-only for that surface (no supported classic Finder or dual primary path in production for that surface).
+- **FR-019b (intermediate core-navigate bar)**: The readiness bar for **Finder primary-navigation hard cut** and **Desktop Content Explorer hard cut** *as intermediate train milestones* is the **same: core navigate only** (FR-001–FR-005 and FR-003 ops): tree + list; open/preview; create/rename/copy/move/delete with confirmations; clear permission/session errors. Product MAY use a **ReducedAction set** (FR-010a) for those ops at that intermediate hard cut. Product MUST NOT require US3/US4/US5/US7 as gates for those intermediate retirement milestones. Product MUST still complete US2 (in-scope hosts), US3, US4, US5, and US7 (matrix) for **8.2 GA** (FR-029).
+- **FR-029**: **Target product release is 8.2.** All in-scope work for this feature—including core explorer, Finder and Desktop CE hard cuts, reusable content browser, all in-scope host migrations, full action menus, folder ACL UI, search, and advanced CE capability-matrix rows—MUST be complete for **8.2 GA**. **Functional parity** (defined as: capability matrix in-scope rows **Done** with acceptance criteria met; SC-001–SC-011 applicable outcomes green for 8.2 scope) **blocks the 8.2 release**. Product MUST NOT ship 8.2 with incomplete functional parity, dual primary content explorers, or matrix rows left as “later release.”
+- **FR-020**: When Finder is retired for primary navigation, production MUST NOT load miller-column Finder as the content exploration UI (not merely “not default”—classic is absent as a supported path).
+- **FR-021**: When Desktop Content Explorer is retired for in-scope workflows (same core-navigate bar as FR-019b), product docs and distribution MUST NOT require it for those workflows; known launch entry points MUST map to the modern web explorer or a clear unavailable message—not launch classic CE as a fallback.
+- **FR-022**: Implementers MUST maintain a durable **capability and cutover inventory** under `specs/992-react-content-explorer/` (e.g. `contracts/capability-matrix.md` and `checklists/cutover-inventory.md`) listing CE capabilities, Finder touchpoints, dialog hosts, keep/drop decisions, and test replacements. PR/release review signs off inventories for each retirement phase.
+- **FR-023**: Automated tests MUST cover critical explorer navigation, browser selection, at least one ACL save path (authorized), and representative action invocations at modern UI and/or service-contract level with passing CI on the target JDK/branch.
+- **FR-024**: Legacy-only tests that solely exercise miller-column Finder or desktop CE for in-scope flows MUST be replaced (not permanently skipped) when those surfaces are removed.
+
+#### Quality, a11y, i18n
+- **FR-025**: Primary explorer and browser surfaces MUST meet the same accessibility bar as other modern CM UI (keyboard operable, labeled controls, operable menus).
+- **FR-026**: User-visible chrome strings MUST follow product localization practice used by other modern CM surfaces (TMX / existing client message resolution)—not English-only hardcoding as the production bar.
+- **FR-027**: Display of list columns SHOULD respect product display formats where CE uses them for folder contents; if a reduced default column set ships first, the capability matrix MUST mark full display-format parity as a follow-on with explicit status.
+
+### Key Entities
+- **Content Explorer workspace**: Primary web UI for browsing and managing the content repository hierarchy.
+- **Content browser (component)**: Embeddable navigate/search/select experience for dialogs and host features.
+- **Folder / path item**: Node in the site/folder tree with permissions and children.
+- **Content item**: Page, asset, or other CMS object listed under a folder.
+- **Action / menu definition**: Configured operation available for a selection (open, edit, transition, properties, etc.).
+- **Folder ACL / permission**: Access control entries and permission level on a folder.
+- **Search query / result**: Criteria and matching items for locate flows.
+- **Selection result**: Payload returned to a host dialog (ids, paths, types).
+- **Cutover inventory**: Documented map of legacy surfaces → modern replacements.
+- **Capability matrix**: Phased inventory of CE capabilities (core, menus, ACL, search, advanced tools) with acceptance labels.
+
+## Success Criteria
+### Measurable Outcomes
+- **SC-001**: In scripted UAT for the **Finder primary-nav hard cut**, trained content users complete navigate → open item → create folder → move or copy → delete (where permitted) **entirely in the modern web explorer** with **100%** of checklist steps passed and **zero** steps requiring miller-column Finder. Full CE menus, ACL UI, and full search are **not** required for this gate.
+- **SC-002**: In scripted UAT for **each browser host hard-cut phase**, that host’s dialog flow completes navigate or search → select → confirm using the **reusable content browser**, returning a valid selection to the host, **100%** of checklist steps passed (other hosts may still be unmigrated).
+- **SC-003**: For a checklist of high-value CE actions (minimum **10** actions spanning open/edit, folder ops, and at least two workflow or properties actions), each action is available from the modern UI for an authorized user and completes successfully in UAT (**100%** of list)—gate for **full menu / CE-parity phase**, not for Finder primary-nav hard cut.
+- **SC-004**: Authorized admin completes view → edit → save of folder ACL/permissions on a test folder in the modern UI; a second user session reflects access changes on refresh (**pass/fail** scripted scenario)—gate for **ACL phase**, not Finder primary-nav hard cut.
+- **SC-005**: Explorer remains usable on a folder with a large child set used in UAT (product-agreed fixture, target **≥ 500** children): user can scroll/page and open an item within **10 seconds** of selecting the folder on a standard office network in the test environment (applies at Finder primary-nav hard cut).
+- **SC-006**: After Finder primary-navigation hard cut, production Web Management content entry loads **zero** miller-column Finder chrome and offers **no** production classic fallback; cutover inventory items for that phase are **100%** signed off; SC-001 and SC-005 pass.
+- **SC-007**: After Desktop CE retirement for in-scope workflows, UAT and docs confirm core-navigate content admin workflows are completed on modern web only; CE not required (**pass** on retirement checklist)—same core-navigate bar as SC-001/SC-006; full menus/ACL/search not required for this gate.
+- **SC-008**: CI is green for automated coverage required by the phase under test (core navigate at minimum for Finder hard cut; FR-023 expands as menus/ACL/browser land); no permanent skip of replaced legacy-only tests for retired surfaces.
+- **SC-009**: Accessibility spot-check for surfaces in the phase under test (at Finder hard cut: primary tree and list at minimum) are keyboard-completable in UAT checklist (**100%** of that phase’s a11y steps).
+- **SC-010**: Prefer-CE usability signal: in structured feedback from at least **5** internal users familiar with both UIs, majority rate modern explorer as **clearer for daily folder navigation** than miller-column Finder (document scores in UAT notes)—measured at or before Finder primary-nav hard cut.
+- **SC-011**: Capability matrix lists advanced CE items (clipboard, site/subfolder copy wizards, dependency viewer, IA/relationship views) with phase labels; **100%** of in-scope matrix rows (including advanced) are **Done** with acceptance met before 8.2 GA (no unlabeled omit; “scheduled for post-8.2” is **not** allowed).
+- **SC-012**: **8.2 release gate** — 8.2 GA is blocked until functional parity is proven: (1) Finder and Desktop CE retired for in-scope workflows, (2) in-scope content-browser hosts hard-cut, (3) full menus + ACL UI + search complete per matrix, (4) advanced CE matrix rows Done, (5) SC-001–SC-011 applicable checks pass for the 8.2 build. A build missing any of the above MUST NOT be labeled or shipped as 8.2 GA.
+
+## Assumptions
+- Strategic UI direction is the existing modern CM web stack (React/TypeScript in `WebUI`, Track B); this feature does not introduce a second SPA framework.
+- **Explorer paradigm wins**: tree + detail list is the default; miller columns are not retained as the primary UX (optional advanced layout is out of scope unless later justified).
+- Content Explorer’s **server-backed action menus**, **folder security**, **search**, and **tree/list** model define target UX; Finder’s miller columns and iframe-heavy shell do not.
+- Existing CMS storage for folder ACLs and action configuration is reused; first ship avoids schema redesign unless a gap is proven during planning.
+- SOAP-only CE operations will be replaced by existing or new REST/JSON (or equivalent web) contracts during planning; no permanent browser→SOAP dependency from the modern UI.
+- Home Library (`989`) may consume the reusable browser for contributor browse; full admin explorer remains this feature’s responsibility.
+- Desktop CE retirement means **web replacement**, not a rewritten JavaFX shell.
+- **Target product release is 8.2.** All in-scope capability-matrix work is **8.2 scope**; functional parity **blocks 8.2 GA** (FR-029, SC-012).
+- Phased delivery is **within the 8.2 train** (PR/story order), not across product releases after 8.2. **Hard cut per phase** (no production classic fallback once a surface hard-cuts) still applies.
+- Pre-release/feature-branch dual exercise is allowed for QA; it MUST NOT ship as a supported production dual path for a completed hard-cut surface, and MUST NOT appear in 8.2 GA.
+- **Finder primary-nav hard cut and Desktop CE hard cut share one intermediate bar: core navigate only** (tree/list + open + create/rename/copy/move/delete; ReducedAction set OK per FR-010a). They MAY land in sequential integration drops within 8.2 once that bar is met.
+- Full action-configuration menus, folder ACL UI, full search, in-scope host browsers, and advanced CE tools MAY land **after** intermediate hard cuts in the train but **MUST complete before 8.2 GA**.
+- **Dialog/host browser migrations are independent hard-cut phases** from Finder/CE retirement within the train; not all hosts need to move with the first hard cut—**all in-scope hosts must complete before 8.2 GA**.
+- **Advanced CE-only capabilities** (multi-item clipboard, multi-step site/subfolder copy wizards, dependency viewer, IA/relationship views, and similar) are **in scope for this feature and for 8.2**, tracked in the capability matrix—not intermediate retirement gates, not silent drops, and **not post-8.2 deferrals**.
+- Active Assembly editor internals remain separate; only browse/locate dialogs and shared session concerns are in scope for this feature’s browser component.
+- Eclipse Workbench, JSF admin/publishing, and Package Manager remain separate Track B efforts.
+
+## Out of Scope
+- Rewriting the full content editor, Active Assembly canvas, or template designers.
+- Migrating JSF Admin/Publishing, GWT Package Manager, or Eclipse Workbench.
+- Replacing DTS public-site UIs.
+- Re-implementing Desktop CE as a shipped desktop app on a new toolkit.
+- Retaining miller-column Finder as a long-term alternate primary UI.
+- Global removal of all jQuery from Web Management beyond Finder and its exclusive dependencies (other admin screens may still use jQuery until their own migrations).
+- Redesigning the product’s underlying permission model or action-definition schema (consume and surface what exists; extend APIs only as needed for web access).
+- Offline/disconnected desktop content administration.
+- Shipping advanced CE tools (clipboard, site-copy wizards, dependency/IA views) **as intermediate hard-cut gates**—they are matrix phases after intermediate retirement, still **required for 8.2 GA** (FR-029).
+- Deferring any in-scope functional parity work to a product release after 8.2.
+
+## Dependencies
+- Modern CM shell, session/CSRF, and i18n patterns already used by Dashboard / modern Home.
+- Path/folder services and permission utilities in sitemanage/system.
+- Action configuration and folder ACL services currently used by Desktop Content Explorer.
+- Coordination with `989-react-cui-widget-builder` for shared browser adoption on Home Library (non-blocking for explorer P1 if Library keeps interim browse).
+- REST/API gap analysis during planning for any CE capability still SOAP-only.
+
+## Risks
+- **API gaps**: CE features still on SOAP/desktop-only paths may block parity; mitigate with early gap analysis and phased matrix.
+- **Action menu complexity**: Dynamic menus are powerful but easy to get wrong for security; require server-side enforcement + UI tests.
+- **Finder embedding depth**: Many WebUI plugins call `$.perc_finder()`; cutover needs a systematic inventory (FR-022).
+- **User training**: Users only trained on miller columns need brief guidance to tree+list (mitigate with familiar CE patterns and docs).
+- **Scope creep**: CE has decades of edge dialogs; strict capability matrix and Out of Scope prevent unbounded porting.

--- a/specs/992-react-content-explorer/tasks.md
+++ b/specs/992-react-content-explorer/tasks.md
@@ -1,0 +1,364 @@
+# Tasks: Unified React Content Explorer
+
+**Input**: Design documents from `/specs/992-react-content-explorer/`  
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/](./contracts/), [quickstart.md](./quickstart.md)
+
+**Tests**: Required by FR-023, constitution III, and root `AGENTS.md` (Vitest for modern UI; service-contract tests only if REST changes).
+
+**Target release**: **8.2** — **functional parity blocks 8.2 GA** (FR-029, SC-012). All in-scope matrix rows must be **Done** before labeling 8.2; no post-8.2 deferral of in-scope work.
+
+**Organization**: Phases by user story with recommended engineering order for intermediate hard cuts. Prefer **one PR per story** (constitution checkpoint). Suggested PR train:
+
+`US1 → US6 (intermediate hard cut) → US2 (+ hosts) → US3 → US4 → US5 → US7 → Polish/SC-012`
+
+US2 can start after Foundational+US1 in parallel with US6 if staffing allows (different surfaces).
+
+## Format
+
+`- [ ] [TaskID] [P?] [Story?] Description with file path`
+
+- **[P]**: parallelizable (different files; no wait on incomplete sibling work)
+- **[USn]**: user-story phase only
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Orient modules, toolchain, and feature docs for 8.2 work.
+
+- [x] T001 Identify owning modules and read AGENTS hierarchy: root `AGENTS.md`, `WebUI/AGENTS.md` (and sitemanage/rest module AGENTS if present when touching those modules)
+- [x] T002 Confirm JDK 21 branch baseline and that WebUI modern tests run via `./mvn-env.sh -pl WebUI` (and/or frontend npm/vitest per `WebUI` docs)
+- [x] T003 [P] Confirm and expand cutover inventory scaffold in `specs/992-react-content-explorer/checklists/cutover-inventory.md` (FR-022)
+- [x] T004 [P] Confirm capability matrix seed in `specs/992-react-content-explorer/contracts/capability-matrix.md` and mark P0-Core rows as implementer targets for US1
+- [x] T005 [P] Skim contracts: `contracts/path-api.md`, `contracts/content-browser-host.md`, `contracts/action-menu-api.md`, `quickstart.md` Scenarios A–I
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared path API client, registry placeholders, i18n, inventory of Finder call sites. **Blocks US1–US7.**
+
+- [x] T006 Complete Finder primary-nav inventory by searching `WebUI` for `perc_finder`, `PercFinderView`, `finder.jsp`, `finder_js.jsp` and recording rows in `specs/992-react-content-explorer/checklists/cutover-inventory.md`
+- [x] T007 [P] Extend path/search URL constants in `WebUI/src/main/ts/api/paths.ts` for pathmanagement ops used by explorer (`folder`, `paginatedFolder`, `item`, `item/id`, `addNewFolder`, `renameFolder`, `moveItem`, delete, `folderProperties`, `saveFolderProperties`, search extended results) per `contracts/path-api.md`
+- [x] T008 [P] Add typed content-explorer API module under `WebUI/src/main/ts/api/contentExplorer/` (e.g. `pathApi.ts`, `types.ts`) using `WebUI/src/main/ts/api/client.ts` + `csrf.ts`, aligned to `data-model.md` PathNode / FolderProperties
+- [x] T009 [P] Reuse or extend thin i18n helper under `WebUI/src/main/ts/i18n/` for `I18N.message` (FR-026); document explorer key prefix `perc.ui.explorer.*` / `perc.ui.contentBrowser.*`
+- [x] T010 Register placeholder components `ContentExplorerShell` and `ContentBrowser` in `WebUI/src/main/ts/registry.ts` and ensure Vite entry includes them via `WebUI/src/main/ts/index.ts`
+- [x] T011 Assess security surface: CSRF on mutating path calls, session expiry UX, server-side folder AuthZ remains authoritative; note findings under `specs/992-react-content-explorer/research.md` or implementer note (no secrets in logs)
+- [x] T012 [P] Create Vitest directory scaffolds `WebUI/src/test/ts/contentExplorer/` and `WebUI/src/test/ts/contentBrowser/` mirroring Home/Dashboard test patterns
+- [x] T012a [P] Author the **full P-Adv capability matrix row skeleton** for US7 (clipboard, site copy wizard, subfolder copy wizard, dependency viewer, IA/relationship views, display format columns, relationships manager deep tools) in `specs/992-react-content-explorer/contracts/capability-matrix.md` with phase + acceptance label per row (no silent omit — see FR-028 / SC-011)
+- [x] T012b [P] Add the **SC-005 perf fixture + measurement scaffolding**: scripted seed `scripts/create-large-folder-fixture.sh` for ≥500-child fixture, evidence file `specs/992-react-content-explorer/checklists/sc005-perf-evidence.md` with the pass criterion (p95 ≤ 10 s on standard office network) defined in `quickstart.md` Scenario B
+- [x] T012c Enumerate **in-scope hosts for 8.2** in `specs/992-react-content-explorer/checklists/cutover-inventory.md` §C (asset picker, page picker, AA ContentBrowserDialog, folder picker, Home Library optional) with current call-site rows; per-host task IDs **are** T045a–T045f in Phase 5
+- [x] T012d [P] **Evaluate each per-host migration in T045a–T045d** for `system/` server-side wiring need (action-page / content-browser dialog JSPs that cannot be replaced via WebUI + sitemanage + REST); record per-host decision (Keep web-only / Add `system/` task / Mark OUT) in `specs/992-react-content-explorer/checklists/cutover-inventory.md` §C under the host row, citing the constitution II/IV evidence that justifies the choice
+- [x] T012e [P] **If** a per-host decision in T012d requires `system/` wiring, add a concrete task ID under US2 (named `T045X-system-<host>` or similar) referencing the constitution II/IV evidence from T012d and the corresponding threat-model + service-contract test tasks (T052a/T052b pattern); **otherwise** no task is added and `system/` remains untouched
+
+**Checkpoint**: Path API types compile; placeholders mountable; inventory started. No production cutover.
+
+---
+
+## Phase 3: User Story 1 — Explorer-style content workspace (Priority: P1)
+
+**Goal**: Tree + detail list modern explorer with **ReducedAction set** (open, create/rename/move/copy/delete); usable for SC-001/SC-005.  
+**Independent Test**: [quickstart.md](./quickstart.md) Scenario A + B; SC-001, SC-005.
+
+### Tests (Required)
+
+- [ ] T013 [P] [US1] Unit tests for path API helpers (success + error mapping) in `WebUI/src/test/ts/contentExplorer/pathApi.test.ts`
+- [ ] T014 [P] [US1] Component tests for tree expand/select in `WebUI/src/test/ts/contentExplorer/ExplorerTree.test.tsx`
+- [ ] T015 [P] [US1] Component tests for detail list pagination/load in `WebUI/src/test/ts/contentExplorer/DetailList.test.tsx`
+- [ ] T015a [P] [US1] **Vitest perf regression guard** for SC-005: mocked `paginatedFolder` for a 500-child fixture renders first page and opens a selected item within a **tighter dev-machine budget (e.g. ≤ 5 s on the implementer's machine)** — this catches regressions pre-CI; it is **NOT** the SC-005 acceptance measurement. SC-005 itself is proven by `checklists/sc005-perf-evidence.md` against the standard office network per `quickstart.md` Scenario B
+- [ ] T016 [P] [US1] Tests for reduced actions (create/rename/move/delete confirm + error) in `WebUI/src/test/ts/contentExplorer/reducedActions.test.tsx`
+
+### Implementation
+
+- [ ] T017 [P] [US1] Implement `ContentExplorerShell` layout (tree + detail panes) in `WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx` (+ styles under `WebUI/src/main/ts/contentExplorer/`)
+- [ ] T018 [P] [US1] Implement folder tree component in `WebUI/src/main/ts/contentExplorer/ExplorerTree.tsx` loading children via path API
+- [ ] T019 [P] [US1] Implement detail list with pagination/virtualization for large folders in `WebUI/src/main/ts/contentExplorer/DetailList.tsx` using `paginatedFolder` (SC-005)
+- [ ] T020 [US1] Implement **ReducedAction set** bar/menu (open/preview, create folder, rename, move, copy, delete+confirm) in `WebUI/src/main/ts/contentExplorer/ReducedActions.tsx` (FR-010a)
+- [ ] T021 [US1] Wire open/preview to existing product navigation patterns (path/id → editor) from explorer selection under `WebUI/src/main/ts/contentExplorer/`
+- [ ] T022 [US1] Wire empty states, permission denied, and session/CSRF error UX in `WebUI/src/main/ts/contentExplorer/` via TMX keys
+- [ ] T023 [US1] Add/reuse explorer chrome TMX keys in `modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx` with structural locale parity (FR-026)
+- [ ] T024 [US1] Mount explorer in Web Management shell for development (e.g. panel in `WebUI/src/main/webapp/cm/app/webmgt.jsp` or thin shell JSP) via `PercModernUI.mount(..., 'ContentExplorerShell', ...)` without final Finder deletion yet
+- [ ] T024a [US1] **Verify shell-mount integration (FR-005)**: confirm explorer entry is reachable from main product navigation alongside Dashboard/Home, chrome matches other modern surfaces, and there are no Finder-only assumptions in the mount path; document evidence under `checklists/us1-shell-mount-evidence.md`
+- [ ] T025 [US1] Run Vitest for `WebUI/src/test/ts/contentExplorer/` and fix failures
+- [ ] T026 [US1] Update capability matrix P0-Core rows status in `specs/992-react-content-explorer/contracts/capability-matrix.md`
+- [ ] T027 [US1] Commit US1 changes and open PR for review; **per constitution IX, inline reply with mitigation commit hash to every review comment AND run `gh api graphql resolveReviewThread` for each review thread** before merging; pause downstream stories per constitution checkpoint until PR review path is healthy
+
+**Checkpoint**: Explorer usable for core navigate on feature branch; miller Finder may still be present until US6.
+
+---
+
+## Phase 4: User Story 6 — Retire Finder and Desktop Content Explorer (Priority: P3) — intermediate hard cut
+
+**Goal**: Hard-cut primary Finder navigation and Desktop CE requirement for ordinary admin once US1 core bar is met (FR-019b). Full menus/ACL/search/advanced **not** required for this intermediate cut but **are** required for 8.2 GA (FR-029).  
+**Independent Test**: [quickstart.md](./quickstart.md) Scenarios C–D; SC-006, SC-007.
+
+### Tests (Required)
+
+- [ ] T028 [P] [US6] Add/adjust tests proving modern shell mounts without miller-column Finder bootstrap for primary nav entry (e.g. `WebUI/src/test/ts/contentExplorer/primaryNavMount.test.ts` or document manual gate if pure JSP)
+- [ ] T029 [US6] Remove or replace legacy-only automated tests that exercise miller Finder primary nav only (search under `WebUI/src/test` and related); do not permanent-skip (FR-024); add a **CI-gate assertion** (Vitest count comparison or test-report check) proving replaced tests are **running** in CI on the target JDK, not silently zero
+- [ ] T029a [US6] **Per-PR review thread resolution (constitution IX)**: inline reply with mitigation commit hash to every review comment AND run `gh api graphql resolveReviewThread` for each review thread before merging the US6 PR
+
+### Implementation
+
+- [ ] T030 [US6] Finalize primary-nav rows in `specs/992-react-content-explorer/checklists/cutover-inventory.md` for `webmgt.jsp`, `includes/finder.jsp`, `includes/finder_js.jsp`, common js/css Finder deps
+- [ ] T031 [US6] Hard-cut production primary nav: rewire `WebUI/src/main/webapp/cm/app/webmgt.jsp` (and `WebUI/src/main/webapp/cm/pages/app/webmgt.jsp` if mirrored) to mount `ContentExplorerShell` and **stop including** miller Finder for primary exploration (FR-020)
+- [ ] T032 [US6] Remove or stop shipping exclusive Finder entry includes from production path (`WebUI/src/main/webapp/cm/app/includes/finder.jsp`, `finder_js.jsp`) when inventory proves exclusive; keep shared libs still required elsewhere
+- [ ] T033 [US6] Map known legacy Finder/CE deep links to modern explorer destinations; implement clear moved/unavailable message for unknown paths (feature deep-link helper under `WebUI/src/main/ts/contentExplorer/` and/or JSP routing)
+- [ ] T034 [US6] Desktop CE retirement packaging/docs: update install/support docs and distribution notes so ordinary content admin does not require Desktop CE; record in `checklists/cutover-inventory.md` section B (FR-021, SC-007)
+- [ ] T035 [US6] Sign off US6 inventory rows for intermediate hard cut; run quickstart Scenarios C–D
+- [ ] T036 [US6] Commit US6 hard-cut PR; resolve review threads; **do not** claim 8.2 GA (SC-012 still open)
+
+**Checkpoint**: Production primary path is modern explorer only; full parity still incomplete until US2–US5 + US7.
+
+---
+
+## Phase 5: User Story 2 — Reusable content browser component (Priority: P1)
+
+**Goal**: Embeddable `ContentBrowser` with host contract; pilot host hard cut; inventory remaining hosts for 8.2.  
+**Independent Test**: [quickstart.md](./quickstart.md) Scenario E; SC-002; FR-008a.
+
+### Tests (Required)
+
+- [ ] T037 [P] [US2] Unit tests for selection filters (type/folder/multi) in `WebUI/src/test/ts/contentBrowser/selectionRules.test.ts`
+- [ ] T038 [P] [US2] Component tests for navigate → confirm payload in `WebUI/src/test/ts/contentBrowser/ContentBrowser.test.tsx`
+- [ ] T039 [P] [US2] Tests for cancel / empty selection disabled confirm in `WebUI/src/test/ts/contentBrowser/ContentBrowser.confirm.test.tsx`
+
+### Implementation
+
+- [ ] T040 [P] [US2] Implement `ContentBrowser` component in `WebUI/src/main/ts/contentBrowser/ContentBrowser.tsx` reusing path API (`api/contentExplorer/`) per `contracts/content-browser-host.md`
+- [ ] T041 [P] [US2] Implement host props API (mode, multiSelect, filters, onConfirm/onCancel/onError) and `SelectionResult` types under `WebUI/src/main/ts/contentBrowser/`
+- [ ] T042 [US2] Add content-browser TMX keys in `modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx`
+- [ ] T043 [US2] Pilot host hard cut: migrate one low-risk host (document choice in cutover inventory) to `PercModernUI.mount(..., 'ContentBrowser', props)` or React import
+- [ ] T044 [US2] Expand host inventory table in `specs/992-react-content-explorer/checklists/cutover-inventory.md` section C with the in-scope hosts enumerated in T012c (asset picker, page picker, AA ContentBrowserDialog, folder picker, Home Library optional); mark each row Keep / Drop / Status with concrete call-site references
+- [ ] T045a [US2] **Migrate `host-asset-picker`** to `ContentBrowser`; record SC-002 evidence (UAT checklist + Vitest) and cutover-inventory row; per-PR constitution IX review-thread resolution
+- [ ] T045b [US2] **Migrate `host-page-picker`** to `ContentBrowser`; record SC-002 evidence and cutover-inventory row; per-PR constitution IX review-thread resolution
+- [ ] T045c [US2] **Migrate `host-aa-contentbrowser-dialog`** to `ContentBrowser`; record SC-002 evidence and cutover-inventory row; add a `system/` task ONLY if the AA dialog JSP proves it needs server-side wiring (justified per constitution II/IV); per-PR constitution IX review-thread resolution
+- [ ] T045d [US2] **Migrate `host-folder-picker`** to `ContentBrowser`; record SC-002 evidence and cutover-inventory row; per-PR constitution IX review-thread resolution
+- [ ] T045e [US2] *(optional, non-blocking)* **`host-home-library`** consumer adoption from `989-react-cui-widget-builder` if ready; record SC-002 evidence if adopted; otherwise mark OUT for 8.2 with rationale
+- [ ] T045f [US2] Verify **all in-scope hosts** are migrated to `ContentBrowser` before 8.2 GA (FR-008a, FR-029); each host hard-cuts without classic fallback
+- [ ] T046 [US2] Run Vitest under `WebUI/src/test/ts/contentBrowser/` and fix failures
+- [ ] T047 [US2] Commit US2 + host migrations PR(s); per-PR constitution IX review-thread resolution (inline reply with commit hash + `gh api graphql resolveReviewThread`)
+
+**Checkpoint**: Browser reusable; all in-scope hosts modern-only before 8.2 GA.
+
+---
+
+## Phase 6: User Story 3 — Context actions and customizable menus (Priority: P2)
+
+**Goal**: Configuration-driven context menus/toolbar via action REST; keyboard access; SC-003 (≥10 high-value actions).  
+**Independent Test**: [quickstart.md](./quickstart.md) Scenario G; SC-003; FR-010–013.
+
+### Tests (Required)
+
+- [ ] T048 [P] [US3] Unit tests for menu model mapping from action API DTOs in `WebUI/src/test/ts/contentExplorer/actionMenuMapper.test.ts`
+- [ ] T049 [P] [US3] Component tests for context menu open/activate/hide unauthorized in `WebUI/src/test/ts/contentExplorer/ContextMenu.test.tsx`
+- [ ] T050 [P] [US3] Tests for keyboard menu activation path in `WebUI/src/test/ts/contentExplorer/ContextMenu.a11y.test.tsx`
+
+### Implementation
+
+- [ ] T051 [P] [US3] Add typed action-menu API client under `WebUI/src/main/ts/api/contentExplorer/actionMenuApi.ts` aligned to `rest` `ActionMenuResource` and `contracts/action-menu-api.md` (do not invent fields—match live Javadoc/OpenAPI)
+- [ ] T052 [US3] Inventory action **execution** paths (action id → existing REST/URL); record gaps in `contracts/capability-matrix.md` P-Menu rows; implement thin façade in sitemanage only if proven necessary (plan Complexity Tracking)
+- [ ] T052a [US3] If a new façade or REST endpoint is added per T052, write a **service-contract integration test** in `projects/sitemanage` or `rest` per constitution III/IV — happy path + AuthZ negative + CSRF negative; run via `./mvn-env.sh -pl <module> -am test` on JDK 21
+- [ ] T052b [US3] If a new façade or REST endpoint is added per T052, add a **threat-model note** for the new endpoint (zip-slip / XXE / CSRF / server-side AuthZ) per constitution VI in PR evidence; no secrets logged
+- [ ] T053 [US3] Implement context menu + toolbar driven by server actions in `WebUI/src/main/ts/contentExplorer/ContextMenu.tsx` / `ActionToolbar.tsx`
+- [ ] T054 [US3] Wire selection-change refresh of allowed actions and post-action tree/list refresh under `WebUI/src/main/ts/contentExplorer/`
+- [ ] T055 [US3] Ensure keyboard access for open menu and activate item (FR-013); reduce reliance on reduced-fixed-only set while keeping core ops available
+- [ ] T056 [US3] Build SC-003 UAT checklist of ≥10 high-value actions under `specs/992-react-content-explorer/checklists/` (e.g. `sc003-actions-checklist.md`) and execute on feature build
+- [ ] T057 [US3] Run Vitest for action menu tests; commit US3 PR; per-PR constitution IX review-thread resolution (inline reply with commit hash + `gh api graphql resolveReviewThread`)
+
+**Checkpoint**: Full menus on modern explorer; matrix P-Menu rows Done.
+
+---
+
+## Phase 7: User Story 4 — Folder permissions and ACLs (Priority: P2)
+
+**Goal**: View/edit folder permission and ACL via existing folderProperties REST; lockout warning; SC-004.  
+**Independent Test**: [quickstart.md](./quickstart.md) Scenario F; SC-004; FR-014–016.
+
+### Tests (Required)
+
+- [ ] T058 [P] [US4] Unit tests for lockout-self detection helper in `WebUI/src/test/ts/contentExplorer/aclLockout.test.ts`
+- [ ] T059 [P] [US4] Component tests for folder security form load/save/error in `WebUI/src/test/ts/contentExplorer/FolderSecurityPanel.test.tsx`
+
+### Implementation
+
+- [ ] T060 [P] [US4] Implement folder properties/security UI in `WebUI/src/main/ts/contentExplorer/FolderSecurityPanel.tsx` using `folderProperties` + `saveFolderProperties` path API
+- [ ] T061 [US4] Wire open security from explorer actions/context menu; enforce read-only when user lacks rights (FR-016)
+- [ ] T062 [US4] Implement self-lockout warning before save (FR-015) in `WebUI/src/main/ts/contentExplorer/`
+- [ ] T063 [US4] Add ACL-related TMX keys in `modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx`
+- [ ] T064 [US4] Update capability matrix P-ACL rows; run Scenario F; commit US4 PR; per-PR constitution IX review-thread resolution (inline reply with commit hash + `gh api graphql resolveReviewThread`)
+
+**Checkpoint**: ACL UI parity for product folder permission model without Desktop CE.
+
+---
+
+## Phase 8: User Story 5 — Search and locate at scale (Priority: P2)
+
+**Goal**: Explorer + browser search via searchmanagement; open/reveal results; US5.  
+**Independent Test**: Search from explorer and browser; open/reveal; SC for search matrix rows.
+
+### Tests (Required)
+
+- [ ] T065 [P] [US5] Unit tests for search API client in `WebUI/src/test/ts/contentExplorer/searchApi.test.ts`
+- [ ] T066 [P] [US5] Component tests for search results open/reveal in `WebUI/src/test/ts/contentExplorer/SearchPanel.test.tsx`
+
+### Implementation
+
+- [ ] T067 [P] [US5] Implement search API helpers under `WebUI/src/main/ts/api/contentExplorer/searchApi.ts` using searchmanagement endpoints from `paths.ts`
+- [ ] T068 [US5] Implement explorer search panel in `WebUI/src/main/ts/contentExplorer/SearchPanel.tsx` with open + reveal-in-tree
+- [ ] T069 [US5] Enable search mode in `ContentBrowser` when host sets `enableSearch` (`WebUI/src/main/ts/contentBrowser/ContentBrowser.tsx`)
+- [ ] T070 [US5] Empty/error search states + TMX keys; update matrix P-Search rows; commit US5 PR; per-PR constitution IX review-thread resolution (inline reply with commit hash + `gh api graphql resolveReviewThread`)
+
+**Checkpoint**: Everyday search/locate without Finder/CE.
+
+---
+
+## Phase 9: User Story 7 — Advanced CE capabilities (Priority: P3) — required for 8.2 parity
+
+**Goal**: Deliver matrix P-Adv rows: clipboard, site/subfolder copy wizards, dependency viewer, IA/relationship views (FR-028). Incomplete rows **block 8.2** (SC-011/SC-012).  
+**Independent Test**: [quickstart.md](./quickstart.md) Scenario H; each matrix row UAT.
+
+### Tests (Required)
+
+- [ ] T071 [P] [US7] Unit tests for clipboard model (copy/cut/paste validation) in `WebUI/src/test/ts/contentExplorer/clipboard.test.ts`
+- [ ] T072 [P] [US7] Tests for wizard step state machines as implemented under `WebUI/src/test/ts/contentExplorer/wizards/`
+- [ ] T073 [P] [US7] Tests for dependency/relationship view data mapping under `WebUI/src/test/ts/contentExplorer/views/`
+
+### Implementation
+
+- [ ] T074 [US7] Spike and document REST/service gaps for site copy, dependency, relationships in `specs/992-react-content-explorer/research.md` (and matrix notes); prefer existing sitemanage site copy / item services
+- [ ] T075 [US7] Implement multi-item clipboard copy/paste in `WebUI/src/main/ts/contentExplorer/clipboard/` integrated with explorer selection
+- [ ] T076 [US7] Implement site copy wizard UI under `WebUI/src/main/ts/contentExplorer/wizards/SiteCopyWizard.tsx` wired to existing site copy services where available
+- [ ] T077 [US7] Implement subfolder copy wizard under `WebUI/src/main/ts/contentExplorer/wizards/SubfolderCopyWizard.tsx`
+- [ ] T078 [US7] Implement dependency viewer under `WebUI/src/main/ts/contentExplorer/views/DependencyViewer.tsx` — surfaces the relationship entity dimensions defined in `contracts/capability-matrix.md` P-Adv (outgoing/incoming relationships, AA links, taxonomy edges, local/reverse dependencies)
+- [ ] T079 [US7] Implement IA/relationship views under `WebUI/src/main/ts/contentExplorer/views/RelationshipsView.tsx` (scope per matrix acceptance and the dimensions enumerated in `contracts/capability-matrix.md` P-Adv)
+- [ ] T080 [US7] Mark all P-Adv capability matrix rows **Done** with acceptance evidence in `contracts/capability-matrix.md` (no post-8.2 scheduled)
+- [ ] T081 [US7] Run advanced UAT; commit US7 PR(s); per-PR constitution IX review-thread resolution (inline reply with commit hash + `gh api graphql resolveReviewThread`); confirm **all P-Adv matrix rows Done** with acceptance evidence (no post-8.2 scheduled)
+
+**Checkpoint**: Advanced CE matrix complete for 8.2.
+
+---
+
+## Phase 10: Polish & 8.2 release gate (SC-012)
+
+**Purpose**: Cross-cutting quality and formal 8.2 functional parity gate.
+
+- [ ] T082 [P] Accessibility spot-check (SC-009): keyboard tree, list, menus, browser dialog — record results under `specs/992-react-content-explorer/checklists/` (e.g. `a11y-spotcheck.md`)
+- [ ] T082a [P] Add **per-story a11y test gates** under US1 (T013/T014/T015/T016 test set), US2 (T037/T038/T039 test set), and US3 (T048/T049/T050 test set): each component test includes a `jest-axe` / `axe-core` run with zero serious/critical violations on rendered surface. Fails CI if a11y regression detected pre-`/speckit.implement` completes. Complements the manual SC-009 spot-check in T082.
+- [ ] T083 [P] i18n key-presence review for explorer/browser chrome TMX keys (FR-026) in checklist under `specs/992-react-content-explorer/checklists/`
+- [ ] T084 [P] Prefer-CE usability feedback notes (SC-010) for ≥5 internal users under `specs/992-react-content-explorer/checklists/`
+- [ ] T085 Complete full cutover inventory sign-off (all sections) in `checklists/cutover-inventory.md`
+- [ ] T086 Confirm capability matrix **all in-scope rows Done** in `contracts/capability-matrix.md`
+- [ ] T087 Run full [quickstart.md](./quickstart.md) Scenarios A–I on 8.2 candidate build; record pass/fail
+- [ ] T088 [P] Spotless / frontend format checks on touched modules via project standards; explicitly invoke `./mvn-env.sh -pl <module> -am verify` (or `./mvn-env.bat`) on JDK 21 for any touched Java module (WebUI backend, sitemanage, rest, perc-i18n if changed) — per constitution VII
+- [ ] T089 Security review: AuthZ on folder ACL save, action execution, CSRF, no secrets in logs — note in PR/release evidence; include threat-model note for any new façade from T052b
+- [ ] T089a Produce **aggregated 8.2 functional parity evidence artifact** `docs/ai-generated/release/992-8.2-parity-evidence.md` (or extend `checklists/cutover-inventory.md` §F) that consolidates: (1) capability matrix in-scope rows Done with acceptance evidence, (2) SC-001..SC-011 pass results, (3) Finder + Desktop CE retirement sign-offs, (4) **all in-scope P-Host hosts Done with per-host SC-002 evidence (T045a..T045f)**, (5) **all P-Adv matrix rows Done with acceptance evidence (US7 / T081)**, (6) constitution IX review-thread resolution log per PR; T090 consumes this artifact for the GA go/no-go decision
+- [ ] T090 SC-012 decision: **block 8.2 GA** if any FR-029 parity clause fails (including all P-Host hosts Done and all P-Adv matrix rows Done — US7 completion is a parity clause, not just a polish step); only proceed to release labeling when SC-012 passes
+- [ ] T091 Final documentation: update nearest WebUI README or feature notes for operators (modern explorer entry, CE retired)
+
+---
+
+## Dependencies & Execution Order
+
+```text
+Phase 1 Setup
+    ↓
+Phase 2 Foundational  ─────────────────────────────┐
+    ↓                                              │
+Phase 3 US1 (core explorer)                        │
+    ↓                                              │
+    ├─→ Phase 4 US6 (intermediate hard cut)        │
+    │                                              │
+    └─→ Phase 5 US2 (browser + hosts) ←────────────┘
+              ↓
+Phase 6 US3 (menus) ──→ Phase 7 US4 (ACL) ──→ Phase 8 US5 (search)
+              └────────────┬────────────────────┘
+                           ↓
+                    Phase 9 US7 (advanced)
+                           ↓
+                    Phase 10 Polish + SC-012 (8.2 gate)
+```
+
+| Phase | Depends on | Blocks 8.2 if incomplete? |
+|-------|------------|---------------------------|
+| Setup | — | No (dev only) |
+| Foundational | Setup | Indirect (blocks all) |
+| US1 | Foundational | **Yes** |
+| US6 | US1 | **Yes** (hard cut required for GA) |
+| US2 | Foundational + path API (US1 recommended) | **Yes** (hosts) |
+| US3 | US1 | **Yes** |
+| US4 | US1 | **Yes** |
+| US5 | US1 (browser search needs US2 for browser half) | **Yes** |
+| US7 | US1 (+ menus helpful) | **Yes** |
+| Polish / SC-012 | All stories | **Yes** — release gate |
+
+---
+
+## Parallel Execution Examples
+
+```text
+# After Foundational:
+T013–T016 (US1 tests) in parallel
+T017–T019 (shell/tree/list) in parallel after types exist
+
+# After US1:
+US6 hard-cut work (T030–T034) || US2 browser component (T037–T042)
+# Host migrations (T045) sequential per host or parallel if isolated
+
+# After menus API client:
+T048–T050 tests || T051 client
+US4 (T058–T064) can run in parallel with US5 (T065–T070) after US1
+US7 wizards/views (T076–T079) parallel after gap spike T074
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (early train validation only — **not** 8.2 GA)
+
+1. Setup → Foundational → **US1** → validate Scenario A/B.
+2. Optional: **US6** intermediate hard cut to remove miller Finder from primary nav early.
+
+### 8.2 shippable increment
+
+Complete **US1–US7** + Phase 10 with **SC-012 pass**. Functional parity **blocks** 8.2; do not label GA with open matrix rows.
+
+### Story independence
+
+| Story | Independent test focus |
+|-------|------------------------|
+| US1 | Core navigate without Finder/CE |
+| US2 | Host selection payload |
+| US3 | ≥10 configured actions |
+| US4 | ACL save + second-user effect |
+| US5 | Search open/reveal |
+| US6 | No classic primary path |
+| US7 | Advanced matrix row UAT |
+
+### Notes for implementers
+
+- Prefer **reuse** of `PSPathService` / searchmanagement / `ActionMenuResource`; prove gaps before new Java endpoints.
+- Cross-platform path rules apply to any new Java/scripts (`AGENTS.md`).
+- Each story PR: tests green, Erlang-style review before commit when required by project rules, resolve review threads (constitution IX).
+- Coordinate Home Library (`989`) consumption of ContentBrowser without blocking US1.
+
+---
+
+## Task count summary
+
+| Phase | Story | Tasks (approx) |
+|-------|-------|----------------|
+| 1 Setup | — | T001–T005 (5) |
+| 2 Foundational | — | T006–T012 + T012a–T012e (12) |
+| 3 | US1 | T013–T027 + T015a + T024a (17) |
+| 4 | US6 | T028–T036 + T029a (10) |
+| 5 | US2 | T037–T047 → split T045 → T045a–T045f (16) |
+| 6 | US3 | T048–T057 + T052a + T052b (12) |
+| 7 | US4 | T058–T064 (7) |
+| 8 | US5 | T065–T070 (6) |
+| 9 | US7 | T071–T081 (11) |
+| 10 Polish / 8.2 | — | T082–T091 + T089a (11) |
+| **Total** | | **T001–T091 + new IDs (106)** |
+
+**Format validation**: All tasks use `- [ ]`, sequential Task IDs, optional `[P]`, story labels on US phases only, and file paths in descriptions. New tasks (T012a–T012e, T015a, T024a, T029a, T045a–T045f, T052a–T052b, T089a) follow the same format and respect [P] parallelism rules.


### PR DESCRIPTION
## Summary

Phase 1 (Setup) and Phase 2 (Foundational) of feature **992-react-content-explorer** (Unified React Content Explorer, 8.2 release).

Adds the full feature planning directory plus typed REST client, registry placeholders, Vitest scaffolds, and the SC-005 perf fixture seed script.

## What's in this PR

- `specs/992-react-content-explorer/` — feature planning directory:
  - `spec.md`, `plan.md`, `tasks.md` (107 tasks), `research.md`, `data-model.md`
  - 4 contracts: `path-api.md`, `content-browser-host.md`, `action-menu-api.md`, `capability-matrix.md`
  - `quickstart.md` (Scenarios A–I + a11y + usability rubric)
  - 2 checklists: `requirements.md` (16/16 PASS), `cutover-inventory.md` (5/5 §E sign-off rule established; §A–§D populated)
- `WebUI/src/main/ts/api/paths.ts` — 12 new URL constants (`PATH_PAGINATED_FOLDER`, `PATH_ITEM`, `PATH_ITEM_ID`, `PATH_ADD_NEW_FOLDER`, `PATH_RENAME_FOLDER`, `PATH_MOVE_ITEM`, `PATH_DELETE_ITEM`, `PATH_FOLDER_PROPERTIES`, `PATH_SAVE_FOLDER_PROPERTIES`, `PATH_VALIDATE`, `PATH_LAST_EXISTING`, `ACTIONS_ROOT`)
- `WebUI/src/main/ts/api/contentExplorer/{pathApi.ts,types.ts}` — typed REST client + DTO mirrors
- `WebUI/src/main/ts/contentExplorer/ContentExplorerShell.tsx`, `contentBrowser/{ContentBrowser.tsx,types.ts}` — placeholder components registered in `registry.ts`
- `WebUI/src/test/ts/{contentExplorer,contentBrowser}/index.ts` — Vitest directory scaffolds
- `scripts/create-large-folder-fixture.sh` (+ `scripts/README.md`) — SC-005 perf fixture seed
- `docs/ai-generated/code-reviews/992-react-content-explorer-phase1plus2-erlang.md` — pre-commit Erlang review

## What's NOT in this PR (intentional)

- **US1 implementation (T013–T027)** — tree, detail list, ReducedAction set, shell-mount wiring, a11y tests, US1 PR. Halted at the constitution story-checkpoint boundary pending this PR's review.
- **US6 hard-cut (T028–T036)** — Finder/Desktop CE retirement + sign-off.
- **US2 host migrations (T037, T045a–T045f)**.
- **US3 menus, US4 ACL, US5 search, US7 advanced matrix, Phase 10 polish/SC-012.**
- Per-US behavioral Vitest tests — scheduled per US in `tasks.md`.

## Pre-commit review

Erlang report: `docs/ai-generated/code-reviews/992-react-content-explorer-phase1plus2-erlang.md`

Two HARD gates found in `scripts/create-large-folder-fixture.sh` and fixed in this commit:
1. False-green on child-creation failures → explicit per-call HTTP-code tracking, non-zero exit on any non-2xx/409.
2. Secret on process command line → password moved into a 0600 netrc file via `mktemp` + `trap rm EXIT`.

Cross-platform path checklist applied (TS code uses URL `/` correctly; shell targets Linux/macOS with `.cmd` counterpart documented as Windows follow-up; no new filesystem path code).

## Constitution compliance

- I (Module-First Boundaries): AGENTS read for `WebUI` + `rest`; sitemanage + Desktop CE fall back to root.
- II (Evidence Over Invention): path API mirrors live DTOs; no invented fields.
- III (Test Discipline): behavioral tests deferred to per-US PRs; scaffolds in place.
- IV (Contract & Integration Integrity): no new REST in this commit; `T052a/T052b` gated on `T052`.
- V (Safe Modernization): Track B island mount; no Spring Boot.
- VI (Security by Default): CSRF via existing `apiFetch`; no secrets logged; netrc 0600.
- VII (Build & Dependency Hygiene): JDK 21 baseline confirmed via `mvn-env`; no new Maven deps.
- VIII (Documentation & Operability): feature dir + `scripts/README.md` updated; TMX keys planned in T023.
- IX (PR Review Comment Resolution): per-PR inline reply + `resolveReviewThread` subtasks added to `tasks.md` for every story PR.

## Reviewer checklist

- [x] Confirm AGENTS hierarchy read + module scope (`WebUI/AGENTS.md`, `rest/AGENTS.md`; no local AGENTS for sitemanage/Desktop CE).
- [ ] Confirm `cutover-inventory.md` §A–§D evidence matches a fresh `rg 'perc_finder|PercFinderView|finder\.jsp' WebUI`.
- [ ] Confirm `pathApi.ts` DTOs align with `projects/sitemanage` `PSPathItem` / `PSFolderProperties` (constitution II).
- [ ] Confirm `registry.ts` placeholders mount under `window.PercModernUI.mount(..., 'ContentExplorerShell' | 'ContentBrowser', props)` per existing bridge pattern.
- [ ] Confirm Erlang report addresses the two HARD gates (false-green + secret-on-cmdline) and the cross-platform checklist.

## Test plan

- `./mvn-env.sh -pl WebUI -am compile` — TS types compile.
- `cd WebUI/src/main/frontend && npx tsc --noEmit` — verify the new modules type-check under the existing Vite config.
- Manual: `bash scripts/create-large-folder-fixture.sh` against a test CMS instance, confirm non-zero exit on failure (negative test) and success on OK (positive test).

## Related

- Spec: `specs/992-react-content-explorer/spec.md` (FR-001…FR-029, SC-001…SC-012)
- Plan: `specs/992-react-content-explorer/plan.md`
- Tasks: `specs/992-react-content-explorer/tasks.md`
- Erlang review: `docs/ai-generated/code-reviews/992-react-content-explorer-phase1plus2-erlang.md`