### PR TITLE
ci(codeql): skip language jobs when PR/push has no matching sources

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,13 @@
 #
 # Scope: Java and JavaScript/TypeScript only (no Actions, C#, Python, etc.).
 #
+# Path-filtered language jobs (repository-wide on PR + push):
+#   - Analyze (java-kotlin) runs only when Java-relevant paths change
+#   - Analyze (javascript-typescript) runs only when JS/TS-relevant paths change
+#   - Docs-only / markdown-only changes skip both analyzers
+# Full dual-language scan still runs on schedule and workflow_dispatch so the
+# default-branch security picture does not rot.
+#
 # IMPORTANT — only one CodeQL orchestrator may own code-scanning uploads:
 #   - This workflow (.github/workflows/codeql.yml) is the analyzer of record.
 #   - Code scanning *default setup* must stay state=not-configured.
@@ -40,39 +47,97 @@ permissions:
   contents: read
 
 jobs:
-  analyze:
-    name: Analyze (${{ matrix.language }})
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners (GitHub.com only)
+  # ---------------------------------------------------------------------------
+  # Detect which language analyzers must run for this event.
+  # ---------------------------------------------------------------------------
+  changes:
+    name: Detect language changes
     runs-on: ubuntu-latest
     permissions:
-      # required to upload SARIF / open code-scanning alerts
+      contents: read
+      pull-requests: read
+    outputs:
+      java: ${{ steps.resolve.outputs.java }}
+      js: ${{ steps.resolve.outputs.js }}
+    steps:
+      - name: Checkout repository
+        # Only needed for push path-filter base; PRs use the API. Always cheap.
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+
+      - name: Path filter (PR / push)
+        id: filter
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          # Default quantifier is "some": any matching path enables that language.
+          filters: |
+            java:
+              - '**/*.java'
+              - '**/*.kt'
+              - '**/*.kts'
+              - '**/pom.xml'
+              - '**/.mvn/**'
+              - 'mvn-env.sh'
+              - 'mvn-env.bat'
+              - '.github/codeql/**'
+              - '.github/workflows/codeql.yml'
+            js:
+              - '**/*.js'
+              - '**/*.jsx'
+              - '**/*.ts'
+              - '**/*.tsx'
+              - '**/*.mjs'
+              - '**/*.cjs'
+              - '**/package.json'
+              - '**/package-lock.json'
+              - '**/npm-shrinkwrap.json'
+              - '**/yarn.lock'
+              - '**/pnpm-lock.yaml'
+              - '**/tsconfig.json'
+              - '**/tsconfig.*.json'
+              - '**/vite.config.*'
+              - '**/vitest.config.*'
+              - '**/esbuild.config.*'
+              - '**/webpack.config.*'
+              - '.github/codeql/**'
+              - '.github/workflows/codeql.yml'
+
+      - name: Resolve which analyzers run
+        id: resolve
+        run: |
+          set -euo pipefail
+          event="${{ github.event_name }}"
+          # Weekly schedule + manual dispatch: always full dual-language scan.
+          if [ "$event" = "schedule" ] || [ "$event" = "workflow_dispatch" ]; then
+            echo "java=true" >> "$GITHUB_OUTPUT"
+            echo "js=true" >> "$GITHUB_OUTPUT"
+            echo "Event=$event → full CodeQL (java + js)"
+            exit 0
+          fi
+          java="${{ steps.filter.outputs.java }}"
+          js="${{ steps.filter.outputs.js }}"
+          # Empty/missing filter output → fail open (run the analyzer).
+          [ -n "$java" ] || java=true
+          [ -n "$js" ] || js=true
+          echo "java=$java" >> "$GITHUB_OUTPUT"
+          echo "js=$js" >> "$GITHUB_OUTPUT"
+          echo "Event=$event → java=$java js=$js"
+
+  # ---------------------------------------------------------------------------
+  # Language jobs (same check names as before for branch-protection continuity).
+  # ---------------------------------------------------------------------------
+  analyze-java:
+    name: Analyze (java-kotlin)
+    needs: changes
+    if: needs.changes.outputs.java == 'true'
+    runs-on: ubuntu-latest
+    permissions:
       security-events: write
