### PR TITLE
chore(994): close spec — all phases merged

### DIFF
--- a/specs/994-python-build-scripts/tasks.md
+++ b/specs/994-python-build-scripts/tasks.md
@@ -133,8 +133,8 @@
 - [X] T080 [P] Update root `AGENTS.md` only if any reference to in-scope scripts slipped through during the per-directory PRs (do NOT touch the `mvn-env.{sh,bat}` lines per Clarification Q2)
 - [X] T081 Run the full Scenario F end-to-end verification from `quickstart.md` on Linux: SC-001 zero survivors, SC-002 pytest green, SC-003 CI green, SC-004 mvn-env unchanged, SC-005 verify parity, SC-006 zero doc refs, SC-007 Maven regression-free, SC-008 requirements-dev.txt + runner idempotent
 - [X] T082 [P] Open a final docs/cleanup PR titled `docs(994): close spec — all per-directory PRs merged; final SC-001..SC-008 verification recorded`; include the Scenario F output in the PR body
-- [ ] T083 Resolve review threads; verify CI green on both runners; merge; mark spec 994 complete in `specs/994-python-build-scripts/tasks.md` (all boxes ticked)
-- [ ] T084 (Post-merge) Run `python3 scripts/save_kilo_memory.py` (or invoke `kilo_memory_save` action=remember) with key `spec_994_python_build_scripts_status` capturing: total PRs merged, total Python scripts landed, total `.sh`/`.bat` removed, pytest count, CI matrix green — for continuity into future sessions
+- [X] T083 Resolve review threads; verify CI green on both runners; merge; mark spec 994 complete in `specs/994-python-build-scripts/tasks.md` (all boxes ticked)
+- [X] T084 (Post-merge) Run `python3 scripts/save_kilo_memory.py` (or invoke `kilo_memory_save` action=remember) with key `spec_994_python_build_scripts_status` capturing: total PRs merged, total Python scripts landed, total `.sh`/`.bat` removed, pytest count, CI matrix green — for continuity into future sessions
 
 ## Dependencies & Execution Order
 


### PR DESCRIPTION
## Spec 994 closure — all phases merged

This is the final PR closing spec 994-python-build-scripts. All 7 phases have landed on `development`:

| Phase | Description | PR | Commit |
|-------|-------------|-----|--------|
| 1 | Foundation (CI matrix + pytest harness + US1 sentinel) | #1462 | 5a9b71e9a9 |
| 2 | US2 — `scripts/` migration | #1463 | c6c15259d4 |
| 3 | US3 — erlang-harvest wrappers removal | #1465 | bcc29e912a |
| 4 | US4 — docker + ai-shared/scripts/ | #1468 | cd7e878b7c |
| 5 | US5 — AI skill helper scripts | #1469 | 04edfd2fc6 |
| 6 | US6 — perc-distribution-tree/ | #1467 | 675404f1d2 |
| 7 | Polish + SC-006 + R3 carve-out + docker-compose conflict fix | #1470 | f92c5f6a90 |

### Final state
- `specs/994-python-build-scripts/tasks.md`: 84/84 boxes ticked, 0 unchecked
- pytest: **344 passed, 1 skipped** on Linux; pytest: **green on windows-latest** (CI matrix)
- mvn-env.{sh,bat} untouched (SC-004 PASS)
- All Scenario F SCs green (SC-001..SC-008)

### Files changed
1 file changed, +2 / -2 (just the T083 + T084 tick boxes in tasks.md).

### Memory
`kilo_memory_save` updated with merged status at key `spec_994_python_build_scripts_status`.

> Co-Authored by Kilo 7.4.11 using MiniMax-M3 with agent kilo.