### PR TITLE
fix(startup): Log4j webapp visibility, XML catalog, package Betwixt deploy

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSlotDefDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSSlotDefDependencyHandler.java
@@ -455,7 +455,20 @@ public class PSSlotDefDependencyHandler extends PSDependencyHandler implements I
       PSTemplateTypeSlotAssociation assoc[] = ((PSTemplateSlot) slot).getSlotTypeAssociations();
       removeAllAssociationsOnSlot(slot);
       int slotId = slot.getGUID().getUUID();
+      List<PSTemplateTypeSlotAssociation> transformed = new ArrayList<>();
       for (PSTemplateTypeSlotAssociation a : assoc) {
+        // Skip empty associations (Betwixt can emit zeros when PK/id mapping fails).
+        // Mapping content type "0" throws MISSING_ID_MAPPING and aborts package install.
+        if (a.getContentTypeId() == 0L || a.getTemplateId() == 0L) {
+          m_log.warn(
+              "Skipping slot association with contentTypeId={}, templateId={} on slot {}"
+                  + " (zero ids are not valid for id mapping)",
+              a.getContentTypeId(),
+              a.getTemplateId(),
+              dep.getDisplayName());
+          continue;
+        }
+
         String ctId = String.valueOf(a.getContentTypeId());
         a.setSlotId(slotId);
         PSIdMapping ctMap = getIdMapping(ctx, ctId, PSCEDependencyHandler.DEPENDENCY_TYPE);
@@ -481,8 +494,9 @@ public class PSSlotDefDependencyHandler extends PSDependencyHandler implements I
         }
         if (tmpMap != null) tmpId = tmpMap.getTargetId();
         a.setTemplateId(Long.parseLong(tmpId));
+        transformed.add(a);
       }
-      addSlotAssociations(slot, Arrays.asList(assoc));
+      addSlotAssociations(slot, transformed);
     }
   }
 

--- a/docs/ai-generated/code-reviews/upgrade-startup-log4j-xml-package-deploy-erlang.md
+++ b/docs/ai-generated/code-reviews/upgrade-startup-log4j-xml-package-deploy-erlang.md
@@ -1,0 +1,24 @@
+﻿# Erlang-style review: fix/upgrade-startup-log4j-xml-package-deploy
+
+**Date:** 2026-07-27
+**Scope:** Jetty Log4j webapp visibility; XML catalog/secure factory hygiene; Betwixt package-deploy (keyword null root, slot association element names).
+
+## Hard gates
+
+| Gate | Result |
+|------|--------|
+| Behavioral bugs in new logic | Pass after install retest (server starts; packages install) |
+| Unit tests for non-trivial logic | Present: PSXmlSerializationHelperTest, PSCatalogResolverTest, PSSecureXMLUtilsCallSiteOptionsTest, PSTemplateSlotXmlRestoreTest, StartupWarnHygieneTest |
+| Cross-platform paths | Pass — no new OS-hardcoded path construction; rewrite uses string element names only |
+
+## Findings
+
+- **None blocking.** Legacy Betwixt/package contracts are intentionally preserved (root `<null>`, unhyphenated `contenttypeid`).
+- Slot deploy skips zero-id associations with warn (defense if deserialization still fails).
+- Catalog DOCTYPE removal avoids TR9401 fallback AIOOBE under secured SAX.
+- Log4j: `addProtectedClasses` (not hidden) so WEB-INF-excluded log4j-iostreams remains visible (`IoBuilder`).
+
+## Residual risk
+
+- Full Betwixt→Jackson remains #505; this PR is tactical compat only.
+- Other design-object XML using unhyphenated names outside slots may need similar normalizers if found.

--- a/modules/perc-ant/src/test/resources/com/percussion/ant/install/mockinstall/jetty/defaults/start.d/jvm.ini
+++ b/modules/perc-ant/src/test/resources/com/percussion/ant/install/mockinstall/jetty/defaults/start.d/jvm.ini
@@ -29,7 +29,7 @@
 -Dxml.catalog.ignoreMissing=true
 -Dxml.catalog.files=@@rxdir@@/PercussionXMLCatalog.xml;@@rxdir@@/var/config/CustomXMLCatalog.xml
 -Dxml.catalog.prefer=system
--Dxml.catalog.staticCatalog=static-catalog
+-Dxml.catalog.staticCatalog=true
 -Dxml.catalog.allowPI=true
 -Djavax.xml.transform.TransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl
 -Djavax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl

--- a/modules/perc-jetty/src/main/jetty/defaults/modules/perc-logging.mod
+++ b/modules/perc-jetty/src/main/jetty/defaults/modules/perc-logging.mod
@@ -29,6 +29,17 @@ logs/
 basehome:modules/perc-logging
 
 [ini]
-# Keep webapps from loading server Log4j/SLF4J implementation packages.
-jetty.webapp.addHiddenClasses+=,org.apache.logging.log4j.
+# Server-owned Log4j2 must be *visible* to webapps as protected (parent-first)
+# classes. WEB-INF packaging excludes log4j-* jars (see WebUI packagingExcludes);
+# application code such as PSConsole uses org.apache.logging.log4j.io.IoBuilder
+# from log4j-iostreams on the server classpath (lib/perc-logging).
+#
+# GH-1484 originally used addHiddenClasses for log4j, which hid those packages
+# from the webapp classloader and caused:
+#   java.lang.NoClassDefFoundError: org/apache/logging/log4j/io/IoBuilder
+# Use addProtectedClasses so webapps share the server Log4j2 stack and cannot
+# override it with a conflicting WEB-INF copy.
+jetty.webapp.addProtectedClasses+=,org.apache.logging.log4j.
+# Keep server SLF4J packages hidden so WEB-INF slf4j-api (and jcl-over-slf4j)
+# win for Artemis/Spring JMS (see WebUI packagingExcludes comments).
 jetty.webapp.addHiddenClasses+=,org.slf4j.

--- a/modules/perc-jetty/src/main/jetty/defaults/start.d/jvm.ini
+++ b/modules/perc-jetty/src/main/jetty/defaults/start.d/jvm.ini
@@ -35,7 +35,8 @@
 -Dxml.catalog.ignoreMissing=true
 -Dxml.catalog.files=@@rxdir@@/PercussionXMLCatalog.xml;@@rxdir@@/var/config/CustomXMLCatalog.xml
 -Dxml.catalog.prefer=system
--Dxml.catalog.staticCatalog=static-catalog
+# CatalogManager expects true/false/yes/no (not the property name as the value).
+-Dxml.catalog.staticCatalog=true
 -Dxml.catalog.allowPI=true
 -Djavax.xml.transform.TransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl
 # Percussion SAX factory (overrides any stock xerces default for CMS XML apps)

--- a/modules/perc-jetty/src/site/markdown/worklog/jetty-startup-warn-hygiene-1484-1487.md
+++ b/modules/perc-jetty/src/site/markdown/worklog/jetty-startup-warn-hygiene-1484-1487.md
@@ -30,7 +30,17 @@ on the classpath produced “not a subtype” errors and NOP fallback.
 
 - `defaults/modules/perc-logging.mod` → `[provides] logging|default` and
   `logging-log4j2`
-- Hide Log4j/SLF4J packages from webapps via `jetty.webapp.addHiddenClasses`
+- Share server Log4j with webapps via `jetty.webapp.addProtectedClasses` for
+  `org.apache.logging.log4j.` (WEB-INF excludes log4j jars; app code needs
+  `IoBuilder` etc. from server `lib/perc-logging`)
+- Keep server SLF4J hidden via `jetty.webapp.addHiddenClasses` for `org.slf4j.`
+  so WEB-INF `slf4j-api` wins for Artemis/Spring JMS
+
+**Follow-up (upgrade smoke):** An earlier draft of this work used
+`addHiddenClasses` for Log4j as well. That hid `log4j-iostreams` from the
+Rhythmyx webapp and failed startup with
+`NoClassDefFoundError: org/apache/logging/log4j/io/IoBuilder` from
+`PSConsole` static init. Protected (not hidden) is required for Log4j.
 
 Log4j2 remains the sole SLF4J binding from `lib/perc-logging/**.jar`
 (`perc-jetty-logging` assembly, unpacked nested jars).

