### PR TITLE
fix(1500): DTS matrix smoke green for H2, PostgreSQL, MySQL, SQL Server

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml
@@ -1081,6 +1081,21 @@
                                 <delete dir="${assembly-directory}/Deployment/Server/webapps/manager" failonerror="false"/>
                                 <delete dir="${assembly-directory}/Deployment/Server/webapps/host-manager" failonerror="false"/>
                                 <delete failonerror="false" file="${assembly-directory}/Deployment/Server/conf/logging.properties"/>
+                                <!--
+                                  Belt-and-suspenders: cargo:package can leave a stale target/package
+                                  with stock Tomcat conf (HTTP 8080) when configfiles are not reapplied
+                                  on incremental builds. Always force Percussion conf from source so
+                                  ${http.port}=9980 (perc-catalina.properties) is what customers get.
+                                -->
+                                <copy file="${project.basedir}/src/main/tomcat11/conf/server.xml"
+                                      tofile="${assembly-directory}/Deployment/Server/conf/server.xml"
+                                      overwrite="true" failonerror="true"/>
+                                <copy file="${project.basedir}/src/main/tomcat11/conf/catalina.properties"
+                                      tofile="${assembly-directory}/Deployment/Server/conf/catalina.properties"
+                                      overwrite="true" failonerror="true"/>
+                                <copy file="${project.basedir}/src/main/conf/perc/perc-catalina.properties"
+                                      tofile="${assembly-directory}/Deployment/Server/conf/perc/perc-catalina.properties"
+                                      overwrite="true" failonerror="true"/>
                                 <available file="${assembly-directory}/Deployment/Server/conf/server.xml" property="assembly.has.server.xml"/>
                                 <fail message="Assembly missing Deployment/Server/conf/server.xml after staging Cargo package" unless="assembly.has.server.xml"/>
                                 <available file="${assembly-directory}/Deployment/Server/webapps/perc-metadata-services.war" property="assembly.has.metadata.war"/>

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/tomcat11/conf/catalina.properties
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/tomcat11/conf/catalina.properties
@@ -50,7 +50,10 @@ org.apache.jasper.,org.apache.naming.,org.apache.tomcat.
 #       ${catalina.base} path or the ${catalina.home} path contains a comma.
 #       Because double quotes are used for quoting, the double quote character
 #       may not appear in a path.
-common.loader="${catalina.base}/lib","${catalina.base}/lib/*.jar","${catalina.home}/lib","${catalina.home}/lib/*.jar"
+# Percussion: include common/lib so perc-tomcat-common (PSTomcatPropertySource)
+# is on the Tomcat common classloader and can resolve ${http.port} etc. from
+# conf/perc/perc-catalina.properties (see PROPERTY_SOURCE at end of this file).
+common.loader="${catalina.base}/lib","${catalina.base}/lib/*.jar","${catalina.home}/lib","${catalina.home}/lib/*.jar","${catalina.base}/common/lib","${catalina.base}/common/lib/*.jar"
 
 #
 # List of comma-separated paths defining the contents of the "server"
@@ -219,3 +222,7 @@ tomcat.util.buf.StringCache.byte.enabled=true
 # Disable use of some privilege blocks Tomcat doesn't need since calls to the
 # code in question are always already inside a privilege block
 org.apache.el.GET_CLASSLOADER_USE_PRIVILEGED=false
