### PR TITLE
GH-991 DTS preinstall: bundle runtime libs + guard upgrade-only <replace> blocks (issues #1473, #1475)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml
@@ -926,11 +926,10 @@
                           perc-ant.jar / perc-service-wrapper.jar before jar-plugin
                           packages the staging tree.
 
-                          disrupter*.jar is not bundled because installDts.xml line 349
-                          has a glob typo (it should be disruptor*.jar). The actual
-                          `com.lmax:disruptor` jar is copied under the disruptor*.jar
-                          name so the install script's typo'd glob can pick it up if
-                          corrected in a follow-up.
+                          installDts.xml selects disruptor*.jar (typo disrupter* fixed
+                          on this branch). The com.lmax:disruptor jar is staged here so
+                          the Ant log4j2/lib copy finds it even if Cargo packaging order
+                          differs.
                         -->
                         <phase>prepare-package</phase>
                         <configuration>
@@ -1045,6 +1044,52 @@
                         </configuration>
                     </execution>
                     <!--
+                      Stage Cargo Tomcat + DTS wars into the installer assembly.
+
+                      cargo:package (prepare-package) builds a full configured Tomcat under
+                      ${project.build.directory}/package (bin, conf/server.xml, lib, webapps/*.war).
+                      Historically packager/outputLocation was intended to write straight into
+                      ${assembly-directory}/Deployment/Server, but with cargo-maven2→maven3 1.9.x
+                      the package still lands in target/package and the shipping jar only got
+                      root scripts + common/lib — install finished in seconds with no Tomcat.
+
+                      Copy after cargo:package and before jar:jar (this plugin is declared after
+                      cargo / dependency-plugin so prepare-package order is correct).
+                    -->
+                    <execution>
+                        <id>stage-cargo-package-into-assembly</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>prepare-package</phase>
+                        <configuration>
+                            <target>
+                                <property name="cargo.package.dir" location="${project.build.directory}/package"/>
+                                <property name="cargo.package.server.xml" location="${cargo.package.dir}/conf/server.xml"/>
+                                <available file="${cargo.package.server.xml}" property="cargo.package.present"/>
+                                <fail unless="cargo.package.present"
+                                      message="Cargo package incomplete: missing ${cargo.package.server.xml}. cargo:package must run before this step (phase prepare-package)."/>
+                                <mkdir dir="${assembly-directory}/Deployment/Server"/>
+                                <copy todir="${assembly-directory}/Deployment/Server" overwrite="true" verbose="false">
+                                    <fileset dir="${cargo.package.dir}">
+                                        <exclude name="temp/**"/>
+                                    </fileset>
+                                </copy>
+                                <!-- Match prior antrun cleanup: do not ship Tomcat manager apps -->
+                                <delete dir="${assembly-directory}/Deployment/Server/webapps/manager" failonerror="false"/>
+                                <delete dir="${assembly-directory}/Deployment/Server/webapps/host-manager" failonerror="false"/>
+                                <delete file="${assembly-directory}/Deployment/Server/conf/logging.properties" failonerror="false"/>
+                                <available file="${assembly-directory}/Deployment/Server/conf/server.xml" property="assembly.has.server.xml"/>
+                                <fail unless="assembly.has.server.xml"
+                                      message="Assembly missing Deployment/Server/conf/server.xml after staging Cargo package"/>
+                                <available file="${assembly-directory}/Deployment/Server/webapps/perc-metadata-services.war" property="assembly.has.metadata.war"/>
+                                <fail unless="assembly.has.metadata.war"
+                                      message="Assembly missing perc-metadata-services.war after staging Cargo package"/>
+                                <echo message="Staged Cargo package into ${assembly-directory}/Deployment/Server"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <!--
                       GH-1180 regression gate: the packaged installer jar must contain
                       PathValidation after the minimal shade. Runs on every verify so a
                       future pom change cannot drop the shade without failing the build.
@@ -1073,7 +1118,15 @@
                                     <contains string="${dts.installer.listing}" substring="org/apache/logging/log4j/LogManager.class"/>
                                 </condition>
                                 <fail unless="dts.has.log4j.api" message="GH-1180: ${dts.installer.jar} is missing log4j-api (LogManager) required by PathValidation."/>
-                                <echo message="GH-1180: PathValidation + log4j-api present in ${dts.installer.jar}"/>
+                                <condition property="dts.has.server.xml">
+                                    <contains string="${dts.installer.listing}" substring="distribution/Deployment/Server/conf/server.xml"/>
+                                </condition>
+                                <fail unless="dts.has.server.xml" message="DTS installer jar missing distribution/Deployment/Server/conf/server.xml (Cargo package not staged)."/>
+                                <condition property="dts.has.metadata.war">
+                                    <contains string="${dts.installer.listing}" substring="distribution/Deployment/Server/webapps/perc-metadata-services.war"/>
+                                </condition>
+                                <fail unless="dts.has.metadata.war" message="DTS installer jar missing perc-metadata-services.war (Cargo package not staged)."/>
+                                <echo message="GH-1180: PathValidation + log4j-api + Tomcat/server.xml + metadata war present in ${dts.installer.jar}"/>
                             </target>
                         </configuration>
                     </execution>

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/rxconfig/Installer/installDts.xml
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/rxconfig/Installer/installDts.xml
@@ -346,7 +346,7 @@
 					<include name="log4j*.jar" />
 					<include name="commons-logging*.jar" />
 					<include name="slf4j*.jar" />
-					<include name="disrupter*.jar" />
+					<include name="disruptor*.jar" />
 				</fileset>
 			</copy>
 
@@ -474,6 +474,16 @@
 						</fileset>
 					</copy>
 
+					<!-- Fail closed: hollow installer jars (scripts + common/lib only) used to
+					     report BUILD SUCCESSFUL with no Tomcat/webapps. Fresh install must have
+					     a real server tree from the shipping distribution payload. -->
+					<available
+						file="${install.dir}${staging.dir}/Deployment/Server/conf/server.xml"
+						type="file"
+						property="dts.fresh.server.xml.present" />
+					<fail unless="dts.fresh.server.xml.present"
+						message="DTS fresh install: ${install.dir}${staging.dir}/Deployment/Server/conf/server.xml is missing after copying Deployment/** from the installer payload. The delivery-tier-distribution.jar was built without the Cargo Tomcat package (bin/conf/lib/webapps). Rebuild delivery-tier-distribution so jar contains distribution/Deployment/Server/conf/server.xml and webapps/*.war." />
+
 					<copy todir="${install.dir}${staging.dir}/" verbose="true">
 						<fileset dir="${install.src}">
 							<include name="*" />
@@ -595,7 +605,7 @@
 							<include name="log4j*.jar" />
 							<include name="commons-logging*.jar" />
 							<include name="slf4j*.jar" />
-							<include name="disrupter*.jar" />
+							<include name="disruptor*.jar" />
 						</fileset>
 					</copy>
 

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsInstallerJarContainsTomcatTreeTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsInstallerJarContainsTomcatTreeTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.delivery.distribution;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.ZipFile;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression guard: the DTS shipping jar must include the full Cargo-packaged Tomcat tree
+ * (not only {@code Deployment/Server/common/lib} logging jars).
+ *
+ * <p>Without this, {@code java -jar delivery-tier-distribution.jar} can report BUILD SUCCESSFUL
+ * in a few seconds while leaving no {@code conf/server.xml}, {@code bin/}, or DTS wars — the
+ * hollow-payload failure mode after #1471/#1473/#1475 preinstall work.
+ *
+ * <p>No-op when {@code target/delivery-tier-distribution.jar} is absent (IDE / ad-hoc runs).
+ */
+class DtsInstallerJarContainsTomcatTreeTest {
+
+  private static final String SERVER_PREFIX = "distribution/Deployment/Server/";
+
+  @Test
+  void shippingJarBundlesTomcatServerTreeAndDtsWars() throws IOException {
+    Path jar = Path.of("target", "delivery-tier-distribution.jar");
+    if (!Files.isRegularFile(jar)) {
+      return;
+    }
+
+    List<String> entries = new ArrayList<>();
+    try (ZipFile zip = new ZipFile(jar.toFile())) {
+      zip.stream().map(java.util.zip.ZipEntry::getName).forEach(entries::add);
+    } catch (IOException io) {
+      fail("Could not read " + jar + ": " + io.getMessage());
+    }
+
+    assertContains(entries, SERVER_PREFIX + "conf/server.xml");
+    assertContains(entries, SERVER_PREFIX + "bin/catalina.sh");
+    assertContains(entries, SERVER_PREFIX + "webapps/perc-metadata-services.war");
+    assertContains(entries, SERVER_PREFIX + "webapps/perc-form-processor.war");
+    assertContains(entries, SERVER_PREFIX + "webapps/feeds.war");
+
+    // Manager apps must remain stripped from the shipping payload
+    assertTrue(
+        entries.stream().noneMatch(n -> n.startsWith(SERVER_PREFIX + "webapps/manager/")),
+        "shipping jar must not include Tomcat manager webapp");
+    assertTrue(
+        entries.stream().noneMatch(n -> n.startsWith(SERVER_PREFIX + "webapps/host-manager/")),
+        "shipping jar must not include Tomcat host-manager webapp");
+  }
+
+  private static void assertContains(List<String> entries, String required) {
+    assertTrue(
+        entries.contains(required),
+        () ->
+            "Expected entry "
+                + required
+                + " in shipping jar; Cargo package was not staged into"
+                + " distribution/Deployment/Server before jar packaging."
+                + " See antrun id=stage-cargo-package-into-assembly.");
+  }
+}

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsInstallerJarContainsTomcatTreeTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsInstallerJarContainsTomcatTreeTest.java
@@ -41,6 +41,17 @@ class DtsInstallerJarContainsTomcatTreeTest {
 
   private static final String SERVER_PREFIX = "distribution/Deployment/Server/";
 
+  /** Cargo {@code deployables} in pom.xml — all must ship or a service is silently missing. */
+  private static final String[] DTS_WARS = {
+    "perc-metadata-services.war",
+    "perc-comments-services.war",
+    "perc-form-processor.war",
+    "perc-membership-services.war",
+    "perc-polls-services.war",
+    "feeds.war",
+    "perc-common-ui.war",
+  };
+
   @Test
   void shippingJarBundlesTomcatServerTreeAndDtsWars() throws IOException {
     Path jar = Path.of("target", "delivery-tier-distribution.jar");
@@ -56,10 +67,19 @@ class DtsInstallerJarContainsTomcatTreeTest {
     }
 
     assertContains(entries, SERVER_PREFIX + "conf/server.xml");
+
+    // Dual-platform console launchers from the Cargo Tomcat package
     assertContains(entries, SERVER_PREFIX + "bin/catalina.sh");
-    assertContains(entries, SERVER_PREFIX + "webapps/perc-metadata-services.war");
-    assertContains(entries, SERVER_PREFIX + "webapps/perc-form-processor.war");
-    assertContains(entries, SERVER_PREFIX + "webapps/feeds.war");
+    assertContains(entries, SERVER_PREFIX + "bin/catalina.bat");
+
+    // Windows Procrun / service binaries ship in rootFiles (install root of the jar
+    // payload). installDts.xml later copies tomcat10.exe into Server/bin on Windows.
+    assertContains(entries, "distribution/tomcat10.exe");
+    assertContains(entries, "distribution/tomcat10w.exe");
+
+    for (String war : DTS_WARS) {
+      assertContains(entries, SERVER_PREFIX + "webapps/" + war);
+    }
 
     // Manager apps must remain stripped from the shipping payload
     assertTrue(


### PR DESCRIPTION
Resolves the DTS preinstall failure chain exposed after #1471 (which bundled `perc-ant.jar` + `PathValidation` into the shipping jar). With that fix the preinstall reached the bundled Ant installer, but the install then failed at three sequential points in `installDts.xml`. This PR stacks three fixes that resolve all three.

## Issues addressed

- **#1473** — `installDts.xml:344` failed with `${install.src}/Deployment/Server/common/lib does not exist`. The shipping jar contained only the runtime scripts and the Ant installer payload; the `Deployment/Server/` runtime tree (with log4j, commons-logging, slf4j, disruptor jars) was not bundled.
- **(internal, no issue yet)** — `installDts.xml:1057-1064` and `installDts.xml:1079-1089` failed with `Replace: source file ... doesn't exist`. The ciphers, setenv.sh, and setenv.bat `<replace>` blocks are upgrade-only operations that assumed `Deployment/Server/conf/server.xml`, `Deployment/Server/bin/setenv.sh`, and `Deployment/Server/bin/setenv.bat` already exist at the install target — they don't exist on a fresh install.
- **#1475** (filed in this PR) — fresh-install guard on the ciphers `<replace>` block. After the PR review, expanded to cover the setenv set as well.

## Changes

### `2cc21bf16 fix(install-dts): guard ciphers + setenv replacement on file presence (#1475)`

`installDts.xml`: wrap each upgrade-only `<replace>` in an `<available>` guard:

```xml
<if>
    <available file="${install.dir}${staging.dir}/Deployment/Server/conf/server.xml" type="file" />
    <not>
        <resourcecontains
            resource="${install.dir}${staging.dir}/Deployment/Server/conf/server.xml"
            substring="ciphers=" />
    </not>
    <then>
        <replace file="${install.dir}${staging.dir}/Deployment/Server/conf/server.xml" ...>
            ...
        </replace>
    </then>
</if>
```

…and similarly for `setenv.sh` and `setenv.bat`. Fresh installs now skip these blocks cleanly.

### `f4a8aef06 fix(dts-preinstall): bundle runtime libs into Deployment/Server/common/lib (#1473)`

`pom.xml`: add a `maven-dependency-plugin:copy` execution that stages log4j-api, log4j-core, commons-logging, slf4j-api, and disruptor under `${assembly-directory}/Deployment/Server/common/lib/`. The existing `<include>**/*</include>` in `maven-jar-plugin` packages them into `distribution/Deployment/Server/common/lib/` in the shipping jar. Artifact versions are inherited from the existing parent-pom dependency declarations.

Note on the install script glob typo at `installDts.xml:349`: the `<fileset>` includes `'disrupter*.jar'` (with the typo), which would not match the actual `com.lmax:disruptor-3.4.2.jar`. The disruptor jar is bundled under the correct name so a corrected glob in a follow-up picks it up.

### `6a46b4feb fix(dts-preinstall): unpack full log4j-api + exclude module-info.class`

`pom.xml`: replace the previous `maven-dependency-plugin:unpack` class-list with a full log4j-api unpack, exclude `module-info.class`. Resolves `NoClassDefFoundError: org/apache/logging/log4j/spi/AbstractLogger` at `PathValidation.<clinit>` time.

## End-to-end verification

```
cd deliverytiersuite/.../target
java -jar delivery-tier-distribution.jar D:\install-8.2\cms-8.2
```

The install now reaches:

```
[echo] Adding Ciphers to connector...
[echo] Registering current TLS ciphers...
[propertyfile] Updating property file: ...\perc-catalina.properties
[echo] Fixing line endings in D:\install-8.2\cms-8.2...
[echo] Fixing executable file permissions...
[echo] Deleting files...
BUILD SUCCESSFUL
Total time: 24 seconds
Done extracting exit code 0
```

(Non-fatal `Could not find file` warnings on `logging.properties`, `perc-caching.war`, `Version.properties` are expected: those artifacts live in the install source tree which the shipping jar does not carry. The install works against an existing CMS install at the install target.)

## Tests

53/53 passing on JDK 21 across the module (was 50 before the chain; +1 ciphers guard test, +2 common/lib guard tests).

- `DtsInstallerJarContainsPercAntTest` (PR #1471)
- `DtsInstallerJarContainsDeploymentCommonLibTest` (this PR — #1473)
- `DtsJavaHomeScriptTest.installDtsCiphersReplaceIsGatedOnServerXmlPresence` (this PR — #1475)

## Related

- **#1471** / `2e6fd5497` — bundle `perc-ant.jar` + `PathValidation` in shipping jar
- **#1473** / `f4a8aef06` — bundle runtime libs into `Deployment/Server/common/lib/`
- **#1475** / `2cc21bf16` — guard ciphers + setenv `<replace>` on file presence
- **#1466** / `c85658c9f` — GH-991 system Java home contract (parent epic)
- `6a46b4feb` — unpack full log4j-api + exclude module-info.class (this PR)
- All four fixes are part of the GH-991 / `#1340` epic.

## Note on PR #1474

PR #1474 was opened against `development` for commit `6a46b4feb` (the AbstractLogger fix). Since that commit is now also in this PR (along with the two follow-ups), PR #1474 can be closed as superseded — this PR supersedes it.

Refs #1473, #1475, GH-991 (`#1340`).