### PR TITLE
fix(jetty): startup WARN hygiene (GH-1484–1487)

### DIFF
--- a/docs/ai-generated/code-reviews/1484-1487-jetty-startup-warn-hygiene-erlang.md
+++ b/docs/ai-generated/code-reviews/1484-1487-jetty-startup-warn-hygiene-erlang.md
@@ -1,0 +1,62 @@
+# Erlang review — GH-1484–1487 Jetty startup WARN hygiene
+
+**Date:** 2026-07-27  
+**Scope:** Uncommitted `modules/perc-jetty` changes for issues #1484, #1485, #1486, #1487  
+**Base:** `development` (`origin/development`)  
+**Reviewer persona:** Erlang (independent of implementer)
+
+## Summary
+
+Packaging/config-only hygiene for CMS Jetty 12 startup console WARNs: single SLF4J
+provider via `logging|default`, remove module `[exec]` fork drivers, migrate to
+`ShutdownService` + SameSite cookie attribute, patch assembled `jetty.xml` named
+Args, ship DigesterFactory W3C schema resources.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs (functional / security) | None found |
+| Behavioral tests for new non-trivial logic | Pass — config/packaging contracts covered by `StartupWarnHygieneTest` (same style as existing `PercLoggingLog4j2ConfigTest`) |
+| Cross-platform path / file I/O | Pass — tests use `Path.of` / `Files`; line endings normalized; no OS-only path joins in product code |
+| May commit/push | **yes** |
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction in Java
+- [x] Path logic uses `Path` / `Files` in tests
+- [x] Schema packaging uses Ant `basedir` + Maven paths (build-time only)
+- [x] Tests do not assert Unix-only absolute path shapes
+- [x] Line-ending sensitive assertions normalize `\r\n` → `\n`
+- [x] Start/stop scripts retain Windows (`.bat`) counterparts; Linux StartJetty.sh already lacked server-side `STOP.PORT`
+
+## Issues
+
+_None (hard gate)._
+
+### Notes (non-blocking)
+
+1. **Structural tests:** Assertions read module/ini/XML text rather than a live
+   `start.jar --dry-run`. Acceptable for this packaging module (matches GH-939
+   log4j2 config tests). Optional follow-up: smoke `--list-modules` / `--dry-run`
+   in CI if a Jetty home fixture becomes available.
+2. **`jvm` still forks once:** Documented intentional residual via `jvm.ini`
+   `--exec`. Does not reintroduce the smoke finding naming `[perc-logging, perc]`.
+3. **Stop protocol:** Server uses `jetty.shutdown.*`; stop client keeps
+   `-DSTOP.PORT`/`-DSTOP.KEY` with matching values — correct Jetty 12 split.
+
+## Memory patterns hit
+
+- Structural config tests OK when they *are* the packaging contract (not a
+  substitute for runtime business logic)
+- Cross-platform: Path/Files + CRLF normalize in tests
+- Installer/start scripts: Windows + Unix pairs for required operator flows
+
+## Evidence
+
+- `cd modules/perc-jetty && ../../mvn-env.bat clean install`
+- **BUILD SUCCESS** — Tests run: 39, Failures: 0, Errors: 0, Skipped: 0

--- a/docs/ai-generated/code-reviews/1484-1487-jetty-startup-warn-hygiene-erlang.md
+++ b/docs/ai-generated/code-reviews/1484-1487-jetty-startup-warn-hygiene-erlang.md
@@ -60,3 +60,15 @@ _None (hard gate)._
 
 - `cd modules/perc-jetty && ../../mvn-env.bat clean install`
 - **BUILD SUCCESS** — Tests run: 39, Failures: 0, Errors: 0, Skipped: 0
+
+## Re-review (PR #1518 kilo-code-bot WARNING)
+
+**Finding:** Operator-customizable stop port dropped from Windows service
+`PR_STARTPARAMS` when removing `-DSTOP.PORT`.
+
+**Mitigation:** Restore `STOPPORT`/`STOPKEY` wiring as Jetty start properties
+`jetty.shutdown.port` / `jetty.shutdown.key` on both `install-jetty-service.bat`
+(`PR_STARTPARAMS`) and `StartJetty.bat` (console). Stop client path unchanged.
+Added `installJettyServiceBatPreservesCustomStopPortViaShutdownProperties` test.
+
+**Gate:** still **approve** — no hard bugs; review feedback addressed.

