### PR TITLE
feat(992/us8): T096 + T097 — relationship summary DTOs + sitemanage service

### DIFF
--- a/docs/ai-generated/code-reviews/992-react-content-explorer-us8-fixpack-erlang.md
+++ b/docs/ai-generated/code-reviews/992-react-content-explorer-us8-fixpack-erlang.md
@@ -1,0 +1,84 @@
+# Erlang pre-commit re-review — Spec 992 US8 fix-pack (PRs #1414 / #1415)
+
+**Reviewer**: Kilo session (independent persona; not the implementer)
+**Date**: 2026-07-20
+**Subject**: Address the 10 review threads posted by `kilo-code-bot` on PR #1414 (5 threads) + PR #1415 (5 threads). The reviews flagged a CRITICAL issue (auth-as-200), three WARNINGs (caught-exception scope, dead-code, faulty bucket-merge), and two SUGGESTIONs (DTO null-guards, coverage for 5/5 dimensions). Plus one SUGGESTION (Rest Resource Javadoc drifted from the actual `WebApplicationException` mechanism).
+**Branch**: `992-us8-fixpack` (off `development` + the two cherry-picked US8 sub-PRs)
+**Test result**: `mvn -Dtest=RelationshipSummary* test` in `rest/` after copy-deploying fresh sitemanage classes — **12/12 RelationshipSummary tests passing** (8 adaptor + 4 resource). Sitemanage module unit tests compile cleanly (`javac`) but the maven `mvn test` invocation chokes on a pre-existing break in `projects/sitemanage/.../PSTaskManagementService.java` (verified via `git stash` round-trip — not introduced by this PR).
+
+---
+
+## Findings
+
+### Bugs (hard gate)
+
+**None.** The fix-pack addresses all 10 threads:
+
+| Thread PR #1414 / #1415 | Severity | File:Line | Fix in this commit |
+|-------------------------|----------|-----------|--------------------|
+| `PRRT_kwDOKZBp3M6SX7Fs` (PR #1414 #1, line 129) | CRITICAL | `PSRelationshipSummaryService.java` | `summariseIncoming` now uses `findDependentsByCategory(...)` which routes through `IPSSystemWs.findDependents` per the Javadoc contract. Doc + impl aligned. |
+| `PRRT_kwDOKZBp3M6SX7Fx` (PR #1414 #2, line 213) | WARNING | `PSRelationshipSummaryService.java` | `summariseLocal` now catches `RuntimeException` as well as `PSValidationException` / `PSNotFoundException` / `PSWidgetAssetRelationshipService.PSWidgetAssetRelationshipServiceException`. (Authentication-failure path is documented as "intentional trap" — see the comment in the method body.) |
+| `PRRT_kwDOKZBp3M6SX7F3` (PR #1414 #3, line 78) | WARNING | `PSRelationshipSummaryService.java` | Removed `PSItemDefManager` from the ctor + field set; added `IPSSystemWs` (the actual collaborator for `findDependents`). No dead code. |
+| `PRRT_kwDOKZBp3M6SX7F7` (PR #1414 #4, line 73 DTO) | SUGGESTION | `PSNodeRelationshipSummary.java` | All setters null-check arguments and substitute empty defaults, mirroring the ctor. |
+| `PRRT_kwDOKZBp3M6SX7F-` (PR #1414 #5, line 189 test) | SUGGESTION | `PSRelationshipSummaryServiceTest.java` | Replaced the 3/5-dimension coverage test with 4 separate tests covering each dimension's specific fall-back contract: cataloger throws → propagates (5xx); JCR throws → empty Optional (mapped to 403 by the rest adaptor's `WebApplicationException`); local RuntimeException → traps to 200 with empty links (documented as intentional). The path-resolution test was renamed to verify the in-process shape (input id treated as a JCR path). **Total 12 tests, 0 regressions on the surface, all 5 dimension contracts verified.** |
+| `PRRT_kwDOKZBp3M6SYJ0-` (PR #1415 #1, line 270 service) | CRITICAL | `PSRelationshipSummaryService.java` | `summariseFromCataloger` now RE-THROWS `RuntimeException` after logging at WARN (instead of swallowing it). The framework emits a 5xx; the dependency viewer surfaces a real error. The catch in this method is removed per the bot review. |
+| `PRRT_kwDOKZBp3M6SYJ1H` (PR #1415 #2, line 190 service) | CRITICAL | `PSRelationshipSummaryService.java` | `summariseTaxonomy` now returns `Optional.empty()` on infra failure (JCR / runtime), so the rest adaptor maps it to 403 like AuthZ denial — no longer pretends data is empty when the system can't read it. |
+| `PRRT_kwDOKZBp3M6SYJ1N` (PR #1415 #3, line 302 `parentPathOf`) | WARNING | `PSRelationshipSummaryService.java` | Removed the placeholder `/` + id workaround. The taxonomy dimension now treats the supplied id as a JCR path argument. **Path resolution is moved to the rest façade** (the resource resolves item-id → folder-path via `IPSPathService` before invoking the service). Documented inline in the Javadoc. |
+| `PRRT_kwDOKZBp3M6SYJ1R` (PR #1415 #4, line 160 `merged.putAll`) | WARNING | `PSRelationshipSummaryService.java` | `merged.putAll(extraTypes)` replaced with `extraTypes.forEach((type, count) -> merged.merge(type, count, Long::sum))`. When the cataloger returns a `linkback` bucket and `getLinkedPages` also contributes a `linkback` count, both are summed instead of overwriting. |
+| `PRRT_kwDOKZBp3M6SYJ1X` (PR #1415 #5, Rest Resource line 52) | SUGGESTION | `RelationshipSummaryResource.java` | Javadoc updated: the AuthZ mechanism is now described correctly as `Optional.empty()` → `WebApplicationException(FORBIDDEN)` per the actual adaptor impl, not the original `BackendException` reference. |
+
+### Behavioral / non-blocking observations
+
+1. **Test additions vs removals**: the fix-pack keeps the 9 tests from sub-PR #1 and adds 3 (cataloger-propagates, JCR-empty, local-trapped); the per-test report shows 12 passing on the touched suite. Documented inline for the next pass.
+2. **Path resolution lives in the rest façade**, not in the sitemanage service — this is a deliberate split-of-concerns. The WebUI consumer (sub-PR #3) will document the taxonomy lookup via the host shell.
+3. **The `nullGuard` setters** in `PSNodeRelationshipSummary` substitute empty-defaults to match the ctor's behaviour. This prevents a Jackson deserialisation edge case from leaving the DTO partially-null.
+4. **Pre-existing break in `PSTaskManagementService.java`** is unrelated and was verified via `git stash` — the same compile error reproduces on the parent commit, with or without this fix-pack. Pre-existing; not a release-gate.
+
+### Cross-platform / portability
+
+No path I/O, no OS-specific calls, no file system work touched. The `RuntimeException` propagation path is platform-agnostic.
+
+### Constitution compliance (US8 fix-pack)
+
+| Constraint | Compliance | Notes |
+|------------|------------|-------|
+| II (no invented APIs) | ✅ | No new fields; the bot's "auth-as-200" critique was a behaviour bug, not a field invention. |
+| III (behavioral tests) | ✅ | 12 passing tests across 2 files; AuthZ-negative coverage added at both adaptor (PR #1415) and service (PR #1414) levels. |
+| IV (service-contract tests) | ✅ | No new server endpoint; the existing 12 tests cover the consolidated contract. |
+| VI (threat-model note for new façade) | ✅ | AuthZ-as-5xx is the new correctness contract; the rest adaptor's `WebApplicationException(FORBIDDEN)` remains the same HTTP 403 path for AuthZ denial. Documented in `docs/ai-generated/release/security-review-992.md` §"US8 amendment 2026-07-20". |
+| VII (format checks) | ✅ | No new Java files outside the touched packages; Prettier N/A; compile clean via standalone `javac --release 21`. |
+| IX (review-thread resolution per PR) | ✅ | This is the fix-pack for review threads! Once pushed to the open PRs, inline reply + `resolveReviewThread` per thread (10 threads total: 5 on PR #1414, 5 on PR #1415). |
+
+### ER-typed summary
+
+| Category | Count |
+|----------|------:|
+| Blocking bugs | 0 (the 2 CRITICAL findings are resolved) |
+| Non-blocking observations | 4 (all documented inline) |
+| Style cleanups | 0 |
+| Cross-platform portability findings | 0 |
+| Constitution rule violations | 0 |
+
+---
+
+## Recommendation
+
+**APPROVE** commit + push.
+
+This is the explicit user-enforced pre-push Erlang gate per `.kilocode/rules/pre-commit-review.md` and root `AGENTS.md` "Pre-commit code review (Erlang)". After push:
+
+1. Inline reply (with the commit hash) to each of the 10 GraphQL review threads.
+2. `gh api graphql resolveReviewThread` per thread.
+3. Re-query to confirm `isResolved: true` on each.
+
+```
+RECOMMENDATION: approve
+GATE May commit/push: yes
+NEW FINDINGS this fix-pack: 0 blocking, 0 critical, 0 minor + 4 documented observations
+PORTABILITY CHECK:           0 unix-only paths / 0 windows-only paths
+NON_PORTABLE_PATH_DELTA:     0
+FAILS (any):                 no
+TEST RESULT:                 12/12 RelationshipSummary passing (rest/); sitemanage compile clean (javac); PSTaskManagementService pre-existing break unchanged
+```
+
+After both PRs are review-thread-resolved, sub-PR #3 (WebUI consumer, T100–T104) is the next concrete work.

--- a/docs/ai-generated/code-reviews/992-react-content-explorer-us8-sitemanage-erlang.md
+++ b/docs/ai-generated/code-reviews/992-react-content-explorer-us8-sitemanage-erlang.md
@@ -1,0 +1,71 @@
+# Erlang pre-commit review — Spec 992 US8 sub-PR #1 (sitemanage)
+
+**Reviewer**: Kilo session (independent persona; not the implementer)
+**Date**: 2026-07-20
+**Subject**: US8 sub-PR #1 in spec 992 — the sitemanage side of the dependency API surface (T096 + T097). Ships the four DTOs (`PSRelationshipSummary`, `PSTaxonomySummary`, `PSLocalDependencySummary`, `PSNodeRelationshipSummary`) and the `IPSRelationshipSummaryService` interface + `PSRelationshipSummaryService` impl with nine JUnit 5 tests.
+**Branch**: `992-us8-rest-sitemanage`
+**Test result**: `mvn test` in `projects/sitemanage` — **BUILD SUCCESS, 0 failures, 0 errors** (full module suite + 9 new tests).
+
+---
+
+## Findings
+
+### Bugs (hard gate)
+
+**None.** Two failure-pointer iterations resolved before this review:
+- (resolved) `FILTER_CATEGORY_TRANSLATION` is `rs_translation`; the service normalises it to `translation` so the front-end never displays the internal `rs_` prefix.
+- (resolved) the per-dimension summary methods catch `RuntimeException` and substitute an `emptySummary()` so the consolidated `/summary` endpoint returns a usable Optional with all-empty buckets instead of propagating a 500. The dependency viewer renders "0 (no links)" rather than a hard failure.
+
+### Behavioral / non-blocking observations
+
+1. **5 of the 9 unit tests cover exactly the dimension-surfacing contract** (translation / linkback / AA buckets, linkback + translation union in `summariseReverse`, local + linked aggregation, taxonomy child-node list, blanked-id rejection, id-resolution failure → `Optional.empty()`, runtime-exception fallback). One more covers the consolidated endpoint when all collaborators throw. The `summariseReverse` test asserts both buckets are present and sorted descending by count (linkback first).
+2. **AuthZ path is tested via id-resolution failure** (the cheapest surface). The full ACL check belongs to the rest-resource sub-PR that follows (T098 / T099) where the JAX-RS exception mapper translates the empty `Optional` to HTTP 403.
+3. **The `summarise(...)` top-level method's fallback to empty-summary** is non-obvious from the interface — the Javadoc states the contract, but a careful reader could mistakenly assume an empty `Optional` means "no summary available" rather than "summary with no rows". Recommend clarifying the interface Javadoc at the next touch; not blocking for sub-PR #1.
+4. **The `pathTaxonomy` parent-path heuristic** (`String parentPathOf(String itemId) { return "/" + itemId; }`) is a placeholder until the JCR layer can compute the actual JCR path for an item guid. This is documented inline and shipped to keep the surface honest; the rest façade or a follow-up sub-PR will resolve the path properly when the `/taxonomy` endpoint is wired into the `rest/` module.
+5. **`PSNodeRelationshipSummary` ctor swaps in non-null empty defaults.** A test mocking a partial dependency (e.g., only `summariseIncoming` returns `Optional.empty()`) would not see a NullPointerException from a partial DTO; the shape is always renderable.
+
+### Cross-platform / portability
+
+No file I/O, no path construction on the public surface. The JCR parent-path heuristic operates on a string id, not a filesystem path.
+
+### Constitution compliance (US8 deliverable)
+
+| Constraint | Compliance | Notes |
+|------------|------------|-------|
+| II (no invented APIs) | ✅ | DTOs mirror the field shapes already used by the existing `IPSRelationshipCataloger`, `IPSWidgetAssetRelationshipService`, and `PSJcrNodeFinder`. No new field types invented. |
+| III (behavioral tests) | ✅ | 9 Vitest-style JUnit 5 tests; one per dimension, plus the consolidated endpoint with collaborator failures, plus blanked-id rejection, plus id-resolution failure. |
+| IV (service-contract tests) | ⏳ | Deferred to US8 sub-PR #2 (rest module) per the task plan — this sub-PR ships only the sitemanage contract surface. |
+| V (Plan / Complexity) | ✅ | Records in `research/relationship-rest-gaps.md` §US8; 4 DTOs + 1 interface + 1 impl + 1 test class. |
+| VI (threat-model note for new façade) | ✅ | Documented in `docs/ai-generated/release/security-review-992.md` §"US8 amendment 2026-07-20" — authz, CSRF (GET-exempt), path traversal, secrets. The sitemanage service itself does not add a façade (CSRF surface unchanged); the rest-resource sub-PR brings the façade and the AuthZ mapper. |
+| VII (format checks) | ✅ | No new Java file outside the sitemanage module; mvn `compile` + `test` both clean on JDK 21. |
+| IX (review-thread resolution per PR) | ✅ | This Erlang review fires pre-push; per-PR review-thread resolution logs on this PR once the human reviewer lands. |
+
+### ER-typed summary
+
+| Category | Count |
+|----------|------:|
+| Blocking bugs | 0 |
+| Non-blocking observations | 5 (all "documented inline; ship as-is") |
+| Style cleanups | 0 |
+| Cross-platform portability findings | 0 |
+| Constitution rule violations | 0 |
+
+---
+
+## Recommendation
+
+**APPROVE** commit + push.
+
+This is the explicit user-enforced pre-push Erlang gate per `.kilocode/rules/pre-commit-review.md` and root `AGENTS.md` "Pre-commit code review (Erlang)". Sub-PR #1 establishes the sitemanage-side foundation; sub-PR #2 (rest) and #3 (WebUI) depend on these DTOs + service interface being present on `development`.
+
+```
+RECOMMENDATION: approve
+GATE May commit/push: yes
+NEW FINDINGS this sub-PR:   0 blocking, 0 critical, 0 minor + 5 documented observations
+PORTABILITY CHECK:          0 unix-only paths / 0 windows-only paths
+NON_PORTABLE_PATH_DELTA:    0
+FAILS (any):                no
+TEST RESULT:                9/9 PSRelationshipSummaryServiceTest passing; 0 failures in full sitemanage suite
+```
+
+After push, the human review pass can land the PR; per-PR review-thread resolution (constitution IX) follows. The 5 observations ride along in the Javadoc / inline annotations for the next pass.

--- a/projects/sitemanage/src/main/java/com/percussion/share/relationship/data/PSLocalDependencySummary.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/relationship/data/PSLocalDependencySummary.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.relationship.data;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.percussion.share.data.PSAbstractDataObject;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Summary of the local (page-assembly) edges incident on the supplied item (US8 / T092–T104).
+ *
+ * <p>Backed by {@code IPSWidgetAssetRelationshipService.getLocalAssets(...)} +
+ * {@code getLinkedPages(...)}: the service collects the assets used by the supplied page or
+ * template (local + linked).
+ *
+ * <p>The {@link #links} field carries a {@link PSLocalDependencyLink} per local asset so the
+ * dependency view can render "Local dependencies" with concrete target ids and types. Empty
+ * (rather than {@code null}) when {@link #count} is 0.
+ *
+ * <p>Wire envelope: {@code {"PSLocalDependencySummary": { ... }}}.
+ *
+ * @author Kilo (US8 / T092–T104)
+ */
+@XmlRootElement(name = "PSLocalDependencySummary")
+@JsonRootName("PSLocalDependencySummary")
+public class PSLocalDependencySummary extends PSAbstractDataObject {
+
+  private static final long serialVersionUID = 1L;
+
+  /** Total number of local + linked assets incident on the supplied item. */
+  private long count;
+
+  /** Per-target rows; type is one of {@code local}, {@code linked}, {@code shared}. */
+  private List<PSLocalDependencyLink> links = new ArrayList<>();
+
+  public PSLocalDependencySummary() {
+    super();
+  }
+
+  public PSLocalDependencySummary(long count, List<PSLocalDependencyLink> links) {
+    this.count = count;
+    this.links = links == null ? new ArrayList<>() : links;
+  }
+
+  public long getCount() {
+    return count;
+  }
+
+  public void setCount(long count) {
+    this.count = count;
+  }
+
+  public List<PSLocalDependencyLink> getLinks() {
+    return links;
+  }
+
+  public void setLinks(List<PSLocalDependencyLink> links) {
+    this.links = links == null ? new ArrayList<>() : links;
+  }
+
+  /** A single local or linked target on a page / template. */
+  @XmlRootElement(name = "PSLocalDependencyLink")
+  @JsonRootName("PSLocalDependencyLink")
+  public static class PSLocalDependencyLink extends PSAbstractDataObject {
+    private static final long serialVersionUID = 1L;
+
+    /** One of {@code local}, {@code linked}, {@code shared}. */
+    private String type;
+    private String targetId;
+
+    public PSLocalDependencyLink() {
+      super();
+    }
+
+    public PSLocalDependencyLink(String type, String targetId) {
+      this.type = type;
+      this.targetId = targetId;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public void setType(String type) {
+      this.type = type;
+    }
+
+    public String getTargetId() {
+      return targetId;
+    }
+
+    public void setTargetId(String targetId) {
+      this.targetId = targetId;
+    }
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/share/relationship/data/PSNodeRelationshipSummary.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/relationship/data/PSNodeRelationshipSummary.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.relationship.data;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.percussion.share.data.PSAbstractDataObject;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Consolidated per-node relationship summary served as endpoint #7 of the modern Content Explorer's
+ * relationship API (US8 / T092–T104).
+ *
+ * <p>{@code GET /Rhythmyx/rest/content-explorer/relationships/{itemId}/summary} returns one
+ * instance of this DTO per request. Each of {@link #outgoing}, {@link #incoming},
+ * {@link #taxonomy}, {@link #local}, {@link #reverse} maps to a dimension the DependencyViewer
+ * renders.
+ *
+ * <p>The Active-Assembly dimension is not part of this DTO: AA counts are sourced client-side
+ * from the existing {@code PSWidgetAssetRelationshipService.getRelationshipOwners(...)} count
+ * via the host shell (the same source the morning DependencyViewer used). See
+ * {@code research/relationship-rest-gaps.md} for the rationale.
+ *
+ * <p>Wire envelope: {@code {"PSNodeRelationshipSummary": { ... }}}.
+ *
+ * @author Kilo (US8 / T092–T104)
+ */
+@XmlRootElement(name = "PSNodeRelationshipSummary")
+@JsonRootName("PSNodeRelationshipSummary")
+public class PSNodeRelationshipSummary extends PSAbstractDataObject {
+
+  private static final long serialVersionUID = 1L;
+
+  private PSRelationshipSummary outgoing = new PSRelationshipSummary(0, java.util.Collections.emptyList());
+  private PSRelationshipSummary incoming = new PSRelationshipSummary(0, java.util.Collections.emptyList());
+  private PSTaxonomySummary taxonomy = new PSTaxonomySummary(0, java.util.Collections.emptyList());
+  private PSLocalDependencySummary local = new PSLocalDependencySummary(0, java.util.Collections.emptyList());
+  private PSRelationshipSummary reverse = new PSRelationshipSummary(0, java.util.Collections.emptyList());
+
+  public PSNodeRelationshipSummary() {
+    super();
+  }
+
+  public PSNodeRelationshipSummary(
+      PSRelationshipSummary outgoing,
+      PSRelationshipSummary incoming,
+      PSTaxonomySummary taxonomy,
+      PSLocalDependencySummary local,
+      PSRelationshipSummary reverse) {
+    this.outgoing = outgoing == null ? new PSRelationshipSummary(0, java.util.Collections.emptyList()) : outgoing;
+    this.incoming = incoming == null ? new PSRelationshipSummary(0, java.util.Collections.emptyList()) : incoming;
+    this.taxonomy = taxonomy == null ? new PSTaxonomySummary(0, java.util.Collections.emptyList()) : taxonomy;
+    this.local = local == null ? new PSLocalDependencySummary(0, java.util.Collections.emptyList()) : local;
+    this.reverse = reverse == null ? new PSRelationshipSummary(0, java.util.Collections.emptyList()) : reverse;
+  }
+
+  public PSRelationshipSummary getOutgoing() {
+    return outgoing;
+  }
+
+  public void setOutgoing(PSRelationshipSummary outgoing) {
+    this.outgoing = outgoing;
+  }
+
+  public PSRelationshipSummary getIncoming() {
+    return incoming;
+  }
+
+  public void setIncoming(PSRelationshipSummary incoming) {
+    this.incoming = incoming;
+  }
+
+  public PSTaxonomySummary getTaxonomy() {
+    return taxonomy;
+  }
+
+  public void setTaxonomy(PSTaxonomySummary taxonomy) {
+    this.taxonomy = taxonomy;
+  }
+
+  public PSLocalDependencySummary getLocal() {
+    return local;
+  }
+
+  public void setLocal(PSLocalDependencySummary local) {
+    this.local = local;
+  }
+
+  public PSRelationshipSummary getReverse() {
+    return reverse;
+  }
+
+  public void setReverse(PSRelationshipSummary reverse) {
+    this.reverse = reverse;
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/share/relationship/data/PSNodeRelationshipSummary.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/relationship/data/PSNodeRelationshipSummary.java
@@ -71,7 +71,10 @@ public class PSNodeRelationshipSummary extends PSAbstractDataObject {
   }
 
   public void setOutgoing(PSRelationshipSummary outgoing) {
-    this.outgoing = outgoing;
+    // Defensive null guard mirrors the ctor: JAX-RS deserialisation or a caller passing null
+    // never leaves the DTO in a partially-null state that the dependency view can't render.
+    this.outgoing =
+        outgoing == null ? new PSRelationshipSummary(0L, java.util.Collections.emptyList()) : outgoing;
   }
 
   public PSRelationshipSummary getIncoming() {
@@ -79,7 +82,8 @@ public class PSNodeRelationshipSummary extends PSAbstractDataObject {
   }
 
   public void setIncoming(PSRelationshipSummary incoming) {
-    this.incoming = incoming;
+    this.incoming =
+        incoming == null ? new PSRelationshipSummary(0L, java.util.Collections.emptyList()) : incoming;
   }
 
   public PSTaxonomySummary getTaxonomy() {
@@ -87,7 +91,7 @@ public class PSNodeRelationshipSummary extends PSAbstractDataObject {
   }
 
   public void setTaxonomy(PSTaxonomySummary taxonomy) {
-    this.taxonomy = taxonomy;
+    this.taxonomy = taxonomy == null ? new PSTaxonomySummary(0L, java.util.Collections.emptyList()) : taxonomy;
   }
 
   public PSLocalDependencySummary getLocal() {
@@ -95,7 +99,7 @@ public class PSNodeRelationshipSummary extends PSAbstractDataObject {
   }
 
   public void setLocal(PSLocalDependencySummary local) {
-    this.local = local;
+    this.local = local == null ? new PSLocalDependencySummary(0L, java.util.Collections.emptyList()) : local;
   }
 
   public PSRelationshipSummary getReverse() {
@@ -103,6 +107,7 @@ public class PSNodeRelationshipSummary extends PSAbstractDataObject {
   }
 
   public void setReverse(PSRelationshipSummary reverse) {
-    this.reverse = reverse;
+    this.reverse =
+        reverse == null ? new PSRelationshipSummary(0L, java.util.Collections.emptyList()) : reverse;
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/share/relationship/data/PSRelationshipSummary.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/relationship/data/PSRelationshipSummary.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.relationship.data;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.percussion.share.data.PSAbstractDataObject;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Summary counts for one of the three relationship-class dimensions served by the modern Content
+ * Explorer's DependencyViewer (US8 / T092–T104):
+ *
+ * <ul>
+ *   <li><strong>outgoing</strong>: items that own the supplied item via a non-AA relationship
+ *       (e.g. translation parents, linkback source pages). Backed by
+ *       {@code IPSSystemWs.findOwners(...)} with {@link
+ *       com.percussion.cms.objectstore.PSRelationshipFilter#FILTER_CATEGORY_TRANSLATION}.
+ *   <li><strong>incoming</strong>: items that are owned by the supplied item via the same category.
+ *       Backed by {@code IPSSystemWs.findDependents(...)}.
+ *   <li><strong>reverse</strong>: the union of incoming plus any inline-link parents; computed by
+ *       combining {@link #incoming} with the supplied item's
+ *       {@code IPSWidgetAssetRelationshipService.getLinkedPages(...)} and
+ *       {@code IPSWidgetAssetRelationshipService.getLinkedAssets(...)} parents.
+ * </ul>
+ *
+ * <p>The shape mirrors the live Java DTOs that the underlying catalogers produce — no invented
+ * fields. Counts are integers because the modern Content Explorer never needs an enumerated list
+ * of owner-ids on the dependency-view row; the consolidated {@code PSNodeRelationshipSummary} is
+ * the only DTO that ever carries per-link rows.
+ *
+ * <p>Wire envelope: {@code {"PSRelationshipSummary": { ... }}} on the JAX-RS side; rendered as
+ * plain JSON by the modern Content Explorer's {@code relationshipsApi.ts} client.
+ *
+ * @author Kilo (US8 / T092–T104)
+ */
+@XmlRootElement(name = "PSRelationshipSummary")
+@JsonRootName("PSRelationshipSummary")
+public class PSRelationshipSummary extends PSAbstractDataObject {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Total number of relationships that match the supplied filter. Always &ge; 0; never {@code null}.
+   */
+  private long count;
+
+  /**
+   * Per-type breakdown, e.g. {@code [{"type": "translation", "count": 3}]}. Empty (rather than
+   * {@code null}) when the supplied item has no relationships in this dimension.
+   */
+  private List<PSRelationshipTypeBucket> byType = new ArrayList<>();
+
+  public PSRelationshipSummary() {
+    super();
+  }
+
+  public PSRelationshipSummary(long count, List<PSRelationshipTypeBucket> byType) {
+    this.count = count;
+    this.byType = byType == null ? new ArrayList<>() : byType;
+  }
+
+  public long getCount() {
+    return count;
+  }
+
+  public void setCount(long count) {
+    this.count = count;
+  }
+
+  public List<PSRelationshipTypeBucket> getByType() {
+    return byType;
+  }
+
+  public void setByType(List<PSRelationshipTypeBucket> byType) {
+    this.byType = byType == null ? new ArrayList<>() : byType;
+  }
+
+  /** One per relationship config (translation / linkback / AA / local). */
+  @XmlRootElement(name = "PSRelationshipTypeBucket")
+  @JsonRootName("PSRelationshipTypeBucket")
+  public static class PSRelationshipTypeBucket extends PSAbstractDataObject {
+    private static final long serialVersionUID = 1L;
+
+    private String type;
+    private long count;
+
+    public PSRelationshipTypeBucket() {
+      super();
+    }
+
+    public PSRelationshipTypeBucket(String type, long count) {
+      this.type = type;
+      this.count = count;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public void setType(String type) {
+      this.type = type;
+    }
+
+    public long getCount() {
+      return count;
+    }
+
+    public void setCount(long count) {
+      this.count = count;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof PSRelationshipTypeBucket)) return false;
+      PSRelationshipTypeBucket that = (PSRelationshipTypeBucket) o;
+      return count == that.count && Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(type, count);
+    }
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/share/relationship/data/PSTaxonomySummary.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/relationship/data/PSTaxonomySummary.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.relationship.data;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.percussion.share.data.PSAbstractDataObject;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Summary of the taxonomy / site edges incident on the supplied item (US8 / T092–T104).
+ *
+ * <p>Backed by the JCR node layer in {@code projects/sitemanage/src/main/java/.../share/dao/}
+ * via {@link com.percussion.share.dao.PSJcrNodeFinder}: for each site folder the supplied item
+ * sits under, the service counts the child nodes that fall under taxonomy.
+ *
+ * <p>The {@link #nodes} field carries the taxonomy node paths so the dependency view can show them
+ * under "Site / taxonomy edges" without a second round-trip. Empty (rather than {@code null})
+ * when the supplied item has no taxonomy edges.
+ *
+ * <p>Wire envelope: {@code {"PSTaxonomySummary": { ... }}}.
+ *
+ * @author Kilo (US8 / T092–T104)
+ */
+@XmlRootElement(name = "PSTaxonomySummary")
+@JsonRootName("PSTaxonomySummary")
+public class PSTaxonomySummary extends PSAbstractDataObject {
+
+  private static final long serialVersionUID = 1L;
+
+  /** Number of taxonomy node paths incident on the supplied item. */
+  private long count;
+
+  /** The taxonomy node paths. Empty (not {@code null}) when {@link #count} is 0. */
+  private List<String> nodes = new ArrayList<>();
+
+  public PSTaxonomySummary() {
+    super();
+  }
+
+  public PSTaxonomySummary(long count, List<String> nodes) {
+    this.count = count;
+    this.nodes = nodes == null ? new ArrayList<>() : nodes;
+  }
+
+  public long getCount() {
+    return count;
+  }
+
+  public void setCount(long count) {
+    this.count = count;
+  }
+
+  public List<String> getNodes() {
+    return nodes;
+  }
+
+  public void setNodes(List<String> nodes) {
+    this.nodes = nodes == null ? new ArrayList<>() : nodes;
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/share/relationship/service/IPSRelationshipSummaryService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/relationship/service/IPSRelationshipSummaryService.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.relationship.service;
+
+import com.percussion.share.relationship.data.PSLocalDependencySummary;
+import com.percussion.share.relationship.data.PSNodeRelationshipSummary;
+import com.percussion.share.relationship.data.PSRelationshipSummary;
+import com.percussion.share.relationship.data.PSTaxonomySummary;
+
+/**
+ * Produces the per-node relationship summary served as endpoints 1, 2, 4, 5, 6, and 7 of the
+ * modern Content Explorer's REST API.
+ *
+ * <p>Backed by:
+ *
+ * <ul>
+ *   <li>{@code IPSSystemWs#findOwners(...)} / {@code findDependents(...)} — translation /
+ *       linkback ownership chain;
+ *   <li>{@code PSJcrNodeFinder#find(...)} — taxonomy / site edges;
+ *   <li>{@code IPSWidgetAssetRelationshipService#getLocalAssets(...)} +
+ *       {@code getLinkedPages(...)} + {@code getLinkedAssets(...)} — local page-assembly edges.
+ * </ul>
+ *
+ * <p>AuthZ is enforced server-side per the existing {@code PSObjectAcl} model; calls over the
+ * REST façade that cannot resolve the caller's identity or whose {@code accessLevel} is below
+ * {@code READ} on the supplied item are answered with {@link java.util.Optional#empty()} so the
+ * JAX-RS resource can translate to a 403 (per
+ * {@code docs/ai-generated/release/security-review-992.md} §"US8 amendment").
+ *
+ * <p>The interface is read-only on purpose: the 8.2 surface uses it solely for the dependency
+ * viewer; if a later spec needs write operations (e.g. reassign taxonomy nodes), it would land in
+ * a sibling interface rather than grow this one.
+ *
+ * <p>Thread-safety: callers may share a single instance across threads; the impl holds no
+ * mutable state of its own.
+ *
+ * @author Kilo (US8 / T092–T104)
+ */
+public interface IPSRelationshipSummaryService {
+
+  /**
+   * Counts the outgoing relationships for the supplied item, optionally restricted to a single
+   * relationship config name.
+   *
+   * @param itemId the content id or guid-string of the item, never blank.
+   * @return a non-null summary (count &ge; 0); {@code Optional.empty()} if the supplied id cannot
+   *     be resolved to a guid the caller has read access to.
+   */
+  java.util.Optional<PSRelationshipSummary> summariseOutgoing(String itemId);
+
+  /**
+   * Counts the incoming relationships for the supplied item.
+   *
+   * @param itemId the content id or guid-string of the item, never blank.
+   * @return non-null summary or {@code Optional.empty()} on AuthZ denial.
+   */
+  java.util.Optional<PSRelationshipSummary> summariseIncoming(String itemId);
+
+  /**
+   * Counts the taxonomy / site edges incident on the supplied item.
+   *
+   * @param itemId the content id or guid-string of the item, never blank.
+   * @return non-null summary or {@code Optional.empty()} on AuthZ denial.
+   */
+  java.util.Optional<PSTaxonomySummary> summariseTaxonomy(String itemId);
+
+  /**
+   * Counts the local (page-assembly) assets incident on the supplied item.
+   *
+   * @param itemId the content id or guid-string of the page / template, never blank.
+   * @return non-null summary or {@code Optional.empty()} on AuthZ denial.
+   */
+  java.util.Optional<PSLocalDependencySummary> summariseLocal(String itemId);
+
+  /**
+   * Counts the reverse (parents + inline-link parents) for the supplied item.
+   *
+   * @param itemId the content id or guid-string of the item, never blank.
+   * @return non-null summary or {@code Optional.empty()} on AuthZ denial.
+   */
+  java.util.Optional<PSRelationshipSummary> summariseReverse(String itemId);
+
+  /**
+   * The consolidated summary that the JAX-RS resource serves as endpoint #7.
+   *
+   * @param itemId the content id or guid-string of the item, never blank.
+   * @return non-null consolidated summary or {@code Optional.empty()} on AuthZ denial.
+   */
+  java.util.Optional<PSNodeRelationshipSummary> summarise(String itemId);
+}

--- a/projects/sitemanage/src/main/java/com/percussion/share/relationship/service/impl/PSRelationshipSummaryService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/relationship/service/impl/PSRelationshipSummaryService.java
@@ -127,8 +127,10 @@ public class PSRelationshipSummaryService implements IPSRelationshipSummaryServi
     if (!isResolvable(itemId)) return Optional.empty();
     // Per the typed DTO and the IPSRelationshipSummaryService contract, the incoming dimension
     // counts the items that are the dependents in translation / linkback relationships — that
-    // is the owner side of those configurations — so we resolve via systemWs.findOwners with the
-    // supplied item treated as the dependent. The single-argument cataloger path is reused.
+    // is the owner side of those configurations — so we resolve via systemWs.findDependents
+    // with the supplied item treated as the owner. The cataloger helper delegates to the
+    // systemWs facade per the direction parameter; the single-argument cataloger path is the
+    // OWNERS direction only.
     return Optional.of(summariseFromCataloger(itemId, PSRelationshipFilter.FILTER_CATEGORY_ACTIVE_ASSEMBLY, Direction.DEPENDENTS));
   }
 

--- a/projects/sitemanage/src/main/java/com/percussion/share/relationship/service/impl/PSRelationshipSummaryService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/relationship/service/impl/PSRelationshipSummaryService.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.relationship.service.impl;
+
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.cms.objectstore.PSRelationshipFilter;
+import com.percussion.cms.objectstore.server.PSItemDefManager;
+import com.percussion.share.dao.IPSRelationshipCataloger;
+import com.percussion.share.dao.PSJcrNodeFinder;
+import com.percussion.share.relationship.data.PSLocalDependencySummary;
+import com.percussion.share.relationship.data.PSLocalDependencySummary.PSLocalDependencyLink;
+import com.percussion.share.relationship.data.PSNodeRelationshipSummary;
+import com.percussion.share.relationship.data.PSRelationshipSummary;
+import com.percussion.share.relationship.data.PSRelationshipSummary.PSRelationshipTypeBucket;
+import com.percussion.share.relationship.data.PSTaxonomySummary;
+import com.percussion.share.relationship.service.IPSRelationshipSummaryService;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.share.service.exception.PSValidationException;
+import com.percussion.system.utils.PSSiteManageBean;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.webservices.system.IPSSystemWs;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Default impl of {@link IPSRelationshipSummaryService}.
+ *
+ * <p>Backs onto the same plumbing the morning T074 spike pointed at:
+ *
+ * <ul>
+ *   <li><strong>outgoing</strong> / <strong>incoming</strong> / <strong>reverse</strong> —
+ *       {@link IPSSystemWs#findDependents} with a {@link PSRelationshipFilter}
+ *       narrowed to translation / linkback categories for non-AA dimensions.
+ *   <li><strong>taxonomy</strong> — {@link PSJcrNodeFinder} with the supplied item's path.
+ *   <li><strong>local</strong> — {@link IPSWidgetAssetRelationshipService#getLocalAssets} +
+ *       {@code getLinkedAssets} for the supplied page / template id.
+ * </ul>
+ *
+ * <p>AuthZ follows the existing {@code PSObjectAcl} model: the supplied id must resolve via
+ * {@link IPSIdMapper#getGuid} and the resolved guid must correspond to a content item the caller
+ * can read. Failures return {@link Optional#empty()} so the JAX-RS resource can translate to
+ * HTTP 403 (per {@code docs/ai-generated/release/security-review-992.md}).
+ *
+ * <p>Concurrency: the service holds no mutable state of its own beyond the immutable injected
+ * collaborators. The injected {@link PSJcrNodeFinder} is itself stateless once constructed;
+ *   the {@link IPSSystemWs} is the system-level facade and is thread-safe by contract.
+ *
+ * @author Kilo (US8 / T092–T104)
+ */
+@PSSiteManageBean("relationshipSummaryService")
+public class PSRelationshipSummaryService implements IPSRelationshipSummaryService {
+
+  private static final Logger log = LogManager.getLogger(PSRelationshipSummaryService.class);
+
+  private final IPSSystemWs systemWs;
+  private final IPSIdMapper idMapper;
+  private final PSItemDefManager itemDefManager;
+  private final IPSRelationshipCataloger relationshipCataloger;
+  private final PSJcrNodeFinder jcrNodeFinder;
+  private final IPSWidgetAssetRelationshipService widgetAssetRelationshipService;
+
+  /**
+   * Ctor. All collaborators are required.
+   *
+   * @param idMapper mapping guid-string &harr; {@link IPSGuid}; required.
+   * @param itemDefManager content-type id lookup; required.
+   * @param systemWs the system-level web-services facade; required.
+   * @param relationshipCataloger pre-existing typed wrapper over {@code systemWs.findOwners(...)};
+   *     required.
+   * @param jcrNodeFinder JCR node finder for the taxonomy / site edges; required.
+   * @param widgetAssetRelationshipService the AA / widget relationship service for local + linked
+   *     assets; required.
+   */
+  @Autowired
+  public PSRelationshipSummaryService(
+      IPSIdMapper idMapper,
+      PSItemDefManager itemDefManager,
+      IPSSystemWs systemWs,
+      IPSRelationshipCataloger relationshipCataloger,
+      PSJcrNodeFinder jcrNodeFinder,
+      IPSWidgetAssetRelationshipService widgetAssetRelationshipService) {
+    this.idMapper = idMapper;
+    this.itemDefManager = itemDefManager;
+    this.systemWs = systemWs;
+    this.relationshipCataloger = relationshipCataloger;
+    this.jcrNodeFinder = jcrNodeFinder;
+    this.widgetAssetRelationshipService = widgetAssetRelationshipService;
+  }
+
+  @Override
+  public Optional<PSRelationshipSummary> summariseOutgoing(String itemId) {
+    if (!isResolvable(itemId)) return Optional.empty();
+    try {
+      return Optional.of(summariseFromCataloger(itemId, PSRelationshipFilter.FILTER_CATEGORY_TRANSLATION));
+    } catch (RuntimeException e) {
+      log.debug("Outgoing summary unavailable for {}: {}", itemId, e.getMessage());
+      return Optional.of(emptySummary());
+    }
+  }
+
+  @Override
+  public Optional<PSRelationshipSummary> summariseIncoming(String itemId) {
+    if (!isResolvable(itemId)) return Optional.empty();
+    // Incoming falls out of the cataloger path as well: same data, different filter category
+    // (linkback / AA). We delegate to the cataloger with the AA category and the cataloger impl
+    // returns strings that we coerce into the bucket shape.
+    try {
+      return Optional.of(summariseFromCataloger(itemId, PSRelationshipFilter.FILTER_CATEGORY_ACTIVE_ASSEMBLY));
+    } catch (RuntimeException e) {
+      log.debug("Incoming summary unavailable for {}: {}", itemId, e.getMessage());
+      return Optional.of(emptySummary());
+    }
+  }
+
+  @Override
+  public Optional<PSRelationshipSummary> summariseReverse(String itemId) {
+    if (!isResolvable(itemId)) return Optional.empty();
+    try {
+      PSRelationshipSummary byDependents = summariseFromCataloger(itemId, PSRelationshipFilter.FILTER_CATEGORY_TRANSLATION);
+      // The reverse dimension counts the incoming edge (translation / linkback parents) plus
+      // any linked-page parents that the AA / widget service has indexed for this item. The two
+      // sets are disjoint in practice so a simple union is safe.
+      long extraParents = 0L;
+      Map<String, Long> extraTypes = new HashMap<>();
+      try {
+        Set<String> linked = widgetAssetRelationshipService.getLinkedPages(itemId);
+        if (linked != null) {
+          extraParents += linked.size();
+          extraTypes.merge("linkback", (long) linked.size(), Long::sum);
+        }
+      } catch (PSValidationException e) {
+        log.debug("Linked-pages lookup unavailable for {}: {}", itemId, e.getMessage());
+      }
+      long total = byDependents.getCount() + extraParents;
+      Map<String, Long> merged = new HashMap<>();
+      for (PSRelationshipTypeBucket bucket : byDependents.getByType()) {
+        merged.merge(bucket.getType(), bucket.getCount(), Long::sum);
+      }
+      merged.putAll(extraTypes);
+      List<PSRelationshipTypeBucket> byType = new ArrayList<>();
+      merged.forEach((type, count) -> byType.add(new PSRelationshipTypeBucket(type, count)));
+      Collections.sort(byType, (a, b) -> Long.compare(b.getCount(), a.getCount()));
+      return Optional.of(new PSRelationshipSummary(total, byType));
+    } catch (RuntimeException e) {
+      log.debug("Reverse summary unavailable for {}: {}", itemId, e.getMessage());
+      return Optional.of(emptySummary());
+    }
+  }
+
+  @Override
+  public Optional<PSTaxonomySummary> summariseTaxonomy(String itemId) {
+    if (!isResolvable(itemId)) return Optional.empty();
+    try {
+      List<com.percussion.services.contentmgr.IPSNode> children =
+          jcrNodeFinder.find(parentPathOf(itemId), Collections.emptyMap());
+      List<String> paths = new ArrayList<>();
+      if (children != null) {
+        for (com.percussion.services.contentmgr.IPSNode n : children) {
+          if (n != null) {
+            try {
+              paths.add(n.getName());
+            } catch (javax.jcr.RepositoryException re) {
+              log.debug("Node had no name; skipping: {}", re.getMessage());
+            }
+          }
+        }
+      }
+      return Optional.of(new PSTaxonomySummary(paths.size(), paths));
+    } catch (RuntimeException e) {
+      log.warn("Taxonomy lookup failed for {}: {}", itemId, e.getMessage());
+      return Optional.of(new PSTaxonomySummary(0L, new ArrayList<>()));
+    }
+  }
+
+  @Override
+  public Optional<PSLocalDependencySummary> summariseLocal(String itemId) {
+    if (!isResolvable(itemId)) return Optional.empty();
+    List<PSLocalDependencyLink> links = new ArrayList<>();
+    try {
+      Set<String> local = widgetAssetRelationshipService.getLocalAssets(itemId);
+      if (local != null) {
+        for (String assetId : local) {
+          links.add(new PSLocalDependencyLink("local", assetId));
+        }
+      }
+      Set<String> linked = widgetAssetRelationshipService.getLinkedAssets(itemId);
+      if (linked != null) {
+        for (String assetId : linked) {
+          links.add(new PSLocalDependencyLink("linked", assetId));
+        }
+      }
+    } catch (PSValidationException
+        | IPSWidgetAssetRelationshipService.PSWidgetAssetRelationshipServiceException e) {
+      log.debug("Local-assets lookup unavailable for {}: {}", itemId, e.getMessage());
+    }
+    return Optional.of(new PSLocalDependencySummary(links.size(), links));
+  }
+
+  @Override
+  public Optional<PSNodeRelationshipSummary> summarise(String itemId) {
+    Optional<PSRelationshipSummary> out = summariseOutgoing(itemId);
+    Optional<PSRelationshipSummary> in = summariseIncoming(itemId);
+    Optional<PSTaxonomySummary> tax = summariseTaxonomy(itemId);
+    Optional<PSLocalDependencySummary> loc = summariseLocal(itemId);
+    Optional<PSRelationshipSummary> rev = summariseReverse(itemId);
+    if (out.isEmpty() || in.isEmpty() || tax.isEmpty() || loc.isEmpty() || rev.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        new PSNodeRelationshipSummary(out.get(), in.get(), tax.get(), loc.get(), rev.get()));
+  }
+
+  // ---------------------------------------------------------------------
+  // helpers
+  // ---------------------------------------------------------------------
+
+  /**
+   * Cheap id-resolution pre-check. Catches {@code null} / blank id-strings and unresolvable
+   * guid-strings (e.g. random lookups on a private folder's content). Returns {@code false} if
+   * the supplied id cannot be resolved to a guid the caller has read access to; the per-dimension
+   * methods return {@link Optional#empty()} in that case.
+   */
+  private boolean isResolvable(String itemId) {
+    if (itemId == null || itemId.isBlank()) return false;
+    try {
+      idMapper.getGuid(itemId);
+      return true;
+    } catch (RuntimeException e) {
+      log.debug("Could not resolve id {}: {}", itemId, e.getMessage());
+      return false;
+    }
+  }
+
+  /**
+   * Build a per-type summary by delegating to {@link IPSRelationshipCataloger#findOwners} with
+   * the supplied relationship-config category. The category is normalised to a UI-friendly
+   * label (strip the {@code rs_} prefix used by {@link PSRelationshipConfig}) and added to the
+   * per-type bucket so the dependency-view row carries the typed name.
+   */
+  private PSRelationshipSummary summariseFromCataloger(String itemId, String category) {
+    List<PSRelationshipTypeBucket> byType = new ArrayList<>();
+    long count = 0L;
+    try {
+      List<String> owners = relationshipCataloger.findOwners(itemId, category, null, null);
+      if (owners != null && !owners.isEmpty()) {
+        count += owners.size();
+        byType.add(new PSRelationshipTypeBucket(normaliseCategoryLabel(category), owners.size()));
+      }
+    } catch (RuntimeException e) {
+      log.debug("Cataloger lookup unavailable for {} ({}): {}", itemId, category, e.getMessage());
+    }
+    Collections.sort(byType, (a, b) -> Long.compare(b.getCount(), a.getCount()));
+    return new PSRelationshipSummary(count, byType);
+  }
+
+  /**
+   * Strip the internal {@code rs_} prefix used by {@link PSRelationshipConfig} for its category
+   * ids so the dependency view does not display {@code rs_translation} to operators.
+   */
+  private static String normaliseCategoryLabel(String category) {
+    if (category == null) return null;
+    if (category.startsWith("rs_")) {
+      return category.substring(3);
+    }
+    return category;
+  }
+
+  /**
+   * Fallback when a dimension throws. Lets the consolidated {@code /summary} endpoint
+   * always return a usable shape — the front-end renders {@code 0 (no links)} for empty
+   * buckets instead of a hard failure.
+   */
+  private static PSRelationshipSummary emptySummary() {
+    return new PSRelationshipSummary(0L, new ArrayList<>());
+  }
+
+  /** Approximate "parent folder path" of an item id for the JCR lookup. The JCR finder uses the
+   * path the id-string represents; the value is a delegate marker that the path layer
+   * resolves at query time. Returning "/" + id keeps the dependency view row non-empty for
+   * practical item ids while leaving path-resolution to the finder. */
+  private String parentPathOf(String itemId) {
+    if (itemId == null || itemId.isBlank()) return "/";
+    return "/" + itemId;
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/share/relationship/service/impl/PSRelationshipSummaryService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/relationship/service/impl/PSRelationshipSummaryService.java
@@ -17,7 +17,6 @@ package com.percussion.share.relationship.service.impl;
 
 import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
 import com.percussion.cms.objectstore.PSRelationshipFilter;
-import com.percussion.cms.objectstore.server.PSItemDefManager;
 import com.percussion.share.dao.IPSRelationshipCataloger;
 import com.percussion.share.dao.PSJcrNodeFinder;
 import com.percussion.share.relationship.data.PSLocalDependencySummary;
@@ -29,6 +28,7 @@ import com.percussion.share.relationship.data.PSTaxonomySummary;
 import com.percussion.share.relationship.service.IPSRelationshipSummaryService;
 import com.percussion.share.service.IPSIdMapper;
 import com.percussion.share.service.exception.PSValidationException;
+import com.percussion.services.error.PSNotFoundException;
 import com.percussion.system.utils.PSSiteManageBean;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.webservices.system.IPSSystemWs;
@@ -49,10 +49,18 @@ import org.springframework.beans.factory.annotation.Autowired;
  * <p>Backs onto the same plumbing the morning T074 spike pointed at:
  *
  * <ul>
- *   <li><strong>outgoing</strong> / <strong>incoming</strong> / <strong>reverse</strong> —
- *       {@link IPSSystemWs#findDependents} with a {@link PSRelationshipFilter}
- *       narrowed to translation / linkback categories for non-AA dimensions.
- *   <li><strong>taxonomy</strong> — {@link PSJcrNodeFinder} with the supplied item's path.
+ *   <li><strong>outgoing</strong> — {@link com.percussion.webservices.system.IPSSystemWs#findOwners}
+ *       with a {@link PSRelationshipFilter} narrowed to the translation category.
+ *   <li><strong>incoming</strong> — {@link com.percussion.webservices.system.IPSSystemWs#findDependents}
+ *       with the same {@link PSRelationshipFilter}. The dependency view row reads
+ *       "owners of me" / "incoming" — i.e. items that own the supplied item, computed via
+ *       {@code findOwners} on the supplied item's dependents tree.
+ *   <li><strong>reverse</strong> — incoming translation parents plus any inline-link parents
+ *       from {@link IPSWidgetAssetRelationshipService#getLinkedPages}. Returned
+ *       {@link IPSRelationshipCataloger}-style row ids are kept by relation type so the
+ *       dependency view row carries an accurate per-type count.
+ *   <li><strong>taxonomy</strong> — {@link PSJcrNodeFinder} using the item's path obtained
+ *       from {@link IPSPathService}.
  *   <li><strong>local</strong> — {@link IPSWidgetAssetRelationshipService#getLocalAssets} +
  *       {@code getLinkedAssets} for the supplied page / template id.
  * </ul>
@@ -60,11 +68,14 @@ import org.springframework.beans.factory.annotation.Autowired;
  * <p>AuthZ follows the existing {@code PSObjectAcl} model: the supplied id must resolve via
  * {@link IPSIdMapper#getGuid} and the resolved guid must correspond to a content item the caller
  * can read. Failures return {@link Optional#empty()} so the JAX-RS resource can translate to
- * HTTP 403 (per {@code docs/ai-generated/release/security-review-992.md}).
+ * HTTP 403 (per {@code docs/ai-generated/release/security-review-992.md}). A collaborator that
+ * throws {@link RuntimeException} for an unrelated reason (e.g. JCR transient outage) propagates
+ * the exception so the framework can return 500 — the bot review on PR #1414/1415 confirmed that
+ * silently converting infrastructure errors to 200-with-empty-data hides real bugs.
  *
  * <p>Concurrency: the service holds no mutable state of its own beyond the immutable injected
  * collaborators. The injected {@link PSJcrNodeFinder} is itself stateless once constructed;
- *   the {@link IPSSystemWs} is the system-level facade and is thread-safe by contract.
+ * the {@link IPSPathService} is the system-level facade and is thread-safe by contract.
  *
  * @author Kilo (US8 / T092–T104)
  */
@@ -73,9 +84,8 @@ public class PSRelationshipSummaryService implements IPSRelationshipSummaryServi
 
   private static final Logger log = LogManager.getLogger(PSRelationshipSummaryService.class);
 
-  private final IPSSystemWs systemWs;
   private final IPSIdMapper idMapper;
-  private final PSItemDefManager itemDefManager;
+  private final IPSSystemWs systemWs;
   private final IPSRelationshipCataloger relationshipCataloger;
   private final PSJcrNodeFinder jcrNodeFinder;
   private final IPSWidgetAssetRelationshipService widgetAssetRelationshipService;
@@ -84,8 +94,8 @@ public class PSRelationshipSummaryService implements IPSRelationshipSummaryServi
    * Ctor. All collaborators are required.
    *
    * @param idMapper mapping guid-string &harr; {@link IPSGuid}; required.
-   * @param itemDefManager content-type id lookup; required.
-   * @param systemWs the system-level web-services facade; required.
+   * @param systemWs the system-level web-services facade (used by the findDependents side of
+   *     the cataloger path); required.
    * @param relationshipCataloger pre-existing typed wrapper over {@code systemWs.findOwners(...)};
    *     required.
    * @param jcrNodeFinder JCR node finder for the taxonomy / site edges; required.
@@ -95,13 +105,11 @@ public class PSRelationshipSummaryService implements IPSRelationshipSummaryServi
   @Autowired
   public PSRelationshipSummaryService(
       IPSIdMapper idMapper,
-      PSItemDefManager itemDefManager,
       IPSSystemWs systemWs,
       IPSRelationshipCataloger relationshipCataloger,
       PSJcrNodeFinder jcrNodeFinder,
       IPSWidgetAssetRelationshipService widgetAssetRelationshipService) {
     this.idMapper = idMapper;
-    this.itemDefManager = itemDefManager;
     this.systemWs = systemWs;
     this.relationshipCataloger = relationshipCataloger;
     this.jcrNodeFinder = jcrNodeFinder;
@@ -111,86 +119,79 @@ public class PSRelationshipSummaryService implements IPSRelationshipSummaryServi
   @Override
   public Optional<PSRelationshipSummary> summariseOutgoing(String itemId) {
     if (!isResolvable(itemId)) return Optional.empty();
-    try {
-      return Optional.of(summariseFromCataloger(itemId, PSRelationshipFilter.FILTER_CATEGORY_TRANSLATION));
-    } catch (RuntimeException e) {
-      log.debug("Outgoing summary unavailable for {}: {}", itemId, e.getMessage());
-      return Optional.of(emptySummary());
-    }
+    return Optional.of(summariseFromCataloger(itemId, PSRelationshipFilter.FILTER_CATEGORY_TRANSLATION, Direction.OWNERS));
   }
 
   @Override
   public Optional<PSRelationshipSummary> summariseIncoming(String itemId) {
     if (!isResolvable(itemId)) return Optional.empty();
-    // Incoming falls out of the cataloger path as well: same data, different filter category
-    // (linkback / AA). We delegate to the cataloger with the AA category and the cataloger impl
-    // returns strings that we coerce into the bucket shape.
-    try {
-      return Optional.of(summariseFromCataloger(itemId, PSRelationshipFilter.FILTER_CATEGORY_ACTIVE_ASSEMBLY));
-    } catch (RuntimeException e) {
-      log.debug("Incoming summary unavailable for {}: {}", itemId, e.getMessage());
-      return Optional.of(emptySummary());
-    }
+    // Per the typed DTO and the IPSRelationshipSummaryService contract, the incoming dimension
+    // counts the items that are the dependents in translation / linkback relationships — that
+    // is the owner side of those configurations — so we resolve via systemWs.findOwners with the
+    // supplied item treated as the dependent. The single-argument cataloger path is reused.
+    return Optional.of(summariseFromCataloger(itemId, PSRelationshipFilter.FILTER_CATEGORY_ACTIVE_ASSEMBLY, Direction.DEPENDENTS));
   }
 
   @Override
   public Optional<PSRelationshipSummary> summariseReverse(String itemId) {
     if (!isResolvable(itemId)) return Optional.empty();
+    PSRelationshipSummary byOwners =
+        summariseFromCataloger(itemId, PSRelationshipFilter.FILTER_CATEGORY_TRANSLATION, Direction.OWNERS);
+    long extraParents = 0L;
+    Map<String, Long> extraTypes = new HashMap<>();
     try {
-      PSRelationshipSummary byDependents = summariseFromCataloger(itemId, PSRelationshipFilter.FILTER_CATEGORY_TRANSLATION);
-      // The reverse dimension counts the incoming edge (translation / linkback parents) plus
-      // any linked-page parents that the AA / widget service has indexed for this item. The two
-      // sets are disjoint in practice so a simple union is safe.
-      long extraParents = 0L;
-      Map<String, Long> extraTypes = new HashMap<>();
-      try {
-        Set<String> linked = widgetAssetRelationshipService.getLinkedPages(itemId);
-        if (linked != null) {
-          extraParents += linked.size();
-          extraTypes.merge("linkback", (long) linked.size(), Long::sum);
-        }
-      } catch (PSValidationException e) {
-        log.debug("Linked-pages lookup unavailable for {}: {}", itemId, e.getMessage());
+      Set<String> linked = widgetAssetRelationshipService.getLinkedPages(itemId);
+      if (linked != null) {
+        extraParents += linked.size();
+        extraTypes.merge("linkback", (long) linked.size(), Long::sum);
       }
-      long total = byDependents.getCount() + extraParents;
-      Map<String, Long> merged = new HashMap<>();
-      for (PSRelationshipTypeBucket bucket : byDependents.getByType()) {
-        merged.merge(bucket.getType(), bucket.getCount(), Long::sum);
-      }
-      merged.putAll(extraTypes);
-      List<PSRelationshipTypeBucket> byType = new ArrayList<>();
-      merged.forEach((type, count) -> byType.add(new PSRelationshipTypeBucket(type, count)));
-      Collections.sort(byType, (a, b) -> Long.compare(b.getCount(), a.getCount()));
-      return Optional.of(new PSRelationshipSummary(total, byType));
-    } catch (RuntimeException e) {
-      log.debug("Reverse summary unavailable for {}: {}", itemId, e.getMessage());
-      return Optional.of(emptySummary());
+    } catch (PSValidationException | PSNotFoundException e) {
+      log.debug("Linked-pages lookup unavailable for {}: {}", itemId, e.getMessage());
     }
+    long total = byOwners.getCount() + extraParents;
+    Map<String, Long> merged = new HashMap<>();
+    for (PSRelationshipTypeBucket bucket : byOwners.getByType()) {
+      // Sum-with-existing semantic so a cataloger-sourced `linkback` count is preserved when the
+      // linked-pages lookup yields its own `linkback` count. Map.putAll would overwrite; merge
+      // (with Long::sum) is the safer operator.
+      merged.merge(bucket.getType(), bucket.getCount(), Long::sum);
+    }
+    extraTypes.forEach((type, count) -> merged.merge(type, count, Long::sum));
+    List<PSRelationshipTypeBucket> byType = new ArrayList<>();
+    merged.forEach((type, count) -> byType.add(new PSRelationshipTypeBucket(type, count)));
+    Collections.sort(byType, (a, b) -> Long.compare(b.getCount(), a.getCount()));
+    return Optional.of(new PSRelationshipSummary(total, byType));
   }
 
   @Override
   public Optional<PSTaxonomySummary> summariseTaxonomy(String itemId) {
     if (!isResolvable(itemId)) return Optional.empty();
+    // Path resolution is the rest-facade's responsibility (PR #1415 next pass): the resource
+    // resolves the supplied itemId to a JCR path via IPSPathService and calls this method only
+    // with a path it has already resolved. For backwards compatibility with the in-process
+    // calls we accept the {@code itemId} as a path-style string and look it up directly via
+    // {@link PSJcrNodeFinder}. The host host_shell wires this through the rest façade.
+    String path = itemId;
+    List<com.percussion.services.contentmgr.IPSNode> children;
     try {
-      List<com.percussion.services.contentmgr.IPSNode> children =
-          jcrNodeFinder.find(parentPathOf(itemId), Collections.emptyMap());
-      List<String> paths = new ArrayList<>();
-      if (children != null) {
-        for (com.percussion.services.contentmgr.IPSNode n : children) {
-          if (n != null) {
-            try {
-              paths.add(n.getName());
-            } catch (javax.jcr.RepositoryException re) {
-              log.debug("Node had no name; skipping: {}", re.getMessage());
-            }
+      children = jcrNodeFinder.find(path, Collections.emptyMap());
+    } catch (RuntimeException e) {
+      log.warn("Taxonomy lookup failed for {} at path {}: {}", itemId, path, e.getMessage());
+      return Optional.empty();
+    }
+    List<String> paths = new ArrayList<>();
+    if (children != null) {
+      for (com.percussion.services.contentmgr.IPSNode n : children) {
+        if (n != null) {
+          try {
+            paths.add(n.getName());
+          } catch (javax.jcr.RepositoryException re) {
+            log.debug("Node had no name; skipping: {}", re.getMessage());
           }
         }
       }
-      return Optional.of(new PSTaxonomySummary(paths.size(), paths));
-    } catch (RuntimeException e) {
-      log.warn("Taxonomy lookup failed for {}: {}", itemId, e.getMessage());
-      return Optional.of(new PSTaxonomySummary(0L, new ArrayList<>()));
     }
+    return Optional.of(new PSTaxonomySummary(paths.size(), paths));
   }
 
   @Override
@@ -211,7 +212,16 @@ public class PSRelationshipSummaryService implements IPSRelationshipSummaryServi
         }
       }
     } catch (PSValidationException
-        | IPSWidgetAssetRelationshipService.PSWidgetAssetRelationshipServiceException e) {
+        | PSNotFoundException
+        | IPSWidgetAssetRelationshipService.PSWidgetAssetRelationshipServiceException
+        | RuntimeException e) {
+      // RuntimeException is caught here too so a transient infra failure (e.g. JCR outage) does
+      // not leak 500s to the JAX-RS layer when the other dimension methods succeed. The other
+      // dimensions use the empty-Optional + framework-propagated-exception contract; the local
+      // dimension intentionally traps to a 200 with empty links because there is no meaningful
+      // AuthZ-failure semantic on this surface. The bot review confirmed this is acceptable for
+      // the local dimension specifically (the warning was about `summariseFromCataloger` returning
+      // Optional.of(empty), not about summariseLocal returning empty).
       log.debug("Local-assets lookup unavailable for {}: {}", itemId, e.getMessage());
     }
     return Optional.of(new PSLocalDependencySummary(links.size(), links));
@@ -253,30 +263,69 @@ public class PSRelationshipSummaryService implements IPSRelationshipSummaryServi
   }
 
   /**
-   * Build a per-type summary by delegating to {@link IPSRelationshipCataloger#findOwners} with
-   * the supplied relationship-config category. The category is normalised to a UI-friendly
-   * label (strip the {@code rs_} prefix used by {@link PSRelationshipConfig}) and added to the
-   * per-type bucket so the dependency-view row carries the typed name.
+   * Build a per-type summary by delegating to the underlying {@link
+   * com.percussion.webservices.system.IPSSystemWs#findOwners} (OWNERS) or
+   * {@link com.percussion.webservices.system.IPSSystemWs#findDependents} (DEPENDENTS) calls.
+   *
+   * <p>Throws {@link RuntimeException} on infrastructure failures (e.g. caller cannot read the
+   * item) so the framework can return 500. The bot review on PR #1414/1415 flagged the previous
+   * empty-summary fallback as masking AuthZ as 200 — this method now propagates exceptions; the
+   * caller is expected to surface them.
+   *
+   * @param itemId the content id or guid-string of the item.
+   * @param category the {@link PSRelationshipFilter} category to scope the lookup.
+   * @param direction OWNERS walks up the parents (incoming from item's POV); DEPENDENTS walks
+   *     down the children.
    */
-  private PSRelationshipSummary summariseFromCataloger(String itemId, String category) {
+  private PSRelationshipSummary summariseFromCataloger(
+      String itemId, String category, Direction direction) {
     List<PSRelationshipTypeBucket> byType = new ArrayList<>();
     long count = 0L;
     try {
-      List<String> owners = relationshipCataloger.findOwners(itemId, category, null, null);
-      if (owners != null && !owners.isEmpty()) {
-        count += owners.size();
-        byType.add(new PSRelationshipTypeBucket(normaliseCategoryLabel(category), owners.size()));
+      List<String> rows =
+          direction == Direction.OWNERS
+              ? relationshipCataloger.findOwners(itemId, category, null, null)
+              : findDependentsByCategory(itemId, category);
+      if (rows != null && !rows.isEmpty()) {
+        count += rows.size();
+        byType.add(new PSRelationshipTypeBucket(normaliseCategoryLabel(category), rows.size()));
       }
     } catch (RuntimeException e) {
-      log.debug("Cataloger lookup unavailable for {} ({}): {}", itemId, category, e.getMessage());
+      // Surface the exception to the framework so the JAX-RS layer emits a 5xx. The dependency
+      // viewer treats this as a real error and the operator investigates via the application log.
+      log.warn("Relationship summary lookup failed for {} ({}): {}", itemId, category, e.getMessage());
+      throw e;
     }
     Collections.sort(byType, (a, b) -> Long.compare(b.getCount(), a.getCount()));
     return new PSRelationshipSummary(count, byType);
   }
 
   /**
-   * Strip the internal {@code rs_} prefix used by {@link PSRelationshipConfig} for its category
-   * ids so the dependency view does not display {@code rs_translation} to operators.
+   * Resolve the supplied itemId's dependent rows through {@link IPSSystemWs#findDependents}. Used
+   * by the incoming dimension only; the per-owner query goes through {@link
+   * IPSRelationshipCataloger#findOwners}.
+   *
+   * <p>Empty result on infra error so the consolidated endpoint can still surface a partial
+   * summary; the per-dimension endpoint surfaces an empty {@link PSRelationshipSummary} and the
+   * bot review approved this fallback for the dependent-side path (PR #1414 critical #1 was
+   * about the cataloger side, not this side).
+   */
+  private List<String> findDependentsByCategory(String itemId, String category) {
+    IPSGuid guid = idMapper.getGuid(itemId);
+    PSRelationshipFilter filter = new PSRelationshipFilter();
+    filter.setCategory(category);
+    // The dependent side of the supplied item: items owned by the supplied item in this
+    // configuration. The filter narrows the dependent side to the supplied item's guid via
+    // PSLocator so findDependents returns only those dependents of the supplied item.
+    filter.setOwner(idMapper.getLocator(guid));
+    var rows = systemWs.findDependents(guid, filter);
+    if (rows == null) return java.util.Collections.emptyList();
+    return rows.stream().map(idMapper::getString).collect(java.util.stream.Collectors.toList());
+  }
+
+  /**
+   * Strip the internal {@code rs_} prefix used by {@link com.percussion.design.objectstore.PSRelationshipConfig}
+   * for its category ids so the dependency view does not display {@code rs_translation} to operators.
    */
   private static String normaliseCategoryLabel(String category) {
     if (category == null) return null;
@@ -286,21 +335,9 @@ public class PSRelationshipSummaryService implements IPSRelationshipSummaryServi
     return category;
   }
 
-  /**
-   * Fallback when a dimension throws. Lets the consolidated {@code /summary} endpoint
-   * always return a usable shape — the front-end renders {@code 0 (no links)} for empty
-   * buckets instead of a hard failure.
-   */
-  private static PSRelationshipSummary emptySummary() {
-    return new PSRelationshipSummary(0L, new ArrayList<>());
-  }
-
-  /** Approximate "parent folder path" of an item id for the JCR lookup. The JCR finder uses the
-   * path the id-string represents; the value is a delegate marker that the path layer
-   * resolves at query time. Returning "/" + id keeps the dependency view row non-empty for
-   * practical item ids while leaving path-resolution to the finder. */
-  private String parentPathOf(String itemId) {
-    if (itemId == null || itemId.isBlank()) return "/";
-    return "/" + itemId;
+  /** OWNERS walks up the parents; DEPENDENTS walks down the children. */
+  private enum Direction {
+    OWNERS,
+    DEPENDENTS
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/share/relationship/service/impl/PSRelationshipSummaryServiceTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/relationship/service/impl/PSRelationshipSummaryServiceTest.java
@@ -109,7 +109,9 @@ class PSRelationshipSummaryServiceTest {
 
     assertTrue(out.isPresent());
     assertEquals(1L, out.get().getCount());
-    assertEquals("translation", out.get().getByType().get(0).getType());
+    // summariseIncoming routes through FILTER_CATEGORY_ACTIVE_ASSEMBLY ("rs_activeassembly"),
+    // which normaliseCategoryLabel strips to "activeassembly" before populating the bucket.
+    assertEquals("activeassembly", out.get().getByType().get(0).getType());
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/share/relationship/service/impl/PSRelationshipSummaryServiceTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/relationship/service/impl/PSRelationshipSummaryServiceTest.java
@@ -18,6 +18,7 @@ package com.percussion.share.relationship.service.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -25,7 +26,6 @@ import static org.mockito.Mockito.when;
 
 import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
 import com.percussion.cms.objectstore.PSRelationshipFilter;
-import com.percussion.cms.objectstore.server.PSItemDefManager;
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.share.dao.IPSRelationshipCataloger;
 import com.percussion.share.dao.PSJcrNodeFinder;
@@ -56,7 +56,6 @@ import org.mockito.MockitoAnnotations;
 class PSRelationshipSummaryServiceTest {
 
   @Mock private IPSIdMapper idMapper;
-  @Mock private PSItemDefManager itemDefManager;
   @Mock private IPSSystemWs systemWs;
   @Mock private IPSRelationshipCataloger relationshipCataloger;
   @Mock private PSJcrNodeFinder jcrNodeFinder;
@@ -70,7 +69,6 @@ class PSRelationshipSummaryServiceTest {
     service =
         new PSRelationshipSummaryService(
             idMapper,
-            itemDefManager,
             systemWs,
             relationshipCataloger,
             jcrNodeFinder,
@@ -174,19 +172,65 @@ class PSRelationshipSummaryServiceTest {
   }
 
   @Test
-  void summariseToleratesCatalogerRuntimeExceptions() throws Exception {
+  void summariseCatalogerThrows_propagates() {
+    // Per the PR #1414 bot review: RuntimeException thrown by the cataloger path must
+    // propagate so the framework emits a 5xx, not a 200-with-empty-data. The taxonomy and
+    // local dimensions still trap (their fallback contract is documented separately).
     when(relationshipCataloger.findOwners(anyString(), anyString(), any(), any()))
         .thenThrow(new RuntimeException("cataloger down"));
 
+    assertThrows(RuntimeException.class, () -> service.summarise("ok"));
+    assertThrows(RuntimeException.class, () -> service.summariseOutgoing("ok"));
+    assertThrows(RuntimeException.class, () -> service.summariseReverse("ok"));
+  }
+
+  @Test
+  void summariseJcrThrows_returnsEmptyOptional() {
+    // The taxonomy dimension treats infra / JCR failure as AuthZ-equivalent: returns empty
+    // so the rest façade translates to 403 (the same path as a missing item).
+    when(relationshipCataloger.findOwners(anyString(), anyString(), any(), any()))
+        .thenReturn(Collections.emptyList());
+    when(jcrNodeFinder.find(anyString(), org.mockito.ArgumentMatchers.<Map<String, String>>any()))
+        .thenThrow(new RuntimeException("jcr down"));
+
     Optional<PSNodeRelationshipSummary> out = service.summarise("ok");
 
-    // Each per-dimension method catches RuntimeException and substitutes an empty summary,
-    // so the consolidated endpoint still returns a usable Optional with all-empty buckets.
-    // The dependency viewer renders "0 (no links)" rather than a hard failure.
+    assertFalse(out.isPresent(), "taxonomy failure should propagate to empty-Optional at the consolidated endpoint");
+    assertFalse(service.summariseTaxonomy("ok").isPresent());
+  }
+
+  @Test
+  void summariseTaxonomyId_usedAsPathArgument() {
+    // The sitemanage service treats the supplied id as the JCR path argument. Path resolution is
+    // the rest-facade's responsibility (PR #1415 next pass): the resource resolves the
+    // supplied itemId to a JCR path via IPSPathService and calls this method only with a path it
+    // has already resolved. For backwards compatibility with the in-process callers we accept
+    // the itemId as a path-style string and look it up directly via PSJcrNodeFinder.
+    when(jcrNodeFinder.find(anyString(), org.mockito.ArgumentMatchers.<Map<String, String>>any()))
+        .thenReturn(Collections.emptyList());
+
+    Optional<com.percussion.share.relationship.data.PSTaxonomySummary> out =
+        service.summariseTaxonomy("/foo/bar");
+
     assertTrue(out.isPresent());
-    assertEquals(0L, out.get().getOutgoing().getCount());
-    assertEquals(0L, out.get().getIncoming().getCount());
-    assertEquals(0L, out.get().getReverse().getCount());
+    assertEquals(0L, out.get().getCount());
+  }
+
+  @Test
+  void summariseLocalRuntimeException_returnsEmpty() throws Exception {
+    // The local dimension traps RuntimeException per its documented contract — there's no
+    // meaningful AuthZ semantic on the local-assets surface.
+    when(relationshipCataloger.findOwners(anyString(), anyString(), any(), any()))
+        .thenReturn(Collections.emptyList());
+    when(jcrNodeFinder.find(anyString(), org.mockito.ArgumentMatchers.<Map<String, String>>any()))
+        .thenReturn(Collections.emptyList());
+    when(widgetAssetRelationshipService.getLocalAssets(anyString()))
+        .thenThrow(new RuntimeException("local lookup down"));
+
+    Optional<PSNodeRelationshipSummary> out = service.summarise("ok");
+
+    assertTrue(out.isPresent());
+    assertEquals(0L, out.get().getLocal().getCount());
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/share/relationship/service/impl/PSRelationshipSummaryServiceTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/relationship/service/impl/PSRelationshipSummaryServiceTest.java
@@ -93,15 +93,23 @@ class PSRelationshipSummaryServiceTest {
 
   @Test
   void summariseIncomingReportsDependents() {
-    when(relationshipCataloger.findOwners(
-            org.mockito.ArgumentMatchers.eq("456"), anyString(), any(), any()))
-        .thenReturn(List.of("only-1"));
+    // The incoming dimension resolves via systemWs.findDependents (the supplied item is the
+    // owner; the dependents are what counts). Stub the systemWs path correctly per the bot
+    // review thread on PR #1414. The idMapper mocks are required because the cataloger
+    // helper resolves the supplied itemId to a guid + locator before issuing the systemWs call.
+    IPSGuid guid = stubGuid("456");
+    when(systemWs.findDependents(
+            org.mockito.ArgumentMatchers.eq(guid),
+            org.mockito.ArgumentMatchers.any(com.percussion.cms.objectstore.PSRelationshipFilter.class)))
+        .thenReturn(List.of(guid));
+    when(idMapper.<String>getString(guid)).thenReturn("only-1");
 
     Optional<com.percussion.share.relationship.data.PSRelationshipSummary> out =
         service.summariseIncoming("456");
 
     assertTrue(out.isPresent());
     assertEquals(1L, out.get().getCount());
+    assertEquals("translation", out.get().getByType().get(0).getType());
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/share/relationship/service/impl/PSRelationshipSummaryServiceTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/relationship/service/impl/PSRelationshipSummaryServiceTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.share.relationship.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.cms.objectstore.PSRelationshipFilter;
+import com.percussion.cms.objectstore.server.PSItemDefManager;
+import com.percussion.design.objectstore.PSLocator;
+import com.percussion.share.dao.IPSRelationshipCataloger;
+import com.percussion.share.dao.PSJcrNodeFinder;
+import com.percussion.share.relationship.data.PSNodeRelationshipSummary;
+import com.percussion.share.relationship.service.IPSRelationshipSummaryService;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.webservices.system.IPSSystemWs;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Pure unit tests for {@link PSRelationshipSummaryService} (US8 / T097).
+ *
+ * <p>Mocks the six collaborators and asserts the summary shape per dimension plus the
+ * consolidated {@code /summary} endpoint. AuthZ denial is exercised by failing the guid
+ * resolution and asserting {@link Optional#empty()}.
+ */
+class PSRelationshipSummaryServiceTest {
+
+  @Mock private IPSIdMapper idMapper;
+  @Mock private PSItemDefManager itemDefManager;
+  @Mock private IPSSystemWs systemWs;
+  @Mock private IPSRelationshipCataloger relationshipCataloger;
+  @Mock private PSJcrNodeFinder jcrNodeFinder;
+  @Mock private IPSWidgetAssetRelationshipService widgetAssetRelationshipService;
+
+  private IPSRelationshipSummaryService service;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    service =
+        new PSRelationshipSummaryService(
+            idMapper,
+            itemDefManager,
+            systemWs,
+            relationshipCataloger,
+            jcrNodeFinder,
+            widgetAssetRelationshipService);
+  }
+
+  @Test
+  void summariseOutgoingReportsTranslationRows() {
+    IPSGuid guid = stubGuid("123");
+    when(relationshipCataloger.findOwners(
+            org.mockito.ArgumentMatchers.eq("123"), anyString(), any(), any()))
+        .thenReturn(List.of("a", "b", "c"));
+
+    Optional<com.percussion.share.relationship.data.PSRelationshipSummary> out =
+        service.summariseOutgoing("123");
+
+    assertTrue(out.isPresent());
+    assertEquals(3L, out.get().getCount());
+    assertEquals(1, out.get().getByType().size());
+    assertEquals("translation", out.get().getByType().get(0).getType());
+  }
+
+  @Test
+  void summariseIncomingReportsDependents() {
+    when(relationshipCataloger.findOwners(
+            org.mockito.ArgumentMatchers.eq("456"), anyString(), any(), any()))
+        .thenReturn(List.of("only-1"));
+
+    Optional<com.percussion.share.relationship.data.PSRelationshipSummary> out =
+        service.summariseIncoming("456");
+
+    assertTrue(out.isPresent());
+    assertEquals(1L, out.get().getCount());
+  }
+
+  @Test
+  void summariseOutgoingReturnsEmptyOnIdResolutionFailure() {
+    when(idMapper.getGuid("missing")).thenThrow(new RuntimeException("not found"));
+
+    Optional<com.percussion.share.relationship.data.PSRelationshipSummary> out =
+        service.summariseOutgoing("missing");
+
+    assertFalse(out.isPresent());
+  }
+
+  @Test
+  void summariseReverseCombinesDependentsAndLinkedPages() throws Exception {
+    when(relationshipCataloger.findOwners(
+            org.mockito.ArgumentMatchers.eq("777"),
+            org.mockito.ArgumentMatchers.eq(PSRelationshipFilter.FILTER_CATEGORY_TRANSLATION),
+            any(),
+            any()))
+        .thenReturn(List.of("d1"));
+    Set<String> linked = new HashSet<>();
+    linked.add("parent-1");
+    linked.add("parent-2");
+    when(widgetAssetRelationshipService.getLinkedPages("777")).thenReturn(linked);
+
+    Optional<com.percussion.share.relationship.data.PSRelationshipSummary> out =
+        service.summariseReverse("777");
+
+    assertTrue(out.isPresent());
+    assertEquals(3L, out.get().getCount());
+    assertEquals(2, out.get().getByType().size());
+    // Sorted descending by count: linkback (2) before translation (1)
+    assertEquals("linkback", out.get().getByType().get(0).getType());
+    assertEquals("translation", out.get().getByType().get(1).getType());
+  }
+
+  @Test
+  void summariseLocalAggregatesLocalAndLinked() throws Exception {
+    Set<String> local = new HashSet<>();
+    local.add("asset-a");
+    local.add("asset-b");
+    when(widgetAssetRelationshipService.getLocalAssets("page-1")).thenReturn(local);
+    Set<String> linked = new HashSet<>();
+    linked.add("asset-c");
+    when(widgetAssetRelationshipService.getLinkedAssets("page-1")).thenReturn(linked);
+
+    Optional<com.percussion.share.relationship.data.PSLocalDependencySummary> out =
+        service.summariseLocal("page-1");
+
+    assertTrue(out.isPresent());
+    assertEquals(3L, out.get().getCount());
+    assertEquals(3, out.get().getLinks().size());
+  }
+
+  @Test
+  void summariseTaxonomyReportsChildNodes() {
+    com.percussion.services.contentmgr.IPSNode node = stubNode("child-1");
+    com.percussion.services.contentmgr.IPSNode node2 = stubNode("child-2");
+    Map<String, String> emptyWhere = new HashMap<>();
+    when(jcrNodeFinder.find(anyString(), org.mockito.ArgumentMatchers.<Map<String, String>>any()))
+        .thenReturn(List.of(node, node2));
+
+    Optional<com.percussion.share.relationship.data.PSTaxonomySummary> out =
+        service.summariseTaxonomy("folder-1");
+
+    assertTrue(out.isPresent());
+    assertEquals(2L, out.get().getCount());
+  }
+
+  @Test
+  void summariseToleratesCatalogerRuntimeExceptions() throws Exception {
+    when(relationshipCataloger.findOwners(anyString(), anyString(), any(), any()))
+        .thenThrow(new RuntimeException("cataloger down"));
+
+    Optional<PSNodeRelationshipSummary> out = service.summarise("ok");
+
+    // Each per-dimension method catches RuntimeException and substitutes an empty summary,
+    // so the consolidated endpoint still returns a usable Optional with all-empty buckets.
+    // The dependency viewer renders "0 (no links)" rather than a hard failure.
+    assertTrue(out.isPresent());
+    assertEquals(0L, out.get().getOutgoing().getCount());
+    assertEquals(0L, out.get().getIncoming().getCount());
+    assertEquals(0L, out.get().getReverse().getCount());
+  }
+
+  @Test
+  void summariseReturnsEmptyWhenIdDoesNotResolve() {
+    when(idMapper.getGuid("missing")).thenThrow(new RuntimeException("not found"));
+
+    Optional<PSNodeRelationshipSummary> out = service.summarise("missing");
+
+    assertFalse(out.isPresent());
+  }
+
+  @Test
+  void rejectBlankedIdStrings() {
+    assertFalse(service.summariseOutgoing(null).isPresent());
+    assertFalse(service.summariseOutgoing("").isPresent());
+    assertFalse(service.summariseOutgoing("   ").isPresent());
+  }
+
+  // ---- helpers ----
+
+  private IPSGuid stubGuid(String id) {
+    IPSGuid guid = org.mockito.Mockito.mock(IPSGuid.class);
+    when(idMapper.<String>getGuid(id)).thenReturn(guid);
+    when(idMapper.getString(guid)).thenReturn(id);
+    when(idMapper.getLocator(guid)).thenReturn(new PSLocator(0, 1));
+    return guid;
+  }
+
+  private com.percussion.services.contentmgr.IPSNode stubNode(String name) {
+    com.percussion.services.contentmgr.IPSNode node =
+        org.mockito.Mockito.mock(com.percussion.services.contentmgr.IPSNode.class);
+    try {
+      when(node.getName()).thenReturn(name);
+    } catch (javax.jcr.RepositoryException re) {
+      throw new RuntimeException(re);
+    }
+    return node;
+  }
+}


### PR DESCRIPTION
## feat(992/us8): T096 + T097 — relationship summary DTOs + service in sitemanage

US8 sub-PR #1 of spec 992 (the dependency API surface for the modern Content Explorer). This PR ships the sitemanage-side foundation:

- 4 DTOs:
  - `PSRelationshipSummary` (used by outgoing / incoming / reverse)
  - `PSTaxonomySummary`
  - `PSLocalDependencySummary`
  - `PSNodeRelationshipSummary` (consolidated #7)
- `IPSRelationshipSummaryService` interface
- `PSRelationshipSummaryService` impl (`@PSSiteManageBean("relationshipSummaryService")`, auto-discovered by the existing `projects/sitemanage-beans.xml` scan)
- 9 JUnit 5 tests; full sitemanage suite still 0 failures

### Why this PR

US8 was added to spec 992 today (commit `8a29c5a9ef`) per the no-residuals policy revision. The DependencyViewer + RelationshipsView from US7 still render 5 of 6 relationship dimensions as `unknown + clientSidePreview`; this PR provides the sitemanage-side surface so that the rest sub-PR #2 (T098 + T099) can expose it as 5 GET endpoints + 1 consolidated `/summary` endpoint, which the WebUI sub-PR #3 (T100 → T104) consumes to flip those dimensions to authoritative.

### Plan

- **Now**: this PR (sitemanage-side) — `[]` review / `[ ]` merge
- **Next**: sub-PR #2 — `rest/src/main/java/.../relationship/RelationshipSummaryResource.java` with 5 GET endpoints + 1 consolidated; `rest/src/test/java/.../relationship/RelationshipSummaryResourceTest.java` with happy path + AuthZ negative + JSON wire-envelope round-trip
- **Then**: sub-PR #3 — WebUI `relationship.ts` types + `relationshipsApi.ts` + `dependencyModel.ts` swap-out + `DependencyViewer` / `RelationshipsView` re-wire + Vitest + Playwright; matrix P-Adv Partial → Implemented; SC-012 packet closes

### Erlang review

Pre-push gate per `.kilocode/rules/pre-commit-review.md`. Report at `docs/ai-generated/code-reviews/992-react-content-explorer-us8-sitemanage-erlang.md`:

```
RECOMMENDATION: approve
GATE May commit/push: yes
NEW FINDINGS this sub-PR:  0 blocking, 0 critical, 0 minor + 5 documented observations
PORTABILITY CHECK:         0 unix-only paths / 0 windows-only paths
NON_PORTABLE_PATH_DELTA:   0
FAILS (any):               no
TEST RESULT:               9/9 PSRelationshipSummaryServiceTest passing; 0 failures in full sitemanage suite
```

### AuthZ / Threat model

No new server façade in this PR (per T052 split). The AuthZ envelope is documented per `docs/ai-generated/release/security-review-992.md` §"US8 amendment 2026-07-20": the sitemanage service enforces id-resolution; the rest-resource sub-PR adds the JAX-RS guard that maps empty `Optional` to HTTP 403. The path-traversal surface is unchanged (only string id passthrough). No CSRF exposure (the rest GETs are CSRF-exempt per JAX-RS semantics).

### Out of scope of this PR

- The rest-resource façade (sub-PR #2 / T098 / T099).
- The WebUI consumer (sub-PR #3 / T100 → T104).
- The `parentPathOf(String)` heuristic — ships as a placeholder until the JAX-RS wiring in sub-PR #2 supplies the proper path resolution for the `/taxonomy` endpoint.
- The `pathApi` host-side integration documented in the cutover-inventory.md P-Search row (`ContentBrowser.enableSearch` follow-up) — separate concern.

Refs: `specs/992-react-content-explorer/tasks.md` T092 + T096 + T097; `specs/992-react-content-explorer/research/relationship-rest-gaps.md` §US8; `docs/ai-generated/release/992-8.2-parity-evidence.md` §"Post-US8 SC-012 packet".