+
+# Percussion: load connector/port properties from conf/perc/perc-catalina.properties
+# so server.xml can use ${http.port} (default 9980) instead of stock Tomcat 8080.
+org.apache.tomcat.util.digester.PROPERTY_SOURCE=com.percussion.tomcat.PSTomcatPropertySource

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/tomcat11/conf/server.xml
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/tomcat11/conf/server.xml
@@ -1,122 +1,227 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
-	license agreements. See the NOTICE file distributed with this work for additional
-	information regarding copyright ownership. The ASF licenses this file to
-	You under the Apache License, Version 2.0 (the "License"); you may not use
-	this file except in compliance with the License. You may obtain a copy of
-	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
-	by applicable law or agreed to in writing, software distributed under the
-	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
-	OF ANY KIND, either express or implied. See the License for the specific
-	language governing permissions and limitations under the License. -->
-<!-- Note: A "Server" is not itself a "Container", so you may not define
-	subcomponents such as "Valves" at this level. Documentation at /docs/config/server.html -->
-<Server port="8005" shutdown="SHUTDOWN">
-	<Listener
-		className="org.apache.catalina.startup.VersionLoggerListener" />
-	<!-- Security listener. Documentation at /docs/config/listeners.html <Listener
-		className="org.apache.catalina.security.SecurityListener" /> -->
-	<!-- OpenSSL support using Tomcat Native -->
-	<Listener
-		className="org.apache.catalina.core.AprLifecycleListener" />
-	<!-- OpenSSL support using FFM API from Java 22 -->
-	<!-- <Listener className="org.apache.catalina.core.OpenSSLLifecycleListener"
-		/> -->
-	<!-- Prevent memory leaks due to use of particular java/javax APIs -->
-	<Listener
-		className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
-	<Listener
-		className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
-	<Listener
-		className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="${shutdown.port}" shutdown="SHUTDOWN">
+    <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+    <!-- Security listener. Documentation at /docs/config/listeners.html
+    <Listener className="org.apache.catalina.security.SecurityListener" />
+    -->
+    <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+    <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+    <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+    <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
 
-	<!-- Global JNDI resources Documentation at /docs/jndi-resources-howto.html -->
-	<GlobalNamingResources>
-		<!-- Editable user database that can also be used by UserDatabaseRealm
-			to authenticate users -->
-		<Resource name="UserDatabase" auth="Container"
-			type="org.apache.catalina.UserDatabase"
-			description="User database that can be updated and saved"
-			factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
-			pathname="conf/tomcat-users.xml" />
-	</GlobalNamingResources>
-
-	<!-- A "Service" is a collection of one or more "Connectors" that share
-		a single "Container" Note: A "Service" is not itself a "Container", so you
-		may not define subcomponents such as "Valves" at this level. Documentation
-		at /docs/config/service.html -->
-	<Service name="Catalina">
-
-		<!--The connectors can use a shared executor, you can define one or more
-			named thread pools -->
-		<!-- <Executor name="tomcatThreadPool" namePrefix="catalina-exec-" maxThreads="150"
-			minSpareThreads="4"/> -->
+    <!-- Global JNDI resources
+         Documentation at /docs/jndi-resources-howto.html
+    -->
+    <GlobalNamingResources>
+        <!-- Editable user database that can also be used by
+             UserDatabaseRealm to authenticate users
+        -->
+        <Resource name="UserDatabase" auth="Container"
+                  type="org.apache.catalina.UserDatabase"
+                  description="User database that can be updated and saved"
+                  factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+                  pathname="conf/tomcat-users.xml" />
+    </GlobalNamingResources>
 
 
-		<!-- A "Connector" represents an endpoint by which requests are received
-			and responses are returned. Documentation at : HTTP Connector: /docs/config/http.html
-			AJP Connector: /docs/config/ajp.html Define a non-SSL/TLS HTTP/1.1 Connector
-			on port 8080 -->
-		<Connector port="8080" protocol="HTTP/1.1"
-			connectionTimeout="20000" redirectPort="8443"
-			maxParameterCount="1000" />
-		<!-- A "Connector" using the shared thread pool -->
-		<!-- <Connector executor="tomcatThreadPool" port="8080" protocol="HTTP/1.1"
-			connectionTimeout="20000" redirectPort="8443" maxParameterCount="1000" /> -->
-		<!-- Define an SSL/TLS HTTP/1.1 Connector on port 8443 with HTTP/2 This
-			connector uses the NIO implementation. The default SSLImplementation will
-			depend on the presence of the APR/native library and the useOpenSSL attribute
-			of the AprLifecycleListener. Either JSSE or OpenSSL style configuration may
-			be used regardless of the SSLImplementation selected. JSSE style configuration
-			is used below. -->
-		<!-- <Connector port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
-			maxThreads="150" SSLEnabled="true" maxParameterCount="1000" > <UpgradeProtocol
-			className="org.apache.coyote.http2.Http2Protocol" /> <SSLHostConfig> <Certificate
-			certificateKeystoreFile="conf/localhost-rsa.jks" certificateKeystorePassword="changeit"
-			type="RSA" /> </SSLHostConfig> </Connector> -->
+    <!-- A "Service" is a collection of one or more "Connectors" that share
+         a single "Container" Note:  A "Service" is not itself a "Container",
+         so you may not define subcomponents such as "Valves" at this level.
+         Documentation at /docs/config/service.html
+     -->
+    <Service name="Catalina">
 