-
-      # required to fetch internal or private CodeQL packs
       packages: read
-
-      # only required for workflows in private repositories
       actions: read
       contents: read
-
-      # required so PR checks / annotations can be written for the head SHA
       pull-requests: read
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Java only (build-mode none does not analyze Kotlin). Prefer none for
-          # this monorepo size; switch to autobuild/manual if coverage is thin.
-          - language: java-kotlin
-            build-mode: none
-          - language: javascript-typescript
-            build-mode: none
-        # Intentionally NOT scanning: actions, c-cpp, csharp, go, python, ruby, rust, swift
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -80,13 +145,107 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
-          languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
+          languages: java-kotlin
+          build-mode: none
           config-file: ./.github/codeql/codeql-config.yml
-          # Do not pass local pack paths via packs: — GHA fails with "not a valid pack".
-          # Models remain in-repo for docs; use sink-line // codeql + query-filters.
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
-          category: "/language:${{ matrix.language }}"
+          category: "/language:java-kotlin"
+
+  analyze-js:
+    name: Analyze (javascript-typescript)
+    needs: changes
+    if: needs.changes.outputs.js == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+          build-mode: none
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:javascript-typescript"
+
+  # ---------------------------------------------------------------------------
+  # Always-green gate so required checks stay satisfiable when a language is
+  # skipped (docs-only PR) without leaving "Analyze (…)" missing.
+  # Prefer requiring *this* check ("CodeQL") in branch protection if you want a
+  # single required status; language jobs remain visible when they run.
+  # ---------------------------------------------------------------------------
+  codeql-gate:
+    name: CodeQL
+    needs: [changes, analyze-java, analyze-js]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Aggregate language job results
+        run: |
+          set -euo pipefail
+          changes_result="${{ needs.changes.result }}"
+          java_needed="${{ needs.changes.outputs.java }}"
+          js_needed="${{ needs.changes.outputs.js }}"
+          java_result="${{ needs.analyze-java.result }}"
+          js_result="${{ needs.analyze-js.result }}"
+          echo "changes_result=$changes_result"
+          echo "java_needed=$java_needed java_result=$java_result"
+          echo "js_needed=$js_needed js_result=$js_result"
+
+          if [ "$changes_result" != "success" ]; then
+            echo "::error::Detect language changes failed (result=$changes_result)"
+            exit 1
+          fi
+
+          fail=0
+          if [ "$java_needed" = "true" ]; then
+            case "$java_result" in
+              success) ;;
+              skipped)
+                echo "::error::Java analysis was required but the job was skipped"
+                fail=1
+                ;;
+              *)
+                echo "::error::Java CodeQL failed or cancelled (result=$java_result)"
+                fail=1
+                ;;
+            esac
+          else
+            echo "Java CodeQL skipped (no Java-relevant path changes)"
+          fi
+
+          if [ "$js_needed" = "true" ]; then
+            case "$js_result" in
+              success) ;;
+              skipped)
+                echo "::error::JS/TS analysis was required but the job was skipped"
+                fail=1
+                ;;
+              *)
+                echo "::error::JS/TS CodeQL failed or cancelled (result=$js_result)"
+                fail=1
+                ;;
+            esac
+          else
+            echo "JS/TS CodeQL skipped (no JS/TS-relevant path changes)"
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+          echo "CodeQL gate passed"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,6 +289,8 @@ This rule applies to ALL review comments on a PR you own, including comments tha
 
 **Languages in scope:** Java + JavaScript/TypeScript only (see `.github/workflows/codeql.yml`).
 
+**Path-filtered on PR/push (repo-wide):** `Analyze (java-kotlin)` runs only when Java-relevant paths change; `Analyze (javascript-typescript)` only when JS/TS-relevant paths change. Docs-only changes skip both. Weekly schedule + `workflow_dispatch` still run full dual-language scans. Prefer required check name **`CodeQL`** (the always-on gate job) so skipped language jobs do not block merge.
+
 |                            Piece                            |                                                Path / command                                                |
 |-------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
 | Playbook (required reading for security/CodeQL PRs)         | `docs/ai-generated/tasks/gh-codeql-alerts/codeql-pr-playbook.md`                                             |

