### PR TITLE
feat(webui): React Login SPA as product front door (PR-1)

### DIFF
--- a/WebUI/AGENTS.md
+++ b/WebUI/AGENTS.md
@@ -17,8 +17,9 @@ Read the root [@AGENTS.md](../AGENTS.md) for general guidelines. This file conta
 - ✅ Phase 2: Build output separation to `target/generated-webui/`
 - ✅ Phase 3: Full Maven integration validated
 - ✅ Track B Home + Widget Builder: React shells (`HomeShell`, `WidgetBuilderApp`) via `PercModernUI`; classic CUI/WB clients removed on feature `989-react-cui-widget-builder`
+- ✅ **Pure React SPA (login-first):** React Login front door (`rxlogin.jsp` host → `LoginPage`) + post-login SPA landing (`/cm/app/spa.jsp`). Design: `docs/ai-generated/tasks/#000-pure-react-spa/`. Classic markup: `rxlogin-classic.jsp` (reference only).
 - 🔄 Track A: Dojo→jQuery migration planned
-- 🚀 Track B: Incremental React component migration ongoing
+- 🚀 Track B / SPA: Router + feature shells cutover next (Home/Publish/Admin…)
 
 ---
 

--- a/WebUI/src/main/ts/app/LandingShell.tsx
+++ b/WebUI/src/main/ts/app/LandingShell.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { BrandBar, BrandFooter } from "../ui-themes/components";
+import { ThemeProvider } from "../ui-themes/ThemeProvider";
+import type { SpaLandingBootstrap } from "../login/types";
+
+export interface LandingShellProps {
+  bootstrap?: SpaLandingBootstrap;
+}
+
+const shellStyle: React.CSSProperties = {
+  minHeight: "100vh",
+  display: "flex",
+  flexDirection: "column",
+  background: "var(--color-surface-alt, #f5f7fb)",
+  color: "var(--color-text, #181c2c)",
+  fontFamily: "system-ui, -apple-system, sans-serif",
+};
+
+const mainStyle: React.CSSProperties = {
+  flex: 1,
+  padding: "2rem",
+  maxWidth: 960,
+  margin: "0 auto",
+  width: "100%",
+  boxSizing: "border-box",
+};
+
+const cardStyle: React.CSSProperties = {
+  background: "var(--color-surface, #fff)",
+  border: "1px solid var(--color-border, #d8dee9)",
+  borderRadius: 12,
+  padding: "1.5rem 1.75rem",
+  boxShadow: "0 4px 16px rgba(11, 34, 74, 0.06)",
+};
+
+const navStyle: React.CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "0.75rem",
+  marginTop: "1.25rem",
+};
+
+const linkStyle: React.CSSProperties = {
+  display: "inline-block",
+  padding: "0.45rem 0.85rem",
+  borderRadius: 6,
+  background: "var(--color-primary, #4a6aa3)",
+  color: "#fff",
+  textDecoration: "none",
+  fontWeight: 600,
+  fontSize: "0.9rem",
+};
+
+/**
+ * Minimal authenticated SPA landing used until full router + shells are wired.
+ * Stakeholder demo path: Login → this shell.
+ */
+export function LandingShell({
+  bootstrap = {},
+}: LandingShellProps): React.ReactElement {
+  const name = bootstrap.userName?.trim() || "user";
+  const entry = bootstrap.entry || "home";
+
+  return (
+    <ThemeProvider>
+      <div style={shellStyle} data-testid="perc-spa-landing">
+        <BrandBar>
+          <span data-testid="perc-spa-landing-user" style={{ fontSize: "0.9rem" }}>
+            Signed in as <strong>{name}</strong>
+          </span>
+        </BrandBar>
+        <main style={mainStyle}>
+          <div style={cardStyle}>
+            <h1 data-testid="perc-spa-landing-title" style={{ marginTop: 0 }}>
+              Welcome to Percussion CMS
+            </h1>
+            <p style={{ color: "var(--color-text-muted, #5b6478)" }}>
+              You are in the modern React SPA shell
+              {entry ? (
+                <>
+                  {" "}
+                  (entry: <code data-testid="perc-spa-landing-entry">{entry}</code>)
+                </>
+              ) : null}
+              . Feature routes (Home, Publish, Admin, …) land next; this page
+              proves the front-door login → SPA path.
+            </p>
+            <nav style={navStyle} aria-label="Temporary navigation">
+              {/* Full-page exits until SPA routes exist */}
+              <a style={linkStyle} href="/cm/app/?view=home">
+                Home (current product)
+              </a>
+              <a style={linkStyle} href="/cm/app/?view=publish">
+                Publishing
+              </a>
+              <a style={linkStyle} href="/cm/app/?view=dash">
+                Dashboard
+              </a>
+              <a style={linkStyle} href="/logout">
+                Logout
+              </a>
+            </nav>
+          </div>
+        </main>
+        <BrandFooter />
+      </div>
+    </ThemeProvider>
+  );
+}

--- a/WebUI/src/main/ts/index.ts
+++ b/WebUI/src/main/ts/index.ts
@@ -16,13 +16,56 @@
  */
 
 /**
- * Main entry point for the modern UI bundle.
+ * Main entry for the modern UI bundle.
  *
- * <p>Importing this module initialises the bridge layer so that
- * {@code window.PercModernUI.mount()} is available for legacy pages.</p>
+ * <ul>
+ *   <li>Always registers {@code window.PercModernUI} for residual bridge embeds.</li>
+ *   <li>If {@code #perc-login-root} is present, boots the React Login front door.</li>
+ *   <li>If {@code #perc-spa-root} is present, boots the authenticated SPA landing.</li>
+ * </ul>
  */
 
-// Initialise the bridge (registers on window.PercModernUI)
+import React from "react";
+import { createRoot } from "react-dom/client";
 import "./bridge";
+import { LandingShell } from "./app/LandingShell";
+import { LoginPage, readLoginBootstrap, readSpaLandingBootstrap } from "./login";
+
+function bootLogin(): void {
+  const el = document.getElementById("perc-login-root");
+  if (!el) {
+    return;
+  }
+  const bootstrap = readLoginBootstrap();
+  createRoot(el).render(React.createElement(LoginPage, { bootstrap }));
+  console.info("[PercModernUI] Login SPA mounted.");
+}
+
+function bootSpaLanding(): void {
+  const el = document.getElementById("perc-spa-root");
+  if (!el) {
+    return;
+  }
+  const bootstrap = readSpaLandingBootstrap();
+  createRoot(el).render(React.createElement(LandingShell, { bootstrap }));
+  console.info("[PercModernUI] SPA landing mounted.");
+}
+
+function boot(): void {
+  // Login page is public and exclusive; SPA landing is authenticated.
+  if (document.getElementById("perc-login-root")) {
+    bootLogin();
+    return;
+  }
+  if (document.getElementById("perc-spa-root")) {
+    bootSpaLanding();
+  }
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", boot);
+} else {
+  boot();
+}
 
 console.info("[PercModernUI] Modern UI bridge loaded.");

