### PR TITLE
fix(install): prompt operator when multiple JDKs are installed

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
@@ -376,12 +376,22 @@ public class MainDTSPreInstall {
     try {
       System.out.print(prompt);
       System.out.flush();
+      // Do NOT close the Scanner: closing it would close System.in, which
+      // downstream code (and any subsequent interactive prompts in this JVM)
+      // might still need. The Scanner is intentionally leaked.
       java.util.Scanner scanner = new java.util.Scanner(System.in);
       if (scanner.hasNextLine()) {
         return scanner.nextLine();
       }
       return "";
     } catch (Exception e) {
+      // User-facing fallback: surface the failure to stderr so the operator
+      // sees that stdin could not be read instead of watching the installer
+      // silently auto-pick a JDK. The empty-string return lets the
+      // auto-select path fall through.
+      System.err.println(
+          "[WARN] Failed to read interactive line from stdin; falling back to auto-select: "
+              + e);
       return "";
     }
   }

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
@@ -109,23 +109,8 @@ public class MainDTSPreInstall {
 
       System.out.println("Installation folder =" + parsedArgs.installPath());
       var installPath = parsedArgs.installPath();
-      // Issue #1340 / US3 + US4 parity: persist the Java home used by DTS
-      // start, stop, and service install paths into <installPath>/java.properties
-      // before the Ant install runs. Honors -Dperc.java.home; otherwise
-      // discovers eligible Java 21 candidates and prompts when interactive.
-      //
-      // Unattended installs (explicit -Dperc.java.home, or no console + CI
-      // markers per JavaInstallSelection.isInteractiveAvailable) pass null
-      // for the prompt so the operator is never asked to choose. When a
-      // single eligible candidate is found, the installer also auto-selects
-      // without prompting.
       try {
-        var unattended = parseUnattendedJavaHome(System.getProperty(PERC_JAVA_HOME));
-        JavaInstallSelection.InteractivePrompt prompt =
-            unattended == null ? (p -> readInteractiveLine(p)) : null;
-        var outcome =
-            new JavaInstallSelection(installPath, unattended, prompt).selectAndPersist();
-        System.out.println("DTS Java home selection: " + outcome.summary());
+        runJavaSelectionStep(installPath);
       } catch (JavaInstallSelection.JavaSelectionException sel) {
         System.out.println("DTS Java home selection failed: " + sel.getMessage());
         throw new AntJobFailedException(
@@ -360,6 +345,43 @@ public class MainDTSPreInstall {
       return null;
     }
     return java.nio.file.Path.of(trimmed);
+  }
+
+  /**
+   * Resolve and persist the Java home used by DTS start, stop, and service
+   * install paths into {@code <installPath>/java.properties} before the Ant
+   * install runs.
+   *
+   * <p>Selection rules:
+   * <ul>
+   *   <li>{@code -Dperc.java.home=<path>} is honored verbatim; the install
+   *       is treated as unattended and the home is validated for the
+   *       required major.</li>
+   *   <li>Otherwise, if {@code -Dperc.unattended=true} or the
+   *       {@code PERC_INSTALL_UNATTENDED} env var is set, the selector runs
+   *       in unattended mode (no prompt). The system {@code JAVA_HOME}
+   *       env var is used when set; if it is also absent, the selector
+   *       falls back to its candidate discovery — but if that yields zero
+   *       eligible candidates the install fails with a clear message
+   *       naming {@code -Dperc.java.home}. This preserves the original
+   *       {@code -Dperc.java.home} → {@code JAVA_HOME} → fail order for
+   *       scripted installs without hanging on a prompt.</li>
+   *   <li>Otherwise (no explicit unattended flag), the selector is
+   *       interactive: it prompts the operator when multiple eligible
+   *       candidates are discovered and auto-selects when exactly one is
+   *       available.</li>
+   * </ul>
+   */
+  static void runJavaSelectionStep(java.nio.file.Path installPath)
+      throws JavaInstallSelection.JavaSelectionException, IOException {
+    var unattended = parseUnattendedJavaHome(System.getProperty(PERC_JAVA_HOME));
+    boolean unattendedRequested =
+        unattended != null || JavaInstallSelection.isUnattendedRequested();
+    JavaInstallSelection.InteractivePrompt prompt =
+        unattendedRequested ? null : (p -> readInteractiveLine(p));
+    var outcome =
+        new JavaInstallSelection(installPath, unattended, prompt).selectAndPersist();
+    System.out.println("DTS Java home selection: " + outcome.summary());
   }
 
   /**

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
@@ -113,14 +113,18 @@ public class MainDTSPreInstall {
       // start, stop, and service install paths into <installPath>/java.properties
       // before the Ant install runs. Honors -Dperc.java.home; otherwise
       // discovers eligible Java 21 candidates and prompts when interactive.
+      //
+      // Unattended installs (explicit -Dperc.java.home, or no console + CI
+      // markers per JavaInstallSelection.isInteractiveAvailable) pass null
+      // for the prompt so the operator is never asked to choose. When a
+      // single eligible candidate is found, the installer also auto-selects
+      // without prompting.
       try {
         var unattended = parseUnattendedJavaHome(System.getProperty(PERC_JAVA_HOME));
+        JavaInstallSelection.InteractivePrompt prompt =
+            unattended == null ? (p -> readInteractiveLine(p)) : null;
         var outcome =
-            new JavaInstallSelection(
-                    installPath,
-                    unattended,
-                    prompt -> readInteractiveLine(prompt))
-                .selectAndPersist();
+            new JavaInstallSelection(installPath, unattended, prompt).selectAndPersist();
         System.out.println("DTS Java home selection: " + outcome.summary());
       } catch (JavaInstallSelection.JavaSelectionException sel) {
         System.out.println("DTS Java home selection failed: " + sel.getMessage());

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
@@ -119,10 +119,7 @@ public class MainDTSPreInstall {
             new JavaInstallSelection(
                     installPath,
                     unattended,
-                    prompt -> {
-                      java.io.Console c = System.console();
-                      return c == null ? "" : c.readLine(prompt);
-                    })
+                    prompt -> readInteractiveLine(prompt))
                 .selectAndPersist();
         System.out.println("DTS Java home selection: " + outcome.summary());
       } catch (JavaInstallSelection.JavaSelectionException sel) {
@@ -359,6 +356,34 @@ public class MainDTSPreInstall {
       return null;
     }
     return java.nio.file.Path.of(trimmed);
+  }
+
+  /**
+   * Reads a line of input from the operator for the multi-candidate Java
+   * home selection prompt. Uses {@link System#console()} when a real TTY
+   * is available; falls back to a {@link java.util.Scanner} on
+   * {@code System.in} so the prompt also works on Windows hosts launched via
+   * {@code java -jar} from PowerShell (where {@code System.console()}
+   * returns null even though stdin is connected). Returns an empty string
+   * when neither a console nor a readable stdin is available so the
+   * auto-select path can fall through.
+   */
+  static String readInteractiveLine(String prompt) {
+    java.io.Console console = System.console();
+    if (console != null) {
+      return console.readLine(prompt);
+    }
+    try {
+      System.out.print(prompt);
+      System.out.flush();
+      java.util.Scanner scanner = new java.util.Scanner(System.in);
+      if (scanner.hasNextLine()) {
+        return scanner.nextLine();
+      }
+      return "";
+    } catch (Exception e) {
+      return "";
+    }
   }
 
   private static ResolvedDbConfig resolveDbConfig(Map<String, String> cliOptions) {

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
@@ -360,13 +360,16 @@ public class MainDTSPreInstall {
 
   /**
    * Reads a line of input from the operator for the multi-candidate Java
-   * home selection prompt. Uses {@link System#console()} when a real TTY
-   * is available; falls back to a {@link java.util.Scanner} on
-   * {@code System.in} so the prompt also works on Windows hosts launched via
-   * {@code java -jar} from PowerShell (where {@code System.console()}
-   * returns null even though stdin is connected). Returns an empty string
-   * when neither a console nor a readable stdin is available so the
-   * auto-select path can fall through.
+   * home selection prompt. Mirrors the CMS sibling
+   * ({@code modules/perc-distribution-tree/.../Main#readInteractiveLine})
+   * — see that file for the full rationale on
+   * {@link java.io.BufferedReader} vs {@link java.util.Scanner}. The short
+   * version: a Scanner pre-fetches into its internal buffer on construction
+   * and cannot be safely closed (closing would close {@code System.in} for
+   * downstream code), so its leaked buffer can silently steal characters
+   * from any subsequent {@code System.in} read in the same JVM. A
+   * {@code BufferedReader} reads byte-by-byte through {@code System.in.read()}
+   * on demand and has no internal pre-fetch buffer to leak.
    */
   static String readInteractiveLine(String prompt) {
     java.io.Console console = System.console();
@@ -376,12 +379,10 @@ public class MainDTSPreInstall {
     try {
       System.out.print(prompt);
       System.out.flush();
-      // Do NOT close the Scanner: closing it would close System.in, which
-      // downstream code (and any subsequent interactive prompts in this JVM)
-      // might still need. The Scanner is intentionally leaked.
-      java.util.Scanner scanner = new java.util.Scanner(System.in);
-      if (scanner.hasNextLine()) {
-        return scanner.nextLine();
+      java.io.BufferedReader reader =
+          new java.io.BufferedReader(new java.io.InputStreamReader(System.in));
+      if (reader.ready()) {
+        return reader.readLine();
       }
       return "";
     } catch (Exception e) {

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/java/JavaCandidateDiscovery.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/java/JavaCandidateDiscovery.java
@@ -63,9 +63,43 @@ public final class JavaCandidateDiscovery {
     List<Candidate> result = new ArrayList<>();
     addCandidate(seen, result, runningJavaHome != null ? Path.of(runningJavaHome) : null);
     addCandidate(seen, result, env != null ? readJavaHome(env) : null);
+    addVersionedHomeEnvVars(seen, result, env);
     addCommonOsLocations(seen, result);
     addPathLaunchers(seen, result, pathValue);
     return result;
+  }
+
+  /**
+   * Scans the env map for {@code JAVA_HOME_<NN>} variables (e.g. {@code
+   * JAVA_HOME_21}, {@code JAVA_HOME_8}, {@code JAVA_HOME_17}, {@code JAVA_HOME_26}).
+   * These are the per-major-version home directories the project itself uses
+   * in {@code mvn-env.bat} ({@code JAVA_HOME_21} drives the Maven toolchain).
+   * Operators routinely set several of these on a single host; without
+   * scanning them the resolver would only ever see {@code JAVA_HOME} (if set)
+   * or the running JVM home, and the user would be unable to choose between
+   * the available installations.
+   */
+  static void addVersionedHomeEnvVars(Set<Path> seen, List<Candidate> sink,
+      java.util.Map<String, String> env) {
+    if (env == null) {
+      return;
+    }
+    for (java.util.Map.Entry<String, String> e : env.entrySet()) {
+      String key = e.getKey();
+      if (key == null || !key.startsWith("JAVA_HOME_") || key.equals("JAVA_HOME")) {
+        continue;
+      }
+      // e.g. JAVA_HOME_21 -> "21" -> 21
+      String suffix = key.substring("JAVA_HOME_".length());
+      if (suffix.isBlank() || !suffix.chars().allMatch(Character::isDigit)) {
+        continue;
+      }
+      String value = e.getValue();
+      if (value == null || value.isBlank()) {
+        continue;
+      }
+      addCandidate(seen, sink, Path.of(value));
+    }
   }
 
   /**

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/java/JavaCandidateDiscovery.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/java/JavaCandidateDiscovery.java
@@ -86,7 +86,9 @@ public final class JavaCandidateDiscovery {
     }
     for (java.util.Map.Entry<String, String> e : env.entrySet()) {
       String key = e.getKey();
-      if (key == null || !key.startsWith("JAVA_HOME_") || key.equals("JAVA_HOME")) {
+      // Require the literal trailing underscore so the bare "JAVA_HOME"
+      // is left to the readJavaHome(env) path above.
+      if (key == null || !key.startsWith("JAVA_HOME_")) {
         continue;
       }
       // e.g. JAVA_HOME_21 -> "21" -> 21

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/java/JavaCandidateDiscovery.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/java/JavaCandidateDiscovery.java
@@ -22,7 +22,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -44,6 +43,12 @@ import java.util.Set;
  *
  * <p>Eligible candidates pass the minimum-major check (parsed from a sibling
  * {@code release} file when present) and have an executable launcher.
+ *
+ * <p>Note: only the standard {@code JAVA_HOME} env var is scanned. The
+ * per-major {@code JAVA_HOME_<NN>} convention used by the Maven toolchain
+ * ({@code mvn-env.bat}) is intentionally <em>not</em> consulted here, because
+ * that convention is a developer convenience and not part of the
+ * installer / runtime contract. See CMS sibling for the same note.
  */
 public final class JavaCandidateDiscovery {
 
@@ -63,45 +68,9 @@ public final class JavaCandidateDiscovery {
     List<Candidate> result = new ArrayList<>();
     addCandidate(seen, result, runningJavaHome != null ? Path.of(runningJavaHome) : null);
     addCandidate(seen, result, env != null ? readJavaHome(env) : null);
-    addVersionedHomeEnvVars(seen, result, env);
     addCommonOsLocations(seen, result);
     addPathLaunchers(seen, result, pathValue);
     return result;
-  }
-
-  /**
-   * Scans the env map for {@code JAVA_HOME_<NN>} variables (e.g. {@code
-   * JAVA_HOME_21}, {@code JAVA_HOME_8}, {@code JAVA_HOME_17}, {@code JAVA_HOME_26}).
-   * These are the per-major-version home directories the project itself uses
-   * in {@code mvn-env.bat} ({@code JAVA_HOME_21} drives the Maven toolchain).
-   * Operators routinely set several of these on a single host; without
-   * scanning them the resolver would only ever see {@code JAVA_HOME} (if set)
-   * or the running JVM home, and the user would be unable to choose between
-   * the available installations.
-   */
-  static void addVersionedHomeEnvVars(Set<Path> seen, List<Candidate> sink,
-      java.util.Map<String, String> env) {
-    if (env == null) {
-      return;
-    }
-    for (java.util.Map.Entry<String, String> e : env.entrySet()) {
-      String key = e.getKey();
-      // Require the literal trailing underscore so the bare "JAVA_HOME"
-      // is left to the readJavaHome(env) path above.
-      if (key == null || !key.startsWith("JAVA_HOME_")) {
-        continue;
-      }
-      // e.g. JAVA_HOME_21 -> "21" -> 21
-      String suffix = key.substring("JAVA_HOME_".length());
-      if (suffix.isBlank() || !suffix.chars().allMatch(Character::isDigit)) {
-        continue;
-      }
-      String value = e.getValue();
-      if (value == null || value.isBlank()) {
-        continue;
-      }
-      addCandidate(seen, sink, Path.of(value));
-    }
   }
 
   /**

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/java/JavaCandidateDiscovery.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/java/JavaCandidateDiscovery.java
@@ -44,11 +44,9 @@ import java.util.Set;
  * <p>Eligible candidates pass the minimum-major check (parsed from a sibling
  * {@code release} file when present) and have an executable launcher.
  *
- * <p>Note: only the standard {@code JAVA_HOME} env var is scanned. The
- * per-major {@code JAVA_HOME_<NN>} convention used by the Maven toolchain
- * ({@code mvn-env.bat}) is intentionally <em>not</em> consulted here, because
- * that convention is a developer convenience and not part of the
- * installer / runtime contract. See CMS sibling for the same note.
+ * <p>Mirrors the CMS sibling
+ * ({@code modules/perc-distribution-tree/.../JavaCandidateDiscovery}) so the
+ * two copies stay in lockstep.
  */
 public final class JavaCandidateDiscovery {
 

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
@@ -104,7 +104,19 @@ public final class JavaInstallSelection {
   }
 
   private static boolean isInteractiveAvailable() {
-    return System.console() != null;
+    if (System.console() != null) {
+      return true;
+    }
+    // Non-TTY fallback: probe stdin via available() which does NOT consume
+    // bytes. (An earlier Scanner-based probe consumed the user's typed
+    // input before the actual prompt could read it.) The caller's prompt
+    // is responsible for the actual blocking read; this method just
+    // reports whether stdin is open.
+    try {
+      return System.in.available() >= 0;
+    } catch (java.io.IOException e) {
+      return false;
+    }
   }
 
   private Path promptForChoice(List<JavaCandidateDiscovery.Candidate> candidates)

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
@@ -104,41 +104,30 @@ public final class JavaInstallSelection {
   }
 
   /**
-   * Detects whether the user can be prompted interactively. Mirrors the
-   * CMS sibling ({@code modules/perc-distribution-tree/.../JavaInstallSelection})
-   * so the two copies stay in lockstep. See the CMS javadoc for the full
-   * resolution order; the short version is:
+   * Detects whether the user can be prompted interactively. Resolution:
    * <ol>
-   *   <li>{@link System#console()} non-null → interactive.</li>
+   *   <li>{@link System#console()} non-null → interactive (real TTY).</li>
    *   <li>{@link java.io.InputStream#available() available() > 0} on
    *       {@code System.in} → interactive (operator piped input).</li>
-   *   <li>Otherwise, fall through to auto-select <em>only</em> when at
-   *       least one standard CI/cron env marker is set, so that
-   *       {@code < /dev/null}, cron, and CI runners no longer hang on the
-   *       prompt menu.</li>
+   *   <li>Otherwise → non-interactive. The caller MUST pair a non-interactive
+   *       return with an {@link #isUnattendedRequested()} check OR a
+   *       {@link #selectAndPersist} that resolves an explicit {@code
+   *       -Dperc.java.home}; otherwise the install will hang on
+   *       {@link #promptForChoice}.</li>
    * </ol>
-   *
-   * <p>The previous {@code available() >= 0} implementation hung CI / cron
-   * environments because {@code available()} returns {@code 0} for
-   * open-but-empty stdin (e.g. {@code < /dev/null}), so the {@code >= 0}
-   * check returned {@code true} and {@code Scanner.nextLine()} blocked
-   * forever.
    */
   static boolean isInteractiveAvailable() {
-    return isInteractiveAvailable(probeStdinHasBytes(), isCiEnvironment(System.getenv()));
+    return isInteractiveAvailable(probeStdinHasBytes());
   }
 
   /**
    * Pure-logic variant for tests; see CMS sibling for full javadoc.
    */
-  static boolean isInteractiveAvailable(boolean stdinHasBytes, boolean ciEnvironment) {
+  static boolean isInteractiveAvailable(boolean stdinHasBytes) {
     if (System.console() != null) {
       return true;
     }
-    if (stdinHasBytes) {
-      return true;
-    }
-    return !ciEnvironment;
+    return stdinHasBytes;
   }
 
   private static boolean probeStdinHasBytes() {
@@ -149,26 +138,46 @@ public final class JavaInstallSelection {
     }
   }
 
-  static boolean isCiEnvironment(java.util.Map<String, String> env) {
-    if (env == null) {
+  /**
+   * System property / env-var name that the operator sets to flag the
+   * install as unattended (no prompting, no discovery beyond the explicit
+   * Java home override). Mirrors the CMS sibling.
+   */
+  static final String PERC_UNATTENDED = "perc.unattended";
+  static final String PERC_INSTALL_UNATTENDED_ENV = "PERC_INSTALL_UNATTENDED";
+
+  /**
+   * Returns {@code true} when the operator has explicitly requested an
+   * unattended install via {@code -Dperc.unattended=<value>} or the
+   * {@code PERC_INSTALL_UNATTENDED} environment variable. Recognised truthy
+   * values: {@code true} / {@code 1} / {@code yes} (case-insensitive).
+   * Unset, blank, {@code false}, {@code 0}, or {@code no} returns
+   * {@code false}. Returning {@code true} is the installer's contract that
+   * no stdin read may block.
+   */
+  public static boolean isUnattendedRequested() {
+    return isTruthy(System.getProperty(PERC_UNATTENDED))
+        || isTruthy(System.getenv(PERC_INSTALL_UNATTENDED_ENV));
+  }
+
+  static boolean isUnattendedRequested(java.util.Map<String, String> sysProps,
+      java.util.Map<String, String> env) {
+    String propValue = sysProps == null ? null : sysProps.get(PERC_UNATTENDED);
+    String envValue = env == null ? null : env.get(PERC_INSTALL_UNATTENDED_ENV);
+    return isTruthy(propValue) || isTruthy(envValue);
+  }
+
+  private static boolean isTruthy(String value) {
+    if (value == null) {
       return false;
     }
-    String[] markers = {
-        "CI", "CONTINUOUS_INTEGRATION", "GITHUB_ACTIONS",
-        "JENKINS_URL", "BUILDKITE", "TF_BUILD",
-        "GITLAB_CI", "CIRCLECI"
-    };
-    for (String marker : markers) {
-      String value = env.get(marker);
-      if (value == null || value.isBlank()) {
-        continue;
-      }
-      if (value.equalsIgnoreCase("false") || value.equals("0")) {
-        continue;
-      }
-      return true;
+    String trimmed = value.trim();
+    if (trimmed.isEmpty()) {
+      return false;
     }
-    return false;
+    return !"false".equalsIgnoreCase(trimmed)
+        && !"0".equals(trimmed)
+        && !"no".equalsIgnoreCase(trimmed);
   }
 
   private Path promptForChoice(List<JavaCandidateDiscovery.Candidate> candidates)

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
@@ -89,8 +89,8 @@ public final class JavaInstallSelection {
       if (eligible.size() == 1 || interactivePrompt == null || !isInteractiveAvailable()) {
         chosen = eligible.get(0).path().toAbsolutePath().normalize();
         source = eligible.size() == 1
-            ? "auto-selected (single candidate)"
-            : "auto-selected (non-interactive batch)";
+            ? "auto-selected (single eligible candidate: the Java home contract only scans JAVA_HOME and JAVA_HOME_<NN> env vars)"
+            : "auto-selected (non-interactive batch: console or stdin unavailable)";
       } else {
         chosen = promptForChoice(eligible);
         source = "selected by operator";

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
@@ -103,20 +103,72 @@ public final class JavaInstallSelection {
     return new SelectionOutcome(chosen, Path.of(launcher), source);
   }
 
-  private static boolean isInteractiveAvailable() {
+  /**
+   * Detects whether the user can be prompted interactively. Mirrors the
+   * CMS sibling ({@code modules/perc-distribution-tree/.../JavaInstallSelection})
+   * so the two copies stay in lockstep. See the CMS javadoc for the full
+   * resolution order; the short version is:
+   * <ol>
+   *   <li>{@link System#console()} non-null → interactive.</li>
+   *   <li>{@link java.io.InputStream#available() available() > 0} on
+   *       {@code System.in} → interactive (operator piped input).</li>
+   *   <li>Otherwise, fall through to auto-select <em>only</em> when at
+   *       least one standard CI/cron env marker is set, so that
+   *       {@code < /dev/null}, cron, and CI runners no longer hang on the
+   *       prompt menu.</li>
+   * </ol>
+   *
+   * <p>The previous {@code available() >= 0} implementation hung CI / cron
+   * environments because {@code available()} returns {@code 0} for
+   * open-but-empty stdin (e.g. {@code < /dev/null}), so the {@code >= 0}
+   * check returned {@code true} and {@code Scanner.nextLine()} blocked
+   * forever.
+   */
+  static boolean isInteractiveAvailable() {
+    return isInteractiveAvailable(probeStdinHasBytes(), isCiEnvironment(System.getenv()));
+  }
+
+  /**
+   * Pure-logic variant for tests; see CMS sibling for full javadoc.
+   */
+  static boolean isInteractiveAvailable(boolean stdinHasBytes, boolean ciEnvironment) {
     if (System.console() != null) {
       return true;
     }
-    // Non-TTY fallback: probe stdin via available() which does NOT consume
-    // bytes. (An earlier Scanner-based probe consumed the user's typed
-    // input before the actual prompt could read it.) The caller's prompt
-    // is responsible for the actual blocking read; this method just
-    // reports whether stdin is open.
+    if (stdinHasBytes) {
+      return true;
+    }
+    return !ciEnvironment;
+  }
+
+  private static boolean probeStdinHasBytes() {
     try {
-      return System.in.available() >= 0;
+      return System.in.available() > 0;
     } catch (java.io.IOException e) {
       return false;
     }
+  }
+
+  static boolean isCiEnvironment(java.util.Map<String, String> env) {
+    if (env == null) {
+      return false;
+    }
+    String[] markers = {
+        "CI", "CONTINUOUS_INTEGRATION", "GITHUB_ACTIONS",
+        "JENKINS_URL", "BUILDKITE", "TF_BUILD",
+        "GITLAB_CI", "CIRCLECI"
+    };
+    for (String marker : markers) {
+      String value = env.get(marker);
+      if (value == null || value.isBlank()) {
+        continue;
+      }
+      if (value.equalsIgnoreCase("false") || value.equals("0")) {
+        continue;
+      }
+      return true;
+    }
+    return false;
   }
 
   private Path promptForChoice(List<JavaCandidateDiscovery.Candidate> candidates)

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
@@ -89,7 +89,7 @@ public final class JavaInstallSelection {
       if (eligible.size() == 1 || interactivePrompt == null || !isInteractiveAvailable()) {
         chosen = eligible.get(0).path().toAbsolutePath().normalize();
         source = eligible.size() == 1
-            ? "auto-selected (single eligible candidate: the Java home contract only scans JAVA_HOME and JAVA_HOME_<NN> env vars)"
+            ? "auto-selected (single eligible candidate)"
             : "auto-selected (non-interactive batch: console or stdin unavailable)";
       } else {
         chosen = promptForChoice(eligible);

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/java/JavaCandidateDiscoveryTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/java/JavaCandidateDiscoveryTest.java
@@ -83,6 +83,26 @@ class JavaCandidateDiscoveryTest {
     assertFalse(JavaCandidateDiscovery.Candidate.meetsMinimumMajor(null));
   }
 
+  /** Mirror of CMS test — multi-JDK host discovers JAVA_HOME_21 and JAVA_HOME_8. */
+  @Test
+  void discoversVersionedHomeEnvVars(@org.junit.jupiter.api.io.TempDir java.nio.file.Path scratch) throws java.io.IOException {
+    String launcher = launcherForCurrentPlatform();
+    java.nio.file.Path jdk21 = makeHome(scratch.resolve("jdk21"), "21", launcher);
+    java.nio.file.Path jdk8 = makeHome(scratch.resolve("jdk8"), "8", launcher);
+    java.util.Map<String, String> env = java.util.Map.of(
+        "JAVA_HOME_21", jdk21.toString(),
+        "JAVA_HOME_8", jdk8.toString(),
+        "PATH", scratch.resolve("jdk21").resolve("bin").toString());
+    java.util.List<JavaCandidateDiscovery.Candidate> raw =
+        JavaCandidateDiscovery.discover(env, null, env.get("PATH"));
+    assertTrue(
+        raw.stream().anyMatch(c -> c.path().toString().equals(jdk21.toString())),
+        "JAVA_HOME_21 must produce a candidate; found: " + raw);
+    assertTrue(
+        raw.stream().anyMatch(c -> c.path().toString().equals(jdk8.toString())),
+        "JAVA_HOME_8 must produce a candidate; found: " + raw);
+  }
+
   private static String launcherForCurrentPlatform() {
     String os = System.getProperty("os.name", "");
     return os.toLowerCase(java.util.Locale.ROOT).contains("win") ? "java.exe" : "java";

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/java/JavaCandidateDiscoveryTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/java/JavaCandidateDiscoveryTest.java
@@ -89,6 +89,15 @@ class JavaCandidateDiscoveryTest {
    * and are NOT part of the installer / runtime contract. The resolver must
    * ignore them and rely only on the standard {@code JAVA_HOME} and PATH /
    * common-OS-locations discovery.
+   *
+   * <p>Test shape: {@code jdk21} is placed on {@code PATH} (so it is
+   * discovered via PATH-based launcher inference), {@code jdk8} is on
+   * disk but <em>not</em> on {@code PATH}, and both homes are also
+   * exposed via the non-standard {@code JAVA_HOME_<NN>} env vars. If
+   * the resolver honored {@code JAVA_HOME_<NN>}, {@code jdk8} would
+   * appear as a second candidate. Asserting {@code raw.size() == 1} and
+   * the surviving path equals {@code jdk21} proves the
+   * {@code JAVA_HOME_<NN>} scan is truly inactive.
    */
   @Test
   void ignoresVersionedHomeEnvVars(@TempDir Path scratch) throws IOException {
@@ -101,9 +110,11 @@ class JavaCandidateDiscoveryTest {
         "PATH", scratch.resolve("jdk21").resolve("bin").toString());
     List<JavaCandidateDiscovery.Candidate> raw =
         JavaCandidateDiscovery.discover(env, null, env.get("PATH"));
-    assertFalse(
-        raw.stream().anyMatch(c -> c.path().toString().equals(jdk8.toString())),
-        "JAVA_HOME_8 alone must not produce a candidate; found: " + raw);
+    assertEquals(1, raw.size(),
+        "JAVA_HOME_<NN> must not promote a candidate; expected only the PATH-detected jdk21,"
+            + " found: " + raw);
+    assertEquals(jdk21, raw.get(0).path(),
+        "Surviving candidate must be the PATH-detected jdk21; found: " + raw.get(0));
   }
 
   private static String launcherForCurrentPlatform() {

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/java/JavaCandidateDiscoveryTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/java/JavaCandidateDiscoveryTest.java
@@ -85,15 +85,15 @@ class JavaCandidateDiscoveryTest {
 
   /** Mirror of CMS test — multi-JDK host discovers JAVA_HOME_21 and JAVA_HOME_8. */
   @Test
-  void discoversVersionedHomeEnvVars(@org.junit.jupiter.api.io.TempDir java.nio.file.Path scratch) throws java.io.IOException {
+  void discoversVersionedHomeEnvVars(@TempDir Path scratch) throws IOException {
     String launcher = launcherForCurrentPlatform();
-    java.nio.file.Path jdk21 = makeHome(scratch.resolve("jdk21"), "21", launcher);
-    java.nio.file.Path jdk8 = makeHome(scratch.resolve("jdk8"), "8", launcher);
-    java.util.Map<String, String> env = java.util.Map.of(
+    Path jdk21 = makeHome(scratch.resolve("jdk21"), "21", launcher);
+    Path jdk8 = makeHome(scratch.resolve("jdk8"), "8", launcher);
+    Map<String, String> env = Map.of(
         "JAVA_HOME_21", jdk21.toString(),
         "JAVA_HOME_8", jdk8.toString(),
         "PATH", scratch.resolve("jdk21").resolve("bin").toString());
-    java.util.List<JavaCandidateDiscovery.Candidate> raw =
+    List<JavaCandidateDiscovery.Candidate> raw =
         JavaCandidateDiscovery.discover(env, null, env.get("PATH"));
     assertTrue(
         raw.stream().anyMatch(c -> c.path().toString().equals(jdk21.toString())),
@@ -101,6 +101,30 @@ class JavaCandidateDiscoveryTest {
     assertTrue(
         raw.stream().anyMatch(c -> c.path().toString().equals(jdk8.toString())),
         "JAVA_HOME_8 must produce a candidate; found: " + raw);
+  }
+
+  /**
+   * Mirror of CMS test — regression: non-numeric suffixes
+   * ({@code JAVA_HOME_FOO}) and the bare {@code JAVA_HOME} must NOT be
+   * treated as versioned home vars. See CMS sibling for full rationale.
+   */
+  @Test
+  void addVersionedHomeEnvVarsRejectsNonNumeric(@TempDir Path scratch) throws IOException {
+    String launcher = launcherForCurrentPlatform();
+    Path real = makeHome(scratch.resolve("real"), "21", launcher);
+    Map<String, String> env = Map.of(
+        "JAVA_HOME_21", real.toString(),
+        "JAVA_HOME_FOO", scratch.resolve("fake").toString(),
+        "JAVA_HOME_", scratch.resolve("blank").toString(),
+        "JAVA_HOME_21abc", scratch.resolve("suffix").toString());
+    // Empty PATH so addPathLaunchers / addCommonOsLocations contribute nothing;
+    // any candidate in `raw` came from addVersionedHomeEnvVars or readJavaHome.
+    List<JavaCandidateDiscovery.Candidate> raw =
+        JavaCandidateDiscovery.discover(env, null, "");
+    assertEquals(1, raw.size(),
+        "Only JAVA_HOME_21 should resolve to a candidate; found: " + raw);
+    assertEquals(real, raw.get(0).path(),
+        "Surviving candidate must point at JAVA_HOME_21's value; found: " + raw.get(0));
   }
 
   private static String launcherForCurrentPlatform() {

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/java/JavaCandidateDiscoveryTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/java/JavaCandidateDiscoveryTest.java
@@ -83,9 +83,15 @@ class JavaCandidateDiscoveryTest {
     assertFalse(JavaCandidateDiscovery.Candidate.meetsMinimumMajor(null));
   }
 
-  /** Mirror of CMS test — multi-JDK host discovers JAVA_HOME_21 and JAVA_HOME_8. */
+  /**
+   * Mirror of CMS test — regression: the per-major {@code JAVA_HOME_<NN>}
+   * env vars are a developer-only convenience used by {@code mvn-env.bat}
+   * and are NOT part of the installer / runtime contract. The resolver must
+   * ignore them and rely only on the standard {@code JAVA_HOME} and PATH /
+   * common-OS-locations discovery.
+   */
   @Test
-  void discoversVersionedHomeEnvVars(@TempDir Path scratch) throws IOException {
+  void ignoresVersionedHomeEnvVars(@TempDir Path scratch) throws IOException {
     String launcher = launcherForCurrentPlatform();
     Path jdk21 = makeHome(scratch.resolve("jdk21"), "21", launcher);
     Path jdk8 = makeHome(scratch.resolve("jdk8"), "8", launcher);
@@ -95,36 +101,9 @@ class JavaCandidateDiscoveryTest {
         "PATH", scratch.resolve("jdk21").resolve("bin").toString());
     List<JavaCandidateDiscovery.Candidate> raw =
         JavaCandidateDiscovery.discover(env, null, env.get("PATH"));
-    assertTrue(
-        raw.stream().anyMatch(c -> c.path().toString().equals(jdk21.toString())),
-        "JAVA_HOME_21 must produce a candidate; found: " + raw);
-    assertTrue(
+    assertFalse(
         raw.stream().anyMatch(c -> c.path().toString().equals(jdk8.toString())),
-        "JAVA_HOME_8 must produce a candidate; found: " + raw);
-  }
-
-  /**
-   * Mirror of CMS test — regression: non-numeric suffixes
-   * ({@code JAVA_HOME_FOO}) and the bare {@code JAVA_HOME} must NOT be
-   * treated as versioned home vars. See CMS sibling for full rationale.
-   */
-  @Test
-  void addVersionedHomeEnvVarsRejectsNonNumeric(@TempDir Path scratch) throws IOException {
-    String launcher = launcherForCurrentPlatform();
-    Path real = makeHome(scratch.resolve("real"), "21", launcher);
-    Map<String, String> env = Map.of(
-        "JAVA_HOME_21", real.toString(),
-        "JAVA_HOME_FOO", scratch.resolve("fake").toString(),
-        "JAVA_HOME_", scratch.resolve("blank").toString(),
-        "JAVA_HOME_21abc", scratch.resolve("suffix").toString());
-    // Empty PATH so addPathLaunchers / addCommonOsLocations contribute nothing;
-    // any candidate in `raw` came from addVersionedHomeEnvVars or readJavaHome.
-    List<JavaCandidateDiscovery.Candidate> raw =
-        JavaCandidateDiscovery.discover(env, null, "");
-    assertEquals(1, raw.size(),
-        "Only JAVA_HOME_21 should resolve to a candidate; found: " + raw);
-    assertEquals(real, raw.get(0).path(),
-        "Surviving candidate must point at JAVA_HOME_21's value; found: " + raw.get(0));
+        "JAVA_HOME_8 alone must not produce a candidate; found: " + raw);
   }
 
   private static String launcherForCurrentPlatform() {

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/java/JavaInstallSelectionTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/java/JavaInstallSelectionTest.java
@@ -17,6 +17,7 @@
 package com.percussion.preinstall.java;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -36,13 +37,6 @@ class JavaInstallSelectionTest {
 
   @Test
   void zeroEligibleCandidatesFailsClearly() throws Exception {
-    JavaInstallSelection sel = new JavaInstallSelection(tempDir, null, null);
-    // No fixture homes on the path; discovery may still find the running JVM
-    // but for this test we craft an environment where the running JVM's
-    // home is not eligible by passing a temp dir plus making the selection
-    // uses a synthetic scenario. Actually the running JVM's HOME is also a
-    // valid candidate; instead we simulate "no candidates" via the unattended
-    // path pointing at an invalid home.
     Path invalid = tempDir.resolve("does-not-exist");
     JavaInstallSelection unattended =
         new JavaInstallSelection(tempDir, invalid, null);
@@ -61,16 +55,11 @@ class JavaInstallSelectionTest {
     Path installRoot = tempDir.resolve("install");
     Files.createDirectories(installRoot);
     Path jdk = JavaCandidateDiscoveryTest.makeHome(installRoot.resolve("jdk21"), "21", "java");
-    // Override the running JVM + env via a process that only sees our jdk.
-    // We can't easily replace System properties, but we CAN call JavaHomeResolver
-    // directly via a selection that pre-seeds unattendedHome to the only valid
-    // candidate.
     JavaInstallSelection sel = new JavaInstallSelection(installRoot, jdk, null);
     JavaInstallSelection.SelectionOutcome out = sel.selectAndPersist();
     assertEquals(jdk.toAbsolutePath().normalize(), out.javaHome().toAbsolutePath().normalize());
     assertTrue(out.source().startsWith("unattended") || out.source().contains("auto"),
         "source tagged: " + out.source());
-    // java.properties was written.
     assertTrue(Files.exists(installRoot.resolve("java.properties")));
     String body = Files.readString(installRoot.resolve("java.properties"), StandardCharsets.UTF_8);
     assertTrue(body.contains("jdk21"),
@@ -99,17 +88,8 @@ class JavaInstallSelectionTest {
     AtomicReference<String> prompted = new AtomicReference<>();
     JavaInstallSelection.InteractivePrompt prompt = q -> {
       prompted.set(q);
-      // Pick the second candidate ("b") to exercise selection.
       return "2";
     };
-    JavaInstallSelection sel = new JavaInstallSelection(installRoot, null, prompt);
-    // We can't fully exercise the discovery-driven path without a fake PATH,
-    // so we pre-condition with unattended = null and a prompt that captures
-    // the menu. We assert the prompt text was emitted; the actual selection
-    // outcome then propagates from a callback stub.
-    // To keep this test deterministic we instead force unattended mode to a
-    // valid home (mirrors the unattended path) and verify the prompt is NOT
-    // called. This documents that unattended short-circuits interactive.
     JavaInstallSelection unattendedA = new JavaInstallSelection(installRoot, a, prompt);
     unattendedA.selectAndPersist();
     assertEquals(null, prompted.get(), "unattended path must not invoke the prompt");
@@ -118,56 +98,80 @@ class JavaInstallSelectionTest {
   @Test
   void listContainsAtLeastPathLauncherHome() {
     List<JavaCandidateDiscovery.Candidate> candidates = JavaCandidateDiscovery.discover();
-    // Robustness check: candidates list is never null.
     assertTrue(candidates != null);
   }
 
-  // ---------- isInteractiveAvailable() / isCiEnvironment(env) regression ----------
-  // (Mirror of CMS tests; see modules/perc-distribution-tree sibling for full
-  //  rationale on the CI-aware fallback heuristic.)
+  // ---------- isUnattendedRequested() / isInteractiveAvailable() regression ----------
 
   @Test
-  void isCiEnvironmentRecognizesAllStandardMarkers() {
-    String[] markers = {
-        "CI", "CONTINUOUS_INTEGRATION", "GITHUB_ACTIONS",
-        "JENKINS_URL", "BUILDKITE", "TF_BUILD",
-        "GITLAB_CI", "CIRCLECI"
-    };
-    for (String marker : markers) {
-      java.util.Map<String, String> env = java.util.Map.of(marker, "true");
-      assertTrue(JavaInstallSelection.isCiEnvironment(env),
-          "marker must be detected: " + marker);
-    }
+  void isUnattendedRequestedRecognizesAllTruthySources() {
+    assertTrue(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "true"),
+        java.util.Map.of()));
+    assertTrue(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "TRUE"),
+        java.util.Map.of()));
+    assertTrue(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "1"),
+        java.util.Map.of()));
+    assertTrue(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "yes"),
+        java.util.Map.of()));
+    assertTrue(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(),
+        java.util.Map.of(JavaInstallSelection.PERC_INSTALL_UNATTENDED_ENV, "true")));
+    assertTrue(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(),
+        java.util.Map.of(JavaInstallSelection.PERC_INSTALL_UNATTENDED_ENV, "1")));
+    assertTrue(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "true"),
+        java.util.Map.of(JavaInstallSelection.PERC_INSTALL_UNATTENDED_ENV, "true")),
+        "either source is sufficient");
   }
 
   @Test
-  void isCiEnvironmentIgnoresFalseAndZeroAndBlankValues() {
-    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of("CI", "false")));
-    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of("CI", "0")));
-    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of("CI", "")));
-    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of("CI", "FALSE")));
-    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of()));
-    assertTrue(!JavaInstallSelection.isCiEnvironment(null));
+  void isUnattendedRequestedRejectsFalsyAndUnset() {
+    assertFalse(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "false"),
+        java.util.Map.of()));
+    assertFalse(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "FALSE"),
+        java.util.Map.of()));
+    assertFalse(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "0"),
+        java.util.Map.of()));
+    assertFalse(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "no"),
+        java.util.Map.of()));
+    assertFalse(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, ""),
+        java.util.Map.of()));
+    assertFalse(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "   "),
+        java.util.Map.of()));
+    assertFalse(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(),
+        java.util.Map.of()));
+    assertFalse(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "false"),
+        java.util.Map.of(JavaInstallSelection.PERC_INSTALL_UNATTENDED_ENV, "false")),
+        "both falsy sources is still falsy");
+    assertFalse(JavaInstallSelection.isUnattendedRequested(null, null));
+    assertFalse(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(),
+        java.util.Map.of("UNRELATED", "true")),
+        "unrelated env-var must not trigger unattended mode");
   }
 
   @Test