-		<!-- Define an AJP 1.3 Connector on port 8009 -->
-		<!-- <Connector protocol="AJP/1.3" address="::1" port="8009" redirectPort="8443"
-			maxParameterCount="1000" /> -->
+        <!--The connectors can use a shared executor, you can define one or more named thread pools-->
+        <!--
+        <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
+            maxThreads="150" minSpareThreads="4"/>
+        -->
 
-		<!-- An Engine represents the entry point (within Catalina) that processes
-			every request. The Engine implementation for Tomcat stand alone analyzes
-			the HTTP headers included with the request, and passes them on to the appropriate
-			Host (virtual host). Documentation at /docs/config/engine.html -->
 
-		<!-- You should set jvmRoute to support load-balancing via AJP ie : <Engine
-			name="Catalina" defaultHost="localhost" jvmRoute="jvm1"> -->
-		<Engine name="Catalina" defaultHost="localhost">
+        <!-- A "Connector" represents an endpoint by which requests are received
+             and responses are returned. Documentation at :
+             Java HTTP Connector: /docs/config/http.html
+             Java AJP  Connector: /docs/config/ajp.html
+             APR (HTTP/AJP) Connector: /docs/apr.html
+             Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
+        -->
 
-			<!--For clustering, please take a look at documentation at: /docs/cluster-howto.html
-				(simple how to) /docs/config/cluster.html (reference documentation) -->
-			<!-- <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/> -->
+        <Connector  SSLEnabled="${http.SSLEnabled}"
+                    URIEncoding="${http.URIEncoding}"
+                    acceptCount="${http.acceptCount}"
+                    acceptorThreadPriority="${http.acceptorThreadPriority}"
+                    address="${http.address}"
+                    allowHostHeaderMismatch="${http.allowHostHeaderMismatch}"
+                    allowTrace="${http.allowTrace}"
+                    asyncTimeout="${http.asyncTimeout}"
+                    bindOnInit="${http.bindOnInit}"
+                    compressibleMimeType="${http.compressibleMimeType}"
+                    compression="${http.compression}"
+                    compressionMinSize="${http.compressionMinSize}"
+                    connectionTimeout="${http.connectionTimeout}"
+                    disableUploadTimeout="${http.disableUploadTimeout}"
+                    discardFacades="${http.discardFacades}"
+                    enableLookups="${http.enableLookups}"
+                    executorTerminationTimeoutMillis="${http.executorTerminationTimeoutMillis}"
+                    keepAliveTimeout="${http.keepAliveTimeout}"
+                    maxConnections="${http.maxConnections}"
+                    maxCookieCount="${http.maxCookieCount}"
+                    maxExtensionSize="${http.maxExtensionSize}"
+                    maxHeaderCount="${http.maxHeaderCount}"
+                    maxHttpHeaderSize="${http.maxHttpHeaderSize}"
+                    maxKeepAliveRequests="${http.maxKeepAliveRequests}"
+                    maxParameterCount="${http.maxParameterCount}"
+                    maxPostSize="${http.maxPostSize}"
+                    maxSavePostSize="${http.maxSavePostSize}"
+                    maxSwallowSize="${http.maxSwallowSize}"
+                    maxThreads="${http.maxThreads}"
+                    maxTrailerSize="${http.maxTrailerSize}"
+                    minSpareThreads="${http.minSpareThreads}"
+                    noCompressionStrongETag="${http.noCompressionStrongETag}"
+                    parseBodyMethods="${http.parseBodyMethods}"
+                    port="${http.port}"
+                    processorCache="${http.processorCache}"
+                    redirectPort="${http.redirectPort}"
+                    rejectIllegalHeader="${http.rejectIllegalHeader}"
+                    relaxedPathChars="&quot; &lt; &gt; [ \ ] ^ ` { | }"
+                    relaxedQueryChars="&quot; &lt; &gt; [ \ ] ^ ` { | }"
+                    scheme="${http.scheme}"
+                    secure="${http.secure}"
+                    tcpNoDelay="${http.tcpNoDelay}"
+                    threadPriority="${http.threadPriority}"
+                    throwOnFailure="${http.throwOnFailure}"
+                    useAsyncIO="${http.useAsyncIO}"
+                    useBodyEncodingForURI="${http.useBodyEncodingForURI}"
+                    useIPVHosts="${http.useIPVHosts}"
+                    useKeepAliveResponseHeader="${http.useKeepAliveResponseHeader}"
+                    xpoweredBy="${http.xpoweredBy}"
+        />
+        <Connector  SSLEnabled="${https.SSLEnabled}"
+                    URIEncoding="${https.URIEncoding}"
+                    acceptCount="${https.acceptCount}"
+                    acceptorThreadPriority="${https.acceptorThreadPriority}"
+                    address="${https.address}"
+                    allowHostHeaderMismatch="${https.allowHostHeaderMismatch}"
+                    allowTrace="${https.allowTrace}"
+                    asyncTimeout="${https.asyncTimeout}"
+                    bindOnInit="${https.bindOnInit}"
+                    clientAuth="${https.clientAuth}"
+                    compressibleMimeType="${https.compressibleMimeType}"
+                    compression="${https.compression}"
+                    compressionMinSize="${https.compressionMinSize}"
+                    connectionTimeout="${https.connectionTimeout}"
+                    disableUploadTimeout="${https.disableUploadTimeout}"
+                    discardFacades="${https.discardFacades}"
+                    enableLookups="${https.enableLookups}"
+                    keepAliveTimeout="${https.keepAliveTimeout}"
+                    keyAlias="${https.keyAlias}"
+                    keystoreFile="${https.keystoreFile}"
+                    keystorePass="${https.keystorePass}"
+                    keystoreType="${https.keystoreType}"
+                    maxConnections="${https.maxConnections}"
+                    maxCookieCount="${https.maxCookieCount}"
+                    maxExtensionSize="${https.maxExtensionSize}"
+                    maxHeaderCount="${https.maxHeaderCount}"
+                    maxHttpHeaderSize="${https.maxHttpHeaderSize}"
+                    maxKeepAliveRequests="${https.maxKeepAliveRequests}"
+                    maxParameterCount="${https.maxParameterCount}"
+                    maxPostSize="${https.maxPostSize}"
+                    maxSwallowSize="${https.maxSwallowSize}"
+                    maxThreads="${https.maxThreads}"
+                    maxTrailerSize="${https.maxTrailerSize}"
+                    minSpareThreads="${https.minSpareThreads}"
+                    noCompressionStrongETag="${https.noCompressionStrongETag}"
+                    parseBodyMethods="${https.parseBodyMethods}"
+                    port="${https.port}"
+                    processorCache="${https.processorCache}"
+                    sslEnabledProtocols="${https.sslEnabledProtocols}"
+                    rejectIllegalHeader="${https.rejectIllegalHeader}"
+                    relaxedPathChars="&quot; &lt; &gt; [ \ ] ^ ` { | }"
+                    relaxedQueryChars="&quot; &lt; &gt; [ \ ] ^ ` { | }"
+                    scheme="${https.scheme}"
+                    secure="${https.secure}"
+                    ciphers="${https.ciphers}"
+                    tcpNoDelay="${https.tcpNoDelay}"
+                    threadPriority="${https.threadPriority}"
+                    throwOnFailure="${https.throwOnFailure}"
+                    useAsyncIO="${https.useAsyncIO}"
+                    useBodyEncodingForURI="${https.useBodyEncodingForURI}"
+                    useIPVHosts="${https.useIPVHosts}"
+                    useKeepAliveResponseHeader="${https.useKeepAliveResponseHeader}"
+                    xpoweredBy="${https.xpoweredBy}"
+                    sslImplementationName="org.apache.tomcat.util.net.jsse.JSSEImplementation"
+        >
+        </Connector>
 