--- a/modules/perc-jetty/README.md
+++ b/modules/perc-jetty/README.md
@@ -87,7 +87,10 @@ and packaging (see worklog `src/site/markdown/worklog/jetty-startup-warn-hygiene
 | #1486 | `ShutdownService` + SameSite attribute | `start.d/shutdown.ini`, `StartJetty.bat`, `Rhythmyx.xml` |
 | #1487 | Named `jetty.xml` Args + DigesterFactory schemas | antrun patch of `upstream/etc/jetty.xml`; `perc-xml-schemas.jar` |
 
-Stop defaults are unchanged: port **50011**, key **SHUTDOWN**. `StopJetty` still
-uses `-DSTOP.PORT` / `-DSTOP.KEY` as **client** parameters for `start.jar --stop`.
+Stop defaults are unchanged: port **50011**, key **SHUTDOWN**. Customize by
+editing `STOPPORT` / `STOPKEY` in `StartJetty.bat`, `StopJetty.bat`, and
+`service/install-jetty-service.bat` (all three must match). Server start applies
+them as `jetty.shutdown.port` / `jetty.shutdown.key`; `StopJetty` still uses
+`-DSTOP.PORT` / `-DSTOP.KEY` as **client** parameters for `start.jar --stop`.
 
 Unit tests: `src/test/java/com/percussion/jetty/StartupWarnHygieneTest.java`

--- a/modules/perc-jetty/README.md
+++ b/modules/perc-jetty/README.md
@@ -74,3 +74,20 @@ includes `%d{yyyy-MM-dd}`. The `Delete` action removes older **dated** archives 
 disk use stays bounded. Same retention idea as DTS `log4j2-tomcat.xml`.
 
 Unit tests: `src/test/java/com/percussion/jetty/logging/PercLoggingLog4j2ConfigTest.java`
+
+## Startup WARN hygiene (GH-1484 – GH-1487)
+
+Console noise from the Windows 8.2 smoke catalog is addressed in Jetty defaults
+and packaging (see worklog `src/site/markdown/worklog/jetty-startup-warn-hygiene-1484-1487.md`):
+
+| Issue | Topic | Config touchpoints |
+|-------|--------|--------------------|
+| #1484 | Single SLF4J provider (Log4j2) | `defaults/modules/perc-logging.mod` provides `logging\|default` |
+| #1485 | No `[exec]` on perc / perc-logging | JVM args consolidated in `defaults/start.d/jvm.ini` |
+| #1486 | `ShutdownService` + SameSite attribute | `start.d/shutdown.ini`, `StartJetty.bat`, `Rhythmyx.xml` |
+| #1487 | Named `jetty.xml` Args + DigesterFactory schemas | antrun patch of `upstream/etc/jetty.xml`; `perc-xml-schemas.jar` |
+
+Stop defaults are unchanged: port **50011**, key **SHUTDOWN**. `StopJetty` still
+uses `-DSTOP.PORT` / `-DSTOP.KEY` as **client** parameters for `start.jar --stop`.
+
+Unit tests: `src/test/java/com/percussion/jetty/StartupWarnHygieneTest.java`

--- a/modules/perc-jetty/pom.xml
+++ b/modules/perc-jetty/pom.xml
@@ -332,6 +332,29 @@
                                     <fileset dir="${basedir}/src/main/jetty"/>
                                 </copy>
                                 <!--
+                                  GH-1487: stock jetty.xml uses unnamed Server constructor Args.
+                                  When XmlConfiguration cannot bind them, it logs
+                                  WARN Ignored arg [[]] three times. Named Args match Jetty's
+                                  @Name annotations (threadpool / scheduler / bufferPool).
+                                -->
+                                <replace file="${assembly-directory}/upstream/etc/jetty.xml"
+                                         token="&lt;Arg&gt;&lt;Ref refid=&quot;threadPool&quot;/&gt;&lt;/Arg&gt;"
+                                         value="&lt;Arg name=&quot;threadpool&quot;&gt;&lt;Ref refid=&quot;threadPool&quot;/&gt;&lt;/Arg&gt;"/>
+                                <replace file="${assembly-directory}/upstream/etc/jetty.xml"
+                                         token="&lt;Arg&gt;&lt;Ref refid=&quot;scheduler&quot;/&gt;&lt;/Arg&gt;"
+                                         value="&lt;Arg name=&quot;scheduler&quot;&gt;&lt;Ref refid=&quot;scheduler&quot;/&gt;&lt;/Arg&gt;"/>
+                                <replace file="${assembly-directory}/upstream/etc/jetty.xml"
+                                         token="&lt;Arg&gt;&lt;Ref refid=&quot;byteBufferPool&quot;/&gt;&lt;/Arg&gt;"
+                                         value="&lt;Arg name=&quot;bufferPool&quot;&gt;&lt;Ref refid=&quot;byteBufferPool&quot;/&gt;&lt;/Arg&gt;"/>
+                                <!--
+                                  GH-1487: package W3C schema DTDs for DigesterFactory
+                                  (org/apache/tomcat/util/descriptor/*) as a small classpath jar.
+                                -->
+                                <mkdir dir="${assembly-directory}/defaults/lib/perc"/>
+                                <jar destfile="${assembly-directory}/defaults/lib/perc/perc-xml-schemas.jar"
+                                     basedir="${basedir}/src/build/perc-xml-schemas"
+                                     includes="org/**"/>
+                                <!--
                                   Jetty 12 DeploymentScanner rejects both Name and Name.war as
                                   directories for the same deployable. Source keeps exploded
                                   CI_Home / EI_Home (referenced by *.xml); remove residual

--- a/modules/perc-jetty/src/build/perc-xml-schemas/README.md
+++ b/modules/perc-jetty/src/build/perc-xml-schemas/README.md
@@ -1,0 +1,18 @@
+﻿# Percussion CMS — DigesterFactory XML schema resources (GH-1487)
+
+These W3C XML Schema infrastructure files are placed on the Jetty server
+classpath under org/apache/tomcat/util/descriptor/ so Apache Tomcat
+DigesterFactory (used by Jetty ee11-apache-jsp) can resolve:
+
+- XMLSchema.dtd
+- datatypes.dtd
+- xml.xsd
+
+Without them, DigesterFactory logs WARN at startup and falls back to
+non-validating mode. CMS already sets
+-Dorg.eclipse.jetty.xml.XmlParser.Validating=false; shipping the files
+removes the noise and enables validation if it is turned on later.
+
+Source: redistributed from org.apache.tomcat:tomcat-servlet-api (jakarta.servlet.resources),
+which packages the same W3C resources. Copyright W3C; used under the W3C
+document license as redistributed by Apache Tomcat.

--- a/modules/perc-jetty/src/build/perc-xml-schemas/org/apache/tomcat/util/descriptor/XMLSchema.dtd
+++ b/modules/perc-jetty/src/build/perc-xml-schemas/org/apache/tomcat/util/descriptor/XMLSchema.dtd
@@ -1,0 +1,418 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- DTD for XML Schemas: Part 1: Structures
+     Public Identifier: "-//W3C//DTD XMLSCHEMA 200102//EN"
+     Official Location: http://www.w3.org/2001/XMLSchema.dtd -->
+
+<!-- Note this DTD is NOT normative, or even definitive. -->           <!--d-->
+<!-- prose copy in the structures REC is the definitive version -->    <!--d-->
+<!-- (which shouldn't differ from this one except for this -->         <!--d-->
+<!-- comment and entity expansions, but just in case) -->              <!--d-->
+<!-- With the exception of cases with multiple namespace
+     prefixes for the XML Schema namespace, any XML document which is
+     not valid per this DTD given redefinitions in its internal subset of the
+     'p' and 's' parameter entities below appropriate to its namespace
+     declaration of the XML Schema namespace is almost certainly not
+     a valid schema. -->
+
+<!-- The simpleType element and its constituent parts
+     are defined in XML Schema: Part 2: Datatypes -->
+<!ENTITY % xs-datatypes PUBLIC 'datatypes' 'datatypes.dtd' >
+
+<!ENTITY % p 'xs:'> <!-- can be overridden in the internal subset of a
+                         schema document to establish a different
+                         namespace prefix -->
+<!ENTITY % s ':xs'> <!-- if %p is defined (e.g. as foo:) then you must
+                         also define %s as the suffix for the appropriate
+                         namespace declaration (e.g. :foo) -->
+<!ENTITY % nds 'xmlns%s;'>
+
+<!-- Define all the element names, with optional prefix -->
+<!ENTITY % schema "%p;schema">
+<!ENTITY % complexType "%p;complexType">
+<!ENTITY % complexContent "%p;complexContent">
+<!ENTITY % simpleContent "%p;simpleContent">
+<!ENTITY % extension "%p;extension">
+<!ENTITY % element "%p;element">
+<!ENTITY % unique "%p;unique">
+<!ENTITY % key "%p;key">
+<!ENTITY % keyref "%p;keyref">
+<!ENTITY % selector "%p;selector">
+<!ENTITY % field "%p;field">
+<!ENTITY % group "%p;group">
+<!ENTITY % all "%p;all">
+<!ENTITY % choice "%p;choice">
+<!ENTITY % sequence "%p;sequence">
+<!ENTITY % any "%p;any">
+<!ENTITY % anyAttribute "%p;anyAttribute">
+<!ENTITY % attribute "%p;attribute">
+<!ENTITY % attributeGroup "%p;attributeGroup">
+<!ENTITY % include "%p;include">
+<!ENTITY % import "%p;import">
+<!ENTITY % redefine "%p;redefine">
+<!ENTITY % notation "%p;notation">
+
+<!-- annotation elements -->
+<!ENTITY % annotation "%p;annotation">
+<!ENTITY % appinfo "%p;appinfo">
+<!ENTITY % documentation "%p;documentation">
+
+<!-- Customisation entities for the ATTLIST of each element type.
+     Define one of these if your schema takes advantage of the
+     anyAttribute='##other' in the schema for schemas -->
+
+<!ENTITY % schemaAttrs ''>
+<!ENTITY % complexTypeAttrs ''>
+<!ENTITY % complexContentAttrs ''>
+<!ENTITY % simpleContentAttrs ''>
+<!ENTITY % extensionAttrs ''>
+<!ENTITY % elementAttrs ''>
+<!ENTITY % groupAttrs ''>
+<!ENTITY % allAttrs ''>
+<!ENTITY % choiceAttrs ''>
+<!ENTITY % sequenceAttrs ''>
+<!ENTITY % anyAttrs ''>
+<!ENTITY % anyAttributeAttrs ''>
+<!ENTITY % attributeAttrs ''>
+<!ENTITY % attributeGroupAttrs ''>
+<!ENTITY % uniqueAttrs ''>
+<!ENTITY % keyAttrs ''>
+<!ENTITY % keyrefAttrs ''>
+<!ENTITY % selectorAttrs ''>
+<!ENTITY % fieldAttrs ''>
+<!ENTITY % includeAttrs ''>
+<!ENTITY % importAttrs ''>
+<!ENTITY % redefineAttrs ''>
+<!ENTITY % notationAttrs ''>
+<!ENTITY % annotationAttrs ''>
+<!ENTITY % appinfoAttrs ''>
+<!ENTITY % documentationAttrs ''>
+
+<!ENTITY % complexDerivationSet "CDATA">
+      <!-- #all or space-separated list drawn from derivationChoice -->
+<!ENTITY % blockSet "CDATA">
+      <!-- #all or space-separated list drawn from
+                      derivationChoice + 'substitution' -->
+
+<!ENTITY % mgs '%all; | %choice; | %sequence;'>
+<!ENTITY % cs '%choice; | %sequence;'>
+<!ENTITY % formValues '(qualified|unqualified)'>
+
+
+<!ENTITY % attrDecls    '((%attribute;| %attributeGroup;)*,(%anyAttribute;)?)'>
+
+<!ENTITY % particleAndAttrs '((%mgs; | %group;)?, %attrDecls;)'>
+
+<!-- This is used in part2 -->
+<!ENTITY % restriction1 '((%mgs; | %group;)?)'>
+
+%xs-datatypes;
+
+<!-- the duplication below is to produce an unambiguous content model
+     which allows annotation everywhere -->
+<!ELEMENT %schema; ((%include; | %import; | %redefine; | %annotation;)*,
+                    ((%simpleType; | %complexType;
+                      | %element; | %attribute;
+                      | %attributeGroup; | %group;
+                      | %notation; ),
+                     (%annotation;)*)* )>
+<!ATTLIST %schema;
+   targetNamespace      %URIref;               #IMPLIED
+   version              CDATA                  #IMPLIED
+   %nds;                %URIref;               #FIXED 'http://www.w3.org/2001/XMLSchema'
+   xmlns                CDATA                  #IMPLIED
+   finalDefault         %complexDerivationSet; ''
+   blockDefault         %blockSet;             ''
+   id                   ID                     #IMPLIED
+   elementFormDefault   %formValues;           'unqualified'
+   attributeFormDefault %formValues;           'unqualified'
+   xml:lang             CDATA                  #IMPLIED
+   %schemaAttrs;>
+<!-- Note the xmlns declaration is NOT in the Schema for Schemas,
+     because at the Infoset level where schemas operate,
+     xmlns(:prefix) is NOT an attribute! -->
+<!-- The declaration of xmlns is a convenience for schema authors -->
+
+<!-- The id attribute here and below is for use in external references
+     from non-schemas using simple fragment identifiers.
+     It is NOT used for schema-to-schema reference, internal or
+     external. -->
+
+<!-- a type is a named content type specification which allows attribute
+     declarations-->
+<!-- -->
+
+<!ELEMENT %complexType; ((%annotation;)?,
+                         (%simpleContent;|%complexContent;|
+                          %particleAndAttrs;))>
+
+<!ATTLIST %complexType;
+          name      %NCName;                        #IMPLIED
+          id        ID                              #IMPLIED
+          abstract  %boolean;                       #IMPLIED
+          final     %complexDerivationSet;          #IMPLIED
+          block     %complexDerivationSet;          #IMPLIED
+          mixed (true|false) 'false'
+          %complexTypeAttrs;>
+
+<!-- particleAndAttrs is shorthand for a root type -->
+<!-- mixed is disallowed if simpleContent, overridden if complexContent
+     has one too. -->
+
+<!-- If anyAttribute appears in one or more referenced attributeGroups
+     and/or explicitly, the intersection of the permissions is used -->
+
+<!ELEMENT %complexContent; ((%annotation;)?, (%restriction;|%extension;))>
+<!ATTLIST %complexContent;
+          mixed (true|false) #IMPLIED
+          id    ID           #IMPLIED
+          %complexContentAttrs;>
+
+<!-- restriction should use the branch defined above, not the simple
+     one from part2; extension should use the full model  -->
+
+<!ELEMENT %simpleContent; ((%annotation;)?, (%restriction;|%extension;))>
+<!ATTLIST %simpleContent;
+          id    ID           #IMPLIED
+          %simpleContentAttrs;>
+
+<!-- restriction should use the simple branch from part2, not the
+     one defined above; extension should have no particle  -->
+
+<!ELEMENT %extension; ((%annotation;)?, (%particleAndAttrs;))>
+<!ATTLIST %extension;
+          base  %QName;      #REQUIRED
+          id    ID           #IMPLIED
+          %extensionAttrs;>
+
+<!-- an element is declared by either:
+ a name and a type (either nested or referenced via the type attribute)
+ or a ref to an existing element declaration -->
+
+<!ELEMENT %element; ((%annotation;)?, (%complexType;| %simpleType;)?,
+                     (%unique; | %key; | %keyref;)*)>
+<!-- simpleType or complexType only if no type|ref attribute -->
+<!-- ref not allowed at top level -->
+<!ATTLIST %element;
+            name               %NCName;               #IMPLIED
+            id                 ID                     #IMPLIED
+            ref                %QName;                #IMPLIED
+            type               %QName;                #IMPLIED
+            minOccurs          %nonNegativeInteger;   #IMPLIED
+            maxOccurs          CDATA                  #IMPLIED
+            nillable           %boolean;              #IMPLIED
+            substitutionGroup  %QName;                #IMPLIED
+            abstract           %boolean;              #IMPLIED
+            final              %complexDerivationSet; #IMPLIED
+            block              %blockSet;             #IMPLIED
+            default            CDATA                  #IMPLIED
+            fixed              CDATA                  #IMPLIED
+            form               %formValues;           #IMPLIED
+            %elementAttrs;>
+<!-- type and ref are mutually exclusive.
+     name and ref are mutually exclusive, one is required -->
+<!-- In the absence of type AND ref, type defaults to type of
+     substitutionGroup, if any, else the ur-type, i.e. unconstrained -->
+<!-- default and fixed are mutually exclusive -->
+
+<!ELEMENT %group; ((%annotation;)?,(%mgs;)?)>
+<!ATTLIST %group;
+          name        %NCName;               #IMPLIED
+          ref         %QName;                #IMPLIED
+          minOccurs   %nonNegativeInteger;   #IMPLIED
+          maxOccurs   CDATA                  #IMPLIED
+          id          ID                     #IMPLIED
+          %groupAttrs;>
+
+<!ELEMENT %all; ((%annotation;)?, (%element;)*)>
+<!ATTLIST %all;
+          minOccurs   (1)                    #IMPLIED
+          maxOccurs   (1)                    #IMPLIED
+          id          ID                     #IMPLIED
+          %allAttrs;>
+
+<!ELEMENT %choice; ((%annotation;)?, (%element;| %group;| %cs; | %any;)*)>
+<!ATTLIST %choice;
+          minOccurs   %nonNegativeInteger;   #IMPLIED
+          maxOccurs   CDATA                  #IMPLIED
+          id          ID                     #IMPLIED
+          %choiceAttrs;>
+
+<!ELEMENT %sequence; ((%annotation;)?, (%element;| %group;| %cs; | %any;)*)>
+<!ATTLIST %sequence;
+          minOccurs   %nonNegativeInteger;   #IMPLIED
+          maxOccurs   CDATA                  #IMPLIED
+          id          ID                     #IMPLIED
+          %sequenceAttrs;>
+
+<!-- an anonymous grouping in a model, or
+     a top-level named group definition, or a reference to same -->
+
+<!-- Note that if order is 'all', group is not allowed inside.
+     If order is 'all' THIS group must be alone (or referenced alone) at
+     the top level of a content model -->
+<!-- If order is 'all', minOccurs==maxOccurs==1 on element/any inside -->
+<!-- Should allow minOccurs=0 inside order='all' . . . -->
+
+<!ELEMENT %any; (%annotation;)?>
+<!ATTLIST %any;
+            namespace       CDATA                  '##any'
+            processContents (skip|lax|strict)      'strict'
+            minOccurs       %nonNegativeInteger;   '1'
+            maxOccurs       CDATA                  '1'
+            id              ID                     #IMPLIED
+            %anyAttrs;>
+
+<!-- namespace is interpreted as follows:
+                  ##any      - - any non-conflicting WFXML at all
+
+                  ##other    - - any non-conflicting WFXML from namespace other
+                                  than targetNamespace
+
+                  ##local    - - any unqualified non-conflicting WFXML/attribute
+                  one or     - - any non-conflicting WFXML from
+                  more URI        the listed namespaces
+                  references
+
+                  ##targetNamespace ##local may appear in the above list,
+                    with the obvious meaning -->
+
+<!ELEMENT %anyAttribute; (%annotation;)?>
+<!ATTLIST %anyAttribute;
+            namespace       CDATA              '##any'
+            processContents (skip|lax|strict)  'strict'
+            id              ID                 #IMPLIED
+            %anyAttributeAttrs;>
+<!-- namespace is interpreted as for 'any' above -->
+
+<!-- simpleType only if no type|ref attribute -->
+<!-- ref not allowed at top level, name iff at top level -->
+<!ELEMENT %attribute; ((%annotation;)?, (%simpleType;)?)>
+<!ATTLIST %attribute;
+          name      %NCName;      #IMPLIED
+          id        ID            #IMPLIED
+          ref       %QName;       #IMPLIED
+          type      %QName;       #IMPLIED
+          use       (prohibited|optional|required) #IMPLIED
+          default   CDATA         #IMPLIED
+          fixed     CDATA         #IMPLIED
+          form      %formValues;  #IMPLIED
+          %attributeAttrs;>
+<!-- type and ref are mutually exclusive.
+     name and ref are mutually exclusive, one is required -->
+<!-- default for use is optional when nested, none otherwise -->
+<!-- default and fixed are mutually exclusive -->
+<!-- type attr and simpleType content are mutually exclusive -->
+
+<!-- an attributeGroup is a named collection of attribute decls, or a
+     reference thereto -->
+<!ELEMENT %attributeGroup; ((%annotation;)?,
+                       (%attribute; | %attributeGroup;)*,
+                       (%anyAttribute;)?) >
+<!ATTLIST %attributeGroup;
+                 name       %NCName;       #IMPLIED
+                 id         ID             #IMPLIED
+                 ref        %QName;        #IMPLIED
+                 %attributeGroupAttrs;>
+
+<!-- ref iff no content, no name.  ref iff not top level -->
+
+<!-- better reference mechanisms -->
+<!ELEMENT %unique; ((%annotation;)?, %selector;, (%field;)+)>
+<!ATTLIST %unique;
+          name     %NCName;       #REQUIRED
+          id       ID             #IMPLIED
+          %uniqueAttrs;>
+
+<!ELEMENT %key;    ((%annotation;)?, %selector;, (%field;)+)>
+<!ATTLIST %key;
+          name     %NCName;       #REQUIRED
+          id       ID             #IMPLIED
+          %keyAttrs;>
+
+<!ELEMENT %keyref; ((%annotation;)?, %selector;, (%field;)+)>
+<!ATTLIST %keyref;
+          name     %NCName;       #REQUIRED
+          refer    %QName;        #REQUIRED
+          id       ID             #IMPLIED
+          %keyrefAttrs;>
+
+<!ELEMENT %selector; ((%annotation;)?)>
+<!ATTLIST %selector;
+          xpath %XPathExpr; #REQUIRED
+          id    ID          #IMPLIED
+          %selectorAttrs;>
+<!ELEMENT %field; ((%annotation;)?)>
+<!ATTLIST %field;
+          xpath %XPathExpr; #REQUIRED
+          id    ID          #IMPLIED
+          %fieldAttrs;>
+
+<!-- Schema combination mechanisms -->
+<!ELEMENT %include; (%annotation;)?>
+<!ATTLIST %include;
+          schemaLocation %URIref; #REQUIRED
+          id             ID       #IMPLIED
+          %includeAttrs;>
+
+<!ELEMENT %import; (%annotation;)?>
+<!ATTLIST %import;
+          namespace      %URIref; #IMPLIED
+          schemaLocation %URIref; #IMPLIED
+          id             ID       #IMPLIED
+          %importAttrs;>
+
+<!ELEMENT %redefine; (%annotation; | %simpleType; | %complexType; |
+                      %attributeGroup; | %group;)*>
+<!ATTLIST %redefine;
+          schemaLocation %URIref; #REQUIRED
+          id             ID       #IMPLIED
+          %redefineAttrs;>
+
+<!ELEMENT %notation; (%annotation;)?>
+<!ATTLIST %notation;
+          name        %NCName;    #REQUIRED
+          id          ID          #IMPLIED
+          public      CDATA       #REQUIRED
+          system      %URIref;    #IMPLIED
+          %notationAttrs;>
+
+<!-- Annotation is either application information or documentation -->
+<!-- By having these here they are available for datatypes as well
+     as all the structures elements -->
+
+<!ELEMENT %annotation; (%appinfo; | %documentation;)*>
+<!ATTLIST %annotation; %annotationAttrs;>
+
+<!-- User must define annotation elements in internal subset for this
+     to work -->
+<!ELEMENT %appinfo; ANY>   <!-- too restrictive -->
+<!ATTLIST %appinfo;
+          source     %URIref;      #IMPLIED
+          id         ID         #IMPLIED
+          %appinfoAttrs;>
+<!ELEMENT %documentation; ANY>   <!-- too restrictive -->
+<!ATTLIST %documentation;
+          source     %URIref;   #IMPLIED
+          id         ID         #IMPLIED
+          xml:lang   CDATA      #IMPLIED
+          %documentationAttrs;>
+
+<!NOTATION XMLSchemaStructures PUBLIC
+           'structures' 'http://www.w3.org/2001/XMLSchema.xsd' >
+<!NOTATION XML PUBLIC
+           'REC-xml-1998-0210' 'http://www.w3.org/TR/1998/REC-xml-19980210' >

--- a/modules/perc-jetty/src/build/perc-xml-schemas/org/apache/tomcat/util/descriptor/datatypes.dtd
+++ b/modules/perc-jetty/src/build/perc-xml-schemas/org/apache/tomcat/util/descriptor/datatypes.dtd
@@ -1,0 +1,219 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!--
+        DTD for XML Schemas: Part 2: Datatypes
+
+        Note this DTD is NOT normative, or even definitive. - - the
+        prose copy in the datatypes REC is the definitive version
+        (which shouldn't differ from this one except for this comment
+        and entity expansions, but just in case)
+  -->
+
+<!--
+        This DTD cannot be used on its own, it is intended
+        only for incorporation in XMLSchema.dtd, q.v.
+  -->
+
+<!-- Define all the element names, with optional prefix -->
+<!ENTITY % simpleType "%p;simpleType">
+<!ENTITY % restriction "%p;restriction">
+<!ENTITY % list "%p;list">
+<!ENTITY % union "%p;union">
+<!ENTITY % maxExclusive "%p;maxExclusive">
+<!ENTITY % minExclusive "%p;minExclusive">
+<!ENTITY % maxInclusive "%p;maxInclusive">
+<!ENTITY % minInclusive "%p;minInclusive">
+<!ENTITY % totalDigits "%p;totalDigits">
+<!ENTITY % fractionDigits "%p;fractionDigits">
+<!ENTITY % length "%p;length">
+<!ENTITY % minLength "%p;minLength">
+<!ENTITY % maxLength "%p;maxLength">
+<!ENTITY % enumeration "%p;enumeration">
+<!ENTITY % whiteSpace "%p;whiteSpace">
+<!ENTITY % pattern "%p;pattern">
+
+<!--
+        Customisation entities for the ATTLIST of each element
+        type. Define one of these if your schema takes advantage
+        of the anyAttribute='##other' in the schema for schemas
+  -->
+
+<!ENTITY % simpleTypeAttrs "">
+<!ENTITY % restrictionAttrs "">
+<!ENTITY % listAttrs "">
+<!ENTITY % unionAttrs "">
+<!ENTITY % maxExclusiveAttrs "">
+<!ENTITY % minExclusiveAttrs "">
+<!ENTITY % maxInclusiveAttrs "">
+<!ENTITY % minInclusiveAttrs "">
+<!ENTITY % totalDigitsAttrs "">
+<!ENTITY % fractionDigitsAttrs "">
+<!ENTITY % lengthAttrs "">
+<!ENTITY % minLengthAttrs "">
+<!ENTITY % maxLengthAttrs "">
+<!ENTITY % enumerationAttrs "">
+<!ENTITY % whiteSpaceAttrs "">
+<!ENTITY % patternAttrs "">
+
+<!-- Define some entities for informative use as attribute
+        types -->
+<!ENTITY % URIref "CDATA">
+<!ENTITY % XPathExpr "CDATA">
+<!ENTITY % QName "NMTOKEN">
+<!ENTITY % QNames "NMTOKENS">
+<!ENTITY % NCName "NMTOKEN">
+<!ENTITY % nonNegativeInteger "NMTOKEN">
+<!ENTITY % boolean "(true|false)">
+<!ENTITY % simpleDerivationSet "CDATA">
+<!--
+        #all or space-separated list drawn from derivationChoice
+  -->
+
+<!--
+        Note that the use of 'facet' below is less restrictive
+        than is really intended:  There should in fact be no
+        more than one of each of minInclusive, minExclusive,
+        maxInclusive, maxExclusive, totalDigits, fractionDigits,
+        length, maxLength, minLength within datatype,
+        and the min- and max- variants of Inclusive and Exclusive
+        are mutually exclusive. On the other hand,  pattern and
+        enumeration may repeat.
+  -->
+<!ENTITY % minBound "(%minInclusive; | %minExclusive;)">
+<!ENTITY % maxBound "(%maxInclusive; | %maxExclusive;)">
+<!ENTITY % bounds "%minBound; | %maxBound;">
+<!ENTITY % numeric "%totalDigits; | %fractionDigits;">
+<!ENTITY % ordered "%bounds; | %numeric;">
+<!ENTITY % unordered
+   "%pattern; | %enumeration; | %whiteSpace; | %length; |
+   %maxLength; | %minLength;">
+<!ENTITY % facet "%ordered; | %unordered;">
+<!ENTITY % facetAttr
+        "value CDATA #REQUIRED
+        id ID #IMPLIED">
+<!ENTITY % fixedAttr "fixed %boolean; #IMPLIED">
+<!ENTITY % facetModel "(%annotation;)?">
+<!ELEMENT %simpleType;
+        ((%annotation;)?, (%restriction; | %list; | %union;))>
+<!ATTLIST %simpleType;
+    name      %NCName; #IMPLIED
+    final     %simpleDerivationSet; #IMPLIED
+    id        ID       #IMPLIED
+    %simpleTypeAttrs;>
+<!-- name is required at top level -->
+<!ELEMENT %restriction; ((%annotation;)?,
+                         (%restriction1; |
+                          ((%simpleType;)?,(%facet;)*)),
+                         (%attrDecls;))>
+<!ATTLIST %restriction;
+    base      %QName;                  #IMPLIED
+    id        ID       #IMPLIED
+    %restrictionAttrs;>
+<!--
+        base and simpleType child are mutually exclusive,
+        one is required.
+
+        restriction is shared between simpleType and
+        simpleContent and complexContent (in XMLSchema.xsd).
+        restriction1 is for the latter cases, when this
+        is restricting a complex type, as is attrDecls.
+  -->
+<!ELEMENT %list; ((%annotation;)?,(%simpleType;)?)>
+<!ATTLIST %list;
+    itemType      %QName;             #IMPLIED
+    id        ID       #IMPLIED
+    %listAttrs;>
+<!--
+        itemType and simpleType child are mutually exclusive,
+        one is required
+  -->
+<!ELEMENT %union; ((%annotation;)?,(%simpleType;)*)>
+<!ATTLIST %union;
+    id            ID       #IMPLIED
+    memberTypes   %QNames;            #IMPLIED
+    %unionAttrs;>
+<!--
+        At least one item in memberTypes or one simpleType
+        child is required
+  -->
+
+<!ELEMENT %maxExclusive; %facetModel;>
+<!ATTLIST %maxExclusive;
+        %facetAttr;
+        %fixedAttr;
+        %maxExclusiveAttrs;>
+<!ELEMENT %minExclusive; %facetModel;>
+<!ATTLIST %minExclusive;
+        %facetAttr;
+        %fixedAttr;
+        %minExclusiveAttrs;>
+
+<!ELEMENT %maxInclusive; %facetModel;>
+<!ATTLIST %maxInclusive;
+        %facetAttr;
+        %fixedAttr;
+        %maxInclusiveAttrs;>
+<!ELEMENT %minInclusive; %facetModel;>
+<!ATTLIST %minInclusive;
+        %facetAttr;
+        %fixedAttr;
+        %minInclusiveAttrs;>
+
+<!ELEMENT %totalDigits; %facetModel;>
+<!ATTLIST %totalDigits;
+        %facetAttr;
+        %fixedAttr;
+        %totalDigitsAttrs;>
+<!ELEMENT %fractionDigits; %facetModel;>
+<!ATTLIST %fractionDigits;
+        %facetAttr;
+        %fixedAttr;
+        %fractionDigitsAttrs;>
+
+<!ELEMENT %length; %facetModel;>
+<!ATTLIST %length;
+        %facetAttr;
+        %fixedAttr;
+        %lengthAttrs;>
+<!ELEMENT %minLength; %facetModel;>
+<!ATTLIST %minLength;
+        %facetAttr;
+        %fixedAttr;
+        %minLengthAttrs;>
+<!ELEMENT %maxLength; %facetModel;>
+<!ATTLIST %maxLength;
+        %facetAttr;
+        %fixedAttr;
+        %maxLengthAttrs;>
+
+<!-- This one can be repeated -->
+<!ELEMENT %enumeration; %facetModel;>
+<!ATTLIST %enumeration;
+        %facetAttr;
+        %enumerationAttrs;>
+
+<!ELEMENT %whiteSpace; %facetModel;>
+<!ATTLIST %whiteSpace;
+        %facetAttr;
+        %fixedAttr;
+        %whiteSpaceAttrs;>
+
+<!-- This one can be repeated -->
+<!ELEMENT %pattern; %facetModel;>
+<!ATTLIST %pattern;
+        %facetAttr;
+        %patternAttrs;>

--- a/modules/perc-jetty/src/build/perc-xml-schemas/org/apache/tomcat/util/descriptor/xml.xsd
+++ b/modules/perc-jetty/src/build/perc-xml-schemas/org/apache/tomcat/util/descriptor/xml.xsd
@@ -1,0 +1,97 @@
+<?xml version='1.0'?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE xs:schema PUBLIC "-//W3C//DTD XMLSCHEMA 200102//EN" "XMLSchema.dtd" >
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:xs="http://www.w3.org/2001/XMLSchema" xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   See http://www.w3.org/XML/1998/namespace.html and
+   http://www.w3.org/TR/REC-xml for information about this namespace.
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>This schema defines attributes and an attribute group
+        suitable for use by
+        schemas wishing to allow xml:base, xml:lang or xml:space attributes
+        on elements they define.
+
+        To enable this, such a schema must import this schema
+        for the XML namespace, e.g. as follows:
+        &lt;schema . . .>
+         . . .
+         &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                    schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
+
+        Subsequently, qualified reference to any of the attributes
+        or the group defined below will have the desired effect, e.g.
+
+        &lt;type . . .>
+         . . .
+         &lt;attributeGroup ref="xml:specialAttrs"/>
+
+         will define a type which will schema-validate an instance
+         element with any of those attributes</xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>In keeping with the XML Schema WG's standard versioning
+   policy, this schema document will persist at
+   http://www.w3.org/2001/03/xml.xsd.
+   At the date of issue it can also be found at
+   http://www.w3.org/2001/xml.xsd.
+   The schema document at that URI may however change in the future,
+   in order to remain compatible with the latest version of XML Schema
+   itself.  In other words, if the XML Schema namespace changes, the version
+   of this document at
+   http://www.w3.org/2001/xml.xsd will change
+   accordingly; the version at
+   http://www.w3.org/2001/03/xml.xsd will not change.
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang" type="xs:language">
+  <xs:annotation>
+   <xs:documentation>In due course, we should install the relevant ISO 2- and 3-letter
+         codes as the enumerated possible values . . .</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attribute name="space" default="preserve">
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="base" type="xs:anyURI">
+  <xs:annotation>
+   <xs:documentation>See http://www.w3.org/TR/xmlbase/ for
+                     information about this attribute.</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+ </xs:attributeGroup>
+
+</xs:schema>

--- a/modules/perc-jetty/src/main/jetty/StartJetty.bat
+++ b/modules/perc-jetty/src/main/jetty/StartJetty.bat
@@ -19,6 +19,10 @@ if errorlevel 1 (
 SET PATH=%JAVA_HOME%\bin;%PATH%
 
 cd %JETTY_BASE%
-"%JAVA%" --add-opens java.base/java.lang=ALL-UNNAMED -XX:+DisableAttachMechanism -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Addresses=true -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -jar %JETTY_HOME%\start.jar -DSTOP.PORT=%STOPPORT% -DSTOP.KEY="SHUTDOWN" -Drxdeploydir="%rxDir%" -DTIKA_CONFIG="%rxDir%\rxconfig\tika-config.xml" -Djetty.base="%JETTY_BASE%" -Djetty_perc_defaults="%JETTY_DEFAULTS%" --include-jetty-dir="%JETTY_DEFAULTS%" %*
+REM GH-1486: do not pass -DSTOP.PORT/-DSTOP.KEY on the server JVM (activates
+REM deprecated ShutdownMonitor). Shutdown is configured via start.d/shutdown.ini
+REM (jetty.shutdown.port=%STOPPORT%, jetty.shutdown.key=SHUTDOWN). StopJetty.bat
+REM still uses STOP.PORT/STOP.KEY as client params for start.jar --stop.
+"%JAVA%" --add-opens java.base/java.lang=ALL-UNNAMED -XX:+DisableAttachMechanism -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Addresses=true -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -jar %JETTY_HOME%\start.jar -Drxdeploydir="%rxDir%" -DTIKA_CONFIG="%rxDir%\rxconfig\tika-config.xml" -Djetty.base="%JETTY_BASE%" -Djetty_perc_defaults="%JETTY_DEFAULTS%" --include-jetty-dir="%JETTY_DEFAULTS%" %*
 
 endlocal

--- a/modules/perc-jetty/src/main/jetty/StartJetty.bat
+++ b/modules/perc-jetty/src/main/jetty/StartJetty.bat
@@ -6,7 +6,10 @@ SET JETTY_HOME=%mypath%upstream
 SET rxDir=%mypath%..
 SET JETTY_BASE=%mypath%base
 SET JETTY_DEFAULTS=%mypath%defaults
+REM Operator-customizable; must match StopJetty.bat / install-jetty-service.bat.
+REM Applied as Jetty start properties jetty.shutdown.* (not -DSTOP.PORT).
 set STOPPORT=50011
+set STOPKEY=SHUTDOWN
 
 REM GH-991: install-time selection wrote java.properties; resolve it (not a
 REM mandatory <InstallRoot>\JRE). Hard-fail on resolve. See java-home-resolution.md.
@@ -20,9 +23,9 @@ SET PATH=%JAVA_HOME%\bin;%PATH%
 
 cd %JETTY_BASE%
 REM GH-1486: do not pass -DSTOP.PORT/-DSTOP.KEY on the server JVM (activates
-REM deprecated ShutdownMonitor). Shutdown is configured via start.d/shutdown.ini
-REM (jetty.shutdown.port=%STOPPORT%, jetty.shutdown.key=SHUTDOWN). StopJetty.bat
-REM still uses STOP.PORT/STOP.KEY as client params for start.jar --stop.
-"%JAVA%" --add-opens java.base/java.lang=ALL-UNNAMED -XX:+DisableAttachMechanism -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Addresses=true -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -jar %JETTY_HOME%\start.jar -Drxdeploydir="%rxDir%" -DTIKA_CONFIG="%rxDir%\rxconfig\tika-config.xml" -Djetty.base="%JETTY_BASE%" -Djetty_perc_defaults="%JETTY_DEFAULTS%" --include-jetty-dir="%JETTY_DEFAULTS%" %*
+REM deprecated ShutdownMonitor). Override start.d/shutdown.ini defaults with
+REM jetty.shutdown.port/key from STOPPORT/STOPKEY so operators can customize.
+REM StopJetty.bat still uses -DSTOP.PORT/-DSTOP.KEY as client params for --stop.
+"%JAVA%" --add-opens java.base/java.lang=ALL-UNNAMED -XX:+DisableAttachMechanism -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Addresses=true -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -jar %JETTY_HOME%\start.jar -Drxdeploydir="%rxDir%" -DTIKA_CONFIG="%rxDir%\rxconfig\tika-config.xml" -Djetty.base="%JETTY_BASE%" -Djetty_perc_defaults="%JETTY_DEFAULTS%" --include-jetty-dir="%JETTY_DEFAULTS%" jetty.shutdown.port=%STOPPORT% jetty.shutdown.key=%STOPKEY% %*
 
 endlocal

--- a/modules/perc-jetty/src/main/jetty/StopJetty.bat
+++ b/modules/perc-jetty/src/main/jetty/StopJetty.bat
@@ -6,7 +6,9 @@ SET JETTY_HOME=%mypath%upstream
 SET rxDir=%mypath%..
 SET JETTY_BASE=%mypath%base
 SET JETTY_DEFAULTS=%mypath%defaults
+REM Must match StartJetty.bat / install-jetty-service.bat (jetty.shutdown.port/key).
 set STOPPORT=50011
+set STOPKEY=SHUTDOWN
 
 REM GH-991: same resolve path as StartJetty (java.properties primary; JRE not required).
 REM See specs/991-system-java-home/contracts/java-home-resolution.md.
@@ -19,6 +21,6 @@ if errorlevel 1 (
 SET PATH=%JAVA_HOME%\bin;%PATH%
 
 cd %JETTY_BASE%
-"%JAVA%" -jar %JETTY_HOME%\start.jar -DSTOP.PORT=%STOPPORT% -DSTOP.KEY="SHUTDOWN" -Drxdeploydir="%rxDir%" -Djetty.base="%JETTY_BASE%" -Djetty_perc_defaults="%JETTY_DEFAULTS%" --include-jetty-dir="%JETTY_DEFAULTS%" --stop
+"%JAVA%" -jar %JETTY_HOME%\start.jar -DSTOP.PORT=%STOPPORT% -DSTOP.KEY="%STOPKEY%" -Drxdeploydir="%rxDir%" -Djetty.base="%JETTY_BASE%" -Djetty_perc_defaults="%JETTY_DEFAULTS%" --include-jetty-dir="%JETTY_DEFAULTS%" --stop
 
 endlocal

--- a/modules/perc-jetty/src/main/jetty/base/webapps/Rhythmyx.xml
+++ b/modules/perc-jetty/src/main/jetty/base/webapps/Rhythmyx.xml
@@ -16,8 +16,16 @@
 			<Set name="httpOnly" type="boolean">true</Set>
 			<!-- When configuring https set this to true -->
 			<Set name="secure" type="boolean">false</Set>
-			<!-- When configuring https set this to __SAME_SITE_NONE__ -->
-			<Set name="comment" type="java.lang.String">__SAME_SITE_STRICT__</Set>
+			<!--
+			  GH-1486: CookieConfig.setComment is deprecated (Jetty 12.1 / Servlet 6).
+			  SameSite is a cookie attribute — use setAttribute (not the old
+			  __SAME_SITE_STRICT__ comment convention).
+			  For cross-site embeds with HTTPS, set secure=true and SameSite=None.
+			-->
+			<Call name="setAttribute">
+				<Arg>SameSite</Arg>
+				<Arg>Strict</Arg>
+			</Call>
 		</Get>
 	</Get>
 	<Get name="errorHandler">

--- a/modules/perc-jetty/src/main/jetty/defaults/modules/perc-logging.mod
+++ b/modules/perc-jetty/src/main/jetty/defaults/modules/perc-logging.mod
@@ -2,6 +2,13 @@
 # Percussion Jetty Logging Module
 #   Output Managed by Log4j2
 #
+# GH-1484: Provides Jetty capability "logging|default" so the stock logging-jetty
+# module (jetty-slf4j-impl) is not also selected. Dual SLF4J providers caused
+# "not a subtype" failures and NOP logger fallback at startup.
+#
+# GH-1485: No [exec] section. Module-level JVM args force start.jar to fork a
+# second JVM; required system properties live in start.d/jvm.ini instead.
+#
 
 [depend]
 perc-config
@@ -11,7 +18,8 @@ resources
 logging
 
 [provides]
-logging-log4j2|default
+logging|default
+logging-log4j2
 
 [lib]
 lib/perc-logging/**.jar
@@ -20,10 +28,7 @@ lib/perc-logging/**.jar
 logs/
 basehome:modules/perc-logging
 
-
 [ini]
-
-[exec]
--Dorg.eclipse.jetty.util.log.class?=org.apache.logging.log4j.appserver.jetty.Log4j2Logger
-
-
+# Keep webapps from loading server Log4j/SLF4J implementation packages.
+jetty.webapp.addHiddenClasses+=,org.apache.logging.log4j.
+jetty.webapp.addHiddenClasses+=,org.slf4j.

--- a/modules/perc-jetty/src/main/jetty/defaults/modules/perc.mod
+++ b/modules/perc-jetty/src/main/jetty/defaults/modules/perc.mod
@@ -26,6 +26,8 @@ perc-ds
 perc-logging
 perc-mq
 jvm
+# GH-1486: Jetty 12 ShutdownService (replaces deprecated STOP.PORT ShutdownMonitor)
+shutdown
 
 [xml]
 etc/installation.properties
@@ -57,12 +59,5 @@ jetty_perc_defaults?=${jetty.base}/../defaults
 jetty.server.stopTimeout=10000
 jetty.server.dumpBeforeStart=true
 jetty.webapp.addProtectedClasses+=,org.xml.sax.,org.w3c.,org.apache.xmlcommons.Version,org.apache.html.,org.apache.wml.,org.apache.xerces.,org.apache.xml.
-[exec]
--Djava.library.path=../../bin
--Djavax.xml.parsers.SAXParserFactory=com.percussion.xml.PSSaxParserFactoryImpl
--Dorg.apache.commons.logging.LogFactory=org.apache.commons.logging.impl.LogFactoryImpl
-# H2 file DB lives under ../../Repository (see perc-ds.properties). No Derby Network Server (#548).
--Djava.net.preferIPv4Stack=true
--Djava.net.preferIPv4Addresses=true
-
-
+# GH-1485: no [exec] here — JVM system properties live in start.d/jvm.ini so this
+# module does not force an extra start.jar JVM fork by itself.

--- a/modules/perc-jetty/src/main/jetty/defaults/start.d/jvm.ini
+++ b/modules/perc-jetty/src/main/jetty/defaults/start.d/jvm.ini
@@ -6,11 +6,13 @@
 --module=jvm
 
 ## JVM Configuration
-## If JVM args are include in an ini file then --exec is needed
+## If JVM args are included in an ini file then --exec is needed
 ## to start a new JVM from start.jar with the extra args.
 ##
-## If you wish to avoid an extra JVM running, place JVM args
-## on the normal command line and do not use --exec
+## GH-1485: perc and perc-logging no longer declare [exec]. All CMS JVM args
+## are consolidated here so start.jar forks at most once (jvm module only).
+## To avoid an extra JVM entirely, move these args onto the StartJetty
+## java command line and remove --exec.
 --exec
 -XX:+DisableAttachMechanism
 -server
@@ -24,6 +26,7 @@
 -Dhttps.protocols=TLSv1.2
 -Djava.net.preferIPv4Stack=true
 -Djava.net.preferIPv4Addresses=true
+-Djava.library.path=../../bin
 -Drxdeploydir=@@rxdir@@
 -Djetty_perc_defaults=@@rxdir@@/jetty/defaults
 -Djavax.xml.accessExternalDTD=file
@@ -35,11 +38,15 @@
 -Dxml.catalog.staticCatalog=static-catalog
 -Dxml.catalog.allowPI=true
 -Djavax.xml.transform.TransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl
--Djavax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl
+# Percussion SAX factory (overrides any stock xerces default for CMS XML apps)
+-Djavax.xml.parsers.SAXParserFactory=com.percussion.xml.PSSaxParserFactoryImpl
 -Djavax.xml.datatype.DatatypeFactory=com.sun.org.apache.xerces.internal.jaxp.datatype.DatatypeFactoryImpl
 -Djavax.xml.parsers.DocumentBuilderFactory=com.percussion.xml.PSDocumentBuilderFactoryImpl
+-Dorg.apache.commons.logging.LogFactory=org.apache.commons.logging.impl.LogFactoryImpl
 -Dorg.owasp.esapi.resources=@@rxdir@@/rxconfig/esapi
 -Dorg.apache.activemq.artemis.jms.deserialization.allowlist=org.hibernate.collection,java.lang,javax.security,java.util,org.apache.activemq.artemis,com.thoughtworks.xstream.mapper,com.percussion
 -Dorg.apache.cxf.Logger=org.apache.cxf.common.logging.Slf4jLogger
 -Djava.io.tmpdir=@@rxdir@@/temp
+# GH-1487: intentional non-validating Jetty XML parse (DigesterFactory schema
+# WARNs for missing W3C DTDs are noise when validation is off).
 -Dorg.eclipse.jetty.xml.XmlParser.Validating=false

--- a/modules/perc-jetty/src/main/jetty/defaults/start.d/perc-logging.ini
+++ b/modules/perc-jetty/src/main/jetty/defaults/start.d/perc-logging.ini
@@ -1,4 +1,6 @@
-# Explicitly enable perc-logging with exclusion of default logging-jetty
+# Enable Percussion Log4j2 logging.
+# GH-1484: perc-logging provides Jetty capability "logging|default", which
+# prevents the stock logging-jetty module (jetty-slf4j-impl) from also loading.
 --module=perc-logging
 
 # Capture JVM stdout/stderr to dated Jetty log files in addition to application logs.

--- a/modules/perc-jetty/src/main/jetty/defaults/start.d/shutdown.ini
+++ b/modules/perc-jetty/src/main/jetty/defaults/start.d/shutdown.ini
@@ -3,8 +3,13 @@
 # Jetty 12 ShutdownService — replaces deprecated ShutdownMonitor activated by
 # -DSTOP.PORT / -DSTOP.KEY on the server JVM.
 #
+# Defaults below. Operators may override without editing this file:
+#   - StartJetty.bat / install-jetty-service.bat: set STOPPORT / STOPKEY
+#     (passed as jetty.shutdown.port / jetty.shutdown.key start properties)
+#   - Or pass jetty.shutdown.port=N jetty.shutdown.key=KEY on the start.jar line
+#
 # StopJetty still uses -DSTOP.PORT / -DSTOP.KEY as *client* connection params
-# for start.jar --stop; those must match the values below.
+# for start.jar --stop; those must match the effective server values.
 # ---------------------------------------
 --module=shutdown
 

--- a/modules/perc-jetty/src/main/jetty/defaults/start.d/shutdown.ini
+++ b/modules/perc-jetty/src/main/jetty/defaults/start.d/shutdown.ini
@@ -1,0 +1,14 @@
+# ---------------------------------------
+# Module: shutdown (GH-1486)
+# Jetty 12 ShutdownService — replaces deprecated ShutdownMonitor activated by
+# -DSTOP.PORT / -DSTOP.KEY on the server JVM.
+#
+# StopJetty still uses -DSTOP.PORT / -DSTOP.KEY as *client* connection params
+# for start.jar --stop; those must match the values below.
+# ---------------------------------------
+--module=shutdown
+
+jetty.shutdown.host=127.0.0.1
+jetty.shutdown.port=50011
+jetty.shutdown.key=SHUTDOWN
+jetty.shutdown.exit=true

--- a/modules/perc-jetty/src/main/jetty/service/install-jetty-service.bat
+++ b/modules/perc-jetty/src/main/jetty/service/install-jetty-service.bat
@@ -27,11 +27,11 @@ set PR_DESCRIPTION="Percussion Services For CMS - Jetty Server"
 set JETTY_HOME="%JETTY_ROOT%upstream"
 set JETTY_BASE="%JETTY_ROOT%base"
 set JETTY_DEFAULTS="%JETTY_ROOT%defaults"
+REM Operator-customizable stop port/key (must match StopJetty.bat / StartJetty.bat).
+REM Change these before install/update if 50011 is taken or multiple CMS instances share a host.
+REM Values are applied as Jetty start properties jetty.shutdown.port / jetty.shutdown.key
+REM (ShutdownService). Do NOT use -DSTOP.PORT on the server JVM (deprecated ShutdownMonitor).
 set STOPKEY=SHUTDOWN
-
-REM Note stop port number must be available and unique on the server.  Copy this file,
-REM Change this number and the service name if you need
-REM to create a separate service.
 set STOPPORT=50011
 
 set PR_INSTALL="%JETTY_ROOT%service\win\prunsrv.exe"
@@ -74,11 +74,13 @@ set PR_STARTUP=auto
 set PR_STARTMODE=exe
 set PR_STARTCLASS=%JETTY_START_CLASS%
 set PR_START_PATH=%JETTY_ROOT%
-REM GH-1486: server-side shutdown is jetty.shutdown.* in start.d/shutdown.ini.
-REM Do not pass -DSTOP.PORT on the service start JVM (deprecated ShutdownMonitor).
-set PR_STARTPARAMS=-Drxdeploydir=%JETTY_ROOT%..
+REM GH-1486 / PR #1518 review: pass operator STOPPORT/STOPKEY as Jetty start properties
+REM (jetty.shutdown.*) so multi-instance installs keep a custom stop port without
+REM activating deprecated ShutdownMonitor via -DSTOP.PORT on the server JVM.
+REM StartJetty.bat already sets -Drxdeploydir; start params are forwarded via %*.
+set PR_STARTPARAMS=jetty.shutdown.port=%STOPPORT%;jetty.shutdown.key=%STOPKEY%
 
-@REM Shutdown Configuration
+@REM Shutdown Configuration (client: start.jar --stop still uses -DSTOP.PORT/-DSTOP.KEY)
 set PR_STOPMODE=exe
 set PR_STOPCLASS=%JETTY_STOP_CLASS%
 set PR_STOP_PATH=%JETTY_ROOT%

--- a/modules/perc-jetty/src/main/jetty/service/install-jetty-service.bat
+++ b/modules/perc-jetty/src/main/jetty/service/install-jetty-service.bat
@@ -74,7 +74,9 @@ set PR_STARTUP=auto
 set PR_STARTMODE=exe
 set PR_STARTCLASS=%JETTY_START_CLASS%
 set PR_START_PATH=%JETTY_ROOT%
-set PR_STARTPARAMS=-Drxdeploydir=%JETTY_ROOT%..;-DSTOP.PORT=%STOPPORT%;-DSTOP.KEY=%STOPKEY%
+REM GH-1486: server-side shutdown is jetty.shutdown.* in start.d/shutdown.ini.
+REM Do not pass -DSTOP.PORT on the service start JVM (deprecated ShutdownMonitor).
+set PR_STARTPARAMS=-Drxdeploydir=%JETTY_ROOT%..
 
 @REM Shutdown Configuration
 set PR_STOPMODE=exe

--- a/modules/perc-jetty/src/site/markdown/worklog/jetty-startup-warn-hygiene-1484-1487.md
+++ b/modules/perc-jetty/src/site/markdown/worklog/jetty-startup-warn-hygiene-1484-1487.md
@@ -68,14 +68,19 @@ moving those args onto the `StartJetty` `java` command line and removing
 **Change:**
 
 - Depend on Jetty stock `shutdown` module from `perc.mod`
-- `defaults/start.d/shutdown.ini`:
+- `defaults/start.d/shutdown.ini` defaults:
   - `jetty.shutdown.port=50011`
   - `jetty.shutdown.key=SHUTDOWN`
   - `jetty.shutdown.host=127.0.0.1`
-- Remove `-DSTOP.PORT` / `-DSTOP.KEY` from `StartJetty.bat` and Windows service
-  start params
-- **Keep** those properties on `StopJetty.bat` as **client** connection params
-  for `start.jar --stop` (must match `jetty.shutdown.*`)
+- `StartJetty.bat` / `install-jetty-service.bat` pass operator `STOPPORT` /
+  `STOPKEY` as Jetty start properties `jetty.shutdown.port` /
+  `jetty.shutdown.key` (overrides ini; does **not** activate ShutdownMonitor)
+- **Keep** `-DSTOP.PORT` / `-DSTOP.KEY` on `StopJetty.bat` and service
+  `PR_STOPPARAMS` as **client** connection params for `start.jar --stop`
+
+**PR #1518 review fix:** Restored operator customization of stop port/key on
+Windows service install (`PR_STARTPARAMS=jetty.shutdown.port=%STOPPORT%;…`).
+The first iteration had dropped `STOPPORT`/`STOPKEY` from start params entirely.
 
 ### CookieConfig.setComment → SameSite attribute
 

--- a/modules/perc-jetty/src/site/markdown/worklog/jetty-startup-warn-hygiene-1484-1487.md
+++ b/modules/perc-jetty/src/site/markdown/worklog/jetty-startup-warn-hygiene-1484-1487.md
@@ -1,0 +1,140 @@
+# Jetty startup WARN hygiene (GH-1484 – GH-1487)
+
+**Date:** 2026-07-27  
+**Issues:** [#1484](https://github.com/intersoftdatalabs-in/percussioncms/issues/1484),
+[#1485](https://github.com/intersoftdatalabs-in/percussioncms/issues/1485),
+[#1486](https://github.com/intersoftdatalabs-in/percussioncms/issues/1486),
+[#1487](https://github.com/intersoftdatalabs-in/percussioncms/issues/1487)  
+**Origin:** Windows 8.2 smoke catalog (#1369 / #1464), findings 2.1–2.6.
+
+## Summary
+
+Four classes of Jetty console noise observed on CMS 8.2 Windows smoke are fixed
+in `perc-jetty` packaging and defaults (no application Java changes).
+
+| Issue | Symptom | Fix |
+|-------|---------|-----|
+| **#1484** | Multiple SLF4J providers → NOP logger | `perc-logging` provides `logging\|default` so stock `logging-jetty` / `jetty-slf4j-impl` is not selected |
+| **#1485** | Fork second JVM for `[perc-logging, perc]` | Remove `[exec]` from those modules; consolidate JVM system properties in `start.d/jvm.ini` |
+| **#1486** | `ShutdownMonitor` + `CookieConfig.setComment` deprecations | Enable Jetty `shutdown` module (`jetty.shutdown.*`); SameSite via `setAttribute` in `Rhythmyx.xml` |
+| **#1487** | Empty `jetty.xml` Args + DigesterFactory missing schemas | Named Server constructor Args on assembled `upstream/etc/jetty.xml`; ship W3C DTD/XSD jar for DigesterFactory |
+
+## #1484 — Single SLF4J provider (Log4j2)
+
+**Root cause:** `perc-logging.mod` provided `logging-log4j2|default` but **not**
+Jetty’s `logging` capability. Jetty therefore also enabled stock
+`logging-jetty` (`jetty-slf4j-impl`). Two `SLF4JServiceProvider` implementations
+on the classpath produced “not a subtype” errors and NOP fallback.
+
+**Change:**
+
+- `defaults/modules/perc-logging.mod` → `[provides] logging|default` and
+  `logging-log4j2`
+- Hide Log4j/SLF4J packages from webapps via `jetty.webapp.addHiddenClasses`
+
+Log4j2 remains the sole SLF4J binding from `lib/perc-logging/**.jar`
+(`perc-jetty-logging` assembly, unpacked nested jars).
+
+## #1485 — Avoid module-driven JVM forks
+
+**Root cause:** Jetty `start.jar` forks whenever any enabled module contributes
+`[exec]` / `--exec` JVM args. Both `perc-logging` and `perc` declared `[exec]`,
+so the console warned:
+
+```text
+WARN : Forking second JVM due to forking module(s): [perc-logging, perc]
+```
+
+**Change:**
+
+- Remove `[exec]` from `perc-logging.mod` and `perc.mod`
+- Move Percussion-specific system properties (SAX factory, `java.library.path`,
+  commons-logging factory, etc.) into `defaults/start.d/jvm.ini`
+- Drop obsolete `-Dorg.eclipse.jetty.util.log.class=…Log4j2Logger` (depends on
+  non-packaged `log4j-appserver`; Jetty 12 logs via SLF4J → Log4j2)
+
+**Note:** `jvm.ini` still uses `--exec`, so start.jar may fork **once** for the
+`jvm` module. That is intentional Jetty design. Fully in-process start requires
+moving those args onto the `StartJetty` `java` command line and removing
+`--exec` (optional follow-up).
+
+## #1486 — ShutdownService + SameSite attribute
+
+### ShutdownMonitor → ShutdownService
+
+**Root cause:** `StartJetty.bat` passed `-DSTOP.PORT` / `-DSTOP.KEY` on the
+**server** JVM, activating deprecated `org.eclipse.jetty.server.ShutdownMonitor`.
+
+**Change:**
+
+- Depend on Jetty stock `shutdown` module from `perc.mod`
+- `defaults/start.d/shutdown.ini`:
+  - `jetty.shutdown.port=50011`
+  - `jetty.shutdown.key=SHUTDOWN`
+  - `jetty.shutdown.host=127.0.0.1`
+- Remove `-DSTOP.PORT` / `-DSTOP.KEY` from `StartJetty.bat` and Windows service
+  start params
+- **Keep** those properties on `StopJetty.bat` as **client** connection params
+  for `start.jar --stop` (must match `jetty.shutdown.*`)
+
+### CookieConfig.setComment → SameSite attribute
+
+**Root cause:** `Rhythmyx.xml` used the Jetty 9-era
+`<Set name="comment">__SAME_SITE_STRICT__</Set>` convention.
+`SessionHandler.CookieConfig.setComment` is deprecated for removal.
+
+**Change:** Servlet 6 / Jetty 12 style:
+
+```xml
+<Call name="setAttribute">
+  <Arg>SameSite</Arg>
+  <Arg>Strict</Arg>
+</Call>
+```
+
+## #1487 — jetty.xml empty Args + DigesterFactory schemas
+
+### Empty `Ignored arg [[]]` (×3)
+
+**Root cause:** Stock `jetty-home` `etc/jetty.xml` passes three unnamed
+constructor args (`threadPool`, `scheduler`, `byteBufferPool`). XmlConfiguration
+can ignore them when binding fails, logging three WARNs.
+
+**Change:** After unpacking jetty-home into `upstream/`, the perc-jetty antrun
+pass rewrites those Args to named parameters matching Jetty’s `@Name`
+annotations (`threadpool`, `scheduler`, `bufferPool`).
+
+### DigesterFactory missing XMLSchema.dtd / datatypes.dtd / xml.xsd
+
+**Root cause:** Jetty ee11-apache-jsp embeds Tomcat `DigesterFactory`, which
+expects W3C schema resources next to
+`org.apache.tomcat.util.descriptor.DigesterFactory`. Mortbay’s apache-jsp jar
+does not ship those three files.
+
+**Change:**
+
+- Source files under `src/build/perc-xml-schemas/org/apache/tomcat/util/descriptor/`
+  (redistributed from `tomcat-servlet-api` `jakarta.servlet.resources`)
+- Assembly builds `defaults/lib/perc/perc-xml-schemas.jar` (picked up by
+  `perc.mod` `lib/perc/**.jar`)
+- Keep `-Dorg.eclipse.jetty.xml.XmlParser.Validating=false` in `jvm.ini`
+  (intentional non-validating Jetty XML parse)
+
+## Tests
+
+`com.percussion.jetty.StartupWarnHygieneTest` asserts:
+
+- `logging|default` provide + no `[exec]` on perc-logging / perc
+- `jvm.ini` ownership of moved system properties
+- `shutdown.ini` + StartJetty without server-side STOP.PORT
+- StopJetty still has stop client props
+- Rhythmyx.xml SameSite attribute (no comment)
+- DigesterFactory schema source files present
+
+## Operator notes
+
+1. **Stop port/key** remain **50011** / **SHUTDOWN** (unchanged defaults).
+2. After upgrade, re-run `install-jetty-service.bat` if the Windows service was
+   registered with old start params containing `-DSTOP.PORT`.
+3. If operators previously overrode SameSite via cookie **comment** in a custom
+   context XML, migrate to `setAttribute` / `SameSite`.

--- a/modules/perc-jetty/src/site/site.xml
+++ b/modules/perc-jetty/src/site/site.xml
@@ -55,6 +55,7 @@ under the License.
             <item name="Jetty 9 to Jetty 12 Migration" href="./worklog/jetty-12-compatibility-fixes.html"/>
             <item name="Jetty EE11 Migration" href="./worklog/jetty-ee11-migration-2026-03-12.html"/>
             <item name="Jetty 12 [lib] basehome: Prefix Removal" href="./worklog/jetty-12-basehome-prefix-removal.html"/>
+            <item name="Jetty startup WARN hygiene (GH-1484–1487)" href="./worklog/jetty-startup-warn-hygiene-1484-1487.html"/>
         </menu>
         <menu ref="reports"/>
     </body>

--- a/modules/perc-jetty/src/test/java/com/percussion/jetty/StartupWarnHygieneTest.java
+++ b/modules/perc-jetty/src/test/java/com/percussion/jetty/StartupWarnHygieneTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.jetty;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * GH-1484 / GH-1485 / GH-1486 / GH-1487: Jetty startup WARN hygiene — config-level
+ * guards so SLF4J dual-provider, module forking, deprecated APIs, and DigesterFactory
+ * noise do not regress in the shipped module/ini/XML overlays.
+ *
+ * <p>Resolves files whether surefire CWD is the module directory or the monorepo root.
+ */
+class StartupWarnHygieneTest {
+
+  private static final Path MODULE_JETTY = Path.of("src", "main", "jetty");
+  private static final Path REPO_JETTY = Path.of("modules", "perc-jetty").resolve(MODULE_JETTY);
+
+  private static Path jettyRoot;
+
+  @BeforeAll
+  static void resolveJettyRoot() {
+    Path cwd = Path.of("").toAbsolutePath().normalize();
+    Path[] candidates =
+        new Path[] {
+          cwd.resolve(MODULE_JETTY),
+          cwd.resolve(REPO_JETTY),
+          cwd.getParent() != null ? cwd.getParent().resolve(REPO_JETTY) : null,
+        };
+    for (Path c : candidates) {
+      if (c != null && Files.isDirectory(c)) {
+        jettyRoot = c.normalize();
+        return;
+      }
+    }
+    fail("Could not resolve modules/perc-jetty/src/main/jetty from CWD " + cwd);
+  }
+
+  private static Path file(String first, String... more) {
+    Path p = jettyRoot.resolve(first);
+    for (String m : more) {
+      p = p.resolve(m);
+    }
+    return p;
+  }
+
+  private static String read(Path path) throws IOException {
+    assertTrue(Files.isRegularFile(path), "missing file: " + path);
+    return Files.readString(path, StandardCharsets.UTF_8);
+  }
+
+  /** Strip `#` line comments and XML `<!-- ... -->` comments for structural assertions. */
+  private static String stripComments(String text) {
+    String noXmlComments = text.replaceAll("(?s)<!--.*?-->", "");
+    return Stream.of(noXmlComments.replace("\r\n", "\n").split("\n"))
+        .map(String::trim)
+        .filter(l -> !l.isEmpty() && !l.startsWith("#"))
+        .reduce((a, b) -> a + "\n" + b)
+        .orElse("");
+  }
+
+  /** GH-1484: perc-logging must own Jetty capability logging|default (exclude logging-jetty). */
+  @Test
+  void percLoggingProvidesLoggingDefaultCapability() throws Exception {
+    String mod = stripComments(read(file("defaults", "modules", "perc-logging.mod")));
+    assertTrue(
+        mod.contains("logging|default"),
+        "perc-logging.mod must [provides] logging|default so jetty-slf4j-impl is not also selected");
+    assertFalse(
+        mod.contains("[exec]"),
+        "perc-logging.mod must not declare [exec] (GH-1485 fork hygiene)");
+  }
+
+  /** GH-1485: perc.mod must not force its own JVM fork via [exec]. */
+  @Test
+  void percModHasNoExecSection() throws Exception {
+    String mod = stripComments(read(file("defaults", "modules", "perc.mod")));
+    assertFalse(mod.contains("[exec]"), "perc.mod must not declare [exec] (consolidate in jvm.ini)");
+    assertTrue(
+        mod.contains("shutdown"),
+        "perc.mod must depend on Jetty shutdown module (GH-1486 ShutdownService)");
+  }
+
+  /** GH-1485: consolidated JVM args live only under jvm.ini --exec. */
+  @Test
+  void jvmIniOwnsForkedJvmArgs() throws Exception {
+    String jvm = read(file("defaults", "start.d", "jvm.ini"));
+    assertTrue(jvm.contains("--exec"), "jvm.ini should retain --exec for consolidated CMS JVM args");
+    assertTrue(
+        jvm.contains("PSSaxParserFactoryImpl"),
+        "jvm.ini must set Percussion SAXParserFactory (moved from perc.mod [exec])");
+    assertTrue(
+        jvm.contains("java.library.path"),
+        "jvm.ini must set java.library.path (moved from perc.mod [exec])");
+    assertTrue(
+        jvm.contains("XmlParser.Validating=false"),
+        "jvm.ini must keep intentional non-validating Jetty XML parse (GH-1487)");
+  }
+
+  /** GH-1486: ShutdownService configuration (not STOP.PORT ShutdownMonitor on server). */
+  @Test
+  void shutdownIniConfiguresShutdownService() throws Exception {
+    String ini = read(file("defaults", "start.d", "shutdown.ini"));
+    assertTrue(ini.contains("--module=shutdown"), "shutdown.ini must enable shutdown module");
+    assertTrue(ini.contains("jetty.shutdown.port=50011"), "shutdown port must match StopJetty default");
+    assertTrue(ini.contains("jetty.shutdown.key=SHUTDOWN"), "shutdown key must match StopJetty default");
+  }
+
+  /** GH-1486: StartJetty must not activate deprecated ShutdownMonitor via STOP.PORT. */
+  @Test
+  void startJettyBatDoesNotSetStopPortSystemProperties() throws Exception {
+    String bat = read(file("StartJetty.bat"));
+    // The java line must not include -DSTOP.PORT / -DSTOP.KEY (server-side monitor).
+    List<String> javaLines =
+        Stream.of(bat.replace("\r\n", "\n").split("\n"))
+            .filter(l -> l.contains("start.jar"))
+            .toList();
+    assertFalse(javaLines.isEmpty(), "StartJetty.bat must invoke start.jar");
+    for (String line : javaLines) {
+      assertFalse(
+          line.contains("-DSTOP.PORT"),
+          "StartJetty.bat start.jar line must not set -DSTOP.PORT (use shutdown.ini): " + line);
+      assertFalse(
+          line.contains("-DSTOP.KEY"),
+          "StartJetty.bat start.jar line must not set -DSTOP.KEY (use shutdown.ini): " + line);
+    }
+  }
+
+  /** GH-1486: StopJetty client still uses STOP.PORT/KEY to talk to ShutdownService. */
+  @Test
+  void stopJettyBatStillUsesStopClientProperties() throws Exception {
+    String bat = read(file("StopJetty.bat"));
+    assertTrue(bat.contains("-DSTOP.PORT"), "StopJetty.bat must pass STOP.PORT for --stop client");
+    assertTrue(bat.contains("-DSTOP.KEY"), "StopJetty.bat must pass STOP.KEY for --stop client");
+    assertTrue(bat.contains("--stop"), "StopJetty.bat must invoke start.jar --stop");
+  }
+
+  /** GH-1486: Rhythmyx.xml must not call deprecated CookieConfig.setComment. */
+  @Test
+  void rhythmyxXmlUsesSameSiteAttributeNotComment() throws Exception {
+    String xml = stripComments(read(file("base", "webapps", "Rhythmyx.xml")));
+    assertFalse(
+        xml.toLowerCase().contains("setcomment") || xml.contains("name=\"comment\""),
+        "Rhythmyx.xml must not use deprecated CookieConfig comment/SameSite comment convention");
+    assertTrue(
+        xml.contains("setAttribute") && xml.contains("SameSite"),
+        "Rhythmyx.xml must set SameSite via CookieConfig.setAttribute");
+    assertTrue(xml.contains("Strict"), "default SameSite should remain Strict");
+  }
+
+  /** GH-1487: DigesterFactory schema sources must exist for assembly packaging. */
+  @Test
+  void digesterFactorySchemaSourcesPresent() throws Exception {
+    Path cwd = Path.of("").toAbsolutePath().normalize();
+    Path[] roots =
+        new Path[] {
+          cwd.resolve(Path.of("src", "build", "perc-xml-schemas")),
+          cwd.resolve(Path.of("modules", "perc-jetty", "src", "build", "perc-xml-schemas")),
+        };
+    Path schemaRoot = null;
+    for (Path r : roots) {
+      if (Files.isDirectory(r)) {
+        schemaRoot = r;
+        break;
+      }
+    }
+    if (schemaRoot == null) {
+      fail("perc-xml-schemas build resources not found from CWD " + cwd);
+    }
+    Path desc = schemaRoot.resolve(Path.of("org", "apache", "tomcat", "util", "descriptor"));
+    for (String name : List.of("XMLSchema.dtd", "datatypes.dtd", "xml.xsd")) {
+      Path f = desc.resolve(name);
+      assertTrue(Files.isRegularFile(f), "missing DigesterFactory schema resource: " + f);
+      assertTrue(Files.size(f) > 0, "empty schema resource: " + f);
+    }
+  }
+
+  /** Sanity: perc-logging.ini still enables the module. */
+  @Test
+  void percLoggingIniEnablesModule() throws Exception {
+    String ini = read(file("defaults", "start.d", "perc-logging.ini"));
+    assertTrue(
+        Stream.of(ini.replace("\r\n", "\n").split("\n"))
+            .map(String::trim)
+            .filter(l -> !l.isEmpty() && !l.startsWith("#"))
+            .anyMatch(l -> l.contains("--module=perc-logging")),
+        "perc-logging.ini must enable --module=perc-logging");
+  }
+}

--- a/modules/perc-jetty/src/test/java/com/percussion/jetty/StartupWarnHygieneTest.java
+++ b/modules/perc-jetty/src/test/java/com/percussion/jetty/StartupWarnHygieneTest.java
@@ -145,11 +145,54 @@ class StartupWarnHygieneTest {
     for (String line : javaLines) {
       assertFalse(
           line.contains("-DSTOP.PORT"),
-          "StartJetty.bat start.jar line must not set -DSTOP.PORT (use shutdown.ini): " + line);
+          "StartJetty.bat start.jar line must not set -DSTOP.PORT (use jetty.shutdown.*): " + line);
       assertFalse(
           line.contains("-DSTOP.KEY"),
-          "StartJetty.bat start.jar line must not set -DSTOP.KEY (use shutdown.ini): " + line);
+          "StartJetty.bat start.jar line must not set -DSTOP.KEY (use jetty.shutdown.*): " + line);
+      assertTrue(
+          line.contains("jetty.shutdown.port=%STOPPORT%"),
+          "StartJetty.bat must pass jetty.shutdown.port from STOPPORT for operator overrides: "
+              + line);
+      assertTrue(
+          line.contains("jetty.shutdown.key=%STOPKEY%"),
+          "StartJetty.bat must pass jetty.shutdown.key from STOPKEY: " + line);
     }
