### PR TITLE
feat(1513): Interactive CLI installer wizard (CMS + DTS)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/README.md
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/README.md
@@ -44,6 +44,27 @@ Residual checklist: `docs/ai-generated/tasks/667-jakarta-ee11-residual-checklist
 ./mvn-env.sh -pl deliverytiersuite/delivery-tier-suite/delivery-tier-distribution -am clean install
 # Windows: mvn-env.bat -pl deliverytiersuite/delivery-tier-suite/delivery-tier-distribution -am clean install
 
+## Interactive installer mode (issue #1513)
+
+When a **console/TTY is available** and you do **not** pass `--silent` / `--no-tty`, the DTS preinstall walks through:
+
+1. Installation directory (prompted if the path argument is omitted)
+2. System Java 21+ home (discovery / multi-candidate menu; or `-Dperc.java.home=...`)
+3. Server type: Production vs Staging
+4. Database backend (menu: H2, SQL Server/Express, MySQL/MariaDB, PostgreSQL, or env-style config file)
+5. Optional connection test for external backends (best-effort)
+6. Summary (no secrets) and confirm
+
+Silent/automation installs are unchanged:
+
+```bash
+# Interactive (console)
+java -jar PercussionDTS.jar
+
+# Silent / CI
+java -jar PercussionDTS.jar /path/to/install/root --silent --db.type=h2
+```
+
 ## Java home resolution (GH-991 / issue #1340)
 
 Operators **do not** need to place a JRE under `<InstallDir>/JRE`. At DTS

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/InstallPrompt.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/InstallPrompt.java
@@ -18,6 +18,9 @@ package com.percussion.preinstall;
 /**
  * Operator I/O for the DTS interactive installer wizard (issue #1513). Production code uses {@link
  * SystemConsoleInstallPrompt}; unit tests supply scripted answers.
+ *
+ * <p>Callers that receive a non-null {@code char[]} from {@link #readPassword(String)} should zero
+ * the array after converting to the durable form they need.
  */
 public interface InstallPrompt {
 
@@ -39,15 +42,16 @@ public interface InstallPrompt {
    * Prompts and reads a single line of operator input.
    *
    * @param prompt text shown before reading; never {@code null}
-   * @return the line without terminator; empty string if EOF / unavailable (never {@code null})
+   * @return the line without terminator; empty string if EOF (never {@code null})
    */
   String readLine(String prompt);
 
   /**
-   * Prompts and reads a password without echoing when a console is available.
+   * Prompts and reads a password without echoing.
    *
    * @param prompt text shown before reading; never {@code null}
-   * @return password characters, or empty string if unavailable (never {@code null})
+   * @return password characters (caller should zero after use); empty array if the operator entered
+   *     an empty password; {@code null} if no console is available
    */
-  String readPassword(String prompt);
+  char[] readPassword(String prompt);
 }

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/InstallPrompt.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/InstallPrompt.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+/**
+ * Operator I/O for the DTS interactive installer wizard (issue #1513). Production code uses {@link
+ * SystemConsoleInstallPrompt}; unit tests supply scripted answers.
+ */
+public interface InstallPrompt {
+
+  /**
+   * Writes a message to the operator (no trailing newline unless included).
+   *
+   * @param message text to write; may be empty, never {@code null}
+   */
+  void print(String message);
+
+  /**
+   * Writes a message followed by a platform line separator.
+   *
+   * @param message text to write; may be empty, never {@code null}
+   */
+  void println(String message);
+
+  /**
+   * Prompts and reads a single line of operator input.
+   *
+   * @param prompt text shown before reading; never {@code null}
+   * @return the line without terminator; empty string if EOF / unavailable (never {@code null})
+   */
+  String readLine(String prompt);
+
+  /**
+   * Prompts and reads a password without echoing when a console is available.
+   *
+   * @param prompt text shown before reading; never {@code null}
+   * @return password characters, or empty string if unavailable (never {@code null})
+   */
+  String readPassword(String prompt);
+}

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/InteractiveDbConfigCollector.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/InteractiveDbConfigCollector.java
@@ -137,13 +137,24 @@ public final class InteractiveDbConfigCollector {
     return options;
   }
 
-  private static void clearStructured(Map<String, String> options) {
+  /**
+   * Drop structured connection fields and SSL overrides so a backend switch (H2 / env file) does
+   * not inherit stale keys from a prior attempt or CLI partial options.
+   */
+  static void clearStructured(Map<String, String> options) {
     options.remove("db.host");
     options.remove("db.port");
     options.remove("db.name");
     options.remove("db.schema");
     options.remove("db.user");
     options.remove("db.password");
+    options.remove("db.ssl.enabled");
+    options.remove("db.ssl.verify");
+    options.remove("db.ssl.allowSelfSigned");
+    options.remove("db.ssl.trustStorePath");
+    options.remove("db.ssl.trustStorePassword");
+    options.remove("db.ssl.keyStorePath");
+    options.remove("db.ssl.keyStorePassword");
   }
 
   private static void collectExternalFields(

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/InteractiveDbConfigCollector.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/InteractiveDbConfigCollector.java
@@ -18,6 +18,7 @@ package com.percussion.preinstall;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -166,11 +167,7 @@ public final class InteractiveDbConfigCollector {
       }
     }
     options.put("db.user", promptRequired(prompt, "Database user: ", "Database user is required."));
-    String password = prompt.readPassword("Database password: ");
-    if (password == null || password.isEmpty()) {
-      password = prompt.readPassword("Password was empty. Re-enter database password: ");
-    }
-    options.put("db.password", password == null ? "" : password);
+    options.put("db.password", readPasswordToString(prompt));
 
     String sslEnabled =
         promptWithDefault(prompt, "SSL enabled (true/false)", MainDTSPreInstall.DB_SSL_ENABLED_DEFAULT);
@@ -198,6 +195,31 @@ public final class InteractiveDbConfigCollector {
       prompt.println(errorMessage);
     }
     throw new IllegalArgumentException(errorMessage);
+  }
+
+  /**
+   * Read a password as {@code char[]}; convert to String for the options map, then zero the buffer.
+   * {@code null} means no console — fail fast.
+   */
+  static String readPasswordToString(InstallPrompt prompt) {
+    char[] chars = prompt.readPassword("Database password: ");
+    if (chars == null) {
+      throw new IllegalArgumentException(
+          "No console available to read database password (non-interactive environment).");
+    }
+    if (chars.length == 0) {
+      Arrays.fill(chars, '\0');
+      chars = prompt.readPassword("Password was empty. Re-enter database password: ");
+      if (chars == null) {
+        throw new IllegalArgumentException(
+            "No console available to read database password (non-interactive environment).");
+      }
+    }
+    try {
+      return new String(chars);
+    } finally {
+      Arrays.fill(chars, '\0');
+    }
   }
 
   private static String normalizeBool(String raw, String defaultValue) {

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/InteractiveDbConfigCollector.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/InteractiveDbConfigCollector.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Interactive multi-step collection of DTS database options (issue #1513 Phase 4). Populates
+ * structured {@code db.*} keys consumed by {@link MainDTSPreInstall#resolveDbConfig(Map)}.
+ */
+public final class InteractiveDbConfigCollector {
+
+  private InteractiveDbConfigCollector() {}
+
+  /**
+   * Whether CLI already supplies an explicit database target that should skip field prompts.
+   *
+   * @param options CLI options map
+   * @return true when structured host credentials or non-default type are present
+   */
+  public static boolean hasExplicitDbOverride(Map<String, String> options) {
+    if (options == null || options.isEmpty()) {
+      return false;
+    }
+    if (!isBlank(options.get("db.config.env.file"))) {
+      return true;
+    }
+    return !isBlank(options.get("db.host"))
+        || !isBlank(options.get("db.user"))
+        || !isBlank(options.get("db.password"))
+        || (!isBlank(options.get("db.type"))
+            && !"h2".equalsIgnoreCase(options.get("db.type").trim())
+            && !"derby".equalsIgnoreCase(options.get("db.type").trim()));
+  }
+
+  /**
+   * Collect database options interactively, merging into a copy of {@code existingOptions}.
+   *
+   * @param existingOptions CLI options already parsed (may be empty)
+   * @param upgrade true when install root looks like an existing DTS install
+   * @param prompt operator I/O
+   * @return updated options map (never null)
+   */
+  public static Map<String, String> collect(
+      Map<String, String> existingOptions, boolean upgrade, InstallPrompt prompt) {
+    Objects.requireNonNull(prompt, "prompt");
+    Map<String, String> options =
+        existingOptions != null
+            ? new LinkedHashMap<>(existingOptions)
+            : new LinkedHashMap<>();
+
+    if (upgrade) {
+      prompt.println(
+          "Upgrade detected: existing DTS database configuration will be preserved where"
+              + " applicable (database target prompts skipped).");
+      return options;
+    }
+
+    if (hasExplicitDbOverride(options)) {
+      prompt.println(
+          "Using database options supplied on the command line or env file (interactive field"
+              + " prompts skipped).");
+      return options;
+    }
+
+    prompt.println("");
+    prompt.println("DTS database configuration (new install)");
+    prompt.println("  [1] Embedded H2 (default — demo / small site)");
+    prompt.println("  [2] SQL Server (incl. Express — small site / scale-to-corp path)");
+    prompt.println("  [3] MySQL / MariaDB");
+    prompt.println("  [4] PostgreSQL");
+    prompt.println("  [5] Load env-style config file (KEY=VALUE, same as --db.config.env.file)");
+    String choice = prompt.readLine("Select database backend [1]: ").trim();
+    if (choice.isEmpty()) {
+      choice = "1";
+    }
+
+    switch (choice) {
+      case "1" -> {
+        options.put("db.type", "h2");
+        clearStructured(options);
+        prompt.println("Selected embedded H2.");
+      }
+      case "2" -> {
+        options.put("db.type", "sqlserver");
+        prompt.println(
+            "SQL Server / Express: provision an empty database first. Express suits small sites"
+                + " (<~10 users, <~10 GB). Starting on SQL Server can avoid a later H2 migration"
+                + " if you grow into a corporate SQL Server estate.");
+        collectExternalFields(options, prompt, "1433", "DBO", "percussion_dts");
+      }
+      case "3" -> {
+        options.put("db.type", "mysql");
+        collectExternalFields(options, prompt, "3306", "", "percussion_dts");
+      }
+      case "4" -> {
+        options.put("db.type", "postgresql");
+        collectExternalFields(options, prompt, "5432", "public", "percussion_dts");
+      }
+      case "5" -> {
+        String path =
+            promptRequired(
+                prompt, "Path to env-style config file: ", "Config file path is required.");
+        Path p = Paths.get(path).toAbsolutePath().normalize();
+        if (!Files.isRegularFile(p) || !Files.isReadable(p)) {
+          throw new IllegalArgumentException("db.config.env.file not found or not readable: " + p);
+        }
+        options.put("db.config.env.file", p.toString());
+        clearStructured(options);
+        options.remove("db.type");
+      }
+      default ->
+          throw new IllegalArgumentException(
+              "Invalid database selection '" + choice + "'. Choose 1-5.");
+    }
+
+    return options;
+  }
+
+  private static void clearStructured(Map<String, String> options) {
+    options.remove("db.host");
+    options.remove("db.port");
+    options.remove("db.name");
+    options.remove("db.schema");
+    options.remove("db.user");
+    options.remove("db.password");
+  }
+
+  private static void collectExternalFields(
+      Map<String, String> options,
+      InstallPrompt prompt,
+      String defaultPort,
+      String defaultSchema,
+      String defaultName) {
+    options.put("db.host", promptWithDefault(prompt, "Database host", "localhost"));
+    options.put("db.port", promptWithDefault(prompt, "Database port", defaultPort));
+    options.put(
+        "db.name", promptWithDefault(prompt, "Database name", defaultName));
+    if (defaultSchema != null && !defaultSchema.isEmpty()) {
+      options.put("db.schema", promptWithDefault(prompt, "Schema", defaultSchema));
+    } else {
+      String schema = prompt.readLine("Schema (optional, Enter to skip): ").trim();
+      if (!schema.isEmpty()) {
+        options.put("db.schema", schema);
+      } else {
+        options.remove("db.schema");
+      }
+    }
+    options.put("db.user", promptRequired(prompt, "Database user: ", "Database user is required."));
+    String password = prompt.readPassword("Database password: ");
+    if (password == null || password.isEmpty()) {
+      password = prompt.readPassword("Password was empty. Re-enter database password: ");
+    }
+    options.put("db.password", password == null ? "" : password);
+
+    String sslEnabled =
+        promptWithDefault(prompt, "SSL enabled (true/false)", MainDTSPreInstall.DB_SSL_ENABLED_DEFAULT);
+    options.put("db.ssl.enabled", normalizeBool(sslEnabled, MainDTSPreInstall.DB_SSL_ENABLED_DEFAULT));
+    String sslVerify =
+        promptWithDefault(
+            prompt, "SSL verify server cert (true/false)", MainDTSPreInstall.DB_SSL_VERIFY_DEFAULT);
+    options.put("db.ssl.verify", normalizeBool(sslVerify, MainDTSPreInstall.DB_SSL_VERIFY_DEFAULT));
+  }
+
+  static String promptWithDefault(InstallPrompt prompt, String label, String defaultValue) {
+    String line = prompt.readLine(label + " [" + defaultValue + "]: ");
+    if (line == null || line.isBlank()) {
+      return defaultValue;
+    }
+    return line.trim();
+  }
+
+  static String promptRequired(InstallPrompt prompt, String label, String errorMessage) {
+    for (int i = 0; i < 5; i++) {
+      String line = prompt.readLine(label);
+      if (line != null && !line.isBlank()) {
+        return line.trim();
+      }
+      prompt.println(errorMessage);
+    }
+    throw new IllegalArgumentException(errorMessage);
+  }
+
+  private static String normalizeBool(String raw, String defaultValue) {
+    if (raw == null || raw.isBlank()) {
+      return defaultValue;
+    }
+    String v = raw.trim().toLowerCase(Locale.ROOT);
+    if ("true".equals(v) || "yes".equals(v) || "y".equals(v) || "1".equals(v)) {
+      return "true";
+    }
+    if ("false".equals(v) || "no".equals(v) || "n".equals(v) || "0".equals(v)) {
+      return "false";
+    }
+    return defaultValue;
+  }
+
+  private static boolean isBlank(String s) {
+    return s == null || s.isBlank();
+  }
+}

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/InteractiveDtsInstallWizard.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/InteractiveDtsInstallWizard.java
@@ -302,6 +302,10 @@ public final class InteractiveDtsInstallWizard {
       options.remove("db.ssl.enabled");
       options.remove("db.ssl.verify");
       options.remove("db.ssl.allowSelfSigned");
+      options.remove("db.ssl.trustStorePath");
+      options.remove("db.ssl.trustStorePassword");
+      options.remove("db.ssl.keyStorePath");
+      options.remove("db.ssl.keyStorePassword");
     }
     throw new IllegalArgumentException("Too many failed database configuration attempts. Aborting.");
   }

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/InteractiveDtsInstallWizard.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/InteractiveDtsInstallWizard.java
@@ -34,11 +34,17 @@ import java.util.Objects;
  */
 public final class InteractiveDtsInstallWizard {
 
-  /** Exit code when the operator declines to proceed or cancels. */
+  /**
+   * Exit code when the operator declines to proceed or cancels. Zero so interactive cancel is not
+   * treated as a hard automation failure.
+   */
   public static final int EXIT_ABORTED = 0;
 
-  /** Exit code when required input is missing in non-interactive mode. */
-  public static final int EXIT_USAGE = 0;
+  /**
+   * Exit code when required input is missing in non-interactive mode (sysexits-style {@code
+   * EX_USAGE}). Distinct from {@link #EXIT_ABORTED}.
+   */
+  public static final int EXIT_USAGE = 64;
 
   /** Exit code when database configuration validation fails. */
   public static final int EXIT_DB_CONFIG = 1;
@@ -293,6 +299,9 @@ public final class InteractiveDtsInstallWizard {
       options.remove("db.schema");
       options.remove("db.user");
       options.remove("db.password");
+      options.remove("db.ssl.enabled");
+      options.remove("db.ssl.verify");
+      options.remove("db.ssl.allowSelfSigned");
     }
     throw new IllegalArgumentException("Too many failed database configuration attempts. Aborting.");
   }

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/InteractiveDtsInstallWizard.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/InteractiveDtsInstallWizard.java
@@ -1,0 +1,429 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+import com.percussion.preinstall.java.JavaInstallSelection;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Console wizard for DTS preinstall (issue #1513 Phase 4). Mirrors the CMS interactive flow:
+ * install directory, Java home, production/staging, database multi-step, optional connection probe,
+ * summary + confirm. Silent / non-TTY installs skip prompts.
+ */
+public final class InteractiveDtsInstallWizard {
+
+  /** Exit code when the operator declines to proceed or cancels. */
+  public static final int EXIT_ABORTED = 0;
+
+  /** Exit code when required input is missing in non-interactive mode. */
+  public static final int EXIT_USAGE = 0;
+
+  /** Exit code when database configuration validation fails. */
+  public static final int EXIT_DB_CONFIG = 1;
+
+  /** Exit code when Java home selection fails. */
+  public static final int EXIT_JAVA = 2;
+
+  private InteractiveDtsInstallWizard() {}
+
+  /**
+   * Whether {@code --silent} / {@code --no-tty} disable interactive prompts.
+   *
+   * @param options parsed CLI options; may be null
+   * @return true when silent mode is requested
+   */
+  public static boolean isSilentMode(Map<String, String> options) {
+    return MainDTSPreInstall.isSilentMode(options);
+  }
+
+  /**
+   * Interactive wizard runs only when not silent and a console is available.
+   *
+   * @param silent silent CLI flag
+   * @param consoleAvailable true when {@link System#console()} is non-null
+   * @return true when the wizard may prompt
+   */
+  public static boolean isInteractive(boolean silent, boolean consoleAvailable) {
+    return !silent && consoleAvailable;
+  }
+
+  /**
+   * Run the DTS interactive (or non-interactive) pre-confirm phase.
+   *
+   * @param parsedArgs CLI parse result
+   * @param interactive whether to prompt
+   * @param prompt operator I/O; required when interactive
+   * @param unattendedJavaHome explicit Java home or null
+   * @param installProdDtsProperty raw {@code install.prod.dts} system property (may be null)
+   * @return result with proceed flag
+   */
+  public static WizardResult run(
+      MainDTSPreInstall.ParsedArgs parsedArgs,
+      boolean interactive,
+      InstallPrompt prompt,
+      Path unattendedJavaHome,
+      String installProdDtsProperty) {
+    Objects.requireNonNull(parsedArgs, "parsedArgs");
+    if (interactive && prompt == null) {
+      throw new IllegalArgumentException("prompt is required when interactive");
+    }
+
+    Path installPath = parsedArgs.installPath();
+    Map<String, String> options =
+        parsedArgs.options() != null
+            ? new LinkedHashMap<>(parsedArgs.options())
+            : new LinkedHashMap<>();
+
+    if (installPath == null) {
+      if (!interactive) {
+        return WizardResult.abort(EXIT_USAGE, usageMessage());
+      }
+      installPath = promptForInstallPath(prompt);
+      if (installPath == null) {
+        return WizardResult.abort(EXIT_ABORTED, "Installation cancelled: no install directory.");
+      }
+    } else {
+      installPath = installPath.toAbsolutePath().normalize();
+    }
+
+    JavaInstallSelection.SelectionOutcome javaOutcome;
+    try {
+      JavaInstallSelection.InteractivePrompt javaPrompt =
+          interactive && prompt != null ? prompt::readLine : null;
+      javaOutcome =
+          new JavaInstallSelection(installPath, unattendedJavaHome, javaPrompt).selectAndPersist();
+      if (interactive && prompt != null) {
+        prompt.println("DTS Java home selection: " + javaOutcome.summary());
+      }
+    } catch (JavaInstallSelection.JavaSelectionException sel) {
+      return WizardResult.abort(EXIT_JAVA, "DTS Java home selection failed: " + sel.getMessage());
+    } catch (IOException io) {
+      return WizardResult.abort(
+          EXIT_JAVA,
+          "Could not write java.properties at "
+              + installPath.resolve("java.properties")
+              + ": "
+              + io.getMessage());
+    }
+
+    boolean upgrade = isUpgradeInstall(installPath);
+    String isProduction;
+    try {
+      isProduction =
+          resolveServerType(installPath, installProdDtsProperty, upgrade, interactive, prompt);
+    } catch (IllegalArgumentException ex) {
+      return WizardResult.abort(EXIT_ABORTED, ex.getMessage());
+    }
+
+    MainDTSPreInstall.ResolvedDbConfig dbConfig;
+    try {
+      if (interactive) {
+        dbConfig = collectAndResolveDbInteractive(options, upgrade, prompt);
+      } else {
+        dbConfig = MainDTSPreInstall.resolveDbConfig(options);
+      }
+    } catch (IllegalArgumentException badDb) {
+      return WizardResult.abort(
+          EXIT_DB_CONFIG, "Database configuration error: " + badDb.getMessage());
+    }
+
+    if (interactive) {
+      String summary = buildSummary(installPath, dbConfig, javaOutcome, isProduction);
+      prompt.println(summary);
+      boolean defaultYes = isDefaultYesConfirm(dbConfig);
+      if (!confirmProceed(prompt, defaultYes)) {
+        return WizardResult.abort(EXIT_ABORTED, "Installation cancelled by operator.");
+      }
+    }
+
+    return WizardResult.proceed(
+        installPath, Map.copyOf(options), dbConfig, javaOutcome, isProduction);
+  }
+
+  /**
+   * Short usage printed when install path is missing and the session is non-interactive.
+   *
+   * @return multi-line usage text
+   */
+  public static String usageMessage() {
+    return String.join(
+        System.lineSeparator(),
+        "Must specify installation or upgrade folder",
+        "When a console is available, omit the path to enter interactive mode.",
+        "Optional: --db.type= --db.host= --db.port= --db.name= --db.user= --db.password=",
+        "Silent mode: --silent or --no-tty (disables interactive prompts for automated testing)");
+  }
+
+  static boolean isUpgradeInstall(Path installPath) {
+    if (installPath == null) {
+      return false;
+    }
+    return Files.isDirectory(installPath.resolve("Deployment"))
+        || Files.isDirectory(installPath.resolve("Staging"));
+  }
+
+  static boolean isDefaultYesConfirm(MainDTSPreInstall.ResolvedDbConfig dbConfig) {
+    if (dbConfig == null || dbConfig.systemProperties() == null) {
+      return true;
+    }
+    String type =
+        dbConfig
+            .systemProperties()
+            .getOrDefault("perc.db.type", MainDTSPreInstall.DB_TYPE_DEFAULT);
+    String normalized = type == null ? "" : type.trim().toLowerCase(Locale.ROOT);
+    return "h2".equals(normalized) || "derby".equals(normalized);
+  }
+
+  static String buildSummary(
+      Path installPath,
+      MainDTSPreInstall.ResolvedDbConfig dbConfig,
+      JavaInstallSelection.SelectionOutcome javaOutcome,
+      String isProduction) {
+    List<String> lines = new ArrayList<>();
+    lines.add("");
+    lines.add("========================================");
+    lines.add("Percussion DTS installation summary");
+    lines.add("========================================");
+    lines.add("Install path : " + installPath.toAbsolutePath().normalize());
+    lines.add("Mode         : " + (isUpgradeInstall(installPath) ? "Upgrade" : "New install"));
+    lines.add(
+        "Server type  : "
+            + ("true".equalsIgnoreCase(isProduction) ? "Production" : "Staging"));
+    lines.add("Database     : " + formatDbSummary(dbConfig));
+    lines.add(
+        "Java home    : "
+            + (javaOutcome != null
+                ? javaOutcome.javaHome() + " (" + javaOutcome.source() + ")"
+                : "unknown"));
+    lines.add("========================================");
+    return String.join(System.lineSeparator(), lines);
+  }
+
+  static String formatDbSummary(MainDTSPreInstall.ResolvedDbConfig dbConfig) {
+    if (dbConfig == null) {
+      return "(unknown)";
+    }
+    Map<String, String> p = dbConfig.systemProperties();
+    String type = p.getOrDefault("perc.db.type", MainDTSPreInstall.DB_TYPE_DEFAULT);
+    StringBuilder sb = new StringBuilder(type);
+    appendIfPresent(sb, "host", p.get("perc.db.host"));
+    appendIfPresent(sb, "port", p.get("perc.db.port"));
+    appendIfPresent(sb, "name", p.get("perc.db.name"));
+    appendIfPresent(sb, "user", p.get("perc.db.user"));
+    return sb.toString();
+  }
+
+  static Boolean parseYesNo(String answer, boolean defaultYes) {
+    if (answer == null || answer.isBlank()) {
+      return defaultYes;
+    }
+    String a = answer.trim().toLowerCase(Locale.ROOT);
+    if ("y".equals(a) || "yes".equals(a)) {
+      return true;
+    }
+    if ("n".equals(a) || "no".equals(a)) {
+      return false;
+    }
+    return null;
+  }
+
+  static MainDTSPreInstall.ResolvedDbConfig collectAndResolveDbInteractive(
+      Map<String, String> options, boolean upgrade, InstallPrompt prompt) {
+    for (int attempt = 0; attempt < 5; attempt++) {
+      Map<String, String> collected =
+          InteractiveDbConfigCollector.collect(options, upgrade, prompt);
+      options.clear();
+      options.putAll(collected);
+
+      MainDTSPreInstall.ResolvedDbConfig dbConfig = MainDTSPreInstall.resolveDbConfig(options);
+
+      if (upgrade || isDefaultYesConfirm(dbConfig)) {
+        return dbConfig;
+      }
+
+      Boolean test = parseYesNo(prompt.readLine("Test database connection now? [Y/n] "), true);
+      if (test == null || !test) {
+        return dbConfig;
+      }
+
+      RepositoryConnectionProbe.ProbeResult probe =
+          RepositoryConnectionProbe.probe(
+              dbConfig.systemProperties(), RepositoryConnectionProbe.DEFAULT_LOGIN_TIMEOUT_SECONDS);
+      prompt.println(probe.message());
+
+      if (probe.isSuccess() || probe.status() == RepositoryConnectionProbe.ProbeStatus.SKIPPED) {
+        return dbConfig;
+      }
+
+      Boolean retry =
+          parseYesNo(
+              prompt.readLine("Connection test failed. Re-enter database settings? [Y/n] "),
+              true);
+      if (retry == null || !retry) {
+        throw new IllegalArgumentException(
+            "Database connection test failed and operator chose not to re-enter settings.");
+      }
+      options.remove("db.config.env.file");
+      options.remove("db.type");
+      options.remove("db.host");
+      options.remove("db.port");
+      options.remove("db.name");
+      options.remove("db.schema");
+      options.remove("db.user");
+      options.remove("db.password");
+    }
+    throw new IllegalArgumentException("Too many failed database configuration attempts. Aborting.");
+  }
+
+  /**
+   * Resolve production vs staging for DTS install.
+   *
+   * @return {@code "true"} for production, {@code "false"} for staging
+   */
+  static String resolveServerType(
+      Path installPath,
+      String installProdDtsProperty,
+      boolean upgrade,
+      boolean interactive,
+      InstallPrompt prompt) {
+    // Existing tree detection (historical Main behavior)
+    Path staging = installPath.resolve("Staging");
+    Path prod = installPath.resolve("Deployment");
+    if (Files.exists(staging) && !Files.exists(prod)) {
+      return "false";
+    }
+
+    if (installProdDtsProperty != null
+        && !installProdDtsProperty.isBlank()
+        && ("true".equalsIgnoreCase(installProdDtsProperty.trim())
+            || "false".equalsIgnoreCase(installProdDtsProperty.trim()))) {
+      return installProdDtsProperty.trim().toLowerCase(Locale.ROOT);
+    }
+
+    if (interactive && prompt != null && !upgrade) {
+      prompt.println("");
+      prompt.println("DTS server type");
+      prompt.println("  [1] Production (default)");
+      prompt.println("  [2] Staging");
+      String choice = prompt.readLine("Select server type [1]: ").trim();
+      if (choice.isEmpty() || "1".equals(choice)) {
+        return "true";
+      }
+      if ("2".equals(choice)) {
+        return "false";
+      }
+      throw new IllegalArgumentException("Invalid server type selection '" + choice + "'.");
+    }
+
+    // Historical default for non-interactive when unset
+    return "true";
+  }
+
+  private static Path promptForInstallPath(InstallPrompt prompt) {
+    prompt.println("");
+    prompt.println("Percussion DTS interactive installer");
+    prompt.println("Enter the installation directory (new install or existing upgrade root).");
+    for (int attempt = 0; attempt < 5; attempt++) {
+      String line = prompt.readLine("Installation directory: ");
+      if (line == null || line.isBlank()) {
+        prompt.println("Install directory is required. Enter a path or Ctrl+C to abort.");
+        continue;
+      }
+      String trimmed = line.trim();
+      if ((trimmed.startsWith("\"") && trimmed.endsWith("\""))
+          || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+        if (trimmed.length() >= 2) {
+          trimmed = trimmed.substring(1, trimmed.length() - 1).trim();
+        }
+      }
+      if (trimmed.isEmpty()) {
+        prompt.println("Install directory is required.");
+        continue;
+      }
+      try {
+        return Paths.get(trimmed).toAbsolutePath().normalize();
+      } catch (Exception ex) {
+        prompt.println("Invalid path: " + ex.getMessage());
+      }
+    }
+    return null;
+  }
+
+  private static boolean confirmProceed(InstallPrompt prompt, boolean defaultYes) {
+    String hint = defaultYes ? "[Y/n]" : "[y/N]";
+    for (int attempt = 0; attempt < 5; attempt++) {
+      String line = prompt.readLine("Proceed with installation? " + hint + " ");
+      Boolean parsed = parseYesNo(line, defaultYes);
+      if (parsed != null) {
+        return parsed;
+      }
+      prompt.println("Please answer y or n.");
+    }
+    return false;
+  }
+
+  private static void appendIfPresent(StringBuilder sb, String label, String value) {
+    if (value != null && !value.isBlank()) {
+      sb.append(", ").append(label).append('=').append(value.trim());
+    }
+  }
+
+  /**
+   * Outcome of the DTS wizard.
+   *
+   * @param proceed true when install may continue
+   * @param installPath resolved absolute install path when proceed
+   * @param options CLI options map
+   * @param dbConfig resolved DB config when proceed
+   * @param javaOutcome selected Java home when proceed
+   * @param isProduction {@code "true"} or {@code "false"} for install.prod.dts
+   * @param exitCode process exit code when !proceed
+   * @param message operator-facing message when !proceed
+   */
+  public record WizardResult(
+      boolean proceed,
+      Path installPath,
+      Map<String, String> options,
+      MainDTSPreInstall.ResolvedDbConfig dbConfig,
+      JavaInstallSelection.SelectionOutcome javaOutcome,
+      String isProduction,
+      int exitCode,
+      String message) {
+
+    static WizardResult proceed(
+        Path installPath,
+        Map<String, String> options,
+        MainDTSPreInstall.ResolvedDbConfig dbConfig,
+        JavaInstallSelection.SelectionOutcome javaOutcome,
+        String isProduction) {
+      return new WizardResult(
+          true, installPath, options, dbConfig, javaOutcome, isProduction, 0, null);
+    }
+
+    static WizardResult abort(int exitCode, String message) {
+      return new WizardResult(false, null, Map.of(), null, null, null, exitCode, message);
+    }
+  }
+}

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/MainDTSPreInstall.java
@@ -44,13 +44,19 @@ public class MainDTSPreInstall {
   private static final String ANT_INSTALL = "installDts.xml";
 
   /** Default embedded engine after Apache Derby retirement (GitHub #548). */
-  private static final String DB_TYPE_DEFAULT = "h2";
+  public static final String DB_TYPE_DEFAULT = "h2";
 
-  private static final String DB_SSL_ENABLED_DEFAULT = "true";
-  private static final String DB_SSL_VERIFY_DEFAULT = "true";
-  private static final String DB_SSL_ALLOW_SELF_SIGNED_DEFAULT = "false";
+  /** Default SSL enabled value for new DTS installs. */
+  public static final String DB_SSL_ENABLED_DEFAULT = "true";
+
+  /** Default SSL verify value for new DTS installs. */
+  public static final String DB_SSL_VERIFY_DEFAULT = "true";
+
+  /** Default SSL allow-self-signed value for new DTS installs. */
+  public static final String DB_SSL_ALLOW_SELF_SIGNED_DEFAULT = "false";
+
   /** CLI key for silent/non-interactive mode (--silent or --no-tty). */
-  private static final String SILENT_KEY = "silent";
+  public static final String SILENT_KEY = "silent";
 
   /**
    * Find a jar by path pattern to avoid hard coding / forcing version.
@@ -87,7 +93,37 @@ public class MainDTSPreInstall {
   public static void main(String[] args) {
     int exitCode = 0;
     try {
-      var javaHome = System.getProperty(PERC_JAVA_HOME);
+      ParsedArgs parsedArgs = parseArgs(args);
+      boolean silent = isSilentMode(parsedArgs.options());
+      // Issue #1513 Phase 4: interactive path / Java / server type / DB / confirm when TTY.
+      boolean interactive =
+          InteractiveDtsInstallWizard.isInteractive(silent, System.console() != null);
+      InteractiveDtsInstallWizard.WizardResult wizard =
+          InteractiveDtsInstallWizard.run(
+              parsedArgs,
+              interactive,
+              SystemConsoleInstallPrompt.INSTANCE,
+              parseUnattendedJavaHome(System.getProperty(PERC_JAVA_HOME)),
+              System.getProperty("install.prod.dts"));
+      if (!wizard.proceed()) {
+        if (wizard.message() != null && !wizard.message().isBlank()) {
+          System.out.println(wizard.message());
+        }
+        System.exit(wizard.exitCode());
+        return;
+      }
+
+      var installPath = wizard.installPath();
+      ResolvedDbConfig resolvedDbConfig = wizard.dbConfig();
+      var isProduction = wizard.isProduction();
+      if (wizard.javaOutcome() != null) {
+        System.out.println("DTS Java home selection: " + wizard.javaOutcome().summary());
+      }
+
+      var javaHome =
+          wizard.javaOutcome() != null && wizard.javaOutcome().javaHome() != null
+              ? wizard.javaOutcome().javaHome().toString()
+              : System.getProperty(PERC_JAVA_HOME);
       if (javaHome == null || javaHome.trim().isEmpty()) {
         javaHome = System.getProperty(JAVA_HOME);
       }
@@ -105,75 +141,8 @@ public class MainDTSPreInstall {
       System.out.println("perc.java.home=" + javaHome);
       System.out.println("java.executable=" + javabin);
       System.out.println("perc.version=" + percVersion);
-
-      ParsedArgs parsedArgs = parseArgs(args);
-      if (parsedArgs.installPath() == null) {
-        System.out.println("Must specify installation or upgrade folder");
-        System.out.println(
-            "Silent mode: --silent or --no-tty (disables interactive prompts for automated testing)");
-        System.exit(0);
-      }
-
-      System.out.println("Installation folder =" + parsedArgs.installPath());
-      var installPath = parsedArgs.installPath();
-
-      // Check for silent/non-interactive mode (--silent or --no-tty)
-      boolean silent = isSilentMode(parsedArgs.options());
-
-      // Issue #1340 / US3 + US4 parity: persist the Java home used by DTS
-      // start, stop, and service install paths into <installPath>/java.properties
-      // before the Ant install runs. Honors -Dperc.java.home; otherwise
-      // discovers eligible Java 21 candidates and prompts when interactive.
-      try {
-        var unattended = parseUnattendedJavaHome(System.getProperty(PERC_JAVA_HOME));
-        var outcome =
-            new JavaInstallSelection(
-                    installPath,
-                    unattended,
-                    prompt -> {
-                      if (silent) {
-                        return "";
-                      }
-                      java.io.Console c = System.console();
-                      return c == null ? "" : c.readLine(prompt);
-                    })
-                .selectAndPersist();
-        System.out.println("DTS Java home selection: " + outcome.summary());
-      } catch (JavaInstallSelection.JavaSelectionException sel) {
-        System.out.println("DTS Java home selection failed: " + sel.getMessage());
-        throw new AntJobFailedException(String.format("Installation failed. %s", sel.getMessage()));
-      } catch (IOException io) {
-        throw new AntJobFailedException(
-            String.format(
-                "Could not write java.properties at %s: %s",
-                installPath.resolve("java.properties"), io.getMessage()));
-      }
-
-      ResolvedDbConfig resolvedDbConfig = resolveDbConfig(parsedArgs.options());
-      var isProduction = System.getProperty("install.prod.dts");
-      System.out.println(
-          "====Will remove below code if value of is Production comes fine"
-              + " PSDeliveryTierServerTYpePanel"
-              + isProduction);
-
-      var staging = installPath.toFile() + File.separator + "Staging";
-      var f = new File(staging);
-      var prod = installPath.toFile() + File.separator + "Deployment";
-      var f2 = new File(prod);
-
-      if (Files.exists(f.toPath()) && !Files.exists(f2.toPath())) {
-        isProduction = "false";
-      }
-
-      // If isProduction value is not passed in and we are not able to figure out either, then set
-      // the value to be true
-      // e.g. in case of upgrade installer is passing value $DTS_SERVER_TYPE$, which doesn't match
-      // any of the cases and thus fails
-      if (isProduction == null
-          || isProduction.isEmpty()
-          || (!"true".equalsIgnoreCase(isProduction) && !"false".equalsIgnoreCase(isProduction))) {
-        isProduction = "true"; // change done for dev environment
-      }
+      System.out.println("Installation folder =" + installPath);
+      System.out.println("install.prod.dts=" + isProduction);
 
       Path installSrc;
       var currentJar =
@@ -318,7 +287,7 @@ public class MainDTSPreInstall {
     return process.exitValue();
   }
 
-  private static ParsedArgs parseArgs(String[] args) {
+  static ParsedArgs parseArgs(String[] args) {
     Path installPath = null;
     Map<String, String> options = new HashMap<>();
 
@@ -379,7 +348,13 @@ public class MainDTSPreInstall {
    * @param options parsed CLI options
    * @return true if silent mode is enabled
    */
-  private static boolean isSilentMode(Map<String, String> options) {
+  /**
+   * Check if silent/non-interactive mode is enabled via --silent or --no-tty CLI options.
+   *
+   * @param options parsed CLI options
+   * @return true if silent mode is enabled
+   */
+  static boolean isSilentMode(Map<String, String> options) {
     if (options == null) {
       return false;
     }
@@ -393,7 +368,17 @@ public class MainDTSPreInstall {
         || "1".equals(noTty);
   }
 
-  private static ResolvedDbConfig resolveDbConfig(Map<String, String> cliOptions) {
+  /**
+   * Resolve DTS database configuration into {@code perc.db.*} system properties for the ANT install
+   * JVM.
+   *
+   * @param cliOptions options from {@link #parseArgs(String[])}
+   * @return resolved config (never null)
+   */
+  static ResolvedDbConfig resolveDbConfig(Map<String, String> cliOptions) {
+    if (cliOptions == null) {
+      cliOptions = Map.of();
+    }
     Map<String, String> envFileValues = new HashMap<>();
     String envFilePath =
         firstNonBlank(
@@ -639,7 +624,13 @@ public class MainDTSPreInstall {
     }
   }
 
-  private record ParsedArgs(Path installPath, Map<String, String> options) {}
+  /** CLI arguments parsed from the DTS preinstall invocation. */
+  public record ParsedArgs(Path installPath, Map<String, String> options) {}
 
-  private record ResolvedDbConfig(Map<String, String> systemProperties) {}
+  /**
+   * Resolved database configuration for the ANT install JVM.
+   *
+   * @param systemProperties map of {@code perc.db.*} keys for the ANT JVM
+   */
+  public record ResolvedDbConfig(Map<String, String> systemProperties) {}
 }

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/RepositoryConnectionProbe.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/RepositoryConnectionProbe.java
@@ -21,15 +21,27 @@ import java.sql.SQLException;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
+import java.util.regex.Pattern;
 
 /**
  * Best-effort pre-install JDBC connectivity probe for the DTS interactive wizard (issue #1513).
- * Never includes password values in messages.
+ * Never includes password values in messages. JDBC URLs are composed only from validated
+ * host/port/name components.
+ *
+ * <p><strong>Threading:</strong> not safe for concurrent use. {@link DriverManager} login timeout
+ * is process-global; mutations are serialized on an internal lock for the single-threaded
+ * preinstall path only.
  */
 public final class RepositoryConnectionProbe {
 
   /** Default login timeout seconds for the probe. */
   public static final int DEFAULT_LOGIN_TIMEOUT_SECONDS = 10;
+
+  private static final Pattern SAFE_HOST =
+      Pattern.compile("^[A-Za-z0-9._\\-:\\[\\]]{1,253}$");
+  private static final Pattern SAFE_NAME = Pattern.compile("^[A-Za-z0-9._\\-]{1,128}$");
+  private static final Object LOGIN_TIMEOUT_LOCK = new Object();
 
   private RepositoryConnectionProbe() {}
 
@@ -75,12 +87,17 @@ public final class RepositoryConnectionProbe {
     }
 
     String driverClass = systemProperties.get("perc.db.dts.jdbcDriver");
-    String jdbcUrl = systemProperties.get("perc.db.dts.jdbcUrl");
-    if (jdbcUrl == null || jdbcUrl.isBlank()) {
+    String jdbcUrl;
+    try {
       jdbcUrl = buildJdbcUrl(type, systemProperties);
+    } catch (IllegalArgumentException invalid) {
+      return new ProbeResult(ProbeStatus.FAILED, invalid.getMessage());
     }
     String user = systemProperties.get("perc.db.user");
-    String password = systemProperties.get("perc.db.password");
+    String password =
+        systemProperties.containsKey("perc.db.password")
+            ? systemProperties.get("perc.db.password")
+            : null;
 
     if (jdbcUrl == null || jdbcUrl.isBlank()) {
       return new ProbeResult(
@@ -103,35 +120,47 @@ public final class RepositoryConnectionProbe {
       }
     }
 
-    int previous = DriverManager.getLoginTimeout();
-    try {
-      if (loginTimeoutSeconds > 0) {
-        DriverManager.setLoginTimeout(loginTimeoutSeconds);
-      }
-      try (Connection conn =
-          user != null
-              ? DriverManager.getConnection(jdbcUrl, user, password == null ? "" : password)
-              : DriverManager.getConnection(jdbcUrl)) {
-        if (conn == null || conn.isClosed()) {
-          return new ProbeResult(
-              ProbeStatus.FAILED,
-              "Connection failed for " + jdbcUrl + " (null or closed connection).");
+    synchronized (LOGIN_TIMEOUT_LOCK) {
+      int previous = DriverManager.getLoginTimeout();
+      try {
+        if (loginTimeoutSeconds > 0) {
+          DriverManager.setLoginTimeout(loginTimeoutSeconds);
         }
+        try (Connection conn = openConnection(jdbcUrl, user, password)) {
+          if (conn == null || conn.isClosed()) {
+            return new ProbeResult(
+                ProbeStatus.FAILED,
+                "Connection failed for " + jdbcUrl + " (null or closed connection).");
+          }
+          return new ProbeResult(
+              ProbeStatus.SUCCESS,
+              "Connection succeeded for " + jdbcUrl + (user != null ? " user=" + user : "") + ".");
+        }
+      } catch (SQLException e) {
         return new ProbeResult(
-            ProbeStatus.SUCCESS,
-            "Connection succeeded for " + jdbcUrl + (user != null ? " user=" + user : "") + ".");
+            ProbeStatus.FAILED,
+            "Connection failed for "
+                + jdbcUrl
+                + (user != null ? " user=" + user : "")
+                + ": "
+                + safeSqlMessage(e));
+      } finally {
+        DriverManager.setLoginTimeout(previous);
       }
-    } catch (SQLException e) {
-      return new ProbeResult(
-          ProbeStatus.FAILED,
-          "Connection failed for "
-              + jdbcUrl
-              + (user != null ? " user=" + user : "")
-              + ": "
-              + safeSqlMessage(e));
-    } finally {
-      DriverManager.setLoginTimeout(previous);
     }
+  }
+
+  static Connection openConnection(String jdbcUrl, String user, String password)
+      throws SQLException {
+    if (user == null) {
+      return DriverManager.getConnection(jdbcUrl);
+    }
+    Properties props = new Properties();
+    props.setProperty("user", user);
+    if (password != null) {
+      props.setProperty("password", password);
+    }
+    return DriverManager.getConnection(jdbcUrl, props);
   }
 
   static String buildJdbcUrl(String type, Map<String, String> p) {
@@ -141,12 +170,37 @@ public final class RepositoryConnectionProbe {
     if (host == null || port == null || name == null) {
       return null;
     }
+    validateHostPortName(host, port, name);
     return switch (type) {
       case "mysql" -> "jdbc:mysql://" + host + ":" + port + "/" + name;
       case "postgresql", "postgres" -> "jdbc:postgresql://" + host + ":" + port + "/" + name;
       case "sqlserver" -> "jdbc:sqlserver://" + host + ":" + port + ";databaseName=" + name;
       default -> null;
     };
+  }
+
+  static void validateHostPortName(String host, String port, String name) {
+    if (host == null || !SAFE_HOST.matcher(host.trim()).matches() || host.contains(";")) {
+      throw new IllegalArgumentException(
+          "Invalid database host for connection probe (disallowed characters).");
+    }
+    if (port == null || !isSafePort(port.trim())) {
+      throw new IllegalArgumentException(
+          "Invalid database port for connection probe (must be 1-65535).");
+    }
+    if (name == null || !SAFE_NAME.matcher(name.trim()).matches()) {
+      throw new IllegalArgumentException(
+          "Invalid database name for connection probe (disallowed characters).");
+    }
+  }
+
+  static boolean isSafePort(String port) {
+    try {
+      int p = Integer.parseInt(port);
+      return p >= 1 && p <= 65535;
+    } catch (NumberFormatException e) {
+      return false;
+    }
   }
 
   static String safeSqlMessage(SQLException e) {
@@ -157,6 +211,9 @@ public final class RepositoryConnectionProbe {
     if (msg == null) {
       return e.getClass().getSimpleName();
     }
-    return msg.replaceAll("(?i)password\\s*=\\s*[^;\\s]+", "password=***");
+    String redacted =
+        msg.replaceAll("(?i)(password|passwd|pwd)\\s*[=:]\\s*[^;\\s,]+", "$1=***");
+    redacted = redacted.replaceAll("(?i)(://[^:/\\s]+):([^@/\\s]+)@", "$1:***@");
+    return redacted;
   }
 }

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/RepositoryConnectionProbe.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/RepositoryConnectionProbe.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Best-effort pre-install JDBC connectivity probe for the DTS interactive wizard (issue #1513).
+ * Never includes password values in messages.
+ */
+public final class RepositoryConnectionProbe {
+
+  /** Default login timeout seconds for the probe. */
+  public static final int DEFAULT_LOGIN_TIMEOUT_SECONDS = 10;
+
+  private RepositoryConnectionProbe() {}
+
+  /** Probe outcome status. */
+  public enum ProbeStatus {
+    SKIPPED_EMBEDDED,
+    SKIPPED,
+    SUCCESS,
+    FAILED
+  }
+
+  /**
+   * Result of a connectivity probe.
+   *
+   * @param status outcome
+   * @param message operator-facing detail (never contains password)
+   */
+  public record ProbeResult(ProbeStatus status, String message) {
+    public boolean isSuccess() {
+      return status == ProbeStatus.SUCCESS || status == ProbeStatus.SKIPPED_EMBEDDED;
+    }
+  }
+
+  /**
+   * Probe connectivity using resolved installer system properties ({@code perc.db.*}).
+   *
+   * @param systemProperties from {@link MainDTSPreInstall.ResolvedDbConfig#systemProperties()}
+   * @param loginTimeoutSeconds login timeout
+   * @return probe result
+   */
+  public static ProbeResult probe(Map<String, String> systemProperties, int loginTimeoutSeconds) {
+    Objects.requireNonNull(systemProperties, "systemProperties");
+    String type =
+        systemProperties
+            .getOrDefault("perc.db.type", MainDTSPreInstall.DB_TYPE_DEFAULT)
+            .trim()
+            .toLowerCase(Locale.ROOT);
+
+    if ("h2".equals(type) || "derby".equals(type)) {
+      return new ProbeResult(
+          ProbeStatus.SKIPPED_EMBEDDED,
+          "Embedded " + type + " — connectivity is validated during install setup.");
+    }
+
+    String driverClass = systemProperties.get("perc.db.dts.jdbcDriver");
+    String jdbcUrl = systemProperties.get("perc.db.dts.jdbcUrl");
+    if (jdbcUrl == null || jdbcUrl.isBlank()) {
+      jdbcUrl = buildJdbcUrl(type, systemProperties);
+    }
+    String user = systemProperties.get("perc.db.user");
+    String password = systemProperties.get("perc.db.password");
+
+    if (jdbcUrl == null || jdbcUrl.isBlank()) {
+      return new ProbeResult(
+          ProbeStatus.FAILED,
+          "Could not compose a JDBC URL for db.type=" + type + " (check host/port/name).");
+    }
+
+    if (driverClass != null && !driverClass.isBlank()) {
+      try {
+        Class.forName(driverClass);
+      } catch (ClassNotFoundException e) {
+        return new ProbeResult(
+            ProbeStatus.SKIPPED,
+            "JDBC driver class not on preinstall classpath ("
+                + driverClass
+                + "). Connection will be validated during install after drivers are staged. Target"
+                + " URL (no secrets): "
+                + jdbcUrl
+                + (user != null ? " user=" + user : ""));
+      }
+    }
+
+    int previous = DriverManager.getLoginTimeout();
+    try {
+      if (loginTimeoutSeconds > 0) {
+        DriverManager.setLoginTimeout(loginTimeoutSeconds);
+      }
+      try (Connection conn =
+          user != null
+              ? DriverManager.getConnection(jdbcUrl, user, password == null ? "" : password)
+              : DriverManager.getConnection(jdbcUrl)) {
+        if (conn == null || conn.isClosed()) {
+          return new ProbeResult(
+              ProbeStatus.FAILED,
+              "Connection failed for " + jdbcUrl + " (null or closed connection).");
+        }
+        return new ProbeResult(
+            ProbeStatus.SUCCESS,
+            "Connection succeeded for " + jdbcUrl + (user != null ? " user=" + user : "") + ".");
+      }
+    } catch (SQLException e) {
+      return new ProbeResult(
+          ProbeStatus.FAILED,
+          "Connection failed for "
+              + jdbcUrl
+              + (user != null ? " user=" + user : "")
+              + ": "
+              + safeSqlMessage(e));
+    } finally {
+      DriverManager.setLoginTimeout(previous);
+    }
+  }
+
+  static String buildJdbcUrl(String type, Map<String, String> p) {
+    String host = p.get("perc.db.host");
+    String port = p.get("perc.db.port");
+    String name = p.get("perc.db.name");
+    if (host == null || port == null || name == null) {
+      return null;
+    }
+    return switch (type) {
+      case "mysql" -> "jdbc:mysql://" + host + ":" + port + "/" + name;
+      case "postgresql", "postgres" -> "jdbc:postgresql://" + host + ":" + port + "/" + name;
+      case "sqlserver" -> "jdbc:sqlserver://" + host + ":" + port + ";databaseName=" + name;
+      default -> null;
+    };
+  }
+
+  static String safeSqlMessage(SQLException e) {
+    if (e == null) {
+      return "unknown SQL error";
+    }
+    String msg = e.getMessage();
+    if (msg == null) {
+      return e.getClass().getSimpleName();
+    }
+    return msg.replaceAll("(?i)password\\s*=\\s*[^;\\s]+", "password=***");
+  }
+}

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/RepositoryConnectionProbe.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/RepositoryConnectionProbe.java
@@ -170,29 +170,48 @@ public final class RepositoryConnectionProbe {
     if (host == null || port == null || name == null) {
       return null;
     }
-    validateHostPortName(host, port, name);
+    ValidatedEndpoint ep = validateHostPortName(host, port, name);
     return switch (type) {
-      case "mysql" -> "jdbc:mysql://" + host + ":" + port + "/" + name;
-      case "postgresql", "postgres" -> "jdbc:postgresql://" + host + ":" + port + "/" + name;
-      case "sqlserver" -> "jdbc:sqlserver://" + host + ":" + port + ";databaseName=" + name;
+      case "mysql" -> "jdbc:mysql://" + ep.host() + ":" + ep.port() + "/" + ep.name();
+      case "postgresql", "postgres" ->
+          "jdbc:postgresql://" + ep.host() + ":" + ep.port() + "/" + ep.name();
+      case "sqlserver" ->
+          "jdbc:sqlserver://" + ep.host() + ":" + ep.port() + ";databaseName=" + ep.name();
       default -> null;
     };
   }
 
-  static void validateHostPortName(String host, String port, String name) {
-    if (host == null || !SAFE_HOST.matcher(host.trim()).matches() || host.contains(";")) {
+  /**
+   * Validate and normalize host, port, and database name for JDBC URL composition.
+   *
+   * @return trimmed components safe for concatenation
+   * @throws IllegalArgumentException when any component is unsafe
+   */
+  static ValidatedEndpoint validateHostPortName(String host, String port, String name) {
+    if (host == null || port == null || name == null) {
+      throw new IllegalArgumentException(
+          "Invalid database host/port/name for connection probe (null component).");
+    }
+    String h = host.trim();
+    String p = port.trim();
+    String n = name.trim();
+    if (h.isEmpty() || !SAFE_HOST.matcher(h).matches()) {
       throw new IllegalArgumentException(
           "Invalid database host for connection probe (disallowed characters).");
     }
-    if (port == null || !isSafePort(port.trim())) {
+    if (!isSafePort(p)) {
       throw new IllegalArgumentException(
           "Invalid database port for connection probe (must be 1-65535).");
     }
-    if (name == null || !SAFE_NAME.matcher(name.trim()).matches()) {
+    if (n.isEmpty() || !SAFE_NAME.matcher(n).matches()) {
       throw new IllegalArgumentException(
           "Invalid database name for connection probe (disallowed characters).");
     }
+    return new ValidatedEndpoint(h, p, n);
   }
+
+  /** Trimmed host/port/name after successful validation. */
+  record ValidatedEndpoint(String host, String port, String name) {}
 
   static boolean isSafePort(String port) {
     try {

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/SystemConsoleInstallPrompt.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/SystemConsoleInstallPrompt.java
@@ -17,10 +17,11 @@ package com.percussion.preinstall;
 
 import java.io.Console;
 import java.io.PrintStream;
+import java.util.Arrays;
 
 /**
  * {@link InstallPrompt} backed by {@link System#console()} when available, otherwise stdout plus
- * empty reads.
+ * empty line reads / null passwords.
  */
 public final class SystemConsoleInstallPrompt implements InstallPrompt {
 
@@ -64,16 +65,18 @@ public final class SystemConsoleInstallPrompt implements InstallPrompt {
   }
 
   @Override
-  public String readPassword(String prompt) {
+  public char[] readPassword(String prompt) {
     print(prompt == null ? "" : prompt);
     Console console = System.console();
     if (console == null) {
-      return "";
+      return null;
     }
     char[] chars = console.readPassword();
     if (chars == null) {
-      return "";
+      return new char[0];
     }
-    return new String(chars);
+    char[] copy = Arrays.copyOf(chars, chars.length);
+    Arrays.fill(chars, '\0');
+    return copy;
   }
 }

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/SystemConsoleInstallPrompt.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/java/com/percussion/preinstall/SystemConsoleInstallPrompt.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+import java.io.Console;
+import java.io.PrintStream;
+
+/**
+ * {@link InstallPrompt} backed by {@link System#console()} when available, otherwise stdout plus
+ * empty reads.
+ */
+public final class SystemConsoleInstallPrompt implements InstallPrompt {
+
+  /** Shared instance for production DTS preinstall. */
+  public static final SystemConsoleInstallPrompt INSTANCE = new SystemConsoleInstallPrompt();
+
+  private final PrintStream out;
+
+  SystemConsoleInstallPrompt() {
+    this(System.out);
+  }
+
+  SystemConsoleInstallPrompt(PrintStream out) {
+    if (out == null) {
+      throw new IllegalArgumentException("out must not be null");
+    }
+    this.out = out;
+  }
+
+  @Override
+  public void print(String message) {
+    out.print(message == null ? "" : message);
+    out.flush();
+  }
+
+  @Override
+  public void println(String message) {
+    out.println(message == null ? "" : message);
+    out.flush();
+  }
+
+  @Override
+  public String readLine(String prompt) {
+    print(prompt == null ? "" : prompt);
+    Console console = System.console();
+    if (console == null) {
+      return "";
+    }
+    String line = console.readLine();
+    return line == null ? "" : line;
+  }
+
+  @Override
+  public String readPassword(String prompt) {
+    print(prompt == null ? "" : prompt);
+    Console console = System.console();
+    if (console == null) {
+      return "";
+    }
+    char[] chars = console.readPassword();
+    if (chars == null) {
+      return "";
+    }
+    return new String(chars);
+  }
+}

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/InteractiveDtsInstallWizardTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/InteractiveDtsInstallWizardTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("UnitTest")
+class InteractiveDtsInstallWizardTest {
+
+  @TempDir Path tempDir;
+
+  private Path runningJavaHome() {
+    return Path.of(System.getProperty("java.home")).toAbsolutePath().normalize();
+  }
+
+  @Test
+  void nonInteractiveMissingPathReturnsUsage() {
+    MainDTSPreInstall.ParsedArgs parsed = new MainDTSPreInstall.ParsedArgs(null, Map.of());
+    InteractiveDtsInstallWizard.WizardResult result =
+        InteractiveDtsInstallWizard.run(parsed, false, null, runningJavaHome(), null);
+    assertFalse(result.proceed());
+    assertEquals(InteractiveDtsInstallWizard.EXIT_USAGE, result.exitCode());
+    assertTrue(result.message().contains("installation or upgrade folder"));
+  }
+
+  @Test
+  void nonInteractiveWithPathProceedsDefaultH2Production() {
+    Path install = tempDir.resolve("dts");
+    MainDTSPreInstall.ParsedArgs parsed =
+        new MainDTSPreInstall.ParsedArgs(install, Map.of());
+    InteractiveDtsInstallWizard.WizardResult result =
+        InteractiveDtsInstallWizard.run(parsed, false, null, runningJavaHome(), null);
+    assertTrue(result.proceed());
+    assertEquals(install.toAbsolutePath().normalize(), result.installPath());
+    assertEquals("h2", result.dbConfig().systemProperties().get("perc.db.type"));
+    assertEquals("true", result.isProduction());
+    assertNotNull(result.javaOutcome());
+    assertTrue(Files.exists(install.resolve("java.properties")));
+  }
+
+  @Test
+  void interactiveFullFlowH2Production() {
+    Path install = tempDir.resolve("dts-i");
+    // path, server type default, DB H2, confirm Y
+    ScriptedPrompt prompt = new ScriptedPrompt(install.toString(), "", "", "");
+    MainDTSPreInstall.ParsedArgs parsed = new MainDTSPreInstall.ParsedArgs(null, Map.of());
+    InteractiveDtsInstallWizard.WizardResult result =
+        InteractiveDtsInstallWizard.run(parsed, true, prompt, runningJavaHome(), null);
+    assertTrue(result.proceed());
+    assertEquals("true", result.isProduction());
+    assertEquals("h2", result.dbConfig().systemProperties().get("perc.db.type"));
+    assertTrue(prompt.outputsAsString().contains("DTS installation summary"));
+  }
+
+  @Test
+  void interactiveStagingAndSqlServer() {
+    Path install = tempDir.resolve("dts-ss");
+    // server type 2 staging, DB menu 2 SQL Server, fields, skip test, confirm y
+    ScriptedPrompt prompt =
+        new ScriptedPrompt(
+            "2",
+            "2",
+            "localhost",
+            "1433",
+            "percussion_dts",
+            "DBO",
+            "sa",
+            "secret-pw",
+            "true",
+            "true",
+            "n",
+            "y");
+    MainDTSPreInstall.ParsedArgs parsed =
+        new MainDTSPreInstall.ParsedArgs(install, Map.of());
+    InteractiveDtsInstallWizard.WizardResult result =
+        InteractiveDtsInstallWizard.run(parsed, true, prompt, runningJavaHome(), null);
+    assertTrue(result.proceed());
+    assertEquals("false", result.isProduction());
+    assertEquals("sqlserver", result.dbConfig().systemProperties().get("perc.db.type"));
+    assertTrue(prompt.outputsAsString().toLowerCase().contains("express"));
+    assertFalse(prompt.outputsAsString().contains("secret-pw"));
+    assertTrue(prompt.outputsAsString().contains("Staging"));
+  }
+
+  @Test
+  void interactiveConfirmNoAborts() {
+    Path install = tempDir.resolve("dts-abort");
+    ScriptedPrompt prompt = new ScriptedPrompt("1", "1", "n");
+    MainDTSPreInstall.ParsedArgs parsed =
+        new MainDTSPreInstall.ParsedArgs(install, Map.of());
+    InteractiveDtsInstallWizard.WizardResult result =
+        InteractiveDtsInstallWizard.run(parsed, true, prompt, runningJavaHome(), null);
+    assertFalse(result.proceed());
+    assertTrue(result.message().toLowerCase().contains("cancelled"));
+  }
+
+  @Test
+  void upgradeDetectsDeploymentTreeAndSkipsDbMenu() throws Exception {
+    Path install = tempDir.resolve("dts-upg");
+    Files.createDirectories(install.resolve("Deployment"));
+    ScriptedPrompt prompt = new ScriptedPrompt("y");
+    MainDTSPreInstall.ParsedArgs parsed =
+        new MainDTSPreInstall.ParsedArgs(install, Map.of());
+    InteractiveDtsInstallWizard.WizardResult result =
+        InteractiveDtsInstallWizard.run(parsed, true, prompt, runningJavaHome(), "true");
+    assertTrue(result.proceed());
+    assertTrue(prompt.outputsAsString().toLowerCase().contains("upgrade"));
+    assertTrue(prompt.outputsAsString().contains("Upgrade"));
+  }
+
+  @Test
+  void invalidJavaAborts() {
+    Path install = tempDir.resolve("dts-bad-java");
+    Path invalid = tempDir.resolve("no-jdk");
+    MainDTSPreInstall.ParsedArgs parsed =
+        new MainDTSPreInstall.ParsedArgs(install, Map.of());
+    InteractiveDtsInstallWizard.WizardResult result =
+        InteractiveDtsInstallWizard.run(parsed, false, null, invalid, null);
+    assertFalse(result.proceed());
+    assertEquals(InteractiveDtsInstallWizard.EXIT_JAVA, result.exitCode());
+  }
+
+  @Test
+  void externalDbCliOverrideSkipsMenu() {
+    Path install = tempDir.resolve("dts-cli-db");
+    Map<String, String> opts = new HashMap<>();
+    opts.put("db.type", "mysql");
+    opts.put("db.host", "db.example.com");
+    opts.put("db.port", "3306");
+    opts.put("db.name", "dts");
+    opts.put("db.user", "u");
+    opts.put("db.password", "p-secret");
+    // test connection n, confirm yes
+    ScriptedPrompt prompt = new ScriptedPrompt("n", "yes");
+    MainDTSPreInstall.ParsedArgs parsed =
+        new MainDTSPreInstall.ParsedArgs(install, opts);
+    InteractiveDtsInstallWizard.WizardResult result =
+        InteractiveDtsInstallWizard.run(parsed, true, prompt, runningJavaHome(), "true");
+    assertTrue(result.proceed());
+    assertEquals("mysql", result.dbConfig().systemProperties().get("perc.db.type"));
+    assertFalse(prompt.outputsAsString().contains("p-secret"));
+  }
+
+  private static final class ScriptedPrompt implements InstallPrompt {
+    private final Deque<String> answers;
+    private final List<String> outputs = new ArrayList<>();
+
+    ScriptedPrompt(String... answers) {
+      this.answers = new ArrayDeque<>();
+      for (String a : answers) {
+        this.answers.addLast(a);
+      }
+    }
+
+    @Override
+    public void print(String message) {
+      outputs.add(message == null ? "" : message);
+    }
+
+    @Override
+    public void println(String message) {
+      outputs.add((message == null ? "" : message) + "\n");
+    }
+
+    @Override
+    public String readLine(String prompt) {
+      print(prompt);
+      return answers.isEmpty() ? "" : answers.removeFirst();
+    }
+
+    @Override
+    public String readPassword(String prompt) {
+      return readLine(prompt);
+    }
+
+    String outputsAsString() {
+      StringBuilder sb = new StringBuilder();
+      for (String o : outputs) {
+        sb.append(o);
+      }
+      return sb.toString();
+    }
+  }
+}

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/InteractiveDtsInstallWizardTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/preinstall/InteractiveDtsInstallWizardTest.java
@@ -197,8 +197,9 @@ class InteractiveDtsInstallWizardTest {
     }
 
     @Override
-    public String readPassword(String prompt) {
-      return readLine(prompt);
+    public char[] readPassword(String prompt) {
+      String s = readLine(prompt);
+      return s == null ? null : s.toCharArray();
     }
 
     String outputsAsString() {

--- a/docs/ai-generated/tasks/interactive-installer-mode/PLAN.md
+++ b/docs/ai-generated/tasks/interactive-installer-mode/PLAN.md
@@ -1,0 +1,250 @@
+# Plan: Interactive Installer Mode (CMS + DTS)
+
+**GitHub issue:** [#1513](https://github.com/intersoftdatalabs-in/percussioncms/issues/1513)  
+**Feature branch:** `feat/1513-interactive-installer`  
+**Process:** Issue + feature branch implementation — **not** full Speckit  
+**Branch base:** `development`  
+**Status:** Ready for implementation (MVP phases 1–3 CMS first)  
+**Primary modules:** `modules/perc-distribution-tree` (CMS preinstall), `deliverytiersuite/.../delivery-tier-distribution` (DTS preinstall)  
+**Related work already landed:**
+
+| Area | What exists today | Gap for interactive UX |
+|------|-------------------|------------------------|
+| Install path | Required first CLI positional arg | No prompt if omitted |
+| Java home | Discovery + multi-candidate prompt (`JavaInstallSelection`, issue #1340 / specs/991) | Only when path already known; not step 1 of a wizard |
+| DB target | Fully parameter-driven: `--dbprops`, `--db.*`, env file, env vars, default H2 (`DbInstallConfigResolver`, specs/006) | No guided multi-step capture |
+| DB test | ANT task `PSValidateRepositoryConnection` **after** files are written (new install) | No optional **pre-install** test in the wizard |
+| Summary / confirm | None — install proceeds once args parse | No review/confirm step |
+| Silent mode | `--silent` / `--no-tty` | Keep as hard non-interactive path |
+
+---
+
+## Problem
+
+CLI installers currently require operators (or automation) to pass everything up front:
+
+```text
+java -jar PercussionCMS.jar <installDir> [--dbprops=...] [--db.type=...] ...
+java -jar PercussionDTS.jar  <installDir> [--db.type=...] ...
+```
+
+If `installDir` is missing, the process exits with a short usage message. Interactive pieces exist only as **islands** (Java multi-home pick; upgrade “clean obsolete dirs” y/N). There is no end-to-end walkthrough for a human at a TTY.
+
+---
+
+## Goal
+
+When a **TTY is available** and the operator did **not** pass `--silent` / `--no-tty`, run a linear console wizard that collects and confirms configuration, then hands the same resolved inputs into the existing install pipeline (no second configuration system).
+
+When silent / no TTY / fully parameterized automation runs: **behavior unchanged** (parameters + defaults; no new prompts).
+
+---
+
+## Target interactive flow
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│  0. Mode detection                                          │
+│     TTY && !silent  → interactive wizard                    │
+│     else            → current CLI/env/dbprops path only     │
+└───────────────────────────┬─────────────────────────────────┘
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│  1. Installation directory                                  │
+│     Prompt if positional path omitted                       │
+│     Default: cwd or last known? (decide in spec; start      │
+│     simple — no default, require explicit path)             │
+│     Validate: writable parent, refuse unsafe paths          │
+│     Detect upgrade vs new install (Version.properties)      │
+└───────────────────────────┬─────────────────────────────────┘
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│  2. System Java JRE/JDK directory                           │
+│     Reuse JavaInstallSelection (discover eligible 21+)      │
+│     Unattended -Dperc.java.home still wins                  │
+│     Multi-candidate menu; single → auto-select; zero → fail │
+│     Optional: allow typed path override if not in list      │
+└───────────────────────────┬─────────────────────────────────┘
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│  3. Database connection (new install only; multi-step)      │
+│     Skip / preserve-on-upgrade when existing repo config    │
+│                                                             │
+│     3a. Backend choice (wizard menu):                       │
+│         • Embedded H2 (default demo / small site)           │
+│         • SQL Server Express (small-site path — see note) │
+│         • External MySQL/MariaDB | SQL Server | Oracle |    │
+│           PostgreSQL                                        │
+│     3b. H2: no further DB fields                            │
+│     3c. Express / external: host, port, name/service,       │
+│         schema, user, password (masked), SSL flags          │
+│     3d. Alt: load from --dbprops / path prompt              │
+│         (file path short-circuits field prompts)            │
+│     Map answers → same Map/ResolvedDbConfig as today        │
+└───────────────────────────┬─────────────────────────────────┘
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│  4. Test database connection (optional)                     │
+│     Offer [Y/n] for external backends only                  │
+│     Reuse connection logic (extract pure helper from        │
+│     PSValidateRepositoryConnection / InstallUtil)           │
+│     Success → continue; failure → re-edit DB / abort        │
+│     Never print passwords                                   │
+└───────────────────────────┬─────────────────────────────────┘
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│  5. Summary + proceed                                       │
+│     Show install path, upgrade/new, Java home, DB type,     │
+│     host/name/user (no password), SSL summary               │
+│     Confirm [Y/n]; N → back to edit step or exit            │
+│     On Y → existing extract + ANT install path              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Upgrade path note:** Steps 3–4 should default to “use existing repository configuration” when `Version.properties` / repo props already exist. Optional later: interactive clean-install-dir already exists and can remain a side prompt after path detection.
+
+---
+
+## Design principles
+
+1. **Single configuration contract** — Wizard fills the same structures `DbInstallConfigResolver` / `JavaInstallSelection` already produce. Prefer building a synthetic options map (or calling shared resolvers with prompted values) over forking ANT property names.
+2. **CLI wins over prompts** — If the operator already passed install path, `--dbprops`, `--db.host`, `-Dperc.java.home`, etc., skip those wizard steps (or pre-fill and allow override only when interactively requested).
+3. **Silent is sacred** — Docker/matrix/CI (`--silent` / no console) must not hang waiting for input. Same exit codes and validation messages as today.
+4. **Console-only MVP** — No Swing/JavaFX GUI in this plan. `System.console()` / injectable `InteractivePrompt` (already used for Java selection).
+5. **Cross-platform** — Paths via `Path` / `Path.of`; password read via `Console.readPassword()` when available; Windows + Linux + macOS.
+6. **Secrets hygiene** — Never echo/log `PWD` / `db.password`; summary redacts credentials.
+7. **Testability** — Wizard steps accept `InteractivePrompt` (or a small `LineReader` + `PasswordReader`) so unit tests drive answers without a real TTY.
+
+---
+
+## Proposed code shape (CMS first)
+
+| Piece | Responsibility |
+|-------|----------------|
+| `InteractiveInstallWizard` (new, preinstall package) | Orchestrates steps 1–5; returns `WizardResult` (installPath, options map / ResolvedDbConfig, java selection already persisted or deferred) |
+| `ConsolePrompts` (new, thin) | Defaults, yes/no, menu, masked password, path validation |
+| `DbInstallConfigResolver` | Keep pure resolution/validation; add package-visible helpers if needed for “build options from answers” |
+| `JavaInstallSelection` | Already step 2; call from wizard after path known |
+| `RepositoryConnectionTester` (new pure helper, or extract from perc-ant) | Pre-install connectivity test without ANT; share logic with `PSValidateRepositoryConnection` |
+| `Main.main` | If interactive mode and incomplete required inputs → run wizard; else current path |
+
+DTS (`MainDTSPreInstall`) should get a **parallel** wizard (same UX language, DTS field set / production vs staging where relevant), reusing shared prompt helpers if we extract a tiny common module—or duplicate thin wizard code initially to avoid a new shared artifact (prefer extract only if duplication hurts).
+
+---
+
+## Precedence (interactive session)
+
+Recommended order for each field:
+
+1. Explicit CLI / system property already supplied  
+2. Env file / environment (existing `DbInstallConfigResolver` precedence)  
+3. Interactive answer  
+4. Product default (e.g. `h2`, SSL defaults)
+
+---
+
+## Non-goals (this plan)
+
+- GUI / web-based installer  
+- Changing silent/automation contracts or sample `rxrepository.*.properties` format  
+- Replacing ANT install steps  
+- Shipping a bundled JRE  
+- Full Speckit constitution/spec unless product prioritizes a tracked feature branch  
+
+---
+
+## Implementation phases
+
+### Phase 0 — Spec spike (short)
+
+- Capture UX copy defaults (menus, defaults, cancel keys).  
+- Confirm DTS parity scope (same 5 steps vs DTS-specific production/staging).  
+- Confirm whether typed custom Java path is in MVP.
+
+### Phase 1 — CMS wizard skeleton
+
+- Detect interactive mode in `Main`.  
+- Step 1: install directory prompt when missing.  
+- Step 5: summary + confirm (even if DB/Java still from CLI defaults).  
+- Unit tests with fake prompt.
+
+### Phase 2 — Java step integration
+
+- Run `JavaInstallSelection` as wizard step 2 (already mostly done; order after install path).  
+- Optional custom path entry.
+
+### Phase 3 — Database multi-step + optional test
+
+- Wizard collects structured fields → options map → `resolveDbConfig`.  
+- Optional connection test for external backends; re-prompt on failure.  
+- Extract/shared tester so ANT post-write validation and pre-install test stay consistent.
+
+### Phase 4 — DTS parity + docs
+
+- Mirror flow in DTS preinstall.  
+- Update `modules/perc-distribution-tree/README.md` and DTS distribution README.  
+- Matrix/Docker remain on `--silent` + flags (document “interactive is for operators at a console”).
+
+### Phase 5 — Polish
+
+- “Back” navigation between steps (nice-to-have).  
+- Upgrade-specific messaging.  
+- Help text when launched with zero args (print “interactive mode available” vs usage-only exit).
+
+---
+
+## Acceptance criteria (MVP)
+
+1. **TTY + no install path:** operator is prompted for install directory; install can complete without any prior CLI args for a default H2 install.  
+2. **TTY + new install + external DB:** multi-step prompts produce a valid `ResolvedDbConfig` equivalent to `--db.type=... --db.host=...` etc.  
+3. **Optional DB test:** operator can test connectivity before extract/ANT; failure does not leave a half-written install.  
+4. **Summary:** operator sees non-secret options and must confirm before install work begins.  
+5. **Silent / no TTY / full CLI:** no new prompts; existing automation green.  
+6. **Passwords:** never printed in prompts (echo off), summary, or logs.  
+7. **Unit tests** cover wizard branching (defaults, skip-when-CLI-supplied, test-fail re-edit, confirm-no abort).
+
+---
+
+## Decisions (resolved)
+
+| # | Question | Decision |
+|---|----------|----------|
+| 1 | Zero-arg + TTY | **Enter wizard** (do not only print usage and exit). Usage still printed for `--help` / silent-missing-path cases as appropriate. |
+| 2 | Final confirm default | **Default Y for embedded H2**; **require explicit Y** for external / SQL Server Express (or any non-default backend). |
+| 3 | DTS production vs staging | **Include as a wizard step** on DTS interactive path (parity with knowing server type up front). |
+| 4 | dbprops vs fields | **Offer menu:** “Enter fields” / “Load properties file”. |
+| 5 | Tracking | **GitHub issue + feature branch**; no Speckit constitution/spec/tasks set for this feature. |
+
+---
+
+## Design note (open product choice): SQL Server Express on the “small site” path
+
+**Idea (under consideration, not MVP-blocking):** On the interactive database step, alongside embedded H2, offer **SQL Server Express** as a guided option aimed at small deployments (**&lt; ~10 users**, **&lt; ~10 GB** repository), with clear sizing guidance in the prompt copy.
+
+**Why it may matter:** If a customer later scales and corporate standard is SQL Server, starting on Express can **avoid a future H2 → SQL Server migration**. Express is still the product’s existing `sqlserver` backend path (host/port/db/user/password), not a second engine — UX can default localhost/named instance patterns and SSL defaults appropriate for Express.
+
+**What this is *not* (unless we decide later):**
+
+- Not replacing H2 as the zero-config default for demos/CI.
+- Not auto-installing SQL Server Express (operator provisions the instance; installer only configures CMS/DTS to use it).
+- Not a free license entitlement claim — copy must say operator supplies a licensed Express (or full SQL Server) instance.
+
+**MVP stance:**
+
+1. Implement interactive flow with backends already supported (`h2`, `mysql`, `sqlserver`, `oracle`, `postgresql`).
+2. Add an Express-oriented **menu label / defaults / help text** for `sqlserver` (e.g. default host `localhost`, default port `1433`, schema `dbo`) without a separate `db.type`.
+3. Capture full Express “productized small-site path” (docs, sample props, sizing guardrails, optional local discovery) as a **follow-up** on the same issue or a child issue after MVP lands.
+
+**Risks / follow-ups to decide before over-investing:**
+
+- Express edition limits (10 GB user DB, CPU/RAM caps) vs product growth messaging.
+- Auth modes (SQL auth vs Windows/integrated) — today structured install leans SQL auth + password; Windows auth may be out of MVP.
+- Whether DTS should share the same Express instance/database vs separate DB (likely separate schema/db names for prod practice).
+
+---
+
+## Suggested next step
+
+1. Implement on `feat/1513-interactive-installer` against [#1513](https://github.com/intersoftdatalabs-in/percussioncms/issues/1513) (CMS Phase 1–3 first).  
+2. DTS parity (Phase 4) in a follow-up PR on the same branch or stacked PR.  
+3. Express menu copy + defaults can land with Phase 3 DB step; deeper Express packaging stays optional.

--- a/docs/ai-generated/tasks/interactive-installer-mode/PLAN.md
+++ b/docs/ai-generated/tasks/interactive-installer-mode/PLAN.md
@@ -4,7 +4,7 @@
 **Feature branch:** `feat/1513-interactive-installer`  
 **Process:** Issue + feature branch implementation — **not** full Speckit  
 **Branch base:** `development`  
-**Status:** Ready for implementation (MVP phases 1–3 CMS first)  
+**Status:** Phase 1 implemented on branch (CMS path prompt + summary/confirm)  
 **Primary modules:** `modules/perc-distribution-tree` (CMS preinstall), `deliverytiersuite/.../delivery-tier-distribution` (DTS preinstall)  
 **Related work already landed:**
 
@@ -161,12 +161,13 @@ Recommended order for each field:
 - Confirm DTS parity scope (same 5 steps vs DTS-specific production/staging).  
 - Confirm whether typed custom Java path is in MVP.
 
-### Phase 1 — CMS wizard skeleton
+### Phase 1 — CMS wizard skeleton ✅
 
 - Detect interactive mode in `Main`.  
 - Step 1: install directory prompt when missing.  
 - Step 5: summary + confirm (even if DB/Java still from CLI defaults).  
-- Unit tests with fake prompt.
+- Unit tests with fake prompt.  
+- **Landed:** `InteractiveInstallWizard`, `InstallPrompt`, `SystemConsoleInstallPrompt`, wired from `Main`; tests in `InteractiveInstallWizardTest`.
 
 ### Phase 2 — Java step integration
 

--- a/docs/ai-generated/tasks/interactive-installer-mode/PLAN.md
+++ b/docs/ai-generated/tasks/interactive-installer-mode/PLAN.md
@@ -4,7 +4,7 @@
 **Feature branch:** `feat/1513-interactive-installer`  
 **Process:** Issue + feature branch implementation — **not** full Speckit  
 **Branch base:** `development`  
-**Status:** CMS Phases 1–3 implemented on branch (path, Java, DB multi-step, probe, confirm)  
+**Status:** CMS Phases 1–3 + DTS Phase 4 implemented on branch (single PR)  
 **Primary modules:** `modules/perc-distribution-tree` (CMS preinstall), `deliverytiersuite/.../delivery-tier-distribution` (DTS preinstall)  
 **Related work already landed:**
 
@@ -180,11 +180,12 @@ Recommended order for each field:
 - `RepositoryConnectionProbe` best-effort preinstall probe (SKIPPED when driver not on classpath).  
 - ANT `PSValidateRepositoryConnection` remains authoritative after files are written.
 
-### Phase 4 — DTS parity + docs
+### Phase 4 — DTS parity + docs ✅
 
-- Mirror flow in DTS preinstall.  
-- Update `modules/perc-distribution-tree/README.md` and DTS distribution README.  
-- Matrix/Docker remain on `--silent` + flags (document “interactive is for operators at a console”).
+- `InteractiveDtsInstallWizard` + collectors/probe in `delivery-tier-distribution`.  
+- Production vs staging wizard step.  
+- CMS + DTS READMEs document interactive mode.  
+- Matrix/Docker remain on `--silent` + flags.
 
 ### Phase 5 — Polish
 

--- a/docs/ai-generated/tasks/interactive-installer-mode/PLAN.md
+++ b/docs/ai-generated/tasks/interactive-installer-mode/PLAN.md
@@ -4,7 +4,7 @@
 **Feature branch:** `feat/1513-interactive-installer`  
 **Process:** Issue + feature branch implementation — **not** full Speckit  
 **Branch base:** `development`  
-**Status:** Phase 1 implemented on branch (CMS path prompt + summary/confirm)  
+**Status:** CMS Phases 1–3 implemented on branch (path, Java, DB multi-step, probe, confirm)  
 **Primary modules:** `modules/perc-distribution-tree` (CMS preinstall), `deliverytiersuite/.../delivery-tier-distribution` (DTS preinstall)  
 **Related work already landed:**
 
@@ -169,16 +169,16 @@ Recommended order for each field:
 - Unit tests with fake prompt.  
 - **Landed:** `InteractiveInstallWizard`, `InstallPrompt`, `SystemConsoleInstallPrompt`, wired from `Main`; tests in `InteractiveInstallWizardTest`.
 
-### Phase 2 — Java step integration
+### Phase 2 — Java step integration ✅
 
-- Run `JavaInstallSelection` as wizard step 2 (already mostly done; order after install path).  
-- Optional custom path entry.
+- Run `JavaInstallSelection` as wizard step 2 (before summary).  
+- Optional custom path entry (deferred — discovery + `-Dperc.java.home` covers MVP).
 
-### Phase 3 — Database multi-step + optional test
+### Phase 3 — Database multi-step + optional test ✅
 
-- Wizard collects structured fields → options map → `resolveDbConfig`.  
-- Optional connection test for external backends; re-prompt on failure.  
-- Extract/shared tester so ANT post-write validation and pre-install test stay consistent.
+- `InteractiveDbConfigCollector` menu + structured fields (incl. SQL Server Express copy).  
+- `RepositoryConnectionProbe` best-effort preinstall probe (SKIPPED when driver not on classpath).  
+- ANT `PSValidateRepositoryConnection` remains authoritative after files are written.
 
 ### Phase 4 — DTS parity + docs
 

--- a/modules/perc-distribution-tree/README.md
+++ b/modules/perc-distribution-tree/README.md
@@ -79,6 +79,26 @@ JARs are placed in the install with their Maven-resolved filenames (e.g. `mariad
 
 Integrators who need a driver that is not bundled (for example an enterprise Oracle driver) can simply drop a JDBC driver JAR into `jetty/base/lib/jdbc/` of the unpacked distribution. The install scripts (`rxconfig/Installer/install.xml`, `installServer.xml`, `installRepository.xml`) do not purge this folder.
 
