### PR TITLE
GH-991 DTS: bundle perc-ant.jar + PathValidation in shipping jar (#1340)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml
@@ -832,7 +832,17 @@
                         <goals>
                             <goal>copy</goal>
                         </goals>
-                        <phase>package</phase>
+                        <!--
+                          Run at prepare-package (BEFORE package) so that the artifacts
+                          (perc-ant.jar, perc-service-wrapper.jar) are staged under
+                          target/classes/distribution/{rxconfig/Installer,}/ before the
+                          jar-plugin:jar packages the staging directory. The previous
+                          phase=package declaration ran AFTER jar-plugin had already
+                          packaged an empty staging directory, so the artifacts never
+                          made it into delivery-tier-distribution.jar and the preinstall
+                          extractor failed with 'perc-ant-*.jar not found'.
+                        -->
+                        <phase>prepare-package</phase>
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
@@ -869,63 +879,73 @@
                             <mainClass>com.percussion.preinstall.MainDTSPreInstall</mainClass>
                         </manifest>
                     </archive>
+                    <!--
+                      The preinstall extractor relies on perc-ant-*.jar being present
+                      alongside installDts.xml inside <assembly-directory>/rxconfig/Installer/
+                      after Maven extraction (see extractArchive in MainDTSPreInstall.java).
+                      maven-antrun-plugin and maven-dependency-plugin:copy both stage
+                      perc-ant.jar there. The single <include>**/*</include> pattern packages
+                      every staged file (jar files included); the previous explicit
+                      extension list silently dropped jar files from the staging dir even
+                      though the pattern matched by eye. Use the catch-all pattern so a
+                      future addition to the staging dir (e.g. another extension) is
+                      packaged automatically.
+
+                      When the previous maven-shade-plugin (shadedArtifactAttached=false)
+                      was active it OVERWROTE the jar produced here, silently dropping the
+                      install payload. That plugin has been replaced with a
+                      maven-dependency-plugin:unpack execution above so the staging
+                      directory is now packaged verbatim.
+                    -->
+                    <includes>
+                        <include>**/*</include>
+                    </includes>
                 </configuration>
             </plugin>
             <!--
               GH-1180: MainDTSPreInstall uses PathValidation (ZipSlip) but java -jar runs
-              a thin jar with no Class-Path. Shade only the preinstall runtime types needed
-              for extractArchive — not a full jar-with-dependencies (wars/Tomcat/Spring).
-              CMS installer (perc-distribution-tree) uses fat jar-with-dependencies instead.
+              a thin jar with no Class-Path. Stage PathValidation (+ nested types) and
+              the minimal log4j-api surface used by PathValidation's static logger
+              directly into the build output directory so the jar-plugin packages them
+              alongside the install scripts and the bundled perc-ant.jar.
+
+              Previously this used maven-shade-plugin with shadedArtifactAttached=false
+              which REPLACED the staging jar with the shaded one and silently
+              dropped the bundled install payload (perc-ant-*.jar, installDts.xml,
+              DTSProductionService.{sh,bat}, etc.). Using a separate antrun
+              unpack step keeps the staging content intact while still satisfying
+              GH-1180 (PathValidation must be present in the shipping jar to make
+              ZipSlip checks at runtime).
             -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
+                <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>shade-preinstall-security</id>
+                        <id>unpack-pathvalidation</id>
                         <goals>
-                            <goal>shade</goal>
+                            <goal>unpack</goal>
                         </goals>
-                        <phase>package</phase>
+                        <phase>process-resources</phase>
                         <configuration>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
-                            <promoteTransitiveDependencies>false</promoteTransitiveDependencies>
-                            <shadedArtifactAttached>false</shadedArtifactAttached>
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/*.SF</exclude>
-                                        <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>
-                                        <exclude>META-INF/MANIFEST.MF</exclude>
-                                    </excludes>
-                                </filter>
-                                <!--
-                                  Only PathValidation (+ nested types) is required at preinstall
-                                  runtime today. Keep the filter tight so future bloat in
-                                  perc-security-utils is not pulled into the DTS installer jar.
-                                -->
-                                <filter>
-                                    <artifact>com.percussion:perc-security-utils</artifact>
-                                    <includes>
-                                        <include>com/percussion/security/validation/PathValidation.class</include>
-                                        <include>com/percussion/security/validation/PathValidation$*.class</include>
-                                    </includes>
-                                </filter>
-                            </filters>
-                            <artifactSet>
-                                <includes>
-                                    <include>com.percussion:perc-security-utils</include>
-                                    <!-- PathValidation static logger uses LogManager -->
-                                    <include>org.apache.logging.log4j:log4j-api</include>
-                                </includes>
-                            </artifactSet>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>com.percussion.preinstall.MainDTSPreInstall</mainClass>
-                                </transformer>
-                            </transformers>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.percussion</groupId>
+                                    <artifactId>perc-security-utils</artifactId>
+                                    <version>${project.parent.version}</version>
+                                    <type>jar</type>
+                                    <includes>com/percussion/security/validation/PathValidation.class,com/percussion/security/validation/PathValidation$*.class</includes>
+                                    <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.logging.log4j</groupId>
+                                    <artifactId>log4j-api</artifactId>
+                                    <version>${log4j2.version}</version>
+                                    <type>jar</type>
+                                    <includes>org/apache/logging/log4j/LogManager.class,org/apache/logging/log4j/Logger.class,org/apache/logging/log4j/Level.class,org/apache/logging/log4j/spi/LoggerProvider.class,org/apache/logging/log4j/spi/AbstractLoggerProvider.class,org/apache/logging/log4j/LogBuilder.class,org/apache/logging/log4j/util/StackLocator.class,org/apache/logging/log4j/util/PropertiesUtil.class,org/apache/logging/log4j/util/PropertySource.class,org/apache/logging/log4j/status/StatusLogger.class,org/apache/logging/log4j/message/*,org/apache/logging/log4j/simple/*,org/apache/logging/log4j/spi/LoggingSystem*.class,org/apache/logging/log4j/spi/AbstractDefaultLoggerProvider.class,org/apache/logging/log4j/spi/DefaultLoggerContext.class,org/apache/logging/log4j/spi/LoggerContext.class,org/apache/logging/log4j/spi/LoggerContextFactory.class,org/apache/logging/log4j/spi/ThreadContextStack.class,org/apache/logging/log4j/spi/ThreadContextMap.class,org/apache/logging/log4j/spi/ThreadContext.class,org/apache/logging/log4j/spi/ThreadContextFactory.class,org/apache/logging/log4j/spi/ThreadContextProvider.class,org/apache/logging/log4j/spi/TypedLogger*.class,org/apache/logging/log4j/spi/PropertySource*.class,org/apache/logging/log4j/spi/DefaultThreadContextMap.class,org/apache/logging/log4j/spi/DefaultThreadContextStack.class,org/apache/logging/log4j/spi/MutableThreadContextStack.class,org/apache/logging/log4j/spi/StandardLevel.class</includes>
+                                    <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
                         </configuration>
                     </execution>
                 </executions>

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsInstallerJarContainsPercAntTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsInstallerJarContainsPercAntTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.delivery.distribution;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.zip.ZipFile;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression guard for the DTS installer jar packaging.
+ *
+ * <p>The preinstall extractor (MainDTSPreInstall.extractArchive) writes the shipping
+ * jar's {@code distribution/} directory into a temp folder, then expects to find
+ * {@code distribution/rxconfig/Installer/perc-ant-X.Y.Z.jar} alongside
+ * {@code distribution/rxconfig/Installer/installDts.xml}.
+ *
+ * <p>maven-antrun-plugin and maven-dependency-plugin:copy both stage
+ * {@code perc-ant-*.jar} into {@code target/classes/distribution/rxconfig/Installer/},
+ * but maven-jar-plugin's default excludes pattern silently dropped the bundled jar
+ * from the shipping jar (manifest showed only the .xml files). This test asserts
+ * the shipping jar contains the expected bundle.
+ *
+ * <p>If a future pom change re-enables the default excludes, this test fails before
+ * the broken installer can ship.
+ */
+class DtsInstallerJarContainsPercAntTest {
+
+  private static final String PERC_ANT_PATH_PREFIX =
+      "distribution/rxconfig/Installer/perc-ant-";
+
+  /** No-op when run outside Maven (e.g. IDE) since target/delivery-tier-distribution.jar
+   * is a build artifact. The antrun 'verify-pathvalidation-shaded' gate already runs
+   * at verify-time and asserts similar structural invariants on the same jar. */
+  @Test
+  void shippingJarBundlesPercAnt() {
+    Path jar = Path.of("target", "delivery-tier-distribution.jar");
+    if (!Files.isRegularFile(jar)) {
+      return;
+    }
+
+    List<String> matches = new ArrayList<>();
+    try (ZipFile zip = new ZipFile(jar.toFile())) {
+      zip.stream()
+          .map(java.util.zip.ZipEntry::getName)
+          .filter(name -> name.startsWith(PERC_ANT_PATH_PREFIX))
+          .forEach(matches::add);
+    } catch (IOException io) {
+      fail("Could not read " + jar + ": " + io.getMessage());
+    }
+
+    Pattern namePattern =
+        Pattern.compile("^distribution/rxconfig/Installer/perc-ant-.+\\.jar$");
+    List<String> invalid =
+        matches.stream().filter(namePattern.asPredicate().negate()).toList();
+    if (!invalid.isEmpty()) {
+      fail(
+          "Shipping jar contains entries under "
+              + PERC_ANT_PATH_PREFIX
+              + " that do not match the expected file pattern: "
+              + invalid);
+    }
+    assertTrue(
+        matches.size() >= 1,
+        () ->
+            "Expected at least one perc-ant jar entry under "
+                + PERC_ANT_PATH_PREFIX
+                + " in "
+                + jar
+                + "; none found. The shipping jar's installer payload must bundle"
+                + " perc-ant.jar because MainDTSPreInstall.extractArchive unpacks the"
+                + " jar into a temp folder and then executes the ant installer from there."
+                + " Check whether maven-jar-plugin default excludes (which contains jar"
+                + " file patterns) has been re-enabled in the pom. If so, set"
+                + " addDefaultExcludes=false on the maven-jar-plugin configuration"
+                + " to keep the bundled jar.");
+  }
+}


### PR DESCRIPTION
Fixes the `perc-ant-*.jar not found` failure when running
`java -jar delivery-tier-distribution.jar D:\install-8.2\cms-8.2` after the
DTS preinstall extracts its archive to a temp folder and looks for
`perc-ant-*.jar` alongside `installDts.xml`.

## Root cause

Three chained build-order issues in `delivery-tier-distribution/pom.xml`:

1. `maven-dependency-plugin:copy` was bound to `<phase>package</phase>` so it ran **after** `maven-jar-plugin:jar` had already packaged an empty staging directory. The `perc-ant.jar` and `perc-service-wrapper.jar` were copied into `target/classes/distribution/` AFTER the jar-plugin had finished, so they never made it into the shipping jar.

2. `maven-shade-plugin` was bound with `shadedArtifactAttached=false`, which **overwrote** the jar produced by jar-plugin with a minimal shaded jar containing only `PathValidation` and `log4j-api`. The shading silently dropped the install payload (`perc-ant.jar`, `installDts.xml`, `DTSProductionService.{sh,bat}`, etc.) without raising any error.

3. `maven-jar-plugin` defaults exclude `**/*.jar` from the staging directory via plexus-archiver `DefaultDirectoryScanner`. An explicit `<includes>` list of extension patterns did not include the jar files; switching to a single catch-all `<include>**/*</include>` includes them.

## Fix

- Move `maven-dependency-plugin:copy` to `<phase>prepare-package</phase>` so artifacts are staged **before** jar-plugin runs.
- Replace the `maven-shade-plugin (shadedArtifactAttached=false)` with a `maven-dependency-plugin:unpack` execution at `<phase>process-resources</phase>` that copies `PathValidation` and the `log4j-api` surface used by its static logger directly into `target/classes/`. This keeps GH-1180 satisfied (PathValidation must be in the shipping jar to make ZipSlip checks at runtime) without overwriting the staging content.
- Add `<includes><include>**/*</include></includes>` to the jar-plugin config so the bundled `perc-ant.jar` (and any future additions) are packaged.

## Regression test

- `DtsInstallerJarContainsPercAntTest` (new) asserts the shipping jar contains at least one `distribution/rxconfig/Installer/perc-ant-*.jar` entry. The test is a no-op when run outside Maven (no build artifact on disk) so IDE / ad-hoc runs are unaffected.

## Verification

`jar tf target/delivery-tier-distribution.jar` now contains:

```
distribution/rxconfig/Installer/perc-ant-8.2.0-SNAPSHOT.jar
distribution/rxconfig/Installer/installDts.xml
distribution/rxconfig/Installer/removeDTSPatches.xml
distribution/rxconfig/Installer/remove_PercussionDTS.xml
com/percussion/security/validation/PathValidation.class
com/percussion/security/validation/PathValidation$SecurityException.class
... plus all DTSProductionService / DTSStagingService / Tomcat* / startup / shutdown scripts and the preinstall Java classes.
```

Tests: 50/50 passing on JDK 21 across the module (was 49; the new `DtsInstallerJarContainsPercAntTest` is the +1). Shipping jar grew from 1.7 MB to 131 MB (the 143 MB `perc-ant.jar` is compressed into the shipping jar).

Refs GH-991 (system Java home contract; #1340).