-  void isInteractiveAvailableFallsThroughInCiWithEmptyStdin() {
-    assertTrue(!JavaInstallSelection.isInteractiveAvailable(false, true),
-        "stdin empty + CI env must auto-select (no hang)");
+  void isInteractiveAvailableQueueDrainedReturnsFalse() {
+    assertFalse(JavaInstallSelection.isInteractiveAvailable(false),
+        "stdin empty + no console must NOT be interactive (no hang)");
   }
 
   @Test
-  void isInteractiveAvailableAllowsPromptInPowerShellStyleEnvironment() {
-    assertTrue(JavaInstallSelection.isInteractiveAvailable(false, false),
-        "stdin empty + no CI env must still treat as interactive "
-            + "(PowerShell / desktop operator case)");
-  }
-
-  @Test
-  void isInteractiveAvailableTreatsQueuedBytesAsInteractive() {
-    assertTrue(JavaInstallSelection.isInteractiveAvailable(true, false),
-        "stdin with queued bytes must be interactive");
-    assertTrue(JavaInstallSelection.isInteractiveAvailable(true, true),
-        "stdin with queued bytes must be interactive even in CI");
+  void isInteractiveAvailableQueuedBytesAreInteractive() {
+    assertTrue(JavaInstallSelection.isInteractiveAvailable(true),
+        "stdin with queued bytes must be interactive (operator piped input)");
   }
 }

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/java/JavaInstallSelectionTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/java/JavaInstallSelectionTest.java
@@ -121,4 +121,53 @@ class JavaInstallSelectionTest {
     // Robustness check: candidates list is never null.
     assertTrue(candidates != null);
   }
+
+  // ---------- isInteractiveAvailable() / isCiEnvironment(env) regression ----------
+  // (Mirror of CMS tests; see modules/perc-distribution-tree sibling for full
+  //  rationale on the CI-aware fallback heuristic.)
+
+  @Test
+  void isCiEnvironmentRecognizesAllStandardMarkers() {
+    String[] markers = {
+        "CI", "CONTINUOUS_INTEGRATION", "GITHUB_ACTIONS",
+        "JENKINS_URL", "BUILDKITE", "TF_BUILD",
+        "GITLAB_CI", "CIRCLECI"
+    };
+    for (String marker : markers) {
+      java.util.Map<String, String> env = java.util.Map.of(marker, "true");
+      assertTrue(JavaInstallSelection.isCiEnvironment(env),
+          "marker must be detected: " + marker);
+    }
+  }
+
+  @Test
+  void isCiEnvironmentIgnoresFalseAndZeroAndBlankValues() {
+    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of("CI", "false")));
+    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of("CI", "0")));
+    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of("CI", "")));
+    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of("CI", "FALSE")));
+    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of()));
+    assertTrue(!JavaInstallSelection.isCiEnvironment(null));
+  }
+
+  @Test
+  void isInteractiveAvailableFallsThroughInCiWithEmptyStdin() {
+    assertTrue(!JavaInstallSelection.isInteractiveAvailable(false, true),
+        "stdin empty + CI env must auto-select (no hang)");
+  }
+
+  @Test
+  void isInteractiveAvailableAllowsPromptInPowerShellStyleEnvironment() {
+    assertTrue(JavaInstallSelection.isInteractiveAvailable(false, false),
+        "stdin empty + no CI env must still treat as interactive "
+            + "(PowerShell / desktop operator case)");
+  }
+
+  @Test
+  void isInteractiveAvailableTreatsQueuedBytesAsInteractive() {
+    assertTrue(JavaInstallSelection.isInteractiveAvailable(true, false),
+        "stdin with queued bytes must be interactive");
+    assertTrue(JavaInstallSelection.isInteractiveAvailable(true, true),
+        "stdin with queued bytes must be interactive even in CI");
+  }
 }

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
@@ -154,14 +154,18 @@ public class Main {
       // environment by auto-selecting single candidates and failing loudly
       // when zero are eligible — never silently fall back to a manual
       // <InstallDir>/JRE copy.
+      //
+      // Unattended installs (explicit -Dperc.java.home, or no console + CI
+      // markers per JavaInstallSelection.isInteractiveAvailable) pass null
+      // for the prompt so the operator is never asked to choose. When a
+      // single eligible candidate is found, the installer also auto-selects
+      // without prompting.
       try {
         Path unattended = parseUnattendedJavaHome(System.getProperty(PERC_JAVA_HOME));
+        JavaInstallSelection.InteractivePrompt prompt =
+            unattended == null ? (p -> readInteractiveLine(p)) : null;
         JavaInstallSelection.SelectionOutcome outcome =
-            new JavaInstallSelection(
-                    installPath,
-                    unattended,
-                    prompt -> readInteractiveLine(prompt))
-                .selectAndPersist();
+            new JavaInstallSelection(installPath, unattended, prompt).selectAndPersist();
         System.out.println("Java home selection: " + outcome.summary());
       } catch (JavaInstallSelection.JavaSelectionException sel) {
         System.out.println("Java home selection failed: " + sel.getMessage());

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
@@ -292,12 +292,21 @@ public class Main {
   /**
    * Reads a line of input from the operator for the multi-candidate Java
    * home selection prompt. Uses {@link System#console()} when a real TTY
-   * is available; falls back to a {@link java.util.Scanner} on
+   * is available; falls back to a {@link java.io.BufferedReader} on
    * {@code System.in} so the prompt also works on Windows hosts launched via
    * {@code java -jar} from PowerShell (where {@code System.console()}
    * returns null even though stdin is connected). Returns an empty string
    * when neither a console nor a readable stdin is available so the
    * auto-select path can fall through.
+   *
+   * <p>A {@link java.io.BufferedReader} is preferred over a {@link
+   * java.util.Scanner} here because a Scanner reads ahead into its
+   * internal buffer on construction; that buffer is not closed (closing
+   * the Scanner would close {@code System.in} for downstream code) and
+   * could therefore silently steal characters from any subsequent
+   * {@code System.in} read in the same JVM. A {@code BufferedReader}
+   * reads byte-by-byte through {@code System.in.read()} on demand and
+   * has no internal pre-fetch buffer to leak.
    */
   static String readInteractiveLine(String prompt) {
     java.io.Console console = System.console();
@@ -307,12 +316,14 @@ public class Main {
     try {
       System.out.print(prompt);
       System.out.flush();
-      // Do NOT close the Scanner: closing it would close System.in, which
-      // downstream code (and any subsequent interactive prompts in this JVM)
-      // might still need. The Scanner is intentionally leaked.
-      java.util.Scanner scanner = new java.util.Scanner(System.in);
-      if (scanner.hasNextLine()) {
-        return scanner.nextLine();
+      java.io.BufferedReader reader =
+          new java.io.BufferedReader(new java.io.InputStreamReader(System.in));
+      // Use ready() rather than reading directly so we don't block the
+      // caller forever when stdin is closed (e.g. CI redirect from
+      // /dev/null). If no input is ready within the Java SE guarantee,
+      // fall through to the empty-string / auto-select path.
+      if (reader.ready()) {
+        return reader.readLine();
       }
       return "";
     } catch (Exception e) {

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
@@ -160,10 +160,7 @@ public class Main {
             new JavaInstallSelection(
                     installPath,
                     unattended,
-                    prompt -> {
-                      java.io.Console c = System.console();
-                      return c == null ? "" : c.readLine(prompt);
-                    })
+                    prompt -> readInteractiveLine(prompt))
                 .selectAndPersist();
         System.out.println("Java home selection: " + outcome.summary());
       } catch (JavaInstallSelection.JavaSelectionException sel) {
@@ -290,6 +287,34 @@ public class Main {
       return null;
     }
     return java.nio.file.Path.of(trimmed);
+  }
+
+  /**
+   * Reads a line of input from the operator for the multi-candidate Java
+   * home selection prompt. Uses {@link System#console()} when a real TTY
+   * is available; falls back to a {@link java.util.Scanner} on
+   * {@code System.in} so the prompt also works on Windows hosts launched via
+   * {@code java -jar} from PowerShell (where {@code System.console()}
+   * returns null even though stdin is connected). Returns an empty string
+   * when neither a console nor a readable stdin is available so the
+   * auto-select path can fall through.
+   */
+  static String readInteractiveLine(String prompt) {
+    java.io.Console console = System.console();
+    if (console != null) {
+      return console.readLine(prompt);
+    }
+    try {
+      System.out.print(prompt);
+      System.out.flush();
+      java.util.Scanner scanner = new java.util.Scanner(System.in);
+      if (scanner.hasNextLine()) {
+        return scanner.nextLine();
+      }
+      return "";
+    } catch (Exception e) {
+      return "";
+    }
   }
 
   static void runObsoleteInstallDirCleanup(

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
@@ -307,12 +307,22 @@ public class Main {
     try {
       System.out.print(prompt);
       System.out.flush();
+      // Do NOT close the Scanner: closing it would close System.in, which
+      // downstream code (and any subsequent interactive prompts in this JVM)
+      // might still need. The Scanner is intentionally leaked.
       java.util.Scanner scanner = new java.util.Scanner(System.in);
       if (scanner.hasNextLine()) {
         return scanner.nextLine();
       }
       return "";
     } catch (Exception e) {
+      // User-facing fallback: surface the failure to stderr so the operator
+      // sees that stdin could not be read instead of watching the installer
+      // silently auto-pick a JDK. The empty-string return lets the
+      // auto-select path fall through.
+      System.err.println(
+          "[WARN] Failed to read interactive line from stdin; falling back to auto-select: "
+              + e);
       return "";
     }
   }

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
@@ -147,26 +147,8 @@ public class Main {
 
       System.out.println("Installation folder is " + installPath.toAbsolutePath().toString());
 
-      // Issue #1340 / US3 + US4: resolve and persist the Java home used at
-      // runtime by CMS / DTS start, stop, and service install paths. Honor an
-      // explicit -Dperc.java.home=... override; otherwise discover and (when
-      // interactive) prompt for a Java 21 home. Survives a non-interactive
-      // environment by auto-selecting single candidates and failing loudly
-      // when zero are eligible — never silently fall back to a manual
-      // <InstallDir>/JRE copy.
-      //
-      // Unattended installs (explicit -Dperc.java.home, or no console + CI
-      // markers per JavaInstallSelection.isInteractiveAvailable) pass null
-      // for the prompt so the operator is never asked to choose. When a
-      // single eligible candidate is found, the installer also auto-selects
-      // without prompting.
       try {
-        Path unattended = parseUnattendedJavaHome(System.getProperty(PERC_JAVA_HOME));
-        JavaInstallSelection.InteractivePrompt prompt =
-            unattended == null ? (p -> readInteractiveLine(p)) : null;
-        JavaInstallSelection.SelectionOutcome outcome =
-            new JavaInstallSelection(installPath, unattended, prompt).selectAndPersist();
-        System.out.println("Java home selection: " + outcome.summary());
+        runJavaSelectionStep(installPath);
       } catch (JavaInstallSelection.JavaSelectionException sel) {
         System.out.println("Java home selection failed: " + sel.getMessage());
         System.exit(2);
@@ -291,6 +273,40 @@ public class Main {
       return null;
     }
     return java.nio.file.Path.of(trimmed);
+  }
+
+  /**
+   * Resolve and persist the Java home used at runtime by CMS / DTS start,
+   * stop, and service install paths into {@code <installPath>/java.properties}
+   * before the ANT installer runs.
+   *
+   * <p>Selection rules:
+   * <ul>
+   *   <li>{@code -Dperc.java.home=<path>} is honored verbatim; the install
+   *       is treated as unattended and the home is validated for the
+   *       required major.</li>
+   *   <li>Otherwise, if {@code -Dperc.unattended=true} or the
+   *       {@code PERC_INSTALL_UNATTENDED} env var is set, the selector runs
+   *       in unattended mode (no prompt). The candidate discovery still
+   *       applies; if it yields zero eligible candidates the install fails
+   *       with a clear message naming {@code -Dperc.java.home}. This
+   *       preserves the original {@code -Dperc.java.home} → discovery →
+   *       fail order for scripted installs without hanging on a prompt.</li>
+   *   <li>Otherwise, the selector is interactive: it prompts the operator
+   *       when multiple eligible candidates are discovered and
+   *       auto-selects when exactly one is available.</li>
+   * </ul>
+   */
+  static void runJavaSelectionStep(Path installPath)
+      throws JavaInstallSelection.JavaSelectionException, IOException {
+    Path unattended = parseUnattendedJavaHome(System.getProperty(PERC_JAVA_HOME));
+    boolean unattendedRequested =
+        unattended != null || JavaInstallSelection.isUnattendedRequested();
+    JavaInstallSelection.InteractivePrompt prompt =
+        unattendedRequested ? null : (p -> readInteractiveLine(p));
+    JavaInstallSelection.SelectionOutcome outcome =
+        new JavaInstallSelection(installPath, unattended, prompt).selectAndPersist();
+    System.out.println("Java home selection: " + outcome.summary());
   }
 
   /**

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaCandidateDiscovery.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaCandidateDiscovery.java
@@ -22,7 +22,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -44,6 +43,12 @@ import java.util.Set;
  *
  * <p>Eligible candidates pass the minimum-major check (parsed from a sibling
  * {@code release} file when present) and have an executable launcher.
+ *
+ * <p>Note: only the standard {@code JAVA_HOME} env var is scanned. The
+ * per-major {@code JAVA_HOME_<NN>} convention used by the Maven toolchain
+ * ({@code mvn-env.bat}) is intentionally <em>not</em> consulted here, because
+ * that convention is a developer convenience and not part of the
+ * installer / runtime contract.
  */
 public final class JavaCandidateDiscovery {
 
@@ -67,45 +72,9 @@ public final class JavaCandidateDiscovery {
     List<Candidate> result = new ArrayList<>();
     addCandidate(seen, result, runningJavaHome != null ? Path.of(runningJavaHome) : null);
     addCandidate(seen, result, env != null ? readJavaHome(env) : null);
-    addVersionedHomeEnvVars(seen, result, env);
     addCommonOsLocations(seen, result);
     addPathLaunchers(seen, result, pathValue);
     return result;
-  }
-
-  /**
-   * Scans the env map for {@code JAVA_HOME_<NN>} variables (e.g. {@code
-   * JAVA_HOME_21}, {@code JAVA_HOME_8}, {@code JAVA_HOME_17}, {@code JAVA_HOME_26}).
-   * These are the per-major-version home directories the project itself uses
-   * in {@code mvn-env.bat} ({@code JAVA_HOME_21} drives the Maven toolchain).
-   * Operators routinely set several of these on a single host; without
-   * scanning them the resolver would only ever see {@code JAVA_HOME} (if set)
-   * or the running JVM home, and the user would be unable to choose between
-   * the available installations.
-   */
-  static void addVersionedHomeEnvVars(Set<Path> seen, List<Candidate> sink,
-      java.util.Map<String, String> env) {
-    if (env == null) {
-      return;
-    }
-    for (java.util.Map.Entry<String, String> e : env.entrySet()) {
-      String key = e.getKey();
-      // Require the literal trailing underscore so the bare "JAVA_HOME"
-      // is left to the readJavaHome(env) path above.
-      if (key == null || !key.startsWith("JAVA_HOME_")) {
-        continue;
-      }
-      // e.g. JAVA_HOME_21 -> "21" -> 21
-      String suffix = key.substring("JAVA_HOME_".length());
-      if (suffix.isBlank() || !suffix.chars().allMatch(Character::isDigit)) {
-        continue;
-      }
-      String value = e.getValue();
-      if (value == null || value.isBlank()) {
-        continue;
-      }
-      addCandidate(seen, sink, Path.of(value));
-    }
   }
 
   /**

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaCandidateDiscovery.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaCandidateDiscovery.java
@@ -67,9 +67,43 @@ public final class JavaCandidateDiscovery {
     List<Candidate> result = new ArrayList<>();
     addCandidate(seen, result, runningJavaHome != null ? Path.of(runningJavaHome) : null);
     addCandidate(seen, result, env != null ? readJavaHome(env) : null);
+    addVersionedHomeEnvVars(seen, result, env);
     addCommonOsLocations(seen, result);
     addPathLaunchers(seen, result, pathValue);
     return result;
+  }
+
+  /**
+   * Scans the env map for {@code JAVA_HOME_<NN>} variables (e.g. {@code
+   * JAVA_HOME_21}, {@code JAVA_HOME_8}, {@code JAVA_HOME_17}, {@code JAVA_HOME_26}).
+   * These are the per-major-version home directories the project itself uses
+   * in {@code mvn-env.bat} ({@code JAVA_HOME_21} drives the Maven toolchain).
+   * Operators routinely set several of these on a single host; without
+   * scanning them the resolver would only ever see {@code JAVA_HOME} (if set)
+   * or the running JVM home, and the user would be unable to choose between
+   * the available installations.
+   */
+  static void addVersionedHomeEnvVars(Set<Path> seen, List<Candidate> sink,
+      java.util.Map<String, String> env) {
+    if (env == null) {
+      return;
+    }
+    for (java.util.Map.Entry<String, String> e : env.entrySet()) {
+      String key = e.getKey();
+      if (key == null || !key.startsWith("JAVA_HOME_") || key.equals("JAVA_HOME")) {
+        continue;
+      }
+      // e.g. JAVA_HOME_21 -> "21" -> 21
+      String suffix = key.substring("JAVA_HOME_".length());
+      if (suffix.isBlank() || !suffix.chars().allMatch(Character::isDigit)) {
+        continue;
+      }
+      String value = e.getValue();
+      if (value == null || value.isBlank()) {
+        continue;
+      }
+      addCandidate(seen, sink, Path.of(value));
+    }
   }
 
   /**

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaCandidateDiscovery.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaCandidateDiscovery.java
@@ -90,7 +90,9 @@ public final class JavaCandidateDiscovery {
     }
     for (java.util.Map.Entry<String, String> e : env.entrySet()) {
       String key = e.getKey();
-      if (key == null || !key.startsWith("JAVA_HOME_") || key.equals("JAVA_HOME")) {
+      // Require the literal trailing underscore so the bare "JAVA_HOME"
+      // is left to the readJavaHome(env) path above.
+      if (key == null || !key.startsWith("JAVA_HOME_")) {
         continue;
       }
       // e.g. JAVA_HOME_21 -> "21" -> 21

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaCandidateDiscovery.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaCandidateDiscovery.java
@@ -43,12 +43,6 @@ import java.util.Set;
  *
  * <p>Eligible candidates pass the minimum-major check (parsed from a sibling
  * {@code release} file when present) and have an executable launcher.
- *
- * <p>Note: only the standard {@code JAVA_HOME} env var is scanned. The
- * per-major {@code JAVA_HOME_<NN>} convention used by the Maven toolchain
- * ({@code mvn-env.bat}) is intentionally <em>not</em> consulted here, because
- * that convention is a developer convenience and not part of the
- * installer / runtime contract.
  */
 public final class JavaCandidateDiscovery {
 

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
@@ -99,8 +99,8 @@ public final class JavaInstallSelection {
       if (eligible.size() == 1 || interactivePrompt == null || !isInteractiveAvailable()) {
         chosen = eligible.get(0).path().toAbsolutePath().normalize();
         source = eligible.size() == 1
-            ? "auto-selected (single candidate)"
-            : "auto-selected (non-interactive batch)";
+            ? "auto-selected (single eligible candidate: the Java home contract only scans JAVA_HOME and JAVA_HOME_<NN> env vars)"
+            : "auto-selected (non-interactive batch: console or stdin unavailable)";
       } else {
         chosen = promptForChoice(eligible);
         source = "selected by operator";
@@ -113,8 +113,41 @@ public final class JavaInstallSelection {
     return new SelectionOutcome(chosen, Path.of(launcher), source);
   }
 
+  /**
+   * Detects whether the user can be prompted interactively.
+   *
+   * <p>The primary check is {@link System#console()} non-null. On Windows
+   * hosts launched via {@code java -jar} from PowerShell, {@code
+   * System.console()} returns null even when stdin/stdout are connected to
+   * a terminal — a known JDK limitation. The {@link Main} / {@link
+   * MainDTSPreInstall} InteractivePrompt implementations handle that case
+   * by using a {@link java.util.Scanner} on {@code System.in} directly, so
+   * the prompt can still read user input. We use a non-blocking probe
+   * ({@code System.in.available() > 0} or stream open) as the fallback to
+   * confirm the prompt has a real stdin to read from, since auto-selecting
+   * with no input available is the documented behavior for non-interactive
+   * installs.
+   */
   private static boolean isInteractiveAvailable() {
-    return System.console() != null;
+    if (System.console() != null) {
+      return true;
+    }
+    // Fallback: probe stdin. If a Scanner can be opened on System.in and
+    // either has input available OR is open (will be when stdin is connected
+    // to a TTY or pipe), treat as interactive. The call-site prompt
+    // implementation is responsible for actually reading.
+    try (java.util.Scanner probe = new java.util.Scanner(System.in)) {
+      if (probe.hasNextLine()) {
+        return true; // there's data already pending
+      }
+      // No pending data; assume stdin is connected (TTY or pipe) and the
+      // caller's prompt will block on readLine. If the caller's prompt
+      // returns "" without blocking (true no-input), the selection falls
+      // through to auto-select.
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
   }
 
   private Path promptForChoice(List<JavaCandidateDiscovery.Candidate> candidates)

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
@@ -99,7 +99,7 @@ public final class JavaInstallSelection {
       if (eligible.size() == 1 || interactivePrompt == null || !isInteractiveAvailable()) {
         chosen = eligible.get(0).path().toAbsolutePath().normalize();
         source = eligible.size() == 1
-            ? "auto-selected (single eligible candidate: the Java home contract only scans JAVA_HOME and JAVA_HOME_<NN> env vars)"
+            ? "auto-selected (single eligible candidate)"
             : "auto-selected (non-interactive batch: console or stdin unavailable)";
       } else {
         chosen = promptForChoice(eligible);

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
@@ -114,53 +114,30 @@ public final class JavaInstallSelection {
   }
 
   /**
-   * Detects whether the user can be prompted interactively.
-   *
-   * <p>Resolution order:
+   * Detects whether the user can be prompted interactively. Resolution:
    * <ol>
-   *   <li>If {@link System#console()} is non-null, the operator is at a real
-   *       TTY — interactive.</li>
-   *   <li>Otherwise (Windows PowerShell {@code java -jar}, CI runners, cron,
-   *       piped input, etc.), we probe stdin non-blockingly via
-   *       {@link java.io.InputStream#available()}. If bytes are already queued
-   *       ({@code > 0}), the operator piped input or is mid-typing — interactive.</li>
-   *   <li>Finally, if stdin is reachable but no bytes are queued, we fall
-   *       through to auto-select <em>only</em> when at least one standard
-   *       CI/cron environment marker is set ({@code CI},
-   *       {@code CONTINUOUS_INTEGRATION}, {@code GITHUB_ACTIONS},
-   *       {@code JENKINS_URL}, {@code BUILDKITE}, {@code TF_BUILD},
-   *       {@code GITLAB_CI}, {@code CIRCLECI}). This preserves the documented
-   *       "non-interactive installs auto-select" behavior on CI runners
-   *       while still showing the prompt menu to an operator who launched
-   *       the installer from PowerShell on a workstation (where none of
-   *       those markers are set).</li>
+   *   <li>{@link System#console()} non-null → interactive (real TTY).</li>
+   *   <li>{@link java.io.InputStream#available() available() > 0} on
+   *       {@code System.in} → interactive (operator piped input).</li>
+   *   <li>Otherwise → non-interactive. The caller MUST pair a non-interactive
+   *       return with an {@link #isUnattendedRequested()} check OR a
+   *       {@link #selectAndPersist} that resolves an explicit {@code
+   *       -Dperc.java.home}; otherwise the install will hang on
+   *       {@link #promptForChoice}.</li>
    * </ol>
-   *
-   * <p>The previous implementation used {@code System.in.available() >= 0},
-   * which returned {@code true} for an open-but-empty stdin (e.g.
-   * {@code < /dev/null} on Unix, or an exhausted pipe in a CI runner). That
-   * caused {@link #promptForChoice} to enter the interactive path, print
-   * the menu, and block forever on {@code Scanner.nextLine()} because no
-   * operator was watching — a hard hang in non-interactive environments.
    */
   static boolean isInteractiveAvailable() {
-    return isInteractiveAvailable(probeStdinHasBytes(), isCiEnvironment(System.getenv()));
+    return isInteractiveAvailable(probeStdinHasBytes());
   }
 
   /**
-   * Pure-logic variant of {@link #isInteractiveAvailable()} for tests. The
-   * {@link System#console()} check is still applied (it cannot be mocked
-   * cleanly from JUnit), so this overload primarily exercises the
-   * "no-console" decision branch.
+   * Pure-logic variant of {@link #isInteractiveAvailable()} for tests.
    */
-  static boolean isInteractiveAvailable(boolean stdinHasBytes, boolean ciEnvironment) {
+  static boolean isInteractiveAvailable(boolean stdinHasBytes) {
     if (System.console() != null) {
       return true;
     }
-    if (stdinHasBytes) {
-      return true;
-    }
-    return !ciEnvironment;
+    return stdinHasBytes;
   }
 
   /**
@@ -177,31 +154,45 @@ public final class JavaInstallSelection {
   }
 
   /**
-   * Detects whether the current process is running inside a CI / cron /
-   * batch environment by inspecting standard env-var markers. The marker
-   * is considered "set" when it is non-blank and not a literal
-   * {@code "false"} / {@code "0"}.
+   * System property / env-var names that flag the install as unattended
+   * (no prompting, no discovery beyond the explicit Java home override).
+   * Mirrors the DTS sibling.
    */
-  static boolean isCiEnvironment(java.util.Map<String, String> env) {
-    if (env == null) {
+  static final String PERC_UNATTENDED = "perc.unattended";
+  static final String PERC_INSTALL_UNATTENDED_ENV = "PERC_INSTALL_UNATTENDED";
+
+  /**
+   * Returns {@code true} when the operator has explicitly requested an
+   * unattended install via {@code -Dperc.unattended=<value>} or the
+   * {@code PERC_INSTALL_UNATTENDED} environment variable. Recognised truthy
+   * values: {@code true} / {@code 1} / {@code yes} (case-insensitive).
+   * Unset, blank, {@code false}, {@code 0}, or {@code no} returns
+   * {@code false}. Returning {@code true} is the installer's contract that
+   * no stdin read may block.
+   */
+  public static boolean isUnattendedRequested() {
+    return isTruthy(System.getProperty(PERC_UNATTENDED))
+        || isTruthy(System.getenv(PERC_INSTALL_UNATTENDED_ENV));
+  }
+
+  static boolean isUnattendedRequested(java.util.Map<String, String> sysProps,
+      java.util.Map<String, String> env) {
+    String propValue = sysProps == null ? null : sysProps.get(PERC_UNATTENDED);
+    String envValue = env == null ? null : env.get(PERC_INSTALL_UNATTENDED_ENV);
+    return isTruthy(propValue) || isTruthy(envValue);
+  }
+
+  private static boolean isTruthy(String value) {
+    if (value == null) {
       return false;
     }
-    String[] markers = {
-        "CI", "CONTINUOUS_INTEGRATION", "GITHUB_ACTIONS",
-        "JENKINS_URL", "BUILDKITE", "TF_BUILD",
-        "GITLAB_CI", "CIRCLECI"
-    };
-    for (String marker : markers) {
-      String value = env.get(marker);
-      if (value == null || value.isBlank()) {
-        continue;
-      }
-      if (value.equalsIgnoreCase("false") || value.equals("0")) {
-        continue;
-      }
-      return true;
+    String trimmed = value.trim();
+    if (trimmed.isEmpty()) {
+      return false;
     }
-    return false;
+    return !"false".equalsIgnoreCase(trimmed)
+        && !"0".equals(trimmed)
+        && !"no".equalsIgnoreCase(trimmed);
   }
 
   private Path promptForChoice(List<JavaCandidateDiscovery.Candidate> candidates)

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
@@ -132,20 +132,14 @@ public final class JavaInstallSelection {
     if (System.console() != null) {
       return true;
     }
-    // Fallback: probe stdin. If a Scanner can be opened on System.in and
-    // either has input available OR is open (will be when stdin is connected
-    // to a TTY or pipe), treat as interactive. The call-site prompt
-    // implementation is responsible for actually reading.
-    try (java.util.Scanner probe = new java.util.Scanner(System.in)) {
-      if (probe.hasNextLine()) {
-        return true; // there's data already pending
-      }
-      // No pending data; assume stdin is connected (TTY or pipe) and the
-      // caller's prompt will block on readLine. If the caller's prompt
-      // returns "" without blocking (true no-input), the selection falls
-      // through to auto-select.
-      return true;
-    } catch (Exception e) {
+    // Non-TTY fallback: probe stdin via available() which does NOT consume
+    // bytes. (An earlier Scanner-based probe consumed the user's typed
+    // input before the actual prompt could read it.) The caller's prompt
+    // is responsible for the actual blocking read; this method just
+    // reports whether stdin is open.
+    try {
+      return System.in.available() >= 0;
+    } catch (java.io.IOException e) {
       return false;
     }
   }

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
@@ -123,10 +123,10 @@ public final class JavaInstallSelection {
    * MainDTSPreInstall} InteractivePrompt implementations handle that case
    * by using a {@link java.util.Scanner} on {@code System.in} directly, so
    * the prompt can still read user input. We use a non-blocking probe
-   * ({@code System.in.available() > 0} or stream open) as the fallback to
-   * confirm the prompt has a real stdin to read from, since auto-selecting
-   * with no input available is the documented behavior for non-interactive
-   * installs.
+   * ({@code System.in.available() >= 0} — i.e. the stream is reachable
+   * without throwing) as the fallback to confirm the prompt has a real
+   * stdin to read from, since auto-selecting with no input available is
+   * the documented behavior for non-interactive installs.
    */
   private static boolean isInteractiveAvailable() {
     if (System.console() != null) {
@@ -136,7 +136,7 @@ public final class JavaInstallSelection {
     // bytes. (An earlier Scanner-based probe consumed the user's typed
     // input before the actual prompt could read it.) The caller's prompt
     // is responsible for the actual blocking read; this method just
-    // reports whether stdin is open.
+    // reports whether stdin is reachable (returns >= 0) without throwing.
     try {
       return System.in.available() >= 0;
     } catch (java.io.IOException e) {

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
@@ -116,32 +116,92 @@ public final class JavaInstallSelection {
   /**
    * Detects whether the user can be prompted interactively.
    *
-   * <p>The primary check is {@link System#console()} non-null. On Windows
-   * hosts launched via {@code java -jar} from PowerShell, {@code
-   * System.console()} returns null even when stdin/stdout are connected to
-   * a terminal — a known JDK limitation. The {@link Main} / {@link
-   * MainDTSPreInstall} InteractivePrompt implementations handle that case
-   * by using a {@link java.util.Scanner} on {@code System.in} directly, so
-   * the prompt can still read user input. We use a non-blocking probe
-   * ({@code System.in.available() >= 0} — i.e. the stream is reachable
-   * without throwing) as the fallback to confirm the prompt has a real
-   * stdin to read from, since auto-selecting with no input available is
-   * the documented behavior for non-interactive installs.
+   * <p>Resolution order:
+   * <ol>
+   *   <li>If {@link System#console()} is non-null, the operator is at a real
+   *       TTY — interactive.</li>
+   *   <li>Otherwise (Windows PowerShell {@code java -jar}, CI runners, cron,
+   *       piped input, etc.), we probe stdin non-blockingly via
+   *       {@link java.io.InputStream#available()}. If bytes are already queued
+   *       ({@code > 0}), the operator piped input or is mid-typing — interactive.</li>
+   *   <li>Finally, if stdin is reachable but no bytes are queued, we fall
+   *       through to auto-select <em>only</em> when at least one standard
+   *       CI/cron environment marker is set ({@code CI},
+   *       {@code CONTINUOUS_INTEGRATION}, {@code GITHUB_ACTIONS},
+   *       {@code JENKINS_URL}, {@code BUILDKITE}, {@code TF_BUILD},
+   *       {@code GITLAB_CI}, {@code CIRCLECI}). This preserves the documented
+   *       "non-interactive installs auto-select" behavior on CI runners
+   *       while still showing the prompt menu to an operator who launched
+   *       the installer from PowerShell on a workstation (where none of
+   *       those markers are set).</li>
+   * </ol>
+   *
+   * <p>The previous implementation used {@code System.in.available() >= 0},
+   * which returned {@code true} for an open-but-empty stdin (e.g.
+   * {@code < /dev/null} on Unix, or an exhausted pipe in a CI runner). That
+   * caused {@link #promptForChoice} to enter the interactive path, print
+   * the menu, and block forever on {@code Scanner.nextLine()} because no
+   * operator was watching — a hard hang in non-interactive environments.
    */
-  private static boolean isInteractiveAvailable() {
+  static boolean isInteractiveAvailable() {
+    return isInteractiveAvailable(probeStdinHasBytes(), isCiEnvironment(System.getenv()));
+  }
+
+  /**
+   * Pure-logic variant of {@link #isInteractiveAvailable()} for tests. The
+   * {@link System#console()} check is still applied (it cannot be mocked
+   * cleanly from JUnit), so this overload primarily exercises the
+   * "no-console" decision branch.
+   */
+  static boolean isInteractiveAvailable(boolean stdinHasBytes, boolean ciEnvironment) {
     if (System.console() != null) {
       return true;
     }
-    // Non-TTY fallback: probe stdin via available() which does NOT consume
-    // bytes. (An earlier Scanner-based probe consumed the user's typed
-    // input before the actual prompt could read it.) The caller's prompt
-    // is responsible for the actual blocking read; this method just
-    // reports whether stdin is reachable (returns >= 0) without throwing.
+    if (stdinHasBytes) {
+      return true;
+    }
+    return !ciEnvironment;
+  }
+
+  /**
+   * Non-blocking probe of {@link System#in} that does NOT consume bytes
+   * (a previous {@code Scanner}-based probe consumed the operator's typed
+   * input before the actual prompt could read it).
+   */
+  private static boolean probeStdinHasBytes() {
     try {
-      return System.in.available() >= 0;
+      return System.in.available() > 0;
     } catch (java.io.IOException e) {
       return false;
     }
+  }
+
+  /**
+   * Detects whether the current process is running inside a CI / cron /
+   * batch environment by inspecting standard env-var markers. The marker
+   * is considered "set" when it is non-blank and not a literal
+   * {@code "false"} / {@code "0"}.
+   */
+  static boolean isCiEnvironment(java.util.Map<String, String> env) {
+    if (env == null) {
+      return false;
+    }
+    String[] markers = {
+        "CI", "CONTINUOUS_INTEGRATION", "GITHUB_ACTIONS",
+        "JENKINS_URL", "BUILDKITE", "TF_BUILD",
+        "GITLAB_CI", "CIRCLECI"
+    };
+    for (String marker : markers) {
+      String value = env.get(marker);
+      if (value == null || value.isBlank()) {
+        continue;
+      }
+      if (value.equalsIgnoreCase("false") || value.equals("0")) {
+        continue;
+      }
+      return true;
+    }
+    return false;
   }
 
   private Path promptForChoice(List<JavaCandidateDiscovery.Candidate> candidates)

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/java/JavaCandidateDiscoveryTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/java/JavaCandidateDiscoveryTest.java
@@ -84,13 +84,14 @@ class JavaCandidateDiscoveryTest {
   }
 
   /**
-   * Regression for the multi-JDK host case: when operators set several of the
-   * project-standard per-major env vars (e.g. {@code JAVA_HOME_21},
-   * {@code JAVA_HOME_8}, {@code JAVA_HOME_17}), the resolver must scan
-   * them so the user can choose between available installations.
+   * Regression: the per-major {@code JAVA_HOME_<NN>} env vars (e.g.
+   * {@code JAVA_HOME_21}) are a developer-only convenience used by
+   * {@code mvn-env.bat} and are NOT part of the installer / runtime
+   * contract. The resolver must ignore them and rely only on the standard
+   * {@code JAVA_HOME} and PATH / common-OS-locations discovery.
    */
   @Test
-  void discoversVersionedHomeEnvVars(@TempDir Path scratch) throws IOException {
+  void ignoresVersionedHomeEnvVars(@TempDir Path scratch) throws IOException {
     String launcher = launcherForCurrentPlatform();
     Path jdk21 = makeHome(scratch.resolve("jdk21"), "21", launcher);
     Path jdk8 = makeHome(scratch.resolve("jdk8"), "8", launcher);
@@ -98,44 +99,18 @@ class JavaCandidateDiscoveryTest {
         "JAVA_HOME_21", jdk21.toString(),
         "JAVA_HOME_8", jdk8.toString(),
         "PATH", scratch.resolve("jdk21").resolve("bin").toString());
-    // Both JAVA_HOME_21 and JAVA_HOME_8 must appear as candidates.
+    // JAVA_HOME_<NN> must NOT be promoted to a candidate on its own — only the
+    // PATH-resident bin (jdk21) is discovered. jdk8 is on disk but not on PATH
+    // and is not exposed via any standard env var, so it must NOT appear.
     List<JavaCandidateDiscovery.Candidate> raw =
-        JavaCandidateDiscovery.discover(env, /*runningJavaHome*/ null, env.get("PATH"));
-    assertTrue(
-        raw.stream().anyMatch(c -> c.path().toString().equals(jdk21.toString())),
-        "JAVA_HOME_21 must produce a candidate; found: " + raw);
-    assertTrue(
+        JavaCandidateDiscovery.discover(env, /* runningJavaHome */ null, env.get("PATH"));
+    assertFalse(
         raw.stream().anyMatch(c -> c.path().toString().equals(jdk8.toString())),
-        "JAVA_HOME_8 must produce a candidate; found: " + raw);
-  }
-
-  /**
-   * Regression: non-numeric suffixes (e.g. {@code JAVA_HOME_FOO}) and the bare
-   * {@code JAVA_HOME} must NOT be treated as versioned home vars. The bare
-   * {@code JAVA_HOME} is still consulted via the existing
-   * {@code addCandidate(... readJavaHome(env) ...)} path; this test asserts
-   * the {@code addVersionedHomeEnvVars} helper itself filters strictly.
-   */
-  @Test
-  void addVersionedHomeEnvVarsRejectsNonNumeric(@TempDir Path scratch) throws IOException {
-    String launcher = launcherForCurrentPlatform();
-    Path real = makeHome(scratch.resolve("real"), "21", launcher);
-    Map<String, String> env = Map.of(
-        "JAVA_HOME_21", real.toString(),
-        "JAVA_HOME_FOO", scratch.resolve("fake").toString(),
-        "JAVA_HOME_", scratch.resolve("blank").toString(),
-        "JAVA_HOME_21abc", scratch.resolve("suffix").toString());
-    // Empty PATH so addPathLaunchers / addCommonOsLocations contribute nothing;
-    // any candidate in `raw` came from addVersionedHomeEnvVars or readJavaHome.
-    List<JavaCandidateDiscovery.Candidate> raw =
-        JavaCandidateDiscovery.discover(env, null, "");
-    // Only JAVA_HOME_21 is recognized as a versioned home; the others are
-    // silently filtered. JAVA_HOME itself is NOT in the env map here, so the
-    // versioned path produces exactly one candidate total.
-    assertEquals(1, raw.size(),
-        "Only JAVA_HOME_21 should resolve to a candidate; found: " + raw);
-    assertEquals(real, raw.get(0).path(),
-        "Surviving candidate must point at JAVA_HOME_21's value; found: " + raw.get(0));
+        "JAVA_HOME_8 alone must not produce a candidate; found: " + raw);
+    assertFalse(
+        raw.stream().anyMatch(c -> c.path().toString().equals(jdk21.toString())
+            && !c.path().toString().equals(scratch.resolve("jdk21").toString())),
+        "JAVA_HOME_21 alone must not produce a candidate; found: " + raw);
   }
 
   private static String launcherForCurrentPlatform() {

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/java/JavaCandidateDiscoveryTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/java/JavaCandidateDiscoveryTest.java
@@ -125,16 +125,17 @@ class JavaCandidateDiscoveryTest {
         "JAVA_HOME_FOO", scratch.resolve("fake").toString(),
         "JAVA_HOME_", scratch.resolve("blank").toString(),
         "JAVA_HOME_21abc", scratch.resolve("suffix").toString());
+    // Empty PATH so addPathLaunchers / addCommonOsLocations contribute nothing;
+    // any candidate in `raw` came from addVersionedHomeEnvVars or readJavaHome.
     List<JavaCandidateDiscovery.Candidate> raw =
         JavaCandidateDiscovery.discover(env, null, "");
     // Only JAVA_HOME_21 is recognized as a versioned home; the others are
     // silently filtered. JAVA_HOME itself is NOT in the env map here, so the
-    // versioned path produces exactly one candidate.
-    long numeric = raw.stream()
-        .filter(c -> c.path().toString().equals(real.toString()))
-        .count();
-    assertEquals(1, numeric,
+    // versioned path produces exactly one candidate total.
+    assertEquals(1, raw.size(),
         "Only JAVA_HOME_21 should resolve to a candidate; found: " + raw);
+    assertEquals(real, raw.get(0).path(),
+        "Surviving candidate must point at JAVA_HOME_21's value; found: " + raw.get(0));
   }
 
   private static String launcherForCurrentPlatform() {

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/java/JavaCandidateDiscoveryTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/java/JavaCandidateDiscoveryTest.java
@@ -89,6 +89,15 @@ class JavaCandidateDiscoveryTest {
    * {@code mvn-env.bat} and are NOT part of the installer / runtime
    * contract. The resolver must ignore them and rely only on the standard
    * {@code JAVA_HOME} and PATH / common-OS-locations discovery.
+   *
+   * <p>Test shape: {@code jdk21} is placed on {@code PATH} (so it is
+   * discovered via PATH-based launcher inference), {@code jdk8} is on
+   * disk but <em>not</em> on {@code PATH}, and both homes are also
+   * exposed via the non-standard {@code JAVA_HOME_<NN>} env vars. If
+   * the resolver honored {@code JAVA_HOME_<NN>}, {@code jdk8} would
+   * appear as a second candidate. Asserting {@code raw.size() == 1} and
+   * the surviving path equals {@code jdk21} proves the
+   * {@code JAVA_HOME_<NN>} scan is truly inactive.
    */
   @Test
   void ignoresVersionedHomeEnvVars(@TempDir Path scratch) throws IOException {
@@ -99,18 +108,15 @@ class JavaCandidateDiscoveryTest {
         "JAVA_HOME_21", jdk21.toString(),
         "JAVA_HOME_8", jdk8.toString(),
         "PATH", scratch.resolve("jdk21").resolve("bin").toString());
-    // JAVA_HOME_<NN> must NOT be promoted to a candidate on its own — only the
-    // PATH-resident bin (jdk21) is discovered. jdk8 is on disk but not on PATH
-    // and is not exposed via any standard env var, so it must NOT appear.
     List<JavaCandidateDiscovery.Candidate> raw =
         JavaCandidateDiscovery.discover(env, /* runningJavaHome */ null, env.get("PATH"));
-    assertFalse(
-        raw.stream().anyMatch(c -> c.path().toString().equals(jdk8.toString())),
-        "JAVA_HOME_8 alone must not produce a candidate; found: " + raw);
-    assertFalse(
-        raw.stream().anyMatch(c -> c.path().toString().equals(jdk21.toString())
-            && !c.path().toString().equals(scratch.resolve("jdk21").toString())),
-        "JAVA_HOME_21 alone must not produce a candidate; found: " + raw);
+    // Only the PATH-resident jdk21 should appear; jdk8 must NOT be promoted
+    // to a candidate via JAVA_HOME_8 alone.
+    assertEquals(1, raw.size(),
+        "JAVA_HOME_<NN> must not promote a candidate; expected only the PATH-detected jdk21,"
+            + " found: " + raw);
+    assertEquals(jdk21, raw.get(0).path(),
+        "Surviving candidate must be the PATH-detected jdk21; found: " + raw.get(0));
   }
 
   private static String launcherForCurrentPlatform() {

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/java/JavaCandidateDiscoveryTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/java/JavaCandidateDiscoveryTest.java
@@ -83,6 +83,60 @@ class JavaCandidateDiscoveryTest {
     assertFalse(JavaCandidateDiscovery.Candidate.meetsMinimumMajor(null));
   }
 
+  /**
+   * Regression for the multi-JDK host case: when operators set several of the
+   * project-standard per-major env vars (e.g. {@code JAVA_HOME_21},
+   * {@code JAVA_HOME_8}, {@code JAVA_HOME_17}), the resolver must scan
+   * them so the user can choose between available installations.
+   */
+  @Test
+  void discoversVersionedHomeEnvVars(@TempDir Path scratch) throws IOException {
+    String launcher = launcherForCurrentPlatform();
+    Path jdk21 = makeHome(scratch.resolve("jdk21"), "21", launcher);
+    Path jdk8 = makeHome(scratch.resolve("jdk8"), "8", launcher);
+    Map<String, String> env = Map.of(
+        "JAVA_HOME_21", jdk21.toString(),
+        "JAVA_HOME_8", jdk8.toString(),
+        "PATH", scratch.resolve("jdk21").resolve("bin").toString());
+    // Both JAVA_HOME_21 and JAVA_HOME_8 must appear as candidates.
+    List<JavaCandidateDiscovery.Candidate> raw =
+        JavaCandidateDiscovery.discover(env, /*runningJavaHome*/ null, env.get("PATH"));
+    assertTrue(
+        raw.stream().anyMatch(c -> c.path().toString().equals(jdk21.toString())),
+        "JAVA_HOME_21 must produce a candidate; found: " + raw);
+    assertTrue(
+        raw.stream().anyMatch(c -> c.path().toString().equals(jdk8.toString())),
+        "JAVA_HOME_8 must produce a candidate; found: " + raw);
+  }
+
+  /**
+   * Regression: non-numeric suffixes (e.g. {@code JAVA_HOME_FOO}) and the bare
+   * {@code JAVA_HOME} must NOT be treated as versioned home vars. The bare
+   * {@code JAVA_HOME} is still consulted via the existing
+   * {@code addCandidate(... readJavaHome(env) ...)} path; this test asserts
+   * the {@code addVersionedHomeEnvVars} helper itself filters strictly.
+   */
+  @Test
+  void addVersionedHomeEnvVarsRejectsNonNumeric(@TempDir Path scratch) throws IOException {
+    String launcher = launcherForCurrentPlatform();
+    Path real = makeHome(scratch.resolve("real"), "21", launcher);
+    Map<String, String> env = Map.of(
+        "JAVA_HOME_21", real.toString(),
+        "JAVA_HOME_FOO", scratch.resolve("fake").toString(),
+        "JAVA_HOME_", scratch.resolve("blank").toString(),
+        "JAVA_HOME_21abc", scratch.resolve("suffix").toString());
+    List<JavaCandidateDiscovery.Candidate> raw =
+        JavaCandidateDiscovery.discover(env, null, "");
+    // Only JAVA_HOME_21 is recognized as a versioned home; the others are
+    // silently filtered. JAVA_HOME itself is NOT in the env map here, so the
+    // versioned path produces exactly one candidate.
+    long numeric = raw.stream()
+        .filter(c -> c.path().toString().equals(real.toString()))
+        .count();
+    assertEquals(1, numeric,
+        "Only JAVA_HOME_21 should resolve to a candidate; found: " + raw);
+  }
+
   private static String launcherForCurrentPlatform() {
     String os = System.getProperty("os.name", "");
     return os.toLowerCase(java.util.Locale.ROOT).contains("win") ? "java.exe" : "java";

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/java/JavaInstallSelectionTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/java/JavaInstallSelectionTest.java
@@ -17,6 +17,7 @@
 package com.percussion.preinstall.java;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -36,13 +37,6 @@ class JavaInstallSelectionTest {
 
   @Test
   void zeroEligibleCandidatesFailsClearly() throws Exception {
-    JavaInstallSelection sel = new JavaInstallSelection(tempDir, null, null);
-    // No fixture homes on the path; discovery may still find the running JVM
-    // but for this test we craft an environment where the running JVM's
-    // home is not eligible by passing a temp dir plus making the selection
-    // uses a synthetic scenario. Actually the running JVM's HOME is also a
-    // valid candidate; instead we simulate "no candidates" via the unattended
-    // path pointing at an invalid home.
     Path invalid = tempDir.resolve("does-not-exist");
     JavaInstallSelection unattended =
         new JavaInstallSelection(tempDir, invalid, null);
@@ -61,16 +55,11 @@ class JavaInstallSelectionTest {
     Path installRoot = tempDir.resolve("install");
     Files.createDirectories(installRoot);
     Path jdk = JavaCandidateDiscoveryTest.makeHome(installRoot.resolve("jdk21"), "21", "java");
-    // Override the running JVM + env via a process that only sees our jdk.
-    // We can't easily replace System properties, but we CAN call JavaHomeResolver
-    // directly via a selection that pre-seeds unattendedHome to the only valid
-    // candidate.
     JavaInstallSelection sel = new JavaInstallSelection(installRoot, jdk, null);
     JavaInstallSelection.SelectionOutcome out = sel.selectAndPersist();
     assertEquals(jdk.toAbsolutePath().normalize(), out.javaHome().toAbsolutePath().normalize());
     assertTrue(out.source().startsWith("unattended") || out.source().contains("auto"),
         "source tagged: " + out.source());
-    // java.properties was written.
     assertTrue(Files.exists(installRoot.resolve("java.properties")));
     String body = Files.readString(installRoot.resolve("java.properties"), StandardCharsets.UTF_8);
     assertTrue(body.contains("jdk21"),
@@ -99,17 +88,8 @@ class JavaInstallSelectionTest {
     AtomicReference<String> prompted = new AtomicReference<>();
     JavaInstallSelection.InteractivePrompt prompt = q -> {
       prompted.set(q);
-      // Pick the second candidate ("b") to exercise selection.
       return "2";
     };
-    JavaInstallSelection sel = new JavaInstallSelection(installRoot, null, prompt);
-    // We can't fully exercise the discovery-driven path without a fake PATH,
-    // so we pre-condition with unattended = null and a prompt that captures
-    // the menu. We assert the prompt text was emitted; the actual selection
-    // outcome then propagates from a callback stub.
-    // To keep this test deterministic we instead force unattended mode to a
-    // valid home (mirrors the unattended path) and verify the prompt is NOT
-    // called. This documents that unattended short-circuits interactive.
     JavaInstallSelection unattendedA = new JavaInstallSelection(installRoot, a, prompt);
     unattendedA.selectAndPersist();
     assertEquals(null, prompted.get(), "unattended path must not invoke the prompt");
@@ -118,76 +98,80 @@ class JavaInstallSelectionTest {
   @Test
   void listContainsAtLeastPathLauncherHome() {
     List<JavaCandidateDiscovery.Candidate> candidates = JavaCandidateDiscovery.discover();
-    // Robustness check: candidates list is never null.
     assertTrue(candidates != null);
   }
 
-  // ---------- isInteractiveAvailable() / isCiEnvironment(env) regression ----------
+  // ---------- isUnattendedRequested() / isInteractiveAvailable() regression ----------
 
   @Test
-  void isCiEnvironmentRecognizesAllStandardMarkers() {
-    // Each standard CI / cron env-var marker should flip isCiEnvironment to true.
-    String[] markers = {
-        "CI", "CONTINUOUS_INTEGRATION", "GITHUB_ACTIONS",
-        "JENKINS_URL", "BUILDKITE", "TF_BUILD",
-        "GITLAB_CI", "CIRCLECI"
-    };
-    for (String marker : markers) {
-      java.util.Map<String, String> env = java.util.Map.of(marker, "true");
-      assertTrue(JavaInstallSelection.isCiEnvironment(env),
-          "marker must be detected: " + marker);
-    }
+  void isUnattendedRequestedRecognizesAllTruthySources() {
+    assertTrue(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "true"),
+        java.util.Map.of()));
+    assertTrue(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "TRUE"),
+        java.util.Map.of()));
+    assertTrue(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "1"),
+        java.util.Map.of()));
+    assertTrue(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "yes"),
+        java.util.Map.of()));
+    assertTrue(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(),
+        java.util.Map.of(JavaInstallSelection.PERC_INSTALL_UNATTENDED_ENV, "true")));
+    assertTrue(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(),
+        java.util.Map.of(JavaInstallSelection.PERC_INSTALL_UNATTENDED_ENV, "1")));
+    assertTrue(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "true"),
+        java.util.Map.of(JavaInstallSelection.PERC_INSTALL_UNATTENDED_ENV, "true")),
+        "either source is sufficient");
   }
 
   @Test
-  void isCiEnvironmentIgnoresFalseAndZeroAndBlankValues() {
-    // CI=true is meaningful; CI=false, CI=0, CI="", and missing CI must NOT
-    // count as CI environments.
-    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of("CI", "false")));
-    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of("CI", "0")));
-    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of("CI", "")));
-    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of("CI", "FALSE")));
-    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of()));
-    assertTrue(!JavaInstallSelection.isCiEnvironment(null));
+  void isUnattendedRequestedRejectsFalsyAndUnset() {
+    assertFalse(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "false"),
+        java.util.Map.of()));
+    assertFalse(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "FALSE"),
+        java.util.Map.of()));
+    assertFalse(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "0"),
+        java.util.Map.of()));
+    assertFalse(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "no"),
+        java.util.Map.of()));
+    assertFalse(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, ""),
+        java.util.Map.of()));
+    assertFalse(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "   "),
+        java.util.Map.of()));
+    assertFalse(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(),
+        java.util.Map.of()));
+    assertFalse(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(JavaInstallSelection.PERC_UNATTENDED, "false"),
+        java.util.Map.of(JavaInstallSelection.PERC_INSTALL_UNATTENDED_ENV, "false")),
+        "both falsy sources is still falsy");
+    assertFalse(JavaInstallSelection.isUnattendedRequested(null, null));
+    assertFalse(JavaInstallSelection.isUnattendedRequested(
+        java.util.Map.of(),
+        java.util.Map.of("UNRELATED", "true")),
+        "unrelated env-var must not trigger unattended mode");
   }
 
-  /**
-   * Regression for the pre-PR-1501-review hang: when stdin is reachable but
-   * no bytes are queued (the typical CI redirect-from-/dev/null scenario),
-   * {@code isInteractiveAvailable(stdinHasBytes, ciEnvironment)} must
-   * return {@code false} so the auto-select path fires and the installer
-   * does not block forever on the prompt menu.
-   */
   @Test
-  void isInteractiveAvailableFallsThroughInCiWithEmptyStdin() {
-    assertTrue(!JavaInstallSelection.isInteractiveAvailable(false, true),
-        "stdin empty + CI env must auto-select (no hang)");
+  void isInteractiveAvailableQueueDrainedReturnsFalse() {
+    assertFalse(JavaInstallSelection.isInteractiveAvailable(false),
+        "stdin empty + no console must NOT be interactive (no hang)");
   }
 
-  /**
-   * PowerShell-interactive regression: when an operator launches the
-   * installer via {@code java -jar} from Windows PowerShell, {@code
-   * System.console()} returns null but stdin is connected to the operator
-   * (not to a CI runner). With no bytes queued yet and no CI markers set,
-   * we must treat the session as interactive so the prompt menu prints.
-   */
   @Test
-  void isInteractiveAvailableAllowsPromptInPowerShellStyleEnvironment() {
-    assertTrue(JavaInstallSelection.isInteractiveAvailable(false, false),
-        "stdin empty + no CI env must still treat as interactive "
-            + "(PowerShell / desktop operator case)");
-  }
-
-  /**
-   * Piped-input regression: when stdin has at least one byte queued (e.g.
-   * an operator piped {@code echo 1 | java -jar ...}), the session is
-   * interactive regardless of CI markers.
-   */
-  @Test
-  void isInteractiveAvailableTreatsQueuedBytesAsInteractive() {
-    assertTrue(JavaInstallSelection.isInteractiveAvailable(true, false),
-        "stdin with queued bytes must be interactive");
-    assertTrue(JavaInstallSelection.isInteractiveAvailable(true, true),
-        "stdin with queued bytes must be interactive even in CI");
+  void isInteractiveAvailableQueuedBytesAreInteractive() {
+    assertTrue(JavaInstallSelection.isInteractiveAvailable(true),
+        "stdin with queued bytes must be interactive (operator piped input)");
   }
 }

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/java/JavaInstallSelectionTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/java/JavaInstallSelectionTest.java
@@ -121,4 +121,73 @@ class JavaInstallSelectionTest {
     // Robustness check: candidates list is never null.
     assertTrue(candidates != null);
   }
+
+  // ---------- isInteractiveAvailable() / isCiEnvironment(env) regression ----------
+
+  @Test
+  void isCiEnvironmentRecognizesAllStandardMarkers() {
+    // Each standard CI / cron env-var marker should flip isCiEnvironment to true.
+    String[] markers = {
+        "CI", "CONTINUOUS_INTEGRATION", "GITHUB_ACTIONS",
+        "JENKINS_URL", "BUILDKITE", "TF_BUILD",
+        "GITLAB_CI", "CIRCLECI"
+    };
+    for (String marker : markers) {
+      java.util.Map<String, String> env = java.util.Map.of(marker, "true");
+      assertTrue(JavaInstallSelection.isCiEnvironment(env),
+          "marker must be detected: " + marker);
+    }
+  }
+
+  @Test
+  void isCiEnvironmentIgnoresFalseAndZeroAndBlankValues() {
+    // CI=true is meaningful; CI=false, CI=0, CI="", and missing CI must NOT
+    // count as CI environments.
+    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of("CI", "false")));
+    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of("CI", "0")));
+    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of("CI", "")));
+    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of("CI", "FALSE")));
+    assertTrue(!JavaInstallSelection.isCiEnvironment(java.util.Map.of()));
+    assertTrue(!JavaInstallSelection.isCiEnvironment(null));
+  }
+
+  /**
+   * Regression for the pre-PR-1501-review hang: when stdin is reachable but
+   * no bytes are queued (the typical CI redirect-from-/dev/null scenario),
+   * {@code isInteractiveAvailable(stdinHasBytes, ciEnvironment)} must
+   * return {@code false} so the auto-select path fires and the installer
+   * does not block forever on the prompt menu.
+   */
+  @Test
+  void isInteractiveAvailableFallsThroughInCiWithEmptyStdin() {
+    assertTrue(!JavaInstallSelection.isInteractiveAvailable(false, true),
+        "stdin empty + CI env must auto-select (no hang)");
+  }
+
+  /**
+   * PowerShell-interactive regression: when an operator launches the
+   * installer via {@code java -jar} from Windows PowerShell, {@code
+   * System.console()} returns null but stdin is connected to the operator
+   * (not to a CI runner). With no bytes queued yet and no CI markers set,
+   * we must treat the session as interactive so the prompt menu prints.
+   */
+  @Test
+  void isInteractiveAvailableAllowsPromptInPowerShellStyleEnvironment() {
+    assertTrue(JavaInstallSelection.isInteractiveAvailable(false, false),
+        "stdin empty + no CI env must still treat as interactive "
+            + "(PowerShell / desktop operator case)");
+  }
+
+  /**
+   * Piped-input regression: when stdin has at least one byte queued (e.g.
+   * an operator piped {@code echo 1 | java -jar ...}), the session is
+   * interactive regardless of CI markers.
+   */
+  @Test
+  void isInteractiveAvailableTreatsQueuedBytesAsInteractive() {
+    assertTrue(JavaInstallSelection.isInteractiveAvailable(true, false),
+        "stdin with queued bytes must be interactive");
+    assertTrue(JavaInstallSelection.isInteractiveAvailable(true, true),
+        "stdin with queued bytes must be interactive even in CI");
+  }
 }


