### PR TITLE
Fix #1520: Resolve Javadoc errors and warnings in perc-comments-services

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/PSCommentsApplication.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/PSCommentsApplication.java
@@ -41,6 +41,7 @@ import org.glassfish.jersey.server.spring.scope.RequestContextFilter;
 @ApplicationPath("/")
 public class PSCommentsApplication extends ResourceConfig {
 
+  /** Registers Jersey/Spring components, REST resources, features, and providers for the comments and likes REST APIs. */
   public PSCommentsApplication() {
     // Register Jersey and Spring integration components
     register(RequestContextFilter.class);

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/IPSComment.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/IPSComment.java
@@ -22,67 +22,93 @@ import java.util.Date;
 import java.util.Set;
 
 /**
+ * Represents a comment stored by the delivery tier comment service.
+ *
  * @author erikserating
  */
 public interface IPSComment {
   /**
+   * Gets the unique id assigned to this comment by the persistence layer.
+   *
    * @return the id for this comment, this is assigned by the persistence layer.
    */
   String getId();
 
   /**
+   * Gets the id of the parent comment.
+   *
    * @return the id of the parent comment. Used for comment threading.
    */
   String getParent();
 
   /**
+   * Gets the body text of the comment.
+   *
    * @return the comment text, never <code>null</code>, may be empty.
    */
   String getText();
 
   /**
+   * Gets the title of the comment.
+   *
    * @return the comment title, may be <code>null</code> or empty.
    */
   String getTitle();
 
   /**
+   * Gets the site this comment belongs to.
+   *
    * @return the sitename of the site the comment is in.
    */
   String getSite();
 
   /**
+   * Gets the relative path of the page the comment is on.
+   *
    * @return the page path, the relative path to the page that this comment is on, not including the
    *     site. Never <code>null</code> or empty.
    */
   String getPagePath();
 
   /**
+   * Gets the user name of the comment author.
+   *
    * @return the user name of the person who wrote the comment. May be <code>null</code> or empty.
    */
   String getUsername();
 
   /**
+   * Gets the URL entered by the comment author.
+   *
    * @return the url that the comment author entered. May be <code>null</code> or empty.
    */
   String getUrl();
 
   /**
+   * Gets the email of the comment author.
+   *
    * @return the email for the user who wrote the comment. May be <code>null</code> or empty.
    */
   String getEmail();
 
   /**
+   * Gets the date this comment was created.
+   *
    * @return the created date for this comment. Never <code>null</code> or empty.
    */
   @JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.class)
   Date getCreatedDate();
 
   /**
+   * Gets the unique tags assigned to this comment.
+   *
    * @return set of all unique tag strings for this comment. Never <code>null</code>, may be empty.
    */
   Set<String> getTags();
 
   /**
+   * Gets the current approval state of this comment.
+   *
    * @return the current approval state for this comment. Never <code>null</code>. Defaults to
    *     <code>APPROVAL_STATE.PENDING</code>.
    */
@@ -107,72 +133,106 @@ public interface IPSComment {
   /**
    * Set the viewed flag to indicate the comment has been viewed once by a moderator.
    *
-   * @param viewed
+   * @param viewed the new viewed flag value.
    */
   void setViewed(boolean viewed);
 
   /**
+   * Sets the date this comment was created.
+   *
    * @param createdDate the createdDate to set
    */
   void setCreatedDate(Date createdDate);
 
   /**
+   * Sets the unique id for this comment.
+   *
    * @param id the id to set
    */
   void setId(String id);
 
   /**
+   * Sets the relative path of the page this comment is on.
+   *
    * @param pagePath the pagePath to set
    */
   void setPagePath(String pagePath);
 
   /**
+   * Sets the email of the comment author.
+   *
    * @param email the email to set
    */
   void setEmail(String email);
 
   /**
+   * Sets the user name of the comment author.
+   *
    * @param username the username to set
    */
   void setUsername(String username);
 
   /**
+   * Sets the body text of this comment.
+   *
    * @param text the text to set
    */
   void setText(String text);
 
   /**
+   * Sets the id of the parent comment.
+   *
    * @param parent the parent to set
    */
   void setParent(String parent);
 
   /**
+   * Sets the approval state of this comment.
+   *
    * @param approvalState the approvalState to set
    */
   void setApprovalState(APPROVAL_STATE approvalState);
 
   /**
+   * Sets the moderated flag of this comment.
+   *
    * @param moderated the moderated to set
    */
   void setModerated(boolean moderated);
 
   /**
+   * Sets the site this comment belongs to.
+   *
    * @param site the site to set
    */
   void setSite(String site);
 
   /**
+   * Sets the URL entered by the comment author.
+   *
    * @param url the url to set
    */
   void setUrl(String url);
 
   /**
+   * Sets the title of this comment.
+   *
    * @param title the title to set
    */
   void setTitle(String title);
 
+  /**
+   * Gets the comment created date as a string. Used for legacy clients that expect a string value.
+   *
+   * @return the comment created date as a string.
+   */
   String getCommentCreatedDate();
 
+  /**
+   * Sets the comment created date from a string. Used for legacy clients that supply a string.
+   *
+   * @param commentCreatedDate the comment created date as a string.
+   */
   void setCommentCreatedDate(String commentCreatedDate);
 
   /**
@@ -188,7 +248,9 @@ public interface IPSComment {
 
   /** Comment approval states. */
   public enum APPROVAL_STATE {
+    /** The comment has been approved by a moderator. */
     APPROVED,
+    /** The comment has been rejected by a moderator. */
     REJECTED
   }
 }

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/IPSDefaultModerationState.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/IPSDefaultModerationState.java
@@ -18,25 +18,36 @@
 
 package com.percussion.delivery.comments.data;
 
+/**
+ * Represents the default moderation state configured for a site.
+ */
 public interface IPSDefaultModerationState {
 
-  /* (non-Javadoc)
-   * @see com.percussion.delivery.comments.service.rdbms.IPSDefaultModerationState#getSite()
+  /**
+   * Gets the site name the default moderation state is associated with.
+   *
+   * @return the site name, never {@code null} or empty.
    */
   public abstract String getSite();
 
-  /* (non-Javadoc)
-   * @see com.percussion.delivery.comments.service.rdbms.IPSDefaultModerationState#setSite(java.lang.String)
+  /**
+   * Sets the site name the default moderation state is associated with.
+   *
+   * @param site the site name, must not be {@code null} or empty.
    */
   public abstract void setSite(String site);
 
-  /* (non-Javadoc)
-   * @see com.percussion.delivery.comments.service.rdbms.IPSDefaultModerationState#getDefaultState()
+  /**
+   * Gets the default moderation state for the site.
+   *
+   * @return the default approval state, never {@code null}.
    */
   public abstract String getDefaultState();
 
-  /* (non-Javadoc)
-   * @see com.percussion.delivery.comments.service.rdbms.IPSDefaultModerationState#setDefaultState(java.lang.String)
+  /**
+   * Sets the default moderation state for the site.
+   *
+   * @param defaultState the default approval state, must not be {@code null}.
    */
   public abstract void setDefaultState(String defaultState);
 }

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSCommentCriteria.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSCommentCriteria.java
@@ -31,6 +31,9 @@ import org.apache.logging.log4j.Logger;
 public class PSCommentCriteria {
   private static final Logger log = LogManager.getLogger(PSCommentCriteria.class);
 
+  /** Default no-arg constructor required for bean-style instantiation and JSON deserialization. */
+  public PSCommentCriteria() {}
+
   private String sortby;
   private String ascending;
   private String callback;
@@ -83,6 +86,8 @@ public class PSCommentCriteria {
   private String lastCommentId;
 
   /**
+   * Gets the page path filter.
+   *
    * @return the pagepath
    */
   public String getPagepath() {
@@ -90,6 +95,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Sets the page path filter.
+   *
    * @param pagepath the pagepath to set
    */
   public void setPagepath(String pagepath) {
@@ -97,6 +104,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Gets the username filter.
+   *
    * @return the username
    */
   public String getUsername() {
@@ -104,6 +113,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Sets the username filter.
+   *
    * @param username the username to set
    */
   public void setUsername(String username) {
@@ -111,6 +122,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Gets the tag filter.
+   *
    * @return the tag
    */
   public String getTag() {
@@ -118,6 +131,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Sets the tag filter.
+   *
    * @param tag the tag to set
    */
   public void setTag(String tag) {
@@ -125,6 +140,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Gets the sort order.
+   *
    * @return the sort
    */
   public PSCommentSort getSort() {
@@ -132,6 +149,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Sets the sort order.
+   *
    * @param sort the sort to set
    */
   public void setSort(PSCommentSort sort) {
@@ -139,6 +158,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Gets the approval state filter.
+   *
    * @return the state
    */
   public APPROVAL_STATE getState() {
@@ -146,6 +167,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Sets the approval state filter.
+   *
    * @param state the state to set
    */
   public void setState(APPROVAL_STATE state) {
@@ -153,6 +176,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Gets the site filter.
+   *
    * @return the site
    */
   public String getSite() {
@@ -160,6 +185,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Sets the site filter.
+   *
    * @param site the site to set
    */
   public void setSite(String site) {
@@ -167,6 +194,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Gets the maximum number of results to return.
+   *
    * @return the maxResults
    */
   public int getMaxResults() {
@@ -174,6 +203,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Sets the maximum number of results to return.
+   *
    * @param maxResults the maxResults to set
    */
   public void setMaxResults(int maxResults) {
@@ -181,6 +212,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Gets the start index used for paging.
+   *
    * @return the startIndex
    */
   public int getStartIndex() {
@@ -188,6 +221,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Sets the start index used for paging.
+   *
    * @param startIndex the startIndex to set
    */
   public void setStartIndex(int startIndex) {
@@ -195,6 +230,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Checks whether the moderated filter is set.
+   *
    * @return the moderated
    */
   public Boolean isModerated() {
@@ -202,6 +239,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Sets the moderated filter.
+   *
    * @param moderated the moderated to set
    */
   public void setModerated(Boolean moderated) {
@@ -209,6 +248,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Checks whether the viewed filter is set.
+   *
    * @return the viewed
    */
   public Boolean isViewed() {
@@ -216,6 +257,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Sets the viewed filter.
+   *
    * @param viewed the viewed to set
    */
   public void setViewed(Boolean viewed) {
@@ -223,6 +266,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Gets the id of the last comment added.
+   *
    * @return the id of the last comment
    */
   public String getLastCommentId() {
@@ -230,6 +275,8 @@ public class PSCommentCriteria {
   }
 
   /**
+   * Sets the id of the last comment added.
+   *
    * @param lastCommentId the id of the last comment to set
    */
   public void setLastCommentId(String lastCommentId) {
@@ -253,27 +300,56 @@ public class PSCommentCriteria {
     return ret;
   }
 
-  /** The relative path of the page not including the site. May be <code>null</code> or empty. */
+  /**
+   * Gets the relative path of the page not including the site. May be <code>null</code> or empty.
+   *
+   * @return the relative page path filter.
+   */
   public String getSortby() {
     return sortby;
   }
 
+  /**
+   * Sets the relative path of the page not including the site.
+   *
+   * @param sortby the sortby value to set.
+   */
   public void setSortby(String sortby) {
     this.sortby = sortby;
   }
 
+  /**
+   * Gets the ascending sort flag.
+   *
+   * @return the ascending flag value.
+   */
   public String getAscending() {
     return ascending;
   }
 
+  /**
+   * Sets the ascending sort flag.
+   *
+   * @param ascending the ascending flag value to set.
+   */
   public void setAscending(String ascending) {
     this.ascending = ascending;
   }
 
+  /**
+   * Gets the JSONP callback name.
+   *
+   * @return the JSONP callback name.
+   */
   public String getCallback() {
     return callback;
   }
 
+  /**
+   * Sets the JSONP callback name.
+   *
+   * @param callback the JSONP callback name to set.
+   */
   public void setCallback(String callback) {
     this.callback = callback;
   }

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSCommentIds.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSCommentIds.java
@@ -30,11 +30,14 @@ public class PSCommentIds {
 
   private Collection<String> comments;
 
+  /** Default no-arg constructor required by JAXB. Initializes the list to empty. */
   public PSCommentIds() {
     comments = new ArrayList<>();
   }
 
   /**
+   * Gets the wrapped collection of comment ids.
+   *
    * @return the ids
    */
   public Collection<String> getComments() {
@@ -42,7 +45,9 @@ public class PSCommentIds {
   }
 
   /**
-   * @param ids the ids to set
+   * Replaces the wrapped collection of comment ids.
+   *
+   * @param comments the comments to set
    */
   public void setComments(Collection<String> comments) {
     this.comments = comments;

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSCommentSort.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSCommentSort.java
@@ -43,6 +43,8 @@ public class PSCommentSort {
   }
 
   /**
+   * Gets the sort field.
+   *
    * @return the sortby field, never <code>null</code>.
    */
   public SORTBY getSortBy() {
@@ -50,6 +52,8 @@ public class PSCommentSort {
   }
 
   /**
+   * Indicates the sort direction.
+   *
    * @return <code>true</code> indicates an ascending sort direction.
    */
   public boolean isAscending() {
@@ -58,8 +62,11 @@ public class PSCommentSort {
 
   /** Enumeration of sort field options. */
   public enum SORTBY {
+    /** Sort by the comment creation date. */
     CREATEDDATE,
+    /** Sort by the comment author email. */
     EMAIL,
+    /** Sort by the comment author user name. */
     USERNAME
   }
 }

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSComments.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSComments.java
@@ -39,6 +39,7 @@ import java.util.Objects;
 public class PSComments {
   private List<IPSComment> comments;
 
+  /** Default no-arg constructor required by JAXB. Initializes the comments list to empty. */
   public PSComments() {
     comments = new ArrayList<>();
   }
@@ -57,6 +58,8 @@ public class PSComments {
   }
 
   /**
+   * Gets the list of comments held by this container.
+   *
    * @return the list of comments. Never <code>null</code>.
    */
   public List<IPSComment> getComments() {

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSPageInfo.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSPageInfo.java
@@ -18,6 +18,10 @@
 
 package com.percussion.delivery.comments.data;
 
+/**
+ * Lightweight value object that summarizes a single page that has comments. Used in REST responses
+ * listing pages with comments.
+ */
 public class PSPageInfo {
 
   private String pagePath;
@@ -25,6 +29,14 @@ public class PSPageInfo {
   private long commentCount;
   private boolean viewed;
 
+  /**
+   * Creates a new page summary.
+   *
+   * @param pagePath the relative page path, must not be {@code null}.
+   * @param approvalState the approval state value as a string, may be {@code null}.
+   * @param commentCount the total number of comments on the page.
+   * @param viewed whether the page has been viewed by an admin.
+   */
   public PSPageInfo(String pagePath, String approvalState, long commentCount, boolean viewed) {
     this.pagePath = pagePath;
     this.approvalState = approvalState;
@@ -32,18 +44,38 @@ public class PSPageInfo {
     this.viewed = viewed;
   }
 
+  /**
+   * Gets the relative page path.
+   *
+   * @return the page path.
+   */
   public String getPagePath() {
     return pagePath;
   }
 
+  /**
+   * Gets the approval state of the page's comments.
+   *
+   * @return the approval state.
+   */
   public String getApprovalState() {
     return approvalState;
   }
 
+  /**
+   * Gets the number of comments on the page.
+   *
+   * @return the comment count.
+   */
   public long getCommentCount() {
     return commentCount;
   }
 
+  /**
+   * Checks whether an admin has viewed this page's comments.
+   *
+   * @return {@code true} if the page has been viewed.
+   */
   public boolean isViewed() {
     return viewed;
   }

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSPageSummaries.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSPageSummaries.java
@@ -34,12 +34,26 @@ import java.util.List;
     name = "",
     propOrder = {"summaries"})
 public class PSPageSummaries {
+  /** List of {@link PSPageSummary} entries. */
   protected List<PSPageSummary> summaries;
 
+  /** Default no-arg constructor required by JAXB. */
+  public PSPageSummaries() {}
+
+  /**
+   * Creates a new page summaries container.
+   *
+   * @param summaries the initial list of summaries, may be {@code null}.
+   */
   public PSPageSummaries(List<PSPageSummary> summaries) {
     this.summaries = summaries;
   }
 
+  /**
+   * Gets the list of page summaries. Lazily initializes an empty list if needed.
+   *
+   * @return the list of summaries, never {@code null}.
+   */
   public List<PSPageSummary> getSummaries() {
     if (summaries == null) summaries = new ArrayList<>();
     return summaries;

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSPageSummary.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSPageSummary.java
@@ -31,12 +31,15 @@ public class PSPageSummary {
 
   private long newCommentCount;
 
-  /** */
+  /** Default no-arg constructor required by JAXB. */
   public PSPageSummary() {}
 
   /**
-   * @param pagePath
-   * @param commentCount
+   * Creates a new page summary without a new-comment count.
+   *
+   * @param pagePath the relative path of the page.
+   * @param commentCount the total number of comments on the page.
+   * @param approvedCount the number of approved comments on the page.
    */
   public PSPageSummary(String pagePath, long commentCount, long approvedCount) {
     this.pagePath = pagePath;
@@ -45,10 +48,12 @@ public class PSPageSummary {
   }
 
   /**
-   * @param pagePath
-   * @param commentCount
-   * @param approvedCount
-   * @param newCommentCount
+   * Creates a new page summary including the new-comment count.
+   *
+   * @param pagePath the relative path of the page.
+   * @param commentCount the total number of comments on the page.
+   * @param approvedCount the number of approved comments on the page.
+   * @param newCommentCount the number of comments that have not yet been viewed.
    */
   public PSPageSummary(
       String pagePath, long commentCount, long approvedCount, long newCommentCount) {
@@ -59,6 +64,8 @@ public class PSPageSummary {
   }
 
   /**
+   * Gets the relative page path.
+   *
    * @return the pagePath
    */
   public String getPagePath() {
@@ -66,6 +73,8 @@ public class PSPageSummary {
   }
 
   /**
+   * Sets the relative page path.
+   *
    * @param pagePath the pagePath to set
    */
   public void setPagePath(String pagePath) {
@@ -73,6 +82,8 @@ public class PSPageSummary {
   }
 
   /**
+   * Gets the total comment count for the page.
+   *
    * @return the commentCount
    */
   public long getCommentCount() {
@@ -80,6 +91,8 @@ public class PSPageSummary {
   }
 
   /**
+   * Sets the total comment count for the page.
+   *
    * @param commentCount the commentCount to set
    */
   public void setCommentCount(long commentCount) {
@@ -87,6 +100,8 @@ public class PSPageSummary {
   }
 
   /**
+   * Gets the number of approved comments for the page.
+   *
    * @return the approvedCount
    */
   public long getApprovedCount() {
@@ -94,6 +109,8 @@ public class PSPageSummary {
   }
 
   /**
+   * Sets the number of approved comments for the page.
+   *
    * @param approvedCount the approvedCount to set
    */
   public void setApprovedCount(long approvedCount) {
@@ -101,6 +118,8 @@ public class PSPageSummary {
   }
 
   /**
+   * Gets the number of unviewed (new) comments for the page.
+   *
    * @return the newCommentCount
    */
   public long getNewCommentCount() {
@@ -108,6 +127,8 @@ public class PSPageSummary {
   }
 
   /**
+   * Sets the number of unviewed (new) comments for the page.
+   *
    * @param newCommentCount the newCommentCount to set
    */
   public void setNewCommentCount(long newCommentCount) {

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSRestComment.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSRestComment.java
@@ -22,6 +22,9 @@ import java.util.Date;
 import java.util.Set;
 
 /**
+ * REST-friendly implementation of {@link IPSComment}. Mirrors all the standard comment fields so
+ * they can be serialized to and from JSON without exposing persistence layer concerns.
+ *
  * @author erikserating
  */
 public class PSRestComment implements IPSComment {
@@ -42,6 +45,7 @@ public class PSRestComment implements IPSComment {
   private String url;
   private String commentCreatedDate;
 
+  /** Default no-arg constructor required by Jackson and JAXB. */
   public PSRestComment() {}
 
   /**
@@ -180,6 +184,8 @@ public class PSRestComment implements IPSComment {
   }
 
   /**
+   * Replaces the tag set for this comment.
+   *
    * @param tags the tags to set
    */
   public void setTags(Set<String> tags) {

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/SORTBY.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/SORTBY.java
@@ -3,9 +3,13 @@ package com.percussion.delivery.comments.data;
 
 /** Enum representing the available sort options for comments. */
 public enum SORTBY {
+  /** Sort by the comment creation date. */
   CREATED_DATE,
+  /** Sort by the comment author user name. */
   USERNAME,
+  /** Sort by the comment title. */
   TITLE,
+  /** Sort by the approval state. */
   STATE;
 
   /**

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSComment.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSComment.java
@@ -43,6 +43,10 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 /**
+ * RDBMS-backed entity representing a comment. Mapped to the {@code PERC_PAGE_COMMENTS} table and
+ * related to its tags via {@link PSCommentTag}. Implements {@link IPSComment} so it can be used
+ * directly by the delivery tier service layer.
+ *
  * @author erikserating
  */
 @Entity
@@ -51,6 +55,7 @@ import org.hibernate.annotations.OnDeleteAction;
 public class PSComment implements IPSComment, Serializable {
   private static final long serialVersionUID = 1L;
 
+  /** Unique identifier for the comment. Assigned by the persistence layer. */
   @TableGenerator(
       name = "commentId",
       table = "PERC_ID_GEN",
@@ -62,32 +67,41 @@ public class PSComment implements IPSComment, Serializable {
   @GeneratedValue(strategy = GenerationType.TABLE, generator = "commentId")
   private long id;
 
+  /** Current approval state of the comment, stored as the string form of {@link APPROVAL_STATE}. */
   @Basic
   private String approvalState =
       IPSComment.approvalStateToString(IPSComment.APPROVAL_STATE.APPROVED);
 
+  /** Date and time the comment was created. */
   @Basic private Date createdDate;
 
+  /** Relative path of the page being commented on, not including the site. */
   @Basic private String pagePath;
 
+  /** Email address supplied by the comment author. May be {@code null}. */
   @Basic
   @Column(length = 4000)
   private String email;
 
+  /** User name supplied by the comment author. May be {@code null}. */
   @Basic
   @Column(length = 4000)
   private String username;
 
+  /** Body text of the comment. May be {@code null}. */
   @Lob
   @Column(length = Integer.MAX_VALUE)
   private String text;
 
+  /** Title of the comment. May be {@code null}. */
   @Basic
   @Column(length = 4000)
   private String title;
 
+  /** Numeric id of the parent comment, or {@code 0} for top-level comments. */
   @Basic private long parent;
 
+  /** Set of {@link PSCommentTag} entities associated with this comment. */
   @OneToMany(
       fetch = FetchType.EAGER,
       cascade = CascadeType.ALL,
@@ -98,18 +112,24 @@ public class PSComment implements IPSComment, Serializable {
   @OnDelete(action = OnDeleteAction.CASCADE)
   private Set<PSCommentTag> commentTags = new HashSet<>();
 
+  /** Flag indicating the comment has been moderated by a user action. */
   @Basic private boolean moderated;
 
+  /** Flag indicating the comment has been viewed by an admin. */
   @Basic private boolean viewed;
 
+  /** Site this comment belongs to. */
   @Basic private String site;
 
+  /** URL supplied by the comment author. May be {@code null}. */
   @Basic
   @Column(length = 2000)
   private String url;
 
+  /** Comment created date as a string, used for legacy clients. Not persisted. */
   @Transient private String commentCreatedDate;
 
+  /** Default no-arg constructor required by Hibernate. */
   public PSComment() {}
 
   /**
@@ -194,6 +214,11 @@ public class PSComment implements IPSComment, Serializable {
     return tagsAsString;
   }
 
+  /**
+   * Gets the set of tag entities attached to this comment.
+   *
+   * @return the set of {@link PSCommentTag} entities, never {@code null}.
+   */
   public Set<PSCommentTag> getCommentTags() {
     return this.commentTags;
   }
@@ -270,6 +295,12 @@ public class PSComment implements IPSComment, Serializable {
     this.parent = Long.valueOf(parent);
   }
 
+  /**
+   * Replaces the tags for this comment with a new set of tag strings. Each string is converted to a
+   * {@link PSCommentTag} and linked back to this comment.
+   *
+   * @param tags the tag strings, may be {@code null} (in which case no change is made).
+   */
   public void setTags(final Set<String> tags) {
     if (tags == null) return;
     PSCommentTag commentTag;
@@ -281,6 +312,11 @@ public class PSComment implements IPSComment, Serializable {
     }
   }
 
+  /**
+   * Replaces the tag entities for this comment.
+   *
+   * @param commentTags the new set of {@link PSCommentTag} entities, must not be {@code null}.
+   */
   public void setCommentTags(final Set<PSCommentTag> commentTags) {
     this.commentTags = commentTags;
   }

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSCommentTag.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSCommentTag.java
@@ -29,6 +29,9 @@ import jakarta.persistence.Table;
 import jakarta.persistence.TableGenerator;
 
 /**
+ * Represents a tag attached to a comment. Tags are stored in their own table and linked back to a
+ * {@link PSComment} via a many-to-one relationship.
+ *
  * @author miltonpividori
  */
 @Entity
@@ -52,28 +55,59 @@ public class PSCommentTag {
 
   @Basic private String name;
 
+  /** Default no-arg constructor required by Hibernate. */
   public PSCommentTag() {}
 
+  /**
+   * Creates a new tag with the given name.
+   *
+   * @param name the tag name, must not be {@code null}.
+   */
   public PSCommentTag(String name) {
     this.name = name;
   }
 
+  /**
+   * Gets the unique id assigned to this tag.
+   *
+   * @return the id.
+   */
   public long getId() {
     return id;
   }
 
+  /**
+   * Gets the comment this tag is attached to.
+   *
+   * @return the parent {@link PSComment}.
+   */
   public PSComment getComment() {
     return comment;
   }
 
+  /**
+   * Sets the comment this tag is attached to.
+   *
+   * @param comment the parent {@link PSComment}.
+   */
   public void setComment(PSComment comment) {
     this.comment = comment;
   }
 
+  /**
+   * Gets the tag name.
+   *
+   * @return the tag name.
+   */
   public String getName() {
     return name;
   }
 
+  /**
+   * Sets the tag name.
+   *
+   * @param name the tag name.
+   */
   public void setName(String name) {
     this.name = name;
   }

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSCommentsDao.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSCommentsDao.java
@@ -43,13 +43,25 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
+ * RDBMS-backed implementation of {@link IPSCommentsDao}. Performs all comment persistence through
+ * Hibernate against the delivery tier database.
+ *
  * @author erikserating
  */
 @Repository
 public class PSCommentsDao implements IPSCommentsDao {
 
+  /** Hibernate session factory used by this DAO. */
   private SessionFactory sessionFactory;
 
+  /** Default no-arg constructor required by Spring for bean instantiation. */
+  public PSCommentsDao() {}
+
+  /**
+   * Injects the Hibernate {@link SessionFactory} used by this DAO.
+   *
+   * @param sessionFactory the session factory to use, must not be {@code null}.
+   */
   @Autowired
   public void setSessionFactory(SessionFactory sessionFactory) {
     this.sessionFactory = sessionFactory;

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSDefaultModerationState.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSDefaultModerationState.java
@@ -40,8 +40,15 @@ public class PSDefaultModerationState implements IPSDefaultModerationState {
 
   @Basic private String defaultState;
 
+  /** Default no-arg constructor required by Hibernate. */
   public PSDefaultModerationState() {}
 
+  /**
+   * Creates a new default moderation state for the given site.
+   *
+   * @param site the site name, must not be blank.
+   * @param defaultState the default approval state, must not be blank.
+   */
   public PSDefaultModerationState(String site, String defaultState) {
     if (StringUtils.isBlank(site))
       throw new IllegalArgumentException("site cannot be null or empty.");
@@ -51,41 +58,37 @@ public class PSDefaultModerationState implements IPSDefaultModerationState {
     this.defaultState = defaultState;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.delivery.comments.service.rdbms.IPSDefaultModerationState#getSite()
-   */
-  /* (non-Javadoc)
-   * @see com.percussion.delivery.comments.service.rdbms.IPSDefaultModerationState#getSite()
+  /**
+   * Gets the site name this default moderation state is associated with.
+   *
+   * @return the site name.
    */
   public String getSite() {
     return site;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.delivery.comments.service.rdbms.IPSDefaultModerationState#setSite(java.lang.String)
-   */
-  /* (non-Javadoc)
-   * @see com.percussion.delivery.comments.service.rdbms.IPSDefaultModerationState#setSite(java.lang.String)
+  /**
+   * Sets the site name this default moderation state is associated with.
+   *
+   * @param site the site name.
    */
   public void setSite(String site) {
     this.site = site;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.delivery.comments.service.rdbms.IPSDefaultModerationState#getDefaultState()
-   */
-  /* (non-Javadoc)
-   * @see com.percussion.delivery.comments.service.rdbms.IPSDefaultModerationState#getDefaultState()
+  /**
+   * Gets the default approval state for the site.
+   *
+   * @return the default approval state.
    */
   public String getDefaultState() {
     return defaultState;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.delivery.comments.service.rdbms.IPSDefaultModerationState#setDefaultState(java.lang.String)
-   */
-  /* (non-Javadoc)
-   * @see com.percussion.delivery.comments.service.rdbms.IPSDefaultModerationState#setDefaultState(java.lang.String)
+  /**
+   * Sets the default approval state for the site.
+   *
+   * @param defaultState the default approval state.
    */
   public void setDefaultState(String defaultState) {
     this.defaultState = defaultState;

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/services/IPSCommentRestService.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/services/IPSCommentRestService.java
@@ -103,6 +103,7 @@ public interface IPSCommentRestService extends IPSRestService {
    * @param containerRequest request context.
    * @param action form action.
    * @param headers request headers.
+   * @return a response that redirects back to the referer after the comment is added.
    */
   @POST
   @Path("/addcomment")
@@ -163,14 +164,23 @@ public interface IPSCommentRestService extends IPSRestService {
   String getDefaultModerationState(@PathParam("site") String site);
 
   // Form field param constants
+  /** Form field name for the comment author's user name. */
   String FORM_PARAM_USERNAME = "username";
+  /** Form field name for the site the comment belongs to. */
   String FORM_PARAM_SITE = "site";
+  /** Form field name for the relative path of the page being commented on. */
   String FORM_PARAM_PAGEPATH = "pagepath";
+  /** Form field name for the comment author's email address. */
   String FORM_PARAM_EMAIL = "email";
+  /** Form field name for the comment body text. */
   String FORM_PARAM_TEXT = "text";
+  /** Form field name for the comment title. */
   String FORM_PARAM_TITLE = "title";
+  /** Form field name for the comma or pipe separated list of comment tags. */
   String FORM_PARAM_TAGS = "tags";
+  /** Form field name for a URL supplied by the comment author. */
   String FORM_PARAM_URL = "url";
   // Honeypot spelled backwards.
+  /** Honeypot form field name (spelled backwards). Bots fill this in; humans do not. */
   String FORM_PARAM_HONEYPOT = "topyenoh";
 }

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/services/IPSCommentsDao.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/services/IPSCommentsDao.java
@@ -32,19 +32,73 @@ import java.util.Set;
  */
 public interface IPSCommentsDao {
 
+  /**
+   * Finds comments matching the supplied criteria.
+   *
+   * @param criteria the criteria to filter by, must not be {@code null}.
+   * @return list of matching comments, never {@code null}, may be empty.
+   * @throws Exception if an error occurs during the lookup.
+   */
   List<IPSComment> find(PSCommentCriteria criteria) throws Exception;
 
+  /**
+   * Finds page summaries for all pages that have comments for the specified site.
+   *
+   * @param site the site name, must not be {@code null} or empty.
+   * @return list of page info, never {@code null}, may be empty.
+   * @throws Exception if an error occurs during the lookup.
+   */
   List<PSPageInfo> findPagesWithComments(String site) throws Exception;
 
+  /**
+   * Finds the distinct set of sites that own the specified comment ids.
+   *
+   * @param ids the comment ids to look up, must not be {@code null}.
+   * @return set of site names, never {@code null}, may be empty.
+   * @throws Exception if an error occurs during the lookup.
+   */
   Set<String> findSitesForCommentIds(Collection<String> ids) throws Exception;
 
+  /**
+   * Finds the default moderation state configured for the specified site.
+   *
+   * @param site the site name, must not be {@code null} or empty.
+   * @return the default approval state for the site, never {@code null}.
+   * @throws Exception if an error occurs during the lookup.
+   */
   APPROVAL_STATE findDefaultModerationState(String site) throws Exception;
 
+  /**
+   * Persists the supplied comment.
+   *
+   * @param comment the comment to save, must not be {@code null}.
+   * @throws Exception if an error occurs during the save.
+   */
   void save(IPSComment comment) throws Exception;
 
+  /**
+   * Persists the default moderation state for the specified site.
+   *
+   * @param sitename the site name, must not be {@code null} or empty.
+   * @param state the default approval state, must not be {@code null}.
+   * @throws Exception if an error occurs during the save.
+   */
   void saveDefaultModerationState(String sitename, APPROVAL_STATE state) throws Exception;
 
+  /**
+   * Deletes the comments with the specified ids.
+   *
+   * @param commentIds the comment ids to delete, must not be {@code null}.
+   * @throws Exception if an error occurs during deletion.
+   */
   void delete(Collection<String> commentIds) throws Exception;
 
+  /**
+   * Updates the approval state of the specified comments.
+   *
+   * @param commentIds the comment ids to moderate, must not be {@code null}.
+   * @param newApprovalState the new approval state to apply, must not be {@code null}.
+   * @throws Exception if an error occurs during the update.
+   */
   void moderate(Collection<String> commentIds, APPROVAL_STATE newApprovalState) throws Exception;
 }

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/services/IPSCommentsService.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/services/IPSCommentsService.java
@@ -42,6 +42,7 @@ public interface IPSCommentsService {
    *     true</code> then any comments returned by this method call will have their "viewed" flag
    *     set to <code>true</code> and persisted.
    * @return list of comments, never <code>null</code>, may be empty.
+   * @throws Exception if an error occurs while retrieving the comments.
    */
   public PSComments getComments(PSCommentCriteria criteria, boolean isModerator) throws Exception;
 
@@ -54,6 +55,7 @@ public interface IPSCommentsService {
    * @param startIndex the index offset of results returned, used for paging. If zero or less then
    *     start index will be zero.
    * @return a page summaries object, never <code>null</code>, may be empty.
+   * @throws Exception if an error occurs while retrieving the page summaries.
    */
   public PSPageSummaries getPagesWithComments(String site, int maxResults, int startIndex)
       throws Exception;
@@ -76,6 +78,7 @@ public interface IPSCommentsService {
    * @param criteria the comment criteria object that specifies the comments to be returned. Cannot
    *     be <code>null</code>.
    * @return list of comments, never <code>null</code>, may be empty.
+   * @throws Exception if an error occurs while retrieving the comments.
    */
   public PSComments getComments(PSCommentCriteria criteria) throws Exception;
 
@@ -87,6 +90,7 @@ public interface IPSCommentsService {
    *
    * @param comment the comment object, cannot be <code>null</code>.
    * @return The newly added comment instance. This one has the comment ID inserted in the database.
+   * @throws Exception if an error occurs while adding the comment.
    */
   public IPSComment addComment(IPSComment comment) throws Exception;
 
@@ -124,6 +128,8 @@ public interface IPSCommentsService {
   public void deleteComments(Collection<String> ids);
 
   /**
+   * Retrieves the default moderation state configured for the specified site.
+   *
    * @param sitename the site who's default moderation state we want to retrieve. Cannot be <code>
    *     null</code> or empty.
    * @return the current default, never <code>null</code>.

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/services/PSCommentsRestService.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/services/PSCommentsRestService.java
@@ -84,12 +84,24 @@ public class PSCommentsRestService extends PSAbstractRestService implements IPSC
 
   private final IPSCommentsService commentService;
 
+  /**
+   * Creates a new comments REST service backed by the supplied service.
+   *
+   * @param service the underlying comments service, must not be {@code null}.
+   */
   @Inject
   @Autowired
   public PSCommentsRestService(IPSCommentsService service) {
     this.commentService = service;
   }
 
+  /**
+   * Issues a CSRF token response header derived from the {@code XSRF-TOKEN} cookie if present. Used
+   * by the comment form to satisfy CSRF protection.
+   *
+   * @param request the HTTP request.
+   * @param response the HTTP response, which receives the CSRF headers when applicable.
+   */
   @HEAD
   @Path("/csrf")
   public void csrf(@Context HttpServletRequest request, @Context HttpServletResponse response) {

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/services/PSCommentsService.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/services/PSCommentsService.java
@@ -59,6 +59,11 @@ public class PSCommentsService implements IPSCommentsService {
   private List<IPSServiceDataChangeListener> listeners = new ArrayList<>();
   private final String[] PERC_COMMENTS_SERVICES = {"perc-comments-services"};
 
+  /**
+   * Creates a new comments service backed by the supplied DAO.
+   *
+   * @param dao the comments data access object, must not be {@code null}.
+   */
   @Autowired
   public PSCommentsService(IPSCommentsDao dao) {
     this.dao = dao;
@@ -87,7 +92,7 @@ public class PSCommentsService implements IPSCommentsService {
    * Adds a new comment in the database.
    * Notifies listeners of changes in comments so that cache regions can be flushed.
    *
-   * @param comment Comment to add. Must not be <code>null</null>.
+   * @param comment Comment to add. Must not be {@code null}.
    * May be any implementation of IPSComment interface.
    */
   public IPSComment addComment(IPSComment comment) {
@@ -493,16 +498,20 @@ public class PSCommentsService implements IPSCommentsService {
     throw new UnsupportedOperationException();
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.metadata.IPSMetadataIndexerService#addMetadataListener(com.percussion.metadata.event.IPSMetadataListener)
+  /**
+   * Adds a data change listener to this service.
+   *
+   * @param listener the listener to add, must not be {@code null}.
    */
   public void addMetadataListener(IPSServiceDataChangeListener listener) {
     Validate.notNull(listener, "listener cannot be null.");
     if (!listeners.contains(listener)) listeners.add(listener);
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.metadata.IPSMetadataIndexerService#removeMetadataListener(com.percussion.metadata.event.IPSMetadataListener)
+  /**
+   * Removes a data change listener from this service.
+   *
+   * @param listener the listener to remove, must not be {@code null}.
    */
   public void removeMetadataListener(IPSServiceDataChangeListener listener) {
     Validate.notNull(listener, "listener cannot be null.");

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/services/PSProfanityFilter.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/services/PSProfanityFilter.java
@@ -64,6 +64,11 @@ public class PSProfanityFilter {
     setProfanity();
   }
 
+  /**
+   * Creates a profanity filter that loads its word list from the supplied sample file.
+   *
+   * @param fileSample the file to load the profanity word list from, must not be {@code null}.
+   */
   public PSProfanityFilter(File fileSample) {
     profanityFile = fileSample;
     setProfanity();

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/data/IPSLikes.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/data/IPSLikes.java
@@ -96,8 +96,11 @@ public interface IPSLikes {
 
   /** Like types. */
   enum Type {
+    /** Like applied to a page. */
     page,
+    /** Like applied to a comment. */
     comment,
+    /** Like applied to an image. */
     image
   }
 }

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/data/PSLikes.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/data/PSLikes.java
@@ -38,14 +38,25 @@ public class PSLikes {
 
   private List<IPSLikes> likes;
 
+  /** Default no-arg constructor required by JAXB. */
   public PSLikes() {
     // Default constructor
   }
 
+  /**
+   * Creates a new likes container with the supplied list.
+   *
+   * @param likes the initial list of likes, may be {@code null}.
+   */
   public PSLikes(List<IPSLikes> likes) {
     this.likes = likes;
   }
 
+  /**
+   * Gets the wrapped list of likes. Lazily initializes an empty list if needed.
+   *
+   * @return the list of likes, never {@code null}.
+   */
   public List<IPSLikes> getLikes() {
     if (likes == null) {
       likes = new ArrayList<>();

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/data/PSLikesSummary.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/data/PSLikesSummary.java
@@ -27,12 +27,20 @@ public class PSLikesSummary {
   /** Total number of likes. */
   private int total;
 
+  /** The like identifier. */
   private String likeId;
 
+  /** Default no-arg constructor required by JAXB. */
   public PSLikesSummary() {
     // Default constructor
   }
 
+  /**
+   * Creates a new likes summary with the supplied total and like id.
+   *
+   * @param total the total number of likes.
+   * @param likeId the like identifier.
+   */
   public PSLikesSummary(int total, String likeId) {
     this.total = total;
     this.likeId = likeId;

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/data/PSRestLikes.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/data/PSRestLikes.java
@@ -24,10 +24,17 @@ package com.percussion.delivery.likes.data;
  */
 public class PSRestLikes implements IPSLikes {
 
+  /** Default no-arg constructor required by Jackson and JAXB. */
+  public PSRestLikes() {}
+
+  /** The unique identifier for this like. */
   private String id;
   private String likeId;
+  /** The type of liked entity (page, comment, image). */
   private String type;
+  /** The site this like belongs to. */
   private String site;
+  /** The current total number of likes. */
   private int total;
 
   /**

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/service/rdbms/PSLikes.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/service/rdbms/PSLikes.java
@@ -31,6 +31,9 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 /**
+ * RDBMS-backed entity representing a like count for a (site, likeId, type) tuple. Stored in the
+ * {@code PERC_PAGE_LIKES} table with a uniqueness constraint on those three columns.
+ *
  * @author davidpardini
  */
 @Entity
@@ -41,6 +44,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 public class PSLikes implements IPSLikes, Serializable {
   private static final long serialVersionUID = 1L;
 
+  /** Unique identifier for the like row. Assigned by the persistence layer. */
   @TableGenerator(
       name = "likesId",
       table = "PERC_ID_GEN",
@@ -52,14 +56,19 @@ public class PSLikes implements IPSLikes, Serializable {
   @GeneratedValue(strategy = GenerationType.TABLE, generator = "likesId")
   private long id;
 
+  /** Site the like belongs to. */
   @Basic private String site;
 
+  /** Identifier of the liked entity. */
   @Basic private String likeId;
 
+  /** Type of liked entity (page, comment, image). */
   @Basic private String type;
 
+  /** Current total number of likes. */
   @Basic private int total;
 
+  /** Default no-arg constructor required by Hibernate. */
   public PSLikes() {}
 
   /**
@@ -74,6 +83,13 @@ public class PSLikes implements IPSLikes, Serializable {
     this.total = likes.getTotal();
   }
 
+  /**
+   * Creates a new likes row for the given site, like id and type.
+   *
+   * @param site the site name, must not be {@code null}.
+   * @param likeId the like id, must not be {@code null}.
+   * @param type the like type, must not be {@code null}.
+   */
   public PSLikes(String site, String likeId, String type) {
     super();
     this.site = site;
@@ -82,6 +98,8 @@ public class PSLikes implements IPSLikes, Serializable {
   }
 
   /**
+   * Sets the unique identifier for this like.
+   *
    * @param id the id to set
    */
   public void setId(String id) {
@@ -89,6 +107,8 @@ public class PSLikes implements IPSLikes, Serializable {
   }
 
   /**
+   * Gets the like identifier.
+   *
    * @return the likeId
    */
   public String getLikeId() {
@@ -96,13 +116,17 @@ public class PSLikes implements IPSLikes, Serializable {
   }
 
   /**
-   * @param url the likeId to set
+   * Sets the like identifier.
+   *
+   * @param likeId the likeId to set
    */
   public void setLikeId(String likeId) {
     this.likeId = likeId;
   }
 
   /**
+   * Gets the type of liked entity.
+   *
    * @return the type
    */
   public String getType() {
@@ -110,6 +134,8 @@ public class PSLikes implements IPSLikes, Serializable {
   }
 
   /**
+   * Sets the type of liked entity.
+   *
    * @param type the type to set
    */
   public void setType(String type) {
@@ -117,6 +143,8 @@ public class PSLikes implements IPSLikes, Serializable {
   }
 
   /**
+   * Gets the site this like belongs to.
+   *
    * @return the site
    */
   public String getSite() {
@@ -124,6 +152,8 @@ public class PSLikes implements IPSLikes, Serializable {
   }
 
   /**
+   * Sets the site this like belongs to.
+   *
    * @param site the site to set
    */
   public void setSite(String site) {
@@ -131,6 +161,8 @@ public class PSLikes implements IPSLikes, Serializable {
   }
 
   /**
+   * Gets the unique identifier for this like.
+   *
    * @return the id
    */
   public String getId() {
@@ -138,6 +170,8 @@ public class PSLikes implements IPSLikes, Serializable {
   }
 
   /**
+   * Gets the current total number of likes.
+   *
    * @return the total
    */
   public int getTotal() {
@@ -145,6 +179,8 @@ public class PSLikes implements IPSLikes, Serializable {
   }
 
   /**
+   * Sets the current total number of likes.
+   *
    * @param total the total to set
    */
   public void setTotal(int total) {

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/service/rdbms/PSLikesDao.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/service/rdbms/PSLikesDao.java
@@ -36,13 +36,26 @@ import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * RDBMS-backed implementation of {@link IPSLikesDao}. Performs all likes persistence through
+ * Hibernate against the delivery tier database.
+ */
 @Repository
 @Scope("singleton")
 @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED)
 public class PSLikesDao implements IPSLikesDao {
 
+  /** Hibernate session factory used by this DAO. */
   private SessionFactory sessionFactory;
 
+  /** Default no-arg constructor required by Spring for bean instantiation. */
+  public PSLikesDao() {}
+
+  /**
+   * Injects the Hibernate {@link SessionFactory} used by this DAO.
+   *
+   * @param sessionFactory the session factory to use, must not be {@code null}.
+   */
   @Autowired
   public void setSessionFactory(SessionFactory sessionFactory) {
     this.sessionFactory = sessionFactory;

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/services/IPSLikesDao.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/services/IPSLikesDao.java
@@ -22,20 +22,84 @@ import com.percussion.delivery.likes.data.IPSLikes;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * Data access interface for likes.
+ */
 public interface IPSLikesDao {
+  /**
+   * Finds likes for the specified site, like id and type.
+   *
+   * @param site the site name, must not be {@code null} or empty.
+   * @param likeId the like id, must not be {@code null} or empty.
+   * @param type the like type, must not be {@code null}.
+   * @return list of matching likes, never {@code null}, may be empty.
+   * @throws Exception if an error occurs during the lookup.
+   */
   public List<IPSLikes> find(String site, String likeId, String type) throws Exception;
 
+  /**
+   * Finds all likes associated with the specified site.
+   *
+   * @param site the site name, must not be {@code null} or empty.
+   * @return list of likes for the site, never {@code null}, may be empty.
+   * @throws Exception if an error occurs during the lookup.
+   */
   public List<IPSLikes> findLikesForSite(String site) throws Exception;
 
+  /**
+   * Deletes the likes with the specified ids.
+   *
+   * @param ids the collection of like ids to delete, must not be {@code null}.
+   * @throws Exception if an error occurs during deletion.
+   */
   public void delete(Collection<String> ids) throws Exception;
 
+  /**
+   * Persists a single like.
+   *
+   * @param like the like to save, must not be {@code null}.
+   * @throws Exception if an error occurs during the save.
+   */
   public void save(IPSLikes like) throws Exception;
 
+  /**
+   * Persists a list of likes.
+   *
+   * @param likes the likes to save, must not be {@code null}.
+   * @throws Exception if an error occurs during the save.
+   */
   public void save(List<IPSLikes> likes) throws Exception;
 
+  /**
+   * Creates a new like entry for the specified site, like id and type.
+   *
+   * @param site the site name, must not be {@code null} or empty.
+   * @param likeId the like id, must not be {@code null} or empty.
+   * @param type the like type, must not be {@code null}.
+   * @return the newly created like, never {@code null}.
+   * @throws Exception if an error occurs during creation.
+   */
   public IPSLikes create(String site, String likeId, String type) throws Exception;
 
+  /**
+   * Increments the total number of likes for the specified entity.
+   *
+   * @param site the site name, must not be {@code null} or empty.
+   * @param likeId the like id, must not be {@code null} or empty.
+   * @param type the like type, must not be {@code null}.
+   * @return the updated total count of likes.
+   * @throws Exception if an error occurs during the increment.
+   */
   public int incrementTotal(String site, String likeId, String type) throws Exception;
 
+  /**
+   * Decrements the total number of likes for the specified entity.
+   *
+   * @param site the site name, must not be {@code null} or empty.
+   * @param likeId the like id, must not be {@code null} or empty.
+   * @param type the like type, must not be {@code null}.
+   * @return the updated total count of likes.
+   * @throws Exception if an error occurs during the decrement.
+   */
   public int decrementTotal(String site, String likeId, String type) throws Exception;
 }

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/services/IPSLikesService.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/services/IPSLikesService.java
@@ -28,30 +28,30 @@ public interface IPSLikesService {
   /**
    * Returns the total number of likes for the given URL, site and type
    *
-   * @param type
-   * @param likeId
-   * @param site
-   * @return int total
+   * @param site the site the like is associated with. Must not be {@code null} or empty.
+   * @param likeId the id of the liked entity. Must not be {@code null} or empty.
+   * @param type the type of the liked entity (page, comment, image). Must not be {@code null}.
+   * @return int total of likes for the specified entity.
    */
   public int getTotalLikes(String site, String likeId, String type);
 
   /**
    * Increments the total number of likes for the given URL and returns the number of total likes
    *
-   * @param type
-   * @param likeId
-   * @param site
-   * @return int total
+   * @param site the site the like is associated with. Must not be {@code null} or empty.
+   * @param likeId the id of the liked entity. Must not be {@code null} or empty.
+   * @param type the type of the liked entity (page, comment, image). Must not be {@code null}.
+   * @return int total of likes after the increment.
    */
   public int like(String site, String likeId, String type);
 
   /**
    * Decrements the total number of likes for the given URL and returns the number of total likes
    *
-   * @param type
-   * @param likeId
-   * @param site
-   * @return int total
+   * @param site the site the like is associated with. Must not be {@code null} or empty.
+   * @param likeId the id of the liked entity. Must not be {@code null} or empty.
+   * @param type the type of the liked entity (page, comment, image). Must not be {@code null}.
+   * @return int total of likes after the decrement.
    */
   public int unlike(String site, String likeId, String type);
 

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/services/PSLikesRestService.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/services/PSLikesRestService.java
@@ -44,6 +44,11 @@ public class PSLikesRestService extends PSAbstractRestService {
 
   private static final Logger log = LogManager.getLogger(PSLikesRestService.class);
 
+  /**
+   * Creates a new likes REST service backed by the supplied likes service.
+   *
+   * @param service the underlying likes service, must not be {@code null}.
+   */
   @Inject
   @Autowired
   public PSLikesRestService(IPSLikesService service) {
@@ -53,6 +58,11 @@ public class PSLikesRestService extends PSAbstractRestService {
   /**
    * Tally of how many users have Liked a page, a comment.
    *
+   * @param site the site the like is associated with, taken from the URL path. Must not be {@code
+   *     null} or empty.
+   * @param type the type of the liked entity, taken from the URL path. Must not be {@code null}.
+   * @param likeId the id of the liked entity, taken from the URL path. Must not be {@code null} or
+   *     empty.
    * @return int, never <code>null</code> may be empty.
    */
   @POST
@@ -72,6 +82,11 @@ public class PSLikesRestService extends PSAbstractRestService {
   /**
    * To Like a page, a comment.
    *
+   * @param site the site the like is associated with, taken from the URL path. Must not be {@code
+   *     null} or empty.
+   * @param type the type of the liked entity, taken from the URL path. Must not be {@code null}.
+   * @param likeId the id of the liked entity, taken from the URL path. Must not be {@code null} or
+   *     empty.
    * @return int, never <code>null</code> may be empty.
    */
   @POST
@@ -91,6 +106,11 @@ public class PSLikesRestService extends PSAbstractRestService {
   /**
    * To UnLike a page, a comment.
    *
+   * @param site the site the like is associated with, taken from the URL path. Must not be {@code
+   *     null} or empty.
+   * @param type the type of the liked entity, taken from the URL path. Must not be {@code null}.
+   * @param likeId the id of the liked entity, taken from the URL path. Must not be {@code null} or
+   *     empty.
    * @return int, never <code>null</code> may be empty.
    */
   @POST

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/services/PSLikesService.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/likes/services/PSLikesService.java
@@ -31,16 +31,31 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 
+/**
+ * Default implementation of {@link IPSLikesService} backed by a {@link IPSLikesDao}.
+ */
 public class PSLikesService implements IPSLikesService {
 
+  /** DAO used to read and write likes. */
   private IPSLikesDao dao;
 
+  /** List of registered data change listeners. */
   private List<IPSServiceDataChangeListener> listeners = new ArrayList<>();
+
+  /** Names of services whose cache regions must be flushed when likes change. */
   private final String[] PERC_LIKES_SERVICES = {"perc-likes-services"};
 
   /** Logger for this class */
   public static final Logger log = LogManager.getLogger(PSCommentsService.class);
 
+  /** Default no-arg constructor required by Spring for bean instantiation. */
+  public PSLikesService() {}
+
+  /**
+   * Creates a new likes service backed by the supplied DAO.
+   *
+   * @param dao the likes data access object, must not be {@code null}.
+   */
   @Autowired
   public PSLikesService(IPSLikesDao dao) {
     this.dao = dao;
@@ -49,9 +64,9 @@ public class PSLikesService implements IPSLikesService {
   /**
    * Tally of how many users have Liked a page, a comment.
    *
-   * @param site Must not be <code>null</null>.
-   * @param likeId Must not be <code>null</null>.
-   * @param type Must not be <code>null</null>. May be any implementation of
+   * @param site Must not be {@code null}.
+   * @param likeId Must not be {@code null}.
+   * @param type Must not be {@code null}. May be any implementation of
    *            IPSLikes interface.
    *
    */
@@ -74,9 +89,9 @@ public class PSLikesService implements IPSLikesService {
   /**
    * To Like a page, a comment.
    *
-   * @param site Must not be <code>null</null>.
-   * @param likeId Must not be <code>null</null>.
-   * @param type Must not be <code>null</null>. May be any implementation of
+   * @param site Must not be {@code null}.
+   * @param likeId Must not be {@code null}.
+   * @param type Must not be {@code null}. May be any implementation of
    *            IPSLikes interface.
    *
    * @return int total of likes after of last like.
@@ -88,9 +103,9 @@ public class PSLikesService implements IPSLikesService {
   /**
    * To UnLike a page, a comment.
    *
-   * @param site Must not be <code>null</null>.
-   * @param likeId Must not be <code>null</null>.
-   * @param type Must not be <code>null</null>. May be any implementation of
+   * @param site Must not be {@code null}.
+   * @param likeId Must not be {@code null}.
+   * @param type Must not be {@code null}. May be any implementation of
    *            IPSLikes interface.
    * @return updated count.
    */
@@ -100,11 +115,11 @@ public class PSLikesService implements IPSLikesService {
 
   /**
    * Method to do the work of liking or unliking an object.
-   * @param site . Must not be <code>null</null>.
-   * @param likeId . Must not be <code>null</null>.
-   * @param type . Must not be <code>null</null>. May be any implementation of
+   * @param site . Must not be {@code null}.
+   * @param likeId . Must not be {@code null}.
+   * @param type . Must not be {@code null}. May be any implementation of
    *            IPSLikes interface.
-   * @param isLike if <code>true</code> then this is a like operation.
+   * @param isLike if {@code true} then this is a like operation.
    * @return updated count.
    */
   private int likeUnlike(String site, String likeId, String type, boolean isLike) {
@@ -141,15 +156,19 @@ public class PSLikesService implements IPSLikesService {
   }
 
   /**
-   * @param listener
+   * Adds a data change listener to this service.
+   *
+   * @param listener the listener to add, must not be {@code null}.
    */
   public void addServicedataChangeListener(IPSServiceDataChangeListener listener) {
     Validate.notNull(listener, "listener cannot be null.");
     if (!listeners.contains(listener)) listeners.add(listener);
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.metadata.IPSMetadataIndexerService#removeMetadataListener(com.percussion.metadata.event.IPSMetadataListener)
+  /**
+   * Removes a data change listener from this service.
+   *
+   * @param listener the listener to remove, must not be {@code null}.
    */
   public void removeServicedataChangeListener(IPSServiceDataChangeListener listener) {
     Validate.notNull(listener, "listener cannot be null.");


### PR DESCRIPTION
## Summary

Resolves all Javadoc errors and warnings in the **perc-comments-services** module (DTS comments/likes) without changing any public API or signature.

Closes #1520

## Changes

- **Errors (22 -> 0):**
  - Replaced broken \</null>\ HTML tags with proper \{@code null}\ markup in \PSCommentsService\ and \PSLikesService\.
  - Fixed \@param\ name mismatches in \PSCommentIds\ (\ids\ -> \comments\) and rdbms \PSLikes\ (\url\ -> \likeId\).

- **Warnings (100 -> 0)** across 32 files:
  - Added class/interface level Javadoc descriptions.
  - Added summary sentences to blocks that only had \@param\/\@return\ tags.
  - Added Javadoc to interface methods, enum constants, form-param constants, private fields, and no-arg / parameterized constructors.
  - Added \@throws Exception\ documentation.
  - Filled in empty \@param\ descriptions.
  - Added missing \@return\ tags.

No functional code or signature changes; no CodeQL suppressions altered.

## Verification

\mvn-env.bat clean install\ from \deliverytiersuite/delivery-tier-suite/comments\:

- BUILD SUCCESS
- Tests run: **72**, Failures: 0, Errors: 0, Skipped: 3
- 0 Javadoc errors
- 0 Javadoc warnings

## Files changed

32 files changed, 677 insertions(+), 73 deletions(-)