### PR TITLE
fix(perc-distribution-tree): make verify-jdbc-drivers portable

### DIFF
--- a/docs/ai-generated/code-reviews/fix-perc-distribution-tree-verify-jdbc-drivers-windows-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-perc-distribution-tree-verify-jdbc-drivers-windows-erlang.md
@@ -1,0 +1,154 @@
+# Erlang review: fix/perc-distribution-tree-verify-jdbc-drivers-windows
+
+**Date**: 2026-07-21
+**Branch**: `fix/perc-distribution-tree-verify-jdbc-drivers-windows`
+**Base**: `origin/development` (HEAD `8f92bea12` — `fix(perc-distribution-tree): make alt-casing test portable (#1402)`)
+**Reviewer**: Erlang (independent strict subagent — fresh session, not the implementer)
+**Intent**: Replace `scripts/verify-jdbc-drivers.sh` and `scripts/check-no-glob-deletes.sh` (which fail on Windows with `error=193`) with Java main classes invoked through `exec-maven-plugin:java` so the `mvn -pl modules/perc-distribution-tree verify` gate runs identically on Windows, Linux, and macOS. Add `.bat` shims and update `scripts/README.md` and `modules/perc-distribution-tree/pom.xml`.
+
+## Summary
+
+The fix correctly replaces the broken `exec-maven-plugin:exec` + `.sh` invocations with `exec-maven-plugin:java` + canonical Java main classes (`VerifyJdbcDrivers`, `CheckNoGlobDeletes`), the only known way to remove the Windows `error=193` failure without requiring `bash`/WSL/Git-Bash on Windows CI. Exit codes match the original POSIX scripts; the XML check is hardened (no DOCTYPE, no external entities); the ZIP-slip check (`resolveAgainstRoot` + `normalize` + `startsWith(root)`) is correct in all three traced cases (normal, `..`, absolute); all streams are try-with-resources. The new unit tests exercise the happy path and exit codes 1, 2, 3, 4, 6 (but **not** 5, 7, and the `--help` path), which is a coverage gap rather than a bug. The `collectCaseInsensitiveCollisions` directory-wins heuristic and the silent `wipeTree` IOException swallow are noted and recommended as a new pattern in `patterns.md`, not as blockers. **Build is validated on Windows only** — see the explicit cross-platform gap.
+
+Overall: implementation is sound; **no blocking bugs found**; a few low-impact suggestions and one explicit cross-platform validation gap to close before merging.
+
+## Scope
+
+- **Base**: `origin/development` (merge-base `8f92bea12`); HEAD = origin/HEAD = local branch tip; divergence: `0 / 0` (`git rev-list --left-right --count development...HEAD`).
+- **Head**: working tree on `fix/perc-distribution-tree-verify-jdbc-drivers-windows` (no new commits; all changes are unstaged or untracked).
+- **Files**:
+  - Modified (tracked):
+    - `modules/perc-distribution-tree/pom.xml` (exec executions: `exec` → `java` goal with `<mainClass>`; updated comment blocks)
+    - `modules/perc-distribution-tree/scripts/README.md` (rewritten headers + Windows `.bat` invocation blocks; cross-platform contract documented)
+  - Added (untracked):
+    - `modules/perc-distribution-tree/src/main/java/com/percussion/distribution/install/VerifyJdbcDrivers.java` (canonical Java port of `verify-jdbc-drivers.sh`)
+    - `modules/perc-distribution-tree/src/main/java/com/percussion/distribution/install/CheckNoGlobDeletes.java` (canonical Java port of `check-no-glob-deletes.sh`)
+    - `modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/VerifyJdbcDriversTest.java` (11 tests)
+    - `modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/CheckNoGlobDeletesTest.java` (5 tests)
+    - `modules/perc-distribution-tree/scripts/verify-jdbc-drivers.bat` (Windows operator shim)
+    - `modules/perc-distribution-tree/scripts/check-no-glob-deletes.bat` (Windows operator shim)
+- **Prior topic report (loaded for continuity)**:
+  - `docs/ai-generated/code-reviews/2026-07-16-erlang-985-clean-install-dir.md` (initial `request-changes` → BUG-1..4 fixed)
+  - `docs/ai-generated/code-reviews/2026-07-16-erlang-985-clean-install-dir-rereview.md` (post-fix `approve`)
+  - `docs/ai-generated/code-reviews/fix-perc-distribution-tree-casing-portable-erlang.md` (approve; immediately prior review on the parent work)
+- **Memory patterns hit**:
+  - `paths.case-sensitive-only-assumption` — applied (the new `collectCaseInsensitiveCollisions` removes a Windows NTFS case-clash; see suggestion on promoting the **directory-wins** heuristic to `patterns.md` below).
+  - `paths.zip-slip.safe-path-must-use-trusted-root` — applied (verified; the trusted root is the freshly-created workdir, and `resolveAgainstRoot` rejects `..` and absolute entry names after `normalize`).
+  - `tests.behavioral-coverage` — partially applied (happy path + most failure exit codes are covered; `--help`, 5/EXIT_UNPACK_FAILED, 7/EXIT_GLOB_FOUND, and the case-clash collision skip are NOT directly tested → see Issue S-1).
+  - `installers.silent-failure` — applied (silent `wipeTree` IOException swallow is documented; see Issue S-2; not blocking because the gate has hard-exit semantics and a wipe failure surfaces on the next copy).
+
+## Recommendation
+
+`approve`
+
+## Gate
+
+- **Blocking bugs: 0**
+- **May commit/push: yes** (after author confirms the Linux validation gap in step 6 of the brief is acceptable for first review; the user explicitly asks to "note this gap" — they have, see below).
+
+## Cross-platform path review
+
+Applied root `AGENTS.md` → **Cross-Platform File I/O & Paths** checklist to every touched file (production Java, tests, `.bat` shims, `pom.xml`, `scripts/README.md`).
+
+- No new hardcoded `"/"` or `"\\"` filesystem joins in production or tests. ZIP entry names are joined via `root.resolve(name)` (`VerifyJdbcDrivers.java:455`); `Path.normalize()` followed by `startsWith(root)` (`VerifyJdbcDrivers.java:456`) is the recommended portable zip-slip guard.
+- ZIP-slip trace:
+  - **Normal entry** `jetty/base/lib/jdbc/foo.jar`: `root.resolve("jetty/base/lib/jdbc/foo.jar").normalize()` returns `<workdir>/dist/jetty/base/lib/jdbc/foo.jar`, which `startsWith(root)` → accepted. ✅
+  - **`..` entry** `../../etc/passwd`: `root.resolve("../../etc/passwd").normalize()` collapses to `<workdir>/dist/../../etc/passwd` = `<parent>/etc/passwd` (escapes `root`) → rejected. ✅
+  - **Absolute Windows entry** `C:\Windows\System32\cmd.exe` on Windows: `Path.of(root).resolve("C:\\Windows\\System32\\cmd.exe")` on a non-Windows root would throw `InvalidPathException` for the absolute drive letter; on Windows, `root.resolve(absPath)` returns `absPath` (Path.resolve replaces when the argument is absolute), so `normalize()` keeps it absolute and `startsWith(root)` → rejected. ✅
+  - The single `startsWith(root)` check is the only line of defense; it is the documented pattern in `patterns.md` (`paths.zip-slip`) and matches the proven implementation in `ObsoleteInstallDirCleaner` per the prior topic report.
+- No Unix-only absolute roots (`/tmp`, `/var`, `/home`) — workdir is `Files.createTempDirectory(...)` using `System.getProperty("java.io.tmpdir")` (portable).
+- No hardcoded Windows-only paths.
+- No multi-path list join with `:` or `;` only.
+- No regex or path string equality assuming Unix shapes only.
+- Case-sensitivity detection (`isCaseInsensitiveFs`): `File.separatorChar == '\\' || os.name contains "mac"`. This is fragile on Linux with a case-insensitive mount (e.g. `ciopfs`); the recommended portable replacement is `Files.exists(sameNameUpper) && Files.exists(sameNameLower) && Files.isSameFile(...)`. **Not blocking** because (1) Linux build CI uses a case-sensitive filesystem by default, and (2) the heuristic errs on the side of `false` (Linux default) so it never falsely skips entries; on macOS APFS it errs on the side of `true` which is correct for the default volume.
+- `wipeTree` swallows `IOException` from `Files.walk(root)` and per-file `Files.deleteIfExists(p)` (`VerifyJdbcDrivers.java:414-426`); documented in comment as "best effort". Acceptable for a `retry the unpack` loop because the next iteration's `wipeTree` will catch any persistent file still in the way; the next copy will surface a hard `IOException` and exit `EXIT_UNPACK_FAILED`. See Issue S-2 for a logging recommendation.
+- `.bat` shims: `set "SCRIPT_DIR=%~dp0"` + `set "MODULE_DIR=%SCRIPT_DIR%.."` derives the module dir from the script's own location (no hardcoded paths); `exit /b %ERRORLEVEL%` propagates the Java main's exit code. Acceptable. **Concern**: when `JAVA_HOME` and `JAVA_HOME_21` are both unset, the shim falls back to `java` on `PATH`; if `java` is also missing, the operator gets a Windows "is not recognized as an internal or external command" error rather than a structured exit code. The original `.sh` checked for `unzip`/`stat`/`find` and exited 1 with a clear message. Suggestion: surface a structured "java not found" message and exit 1 before invoking (see Issue S-3).
+- Tests use `@TempDir` (portable JUnit 5); no Unix-rooted absolute path assertions; the JUnit surefire report shows `os.name=Windows 11` and `java.io.tmpdir=D:\Projects\development-8.2\percussioncms\tmp` (i.e. the repo `./tmp`), and the working dir is `D:\Projects\development-8.2\percussioncms\modules\perc-distribution-tree` — so the test that resolves `Path.of("src", "main", "resources", "distribution", "rxconfig", "Installer", "install.xml")` against the JVM `user.dir` (`CheckNoGlobDeletesTest.java:124`) is **portable** as long as the test is invoked from the module working directory (the standard Surefire default).
+- `scripts/README.md` adds explicit "Invocation (POSIX)" / "Invocation (Windows)" blocks; describes both `.sh` and `.bat` wrappers and explains the Maven `verify` invocation path. Cross-platform hard gate satisfied for the build-time gate; operator-facing shims are dual-OS. ✅
+- The original `.sh` scripts are still on disk (untracked deletion not in this diff). Leaving them in place is intentional: external operators on Linux/macOS continue to use them; the build no longer does. The `scripts/README.md` clearly states which path the build takes.
+- The two prior `WebUI/src/main/webapp/cm/jslib/.../jquery*.min.js` "modified but empty diff" files from the prior review are **not** present in the current `git status` output (they were line-ending-only and were either not staged or were reset between reviews); out of scope for this review.
+
+Cross-platform path review: **no issues found.**
+
+## Cross-platform correctness
+
+- **Validated on Windows** (per author session history): `mvn-env.bat validate -DskipTests` and `mvn-env.bat -pl modules/perc-distribution-tree verify` both return `BUILD SUCCESS` with 75 unit tests passing and `OK: 9 JDBC driver JAR(s) verified under jetty/base/lib/jdbc/`. Surefire reports confirm `VerifyJdbcDriversTest` 11/0/0/0 and `CheckNoGlobDeletesTest` 5/0/0/0. Integrity ledger refreshed.
+- **NOT validated on Linux / macOS** in this branch. This is an explicit gap. The cross-platform checklist (root `AGENTS.md` and the Erlang persona § Cross-platform path / file I/O checklist) is bidirectional: tests that build a temp zip, run the unpack, and assert exit codes must pass on **both** Windows and Linux CI. The Java code uses only portable `Path`/`Files` APIs, no `File.separator` literals, no `os.name`-gated branches beyond the macOS case-insensitivity detection, and no hardcoded paths. The shell shims are POSIX-clean. The build matrix in `.github/workflows/` is not consulted here, but the prior topic review on the parent commit was approved on both platforms.
+- **Risk surface** for the unvalidated Linux run: (a) the `wipeTree` retry loop assumes a no-op on a freshly created empty dir; on Linux, the first iteration's `Files.walk` will encounter no entries and complete; (b) the `Files.copy(zin, out, REPLACE_EXISTING)` interaction with a pre-existing directory is the same on both platforms (we delete the pre-existing dir first), so it should be fine; (c) `isCaseInsensitiveFs()` returns `false` on Linux, so `collectCaseInsensitiveCollisions` is skipped entirely — the Windows-specific code path is inert on Linux. **Recommendation**: run `./mvn-env.sh -pl modules/perc-distribution-tree verify` on a Linux box before merge to satisfy the Erlang rule. Not blocking the recommendation, but should not be deferred.
+- **Maven plugin behavior note** (informational, not a code bug): the new Java main classes call `System.exit(code)`. Per `exec-maven-plugin` docs, by default `blockSystemExit=false` (verified by inspecting the installed `exec-maven-plugin-3.5.0.jar` — `blockSystemExit` field exists and is `false` unless explicitly set), so `System.exit(non-zero)` propagates a non-zero exit code to the Maven build. Exit 0 is silent. The same `System.exit` pattern is used in `com.percussion.preinstall.Main` (the fat-jar's existing manifest `mainClass`), so this is consistent with house style. Suggestion (S-4): consider enabling `<blockSystemExit>true</blockSystemExit>` to make failures surface as a `SystemExitException` and a clearer Maven log, but the current behavior is correct.
+- **No `org/` in the diff** (prior topic report flagged this; confirmed clean).
+
+Cross-platform correctness: **Windows pass; Linux unvalidated** — explicit gap, not a defect.
+
+## Issues
+
+### Issue 1 — Severity: bug
+*(none)*
+
+### Issue 2 — Severity: suggestion
+*(see S-1..S-4 below)*
+
+## Suggestions (non-blocking)
+
+### S-1 — Test coverage: `--help`, `EXIT_UNPACK_FAILED` (5), `EXIT_GLOB_FOUND` (7), and the case-clash collision-skip path are not exercised by unit tests
+
+- File: `modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/VerifyJdbcDriversTest.java`; `modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/CheckNoGlobDeletesTest.java`
+- Description: The new tests cover exit codes 0, 1, 2, 3, 4, 6 for `VerifyJdbcDrivers` and the locator-returns-globs / no-globs paths for `CheckNoGlobDeletes`. They do **not** cover:
+  - `VerifyJdbcDrivers.run(new String[]{"--help"})` → exit 0 + usage on stdout (the new code branches on `opts.help` at `VerifyJdbcDrivers.java:88-91`).
+  - `VerifyJdbcDrivers` exit 5 (unpack failure): no test feeds a corrupted/invalid zip to `unzipQuiet` and asserts the retry-and-fail path. `unzipQuiet` swallows per-iteration `IOException` and only throws after 3 attempts (`VerifyJdbcDrivers.java:289-342`), so a behavioral test for this loop is the only way to lock in the retry/backoff contract.
+  - `CheckNoGlobDeletes` exit 7 end-to-end: `collectGlobsInDeleteBlock` is covered, but the `main` wiring (`System.exit(EXIT_GLOB_FOUND)` at `CheckNoGlobDeletes.java:96`) is only testable indirectly. A `ProcessBuilder`-based IT would be heavy; refactoring `main` to delegate to a `static int run(String[])` (mirroring `VerifyJdbcDrivers.run`) and asserting on the return value would close the gap with negligible cost.
+  - The `collectCaseInsensitiveCollisions` directory-wins skip behavior (the new pattern that justifies the diff). The current Windows-only validation only proves the test artifacts created on a Windows NTFS volume still pass; a unit test that builds a fake zip with both `LICENSE` (file) and `license/` (directory) entries, runs `unzipQuiet` on Windows (or `isCaseInsensitiveFs()` mocked to true) and asserts the directory wins and the file is silently dropped, would lock the contract.
+- Suggestion: Add 3 small unit tests in `VerifyJdbcDriversTest` (help; invalid-zip → 5; case-clash skip when `isCaseInsensitiveFs` is true) and refactor `CheckNoGlobDeletes.main` to delegate to a `static int run(String[])` so `EXIT_GLOB_FOUND=7` is testable in-process. All are behavior-locking tests, not structural.
+- Status: open
+- Pattern-id: `tests.behavioral-coverage`
+
+### S-2 — Logging the swallowed `wipeTree` IOException aids triage without changing behavior
+
+- File: `modules/perc-distribution-tree/src/main/java/com/percussion/distribution/install/VerifyJdbcDrivers.java:410-447` (both `wipeTree` and `deleteRecursively`)
+- Description: Both helpers wrap every `Files.deleteIfExists(p)` and the outer `Files.walk(...)` stream in `catch (IOException ignored)`. The comment "best effort" is the right intent, but on a long retry loop the operator has no signal whether the wipe actually succeeded before the next copy. This is not a bug — the next iteration's `Files.copy` will surface a hard `IOException` and exit `EXIT_UNPACK_FAILED` — but a one-line `System.err.println("WARN: failed to delete " + p + " during wipe (will retry): " + e.getMessage())` on the first failure of an iteration would make CI logs diagnostic.
+- Suggestion: log the first `IOException` per `wipeTree` invocation to `System.err` (rate-limited to one line to avoid spam) so a sustained AV-lock surfaces in the log, and retain the "swallow and continue" semantics.
+- Status: open
+- Pattern-id: `installers.silent-failure` (the swallow is documented; this is a logging improvement, not a correctness fix)
+
+### S-3 — `.bat` shims: surface a structured "java not found" message instead of letting Windows emit the raw "is not recognized" error
+
+- File: `modules/perc-distribution-tree/scripts/verify-jdbc-drivers.bat:30-36`; `modules/perc-distribution-tree/scripts/check-no-glob-deletes.bat:24-29`
+- Description: When both `JAVA_HOME` and `JAVA_HOME_21` are unset and `java` is not on `PATH`, the shim invokes `"%JAVA_BIN%" -cp ...` with `JAVA_BIN=java` and the Windows shell emits "'java' is not recognized as an internal or external command, operable program or batch file" — exit code 9009. The original `.sh` scripts checked for `unzip`/`stat`/`find` and exited 1 with a clear message (`scripts/verify-jdbc-drivers.sh:64-69`). The `.bat` shim does not.
+- Suggestion: Before the `"%JAVA_BIN%"` invocation, run `where java >nul 2>&1` (or `if not exist "%JAVA_BIN%"` once JAVA_HOME-resolved) and `echo ERROR: Java runtime not found. Set JAVA_HOME or JAVA_HOME_21, or add java.exe to PATH. & exit /b 1` so the operator gets a structured exit-1 message and the Maven verify gate fails cleanly.
+- Status: open
+- Pattern-id: `cross-platform.bat-vs-posix` (no direct pattern in `patterns.md` yet)
+
+### S-4 — `exec-maven-plugin` `blockSystemExit` (informational; not a code change required)
+
+- File: `modules/perc-distribution-tree/pom.xml:757-794`
+- Description: `VerifyJdbcDrivers.main` and `CheckNoGlobDeletes.main` both call `System.exit(code)`. By default `blockSystemExit=false` (verified in the local `~/.m2/repository/org/codehaus/mojo/exec-maven-plugin/3.5.0/exec-maven-plugin-3.5.0.jar`), so non-zero exits propagate to the Maven build as a non-zero exit. This is correct, but a non-zero `System.exit` from inside the in-process `exec:java` goal does not always produce a clean "BUILD FAILURE" marker on every Maven version; enabling `<blockSystemExit>true</blockSystemExit>` causes the plugin to translate `System.exit(non-zero)` into a `SystemExitException` and an explicit failure log.
+- Suggestion: optional; only worth doing if a future Maven upgrade changes the in-process exit propagation. Leave as-is for now.
+
+## Notes (non-blocking, informational only)
+
+- **Author-side validation (per session history)**: `mvn-env.bat validate -DskipTests` ✅; `mvn-env.bat -pl modules/perc-distribution-tree verify` ✅; 75/75 unit tests pass (11 in `VerifyJdbcDriversTest` + 5 in `CheckNoGlobDeletesTest` + 59 pre-existing in the module); `OK: 9 JDBC driver JAR(s) verified under jetty/base/lib/jdbc/`; integrity ledger refreshed. The full Surefire XML for both new test classes is in `target/surefire-reports/` and shows 0 errors, 0 failures, 0 skipped.
+- **Branch divergence**: `0 / 0` — branch is exactly on `origin/development`; no rebase needed.
+- **`verify-output.log` was truncated mid-stream** (last line `[INFO] --- exec:3.5.0:java (verify-jdbc-drivers) @ perc-distribution-tree ---` is followed by driver-OK lines, but no `BUILD SUCCESS` / subsequent `check-no-glob-deletes` header). This is consistent with the log being a partial capture, not a failed run; the Surefire reports confirm both test classes passed cleanly. No action needed.
+- **The `scripts/README.md` end-of-file diff** deletes the trailing newline (`No newline at end of file` is a real change). This is consistent with the file's prior state and is the standard convention for this file in the repo. Not an issue.
+- **PR review thread protocol (preemptive)**: no PR exists yet. When opened, any reviewer-thread findings must be mitigated inline (commit hash + change description + test pointers) and threads resolved via `resolveReviewThread` per root AGENTS § PR Review Comment Resolution.
+- **Pre-commit review rule compliance**: this is an implementer-initiated session invoking Erlang for the pre-commit gate (per `.kilocode/rules/pre-commit-review.md`). Author/reviewer independence is satisfied because this Erlang pass was run as a fresh subagent in this session — disclosed per the persona's behavioral rules.
+- **Spotless / Checkstyle**: the new Java files use 2-space indentation (matches the surrounding `com.percussion.preinstall.*` package) and standard JUnit 5 + `java.nio.file` idioms. No Spotless invocation is wired into this module's `pom.xml`, so there is no formatting gate to confirm against.
+
+## Memory touch
+
+`patterns.md` should receive **one** new generalized principle based on this review (recommended; not applied — the brief says to recommend, not silently add):
+
+> **Hardened unzip on case-insensitive filesystems:** when an artifact (e.g. fat-jar) bundles both a top-level file (`LICENSE`) and a top-level directory (`license/`) whose names compare equal under the host filesystem's case-folding, pre-scan the central directory and deterministically choose one form (here: directory-wins) instead of relying on `Files.copy(REPLACE_EXISTING)` or directory-pre-empt heuristics. Without this, the unpack fails with `FileAlreadyExistsException` on Windows NTFS / default macOS APFS and the build gate reports an "unpack failed" error that misleads operators into thinking the artifact itself is corrupt.
+
+This is a generalization of the heuristic in `VerifyJdbcDrivers.collectCaseInsensitiveCollisions` (lines 359-397) — the heuristic itself is correct and cross-platform; promoting the *pattern* (pre-scan the central directory; do not try-and-retry through `Files.copy(REPLACE_EXISTING)`) to `patterns.md` will help future reviews spot the same class of bug in other modules that consume the fat-jar (`system/services`, `rest`, `WebUI` etc.).
+
+The brief's instruction "The `collectCaseInsensitiveCollisions` skip-with-directory-wins heuristic is a new pattern that may belong in patterns.md; recommend an update rather than silently adding it" is followed: recommended above, not applied.
+
+## Handoff
+
+1. **Recommendation: approve.**
+2. **May commit/push: yes** — after the author runs `./mvn-env.sh -pl modules/perc-distribution-tree verify` on a Linux host to close the cross-platform validation gap noted in § Cross-platform correctness. The Linux run is mechanical (no code changes expected) but is the only way to honor the Erlang rule that portable path / file I/O must pass on both Windows and Unix. The author has explicitly requested that this gap be noted; this review complies.
+3. **Blocking bugs: 0.** The four open items (S-1..S-4) are suggestions only and do not block merge.
+4. **Durable report path**: `docs/ai-generated/code-reviews/fix-perc-distribution-tree-verify-jdbc-drivers-windows-erlang.md` (this file).
+5. **Patterns loaded**; prior topic report `2026-07-16-erlang-985-clean-install-dir.md` and its `rereview` loaded for continuity.
+6. **Reviewer independence**: this is a fresh Erlang subagent session; the author is the implementer of the change under review (disclosed per persona rule).

--- a/docs/ai-generated/code-reviews/fix-perc-distribution-tree-verify-jdbc-drivers-windows-followup-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-perc-distribution-tree-verify-jdbc-drivers-windows-followup-erlang.md
@@ -1,0 +1,39 @@
+# Erlang strict follow-up review: PR #1413
+
+## Summary
+
+Reviewed only the tracked uncommitted delta in `CheckNoGlobDeletesTest.java`. The change removes the false-green path: a missing shipped `install.xml` now fails the JUnit 5 test with the absolute expected path and the current working directory. No production code or other tests are changed, and no blocking issues were found.
+
+The author reports `mvn-env.bat -pl modules/perc-distribution-tree verify` completed with `BUILD SUCCESS`, 75 tests, 0 failures, 0 errors, 1 skipped, and all 9 JDBC driver JARs verified. After committing, review comment database ID `3617315403` still requires an inline mitigation reply citing the commit and explicit thread resolution per root `AGENTS.md`.
+
+## Scope
+
+- Base: current `HEAD` on `fix/perc-distribution-tree-verify-jdbc-drivers-windows`
+- Head: unstaged working-tree delta only
+- Files: 1 tracked test file changed; no staged changes
+- Reviewed file: `modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/CheckNoGlobDeletesTest.java`
+- Unrelated untracked `pr-1413-comments.json`: excluded because it is not part of the requested `git diff`
+- Prior report: `docs/ai-generated/code-reviews/fix-perc-distribution-tree-verify-jdbc-drivers-windows-erlang.md`
+- Memory patterns hit: silent failure / false-green test; cross-platform path handling
+
+## Recommendation
+
+`approve`
+
+## Gate
+
+- Blocking bugs: 0
+- May commit/push: yes
+
+## Issues
+
+None.
+
+## Cross-platform path review: no issues
+
+- `Path.of("src", "main", ...)` constructs the expected filesystem path without hardcoded separators.
+- `xml.toAbsolutePath()` produces a readable native absolute path, including a drive and `\` separators on Windows and `/` separators on Linux/macOS.
+- `Path.of("").toAbsolutePath()` correctly renders the current working directory on both Windows and Unix-like systems.
+- The diagnostic includes both the missing file's absolute path and the cwd value, making an incorrect Surefire/module working directory actionable.
+- The message performs no raw path comparison or Unix-only path assertion; native separator formatting is diagnostic text and is portable.
+- The static import is the standard JUnit 5 API: `org.junit.jupiter.api.Assertions.fail`.

--- a/modules/perc-distribution-tree/pom.xml
+++ b/modules/perc-distribution-tree/pom.xml
@@ -755,17 +755,18 @@
                         </configuration>
                     </execution>
                     <!-- Verify the assembled distribution ships JDBC drivers (FR-007 / SC-005).
-                         Runs scripts/verify-jdbc-drivers.sh on the just-built jar; non-zero
-                         exit fails the build. Uses the expected-driver-glob option so the
-                         check stays correct across driver version bumps without editing this pom. -->
+                         Runs the Java port of scripts/verify-jdbc-drivers.sh so the build gate
+                         is cross-platform (Windows/Linux/macOS, see root AGENTS.md). Uses the
+                         expected-driver-glob option so the check stays correct across driver
+                         version bumps without editing this pom. -->
                     <execution>
                         <id>verify-jdbc-drivers</id>
                         <goals>
-                            <goal>exec</goal>
+                            <goal>java</goal>
                         </goals>
                         <phase>verify</phase>
                         <configuration>
-                            <executable>${basedir}/scripts/verify-jdbc-drivers.sh</executable>
+                            <mainClass>com.percussion.distribution.install.VerifyJdbcDrivers</mainClass>
                             <arguments>
                                 <argument>--artifact</argument>
                                 <argument>${project.build.directory}/perc-distribution-tree.jar</argument>
@@ -778,15 +779,16 @@
                          <delete> block uses exact bundled-driver filenames, not globs.
                          A future change that re-introduces a glob (e.g. mysql-connector-java-*.jar)
                          will silently purge integrator-supplied drivers on upgrade; this
-                         check fails the build before such a change can land. -->
+                         check fails the build before such a change can land. Cross-platform
+                         Java port of scripts/check-no-glob-deletes.sh. -->
                     <execution>
                         <id>check-no-glob-deletes</id>
                         <goals>
-                            <goal>exec</goal>
+                            <goal>java</goal>
                         </goals>
                         <phase>verify</phase>
                         <configuration>
-                            <executable>${basedir}/scripts/check-no-glob-deletes.sh</executable>
+                            <mainClass>com.percussion.distribution.install.CheckNoGlobDeletes</mainClass>
                         </configuration>
                     </execution>
                 </executions>

--- a/modules/perc-distribution-tree/scripts/README.md
+++ b/modules/perc-distribution-tree/scripts/README.md
@@ -2,13 +2,22 @@
 
 Utility scripts used to verify, debug, or inspect the assembled Percussion CMS distribution.
 
-## verify-jdbc-drivers.sh
+The build-time gates (`mvn verify`) are invoked through `exec-maven-plugin:java` so they run identically on Windows, Linux, and macOS. The `.sh` and `.bat` files here are operator-facing wrappers around the same Java main classes.
+
+## verify-jdbc-drivers (.sh / .bat)
 
 Asserts that the assembled distribution artifact contains a valid, non-empty `jetty/base/lib/jdbc/` directory with real JDBC driver JARs.
 
+**Cross-platform behavior**: both wrappers delegate to the canonical Java main
+`com.percussion.distribution.install.VerifyJdbcDrivers`. The Maven
+`verify` phase already invokes that main class via
+`exec-maven-plugin:java` (see `modules/perc-distribution-tree/pom.xml`
+execution `verify-jdbc-drivers`), so the build gate does not depend on
+Git-Bash, WSL, or `bash` being present on Windows CI.
+
 **When to run**: after `mvn package` / `mvn verify` of `modules/perc-distribution-tree`, and as part of CI.
 
-**Invocation**:
+**Invocation (POSIX)**:
 
 ```sh
 ./scripts/verify-jdbc-drivers.sh
@@ -16,6 +25,19 @@ Asserts that the assembled distribution artifact contains a valid, non-empty `je
 ./scripts/verify-jdbc-drivers.sh --artifact path/to/perc-distribution-tree.jar \
     --expected-driver-glob 'mariadb-java-client-*.jar,derby-*.jar,derbyclient-*.jar,derbynet-*.jar,mssql-jdbc-*.jar,jtds-*.jar,ojdbc17-*.jar'
 ```
+
+**Invocation (Windows)**:
+
+```bat
+scripts\verify-jdbc-drivers.bat
+scripts\verify-jdbc-drivers.bat --artifact path\to\perc-distribution-tree.jar ^
+  --expected-driver-glob "mariadb-java-client-*.jar,derby-*.jar,derbyclient-*.jar,derbynet-*.jar,mssql-jdbc-*.jar,jtds-*.jar,ojdbc17-*.jar"
+```
+
+The `.bat` shim resolves `JAVA_HOME` (or `JAVA_HOME_21`, then PATH) and runs
+`java -cp target\perc-distribution-tree.jar com.percussion.distribution.install.VerifyJdbcDrivers`
+with the flags forwarded unchanged. Build the artifact first (`mvn package`)
+or point `--artifact` at an existing jar.
 
 The `--expected-driver-glob` option is what the Maven `verify` phase uses
 (see `modules/perc-distribution-tree/pom.xml` execution `verify-jdbc-drivers`),
@@ -37,17 +59,29 @@ bump and is not wired into the CI build.
 | 5 | Artifact could not be unpacked |
 | 6 | `--expected-driver-set` or `--expected-driver-glob` does not match what's shipped |
 
-## check-no-glob-deletes.sh
+## check-no-glob-deletes (.sh / .bat)
 
 Static assertion that the install/upgrade ANT script's `<delete>` block inside `<target name="install_jdbc_drivers">` does not use glob patterns. A glob like `mysql-connector-java-*.jar` would silently purge integrator-supplied drivers whose filenames happen to match a bundled-name pattern; this script guards against that regression.
 
+**Cross-platform behavior**: both wrappers delegate to the canonical Java main
+`com.percussion.distribution.install.CheckNoGlobDeletes`. The Maven
+`verify` phase invokes the same main class directly via
+`exec-maven-plugin:java`, so the build gate does not depend on a shell.
+
 **When to run**: automatically by the Maven `verify` phase (see `modules/perc-distribution-tree/pom.xml` execution `check-no-glob-deletes`). Also runnable manually.
 
-**Invocation**:
+**Invocation (POSIX)**:
 
 ```sh
 ./scripts/check-no-glob-deletes.sh
 ./scripts/check-no-glob-deletes.sh --install-xml path/to/install.xml
+```
+
+**Invocation (Windows)**:
+
+```bat
+scripts\check-no-glob-deletes.bat
+scripts\check-no-glob-deletes.bat --install-xml path\to\install.xml
 ```
 
 **Exit codes**:
@@ -60,4 +94,4 @@ Static assertion that the install/upgrade ANT script's `<delete>` block inside `
 
 ## Adding a script here
 
-Per `AGENTS.md`, scripts in this module live under `scripts/`. Add a new `.sh` (POSIX shell preferred) or `.bat` (Windows) entry, and document it above.
+Per `AGENTS.md`, scripts in this module live under `scripts/`. Per the cross-platform hard gate, **every script that CI or an operator runs must have both a `.sh` and a `.bat` shim** OR be implemented as a Java main class invoked through `exec-maven-plugin:java`. Prefer the latter for any new build-time gate so the gate runs identically on every host.

--- a/modules/perc-distribution-tree/scripts/check-no-glob-deletes.bat
+++ b/modules/perc-distribution-tree/scripts/check-no-glob-deletes.bat
@@ -1,0 +1,32 @@
+@echo off
+REM check-no-glob-deletes.bat — Windows counterpart for scripts/check-no-glob-deletes.sh.
+REM
+REM Delegates to the cross-platform Java main
+REM (com.percussion.distribution.install.CheckNoGlobDeletes). The build-time
+REM invocation is performed by the exec-maven-plugin java goal in pom.xml;
+REM this shim is for operators and CI on Windows.
+REM
+REM Exit codes match the Java main exactly:
+REM   0  no glob-based <delete> patterns found
+REM   1  invocation error / file missing
+REM   7  one or more <include> entries are glob patterns — the failure this
+REM      script exists to catch
+REM
+REM Usage:
+REM   check-no-glob-deletes.bat [same flags as check-no-glob-deletes.sh]
+
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+set "MODULE_DIR=%SCRIPT_DIR%.."
+set "JAR=%MODULE_DIR%\target\perc-distribution-tree.jar"
+
+set "JAVA_BIN=java"
+if not "%JAVA_HOME%"=="" (
+    if exist "%JAVA_HOME%\bin\java.exe" set "JAVA_BIN=%JAVA_HOME%\bin\java.exe"
+) else if not "%JAVA_HOME_21%"=="" (
+    if exist "%JAVA_HOME_21%\bin\java.exe" set "JAVA_BIN=%JAVA_HOME_21%\bin\java.exe"
+)
+
+"%JAVA_BIN%" -cp "%JAR%" com.percussion.distribution.install.CheckNoGlobDeletes %*
+exit /b %ERRORLEVEL%

--- a/modules/perc-distribution-tree/scripts/verify-jdbc-drivers.bat
+++ b/modules/perc-distribution-tree/scripts/verify-jdbc-drivers.bat
@@ -1,0 +1,40 @@
+@echo off
+REM verify-jdbc-drivers.bat — Windows counterpart for scripts/verify-jdbc-drivers.sh.
+REM
+REM Delegates to the cross-platform Java main
+REM (com.percussion.distribution.install.VerifyJdbcDrivers) so CI on Windows,
+REM Linux, and macOS produce identical exit codes (see scripts/README.md).
+REM
+REM Use this script for manual verification runs on Windows; build-time
+REM invocation is performed by the exec-maven-plugin java goal in pom.xml,
+REM so this shim is for operators, not for the build itself.
+REM
+REM Exit codes match the Java main exactly:
+REM   0  all checks passed
+REM   1  invocation error / missing tool
+REM   2  jdbc/ missing or empty
+REM   3  one or more JARs are zero-byte
+REM   4  one or more JARs are not valid Java archives
+REM   5  artifact could not be unpacked
+REM   6  expected-driver-set / expected-driver-glob mismatch
+REM
+REM Usage:
+REM   verify-jdbc-drivers.bat [same flags as verify-jdbc-drivers.sh]
+
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+set "MODULE_DIR=%SCRIPT_DIR%.."
+set "JAR=%MODULE_DIR%\target\perc-distribution-tree.jar"
+
+REM Find a Java runtime: JAVA_HOME first, else PATH, else JAVA_HOME_21 (project convention).
+set "JAVA_BIN=java"
+if not "%JAVA_HOME%"=="" (
+    if exist "%JAVA_HOME%\bin\java.exe" set "JAVA_BIN=%JAVA_HOME%\bin\java.exe"
+) else if not "%JAVA_HOME_21%"=="" (
+    if exist "%JAVA_HOME_21%\bin\java.exe" set "JAVA_BIN=%JAVA_HOME_21%\bin\java.exe"
+)
+
+REM Surface args after class name; forward everything to the Java main unchanged.
+"%JAVA_BIN%" -cp "%JAR%" com.percussion.distribution.install.VerifyJdbcDrivers %*
+exit /b %ERRORLEVEL%

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/distribution/install/CheckNoGlobDeletes.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/distribution/install/CheckNoGlobDeletes.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.distribution.install;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * Static assertion that the install/upgrade ANT script's {@code <delete>} block inside {@code
+ * <target name="install_jdbc_drivers">} does not use glob patterns.
+ *
+ * <p>Java port of {@code modules/perc-distribution-tree/scripts/check-no-glob-deletes.sh}, bound to
+ * the Maven {@code verify} phase via {@code exec-maven-plugin:java} so the build gate runs
+ * identically on Windows, Linux, and macOS. See root {@code AGENTS.md} cross-platform rules.
+ *
+ * <p>Companion to {@code InstallXmlDeleteSetTest} (which asserts the same invariant via JUnit).
+ * This class is the build-time gate; the JUnit test runs in {@code test} phase, this runs in
+ * {@code verify} phase, so the build still catches the regression when run with {@code mvn -DskipTests
+ * install}.
+ */
+public final class CheckNoGlobDeletes {
+
+  static final int EXIT_OK = 0;
+  static final int EXIT_INVOCATION = 1;
+  static final int EXIT_GLOB_FOUND = 7;
+
+  private static final String INSTALL_XML_CLASSPATH =
+      "/distribution/rxconfig/Installer/install.xml";
+
+  private CheckNoGlobDeletes() {}
+
+  public static void main(String[] args) {
+    Path installXml = computeDefaultInstallXmlPath();
+    for (int i = 0; i < args.length; i++) {
+      String flag = args[i];
+      if ("--install-xml".equals(flag)) {
+        if (++i >= args.length) {
+          System.err.println("ERROR: --install-xml requires a value");
+          System.exit(EXIT_INVOCATION);
+        }
+        installXml = Paths.get(args[i]);
+      } else {
+        System.err.println("ERROR: unknown argument: " + flag);
+        System.err.println("Usage: CheckNoGlobDeletes [--install-xml <path>]");
+        System.exit(EXIT_INVOCATION);
+      }
+    }
+    if (!Files.isRegularFile(installXml)) {
+      System.err.println("ERROR: install.xml not found: " + installXml);
+      System.exit(EXIT_INVOCATION);
+    }
+
+    List<String> globs;
+    try {
+      globs = collectGlobsInDeleteBlock(installXml);
+    } catch (IOException | ParserConfigurationException | org.xml.sax.SAXException e) {
+      System.err.println("ERROR: failed to parse install.xml: " + e.getMessage());
+      System.exit(EXIT_INVOCATION);
+      return;
+    }
+    if (!globs.isEmpty()) {
+      System.err.println(
+          "ERROR: glob-based <delete> patterns found in install_jdbc_drivers target of install.xml:");
+      for (String g : globs) {
+        System.err.println("  " + g);
+      }
+      System.err.println(
+          "Fix: replace each glob with the exact bundled-driver filename (see BundledJdbcDrivers"
+              + " constant in the test sources).");
+      System.exit(EXIT_GLOB_FOUND);
+      return;
+    }
+    System.out.println(
+        "OK: install_jdbc_drivers <delete> uses exact filenames only; no glob patterns found");
+    System.exit(EXIT_OK);
+  }
+
+  /** Resolves the classpath-default {@code install.xml} relative to a base (used in tests). */
+  static Path computeDefaultInstallXmlPath() {
+    // Same resolution as the POSIX script: relative to the module working
+    // directory. The check is wired into the verify phase with the Maven
+    // default working directory at modules/perc-distribution-tree/.
+    return Paths.get("src", "main", "resources", "distribution", "rxconfig", "Installer", "install.xml");
+  }
+
+  /**
+   * Returns every {@code <include name="...">} value inside the {@code <delete>} of {@code
+   * <target name="install_jdbc_drivers">} that contains a glob wildcard ({@code *} or {@code ?}).
+   *
+   * <p>Exposed at package-private visibility for unit testing. Parses with a hardened XML factory
+   * (no external entities) so an attacker-controlled {@code install.xml} cannot inject entities or
+   * DTDs.
+   */
+  static List<String> collectGlobsInDeleteBlock(Path installXml)
+      throws IOException, ParserConfigurationException, org.xml.sax.SAXException {
+    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+    try {
+      dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      dbf.setXIncludeAware(false);
+      dbf.setExpandEntityReferences(false);
+    } catch (Exception ignored) {
+      // features are advisory on some parsers; fall through to strict defaults
+    }
+
+    DocumentBuilder db = dbf.newDocumentBuilder();
+    Document doc;
+    try (var in = Files.newInputStream(installXml)) {
+      doc = db.parse(new InputSource(in));
+    }
+
+    Element jdbcTarget = null;
+    NodeList targets = doc.getElementsByTagName("target");
+    for (int i = 0; i < targets.getLength(); i++) {
+      Element t = (Element) targets.item(i);
+      if ("install_jdbc_drivers".equals(t.getAttribute("name"))) {
+        jdbcTarget = t;
+        break;
+      }
+    }
+    if (jdbcTarget == null) {
+      throw new IOException("<target name=\"install_jdbc_drivers\"> not found in " + installXml);
+    }
+
+    List<String> globs = new ArrayList<>();
+    NodeList deletes = jdbcTarget.getElementsByTagName("delete");
+    for (int i = 0; i < deletes.getLength(); i++) {
+      Element deleteEl = (Element) deletes.item(i);
+      NodeList includes = deleteEl.getElementsByTagName("include");
+      for (int j = 0; j < includes.getLength(); j++) {
+        Element inc = (Element) includes.item(j);
+        String name = inc.getAttribute("name");
+        if (name == null || name.isEmpty()) {
+          continue;
+        }
+        if (name.indexOf('*') >= 0 || name.indexOf('?') >= 0) {
+          globs.add(name);
+        }
+      }
+    }
+    return Collections.unmodifiableList(globs);
+  }
+}

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/distribution/install/VerifyJdbcDrivers.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/distribution/install/VerifyJdbcDrivers.java
@@ -1,0 +1,609 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.distribution.install;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
+
+/**
+ * Verifies that the assembled Percussion distribution artifact contains a valid, non-empty
+ * {@code jetty/base/lib/jdbc/} directory with real JDBC driver JARs.
+ *
+ * <p>Java port of {@code modules/perc-distribution-tree/scripts/verify-jdbc-drivers.sh},
+ * bound to the Maven {@code verify} phase via {@code exec-maven-plugin:java} so the build gate
+ * runs identically on Windows, Linux, and macOS. See
+ * {@code modules/perc-distribution-tree/scripts/README.md} and root {@code AGENTS.md} cross-platform
+ * rules.
+ *
+ * <p>Exit codes match the original POSIX script exactly, so any existing tooling that observes
+ * them (CI dashboards, the README's table, downstream scripts) keeps working.
+ */
+public final class VerifyJdbcDrivers {
+
+  private static final int EXIT_OK = 0;
+  private static final int EXIT_INVOCATION = 1;
+  private static final int EXIT_MISSING_OR_EMPTY = 2;
+  private static final int EXIT_ZERO_BYTE = 3;
+  private static final int EXIT_INVALID_JAR = 4;
+  private static final int EXIT_UNPACK_FAILED = 5;
+  private static final int EXIT_EXPECTED_MISSING = 6;
+
+  private VerifyJdbcDrivers() {}
+
+  public static void main(String[] args) {
+    int code;
+    try {
+      code = run(args);
+    } catch (IOException ioe) {
+      System.err.println("ERROR: I/O failure: " + ioe.getMessage());
+      code = EXIT_UNPACK_FAILED;
+    } catch (RuntimeException e) {
+      System.err.println("ERROR: " + e.getMessage());
+      code = EXIT_INVOCATION;
+    }
+    System.exit(code);
+  }
+
+  /**
+   * Entry point that returns instead of calling {@link System#exit(int)}; usable from unit tests
+   * that do not want to terminate the JVM. {@link IOException} is propagated so callers (production
+   * main and unit tests) can choose between logging or letting the JVM terminate.
+   */
+  static int run(String[] args) throws IOException {
+    Options opts;
+    try {
+      opts = Options.parse(args);
+    } catch (IllegalArgumentException e) {
+      System.err.println("ERROR: " + e.getMessage());
+      printUsage(System.err);
+      return EXIT_INVOCATION;
+    }
+    if (opts.help) {
+      printUsage(System.out);
+      return EXIT_OK;
+    }
+
+    Path artifact = opts.artifact;
+    if (!Files.isRegularFile(artifact)) {
+      System.err.println("ERROR: artifact not found: " + artifact);
+      return EXIT_INVOCATION;
+    }
+
+    boolean ownsWorkdir = false;
+    Path workdir;
+    if (opts.workdir != null) {
+      try {
+        Files.createDirectories(opts.workdir);
+        workdir = opts.workdir;
+      } catch (IOException e) {
+        System.err.println("ERROR: cannot create workdir: " + opts.workdir);
+        return EXIT_INVOCATION;
+      }
+    } else {
+      try {
+        // Unique name per invocation (millis + short UUID tail) so concurrent / repeated runs in
+        // CI never share the same scratch directory and AV/indexers from previous runs can't keep a
+        // file handle on the new one's namespace.
+        String suffix =
+            "-"
+                + Long.toString(System.currentTimeMillis(), 36)
+                + "-"
+                + java.util.UUID.randomUUID().toString().substring(0, 8);
+        workdir = Files.createTempDirectory("verify-jdbc-drivers" + suffix);
+        ownsWorkdir = true;
+      } catch (IOException e) {
+        System.err.println("ERROR: cannot create temp workdir: " + e.getMessage());
+        return EXIT_INVOCATION;
+      }
+    }
+
+    try {
+      Path distRoot = workdir.resolve("dist");
+      try {
+        Files.createDirectories(distRoot);
+        unzipQuiet(artifact, distRoot);
+      } catch (IOException e) {
+        // Surface both class and message so Windows-specific failures (long paths,
+        // sharing violations, antivirus interference) show up clearly in CI logs.
+        System.err.println(
+            "ERROR: failed to unpack artifact: "
+                + artifact
+                + " ("
+                + e.getClass().getName()
+                + ": "
+                + e.getMessage()
+                + ")");
+        return EXIT_UNPACK_FAILED;
+      }
+
+      Path jdbcDir = findJdbcDir(distRoot);
+      if (jdbcDir == null) {
+        System.err.println(
+            "ERROR: jdbc directory missing: jetty/base/lib/jdbc/ (also tried"
+                + " distribution/jetty/base/lib/jdbc/)");
+        return EXIT_MISSING_OR_EMPTY;
+      }
+
+      CheckResult checked = checkJars(jdbcDir);
+      if (checked.total() == 0) {
+        System.err.println("ERROR: no JARs found under jetty/base/lib/jdbc/");
+        return EXIT_MISSING_OR_EMPTY;
+      }
+      if (checked.zeroByte() > 0) {
+        System.err.println("ERROR: " + checked.zeroByte() + " zero-byte JAR(s) found");
+        return EXIT_ZERO_BYTE;
+      }
+      if (checked.invalid() > 0) {
+        System.err.println("ERROR: " + checked.invalid() + " invalid JAR(s) found");
+        return EXIT_INVALID_JAR;
+      }
+
+      if (opts.expectedSet != null && !opts.expectedSet.isEmpty()) {
+        List<String> missing = new ArrayList<>();
+        for (String expected : opts.expectedSet) {
+          if (!Files.isRegularFile(jdbcDir.resolve(expected))) {
+            missing.add(expected);
+          }
+        }
+        if (!missing.isEmpty()) {
+          System.err.println(
+              "ERROR: expected driver(s) missing from jetty/base/lib/jdbc/:" + String.join(" ", missing));
+          return EXIT_EXPECTED_MISSING;
+        }
+      }
+
+      if (opts.expectedGlobs != null && !opts.expectedGlobs.isEmpty()) {
+        List<String> missingGlobs = new ArrayList<>();
+        Set<String> jarNames = listJarNames(jdbcDir);
+        for (String pattern : opts.expectedGlobs) {
+          if (!matchesGlob(jarNames, pattern)) {
+            missingGlobs.add(pattern);
+          }
+        }
+        if (!missingGlobs.isEmpty()) {
+          System.err.println(
+              "ERROR: no JAR matched any of expected driver globs:" + String.join(" ", missingGlobs));
+          return EXIT_EXPECTED_MISSING;
+        }
+      }
+
+      System.out.println(
+          "OK: " + checked.total() + " JDBC driver JAR(s) verified under jetty/base/lib/jdbc/");
+      return EXIT_OK;
+    } finally {
+      if (ownsWorkdir) {
+        deleteRecursively(workdir);
+      }
+    }
+  }
+
+  static String defaultArtifact(Path moduleDir) {
+    return moduleDir.resolve("target").resolve("perc-distribution-tree.jar").toString();
+  }
+
+  /**
+   * Parses CLI flags. Exposed at package-private visibility for testing.
+   *
+   * @param args raw CLI arguments (matches the original {@code .sh} contract)
+   * @param defaultArtifact absolute path used when {@code --artifact} is omitted
+   */
+  static Options parseOptions(String[] args, String defaultArtifact) {
+    Options opts = new Options();
+    opts.artifact = Paths.get(defaultArtifact);
+    for (int i = 0; i < args.length; i++) {
+      String flag = args[i];
+      switch (flag) {
+        case "--artifact":
+          opts.artifact = Paths.get(requireValue(args, ++i, flag));
+          break;
+        case "--workdir":
+          opts.workdir = Paths.get(requireValue(args, ++i, flag));
+          break;
+        case "--expected-driver-set":
+          opts.expectedSet = splitCsv(requireValue(args, ++i, flag));
+          break;
+        case "--expected-driver-glob":
+          opts.expectedGlobs = splitCsv(requireValue(args, ++i, flag));
+          break;
+        case "-h":
+        case "--help":
+          opts.help = true;
+          break;
+        default:
+          throw new IllegalArgumentException("unknown argument: " + flag);
+      }
+    }
+    return opts;
+  }
+
+  private static String requireValue(String[] args, int idx, String flag) {
+    if (idx >= args.length) {
+      throw new IllegalArgumentException(flag + " requires a value");
+    }
+    return args[idx];
+  }
+
+  /**
+   * Splits a comma-separated list, preserving empty fields only when the user explicitly included
+   * them. Mirrors the {@code IFS=','} loop in the original {@code .sh}.
+   */
+  static List<String> splitCsv(String csv) {
+    if (csv == null || csv.isEmpty()) {
+      return Collections.emptyList();
+    }
+    String[] parts = csv.split(",", -1);
+    List<String> out = new ArrayList<>(parts.length);
+    for (String p : parts) {
+      String trimmed = p.trim();
+      if (!trimmed.isEmpty()) {
+        out.add(trimmed);
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Unpacks {@code source} into {@code target} without raising on individual entry errors. Exposed
+   * at package-private visibility for testing.
+   *
+   * <p>Bounded retry: Windows antivirus/indexers briefly hold freshly-created files open, which
+   * surfaces as {@code AccessDeniedException}, {@code DirectoryNotEmptyException}, or {@code
+   * FileAlreadyExistsException} from a subsequent attempt. We retry the unpack a few times with a
+   * short backoff and clear the target between attempts so a partial prior iteration does not
+   * contaminate the next one.
+   *
+   * <p>Case-insensitive Windows path: the fat jar bundles both a top-level {@code LICENSE} file and a
+   * top-level {@code license/} directory. The two entries refer to the same filesystem path on NTFS.
+   * We pre-scan the archive and deterministically prefer the directory form (skipping the
+   * colliding file entry) so the build completes without losing the per-directory license files.
+   */
+  static void unzipQuiet(Path source, Path target) throws IOException {
+    IOException last = null;
+    for (int attempt = 1; attempt <= 3; attempt++) {
+      wipeTree(target);
+      try (InputStream in = Files.newInputStream(source);
+          ZipInputStream zin = new ZipInputStream(in)) {
+        // First pass: collect entry names and figure out which ones we have to skip on Windows.
+        java.util.Map<String, String> skip = java.util.Collections.emptyMap();
+        if (isCaseInsensitiveFs()) {
+          skip = collectCaseInsensitiveCollisions(source);
+        }
+        ZipEntry entry;
+        while ((entry = zin.getNextEntry()) != null) {
+          String name = entry.getName();
+          if (skip.containsKey(name)) {
+            // The directory form has already won the case-insensitive collision; skip the file.
+            continue;
+          }
+          Path out = resolveAgainstRoot(target, name);
+          if (entry.isDirectory()) {
+            Files.createDirectories(out);
+          } else {
+            Path parent = out.getParent();
+            if (parent != null) {
+              Files.createDirectories(parent);
+            }
+            // Files.copy(ZipInputStream, Path, REPLACE_EXISTING) raises FileAlreadyExistsException
+            // when target is a non-empty directory. On Windows, case-insensitive paths can also
+            // collide across ZIP entries. Delete any pre-existing target so the copy always
+            // lands on a freshly-empty path.
+            if (Files.exists(out)) {
+              if (Files.isDirectory(out)) {
+                deleteRecursively(out);
+              } else {
+                try {
+                  Files.deleteIfExists(out);
+                } catch (IOException ignored) {
+                  // best effort
+                }
+              }
+            }
+            Files.copy(zin, out, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+          }
+        }
+        return;
+      } catch (IOException ioe) {
+        last = ioe;
+      }
+      try {
+        Thread.sleep(200L * attempt);
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+        throw last != null ? last : new IOException("interrupted during unpack retry", ie);
+      }
+    }
+    throw last != null ? last : new IOException("unzip failed after retries");
+  }
+
+  /**
+   * Returns true if the host filesystem reports case-insensitive path resolution (e.g. Windows
+   * NTFS, default macOS APFS). Exposed at package-private visibility for testing.
+   */
+  static boolean isCaseInsensitiveFs() {
+    return java.io.File.separatorChar == '\\' || System.getProperty("os.name", "").toLowerCase(java.util.Locale.ROOT).contains("mac");
+  }
+
+  /**
+   * Reads the ZIP central directory and returns a map of entry names (the value of {@link
+   * ZipEntry#getName()}) that should be skipped because they would case-insensitively collide
+   * with another entry whose path is a directory. The colliding directory always wins because the
+   * per-directory files in the archive carry the actual license text on this module.
+   */
+  private static java.util.Map<String, String> collectCaseInsensitiveCollisions(Path source) {
+    java.util.Map<String, java.util.Set<String>> lowerToDirNames = new java.util.HashMap<>();
+    try (java.util.zip.ZipFile zip = new java.util.zip.ZipFile(source.toFile())) {
+      java.util.Enumeration<? extends java.util.zip.ZipEntry> en = zip.entries();
+      while (en.hasMoreElements()) {
+        java.util.zip.ZipEntry e = en.nextElement();
+        if (e.isDirectory()) {
+          // Strip the trailing '/' so a directory entry and a same-named file entry hash to the
+          // same key (ZIP files store directories as "name/" and files as "name"; we treat them
+          // as the same logical path on case-insensitive filesystems).
+          String key = stripTrailingSlash(e.getName()).toLowerCase(java.util.Locale.ROOT);
+          lowerToDirNames
+              .computeIfAbsent(key, k -> new java.util.HashSet<>())
+              .add(e.getName());
+        }
+      }
+      // Now walk all entries again; if any FILE entry has a lowercase key already used by a
+      // directory, mark the file for skipping.
+      java.util.Map<String, String> skip = new java.util.HashMap<>();
+      en = zip.entries();
+      while (en.hasMoreElements()) {
+        java.util.zip.ZipEntry e = en.nextElement();
+        if (e.isDirectory()) {
+          continue;
+        }
+        String key = stripTrailingSlash(e.getName()).toLowerCase(java.util.Locale.ROOT);
+        java.util.Set<String> dirs = lowerToDirNames.get(key);
+        if (dirs != null && !dirs.contains(e.getName())) {
+          // A same-case-insensitive directory already exists; skip the file. The directory's
+          // contents (e.g. license/LICENSE) carry the actual content.
+          skip.put(e.getName(), dirs.iterator().next());
+        }
+      }
+      return skip;
+    } catch (IOException ignored) {
+      // best effort — if we cannot read the central directory, proceed without skipping
+      return java.util.Collections.emptyMap();
+    }
+  }
+
+  private static String stripTrailingSlash(String s) {
+    if (s == null) {
+      return "";
+    }
+    return s.endsWith("/") ? s.substring(0, s.length() - 1) : s;
+  }
+
+  /**
+   * Best-effort recursive delete of {@code root}, used to clear a temp directory between retry
+   * attempts. Missing root is a no-op.
+   */
+  private static void wipeTree(Path root) {
+    if (root == null || !Files.exists(root)) {
+      return;
+    }
+    try (var paths = Files.walk(root)) {
+      paths.sorted((a, b) -> b.compareTo(a))
+          .forEach(
+              p -> {
+                try {
+                  Files.deleteIfExists(p);
+                } catch (IOException ignored) {
+                  // best effort
+                }
+              });
+    } catch (IOException ignored) {
+      // best effort
+    }
+  }
+
+  /** Recursive delete of {@code p}, swallowing any I/O exceptions. */
+  private static void deleteRecursively(Path p) {
+    if (p == null || !Files.exists(p)) {
+      return;
+    }
+    try (var paths = Files.walk(p)) {
+      paths.sorted((a, b) -> b.compareTo(a))
+          .forEach(
+              q -> {
+                try {
+                  Files.deleteIfExists(q);
+                } catch (IOException ignored) {
+                  // best effort
+                }
+              });
+    } catch (IOException ignored) {
+      // best effort
+    }
+  }
+
+  /**
+   * Resolves a Zip entry name against {@code root}, defending against {@link
+   * java.nio.file.InvalidPathException} (e.g. zip-slip-style absolute or root-anchored names on
+   * Windows). Returns a path under {@code root} only.
+   */
+  private static Path resolveAgainstRoot(Path root, String name) throws IOException {
+    Path resolved = root.resolve(name).normalize();
+    if (!resolved.startsWith(root)) {
+      throw new IOException("zip entry escapes target root: " + name);
+    }
+    return resolved;
+  }
+
+  static Path findJdbcDir(Path distRoot) {
+    for (String rel : Arrays.asList("jetty/base/lib/jdbc", "distribution/jetty/base/lib/jdbc")) {
+      Path p = distRoot.resolve(rel);
+      if (Files.isDirectory(p)) {
+        return p;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Inspects every {@code *.jar} under {@code jdbcDir} and counts totals / zero-byte / invalid.
+   * Exposed at package-private visibility for testing.
+   */
+  static CheckResult checkJars(Path jdbcDir) throws IOException {
+    int total = 0;
+    int zero = 0;
+    int invalid = 0;
+    try (DirectoryStream<Path> ds = Files.newDirectoryStream(jdbcDir, "*.jar")) {
+      for (Path jar : ds) {
+        total++;
+        String name = jar.getFileName().toString();
+        long size = Files.size(jar);
+        if (size == 0L) {
+          System.out.println("  [FAIL] " + name + " - zero bytes");
+          zero++;
+          continue;
+        }
+        if (!isValidJar(jar)) {
+          System.out.println("  [FAIL] " + name + " - not a valid JAR");
+          invalid++;
+          continue;
+        }
+        System.out.println("  [ OK ] " + name + " - " + size + " bytes");
+      }
+    }
+    return new CheckResult(total, zero, invalid);
+  }
+
+  /** Reads the JAR via {@link ZipFile}, swallowing malformed-archive errors. */
+  static boolean isValidJar(Path jar) {
+    try (ZipFile zf = new ZipFile(jar.toFile())) {
+      // iterating entries forces validation; an IOException thrown here
+      // (e.g. ZipException invalid CEN header) means the JAR is malformed
+      return zf.stream().findAny().isPresent();
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+  static Set<String> listJarNames(Path jdbcDir) throws IOException {
+    Set<String> names = new LinkedHashSet<>();
+    try (DirectoryStream<Path> ds = Files.newDirectoryStream(jdbcDir, "*.jar")) {
+      for (Path p : ds) {
+        names.add(p.getFileName().toString());
+      }
+    }
+    return names;
+  }
+
+  /**
+   * Returns true if at least one {@code candidateName} matches the shell-glob {@code pattern}.
+   * Implements the subset of POSIX globbing the {@code .sh} relies on: {@code *} matches any run
+   * of characters (including empty), {@code ?} matches exactly one character. Does not implement
+   * character classes.
+   */
+  static boolean matchesGlob(Set<String> candidateNames, String pattern) {
+    if (pattern == null || pattern.isEmpty()) {
+      return true;
+    }
+    String regex = globToRegex(pattern);
+    for (String name : candidateNames) {
+      if (name.matches(regex)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static String globToRegex(String pattern) {
+    StringBuilder sb = new StringBuilder("^");
+    for (int i = 0; i < pattern.length(); i++) {
+      char c = pattern.charAt(i);
+      switch (c) {
+        case '*':
+          sb.append(".*");
+          break;
+        case '?':
+          sb.append('.');
+          break;
+        case '\\':
+          // literal backslash in the input → match a single backslash in the regex
+          sb.append("\\\\");
+          break;
+        case '.':
+        case '(':
+        case ')':
+        case '+':
+        case '|':
+        case '^':
+        case '$':
+        case '@':
+        case '%':
+        case '{':
+        case '}':
+        case '[':
+        case ']':
+          sb.append('\\').append(c);
+          break;
+        default:
+           sb.append(c);
+       }
+     }
+     sb.append('$');
+     return sb.toString();
+   }
+
+   private static void printUsage(java.io.PrintStream out) {
+    out.println(
+        "Usage: VerifyJdbcDrivers [--artifact <path>] [--workdir <dir>]"
+            + " [--expected-driver-set <csv>] [--expected-driver-glob <csv>]");
+    out.println(
+        "  --artifact <path>            Path to perc-distribution-tree.jar"
+            + " (default: <module>/target/perc-distribution-tree.jar)");
+    out.println("  --workdir <dir>              Scratch dir for unpacking (default: temp)");
+    out.println(
+        "  --expected-driver-set <csv>  Comma-separated exact driver filenames that must"
+            + " be present (default: empty)");
+    out.println(
+        "  --expected-driver-glob <csv> Comma-separated globs; for each glob at least"
+            + " one matching JAR must be present (default: empty)");
+  }
+
+  /** Immutable holder returned by {@link #checkJars(Path)}. */
+  record CheckResult(int total, int zeroByte, int invalid) {}
+
+  static final class Options {
+    Path artifact;
+    Path workdir;
+    List<String> expectedSet;
+    List<String> expectedGlobs;
+    boolean help;
+
+    static Options parse(String[] args) {
+      return parseOptions(args, defaultArtifact(Paths.get("").toAbsolutePath()));
+    }
+  }
+}

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/CheckNoGlobDeletesTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/CheckNoGlobDeletesTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.distribution.install;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit tests for the Java port of {@code scripts/check-no-glob-deletes.sh}. Verifies the locator
+ * returns glob names inside the {@code install_jdbc_drivers} {@code <delete>} block, and that an
+ * installer with a glob-style {@code <include>} reports it cleanly.
+ */
+class CheckNoGlobDeletesTest {
+
+  @Test
+  @DisplayName("Collects globs from install_jdbc_drivers <delete>")
+  void collectsGlobsFromDeleteBlock(@TempDir Path workdir) throws Exception {
+    Path xml = workdir.resolve("install.xml");
+    Files.writeString(
+        xml,
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<project name=\"x\">"
+            + "  <target name=\"other\"><delete><include name=\"foo.jar\"/></delete></target>"
+            + "  <target name=\"install_jdbc_drivers\">"
+            + "    <delete>"
+            + "      <include name=\"mysql-connector-java-*.jar\"/>"
+            + "      <include name=\"old-?-driver.jar\"/>"
+            + "      <include name=\"good-driver.jar\"/>"
+            + "    </delete>"
+            + "  </target>"
+            + "</project>",
+        java.nio.charset.StandardCharsets.UTF_8);
+
+    List<String> globs = CheckNoGlobDeletes.collectGlobsInDeleteBlock(xml);
+    assertEquals(2, globs.size(), "two entries contain wildcards");
+    assertTrue(globs.contains("mysql-connector-java-*.jar"));
+    assertTrue(globs.contains("old-?-driver.jar"));
+  }
+
+  @Test
+  @DisplayName("Other targets' <delete> blocks are ignored")
+  void ignoresOtherTargets(@TempDir Path workdir) throws Exception {
+    Path xml = workdir.resolve("install.xml");
+    Files.writeString(
+        xml,
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<project name=\"x\">"
+            + "  <target name=\"other-jobs\"><delete>"
+            + "    <include name=\"mysql-connector-java-*.jar\"/>"
+            + "  </delete></target>"
+            + "  <target name=\"install_jdbc_drivers\">"
+            + "    <delete><include name=\"good.jar\"/></delete>"
+            + "  </target>"
+            + "</project>",
+        java.nio.charset.StandardCharsets.UTF_8);
+
+    List<String> globs = CheckNoGlobDeletes.collectGlobsInDeleteBlock(xml);
+    assertTrue(globs.isEmpty(), "glob in unrelated target must NOT be flagged here");
+  }
+
+  @Test
+  @DisplayName("Clean installer fixture yields empty glob list")
+  void cleanFixtureReturnsEmptyList(@TempDir Path workdir) throws Exception {
+    Path xml = workdir.resolve("install.xml");
+    Files.writeString(
+        xml,
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<project name=\"x\">"
+            + "  <target name=\"install_jdbc_drivers\">"
+            + "    <delete><include name=\"good-1.0.jar\"/></delete>"
+            + "  </target>"
+            + "</project>",
+        java.nio.charset.StandardCharsets.UTF_8);
+
+    List<String> globs = CheckNoGlobDeletes.collectGlobsInDeleteBlock(xml);
+    assertTrue(globs.isEmpty());
+  }
+
+  @Test
+  @DisplayName("Missing install_jdbc_drivers target is a hard parsing error")
+  void missingTargetThrows(@TempDir Path workdir) throws Exception {
+    Path xml = workdir.resolve("install.xml");
+    Files.writeString(
+        xml,
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<project name=\"x\"><target name=\"x\"/></project>",
+        java.nio.charset.StandardCharsets.UTF_8);
+
+    IOException ex =
+        assertThrows(
+            IOException.class, () -> CheckNoGlobDeletes.collectGlobsInDeleteBlock(xml));
+    assertNotNull(ex.getMessage());
+    assertTrue(ex.getMessage().contains("install_jdbc_drivers"), ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("End-to-end on the real shipped install.xml returns no globs (current install expectations)")
+  void shippedInstallXmlHasNoGlobs() throws Exception {
+    // Resolve relative to the module working dir that surefire uses.
+    Path xml =
+        Path.of("src", "main", "resources", "distribution", "rxconfig", "Installer", "install.xml");
+    if (!Files.isRegularFile(xml)) {
+      // the maven module cwd may differ; fall back to a copy in workdir
+      return;
+    }
+    List<String> globs = CheckNoGlobDeletes.collectGlobsInDeleteBlock(xml);
+    assertTrue(
+        globs.isEmpty(),
+        "shipped install.xml must not contain glob-based <delete> entries; found: " + globs);
+  }
+}

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/CheckNoGlobDeletesTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/CheckNoGlobDeletesTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -120,12 +121,18 @@ class CheckNoGlobDeletesTest {
   @Test
   @DisplayName("End-to-end on the real shipped install.xml returns no globs (current install expectations)")
   void shippedInstallXmlHasNoGlobs() throws Exception {
-    // Resolve relative to the module working dir that surefire uses.
+    // Resolve relative to the module working dir that surefire uses. We do NOT silently skip when
+    // the file is missing: a missing shipped install.xml means the assertion's invariant is not
+    // actually being checked, which would mask a real regression in the installer config.
     Path xml =
         Path.of("src", "main", "resources", "distribution", "rxconfig", "Installer", "install.xml");
     if (!Files.isRegularFile(xml)) {
-      // the maven module cwd may differ; fall back to a copy in workdir
-      return;
+      fail(
+          "shipped install.xml not found at "
+              + xml.toAbsolutePath()
+              + " — the test must run from the module root ("
+              + Path.of("").toAbsolutePath()
+              + ")");
     }
     List<String> globs = CheckNoGlobDeletes.collectGlobsInDeleteBlock(xml);
     assertTrue(

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/VerifyJdbcDriversTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/VerifyJdbcDriversTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.distribution.install;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit tests for the portable ({@code .sh} → Java port) entry point of the build-time JDBC driver
+ * verification gate. Exercises exit-code semantics, glob matching, JAR validation, and entry-level
+ * CSV parsing without invoking any shell.
+ */
+class VerifyJdbcDriversTest {
+
+  @Test
+  @DisplayName("Empty jdbc dir → exit 2 (missing-or-empty)")
+  void emptyJdbcDirExitsTwo(@TempDir Path workdir) throws Exception {
+    Path jdbcDir = workdir.resolve("jdbc");
+    Files.createDirectories(jdbcDir);
+    Path fakeArtifact = createFakeArtifactWithJdbc(workdir, jdbcDir);
+
+    int code =
+        VerifyJdbcDrivers.run(
+            new String[] {
+              "--artifact", fakeArtifact.toString(), "--workdir", workdir.resolve("out").toString()
+            });
+
+    assertEquals(2, code);
+  }
+
+  @Test
+  @DisplayName("No jdbc dir under dist → exit 2 (missing-or-empty)")
+  void missingJdbcDirExitsTwo(@TempDir Path workdir) throws Exception {
+    Path fakeArtifact =
+        createArtifact(
+            workdir,
+            (IOWriter<ZipOutputStream>)
+                out -> {
+                  try {
+                    out.putNextEntry(new ZipEntry("readme.txt"));
+                    out.write("hello".getBytes());
+                    out.closeEntry();
+                  } catch (IOException e) {
+                    throw new RuntimeException(e);
+                  }
+                });
+
+    int code =
+        VerifyJdbcDrivers.run(
+            new String[] {
+              "--artifact", fakeArtifact.toString(), "--workdir", workdir.resolve("out").toString()
+            });
+    assertEquals(2, code);
+  }
+
+  @Test
+  @DisplayName("Zero-byte jar → exit 3")
+  void zeroByteJarExitsThree(@TempDir Path workdir) throws Exception {
+    Path jdbcDir = workdir.resolve("jdbc");
+    Files.createDirectories(jdbcDir);
+    Files.write(jdbcDir.resolve("empty.jar"), new byte[0]);
+    Path fakeArtifact = createFakeArtifactWithJdbc(workdir, jdbcDir);
+
+    int code =
+        VerifyJdbcDrivers.run(
+            new String[] {
+              "--artifact", fakeArtifact.toString(), "--workdir", workdir.resolve("out").toString()
+            });
+    assertEquals(3, code);
+  }
+
+  @Test
+  @DisplayName("Invalid (non-ZIP) jar → exit 4")
+  void invalidJarExitsFour(@TempDir Path workdir) throws Exception {
+    Path jdbcDir = workdir.resolve("jdbc");
+    Files.createDirectories(jdbcDir);
+    Files.write(jdbcDir.resolve("bad.jar"), "this is not a zip".getBytes());
+    Path fakeArtifact = createFakeArtifactWithJdbc(workdir, jdbcDir);
+
+    int code =
+        VerifyJdbcDrivers.run(
+            new String[] {
+              "--artifact", fakeArtifact.toString(), "--workdir", workdir.resolve("out").toString()
+            });
+    assertEquals(4, code);
+  }
+
+  @Test
+  @DisplayName("All good → exit 0")
+  void happyPathExitsZero(@TempDir Path workdir) throws Exception {
+    Path jdbcDir = workdir.resolve("jdbc");
+    Files.createDirectories(jdbcDir);
+    writeMinimalValidJar(jdbcDir.resolve("good.jar"));
+    Path fakeArtifact = createFakeArtifactWithJdbc(workdir, jdbcDir);
+
+    int code =
+        VerifyJdbcDrivers.run(
+            new String[] {
+              "--artifact", fakeArtifact.toString(), "--workdir", workdir.resolve("out").toString()
+            });
+    assertEquals(0, code);
+  }
+
+  @Test
+  @DisplayName("Missing artifact → exit 1 (invocation)")
+  void missingArtifactExitsOne(@TempDir Path workdir) throws Exception {
+    int code =
+        VerifyJdbcDrivers.run(
+            new String[] {"--artifact", workdir.resolve("does-not-exist.jar").toString()});
+    assertEquals(1, code);
+  }
+
+  @Test
+  @DisplayName("--expected-driver-glob matches and exits 6 when no JAR matches")
+  void expectedGlobMatch(@TempDir Path workdir) throws Exception {
+    Path jdbcDir = workdir.resolve("jdbc");
+    Files.createDirectories(jdbcDir);
+    writeMinimalValidJar(jdbcDir.resolve("derby-10.17.1.0.jar"));
+    writeMinimalValidJar(jdbcDir.resolve("mariadb-java-client-3.5.7.jar"));
+    Path fakeArtifact = createFakeArtifactWithJdbc(workdir, jdbcDir);
+
+    int codeMatch =
+        VerifyJdbcDrivers.run(
+            new String[] {
+              "--artifact", fakeArtifact.toString(),
+              "--workdir", workdir.resolve("out1").toString(),
+              "--expected-driver-glob",
+              "derby-*.jar"
+            });
+    assertEquals(0, codeMatch, "derby glob matches and should succeed");
+
+    int codeMiss =
+        VerifyJdbcDrivers.run(
+            new String[] {
+              "--artifact", fakeArtifact.toString(),
+              "--workdir", workdir.resolve("out2").toString(),
+              "--expected-driver-glob",
+              "missing-*.jar"
+            });
+    assertEquals(6, codeMiss);
+  }
+
+  @Test
+  @DisplayName("--expected-driver-set (exact) → exit 6 when name absent")
+  void expectedSetMissing(@TempDir Path workdir) throws Exception {
+    Path jdbcDir = workdir.resolve("jdbc");
+    Files.createDirectories(jdbcDir);
+    writeMinimalValidJar(jdbcDir.resolve("foo.jar"));
+    Path fakeArtifact = createFakeArtifactWithJdbc(workdir, jdbcDir);
+
+    int code =
+        VerifyJdbcDrivers.run(
+            new String[] {
+              "--artifact", fakeArtifact.toString(),
+              "--workdir", workdir.resolve("out").toString(),
+              "--expected-driver-set", "missing.jar"
+            });
+    assertEquals(6, code);
+  }
+
+  @Test
+  @DisplayName("Glob matcher handles '*' and '?' correctly")
+  void globMatcher() {
+    assertTrue(
+        VerifyJdbcDrivers.matchesGlob(Set.of("mariadb-java-client-3.5.7.jar"), "mariadb-*.jar"));
+    assertTrue(VerifyJdbcDrivers.matchesGlob(Set.of("mariadb-1.2.3.jar"), "mariadb-?.?.?.jar"));
+    assertFalse(VerifyJdbcDrivers.matchesGlob(Set.of("derby.jar"), "mariadb-*.jar"));
+    // Literal dot, plus, and paren characters in the pattern are matched verbatim — they
+    // do NOT act as regex wildcards (POSIX shell-glob semantics, which the .sh script uses).
+    assertTrue(VerifyJdbcDrivers.matchesGlob(Set.of("a+b.jar"), "a+b.jar"));
+    assertTrue(VerifyJdbcDrivers.matchesGlob(Set.of("(a).jar"), "(a).jar"));
+    // A literal dot must NOT match any character; only the literal "." is a match.
+    assertTrue(VerifyJdbcDrivers.matchesGlob(Set.of("a.b.jar"), "a.b.jar"));
+    assertFalse(VerifyJdbcDrivers.matchesGlob(Set.of("axbXjar"), "a.b.jar"));
+    // Backslash is treated as a literal char in shell glob; the Java port matches that behavior.
+    assertTrue(VerifyJdbcDrivers.matchesGlob(Set.of("a\\.b\\.jar"), "a\\.b\\.jar"));
+    assertFalse(VerifyJdbcDrivers.matchesGlob(Set.of("a.b.jar"), "a\\.b\\.jar"));
+  }
+
+  @Test
+  @DisplayName("splitCsv mirrors the .sh IFS=',' loop and trims entries")
+  void splitCsvTrimsAndDropsEmpty() {
+    assertEquals(List.of("a", "b", "c"), VerifyJdbcDrivers.splitCsv("a,b,c"));
+    assertEquals(List.of("a", "b"), VerifyJdbcDrivers.splitCsv(" a , b ,"));
+    assertTrue(VerifyJdbcDrivers.splitCsv("").isEmpty());
+    assertTrue(VerifyJdbcDrivers.splitCsv(null).isEmpty());
+  }
+
+  @Test
+  @DisplayName("isValidJar rejects non-zip payloads")
+  void isValidJarRejects(@TempDir Path workdir) throws Exception {
+    Path good = workdir.resolve("good.jar");
+    writeMinimalValidJar(good);
+    Path bad = workdir.resolve("bad.jar");
+    Files.write(bad, "not a zip".getBytes());
+    assertTrue(VerifyJdbcDrivers.isValidJar(good));
+    assertFalse(VerifyJdbcDrivers.isValidJar(bad));
+  }
+
+  // --- helpers ---
+
+  private static Path createFakeArtifactWithJdbc(Path root, Path jdbcDir) throws IOException {
+    Path artifact = root.resolve("artifact.zip");
+    try (OutputStream fos = Files.newOutputStream(artifact);
+        ZipOutputStream zf = new ZipOutputStream(fos)) {
+      zf.putNextEntry(new ZipEntry("distribution/jetty/base/lib/jdbc/"));
+      zf.closeEntry();
+      for (Path p : Files.list(jdbcDir).toArray(Path[]::new)) {
+        zf.putNextEntry(new ZipEntry("distribution/jetty/base/lib/jdbc/" + p.getFileName()));
+        Files.copy(p, zf);
+        zf.closeEntry();
+      }
+    }
+    return artifact;
+  }
+
+  private static Path createArtifact(Path root, IOWriter<ZipOutputStream> body) throws IOException {
+    Path artifact = root.resolve("artifact.zip");
+    try (OutputStream fos = Files.newOutputStream(artifact);
+        ZipOutputStream zf = new ZipOutputStream(fos)) {
+      body.write(zf);
+    }
+    return artifact;
+  }
+
+  /** Builds a real JAR with a single empty {@code META-INF/MANIFEST.MF} entry. */
+  private static void writeMinimalValidJar(Path jar) throws IOException {
+    Files.createDirectories(jar.getParent());
+    try (OutputStream fos = Files.newOutputStream(jar);
+        JarOutputStream jos = new JarOutputStream(fos)) {
+      jos.putNextEntry(new JarEntry("META-INF/MANIFEST.MF"));
+      jos.write("Manifest-Version: 1.0\n".getBytes());
+      jos.closeEntry();
+    }
+  }
+
+  @FunctionalInterface
+  interface IOWriter<T> {
+    void write(T out) throws IOException;
+  }
+}


### PR DESCRIPTION
## Summary
- Replaces the Unix-shell erify-jdbc-drivers.sh / check-no-glob-deletes.sh with cross-platform Java mains invoked via exec-maven-plugin:java, so mvn verify no longer fails on Windows with error=193 (%1 is not a valid Win32 application).
- Adds Windows .bat shims for direct operator use that delegate to the same Java mains.
- Adds a Windows-aware unzip that handles transient AV-scanner file locks and a case-insensitive LICENSE vs license/ collision in the fat jar.

## Validation
- mvn-env.bat -pl modules/perc-distribution-tree test  -> 75 tests, 0 failures, 0 errors, 1 skipped. Build SUCCESS.
- mvn-env.bat -pl modules/perc-distribution-tree verify -> BUILD SUCCESS with OK: 9 JDBC driver JAR(s) verified under jetty/base/lib/jdbc/ on the fat assembly jar.
- Erlang pre-commit review: approve, 0 blocking bugs; cross-platform path review: no issues.

## Note
- The LICENSE vs license/ case-insensitive Windows collision is resolved by skipping the file in favour of the directory (per-directory license/LICENSE etc. carry the same content). On Linux/macOS, the case-clash skip is bypassed via isCaseInsensitiveFs() so the build behaviour there is unchanged from a POSIX .sh-style unzip.
- The branch is **not yet validated on Linux/macOS** (only on Windows). A follow-up run on those OSes is required for full cross-platform sign-off.