-			<!-- Use the LockOutRealm to prevent attempts to guess user passwords
-				via a brute-force attack -->
-			<Realm className="org.apache.catalina.realm.LockOutRealm">
-				<!-- This Realm uses the UserDatabase configured in the global JNDI resources
-					under the key "UserDatabase". Any edits that are performed against this UserDatabase
-					are immediately available for use by the Realm. -->
-				<Realm className="org.apache.catalina.realm.UserDatabaseRealm"
-					resourceName="UserDatabase" />
-			</Realm>
+        <!--
+                certificateKeyPassword ="${https.certificateKeyPassword}"
+                certificateFile="${https.certificateFile}"
+                certificateChainFile="${https.certificateChainFile}"
+                certificateKeyFile="${https.certificateKeyFile}"
+                -->
 
-			<Host name="localhost" appBase="webapps" unpackWARs="true"
-				autoDeploy="true">
+        <!-- An Engine represents the entry point (within Catalina) that processes
+             every request.  The Engine implementation for Tomcat stand alone
+             analyzes the HTTP headers included with the request, and passes them
+             on to the appropriate Host (virtual host).
+             Documentation at /docs/config/engine.html -->
 
-				<!-- SingleSignOn valve, share authentication between web applications
-					Documentation at: /docs/config/valve.html -->
-				<!-- <Valve className="org.apache.catalina.authenticator.SingleSignOn"
-					/> -->
+        <!-- You should set jvmRoute to support load-balancing via AJP ie :
+        <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+        -->
+        <Engine name="Catalina" defaultHost="localhost">
 
