### PR TITLE
fix(login): Jetty redirect double-encoding and Jasper empty EL in siteimprove

### DIFF
--- a/WebUI/src/main/webapp/cm/app/includes/siteimprove_integration.html
+++ b/WebUI/src/main/webapp/cm/app/includes/siteimprove_integration.html
@@ -186,7 +186,10 @@
 
     function getParameterByName(name) {
       url = window.location.href;
-      name = String(name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      // Jasper EL parses template text even inside JS comments, so do not write
+      // dollar-brace with nothing between them in this file. Character class keeps
+      // $ and braces as separate members (same RegExp-escape semantics).
+      name = String(name).replace(/[.*+?^$()|[\]\\{}]/g, "\\$&");
       var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
         results = regex.exec(url);
       if (!results) return null;

--- a/WebUI/src/main/webapp/cm/pages/app/includes/siteimprove_integration.html
+++ b/WebUI/src/main/webapp/cm/pages/app/includes/siteimprove_integration.html
@@ -186,7 +186,10 @@
 
     function getParameterByName(name) {
       url = window.location.href;
-      name = String(name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      // Jasper EL parses template text even inside JS comments, so do not write
+      // dollar-brace with nothing between them in this file. Character class keeps
+      // $ and braces as separate members (same RegExp-escape semantics).
+      name = String(name).replace(/[.*+?^$()|[\]\\{}]/g, "\\$&");
       var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
         results = regex.exec(url);
       if (!results) return null;

--- a/WebUI/src/test/js/percIncompleteSanitization.test.js
+++ b/WebUI/src/test/js/percIncompleteSanitization.test.js
@@ -194,11 +194,13 @@ describe("siteimprove_integration.html (alerts #1134/#1135/#1115/#1116)", () => 
       });
 
       it("uses a full RegExp-escape for query-param names (incl. backslash)", () => {
-        // name = String(name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        // name = String(name).replace(/[.*+?^$()|[\]\\{}]/g, "\\$&");
+        // Must not contain empty EL (dollar immediately followed by open-brace);
+        // Jasper rejects that when this HTML is static-included into a JSP.
         expect(src).toMatch(/String\s*\(\s*name\s*\)\.replace\s*\(/);
-        // Character class must include backslash and common metacharacters;
-        // replacement must use $& (whole match) with a leading escape.
-        expect(src).toContain("[.*+?^${}()|[\\]\\\\]");
+        expect(src).not.toMatch(/\$\{}/);
+        // Metacharacters (incl. backslash) remain; $ and braces as separate class members.
+        expect(src).toMatch(/\[\.\*\+\?\^\$\(\)\|\[\\\]\\\\\{\}\]/);
         expect(src).toContain("$&");
       });
 
@@ -224,12 +226,15 @@ describe("siteimprove_integration.html (alerts #1134/#1135/#1115/#1116)", () => 
   });
 
   it("behaviourally escapes all RegExp metacharacters including backslash", () => {
+    // Same class as siteimprove_integration.html (JSP-safe: no "${}" sequence)
     const escape = (s) =>
-      String(s).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      String(s).replace(/[.*+?^$()|[\]\\{}]/g, "\\$&");
     expect(escape("id")).toBe("id");
     expect(escape("a.b")).toBe("a\\.b");
     expect(escape("x[0]")).toBe("x\\[0\\]");
     expect(escape("a\\b")).toBe("a\\\\b");
+    expect(escape("a{1}")).toBe("a\\{1\\}");
+    expect(escape("$x")).toBe("\\$x");
     // Incomplete pre-fix only handled [ and ]:
     const preFix = (s) => s.replace(/[\[\]]/g, "\\$&");
     expect(preFix("a.b")).toBe("a.b"); // still special in RegExp

--- a/WebUI/war/app/includes/siteimprove_integration.html
+++ b/WebUI/war/app/includes/siteimprove_integration.html
@@ -186,7 +186,10 @@
 
     function getParameterByName(name) {
       url = window.location.href;
-      name = String(name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      // Jasper EL parses template text even inside JS comments, so do not write
+      // dollar-brace with nothing between them in this file. Character class keeps
+      // $ and braces as separate members (same RegExp-escape semantics).
+      name = String(name).replace(/[.*+?^$()|[\]\\{}]/g, "\\$&");
       var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
         results = regex.exec(url);
       if (!results) return null;

--- a/docs/ai-generated/code-reviews/fix-login-redirect-encoding-and-jsp-el-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-login-redirect-encoding-and-jsp-el-erlang.md
@@ -1,0 +1,45 @@
+# Erlang review: fix/login-redirect-encoding-and-jsp-el
+
+**Scope:** Uncommitted changes for Jetty login redirect double-encoding + Jasper empty-EL in siteimprove include  
+**Date:** 2026-07-23  
+**Reviewer:** Erlang (independent of implementer)
+
+## Summary
+
+Two production blockers after CodeQL redirect rebuilds and modern Jasper EL:
+
+1. **Login:** `new URI(..., getRawPath(), getRawQuery(), ...).toASCIIString()` double-encodes `%` → Jetty `Ambiguous URI path encoding` on post-login `sendRedirect`. Root leak was unauthenticated → login Location with `sys_redirect=http%253a%252f%252f...`.
+2. **Dashboard JSP:** static include of `siteimprove_integration.html` contained JS character class with empty EL sequence `${}` → Jasper `Failed to parse the expression [${}]`.
+
+Fix centralizes non-reencoding rebuild + decode defense in `PSRedirectValidation`; login/security filter call it; siteimprove regex reordered so `$` is not adjacent to `{`.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- **May commit/push:** yes
+- Bugs: none remaining in diff
+- Behavioral tests: present for rebuild/decode and login resolve; JS sanitization test updated
+- Cross-platform path/file I/O: **N/A** (no new filesystem path construction; URI/URL only)
+
+## Issues
+
+None blocking.
+
+### Suggestions (non-blocking)
+
+1. **decodeOverEncodedRedirect** stops on path-absolute even if query still over-encoded; acceptable for login use (absolute hosts or clean paths).
+2. **WebUI/war/** copy of siteimprove is a packaged/war tree duplicate — keep lockstep with `src/main/webapp` as done.
+
+## Memory patterns hit
+
+- Double-encoding via multi-arg `URI` + raw components (Jetty UriCompliance)
+- Jasper EL in static-included non-JSP text (including JS comments)
+
+## Verification evidence (implementer)
+
+- `modules/perc-security-utils` clean install
+- `system` `PSLoginServletTest`
+- Live: single-encoded login Location; post-login 302; dashboard/editor/design 200 after siteimprove deploy

--- a/modules/perc-security-utils/src/main/java/com/percussion/security/utils/PSRedirectValidation.java
+++ b/modules/perc-security-utils/src/main/java/com/percussion/security/utils/PSRedirectValidation.java
@@ -19,6 +19,8 @@ package com.percussion.security.utils;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
@@ -221,5 +223,122 @@ public class PSRedirectValidation {
       }
     }
     return whitelist;
+  }
+
+  /**
+   * Rebuilds a <em>validated</em> redirect location from URI components without re-encoding.
+   *
+   * <p>Used to clear CodeQL {@code java/unvalidated-url-redirection} residual taint after {@link
+   * #validateRedirectUrl} / {@link #validateInternalRedirectUrl} accept a location.
+   *
+   * <p><strong>Why not {@code new URI(scheme, authority, path, query, fragment)}?</strong> That
+   * constructor treats path/query as <em>decoded</em> text and re-encodes. Passing already-encoded
+   * raw components (from {@link URI#getRawPath()} / {@link URI#getRawQuery()}) double-encodes
+   * {@code %} as {@code %25}. Jetty 12 {@code UriCompliance.DEFAULT_REDIRECT} then rejects the
+   * Location with {@code IllegalArgumentException: Ambiguous URI path encoding} (and encoded {@code
+   * /} as path separator). That broke login after CodeQL redirect rebuilds: {@code
+   * /login?sys_redirect=http%3a%2f%2f...} became {@code sys_redirect=http%253a%252f%252f...}.
+   *
+   * <p>Assembling raw components into a new string preserves encoding and still yields a fresh
+   * non-tainted value for {@code sendRedirect}.
+   *
+   * @param safe location already accepted by a validate* method; may be {@code null}
+   * @return rebuilt location, or {@code null} if blank/unparseable
+   */
+  public static String rebuildValidatedRedirect(String safe) {
+    if (StringUtils.isBlank(safe)) {
+      return null;
+    }
+    try {
+      String trimmed = safe.trim();
+      URI parsed = URI.create(trimmed);
+      StringBuilder sb = new StringBuilder(trimmed.length() + 8);
+      if (parsed.isAbsolute()) {
+        sb.append(parsed.getScheme()).append(':');
+        if (parsed.getRawAuthority() != null) {
+          sb.append("//").append(parsed.getRawAuthority());
+        }
+        String path = parsed.getRawPath();
+        sb.append(path != null && !path.isEmpty() ? path : "/");
+        if (parsed.getRawQuery() != null) {
+          sb.append('?').append(parsed.getRawQuery());
+        }
+        if (parsed.getRawFragment() != null) {
+          sb.append('#').append(parsed.getRawFragment());
+        }
+        return sb.toString();
+      }
+
+      // Relative: path-absolute ("/cm/app") or path-relative ("index.jsp")
+      String path = parsed.getRawPath();
+      if (path == null || path.isEmpty()) {
+        int q = trimmed.indexOf('?');
+        int h = trimmed.indexOf('#');
+        int end = trimmed.length();
+        if (q >= 0) {
+          end = Math.min(end, q);
+        }
+        if (h >= 0) {
+          end = Math.min(end, h);
+        }
+        path = trimmed.substring(0, end);
+      }
+      if (path.isEmpty()) {
+        return null;
+      }
+      sb.append(path);
+      if (parsed.getRawQuery() != null) {
+        sb.append('?').append(parsed.getRawQuery());
+      }
+      if (parsed.getRawFragment() != null) {
+        sb.append('#').append(parsed.getRawFragment());
+      }
+      return sb.toString();
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  /**
+   * Undoes accidental over-encoding of redirect targets (e.g. double-encoded {@code sys_redirect}
+   * values left in bookmarks or older sessions).
+   *
+   * <p>Stops when the value looks like a normal absolute URL ({@code scheme://}) or a path-absolute
+   * internal redirect, or after a small fixed number of decode rounds.
+   *
+   * @param candidate redirect candidate, may be {@code null}
+   * @return decoded candidate, or original when blank/undecodable
+   */
+  public static String decodeOverEncodedRedirect(String candidate) {
+    if (StringUtils.isBlank(candidate)) {
+      return candidate;
+    }
+    String current = candidate.trim();
+    for (int i = 0; i < 3; i++) {
+      boolean absolute = current.contains("://");
+      boolean pathAbsolute = current.startsWith("/") && !current.startsWith("//");
+      boolean stillEncodedAbsolute =
+          startsWithIgnoreCase(current, "http%") || startsWithIgnoreCase(current, "https%");
+      if ((absolute || pathAbsolute) && !stillEncodedAbsolute) {
+        return current;
+      }
+      if (!current.contains("%")) {
+        return current;
+      }
+      try {
+        String decoded = URLDecoder.decode(current, StandardCharsets.UTF_8);
+        if (decoded.equals(current)) {
+          return current;
+        }
+        current = decoded;
+      } catch (IllegalArgumentException e) {
+        return current;
+      }
+    }
+    return current;
+  }
+
+  private static boolean startsWithIgnoreCase(String value, String prefix) {
+    return value.regionMatches(true, 0, prefix, 0, prefix.length());
   }
 }

--- a/modules/perc-security-utils/src/main/java/com/percussion/security/utils/PSRedirectValidation.java
+++ b/modules/perc-security-utils/src/main/java/com/percussion/security/utils/PSRedirectValidation.java
@@ -258,8 +258,12 @@ public class PSRedirectValidation {
         if (parsed.getRawAuthority() != null) {
           sb.append("//").append(parsed.getRawAuthority());
         }
+        // Preserve path-less absolute form (http://host) — do not force a trailing "/".
+        // Only emit an explicit path when the URI had one (including empty path as "").
         String path = parsed.getRawPath();
-        sb.append(path != null && !path.isEmpty() ? path : "/");
+        if (path != null && !path.isEmpty()) {
+          sb.append(path);
+        }
         if (parsed.getRawQuery() != null) {
           sb.append('?').append(parsed.getRawQuery());
         }
@@ -303,8 +307,10 @@ public class PSRedirectValidation {
    * Undoes accidental over-encoding of redirect targets (e.g. double-encoded {@code sys_redirect}
    * values left in bookmarks or older sessions).
    *
-   * <p>Stops when the value looks like a normal absolute URL ({@code scheme://}) or a path-absolute
-   * internal redirect, or after a small fixed number of decode rounds.
+   * <p>Stops when the value looks like a normal absolute URL ({@code scheme://}) without remaining
+   * {@code http%} prefix encoding, or a path-absolute redirect with no remaining percent escapes,
+   * or after a small fixed number of decode rounds. Path-absolute values that still contain {@code
+   * %} (e.g. {@code /%2e%2e/secret}) continue decoding so later {@code ..} gates see real dots.
    *
    * @param candidate redirect candidate, may be {@code null}
    * @return decoded candidate, or original when blank/undecodable
@@ -319,7 +325,12 @@ public class PSRedirectValidation {
       boolean pathAbsolute = current.startsWith("/") && !current.startsWith("//");
       boolean stillEncodedAbsolute =
           startsWithIgnoreCase(current, "http%") || startsWithIgnoreCase(current, "https%");
-      if ((absolute || pathAbsolute) && !stillEncodedAbsolute) {
+      // Absolute http(s) URL fully decoded — done
+      if (absolute && !stillEncodedAbsolute) {
+        return current;
+      }
+      // Path-absolute with no remaining percent escapes — done (decode first if % present)
+      if (pathAbsolute && !stillEncodedAbsolute && !current.contains("%")) {
         return current;
       }
       if (!current.contains("%")) {

--- a/modules/perc-security-utils/src/test/java/com/percussion/security/utils/PSRedirectValidationTest.java
+++ b/modules/perc-security-utils/src/test/java/com/percussion/security/utils/PSRedirectValidationTest.java
@@ -548,5 +548,30 @@ class PSRedirectValidationTest {
       assertEquals("/cm/app", PSRedirectValidation.decodeOverEncodedRedirect("/cm/app"));
       assertEquals("index.jsp", PSRedirectValidation.decodeOverEncodedRedirect("index.jsp"));
     }
+
+    @Test
+    @DisplayName("Decodes path-absolute percent sequences before .. gate (e.g. %2e%2e)")
+    void decodesPathAbsoluteEncodedDotDot() {
+      assertEquals(
+          "/../secret", PSRedirectValidation.decodeOverEncodedRedirect("/%2e%2e/secret"));
+      assertEquals(
+          "/../secret", PSRedirectValidation.decodeOverEncodedRedirect("/%2E%2E/secret"));
+    }
+  }
+
+  @Nested
+  @DisplayName("rebuildValidatedRedirect — path-less absolute URIs")
+  class RebuildPathlessAbsoluteTests {
+
+    @Test
+    @DisplayName("Does not force trailing slash on path-less absolute hosts")
+    void rebuildPreservesPathlessAbsolute() {
+      assertEquals(
+          "http://example.com",
+          PSRedirectValidation.rebuildValidatedRedirect("http://example.com"));
+      assertEquals(
+          "https://example.com:8443",
+          PSRedirectValidation.rebuildValidatedRedirect("https://example.com:8443"));
+    }
   }
 }

--- a/modules/perc-security-utils/src/test/java/com/percussion/security/utils/PSRedirectValidationTest.java
+++ b/modules/perc-security-utils/src/test/java/com/percussion/security/utils/PSRedirectValidationTest.java
@@ -475,4 +475,78 @@ class PSRedirectValidationTest {
       assertNotNull(result, "Legitimate post-login redirect should be allowed");
     }
   }
+
+  @Nested
+  @DisplayName("rebuildValidatedRedirect — preserve encoding (Jetty UriCompliance)")
+  class RebuildValidatedRedirectTests {
+
+    @Test
+    @DisplayName("Must not double-encode login sys_redirect query (Jetty Ambiguous URI path encoding)")
+    void rebuildPreservesSingleEncodedSysRedirectQuery() {
+      // addRedirect encodes once; rebuild must not turn %3a into %253a
+      String loginWithRedirect =
+          "/login?sys_redirect=http%3a%2f%2flocalhost%3a9992%2fRhythmyx%2fcm%2fapp";
+      String rebuilt = PSRedirectValidation.rebuildValidatedRedirect(loginWithRedirect);
+      assertEquals(loginWithRedirect, rebuilt);
+      assertFalse(rebuilt.contains("%25"), "must not produce %25 (double-encoded %)");
+    }
+
+    @Test
+    @DisplayName("Preserves absolute URL path encoding without %2520")
+    void rebuildPreservesEncodedPath() {
+      String url = "http://example.com/path%20with%20spaces";
+      assertEquals(url, PSRedirectValidation.rebuildValidatedRedirect(url));
+    }
+
+    @Test
+    @DisplayName("Preserves simple absolute and relative targets")
+    void rebuildSimpleTargets() {
+      assertEquals("index.jsp", PSRedirectValidation.rebuildValidatedRedirect("index.jsp"));
+      assertEquals("/cm/app", PSRedirectValidation.rebuildValidatedRedirect("/cm/app"));
+      assertEquals(
+          "http://example.com/logout",
+          PSRedirectValidation.rebuildValidatedRedirect("http://example.com/logout"));
+    }
+
+    @Test
+    @DisplayName("Returns null for blank")
+    void rebuildBlank() {
+      assertNull(PSRedirectValidation.rebuildValidatedRedirect(null));
+      assertNull(PSRedirectValidation.rebuildValidatedRedirect("   "));
+    }
+  }
+
+  @Nested
+  @DisplayName("decodeOverEncodedRedirect — fix double-encoded sys_redirect")
+  class DecodeOverEncodedRedirectTests {
+
+    @Test
+    @DisplayName("Decodes double-encoded absolute URL (session after buggy Location header)")
+    void decodeDoubleEncodedAbsolute() {
+      // After getParameter once-decodes double-encoded Location query
+      String stillEncoded = "http%3a%2f%2flocalhost%3a9992%2fRhythmyx%2fcm%2fapp";
+      assertEquals(
+          "http://localhost:9992/Rhythmyx/cm/app",
+          PSRedirectValidation.decodeOverEncodedRedirect(stillEncoded));
+    }
+
+    @Test
+    @DisplayName("Decodes triple-encoded absolute URL down to usable form")
+    void decodeTripleEncodedAbsolute() {
+      String triple = "http%253a%252f%252flocalhost%253a9992%252fRhythmyx%252fcm%252fapp";
+      assertEquals(
+          "http://localhost:9992/Rhythmyx/cm/app",
+          PSRedirectValidation.decodeOverEncodedRedirect(triple));
+    }
+
+    @Test
+    @DisplayName("Leaves normal URLs and paths unchanged")
+    void leavesNormalUnchanged() {
+      assertEquals(
+          "http://localhost:9992/cm/app",
+          PSRedirectValidation.decodeOverEncodedRedirect("http://localhost:9992/cm/app"));
+      assertEquals("/cm/app", PSRedirectValidation.decodeOverEncodedRedirect("/cm/app"));
+      assertEquals("index.jsp", PSRedirectValidation.decodeOverEncodedRedirect("index.jsp"));
+    }
+  }
 }

--- a/system/src/main/java/com/percussion/servlets/PSLoginServlet.java
+++ b/system/src/main/java/com/percussion/servlets/PSLoginServlet.java
@@ -252,7 +252,9 @@ public class PSLoginServlet extends HttpServlet {
       }
     }
 
-    String redirect = request.getParameter(IPSHtmlParameters.SYS_REDIRECT);
+    String redirect =
+        PSRedirectValidation.decodeOverEncodedRedirect(
+            request.getParameter(IPSHtmlParameters.SYS_REDIRECT));
     if (isValidRedirectUri(request, redirect)) {
       request.getSession().setAttribute(REDIRECT_URL, redirect);
     }
@@ -311,7 +313,8 @@ public class PSLoginServlet extends HttpServlet {
    * @return safe redirect string, never {@code null}
    */
   static String resolveSafePostLoginRedirect(HttpServletRequest request, String redirect) {
-    String candidate = sanitizeRedirectPath(redirect);
+    String candidate =
+        sanitizeRedirectPath(PSRedirectValidation.decodeOverEncodedRedirect(redirect));
     if (StringUtils.isBlank(candidate)) {
       return CMS_INDEX_PAGE;
     }
@@ -365,34 +368,13 @@ public class PSLoginServlet extends HttpServlet {
    * Rebuilds a validated redirect from URI components so residual CodeQL taint from the original
    * session string does not reach {@code sendRedirect} (same pattern as {@code
    * PSSecurityFilter.sendValidatedRedirect}).
+   *
+   * <p>Delegates to {@link PSRedirectValidation#rebuildValidatedRedirect(String)} which preserves
+   * percent-encoding (must not use multi-arg {@link URI} with raw components — that double-encodes
+   * and trips Jetty {@code Ambiguous URI path encoding}).
    */
   static String rebuildRedirectTarget(String safe) {
-    if (StringUtils.isBlank(safe)) {
-      return null;
-    }
-    try {
-      URI parsed = URI.create(safe);
-      if (parsed.isAbsolute()) {
-        return new URI(
-                parsed.getScheme(),
-                parsed.getAuthority(),
-                parsed.getRawPath() != null ? parsed.getRawPath() : "/",
-                parsed.getRawQuery(),
-                parsed.getRawFragment())
-            .toASCIIString();
-      }
-      // Relative: path may be "index.jsp" or "/cm/app" (path-only URI)
-      String path = parsed.getRawPath();
-      if (path == null || path.isEmpty()) {
-        // URI.create("index.jsp") stores the value as a path-relative scheme-specific part
-        path = safe;
-      }
-      return new URI(null, null, path, parsed.getRawQuery(), parsed.getRawFragment())
-          .toASCIIString();
-    } catch (Exception e) {
-      log.debug("Failed to rebuild redirect target: {}", e.toString());
-      return null;
-    }
+    return PSRedirectValidation.rebuildValidatedRedirect(safe);
   }
 
   /**

--- a/system/src/main/java/com/percussion/servlets/PSSecurityFilter.java
+++ b/system/src/main/java/com/percussion/servlets/PSSecurityFilter.java
@@ -1384,13 +1384,14 @@ public class PSSecurityFilter implements Filter {
       // and breaks Jetty UriCompliance (Ambiguous URI path encoding) on login sys_redirect.
       String redirect = PSRedirectValidation.rebuildValidatedRedirect(safe);
       if (redirect == null) {
-        ms_log.warn("Failed to rebuild redirect location: {}", sanitizeForLog(location));
+        // Log validated target (safe), not raw location — more actionable on rebuild failure
+        ms_log.warn("Failed to rebuild redirect location: {}", sanitizeForLog(safe));
         response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid redirect location");
         return;
       }
       response.sendRedirect(redirect);
     } catch (Exception e) {
-      ms_log.warn("Failed to rebuild redirect location: {}", sanitizeForLog(location));
+      ms_log.warn("Failed to rebuild redirect location: {}", sanitizeForLog(safe));
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid redirect location");
     }
   }

--- a/system/src/main/java/com/percussion/servlets/PSSecurityFilter.java
+++ b/system/src/main/java/com/percussion/servlets/PSSecurityFilter.java
@@ -1379,28 +1379,14 @@ public class PSSecurityFilter implements Filter {
       return;
     }
     try {
-      // Rebuild redirect target from validated URI components to clear residual
-      // CodeQL java/unvalidated-url-redirection taint (#1779).
-      java.net.URI parsed = java.net.URI.create(safe);
-      String redirect;
-      if (parsed.isAbsolute()) {
-        redirect =
-            new java.net.URI(
-                    parsed.getScheme(),
-                    parsed.getAuthority(),
-                    parsed.getRawPath() != null ? parsed.getRawPath() : "/",
-                    parsed.getRawQuery(),
-                    parsed.getRawFragment())
-                .toASCIIString();
-      } else {
-        redirect =
-            new java.net.URI(
-                    null,
-                    null,
-                    parsed.getRawPath() != null ? parsed.getRawPath() : "/",
-                    parsed.getRawQuery(),
-                    parsed.getRawFragment())
-                .toASCIIString();
+      // Rebuild from validated components to clear CodeQL taint (#1779) without re-encoding.
+      // Multi-arg URI(scheme, auth, rawPath, rawQuery, frag).toASCIIString() double-encodes %
+      // and breaks Jetty UriCompliance (Ambiguous URI path encoding) on login sys_redirect.
+      String redirect = PSRedirectValidation.rebuildValidatedRedirect(safe);
+      if (redirect == null) {
+        ms_log.warn("Failed to rebuild redirect location: {}", sanitizeForLog(location));
+        response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid redirect location");
+        return;
       }
       response.sendRedirect(redirect);
     } catch (Exception e) {

--- a/system/src/test/java/com/percussion/servlets/PSLoginServletTest.java
+++ b/system/src/test/java/com/percussion/servlets/PSLoginServletTest.java
@@ -103,4 +103,29 @@ public class PSLoginServletTest {
             request, "http://evil.example/path"));
     assertEquals("index.jsp", PSLoginServlet.validatePostLoginRedirectCandidate(request, "index.jsp"));
   }
+
+  @Test
+  public void testRebuildRedirectTargetDoesNotDoubleEncode() {
+    // Jetty 12: Ambiguous URI path encoding when % is re-encoded to %25
+    String withEncodedSpace = "http://perc-test:9992/path%20x";
+    assertEquals(withEncodedSpace, PSLoginServlet.rebuildRedirectTarget(withEncodedSpace));
+    assertFalse(PSLoginServlet.rebuildRedirectTarget(withEncodedSpace).contains("%25"));
+
+    String loginSysRedirect =
+        "/login?sys_redirect=http%3a%2f%2flocalhost%3a9992%2fRhythmyx%2fcm%2fapp";
+    assertEquals(loginSysRedirect, PSLoginServlet.rebuildRedirectTarget(loginSysRedirect));
+  }
+
+  @Test
+  public void testResolveSafePostLoginRedirectDecodesOverEncodedSysRedirect() {
+    // Realistic session value after getParameter once-decodes a double-encoded Location query
+    request.setScheme("http");
+    request.setServerPort(9992);
+    request.setServerName("localhost");
+
+    String stillEncoded = "http%3a%2f%2flocalhost%3a9992%2fRhythmyx%2fcm%2fapp";
+    assertEquals(
+        "http://localhost:9992/Rhythmyx/cm/app",
+        PSLoginServlet.resolveSafePostLoginRedirect(request, stillEncoded));
+  }
 }


### PR DESCRIPTION
## Summary

- **Login / Jetty 12:** CodeQL-era redirect rebuild used `new URI(scheme, auth, getRawPath(), getRawQuery(), …).toASCIIString()`, which double-encodes `%` → `IllegalArgumentException: Ambiguous URI path encoding` on post-login `sendRedirect`. Login Location showed `sys_redirect=http%253a%252f%252f…`.
- **Fix:** `PSRedirectValidation.rebuildValidatedRedirect` assembles raw components without re-encoding; `decodeOverEncodedRedirect` recovers over-encoded session values. Wired from `PSLoginServlet` and `PSSecurityFilter`.
- **Dashboard JSP:** `siteimprove_integration.html` (static-included) had a JS regex with empty EL `${}`; Jasper rejects it and `index.jsp` fails at `pageContext.forward`. Reordered character class so `$` and `{}` are separate members (same escape semantics).

## Test plan

- [x] `cd modules/perc-security-utils && ../../mvn-env.sh clean install` — BUILD SUCCESS
- [x] `cd system && ../mvn-env.sh clean install` — BUILD SUCCESS
- [x] `cd system && ../mvn-env.sh test -Dtest=PSLoginServletTest` — pass
- [x] WebUI: `npm test -- src/test/js/percIncompleteSanitization.test.js` — 30 passed
- [x] Live install: unauth `/cm/app` → single-encoded `sys_redirect`; Admin login → 302; `/cm/app/?view=dash|editor|home` → 200
- [ ] CI green on PR

## Pre-PR gates

- Erlang review: `docs/ai-generated/code-reviews/fix-login-redirect-encoding-and-jsp-el-erlang.md` (approve)
- No new path/file I/O portability issues

> Co-Authored by Grok Build 0.2.111 using grok-4.5 with agent Grok.