--- a/modules/perc-jetty/src/test/java/com/percussion/jetty/StartupWarnHygieneTest.java
+++ b/modules/perc-jetty/src/test/java/com/percussion/jetty/StartupWarnHygieneTest.java
@@ -97,6 +97,25 @@ class StartupWarnHygieneTest {
         "perc-logging.mod must not declare [exec] (GH-1485 fork hygiene)");
   }
 
+  /**
+   * Log4j2 is server-owned (WEB-INF excludes log4j-* jars). Packages must be
+   * {@code addProtectedClasses} so webapps can load {@code IoBuilder} etc. Hiding them
+   * (addHiddenClasses) caused NoClassDefFoundError for org.apache.logging.log4j.io.IoBuilder.
+   */
+  @Test
+  void percLoggingExposesLog4jToWebappsAsProtected() throws Exception {
+    String mod = stripComments(read(file("defaults", "modules", "perc-logging.mod")));
+    assertTrue(
+        mod.contains("jetty.webapp.addProtectedClasses+=,org.apache.logging.log4j."),
+        "perc-logging.mod must protect (share) server Log4j with webapps");
+    assertFalse(
+        mod.contains("jetty.webapp.addHiddenClasses+=,org.apache.logging.log4j."),
+        "perc-logging.mod must not hide Log4j from webapps (breaks IoBuilder/PSConsole)");
+    assertTrue(
+        mod.contains("jetty.webapp.addHiddenClasses+=,org.slf4j."),
+        "perc-logging.mod should still hide server SLF4J so WEB-INF slf4j-api wins");
+  }
+
   /** GH-1485: perc.mod must not force its own JVM fork via [exec]. */
   @Test
   void percModHasNoExecSection() throws Exception {
@@ -121,6 +140,12 @@ class StartupWarnHygieneTest {
     assertTrue(
         jvm.contains("XmlParser.Validating=false"),
         "jvm.ini must keep intentional non-validating Jetty XML parse (GH-1487)");
+    assertTrue(
+        jvm.contains("xml.catalog.staticCatalog=true"),
+        "xml.catalog.staticCatalog must be boolean true (CatalogManager rejects non-true/yes)");
+    assertFalse(
+        jvm.contains("xml.catalog.staticCatalog=static-catalog"),
+        "xml.catalog.staticCatalog must not be set to the property name string");
   }
 
   /** GH-1486: ShutdownService configuration (not STOP.PORT ShutdownMonitor on server). */

--- a/modules/perc-xml-security/pom.xml
+++ b/modules/perc-xml-security/pom.xml
@@ -35,6 +35,11 @@
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/modules/perc-xml-security/src/main/java/com/percussion/security/xml/PSCatalogResolver.java
+++ b/modules/perc-xml-security/src/main/java/com/percussion/security/xml/PSCatalogResolver.java
@@ -34,6 +34,20 @@ public class PSCatalogResolver extends CatalogResolver {
   private static final Logger log = LogManager.getLogger(PSCatalogResolver.class);
   private IPSInternalRequestURIResolver internalRequestURIResolver = null;
 
+  /**
+   * Builds a CatalogManager that tolerates missing catalog entries and prefers system IDs. Catalog
+   * file paths still come from {@code xml.catalog.files} / CatalogManager.properties when set by
+   * the JVM (see perc-jetty {@code jvm.ini}).
+   */
+  static CatalogManager createDefaultCatalogManager() {
+    CatalogManager manager = new CatalogManager();
+    manager.setIgnoreMissingProperties(true);
+    manager.setPreferPublic(false); // prefer system (matches xml.catalog.prefer=system)
+    manager.setUseStaticCatalog(true);
+    manager.setVerbosity(0);
+    return manager;
+  }
+
   public IPSInternalRequestURIResolver getInternalRequestURIResolver() {
     return internalRequestURIResolver;
   }
@@ -43,18 +57,27 @@ public class PSCatalogResolver extends CatalogResolver {
     this.internalRequestURIResolver = internalRequestURIResolver;
   }
 
-  /** Constructor */
+  /**
+   * Constructor. Uses a private CatalogManager so catalog parse failures (e.g. legacy TR9401
+   * fallback AIOOBE on mis-formed catalogs) cannot corrupt the static CatalogManager shared by
+   * other resolvers.
+   */
   public PSCatalogResolver() {
-    super();
+    super(createDefaultCatalogManager());
   }
 
   /**
    * Constructor
    *
-   * @param privateCatalog
+   * @param privateCatalog when {@code true}, uses a private catalog instance (preferred)
    */
   public PSCatalogResolver(boolean privateCatalog) {
-    super(privateCatalog);
+    // CatalogResolver(boolean) uses the static CatalogManager; prefer our configured manager
+    // with a private catalog either way to avoid shared-state parse corruption.
+    super(createDefaultCatalogManager());
+    if (!privateCatalog) {
+      log.debug("PSCatalogResolver(false): still using private CatalogManager for isolation");
+    }
   }
 
   /**
@@ -63,7 +86,7 @@ public class PSCatalogResolver extends CatalogResolver {
    * @param manager
    */
   public PSCatalogResolver(CatalogManager manager) {
-    super(manager);
+    super(manager != null ? manager : createDefaultCatalogManager());
   }
 
   /** Return the underlying catalog */

--- a/modules/perc-xml-security/src/main/java/com/percussion/security/xml/PSCatalogResolver.java
+++ b/modules/perc-xml-security/src/main/java/com/percussion/security/xml/PSCatalogResolver.java
@@ -35,15 +35,31 @@ public class PSCatalogResolver extends CatalogResolver {
   private IPSInternalRequestURIResolver internalRequestURIResolver = null;
 
   /**
-   * Builds a CatalogManager that tolerates missing catalog entries and prefers system IDs. Catalog
-   * file paths still come from {@code xml.catalog.files} / CatalogManager.properties when set by
-   * the JVM (see perc-jetty {@code jvm.ini}).
+   * Builds a CatalogManager that prefers system IDs and uses a <em>private</em> catalog instance
+   * ({@code useStaticCatalog=false}) so one resolver's parse failures cannot corrupt a process-wide
+   * static catalog.
+   *
+   * <p>Catalog file paths still come from {@code xml.catalog.files} / CatalogManager.properties
+   * when set by the JVM (see perc-jetty {@code jvm.ini}). This product does not ship a classpath
+   * {@code CatalogManager.properties}; {@code ignoreMissingProperties=true} avoids a noisy
+   * CatalogManager warning on every resolver construction. Operators still configure catalogs via
+   * the JVM system properties above.
    */
   static CatalogManager createDefaultCatalogManager() {
+    return createCatalogManager(true);
+  }
+
+  /**
+   * @param privateCatalog when {@code true}, use a non-static (per-manager) catalog; when {@code
+   *     false}, allow CatalogManager's shared static catalog
+   */
+  static CatalogManager createCatalogManager(boolean privateCatalog) {
     CatalogManager manager = new CatalogManager();
+    // No CatalogManager.properties on the product classpath — ignore is intentional (see above).
     manager.setIgnoreMissingProperties(true);
     manager.setPreferPublic(false); // prefer system (matches xml.catalog.prefer=system)
-    manager.setUseStaticCatalog(true);
+    // false => getCatalog() returns a private Catalog (see CatalogManager.getCatalog)
+    manager.setUseStaticCatalog(!privateCatalog);
     manager.setVerbosity(0);
     return manager;
   }
@@ -59,31 +75,27 @@ public class PSCatalogResolver extends CatalogResolver {
 
   /**
    * Constructor. Uses a private CatalogManager so catalog parse failures (e.g. legacy TR9401
-   * fallback AIOOBE on mis-formed catalogs) cannot corrupt the static CatalogManager shared by
-   * other resolvers.
+   * fallback AIOOBE on mis-formed catalogs) cannot corrupt a shared static Catalog used by other
+   * resolvers.
    */
   public PSCatalogResolver() {
     super(createDefaultCatalogManager());
   }
 
   /**
-   * Constructor
+   * Constructor.
    *
-   * @param privateCatalog when {@code true}, uses a private catalog instance (preferred)
+   * @param privateCatalog when {@code true} (preferred), the CatalogManager uses a private catalog
+   *     instance; when {@code false}, the manager may use CatalogManager's shared static catalog
    */
   public PSCatalogResolver(boolean privateCatalog) {
-    // CatalogResolver(boolean) uses the static CatalogManager; prefer our configured manager
-    // with a private catalog either way to avoid shared-state parse corruption.
-    super(createDefaultCatalogManager());
-    if (!privateCatalog) {
-      log.debug("PSCatalogResolver(false): still using private CatalogManager for isolation");
-    }
+    super(createCatalogManager(privateCatalog));
   }
 
   /**
    * Constructor
    *
-   * @param manager
+   * @param manager catalog manager to use; when {@code null}, a private default manager is used
    */
   public PSCatalogResolver(CatalogManager manager) {
     super(manager != null ? manager : createDefaultCatalogManager());

--- a/modules/perc-xml-security/src/main/java/com/percussion/security/xml/PSSecureXMLUtils.java
+++ b/modules/perc-xml-security/src/main/java/com/percussion/security/xml/PSSecureXMLUtils.java
@@ -55,20 +55,24 @@ public class PSSecureXMLUtils {
   public static final String SAX_GENERAL_EXTERNAL_ENTITIES_FEATURE =
       "http://xml.org/sax/features/external-general-entities";
 
-  // Set to true
+  /**
+   * Xerces / JDK feature IDs for external entities. Note: these are the real
+   * Apache feature URIs — not the xerces.apache.org documentation page URLs that
+   * were previously used and always produced "feature is not recognized" noise.
+   */
   public static final String X1_GENERAL_EXTERNAL_ENTITIES_FEATURE =
-      "http://xerces.apache.org/xerces-j/features.html#external-general-entities";
+      "http://apache.org/xml/features/external-general-entities";
 
-  // Set to true
+  /** Alias retained for callers; same URI as {@link #X1_GENERAL_EXTERNAL_ENTITIES_FEATURE}. */
   public static final String X2_GENERAL_EXTERNAL_ENTITIES_FEATURE =
-      "http://xerces.apache.org/xerces2-j/features.html#external-general-entities";
+      X1_GENERAL_EXTERNAL_ENTITIES_FEATURE;
 
-  // false
   public static final String X1_EXTERNAL_PARAMETER_ENTITIES_FEATURE =
-      "http://xerces.apache.org/xerces-j/features.html#external-parameter-entities";
+      "http://apache.org/xml/features/external-parameter-entities";
 
+  /** Alias retained for callers; same URI as {@link #X1_EXTERNAL_PARAMETER_ENTITIES_FEATURE}. */
   public static final String X2_EXTERNAL_PARAMETER_ENTITIES_FEATURE =
-      "http://xerces.apache.org/xerces2-j/features.html#external-parameter-entities";
+      X1_EXTERNAL_PARAMETER_ENTITIES_FEATURE;
 
   public static final String SAX_EXTERNAL_PARAMETER_ENTITIES_FEATURE =
       "http://xml.org/sax/features/external-parameter-entities";

--- a/modules/perc-xml-security/src/main/resources/CustomXMLCatalog.xml
+++ b/modules/perc-xml-security/src/main/resources/CustomXMLCatalog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<!DOCTYPE catalog
-        PUBLIC "-//OASIS//DTD Entity Resolution XML Catalog V1.0//EN"
-        "http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
+<!--
+  Operator-custom OASIS XML Catalog. No DOCTYPE (see PercussionXMLCatalog.xml).
+-->
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
 	prefer="system" xml:base="file://@@rxdir@@">
 	<!-- Add any custom DTD, Entity, Namespace, XSL (import, include, document)

--- a/modules/perc-xml-security/src/main/resources/PercussionXMLCatalog.xml
+++ b/modules/perc-xml-security/src/main/resources/PercussionXMLCatalog.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0"?>
-<!DOCTYPE catalog
-        PUBLIC "-//OASIS//DTD Entity Resolution XML Catalog V1.0//EN"
-        "http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
-<!-- This catalog is for any external DTD and Entity references. We block
-	external entities and DTD references that are not defined in this catalog
-	file to prevent XXE vulnerabilities -->
+<!--
+  OASIS XML Catalog for local DTD/entity resolution (XXE mitigation).
+  No DOCTYPE: under secured SAX (no external DTD load), a DOCTYPE that
+  references the oasis-open.org catalog.dtd causes SAX parse failure, then
+  xml-resolver falls back to TR9401 text parsing and throws
+  ArrayIndexOutOfBoundsException in TextCatalogReader.
+  OASISXMLCatalogReader keys off the catalog namespace below, not DOCTYPE.
+-->
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
 	prefer="system" xml:base="file://@@rxdir@@">
 

--- a/modules/perc-xml-security/src/test/java/com/percussion/security/xml/PSCatalogResolverTest.java
+++ b/modules/perc-xml-security/src/test/java/com/percussion/security/xml/PSCatalogResolverTest.java
@@ -52,8 +52,15 @@ class PSCatalogResolverTest {
     CatalogManager manager = PSCatalogResolver.createDefaultCatalogManager();
     assertNotNull(manager);
     assertTrue(manager.getIgnoreMissingProperties());
-    assertTrue(manager.getUseStaticCatalog());
+    // Private (non-static) catalog by default — avoids process-wide shared catalog corruption
+    assertFalse(manager.getUseStaticCatalog());
     assertFalse(manager.getPreferPublic());
+  }
+
+  @Test
+  void privateCatalogFlagControlsStaticCatalogSetting() {
+    assertFalse(PSCatalogResolver.createCatalogManager(true).getUseStaticCatalog());
+    assertTrue(PSCatalogResolver.createCatalogManager(false).getUseStaticCatalog());
   }
 
   @Test

--- a/modules/perc-xml-security/src/test/java/com/percussion/security/xml/PSCatalogResolverTest.java
+++ b/modules/perc-xml-security/src/test/java/com/percussion/security/xml/PSCatalogResolverTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.security.xml;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.xml.resolver.CatalogManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression: OASIS XML catalogs must load under secured SAX without TR9401 fallback AIOOBE, and
+ * {@link PSCatalogResolver} must construct without failing startup.
+ */
+class PSCatalogResolverTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void defaultConstructorDoesNotThrow() {
+    assertDoesNotThrow(
+        () -> {
+          new PSCatalogResolver();
+        });
+  }
+
+  @Test
+  void createDefaultCatalogManagerIsConfigured() {
+    CatalogManager manager = PSCatalogResolver.createDefaultCatalogManager();
+    assertNotNull(manager);
+    assertTrue(manager.getIgnoreMissingProperties());
+    assertTrue(manager.getUseStaticCatalog());
+    assertFalse(manager.getPreferPublic());
+  }
+
+  @Test
+  void oasisCatalogWithoutDoctypeLoadsWithoutAioobe() throws Exception {
+    // Minimal OASIS catalog (no DOCTYPE) — same shape as shipping PercussionXMLCatalog.xml
+    String catalogXml =
+        """
+        <?xml version="1.0"?>
+        <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
+          <public publicId="-//Test//DTD Example//EN" uri="example.dtd"/>
+        </catalog>
+        """;
+    Path catalogFile = tempDir.resolve("test-catalog.xml");
+    Files.writeString(catalogFile, catalogXml, StandardCharsets.UTF_8);
+
+    CatalogManager manager = PSCatalogResolver.createDefaultCatalogManager();
+    // file URI form that CatalogManager accepts on all platforms
+    String catalogUri = catalogFile.toUri().toString();
+    manager.setCatalogFiles(catalogUri);
+
+    PSCatalogResolver resolver = new PSCatalogResolver(manager);
+    assertNotNull(resolver);
+    assertNotNull(resolver.getCatalog());
+  }
+
+  @Test
+  void packagedCatalogsDoNotDeclareDoctype() throws Exception {
+    for (String resource : new String[] {"PercussionXMLCatalog.xml", "CustomXMLCatalog.xml"}) {
+      URL url = PSCatalogResolver.class.getClassLoader().getResource(resource);
+      assertNotNull(url, "classpath resource missing: " + resource);
+      try (InputStream in = url.openStream()) {
+        String text = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        // Normalize for assertion; packaged catalogs must not force external catalog.dtd
+        assertFalse(
+            text.toUpperCase().contains("<!DOCTYPE"),
+            resource + " must not declare DOCTYPE (breaks OASIS parse under secured SAX)");
+      }
+    }
+  }
+
+  @Test
+  void apacheFeatureUrisAreRealFeatureIdsNotDocPages() {
+    assertTrue(
+        PSSecureXMLUtils.X1_GENERAL_EXTERNAL_ENTITIES_FEATURE.startsWith(
+            "http://apache.org/xml/features/"),
+        "external-general-entities must use Apache feature URI");
+    assertTrue(
+        PSSecureXMLUtils.X1_EXTERNAL_PARAMETER_ENTITIES_FEATURE.startsWith(
+            "http://apache.org/xml/features/"),
+        "external-parameter-entities must use Apache feature URI");
+    assertFalse(
+        PSSecureXMLUtils.X1_GENERAL_EXTERNAL_ENTITIES_FEATURE.contains("xerces.apache.org"),
+        "must not use documentation-page URLs as feature IDs");
+  }
+}

--- a/modules/perc-xml-security/src/test/java/com/percussion/security/xml/PSSecureXMLUtilsCallSiteOptionsTest.java
+++ b/modules/perc-xml-security/src/test/java/com/percussion/security/xml/PSSecureXMLUtilsCallSiteOptionsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.security.xml;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.SAXParserFactory;
+import org.junit.jupiter.api.Test;
+
+/** Ensures secure factory helpers accept secureWithDtd options without requesting external XXE. */
+class PSSecureXMLUtilsCallSiteOptionsTest {
+
+  @Test
+  void secureWithDtdDisablesExternalEntities() {
+    PSXmlSecurityOptions opts = PSXmlSecurityOptions.secureWithDtd();
+    assertFalse(opts.isEnableExternalEntities());
+    assertFalse(opts.isEnableExternalParameterEntities());
+    assertTrue(opts.isEnableDtdDeclarations());
+    assertTrue(opts.isEnableExternalDtdReferences());
+  }
+
+  @Test
+  void securedDocumentBuilderFactoryAcceptsSecureWithDtd() {
+    DocumentBuilderFactory dbf =
+        PSSecureXMLUtils.getSecuredDocumentBuilderFactory(PSXmlSecurityOptions.secureWithDtd());
+    assertNotNull(dbf);
+  }
+
+  @Test
+  void securedSaxParserFactoryAcceptsSecureWithDtd() {
+    SAXParserFactory spf =
+        PSSecureXMLUtils.getSecuredSaxParserFactory(PSXmlSecurityOptions.secureWithDtd());
+    assertNotNull(spf);
+  }
+}

--- a/modules/perc-xml-security/src/test/resources/TestingXMLCatalog.xml
+++ b/modules/perc-xml-security/src/test/resources/TestingXMLCatalog.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE catalog
-        PUBLIC "-//OASIS//DTD Entity Resolution XML Catalog V1.0//EN"
-        "http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
-<!-- This catalog is for any external DTD and Entity references. We block
-	external entities and DTD references that are not defined in this catalog
-	file to prevent XXE vulnerabilities -->
+<!-- Test OASIS XML Catalog — no DOCTYPE (secure SAX cannot load external catalog.dtd). -->
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
 	prefer="system">
 

--- a/modules/utils/src/main/java/com/percussion/services/utils/xml/PSXmlSerializationHelper.java
+++ b/modules/utils/src/main/java/com/percussion/services/utils/xml/PSXmlSerializationHelper.java
@@ -425,8 +425,7 @@ public class PSXmlSerializationHelper {
     }
     FindIdAttribute fia = new FindIdAttribute();
     SAXParserFactory fact =
-        PSSecureXMLUtils.getSecuredSaxParserFactory(
-            new PSXmlSecurityOptions(true, true, true, false, true, false));
+        PSSecureXMLUtils.getSecuredSaxParserFactory(PSXmlSecurityOptions.secureWithDtd());
 
     try {
       SAXParser parser = fact.newSAXParser();
@@ -487,7 +486,19 @@ public class PSXmlSerializationHelper {
     if (StringUtils.isBlank(xmlString)) {
       throw new IllegalArgumentException("xmlString may not be null or empty");
     }
-    Document doc = PSXmlDocumentBuilder.createXmlDocument(new StringReader(xmlString), false);
+
+    // Rewrite legacy Betwixt root <null>…</null> to the mapped type element name
+    // before parsing. Package payloads (keywords, etc.) were often written with a
+    // root of "null"; Betwixt 0.7 only allows one registered name per class, and
+    // registerBeanClass(Class) binds the mapped name (e.g. "keyword"), so parse()
+    // of a <null> root returns null → "No bean found".
+    String parseXml = rewriteLegacyNullRoot(xmlString, clazz);
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument(new StringReader(parseXml), false);
+    String rootName =
+        (doc != null && doc.getDocumentElement() != null)
+            ? doc.getDocumentElement().getTagName()
+            : null;
 
     SAXParser parser = null;
     Object restored = null;
@@ -497,7 +508,7 @@ public class PSXmlSerializationHelper {
       BeanReader reader = new BeanReader(parser);
 
       standardBetwixtConfiguration(reader, clazz);
-      Reader r = new StringReader(xmlString);
+      Reader r = new StringReader(parseXml);
 
       BeanCreationList chain = BeanCreationList.createStandardChain();
       chain.insertBeanCreator(1, getBeanCreator());
@@ -505,12 +516,61 @@ public class PSXmlSerializationHelper {
 
       restored = reader.parse(r);
     } catch (ParserConfigurationException e) {
-      throw new SAXException("No bean found");
+      throw new SAXException(
+          "No bean found (parser configuration failed"
+              + (clazz != null ? " for " + clazz.getName() : "")
+              + (rootName != null ? ", root='" + rootName + "'" : "")
+              + "): "
+              + e.getMessage(),
+          e);
     }
     if (restored == null) {
-      throw new SAXException("No bean found");
+      throw new SAXException(
+          "No bean found"
+              + (clazz != null ? " for " + clazz.getName() : "")
+              + (rootName != null ? ", root element '" + rootName + "'" : "")
+              + ". Check that the root element is registered for Betwixt.");
     }
     return restored;
+  }
+
+  /**
+   * When {@code clazz} is provided and the document root is the legacy element name {@code null},
+   * rewrite open/close root tags to the Betwixt-mapped type name (via {@link PSNameMapper}).
+   *
+   * <p>Package archives under {@code modules/perc-packages} commonly contain keyword XML whose root
+   * is {@code <null id="…">} rather than {@code <keyword>}. Left unchanged, Betwixt cannot bind the
+   * root and {@link #readFromXML(String, Class)} fails with "No bean found".
+   *
+   * @param xmlString original XML, never blank
+   * @param clazz target type, may be {@code null} (no rewrite)
+   * @return XML ready for Betwixt (possibly unchanged)
+   */
+  static String rewriteLegacyNullRoot(String xmlString, Class<?> clazz) {
+    if (clazz == null || StringUtils.isBlank(xmlString)) {
+      return xmlString;
+    }
+    // Fast path: most modern payloads are already correctly named
+    if (!xmlString.contains("<null") && !xmlString.contains("</null>")) {
+      return xmlString;
+    }
+
+    PSNameMapper mapper = new PSNameMapper();
+    String mapped = mapper.mapTypeToElementName(clazz.getSimpleName());
+    if (StringUtils.isBlank(mapped) || "null".equals(mapped)) {
+      return xmlString;
+    }
+
+    // Only rewrite when the document element is literally "null" (not a nested tag).
+    // Match: optional XML declaration, then <null …> or <null>
+    String openReplaced =
+        xmlString.replaceFirst(
+            "(?is)^(\\s*<\\?xml\\b[^?]*\\?>\\s*)?<null(\\s|>)", "$1<" + mapped + "$2");
+    if (openReplaced.equals(xmlString)) {
+      return xmlString; // root was not <null>
+    }
+    // Matching close tag at end of document (allow trailing whitespace)
+    return openReplaced.replaceFirst("(?is)</null>\\s*$", "</" + mapped + ">");
   }
 
   /**

--- a/modules/utils/src/main/java/com/percussion/services/utils/xml/PSXmlSerializationHelper.java
+++ b/modules/utils/src/main/java/com/percussion/services/utils/xml/PSXmlSerializationHelper.java
@@ -550,7 +550,7 @@ public class PSXmlSerializationHelper {
     if (clazz == null || StringUtils.isBlank(xmlString)) {
       return xmlString;
     }
-    // Fast path: most modern payloads are already correctly named
+    // Fast path: most modern payloads are already correctly named (case-sensitive)
     if (!xmlString.contains("<null") && !xmlString.contains("</null>")) {
       return xmlString;
     }
@@ -561,16 +561,36 @@ public class PSXmlSerializationHelper {
       return xmlString;
     }
 
-    // Only rewrite when the document element is literally "null" (not a nested tag).
-    // Match: optional XML declaration, then <null …> or <null>
-    String openReplaced =
-        xmlString.replaceFirst(
-            "(?is)^(\\s*<\\?xml\\b[^?]*\\?>\\s*)?<null(\\s|>)", "$1<" + mapped + "$2");
-    if (openReplaced.equals(xmlString)) {
-      return xmlString; // root was not <null>
+    // Case-sensitive: only legacy Betwixt root <null>, not <Null>/<NULL> or other types.
+    // Optional XML declaration, then root open tag. DOTALL for multiline prolog only.
+    java.util.regex.Pattern openPat =
+        java.util.regex.Pattern.compile(
+            "^(\\s*<\\?xml\\b[^?]*\\?>\\s*)?<null(\\s|>)", java.util.regex.Pattern.DOTALL);
+    java.util.regex.Matcher openM = openPat.matcher(xmlString);
+    if (!openM.find()) {
+      return xmlString;
     }
-    // Matching close tag at end of document (allow trailing whitespace)
-    return openReplaced.replaceFirst("(?is)</null>\\s*$", "</" + mapped + ">");
+    String decl = openM.group(1) != null ? openM.group(1) : "";
+    String afterName = openM.group(2);
+    StringBuffer openBuf = new StringBuffer();
+    // quoteReplacement so mapped names with $ or \ never act as backreferences
+    openM.appendReplacement(
+        openBuf, java.util.regex.Matcher.quoteReplacement(decl + "<" + mapped + afterName));
+    openM.appendTail(openBuf);
+    String openReplaced = openBuf.toString();
+
+    // Root close is the last </null> (package keyword XML has no nested <null>).
+    // Do not require end-of-string so trailing comments/whitespace remain valid.
+    final String closeLegacy = "</null>";
+    int closeAt = openReplaced.lastIndexOf(closeLegacy);
+    if (closeAt < 0) {
+      return openReplaced;
+    }
+    return openReplaced.substring(0, closeAt)
+        + "</"
+        + mapped
+        + ">"
+        + openReplaced.substring(closeAt + closeLegacy.length());
   }
 
   /**

--- a/modules/utils/src/main/java/com/percussion/utils/xml/PSSaxHelper.java
+++ b/modules/utils/src/main/java/com/percussion/utils/xml/PSSaxHelper.java
@@ -49,10 +49,13 @@ import org.xml.sax.helpers.DefaultHandler;
  */
 public class PSSaxHelper {
 
-  /** Parser factory used in the static helper methods here. The */
+  /**
+   * Parser factory used in the static helper methods here. Uses secure defaults with DTD allowed
+   * for local catalog-backed legacy content; external entities remain hard-disabled by {@link
+   * PSSecureXMLUtils}.
+   */
   static final SAXParserFactory ms_factory =
-      PSSecureXMLUtils.getSecuredSaxParserFactory(
-          new PSXmlSecurityOptions(true, true, true, false, true, false));
+      PSSecureXMLUtils.getSecuredSaxParserFactory(PSXmlSecurityOptions.secureWithDtd());
 
   /**
    * This method instantiates the passed content handler with the arguments given. The passed

--- a/modules/utils/src/main/java/com/percussion/xml/PSSaxParserFactoryImpl.java
+++ b/modules/utils/src/main/java/com/percussion/xml/PSSaxParserFactoryImpl.java
@@ -46,7 +46,7 @@ public class PSSaxParserFactoryImpl extends SAXParserFactory {
                   PSSecureXMLUtils.getSecuredSaxParserFactory(
                       "org.apache.xerces.jaxp.SAXParserFactoryImpl",
                       null,
-                      new PSXmlSecurityOptions(true, true, true, false, true, false));
+                      PSXmlSecurityOptions.secureWithDtd());
               factory.setNamespaceAware(true);
               factory.setValidating(false);
               factory.setFeature("http://xml.org/sax/features/namespaces", true);
@@ -73,8 +73,8 @@ public class PSSaxParserFactoryImpl extends SAXParserFactory {
     try {
       factoryThreadLocal.get().setFeature(name, value);
     } catch (SAXNotRecognizedException | SAXNotSupportedException e1) {
-      log.warn(e1.getMessage());
-      log.debug(e1.getMessage(), e1);
+      // Optional / implementation-specific features are common; keep console clean.
+      log.debug("SAX feature not supported by underlying factory: {} — {}", name, e1.getMessage());
     }
   }
 

--- a/modules/utils/src/main/java/com/percussion/xml/PSXmlDocumentBuilder.java
+++ b/modules/utils/src/main/java/com/percussion/xml/PSXmlDocumentBuilder.java
@@ -205,9 +205,11 @@ public class PSXmlDocumentBuilder {
 
     try {
       if (dbf == null) {
-        dbf =
-            PSSecureXMLUtils.getSecuredDocumentBuilderFactory(
-                new PSXmlSecurityOptions(true, true, true, true, true, validating));
+        // External entities always hard-disabled by PSSecureXMLUtils; request
+        // secure defaults so we do not WARN on every factory create (CWE-611).
+        PSXmlSecurityOptions opts = PSXmlSecurityOptions.secureWithDtd();
+        opts.setEnableValidation(validating);
+        dbf = PSSecureXMLUtils.getSecuredDocumentBuilderFactory(opts);
       }
     } catch (FactoryConfigurationError err) {
       dbf = null;
@@ -215,10 +217,11 @@ public class PSXmlDocumentBuilder {
 
     if (dbf == null) {
       try {
+        PSXmlSecurityOptions opts = PSXmlSecurityOptions.secureWithDtd();
+        opts.setEnableValidation(false);
         dbf =
             PSSecureXMLUtils.getSecuredDocumentBuilderFactory(
-                "org.apache.xerces.jaxp.DocumentBuilderFactoryImpl",
-                new PSXmlSecurityOptions(true, true, true, false, true, false));
+                "org.apache.xerces.jaxp.DocumentBuilderFactoryImpl", opts);
       } catch (Exception e) {
         dbf = null;
         throw new RuntimeException(e);

--- a/modules/utils/src/test/java/com/percussion/services/utils/xml/PSXmlSerializationHelperTest.java
+++ b/modules/utils/src/test/java/com/percussion/services/utils/xml/PSXmlSerializationHelperTest.java
@@ -149,6 +149,23 @@ class PSXmlSerializationHelperTest {
   }
 
   @Test
+  void rewriteLegacyNullRootIsCaseSensitive() {
+    String xml = "<?xml version=\"1.0\"?><Null id=\"1\"><label>X</label></Null>";
+    assertEquals(xml, PSXmlSerializationHelper.rewriteLegacyNullRoot(xml, SampleKeyword.class));
+  }
+
+  @Test
+  void rewriteLegacyNullRootAllowsTrailingCommentAfterClose() {
+    String xml =
+        "<?xml version=\"1.0\"?><null id=\"1\"><label>Time_Zones</label></null><!-- trailing -->\n";
+    String rewritten = PSXmlSerializationHelper.rewriteLegacyNullRoot(xml, SampleKeyword.class);
+    assertTrue(rewritten.contains("<sample-keyword"), rewritten);
+    assertTrue(rewritten.contains("</sample-keyword>"), rewritten);
+    assertTrue(rewritten.contains("<!-- trailing -->"), rewritten);
+    assertTrue(!rewritten.contains("</null>"), rewritten);
+  }
+
+  @Test
   void readFromXmlAcceptsLegacyNullRootElement() throws Exception {
     // Mirrors Time_Zones.keyword / other packaged keywords (root element is literally "null")
     // Register nested choice element name used in package XML (collection singular "choice").

--- a/modules/utils/src/test/java/com/percussion/services/utils/xml/PSXmlSerializationHelperTest.java
+++ b/modules/utils/src/test/java/com/percussion/services/utils/xml/PSXmlSerializationHelperTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.utils.xml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for package-deploy keyword install: Betwixt payloads often use a root element named
+ * {@code null} instead of the mapped type name. Deserialization must still restore the bean.
+ */
+class PSXmlSerializationHelperTest {
+
+  /** Minimal bean shaped like packaged keyword/choice XML. */
+  public static class SampleKeyword {
+    private long id;
+    private String label;
+    private String value;
+    private List<SampleChoice> choices = new ArrayList<>();
+
+    public long getId() {
+      return id;
+    }
+
+    public void setId(long id) {
+      this.id = id;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+
+    public void setLabel(String label) {
+      this.label = label;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    public void setValue(String value) {
+      this.value = value;
+    }
+
+    public List<SampleChoice> getChoices() {
+      return choices;
+    }
+
+    public void setChoices(List<SampleChoice> choices) {
+      this.choices = choices;
+    }
+  }
+
+  public static class SampleChoice {
+    private long id;
+    private String label;
+    private String value;
+    private int sequence;
+
+    public long getId() {
+      return id;
+    }
+
+    public void setId(long id) {
+      this.id = id;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+
+    public void setLabel(String label) {
+      this.label = label;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    public void setValue(String value) {
+      this.value = value;
+    }
+
+    public int getSequence() {
+      return sequence;
+    }
+
+    public void setSequence(int sequence) {
+      this.sequence = sequence;
+    }
+  }
+
+  @Test
+  void rewriteLegacyNullRootMapsToTypeElementName() {
+    String xml =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <null id="1">
+          <label>Time_Zones</label>
+        </null>
+        """;
+    String rewritten = PSXmlSerializationHelper.rewriteLegacyNullRoot(xml, SampleKeyword.class);
+    assertTrue(rewritten.contains("<sample-keyword"), "open tag should be mapped type name");
+    assertTrue(rewritten.contains("</sample-keyword>"), "close tag should be mapped type name");
+    assertTrue(!rewritten.contains("<null"), "legacy null root open tag removed");
+  }
+
+  /**
+   * Shipping package keyword files put the XML declaration and {@code <null>} root on one line with
+   * intervening spaces (see perc.Baseline Time_Zones.keyword).
+   */
+  @Test
+  void rewriteLegacyNullRootHandlesSameLineDeclarationAndRoot() {
+    String xml =
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>  <null id=\"1\">\n"
+            + "    <label>Time_Zones</label>\n"
+            + "    <value>401</value>\n"
+            + "  </null>\n";
+    String rewritten = PSXmlSerializationHelper.rewriteLegacyNullRoot(xml, SampleKeyword.class);
+    assertTrue(rewritten.contains("<sample-keyword id=\"1\">"), rewritten);
+    assertTrue(rewritten.contains("</sample-keyword>"), rewritten);
+    assertTrue(!rewritten.contains("<null"), rewritten);
+  }
+
+  @Test
+  void rewriteLegacyNullRootLeavesNonNullRootUnchanged() {
+    String xml = "<?xml version=\"1.0\"?><sample-keyword id=\"1\"><label>X</label></sample-keyword>";
+    assertEquals(xml, PSXmlSerializationHelper.rewriteLegacyNullRoot(xml, SampleKeyword.class));
+  }
+
+  @Test
+  void readFromXmlAcceptsLegacyNullRootElement() throws Exception {
+    // Mirrors Time_Zones.keyword / other packaged keywords (root element is literally "null")
+    // Register nested choice element name used in package XML (collection singular "choice").
+    PSXmlSerializationHelper.addType("choice", SampleChoice.class);
+
+    String xml =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <null id="1">
+          <choices>
+            <choice id="2">
+              <label>ACT</label>
+              <sequence>1</sequence>
+              <value>ACT</value>
+            </choice>
+          </choices>
+          <label>Time_Zones</label>
+          <value>401</value>
+        </null>
+        """;
+
+    SampleKeyword target = new SampleKeyword();
+    Object restored = PSXmlSerializationHelper.readFromXML(xml, target);
+    assertNotNull(restored);
+    assertTrue(restored instanceof SampleKeyword);
+    SampleKeyword keyword = (SampleKeyword) restored;
+    assertEquals("Time_Zones", keyword.getLabel());
+    assertEquals("401", keyword.getValue());
+    // Root bind is the regression under test; nested choices need type map (as above).
+    assertNotNull(keyword.getChoices());
+  }
+
+  @Test
+  void readFromXmlStillAcceptsMappedTypeRootElement() throws Exception {
+    // Round-trip write produces a mapped root (not "null"); must still parse
+    SampleKeyword original = new SampleKeyword();
+    original.setId(7);
+    original.setLabel("Demo");
+    original.setValue("7");
+
+    String xml = PSXmlSerializationHelper.writeToXml(original);
+    assertNotNull(xml);
+    assertTrue(!xml.trim().startsWith("<null"), "write path should not emit legacy null root");
+
+    SampleKeyword target = new SampleKeyword();
+    SampleKeyword restored = (SampleKeyword) PSXmlSerializationHelper.readFromXML(xml, target);
+    assertEquals("Demo", restored.getLabel());
+    assertEquals("7", restored.getValue());
+  }
+}

--- a/system/services/src/com/percussion/services/assembly/data/PSTemplateSlot.java
+++ b/system/services/src/com/percussion/services/assembly/data/PSTemplateSlot.java
@@ -346,22 +346,36 @@ public class PSTemplateSlot
     }
 
     /**
-     * Rewrites legacy package element names on slot-type associations to hyphenated names
-     * expected by {@link PSXmlSerializationHelper}'s name mapper.
+     * Rewrites legacy package element names on slot-type associations to hyphenated names expected
+     * by {@link PSXmlSerializationHelper}'s name mapper.
+     *
+     * <p>Only rewrites element open/close tags ({@code <name>} / {@code </name>} / {@code
+     * <name ...>}), not bare text or attribute values such as {@code name="contenttypeid"}.
      */
     static String normalizePackageAssociationElementNames(String xml) {
         if (xml == null || xml.isEmpty()) {
             return xml;
         }
         String out = xml;
-        // Tag names only (not attribute values / text)
-        out = out.replace("<contenttypeid>", "<content-type-id>");
-        out = out.replace("</contenttypeid>", "</content-type-id>");
-        out = out.replace("<templateid>", "<template-id>");
-        out = out.replace("</templateid>", "</template-id>");
-        out = out.replace("<slotid>", "<slot-id>");
-        out = out.replace("</slotid>", "</slot-id>");
+        out = renameElementTags(out, "contenttypeid", "content-type-id");
+        out = renameElementTags(out, "templateid", "template-id");
+        out = renameElementTags(out, "slotid", "slot-id");
         return out;
+    }
+
+    /**
+     * Renames open/close tags for {@code from} to {@code to}. Open tags may include attributes
+     * ({@code <from attr="x">}) or self-close ({@code <from/>}).
+     */
+    static String renameElementTags(String xml, String from, String to) {
+        // Open or self-closing: <from> <from/> <from attr=...>
+        String open =
+                xml.replaceAll(
+                        "<" + java.util.regex.Pattern.quote(from) + "(\\s|/?>)",
+                        "<" + java.util.regex.Matcher.quoteReplacement(to) + "$1");
+        return open.replaceAll(
+                "</" + java.util.regex.Pattern.quote(from) + ">",
+                "</" + java.util.regex.Matcher.quoteReplacement(to) + ">");
     }
 
     /**

--- a/system/services/src/com/percussion/services/assembly/data/PSTemplateSlot.java
+++ b/system/services/src/com/percussion/services/assembly/data/PSTemplateSlot.java
@@ -338,7 +338,30 @@ public class PSTemplateSlot
     public void fromXML(String xmlsource) throws IOException, SAXException {
         id = 0L; // Avoid problems during restore
         this.version=null;
-        PSXmlSerializationHelper.readFromXML(xmlsource, this);
+        // Package archives (perc.nav etc.) use unhyphenated association field names
+        // (contenttypeid/templateid/slotid). Default Betwixt/PSNameMapper expects
+        // content-type-id etc.; without that rewrite, associations restore as zeros and
+        // deploy fails with "ContentType with source ID 0".
+        PSXmlSerializationHelper.readFromXML(normalizePackageAssociationElementNames(xmlsource), this);
+    }
+
+    /**
+     * Rewrites legacy package element names on slot-type associations to hyphenated names
+     * expected by {@link PSXmlSerializationHelper}'s name mapper.
+     */
+    static String normalizePackageAssociationElementNames(String xml) {
+        if (xml == null || xml.isEmpty()) {
+            return xml;
+        }
+        String out = xml;
+        // Tag names only (not attribute values / text)
+        out = out.replace("<contenttypeid>", "<content-type-id>");
+        out = out.replace("</contenttypeid>", "</content-type-id>");
+        out = out.replace("<templateid>", "<template-id>");
+        out = out.replace("</templateid>", "</template-id>");
+        out = out.replace("<slotid>", "<slot-id>");
+        out = out.replace("</slotid>", "</slot-id>");
+        return out;
     }
 
     /**

--- a/system/services/src/com/percussion/services/assembly/data/PSTemplateTypeSlotAssociation.betwixt
+++ b/system/services/src/com/percussion/services/assembly/data/PSTemplateTypeSlotAssociation.betwixt
@@ -1,8 +1,14 @@
 <?xml version="1.0"?>
+<!--
+  Explicit property map for package slot-type-association payloads.
+  Archives use unhyphenated names (contenttypeid, templateid, slotid), not the
+  default hyphenated mapper output (content-type-id, etc.).
+-->
 <info primitiveTypes="element">
-  <element>
+  <element name="slot-type-association">
     <element name="slotid" property="slotId"/>
     <element name="templateid" property="templateId"/>
     <element name="contenttypeid" property="contentTypeId"/>
+    <element name="version" property="version"/>
   </element>
 </info>

--- a/system/services/src/com/percussion/services/assembly/data/PSTemplateTypeSlotAssociation.java
+++ b/system/services/src/com/percussion/services/assembly/data/PSTemplateTypeSlotAssociation.java
@@ -18,6 +18,7 @@ package com.percussion.services.assembly.data;
 
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.xml.IPSXmlSerialization;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
@@ -84,6 +85,12 @@ public class PSTemplateTypeSlotAssociation implements Serializable
    }
 
 
+   /**
+    * Hibernate embedded id. Suppressed from Betwixt so package XML attributes like {@code
+    * id="2"} (Betwixt object identity) are not mapped onto this PK — that left content/template
+    * ids at 0 and broke perc.nav slot deploy (ContentType source ID 0).
+    */
+   @IPSXmlSerialization(suppress = true)
    public PSTemplateTypeSlotAssociationPK getId() {
       return id;
    }

--- a/system/services/src/com/percussion/services/content/data/PSKeyword.java
+++ b/system/services/src/com/percussion/services/content/data/PSKeyword.java
@@ -113,6 +113,12 @@ public class PSKeyword implements Serializable, IPSCatalogSummary,
    @Transient
    private List<PSKeywordChoice> m_choices = new ArrayList<>();
 
+   static {
+      // Package XML uses <choice> (collection singular of "choices"), not the mapped type name
+      // "keyword-choice". Register once for Betwixt (not on every fromXML call).
+      PSXmlSerializationHelper.addType("choice", PSKeywordChoice.class);
+   }
+
    /**
     * Default constructor required by JPA/Hibernate.
     * Use factory methods or parameterized constructors for creating new instances.
@@ -522,9 +528,6 @@ public class PSKeyword implements Serializable, IPSCatalogSummary,
     */
    public void fromXML(String xmlsource) throws IOException, SAXException
    {
-      // Package XML uses <choice> (collection singular of "choices"), not the
-      // mapped type name "keyword-choice". Register before Betwixt parse.
-      PSXmlSerializationHelper.addType("choice", PSKeywordChoice.class);
       PSXmlSerializationHelper.readFromXML(xmlsource, this);
    }
 

--- a/system/services/src/com/percussion/services/content/data/PSKeyword.java
+++ b/system/services/src/com/percussion/services/content/data/PSKeyword.java
@@ -522,6 +522,9 @@ public class PSKeyword implements Serializable, IPSCatalogSummary,
     */
    public void fromXML(String xmlsource) throws IOException, SAXException
    {
+      // Package XML uses <choice> (collection singular of "choices"), not the
+      // mapped type name "keyword-choice". Register before Betwixt parse.
+      PSXmlSerializationHelper.addType("choice", PSKeywordChoice.class);
       PSXmlSerializationHelper.readFromXML(xmlsource, this);
    }
 

--- a/system/src/test/java/com/percussion/services/assembly/data/PSTemplateSlotXmlRestoreTest.java
+++ b/system/src/test/java/com/percussion/services/assembly/data/PSTemplateSlotXmlRestoreTest.java
@@ -86,11 +86,21 @@ class PSTemplateSlotXmlRestoreTest {
 
   @Test
   void normalizePackageAssociationElementNamesRewritesTags() {
-    String in = "<slot-type-association><slotid>1</slotid><templateid>2</templateid><contenttypeid>3</contenttypeid></slot-type-association>";
+    String in =
+        "<slot-type-association><slotid>1</slotid><templateid>2</templateid><contenttypeid>3</contenttypeid></slot-type-association>";
     String out = PSTemplateSlot.normalizePackageAssociationElementNames(in);
     assertTrue(out.contains("<content-type-id>3</content-type-id>"), out);
     assertTrue(out.contains("<template-id>2</template-id>"), out);
     assertTrue(out.contains("<slot-id>1</slot-id>"), out);
+  }
+
+  @Test
+  void normalizePackageAssociationElementNamesDoesNotTouchAttributeValues() {
+    String in = "<x name=\"contenttypeid\" templateid=\"keep\"><contenttypeid>9</contenttypeid></x>";
+    String out = PSTemplateSlot.normalizePackageAssociationElementNames(in);
+    assertTrue(out.contains("name=\"contenttypeid\""), out);
+    assertTrue(out.contains("templateid=\"keep\""), out);
+    assertTrue(out.contains("<content-type-id>9</content-type-id>"), out);
   }
 
   private static String describe(PSTemplateTypeSlotAssociation[] assocs) {

--- a/system/src/test/java/com/percussion/services/assembly/data/PSTemplateSlotXmlRestoreTest.java
+++ b/system/src/test/java/com/percussion/services/assembly/data/PSTemplateSlotXmlRestoreTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.assembly.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Package deploy of perc.nav slots failed with ContentType source ID 0 during association id
+ * transforms. Ensure package-shaped slot XML restores non-zero content type / template ids.
+ */
+class PSTemplateSlotXmlRestoreTest {
+
+  /** Minimal copy of perc.nav.image.slotDef from perc.nav.ppkg. */
+  private static final String PERC_NAV_IMAGE_SLOT =
+      """
+      <?xml version="1.0" encoding="utf-8"?>  <template-slot id="1">
+          <guid>0-5-513</guid>
+          <description>navigation image for rollovers</description>
+          <finder-arguments/>
+          <finder-name>Java/global/percussion/slotcontentfinder/sys_RelationshipContentFinder</finder-name>
+          <label>Nav Image</label>
+          <name>perc.nav.image</name>
+          <relationship-name>ActiveAssembly</relationship-name>
+          <slot-type-associations>
+            <slot-type-association id="2">
+              <slotid>513</slotid>
+              <templateid>550</templateid>
+              <contenttypeid>313</contenttypeid>
+            </slot-type-association>
+          </slot-type-associations>
+          <slottype>0</slottype>
+          <system-slot>false</system-slot>
+          <version>2</version>
+        </template-slot>
+      """;
+
+  @Test
+  void fromXmlRestoresSlotTypeAssociationIds() throws Exception {
+    PSTemplateSlot slot = new PSTemplateSlot();
+    slot.fromXML(PERC_NAV_IMAGE_SLOT);
+
+    PSTemplateTypeSlotAssociation[] assocs = slot.getSlotTypeAssociations();
+    assertTrue(assocs != null && assocs.length >= 1, "expected at least one slot-type-association");
+
+    boolean found = false;
+    for (PSTemplateTypeSlotAssociation a : assocs) {
+      if (a.getContentTypeId() == 313L && a.getTemplateId() == 550L) {
+        found = true;
+        break;
+      }
+    }
+    assertTrue(
+        found,
+        "expected association contentTypeId=313 templateId=550; got: " + describe(assocs));
+  }
+
+  @Test
+  void fromXmlDoesNotProduceZeroContentTypeAssociations() throws Exception {
+    PSTemplateSlot slot = new PSTemplateSlot();
+    slot.fromXML(PERC_NAV_IMAGE_SLOT);
+    for (PSTemplateTypeSlotAssociation a : slot.getSlotTypeAssociations()) {
+      assertTrue(
+          a.getContentTypeId() != 0L,
+          "contentTypeId must not be 0 (deploy maps CT id and fails with source ID 0)");
+      assertTrue(a.getTemplateId() != 0L, "templateId must not be 0");
+    }
+  }
+
+  @Test
+  void normalizePackageAssociationElementNamesRewritesTags() {
+    String in = "<slot-type-association><slotid>1</slotid><templateid>2</templateid><contenttypeid>3</contenttypeid></slot-type-association>";
+    String out = PSTemplateSlot.normalizePackageAssociationElementNames(in);
+    assertTrue(out.contains("<content-type-id>3</content-type-id>"), out);
+    assertTrue(out.contains("<template-id>2</template-id>"), out);
+    assertTrue(out.contains("<slot-id>1</slot-id>"), out);
+  }
+
+  private static String describe(PSTemplateTypeSlotAssociation[] assocs) {
+    StringBuilder sb = new StringBuilder();
+    for (PSTemplateTypeSlotAssociation a : assocs) {
+      sb.append("[ct=")
+          .append(a.getContentTypeId())
+          .append(",tmp=")
+          .append(a.getTemplateId())
+          .append(",slot=")
+          .append(a.getSlotId())
+          .append(']');
+    }
+    return sb.toString();
+  }
+}


### PR DESCRIPTION
## Summary

Fixes post-upgrade CMS startup and package deploy failures observed on Windows install smoke (`C:\Installs\8.2-july-03`).

### Jetty / Log4j
- **`perc-logging.mod`**: use `addProtectedClasses` for `org.apache.logging.log4j.` (not `addHiddenClasses`) so the webapp can load server Log4j, including `IoBuilder` used by `PSConsole`. WEB-INF packaging continues to exclude log4j jars.
- Keep SLF4J hidden so WEB-INF `slf4j-api` wins.

### XML security / catalogs
- Remove OASIS catalog **DOCTYPE** (remote `catalog.dtd`) that broke OASIS XML catalog parse under secured SAX and fell back to TR9401 (`ArrayIndexOutOfBoundsException`).
- `xml.catalog.staticCatalog=true` (was invalid value `static-catalog`).
- `PSCatalogResolver`: private configured `CatalogManager`.
- Call sites use `PSXmlSecurityOptions.secureWithDtd()`; real Apache XXE feature URIs (not doc-page URLs).

### Package deploy (Betwixt)
- **Keywords**: rewrite legacy package root `<null>` to mapped type name before Betwixt parse; register `choice` → `PSKeywordChoice`.
- **Slots (perc.nav)**: normalize package association tags `contenttypeid`/`templateid`/`slotid` → hyphenated names; suppress association Hibernate PK from Betwixt; skip zero-id associations during id transform.

## Test plan

- [x] `modules/perc-xml-security` clean install (catalog + options tests)
- [x] `modules/utils` clean install (`PSXmlSerializationHelperTest`)
- [x] `modules/perc-jetty` clean install (`StartupWarnHygieneTest`)
- [x] `system` / `deployer` builds; `PSTemplateSlotXmlRestoreTest`
- [x] Windows upgrade install retest: server starts; startup packages (incl. Baseline, perc.nav) install; no maintenance mode from package failures

## Related

- Follow-up for full Betwixt→Jackson: #505 (commented with this upgrade signal)
- Related Jetty hygiene: #1484–#1487

## Pre-PR Maven (standalone)

```
cd modules/perc-xml-security && ../../mvn-env.bat clean install
cd modules/utils && ../../mvn-env.bat clean install
cd modules/perc-jetty && ../../mvn-env.bat clean install
cd system && ../mvn-env.bat clean install -DskipTests  # + PSTemplateSlotXmlRestoreTest
cd deployer && ../mvn-env.bat clean install -DskipTests
```

BUILD SUCCESS on changed modules; package-deploy path validated on live upgrade install.

> Co-Authored by Grok Build using grok-4.5 with agent Grok.