-				<!-- Access log processes all example. Documentation at: /docs/config/valve.html
-					Note: The pattern used is equivalent to using pattern="common" -->
-				<Valve className="org.apache.catalina.valves.AccessLogValve"
-					directory="logs" prefix="localhost_access_log" suffix=".txt"
-					pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+            <!--For clustering, please take a look at documentation at:
+                /docs/cluster-howto.html  (simple how to)
+                /docs/config/cluster.html (reference documentation) -->
+            <!--
+            <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
+            -->
 
-			</Host>
-		</Engine>
-	</Service>
+
+            <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+                 via a brute-force attack -->
+            <Realm className="org.apache.catalina.realm.LockOutRealm">
+                <!-- This Realm uses the UserDatabase configured in the global JNDI
+                     resources under the key "UserDatabase".  Any edits
+                     that are performed against this UserDatabase are immediately
+                     available for use by the Realm.  -->
+                <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+                       resourceName="UserDatabase">
+                    <CredentialHandler className="org.apache.catalina.realm.MessageDigestCredentialHandler"
+                                       algorithm="SHA"
+                    />
+                </Realm>
+            </Realm>
+
+            <Host name="localhost"  appBase="webapps"
+                  unpackWARs="true" autoDeploy="true">
+
+
+                <!-- Access log processes all example.
+                     Documentation at: /docs/config/valve.html
+                     Note: The pattern used is equivalent to using pattern="common" -->
+                <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+                       prefix="localhost_access_log" suffix=".txt"
+                       pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+                <Valve className="org.apache.catalina.valves.ErrorReportValve"
+                       errorCode.403="webapps/ROOT/error.html"
+                       errorCode.404="webapps/ROOT/error.html"
+                       errorCode.414="webapps/ROOT/error.html"
+                       errorCode.415="webapps/ROOT/error.html"
+                       errorCode.501="webapps/ROOT/error.html"
+                       errorCode.500="webapps/ROOT/error.html"
+                       errorCode.502="webapps/ROOT/error.html"
+                       showReport="false"
+                       showServerInfo="false" />
+            </Host>
+
+            <Valve className="com.percussion.tomcat.valves.PSSimpleRedirectorValve" targetHost="localhost" serviceNames="perc-form-processor,perc-common-ui,perc-metadata-services,perc-comments-services,feeds,perc-membership-services,perc-generickey-services,perc-polls-services,perc-thirdparty-services"/>
+
+        </Engine>
+    </Service>
 </Server>

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsInstallerJarContainsDeploymentCommonLibTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsInstallerJarContainsDeploymentCommonLibTest.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import org.junit.jupiter.api.Test;
 
@@ -109,6 +110,68 @@ class DtsInstallerJarContainsDeploymentCommonLibTest {
                 + "; expected the runtime jars staged by the"
                 + " copy-deployment-server-common-lib maven-dependency-plugin:copy"
                 + " execution.");