+## CLI installer: interactive mode (issue #1513)
+
+When a **console/TTY is available** and you do **not** pass `--silent` / `--no-tty`, the CMS preinstall walks through:
+
+1. Installation directory (prompted if the path argument is omitted)
+2. System Java 21+ home (discovery / multi-candidate menu; or `-Dperc.java.home=...`)
+3. Database backend (menu: H2, SQL Server/Express, MySQL/MariaDB, PostgreSQL, Oracle, or load a properties file)
+4. Optional connection test for external backends (best-effort; full validation still runs during install)
+5. Summary (no secrets) and confirm
+
+Silent/automation installs are unchanged: pass the install path and `--dbprops` / `--db.*` as before.
+
+```bash
+# Interactive (console): omit path to be prompted
+java -jar PercussionCMS.jar
+
+# Silent / CI
+java -jar PercussionCMS.jar /path/to/install/root --silent --db.type=h2
+```
+
 ## CLI installer: database targets for new installs
 
 By default a **new** command-line install uses the embedded **H2** repository (GitHub #548; Apache Derby is retired as the live default and retained only for upgrade migration). To target MySQL/MariaDB, SQL Server, or Oracle on a **new install only**, supply a repository properties file in the same format as `rxconfig/Installer/rxrepository.properties`:

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InstallPrompt.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InstallPrompt.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+/**
+ * Operator I/O for the interactive installer wizard. Production code uses {@link
+ * SystemConsoleInstallPrompt}; unit tests supply scripted answers.
+ *
+ * <p>Implementations must never log or echo password characters returned from {@link
+ * #readPassword(String)}.
+ */
+public interface InstallPrompt {
+
+  /**
+   * Writes a message to the operator (no trailing newline unless included in {@code message}).
+   *
+   * @param message text to write; may be empty, never {@code null}
+   */
+  void print(String message);
+
+  /**
+   * Writes a message followed by a platform line separator.
+   *
+   * @param message text to write; may be empty, never {@code null}
+   */
+  void println(String message);
+
+  /**
+   * Prompts and reads a single line of operator input.
+   *
+   * @param prompt text shown before reading; never {@code null}
+   * @return the line without terminator; empty string if EOF / unavailable (never {@code null})
+   */
+  String readLine(String prompt);
+
+  /**
+   * Prompts and reads a password without echoing. Phase 1 may not use this; later DB steps will.
+   *
+   * @param prompt text shown before reading; never {@code null}
+   * @return password characters, or empty string if unavailable (never {@code null})
+   */
+  String readPassword(String prompt);
+}

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InstallPrompt.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InstallPrompt.java
@@ -19,8 +19,9 @@ package com.percussion.preinstall;
  * Operator I/O for the interactive installer wizard. Production code uses {@link
  * SystemConsoleInstallPrompt}; unit tests supply scripted answers.
  *
- * <p>Implementations must never log or echo password characters returned from {@link
- * #readPassword(String)}.
+ * <p>Implementations must never log or echo password characters. Callers that receive a non-null
+ * {@code char[]} from {@link #readPassword(String)} should zero the array after converting to the
+ * durable form they need (e.g. options map).
  */
 public interface InstallPrompt {
 
@@ -42,15 +43,17 @@ public interface InstallPrompt {
    * Prompts and reads a single line of operator input.
    *
    * @param prompt text shown before reading; never {@code null}
-   * @return the line without terminator; empty string if EOF / unavailable (never {@code null})
+   * @return the line without terminator; empty string if EOF (never {@code null})
    */
   String readLine(String prompt);
 
   /**
-   * Prompts and reads a password without echoing. Phase 1 may not use this; later DB steps will.
+   * Prompts and reads a password without echoing.
    *
    * @param prompt text shown before reading; never {@code null}
-   * @return password characters, or empty string if unavailable (never {@code null})
+   * @return password characters (caller should zero after use); empty array if the operator entered
+   *     an empty password; {@code null} if no console is available (non-interactive / unavailable —
+   *     do not re-prompt forever)
    */
-  String readPassword(String prompt);
+  char[] readPassword(String prompt);
 }

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InteractiveDbConfigCollector.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InteractiveDbConfigCollector.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Interactive multi-step collection of repository database options for new CMS installs (issue
+ * #1513 Phase 3). Populates the same structured {@code db.*} keys consumed by {@link
+ * DbInstallConfigResolver}.
+ *
+ * <p>Does not print password values. Upgrade installs skip collection (existing repo config is
+ * preserved by the install path).
+ */
+public final class InteractiveDbConfigCollector {
+
+  private InteractiveDbConfigCollector() {}
+
+  /**
+   * Whether CLI already supplies an explicit database target that should skip field prompts.
+   *
+   * @param options CLI options map
+   * @return true when dbprops path is set or structured host credentials are present
+   */
+  public static boolean hasExplicitDbOverride(Map<String, String> options) {
+    if (options == null || options.isEmpty()) {
+      return false;
+    }
+    if (!isBlank(options.get(DbInstallConfigResolver.DBPROPS_KEY))
+        || !isBlank(options.get("db.props"))) {
+      return true;
+    }
+    // Structured partial/full override: any of these means operator chose non-wizard input
+    return !isBlank(options.get("db.host"))
+        || !isBlank(options.get("db.user"))
+        || !isBlank(options.get("db.password"))
+        || (!isBlank(options.get("db.type"))
+            && !"h2".equalsIgnoreCase(options.get("db.type").trim())
+            && !"derby".equalsIgnoreCase(options.get("db.type").trim()));
+  }
+
+  /**
+   * Collect database options interactively, merging into a copy of {@code existingOptions}.
+   *
+   * @param existingOptions CLI options already parsed (may be empty)
+   * @param upgrade true when install root is an upgrade
+   * @param prompt operator I/O
+   * @return updated options map (never null)
+   */
+  public static Map<String, String> collect(
+      Map<String, String> existingOptions, boolean upgrade, InstallPrompt prompt) {
+    Objects.requireNonNull(prompt, "prompt");
+    Map<String, String> options =
+        existingOptions != null
+            ? new LinkedHashMap<>(existingOptions)
+            : new LinkedHashMap<>();
+
+    if (upgrade) {
+      prompt.println(
+          "Upgrade detected: existing repository configuration will be preserved (database"
+              + " target prompts skipped).");
+      return options;
+    }
+
+    if (hasExplicitDbOverride(options)) {
+      if (!isBlank(options.get(DbInstallConfigResolver.DBPROPS_KEY))) {
+        prompt.println(
+            "Using database properties file: " + options.get(DbInstallConfigResolver.DBPROPS_KEY));
+      } else if (!isBlank(options.get("db.props"))) {
+        prompt.println("Using database properties file: " + options.get("db.props"));
+      } else {
+        prompt.println(
+            "Using database options supplied on the command line (interactive field prompts"
+                + " skipped).");
+      }
+      return options;
+    }
+
+    prompt.println("");
+    prompt.println("Database configuration (new install)");
+    prompt.println("  [1] Embedded H2 (default — demo / small site)");
+    prompt.println("  [2] SQL Server (incl. Express — small site / scale-to-corp path)");
+    prompt.println("  [3] MySQL / MariaDB");
+    prompt.println("  [4] PostgreSQL");
+    prompt.println("  [5] Oracle");
+    prompt.println("  [6] Load properties file (rxrepository.properties format)");
+    String choice = prompt.readLine("Select database backend [1]: ").trim();
+    if (choice.isEmpty()) {
+      choice = "1";
+    }
+
+    switch (choice) {
+      case "1" -> {
+        options.put("db.type", "h2");
+        // Clear any stale structured keys
+        options.remove("db.host");
+        options.remove("db.port");
+        options.remove("db.name");
+        options.remove("db.schema");
+        options.remove("db.user");
+        options.remove("db.password");
+        prompt.println("Selected embedded H2.");
+      }
+      case "2" -> {
+        options.put("db.type", "sqlserver");
+        prompt.println(
+            "SQL Server / Express: provision an empty database first. Express is suitable for"
+                + " small sites (<~10 users, <~10 GB). Starting on SQL Server can avoid a later"
+                + " H2 migration if you grow into a corporate SQL Server estate.");
+        collectExternalFields(options, prompt, "1433", "dbo", "percussion");
+      }
+      case "3" -> {
+        options.put("db.type", "mysql");
+        collectExternalFields(options, prompt, "3306", "", "percussion");
+      }
+      case "4" -> {
+        options.put("db.type", "postgresql");
+        collectExternalFields(options, prompt, "5432", "public", "percussion");
+      }
+      case "5" -> {
+        options.put("db.type", "oracle");
+        collectExternalFields(options, prompt, "1521", "", "ORCL");
+      }
+      case "6" -> {
+        String path =
+            promptRequired(
+                prompt, "Path to repository properties file: ", "Properties file path is required.");
+        Path p = Paths.get(path).toAbsolutePath().normalize();
+        if (!Files.isRegularFile(p) || !Files.isReadable(p)) {
+          throw new IllegalArgumentException(
+              "dbprops file not found or not readable: " + p);
+        }
+        options.put(DbInstallConfigResolver.DBPROPS_KEY, p.toString());
+        options.remove("db.type");
+        options.remove("db.host");
+        options.remove("db.port");
+        options.remove("db.name");
+        options.remove("db.schema");
+        options.remove("db.user");
+        options.remove("db.password");
+      }
+      default ->
+          throw new IllegalArgumentException(
+              "Invalid database selection '" + choice + "'. Choose 1-6.");
+    }
+
+    return options;
+  }
+
+  private static void collectExternalFields(
+      Map<String, String> options,
+      InstallPrompt prompt,
+      String defaultPort,
+      String defaultSchema,
+      String defaultName) {
+    options.put(
+        "db.host",
+        promptWithDefault(prompt, "Database host", "localhost"));
+    options.put(
+        "db.port",
+        promptWithDefault(prompt, "Database port", defaultPort));
+    options.put(
+        "db.name",
+        promptWithDefault(prompt, "Database name (or Oracle service/SID)", defaultName));
+    if (defaultSchema != null && !defaultSchema.isEmpty()) {
+      options.put(
+          "db.schema",
+          promptWithDefault(prompt, "Schema", defaultSchema));
+    } else {
+      String schema = prompt.readLine("Schema (optional, Enter to skip): ").trim();
+      if (!schema.isEmpty()) {
+        options.put("db.schema", schema);
+      } else {
+        options.remove("db.schema");
+      }
+    }
+    options.put(
+        "db.user",
+        promptRequired(prompt, "Database user: ", "Database user is required."));
+    String password = prompt.readPassword("Database password: ");
+    if (password == null || password.isEmpty()) {
+      // allow empty only if re-prompt once empty intentionally
+      password = prompt.readPassword("Password was empty. Re-enter database password: ");
+    }
+    if (password == null) {
+      password = "";
+    }
+    options.put("db.password", password);
+
+    String sslEnabled =
+        promptWithDefault(prompt, "SSL enabled (true/false)", DbInstallConfigResolver.DB_SSL_ENABLED_DEFAULT);
+    options.put("db.ssl.enabled", normalizeBool(sslEnabled, DbInstallConfigResolver.DB_SSL_ENABLED_DEFAULT));
+    String sslVerify =
+        promptWithDefault(prompt, "SSL verify server cert (true/false)", DbInstallConfigResolver.DB_SSL_VERIFY_DEFAULT);
+    options.put("db.ssl.verify", normalizeBool(sslVerify, DbInstallConfigResolver.DB_SSL_VERIFY_DEFAULT));
+  }
+
+  static String promptWithDefault(InstallPrompt prompt, String label, String defaultValue) {
+    String line = prompt.readLine(label + " [" + defaultValue + "]: ");
+    if (line == null || line.isBlank()) {
+      return defaultValue;
+    }
+    return line.trim();
+  }
+
+  static String promptRequired(InstallPrompt prompt, String label, String errorMessage) {
+    for (int i = 0; i < 5; i++) {
+      String line = prompt.readLine(label);
+      if (line != null && !line.isBlank()) {
+        return line.trim();
+      }
+      prompt.println(errorMessage);
+    }
+    throw new IllegalArgumentException(errorMessage);
+  }
+
+  private static String normalizeBool(String raw, String defaultValue) {
+    if (raw == null || raw.isBlank()) {
+      return defaultValue;
+    }
+    String v = raw.trim().toLowerCase(Locale.ROOT);
+    if ("true".equals(v) || "yes".equals(v) || "y".equals(v) || "1".equals(v)) {
+      return "true";
+    }
+    if ("false".equals(v) || "no".equals(v) || "n".equals(v) || "0".equals(v)) {
+      return "false";
+    }
+    return defaultValue;
+  }
+
+  private static boolean isBlank(String s) {
+    return s == null || s.isBlank();
+  }
+}

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InteractiveDbConfigCollector.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InteractiveDbConfigCollector.java
@@ -18,6 +18,7 @@ package com.percussion.preinstall;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -196,15 +197,7 @@ public final class InteractiveDbConfigCollector {
     options.put(
         "db.user",
         promptRequired(prompt, "Database user: ", "Database user is required."));
-    String password = prompt.readPassword("Database password: ");
-    if (password == null || password.isEmpty()) {
-      // allow empty only if re-prompt once empty intentionally
-      password = prompt.readPassword("Password was empty. Re-enter database password: ");
-    }
-    if (password == null) {
-      password = "";
-    }
-    options.put("db.password", password);
+    options.put("db.password", readPasswordToString(prompt));
 
     String sslEnabled =
         promptWithDefault(prompt, "SSL enabled (true/false)", DbInstallConfigResolver.DB_SSL_ENABLED_DEFAULT);
@@ -231,6 +224,32 @@ public final class InteractiveDbConfigCollector {
       prompt.println(errorMessage);
     }
     throw new IllegalArgumentException(errorMessage);
+  }
+
+  /**
+   * Read a password as {@code char[]}; convert to String for the options map (CLI contract), then
+   * zero the buffer. {@code null} from the prompt means no console — fail fast rather than
+   * re-prompt forever.
+   */
+  static String readPasswordToString(InstallPrompt prompt) {
+    char[] chars = prompt.readPassword("Database password: ");
+    if (chars == null) {
+      throw new IllegalArgumentException(
+          "No console available to read database password (non-interactive environment).");
+    }
+    if (chars.length == 0) {
+      Arrays.fill(chars, '\0');
+      chars = prompt.readPassword("Password was empty. Re-enter database password: ");
+      if (chars == null) {
+        throw new IllegalArgumentException(
+            "No console available to read database password (non-interactive environment).");
+      }
+    }
+    try {
+      return new String(chars);
+    } finally {
+      Arrays.fill(chars, '\0');
+    }
   }
 
   private static String normalizeBool(String raw, String defaultValue) {

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InteractiveDbConfigCollector.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InteractiveDbConfigCollector.java
@@ -112,13 +112,7 @@ public final class InteractiveDbConfigCollector {
     switch (choice) {
       case "1" -> {
         options.put("db.type", "h2");
-        // Clear any stale structured keys
-        options.remove("db.host");
-        options.remove("db.port");
-        options.remove("db.name");
-        options.remove("db.schema");
-        options.remove("db.user");
-        options.remove("db.password");
+        clearStructuredAndSsl(options);
         prompt.println("Selected embedded H2.");
       }
       case "2" -> {
@@ -152,12 +146,7 @@ public final class InteractiveDbConfigCollector {
         }
         options.put(DbInstallConfigResolver.DBPROPS_KEY, p.toString());
         options.remove("db.type");
-        options.remove("db.host");
-        options.remove("db.port");
-        options.remove("db.name");
-        options.remove("db.schema");
-        options.remove("db.user");
-        options.remove("db.password");
+        clearStructuredAndSsl(options);
       }
       default ->
           throw new IllegalArgumentException(
@@ -165,6 +154,26 @@ public final class InteractiveDbConfigCollector {
     }
 
     return options;
+  }
+
+  /**
+   * Drop structured connection fields and SSL overrides so a backend switch (or H2 / dbprops path)
+   * does not inherit stale keys from a prior attempt or CLI partial options.
+   */
+  static void clearStructuredAndSsl(Map<String, String> options) {
+    options.remove("db.host");
+    options.remove("db.port");
+    options.remove("db.name");
+    options.remove("db.schema");
+    options.remove("db.user");
+    options.remove("db.password");
+    options.remove("db.ssl.enabled");
+    options.remove("db.ssl.verify");
+    options.remove("db.ssl.allowSelfSigned");
+    options.remove("db.ssl.trustStorePath");
+    options.remove("db.ssl.trustStorePassword");
+    options.remove("db.ssl.keyStorePath");
+    options.remove("db.ssl.keyStorePassword");
   }
 
   private static void collectExternalFields(

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InteractiveInstallWizard.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InteractiveInstallWizard.java
@@ -15,6 +15,8 @@
  */
 package com.percussion.preinstall;
 
+import com.percussion.preinstall.java.JavaInstallSelection;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -28,9 +30,13 @@ import java.util.Objects;
 /**
  * Console wizard for CMS preinstall (issue #1513).
  *
- * <p><strong>Phase 1:</strong> installation directory (when missing) and summary + confirm. Later
- * phases add Java selection orchestration, multi-step database capture, and optional connection
- * test. Silent / non-TTY installs skip prompts and keep the existing parameter-driven contract.
+ * <p><strong>Phase 1:</strong> installation directory (when missing) and summary + confirm.
+ *
+ * <p><strong>Phase 2:</strong> Java home selection ({@link JavaInstallSelection}) after path.
+ *
+ * <p><strong>Phase 3:</strong> interactive multi-step database capture ({@link
+ * InteractiveDbConfigCollector}) and optional {@link RepositoryConnectionProbe} for external
+ * backends. Silent / non-TTY installs skip prompts and keep the existing parameter-driven contract.
  *
  * <p>Passwords and other secret values from resolved DB config are never printed in the summary.
  */
@@ -44,6 +50,9 @@ public final class InteractiveInstallWizard {
 
   /** Exit code when database configuration validation fails. */
   public static final int EXIT_DB_CONFIG = 1;
+
+  /** Exit code when Java home selection fails (matches historical Main exit code). */
+  public static final int EXIT_JAVA = 2;
 
   private InteractiveInstallWizard() {}
 
@@ -75,8 +84,8 @@ public final class InteractiveInstallWizard {
   }
 
   /**
-   * Phase 1: ensure install path, resolve DB config from existing CLI/env defaults, show summary,
-   * and confirm when interactive.
+   * Phase 1–2: ensure install path, select/persist Java home, resolve DB config from existing
+   * CLI/env defaults, show summary, and confirm when interactive.
    *
    * @param parsedArgs CLI parse result (path may be null)
    * @param interactive whether to prompt
@@ -85,6 +94,20 @@ public final class InteractiveInstallWizard {
    */
   public static Phase1Result runPhase1(
       DbInstallConfigResolver.ParsedArgs parsedArgs, boolean interactive, InstallPrompt prompt) {
+    return runPhase1(parsedArgs, interactive, prompt, Main.parseUnattendedJavaHome(System.getProperty(Main.PERC_JAVA_HOME)));
+  }
+
+  /**
+   * Same as {@link #runPhase1(DbInstallConfigResolver.ParsedArgs, boolean, InstallPrompt)} with an
+   * explicit unattended Java home (tests inject a fixture home).
+   *
+   * @param unattendedJavaHome explicit Java home override, or null to discover
+   */
+  public static Phase1Result runPhase1(
+      DbInstallConfigResolver.ParsedArgs parsedArgs,
+      boolean interactive,
+      InstallPrompt prompt,
+      Path unattendedJavaHome) {
     Objects.requireNonNull(parsedArgs, "parsedArgs");
     if (interactive && prompt == null) {
       throw new IllegalArgumentException("prompt is required when interactive");
@@ -108,15 +131,40 @@ public final class InteractiveInstallWizard {
       installPath = installPath.toAbsolutePath().normalize();
     }
 
+    JavaInstallSelection.SelectionOutcome javaOutcome;
+    try {
+      JavaInstallSelection.InteractivePrompt javaPrompt =
+          interactive && prompt != null ? prompt::readLine : null;
+      javaOutcome =
+          new JavaInstallSelection(installPath, unattendedJavaHome, javaPrompt).selectAndPersist();
+      if (interactive && prompt != null) {
+        prompt.println("Java home selection: " + javaOutcome.summary());
+      }
+    } catch (JavaInstallSelection.JavaSelectionException sel) {
+      return Phase1Result.abort(EXIT_JAVA, "Java home selection failed: " + sel.getMessage());
+    } catch (IOException io) {
+      return Phase1Result.abort(
+          EXIT_JAVA,
+          "Could not write java.properties at "
+              + installPath.resolve("java.properties")
+              + ": "
+              + io.getMessage());
+    }
+
+    boolean upgrade = isUpgradeInstall(installPath);
     DbInstallConfigResolver.ResolvedDbConfig dbConfig;
     try {
-      dbConfig = DbInstallConfigResolver.resolveDbConfig(options);
+      if (interactive) {
+        dbConfig = collectAndResolveDbInteractive(options, upgrade, prompt);
+      } else {
+        dbConfig = DbInstallConfigResolver.resolveDbConfig(options);
+      }
     } catch (IllegalArgumentException badDb) {
       return Phase1Result.abort(EXIT_DB_CONFIG, "Database configuration error: " + badDb.getMessage());
     }
 
     if (interactive) {
-      String summary = buildSummary(installPath, dbConfig);
+      String summary = buildSummary(installPath, dbConfig, javaOutcome);
       prompt.println(summary);
       boolean defaultYes = isDefaultYesConfirm(dbConfig);
       if (!confirmProceed(prompt, defaultYes)) {
@@ -124,7 +172,68 @@ public final class InteractiveInstallWizard {
       }
     }
 
-    return Phase1Result.proceed(installPath, Map.copyOf(options), dbConfig);
+    return Phase1Result.proceed(installPath, Map.copyOf(options), dbConfig, javaOutcome);
+  }
+
+  /**
+   * Interactive DB collection, resolve, optional connection probe with re-edit loop.
+   *
+   * @param options mutable options map (updated in place)
+   * @param upgrade whether install root is an upgrade
+   * @param prompt operator I/O
+   * @return resolved DB config
+   */
+  static DbInstallConfigResolver.ResolvedDbConfig collectAndResolveDbInteractive(
+      Map<String, String> options, boolean upgrade, InstallPrompt prompt) {
+    for (int attempt = 0; attempt < 5; attempt++) {
+      Map<String, String> collected =
+          InteractiveDbConfigCollector.collect(options, upgrade, prompt);
+      options.clear();
+      options.putAll(collected);
+
+      DbInstallConfigResolver.ResolvedDbConfig dbConfig =
+          DbInstallConfigResolver.resolveDbConfig(options);
+
+      if (upgrade || isDefaultYesConfirm(dbConfig)) {
+        return dbConfig;
+      }
+
+      Boolean test =
+          parseYesNo(prompt.readLine("Test database connection now? [Y/n] "), true);
+      if (test == null || !test) {
+        return dbConfig;
+      }
+
+      RepositoryConnectionProbe.ProbeResult probe =
+          RepositoryConnectionProbe.probe(
+              dbConfig.systemProperties(), RepositoryConnectionProbe.DEFAULT_LOGIN_TIMEOUT_SECONDS);
+      prompt.println(probe.message());
+
+      if (probe.isSuccess() || probe.status() == RepositoryConnectionProbe.ProbeStatus.SKIPPED) {
+        return dbConfig;
+      }
+
+      Boolean retry =
+          parseYesNo(
+              prompt.readLine("Connection test failed. Re-enter database settings? [Y/n] "),
+              true);
+      if (retry == null || !retry) {
+        throw new IllegalArgumentException(
+            "Database connection test failed and operator chose not to re-enter settings.");
+      }
+      // Force re-prompt of fields on next loop (clear explicit override keys except silent flags)
+      options.remove(DbInstallConfigResolver.DBPROPS_KEY);
+      options.remove("db.props");
+      options.remove("db.type");
+      options.remove("db.host");
+      options.remove("db.port");
+      options.remove("db.name");
+      options.remove("db.schema");
+      options.remove("db.user");
+      options.remove("db.password");
+    }
+    throw new IllegalArgumentException(
+        "Too many failed database configuration attempts. Aborting.");
   }
 
   /**
@@ -164,10 +273,13 @@ public final class InteractiveInstallWizard {
    *
    * @param installPath absolute install path
    * @param dbConfig resolved DB config
+   * @param javaOutcome selected Java home (may be null before Phase 2)
    * @return multi-line summary text
    */
   static String buildSummary(
-      Path installPath, DbInstallConfigResolver.ResolvedDbConfig dbConfig) {
+      Path installPath,
+      DbInstallConfigResolver.ResolvedDbConfig dbConfig,
+      JavaInstallSelection.SelectionOutcome javaOutcome) {
     List<String> lines = new ArrayList<>();
     lines.add("");
     lines.add("========================================");
@@ -176,9 +288,16 @@ public final class InteractiveInstallWizard {
     lines.add("Install path : " + installPath.toAbsolutePath().normalize());
     lines.add("Mode         : " + (isUpgradeInstall(installPath) ? "Upgrade" : "New install"));
     lines.add("Database     : " + formatDbSummary(dbConfig));
-    lines.add("Java home    : " + formatJavaHomeHint());
+    lines.add("Java home    : " + formatJavaHomeLine(javaOutcome));
     lines.add("========================================");
     return String.join(System.lineSeparator(), lines);
+  }
+
+  /** Convenience for tests that omit a Java selection outcome. */
+  @Deprecated
+  static String buildSummary(
+      Path installPath, DbInstallConfigResolver.ResolvedDbConfig dbConfig) {
+    return buildSummary(installPath, dbConfig, null);
   }
 
   static boolean isUpgradeInstall(Path installPath) {
@@ -204,7 +323,10 @@ public final class InteractiveInstallWizard {
     return sb.toString();
   }
 
-  static String formatJavaHomeHint() {
+  static String formatJavaHomeLine(JavaInstallSelection.SelectionOutcome javaOutcome) {
+    if (javaOutcome != null && javaOutcome.javaHome() != null) {
+      return javaOutcome.javaHome() + " (" + javaOutcome.source() + ")";
+    }
     String unattended = System.getProperty(Main.PERC_JAVA_HOME);
     if (unattended != null
         && !unattended.isBlank()
@@ -305,12 +427,13 @@ public final class InteractiveInstallWizard {
   }
 
   /**
-   * Outcome of Phase 1 wizard (path + DB resolve + optional confirm).
+   * Outcome of Phase 1–2 wizard (path + Java + DB resolve + optional confirm).
    *
    * @param proceed true when install may continue
    * @param installPath resolved absolute install path when proceed (or null if aborted early)
    * @param options CLI options map (immutable when proceed)
    * @param dbConfig resolved DB config when proceed
+   * @param javaOutcome selected Java home when proceed
    * @param exitCode process exit code when !proceed
    * @param message operator-facing message when !proceed (may be null)
    */
@@ -319,18 +442,20 @@ public final class InteractiveInstallWizard {
       Path installPath,
       Map<String, String> options,
       DbInstallConfigResolver.ResolvedDbConfig dbConfig,
+      JavaInstallSelection.SelectionOutcome javaOutcome,
       int exitCode,
       String message) {
 
     static Phase1Result proceed(
         Path installPath,
         Map<String, String> options,
-        DbInstallConfigResolver.ResolvedDbConfig dbConfig) {
-      return new Phase1Result(true, installPath, options, dbConfig, 0, null);
+        DbInstallConfigResolver.ResolvedDbConfig dbConfig,
+        JavaInstallSelection.SelectionOutcome javaOutcome) {
+      return new Phase1Result(true, installPath, options, dbConfig, javaOutcome, 0, null);
     }
 
     static Phase1Result abort(int exitCode, String message) {
-      return new Phase1Result(false, null, Map.of(), null, exitCode, message);
+      return new Phase1Result(false, null, Map.of(), null, null, exitCode, message);
     }
   }
 }

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InteractiveInstallWizard.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InteractiveInstallWizard.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Console wizard for CMS preinstall (issue #1513).
+ *
+ * <p><strong>Phase 1:</strong> installation directory (when missing) and summary + confirm. Later
+ * phases add Java selection orchestration, multi-step database capture, and optional connection
+ * test. Silent / non-TTY installs skip prompts and keep the existing parameter-driven contract.
+ *
+ * <p>Passwords and other secret values from resolved DB config are never printed in the summary.
+ */
+public final class InteractiveInstallWizard {
+
+  /** Exit code when the operator declines to proceed or cancels. */
+  public static final int EXIT_ABORTED = 0;
+
+  /** Exit code when required input is missing in non-interactive mode. */
+  public static final int EXIT_USAGE = 0;
+
+  /** Exit code when database configuration validation fails. */
+  public static final int EXIT_DB_CONFIG = 1;
+
+  private InteractiveInstallWizard() {}
+
+  /**
+   * Whether {@code --silent} / {@code --no-tty} (or aliases) disable interactive prompts.
+   *
+   * @param options parsed CLI options; may be null
+   * @return true when silent mode is requested
+   */
+  public static boolean isSilentMode(Map<String, String> options) {
+    if (options == null) {
+      return false;
+    }
+    String silent = options.get(DbInstallConfigResolver.SILENT_KEY);
+    String noTty = options.get("no-tty");
+    return isTruthy(silent) || isTruthy(noTty);
+  }
+
+  /**
+   * Interactive wizard runs only when not silent and a console (or test harness) is available.
+   *
+   * @param silent silent CLI flag
+   * @param consoleAvailable true when {@link System#console()} is non-null or tests inject a
+   *     console
+   * @return true when the wizard may prompt
+   */
+  public static boolean isInteractive(boolean silent, boolean consoleAvailable) {
+    return !silent && consoleAvailable;
+  }
+
+  /**
+   * Phase 1: ensure install path, resolve DB config from existing CLI/env defaults, show summary,
+   * and confirm when interactive.
+   *
+   * @param parsedArgs CLI parse result (path may be null)
+   * @param interactive whether to prompt
+   * @param prompt operator I/O; required when interactive
+   * @return result with proceed flag and exit code when aborted
+   */
+  public static Phase1Result runPhase1(
+      DbInstallConfigResolver.ParsedArgs parsedArgs, boolean interactive, InstallPrompt prompt) {
+    Objects.requireNonNull(parsedArgs, "parsedArgs");
+    if (interactive && prompt == null) {
+      throw new IllegalArgumentException("prompt is required when interactive");
+    }
+
+    Path installPath = parsedArgs.installPath();
+    Map<String, String> options =
+        parsedArgs.options() != null
+            ? new LinkedHashMap<>(parsedArgs.options())
+            : new LinkedHashMap<>();
+
+    if (installPath == null) {
+      if (!interactive) {
+        return Phase1Result.abort(EXIT_USAGE, usageMessage());
+      }
+      installPath = promptForInstallPath(prompt);
+      if (installPath == null) {
+        return Phase1Result.abort(EXIT_ABORTED, "Installation cancelled: no install directory.");
+      }
+    } else {
+      installPath = installPath.toAbsolutePath().normalize();
+    }
+
+    DbInstallConfigResolver.ResolvedDbConfig dbConfig;
+    try {
+      dbConfig = DbInstallConfigResolver.resolveDbConfig(options);
+    } catch (IllegalArgumentException badDb) {
+      return Phase1Result.abort(EXIT_DB_CONFIG, "Database configuration error: " + badDb.getMessage());
+    }
+
+    if (interactive) {
+      String summary = buildSummary(installPath, dbConfig);
+      prompt.println(summary);
+      boolean defaultYes = isDefaultYesConfirm(dbConfig);
+      if (!confirmProceed(prompt, defaultYes)) {
+        return Phase1Result.abort(EXIT_ABORTED, "Installation cancelled by operator.");
+      }
+    }
+
+    return Phase1Result.proceed(installPath, Map.copyOf(options), dbConfig);
+  }
+
+  /**
+   * Short usage printed when install path is missing and the session is non-interactive.
+   *
+   * @return multi-line usage text
+   */
+  public static String usageMessage() {
+    return String.join(
+        System.lineSeparator(),
+        "Must specify installation or upgrade folder",
+        "When a console is available, omit the path to enter interactive mode.",
+        "Optional database target for new installs: -Ddbprops=<path> or --dbprops=<path>",
+        "Optional upgrade cleanup: --clean-install-dir (default false) removes obsolete"
+            + " folders such as PreInstall",
+        "Silent mode: --silent or --no-tty (disables interactive prompts for automated testing)");
+  }
+
+  /**
+   * Whether the final confirm defaults to yes (embedded engines only).
+   *
+   * @param dbConfig resolved database configuration
+   * @return true for h2/derby defaults
+   */
+  static boolean isDefaultYesConfirm(DbInstallConfigResolver.ResolvedDbConfig dbConfig) {
+    if (dbConfig == null || dbConfig.systemProperties() == null) {
+      return true;
+    }
+    String type =
+        dbConfig.systemProperties().getOrDefault("perc.db.type", DbInstallConfigResolver.DB_TYPE_DEFAULT);
+    String normalized = type == null ? "" : type.trim().toLowerCase(Locale.ROOT);
+    return "h2".equals(normalized) || "derby".equals(normalized);
+  }
+
+  /**
+   * Builds a non-secret installation summary for the operator.
+   *
+   * @param installPath absolute install path
+   * @param dbConfig resolved DB config
+   * @return multi-line summary text
+   */
+  static String buildSummary(
+      Path installPath, DbInstallConfigResolver.ResolvedDbConfig dbConfig) {
+    List<String> lines = new ArrayList<>();
+    lines.add("");
+    lines.add("========================================");
+    lines.add("Percussion CMS installation summary");
+    lines.add("========================================");
+    lines.add("Install path : " + installPath.toAbsolutePath().normalize());
+    lines.add("Mode         : " + (isUpgradeInstall(installPath) ? "Upgrade" : "New install"));
+    lines.add("Database     : " + formatDbSummary(dbConfig));
+    lines.add("Java home    : " + formatJavaHomeHint());
+    lines.add("========================================");
+    return String.join(System.lineSeparator(), lines);
+  }
+
+  static boolean isUpgradeInstall(Path installPath) {
+    if (installPath == null) {
+      return false;
+    }
+    return Files.isRegularFile(installPath.resolve(Main.VERSION_PROPERTIES));
+  }
+
+  static String formatDbSummary(DbInstallConfigResolver.ResolvedDbConfig dbConfig) {
+    if (dbConfig == null) {
+      return "(unknown)";
+    }
+    Map<String, String> p = dbConfig.systemProperties();
+    String type = p.getOrDefault("perc.db.type", DbInstallConfigResolver.DB_TYPE_DEFAULT);
+    StringBuilder sb = new StringBuilder(type);
+    sb.append(" (source=").append(dbConfig.source()).append(')');
+    appendIfPresent(sb, "host", p.get("perc.db.host"));
+    appendIfPresent(sb, "port", p.get("perc.db.port"));
+    appendIfPresent(sb, "name", firstNonBlank(p.get("perc.db.name"), p.get("perc.db.cms.name")));
+    appendIfPresent(sb, "user", p.get("perc.db.user"));
+    // Never append password / perc.db.password / truststore passwords
+    return sb.toString();
+  }
+
+  static String formatJavaHomeHint() {
+    String unattended = System.getProperty(Main.PERC_JAVA_HOME);
+    if (unattended != null
+        && !unattended.isBlank()
+        && !"${perc.java.home}".equals(unattended.trim())) {
+      return unattended.trim() + " (from -Dperc.java.home)";
+    }
+    return "will be selected next (discover Java 21+)";
+  }
+
+  /**
+   * Parse a yes/no answer. Empty input uses {@code defaultYes}.
+   *
+   * @param answer raw operator input
+   * @param defaultYes value when answer is blank
+   * @return true for yes, false for no, null if unparseable
+   */
+  static Boolean parseYesNo(String answer, boolean defaultYes) {
+    if (answer == null || answer.isBlank()) {
+      return defaultYes;
+    }
+    String a = answer.trim().toLowerCase(Locale.ROOT);
+    if ("y".equals(a) || "yes".equals(a)) {
+      return true;
+    }
+    if ("n".equals(a) || "no".equals(a)) {
+      return false;
+    }
+    return null;
+  }
+
+  private static Path promptForInstallPath(InstallPrompt prompt) {
+    prompt.println("");
+    prompt.println("Percussion CMS interactive installer");
+    prompt.println("Enter the installation directory (new install or existing upgrade root).");
+    for (int attempt = 0; attempt < 5; attempt++) {
+      String line = prompt.readLine("Installation directory: ");
+      if (line == null || line.isBlank()) {
+        prompt.println("Install directory is required. Enter a path or Ctrl+C to abort.");
+        continue;
+      }
+      String trimmed = line.trim();
+      // Strip matching quotes operators may paste from docs
+      if ((trimmed.startsWith("\"") && trimmed.endsWith("\""))
+          || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+        if (trimmed.length() >= 2) {
+          trimmed = trimmed.substring(1, trimmed.length() - 1).trim();
+        }
+      }
+      if (trimmed.isEmpty()) {
+        prompt.println("Install directory is required.");
+        continue;
+      }
+      try {
+        return Paths.get(trimmed).toAbsolutePath().normalize();
+      } catch (Exception ex) {
+        prompt.println("Invalid path: " + ex.getMessage());
+      }
+    }
+    return null;
+  }
+
+  private static boolean confirmProceed(InstallPrompt prompt, boolean defaultYes) {
+    String hint = defaultYes ? "[Y/n]" : "[y/N]";
+    for (int attempt = 0; attempt < 5; attempt++) {
+      String line = prompt.readLine("Proceed with installation? " + hint + " ");
+      Boolean parsed = parseYesNo(line, defaultYes);
+      if (parsed != null) {
+        return parsed;
+      }
+      prompt.println("Please answer y or n.");
+    }
+    return false;
+  }
+
+  private static void appendIfPresent(StringBuilder sb, String label, String value) {
+    if (value != null && !value.isBlank()) {
+      sb.append(", ").append(label).append('=').append(value.trim());
+    }
+  }
+
+  private static String firstNonBlank(String a, String b) {
+    if (a != null && !a.isBlank()) {
+      return a;
+    }
+    if (b != null && !b.isBlank()) {
+      return b;
+    }
+    return null;
+  }
+
+  private static boolean isTruthy(String value) {
+    if (value == null) {
+      return false;
+    }
+    return "true".equalsIgnoreCase(value)
+        || "yes".equalsIgnoreCase(value)
+        || "1".equals(value);
+  }
+
+  /**
+   * Outcome of Phase 1 wizard (path + DB resolve + optional confirm).
+   *
+   * @param proceed true when install may continue
+   * @param installPath resolved absolute install path when proceed (or null if aborted early)
+   * @param options CLI options map (immutable when proceed)
+   * @param dbConfig resolved DB config when proceed
+   * @param exitCode process exit code when !proceed
+   * @param message operator-facing message when !proceed (may be null)
+   */
+  public record Phase1Result(
+      boolean proceed,
+      Path installPath,
+      Map<String, String> options,
+      DbInstallConfigResolver.ResolvedDbConfig dbConfig,
+      int exitCode,
+      String message) {
+
+    static Phase1Result proceed(
+        Path installPath,
+        Map<String, String> options,
+        DbInstallConfigResolver.ResolvedDbConfig dbConfig) {
+      return new Phase1Result(true, installPath, options, dbConfig, 0, null);
+    }
+
+    static Phase1Result abort(int exitCode, String message) {
+      return new Phase1Result(false, null, Map.of(), null, exitCode, message);
+    }
+  }
+}

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InteractiveInstallWizard.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InteractiveInstallWizard.java
@@ -240,6 +240,10 @@ public final class InteractiveInstallWizard {
       options.remove("db.ssl.enabled");
       options.remove("db.ssl.verify");
       options.remove("db.ssl.allowSelfSigned");
+      options.remove("db.ssl.trustStorePath");
+      options.remove("db.ssl.trustStorePassword");
+      options.remove("db.ssl.keyStorePath");
+      options.remove("db.ssl.keyStorePassword");
     }
     throw new IllegalArgumentException(
         "Too many failed database configuration attempts. Aborting.");
@@ -416,12 +420,13 @@ public final class InteractiveInstallWizard {
     }
   }
 
+  /** First non-blank value, trimmed (aligned with {@code RepositoryConnectionProbe} contract). */
   private static String firstNonBlank(String a, String b) {
     if (a != null && !a.isBlank()) {
-      return a;
+      return a.trim();
     }
     if (b != null && !b.isBlank()) {
-      return b;
+      return b.trim();
     }
     return null;
   }

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InteractiveInstallWizard.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InteractiveInstallWizard.java
@@ -42,11 +42,17 @@ import java.util.Objects;
  */
 public final class InteractiveInstallWizard {
 
-  /** Exit code when the operator declines to proceed or cancels. */
+  /**
+   * Exit code when the operator declines to proceed or cancels. Zero so interactive cancel is not
+   * treated as a hard automation failure.
+   */
   public static final int EXIT_ABORTED = 0;
 
-  /** Exit code when required input is missing in non-interactive mode. */
-  public static final int EXIT_USAGE = 0;
+  /**
+   * Exit code when required input is missing in non-interactive mode (sysexits-style {@code
+   * EX_USAGE}). Distinct from {@link #EXIT_ABORTED} so scripts can detect missing path/args.
+   */
+  public static final int EXIT_USAGE = 64;
 
   /** Exit code when database configuration validation fails. */
   public static final int EXIT_DB_CONFIG = 1;
@@ -231,6 +237,9 @@ public final class InteractiveInstallWizard {
       options.remove("db.schema");
       options.remove("db.user");
       options.remove("db.password");
+      options.remove("db.ssl.enabled");
+      options.remove("db.ssl.verify");
+      options.remove("db.ssl.allowSelfSigned");
     }
     throw new IllegalArgumentException(
         "Too many failed database configuration attempts. Aborting.");

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
@@ -117,13 +117,21 @@ public class Main {
       Path installPath = phase1.installPath();
       options = phase1.options();
       DbInstallConfigResolver.ResolvedDbConfig resolvedDbConfig = phase1.dbConfig();
+      // Issue #1340 / #1513 Phase 2: Java home already selected and persisted by the wizard.
+      JavaInstallSelection.SelectionOutcome javaOutcome = phase1.javaOutcome();
+      if (javaOutcome != null) {
+        System.out.println("Java home selection: " + javaOutcome.summary());
+      }
 
       debug = System.getProperty("DEBUG");
       if (debug == null || debug.equalsIgnoreCase("")) {
         debug = "false";
       }
 
-      String javaHome = System.getProperty(PERC_JAVA_HOME);
+      String javaHome =
+          javaOutcome != null && javaOutcome.javaHome() != null
+              ? javaOutcome.javaHome().toString()
+              : System.getProperty(PERC_JAVA_HOME);
       if (javaHome == null || javaHome.trim().equalsIgnoreCase(""))
         javaHome = System.getProperty(JAVA_HOME);
 
@@ -148,42 +156,6 @@ public class Main {
       System.out.println(DEVELOPMENT + "=" + developmentFlag);
 
       System.out.println("Installation folder is " + installPath.toAbsolutePath().toString());
-
-      // Issue #1340 / US3 + US4: resolve and persist the Java home used at
-      // runtime by CMS / DTS start, stop, and service install paths. Honor an
-      // explicit -Dperc.java.home=... override; otherwise discover and (when
-      // interactive) prompt for a Java 21 home. Survives a non-interactive
-      // environment by auto-selecting single candidates and failing loudly
-      // when zero are eligible — never silently fall back to a manual
-      // <InstallDir>/JRE copy.
-      try {
-        Path unattended = parseUnattendedJavaHome(System.getProperty(PERC_JAVA_HOME));
-        JavaInstallSelection.SelectionOutcome outcome =
-            new JavaInstallSelection(
-                    installPath,
-                    unattended,
-                    prompt -> {
-                      if (silent) {
-                        return "";
-                      }
-                      java.io.Console c = System.console();
-                      return c == null ? "" : c.readLine(prompt);
-                    })
-                .selectAndPersist();
-        System.out.println("Java home selection: " + outcome.summary());
-      } catch (JavaInstallSelection.JavaSelectionException sel) {
-        System.out.println("Java home selection failed: " + sel.getMessage());
-        System.exit(2);
-        return;
-      } catch (IOException io) {
-        System.out.println(
-            "Could not write java.properties at "
-                + installPath.resolve("java.properties")
-                + ": "
-                + io.getMessage());
-        System.exit(2);
-        return;
-      }
 
       Properties existingVersion = loadVersionProperties(installPath);
       if (existingVersion != null) {

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
@@ -96,32 +96,27 @@ public class Main {
     try {
 
       DbInstallConfigResolver.ParsedArgs parsedArgs = DbInstallConfigResolver.parseArgs(args);
-      if (parsedArgs.installPath() == null) {
-        System.out.println("Must specify installation or upgrade folder");
-        System.out.println(
-            "Optional database target for new installs: -Ddbprops=<path> or --dbprops=<path>");
-        System.out.println(
-            "Optional upgrade cleanup: --clean-install-dir (default false) removes obsolete"
-                + " folders such as PreInstall");
-        System.out.println(
-            "Silent mode: --silent or --no-tty (disables interactive prompts for automated testing)");
-        System.exit(0);
-      }
-
-      Path installPath = parsedArgs.installPath();
-
-      // Check for silent/non-interactive mode (--silent or --no-tty)
       Map<String, String> options = parsedArgs.options();
+      // Check for silent/non-interactive mode (--silent or --no-tty)
       boolean silent = isSilentMode(options);
-
-      DbInstallConfigResolver.ResolvedDbConfig resolvedDbConfig;
-      try {
-        resolvedDbConfig = DbInstallConfigResolver.resolveDbConfig(parsedArgs.options());
-      } catch (IllegalArgumentException badDbConfig) {
-        System.out.println("Database configuration error: " + badDbConfig.getMessage());
-        System.exit(1);
+      // Issue #1513 Phase 1: interactive path prompt + summary/confirm when a TTY is present.
+      // Silent / no-console keeps the historical parameter-driven contract (usage if no path).
+      boolean interactive =
+          InteractiveInstallWizard.isInteractive(silent, System.console() != null);
+      InteractiveInstallWizard.Phase1Result phase1 =
+          InteractiveInstallWizard.runPhase1(
+              parsedArgs, interactive, SystemConsoleInstallPrompt.INSTANCE);
+      if (!phase1.proceed()) {
+        if (phase1.message() != null && !phase1.message().isBlank()) {
+          System.out.println(phase1.message());
+        }
+        System.exit(phase1.exitCode());
         return;
       }
+
+      Path installPath = phase1.installPath();
+      options = phase1.options();
+      DbInstallConfigResolver.ResolvedDbConfig resolvedDbConfig = phase1.dbConfig();
 
       debug = System.getProperty("DEBUG");
       if (debug == null || debug.equalsIgnoreCase("")) {
@@ -202,7 +197,7 @@ public class Main {
 
       // Issue #1157: optional early cleanup of obsolete install-root directories on upgrade only
       try {
-        runObsoleteInstallDirCleanup(installPath, parsedArgs.options(), silent);
+        runObsoleteInstallDirCleanup(installPath, options, silent);
       } catch (Exception cleanupEx) {
         System.out.println(
             "Obsolete directory cleanup reported an error (upgrade will continue): "
@@ -372,18 +367,8 @@ public class Main {
    * @param options parsed CLI options
    * @return true if silent mode is enabled
    */
-  private static boolean isSilentMode(Map<String, String> options) {
-    if (options == null) {
-      return false;
-    }
-    String silent = options.get(DbInstallConfigResolver.SILENT_KEY);
-    String noTty = options.get("no-tty");
-    return "true".equalsIgnoreCase(silent)
-        || "yes".equalsIgnoreCase(silent)
-        || "1".equals(silent)
-        || "true".equalsIgnoreCase(noTty)
-        || "yes".equalsIgnoreCase(noTty)
-        || "1".equals(noTty);
+  static boolean isSilentMode(Map<String, String> options) {
+    return InteractiveInstallWizard.isSilentMode(options);
   }
 
   private static void deleteOldJDBCJars(Path installPath) {

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/RepositoryConnectionProbe.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/RepositoryConnectionProbe.java
@@ -21,6 +21,8 @@ import java.sql.SQLException;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
+import java.util.regex.Pattern;
 
 /**
  * Best-effort pre-install JDBC connectivity probe for the interactive wizard (issue #1513).
@@ -31,12 +33,31 @@ import java.util.Objects;
  * ProbeStatus#SKIPPED} so the operator can continue and rely on ANT {@code
  * PSValidateRepositoryConnection} after files are written.
  *
- * <p>Never includes password values in messages.
+ * <p>Never includes password values in messages. JDBC URLs are composed only from validated
+ * host/port/name components (no operator-controlled query/parameter injection via {@code ;} /
+ * {@code ?} in host or name).
+ *
+ * <p><strong>Threading:</strong> not safe for concurrent use. {@link DriverManager} login timeout is
+ * process-global; this class serializes timeout set/restore on an internal lock and is intended for
+ * the single-threaded preinstall path only.
  */
 public final class RepositoryConnectionProbe {
 
   /** Default login timeout seconds for the probe. */
   public static final int DEFAULT_LOGIN_TIMEOUT_SECONDS = 10;
+
+  /**
+   * Host allowlist: letters, digits, dots, hyphens, underscores, colons/brackets (IPv6), no JDBC
+   * separators.
+   */
+  private static final Pattern SAFE_HOST =
+      Pattern.compile("^[A-Za-z0-9._\\-:\\[\\]]{1,253}$");
+
+  /** Database / service name allowlist (no JDBC parameter separators). */
+  private static final Pattern SAFE_NAME = Pattern.compile("^[A-Za-z0-9._\\-]{1,128}$");
+
+  /** Serializes mutations of {@link DriverManager#setLoginTimeout(int)}. */
+  private static final Object LOGIN_TIMEOUT_LOCK = new Object();
 
   private RepositoryConnectionProbe() {}
 
@@ -90,12 +111,22 @@ public final class RepositoryConnectionProbe {
           "Embedded " + type + " — connectivity is validated during install setup.");
     }
 
-    String driverClass = firstNonBlank(
-        systemProperties.get("perc.db.cms.driverClass"),
-        systemProperties.get("perc.db.dts.jdbcDriver"));
-    String jdbcUrl = buildJdbcUrl(type, systemProperties);
+    String driverClass =
+        firstNonBlank(
+            systemProperties.get("perc.db.cms.driverClass"),
+            systemProperties.get("perc.db.dts.jdbcDriver"));
+    String jdbcUrl;
+    try {
+      jdbcUrl = buildJdbcUrl(type, systemProperties);
+    } catch (IllegalArgumentException invalid) {
+      return new ProbeResult(ProbeStatus.FAILED, invalid.getMessage());
+    }
     String user = systemProperties.get("perc.db.user");
-    String password = systemProperties.get("perc.db.password");
+    // Preserve null vs empty: null means "no password property"; empty means explicit empty.
+    String password =
+        systemProperties.containsKey("perc.db.password")
+            ? systemProperties.get("perc.db.password")
+            : null;
 
     if (jdbcUrl == null || jdbcUrl.isBlank()) {
       return new ProbeResult(
@@ -118,38 +149,58 @@ public final class RepositoryConnectionProbe {
       }
     }
 
-    int previous = DriverManager.getLoginTimeout();
-    try {
-      if (loginTimeoutSeconds > 0) {
-        DriverManager.setLoginTimeout(loginTimeoutSeconds);
-      }
-      try (Connection conn =
-          user != null
-              ? DriverManager.getConnection(jdbcUrl, user, password == null ? "" : password)
-              : DriverManager.getConnection(jdbcUrl)) {
-        if (conn == null || conn.isClosed()) {
-          return new ProbeResult(
-              ProbeStatus.FAILED,
-              "Connection failed for " + jdbcUrl + " (null or closed connection).");
+    synchronized (LOGIN_TIMEOUT_LOCK) {
+      int previous = DriverManager.getLoginTimeout();
+      try {
+        if (loginTimeoutSeconds > 0) {
+          DriverManager.setLoginTimeout(loginTimeoutSeconds);
         }
+        try (Connection conn = openConnection(jdbcUrl, user, password)) {
+          if (conn == null || conn.isClosed()) {
+            return new ProbeResult(
+                ProbeStatus.FAILED,
+                "Connection failed for " + jdbcUrl + " (null or closed connection).");
+          }
+          return new ProbeResult(
+              ProbeStatus.SUCCESS,
+              "Connection succeeded for "
+                  + jdbcUrl
+                  + (user != null ? " user=" + user : "")
+                  + ".");
+        }
+      } catch (SQLException e) {
         return new ProbeResult(
-            ProbeStatus.SUCCESS,
-            "Connection succeeded for "
+            ProbeStatus.FAILED,
+            "Connection failed for "
                 + jdbcUrl
                 + (user != null ? " user=" + user : "")
-                + ".");
+                + ": "
+                + safeSqlMessage(e));
+      } finally {
+        DriverManager.setLoginTimeout(previous);
       }
-    } catch (SQLException e) {
-      return new ProbeResult(
-          ProbeStatus.FAILED,
-          "Connection failed for "
-              + jdbcUrl
-              + (user != null ? " user=" + user : "")
-              + ": "
-              + safeSqlMessage(e));
-    } finally {
-      DriverManager.setLoginTimeout(previous);
     }
+  }
+
+  /**
+   * Opens a connection without coercing a missing password to {@code ""}.
+   *
+   * @param jdbcUrl validated URL
+   * @param user user id or null
+   * @param password password or null when absent
+   */
+  static Connection openConnection(String jdbcUrl, String user, String password)
+      throws SQLException {
+    if (user == null) {
+      return DriverManager.getConnection(jdbcUrl);
+    }
+    Properties props = new Properties();
+    props.setProperty("user", user);
+    if (password != null) {
+      // Only set password when present; omit property entirely when null (not empty string).
+      props.setProperty("password", password);
+    }
+    return DriverManager.getConnection(jdbcUrl, props);
   }
 
   /**
@@ -158,61 +209,179 @@ public final class RepositoryConnectionProbe {
    * @param type normalized db type
    * @param p system properties
    * @return jdbc url or null
+   * @throws IllegalArgumentException when components fail safety validation
    */
   static String buildJdbcUrl(String type, Map<String, String> p) {
-    String dtsUrl = p.get("perc.db.dts.jdbcUrl");
-    if (dtsUrl != null && !dtsUrl.isBlank()) {
-      return dtsUrl.trim();
-    }
-
+    // Prefer product-composed DTS URL only when it was built from structured fields we can
+    // re-validate via host/port/name. Fall through to validated component composition.
     String host = p.get("perc.db.host");
     String port = p.get("perc.db.port");
     String name = firstNonBlank(p.get("perc.db.name"), p.get("perc.db.cms.name"));
-    if (host == null || port == null || name == null) {
-      // Fall back to cms.server composition when only dbprops path was used
-      String cmsServer = p.get("perc.db.cms.server");
-      String driverName = p.get("perc.db.cms.driverName");
-      if (cmsServer != null && driverName != null) {
-        return composeFromCmsServer(type, driverName, cmsServer, name);
-      }
-      return null;
+
+    if (host != null && port != null && name != null) {
+      validateHostPortName(host, port, name);
+      return switch (type) {
+        case "mysql" -> "jdbc:mysql://" + host + ":" + port + "/" + name;
+        case "postgresql" -> "jdbc:postgresql://" + host + ":" + port + "/" + name;
+        case "sqlserver" -> "jdbc:sqlserver://" + host + ":" + port + ";databaseName=" + name;
+        case "oracle" -> "jdbc:oracle:thin:@" + host + ":" + port + ":" + name;
+        default -> null;
+      };
     }
 
-    return switch (type) {
-      case "mysql" -> "jdbc:mysql://" + host + ":" + port + "/" + name;
-      case "postgresql" -> "jdbc:postgresql://" + host + ":" + port + "/" + name;
-      case "sqlserver" ->
-          "jdbc:sqlserver://" + host + ":" + port + ";databaseName=" + name;
-      case "oracle" -> "jdbc:oracle:thin:@" + host + ":" + port + ":" + name;
-      default -> null;
-    };
+    // Fall back to cms.server composition when only dbprops path was used
+    String cmsServer = p.get("perc.db.cms.server");
+    String driverName = p.get("perc.db.cms.driverName");
+    if (cmsServer != null && driverName != null) {
+      return composeFromCmsServer(type, driverName, cmsServer, name);
+    }
+    return null;
+  }
+
+  /**
+   * Validate host, port, and database/service name for use in JDBC URL composition.
+   *
+   * @throws IllegalArgumentException when any component is unsafe
+   */
+  static void validateHostPortName(String host, String port, String name) {
+    if (host == null || !SAFE_HOST.matcher(host.trim()).matches() || host.contains(";")) {
+      throw new IllegalArgumentException(
+          "Invalid database host for connection probe (disallowed characters).");
+    }
+    if (port == null || !isSafePort(port.trim())) {
+      throw new IllegalArgumentException(
+          "Invalid database port for connection probe (must be 1-65535).");
+    }
+    if (name == null || !SAFE_NAME.matcher(name.trim()).matches()) {
+      throw new IllegalArgumentException(
+          "Invalid database name for connection probe (disallowed characters).");
+    }
+  }
+
+  static boolean isSafePort(String port) {
+    try {
+      int p = Integer.parseInt(port);
+      return p >= 1 && p <= 65535;
+    } catch (NumberFormatException e) {
+      return false;
+    }
   }
 
   private static String composeFromCmsServer(
       String type, String driverName, String cmsServer, String name) {
-    // MySQL-style server already starts with //host:port/db?...
-    if ("mysql".equals(type) || "mysql".equalsIgnoreCase(driverName)) {
-      String s = cmsServer.startsWith("//") ? cmsServer : "//" + cmsServer;
-      int q = s.indexOf('?');
-      if (q > 0) {
-        s = s.substring(0, q);
-      }
-      return "jdbc:mysql:" + s;
+    // Reject obvious injection / credential embedding before any composition.
+    if (cmsServer == null || cmsServer.isBlank()) {
+      return null;
     }
-    if ("sqlserver".equals(type) || "sqlserver".equalsIgnoreCase(driverName)) {
-      String s = cmsServer.startsWith("//") ? cmsServer.substring(2) : cmsServer;
-      return "jdbc:sqlserver:" + (s.startsWith("//") ? s : "//" + s);
+    if (cmsServer.indexOf('@') >= 0 || cmsServer.contains("..")) {
+      throw new IllegalArgumentException(
+          "Invalid DB_SERVER for connection probe (credentials or path traversal rejected).");
     }
-    if ("oracle".equals(type) || (driverName != null && driverName.contains("oracle"))) {
-      String s = cmsServer.startsWith("@") ? cmsServer.substring(1) : cmsServer;
-      return "jdbc:oracle:thin:@" + s;
+
+    ParsedServer parsed = parseCmsServer(type, driverName, cmsServer, name);
+    if (parsed == null) {
+      throw new IllegalArgumentException(
+          "Unable to parse DB_SERVER into safe host/port/name for connection probe.");
     }
-    if ("postgresql".equals(type) || "postgresql".equalsIgnoreCase(driverName)) {
-      String s = cmsServer.startsWith("//") ? cmsServer : "//" + cmsServer;
-      return "jdbc:postgresql:" + s;
-    }
-    return null;
+    validateHostPortName(parsed.host(), parsed.port(), parsed.name());
+    return switch (parsed.type()) {
+      case "mysql" -> "jdbc:mysql://" + parsed.host() + ":" + parsed.port() + "/" + parsed.name();
+      case "postgresql" ->
+          "jdbc:postgresql://" + parsed.host() + ":" + parsed.port() + "/" + parsed.name();
+      case "sqlserver" ->
+          "jdbc:sqlserver://"
+              + parsed.host()
+              + ":"
+              + parsed.port()
+              + ";databaseName="
+              + parsed.name();
+      case "oracle" ->
+          "jdbc:oracle:thin:@" + parsed.host() + ":" + parsed.port() + ":" + parsed.name();
+      default -> null;
+    };
   }
+
+  /**
+   * Best-effort parse of product {@code DB_SERVER} / {@code perc.db.cms.server} shapes into host,
+   * port, and name without carrying query strings or extra properties.
+   */
+  static ParsedServer parseCmsServer(
+      String type, String driverName, String cmsServer, String fallbackName) {
+    String t = type == null ? "" : type.toLowerCase(Locale.ROOT);
+    if (t.isEmpty() && driverName != null) {
+      String d = driverName.toLowerCase(Locale.ROOT);
+      if (d.contains("mysql")) {
+        t = "mysql";
+      } else if (d.contains("postgres")) {
+        t = "postgresql";
+      } else if (d.contains("sqlserver") || d.contains("mssql")) {
+        t = "sqlserver";
+      } else if (d.contains("oracle")) {
+        t = "oracle";
+      }
+    }
+
+    String s = cmsServer.trim();
+    // Strip query string
+    int q = s.indexOf('?');
+    if (q >= 0) {
+      s = s.substring(0, q);
+    }
+    // SQL Server often embeds ;databaseName= — take only host:port portion
+    int semi = s.indexOf(';');
+    if (semi >= 0) {
+      s = s.substring(0, semi);
+    }
+    if (s.startsWith("//")) {
+      s = s.substring(2);
+    }
+    if (s.startsWith("@")) {
+      s = s.substring(1);
+    }
+
+    // forms: host:port/name  or  host:port:sid  or  host:port
+    String host;
+    String port;
+    String dbName = fallbackName;
+
+    int slash = s.indexOf('/');
+    if (slash >= 0) {
+      String hp = s.substring(0, slash);
+      dbName = s.substring(slash + 1);
+      int colon = hp.lastIndexOf(':');
+      if (colon <= 0) {
+        return null;
+      }
+      host = hp.substring(0, colon);
+      port = hp.substring(colon + 1);
+    } else {
+      // host:port:sid (oracle) or host:port
+      String[] parts = s.split(":");
+      if (parts.length == 2) {
+        host = parts[0];
+        port = parts[1];
+      } else if (parts.length == 3) {
+        host = parts[0];
+        port = parts[1];
+        dbName = parts[2];
+        if (t.isEmpty()) {
+          t = "oracle";
+        }
+      } else {
+        return null;
+      }
+    }
+
+    if (dbName == null || dbName.isBlank()) {
+      return null;
+    }
+    if (t.isEmpty()) {
+      t = "mysql";
+    }
+    return new ParsedServer(t, host, port, dbName);
+  }
+
+  record ParsedServer(String type, String host, String port, String name) {}
 
   static String safeSqlMessage(SQLException e) {
     if (e == null) {
@@ -222,8 +391,14 @@ public final class RepositoryConnectionProbe {
     if (msg == null) {
       return e.getClass().getSimpleName();
     }
-    // Strip common password-like substrings defensively
-    return msg.replaceAll("(?i)password\\s*=\\s*[^;\\s]+", "password=***");
+    String redacted = msg;
+    // password= / password: / pwd= / passwd=
+    redacted =
+        redacted.replaceAll(
+            "(?i)(password|passwd|pwd)\\s*[=:]\\s*[^;\\s,]+", "$1=***");
+    // user:secret@host in URL-like fragments
+    redacted = redacted.replaceAll("(?i)(://[^:/\\s]+):([^@/\\s]+)@", "$1:***@");
+    return redacted;
   }
 
   private static String firstNonBlank(String a, String b) {

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/RepositoryConnectionProbe.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/RepositoryConnectionProbe.java
@@ -219,12 +219,14 @@ public final class RepositoryConnectionProbe {
     String name = firstNonBlank(p.get("perc.db.name"), p.get("perc.db.cms.name"));
 
     if (host != null && port != null && name != null) {
-      validateHostPortName(host, port, name);
+      ValidatedEndpoint ep = validateHostPortName(host, port, name);
       return switch (type) {
-        case "mysql" -> "jdbc:mysql://" + host + ":" + port + "/" + name;
-        case "postgresql" -> "jdbc:postgresql://" + host + ":" + port + "/" + name;
-        case "sqlserver" -> "jdbc:sqlserver://" + host + ":" + port + ";databaseName=" + name;
-        case "oracle" -> "jdbc:oracle:thin:@" + host + ":" + port + ":" + name;
+        case "mysql" -> "jdbc:mysql://" + ep.host() + ":" + ep.port() + "/" + ep.name();
+        case "postgresql" ->
+            "jdbc:postgresql://" + ep.host() + ":" + ep.port() + "/" + ep.name();
+        case "sqlserver" ->
+            "jdbc:sqlserver://" + ep.host() + ":" + ep.port() + ";databaseName=" + ep.name();
+        case "oracle" -> "jdbc:oracle:thin:@" + ep.host() + ":" + ep.port() + ":" + ep.name();
         default -> null;
       };
     }
@@ -239,24 +241,36 @@ public final class RepositoryConnectionProbe {
   }
 
   /**
-   * Validate host, port, and database/service name for use in JDBC URL composition.
+   * Validate and normalize host, port, and database/service name for JDBC URL composition.
    *
+   * @return trimmed components safe for concatenation
    * @throws IllegalArgumentException when any component is unsafe
    */
-  static void validateHostPortName(String host, String port, String name) {
-    if (host == null || !SAFE_HOST.matcher(host.trim()).matches() || host.contains(";")) {
+  static ValidatedEndpoint validateHostPortName(String host, String port, String name) {
+    if (host == null || port == null || name == null) {
+      throw new IllegalArgumentException(
+          "Invalid database host/port/name for connection probe (null component).");
+    }
+    String h = host.trim();
+    String p = port.trim();
+    String n = name.trim();
+    if (h.isEmpty() || !SAFE_HOST.matcher(h).matches()) {
       throw new IllegalArgumentException(
           "Invalid database host for connection probe (disallowed characters).");
     }
-    if (port == null || !isSafePort(port.trim())) {
+    if (!isSafePort(p)) {
       throw new IllegalArgumentException(
           "Invalid database port for connection probe (must be 1-65535).");
     }
-    if (name == null || !SAFE_NAME.matcher(name.trim()).matches()) {
+    if (n.isEmpty() || !SAFE_NAME.matcher(n).matches()) {
       throw new IllegalArgumentException(
           "Invalid database name for connection probe (disallowed characters).");
     }
+    return new ValidatedEndpoint(h, p, n);
   }
+
+  /** Trimmed host/port/name after successful validation. */
+  record ValidatedEndpoint(String host, String port, String name) {}
 
   static boolean isSafePort(String port) {
     try {
@@ -283,20 +297,15 @@ public final class RepositoryConnectionProbe {
       throw new IllegalArgumentException(
           "Unable to parse DB_SERVER into safe host/port/name for connection probe.");
     }
-    validateHostPortName(parsed.host(), parsed.port(), parsed.name());
+    ValidatedEndpoint ep =
+        validateHostPortName(parsed.host(), parsed.port(), parsed.name());
     return switch (parsed.type()) {
-      case "mysql" -> "jdbc:mysql://" + parsed.host() + ":" + parsed.port() + "/" + parsed.name();
+      case "mysql" -> "jdbc:mysql://" + ep.host() + ":" + ep.port() + "/" + ep.name();
       case "postgresql" ->
-          "jdbc:postgresql://" + parsed.host() + ":" + parsed.port() + "/" + parsed.name();
+          "jdbc:postgresql://" + ep.host() + ":" + ep.port() + "/" + ep.name();
       case "sqlserver" ->
-          "jdbc:sqlserver://"
-              + parsed.host()
-              + ":"
-              + parsed.port()
-              + ";databaseName="
-              + parsed.name();
-      case "oracle" ->
-          "jdbc:oracle:thin:@" + parsed.host() + ":" + parsed.port() + ":" + parsed.name();
+          "jdbc:sqlserver://" + ep.host() + ":" + ep.port() + ";databaseName=" + ep.name();
+      case "oracle" -> "jdbc:oracle:thin:@" + ep.host() + ":" + ep.port() + ":" + ep.name();
       default -> null;
     };
   }
@@ -342,28 +351,28 @@ public final class RepositoryConnectionProbe {
     // forms: host:port/name  or  host:port:sid  or  host:port
     String host;
     String port;
-    String dbName = fallbackName;
+    String dbName = fallbackName == null ? null : fallbackName.trim();
 
     int slash = s.indexOf('/');
     if (slash >= 0) {
-      String hp = s.substring(0, slash);
-      dbName = s.substring(slash + 1);
+      String hp = s.substring(0, slash).trim();
+      dbName = s.substring(slash + 1).trim();
       int colon = hp.lastIndexOf(':');
       if (colon <= 0) {
         return null;
       }
-      host = hp.substring(0, colon);
-      port = hp.substring(colon + 1);
+      host = hp.substring(0, colon).trim();
+      port = hp.substring(colon + 1).trim();
     } else {
       // host:port:sid (oracle) or host:port
       String[] parts = s.split(":");
       if (parts.length == 2) {
-        host = parts[0];
-        port = parts[1];
+        host = parts[0].trim();
+        port = parts[1].trim();
       } else if (parts.length == 3) {
-        host = parts[0];
-        port = parts[1];
-        dbName = parts[2];
+        host = parts[0].trim();
+        port = parts[1].trim();
+        dbName = parts[2].trim();
         if (t.isEmpty()) {
           t = "oracle";
         }

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/RepositoryConnectionProbe.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/RepositoryConnectionProbe.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Best-effort pre-install JDBC connectivity probe for the interactive wizard (issue #1513).
+ *
+ * <p>Uses {@link DriverManager} and optional {@link Class#forName(String)} when a driver class is
+ * known from resolved {@code perc.db.*} properties. When the driver is not on the preinstall
+ * classpath (typical until distribution JDBC jars are extracted), returns {@link
+ * ProbeStatus#SKIPPED} so the operator can continue and rely on ANT {@code
+ * PSValidateRepositoryConnection} after files are written.
+ *
+ * <p>Never includes password values in messages.
+ */
+public final class RepositoryConnectionProbe {
+
+  /** Default login timeout seconds for the probe. */
+  public static final int DEFAULT_LOGIN_TIMEOUT_SECONDS = 10;
+
+  private RepositoryConnectionProbe() {}
+
+  /** Probe outcome status. */
+  public enum ProbeStatus {
+    /** Embedded engine — no network probe. */
+    SKIPPED_EMBEDDED,
+    /** Driver not loadable on this classpath. */
+    SKIPPED,
+    /** Connection succeeded. */
+    SUCCESS,
+    /** Connection or driver failure with operator message. */
+    FAILED
+  }
+
+  /**
+   * Result of a connectivity probe.
+   *
+   * @param status outcome
+   * @param message operator-facing detail (never contains password)
+   */
+  public record ProbeResult(ProbeStatus status, String message) {
+    public boolean isSuccess() {
+      return status == ProbeStatus.SUCCESS || status == ProbeStatus.SKIPPED_EMBEDDED;
+    }
+
+    public boolean mayRetry() {
+      return status == ProbeStatus.FAILED;
+    }
+  }
+
+  /**
+   * Probe connectivity using resolved installer system properties ({@code perc.db.*}).
+   *
+   * @param systemProperties from {@link DbInstallConfigResolver.ResolvedDbConfig#systemProperties()}
+   * @param loginTimeoutSeconds login timeout; use {@link #DEFAULT_LOGIN_TIMEOUT_SECONDS} when
+   *     unsure
+   * @return probe result
+   */
+  public static ProbeResult probe(Map<String, String> systemProperties, int loginTimeoutSeconds) {
+    Objects.requireNonNull(systemProperties, "systemProperties");
+    String type =
+        systemProperties
+            .getOrDefault("perc.db.type", DbInstallConfigResolver.DB_TYPE_DEFAULT)
+            .trim()
+            .toLowerCase(Locale.ROOT);
+
+    if ("h2".equals(type) || "derby".equals(type)) {
+      return new ProbeResult(
+          ProbeStatus.SKIPPED_EMBEDDED,
+          "Embedded " + type + " — connectivity is validated during install setup.");
+    }
+
+    String driverClass = firstNonBlank(
+        systemProperties.get("perc.db.cms.driverClass"),
+        systemProperties.get("perc.db.dts.jdbcDriver"));
+    String jdbcUrl = buildJdbcUrl(type, systemProperties);
+    String user = systemProperties.get("perc.db.user");
+    String password = systemProperties.get("perc.db.password");
+
+    if (jdbcUrl == null || jdbcUrl.isBlank()) {
+      return new ProbeResult(
+          ProbeStatus.FAILED,
+          "Could not compose a JDBC URL for db.type=" + type + " (check host/port/name).");
+    }
+
+    if (driverClass != null && !driverClass.isBlank()) {
+      try {
+        Class.forName(driverClass);
+      } catch (ClassNotFoundException e) {
+        return new ProbeResult(
+            ProbeStatus.SKIPPED,
+            "JDBC driver class not on preinstall classpath ("
+                + driverClass
+                + "). Connection will be validated during install after drivers are staged under"
+                + " jetty/base/lib/jdbc. Target URL (no secrets): "
+                + jdbcUrl
+                + (user != null ? " user=" + user : ""));
+      }
+    }
+
+    int previous = DriverManager.getLoginTimeout();
+    try {
+      if (loginTimeoutSeconds > 0) {
+        DriverManager.setLoginTimeout(loginTimeoutSeconds);
+      }
+      try (Connection conn =
+          user != null
+              ? DriverManager.getConnection(jdbcUrl, user, password == null ? "" : password)
+              : DriverManager.getConnection(jdbcUrl)) {
+        if (conn == null || conn.isClosed()) {
+          return new ProbeResult(
+              ProbeStatus.FAILED,
+              "Connection failed for " + jdbcUrl + " (null or closed connection).");
+        }
+        return new ProbeResult(
+            ProbeStatus.SUCCESS,
+            "Connection succeeded for "
+                + jdbcUrl
+                + (user != null ? " user=" + user : "")
+                + ".");
+      }
+    } catch (SQLException e) {
+      return new ProbeResult(
+          ProbeStatus.FAILED,
+          "Connection failed for "
+              + jdbcUrl
+              + (user != null ? " user=" + user : "")
+              + ": "
+              + safeSqlMessage(e));
+    } finally {
+      DriverManager.setLoginTimeout(previous);
+    }
+  }
+
+  /**
+   * Compose a JDBC URL from structured perc.db properties for known backends.
+   *
+   * @param type normalized db type
+   * @param p system properties
+   * @return jdbc url or null
+   */
+  static String buildJdbcUrl(String type, Map<String, String> p) {
+    String dtsUrl = p.get("perc.db.dts.jdbcUrl");
+    if (dtsUrl != null && !dtsUrl.isBlank()) {
+      return dtsUrl.trim();
+    }
+
+    String host = p.get("perc.db.host");
+    String port = p.get("perc.db.port");
+    String name = firstNonBlank(p.get("perc.db.name"), p.get("perc.db.cms.name"));
+    if (host == null || port == null || name == null) {
+      // Fall back to cms.server composition when only dbprops path was used
+      String cmsServer = p.get("perc.db.cms.server");
+      String driverName = p.get("perc.db.cms.driverName");
+      if (cmsServer != null && driverName != null) {
+        return composeFromCmsServer(type, driverName, cmsServer, name);
+      }
+      return null;
+    }
+
+    return switch (type) {
+      case "mysql" -> "jdbc:mysql://" + host + ":" + port + "/" + name;
+      case "postgresql" -> "jdbc:postgresql://" + host + ":" + port + "/" + name;
+      case "sqlserver" ->
+          "jdbc:sqlserver://" + host + ":" + port + ";databaseName=" + name;
+      case "oracle" -> "jdbc:oracle:thin:@" + host + ":" + port + ":" + name;
+      default -> null;
+    };
+  }
+
+  private static String composeFromCmsServer(
+      String type, String driverName, String cmsServer, String name) {
+    // MySQL-style server already starts with //host:port/db?...
+    if ("mysql".equals(type) || "mysql".equalsIgnoreCase(driverName)) {
+      String s = cmsServer.startsWith("//") ? cmsServer : "//" + cmsServer;
+      int q = s.indexOf('?');
+      if (q > 0) {
+        s = s.substring(0, q);
+      }
+      return "jdbc:mysql:" + s;
+    }
+    if ("sqlserver".equals(type) || "sqlserver".equalsIgnoreCase(driverName)) {
+      String s = cmsServer.startsWith("//") ? cmsServer.substring(2) : cmsServer;
+      return "jdbc:sqlserver:" + (s.startsWith("//") ? s : "//" + s);
+    }
+    if ("oracle".equals(type) || (driverName != null && driverName.contains("oracle"))) {
+      String s = cmsServer.startsWith("@") ? cmsServer.substring(1) : cmsServer;
+      return "jdbc:oracle:thin:@" + s;
+    }
+    if ("postgresql".equals(type) || "postgresql".equalsIgnoreCase(driverName)) {
+      String s = cmsServer.startsWith("//") ? cmsServer : "//" + cmsServer;
+      return "jdbc:postgresql:" + s;
+    }
+    return null;
+  }
+
+  static String safeSqlMessage(SQLException e) {
+    if (e == null) {
+      return "unknown SQL error";
+    }
+    String msg = e.getMessage();
+    if (msg == null) {
+      return e.getClass().getSimpleName();
+    }
+    // Strip common password-like substrings defensively
+    return msg.replaceAll("(?i)password\\s*=\\s*[^;\\s]+", "password=***");
+  }
+
+  private static String firstNonBlank(String a, String b) {
+    if (a != null && !a.isBlank()) {
+      return a.trim();
+    }
+    if (b != null && !b.isBlank()) {
+      return b.trim();
+    }
+    return null;
+  }
+}

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/SystemConsoleInstallPrompt.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/SystemConsoleInstallPrompt.java
@@ -17,10 +17,11 @@ package com.percussion.preinstall;
 
 import java.io.Console;
 import java.io.PrintStream;
+import java.util.Arrays;
 
 /**
  * {@link InstallPrompt} backed by {@link System#console()} when available, otherwise stdout plus
- * empty reads (caller should not treat as interactive when console is null).
+ * empty line reads / null passwords.
  */
 public final class SystemConsoleInstallPrompt implements InstallPrompt {
 
@@ -34,8 +35,7 @@ public final class SystemConsoleInstallPrompt implements InstallPrompt {
   }
 
   /**
-   * Visible for tests that need a redirected print stream while still using the system console for
-   * reads (rare). Prefer a scripted {@link InstallPrompt} in unit tests.
+   * Visible for tests that need a redirected print stream.
    *
    * @param out stream for messages; never {@code null}
    */
@@ -70,16 +70,20 @@ public final class SystemConsoleInstallPrompt implements InstallPrompt {
   }
 
   @Override
-  public String readPassword(String prompt) {
+  public char[] readPassword(String prompt) {
     print(prompt == null ? "" : prompt);
     Console console = System.console();
     if (console == null) {
-      return "";
+      // Distinguish unavailable console from empty password (empty char[]).
+      return null;
     }
     char[] chars = console.readPassword();
     if (chars == null) {
-      return "";
+      return new char[0];
     }
-    return new String(chars);
+    // Return a copy so Console's buffer can be zeroed if the implementation reuses it.
+    char[] copy = Arrays.copyOf(chars, chars.length);
+    Arrays.fill(chars, '\0');
+    return copy;
   }
 }

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/SystemConsoleInstallPrompt.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/SystemConsoleInstallPrompt.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+import java.io.Console;
+import java.io.PrintStream;
+
+/**
+ * {@link InstallPrompt} backed by {@link System#console()} when available, otherwise stdout plus
+ * empty reads (caller should not treat as interactive when console is null).
+ */
+public final class SystemConsoleInstallPrompt implements InstallPrompt {
+
+  /** Shared instance for production preinstall entry points. */
+  public static final SystemConsoleInstallPrompt INSTANCE = new SystemConsoleInstallPrompt();
+
+  private final PrintStream out;
+
+  SystemConsoleInstallPrompt() {
+    this(System.out);
+  }
+
+  /**
+   * Visible for tests that need a redirected print stream while still using the system console for
+   * reads (rare). Prefer a scripted {@link InstallPrompt} in unit tests.
+   *
+   * @param out stream for messages; never {@code null}
+   */
+  SystemConsoleInstallPrompt(PrintStream out) {
+    if (out == null) {
+      throw new IllegalArgumentException("out must not be null");
+    }
+    this.out = out;
+  }
+
+  @Override
+  public void print(String message) {
+    out.print(message == null ? "" : message);
+    out.flush();
+  }
+
+  @Override
+  public void println(String message) {
+    out.println(message == null ? "" : message);
+    out.flush();
+  }
+
+  @Override
+  public String readLine(String prompt) {
+    print(prompt == null ? "" : prompt);
+    Console console = System.console();
+    if (console == null) {
+      return "";
+    }
+    String line = console.readLine();
+    return line == null ? "" : line;
+  }
+
+  @Override
+  public String readPassword(String prompt) {
+    print(prompt == null ? "" : prompt);
+    Console console = System.console();
+    if (console == null) {
+      return "";
+    }
+    char[] chars = console.readPassword();
+    if (chars == null) {
+      return "";
+    }
+    return new String(chars);
+  }
+}

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/InteractiveDbConfigCollectorTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/InteractiveDbConfigCollectorTest.java
@@ -68,6 +68,32 @@ class InteractiveDbConfigCollectorTest {
   }
 
   @Test
+  void h2SelectionClearsStaleSslKeys() {
+    // SSL-only leftovers (no host/user/password override) so the interactive menu still runs.
+    Map<String, String> existing = new HashMap<>();
+    existing.put("db.ssl.enabled", "false");
+    existing.put("db.ssl.verify", "false");
+    existing.put("db.ssl.trustStorePath", "/tmp/ts");
+    ScriptedPrompt prompt = new ScriptedPrompt("1");
+    Map<String, String> out =
+        InteractiveDbConfigCollector.collect(existing, false, prompt);
+    assertEquals("h2", out.get("db.type"));
+    assertFalse(out.containsKey("db.ssl.enabled"));
+    assertFalse(out.containsKey("db.ssl.verify"));
+    assertFalse(out.containsKey("db.ssl.trustStorePath"));
+  }
+
+  @Test
+  void clearStructuredAndSslRemovesAllSensitiveKeys() {
+    Map<String, String> opts = new HashMap<>();
+    opts.put("db.host", "h");
+    opts.put("db.ssl.enabled", "true");
+    opts.put("db.ssl.trustStorePassword", "x");
+    InteractiveDbConfigCollector.clearStructuredAndSsl(opts);
+    assertTrue(opts.isEmpty());
+  }
+
+  @Test
   void loadPropertiesFileOption() throws Exception {
     Path props = tempDir.resolve("rxrepository.mysql.properties");
     Files.writeString(

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/InteractiveDbConfigCollectorTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/InteractiveDbConfigCollectorTest.java
@@ -119,8 +119,9 @@ class InteractiveDbConfigCollectorTest {
     }
 
     @Override
-    public String readPassword(String prompt) {
-      return readLine(prompt);
+    public char[] readPassword(String prompt) {
+      String s = readLine(prompt);
+      return s == null ? null : s.toCharArray();
     }
 
     String outputsAsString() {

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/InteractiveDbConfigCollectorTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/InteractiveDbConfigCollectorTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("UnitTest")
+class InteractiveDbConfigCollectorTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void hasExplicitDbOverrideDetectsDbpropsAndStructured() {
+    assertFalse(InteractiveDbConfigCollector.hasExplicitDbOverride(Map.of()));
+    assertTrue(
+        InteractiveDbConfigCollector.hasExplicitDbOverride(Map.of("dbprops", "/tmp/x.properties")));
+    assertTrue(
+        InteractiveDbConfigCollector.hasExplicitDbOverride(Map.of("db.type", "mysql")));
+    assertTrue(
+        InteractiveDbConfigCollector.hasExplicitDbOverride(Map.of("db.host", "h")));
+    assertFalse(
+        InteractiveDbConfigCollector.hasExplicitDbOverride(Map.of("db.type", "h2")));
+  }
+
+  @Test
+  void upgradeSkipsPrompts() {
+    ScriptedPrompt prompt = new ScriptedPrompt();
+    Map<String, String> out =
+        InteractiveDbConfigCollector.collect(Map.of(), true, prompt);
+    assertTrue(out.isEmpty());
+    assertTrue(prompt.outputsAsString().toLowerCase().contains("upgrade"));
+  }
+
+  @Test
+  void defaultMenuSelectsH2() {
+    ScriptedPrompt prompt = new ScriptedPrompt("");
+    Map<String, String> out =
+        InteractiveDbConfigCollector.collect(new HashMap<>(), false, prompt);
+    assertEquals("h2", out.get("db.type"));
+  }
+
+  @Test
+  void loadPropertiesFileOption() throws Exception {
+    Path props = tempDir.resolve("rxrepository.mysql.properties");
+    Files.writeString(
+        props,
+        """
+        DB_BACKEND=MYSQL
+        DB_DRIVER_NAME=mysql
+        DB_DRIVER_CLASS_NAME=org.mariadb.jdbc.Driver
+        DB_SERVER=//localhost:3306/percussion
+        DB_NAME=percussion
+        UID=cms
+        PWD=secret
+        """,
+        StandardCharsets.UTF_8);
+    ScriptedPrompt prompt = new ScriptedPrompt("6", props.toString());
+    Map<String, String> out =
+        InteractiveDbConfigCollector.collect(new HashMap<>(), false, prompt);
+    assertEquals(props.toAbsolutePath().normalize().toString(), out.get("dbprops"));
+    DbInstallConfigResolver.ResolvedDbConfig cfg =
+        DbInstallConfigResolver.resolveDbConfig(out);
+    assertEquals("mysql", cfg.systemProperties().get("perc.db.type"));
+  }
+
+  private static final class ScriptedPrompt implements InstallPrompt {
+    private final Deque<String> answers;
+    private final List<String> outputs = new ArrayList<>();
+
+    ScriptedPrompt(String... answers) {
+      this.answers = new ArrayDeque<>();
+      for (String a : answers) {
+        this.answers.addLast(a);
+      }
+    }
+
+    @Override
+    public void print(String message) {
+      outputs.add(message == null ? "" : message);
+    }
+
+    @Override
+    public void println(String message) {
+      outputs.add((message == null ? "" : message) + "\n");
+    }
+
+    @Override
+    public String readLine(String prompt) {
+      print(prompt);
+      return answers.isEmpty() ? "" : answers.removeFirst();
+    }
+
+    @Override
+    public String readPassword(String prompt) {
+      return readLine(prompt);
+    }
+
+    String outputsAsString() {
+      StringBuilder sb = new StringBuilder();
+      for (String o : outputs) {
+        sb.append(o);
+      }
+      return sb.toString();
+    }
+  }
+}

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/InteractiveInstallWizardTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/InteractiveInstallWizardTest.java
@@ -39,6 +39,11 @@ class InteractiveInstallWizardTest {
 
   @TempDir Path tempDir;
 
+  /** Use the running JVM home so selection does not depend on host discovery. */
+  private Path runningJavaHome() {
+    return Path.of(System.getProperty("java.home")).toAbsolutePath().normalize();
+  }
+
   @Test
   void silentModeRecognizesSilentAndNoTtyFlags() {
     assertTrue(InteractiveInstallWizard.isSilentMode(Map.of("silent", "true")));
@@ -75,35 +80,40 @@ class InteractiveInstallWizardTest {
     DbInstallConfigResolver.ParsedArgs parsed =
         new DbInstallConfigResolver.ParsedArgs(install, Map.of());
     InteractiveInstallWizard.Phase1Result result =
-        InteractiveInstallWizard.runPhase1(parsed, false, null);
+        InteractiveInstallWizard.runPhase1(parsed, false, null, runningJavaHome());
     assertTrue(result.proceed());
     assertEquals(install.toAbsolutePath().normalize(), result.installPath());
     assertEquals("h2", result.dbConfig().systemProperties().get("perc.db.type"));
+    assertNotNull(result.javaOutcome());
+    assertTrue(Files.exists(install.resolve("java.properties")));
   }
 
   @Test
   void interactivePromptsForPathAndConfirmsDefaultYesForH2() {
     Path install = tempDir.resolve("interactive-cms");
-    ScriptedPrompt prompt = new ScriptedPrompt(install.toString(), ""); // empty confirm → Y for H2
+    // path → DB menu default H2 → confirm default Y
+    ScriptedPrompt prompt = new ScriptedPrompt(install.toString(), "", "");
     DbInstallConfigResolver.ParsedArgs parsed =
         new DbInstallConfigResolver.ParsedArgs(null, Map.of());
     InteractiveInstallWizard.Phase1Result result =
-        InteractiveInstallWizard.runPhase1(parsed, true, prompt);
+        InteractiveInstallWizard.runPhase1(parsed, true, prompt, runningJavaHome());
     assertTrue(result.proceed());
     assertEquals(install.toAbsolutePath().normalize(), result.installPath());
     assertEquals("h2", result.dbConfig().systemProperties().get("perc.db.type"));
     assertTrue(prompt.outputsAsString().contains("installation summary"));
     assertTrue(prompt.outputsAsString().contains("h2"));
+    assertTrue(prompt.outputsAsString().contains("Java home"));
   }
 
   @Test
   void interactiveConfirmNoAborts() {
     Path install = tempDir.resolve("abort-cms");
-    ScriptedPrompt prompt = new ScriptedPrompt(install.toString(), "n");
+    // path → H2 menu → confirm n
+    ScriptedPrompt prompt = new ScriptedPrompt(install.toString(), "1", "n");
     DbInstallConfigResolver.ParsedArgs parsed =
         new DbInstallConfigResolver.ParsedArgs(null, Map.of());
     InteractiveInstallWizard.Phase1Result result =
-        InteractiveInstallWizard.runPhase1(parsed, true, prompt);
+        InteractiveInstallWizard.runPhase1(parsed, true, prompt, runningJavaHome());
     assertFalse(result.proceed());
     assertEquals(InteractiveInstallWizard.EXIT_ABORTED, result.exitCode());
     assertTrue(result.message().toLowerCase().contains("cancelled"));
@@ -112,11 +122,12 @@ class InteractiveInstallWizardTest {
   @Test
   void interactivePathAlreadySuppliedStillConfirms() {
     Path install = tempDir.resolve("cli-path");
-    ScriptedPrompt prompt = new ScriptedPrompt("y");
+    // H2 menu → confirm y
+    ScriptedPrompt prompt = new ScriptedPrompt("1", "y");
     DbInstallConfigResolver.ParsedArgs parsed =
         new DbInstallConfigResolver.ParsedArgs(install, Map.of());
     InteractiveInstallWizard.Phase1Result result =
-        InteractiveInstallWizard.runPhase1(parsed, true, prompt);
+        InteractiveInstallWizard.runPhase1(parsed, true, prompt, runningJavaHome());
     assertTrue(result.proceed());
     assertEquals(install.toAbsolutePath().normalize(), result.installPath());
     assertTrue(prompt.outputsAsString().contains("Install path"));
@@ -133,12 +144,12 @@ class InteractiveInstallWizardTest {
     opts.put("db.user", "cms");
     opts.put("db.password", "s3cret-should-not-appear");
 
-    // empty confirm with defaultYes=false → treated as No
-    ScriptedPrompt prompt = new ScriptedPrompt("");
+    // skip field prompts (CLI override) → test connection n → confirm empty → No
+    ScriptedPrompt prompt = new ScriptedPrompt("n", "");
     DbInstallConfigResolver.ParsedArgs parsed =
         new DbInstallConfigResolver.ParsedArgs(install, opts);
     InteractiveInstallWizard.Phase1Result result =
-        InteractiveInstallWizard.runPhase1(parsed, true, prompt);
+        InteractiveInstallWizard.runPhase1(parsed, true, prompt, runningJavaHome());
     assertFalse(result.proceed());
     assertTrue(prompt.outputsAsString().contains("mysql"));
     assertTrue(prompt.outputsAsString().contains("db.example.com"));
@@ -156,14 +167,43 @@ class InteractiveInstallWizardTest {
     opts.put("db.user", "cms");
     opts.put("db.password", "s3cret-should-not-appear");
 
-    ScriptedPrompt prompt = new ScriptedPrompt("yes");
+    // test connection n → confirm yes
+    ScriptedPrompt prompt = new ScriptedPrompt("n", "yes");
     DbInstallConfigResolver.ParsedArgs parsed =
         new DbInstallConfigResolver.ParsedArgs(install, opts);
     InteractiveInstallWizard.Phase1Result result =
-        InteractiveInstallWizard.runPhase1(parsed, true, prompt);
+        InteractiveInstallWizard.runPhase1(parsed, true, prompt, runningJavaHome());
     assertTrue(result.proceed());
     assertEquals("mysql", result.dbConfig().systemProperties().get("perc.db.type"));
     assertFalse(prompt.outputsAsString().contains("s3cret-should-not-appear"));
+  }
+
+  @Test
+  void interactiveSqlServerExpressPathCollectsStructuredFields() {
+    Path install = tempDir.resolve("express-cms");
+    // menu 2 (SQL Server) → host/port/name/schema/user/password/ssl/sslVerify → skip test → confirm
+    ScriptedPrompt prompt =
+        new ScriptedPrompt(
+            "2",
+            "localhost",
+            "1433",
+            "percussion",
+            "dbo",
+            "sa",
+            "pw-secret",
+            "true",
+            "true",
+            "n",
+            "y");
+    DbInstallConfigResolver.ParsedArgs parsed =
+        new DbInstallConfigResolver.ParsedArgs(install, Map.of());
+    InteractiveInstallWizard.Phase1Result result =
+        InteractiveInstallWizard.runPhase1(parsed, true, prompt, runningJavaHome());
+    assertTrue(result.proceed());
+    assertEquals("sqlserver", result.dbConfig().systemProperties().get("perc.db.type"));
+    assertEquals("sa", result.dbConfig().systemProperties().get("perc.db.user"));
+    assertTrue(prompt.outputsAsString().toLowerCase().contains("express"));
+    assertFalse(prompt.outputsAsString().contains("pw-secret"));
   }
 
   @Test
@@ -175,11 +215,24 @@ class InteractiveInstallWizardTest {
     DbInstallConfigResolver.ParsedArgs parsed =
         new DbInstallConfigResolver.ParsedArgs(install, opts);
     InteractiveInstallWizard.Phase1Result result =
-        InteractiveInstallWizard.runPhase1(parsed, false, null);
+        InteractiveInstallWizard.runPhase1(parsed, false, null, runningJavaHome());
     assertFalse(result.proceed());
     assertEquals(InteractiveInstallWizard.EXIT_DB_CONFIG, result.exitCode());
     assertTrue(result.message().toLowerCase().contains("database"));
     assertFalse(result.message().toLowerCase().contains("password"));
+  }
+
+  @Test
+  void invalidJavaHomeAbortsWithJavaExitCode() {
+    Path install = tempDir.resolve("bad-java");
+    Path invalid = tempDir.resolve("not-a-jdk");
+    DbInstallConfigResolver.ParsedArgs parsed =
+        new DbInstallConfigResolver.ParsedArgs(install, Map.of());
+    InteractiveInstallWizard.Phase1Result result =
+        InteractiveInstallWizard.runPhase1(parsed, false, null, invalid);
+    assertFalse(result.proceed());
+    assertEquals(InteractiveInstallWizard.EXIT_JAVA, result.exitCode());
+    assertTrue(result.message().toLowerCase().contains("java"));
   }
 
   @Test

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/InteractiveInstallWizardTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/InteractiveInstallWizardTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("UnitTest")
+class InteractiveInstallWizardTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void silentModeRecognizesSilentAndNoTtyFlags() {
+    assertTrue(InteractiveInstallWizard.isSilentMode(Map.of("silent", "true")));
+    assertTrue(InteractiveInstallWizard.isSilentMode(Map.of("silent", "yes")));
+    assertTrue(InteractiveInstallWizard.isSilentMode(Map.of("no-tty", "1")));
+    assertFalse(InteractiveInstallWizard.isSilentMode(Map.of()));
+    assertFalse(InteractiveInstallWizard.isSilentMode(null));
+  }
+
+  @Test
+  void isInteractiveRequiresConsoleAndNotSilent() {
+    assertTrue(InteractiveInstallWizard.isInteractive(false, true));
+    assertFalse(InteractiveInstallWizard.isInteractive(true, true));
+    assertFalse(InteractiveInstallWizard.isInteractive(false, false));
+    assertFalse(InteractiveInstallWizard.isInteractive(true, false));
+  }
+
+  @Test
+  void nonInteractiveMissingPathReturnsUsage() {
+    DbInstallConfigResolver.ParsedArgs parsed =
+        new DbInstallConfigResolver.ParsedArgs(null, Map.of());
+    InteractiveInstallWizard.Phase1Result result =
+        InteractiveInstallWizard.runPhase1(parsed, false, null);
+    assertFalse(result.proceed());
+    assertEquals(InteractiveInstallWizard.EXIT_USAGE, result.exitCode());
+    assertNotNull(result.message());
+    assertTrue(result.message().contains("installation or upgrade folder"));
+    assertTrue(result.message().toLowerCase().contains("interactive"));
+  }
+
+  @Test
+  void nonInteractiveWithPathSkipsConfirmAndProceeds() {
+    Path install = tempDir.resolve("cms");
+    DbInstallConfigResolver.ParsedArgs parsed =
+        new DbInstallConfigResolver.ParsedArgs(install, Map.of());
+    InteractiveInstallWizard.Phase1Result result =
+        InteractiveInstallWizard.runPhase1(parsed, false, null);
+    assertTrue(result.proceed());
+    assertEquals(install.toAbsolutePath().normalize(), result.installPath());
+    assertEquals("h2", result.dbConfig().systemProperties().get("perc.db.type"));
+  }
+
+  @Test
+  void interactivePromptsForPathAndConfirmsDefaultYesForH2() {
+    Path install = tempDir.resolve("interactive-cms");
+    ScriptedPrompt prompt = new ScriptedPrompt(install.toString(), ""); // empty confirm → Y for H2
+    DbInstallConfigResolver.ParsedArgs parsed =
+        new DbInstallConfigResolver.ParsedArgs(null, Map.of());
+    InteractiveInstallWizard.Phase1Result result =
+        InteractiveInstallWizard.runPhase1(parsed, true, prompt);
+    assertTrue(result.proceed());
+    assertEquals(install.toAbsolutePath().normalize(), result.installPath());
+    assertEquals("h2", result.dbConfig().systemProperties().get("perc.db.type"));
+    assertTrue(prompt.outputsAsString().contains("installation summary"));
+    assertTrue(prompt.outputsAsString().contains("h2"));
+  }
+
+  @Test
+  void interactiveConfirmNoAborts() {
+    Path install = tempDir.resolve("abort-cms");
+    ScriptedPrompt prompt = new ScriptedPrompt(install.toString(), "n");
+    DbInstallConfigResolver.ParsedArgs parsed =
+        new DbInstallConfigResolver.ParsedArgs(null, Map.of());
+    InteractiveInstallWizard.Phase1Result result =
+        InteractiveInstallWizard.runPhase1(parsed, true, prompt);
+    assertFalse(result.proceed());
+    assertEquals(InteractiveInstallWizard.EXIT_ABORTED, result.exitCode());
+    assertTrue(result.message().toLowerCase().contains("cancelled"));
+  }
+
+  @Test
+  void interactivePathAlreadySuppliedStillConfirms() {
+    Path install = tempDir.resolve("cli-path");
+    ScriptedPrompt prompt = new ScriptedPrompt("y");
+    DbInstallConfigResolver.ParsedArgs parsed =
+        new DbInstallConfigResolver.ParsedArgs(install, Map.of());
+    InteractiveInstallWizard.Phase1Result result =
+        InteractiveInstallWizard.runPhase1(parsed, true, prompt);
+    assertTrue(result.proceed());
+    assertEquals(install.toAbsolutePath().normalize(), result.installPath());
+    assertTrue(prompt.outputsAsString().contains("Install path"));
+  }
+
+  @Test
+  void externalDbRequiresExplicitYesOnEmptyConfirm() {
+    Path install = tempDir.resolve("mysql-cms");
+    Map<String, String> opts = new HashMap<>();
+    opts.put("db.type", "mysql");
+    opts.put("db.host", "db.example.com");
+    opts.put("db.port", "3306");
+    opts.put("db.name", "percussion");
+    opts.put("db.user", "cms");
+    opts.put("db.password", "s3cret-should-not-appear");
+
+    // empty confirm with defaultYes=false → treated as No
+    ScriptedPrompt prompt = new ScriptedPrompt("");
+    DbInstallConfigResolver.ParsedArgs parsed =
+        new DbInstallConfigResolver.ParsedArgs(install, opts);
+    InteractiveInstallWizard.Phase1Result result =
+        InteractiveInstallWizard.runPhase1(parsed, true, prompt);
+    assertFalse(result.proceed());
+    assertTrue(prompt.outputsAsString().contains("mysql"));
+    assertTrue(prompt.outputsAsString().contains("db.example.com"));
+    assertFalse(prompt.outputsAsString().contains("s3cret-should-not-appear"));
+  }
+
+  @Test
+  void externalDbExplicitYesProceedsAndRedactsPassword() {
+    Path install = tempDir.resolve("mysql-cms-ok");
+    Map<String, String> opts = new HashMap<>();
+    opts.put("db.type", "mysql");
+    opts.put("db.host", "db.example.com");
+    opts.put("db.port", "3306");
+    opts.put("db.name", "percussion");
+    opts.put("db.user", "cms");
+    opts.put("db.password", "s3cret-should-not-appear");
+
+    ScriptedPrompt prompt = new ScriptedPrompt("yes");
+    DbInstallConfigResolver.ParsedArgs parsed =
+        new DbInstallConfigResolver.ParsedArgs(install, opts);
+    InteractiveInstallWizard.Phase1Result result =
+        InteractiveInstallWizard.runPhase1(parsed, true, prompt);
+    assertTrue(result.proceed());
+    assertEquals("mysql", result.dbConfig().systemProperties().get("perc.db.type"));
+    assertFalse(prompt.outputsAsString().contains("s3cret-should-not-appear"));
+  }
+
+  @Test
+  void badDbConfigAbortsWithDbExitCode() {
+    Path install = tempDir.resolve("bad-db");
+    // Unreadable dbprops path fails fast without depending on process env filling --db.* fields.
+    Map<String, String> opts =
+        Map.of("dbprops", tempDir.resolve("missing-rxrepository.properties").toString());
+    DbInstallConfigResolver.ParsedArgs parsed =
+        new DbInstallConfigResolver.ParsedArgs(install, opts);
+    InteractiveInstallWizard.Phase1Result result =
+        InteractiveInstallWizard.runPhase1(parsed, false, null);
+    assertFalse(result.proceed());
+    assertEquals(InteractiveInstallWizard.EXIT_DB_CONFIG, result.exitCode());
+    assertTrue(result.message().toLowerCase().contains("database"));
+    assertFalse(result.message().toLowerCase().contains("password"));
+  }
+
+  @Test
+  void summaryDetectsUpgradeWhenVersionPropertiesPresent() throws Exception {
+    Path install = tempDir.resolve("upgrade-root");
+    Files.createDirectories(install);
+    Files.writeString(
+        install.resolve(Main.VERSION_PROPERTIES),
+        "majorVersion=8\nminorVersion=2\n",
+        StandardCharsets.UTF_8);
+    DbInstallConfigResolver.ResolvedDbConfig db =
+        DbInstallConfigResolver.resolveDbConfig(Map.of());
+    String summary = InteractiveInstallWizard.buildSummary(install, db);
+    assertTrue(summary.contains("Upgrade"));
+    assertFalse(summary.contains("New install"));
+  }
+
+  @Test
+  void parseYesNoDefaultsAndValues() {
+    assertEquals(Boolean.TRUE, InteractiveInstallWizard.parseYesNo("", true));
+    assertEquals(Boolean.FALSE, InteractiveInstallWizard.parseYesNo("", false));
+    assertEquals(Boolean.TRUE, InteractiveInstallWizard.parseYesNo("Y", false));
+    assertEquals(Boolean.FALSE, InteractiveInstallWizard.parseYesNo("no", true));
+    assertNull(InteractiveInstallWizard.parseYesNo("maybe", true));
+  }
+
+  @Test
+  void isDefaultYesConfirmOnlyForEmbedded() {
+    assertTrue(
+        InteractiveInstallWizard.isDefaultYesConfirm(
+            DbInstallConfigResolver.resolveDbConfig(Map.of())));
+    Map<String, String> mysql = new HashMap<>();
+    mysql.put("db.type", "mysql");
+    mysql.put("db.host", "h");
+    mysql.put("db.port", "3306");
+    mysql.put("db.name", "n");
+    mysql.put("db.user", "u");
+    mysql.put("db.password", "p");
+    assertFalse(
+        InteractiveInstallWizard.isDefaultYesConfirm(
+            DbInstallConfigResolver.resolveDbConfig(mysql)));
+  }
+
+  /** Scripted prompt: answers consumed in order for readLine/readPassword. */
+  private static final class ScriptedPrompt implements InstallPrompt {
+    private final Deque<String> answers;
+    private final List<String> outputs = new ArrayList<>();
+
+    ScriptedPrompt(String... answers) {
+      this.answers = new ArrayDeque<>();
+      for (String a : answers) {
+        this.answers.addLast(a);
+      }
+    }
+
+    @Override
+    public void print(String message) {
+      outputs.add(message == null ? "" : message);
+    }
+
+    @Override
+    public void println(String message) {
+      outputs.add((message == null ? "" : message) + "\n");
+    }
+
+    @Override
+    public String readLine(String prompt) {
+      print(prompt);
+      return answers.isEmpty() ? "" : answers.removeFirst();
+    }
+
+    @Override
+    public String readPassword(String prompt) {
+      return readLine(prompt);
+    }
+
+    String outputsAsString() {
+      StringBuilder sb = new StringBuilder();
+      for (String o : outputs) {
+        sb.append(o);
+      }
+      return sb.toString();
+    }
+  }
+}

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/InteractiveInstallWizardTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/InteractiveInstallWizardTest.java
@@ -305,8 +305,9 @@ class InteractiveInstallWizardTest {
     }
 
     @Override
-    public String readPassword(String prompt) {
-      return readLine(prompt);
+    public char[] readPassword(String prompt) {
+      String s = readLine(prompt);
+      return s == null ? null : s.toCharArray();
     }
 
     String outputsAsString() {

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/RepositoryConnectionProbeTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/RepositoryConnectionProbeTest.java
@@ -91,6 +91,26 @@ class RepositoryConnectionProbeTest {
   }
 
   @Test
+  void buildJdbcUrlTrimsHostPortNameBeforeComposition() {
+    Map<String, String> props = new HashMap<>();
+    props.put("perc.db.host", "  myhost  ");
+    props.put("perc.db.port", " 3306 ");
+    props.put("perc.db.name", "  db  ");
+    assertEquals(
+        "jdbc:mysql://myhost:3306/db",
+        RepositoryConnectionProbe.buildJdbcUrl("mysql", props));
+  }
+
+  @Test
+  void validateHostPortNameReturnsTrimmedComponents() {
+    RepositoryConnectionProbe.ValidatedEndpoint ep =
+        RepositoryConnectionProbe.validateHostPortName(" host ", " 5432 ", " name ");
+    assertEquals("host", ep.host());
+    assertEquals("5432", ep.port());
+    assertEquals("name", ep.name());
+  }
+
+  @Test
   void probeFailsCleanlyOnUnsafeHost() {
     Map<String, String> props = new HashMap<>();
     props.put("perc.db.type", "mysql");

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/RepositoryConnectionProbeTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/RepositoryConnectionProbeTest.java
@@ -17,6 +17,7 @@ package com.percussion.preinstall;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
@@ -45,7 +46,6 @@ class RepositoryConnectionProbeTest {
     props.put("perc.db.user", "cms");
     props.put("perc.db.password", "secret-password-value");
     props.put("perc.db.cms.driverClass", "com.example.NonExistentDriver");
-    props.put("perc.db.dts.jdbcUrl", "jdbc:mysql://db.example.com:3306/percussion");
 
     RepositoryConnectionProbe.ProbeResult r = RepositoryConnectionProbe.probe(props, 5);
     assertEquals(RepositoryConnectionProbe.ProbeStatus.SKIPPED, r.status());
@@ -80,11 +80,48 @@ class RepositoryConnectionProbeTest {
   }
 
   @Test
+  void buildJdbcUrlRejectsInjectionInHost() {
+    Map<String, String> props = new HashMap<>();
+    props.put("perc.db.host", "db.example.com;allowPublicKeyRetrieval=true");
+    props.put("perc.db.port", "3306");
+    props.put("perc.db.name", "db");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> RepositoryConnectionProbe.buildJdbcUrl("mysql", props));
+  }
+
+  @Test
+  void probeFailsCleanlyOnUnsafeHost() {
+    Map<String, String> props = new HashMap<>();
+    props.put("perc.db.type", "mysql");
+    props.put("perc.db.host", "evil;x=1");
+    props.put("perc.db.port", "3306");
+    props.put("perc.db.name", "db");
+    props.put("perc.db.user", "u");
+    props.put("perc.db.password", "p");
+    props.put("perc.db.cms.driverClass", "com.example.NonExistentDriver");
+    RepositoryConnectionProbe.ProbeResult r = RepositoryConnectionProbe.probe(props, 5);
+    assertEquals(RepositoryConnectionProbe.ProbeStatus.FAILED, r.status());
+    assertTrue(r.message().toLowerCase().contains("host"));
+  }
+
+  @Test
   void safeSqlMessageRedactsPasswordFragments() {
     java.sql.SQLException ex =
-        new java.sql.SQLException("login failed password=supersecret; host=x");
+        new java.sql.SQLException(
+            "login failed password=supersecret; pwd=also; user:token@host; PASSWORD:x");
     String msg = RepositoryConnectionProbe.safeSqlMessage(ex);
     assertFalse(msg.contains("supersecret"));
+    assertFalse(msg.contains("also"));
     assertTrue(msg.contains("***"));
+  }
+
+  @Test
+  void openConnectionOmitsPasswordPropertyWhenNull() throws Exception {
+    // Cannot open a real connection without a driver/URL; just ensure method accepts null password
+    // without NPE when URL is invalid — SQLException is expected, not NPE.
+    assertThrows(
+        java.sql.SQLException.class,
+        () -> RepositoryConnectionProbe.openConnection("jdbc:invalid:test", "user", null));
   }
 }

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/RepositoryConnectionProbeTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/RepositoryConnectionProbeTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+class RepositoryConnectionProbeTest {
+
+  @Test
+  void embeddedH2IsSkipped() {
+    Map<String, String> props = Map.of("perc.db.type", "h2");
+    RepositoryConnectionProbe.ProbeResult r = RepositoryConnectionProbe.probe(props, 5);
+    assertEquals(RepositoryConnectionProbe.ProbeStatus.SKIPPED_EMBEDDED, r.status());
+    assertTrue(r.isSuccess());
+  }
+
+  @Test
+  void missingDriverIsSkippedNotFailed() {
+    Map<String, String> props = new HashMap<>();
+    props.put("perc.db.type", "mysql");
+    props.put("perc.db.host", "db.example.com");
+    props.put("perc.db.port", "3306");
+    props.put("perc.db.name", "percussion");
+    props.put("perc.db.user", "cms");
+    props.put("perc.db.password", "secret-password-value");
+    props.put("perc.db.cms.driverClass", "com.example.NonExistentDriver");
+    props.put("perc.db.dts.jdbcUrl", "jdbc:mysql://db.example.com:3306/percussion");
+
+    RepositoryConnectionProbe.ProbeResult r = RepositoryConnectionProbe.probe(props, 5);
+    assertEquals(RepositoryConnectionProbe.ProbeStatus.SKIPPED, r.status());
+    assertFalse(r.message().contains("secret-password-value"));
+    assertTrue(r.message().toLowerCase().contains("classpath") || r.message().contains("driver"));
+  }
+
+  @Test
+  void buildJdbcUrlForStructuredBackends() {
+    Map<String, String> mysql = new HashMap<>();
+    mysql.put("perc.db.host", "h");
+    mysql.put("perc.db.port", "3306");
+    mysql.put("perc.db.name", "db");
+    assertEquals(
+        "jdbc:mysql://h:3306/db", RepositoryConnectionProbe.buildJdbcUrl("mysql", mysql));
+
+    Map<String, String> pg = new HashMap<>();
+    pg.put("perc.db.host", "h");
+    pg.put("perc.db.port", "5432");
+    pg.put("perc.db.name", "db");
+    assertEquals(
+        "jdbc:postgresql://h:5432/db",
+        RepositoryConnectionProbe.buildJdbcUrl("postgresql", pg));
+
+    Map<String, String> mssql = new HashMap<>();
+    mssql.put("perc.db.host", "h");
+    mssql.put("perc.db.port", "1433");
+    mssql.put("perc.db.name", "db");
+    assertEquals(
+        "jdbc:sqlserver://h:1433;databaseName=db",
+        RepositoryConnectionProbe.buildJdbcUrl("sqlserver", mssql));
+  }
+
+  @Test
+  void safeSqlMessageRedactsPasswordFragments() {
+    java.sql.SQLException ex =
+        new java.sql.SQLException("login failed password=supersecret; host=x");
+    String msg = RepositoryConnectionProbe.safeSqlMessage(ex);
+    assertFalse(msg.contains("supersecret"));
+    assertTrue(msg.contains("***"));
+  }
+}


### PR DESCRIPTION
## Summary

Adds a console **interactive installer wizard** for CMS and DTS so operators no longer need to memorize CLI flags for a guided install. Silent/automation paths (`--silent` / `--no-tty`, full `--db.*` / `--dbprops`) are unchanged.

Closes / tracks **#1513**.

### Interactive flow (TTY, not silent)

| Step | CMS | DTS |
|------|-----|-----|
| 1. Install directory | Prompt if omitted | Same |
| 2. Java 21+ home | `JavaInstallSelection` (discover / multi-pick / `-Dperc.java.home`) | Same |
| 3. Server type | n/a | Production vs Staging |
| 4. Database multi-step | H2, SQL Server/Express, MySQL, PostgreSQL, Oracle, dbprops file | H2, SQL Server/Express, MySQL, PostgreSQL, env-style file |
| 5. Optional connection test | Best-effort probe; SKIPPED if driver not on preinstall classpath | Same |
| 6. Summary + confirm | Default **Y** for H2; explicit **Y** for external | Same |

**SQL Server Express:** menu guidance for small sites (&lt;~10 users, &lt;~10 GB) as a scale-to-corp path that can avoid a later H2→SQL Server migration. Still uses `db.type=sqlserver` (no new engine type). Installer does not install Express.

### Key code

**CMS** (`modules/perc-distribution-tree`)
- `InteractiveInstallWizard`, `InteractiveDbConfigCollector`, `RepositoryConnectionProbe`, `InstallPrompt`
- Wired from `Main`

**DTS** (`delivery-tier-distribution`)
- `InteractiveDtsInstallWizard` + parallel helpers
- Wired from `MainDTSPreInstall`

**Docs:** plan under `docs/ai-generated/tasks/interactive-installer-mode/PLAN.md`; module READMEs.

## Test plan

- [x] CMS: `cd modules/perc-distribution-tree && ../../mvn-env.sh clean install` → **BUILD SUCCESS**, Tests run: **154**, Failures: 0
- [x] DTS: `cd deliverytiersuite/delivery-tier-suite/delivery-tier-distribution && ../../../mvn-env.sh clean install` → **BUILD SUCCESS**, Tests run: **77**, Failures: 0
- [x] Unit coverage: path prompt, confirm abort, password redaction, Express menu, Java failure exit, silent/no-path usage, DTS production/staging
- [ ] Manual (optional): run CMS/DTS installer jar with a console, no path arg; complete H2 flow and cancel path
- [ ] CI matrix / Docker remains on `--silent` + flags (no hang)

## Notes

- Preinstall connection probe is **best-effort**; ANT `PSValidateRepositoryConnection` remains authoritative after files are written (CMS).
- Phase 5 polish (back navigation) deferred.
- Deeper Express productization can be a follow-up on #1513.

> Co-Authored by Grok Build using grok-4.5 with agent main.