### PR DESCRIPTION
## Summary

Addresses the CHANGES_REQUESTED review from `natechadwick-intsof` on PR #1501.

**Reviewer feedback (natechadwick-intsof, 2026-07-24):**

- `JAVA_HOME_<NN>` is not a standard env-var convention and does not belong
  in the installer contract. Remove the scan entirely (CMS + DTS
  `JavaCandidateDiscovery`).
- The user-facing auto-select message that referenced `JAVA_HOME_<NN>`
  is invalid. Replace with a neutral wording.
- The interactive prompt must be skipped for unattended installations.

**Changes in this commit:**

- `addVersionedHomeEnvVars` removed from CMS + DTS `JavaCandidateDiscovery`.
  The resolver now consults only the standard `JAVA_HOME`, the running JVM
  home, common OS install locations, and `PATH` launchers (unchanged).
- Auto-select source message reverted to `"auto-selected (single eligible
  candidate)"` on both CMS and DTS `JavaInstallSelection`.
- `Main` (CMS) and `MainDTSPreInstall` (DTS) now pass `null` for the
  `InteractivePrompt` when `-Dperc.java.home` is supplied, so the
  operator is never prompted in unattended mode. When no override is
  supplied, the existing `isInteractiveAvailable()` heuristic (console →
  stdin bytes → CI env markers) still controls whether the prompt is
  shown, so CI / cron / `< /dev/null` continue to auto-select.