+  }
+
+  /**
+   * #1500 DTS matrix: {@code server.xml} loads {@code
+   * com.percussion.tomcat.valves.PSSimpleRedirectorValve}. A missing package declaration compiled
+   * that class into the default package (jar root) and Tomcat failed with FATAL "Cannot start
+   * server".
+   */
+  @Test
+  void percTomcatCommonBundlesRedirectorValveInCorrectPackage() throws IOException {
+    Path jar = Path.of("target", "delivery-tier-distribution.jar");
+    if (!Files.isRegularFile(jar)) {
+      return;
+    }
+
+    String tomcatCommonEntry = null;
+    try (ZipFile zip = new ZipFile(jar.toFile())) {
+      tomcatCommonEntry =
+          zip.stream()
+              .map(ZipEntry::getName)
+              .filter(n -> n.startsWith(COMMON_LIB_PATH_PREFIX))
+              .filter(n -> n.contains("perc-tomcat-common") && n.endsWith(".jar"))
+              .findFirst()
+              .orElse(null);
+    }
+    if (tomcatCommonEntry == null) {
+      fail("Shipping jar missing perc-tomcat-common under " + COMMON_LIB_PATH_PREFIX);
+    }
+
+    // Nested jar: extract entry bytes to a temp file and inspect package path.
+    Path nested = Files.createTempFile("perc-tomcat-common-", ".jar");
+    try {
+      try (ZipFile zip = new ZipFile(jar.toFile())) {
+        ZipEntry entry = zip.getEntry(tomcatCommonEntry);
+        try (var in = zip.getInputStream(entry)) {
+          Files.write(nested, in.readAllBytes());
+        }
+      }
+      boolean foundCorrect = false;
+      boolean foundDefaultPackage = false;
+      try (ZipFile nestedZip = new ZipFile(nested.toFile())) {
+        for (var it = nestedZip.entries().asIterator(); it.hasNext(); ) {
+          String name = it.next().getName();
+          if ("com/percussion/tomcat/valves/PSSimpleRedirectorValve.class".equals(name)) {
+            foundCorrect = true;
+          }
+          if ("PSSimpleRedirectorValve.class".equals(name)) {
+            foundDefaultPackage = true;
+          }
+        }
+      }
+      assertTrue(
+          foundCorrect,
+          "perc-tomcat-common must contain"
+              + " com/percussion/tomcat/valves/PSSimpleRedirectorValve.class"
+              + " (package declaration required for Tomcat digester)");
+      assertTrue(
+          !foundDefaultPackage,
+          "PSSimpleRedirectorValve.class must not be in the default package (jar root)");
+    } finally {
+      Files.deleteIfExists(nested);
+    }
   }
 
   @Test

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsInstallerJarContainsTomcatTreeTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsInstallerJarContainsTomcatTreeTest.java
@@ -20,10 +20,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import org.junit.jupiter.api.Test;
 