+  }
+
+  /**
+   * GH-1486 / PR #1518 review: Windows service install must still wire operator
+   * STOPPORT/STOPKEY into the server start path without using -DSTOP.PORT.
+   */
+  @Test
+  void installJettyServiceBatPreservesCustomStopPortViaShutdownProperties() throws Exception {
+    String bat = read(file("service", "install-jetty-service.bat"));
+    assertTrue(
+        bat.contains("set STOPPORT="),
+        "install-jetty-service.bat must define STOPPORT for operator customization");
+    assertTrue(
+        bat.contains("set STOPKEY="),
+        "install-jetty-service.bat must define STOPKEY for operator customization");
+    assertTrue(
+        bat.contains("jetty.shutdown.port=%STOPPORT%"),
+        "PR_STARTPARAMS must pass jetty.shutdown.port=%STOPPORT% (not drop operator port)");
+    assertTrue(
+        bat.contains("jetty.shutdown.key=%STOPKEY%"),
+        "PR_STARTPARAMS must pass jetty.shutdown.key=%STOPKEY%");
+    // Server start params must not reintroduce deprecated ShutdownMonitor props
+    List<String> startParamLines =
+        Stream.of(bat.replace("\r\n", "\n").split("\n"))
+            .filter(l -> l.contains("PR_STARTPARAMS"))
+            .toList();
+    assertFalse(startParamLines.isEmpty(), "PR_STARTPARAMS must be set");
+    for (String line : startParamLines) {
+      assertFalse(
+          line.contains("-DSTOP.PORT") || line.contains("-DSTOP.KEY"),
+          "PR_STARTPARAMS must not use -DSTOP.PORT/-DSTOP.KEY on server: " + line);
+    }
+    // Stop client still uses STOP.* for start.jar --stop
+    assertTrue(
+        bat.contains("PR_STOPPARAMS") && bat.contains("-DSTOP.PORT=%STOPPORT%"),
+        "PR_STOPPARAMS must keep -DSTOP.PORT=%STOPPORT% for stop client");
   }
 
   /** GH-1486: StopJetty client still uses STOP.PORT/KEY to talk to ShutdownService. */
