### PR TITLE
GH-991 DTS preinstall: fix NoClassDefFoundError for log4j-api AbstractLogger

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml
@@ -825,6 +825,7 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
@@ -868,6 +869,48 @@
                             <overWriteSnapshots>true</overWriteSnapshots>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>unpack-pathvalidation</id>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.percussion</groupId>
+                                    <artifactId>perc-security-utils</artifactId>
+                                    <version>${project.parent.version}</version>
+                                    <type>jar</type>
+                                    <includes>com/percussion/security/validation/PathValidation.class,com/percussion/security/validation/PathValidation$*.class</includes>
+                                    <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.logging.log4j</groupId>
+                                    <artifactId>log4j-api</artifactId>
+                                    <version>${log4j2.version}</version>
+                                    <type>jar</type>
+                                    <!--
+                                      PathValidation's <clinit> resolves LogManager at
+                                      class init, and LogManager's <clinit> transitively
+                                      loads org.apache.logging.log4j.spi.AbstractLogger (the
+                                      superclass of Logger) plus many other log4j-api
+                                      classes. Listing each class by hand is brittle —
+                                      previous attempt missed AbstractLogger and produced
+                                      a NoClassDefFoundError at first use. Unpack the
+                                      full log4j-api jar so every internal class is
+                                      present; the size overhead (~1.5 MB) is negligible
+                                      compared to the 143 MB perc-ant.jar already bundled.
+                                      module-info.class is excluded so the JPMS
+                                      `requires org.osgi.core` it declares does not have
+                                      to be resolvable in this non-modular runtime.
+                                    -->
+                                    <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                                    <excludes>module-info.class</excludes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -901,54 +944,6 @@
                         <include>**/*</include>
                     </includes>
                 </configuration>
-            </plugin>
-            <!--
-              GH-1180: MainDTSPreInstall uses PathValidation (ZipSlip) but java -jar runs
-              a thin jar with no Class-Path. Stage PathValidation (+ nested types) and
-              the minimal log4j-api surface used by PathValidation's static logger
-              directly into the build output directory so the jar-plugin packages them
-              alongside the install scripts and the bundled perc-ant.jar.
-
-              Previously this used maven-shade-plugin with shadedArtifactAttached=false
-              which REPLACED the staging jar with the shaded one and silently
-              dropped the bundled install payload (perc-ant-*.jar, installDts.xml,
-              DTSProductionService.{sh,bat}, etc.). Using a separate antrun
-              unpack step keeps the staging content intact while still satisfying
-              GH-1180 (PathValidation must be present in the shipping jar to make
-              ZipSlip checks at runtime).
-            -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>unpack-pathvalidation</id>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <phase>process-resources</phase>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.percussion</groupId>
-                                    <artifactId>perc-security-utils</artifactId>
-                                    <version>${project.parent.version}</version>
-                                    <type>jar</type>
-                                    <includes>com/percussion/security/validation/PathValidation.class,com/percussion/security/validation/PathValidation$*.class</includes>
-                                    <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.apache.logging.log4j</groupId>
-                                    <artifactId>log4j-api</artifactId>
-                                    <version>${log4j2.version}</version>
-                                    <type>jar</type>
-                                    <includes>org/apache/logging/log4j/LogManager.class,org/apache/logging/log4j/Logger.class,org/apache/logging/log4j/Level.class,org/apache/logging/log4j/spi/LoggerProvider.class,org/apache/logging/log4j/spi/AbstractLoggerProvider.class,org/apache/logging/log4j/LogBuilder.class,org/apache/logging/log4j/util/StackLocator.class,org/apache/logging/log4j/util/PropertiesUtil.class,org/apache/logging/log4j/util/PropertySource.class,org/apache/logging/log4j/status/StatusLogger.class,org/apache/logging/log4j/message/*,org/apache/logging/log4j/simple/*,org/apache/logging/log4j/spi/LoggingSystem*.class,org/apache/logging/log4j/spi/AbstractDefaultLoggerProvider.class,org/apache/logging/log4j/spi/DefaultLoggerContext.class,org/apache/logging/log4j/spi/LoggerContext.class,org/apache/logging/log4j/spi/LoggerContextFactory.class,org/apache/logging/log4j/spi/ThreadContextStack.class,org/apache/logging/log4j/spi/ThreadContextMap.class,org/apache/logging/log4j/spi/ThreadContext.class,org/apache/logging/log4j/spi/ThreadContextFactory.class,org/apache/logging/log4j/spi/ThreadContextProvider.class,org/apache/logging/log4j/spi/TypedLogger*.class,org/apache/logging/log4j/spi/PropertySource*.class,org/apache/logging/log4j/spi/DefaultThreadContextMap.class,org/apache/logging/log4j/spi/DefaultThreadContextStack.class,org/apache/logging/log4j/spi/MutableThreadContextStack.class,org/apache/logging/log4j/spi/StandardLevel.class</includes>
-                                    <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fixes the `NoClassDefFoundError: org/apache/logging/log4j/spi/AbstractLogger` at DTS preinstall runtime that surfaces once `perc-ant-*.jar not found` (PR #1471) is resolved.

## Symptom

After #1471 (which bundles `perc-ant.jar` + `PathValidation` into the shipping jar), running the DTS preinstall cleanly extracts the archive and starts the bundled Ant installer. The install then crashes on the next class init:

```
Caused by: java.lang.ClassNotFoundException: org.apache.logging.log4j.spi.AbstractLogger
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
        ...
        at org.apache.logging.log4j.LogManager.<clinit>(LogManager.java:57)
        at com.percussion.security.validation.PathValidation.<clinit>(PathValidation.java:106)
        at com.percussion.preinstall.MainDTSPreInstall.extractArchive(MainDTSPreInstall.java:238)
```

## Root cause

`PathValidation.<clinit>` resolves `LogManager` at class init. `LogManager.<clinit>` transitively loads `org.apache.logging.log4j.spi.AbstractLogger` (the superclass of `Logger`) plus many other log4j-api classes. The previous approach listed each class by hand in `maven-dependency-plugin:unpack` and missed `AbstractLogger`, so the shipping jar was missing the parent of `Logger` and the JVM failed at first use.

## Fix

Unpack the full `log4j-api` jar instead of an explicit class list. Size overhead is ~1.5 MB; the 143 MB `perc-ant.jar` already bundled makes it negligible.

`module-info.class` is excluded from the unpack because `log4j-api 2.25.4` declares `requires org.osgi.core` in its JPMS descriptor. This non-modular preinstall runtime does not need to resolve OSGi services, so the module-info would otherwise produce a `module not found: org.osgi.core` linkage error during the next build phase.

## End-to-end verification

```cmd
cd deliverytiersuite\delivery-tier-suite\delivery-tier-distribution\target
java -jar delivery-tier-distribution.jar D:\install-8.2\cms-8.2
```

```
perc.java.home=D:\tools\jdk-21.0.9
DTS Java home selection: JAVA_HOME=D:\tools\jdk-21.0.9 source=auto-selected (single candidate)
Creating file ...\percDTSInstallTmp_*\rxconfig\Installer\perc-ant-8.2.0-SNAPSHOT.jar   <- perc-ant.jar found
Creating file ...\rxconfig\Installer\installDts.xml
Creating file ...\DTSProductionService.{sh,bat}, DTSStagingService.{sh,bat}
Creating file ...\TomcatStartup.{sh,bat}, TomcatShutdown.{sh,bat}
Creating file ...\resolve-java-home.{sh,bat}, startup.{sh,bat}, shutdown.{sh,bat}
```

The `AbstractLogger` `NoClassDefFoundError` is gone. The preinstall now successfully reaches `installDts.xml:129`.

## Note on the next failure

The installer then fails at `installDts.xml:344` with a separate, pre-existing error:

```
<tempdir>/Deployment/Server/common/lib does not exist.
```

That is filed as issue **#1473** — the DTS distribution payload is missing the `Deployment/Server/` runtime library tree (log4j jars, commons-logging, slf4j, disrupter) that `installDts.xml` expects to copy into the install target. Out of scope for this PR.

## Tests

50/50 passing on JDK 21 across the module (no regressions; the new `DtsInstallerJarContainsPercAntTest` regression guard from #1471 still passes).

Refs GH-991 (`#1340`) system Java home contract; supersedes the local-only commit `6a46b4feb` on `development` branch tip.