### PR TITLE
feat(webui): SPA routes for HomeShell and PublishingShell

### DIFF
--- a/WebUI/src/main/ts/api/client.ts
+++ b/WebUI/src/main/ts/api/client.ts
@@ -32,6 +32,23 @@ export interface ApiError {
   body: unknown;
 }
 
+/**
+ * Thrown after a mid-session 401 has already started navigation to React Login.
+ * Callers should not surface this as a normal API failure (toasts / form errors).
+ */
+export class SessionRedirectError extends Error {
+  readonly status = 401;
+  constructor(message = "Session expired; redirecting to login") {
+    super(message);
+    this.name = "SessionRedirectError";
+  }
+}
+
+/** True when the error is a terminal session redirect (page is navigating away). */
+export function isSessionRedirectError(err: unknown): boolean {
+  return err instanceof SessionRedirectError;
+}
+
 function buildHeaders(extra: HeadersInit = {}, preferJson = true): Headers {
   const headers = new Headers(extra);
   if (!headers.has("Content-Type") && preferJson) {
@@ -72,9 +89,12 @@ async function parseBody(response: Response): Promise<unknown> {
 
 async function handleResponse<T>(response: Response): Promise<T> {
   if (!response.ok) {
-    // Mid-session expiry / auth loss → React Login (query return URL)
+    // Mid-session expiry / auth loss → React Login (query return URL).
+    // Do not parse the body or throw a normal ApiError — callers would race
+    // setState/toasts while the document navigates away (#1526 review).
     if (response.status === 401) {
       redirectToLoginOnUnauthorized({ reason: "api-401" });
+      throw new SessionRedirectError();
     }
     let body: unknown;
     try {

--- a/WebUI/src/main/ts/app/auth/sessionHandlers.ts
+++ b/WebUI/src/main/ts/app/auth/sessionHandlers.ts
@@ -20,7 +20,16 @@ import { parseEntryQuery, toSpaEntryUrl } from "../deepLinks/parseEntryQuery";
 
 export const REACT_LOGIN_PATH = "/rxlogin.jsp";
 
+/**
+ * Latch so concurrent 401s only navigate once. Reset on each SPA boot so
+ * remount/HMR does not permanently suppress redirects (#1526 review).
+ */
 let redirectingToLogin = false;
+
+/** Reset the redirect latch (call from SPA boot; tests may also call). */
+export function resetLoginRedirectLatch(): void {
+  redirectingToLogin = false;
+}
 
 /**
  * Build React Login URL with allowlisted SPA return query (never hash).
@@ -79,7 +88,7 @@ export function redirectToLoginOnUnauthorized(
   window.location.assign(target);
 }
 
-/** Test-only: reset redirect latch. */
+/** @deprecated Use {@link resetLoginRedirectLatch} */
 export function __resetLoginRedirectLatchForTests(): void {
-  redirectingToLogin = false;
+  resetLoginRedirectLatch();
 }

--- a/WebUI/src/main/ts/app/layout/TopNav.tsx
+++ b/WebUI/src/main/ts/app/layout/TopNav.tsx
@@ -37,16 +37,22 @@ export function TopNav(): React.ReactElement {
     <nav className={styles.topNav} aria-label="Main" data-testid="perc-spa-topnav">
       <ul className={styles.navGroup}>
         <li>
-          <NavLink to="/home" className={linkClass} data-testid="nav-home">
+          {/* Product default landing after login (not a separate “dashboard” SPA) */}
+          <NavLink to="/home" className={linkClass} end data-testid="nav-home">
             Home
           </NavLink>
         </li>
         <li>
-          {/* Temporary hybrid exit until SPA dashboard route (PR-7) */}
+          {/*
+            Legacy jQuery dashboard exit only. Product direction: Home is the
+            primary landing; we may fold dashboard widgets into Home later
+            rather than a peer SPA /dashboard route.
+          */}
           <a
             className={styles.navLink}
             href="/cm/app/?view=dash"
             data-testid="nav-dashboard"
+            title="Legacy dashboard (may merge into Home)"
           >
             Dashboard
           </a>

--- a/WebUI/src/main/ts/app/main.tsx
+++ b/WebUI/src/main/ts/app/main.tsx
@@ -18,12 +18,15 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { resetLoginRedirectLatch } from "./auth/sessionHandlers";
 import { loadSpaBootstrap } from "./bootstrap/loadBootstrap";
 
 /**
  * Boot the authenticated SPA into the given root element.
  */
 export function boot(rootEl: HTMLElement): void {
+  // Fresh SPA lifecycle — allow mid-session 401 redirects again
+  resetLoginRedirectLatch();
   const bootstrap = loadSpaBootstrap();
   createRoot(rootEl).render(React.createElement(App, { bootstrap }));
   console.info("[PercModernUI] SPA App mounted.");

--- a/WebUI/src/main/ts/app/routes.tsx
+++ b/WebUI/src/main/ts/app/routes.tsx
@@ -19,55 +19,23 @@ import React from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import { FeaturePlaceholder } from "./FeaturePlaceholder";
 import { AppLayout } from "./layout/AppLayout";
+import { HomeRoute } from "./routes/HomeRoute";
+import { PublishRoute } from "./routes/PublishRoute";
 
 /**
- * Authenticated SPA routes. Placeholders until PR-3/PR-4 embed real shells.
+ * Authenticated SPA routes.
+ * Home is the product default landing. Publish is fully embedded (PR-3).
+ * Other modern modules remain placeholders until PR-4+.
  */
 export function AppRoutes(): React.ReactElement {
   return (
     <Routes>
       <Route element={<AppLayout />}>
         <Route index element={<Navigate to="/home" replace />} />
-        <Route
-          path="home"
-          element={
-            <FeaturePlaceholder
-              title="Home"
-              legacyHref="/cm/app/?view=home"
-              testId="route-home"
-            />
-          }
-        />
-        <Route
-          path="home/:section"
-          element={
-            <FeaturePlaceholder
-              title="Home"
-              legacyHref="/cm/app/?view=home"
-              testId="route-home"
-            />
-          }
-        />
-        <Route
-          path="publish"
-          element={
-            <FeaturePlaceholder
-              title="Publish"
-              legacyHref="/cm/app/?view=publish"
-              testId="route-publish"
-            />
-          }
-        />
-        <Route
-          path="publish/:section"
-          element={
-            <FeaturePlaceholder
-              title="Publish"
-              legacyHref="/cm/app/?view=publish"
-              testId="route-publish"
-            />
-          }
-        />
+        <Route path="home" element={<HomeRoute />} />
+        <Route path="home/:section" element={<HomeRoute />} />
+        <Route path="publish" element={<PublishRoute />} />
+        <Route path="publish/:section" element={<PublishRoute />} />
         <Route
           path="workflow"
           element={
@@ -134,10 +102,7 @@ export function AppRoutes(): React.ReactElement {
             <FeaturePlaceholder title="Unavailable" testId="route-unavailable" />
           }
         />
-        <Route
-          path="*"
-          element={<Navigate to="/unavailable" replace />}
-        />
+        <Route path="*" element={<Navigate to="/unavailable" replace />} />
       </Route>
     </Routes>
   );

--- a/WebUI/src/main/ts/app/routes.tsx
+++ b/WebUI/src/main/ts/app/routes.tsx
@@ -91,7 +91,7 @@ export function AppRoutes(): React.ReactElement {
           element={
             <FeaturePlaceholder
               title="Content Explorer"
-              legacyHref="/cm/app/?view=home"
+              legacyHref="/cm/app/explorerModern.jsp"
               testId="route-explorer"
             />
           }

--- a/WebUI/src/main/ts/app/routes/HomeRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/HomeRoute.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { Suspense, lazy } from "react";
+import { useParams } from "react-router-dom";
+import { useSpaBootstrap } from "../bootstrap/BootstrapContext";
+import { loadComponent } from "../../registry";
+
+const HomeShellLazy = lazy(() =>
+  loadComponent("HomeShell").then((C) => ({ default: C })),
+);
+
+/**
+ * SPA Home route — product default landing after login.
+ * Dashboard is intentionally not a peer SPA route; legacy dash remains optional exit.
+ */
+export function HomeRoute(): React.ReactElement {
+  const { section } = useParams();
+  const { isAdmin } = useSpaBootstrap();
+
+  return (
+    <Suspense
+      fallback={
+        <div data-testid="route-home-loading" style={{ padding: "1.5rem" }}>
+          Loading Home…
+        </div>
+      }
+    >
+      <HomeShellLazy
+        embedded
+        initialSection={section}
+        isAdmin={isAdmin}
+      />
+    </Suspense>
+  );
+}

--- a/WebUI/src/main/ts/app/routes/PublishRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/PublishRoute.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { Suspense, lazy } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
+import { useSpaBootstrap } from "../bootstrap/BootstrapContext";
+import { loadComponent } from "../../registry";
+
+const PublishingShellLazy = lazy(() =>
+  loadComponent("PublishingShell").then((C) => ({ default: C })),
+);
+
+/**
+ * SPA Publish route — embeds PublishingShell under AppLayout.
+ */
+export function PublishRoute(): React.ReactElement {
+  const { section } = useParams();
+  const [search] = useSearchParams();
+  const { isAdmin, isDesigner } = useSpaBootstrap();
+  const siteId = search.get("siteId") ?? undefined;
+  const serverId = search.get("serverId") ?? undefined;
+  // Design section for Admin/Designer (product progressive disclosure)
+  const showDesign = isAdmin || isDesigner;
+
+  return (
+    <Suspense
+      fallback={
+        <div data-testid="route-publish-loading" style={{ padding: "1.5rem" }}>
+          Loading Publish…
+        </div>
+      }
+    >
+      <PublishingShellLazy
+        embedded
+        section={section}
+        siteId={siteId}
+        serverId={serverId}
+        showDesign={showDesign}
+      />
+    </Suspense>
+  );
+}

--- a/WebUI/src/main/ts/home/HomeShell.tsx
+++ b/WebUI/src/main/ts/home/HomeShell.tsx
@@ -42,6 +42,11 @@ export interface HomeShellProps {
   /** When true, show admin empty-state messaging for no sites */
   isAdmin?: boolean;
   /**
+   * When true (SPA AppLayout), omit ThemeProvider / BrandBar / BrandFooter so
+   * chrome is not doubled under the product shell.
+   */
+  embedded?: boolean;
+  /**
    * Optional open-item handoff. Defaults to navigating parent to editor
    * when id/path are present.
    */
@@ -73,11 +78,11 @@ function defaultOpenItem(item: ContentListItem): void {
   }
 }
 
-export function HomeShell({
+function HomeShellBody({
   initialSection,
   isAdmin = false,
   onOpenItem = defaultOpenItem,
-}: HomeShellProps): React.ReactElement {
+}: Omit<HomeShellProps, "embedded">): React.ReactElement {
   const start = useMemo(
     () => mapInitialScreenToSection(initialSection),
     [initialSection],
@@ -85,44 +90,61 @@ export function HomeShell({
   const [section, setSection] = useState<HomeSection>(start);
 
   return (
+    <>
+      <header style={headerStyle}>
+        <h1 style={{ margin: 0, fontSize: "1.25rem" }}>
+          {message(MSG.HOME_TITLE)}
+        </h1>
+      </header>
+      <nav style={navStyle} aria-label={message(MSG.HOME_TITLE)}>
+        {SECTIONS.map((s) => (
+          <button
+            key={s.id}
+            type="button"
+            style={navButtonStyle(section === s.id)}
+            aria-current={section === s.id ? "page" : undefined}
+            onClick={() => setSection(s.id)}
+          >
+            {message(s.key)}
+          </button>
+        ))}
+      </nav>
+      <main style={mainStyle}>
+        {section === "recent" && <RecentSection onOpenItem={onOpenItem} />}
+        {section === "bookmarks" && (
+          <BookmarksSection onOpenItem={onOpenItem} />
+        )}
+        {section === "library" && (
+          <LibrarySection isAdmin={isAdmin} onOpenItem={onOpenItem} />
+        )}
+        {section === "search" && <SearchSection onOpenItem={onOpenItem} />}
+        {section === "create" && <CreateSection />}
+      </main>
+    </>
+  );
+}
+
+export function HomeShell({
+  embedded = false,
+  ...bodyProps
+}: HomeShellProps): React.ReactElement {
+  const inner = (
+    <div style={shellStyle} data-testid="home-shell">
+      <HomeShellBody {...bodyProps} />
+    </div>
+  );
+  if (embedded) {
+    return inner;
+  }
+  return (
     <ThemeProvider
       as="div"
       className="perc-home-theme-root"
       data-testid="home-theme-root"
     >
-      <div style={shellStyle} data-testid="home-shell">
-        <BrandBar />
-        <header style={headerStyle}>
-          <h1 style={{ margin: 0, fontSize: "1.25rem" }}>
-            {message(MSG.HOME_TITLE)}
-          </h1>
-        </header>
-        <nav style={navStyle} aria-label={message(MSG.HOME_TITLE)}>
-          {SECTIONS.map((s) => (
-            <button
-              key={s.id}
-              type="button"
-              style={navButtonStyle(section === s.id)}
-              aria-current={section === s.id ? "page" : undefined}
-              onClick={() => setSection(s.id)}
-            >
-              {message(s.key)}
-            </button>
-          ))}
-        </nav>
-        <main style={mainStyle}>
-          {section === "recent" && <RecentSection onOpenItem={onOpenItem} />}
-          {section === "bookmarks" && (
-            <BookmarksSection onOpenItem={onOpenItem} />
-          )}
-          {section === "library" && (
-            <LibrarySection isAdmin={isAdmin} onOpenItem={onOpenItem} />
-          )}
-          {section === "search" && <SearchSection onOpenItem={onOpenItem} />}
-          {section === "create" && <CreateSection />}
-        </main>
-        <BrandFooter />
-      </div>
+      <BrandBar />
+      {inner}
+      <BrandFooter />
     </ThemeProvider>
   );
 }

--- a/WebUI/src/main/ts/index.ts
+++ b/WebUI/src/main/ts/index.ts
@@ -54,9 +54,16 @@ function bootSpa(): void {
   if (!el) {
     return;
   }
-  void import("./app/main").then((m) => {
-    m.boot(el);
-  });
+  void import("./app/main")
+    .then((m) => {
+      m.boot(el);
+    })
+    .catch((err) => {
+      console.error("[PercModernUI] Failed to load SPA app module", err);
+      el.setAttribute("data-perc-spa-boot-error", "1");
+      el.textContent =
+        "Unable to load the modern UI. Check the browser console or reload the page.";
+    });
 }
 
 function boot(): void {

--- a/WebUI/src/main/ts/publishing/PublishingShell.tsx
+++ b/WebUI/src/main/ts/publishing/PublishingShell.tsx
@@ -45,6 +45,11 @@ export interface PublishingShellProps {
    * Default true — server does not yet expose a dedicated design role to the shell.
    */
   showDesign?: boolean;
+  /**
+   * When true (SPA AppLayout), shell is already under product chrome.
+   * Reserved for future chrome tweaks; currently no outer BrandBar.
+   */
+  embedded?: boolean;
 }
 
 /** Ops-first sections; design/runtime are secondary (US7 progressive disclosure). */

--- a/WebUI/src/main/ts/registry.ts
+++ b/WebUI/src/main/ts/registry.ts
@@ -150,9 +150,3 @@ export function isRegisteredComponent(name: string): boolean {
 export function listRegisteredComponentNames(): string[] {
   return Object.keys(loaders).sort();
 }
-
-/**
- * @deprecated Prefer {@link loadComponent}. Sync map is empty; kept for type
- * compatibility with older tests that import {@code componentRegistry}.
- */
-export const componentRegistry = new Map<string, ComponentType<any>>();

--- a/WebUI/src/test/ts/api/clientSessionRedirect.test.ts
+++ b/WebUI/src/test/ts/api/clientSessionRedirect.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  get,
+  isSessionRedirectError,
+  SessionRedirectError,
+} from "../../../main/ts/api/client";
+import { resetLoginRedirectLatch } from "../../../main/ts/app/auth/sessionHandlers";
+
+describe("api client 401 session redirect", () => {
+  afterEach(() => {
+    resetLoginRedirectLatch();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("redirects and throws SessionRedirectError without treating as normal ApiError", async () => {
+    const assign = vi.fn();
+    const original = window.location;
+    // @ts-expect-error test stub
+    delete (window as { location?: Location }).location;
+    // @ts-expect-error test stub
+    window.location = {
+      ...original,
+      pathname: "/cm/app/spa.jsp",
+      search: "?entry=home",
+      href: "http://localhost/cm/app/spa.jsp?entry=home",
+      origin: "http://localhost",
+      assign,
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "unauthorized" }), {
+          status: 401,
+          statusText: "Unauthorized",
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    await expect(get("/Rhythmyx/test")).rejects.toSatisfy(
+      (err: unknown) => isSessionRedirectError(err) && err instanceof SessionRedirectError,
+    );
+    expect(assign).toHaveBeenCalledTimes(1);
+    expect(String(assign.mock.calls[0][0])).toContain("/rxlogin.jsp");
+
+    // @ts-expect-error restore
+    window.location = original;
+  });
+});

--- a/WebUI/src/test/ts/app/App.test.tsx
+++ b/WebUI/src/test/ts/app/App.test.tsx
@@ -4,9 +4,22 @@
 
 import React from "react";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../../../main/ts/app/App";
 import type { SpaBootstrap } from "../../../main/ts/app/bootstrap/types";
+
+vi.mock("../../../main/ts/api/home/homeApi", () => ({
+  fetchRecentItems: vi.fn().mockResolvedValue([]),
+  fetchMyContent: vi.fn().mockResolvedValue([]),
+  fetchSites: vi.fn().mockResolvedValue([]),
+  fetchFolderChildren: vi.fn().mockResolvedValue([]),
+  searchContent: vi.fn().mockResolvedValue([]),
+  createPage: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("../../../main/ts/api/publishing", () => ({
+  // Publishing sections load their own APIs; keep module resolution soft
+}));
 
 const bootstrap: SpaBootstrap = {
   userName: "demo",
@@ -18,24 +31,33 @@ const bootstrap: SpaBootstrap = {
 };
 
 describe("App shell", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+  });
+
   afterEach(() => {
     cleanup();
   });
 
-  it("renders TopNav and home placeholder from entry query", async () => {
+  it("renders TopNav and embedded Home shell from entry query", async () => {
     render(<App bootstrap={bootstrap} entrySearch="?entry=home" />);
     expect(screen.getByTestId("perc-spa-topnav")).toBeTruthy();
     expect(screen.getByTestId("perc-spa-user-name").textContent).toContain(
       "demo",
     );
     await waitFor(() => {
-      expect(screen.getByTestId("route-home-title").textContent).toMatch(/Home/i);
+      expect(screen.getByTestId("home-shell")).toBeTruthy();
     });
   });
 
-  it("shows publish nav for designer", () => {
+  it("shows publish nav for designer and loads PublishingShell", async () => {
     render(<App bootstrap={bootstrap} entrySearch="?entry=publish" />);
     expect(screen.getByTestId("nav-publish")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId("publishing-shell")).toBeTruthy();
+    });
   });
 
   it("hides admin tools for non-admin", () => {

--- a/WebUI/src/test/ts/app/auth/sessionHandlers.test.ts
+++ b/WebUI/src/test/ts/app/auth/sessionHandlers.test.ts
@@ -4,15 +4,15 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  __resetLoginRedirectLatchForTests,
   buildLoginReturnUrl,
   currentSpaReturnUrl,
   redirectToLoginOnUnauthorized,
+  resetLoginRedirectLatch,
 } from "../../../../main/ts/app/auth/sessionHandlers";
 
 describe("sessionHandlers", () => {
   afterEach(() => {
-    __resetLoginRedirectLatchForTests();
+    resetLoginRedirectLatch();
     vi.restoreAllMocks();
   });
 

--- a/WebUI/src/test/ts/home/HomeShell.test.tsx
+++ b/WebUI/src/test/ts/home/HomeShell.test.tsx
@@ -56,6 +56,13 @@ describe("HomeShell", () => {
     expect(screen.getByTestId("perc-brand-footer")).toBeDefined();
   });
 
+  it("embedded mode omits brand chrome for SPA AppLayout", () => {
+    render(<HomeShell embedded initialSection="list" />);
+    expect(screen.getByTestId("home-shell")).toBeDefined();
+    expect(screen.queryByTestId("perc-brand-bar")).toBeNull();
+    expect(screen.queryByTestId("perc-brand-footer")).toBeNull();
+  });
+
   it("starts on library when initialScreen is library", async () => {
     render(<HomeShell initialSection="library" />);
     await waitFor(() => {

--- a/docs/ai-generated/code-reviews/000-react-spa-pr3-home-publish-erlang.md
+++ b/docs/ai-generated/code-reviews/000-react-spa-pr3-home-publish-erlang.md
@@ -1,0 +1,25 @@
+# Erlang review — feat/000-react-spa-pr3-home-publish
+
+**Date:** 2026-07-27  
+**Scope:** SPA PR-3 — embed HomeShell + PublishingShell; Home default landing. Stacked on PR-2.  
+**Memory patterns hit:** dual chrome; missing tests; open redirects.
+
+## Summary
+
+Home and Publish are real SPA routes (lazy `loadComponent`). `HomeShell` supports `embedded` to avoid double BrandBar under AppLayout. Dashboard remains a legacy exit with product note that it may fold into Home (not a peer SPA route).
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs | None |
+| Behavioral tests | App + HomeShell embedded + existing shell tests |
+| May commit/push | **yes** |
+
+## Issues
+
+None.

--- a/docs/ai-generated/tasks/#000-pure-react-spa/design.md
+++ b/docs/ai-generated/tasks/#000-pure-react-spa/design.md
@@ -58,7 +58,7 @@ Pain of the current hybrid:
 | `UnavailableView` | `home/UnavailableView.tsx` | `unavailableModern.jsp` | SPA 404 / unknown |
 | `ContentExplorerShell` | `contentExplorer/…` | explorerModern + embeds | Product route **and** optional bridge mount only inside **still-legacy** jQuery pages |
 | `ContentBrowser`, `SearchPanel`, `FolderSecurityPanel`, `ActionToolbar`, `ContextMenu` | contentExplorer / contentBrowser | host dialog JSPs | Prefer SPA dialog routes when openers allow; else keep thin host until openers updated |
-| `Dashboard` + widgets | `dashboard/*` | Registered; product `dashboard.jsp` still jQuery PercDashboard | **SPA dashboard route** preferred aggressively once wired; until then legacy exit `?view=dash` is temporary hybrid exit only |
+| `Dashboard` + widgets | `dashboard/*` | Registered; product `dashboard.jsp` still jQuery PercDashboard | **Gadgets stay valuable** — long-term target is **compose on Home** (not a peer SPA `/dashboard`). Until then: legacy exit `?view=dash` only |
 
 #### B. `index.jsp` modern views → SPA immediately (aggressive)
 
@@ -75,7 +75,7 @@ Pain of the current hybrid:
 
 | `?view=` | JSP | Notes |
 |----------|-----|-------|
-| `dash` | `dashboard.jsp` | Until SPA Dashboard route ships |
+| `dash` | `dashboard.jsp` | Until gadgets live on Home; then remove peer dash surface |
 | `editor` | `webmgt.jsp` | Long-lived until editor migration |
 | `design` | `admin.jsp` | Temporary exit |
 | `arch` | `siteArchitecture.jsp` | Temporary exit |
@@ -240,7 +240,7 @@ Canonical SPA document: **`/cm/app/spa.jsp`** (or same params on the URL that `i
 | `/widget-builder` | WidgetBuilderApp | Admin or Designer + WB active |
 | `/explorer` | ContentExplorerShell | Auth |
 | `/unavailable` | UnavailableView | Auth |
-| *(future)* `/dashboard` | React Dashboard | Auth |
+| *(do not target)* `/dashboard` | — | Prefer **Home section / widgets**; avoid peer SPA dashboard |
 
 #### Router choice (client-only; still one product UI)
 
@@ -280,8 +280,9 @@ Do **not** keep serving `homeModern.jsp` as a working product alternative.
 ### 2.5 Layout & navigation
 
 - SPA always uses React `AppLayout` + `TopNav` (no jQuery `header.jsp` / `mainnav.jsp` on SPA document).
-- Nav parity with `mainnav.jsp`:
-  - Always: Home, Dashboard (**exit** or SPA dashboard when ready), Editor (**exit**)
+- Nav parity with `mainnav.jsp` (adjusted for product direction):
+  - Always: **Home** (default landing), Editor (**exit**)
+  - **Dashboard:** temporary **legacy exit** only (`?view=dash`) while gadgets still live on jQuery dash; **do not** invest in a peer SPA dashboard route — fold React gadgets into **Home** instead
   - Admin or Designer: Architecture (**exit**), Design (**exit**), Publish (**SPA**)
   - Admin: Administration → **SPA workflow** (product label unchanged)
   - WB active + Admin/Designer: Widget Builder → **SPA**
@@ -400,7 +401,7 @@ else:
 Default homepage:
 
 - User homepage Home → `spa.jsp?entry=home`  
-- Dashboard → legacy dash (until SPA dashboard)  
+- Dashboard → legacy dash exit only (until gadgets on Home)  
 - Editor → legacy editor  
 
 **Stop forwarding modern views to `*Modern.jsp`.** Those files become reference-only (or 302 to `spa.jsp?entry=…` with **query** params and **proxyURL**).
@@ -482,7 +483,7 @@ Mount Home, Publish, Workflow, Admin, Widget Builder, Explorer, Unavailable with
 ### Phase 4 — Cleanup reference files + remaining hybrid exits
 
 - Delete obsolete `*Modern.jsp` (and dead mounts) once SPA routes + tests own them.
-- SPA Dashboard route (retire jQuery dash when ready).
+- Compose gadgets into Home (retire peer dash surface when ready).
 - Dialog hosts → SPA dialogs or delete when openers updated.
 - Optional BrowserRouter + rewrite.
 - Align docs; mark stale REACT-ROUTER/REDUX guides non-authoritative.
@@ -503,7 +504,7 @@ See §2.4 tables (canonical paths/hashes, aliases, `?view=` map). That is the im
 
 | Kind | Behavior |
 |------|----------|
-| **SPA product** | Home, Publish, Workflow, Admin, Widget Builder, (Explorer), (Dashboard when ready) |
+| **SPA product** | Home (+ gadgets when folded in), Publish, Workflow, Admin, Widget Builder, (Explorer) |
 | **Legacy exit** | Full `window.location` to remaining JSPs |
 | **Legacy embed** | Bridge mount of explorer (etc.) **inside** those JSPs until page deleted |
 | **Not allowed** | Shipping the same feature as both live JSP shell and SPA “optional mode” |
@@ -557,7 +558,7 @@ Manual QA (short):
 2. Deep publish via `spa.jsp?entry=publish&section=logs` then refresh (client route stable).  
 3. Designer: publish OK; workflow denied server-side.  
 4. Editor exit works; return Home SPA.  
-5. Dashboard exit (or SPA dashboard if shipped).  
+5. Home as landing; gadgets on Home when ready (legacy dash exit until then).  
 6. Bootstrap XSS test fixtures green.
 
 ---
@@ -602,7 +603,7 @@ Manual QA (short):
 | ID | Question | Status |
 |----|----------|--------|
 | OQ-1 | Client hash vs path URLs | **Pragmatic lock:** client Hash first OK; **server always query `entry`**. Path client later. |
-| OQ-2 | Dashboard SPA now vs temporary dash exit | Prefer SPA Dashboard soon; hybrid exit only until then |
+| OQ-2 | Dashboard SPA vs Home | **Resolved:** gadgets → **Home**; no long-term peer SPA dashboard |
 | OQ-3 | Dialog hosts → SPA routes timing | Keep thin hosts until openers updated; not dual product for main nav |
 | OQ-4 | Feature flag soft cutover | **Closed — not used** |
 | OQ-5 | Administration → workflow | **Locked** (preserve mainnav) |
@@ -770,14 +771,14 @@ Each PR advances **SPA product UI**, starting at the **front door**. No soft-fla
 | **Deps** | PR-5 |
 | **Description** | Primary explorer in SPA; embeds only on remaining legacy pages. |
 
-### PR-7 — Dashboard SPA (or explicit exit only)
+### PR-7 — Gadgets on Home (not peer Dashboard SPA)
 
 | | |
 |--|--|
-| **Title** | `feat(webui): Dashboard SPA route using React Dashboard` **or** `chore(webui): TopNav dashboard legacy exit only` |
-| **Files** | dashboard route **or** nav exit; prefer React Dashboard if ready |
-| **Deps** | PR-5 |
-| **Description** | Prefer aggressive Dashboard SPA; temporary exit acceptable briefly. |
+| **Title** | `feat(webui): compose Dashboard gadgets into Home` (retire peer dash surface) |
+| **Files** | `home/*` (section or widgets area); reuse `dashboard/*` React widgets; TopNav (drop/relabel legacy dash exit); optional retire `dashboard.jsp` |
+| **Deps** | PR-3 (Home SPA route) |
+| **Description** | **Product lock:** gadget utility stays; **placement is Home**, not a separate SPA `/dashboard`. Reuse existing React widget components. Legacy jQuery dash exit only until this lands. |
 
 ### PR-8 — Delete obsolete login/Modern JSP product hosts + docs
 
@@ -817,7 +818,7 @@ Each PR advances **SPA product UI**, starting at the **front door**. No soft-fla
 | AdminShell | no shared header | title/tabs | tab (+ tools) | same |
 | WidgetBuilderApp | yes | app chrome | — | same |
 | ContentExplorerShell | host-dependent | panel | path | route or legacy embed |
-| Dashboard (React) | n/a product | layout | — | SPA when shipped |
+| Dashboard gadgets (React) | Home | widgets/section | reuse `dashboard/*` | Compose into Home; no peer SPA |
 
 ## Appendix C — What “aggressive” is not
 

--- a/docs/ai-generated/tasks/#000-pure-react-spa/summary.md
+++ b/docs/ai-generated/tasks/#000-pure-react-spa/summary.md
@@ -37,12 +37,12 @@
 ## PR plan (login-first)
 
 1. **Login front door** + SPA landing — **done** (#1523)  
-2. App shell + TopNav + entry query + 401→Login — **in progress** (`feat/000-react-spa-pr2-app-shell`)  
-3. Home + Publish routes (embedded shells)  
+2. App shell + TopNav + entry query + 401→Login — **PR** (#1526)  
+3. Home + Publish routes (embedded shells) — **in progress** (`feat/000-react-spa-pr3-home-publish`); **Home is default landing**  
 4. Workflow + Admin + Widget Builder  
 5. Aggressive `index.jsp` cutover  
 6. Explorer  
-7. Dashboard  
+7. **Dashboard:** deferred / likely **merge into Home** (not a separate SPA peer); legacy `?view=dash` exit only for now  
 8. Delete obsolete JSPs  
 9. Optional path URLs  
 

--- a/docs/ai-generated/tasks/#000-pure-react-spa/summary.md
+++ b/docs/ai-generated/tasks/#000-pure-react-spa/summary.md
@@ -11,6 +11,8 @@
 
 1. **SPA is the product UI** for modern features. No dual-mode, no soft feature-flag cutover. Old JSPs = reference until delete.
 2. **Start at the front door:** React Login is the first shippable slice for **stakeholder demos** (Login → SPA), then authenticated routes.
+3. **Home is the default product landing** after sign-in (not a separate “dashboard” peer).
+4. **Dashboard gadgets have real product value**, but that capability should **live on Home** (section / widgets / compose), **not** as a long-term separate SPA route. Until then: legacy `?view=dash` full-page exit only.
 
 ## Stakeholder demo path
 
@@ -42,7 +44,7 @@
 4. Workflow + Admin + Widget Builder  
 5. Aggressive `index.jsp` cutover  
 6. Explorer  
-7. **Dashboard:** deferred / likely **merge into Home** (not a separate SPA peer); legacy `?view=dash` exit only for now  
+7. **Home + gadgets:** fold React Dashboard **widgets into Home** (not a peer `/dashboard` SPA). Legacy jQuery dash remains temporary exit until then.  
 8. Delete obsolete JSPs  
 9. Optional path URLs  
 


### PR DESCRIPTION
## Summary

**Pure React SPA PR-3** (builds on #1526 app shell, now on `development`):

- **Home** is the **default product landing** after login (`/` → `/home`; `entry=home`).
- **HomeShell** embeds under `AppLayout` with `embedded` (no second BrandBar/footer).
- **PublishingShell** embeds on `/publish` and `/publish/:section` (lazy `loadComponent`; `siteId`/`serverId` from search).
- **Dashboard:** not a SPA peer route. TopNav keeps a **legacy** `?view=dash` exit only — product may **merge dashboard into Home** later rather than a separate SPA surface.

## Pre-PR verification

| Check | Result |
|--------|--------|
| Vitest app/login/bridge/home/publish | **35 tests, 0 failures** |
| `cd WebUI && ../mvn-env.sh clean install -Dai.integrity.skip=true` | **BUILD SUCCESS** |

Erlang: `docs/ai-generated/code-reviews/000-react-spa-pr3-home-publish-erlang.md` — **approve**.

## Test plan

- [ ] Login → Home shell (sections work; default landing)
- [ ] TopNav Home is primary product landing
- [ ] Publish (Admin/Designer) loads PublishingShell; section deep links
- [ ] Standalone JSP HomeShell still has BrandBar when not `embedded`
- [ ] Dashboard remains full-page legacy exit (not SPA)

## Next

PR-4: Workflow + Admin + Widget Builder routes.

> Co-Authored by Grok Build using grok-4.5 with agent Grok.