### PR TITLE
fix(deployer): restore SRC_SERVER_BUILD_DATE column name (startup package install)

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/server/PSLogHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSLogHandler.java
@@ -1286,7 +1286,8 @@ public class PSLogHandler {
   private static final String ALS_SRC_SERVER_NAME = "SRC_SERVER_NAME";
   private static final String ALS_SRC_SERVER_VERSION = "SRC_SERVER_VERSION";
   private static final String ALS_SRC_SERVER_BUILD_ID = "SRC_SERVER_BUILD_ID";
-  private static final String ALS_SRC_SERVER_BUILD_DATE = "ALS_SRC_SERVER_BUILD_DATE";
+  // Physical column is SRC_SERVER_BUILD_DATE (ALS_ is Java-only naming, like other ALS_* keys).
+  private static final String ALS_SRC_SERVER_BUILD_DATE = "SRC_SERVER_BUILD_DATE";
   private static final String ALS_TGT_SERVER_NAME = "TGT_SERVER_NAME";
   private static final String ALS_ARCHIVE_INFO = "ARCHIVE_INFO";
   private static final String ALS_ARCHIVE_MANIFEST = "ARCHIVE_MANIFEST";

--- a/deployer/src/test/java/com/percussion/deployer/server/PSLogHandlerTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/server/PSLogHandlerTest.java
@@ -78,7 +78,7 @@ class PSLogHandlerTest {
     assertEquals("8.2.0", colsByName.get("SRC_SERVER_VERSION"));
     assertEquals("2026.07.21", colsByName.get("SRC_SERVER_BUILD_ID"));
     assertEquals("rhythmx-target:9992", colsByName.get("TGT_SERVER_NAME"));
-    assertEquals("2026-07-21 15:30:45", colsByName.get("ALS_SRC_SERVER_BUILD_DATE"));
+    assertEquals("2026-07-21 15:30:45", colsByName.get("SRC_SERVER_BUILD_DATE"));
     assertNotNull(colsByName.get("ARCHIVE_INFO"));
     assertNotNull(colsByName.get("ARCHIVE_MANIFEST"));
   }
@@ -108,7 +108,7 @@ class PSLogHandlerTest {
     String buildDateValue = null;
     while (cols.hasNext()) {
       PSJdbcColumnData col = cols.next();
-      if ("ALS_SRC_SERVER_BUILD_DATE".equalsIgnoreCase(col.getName())) {
+      if ("SRC_SERVER_BUILD_DATE".equalsIgnoreCase(col.getName())) {
         buildDateValue = col.getValue();
         break;
       }

--- a/docs/ai-generated/code-reviews/fix-als-src-server-build-date-column-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-als-src-server-build-date-column-erlang.md
@@ -1,0 +1,38 @@
+# Erlang review: fix ALS_SRC_SERVER_BUILD_DATE column name regression
+
+**Date:** 2026-07-23  
+**Scope:** Uncommitted deployer fix vs `development` (excludes unrelated staged `pom.xml` ai-build-integrity bump)  
+**Intent:** Restore physical DB column name for `DPL_ARCHIVE_LOG_SUMMARY.SRC_SERVER_BUILD_DATE` after PR #1459 incorrectly set the Java constant value to `ALS_SRC_SERVER_BUILD_DATE`, breaking startup package install.
+
+## Summary
+
+PR #1459 renamed the *value* of `ALS_SRC_SERVER_BUILD_DATE` from `SRC_SERVER_BUILD_DATE` to `ALS_SRC_SERVER_BUILD_DATE`. Sibling constants (`ALS_SRC_SERVER_NAME` → `SRC_SERVER_NAME`, etc.) correctly omit the `ALS_` prefix from the physical column name. Schema in `cmsTableDef.xml` defines `SRC_SERVER_BUILD_DATE`. Runtime error: `PSDbmsHelper.processTable` → column not found in table schema → all startup packages fail.
+
+This change restores the correct constant value and aligns unit test assertions. Date format fix from #1459 (`yyyy-MM-dd HH:mm:ss`) is preserved.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs | none |
+| Behavioral tests for changed logic | present (`PSLogHandlerTest` asserts column name + JDBC date format) |
+| Cross-platform path/file I/O | N/A (no path I/O) |
+| Security / silent failure | none — restores correct metadata write path |
+| May commit/push | **yes** |
+
+## Issues
+
+None.
+
+## Memory patterns hit
+
+- Column name / schema alignment: constant value must match physical schema, not Java naming prefix.
+
+## Verification noted
+
+- `cd deployer && ../mvn-env.sh -o test -Dtest=PSLogHandlerTest` — Tests run: 2, Failures: 0
+- Pre-PR: `cd deployer && ../mvn-env.sh -o clean install` (standalone)


### PR DESCRIPTION
## Summary

- Restores the physical DB column name for archive-log summary writes: `SRC_SERVER_BUILD_DATE` (not `ALS_SRC_SERVER_BUILD_DATE`).
- Regression from PR #1459 (`Fix/922 date format patterns`), which left the correct JDBC date format change but misnamed the column constant value.
- Symptom on startup installs: `The column definition for the column (ALS_SRC_SERVER_BUILD_DATE) in the data for table (DPL_ARCHIVE_LOG_SUMMARY) was not found in the table schema` — every package install fails (e.g. `perc.widget.calendar`).
- No schema migration needed; `cmsTableDef.xml` already defines `SRC_SERVER_BUILD_DATE`. Sibling constants already map `ALS_*` Java names to unprefixed physical columns.

## Pre-PR verification

| Gate | Result |
|------|--------|
| Erlang review | **approve** — `docs/ai-generated/code-reviews/fix-als-src-server-build-date-column-erlang.md` |
| Maven | `cd deployer && ../mvn-env.sh -o clean install` — **BUILD SUCCESS** (standalone; parent POM not in this change) |
| Tests | `Tests run: 157, Failures: 0, Errors: 0, Skipped: 19` |
| New warnings | None attributable to this change (baseline deployer warnings only) |

## Test plan

- [x] `PSLogHandlerTest` asserts `SRC_SERVER_BUILD_DATE` name + `yyyy-MM-dd HH:mm:ss` value
- [x] Full deployer module `clean install`
- [ ] Redeploy `perc-deployer` into a local 8.2 install and confirm startup package install succeeds without the `ALS_SRC_SERVER_BUILD_DATE` schema error

> Co-Authored by Grok Build using grok-4.5 with agent main.