--- a/WebUI/src/main/ts/login/LoginPage.module.css
+++ b/WebUI/src/main/ts/login/LoginPage.module.css
@@ -1,0 +1,133 @@
+/*
+ * Login page styles — Intersoft theme tokens via CSS variables on ThemeProvider.
+ */
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-surface-alt, #f5f7fb);
+  color: var(--color-text, #181c2c);
+  font-family: var(--font-family-sans, system-ui, -apple-system, sans-serif);
+}
+
+.main {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem 3rem;
+}
+
+.card {
+  width: 100%;
+  max-width: 420px;
+  background: var(--color-surface, #ffffff);
+  border: 1px solid var(--color-border, #d8dee9);
+  border-radius: 12px;
+  box-shadow: 0 8px 28px rgba(11, 34, 74, 0.08);
+  padding: 2rem 1.75rem 1.75rem;
+}
+
+.logoWrap {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1.25rem;
+}
+
+.logo {
+  max-height: 48px;
+  width: auto;
+}
+
+.title {
+  margin: 0 0 0.25rem;
+  font-size: 1.35rem;
+  font-weight: 600;
+  text-align: center;
+  color: var(--color-brand-900, #0b224a);
+}
+
+.subtitle {
+  margin: 0 0 1.5rem;
+  text-align: center;
+  font-size: 0.9rem;
+  color: var(--color-text-muted, #5b6478);
+}
+
+.formGroup {
+  margin-bottom: 1rem;
+}
+
+.label {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+  color: var(--color-text, #181c2c);
+}
+
+.input,
+.select {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid var(--color-border, #d8dee9);
+  border-radius: 6px;
+  font-size: 1rem;
+  background: var(--color-surface, #fff);
+  color: var(--color-text, #181c2c);
+}
+
+.input:focus,
+.select:focus {
+  outline: 2px solid var(--color-primary, #4a6aa3);
+  outline-offset: 1px;
+  border-color: var(--color-primary, #4a6aa3);
+}
+
+.checkboxRow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+  font-size: 0.9rem;
+}
+
+.checkboxRow input {
+  width: 1rem;
+  height: 1rem;
+}
+
+.submit {
+  width: 100%;
+  border: none;
+  border-radius: 6px;
+  padding: 0.7rem 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--color-primary, #4a6aa3);
+  color: var(--color-text-inverse, #ffffff);
+}
+
+.submit:hover {
+  background: var(--color-primary-hover, #2f456e);
+}
+
+.submit:focus {
+  outline: 2px solid var(--color-accent, #fbb03b);
+  outline-offset: 2px;
+}
+
+.error {
+  margin-top: 1rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 6px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+  font-size: 0.9rem;
+  font-weight: 600;
+  word-break: break-word;
+}

--- a/WebUI/src/main/ts/login/LoginPage.tsx
+++ b/WebUI/src/main/ts/login/LoginPage.tsx
@@ -1,0 +1,212 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useState } from "react";
+import { BrandBar, BrandFooter } from "../ui-themes/components";
+import { ThemeProvider } from "../ui-themes/ThemeProvider";
+import { useTheme } from "../ui-themes/ThemeProvider";
+import type { LoginBootstrap } from "./types";
+import styles from "./LoginPage.module.css";
+
+const SELECT_UI_STORAGE_KEY = "perc-login-select-ui-checked";
+
+export interface LoginPageProps {
+  bootstrap: LoginBootstrap;
+}
+
+function LoginForm({ bootstrap }: LoginPageProps): React.ReactElement {
+  const theme = useTheme();
+  const [username, setUsername] = useState(bootstrap.username ?? "");
+  const [password, setPassword] = useState("");
+  const [locale, setLocale] = useState(
+    bootstrap.selectedLocale || bootstrap.locales[0]?.name || "en-us",
+  );
+  const [selectUi, setSelectUi] = useState(false);
+
+  useEffect(() => {
+    try {
+      setSelectUi(localStorage.getItem(SELECT_UI_STORAGE_KEY) === "true");
+    } catch {
+      // private mode / blocked storage — ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    const el = document.getElementById("perc-login-username");
+    if (el instanceof HTMLInputElement) {
+      el.focus();
+    }
+  }, []);
+
+  const onSelectUiChange = (checked: boolean): void => {
+    setSelectUi(checked);
+    try {
+      localStorage.setItem(SELECT_UI_STORAGE_KEY, String(checked));
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div className={styles.page} data-testid="perc-login-page">
+      <BrandBar />
+      <main className={styles.main}>
+        <div className={styles.card}>
+          <div className={styles.logoWrap}>
+            <img
+              className={styles.logo}
+              src={theme.brand.logoHorizontal}
+              alt={`${theme.brand.publisher} logo`}
+              data-testid="perc-login-logo"
+            />
+          </div>
+          <h1 className={styles.title} data-testid="perc-login-title">
+            Sign in
+          </h1>
+          <p className={styles.subtitle}>{theme.brand.productName}</p>
+
+          {/*
+            Native form POST to existing /login servlet (multipart).
+            Do not convert to fetch/XHR — session cookie + redirect flow is server-owned.
+          */}
+          <form
+            id="loginform"
+            name="loginform"
+            method="post"
+            encType="multipart/form-data"
+            action={bootstrap.formAction || "/login"}
+            autoComplete={bootstrap.autocomplete || "on"}
+            data-testid="perc-login-form"
+          >
+            <input
+              type="hidden"
+              name={bootstrap.csrfTokenName}
+              value={bootstrap.csrfTokenValue}
+              data-testid="perc-login-csrf"
+            />
+            <input
+              type="hidden"
+              name="sys_redirect"
+              value={bootstrap.defaultRedirect}
+              data-testid="perc-login-redirect"
+            />
+
+            <div className={styles.formGroup}>
+              <label className={styles.label} htmlFor="perc-login-username">
+                User name
+              </label>
+              <input
+                className={styles.input}
+                type="text"
+                id="perc-login-username"
+                name="j_username"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                tabIndex={1}
+                autoComplete={bootstrap.autocomplete === "off" ? "off" : "username"}
+                data-testid="perc-login-username"
+              />
+            </div>
+
+            <div className={styles.formGroup}>
+              <label className={styles.label} htmlFor="perc-login-password">
+                Password
+              </label>
+              <input
+                className={styles.input}
+                type="password"
+                id="perc-login-password"
+                name="j_password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                tabIndex={2}
+                autoComplete={
+                  bootstrap.autocomplete === "off" ? "off" : "current-password"
+                }
+                data-testid="perc-login-password"
+              />
+            </div>
+
+            <div className={styles.formGroup}>
+              <label className={styles.label} htmlFor="perc-login-locale">
+                Locale
+              </label>
+              <select
+                className={styles.select}
+                id="perc-login-locale"
+                name="j_locale"
+                value={locale}
+                onChange={(e) => setLocale(e.target.value)}
+                data-testid="perc-login-locale"
+              >
+                {bootstrap.locales.map((loc) => (
+                  <option key={loc.name} value={loc.name}>
+                    {loc.displayName}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className={styles.checkboxRow}>
+              <input
+                type="checkbox"
+                id="perc-login-select-ui"
+                name="j_selectUI"
+                checked={selectUi}
+                onChange={(e) => onSelectUiChange(e.target.checked)}
+                data-testid="perc-login-select-ui"
+              />
+              <label htmlFor="perc-login-select-ui">Use legacy UI</label>
+            </div>
+
+            <button
+              type="submit"
+              id="perc-login-button"
+              className={styles.submit}
+              data-testid="perc-login-submit"
+            >
+              Login
+            </button>
+          </form>
+
+          {bootstrap.error ? (
+            <div
+              className={styles.error}
+              role="alert"
+              data-testid="perc-login-error"
+            >
+              {bootstrap.error}
+            </div>
+          ) : null}
+        </div>
+      </main>
+      <BrandFooter />
+    </div>
+  );
+}
+
+/**
+ * Product front-door login page (React). Posts credentials to the existing
+ * {@code /login} servlet — no parallel auth API.
+ */
+export function LoginPage({ bootstrap }: LoginPageProps): React.ReactElement {
+  return (
+    <ThemeProvider data-testid="perc-login-theme">
+      <LoginForm bootstrap={bootstrap} />
+    </ThemeProvider>
+  );
+}

--- a/WebUI/src/main/ts/login/bootstrap.ts
+++ b/WebUI/src/main/ts/login/bootstrap.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  DEFAULT_SPA_ENTRY_REDIRECT,
+  sanitizeLoginRedirect,
+} from "./redirect";
+import type { LoginBootstrap, SpaLandingBootstrap } from "./types";
+
+const LOGIN_BOOTSTRAP_ID = "perc-login-bootstrap";
+const SPA_BOOTSTRAP_ID = "perc-bootstrap";
+
+function parseJsonScript(elementId: string): unknown {
+  const el = document.getElementById(elementId);
+  if (!el || !el.textContent) {
+    return null;
+  }
+  try {
+    return JSON.parse(el.textContent);
+  } catch {
+    console.error(`[PercModernUI] Failed to parse bootstrap JSON (#${elementId})`);
+    return null;
+  }
+}
+
+function resolveCsrf(
+  rawName: string | undefined,
+  rawValue: string | undefined,
+): { name: string; value: string } {
+  let name =
+    typeof rawName === "string" && rawName.trim() ? rawName.trim() : "OWASP_CSRFTOKEN";
+  let value = typeof rawValue === "string" ? rawValue : "";
+
+  if (!value) {
+    const holder = document.getElementById("perc-csrf-holder");
+    if (holder) {
+      const hName = holder.getAttribute("data-csrf-name");
+      const hValue = holder.getAttribute("data-csrf-value");
+      if (hName) name = hName;
+      if (hValue) value = hValue;
+    }
+  }
+  if (!value && typeof window !== "undefined") {
+    const tok = window.OWASP_CSRFTOKEN?.token;
+    if (tok) value = tok;
+  }
+  return { name, value };
+}
+
+/**
+ * Reads login bootstrap from the host page JSON script tag.
+ */
+export function readLoginBootstrap(): LoginBootstrap {
+  const raw = parseJsonScript(LOGIN_BOOTSTRAP_ID) as Partial<LoginBootstrap> | null;
+  const locales = Array.isArray(raw?.locales)
+    ? raw!.locales.filter(
+        (l) =>
+          l &&
+          typeof l.name === "string" &&
+          typeof l.displayName === "string",
+      )
+    : [{ name: "en-us", displayName: "English (United States)" }];
+
+  const csrf = resolveCsrf(raw?.csrfTokenName, raw?.csrfTokenValue);
+
+  return {
+    locales,
+    selectedLocale:
+      typeof raw?.selectedLocale === "string" ? raw.selectedLocale : "en-us",
+    username: typeof raw?.username === "string" ? raw.username : "",
+    error: typeof raw?.error === "string" && raw.error.length > 0 ? raw.error : null,
+    autocomplete: raw?.autocomplete === "off" ? "off" : "on",
+    defaultRedirect: sanitizeLoginRedirect(
+      raw?.defaultRedirect,
+      DEFAULT_SPA_ENTRY_REDIRECT,
+    ),
+    csrfTokenName: csrf.name,
+    csrfTokenValue: csrf.value,
+    // Prefer relative "login" (same as classic rxlogin) so context-path deployments work.
+    formAction:
+      typeof raw?.formAction === "string" && raw.formAction
+        ? raw.formAction
+        : "login",
+  };
+}
+
+/**
+ * Reads authenticated SPA landing bootstrap (optional).
+ */
+export function readSpaLandingBootstrap(): SpaLandingBootstrap {
+  const raw = parseJsonScript(SPA_BOOTSTRAP_ID) as Partial<SpaLandingBootstrap> | null;
+  return {
+    userName: typeof raw?.userName === "string" ? raw.userName : undefined,
+    locale: typeof raw?.locale === "string" ? raw.locale : undefined,
+    entry: typeof raw?.entry === "string" ? raw.entry : "home",
+  };
+}

--- a/WebUI/src/main/ts/login/index.ts
+++ b/WebUI/src/main/ts/login/index.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { LoginPage } from "./LoginPage";
+export type { LoginPageProps } from "./LoginPage";
+export { readLoginBootstrap, readSpaLandingBootstrap } from "./bootstrap";
+export {
+  buildSpaEntryRedirect,
+  sanitizeLoginRedirect,
+  DEFAULT_SPA_ENTRY_REDIRECT,
+} from "./redirect";
+export type { LoginBootstrap, LoginLocaleOption, SpaLandingBootstrap } from "./types";

--- a/WebUI/src/main/ts/login/redirect.ts
+++ b/WebUI/src/main/ts/login/redirect.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Allowlisted SPA post-login entry paths (server entry contract — query only).
+ *
+ * @see docs/ai-generated/tasks/#000-pure-react-spa/design.md
+ */
+export const DEFAULT_SPA_ENTRY_REDIRECT = "/cm/app/spa.jsp?entry=home";
+
+const ALLOWED_ENTRIES = new Set([
+  "home",
+  "publish",
+  "workflow",
+  "admin",
+  "widget-builder",
+  "explorer",
+  "unavailable",
+]);
+
+/**
+ * Builds a path-absolute SPA entry URL. Rejects open redirects and fragments.
+ *
+ * @param entry - allowlisted entry id
+ * @param extra - optional allowlisted query pairs (section, tab, path, siteId, serverId)
+ * @returns safe path + query, or default home entry
+ */
+export function buildSpaEntryRedirect(
+  entry: string = "home",
+  extra: Record<string, string> = {},
+): string {
+  const e = (entry || "home").trim().toLowerCase();
+  const safeEntry = ALLOWED_ENTRIES.has(e) ? e : "home";
+  const params = new URLSearchParams();
+  params.set("entry", safeEntry);
+
+  const allowExtra = new Set(["section", "tab", "path", "siteId", "serverId"]);
+  for (const [k, v] of Object.entries(extra)) {
+    if (!allowExtra.has(k) || v == null) continue;
+    const trimmed = String(v).trim();
+    if (!trimmed || trimmed.length > 2048) continue;
+    // path must be relative absolute path without schemes
+    if (k === "path") {
+      if (!trimmed.startsWith("/") || trimmed.includes("://") || trimmed.includes("..")) {
+        continue;
+      }
+    }
+    params.set(k, trimmed);
+  }
+
+  return `/cm/app/spa.jsp?${params.toString()}`;
+}
+
+/**
+ * Validates a candidate post-login redirect for use as the form {@code sys_redirect} value.
+ * Only path-absolute same-app URLs to the SPA (or known CMS app roots) are accepted.
+ *
+ * @param candidate - raw redirect from bootstrap or query
+ * @param fallback - used when candidate is invalid
+ */
+export function sanitizeLoginRedirect(
+  candidate: string | null | undefined,
+  fallback: string = DEFAULT_SPA_ENTRY_REDIRECT,
+): string {
+  if (candidate == null || !String(candidate).trim()) {
+    return fallback;
+  }
+  const raw = String(candidate).trim();
+  // Never allow fragments or schemes (open redirect / fragment redirect bugs)
+  if (raw.includes("#") || raw.includes("://") || raw.startsWith("//")) {
+    return fallback;
+  }
+  if (!raw.startsWith("/") || raw.includes("..")) {
+    return fallback;
+  }
+  // Prefer SPA entry; also allow /cm/app for transitional landings
+  if (raw.startsWith("/cm/app/spa.jsp") || raw === "/cm/app" || raw.startsWith("/cm/app?")) {
+    return raw.length > 2048 ? fallback : raw;
+  }
+  return fallback;
+}

--- a/WebUI/src/main/ts/login/types.ts
+++ b/WebUI/src/main/ts/login/types.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Server-provided bootstrap for the React login page (XSS-safe JSON text node).
+ */
+export interface LoginLocaleOption {
+  name: string;
+  displayName: string;
+}
+
+export interface LoginBootstrap {
+  /** Available CMS locales for the login form */
+  locales: LoginLocaleOption[];
+  /** Selected locale name (e.g. en-us) */
+  selectedLocale?: string;
+  /** Prefill username when re-rendering after error */
+  username?: string;
+  /** Server error message; already intended for display (client still escapes in React) */
+  error?: string | null;
+  /** HTML autocomplete attribute value for username/password */
+  autocomplete?: "on" | "off";
+  /** Post-login path-absolute redirect (query entry contract) */
+  defaultRedirect: string;
+  /** CSRF token field name (OWASP CSRFGuard) */
+  csrfTokenName: string;
+  /** CSRF token value */
+  csrfTokenValue: string;
+  /** Form action path (default /login) */
+  formAction?: string;
+}
+
+/** Minimal authenticated SPA landing bootstrap */
+export interface SpaLandingBootstrap {
+  userName?: string;
+  locale?: string;
+  entry?: string;
+}

--- a/WebUI/src/main/webapp/WEB-INF/config/security/system-security-conf.xml
+++ b/WebUI/src/main/webapp/WEB-INF/config/security/system-security-conf.xml
@@ -27,7 +27,11 @@
 	<path authType="anonymous">/cm/jslib/*</path>
 	<path authType="anonymous">/cm/css/*</path>
 	<path authType="anonymous">/cm/images/*</path>
+	<!-- React Login SPA assets (public front door) -->
+	<path authType="anonymous">/cm/modern/*</path>
+	<path authType="anonymous">/cm/themes/*</path>
 	<path authType="anonymous">/rxlogin.jsp</path>
+	<path authType="anonymous">/rxlogin-classic.jsp</path>
 	<path authType="anonymous">/locale.jsp</path>
 	<path authType="anonymous">/sessionstatus.jsp</path>
 	<path authType="anonymous">/rxlogin.jsp</path>

--- a/WebUI/src/main/webapp/cm/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/app/spa.jsp
@@ -1,0 +1,90 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ page import="com.percussion.services.utils.jspel.PSRoleUtilities" %>
+<%@ taglib uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" prefix="csrf" %>
+<%--
+  Minimal authenticated SPA landing (PR-1).
+  Full router + feature shells land in subsequent PRs.
+  Entry: /cm/app/spa.jsp?entry=home (query contract — no hash redirects).
+--%>
+<%!
+    private static String jsonString(String s) {
+        if (s == null) {
+            return "null";
+        }
+        StringBuilder sb = new StringBuilder(s.length() + 16);
+        sb.append('"');
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\': sb.append("\\\\"); break;
+                case '"': sb.append("\\\""); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\t': sb.append("\\t"); break;
+                case '<': sb.append("\\u003c"); break;
+                case '>': sb.append("\\u003e"); break;
+                case '&': sb.append("\\u0026"); break;
+                case '\u2028': sb.append("\\u2028"); break;
+                case '\u2029': sb.append("\\u2029"); break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        sb.append('"');
+        return sb.toString();
+    }
+
+    private static String allowEntry(String raw) {
+        if (raw == null) {
+            return "home";
+        }
+        String n = raw.trim().toLowerCase(java.util.Locale.ROOT);
+        if ("home".equals(n) || "publish".equals(n) || "workflow".equals(n)
+                || "admin".equals(n) || "widget-builder".equals(n)
+                || "explorer".equals(n) || "unavailable".equals(n)) {
+            return n;
+        }
+        return "home";
+    }
+%>
+<%
+    String locale = PSRoleUtilities.getUserCurrentLocale();
+    String lang = "en";
+    if (locale == null) {
+        locale = "en-us";
+    } else if (locale.contains("-")) {
+        lang = locale.split("-")[0];
+    } else {
+        lang = locale;
+    }
+    String entry = allowEntry(request.getParameter("entry"));
+    String userName = request.getRemoteUser();
+    if (userName == null) {
+        userName = "";
+    }
+%>
+<!DOCTYPE html>
+<html lang="<%= lang %>">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>Percussion CMS</title>
+    <meta name="_csrf_header" content="<csrf:tokenname/>"/>
+    <meta name="_csrf" content="<csrf:tokenvalue/>"/>
+    <script src="/JavaScriptServlet"></script>
+    <script type="module" src="/cm/modern/assets/perc-modern-ui.js"></script>
+    <style>html, body { margin: 0; padding: 0; }</style>
+</head>
+<body>
+<script type="application/json" id="perc-bootstrap">{
+    "userName":<%= jsonString(userName) %>,
+    "locale":<%= jsonString(locale) %>,
+    "entry":<%= jsonString(entry) %>
+}</script>
+<div id="perc-spa-root" data-testid="perc-spa-root"></div>
+</body>
+</html>

--- a/WebUI/src/main/webapp/cm/pages/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/spa.jsp
@@ -1,0 +1,90 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ page import="com.percussion.services.utils.jspel.PSRoleUtilities" %>
+<%@ taglib uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" prefix="csrf" %>
+<%--
+  Minimal authenticated SPA landing (PR-1).
+  Full router + feature shells land in subsequent PRs.
+  Entry: /cm/app/spa.jsp?entry=home (query contract — no hash redirects).
+--%>
+<%!
+    private static String jsonString(String s) {
+        if (s == null) {
+            return "null";
+        }
+        StringBuilder sb = new StringBuilder(s.length() + 16);
+        sb.append('"');
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\': sb.append("\\\\"); break;
+                case '"': sb.append("\\\""); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\t': sb.append("\\t"); break;
+                case '<': sb.append("\\u003c"); break;
+                case '>': sb.append("\\u003e"); break;
+                case '&': sb.append("\\u0026"); break;
+                case '\u2028': sb.append("\\u2028"); break;
+                case '\u2029': sb.append("\\u2029"); break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        sb.append('"');
+        return sb.toString();
+    }
+
+    private static String allowEntry(String raw) {
+        if (raw == null) {
+            return "home";
+        }
+        String n = raw.trim().toLowerCase(java.util.Locale.ROOT);
+        if ("home".equals(n) || "publish".equals(n) || "workflow".equals(n)
+                || "admin".equals(n) || "widget-builder".equals(n)
+                || "explorer".equals(n) || "unavailable".equals(n)) {
+            return n;
+        }
+        return "home";
+    }
+%>
+<%
+    String locale = PSRoleUtilities.getUserCurrentLocale();
+    String lang = "en";
+    if (locale == null) {
+        locale = "en-us";
+    } else if (locale.contains("-")) {
+        lang = locale.split("-")[0];
+    } else {
+        lang = locale;
+    }
+    String entry = allowEntry(request.getParameter("entry"));
+    String userName = request.getRemoteUser();
+    if (userName == null) {
+        userName = "";
+    }
+%>
+<!DOCTYPE html>
+<html lang="<%= lang %>">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>Percussion CMS</title>
+    <meta name="_csrf_header" content="<csrf:tokenname/>"/>
+    <meta name="_csrf" content="<csrf:tokenvalue/>"/>
+    <script src="/JavaScriptServlet"></script>
+    <script type="module" src="/cm/modern/assets/perc-modern-ui.js"></script>
+    <style>html, body { margin: 0; padding: 0; }</style>
+</head>
+<body>
+<script type="application/json" id="perc-bootstrap">{
+    "userName":<%= jsonString(userName) %>,
+    "locale":<%= jsonString(locale) %>,
+    "entry":<%= jsonString(entry) %>
+}</script>
+<div id="perc-spa-root" data-testid="perc-spa-root"></div>
+</body>
+</html>

--- a/WebUI/src/main/webapp/rxlogin-classic.jsp
+++ b/WebUI/src/main/webapp/rxlogin-classic.jsp
@@ -1,0 +1,165 @@
+<%@ page import="java.util.*" %>
+<%@ page import="com.percussion.server.PSServer" %>
+<%@ page import="com.percussion.i18n.PSI18nUtils" %>
+<%@ page import="com.percussion.i18n.PSLocaleManager" %>
+<%@ page import="com.percussion.i18n.PSLocale" session="true" %>
+<%@ page import="com.percussion.i18n.PSLocaleException" %>
+<%@ taglib uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" prefix="csrf" %>
+<%@ taglib uri="http://rhythmyx.percussion.com/components"
+		   prefix="rxcomp"%>
+<%
+	String username = request.getParameter("j_username");
+	String password = request.getParameter("j_password");
+	String locale = request.getParameter("j_locale");
+	String error = request.getParameter("j_error");
+	String lang="en";
+
+	if (username == null)
+		username = "";
+	if (password == null)
+		password = "";
+
+	if(locale==null){
+		locale= PSI18nUtils.getSystemLanguage();
+	}else{
+		if(locale.contains("-"))
+			lang=locale.split("-")[0];
+		else
+			lang=locale;
+	}
+
+	pageContext.setAttribute("locale",locale);
+
+	String loginComplete = PSServer.getServerProps().getProperty("loginAutoComplete");
+	String autoComplete;
+	if(loginComplete != null && loginComplete.equalsIgnoreCase("off") ){
+		autoComplete = "autocomplete='off'";
+	}else{
+		autoComplete = "autocomplete='on'";
+	}
+
+	PSLocaleManager locManager = PSLocaleManager.getInstance();
+
+%>
+<!DOCTYPE html>
+<html lang="<%=lang %>">
+<head>
+	<title>${rxcomp:i18ntext('jsp_login@Percussion Login',locale)}</title>
+	<style>
+		body {
+			font-family: Verdana, serif; margin: 0; padding: 0; }
+		.perc-login-logo {color: #121212; margin-top: 50px; margin-bottom: 50px;}
+		#loginform .perc-form    { }
+		#perc-forgot {color: #fff;}
+		#perc-forgot-username{display:none;}
+		#perc-forgot-pass{display:none;}
+		#perc-register{display:none;}
+
+		#perc-forgot:hover   {cursor:pointer;}
+		input { padding: 0; }
+		img:hover    {cursor: pointer;}
+		.error {font-weight:bold; margin-top:10px; }
+		.btn-primary {
+			background-color: #133c55 !important;
+			border-color: #FFFFFF !important;
+			color: #FFFFFF;
+		}
+	</style>
+	<script>
+		function setCursor() {
+			// leave focus in username
+			cmd = document.getElementById("perc-login-username");
+			cmd.focus();
+		}
+	</script>
+	<link rel="stylesheet" type="text/css" href="/cm/jslib/profiles/3x/libraries/bootstrap/css/bootstrap.min.css"/>
+	<script
+			src="/Rhythmyx/tmx/tmx.jsp?mode=js&amp;prefix=perc.ui.&amp;sys_lang=en-us"></script>
+	<script src="/JavaScriptServlet"></script>
+	<script src="/cm/jslib/profiles/3x/jquery/jquery-3.6.0.js"></script>
+	<script src="/cm/jslib/profiles/3x/jquery/jquery-migrate-3.3.2.js"></script>
+
+	<script src="/cm/jslib/profiles/3x/libraries/bootstrap/js/bootstrap.min.js"></script>
+</head>
+<body onload="setCursor()">
+<div class="container">
+	<div class='perc-login row center-block'>
+		<csrf:form id="loginform" name="loginform" method="post" enctype="multipart/form-data" action="login">
+			<div class='perc-login-logo'><img src="/sys_resources/images/percussion-logo.png" alt="${rxcomp:i18ntext('general@Percussion Logo Alt',locale)}" title="${rxcomp:i18ntext('general@Percussion Logo Title',locale)}"/></div>
+			<div class='perc-form'>
+				<div class="form-group">
+					<label for="perc-login-username">${rxcomp:i18ntext('jsp_login@User name',locale)}</label>
+					<input type="text" id="perc-login-username"  name="j_username"  value="<%= username %>" tabindex="1" class="form-control" <%= autoComplete %>/>
+				</div>
+				<div class="form-group">
+					<label for="perc-login-password">${rxcomp:i18ntext('jsp_login@Password',locale)}</label>
+					<input type="password" id="perc-login-password" name="j_password" value="<%= password %>" tabindex="2" class="form-control" <%= autoComplete %>/>
+				</div>
+				<div class="form-group">
+					<label for="perc-login-locale">${rxcomp:i18ntext('jsp_login@Locale',locale)}</label>
+					<select id="perc-login-locale" name="j_locale" class="form-control">
+						<%
+							Iterator<PSLocale> locales = locManager.getLocales();
+							while (locales.hasNext())
+							{
+								PSLocale loc= locales.next();
+								String selected = "false";
+								if(loc.getName().equalsIgnoreCase("en-us"))
+									selected = "true";
+						%>
+						<option selected="<%= selected %>" value="<%=loc.getName() %>"><%= loc.getDisplayName() %></option>
+						<% }%>
+					</select>
+				</div>
+				<div class="form-group">
+					<label for="perc-login-select-ui">${rxcomp:i18ntext('jsp_login@SelectUI',locale)}</label>
+					<input id="perc-login-select-ui" name="j_selectUI" type="checkbox">
+				</div>
+				<button type="submit" id="perc-login-button" form="loginform" class="btn btn-primary btn-default">${rxcomp:i18ntext('jsp_login@LoginButton',locale)}</button>
+			</div>
+		</csrf:form>
+	</div>
+	<div class="row">
+		<div class="col-sm-4">
+			<hr/>
+		</div>
+	</div>
+	<div class="row">
+		<div id="perc-forgot-username" class="col-sm-4">
+			<p>
+				${rxcomp:i18ntext('jsp_login@Forgot your username',locale)} <a href="#" title="${rxcomp:i18ntext('jsp_login@Forgot your username',locale)}">${rxcomp:i18ntext('general@click here',locale)}</a>
+			</p>
+		</div>
+		<div id="perc-forgot-pass" class="col-sm-8">
+			<p>
+				${rxcomp:i18ntext('jsp_login@Forgot your password',locale)} <a href="#" title="${rxcomp:i18ntext('jsp_login@Forgot your password',locale)}">${rxcomp:i18ntext('general@click here',locale)}</a>
+			</p>
+		</div>
+	</div>
+	<div class="row">
+		<div id="perc-register" class="span 12">
+			<p>Don't have a login?  Click the button below to request access from your System Administrator.</p>
+			<button type="button" id="perc-register-button" class="btn btn-primary">Request an Account</button>
+		</div>
+	</div>
+	<%
+		if (error != null)
+		{
+	%>
+	<div class="error"><%=error%></div>
+	<%  }
+	%>
+
+</div>
+<script>
+	jQuery(function ($) {
+		var checked = localStorage.getItem('perc-login-select-ui-checked') === "true";
+		$('#perc-login-select-ui').prop('checked', checked);
+		$('#perc-login-select-ui').on("change",function () {
+			var isChecked = $(this).is(':checked');
+			localStorage.setItem('perc-login-select-ui-checked', isChecked);
+		});
+	});
+</script>
+</body>
+</html>

--- a/WebUI/src/main/webapp/rxlogin.jsp
+++ b/WebUI/src/main/webapp/rxlogin.jsp
@@ -1,165 +1,154 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ page import="java.util.*" %>
 <%@ page import="com.percussion.server.PSServer" %>
 <%@ page import="com.percussion.i18n.PSI18nUtils" %>
 <%@ page import="com.percussion.i18n.PSLocaleManager" %>
-<%@ page import="com.percussion.i18n.PSLocale" session="true" %>
-<%@ page import="com.percussion.i18n.PSLocaleException" %>
+<%@ page import="com.percussion.i18n.PSLocale" %>
 <%@ taglib uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" prefix="csrf" %>
-<%@ taglib uri="http://rhythmyx.percussion.com/components"
-		   prefix="rxcomp"%>
+<%--
+  React Login SPA host (product front door).
+  Classic markup retained as reference: rxlogin-classic.jsp
+  Auth remains POST /login — this page hosts the React UI + XSS-safe bootstrap.
+--%>
+<%!
+    private static String jsonString(String s) {
+        if (s == null) {
+            return "null";
+        }
+        StringBuilder sb = new StringBuilder(s.length() + 16);
+        sb.append('"');
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\': sb.append("\\\\"); break;
+                case '"': sb.append("\\\""); break;
+                case '\b': sb.append("\\b"); break;
+                case '\f': sb.append("\\f"); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\t': sb.append("\\t"); break;
+                case '<': sb.append("\\u003c"); break;
+                case '>': sb.append("\\u003e"); break;
+                case '&': sb.append("\\u0026"); break;
+                case '\u2028': sb.append("\\u2028"); break;
+                case '\u2029': sb.append("\\u2029"); break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        sb.append('"');
+        return sb.toString();
+    }
+%>
 <%
-	String username = request.getParameter("j_username");
-	String password = request.getParameter("j_password");
-	String locale = request.getParameter("j_locale");
-	String error = request.getParameter("j_error");
-	String lang="en";
+    String username = request.getParameter("j_username");
+    String locale = request.getParameter("j_locale");
+    String error = request.getParameter("j_error");
+    String lang = "en";
 
-	if (username == null)
-		username = "";
-	if (password == null)
-		password = "";
+    if (username == null) {
+        username = "";
+    }
+    if (locale == null) {
+        locale = PSI18nUtils.getSystemLanguage();
+    }
+    if (locale != null && locale.contains("-")) {
+        lang = locale.split("-")[0];
+    } else if (locale != null) {
+        lang = locale;
+    }
 
-	if(locale==null){
-		locale= PSI18nUtils.getSystemLanguage();
-	}else{
-		if(locale.contains("-"))
-			lang=locale.split("-")[0];
-		else
-			lang=locale;
-	}
+    String loginComplete = PSServer.getServerProps().getProperty("loginAutoComplete");
+    String autocomplete = "on";
+    if (loginComplete != null && loginComplete.equalsIgnoreCase("off")) {
+        autocomplete = "off";
+    }
 
-	pageContext.setAttribute("locale",locale);
+    // Default post-login SPA entry (query contract — never use # fragments).
+    String defaultRedirect = "/cm/app/spa.jsp?entry=home";
+    String returnParam = request.getParameter("return");
+    if (returnParam != null
+            && returnParam.startsWith("/cm/app/spa.jsp")
+            && !returnParam.contains("..")
+            && !returnParam.contains("://")
+            && !returnParam.contains("#")
+            && returnParam.length() < 2048) {
+        defaultRedirect = returnParam;
+    }
 
-	String loginComplete = PSServer.getServerProps().getProperty("loginAutoComplete");
-	String autoComplete;
-	if(loginComplete != null && loginComplete.equalsIgnoreCase("off") ){
-		autoComplete = "autocomplete='off'";
-	}else{
-		autoComplete = "autocomplete='on'";
-	}
-
-	PSLocaleManager locManager = PSLocaleManager.getInstance();
-
+    PSLocaleManager locManager = PSLocaleManager.getInstance();
+    StringBuilder localesJson = new StringBuilder();
+    localesJson.append('[');
+    boolean first = true;
+    Iterator<PSLocale> locales = locManager.getLocales();
+    while (locales.hasNext()) {
+        PSLocale loc = locales.next();
+        if (!first) {
+            localesJson.append(',');
+        }
+        first = false;
+        localesJson.append('{')
+                .append("\"name\":").append(jsonString(loc.getName())).append(',')
+                .append("\"displayName\":").append(jsonString(loc.getDisplayName()))
+                .append('}');
+    }
+    localesJson.append(']');
 %>
 <!DOCTYPE html>
-<html lang="<%=lang %>">
+<html lang="<%= lang %>">
 <head>
-	<title>${rxcomp:i18ntext('jsp_login@Percussion Login',locale)}</title>
-	<style>
-		body {
-			font-family: Verdana, serif; margin: 0; padding: 0; }
-		.perc-login-logo {color: #121212; margin-top: 50px; margin-bottom: 50px;}
-		#loginform .perc-form    { }
-		#perc-forgot {color: #fff;}
-		#perc-forgot-username{display:none;}
-		#perc-forgot-pass{display:none;}
-		#perc-register{display:none;}
-
-		#perc-forgot:hover   {cursor:pointer;}
-		input { padding: 0; }
-		img:hover    {cursor: pointer;}
-		.error {font-weight:bold; margin-top:10px; }
-		.btn-primary {
-			background-color: #133c55 !important;
-			border-color: #FFFFFF !important;
-			color: #FFFFFF;
-		}
-	</style>
-	<script>
-		function setCursor() {
-			// leave focus in username
-			cmd = document.getElementById("perc-login-username");
-			cmd.focus();
-		}
-	</script>
-	<link rel="stylesheet" type="text/css" href="/cm/jslib/profiles/3x/libraries/bootstrap/css/bootstrap.min.css"/>
-	<script
-			src="/Rhythmyx/tmx/tmx.jsp?mode=js&amp;prefix=perc.ui.&amp;sys_lang=en-us"></script>
-	<script src="/JavaScriptServlet"></script>
-	<script src="/cm/jslib/profiles/3x/jquery/jquery-3.6.0.js"></script>
-	<script src="/cm/jslib/profiles/3x/jquery/jquery-migrate-3.3.2.js"></script>
-
-	<script src="/cm/jslib/profiles/3x/libraries/bootstrap/js/bootstrap.min.js"></script>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>Percussion CMS — Sign in</title>
+    <meta name="_csrf_header" content="<csrf:tokenname/>"/>
+    <meta name="_csrf" content="<csrf:tokenvalue/>"/>
+    <script src="/JavaScriptServlet"></script>
+    <script type="module" src="/cm/modern/assets/perc-modern-ui.js"></script>
+    <style>html, body { margin: 0; padding: 0; }</style>
 </head>
-<body onload="setCursor()">
-<div class="container">
-	<div class='perc-login row center-block'>
-		<csrf:form id="loginform" name="loginform" method="post" enctype="multipart/form-data" action="login">
-			<div class='perc-login-logo'><img src="/sys_resources/images/percussion-logo.png" alt="${rxcomp:i18ntext('general@Percussion Logo Alt',locale)}" title="${rxcomp:i18ntext('general@Percussion Logo Title',locale)}"/></div>
-			<div class='perc-form'>
-				<div class="form-group">
-					<label for="perc-login-username">${rxcomp:i18ntext('jsp_login@User name',locale)}</label>
-					<input type="text" id="perc-login-username"  name="j_username"  value="<%= username %>" tabindex="1" class="form-control" <%= autoComplete %>/>
-				</div>
-				<div class="form-group">
-					<label for="perc-login-password">${rxcomp:i18ntext('jsp_login@Password',locale)}</label>
-					<input type="password" id="perc-login-password" name="j_password" value="<%= password %>" tabindex="2" class="form-control" <%= autoComplete %>/>
-				</div>
-				<div class="form-group">
-					<label for="perc-login-locale">${rxcomp:i18ntext('jsp_login@Locale',locale)}</label>
-					<select id="perc-login-locale" name="j_locale" class="form-control">
-						<%
-							Iterator<PSLocale> locales = locManager.getLocales();
-							while (locales.hasNext())
-							{
-								PSLocale loc= locales.next();
-								String selected = "false";
-								if(loc.getName().equalsIgnoreCase("en-us"))
-									selected = "true";
-						%>
-						<option selected="<%= selected %>" value="<%=loc.getName() %>"><%= loc.getDisplayName() %></option>
-						<% }%>
-					</select>
-				</div>
-				<div class="form-group">
-					<label for="perc-login-select-ui">${rxcomp:i18ntext('jsp_login@SelectUI',locale)}</label>
-					<input id="perc-login-select-ui" name="j_selectUI" type="checkbox">
-				</div>
-				<button type="submit" id="perc-login-button" form="loginform" class="btn btn-primary btn-default">${rxcomp:i18ntext('jsp_login@LoginButton',locale)}</button>
-			</div>
-		</csrf:form>
-	</div>
-	<div class="row">
-		<div class="col-sm-4">
-			<hr/>
-		</div>
-	</div>
-	<div class="row">
-		<div id="perc-forgot-username" class="col-sm-4">
-			<p>
-				${rxcomp:i18ntext('jsp_login@Forgot your username',locale)} <a href="#" title="${rxcomp:i18ntext('jsp_login@Forgot your username',locale)}">${rxcomp:i18ntext('general@click here',locale)}</a>
-			</p>
-		</div>
-		<div id="perc-forgot-pass" class="col-sm-8">
-			<p>
-				${rxcomp:i18ntext('jsp_login@Forgot your password',locale)} <a href="#" title="${rxcomp:i18ntext('jsp_login@Forgot your password',locale)}">${rxcomp:i18ntext('general@click here',locale)}</a>
-			</p>
-		</div>
-	</div>
-	<div class="row">
-		<div id="perc-register" class="span 12">
-			<p>Don't have a login?  Click the button below to request access from your System Administrator.</p>
-			<button type="button" id="perc-register-button" class="btn btn-primary">Request an Account</button>
-		</div>
-	</div>
-	<%
-		if (error != null)
-		{
-	%>
-	<div class="error"><%=error%></div>
-	<%  }
-	%>
-
-</div>
+<body>
+<%-- Hidden holder for CSRF tags (merged into bootstrap before React mounts). --%>
+<div id="perc-csrf-holder"
+     data-csrf-name="<csrf:tokenname/>"
+     data-csrf-value="<csrf:tokenvalue/>"
+     hidden
+     aria-hidden="true"></div>
+<script type="application/json" id="perc-login-bootstrap">{
+  "locales":<%= localesJson.toString() %>,
+  "selectedLocale":<%= jsonString(locale) %>,
+  "username":<%= jsonString(username) %>,
+  "error":<%= error == null || error.isEmpty() ? "null" : jsonString(error) %>,
+  "autocomplete":<%= jsonString(autocomplete) %>,
+  "defaultRedirect":<%= jsonString(defaultRedirect) %>,
+  "csrfTokenName":"OWASP_CSRFTOKEN",
+  "csrfTokenValue":"",
+  "formAction":"login"
+}</script>
+<div id="perc-login-root" data-testid="perc-login-root"></div>
 <script>
-	jQuery(function ($) {
-		var checked = localStorage.getItem('perc-login-select-ui-checked') === "true";
-		$('#perc-login-select-ui').prop('checked', checked);
-		$('#perc-login-select-ui').on("change",function () {
-			var isChecked = $(this).is(':checked');
-			localStorage.setItem('perc-login-select-ui-checked', isChecked);
-		});
-	});
+    (function () {
+        try {
+            var holder = document.getElementById("perc-csrf-holder");
+            var bootEl = document.getElementById("perc-login-bootstrap");
+            if (!holder || !bootEl || !bootEl.textContent) return;
+            var data = JSON.parse(bootEl.textContent);
+            var name = holder.getAttribute("data-csrf-name") || "OWASP_CSRFTOKEN";
+            var value = holder.getAttribute("data-csrf-value") || "";
+            data.csrfTokenName = name;
+            if (value) {
+                data.csrfTokenValue = value;
+            } else if (window.OWASP_CSRFTOKEN && window.OWASP_CSRFTOKEN.token) {
+                data.csrfTokenValue = window.OWASP_CSRFTOKEN.token;
+            }
+            bootEl.textContent = JSON.stringify(data);
+        } catch (e) {
+            console.error("[rxlogin] CSRF bootstrap merge failed", e);
+        }
+    })();
 </script>
 </body>
 </html>

--- a/WebUI/src/test/ts/app/LandingShell.test.tsx
+++ b/WebUI/src/test/ts/app/LandingShell.test.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LandingShell } from "@/app/LandingShell";
+
+describe("LandingShell", () => {
+  it("renders authenticated landing chrome", () => {
+    render(<LandingShell bootstrap={{ userName: "demo", entry: "home" }} />);
+    expect(screen.getByTestId("perc-spa-landing")).toBeDefined();
+    expect(screen.getByTestId("perc-spa-landing-title").textContent).toMatch(
+      /Welcome/i,
+    );
+    expect(screen.getByTestId("perc-spa-landing-user").textContent).toContain("demo");
+    expect(screen.getByTestId("perc-spa-landing-entry").textContent).toBe("home");
+  });
+});

--- a/WebUI/src/test/ts/login/LoginPage.test.tsx
+++ b/WebUI/src/test/ts/login/LoginPage.test.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { LoginPage } from "@/login/LoginPage";
+import type { LoginBootstrap } from "@/login/types";
+
+const baseBootstrap: LoginBootstrap = {
+  locales: [
+    { name: "en-us", displayName: "English (United States)" },
+    { name: "fr-fr", displayName: "French (France)" },
+  ],
+  selectedLocale: "en-us",
+  username: "",
+  error: null,
+  autocomplete: "on",
+  defaultRedirect: "/cm/app/spa.jsp?entry=home",
+  csrfTokenName: "OWASP_CSRFTOKEN",
+  csrfTokenValue: "test-csrf-token",
+  formAction: "login",
+};
+
+describe("LoginPage", () => {
+  it("renders front-door form fields and posts to /login", () => {
+    render(<LoginPage bootstrap={baseBootstrap} />);
+
+    expect(screen.getByTestId("perc-login-page")).toBeDefined();
+    expect(screen.getByTestId("perc-login-title").textContent).toMatch(/Sign in/i);
+
+    const form = screen.getByTestId("perc-login-form") as HTMLFormElement;
+    expect(form.method.toLowerCase()).toBe("post");
+    // jsdom resolves relative action against the document URL
+    expect(form.getAttribute("action")).toBe("login");
+    expect(form.enctype).toMatch(/multipart\/form-data/i);
+
+    expect(screen.getByTestId("perc-login-username")).toBeDefined();
+    expect(screen.getByTestId("perc-login-password")).toBeDefined();
+    expect(screen.getByTestId("perc-login-locale")).toBeDefined();
+    expect(screen.getByTestId("perc-login-submit")).toBeDefined();
+
+    const csrf = screen.getByTestId("perc-login-csrf") as HTMLInputElement;
+    expect(csrf.name).toBe("OWASP_CSRFTOKEN");
+    expect(csrf.value).toBe("test-csrf-token");
+
+    const redirect = screen.getByTestId("perc-login-redirect") as HTMLInputElement;
+    expect(redirect.name).toBe("sys_redirect");
+    expect(redirect.value).toBe("/cm/app/spa.jsp?entry=home");
+  });
+
+  it("shows server error without interpreting HTML", () => {
+    render(
+      <LoginPage
+        bootstrap={{
+          ...baseBootstrap,
+          error: "<script>alert(1)</script> bad credentials",
+        }}
+      />,
+    );
+    const err = screen.getByTestId("perc-login-error");
+    // React text content escapes — no script child
+    expect(err.textContent).toContain("bad credentials");
+    expect(err.querySelector("script")).toBeNull();
+  });
+
+  it("updates username field state", () => {
+    render(<LoginPage bootstrap={baseBootstrap} />);
+    const input = screen.getByTestId("perc-login-username") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "admin" } });
+    expect(input.value).toBe("admin");
+  });
+
+  it("renders Intersoft brand chrome", () => {
+    render(<LoginPage bootstrap={baseBootstrap} />);
+    expect(screen.getByTestId("perc-brand-bar")).toBeDefined();
+    expect(screen.getByTestId("perc-brand-footer")).toBeDefined();
+  });
+});

--- a/WebUI/src/test/ts/login/redirect.test.ts
+++ b/WebUI/src/test/ts/login/redirect.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildSpaEntryRedirect,
+  sanitizeLoginRedirect,
+  DEFAULT_SPA_ENTRY_REDIRECT,
+} from "@/login/redirect";
+
+describe("login redirect helpers", () => {
+  it("builds default home SPA entry", () => {
+    expect(buildSpaEntryRedirect()).toBe("/cm/app/spa.jsp?entry=home");
+    expect(DEFAULT_SPA_ENTRY_REDIRECT).toBe("/cm/app/spa.jsp?entry=home");
+  });
+
+  it("allowlists entries and rejects unknown", () => {
+    expect(buildSpaEntryRedirect("publish")).toContain("entry=publish");
+    expect(buildSpaEntryRedirect("evil")).toBe("/cm/app/spa.jsp?entry=home");
+  });
+
+  it("includes allowlisted extra params only", () => {
+    const url = buildSpaEntryRedirect("publish", {
+      section: "logs",
+      siteId: "42",
+      evil: "nope",
+    });
+    expect(url).toContain("entry=publish");
+    expect(url).toContain("section=logs");
+    expect(url).toContain("siteId=42");
+    expect(url).not.toContain("evil");
+  });
+
+  it("rejects open redirects and fragments", () => {
+    expect(sanitizeLoginRedirect("http://evil.example/x")).toBe(DEFAULT_SPA_ENTRY_REDIRECT);
+    expect(sanitizeLoginRedirect("//evil.example/x")).toBe(DEFAULT_SPA_ENTRY_REDIRECT);
+    expect(sanitizeLoginRedirect("/cm/app/spa.jsp?entry=home#/hack")).toBe(
+      DEFAULT_SPA_ENTRY_REDIRECT,
+    );
+    expect(sanitizeLoginRedirect("../etc/passwd")).toBe(DEFAULT_SPA_ENTRY_REDIRECT);
+  });
+
+  it("accepts SPA and transitional /cm/app paths", () => {
+    expect(sanitizeLoginRedirect("/cm/app/spa.jsp?entry=workflow")).toBe(
+      "/cm/app/spa.jsp?entry=workflow",
+    );
+    expect(sanitizeLoginRedirect("/cm/app")).toBe("/cm/app");
+  });
+});

--- a/docs/ai-generated/code-reviews/000-react-login-spa-pr1-erlang.md
+++ b/docs/ai-generated/code-reviews/000-react-login-spa-pr1-erlang.md
@@ -1,0 +1,39 @@
+# Erlang review — feat/000-react-login-spa-pr1
+
+**Date:** 2026-07-27  
+**Scope:** Pure React SPA PR-1 — React Login front door + minimal SPA landing vs `origin/development`.  
+**Memory patterns hit:** open redirects; XSS via bootstrap; missing behavioral tests; dual-tree JSP drift.
+
+## Summary
+
+PR-1 ships React Login as the product front door (`rxlogin.jsp` host), preserves classic markup as `rxlogin-classic.jsp`, and lands successful auth on thin authenticated `spa.jsp` hosts with `LandingShell`. Auth remains form POST to existing `/login`. Default `PSLoginServlet` landing is `/cm/app/spa.jsp?entry=home` (query contract, no hash). Client redirect helpers allowlist SPA entries; server-side `resolveSafePostLoginRedirect` tests updated.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs | None found |
+| Behavioral unit tests | Vitest 10/10 login+landing; `PSLoginServletTest` updated for SPA default |
+| Open redirect | Client sanitize + server resolveSafePostLoginRedirect; fragments/schemes rejected |
+| Bootstrap XSS | JSP `jsonString` escapes HTML-sensitive chars into JSON script block |
+| Cross-platform paths | N/A (URL paths use `/` correctly) |
+| May commit/push | **yes** |
+
+## Issues
+
+None (hard gate).
+
+### Suggestions (non-blocking)
+
+1. **Anonymous `/cm/modern/*` and `/cm/themes/*`:** Required so the public login page can load the modern bundle. Accept residual that unauthenticated clients can fetch modern JS/CSS (no secret content assumed). Document in security review if scanners flag it.
+2. **`spa.jsp` dual tree** (`cm/app` + `cm/pages/app`): Aligns with design dual-tree policy; keep in lockstep on future SPA PRs.
+3. **LandingShell is intentionally minimal** (PR-1 demo path); full router is out of scope.
+
+## Test evidence
+
+- `cd WebUI && npm test -- --run src/test/ts/login src/test/ts/app` → 10 tests, 0 failures  
+- `cd system && ../mvn-env.sh test -Dtest=PSLoginServletTest` + clean install (see PR body)  

--- a/docs/ai-generated/tasks/#000-pure-react-spa/design.md
+++ b/docs/ai-generated/tasks/#000-pure-react-spa/design.md
@@ -1,0 +1,865 @@
+# Design: Pure React / TypeScript WebUI — Eliminate JSP Shells
+
+| Field | Value |
+|-------|-------|
+| **Status** | Implementation-ready (rev **3.2** — **aggressive SPA-first**, **login-first demo path**) |
+| **Module** | `WebUI/` |
+| **Branch base** | `development` |
+| **Stack (verified)** | React 19.1, TypeScript 5.8, Vite 8, Jetty WAR under `/cm/` |
+| **Canonical frontend** | `WebUI/src/main/frontend/` (Maven `frontend-maven-plugin` `workingDirectory`). Root `WebUI/package.json` / `WebUI/vite.config.ts` are **not** product build paths. |
+| **Supersedes** | Track B shell architecture in `docs/ai-generated/tasks/#000-unified-ui-plan/unified-ui-plan.md`; design revs 1–2 dual-mode / soft-flag strategies; rev 3.1 “login deferred” sequencing |
+| **Cutover stance** | **Aggressive SPA-first.** The SPA is the product UI. No dual-mode production path, no feature-flag kill-switch story. Old JSP shells may linger as **reference only** until cleanup deletes them. |
+| **Demo sequencing (locked)** | **Start at the front door:** React Login is the first shippable vertical slice so stakeholders can demo Login → SPA app without walking through legacy `rxlogin.jsp`. Authenticated shell routes follow immediately. |
+| **Out of scope (initially)** | Full React rewrite of webmgt editor, template layout/style, site architecture, Dojo AA/CB (Track A), Package Manager GWT, Desktop CE; inventing a parallel auth API (reuse existing `/login` POST) |
+
+---
+
+## 1. Problem statement & current state
+
+### 1.1 Problem
+
+CM1 WebUI modernized features by mounting React shells into per-feature JSP hosts via `window.PercModernUI.mount()`. That bridge got features shipped; it is no longer the product architecture we will extend.
+
+**Product decision (locked):** stop investing in multi-page JSP shells and dual production modes. Build the pure React + TypeScript SPA as the **real** CM1 WebUI for modern features **now**. Navigation, chrome, bootstrap, and deep links live in the SPA. Client routing owns modern feature navigation. Legacy jQuery pages remain temporary **exits** (full page load out of the SPA), not peers of the SPA.
+
+Pain of the current hybrid:
+
+- Full multi-page reloads via `index.jsp` → `*Modern.jsp` between Home, Publish, Workflow Admin, Admin, Widget Builder.
+- Each JSP re-implements locale/TMX, CSRF, header, allowlists, inline mount scripts (XSS surface).
+- No `react-router-dom` today; aspirational `REACT-ROUTER-GUIDE.md` / `REDUX-ARCHITECTURE.md` are **not** implemented.
+- Dual tree drift: `cm/app/` vs `cm/pages/app/` (workflow modern vs legacy; `admin` missing on pages).
+- Static `registry.ts` pulls every shell into one ~882KB bundle for every embed host.
+
+### 1.2 Verified hybrid architecture (code baseline)
+
+| Layer | Path / fact |
+|-------|-------------|
+| TS sources | `WebUI/src/main/ts/` (~95 `.tsx`, ~70 `.ts`) |
+| Canonical build | `WebUI/src/main/frontend/` → Vite `base: "/cm/modern/"`, outDir `target/generated-webui/cm/modern`, entry `assets/perc-modern-ui.js` |
+| Entry today | `index.ts` → `bridge.ts` only |
+| Bridge | `window.PercModernUI.mount(elementId, componentName, props)` |
+| Registry | Static imports of all shells (no code-split) |
+| Dispatcher | `cm/app/index.jsp` (diverging `cm/pages/app/index.jsp`) |
+| REST | `api/client.ts` + feature APIs; CSRF from `window.OWASP_CSRFTOKEN` |
+| i18n | `i18n/message.ts` → TMX `window.I18N` |
+| Themes | `ui-themes/ThemeProvider.tsx` (often per-shell) |
+
+### 1.3 Inventory: what becomes SPA routes vs temporary legacy exit
+
+#### A. SPA-owned product surfaces (compose existing shells — no rewrite)
+
+| Registry / shell | Source | Today host | SPA role |
+|------------------|--------|------------|----------|
+| `HomeShell` | `home/HomeShell.tsx` | `homeModern.jsp` | SPA route; server entry `?entry=home` |
+| `PublishingShell` | `publishing/…` | `publishModern.jsp` | Route publish |
+| `WorkflowAdminShell` | `workflowAdmin/…` | `adminWorkflowModern.jsp` | Route workflow |
+| `AdminShell` | `admin/…` | `adminModern.jsp` | Route admin |
+| `WidgetBuilderApp` | `widgetbuilder/…` | `widgetBuilderModern.jsp` | Route widget-builder |
+| `UnavailableView` | `home/UnavailableView.tsx` | `unavailableModern.jsp` | SPA 404 / unknown |
+| `ContentExplorerShell` | `contentExplorer/…` | explorerModern + embeds | Product route **and** optional bridge mount only inside **still-legacy** jQuery pages |
+| `ContentBrowser`, `SearchPanel`, `FolderSecurityPanel`, `ActionToolbar`, `ContextMenu` | contentExplorer / contentBrowser | host dialog JSPs | Prefer SPA dialog routes when openers allow; else keep thin host until openers updated |
+| `Dashboard` + widgets | `dashboard/*` | Registered; product `dashboard.jsp` still jQuery PercDashboard | **SPA dashboard route** preferred aggressively once wired; until then legacy exit `?view=dash` is temporary hybrid exit only |
+
+#### B. `index.jsp` modern views → SPA immediately (aggressive)
+
+| `?view=` | Old target | Aggressive target |
+|----------|------------|-------------------|
+| `home` | `homeModern.jsp` | **SPA shell** |
+| `publish` | `publishModern.jsp` | **SPA shell** |
+| `workflow` | `adminWorkflowModern.jsp` | **SPA shell** |
+| `widgetbuilder` | `widgetBuilderModern.jsp` | **SPA shell** |
+| `admin` | `adminModern.jsp` | **SPA shell** |
+| unknown | `unavailableModern.jsp` | **SPA** unavailable route |
+
+#### C. Temporary hybrid **exits** (full page leave SPA — not dual-mode)
+
+| `?view=` | JSP | Notes |
+|----------|-----|-------|
+| `dash` | `dashboard.jsp` | Until SPA Dashboard route ships |
+| `editor` | `webmgt.jsp` | Long-lived until editor migration |
+| `design` | `admin.jsp` | Temporary exit |
+| `arch` | `siteArchitecture.jsp` | Temporary exit |
+| `editAsset` / `editTemplate` | legacy JSPs | Temporary exit |
+
+Returning to modern work = navigate back into SPA entry (not a second product UI for the same feature).
+
+#### D. Dual-tree drift (must fix while shipping SPA)
+
+| Item | `cm/app` | `cm/pages/app` |
+|------|----------|----------------|
+| `workflow` | `adminWorkflowModern.jsp` | **legacy** `adminWorkflow.jsp` |
+| `admin` | `adminModern.jsp` | **missing** |
+
+**Policy:** `cm/app` is canonical. Align or redirect `cm/pages/app` in the same PRs that cut over modern views — not a late cleanup afterthought.
+
+#### E. Bridge retention (narrow — not product centerpiece)
+
+`PercModernUI.mount` remains **only** for:
+
+1. ContentExplorer (or similar) **embeds inside still-legacy jQuery pages** that have not been deleted yet (`dashboard.jsp`, `admin.jsp`, `webmgt.jsp`, etc. if they still mount explorer).
+2. True host/popup dialogs until openers move to SPA routes.
+
+The **feature app** (Home, Publish, Workflow, Admin, Widget Builder, primary explorer) is **SPA-owned**. Do not design product pages as “JSP + mount”.
+
+### 1.4 Completed Track B work — reuse, do not redo
+
+**989** Home + Widget Builder · **990** Publishing · **992** content explorer surfaces · **993** WorkflowAdmin + AdminShell.
+
+This design **routes** those shells; it does not re-implement them.
+
+---
+
+## 2. Target architecture
+
+### 2.1 SPA-first high level
+
+```
+Authenticated browser
+        │
+        ▼
+┌───────────────────────────────────────────────────────────┐
+│  Server SPA document (single entry)                       │
+│  /cm/app/  or  /cm/app/spa.jsp  (see §3)                  │
+│  • Auth + maintenance + server role gate for intended view│
+│  • XSS-safe bootstrap JSON                                │
+│  • CSRF (/JavaScriptServlet) → TMX → module               │
+│  • <div id="root">  (or perc-app-root)                    │
+│  • /cm/modern/assets/perc-modern-ui.js                    │
+└────────────────────────┬──────────────────────────────────┘
+                         │ createRoot → <App />
+                         ▼
+┌───────────────────────────────────────────────────────────┐
+│  ThemeProvider → BootstrapProvider → AuthProvider         │
+│  → Router (BrowserRouter preferred; HashRouter only if    │
+│     needed for same-week ship)                            │
+│  AppLayout (TopNav, UserMenu) → <Outlet /> feature shells │
+│  Legacy exit links → window.location full load to JSP     │
+└───────────────────────────────────────────────────────────┘
+
+Legacy jQuery pages (temporary):
+  may still load perc-modern-ui.js and call PercModernUI.mount
+  for embeds only — not the modern feature product path
+```
+
+### 2.2 Application modules
+
+```
+WebUI/src/main/ts/
+  index.ts                 # SPA-first: boot App; register bridge for residual embeds
+  bridge.ts                # PercModernUI.mount/unmount — sync API, async load (§2.9)
+  registry.ts              # loadComponent(name): Promise<ComponentType> via import()
+  app/
+    App.tsx
+    main.tsx               # createRoot on #root; apply entry query → router
+    routes.tsx
+    layout/
+      AppLayout.tsx
+      TopNav.tsx
+      UserMenu.tsx
+    bootstrap/
+      types.ts
+      BootstrapContext.tsx
+      loadBootstrap.ts
+    auth/
+      AuthContext.tsx
+      RequireRole.tsx      # UX; server gates + REST authoritative
+      sessionHandlers.ts   # 401 → login (return URL = query entry contract, no #)
+    deepLinks/
+      allowlists.ts
+      parseEntryQuery.ts   # server-driven ?entry=&section=&… → client route
+      parseRoute.ts
+    legacy/
+      navigateToLegacy.ts  # full-page exit to unmigrated views
+  home/, publishing/, workflowAdmin/, admin/, widgetbuilder/,
+  contentExplorer/, contentBrowser/, dashboard/, api/, ui-themes/, i18n/
+```
+
+### 2.3 SPA-first entry (`index.ts`) — replaces dual-mode design
+
+**Default production path:**
+
+1. Load module on SPA document that contains `#root` (or `#perc-app-root`).
+2. `import("./app/main")` → `createRoot` → render `<App />` with Router + providers.
+3. Always also register `window.PercModernUI` from `bridge.ts` so **legacy embed pages** that load the same bundle still work until those pages are removed.
+
+**Not** the design centerpiece: “boot SPA only if a magic node exists and otherwise live as bridge-only product.” The **product** pages are SPA documents. Bridge is a **secondary export** for residual embeds.
+
+Vite entry remains one bundle path (`perc-modern-ui.js`) for simplicity; registry + routes use dynamic `import()` for code-split.
+
+### 2.4 Routing (aggressive, implementable)
+
+#### Server-driven entry contract (locked — query params only)
+
+**Problem:** `Location` redirects and post-login return URLs that use **fragments** (`…#/home`) are unreliable: many proxies/clients strip or ignore the fragment on redirect; login return flows cannot depend on hash.
+
+**Rule:** All **server-driven** navigations to the SPA use a **query-based entry contract**. Never use `#/…` as the primary server redirect or return URL.
+
+Canonical SPA document: **`/cm/app/spa.jsp`** (or same params on the URL that `index.jsp` ultimately serves as the SPA shell).
+
+| Server entry (examples) | Meaning |
+|-------------------------|---------|
+| `/cm/app/spa.jsp?entry=home` | Home (default section) |
+| `/cm/app/spa.jsp?entry=home&section=library` | Home section |
+| `/cm/app/spa.jsp?entry=publish&section=logs&siteId=…` | Publish deep link |
+| `/cm/app/spa.jsp?entry=workflow&tab=users` | Workflow admin tab |
+| `/cm/app/spa.jsp?entry=admin&tab=tools` | Admin tab (includes `tools`) |
+| `/cm/app/spa.jsp?entry=widget-builder` | Widget Builder |
+| `/cm/app/spa.jsp?entry=explorer&path=/…` | Content explorer |
+| `/cm/app/spa.jsp?entry=unavailable` | Unknown / retired |
+
+**`entry` allowlist (server + client):**  
+`home` | `publish` | `workflow` | `admin` | `widget-builder` | `explorer` | `unavailable`  
+(Map legacy `view=widgetbuilder` → `entry=widget-builder`.)
+
+**Additional query params** (allowlisted per entry; same rules as § deep-link table):  
+`section`, `tab`, `siteId`, `serverId`, `path` (explorer), plus mapped legacy `initialScreen` → `section` on server when translating `?view=home&initialScreen=…`.
+
+**Server role gates** use the same `entry` value (not hash): e.g. `entry=workflow` / `entry=admin` require Admin; `entry=publish` / `entry=widget-builder` require Admin or Designer.
+
+**SPA boot sequence:**
+
+1. Parse `window.location.search` with `parseEntryQuery` (allowlists only).
+2. Map to client route (`/home/library`, `/publish/logs`, …).
+3. `navigate(route, { replace: true })` (HashRouter or BrowserRouter).
+4. Optionally strip entry query via `history.replaceState` / router replace so the address bar shows the client route form only (hash path or clean path) — **after** route applied.
+5. If no/invalid `entry`, default to home (or bootstrap `defaultView` if dash/editor → those are legacy full loads, not SPA entry).
+
+**In-SPA client navigations** use the router normally (hash or path links). No need for `?entry=` after first paint.
+
+**Post-login return URL** must be a **query entry URL** (e.g. `/cm/app/spa.jsp?entry=home`), never `…#/home`.
+
+#### Client routes (after entry applied)
+
+| Client path (basename `/cm/app` if BrowserRouter; or hash `#/…`) | Module | Server gate on `entry` |
+|-----------------------------------------------------------------|--------|-------------------------|
+| `/` or `/home` | HomeShell | Auth |
+| `/home/:section?` | HomeShell | Auth |
+| `/publish` / `/publish/:section` | PublishingShell | Admin or Designer |
+| `/workflow` / `/workflow/:tab` | WorkflowAdminShell | Admin |
+| `/admin` / `/admin/:tab` | AdminShell | Admin |
+| `/widget-builder` | WidgetBuilderApp | Admin or Designer + WB active |
+| `/explorer` | ContentExplorerShell | Auth |
+| `/unavailable` | UnavailableView | Auth |
+| *(future)* `/dashboard` | React Dashboard | Auth |
+
+#### Router choice (client-only; still one product UI)
+
+| Item | Choice |
+|------|--------|
+| Product shell URL | `index.jsp` maps modern views → **`spa.jsp?entry=…`** (query contract) |
+| Server redirects / login return | **Query only** — never `#` fragments |
+| Client router first ship | **HashRouter** OK so *in-SPA* refresh of client routes does not 404 under Jetty |
+| Client router end-state | BrowserRouter + optional rewrite — polish only |
+| `*Modern.jsp` | Not product path; optional 302 → `spa.jsp?entry=…` (query) |
+
+Do **not** keep serving `homeModern.jsp` as a working product alternative.
+
+#### Frozen deep-link allowlists (TS source of truth)
+
+| Area | Canonical | Aliases |
+|------|-----------|---------|
+| Home section | `recent`, `bookmarks`, `library`, `search`, `create` | `list`→`recent`, `newitem`→`create`, `bookmark`→`bookmarks` |
+| Publish section | `sites`, `status`, `logs`, `design`, `runtime`, `editions` | `site`→`sites`, `log`→`logs`, `edition`→`editions`; non-designer `design`→`sites` |
+| Workflow tab | `workflow`, `roles`, `users`, `categories` | — |
+| Admin tab | `tasks`, `logs`, `notifications`, **`tools`** | `tools` is intentional (shell has ToolsSection) |
+| IDs | `siteId`, `serverId` | `^[A-Za-z0-9_-]{1,128}$` |
+| Explorer path | leading `/`, length &lt; 2048, `[/A-Za-z0-9._-]+` | — |
+
+#### `?view=` → SPA query entry map (aggressive)
+
+| Incoming | Server target (use `proxyURL` + path; **no hash**) |
+|----------|-----------------------------------------------------|
+| `view=home` (+ `initialScreen`) | `spa.jsp?entry=home&section={mapped}` |
+| `view=publish` (+ section/ids) | `spa.jsp?entry=publish&section=…&siteId=…&serverId=…` |
+| `view=workflow` (+ section) | `spa.jsp?entry=workflow&tab=…` |
+| `view=admin` (+ tab) | `spa.jsp?entry=admin&tab=…` |
+| `view=widgetbuilder` | `spa.jsp?entry=widget-builder` |
+| unknown modern | `spa.jsp?entry=unavailable` |
+| `dash` / `editor` / `design` / `arch` / edit* | **Legacy JSP exit** (full page, existing forwards) |
+
+### 2.5 Layout & navigation
+
+- SPA always uses React `AppLayout` + `TopNav` (no jQuery `header.jsp` / `mainnav.jsp` on SPA document).
+- Nav parity with `mainnav.jsp`:
+  - Always: Home, Dashboard (**exit** or SPA dashboard when ready), Editor (**exit**)
+  - Admin or Designer: Architecture (**exit**), Design (**exit**), Publish (**SPA**)
+  - Admin: Administration → **SPA workflow** (product label unchanged)
+  - WB active + Admin/Designer: Widget Builder → **SPA**
+- Shells accept `embedded` (or layout context): hide BrandBar/BrandFooter/duplicate ThemeProvider under AppLayout (**required when routed**, not optional polish).
+- **spa entry never includes `header.jsp`** (avoids `dispatched` redirect traps).
+
+### 2.6 Providers
+
+Theme (app root) → Bootstrap JSON → Auth → Router. i18n stays TMX + `message()`. No Redux.
+
+### 2.7 Bundle strategy
+
+1. **Lazy registry** via shared `loadComponent(name)` (`import()` by name) so residual embeds do not static-import all shells into the main chunk.
+2. SPA routes use `React.lazy(() => loadComponent(…))` or equivalent on the **same** loader (shared chunks).
+3. Single Vite entry is fine; dual entry only if size budget forces it later.
+4. **PR-1 exit:** main chunk must not statically import Home/Publish/Workflow/Admin/WB/Dashboard shells; Vitest or build assertion documents that.
+
+### 2.8 Bridge module role (secondary)
+
+```ts
+// index.ts (conceptual)
+import "./bridge"; // registers PercModernUI for legacy embeds that still load this file
+
+const rootEl = document.getElementById("root") ?? document.getElementById("perc-app-root");
+if (rootEl) {
+  void import("./app/main").then((m) => m.boot(rootEl));
+} else {
+  // Bundle loaded on a legacy embed page without SPA root — bridge-only load.
+  // Residual support for embeds, not the product feature path.
+  console.info("[PercModernUI] bridge ready (no SPA root)");
+}
+```
+
+Product modern views **always** include the SPA root.
+
+### 2.9 Bridge mount contract (lazy registry — implement in PR-1)
+
+Today `PercModernUI.mount` is **synchronous** `void` and JSPs call it after a short poll for `window.PercModernUI`. Lazy `import()` must not break that call shape.
+
+| Rule | Spec |
+|------|------|
+| **Public API** | `mount(elementId, componentName, props?): void` and `unmount(elementId): void` remain **sync** (no Promise return to hosts). |
+| **Load** | Internally `void loadComponent(componentName).then(…)` — shared with SPA routes. |
+| **Generation token** | Per `elementId`, increment a generation (or store `AbortController` / nonce) on each `mount`/`unmount`. When a load resolves, apply only if generation still matches; **ignore stale** resolutions. |
+| **unmount** | Sync: unmount active React root if any; **cancel/invalidate** pending load for that id (bump generation) so a late import does not remount. |
+| **Unknown name** | `console.error` with name; do not throw into host page. |
+| **Load failure** | `console.error`; optional `data-perc-mount-error="1"` (or similar) on the container; **no throw** to JSP. |
+| **Missing container** | `console.error`; return (existing behavior). |
+| **Shared loader** | `export function loadComponent(name: string): Promise<ComponentType<any>>` in `registry.ts` (or `componentLoader.ts`); bridge + SPA both use it. |
+| **Main chunk** | Must not static-import all shell modules; only the loader map of dynamic `import()` factories. |
+
+**Vitest (PR-1 hard exit criteria):**
+
+1. Success path: mount registered name → component appears (await microtasks/import).
+2. Unknown name: no throw; error logged.
+3. Race: `mount` then immediate `unmount` before import resolves → no mount / no leftover root; late resolve ignored.
+4. Race: `mount` A then `mount` B same elementId → only B remains after loads settle.
+5. Bundle/static analysis or unit guard: shell modules not in main entry static graph (as practical in Vitest/Vite).
+
+---
+
+## 3. Server integration
+
+### 3.1 Single SPA document
+
+**`WebUI/src/main/webapp/cm/app/spa.jsp`** (or equivalent include used by `index.jsp`):
+
+1. Maintenance redirects (shared with current `index.jsp` logic).
+2. Bootstrap user / roles / sites / WB / defaultView / locale (same beans).
+3. **Server role gates** for the intended modern view using **`entry`** query (and/or legacy `view=` when still on index before forward) — same `adminViews` / `designerViews` semantics. Unauthorized → redirect to default SPA home entry or user default **using query entry URLs only** — **do not** emit privileged chrome.
+4. XSS-safe bootstrap JSON (§3.2).
+5. CSRF + TMX (canonical paths §7).
+6. `<div id="root"></div>` + module script to `perc-modern-ui.js` (optional deploy cache-buster query).
+7. **No** `header.jsp` / `mainnav.jsp` / feature mount scripts.
+8. Preserve allowlisted `entry` / `section` / `tab` / ids / `path` on the request so the client can parse them from `location.search`.
+
+### 3.2 Bootstrap JSON — XSS-safe (mandatory)
+
+`type="application/json"` is **not** a security control. Shared helper must:
+
+1. Serialize with Jackson (or equivalent).
+2. Escape for script context: `<` → `\u003c`, `>` → `\u003e`, `&` → `\u0026`, U+2028/U+2029 escaped.
+3. Emit `<script type="application/json" id="perc-bootstrap">…</script>`.
+4. Client: `JSON.parse(el.textContent)`.
+5. Tests with names/roles containing `</script><script>…`, quotes, Unicode line separators.
+
+```ts
+interface PercBootstrap {
+  user: { name: string; admin: boolean; designer: boolean; accessibility?: boolean; roles: string[] };
+  locale: string;
+  hasSites: boolean;
+  widgetBuilderActive: boolean;
+  defaultView: "home" | "dash" | "editor";
+  // Prefer reading entry from location.search (query contract).
+  // Optional echo of already-allowlisted entry for debugging only — not required.
+}
+```
+
+No `spaEnabled` product kill-switch. SPA **is** the product for modern views.
+
+### 3.3 `index.jsp` aggressive behavior + proxyURL
+
+```
+if maintenance → redirect maint pages
+else if view is modern (home|publish|workflow|admin|widgetbuilder) or null default is home:
+  enforce role gates (map view → entry)
+  redirect or forward to spa.jsp?entry=…&… (allowlisted params only)
+else if view is legacy exit (dash|editor|design|arch|editAsset|editTemplate):
+  forward to existing JSP (unchanged)
+else:
+  spa.jsp?entry=unavailable
+```
+
+**proxyURL parity (mandatory):** Every **redirect** `Location` to the SPA (and any 302 from obsolete `*Modern.jsp`) **must** reuse the same `proxyURL` construction as existing `index.jsp`: when `PSServer.isRequestBehindProxy(request)`, prefix with `PSServer.getProxyURL(request, true)`; otherwise site-relative `/cm/app/spa.jsp?…` is fine. Do not invent a second base-URL scheme. Applies to post-login return targets that point at SPA as well.
+
+Default homepage:
+
+- User homepage Home → `spa.jsp?entry=home`  
+- Dashboard → legacy dash (until SPA dashboard)  
+- Editor → legacy editor  
+
+**Stop forwarding modern views to `*Modern.jsp`.** Those files become reference-only (or 302 to `spa.jsp?entry=…` with **query** params and **proxyURL**).
+
+### 3.4 Dual-tree (`cm/pages/app`)
+
+Same cutover rules on both trees in the cutover PR, **or** pages tree redirects everything to `/cm/app/…`. Do not leave pages serving legacy workflow while app serves SPA.
+
+### 3.5 History / path URLs (later polish, not dual UI)
+
+Optional WebUI filter `com.percussion.webui.filter.PSWebUiSpaFallbackFilter`: GET `/cm/app/{home|publish|workflow|admin|widget-builder|explorer|unavailable}/**` → forward `spa.jsp`; exclude `*.jsp`, static assets, `/cm/modern/**`, non-GET. Used only when switching HashRouter → BrowserRouter. **Still one product UI.**
+
+### 3.6 No soft-flag cutover story
+
+Do **not** implement `perc.webui.spa.enabled` as the delivery model. Ops rollback = **git revert / redeploy** of the cutover commit(s), or temporarily restore JSP forwards in a hotfix — not a long-lived dual production mode. Reference files in tree are not a runtime fallback product.
+
+### 3.7 Query entry vs client hash (summary)
+
+| Actor | Mechanism |
+|-------|-----------|
+| `index.jsp` / login return / 302 from old Modern JSP | `proxyURL` + `/cm/app/spa.jsp?entry=…` (**query only**) |
+| SPA first paint | Parse query → router `navigate(..., { replace: true })` |
+| In-SPA TopNav / links | Client router (hash or path) |
+| Forbidden | Server `Location: …#/…` as primary deep link |
+
+---
+
+## 4. Migration phases (aggressive, **login-first**)
+
+### Stakeholder demo path (product lock)
+
+Demo script from day one of implementation work:
+
+1. Open product URL → **React Login** (not `rxlogin.jsp` chrome).
+2. Sign in → land in **React SPA** shell (TopNav + Home or placeholder).
+3. As routes land, continue demo: Home → Publish → Admin… without multipage `*Modern.jsp` hosts.
+
+Login is intentionally first so the story is “pure React UI from the front door,” not “React after a legacy form.”
+
+### Phase 0 — React Login + minimal SPA boot (start immediately)
+
+- Add `react-router-dom` if needed for post-login app (login page may be a dedicated public document).
+- **`LoginPage` / `LoginApp`** React component: username, password, locale, optional Select UI, error display, Intersoft/theme chrome.
+- Thin public server document (replace or forward `rxlogin.jsp` → SPA login host) with CSRF + TMX + `#root` + modern bundle.
+- **Auth stays server-side:** form POST to existing `/login` (`j_username`, `j_password`, `j_locale`, `j_selectUI`, CSRF) — same as today’s `rxlogin.jsp`. Do **not** invent a parallel login REST API unless product later requires it.
+- Locales: bootstrap JSON from the login JSP (server iterates `PSLocaleManager` as today) — XSS-safe encoding.
+- Success redirect / default return: `proxyURL + /cm/app/spa.jsp?entry=home` (query contract).
+- Error: show `j_error` (and any server error query params) in React UI.
+- Minimal authenticated SPA shell (`#root` + App layout placeholder) so post-login is not a JSP shell.
+- Vitest: Login form fields, allowlisted redirect construction, error rendering; CSRF field present in form.
+
+**Exit:** Stakeholder can demo **React Login → authenticated SPA document**. Legacy `rxlogin.jsp` markup unused (file may remain as reference until delete).
+
+### Phase 1 — SPA App scaffold + entry query + session handlers
+
+- Full `app/` App, routes skeleton, AppLayout + TopNav.
+- Shared `loadComponent` + race-safe bridge mount (§2.9).
+- `spa.jsp` + authenticated XSS-safe bootstrap (`PercBootstrap` user/roles/sites/WB).
+- **`parseEntryQuery`**: boot maps `?entry=` → router `replace`.
+- 401 from SPA → **React Login** with query return URL (`?return=` allowlisted to `spa.jsp?entry=…`).
+- Server role gates on `entry`.
+
+**Exit:** Authenticated GET `spa.jsp?entry=home` shows App; mid-session 401 returns to React Login.
+
+### Phase 2 — Wire all ready shells as SPA routes
+
+Mount Home, Publish, Workflow, Admin, Widget Builder, Explorer, Unavailable with `embedded` + allowlists. Split across PRs for review size; each PR is **product SPA functionality**.
+
+**Exit:** All modern features usable entirely inside SPA without opening `*Modern.jsp`.
+
+### Phase 3 — Aggressive `index.jsp` cutover
+
+- Modern `?view=` → `proxyURL + spa.jsp?entry=…` only (both trees); **no `#` in Location**.
+- `*Modern.jsp`: stop using (302 to query entry or leave unreferenced).
+- TopNav complete; legacy exits for dash/editor/design/arch.
+
+**Exit:** Primary product navigation for modern features never mounts via feature JSP shells.
+
+### Phase 4 — Cleanup reference files + remaining hybrid exits
+
+- Delete obsolete `*Modern.jsp` (and dead mounts) once SPA routes + tests own them.
+- SPA Dashboard route (retire jQuery dash when ready).
+- Dialog hosts → SPA dialogs or delete when openers updated.
+- Optional BrowserRouter + rewrite.
+- Align docs; mark stale REACT-ROUTER/REDUX guides non-authoritative.
+
+### Parallel track
+
+Unmigrated jQuery (editor, templates, arch, Track A): remain **full-page exits** until each is migrated into SPA as its own program of work.
+
+---
+
+## 5. Route map
+
+See §2.4 tables (canonical paths/hashes, aliases, `?view=` map). That is the implementer source of truth.
+
+---
+
+## 6. Hybrid strategy (exits only)
+
+| Kind | Behavior |
+|------|----------|
+| **SPA product** | Home, Publish, Workflow, Admin, Widget Builder, (Explorer), (Dashboard when ready) |
+| **Legacy exit** | Full `window.location` to remaining JSPs |
+| **Legacy embed** | Bridge mount of explorer (etc.) **inside** those JSPs until page deleted |
+| **Not allowed** | Shipping the same feature as both live JSP shell and SPA “optional mode” |
+
+No iframe default for webmgt.
+
+---
+
+## 7. Security model
+
+| Concern | Target |
+|---------|--------|
+| First paint auth | `PSSecurityFilter` on `/*` — unchanged |
+| Mid-session | Global SPA 401 → login with **query entry return URL** (e.g. `/cm/app/spa.jsp?entry=home` or current entry reconstructed from allowlisted state — **never** `#/…`); optional sessionCheck on focus |
+| CSRF | Blocking `/JavaScriptServlet` before module; SPA waits for token or shows error |
+| Role gates | **Server** on index/spa for modern views; client `RequireRole` UX only; REST 403 |
+| Bootstrap XSS | Mandatory script-context encoding + tests |
+| Deep links | Server + TS allowlists on `entry`/`section`/`tab`/ids/`path`; no raw query echo into JS; server redirects use query entry contract only |
+| TMX | Prefer `/tmx/tmx.jsp?...`; `/Rhythmyx/tmx/...` only when context path requires (same idea as `api/paths.ts`) |
+| CSP | External scripts + JSON text; no feature inline mount scripts on SPA |
+
+---
+
+## 8. Build / deploy
+
+| Item | Spec |
+|------|------|
+| package.json / vite | **Only** `WebUI/src/main/frontend/` |
+| Deps | `react-router-dom` (+ types if needed) |
+| Entry | SPA-first `index.ts`; lazy registry/routes |
+| Assets | `/cm/modern/assets/perc-modern-ui.js` |
+| Cache | Deploy cache-buster query or short-cache headers on stable entry name |
+| Pre-PR | `cd WebUI && ../mvn-env.sh clean install` |
+
+---
+
+## 9. Testing strategy
+
+| Layer | Cases |
+|-------|-------|
+| Unit | Allowlists + **parseEntryQuery**; bootstrap parse + **`</script>` XSS payloads**; role UX guards; **bridge mount async races** (§2.9); shared `loadComponent`; routes render shells; 401 handler with query return URL; CSRF missing token |
+| Integration / QA | Login → each modern SPA route → deep link refresh → designer vs admin → WB off → legacy exit editor → return SPA |
+| Cutover | `?view=…` modern maps to `spa.jsp?entry=…` (query, proxyURL); never serves feature mount JSP as product UI; no server redirects with `#` |
+| Dual-tree | Both trees SPA for modern views or pages→app redirect |
+| Embed residual | Legacy pages that still embed explorer still mount via bridge until removed |
+| Bundle | Main chunk must not static-import all shells; loadComponent dynamic graph |
+
+Manual QA (short):
+
+1. Admin: SPA home → publish → workflow → admin → widget-builder without full multipage JSP shells.  
+2. Deep publish via `spa.jsp?entry=publish&section=logs` then refresh (client route stable).  
+3. Designer: publish OK; workflow denied server-side.  
+4. Editor exit works; return Home SPA.  
+5. Dashboard exit (or SPA dashboard if shipped).  
+6. Bootstrap XSS test fixtures green.
+
+---
+
+## 10. Risks & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Jetty path 404 on in-SPA refresh | HashRouter for client routes short-term; server deep links always query `entry` |
+| Aggressive cutover bugs | Fast PR feedback; fix-forward; reference JSPs still in git for comparison (not runtime dual product) |
+| Double chrome | `embedded` required on routed shells |
+| Bundle size on legacy embeds | Lazy `loadComponent` + §2.9 race-safe mount |
+| Dual-tree drift | Cutover both trees together |
+| Bootstrap XSS | Encoder + tests |
+| Missing server role gates | index/spa enforce before HTML |
+| Mid-session expiry | Global 401 handler |
+| Deleting JSPs too early | Phase 3 stop **using**; Phase 4 delete after tests |
+
+---
+
+## 11. Alternatives considered
+
+| Alternative | Verdict |
+|-------------|---------|
+| Dual-mode bridge product + SPA optional | **Rejected by product owner** — do not design this |
+| Soft cutover flag default false | **Rejected** as delivery story — SPA is product now |
+| Keep `*Modern.jsp` as production peers | **Rejected** |
+| Big-bang rewrite shells | Reject — compose existing shells |
+| Permanent multi-JSP + shared includes | Reject for modern features |
+| Redux default | Reject |
+| Next.js / SSR | Reject (Jetty WAR) |
+| HashRouter short-term (client only) | **Accept** for in-SPA refresh convenience |
+| BrowserRouter + rewrite | Accept as URL polish, single UI |
+| Server deep links via `#` fragment | **Reject** — use query `entry` contract |
+| Query-only client router forever | Acceptable if hash/path both blocked |
+| iframe legacy editors | Reject default |
+
+---
+
+## 12. Open questions
+
+| ID | Question | Status |
+|----|----------|--------|
+| OQ-1 | Client hash vs path URLs | **Pragmatic lock:** client Hash first OK; **server always query `entry`**. Path client later. |
+| OQ-2 | Dashboard SPA now vs temporary dash exit | Prefer SPA Dashboard soon; hybrid exit only until then |
+| OQ-3 | Dialog hosts → SPA routes timing | Keep thin hosts until openers updated; not dual product for main nav |
+| OQ-4 | Feature flag soft cutover | **Closed — not used** |
+| OQ-5 | Administration → workflow | **Locked** (preserve mainnav) |
+
+---
+
+## 13. Key Decisions
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| **KD-1** | **SPA-first entry**: product modern UI boots App/Router on `#root`; bridge is secondary for residual embeds only | Product owner: aggressive new UI now; no dual-mode centerpiece |
+| **KD-2** | Compose existing shells as route modules | 989/990/992/993 done |
+| **KD-3** | Single SPA server document (`spa.jsp` / index forward) with XSS-safe bootstrap | One host, security + simplicity |
+| **KD-4** | `react-router-dom`; no Redux default | Router load-bearing |
+| **KD-5** | Server deep links = **query `entry` contract**; client HashRouter OK short-term; BrowserRouter later polish | Fragments unreliable on redirects/login return; still one product UI |
+| **KD-6** | **Aggressive cutover**: modern `?view=` → SPA only; no flag dual path | Owner override of soft cutover |
+| **KD-7** | Unmigrated jQuery = full-page **exits** only | Temporary hybrid boundary |
+| **KD-8** | Deep-link allowlists in TS | XSS hygiene |
+| **KD-9** | **React Login is the first product slice** (front door for demos); posts to existing `/login` | Stakeholder demo from the door; no parallel auth API |
+| **KD-10** | One Vite bundle name; lazy chunks underneath | Hosts + embeds |
+| **KD-11** | Server role gates + REST authoritative; client guards UX | Defense in depth |
+| **KD-12** | PR-1 = Login SPA + post-login SPA landing; PR-2 = full app shell | Demo path first, then depth |
+| **KD-13** | `cm/app` canonical; dual-tree fixed with cutover | Stop drift |
+| **KD-14** | Lazy `loadComponent` + sync mount API with generation tokens (§2.9) | Embed payload + JSP-compatible bridge |
+| **KD-15** | Optional rewrite filter in WebUI module when path URLs wanted | Ownership |
+| **KD-16** | No `spaEnabled` kill-switch product story | Aggressive SPA |
+| **KD-17** | Maven `src/main/frontend` is package.json source of truth | Avoid wrong tree |
+| **KD-18** | `embedded` required for routed shells | No double chrome |
+| **KD-19** | Retain old JSP files as **reference** until cleanup PR deletes them | Not runtime dual UI |
+| **KD-20** | `*Modern.jsp` not production path after Phase 3 | SPA owns modern features |
+| **KD-21** | All server SPA redirects use **proxyURL** parity with existing `index.jsp` | Behind-proxy deployments |
+| **KD-22** | Login posts to existing `/login` form action; success → `spa.jsp?entry=…` (query) | Preserve auth security; SPA owns UI only |
+| **KD-23** | 401 mid-session returns to **React Login**, not `rxlogin.jsp` | Consistent front door |
+| **KD-24** | Logout UI may follow Login (same PR or PR-1b); server logout endpoint unchanged | Demo completeness |
+
+---
+
+## 14. Monday-morning first PR (concrete) — **Login front door**
+
+**Title:** `feat(webui): React Login SPA as product front door`
+
+**Does:**
+
+1. Add `LoginPage` (or `login/LoginApp`) under `WebUI/src/main/ts/` — modern React UI matching product theme direction (`ui-themes` where practical).
+2. Thin public host: rewrite/replace runtime path for `rxlogin.jsp` (or forward it) so the **visible** page is React + CSRF + TMX + locales bootstrap. Keep old JSP as reference until cleanup if needed.
+3. Form: multipart POST to **`login`** with `j_username`, `j_password`, `j_locale`, `j_selectUI` + CSRF token field (same contract as current `rxlogin.jsp`).
+4. Locales list from server bootstrap JSON (XSS-safe), not hardcoded.
+5. Display login errors (`j_error` / server error params) in React.
+6. On successful auth, server continues existing login flow; ensure post-login landing targets **`proxyURL + /cm/app/spa.jsp?entry=home`** (or allowlisted `return` query). Coordinate with security filter / default view if required.
+7. Minimal authenticated `spa.jsp` + `#root` landing shell (placeholder Home or “signed in” chrome) so the demo does not drop into a `*Modern.jsp` host after login.
+8. Vitest for Login form + redirect URL builders + error UI; security review checklist (no password logging, no XSS via error echo).
+9. **No** dual-mode flags; **no** parallel auth API.
+
+**Demo after PR-1:** open CMS → React Login → sign in → React SPA landing.
+
+**Next:** PR-2 full App/TopNav/loadComponent; PR-3+ real shells; index cutover.
+
+---
+
+## 15. Handoff
+
+| Audience | Notes |
+|----------|--------|
+| **Hephaestus** | **Login first**; then SPA shell, query entry, shells, cutover |
+| **DevOps** | Anonymous path still `rxlogin` / login; assets under `/cm/modern/`; proxyURL unchanged |
+| **Sherlock** | Login XSS/error handling; CSRF on form; bootstrap XSS; no password in logs; 401 → React Login |
+| **Patton** | Demo script: Login → SPA → feature routes as they land |
+| **Orchestrator** | login → app shell → routes → index cutover → cleanup |
+
+### Explicitly deferred
+
+Editor/template/arch React; Track A; GWT/Desktop; Redux; dual-mode infrastructure; parallel login REST (unless later required).
+
+---
+
+## 16. Login technical contract (implementer detail)
+
+### 16.1 Current baseline (verified)
+
+| Item | Fact |
+|------|------|
+| Page | `WebUI/src/main/webapp/rxlogin.jsp` (~165 lines) |
+| Form | `<csrf:form … action="login" enctype="multipart/form-data">` |
+| Fields | `j_username`, `j_password`, `j_locale`, `j_selectUI` |
+| Error | `j_error` request param rendered into page |
+| Locales | Server `PSLocaleManager.getLocales()` in JSP |
+| Security | `system-security-conf.xml`: `/rxlogin.jsp`, `/login` anonymous |
+| CSRF | `/JavaScriptServlet` + csrf form tag |
+
+### 16.2 Target
+
+| Item | Spec |
+|------|------|
+| UI | React `LoginPage` in modern bundle |
+| Host | Public HTML document with `#root` (thin JSP or equivalent) — **product path is React** |
+| POST | Unchanged `/login` multipart form + CSRF |
+| Bootstrap (login) | `{ locales: {name, displayName}[], autocomplete, error?, returnUrl? }` XSS-safe |
+| Success | Existing server login success → SPA entry query URL |
+| Failure | Stay on React Login with error message (allowlist/encode error text) |
+| Mid-session | SPA 401 → React Login + allowlisted return |
+
+### 16.3 What Login is *not*
+
+- Not a new OAuth/OIDC project unless product expands scope later.
+- Not dual UI with classic `rxlogin.jsp` still linked from product chrome.
+- Not blocked on full Home/Publish migration — landing shell can be minimal for first demo.
+
+---
+
+## PR Plan
+
+Each PR advances **SPA product UI**, starting at the **front door**. No soft-flag dual-path PRs.
+
+### PR-1 — React Login front door + post-login SPA landing
+
+| | |
+|--|--|
+| **Title** | `feat(webui): React Login SPA as product front door` |
+| **Files** | `ts/login/**`; thin login host JSP; security path if needed; minimal `spa.jsp` landing; Vitest; theme styles |
+| **Deps** | None |
+| **Description** | Stakeholders open product → React Login → POST `/login` → SPA landing. Replace runtime use of classic `rxlogin.jsp` UI. **Exit:** demoable front door; tests; no password leakage; CSRF present. |
+
+### PR-2 — SPA App shell + TopNav + lazy loadComponent + entry query + session
+
+| | |
+|--|--|
+| **Title** | `feat(webui): SPA app shell, TopNav, entry query, race-safe bridge, 401→Login` |
+| **Files** | `app/**`; `loadComponent` / `bridge.ts`; `parseEntryQuery`; auth handlers; `spa.jsp` bootstrap; Vitest |
+| **Deps** | PR-1 |
+| **Description** | Full authenticated App chrome. 401 returns to React Login with query return. Lazy registry contract (§2.9). |
+
+### PR-3 — Home + Publish routes (embedded shells)
+
+| | |
+|--|--|
+| **Title** | `feat(webui): SPA routes for HomeShell and PublishingShell` |
+| **Files** | routes; shell `embedded`; allowlists; tests |
+| **Deps** | PR-2 |
+| **Description** | Product usable for home + publish entirely in SPA. Demo extends past landing. |
+
+### PR-4 — Workflow Admin + Admin + Widget Builder routes
+
+| | |
+|--|--|
+| **Title** | `feat(webui): SPA routes for Workflow, Admin, Widget Builder` |
+| **Files** | routes; shells embedded; WB gate; admin `tools` tab |
+| **Deps** | PR-2 |
+| **Description** | Remaining modern feature modules as SPA routes. |
+
+### PR-5 — Aggressive index.jsp cutover (both trees)
+
+| | |
+|--|--|
+| **Title** | `feat(webui): serve SPA for modern views; stop using *Modern.jsp product hosts` |
+| **Files** | `cm/app/index.jsp`, `cm/pages/app/index.jsp` (align dual-tree); redirects to `spa.jsp?entry=…`; optional 302 from `*Modern.jsp`; TopNav |
+| **Deps** | PR-3, PR-4 |
+| **Description** | **Aggressive:** modern `?view=` → `proxyURL + /cm/app/spa.jsp?entry=…` (query only, never `#`). Role gates on `entry`. Legacy views unchanged. `*Modern.jsp` not product path (reference or 302 with same query contract). |
+
+### PR-6 — Explorer SPA route + residual embed hygiene
+
+| | |
+|--|--|
+| **Title** | `feat(webui): ContentExplorer SPA route; document residual bridge embeds` |
+| **Files** | routes; explorer; docs for which legacy pages still mount bridge |
+| **Deps** | PR-5 |
+| **Description** | Primary explorer in SPA; embeds only on remaining legacy pages. |
+
+### PR-7 — Dashboard SPA (or explicit exit only)
+
+| | |
+|--|--|
+| **Title** | `feat(webui): Dashboard SPA route using React Dashboard` **or** `chore(webui): TopNav dashboard legacy exit only` |
+| **Files** | dashboard route **or** nav exit; prefer React Dashboard if ready |
+| **Deps** | PR-5 |
+| **Description** | Prefer aggressive Dashboard SPA; temporary exit acceptable briefly. |
+
+### PR-8 — Delete obsolete login/Modern JSP product hosts + docs
+
+| | |
+|--|--|
+| **Title** | `chore(webui): remove unused login/*Modern.jsp product shells; update AGENTS/unified-ui-plan` |
+| **Files** | Delete unreferenced shells including classic login markup if unused; dual-tree cleanup; docs |
+| **Deps** | PR-1+ and PR-5+ green without those hosts |
+| **Description** | Reference retention ends; tree cleaned. |
+
+### PR-9 — (Optional) BrowserRouter + WebUI SPA fallback filter
+
+| | |
+|--|--|
+| **Title** | `feat(webui): path-based SPA URLs with PSWebUiSpaFallbackFilter` |
+| **Files** | Filter, web.xml, router switch, tests |
+| **Deps** | PR-5 stable |
+| **Description** | URL polish; still single product UI. |
+
+---
+
+## Appendix A — Evidence anchors
+
+- `WebUI/src/main/ts/bridge.ts`, `registry.ts`, `index.ts`
+- `WebUI/src/main/webapp/cm/app/index.jsp` vs `cm/pages/app/index.jsp`
+- `WebUI/src/main/frontend/vite.config.ts`, `package.json`
+- `api/csrf.ts`, `api/paths.ts`, `home/deepLinkMap.ts`
+- `PSUserService` `/current`, widgetbuilder `/active`
+
+## Appendix B — Shell embedded contract
+
+| Shell | JSP header today | Internal brand | Props | Routed `embedded` |
+|-------|------------------|----------------|-------|-------------------|
+| HomeShell | yes | BrandBar/Theme | section, isAdmin | hide brand; app Theme only |
+| PublishingShell | yes | shell chrome | section, ids, showDesign | no duplicate top chrome |
+| WorkflowAdminShell | minimal | shell header | tab | same |
+| AdminShell | no shared header | title/tabs | tab (+ tools) | same |
+| WidgetBuilderApp | yes | app chrome | — | same |
+| ContentExplorerShell | host-dependent | panel | path | route or legacy embed |
+| Dashboard (React) | n/a product | layout | — | SPA when shipped |
+
+## Appendix C — What “aggressive” is not
+
+- Not rewriting shell business logic  
+- Not deleting git history  
+- Not forcing editor into SPA this program  
+- Not dual production modes “just in case”  
+- Not waiting for perfect path rewrite before shipping SPA product  
+- Not using `Location: …#/…` for server or login deep links  
+
+## Appendix D — Server entry query cheat sheet
+
+```
+# Home
+{proxyURL}/cm/app/spa.jsp?entry=home
+{proxyURL}/cm/app/spa.jsp?entry=home&section=library
+
+# Publish
+{proxyURL}/cm/app/spa.jsp?entry=publish&section=logs&siteId=ID&serverId=ID
+
+# Workflow / Admin
+{proxyURL}/cm/app/spa.jsp?entry=workflow&tab=users
+{proxyURL}/cm/app/spa.jsp?entry=admin&tab=tools
+
+# Widget Builder / Explorer / Unavailable
+{proxyURL}/cm/app/spa.jsp?entry=widget-builder
+{proxyURL}/cm/app/spa.jsp?entry=explorer&path=/Sites/...
+{proxyURL}/cm/app/spa.jsp?entry=unavailable
+```
+
+`proxyURL` empty string or proxy prefix per existing `index.jsp` pattern.
+
+---
+
+## Revision history
+
+| Rev | Notes |
+|-----|--------|
+| 1 | Initial hybrid→SPA design |
+| 2 | Review fixes: XSS bootstrap, Hash interim, dual-tree, lazy registry, soft cutover flags |
+| 3 | **Product owner override:** aggressive SPA-first; remove dual-mode / soft-flag delivery story |
+| **3.1** | Query-based **server entry contract** (`?entry=`); no fragment redirects; bridge **async load + sync mount** race contract; **proxyURL** parity on all SPA redirects |
+| **3.2** | **Login-first sequencing** (product owner): React Login is PR-1 / Phase 0 for stakeholder demos; POST remains existing `/login`; 401 → React Login; PR plan reordered |
+
+*End of design document.*

--- a/docs/ai-generated/tasks/#000-pure-react-spa/summary.md
+++ b/docs/ai-generated/tasks/#000-pure-react-spa/summary.md
@@ -1,0 +1,53 @@
+# Design summary: Pure React / TypeScript WebUI — eliminate JSP shells
+
+## Produced
+
+| Artifact | Path |
+|----------|------|
+| Full design (**rev 3.2** — aggressive SPA-first, **login-first**) | `docs/ai-generated/tasks/#000-pure-react-spa/design.md` |
+| This summary | `docs/ai-generated/tasks/#000-pure-react-spa/summary.md` |
+
+## Product locks
+
+1. **SPA is the product UI** for modern features. No dual-mode, no soft feature-flag cutover. Old JSPs = reference until delete.
+2. **Start at the front door:** React Login is the first shippable slice for **stakeholder demos** (Login → SPA), then authenticated routes.
+
+## Stakeholder demo path
+
+1. Open product → **React Login** (not classic `rxlogin.jsp` UI)
+2. Sign in (POST existing `/login`) → **React SPA** landing
+3. As later PRs land: Home → Publish → Admin… without `*Modern.jsp` hosts
+
+## Implementability locks (still apply)
+
+1. **Server entry = query only** — `spa.jsp?entry=…` (never `Location: …#/…`)
+2. **Bridge** — sync `mount` + lazy `loadComponent` + generation tokens
+3. **proxyURL** parity on all SPA redirects
+4. **Login** — UI is React; auth remains existing form POST to `/login`
+
+## Monday PR-1
+
+`feat(webui): React Login SPA as product front door`
+
+- React LoginPage + thin public host
+- POST `/login` (CSRF, same fields as `rxlogin.jsp`)
+- Success → `spa.jsp?entry=home` (proxyURL-aware)
+- Minimal SPA landing so demo does not drop into a JSP shell
+
+## PR plan (login-first)
+
+1. **Login front door** + SPA landing  
+2. App shell + TopNav + entry query + 401→Login  
+3. Home + Publish routes  
+4. Workflow + Admin + Widget Builder  
+5. Aggressive `index.jsp` cutover  
+6. Explorer  
+7. Dashboard  
+8. Delete obsolete JSPs  
+9. Optional path URLs  
+
+## Explicitly not first
+
+- Dual-mode / feature-flag fallback  
+- Parallel auth REST API  
+- Full editor/template/arch rewrite in PR-1  

--- a/system/src/main/java/com/percussion/servlets/PSLoginServlet.java
+++ b/system/src/main/java/com/percussion/servlets/PSLoginServlet.java
@@ -561,8 +561,13 @@ public class PSLoginServlet extends HttpServlet {
     return new File(getServletContext().getRealPath("/WEB-INF")).getParentFile();
   }
 
-  /** Default CMS page constant */
-  private static final String CMS_INDEX_PAGE = "index.jsp";
+  /**
+   * Default post-login landing for the modern CMS UI.
+   *
+   * <p>Path-absolute SPA entry (query contract). See pure-react-spa design: never use hash
+   * fragments on server redirects. Form posts may also supply {@code sys_redirect}.
+   */
+  private static final String CMS_INDEX_PAGE = "/cm/app/spa.jsp?entry=home";
 
   private static final String LEGACY_INDEX_PAGE = "Rhythmyx/sys_cx/mainpage.html";
 

--- a/system/src/test/java/com/percussion/servlets/PSLoginServletTest.java
+++ b/system/src/test/java/com/percussion/servlets/PSLoginServletTest.java
@@ -59,10 +59,18 @@ public class PSLoginServletTest {
 
     assertEquals("/cm/app", PSLoginServlet.resolveSafePostLoginRedirect(request, "/cm/app"));
     assertEquals("/cm/app", PSLoginServlet.resolveSafePostLoginRedirect(request, "\\cm\\app"));
-    // Default CMS index when blank / null
-    assertEquals("index.jsp", PSLoginServlet.resolveSafePostLoginRedirect(request, null));
-    assertEquals("index.jsp", PSLoginServlet.resolveSafePostLoginRedirect(request, "   "));
-    // App-relative entry points
+    // SPA entry is accepted
+    assertEquals(
+        "/cm/app/spa.jsp?entry=home",
+        PSLoginServlet.resolveSafePostLoginRedirect(request, "/cm/app/spa.jsp?entry=home"));
+    // Default CMS index when blank / null — modern SPA landing
+    assertEquals(
+        "/cm/app/spa.jsp?entry=home",
+        PSLoginServlet.resolveSafePostLoginRedirect(request, null));
+    assertEquals(
+        "/cm/app/spa.jsp?entry=home",
+        PSLoginServlet.resolveSafePostLoginRedirect(request, "   "));
+    // App-relative entry points still allowed
     assertEquals("index.jsp", PSLoginServlet.resolveSafePostLoginRedirect(request, "index.jsp"));
     assertEquals(
         "Rhythmyx/sys_cx/mainpage.html",
@@ -75,16 +83,18 @@ public class PSLoginServletTest {
     request.setServerPort(9992);
     request.setServerName("perc-test");
 
-    // External host → fall back to CMS index
+    // External host → fall back to CMS SPA index
     assertEquals(
-        "index.jsp",
+        "/cm/app/spa.jsp?entry=home",
         PSLoginServlet.resolveSafePostLoginRedirect(request, "http://evil.example/phish"));
     // Path traversal
     assertEquals(
-        "index.jsp", PSLoginServlet.resolveSafePostLoginRedirect(request, "/../../etc/passwd"));
+        "/cm/app/spa.jsp?entry=home",
+        PSLoginServlet.resolveSafePostLoginRedirect(request, "/../../etc/passwd"));
     // javascript: scheme (relative form rejected by colon rule)
     assertEquals(
-        "index.jsp", PSLoginServlet.resolveSafePostLoginRedirect(request, "javascript:alert(1)"));
+        "/cm/app/spa.jsp?entry=home",
+        PSLoginServlet.resolveSafePostLoginRedirect(request, "javascript:alert(1)"));
     // Same-host absolute is allowed
     assertEquals(
         "http://perc-test:9992/logout",


### PR DESCRIPTION
## Summary

Pure React SPA **PR-1** (login-first demo path) from `docs/ai-generated/tasks/#000-pure-react-spa/`:

- **React Login** is the product front door: `rxlogin.jsp` hosts `LoginPage`; classic markup kept as `rxlogin-classic.jsp` (reference only).
- Auth remains **POST `/login`** with existing CSRF/fields (no parallel auth API).
- Successful login lands on **`/cm/app/spa.jsp?entry=home`** (query contract — no hash redirects on server `Location`).
- Minimal authenticated **LandingShell** so stakeholder demos do not drop into a legacy JSP shell.
- Dual-tree SPA hosts: `cm/app/spa.jsp` and `cm/pages/app/spa.jsp`.
- Security: anonymous access for `/cm/modern/*` and `/cm/themes/*` so the public login page can load the modern bundle; classic login path also listed.
- `PSLoginServlet` default CMS landing → SPA entry; open-redirect fallbacks updated; unit tests updated.

**Out of scope (later PRs):** full router, Home/Publish/Admin/Widget Builder routes, aggressive `index.jsp` cutover, JSP deletion.

## Pre-PR verification

| Module | Command | Result |
|--------|---------|--------|
| `WebUI` | `cd WebUI && npm test -- --run src/test/ts/login src/test/ts/app` | **10 tests, 0 failures** |
| `WebUI` | `cd WebUI && ../mvn-env.sh clean install -Dai.integrity.skip=true` | **BUILD SUCCESS** |
| `system` | `cd system && ../mvn-env.sh test -Dtest=PSLoginServletTest -Dai.integrity.skip=true` | **pass** |
| `system` | `cd system && ../mvn-env.sh clean install -Dai.integrity.skip=true` | **BUILD SUCCESS** |

Local AI integrity seal drift: `-Dai.integrity.skip=true` for standalone gates. No new test failures from this change.

Erlang review: `docs/ai-generated/code-reviews/000-react-login-spa-pr1-erlang.md` — **approve**.

## Test plan

- [ ] Open `/rxlogin.jsp` unauthenticated → React Login UI (not classic form markup)
- [ ] Sign in with valid credentials → redirect to `/cm/app/spa.jsp?entry=home` with LandingShell
- [ ] Invalid credentials → error shown on React login
- [ ] Open-redirect attempts on `sys_redirect` / return params → fall back to SPA home
- [ ] Authenticated user hits SPA landing → bootstrap user/locale/entry present
- [ ] Unauthenticated hit on `spa.jsp` → product auth gate (not public)
- [ ] Optional: `rxlogin-classic.jsp` still available as reference only

## Design

- Full design: `docs/ai-generated/tasks/#000-pure-react-spa/design.md` (rev 3.2 login-first)
- Summary: `docs/ai-generated/tasks/#000-pure-react-spa/summary.md`

> Co-Authored by Grok Build using grok-4.5 with agent Grok.