@@ -88,6 +91,39 @@ class DtsInstallerJarContainsTomcatTreeTest {
     assertTrue(
         entries.stream().noneMatch(n -> n.startsWith(SERVER_PREFIX + "webapps/host-manager/")),
         "shipping jar must not include Tomcat host-manager webapp");
+
+    // #1500 matrix / product default: HTTP on ${http.port} (9980 via perc-catalina.properties),
+    // not stock Tomcat 8080. Without PROPERTY_SOURCE + common/lib, digester cannot resolve it.
+    try (ZipFile zip = new ZipFile(jar.toFile())) {
+      String serverXml = readZipEntry(zip, SERVER_PREFIX + "conf/server.xml");
+      assertTrue(
+          serverXml.contains("port=\"${http.port}\""),
+          "server.xml must bind HTTP to ${http.port} (perc-catalina.properties default 9980);"
+              + " stock Tomcat port 8080 breaks matrix probe 9980 and product port docs");
+      assertTrue(
+          serverXml.contains("port=\"${shutdown.port}\"")
+              || serverXml.contains("<Server port=\"${shutdown.port}\""),
+          "server.xml must use ${shutdown.port} for Server shutdown port");
+
+      String catalinaProps = readZipEntry(zip, SERVER_PREFIX + "conf/catalina.properties");
+      assertTrue(
+          catalinaProps.contains(
+              "org.apache.tomcat.util.digester.PROPERTY_SOURCE=com.percussion.tomcat.PSTomcatPropertySource"),
+          "catalina.properties must register PSTomcatPropertySource for ${http.port} resolution");
+      assertTrue(
+          catalinaProps.contains("common/lib"),
+          "catalina.properties common.loader must include common/lib for perc-tomcat-common");
+    }
+  }
+
+  private static String readZipEntry(ZipFile zip, String name) throws IOException {
+    ZipEntry entry = zip.getEntry(name);
+    if (entry == null) {
+      fail("Missing zip entry: " + name);
+    }
+    try (InputStream in = zip.getInputStream(entry)) {
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
   }
 
   private static void assertContains(List<String> entries, String required) {

--- a/deliverytiersuite/delivery-tier-suite/tomcat-common/src/main/java/com/percussion/tomcat/valves/PSSimpleRedirectorValve.java
+++ b/deliverytiersuite/delivery-tier-suite/tomcat-common/src/main/java/com/percussion/tomcat/valves/PSSimpleRedirectorValve.java
@@ -16,6 +16,8 @@
  */
 // REFACTORED: CP-JAVA11
 
+package com.percussion.tomcat.valves;
+
 import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/docker/README.md
+++ b/docker/README.md
@@ -93,6 +93,9 @@ python3 docker/scripts/matrix-install-smoke.py --product cms --db postgresql
 # Both products × H2 and PostgreSQL
 python3 docker/scripts/matrix-install-smoke.py --product cms,dts --db h2,postgresql
 
+# DTS only × full Layer-1 DB matrix (H2 + external compose profiles)
+python3 docker/scripts/matrix-install-smoke.py --product dts --db h2,postgresql,mysql,sqlserver
+
 # Leave cell up for Playwright Layer 2 (perc-qa-automation)
 python3 docker/scripts/matrix-install-smoke.py --product cms --db postgresql --keep
 TEST_CMS_URL=http://localhost:9993 TEST_DB_TYPE=postgresql \
@@ -101,6 +104,18 @@ TEST_CMS_URL=http://localhost:9993 TEST_DB_TYPE=postgresql \
 # Dry-run (no docker)
 python3 docker/scripts/matrix-install-smoke.py --product cms --db h2 --dry-run --skip-image-build
 ```
+
+### DTS packaging notes (HTTP 9980)
+
+DTS Tomcat listens on **`${http.port}`** from `conf/perc/perc-catalina.properties` (default **9980**), not stock Tomcat 8080. The shipping tree requires:
+
+| File | Requirement |
+|------|-------------|
+| `conf/server.xml` | Property-driven connectors (`port="${http.port}"`) + `PSSimpleRedirectorValve` |
+| `conf/catalina.properties` | `common.loader` includes `common/lib`; `PROPERTY_SOURCE=com.percussion.tomcat.PSTomcatPropertySource` |
+| `common/lib/perc-tomcat-common-*.jar` | Must contain `com.percussion.tomcat.valves.PSSimpleRedirectorValve` (correct package) |
+
+Matrix host probe: `http://127.0.0.1:9983/` → container **9980**.
 
 Each run writes `docker/logs/matrix-results-<ts>.json` and a `RESULT:OK|FAIL STEP:matrix LOG:…` line.
 

--- a/docs/ai-generated/code-reviews/1500-dts-matrix-smoke-erlang.md
+++ b/docs/ai-generated/code-reviews/1500-dts-matrix-smoke-erlang.md
@@ -1,0 +1,69 @@
+# Erlang review — 1500 DTS matrix smoke
+
+**Date:** 2026-07-26  
+**Branch:** `1500-dts-matrix-smoke`  
+**Scope:** Uncommitted DTS packaging fixes so Layer-1 matrix install-smoke passes for H2, PostgreSQL, MySQL, SQL Server  
+**Base:** `development` @ `970ed35488` (PR #1507 merged)
+
+## Summary
+
+Restores property-driven Tomcat configuration for DTS (HTTP **9980**) after EE11 packaging left stock Tomcat **8080** server.xml, and fixes a missing `package` declaration on `PSSimpleRedirectorValve` that prevented digester from loading the valve class.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs | None remaining in scope |
+| Behavioral tests for new/changed logic | Yes — jar packaging guards + nested perc-tomcat-common package path |
+| Cross-platform path/file I/O | Clean — NIO `Path`/`Files` in tests; no new OS-specific path joins |
+| May commit/push | **yes** |
+
+## Issues
+
+_None._
+
+### Cross-platform path checklist
+
+- [x] No new hardcoded filesystem separators in product code
+- [x] Tests use `Path.of` / zip entry names with `/` (ZIP paths)
+- [x] Temp file for nested jar uses `Files.createTempFile`
+- [x] Line-ending sensitive assertions not introduced
+
+## Changed files (review)
+
+| Path | Notes |
+|------|--------|
+| `tomcat-common/.../PSSimpleRedirectorValve.java` | Added missing `package com.percussion.tomcat.valves;` |
+| `tomcat11/conf/server.xml` | Property-driven connectors + redirector valve (from working install) |
+| `tomcat11/conf/catalina.properties` | `common/lib` on common.loader + PROPERTY_SOURCE |
+| `delivery-tier-distribution/pom.xml` | Antrun force-overwrite Percussion conf after cargo stage |
+| `DtsInstallerJarContainsTomcatTreeTest.java` | Asserts `${http.port}` + PROPERTY_SOURCE in shipping jar |
+| `DtsInstallerJarContainsDeploymentCommonLibTest.java` | Asserts valve class path inside nested perc-tomcat-common |
+| `docker/README.md` | DTS matrix command + packaging notes |
+
+## Evidence (Layer-1 matrix)
+
+| Cell | Result |
+|------|--------|
+| dts-h2 | RESULT:OK HTTP 200 (~34s) |
+| dts-postgresql | RESULT:OK HTTP 200 (~40s) |
+| dts-mysql | RESULT:OK HTTP 200 (~56s) |
+| dts-sqlserver | RESULT:OK HTTP 200 (~66s) |
+
+## Maven (standalone)
+
+```text
+cd deliverytiersuite/delivery-tier-suite/tomcat-common && ../../../mvn-env.sh clean install
+cd deliverytiersuite/delivery-tier-suite/delivery-tier-distribution && ../../../mvn-env.sh clean install
+```
+
+BUILD SUCCESS both modules; surefire green on packaging tests.
+
+## Memory patterns hit
+
+- Packaging regression after EE11/Tomcat 11 conf tree swap (stock vs Percussion)
+- Nested jar class package path must match digester `className`


### PR DESCRIPTION
## Summary

Makes the **DTS** Layer-1 install matrix smoke green for the same DB set as CMS (#1507): **H2, PostgreSQL, MySQL, SQL Server**.

Root causes after EE11 / Tomcat 11 packaging (#1492):

1. **Stock Tomcat `server.xml` on 8080** while product/matrix expect **`${http.port}` = 9980** via `perc-catalina.properties`.
2. **`catalina.properties`** missing `common/lib` on `common.loader` and missing `PROPERTY_SOURCE=com.percussion.tomcat.PSTomcatPropertySource`.
3. **`PSSimpleRedirectorValve` missing `package` declaration** → class compiled to jar root; digester CNFE → FATAL "Cannot start server".

### Fixes

- Restore property-driven `server.xml` (connectors + redirector valve).
- Wire Percussion `catalina.properties` (`common/lib` + PROPERTY_SOURCE).
- Antrun force-overwrite Percussion conf after cargo stage (guards stale `target/package`).
- Add `package com.percussion.tomcat.valves;` to `PSSimpleRedirectorValve`.
- Packaging tests: `${http.port}` / PROPERTY_SOURCE in shipping jar; nested jar valve path.

## Matrix evidence

| Cell | Result |
|------|--------|
| dts-h2 | RESULT:OK HTTP 200 (~34s) |
| dts-postgresql | RESULT:OK HTTP 200 (~40s) |
| dts-mysql | RESULT:OK HTTP 200 (~56s) |
| dts-sqlserver | RESULT:OK HTTP 200 (~66s) |

```bash
python3 docker/scripts/matrix-install-smoke.py --product dts --db h2,postgresql,mysql,sqlserver
```

## Pre-PR Maven (standalone)

```bash
cd deliverytiersuite/delivery-tier-suite/tomcat-common && ../../../mvn-env.sh clean install
# BUILD SUCCESS

cd deliverytiersuite/delivery-tier-suite/delivery-tier-distribution && ../../../mvn-env.sh clean install
# BUILD SUCCESS — Tests run: 69, Failures: 0
```

No new warnings attributable to this change (baseline javadoc noise unchanged).

## Erlang

`docs/ai-generated/code-reviews/1500-dts-matrix-smoke-erlang.md` — **approve**, May commit/push: yes.

## Related

- Continues #1500 / CMS matrix #1507
- Oracle matrix still backlog #1508 (compose cell not in this PR)

## Test plan

- [x] Unit packaging tests green (Tomcat tree + common/lib + valve package path)
- [x] DTS H2 matrix smoke HTTP 200
- [x] DTS PostgreSQL matrix smoke HTTP 200
- [x] DTS MySQL matrix smoke HTTP 200
- [x] DTS SQL Server matrix smoke HTTP 200
- [ ] CI green on PR

> Co-Authored by Grok Build using grok-4.5 with agent Grok.