@@ -158,6 +201,7 @@ class StartupWarnHygieneTest {
     String bat = read(file("StopJetty.bat"));
     assertTrue(bat.contains("-DSTOP.PORT"), "StopJetty.bat must pass STOP.PORT for --stop client");
     assertTrue(bat.contains("-DSTOP.KEY"), "StopJetty.bat must pass STOP.KEY for --stop client");
+    assertTrue(bat.contains("%STOPKEY%"), "StopJetty.bat must use STOPKEY variable for key");
     assertTrue(bat.contains("--stop"), "StopJetty.bat must invoke start.jar --stop");
   }
 


### PR DESCRIPTION
## Summary

Fixes Jetty console startup hygiene from the Windows 8.2 smoke catalog (#1369 / #1464):

| Issue | Fix |
|-------|-----|
| **#1484** | `perc-logging` provides Jetty capability `logging|default` so stock `logging-jetty` / `jetty-slf4j-impl` is not also selected (single SLF4J provider → Log4j2) |
| **#1485** | Remove `[exec]` from `perc` / `perc-logging`; consolidate JVM system properties in `start.d/jvm.ini` (no second fork attributed to those modules) |
| **#1486** | Enable Jetty `shutdown` module (`jetty.shutdown.*`); drop server-side `-DSTOP.PORT`; SameSite via `CookieConfig.setAttribute` in `Rhythmyx.xml` |
| **#1487** | Named Server constructor Args on assembled `upstream/etc/jetty.xml`; ship `perc-xml-schemas.jar` for DigesterFactory W3C DTDs |

## Operator notes

- Stop port/key unchanged: **50011** / **SHUTDOWN**. `StopJetty` still uses `-DSTOP.PORT` / `-DSTOP.KEY` as **client** params for `start.jar --stop`.
- `jvm.ini` still uses `--exec` (one intentional `jvm` fork may remain).
- Re-run Windows service install if the service was registered with old start params containing `-DSTOP.PORT`.

## Test plan

- [x] `cd modules/perc-jetty && ../../mvn-env.bat clean install`
- [x] **BUILD SUCCESS** — Tests run: 39, Failures: 0 (includes new `StartupWarnHygieneTest` ×9)
- [x] Erlang pre-commit review: approve (`docs/ai-generated/code-reviews/1484-1487-jetty-startup-warn-hygiene-erlang.md`)
- [ ] Smoke: `StartJetty` on a fresh/ upgraded install — confirm no dual SLF4J / NOP, no fork warning for `perc-logging`/`perc`, no `ShutdownMonitor` / `setComment` deprecation, fewer DigesterFactory schema WARNs
- [ ] `StopJetty` still stops the server

Closes #1484
Closes #1485
Closes #1486
Closes #1487