### PR TITLE
feat(webui): SPA app shell, TopNav, entry query, race-safe bridge, 401→Login

### DIFF
--- a/WebUI/package-lock.json
+++ b/WebUI/package-lock.json
@@ -27,6 +27,7 @@
         "mousetrap": "^1.6.5",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-router-dom": "^7.18.1",
         "recharts": "^3.7.0",
         "underscore": "^1.13.7"
       },
@@ -1385,6 +1386,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3027,6 +3041,44 @@
         }
       }
     },
+    "node_modules/react-router": {
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/recharts": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
@@ -3153,6 +3205,12 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {

--- a/WebUI/package.json
+++ b/WebUI/package.json
@@ -33,6 +33,7 @@
     "mousetrap": "^1.6.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router-dom": "^7.18.1",
     "recharts": "^3.7.0",
     "underscore": "^1.13.7"
   },

--- a/WebUI/src/main/frontend/package-lock.json
+++ b/WebUI/src/main/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "mousetrap": "^1.6.5",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-router-dom": "^7.18.1",
         "recharts": "^3.7.0",
         "underscore": "^1.13.7"
       },
@@ -1408,6 +1409,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3076,6 +3090,44 @@
         }
       }
     },
+    "node_modules/react-router": {
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/recharts": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
@@ -3216,6 +3268,12 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {

--- a/WebUI/src/main/frontend/package.json
+++ b/WebUI/src/main/frontend/package.json
@@ -33,6 +33,7 @@
     "mousetrap": "^1.6.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router-dom": "^7.18.1",
     "recharts": "^3.7.0",
     "underscore": "^1.13.7"
   },

--- a/WebUI/src/main/ts/api/client.ts
+++ b/WebUI/src/main/ts/api/client.ts
@@ -23,6 +23,7 @@
  * {@code text/plain} (e.g. widgetbuilder /active) are parsed as text.</p>
  */
 
+import { redirectToLoginOnUnauthorized } from "../app/auth/sessionHandlers";
 import { getCsrfToken } from "./csrf";
 
 export interface ApiError {
@@ -71,6 +72,10 @@ async function parseBody(response: Response): Promise<unknown> {
 
 async function handleResponse<T>(response: Response): Promise<T> {
   if (!response.ok) {
+    // Mid-session expiry / auth loss → React Login (query return URL)
+    if (response.status === 401) {
+      redirectToLoginOnUnauthorized({ reason: "api-401" });
+    }
     let body: unknown;
     try {
       body = await parseBody(response);

--- a/WebUI/src/main/ts/app/App.tsx
+++ b/WebUI/src/main/ts/app/App.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect } from "react";
+import { HashRouter, useNavigate } from "react-router-dom";
+import { ThemeProvider } from "../ui-themes/ThemeProvider";
+import { BootstrapProvider } from "./bootstrap/BootstrapContext";
+import type { SpaBootstrap } from "./bootstrap/types";
+import { parseEntryQuery } from "./deepLinks/parseEntryQuery";
+import { AppRoutes } from "./routes";
+
+export interface AppProps {
+  bootstrap: SpaBootstrap;
+  /** Override search for tests (default window.location.search) */
+  entrySearch?: string;
+}
+
+/**
+ * Applies server-driven {@code ?entry=} query once, then leaves client routing
+ * to HashRouter (refresh-safe under Jetty).
+ */
+function EntryQueryApplier({
+  entrySearch,
+}: {
+  entrySearch?: string;
+}): null {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const search =
+      entrySearch ??
+      (typeof window !== "undefined" ? window.location.search : "");
+    if (!search || search === "?") {
+      return;
+    }
+    const parsed = parseEntryQuery(search);
+    navigate(parsed.clientPath, { replace: true });
+    // Strip entry query from the document URL after client route is applied
+    // so address bar shows hash route only (server entry already consumed).
+    if (typeof window !== "undefined" && window.history?.replaceState) {
+      try {
+        const url = new URL(window.location.href);
+        if (url.searchParams.has("entry") || url.search.length > 1) {
+          url.search = "";
+          window.history.replaceState(null, "", url.pathname + url.hash);
+        }
+      } catch {
+        // ignore
+      }
+    }
+    // Run once on mount for server entry handoff
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return null;
+}
+
+/**
+ * Authenticated SPA root: theme → bootstrap → HashRouter → routes.
+ */
+export function App({ bootstrap, entrySearch }: AppProps): React.ReactElement {
+  return (
+    <ThemeProvider>
+      <BootstrapProvider value={bootstrap}>
+        <HashRouter>
+          <EntryQueryApplier entrySearch={entrySearch} />
+          <AppRoutes />
+        </HashRouter>
+      </BootstrapProvider>
+    </ThemeProvider>
+  );
+}

--- a/WebUI/src/main/ts/app/FeaturePlaceholder.tsx
+++ b/WebUI/src/main/ts/app/FeaturePlaceholder.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { useParams } from "react-router-dom";
+import styles from "./layout/AppLayout.module.css";
+
+export interface FeaturePlaceholderProps {
+  title: string;
+  /** Optional legacy full-page exit while shell embed lands in PR-3+ */
+  legacyHref?: string;
+  testId?: string;
+}
+
+/**
+ * Route placeholder until feature shells are mounted embedded (PR-3 / PR-4).
+ */
+export function FeaturePlaceholder({
+  title,
+  legacyHref,
+  testId = "perc-feature-placeholder",
+}: FeaturePlaceholderProps): React.ReactElement {
+  const params = useParams();
+  const detail = Object.entries(params)
+    .filter(([, v]) => v != null && String(v).length > 0)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(", ");
+
+  return (
+    <div className={styles.placeholder} data-testid={testId}>
+      <h1 data-testid={`${testId}-title`}>{title}</h1>
+      <p>
+        SPA route is active
+        {detail ? (
+          <>
+            {" "}
+            (<code>{detail}</code>)
+          </>
+        ) : null}
+        . Full feature shell mounts in a follow-on PR; use TopNav or the
+        temporary product link below.
+      </p>
+      {legacyHref ? (
+        <p>
+          <a href={legacyHref} data-testid={`${testId}-legacy`}>
+            Open current product UI
+          </a>
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/app/auth/sessionHandlers.ts
+++ b/WebUI/src/main/ts/app/auth/sessionHandlers.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DEFAULT_SPA_ENTRY_REDIRECT } from "../../login/redirect";
+import { parseEntryQuery, toSpaEntryUrl } from "../deepLinks/parseEntryQuery";
+
+export const REACT_LOGIN_PATH = "/rxlogin.jsp";
+
+let redirectingToLogin = false;
+
+/**
+ * Build React Login URL with allowlisted SPA return query (never hash).
+ */
+export function buildLoginReturnUrl(
+  spaReturn: string = DEFAULT_SPA_ENTRY_REDIRECT,
+): string {
+  const safe =
+    spaReturn.startsWith("/cm/app/spa.jsp") &&
+    !spaReturn.includes("#") &&
+    !spaReturn.includes("://") &&
+    !spaReturn.includes("..")
+      ? spaReturn
+      : DEFAULT_SPA_ENTRY_REDIRECT;
+  const params = new URLSearchParams();
+  params.set("return", safe);
+  return `${REACT_LOGIN_PATH}?${params.toString()}`;
+}
+
+/**
+ * Current SPA document return URL from location (query entry or default home).
+ */
+export function currentSpaReturnUrl(
+  search: string = typeof window !== "undefined" ? window.location.search : "",
+): string {
+  try {
+    return toSpaEntryUrl(parseEntryQuery(search));
+  } catch {
+    return DEFAULT_SPA_ENTRY_REDIRECT;
+  }
+}
+
+/**
+ * Mid-session 401 / auth loss → React Login with query return URL.
+ * Idempotent for concurrent API failures.
+ */
+export function redirectToLoginOnUnauthorized(
+  options: { returnUrl?: string; reason?: string } = {},
+): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  if (redirectingToLogin) {
+    return;
+  }
+  // Already on login — do not loop
+  if (window.location.pathname.endsWith("/rxlogin.jsp")) {
+    return;
+  }
+  redirectingToLogin = true;
+  const returnUrl = options.returnUrl ?? currentSpaReturnUrl();
+  const target = buildLoginReturnUrl(returnUrl);
+  if (options.reason) {
+    console.info(`[PercModernUI] Session redirect to login: ${options.reason}`);
+  }
+  window.location.assign(target);
+}
+
+/** Test-only: reset redirect latch. */
+export function __resetLoginRedirectLatchForTests(): void {
+  redirectingToLogin = false;
+}

--- a/WebUI/src/main/ts/app/bootstrap/BootstrapContext.tsx
+++ b/WebUI/src/main/ts/app/bootstrap/BootstrapContext.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { createContext, useContext } from "react";
+import { DEFAULT_SPA_BOOTSTRAP, type SpaBootstrap } from "./types";
+
+const BootstrapContext = createContext<SpaBootstrap>(DEFAULT_SPA_BOOTSTRAP);
+
+export function BootstrapProvider({
+  value,
+  children,
+}: {
+  value: SpaBootstrap;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <BootstrapContext.Provider value={value}>{children}</BootstrapContext.Provider>
+  );
+}
+
+export function useSpaBootstrap(): SpaBootstrap {
+  return useContext(BootstrapContext);
+}

--- a/WebUI/src/main/ts/app/bootstrap/loadBootstrap.ts
+++ b/WebUI/src/main/ts/app/bootstrap/loadBootstrap.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isSpaEntry } from "../deepLinks/allowlists";
+import { DEFAULT_SPA_BOOTSTRAP, type SpaBootstrap } from "./types";
+
+const SPA_BOOTSTRAP_ID = "perc-bootstrap";
+
+/**
+ * Load SPA bootstrap from the host page JSON script tag.
+ */
+export function loadSpaBootstrap(
+  elementId: string = SPA_BOOTSTRAP_ID,
+): SpaBootstrap {
+  const el = document.getElementById(elementId);
+  if (!el || !el.textContent) {
+    return { ...DEFAULT_SPA_BOOTSTRAP };
+  }
+  try {
+    const raw = JSON.parse(el.textContent) as Partial<SpaBootstrap>;
+    const entryRaw =
+      typeof raw.entry === "string" ? raw.entry.trim().toLowerCase() : "home";
+    const entry = isSpaEntry(entryRaw)
+      ? entryRaw
+      : entryRaw === "widgetbuilder"
+        ? "widget-builder"
+        : "home";
+    return {
+      userName: typeof raw.userName === "string" ? raw.userName : "",
+      locale: typeof raw.locale === "string" ? raw.locale : "en-us",
+      entry,
+      isAdmin: raw.isAdmin === true,
+      isDesigner: raw.isDesigner === true,
+      isWidgetBuilderActive: raw.isWidgetBuilderActive === true,
+    };
+  } catch {
+    console.error(`[PercModernUI] Failed to parse SPA bootstrap (#${elementId})`);
+    return { ...DEFAULT_SPA_BOOTSTRAP };
+  }
+}

--- a/WebUI/src/main/ts/app/bootstrap/types.ts
+++ b/WebUI/src/main/ts/app/bootstrap/types.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Authenticated SPA document bootstrap (XSS-safe JSON from spa.jsp). */
+export interface SpaBootstrap {
+  userName: string;
+  locale: string;
+  entry: string;
+  isAdmin: boolean;
+  isDesigner: boolean;
+  isWidgetBuilderActive: boolean;
+}
+
+export const DEFAULT_SPA_BOOTSTRAP: SpaBootstrap = {
+  userName: "",
+  locale: "en-us",
+  entry: "home",
+  isAdmin: false,
+  isDesigner: false,
+  isWidgetBuilderActive: false,
+};

--- a/WebUI/src/main/ts/app/deepLinks/allowlists.ts
+++ b/WebUI/src/main/ts/app/deepLinks/allowlists.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Server + client SPA entry allowlist (query contract). */
+export const SPA_ENTRIES = [
+  "home",
+  "publish",
+  "workflow",
+  "admin",
+  "widget-builder",
+  "explorer",
+  "unavailable",
+] as const;
+
+export type SpaEntry = (typeof SPA_ENTRIES)[number];
+
+export const HOME_SECTIONS = [
+  "recent",
+  "bookmarks",
+  "library",
+  "search",
+  "create",
+] as const;
+
+export type HomeSection = (typeof HOME_SECTIONS)[number];
+
+const HOME_SECTION_ALIASES: Record<string, HomeSection> = {
+  list: "recent",
+  newitem: "create",
+  bookmark: "bookmarks",
+};
+
+export const PUBLISH_SECTIONS = [
+  "sites",
+  "status",
+  "logs",
+  "design",
+  "runtime",
+  "editions",
+] as const;
+
+export type PublishSection = (typeof PUBLISH_SECTIONS)[number];
+
+const PUBLISH_SECTION_ALIASES: Record<string, PublishSection> = {
+  site: "sites",
+  log: "logs",
+  edition: "editions",
+};
+
+export const WORKFLOW_TABS = [
+  "workflow",
+  "roles",
+  "users",
+  "categories",
+] as const;
+
+export type WorkflowTab = (typeof WORKFLOW_TABS)[number];
+
+export const ADMIN_TABS = ["tasks", "logs", "notifications", "tools"] as const;
+
+export type AdminTab = (typeof ADMIN_TABS)[number];
+
+const ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
+const EXPLORER_PATH_RE = /^[/A-Za-z0-9._-]+$/;
+
+export function isSpaEntry(value: string): value is SpaEntry {
+  return (SPA_ENTRIES as readonly string[]).includes(value);
+}
+
+export function normalizeHomeSection(raw: string | null | undefined): HomeSection | undefined {
+  if (raw == null || !raw.trim()) return undefined;
+  const n = raw.trim().toLowerCase();
+  if ((HOME_SECTIONS as readonly string[]).includes(n)) {
+    return n as HomeSection;
+  }
+  return HOME_SECTION_ALIASES[n];
+}
+
+export function normalizePublishSection(
+  raw: string | null | undefined,
+): PublishSection | undefined {
+  if (raw == null || !raw.trim()) return undefined;
+  const n = raw.trim().toLowerCase();
+  if ((PUBLISH_SECTIONS as readonly string[]).includes(n)) {
+    return n as PublishSection;
+  }
+  return PUBLISH_SECTION_ALIASES[n];
+}
+
+export function normalizeWorkflowTab(raw: string | null | undefined): WorkflowTab | undefined {
+  if (raw == null || !raw.trim()) return undefined;
+  const n = raw.trim().toLowerCase();
+  return (WORKFLOW_TABS as readonly string[]).includes(n) ? (n as WorkflowTab) : undefined;
+}
+
+export function normalizeAdminTab(raw: string | null | undefined): AdminTab | undefined {
+  if (raw == null || !raw.trim()) return undefined;
+  const n = raw.trim().toLowerCase();
+  return (ADMIN_TABS as readonly string[]).includes(n) ? (n as AdminTab) : undefined;
+}
+
+export function normalizeId(raw: string | null | undefined): string | undefined {
+  if (raw == null || !raw.trim()) return undefined;
+  const t = raw.trim();
+  return ID_RE.test(t) ? t : undefined;
+}
+
+export function normalizeExplorerPath(raw: string | null | undefined): string | undefined {
+  if (raw == null || !raw.trim()) return undefined;
+  const t = raw.trim();
+  if (!t.startsWith("/") || t.length >= 2048 || t.includes("..") || t.includes("://")) {
+    return undefined;
+  }
+  return EXPLORER_PATH_RE.test(t) ? t : undefined;
+}

--- a/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
+++ b/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  isSpaEntry,
+  normalizeAdminTab,
+  normalizeExplorerPath,
+  normalizeHomeSection,
+  normalizeId,
+  normalizePublishSection,
+  normalizeWorkflowTab,
+  type SpaEntry,
+} from "./allowlists";
+
+/**
+ * Parsed server-driven SPA entry (query contract only — never hash).
+ */
+export interface ParsedSpaEntry {
+  entry: SpaEntry;
+  /** Client hash route path (e.g. /home/library, /publish/logs) */
+  clientPath: string;
+  section?: string;
+  tab?: string;
+  siteId?: string;
+  serverId?: string;
+  path?: string;
+}
+
+/**
+ * Parse {@code window.location.search} (or a synthetic query string) into an
+ * allowlisted SPA entry and client route path.
+ */
+export function parseEntryQuery(
+  search: string = typeof window !== "undefined" ? window.location.search : "",
+): ParsedSpaEntry {
+  const q = search.startsWith("?") ? search.slice(1) : search;
+  const params = new URLSearchParams(q);
+
+  let entryRaw = (params.get("entry") || "home").trim().toLowerCase();
+  // Legacy alias
+  if (entryRaw === "widgetbuilder") {
+    entryRaw = "widget-builder";
+  }
+  const entry: SpaEntry = isSpaEntry(entryRaw) ? entryRaw : "home";
+
+  const sectionParam = params.get("section") ?? params.get("initialScreen");
+  const tabParam = params.get("tab");
+  const siteId = normalizeId(params.get("siteId"));
+  const serverId = normalizeId(params.get("serverId"));
+  const path = normalizeExplorerPath(params.get("path"));
+
+  switch (entry) {
+    case "home": {
+      const section = normalizeHomeSection(sectionParam);
+      return {
+        entry,
+        section,
+        clientPath: section ? `/home/${section}` : "/home",
+      };
+    }
+    case "publish": {
+      const section = normalizePublishSection(sectionParam);
+      let clientPath = section ? `/publish/${section}` : "/publish";
+      const qs = new URLSearchParams();
+      if (siteId) qs.set("siteId", siteId);
+      if (serverId) qs.set("serverId", serverId);
+      const qstr = qs.toString();
+      if (qstr) clientPath += `?${qstr}`;
+      return { entry, section, siteId, serverId, clientPath };
+    }
+    case "workflow": {
+      const tab = normalizeWorkflowTab(tabParam ?? sectionParam);
+      return {
+        entry,
+        tab,
+        clientPath: tab ? `/workflow/${tab}` : "/workflow",
+      };
+    }
+    case "admin": {
+      const tab = normalizeAdminTab(tabParam ?? sectionParam);
+      return {
+        entry,
+        tab,
+        clientPath: tab ? `/admin/${tab}` : "/admin",
+      };
+    }
+    case "widget-builder":
+      return { entry, clientPath: "/widget-builder" };
+    case "explorer": {
+      let clientPath = "/explorer";
+      if (path) {
+        clientPath += `?path=${encodeURIComponent(path)}`;
+      }
+      return { entry, path, clientPath };
+    }
+    case "unavailable":
+      return { entry, clientPath: "/unavailable" };
+    default:
+      return { entry: "home", clientPath: "/home" };
+  }
+}
+
+/**
+ * Rebuild an allowlisted query entry URL for login return / server redirects.
+ */
+export function toSpaEntryUrl(parsed: ParsedSpaEntry): string {
+  const params = new URLSearchParams();
+  params.set("entry", parsed.entry);
+  if (parsed.section) params.set("section", parsed.section);
+  if (parsed.tab) params.set("tab", parsed.tab);
+  if (parsed.siteId) params.set("siteId", parsed.siteId);
+  if (parsed.serverId) params.set("serverId", parsed.serverId);
+  if (parsed.path) params.set("path", parsed.path);
+  return `/cm/app/spa.jsp?${params.toString()}`;
+}

--- a/WebUI/src/main/ts/app/layout/AppLayout.module.css
+++ b/WebUI/src/main/ts/app/layout/AppLayout.module.css
@@ -1,0 +1,109 @@
+.shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-surface-alt, #f5f7fb);
+  color: var(--color-text, #181c2c);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.topNav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.75rem;
+  padding: 0.55rem 1rem;
+  background: var(--color-surface, #fff);
+  border-bottom: 1px solid var(--color-border, #d8dee9);
+  box-shadow: 0 1px 0 rgba(11, 34, 74, 0.04);
+}
+
+.navGroup {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.navLink {
+  display: inline-block;
+  padding: 0.4rem 0.7rem;
+  border-radius: 6px;
+  color: var(--color-text, #181c2c);
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.navLink:hover {
+  background: var(--color-surface-alt, #eef2f8);
+}
+
+.navLinkActive {
+  background: var(--color-primary, #4a6aa3);
+  color: #fff;
+}
+
+.navLinkActive:hover {
+  background: var(--color-primary, #3d5a8a);
+  color: #fff;
+}
+
+.spacer {
+  flex: 1;
+  min-width: 0.5rem;
+}
+
+.main {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.userMenu {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--color-text-muted, #5b6478);
+}
+
+.userName {
+  font-weight: 600;
+  color: var(--color-text, #181c2c);
+}
+
+.logoutLink {
+  color: var(--color-primary, #4a6aa3);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.logoutLink:hover {
+  text-decoration: underline;
+}
+
+.placeholder {
+  margin: 1.5rem auto;
+  max-width: 720px;
+  width: 100%;
+  padding: 1.5rem;
+  box-sizing: border-box;
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-border, #d8dee9);
+  border-radius: 12px;
+}
+
+.placeholder h1 {
+  margin-top: 0;
+  font-size: 1.35rem;
+}
+
+.placeholder p {
+  color: var(--color-text-muted, #5b6478);
+  line-height: 1.5;
+}

--- a/WebUI/src/main/ts/app/layout/AppLayout.tsx
+++ b/WebUI/src/main/ts/app/layout/AppLayout.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { Outlet } from "react-router-dom";
+import { BrandBar, BrandFooter } from "../../ui-themes/components";
+import { TopNav } from "./TopNav";
+import styles from "./AppLayout.module.css";
+
+/**
+ * Authenticated SPA chrome: brand bar, TopNav, feature outlet, footer.
+ * Feature shells should use {@code embedded} (PR-3+) to avoid duplicate chrome.
+ */
+export function AppLayout(): React.ReactElement {
+  return (
+    <div className={styles.shell} data-testid="perc-spa-app">
+      <BrandBar />
+      <TopNav />
+      <main className={styles.main} data-testid="perc-spa-outlet">
+        <Outlet />
+      </main>
+      <BrandFooter />
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/app/layout/TopNav.tsx
+++ b/WebUI/src/main/ts/app/layout/TopNav.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { NavLink } from "react-router-dom";
+import { useSpaBootstrap } from "../bootstrap/BootstrapContext";
+import { UserMenu } from "./UserMenu";
+import styles from "./AppLayout.module.css";
+
+/**
+ * Product top navigation for the SPA shell.
+ * SPA routes use client NavLink; unmigrated surfaces are full-page legacy exits.
+ */
+export function TopNav(): React.ReactElement {
+  const { isAdmin, isDesigner, isWidgetBuilderActive } = useSpaBootstrap();
+  const canPublish = isAdmin || isDesigner;
+  const canWb = isWidgetBuilderActive && (isAdmin || isDesigner);
+
+  const linkClass = ({ isActive }: { isActive: boolean }): string =>
+    isActive ? `${styles.navLink} ${styles.navLinkActive}` : styles.navLink;
+
+  return (
+    <nav className={styles.topNav} aria-label="Main" data-testid="perc-spa-topnav">
+      <ul className={styles.navGroup}>
+        <li>
+          <NavLink to="/home" className={linkClass} data-testid="nav-home">
+            Home
+          </NavLink>
+        </li>
+        <li>
+          {/* Temporary hybrid exit until SPA dashboard route (PR-7) */}
+          <a
+            className={styles.navLink}
+            href="/cm/app/?view=dash"
+            data-testid="nav-dashboard"
+          >
+            Dashboard
+          </a>
+        </li>
+        <li>
+          <a
+            className={styles.navLink}
+            href="/cm/app/?view=editor"
+            data-testid="nav-editor"
+          >
+            Editor
+          </a>
+        </li>
+        {canPublish ? (
+          <>
+            <li>
+              <a
+                className={styles.navLink}
+                href="/cm/app/?view=arch"
+                data-testid="nav-architecture"
+              >
+                Architecture
+              </a>
+            </li>
+            <li>
+              <a
+                className={styles.navLink}
+                href="/cm/app/?view=design"
+                data-testid="nav-design"
+              >
+                Design
+              </a>
+            </li>
+            <li>
+              <NavLink to="/publish" className={linkClass} data-testid="nav-publish">
+                Publish
+              </NavLink>
+            </li>
+          </>
+        ) : null}
+        {isAdmin ? (
+          <li>
+            <NavLink to="/workflow" className={linkClass} data-testid="nav-workflow">
+              Administration
+            </NavLink>
+          </li>
+        ) : null}
+        {isAdmin ? (
+          <li>
+            <NavLink to="/admin" className={linkClass} data-testid="nav-admin">
+              Admin tools
+            </NavLink>
+          </li>
+        ) : null}
+        {canWb ? (
+          <li>
+            <NavLink
+              to="/widget-builder"
+              className={linkClass}
+              data-testid="nav-widget-builder"
+            >
+              Widget Builder
+            </NavLink>
+          </li>
+        ) : null}
+        <li>
+          <NavLink to="/explorer" className={linkClass} data-testid="nav-explorer">
+            Explorer
+          </NavLink>
+        </li>
+      </ul>
+      <div className={styles.spacer} />
+      <UserMenu />
+    </nav>
+  );
+}

--- a/WebUI/src/main/ts/app/layout/UserMenu.tsx
+++ b/WebUI/src/main/ts/app/layout/UserMenu.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { useSpaBootstrap } from "../bootstrap/BootstrapContext";
+import styles from "./AppLayout.module.css";
+
+export function UserMenu(): React.ReactElement {
+  const { userName } = useSpaBootstrap();
+  const name = userName?.trim() || "user";
+
+  return (
+    <div className={styles.userMenu} data-testid="perc-spa-user-menu">
+      <span>
+        Signed in as{" "}
+        <span className={styles.userName} data-testid="perc-spa-user-name">
+          {name}
+        </span>
+      </span>
+      <a className={styles.logoutLink} href="/logout" data-testid="perc-spa-logout">
+        Logout
+      </a>
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/app/main.tsx
+++ b/WebUI/src/main/ts/app/main.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import { loadSpaBootstrap } from "./bootstrap/loadBootstrap";
+
+/**
+ * Boot the authenticated SPA into the given root element.
+ */
+export function boot(rootEl: HTMLElement): void {
+  const bootstrap = loadSpaBootstrap();
+  createRoot(rootEl).render(React.createElement(App, { bootstrap }));
+  console.info("[PercModernUI] SPA App mounted.");
+}

--- a/WebUI/src/main/ts/app/routes.tsx
+++ b/WebUI/src/main/ts/app/routes.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { Navigate, Route, Routes } from "react-router-dom";
+import { FeaturePlaceholder } from "./FeaturePlaceholder";
+import { AppLayout } from "./layout/AppLayout";
+
+/**
+ * Authenticated SPA routes. Placeholders until PR-3/PR-4 embed real shells.
+ */
+export function AppRoutes(): React.ReactElement {
+  return (
+    <Routes>
+      <Route element={<AppLayout />}>
+        <Route index element={<Navigate to="/home" replace />} />
+        <Route
+          path="home"
+          element={
+            <FeaturePlaceholder
+              title="Home"
+              legacyHref="/cm/app/?view=home"
+              testId="route-home"
+            />
+          }
+        />
+        <Route
+          path="home/:section"
+          element={
+            <FeaturePlaceholder
+              title="Home"
+              legacyHref="/cm/app/?view=home"
+              testId="route-home"
+            />
+          }
+        />
+        <Route
+          path="publish"
+          element={
+            <FeaturePlaceholder
+              title="Publish"
+              legacyHref="/cm/app/?view=publish"
+              testId="route-publish"
+            />
+          }
+        />
+        <Route
+          path="publish/:section"
+          element={
+            <FeaturePlaceholder
+              title="Publish"
+              legacyHref="/cm/app/?view=publish"
+              testId="route-publish"
+            />
+          }
+        />
+        <Route
+          path="workflow"
+          element={
+            <FeaturePlaceholder
+              title="Administration"
+              legacyHref="/cm/app/?view=workflow"
+              testId="route-workflow"
+            />
+          }
+        />
+        <Route
+          path="workflow/:tab"
+          element={
+            <FeaturePlaceholder
+              title="Administration"
+              legacyHref="/cm/app/?view=workflow"
+              testId="route-workflow"
+            />
+          }
+        />
+        <Route
+          path="admin"
+          element={
+            <FeaturePlaceholder
+              title="Admin tools"
+              legacyHref="/cm/app/?view=admin"
+              testId="route-admin"
+            />
+          }
+        />
+        <Route
+          path="admin/:tab"
+          element={
+            <FeaturePlaceholder
+              title="Admin tools"
+              legacyHref="/cm/app/?view=admin"
+              testId="route-admin"
+            />
+          }
+        />
+        <Route
+          path="widget-builder"
+          element={
+            <FeaturePlaceholder
+              title="Widget Builder"
+              legacyHref="/cm/app/?view=widgetbuilder"
+              testId="route-widget-builder"
+            />
+          }
+        />
+        <Route
+          path="explorer"
+          element={
+            <FeaturePlaceholder
+              title="Content Explorer"
+              legacyHref="/cm/app/?view=home"
+              testId="route-explorer"
+            />
+          }
+        />
+        <Route
+          path="unavailable"
+          element={
+            <FeaturePlaceholder title="Unavailable" testId="route-unavailable" />
+          }
+        />
+        <Route
+          path="*"
+          element={<Navigate to="/unavailable" replace />}
+        />
+      </Route>
+    </Routes>
+  );
+}

--- a/WebUI/src/main/ts/bridge.ts
+++ b/WebUI/src/main/ts/bridge.ts
@@ -18,19 +18,14 @@
 /**
  * Bridge layer for embedding React components inside existing JSP pages.
  *
- * <p>This module exposes a {@code mountReactComponent} function on
- * {@code window.PercModernUI} so legacy pages can mount React components into
- * arbitrary DOM elements without a full SPA takeover.</p>
- *
- * <p>Usage from a JSP or legacy JS file:</p>
- * <pre>
- *   window.PercModernUI.mount('my-container', 'HelloWorld', { name: 'Sal' });
- * </pre>
+ * <p>{@code mount}/{@code unmount} remain <strong>synchronous</strong> for hosts.
+ * Loads use shared {@link loadComponent} with generation tokens so late resolves
+ * after unmount or remount are ignored (§2.9).</p>
  */
 
 import React from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { componentRegistry } from "./registry";
+import { isRegisteredComponent, loadComponent } from "./registry";
 
 declare global {
   interface Window {
@@ -46,13 +41,17 @@ declare global {
 }
 
 const activeRoots = new Map<string, Root>();
+/** Generation token per elementId — bumped on each mount/unmount. */
+const generations = new Map<string, number>();
+
+function bumpGeneration(elementId: string): number {
+  const next = (generations.get(elementId) ?? 0) + 1;
+  generations.set(elementId, next);
+  return next;
+}
 
 /**
- * Mounts a registered React component into a DOM element.
- *
- * @param elementId - the id of the target container element
- * @param componentName - the key used to register the component
- * @param props - optional props to pass to the component
+ * Mounts a registered React component into a DOM element (sync API; async load).
  */
 export function mountReactComponent(
   elementId: string,
@@ -61,34 +60,52 @@ export function mountReactComponent(
 ): void {
   const container = document.getElementById(elementId);
   if (!container) {
-    console.error(
-      `[PercModernUI] Container element "#${elementId}" not found.`,
-    );
+    console.error(`[PercModernUI] Container element "#${elementId}" not found.`);
     return;
   }
 
-  const Component = componentRegistry.get(componentName);
-  if (!Component) {
+  if (!isRegisteredComponent(componentName)) {
     console.error(
       `[PercModernUI] Component "${componentName}" is not registered.`,
     );
     return;
   }
 
-  // Unmount any existing root at the same element to avoid leaks
-  unmountReactComponent(elementId);
+  // Invalidate any prior pending load for this element
+  const gen = bumpGeneration(elementId);
+  unmountRootOnly(elementId);
 
-  const root = createRoot(container);
-  root.render(React.createElement(Component, props));
-  activeRoots.set(elementId, root);
+  void loadComponent(componentName)
+    .then((Component) => {
+      if (generations.get(elementId) !== gen) {
+        // Stale: unmount or remount happened before resolve
+        return;
+      }
+      const el = document.getElementById(elementId);
+      if (!el) {
+        return;
+      }
+      unmountRootOnly(elementId);
+      const root = createRoot(el);
+      root.render(React.createElement(Component, props));
+      activeRoots.set(elementId, root);
+    })
+    .catch((err) => {
+      if (generations.get(elementId) !== gen) {
+        return;
+      }
+      console.error(
+        `[PercModernUI] Failed to load component "${componentName}"`,
+        err,
+      );
+      const el = document.getElementById(elementId);
+      if (el) {
+        el.setAttribute("data-perc-mount-error", "1");
+      }
+    });
 }
 
-/**
- * Unmounts a previously mounted React component.
- *
- * @param elementId - the id of the container element
- */
-export function unmountReactComponent(elementId: string): void {
+function unmountRootOnly(elementId: string): void {
   const existing = activeRoots.get(elementId);
   if (existing) {
     existing.unmount();
@@ -96,7 +113,18 @@ export function unmountReactComponent(elementId: string): void {
   }
 }
 
-// Expose on the global window so legacy JS/JSP pages can call it
+/**
+ * Unmounts a previously mounted React component and invalidates pending loads.
+ */
+export function unmountReactComponent(elementId: string): void {
+  bumpGeneration(elementId);
+  unmountRootOnly(elementId);
+  const el = document.getElementById(elementId);
+  if (el) {
+    el.removeAttribute("data-perc-mount-error");
+  }
+}
+
 window.PercModernUI = {
   mount: mountReactComponent,
   unmount: unmountReactComponent,

--- a/WebUI/src/main/ts/index.ts
+++ b/WebUI/src/main/ts/index.ts
@@ -21,15 +21,15 @@
  * <ul>
  *   <li>Always registers {@code window.PercModernUI} for residual bridge embeds.</li>
  *   <li>If {@code #perc-login-root} is present, boots the React Login front door.</li>
- *   <li>If {@code #perc-spa-root} is present, boots the authenticated SPA landing.</li>
+ *   <li>If SPA root is present ({@code #perc-spa-root}, {@code #root}, {@code #perc-app-root}),
+ *       boots the authenticated App shell.</li>
  * </ul>
  */
 
 import React from "react";
 import { createRoot } from "react-dom/client";
 import "./bridge";
-import { LandingShell } from "./app/LandingShell";
-import { LoginPage, readLoginBootstrap, readSpaLandingBootstrap } from "./login";
+import { LoginPage, readLoginBootstrap } from "./login";
 
 function bootLogin(): void {
   const el = document.getElementById("perc-login-root");
@@ -41,25 +41,34 @@ function bootLogin(): void {
   console.info("[PercModernUI] Login SPA mounted.");
 }
 
-function bootSpaLanding(): void {
-  const el = document.getElementById("perc-spa-root");
+function findSpaRoot(): HTMLElement | null {
+  return (
+    document.getElementById("perc-spa-root") ??
+    document.getElementById("root") ??
+    document.getElementById("perc-app-root")
+  );
+}
+
+function bootSpa(): void {
+  const el = findSpaRoot();
   if (!el) {
     return;
   }
-  const bootstrap = readSpaLandingBootstrap();
-  createRoot(el).render(React.createElement(LandingShell, { bootstrap }));
-  console.info("[PercModernUI] SPA landing mounted.");
+  void import("./app/main").then((m) => {
+    m.boot(el);
+  });
 }
 
 function boot(): void {
-  // Login page is public and exclusive; SPA landing is authenticated.
   if (document.getElementById("perc-login-root")) {
     bootLogin();
     return;
   }
-  if (document.getElementById("perc-spa-root")) {
-    bootSpaLanding();
+  if (findSpaRoot()) {
+    bootSpa();
+    return;
   }
+  console.info("[PercModernUI] bridge ready (no SPA root)");
 }
 
 if (document.readyState === "loading") {

--- a/WebUI/src/main/ts/registry.ts
+++ b/WebUI/src/main/ts/registry.ts
@@ -10,59 +10,149 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 
 import type { ComponentType } from "react";
-import { HelloWorld } from "./components/HelloWorld";
-import { Dashboard, WorkflowStatusWidget, ActivityWidget, ProcessMonitorWidget, EffectivenessWidget, AssetsStatusWidget, BulkUploadWidget, ReportsWidget, TrafficWidget } from "./dashboard";
-import { HomeShell } from "./home";
-import { UnavailableView } from "./home/UnavailableView";
-import { PublishingShell } from "./publishing";
-import { WidgetBuilderApp } from "./widgetbuilder/WidgetBuilderApp";
-import { ContentExplorerShell } from "./contentExplorer/ContentExplorerShell";
-import { ClipboardPanel } from "./contentExplorer/clipboard/ClipboardPanel";
-import { SiteCopyWizard } from "./contentExplorer/wizards/SiteCopyWizard";
-import { SubfolderCopyWizard } from "./contentExplorer/wizards/SubfolderCopyWizard";
-import { DependencyViewer } from "./contentExplorer/views/DependencyViewer";
-import { RelationshipsView } from "./contentExplorer/views/RelationshipsView";
-import { SearchPanel } from "./contentExplorer/SearchPanel";
-import { FolderSecurityPanel } from "./contentExplorer/FolderSecurityPanel";
-import { ContextMenu } from "./contentExplorer/ContextMenu";
-import { ActionToolbar } from "./contentExplorer/ActionToolbar";
-import { ContentBrowser } from "./contentBrowser/ContentBrowser";
-import { WorkflowAdminShell } from "./workflowAdmin/WorkflowAdminShell";
-import { AdminShell } from "./admin/AdminShell";
 
-/** Map of component names to their React component types. */
+type Loader = () => Promise<{ default: ComponentType<any> } | ComponentType<any>>;
+
+/**
+ * Dynamic import factories — main chunk must not static-import feature shells.
+ * Shared by bridge mounts and future SPA lazy routes.
+ */
+const loaders: Record<string, Loader> = {
+  HelloWorld: () =>
+    import("./components/HelloWorld").then((m) => ({ default: m.HelloWorld })),
+  Dashboard: () =>
+    import("./dashboard").then((m) => ({ default: m.Dashboard })),
+  WorkflowStatusWidget: () =>
+    import("./dashboard").then((m) => ({ default: m.WorkflowStatusWidget })),
+  ActivityWidget: () =>
+    import("./dashboard").then((m) => ({ default: m.ActivityWidget })),
+  ProcessMonitorWidget: () =>
+    import("./dashboard").then((m) => ({ default: m.ProcessMonitorWidget })),
+  EffectivenessWidget: () =>
+    import("./dashboard").then((m) => ({ default: m.EffectivenessWidget })),
+  AssetsStatusWidget: () =>
+    import("./dashboard").then((m) => ({ default: m.AssetsStatusWidget })),
+  BulkUploadWidget: () =>
+    import("./dashboard").then((m) => ({ default: m.BulkUploadWidget })),
+  ReportsWidget: () =>
+    import("./dashboard").then((m) => ({ default: m.ReportsWidget })),
+  TrafficWidget: () =>
+    import("./dashboard").then((m) => ({ default: m.TrafficWidget })),
+  HomeShell: () => import("./home").then((m) => ({ default: m.HomeShell })),
+  PublishingShell: () =>
+    import("./publishing").then((m) => ({ default: m.PublishingShell })),
+  WidgetBuilderApp: () =>
+    import("./widgetbuilder/WidgetBuilderApp").then((m) => ({
+      default: m.WidgetBuilderApp,
+    })),
+  UnavailableView: () =>
+    import("./home/UnavailableView").then((m) => ({ default: m.UnavailableView })),
+  ContentExplorerShell: () =>
+    import("./contentExplorer/ContentExplorerShell").then((m) => ({
+      default: m.ContentExplorerShell,
+    })),
+  ContentBrowser: () =>
+    import("./contentBrowser/ContentBrowser").then((m) => ({
+      default: m.ContentBrowser,
+    })),
+  ClipboardPanel: () =>
+    import("./contentExplorer/clipboard/ClipboardPanel").then((m) => ({
+      default: m.ClipboardPanel,
+    })),
+  SiteCopyWizard: () =>
+    import("./contentExplorer/wizards/SiteCopyWizard").then((m) => ({
+      default: m.SiteCopyWizard,
+    })),
+  SubfolderCopyWizard: () =>
+    import("./contentExplorer/wizards/SubfolderCopyWizard").then((m) => ({
+      default: m.SubfolderCopyWizard,
+    })),
+  DependencyViewer: () =>
+    import("./contentExplorer/views/DependencyViewer").then((m) => ({
+      default: m.DependencyViewer,
+    })),
+  RelationshipsView: () =>
+    import("./contentExplorer/views/RelationshipsView").then((m) => ({
+      default: m.RelationshipsView,
+    })),
+  SearchPanel: () =>
+    import("./contentExplorer/SearchPanel").then((m) => ({
+      default: m.SearchPanel,
+    })),
+  FolderSecurityPanel: () =>
+    import("./contentExplorer/FolderSecurityPanel").then((m) => ({
+      default: m.FolderSecurityPanel,
+    })),
+  ActionToolbar: () =>
+    import("./contentExplorer/ActionToolbar").then((m) => ({
+      default: m.ActionToolbar,
+    })),
+  ContextMenu: () =>
+    import("./contentExplorer/ContextMenu").then((m) => ({
+      default: m.ContextMenu,
+    })),
+  WorkflowAdminShell: () =>
+    import("./workflowAdmin/WorkflowAdminShell").then((m) => ({
+      default: m.WorkflowAdminShell,
+    })),
+  AdminShell: () =>
+    import("./admin/AdminShell").then((m) => ({ default: m.AdminShell })),
+};
+
+const cache = new Map<string, Promise<ComponentType<any>>>();
+
+/**
+ * Lazily load a registered component by name (shared by bridge + SPA).
+ *
+ * @param name - registry key (e.g. HomeShell)
+ * @returns resolved component type
+ */
+export function loadComponent(name: string): Promise<ComponentType<any>> {
+  const existing = cache.get(name);
+  if (existing) {
+    return existing;
+  }
+  const loader = loaders[name];
+  if (!loader) {
+    return Promise.reject(new Error(`Unknown component: ${name}`));
+  }
+  const promise = loader()
+    .then((mod) => {
+      if (typeof mod === "function") {
+        return mod as ComponentType<any>;
+      }
+      const def = (mod as { default: ComponentType<any> }).default;
+      if (!def) {
+        throw new Error(`Component module for "${name}" has no default export`);
+      }
+      return def;
+    })
+    .catch((err) => {
+      cache.delete(name);
+      throw err;
+    });
+  cache.set(name, promise);
+  return promise;
+}
+
+/** Whether a name has a loader (does not load the module). */
+export function isRegisteredComponent(name: string): boolean {
+  return Object.prototype.hasOwnProperty.call(loaders, name);
+}
+
+/** Registered component names (for tests / diagnostics). */
+export function listRegisteredComponentNames(): string[] {
+  return Object.keys(loaders).sort();
+}
+
+/**
+ * @deprecated Prefer {@link loadComponent}. Sync map is empty; kept for type
+ * compatibility with older tests that import {@code componentRegistry}.
+ */
 export const componentRegistry = new Map<string, ComponentType<any>>();
-
-// Register components available to the bridge
-componentRegistry.set("HelloWorld", HelloWorld);
-componentRegistry.set("Dashboard", Dashboard);
-componentRegistry.set("WorkflowStatusWidget", WorkflowStatusWidget);
-componentRegistry.set("ActivityWidget", ActivityWidget);
-componentRegistry.set("ProcessMonitorWidget", ProcessMonitorWidget);
-componentRegistry.set("EffectivenessWidget", EffectivenessWidget);
-componentRegistry.set("AssetsStatusWidget", AssetsStatusWidget);
-componentRegistry.set("BulkUploadWidget", BulkUploadWidget);
-componentRegistry.set("ReportsWidget", ReportsWidget);
-componentRegistry.set("TrafficWidget", TrafficWidget);
-componentRegistry.set("HomeShell", HomeShell);
-componentRegistry.set("PublishingShell", PublishingShell);
-componentRegistry.set("WidgetBuilderApp", WidgetBuilderApp);
-componentRegistry.set("UnavailableView", UnavailableView);
-componentRegistry.set("ContentExplorerShell", ContentExplorerShell);
-componentRegistry.set("ContentBrowser", ContentBrowser);
-componentRegistry.set("ClipboardPanel", ClipboardPanel);
-componentRegistry.set("SiteCopyWizard", SiteCopyWizard);
-componentRegistry.set("SubfolderCopyWizard", SubfolderCopyWizard);
-componentRegistry.set("DependencyViewer", DependencyViewer);
-componentRegistry.set("RelationshipsView", RelationshipsView);
-componentRegistry.set("SearchPanel", SearchPanel);
-componentRegistry.set("FolderSecurityPanel", FolderSecurityPanel);
-componentRegistry.set("ActionToolbar", ActionToolbar);
-componentRegistry.set("ContextMenu", ContextMenu);
-componentRegistry.set("WorkflowAdminShell", WorkflowAdminShell);
-componentRegistry.set("AdminShell", AdminShell);

--- a/WebUI/src/main/webapp/cm/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/app/spa.jsp
@@ -1,10 +1,14 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ page import="com.percussion.services.utils.jspel.PSRoleUtilities" %>
+<%@ page import="com.percussion.user.data.PSCurrentUser" %>
+<%@ page import="com.percussion.user.service.impl.PSUserService" %>
+<%@ page import="com.percussion.utils.PSSpringBeanProvider" %>
+<%@ page import="com.percussion.widgetbuilder.service.PSWidgetBuilderService" %>
 <%@ taglib uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" prefix="csrf" %>
 <%--
-  Minimal authenticated SPA landing (PR-1).
-  Full router + feature shells land in subsequent PRs.
-  Entry: /cm/app/spa.jsp?entry=home (query contract — no hash redirects).
+  Authenticated SPA document (PR-2 app shell).
+  Entry: /cm/app/spa.jsp?entry=home (query contract — no hash on server redirects).
+  No header.jsp / mainnav.jsp — React AppLayout + TopNav.
 --%>
 <%!
     private static String jsonString(String s) {
@@ -43,6 +47,9 @@
             return "home";
         }
         String n = raw.trim().toLowerCase(java.util.Locale.ROOT);
+        if ("widgetbuilder".equals(n)) {
+            return "widget-builder";
+        }
         if ("home".equals(n) || "publish".equals(n) || "workflow".equals(n)
                 || "admin".equals(n) || "widget-builder".equals(n)
                 || "explorer".equals(n) || "unavailable".equals(n)) {
@@ -62,9 +69,44 @@
         lang = locale;
     }
     String entry = allowEntry(request.getParameter("entry"));
+
     String userName = request.getRemoteUser();
     if (userName == null) {
         userName = "";
+    }
+    boolean isAdmin = false;
+    boolean isDesigner = false;
+    boolean isWdgActive = false;
+    try {
+        PSUserService userService =
+            (PSUserService) PSSpringBeanProvider.getBean("userService");
+        PSCurrentUser user = userService.getCurrentUser();
+        if (user != null) {
+            if (user.getName() != null) {
+                userName = user.getName();
+            }
+            isAdmin = user.isAdminUser();
+            isDesigner = user.isDesignerUser();
+        }
+        PSWidgetBuilderService wb =
+            (PSWidgetBuilderService) PSSpringBeanProvider.getBean("widgetBuilderService");
+        if (wb != null) {
+            isWdgActive = wb.isWidgetBuilderEnabled();
+        }
+    } catch (Exception e) {
+        // Fall back to remote user only; nav still works with reduced chrome
+    }
+
+    // Role-based entry gate (server UX; REST remains authoritative)
+    if (("workflow".equals(entry) || "admin".equals(entry)) && !isAdmin) {
+        entry = "home";
+    }
+    if (("publish".equals(entry) || "widget-builder".equals(entry))
+            && !(isAdmin || isDesigner)) {
+        entry = "home";
+    }
+    if ("widget-builder".equals(entry) && !isWdgActive) {
+        entry = "home";
     }
 %>
 <!DOCTYPE html>
@@ -83,7 +125,10 @@
 <script type="application/json" id="perc-bootstrap">{
     "userName":<%= jsonString(userName) %>,
     "locale":<%= jsonString(locale) %>,
-    "entry":<%= jsonString(entry) %>
+    "entry":<%= jsonString(entry) %>,
+    "isAdmin":<%= isAdmin %>,
+    "isDesigner":<%= isDesigner %>,
+    "isWidgetBuilderActive":<%= isWdgActive %>
 }</script>
 <div id="perc-spa-root" data-testid="perc-spa-root"></div>
 </body>

--- a/WebUI/src/main/webapp/cm/pages/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/spa.jsp
@@ -1,10 +1,14 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ page import="com.percussion.services.utils.jspel.PSRoleUtilities" %>
+<%@ page import="com.percussion.user.data.PSCurrentUser" %>
+<%@ page import="com.percussion.user.service.impl.PSUserService" %>
+<%@ page import="com.percussion.utils.PSSpringBeanProvider" %>
+<%@ page import="com.percussion.widgetbuilder.service.PSWidgetBuilderService" %>
 <%@ taglib uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" prefix="csrf" %>
 <%--
-  Minimal authenticated SPA landing (PR-1).
-  Full router + feature shells land in subsequent PRs.
-  Entry: /cm/app/spa.jsp?entry=home (query contract — no hash redirects).
+  Authenticated SPA document (PR-2 app shell).
+  Entry: /cm/app/spa.jsp?entry=home (query contract — no hash on server redirects).
+  No header.jsp / mainnav.jsp — React AppLayout + TopNav.
 --%>
 <%!
     private static String jsonString(String s) {
@@ -43,6 +47,9 @@
             return "home";
         }
         String n = raw.trim().toLowerCase(java.util.Locale.ROOT);
+        if ("widgetbuilder".equals(n)) {
+            return "widget-builder";
+        }
         if ("home".equals(n) || "publish".equals(n) || "workflow".equals(n)
                 || "admin".equals(n) || "widget-builder".equals(n)
                 || "explorer".equals(n) || "unavailable".equals(n)) {
@@ -62,9 +69,44 @@
         lang = locale;
     }
     String entry = allowEntry(request.getParameter("entry"));
+
     String userName = request.getRemoteUser();
     if (userName == null) {
         userName = "";
+    }
+    boolean isAdmin = false;
+    boolean isDesigner = false;
+    boolean isWdgActive = false;
+    try {
+        PSUserService userService =
+            (PSUserService) PSSpringBeanProvider.getBean("userService");
+        PSCurrentUser user = userService.getCurrentUser();
+        if (user != null) {
+            if (user.getName() != null) {
+                userName = user.getName();
+            }
+            isAdmin = user.isAdminUser();
+            isDesigner = user.isDesignerUser();
+        }
+        PSWidgetBuilderService wb =
+            (PSWidgetBuilderService) PSSpringBeanProvider.getBean("widgetBuilderService");
+        if (wb != null) {
+            isWdgActive = wb.isWidgetBuilderEnabled();
+        }
+    } catch (Exception e) {
+        // Fall back to remote user only; nav still works with reduced chrome
+    }
+
+    // Role-based entry gate (server UX; REST remains authoritative)
+    if (("workflow".equals(entry) || "admin".equals(entry)) && !isAdmin) {
+        entry = "home";
+    }
+    if (("publish".equals(entry) || "widget-builder".equals(entry))
+            && !(isAdmin || isDesigner)) {
+        entry = "home";
+    }
+    if ("widget-builder".equals(entry) && !isWdgActive) {
+        entry = "home";
     }
 %>
 <!DOCTYPE html>
@@ -83,7 +125,10 @@
 <script type="application/json" id="perc-bootstrap">{
     "userName":<%= jsonString(userName) %>,
     "locale":<%= jsonString(locale) %>,
-    "entry":<%= jsonString(entry) %>
+    "entry":<%= jsonString(entry) %>,
+    "isAdmin":<%= isAdmin %>,
+    "isDesigner":<%= isDesigner %>,
+    "isWidgetBuilderActive":<%= isWdgActive %>
 }</script>
 <div id="perc-spa-root" data-testid="perc-spa-root"></div>
 </body>

--- a/WebUI/src/test/ts/app/App.test.tsx
+++ b/WebUI/src/test/ts/app/App.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import React from "react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { App } from "../../../main/ts/app/App";
+import type { SpaBootstrap } from "../../../main/ts/app/bootstrap/types";
+
+const bootstrap: SpaBootstrap = {
+  userName: "demo",
+  locale: "en-us",
+  entry: "home",
+  isAdmin: true,
+  isDesigner: true,
+  isWidgetBuilderActive: true,
+};
+
+describe("App shell", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders TopNav and home placeholder from entry query", async () => {
+    render(<App bootstrap={bootstrap} entrySearch="?entry=home" />);
+    expect(screen.getByTestId("perc-spa-topnav")).toBeTruthy();
+    expect(screen.getByTestId("perc-spa-user-name").textContent).toContain(
+      "demo",
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("route-home-title").textContent).toMatch(/Home/i);
+    });
+  });
+
+  it("shows publish nav for designer", () => {
+    render(<App bootstrap={bootstrap} entrySearch="?entry=publish" />);
+    expect(screen.getByTestId("nav-publish")).toBeTruthy();
+  });
+
+  it("hides admin tools for non-admin", () => {
+    render(
+      <App
+        bootstrap={{ ...bootstrap, isAdmin: false, isDesigner: false }}
+        entrySearch="?entry=home"
+      />,
+    );
+    expect(screen.queryByTestId("nav-admin")).toBeNull();
+    expect(screen.queryByTestId("nav-publish")).toBeNull();
+  });
+});

--- a/WebUI/src/test/ts/app/auth/sessionHandlers.test.ts
+++ b/WebUI/src/test/ts/app/auth/sessionHandlers.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetLoginRedirectLatchForTests,
+  buildLoginReturnUrl,
+  currentSpaReturnUrl,
+  redirectToLoginOnUnauthorized,
+} from "../../../../main/ts/app/auth/sessionHandlers";
+
+describe("sessionHandlers", () => {
+  afterEach(() => {
+    __resetLoginRedirectLatchForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("buildLoginReturnUrl uses allowlisted spa return", () => {
+    const url = buildLoginReturnUrl("/cm/app/spa.jsp?entry=publish");
+    expect(url.startsWith("/rxlogin.jsp?")).toBe(true);
+    expect(url).toContain("return=");
+    expect(decodeURIComponent(url)).toContain(
+      "/cm/app/spa.jsp?entry=publish",
+    );
+    expect(url).not.toContain("#");
+  });
+
+  it("buildLoginReturnUrl rejects open redirects", () => {
+    const url = buildLoginReturnUrl("https://evil.example/phish");
+    expect(url).toContain("entry%3Dhome");
+  });
+
+  it("currentSpaReturnUrl parses search", () => {
+    expect(currentSpaReturnUrl("?entry=workflow&tab=users")).toBe(
+      "/cm/app/spa.jsp?entry=workflow&tab=users",
+    );
+  });
+
+  it("redirectToLoginOnUnauthorized assigns login once", () => {
+    const assign = vi.fn();
+    const original = window.location;
+    // @ts-expect-error test stub
+    delete (window as { location?: Location }).location;
+    // @ts-expect-error test stub
+    window.location = {
+      ...original,
+      pathname: "/cm/app/spa.jsp",
+      search: "?entry=home",
+      assign,
+    };
+
+    redirectToLoginOnUnauthorized({ reason: "test" });
+    redirectToLoginOnUnauthorized({ reason: "test-again" });
+    expect(assign).toHaveBeenCalledTimes(1);
+    expect(String(assign.mock.calls[0][0])).toContain("/rxlogin.jsp");
+
+    // @ts-expect-error restore
+    window.location = original;
+  });
+});

--- a/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
+++ b/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  parseEntryQuery,
+  toSpaEntryUrl,
+} from "../../../../main/ts/app/deepLinks/parseEntryQuery";
+
+describe("parseEntryQuery", () => {
+  it("defaults to home", () => {
+    expect(parseEntryQuery("")).toEqual({
+      entry: "home",
+      clientPath: "/home",
+    });
+  });
+
+  it("maps home section and aliases", () => {
+    expect(parseEntryQuery("?entry=home&section=library").clientPath).toBe(
+      "/home/library",
+    );
+    expect(parseEntryQuery("?entry=home&initialScreen=list").section).toBe(
+      "recent",
+    );
+  });
+
+  it("maps publish with ids", () => {
+    const p = parseEntryQuery(
+      "?entry=publish&section=logs&siteId=site1&serverId=srv2",
+    );
+    expect(p.entry).toBe("publish");
+    expect(p.clientPath).toContain("/publish/logs");
+    expect(p.siteId).toBe("site1");
+    expect(p.serverId).toBe("srv2");
+  });
+
+  it("rejects bad ids", () => {
+    const p = parseEntryQuery("?entry=publish&siteId=bad/id");
+    expect(p.siteId).toBeUndefined();
+  });
+
+  it("maps widgetbuilder alias", () => {
+    expect(parseEntryQuery("?entry=widgetbuilder").entry).toBe("widget-builder");
+    expect(parseEntryQuery("?entry=widgetbuilder").clientPath).toBe(
+      "/widget-builder",
+    );
+  });
+
+  it("unknown entry falls back to home", () => {
+    expect(parseEntryQuery("?entry=nope").entry).toBe("home");
+  });
+
+  it("toSpaEntryUrl rebuilds query contract", () => {
+    const url = toSpaEntryUrl({
+      entry: "home",
+      section: "library",
+      clientPath: "/home/library",
+    });
+    expect(url).toBe("/cm/app/spa.jsp?entry=home&section=library");
+  });
+});

--- a/WebUI/src/test/ts/bridge/mountAsync.test.tsx
+++ b/WebUI/src/test/ts/bridge/mountAsync.test.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  mountReactComponent,
+  unmountReactComponent,
+} from "../../../main/ts/bridge";
+
+describe("bridge async mount (§2.9)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("mounts HelloWorld after load", async () => {
+    document.body.innerHTML = '<div id="c1"></div>';
+    mountReactComponent("c1", "HelloWorld", { name: "Test" });
+    await vi.waitFor(() => {
+      expect(document.getElementById("c1")?.textContent).toContain("Hello");
+    });
+  });
+
+  it("unknown name does not throw", () => {
+    document.body.innerHTML = '<div id="c2"></div>';
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => mountReactComponent("c2", "NotARealComponent")).not.toThrow();
+    expect(err).toHaveBeenCalled();
+  });
+
+  it("unmount before resolve leaves no content", async () => {
+    document.body.innerHTML = '<div id="c3"></div>';
+    mountReactComponent("c3", "HelloWorld", { name: "Race" });
+    unmountReactComponent("c3");
+    await new Promise((r) => setTimeout(r, 50));
+    expect(document.getElementById("c3")?.textContent || "").not.toContain(
+      "Hello",
+    );
+  });
+});

--- a/docs/ai-generated/code-reviews/000-react-spa-pr2-app-shell-erlang.md
+++ b/docs/ai-generated/code-reviews/000-react-spa-pr2-app-shell-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review — feat/000-react-spa-pr2-app-shell
+
+**Date:** 2026-07-27  
+**Scope:** Pure React SPA PR-2 — App shell, TopNav, entry query, lazy bridge, 401→Login.  
+**Memory patterns hit:** open redirects; missing behavioral tests; bridge race; secrets.
+
+## Summary
+
+PR-2 adds authenticated SPA chrome (`App` + `HashRouter` + `AppLayout`/`TopNav`), allowlisted `parseEntryQuery`, mid-session 401 redirect to React Login with query return URL, and race-safe async `loadComponent` bridge mounts. Feature routes are placeholders until PR-3/4 embed real shells.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs | None found |
+| Behavioral tests | 27 vitest (entry, session, App, bridge races, login) |
+| Open redirect | 401 return + buildLoginReturnUrl allowlist |
+| Bridge races | generation token on mount/unmount |
+| May commit/push | **yes** |
+
+## Issues
+
+None (hard gate).
+
+### Suggestions
+
+1. Placeholders intentionally defer shell embed to PR-3.
+2. spa.jsp role resolution uses Spring beans; failure soft-falls to reduced nav.
+
+## Test evidence
+
+- Vitest app/login/bridge: 27 pass  
+- WebUI clean install: see PR body  

--- a/docs/ai-generated/tasks/#000-pure-react-spa/summary.md
+++ b/docs/ai-generated/tasks/#000-pure-react-spa/summary.md
@@ -36,9 +36,9 @@
 
 ## PR plan (login-first)
 
-1. **Login front door** + SPA landing  
-2. App shell + TopNav + entry query + 401→Login  
-3. Home + Publish routes  
+1. **Login front door** + SPA landing — **done** (#1523)  
+2. App shell + TopNav + entry query + 401→Login — **in progress** (`feat/000-react-spa-pr2-app-shell`)  
+3. Home + Publish routes (embedded shells)  
 4. Workflow + Admin + Widget Builder  
 5. Aggressive `index.jsp` cutover  
 6. Explorer  


### PR DESCRIPTION
## Summary

**Pure React SPA PR-2** (depends on #1523 login front door):

- **App shell:** `HashRouter` + `AppLayout` / `TopNav` / `UserMenu` (role-aware nav; legacy exits for dash/editor/design/arch)
- **Entry query:** `parseEntryQuery` allowlists map `spa.jsp?entry=…` → client routes (no hash server redirects)
- **401 → Login:** SPA API client sends mid-session 401 to React Login with allowlisted `?return=` SPA entry URL
- **Lazy bridge:** `loadComponent()` dynamic imports; sync `PercModernUI.mount`/`unmount` with generation tokens (stale loads ignored)
- **spa.jsp:** bootstrap includes roles / WB active; server entry role gates; dual-tree `cm/app` + `cm/pages/app`
- **Dep:** `react-router-dom`

Feature **shells** (Home/Publish/…) remain **placeholders** until PR-3/PR-4.

## Pre-PR verification

| Check | Result |
|--------|--------|
| `cd WebUI && npm test -- --run src/test/ts/app src/test/ts/login src/test/ts/bridge` | **27 tests, 0 failures** |
| `cd WebUI && ../mvn-env.sh clean install -Dai.integrity.skip=true` | **BUILD SUCCESS** |

Erlang: `docs/ai-generated/code-reviews/000-react-spa-pr2-app-shell-erlang.md` — **approve**.

## Test plan

- [ ] Login → `/cm/app/spa.jsp?entry=home` shows TopNav + Home placeholder
- [ ] `?entry=publish&section=logs` → Publish route (role-gated)
- [ ] TopNav SPA links update hash routes without full reload
- [ ] Dashboard/Editor still full-page legacy exits
- [ ] Simulate API 401 in SPA → `/rxlogin.jsp?return=…spa.jsp?entry=…` (no `#`)
- [ ] Residual JSP `PercModernUI.mount('…','HelloWorld')` still works (async load)

## Next

PR-3: embed `HomeShell` + `PublishingShell` on routes (remove placeholders).

> Co-Authored by Grok Build using grok-4.5 with agent Grok.