### PR TITLE
fix(apibridge): resolve ClassCastException in FolderAdaptor by using IPSItemSummary.getId() (#1387)

### DIFF
--- a/docs/ai-generated/code-reviews/1387-folderadaptor-classcastexception-erlang.md
+++ b/docs/ai-generated/code-reviews/1387-folderadaptor-classcastexception-erlang.md
@@ -1,0 +1,41 @@
+# Erlang Review: Fix ClassCastException in FolderAdaptor (Issue #1387)
+
+**Date**: 2026-07-21  
+**Scope**: `projects/sitemanage/src/main/java/com/percussion/apibridge/FolderAdaptor.java` (`fix/1387-folderadaptor-classcastexception` vs `origin/development`)  
+**Intent**: Resolve `ClassCastException` on REST endpoints (`/rest/folders/by-path/`, `/rest/items/`) caused by an unsafe cast from `IPSItemSummary` to `PSItemSummary` (`com.percussion.services.content.data.PSItemSummary`).
+
+## Summary
+
+In `FolderAdaptor.java` line 298, `folderSummary` (returned by `folderHelper.findFolder` / `findItemById` as `IPSItemSummary`) was forcibly cast to `com.percussion.services.content.data.PSItemSummary`. At runtime, `folderHelper` returns `PSDataItemSummary` (`com.percussion.share.data.PSDataItemSummary`), causing `ClassCastException` and returning HTTP 500 across REST folder/item endpoints.
+
+**Fix**:
+- Replaced `String.valueOf(((PSItemSummary) folderSummary).getGUID().getUUID())` with `folderSummary.getId()`. The `IPSItemSummary` interface standardizes `getId()`, which both `PSDataItemSummary` and `PSItemSummary` implement safely.
+- Removed unused import `com.percussion.services.content.data.PSItemSummary`.
+
+**Cross-platform path review**: Clean. No local file paths constructed.
+
+## Scope
+
+- Base: `origin/development`
+- Head: `fix/1387-folderadaptor-classcastexception`
+- Files: `projects/sitemanage/src/main/java/com/percussion/apibridge/FolderAdaptor.java`
+- Memory patterns hit: Never cast Spring-injected service interfaces or abstract summary return types to concrete impls.
+
+## Recommendation
+
+**approve**
+
+**May commit/push**: **yes**
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs blocking | None |
+| Behavioral tests for new non-trivial logic | Existing `sitemanage` suite compiles and passes |
+| Secrets | None |
+| Cross-platform path handling | Clean |
+
+## Issues
+
+None open.

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/FolderAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/FolderAdaptor.java
@@ -66,7 +66,6 @@ import com.percussion.server.webservices.PSServerFolderProcessor;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.catalog.data.PSObjectSummary;
 import com.percussion.services.content.data.PSItemStatus;
-import com.percussion.services.content.data.PSItemSummary;
 import com.percussion.services.error.PSNotFoundException;
 import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.guidmgr.data.PSLegacyGuid;
@@ -294,8 +293,8 @@ public class FolderAdaptor implements IFolderAdaptor {
     if (StringUtils.isEmpty(path) && StringUtils.isEmpty(folderName)) {
       isSiteRoot = true;
     }
-    // convert summary guid to string id
-    String summaryId = String.valueOf(((PSItemSummary) folderSummary).getGUID().getUUID());
+    // convert summary to string id
+    String summaryId = folderSummary.getId();
     folder.setId(summaryId);
 
     // Folder properties for workflow


### PR DESCRIPTION
## Summary

Fixes issue #1387 where REST endpoints (e.g., `GET /rest/folders/by-path/Assets`, `GET /rest/items/search`) fail with HTTP 500 `ClassCastException`.

### Root Cause
In `FolderAdaptor.java` line 298:
```java
String summaryId = String.valueOf(((PSItemSummary) folderSummary).getGUID().getUUID());
```
`folderSummary` is returned as `IPSItemSummary` by `folderHelper.findFolder` / `findItemById`. At runtime, `folderHelper` returns `PSDataItemSummary` (`com.percussion.share.data.PSDataItemSummary`), causing a `ClassCastException` when forcibly cast to `com.percussion.services.content.data.PSItemSummary`.

### Fix
- Replaced the unsafe cast with `folderSummary.getId()`, which is defined on `IPSItemSummary` and implemented safely by both `PSDataItemSummary` and `PSItemSummary`.
- Removed the unused import `com.percussion.services.content.data.PSItemSummary`.
- Conducted local Erlang Code Review (`docs/ai-generated/code-reviews/1387-folderadaptor-classcastexception-erlang.md`).

Closes #1387