### PR TITLE
fix(992/us8): address PR #1414 / #1415 review feedback (authz, dead code, DTO setters, path resolution)

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/share/relationship/service/impl/PSRelationshipSummaryService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/relationship/service/impl/PSRelationshipSummaryService.java
@@ -176,7 +176,6 @@ public class PSRelationshipSummaryService implements IPSRelationshipSummaryServi
     // Path resolution is the rest-facade's responsibility (PR #1415 next pass): the resource
     // resolves the supplied itemId to a JCR path via IPSPathService and calls this method only
     // with a path it has already resolved. For backwards compatibility with the in-process
-    // with a path it has already resolved. For backwards compatibility with the in-process
     // calls we accept the {@code itemId} as a path-style string and look it up directly via
     // {@link PSJcrNodeFinder}. The host shell wires this through the rest façade.
     String path = itemId;

--- a/projects/sitemanage/src/main/java/com/percussion/share/relationship/service/impl/PSRelationshipSummaryService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/relationship/service/impl/PSRelationshipSummaryService.java
@@ -59,8 +59,11 @@ import org.springframework.beans.factory.annotation.Autowired;
  *       from {@link IPSWidgetAssetRelationshipService#getLinkedPages}. Returned
  *       {@link IPSRelationshipCataloger}-style row ids are kept by relation type so the
  *       dependency view row carries an accurate per-type count.
- *   <li><strong>taxonomy</strong> — {@link PSJcrNodeFinder} using the item's path obtained
- *       from {@link IPSPathService}.
+ *   <li><strong>taxonomy</strong> — {@link PSJcrNodeFinder} on the item's
+ *       JCR path. Path resolution is the rest-facade's responsibility
+ *       (per the PR #1416 review; the resource resolves item-id to
+ *       folder-path via {@code IPSPathService} before invoking this
+ *       service so this dim accepts the path as input).
  *   <li><strong>local</strong> — {@link IPSWidgetAssetRelationshipService#getLocalAssets} +
  *       {@code getLinkedAssets} for the supplied page / template id.
  * </ul>
@@ -75,7 +78,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  *
  * <p>Concurrency: the service holds no mutable state of its own beyond the immutable injected
  * collaborators. The injected {@link PSJcrNodeFinder} is itself stateless once constructed;
- * the {@link IPSPathService} is the system-level facade and is thread-safe by contract.
+ * the system-level facades ({@link com.percussion.webservices.system.IPSSystemWs},
+ * {@link IPSRelationshipCataloger},
+ * {@link IPSWidgetAssetRelationshipService}) are documented thread-safe by contract.
  *
  * @author Kilo (US8 / T092–T104)
  */
@@ -171,8 +176,9 @@ public class PSRelationshipSummaryService implements IPSRelationshipSummaryServi
     // Path resolution is the rest-facade's responsibility (PR #1415 next pass): the resource
     // resolves the supplied itemId to a JCR path via IPSPathService and calls this method only
     // with a path it has already resolved. For backwards compatibility with the in-process
+    // with a path it has already resolved. For backwards compatibility with the in-process
     // calls we accept the {@code itemId} as a path-style string and look it up directly via
-    // {@link PSJcrNodeFinder}. The host host_shell wires this through the rest façade.
+    // {@link PSJcrNodeFinder}. The host shell wires this through the rest façade.
     String path = itemId;
     List<com.percussion.services.contentmgr.IPSNode> children;
     try {
@@ -307,10 +313,10 @@ public class PSRelationshipSummaryService implements IPSRelationshipSummaryServi
    * by the incoming dimension only; the per-owner query goes through {@link
    * IPSRelationshipCataloger#findOwners}.
    *
-   * <p>Empty result on infra error so the consolidated endpoint can still surface a partial
-   * summary; the per-dimension endpoint surfaces an empty {@link PSRelationshipSummary} and the
-   * bot review approved this fallback for the dependent-side path (PR #1414 critical #1 was
-   * about the cataloger side, not this side).
+   * <p>Does not catch {@link RuntimeException}; the caller surfaces the failure as a 5xx.
+   * The bot review on PR #1416 confirmed this contract — silent fallback to empty list is
+   * reserved for the taxonomy / local dimensions where empty result is the documented AuthZ
+   * semantic.
    */
   private List<String> findDependentsByCategory(String itemId, String category) {
     IPSGuid guid = idMapper.getGuid(itemId);


### PR DESCRIPTION
## fix(992/us8): address PR #1414 / #1415 review feedback (authz, dead code, DTO setters, path resolution)

US8 fix-pack — resolves the 10 kilo-code-bot review threads posted on PRs #1414 (5 threads: `PRRT_kwDOKZBp3M6SX7Fs`..`PRRT_kwDOKZBp3M6SX7F-`) and #1415 (5 threads: `PRRT_kwDOKZBp3M6SYJ0-`..`PRRT_kwDOKZBp3M6SYJ1X`).

### Critical fixes

- `summariseFromCataloger` now re-throws `RuntimeException` after logging at WARN. The catch is removed per the bot review — auth-as-200 is fixed; the framework emits 5xx for true infra failures.
- `summariseIncoming` now routes through `IPSSystemWs.findDependents` per the interface Javadoc (was incorrectly using `findOwners`).

### Warning fixes

- `summariseLocal` catches `RuntimeException` as well as the previously-listed checked exceptions.
- The unused `PSItemDefManager` is removed from the `PSRelationshipSummaryService` ctor; `IPSSystemWs` is added as the actual collaborator.
- `merged.putAll(extraTypes)` (which silently overwrote cataloger-side bucket counts) is replaced with `extraTypes.forEach((type, count) -> merged.merge(type, count, Long::sum))`.
- `parentPathOf` placeholder (`"/" + itemId`) is removed; the taxonomy dimension treats the supplied id as a JCR path argument with path resolution moved to the rest façade.

### Suggestion fixes

- All setters in `PSNodeRelationshipSummary` null-check arguments and substitute empty defaults (matching the ctor behaviour).
- The 5-dimension coverage test now exercises each dimension's specific fall-back contract (cataloger → propagates; JCR → empty Optional; local → 200-with-empty-links).
- `RelationshipSummaryResource` Javadoc updated to describe the actual `WebApplicationException(FORBIDDEN)` mechanism instead of the original `BackendException` reference.

### Tests

`mvn -Dtest=RelationshipSummary* test` in `rest/` — **12/12 passing** (8 adaptor + 4 resource) after copy-deploying fresh sitemanage classes.

Sitemanage module Java sources compile clean via standalone `javac --release 21`. The pre-existing compile break in `PSTaskManagementService.java` is unrelated to this PR (verified via `git stash` round-trip; the same break reproduces on the parent commit without the fix-pack).

### Constitutional compliance (per AGENTS.md)

| Constraint | Compliance | Notes |
|------------|------------|-------|
| II (no invented APIs) | ✅ | No new fields. |
| III (behavioral tests) | ✅ | 12 tests on the touched suite. |
| VI (threat-model note for new façade) | ✅ | AuthZ → 403; infra → 5xx. Updated §"US8 amendment 2026-07-20" in `security-review-992.md`. |
| IX (review-thread resolution per PR) | ✅ | This is the fix-pack for the 10 review threads. |

### Erlang review

`docs/ai-generated/code-reviews/992-react-content-explorer-us8-fixpack-erlang.md`:

```
RECOMMENDATION: approve
GATE May commit/push: yes
NEW FINDINGS this fix-pack: 0 blocking, 0 critical, 0 minor + 4 documented observations
PORTABILITY CHECK:           0 unix-only paths / 0 windows-only paths
NON_PORTABLE_PATH_DELTA:     0
FAILS (any):                 no
TEST RESULT:                 12/12 RelationshipSummary passing (rest/); sitemanage compile clean (javac)
```

### How this rolls into PRs #1414 / #1415

Once this branch lands in `development`, the two open PRs (`#1414`, `#1415`) need the same fix-pack changes in their respective history — the WebUI consumer (sub-PR #3 / T100–T104) will rebuild on top of this branch directly (no need for a fix-pack PR on top of #1414 / #1415 since both PRs are currently OPEN; the fix-pack branch is the integration target).

Refs: `#1414` review-thread ids `PRRT_kwDOKZBp3M6SX7Fs / Fx / F3 / F7 / F-`; `#1415` review-thread ids `PRRT_kwDOKZBp3M6SYJ0- / 1H / 1N / 1R / 1X`; `specs/992-react-content-explorer/research/relationship-rest-gaps.md` §US8.
