### PR TITLE
chore(jms): close out #666 Artemis migration residuals

### DIFF
--- a/system/services/src/com/percussion/services/jms/impl/PSQueueSender.java
+++ b/system/services/src/com/percussion/services/jms/impl/PSQueueSender.java
@@ -60,9 +60,9 @@ public class PSQueueSender implements IPSQueueSender
    private Queue m_queue = null;
 
    /**
-    * A wapper class of {@link QueueSender}. It sets delivery mode to
-    * {@link javax.jms.DeliveryMode#PERSISTENT} and the send message will be
-    * retain indefinitely by the message system.
+    * A wapper class of {@link MessageProducer}. It sets delivery mode to
+    * {@link jakarta.jms.DeliveryMode#NON_PERSISTENT} (time-to-live 0) for
+    * queue send operations.
     */
    private class PSSender
    {
@@ -114,7 +114,7 @@ public class PSQueueSender implements IPSQueueSender
       }
 
       /**
-       * A wrapper method of {@link javax.jms.MessageProducer#setPriority(int)}
+       * A wrapper method of {@link jakarta.jms.MessageProducer#setPriority(int)}
        * @param priority the new priority.
        * @throws JMSException if fail to set the priority.
        */
@@ -132,7 +132,7 @@ public class PSQueueSender implements IPSQueueSender
       }
 
       /**
-       * A wrapper method of {@link javax.jms.MessageProducer#getPriority()}
+       * A wrapper method of {@link jakarta.jms.MessageProducer#getPriority()}
        * @return the message priority for this message sender.
        * @throws JMSException if fail to get the priority.
        */


### PR DESCRIPTION
## Summary

- Fixes residual `javax.jms` javadoc links in `PSQueueSender` after the ActiveMQ Classic → Artemis migration.
- Aligns class-level `PSSender` javadoc with actual `jakarta.jms.MessageProducer` + `NON_PERSISTENT` delivery mode.

Closes residual hygiene for issue #666. The migration itself is already complete (see issue close comment).

## Related

- Issue: https://github.com/intersoftdatalabs-in/percussioncms/issues/666
- Migration restore: https://github.com/intersoftdatalabs-in/percussioncms/pull/1328
- Original cutover commit: `88ca5716b0`

## Test plan

- [x] Javadoc-only change — no runtime behavior change
- [x] Confirmed no remaining `javax.jms` references in `PSQueueSender.java`
- [ ] CI green

## Pre-PR Maven

Javadoc-only (comments); no module compile impact. Skipped full `clean install` for this residual hygiene PR.

> Co-Authored by Grok Build using grok-4.5 with agent Grok.