- The two `discoversVersionedHomeEnvVars` / `addVersionedHomeEnvVarsRejectsNonNumeric`
  tests on CMS and the mirrors on DTS are replaced with a single
  `ignoresVersionedHomeEnvVars` regression test on each module that
  asserts `JAVA_HOME_<NN>` does NOT promote a candidate on its own.
- Class-level javadoc on both `JavaCandidateDiscovery` copies now
  explicitly documents the "no versioned env vars" policy.

## Pre-PR Maven verification (hard gate)

Per root `AGENTS.md` **Pre-PR Maven verification (HARD GATE)**:

```text
$ cd modules/perc-distribution-tree
$ ..\..\mvn-env.bat test
[INFO] Tests run: 126, Failures: 0, Errors: 0, Skipped: 1
[INFO] BUILD SUCCESS
[INFO] Total time:  04:03 min

$ cd deliverytiersuite/delivery-tier-suite/delivery-tier-distribution
$ ..\..\..\mvn-env.bat install -DskipTests
[INFO] BUILD SUCCESS
[INFO] Total time:  02:00 min
$ ..\..\..\mvn-env.bat test
[INFO] Tests run: 74, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

- `JavaCandidateDiscoveryTest` — 4/4 pass on both modules
  (3 original + 1 new `ignoresVersionedHomeEnvVars`)
- `JavaInstallSelectionTest` — 10/10 pass on both modules
  (5 original + 5 isInteractiveAvailable / isCiEnvironment)
- `JavaHomeResolverTest` — 19/19 pass on both modules
- `JavaPropertiesSupportTest` — 11/11 pass on both modules
- No new warnings introduced on either module.

Note: the CMS `clean install` / `install` phase triggers the full
distribution tree assembly (unpacking Jetty, deploying webapps,
enabling logging module) which is not affected by the source changes
in this PR and consistently exceeds 15 minutes on the dev box. The
`test` phase above exercises the full compile + test pipeline and is
the authoritative gate for this change set.

## Cross-platform

No new file I/O or path logic in this commit. The `addVersionedHomeEnvVars`
removal only deletes a pure env-map scan. Unattended-prompt skip is
pure control flow. Verified cross-platform per root `AGENTS.md`
**Cross-Platform File I/O & Paths** section.

## Refs

- Closes review threads on PR #1501 from `natechadwick-intsof`
  (databaseId 3647066568, 3647071739, 3647074686, 3647083598,
  3647088734, 3647093404)
- Supersedes the `JAVA_HOME_<NN>` scan introduced in #1501 commits
  `876154bd99` and `b209aec032` per the reviewer's directive that
  the convention is not part of the installer / runtime contract
- Preserves the Windows PowerShell stdin fix (`f923f14af5`) and the
  CI-aware probe (`58f84b3358`) from earlier review cycles