--- a/docs/ai-generated/tasks/gh-codeql-alerts/codeql-pr-playbook.md
+++ b/docs/ai-generated/tasks/gh-codeql-alerts/codeql-pr-playbook.md
@@ -23,8 +23,24 @@ Structural fixes were correct; **PR gating used the wrong analyzer**. That cause
 2. **Default CodeQL setup is disabled** (`state=not-configured` on the repo).
 3. **GitHub Code Quality** (dynamic workflow `Code Quality: CodeQL Setup` at `dynamic/github-code-scanning/codeql`) must stay **disabled** for this repo. It ignores `codeql-config.yml` / model packs, scans extra languages (C#, Python, Actions, …), and empty/stub analyses on the default branch close open alerts as "fixed".
 4. **Languages in scope**: **Java** (`java-kotlin` with `build-mode: none`) and **JavaScript/TypeScript** only.
-5. Custom sanitizers are modeled in `.github/codeql/models/` first; path `query-filters` are a fallback only.
-6. Dismiss-only is a last resort and must cite model/config + tests.
+5. **Path-filtered language jobs (repo-wide):** on `pull_request` and `push`, each language analyzer runs only when that language’s paths changed (see filters in `.github/workflows/codeql.yml`). Markdown/docs-only PRs skip both. **`schedule`** and **`workflow_dispatch`** still run **full** dual-language analysis so default-branch coverage does not rot.
+6. Custom sanitizers are modeled in `.github/codeql/models/` first; path `query-filters` are a fallback only.
+7. Dismiss-only is a last resort and must cite model/config + tests.
+
+### Path filters & branch protection
+
+| Check name | When it runs |
+|------------|----------------|
+| `Detect language changes` | Always (for PR/push/schedule/manual) |
+| `Analyze (java-kotlin)` | Java-relevant paths, or full scan events |
+| `Analyze (javascript-typescript)` | JS/TS-relevant paths, or full scan events |
+| **`CodeQL`** (gate) | Always — succeeds when required language jobs succeed or were legitimately skipped |
+
+**Prefer requiring the gate check `CodeQL`** in branch protection rather than the individual `Analyze (…)` names, so a docs-only PR is not blocked by a missing Java check.
+
+Java-relevant paths (summary): `**/*.{java,kt,kts}`, `**/pom.xml`, `**/.mvn/**`, `mvn-env.*`, `.github/codeql/**`, `.github/workflows/codeql.yml`.
+
+JS/TS-relevant paths (summary): `**/*.{js,jsx,ts,tsx,mjs,cjs}`, package/lock files, `tsconfig*`, Vite/Vitest/esbuild/webpack configs, same CodeQL workflow/config paths.
 
 ---
 


### PR DESCRIPTION
## Summary

Repository-wide CodeQL path filtering so we do not burn runner minutes (or block PRs) when a language did not change.

| Change | Behavior |
|--------|----------|
| Java-only paths | Run `Analyze (java-kotlin)` only |
| JS/TS-only paths | Run `Analyze (javascript-typescript)` only |
| Docs / markdown only | Skip **both** language jobs |
| Weekly schedule + `workflow_dispatch` | Full dual-language scan (coverage does not rot) |

Implementation: `dorny/paths-filter` detect job → conditional language jobs → always-on **`CodeQL`** gate that fails only if a *required* language job failed.

## Branch protection note

Prefer requiring the check name **`CodeQL`** (gate) instead of (or in addition to) the individual `Analyze (…)` jobs. When Java is skipped on a WebUI-only PR, a *required* `Analyze (java-kotlin)` check can stay missing and block merge.

## Test plan

- [ ] Open/update this PR (workflow change) → both language jobs should run (workflow file is in both filters)
- [ ] Docs-only follow-up commit or separate PR → both language jobs skipped; `CodeQL` gate green
- [ ] Confirm schedule still full-scans (no change needed beyond reading the YAML)

> Co-Authored by Grok Build 0.2.112 using grok-4.5 with agent Grok.