### PR TITLE
fix(1530): resolve Javadoc errors and warnings in extensions-workflow

### DIFF
--- a/docs/ai-generated/code-reviews/fix-1530-extensions-workflow-javadoc-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-1530-extensions-workflow-javadoc-erlang.md
@@ -1,0 +1,65 @@
+# Erlang Code Review — fix/1530-extensions-workflow-javadoc
+
+## Summary
+
+Documentation-only cleanup of `extensions-workflow` per issue #1530. Fixes 18 Javadoc errors (malformed `@param`, malformed HTML, missing/invalid `@return`/`@throws`, broken `@link`) and 133 Javadoc source warnings (missing class/method/field comments, illegal `@author`/`@version` on methods, default-constructor without comment). No public API contract changed; no method signatures altered; no code logic touched. Build now: 0 Javadoc errors, 0 Javadoc warnings, BUILD SUCCESS.
+
+## Scope
+
+- Base: `origin/development` (818bcb8338)
+- Head: `fix/1530-extensions-workflow-javadoc` (uncommitted)
+- Files: 36 changed (all `modules/extensions-workflow/src/main/java/...`)
+- Prior report: none for this branch
+- Memory patterns hit: `docs.java.no-comment-on-constructor`, `docs.java.no-throws-documented`, `docs.java.invalid-param-tag`
+
+## Recommendation
+
+approve
+
+## Gate
+
+- Blocking bugs: 0
+- May commit/push: yes
+
+## Issues
+
+None.
+
+## Review notes
+
+### Behavioral / signature risk
+- Verified all 36 files via `git diff`. Only two candidate breaks were possible (interface methods gaining `throws`), and both were reverted during this review pass before commit:
+  - `IPSContentTypesContext.close()` was originally `void close()`; implementation `PSContentTypesContext.close()` (line 100) has no `throws`. Initial pass added `throws SQLException` to the interface — this would have broken the implementor. **Reverted.**
+  - `IPSContentStatusHistoryContext.close()` was originally `void close()`; implementation `PSContentStatusHistoryContext.close()` (line 469) has no `throws`. Same risk. **Reverted.**
+- All other Javadoc `@throws` additions align with existing method signatures (verified by re-grepping signatures after edits).
+- No public API removed; no `@Deprecated` removed; no `serialVersionUID` altered; no CodeQL suppressions touched.
+
+### Cross-platform path / file I/O
+- Diff does not touch file I/O, paths, installers, packaging, or tests that assert paths.
+- Cross-platform path review: no issues.
+
+### Tests
+- Change is non-functional (Javadoc + a few field/constructor Javadoc lines). No new behavior to test.
+- Module test sources were already not executed by surefire pre-existing (Tests run: 0) — pre-existing condition, not regressed by this change.
+- No behavioral logic changed, so no new behavioral tests required.
+
+### Conventions
+- New Javadoc conforms to project `java-api-writing-specs.md` and `javadoc-checklist.md` style (uses `<code>` tags, period-terminated sentences, proper tag ordering).
+- Imports in `IPSStateRolesContext.java` and `IPSContentTypesContext.java` were reordered to place them before the type-level Javadoc so the comment binds to the declaration (fixed a "no comment" warning and is also the more conventional layout).
+
+### Build evidence
+- `mvn-env.bat clean install -B` from `modules/extensions-workflow/` → BUILD SUCCESS
+- Pre-PR build summary: 0 Javadoc errors, 0 Javadoc plugin warnings, 0 Javadoc source warnings.
+- Remaining 121 compiler warnings (`raw type`, `this escape`, `static qualified`, `serialVersionUID`, `unchecked`) are all pre-existing on the base branch baseline (verified by stashing changes and rebuilding baseline). They are out of scope for the Javadoc cleanup task in #1530.
+
+### Voice / ack
+- Author is the reviewer in this session; conflict disclosed. Did not rubber-stamp — performed signature-by-signature diff sanity check and found two latent breaking changes, both reverted before final build.
+
+## Pre-PR command evidence
+
+```
+cd modules/extensions-workflow
+..\..\mvn-env.bat clean install -B
+```
+
+Result: `BUILD SUCCESS`. Javadoc plugin ran with zero warnings. Tests: 0 run, 0 failures (pre-existing — surefire test selection unchanged).

--- a/modules/extensions-workflow/src/main/java/com/percussion/relationship/effect/PSNotifyEffect.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/relationship/effect/PSNotifyEffect.java
@@ -42,6 +42,10 @@ import org.w3c.dom.Document;
  * relationship is created.
  */
 public class PSNotifyEffect extends PSEffect {
+
+  /** Default constructor for the extension framework. */
+  public PSNotifyEffect() {}
+
   /**
    * This effect is only executed if the execution context indicates that this relationship was just
    * created. See base class for additional information.
@@ -66,9 +70,8 @@ public class PSNotifyEffect extends PSEffect {
    * @param request the request for which to send the notifications, not <code>null</code>.
    * @param context the execution context for which to process this effect, not used, can be <code>
    *     null</code>.
-   * @param result - effect result that is used to communicate effect result back to the engine,
+   * @param result the effect result that is used to communicate effect result back to the engine,
    *     assumed never <code>null</code>.
-   * @return <code>true</code> if the notifications are sent successfully.
    * @throws PSExtensionProcessingException for any error catched while notifying the assignees.
    */
   public void attempt(

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/IPSContentStatusHistoryContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/IPSContentStatusHistoryContext.java
@@ -165,18 +165,13 @@ public interface IPSContentStatusHistoryContext {
 
   /**
    * Closes the transition context freeing all JDBC resources.
-   *
-   * @author Ram
-   * @version 1.0
    */
   public void close();
 
   /**
    * Indicates whether the set of history records for this content item is empty.
    *
-   * @author Ram
-   * @version 1.0
-   * @return <CODE>true</CODE> if no history records for this content item else <CODE>false</CODE>
+   * @return <CODE>true</CODE> if no history records for this content item else <CODE>false</CODE>.
    */
   public boolean isEmpty();
 
@@ -184,9 +179,8 @@ public interface IPSContentStatusHistoryContext {
    * Moves the database cursor to the next transition in the list, making data available, trimming
    * whitespace around string data.
    *
-   * @author Ram
-   * @version 1.0
    * @return <CODE>true</CODE> if cursor movement is successful, else <CODE>false</CODE>.
+   * @throws SQLException if an SQL error occurs while advancing the cursor.
    */
   public boolean moveNext() throws SQLException;
 }

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/IPSContentTypesContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/IPSContentTypesContext.java
@@ -17,6 +17,8 @@
 
 package com.percussion.workflow;
 
+import java.sql.SQLException;
+
 /**
  * An interface that defines methods for content types context.
  *
@@ -25,61 +27,50 @@ package com.percussion.workflow;
  * @since 2.0
  * @deprecated
  */
-import java.sql.SQLException;
-
 @Deprecated
 public interface IPSContentTypesContext {
   /**
    * Gets Query Request for the current entry in the context.
    *
-   * @author Ram
-   * @version 1.0
-   * @param quesry request
+   * @return the query request string for the current entry in the context.
+   * @throws SQLException if an SQL error occurs while building the request.
    */
   public String getContentTypeQueryRequest() throws SQLException;
 
   /**
    * Gets Update Request for the current entry in the context.
    *
-   * @author Ram
-   * @version 1.0
-   * @param update request
+   * @return the update request string for the current entry in the context.
+   * @throws SQLException if an SQL error occurs while building the request.
    */
   public String getContentTypeUpdateRequest() throws SQLException;
 
   /**
    * Gets New Request for the current entry in the context.
    *
-   * @author Ram
-   * @version 1.0
-   * @param new request
+   * @return the new request string for the current entry in the context.
+   * @throws SQLException if an SQL error occurs while building the request.
    */
   public String getContentTypeNewRequest() throws SQLException;
 
   /**
    * Gets content type name for the current entry in the context.
    *
-   * @author Ram
-   * @version 1.0
-   * @param content type name
+   * @return the content type name for the current entry in the context.
+   * @throws SQLException if an SQL error occurs while accessing the data.
    */
   public String getContentTypeName() throws SQLException;
 
   /**
    * Gets content type description for the current entry in the context.
    *
-   * @author Ram
-   * @version 1.0
-   * @param content type description
+   * @return the content type description for the current entry in the context.
+   * @throws SQLException if an SQL error occurs while accessing the data.
    */
   public String getContentTypeDescription() throws SQLException;
 
   /**
    * Closes the context freeing all JDBC resources.
-   *
-   * @author Ram
-   * @version 1.0
-   * @param none
    */
   public void close();
 }

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/IPSNotificationsContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/IPSNotificationsContext.java
@@ -29,20 +29,14 @@ public interface IPSNotificationsContext {
   /**
    * Gets the subject field for the current entry in the context.
    *
-   * @author Ram
-   * @version 1.0
-   * @param none
-   * @return subject
+   * @return the subject for the current entry in the context.
    */
   public String getSubject();
 
   /**
    * Gets Body field for the current entry in the context.
    *
-   * @author Ram
-   * @version 1.0
-   * @param none
-   * @return Body
+   * @return the body for the current entry in the context.
    */
   public String getBody();
 }

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/IPSStateRolesContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/IPSStateRolesContext.java
@@ -17,6 +17,9 @@
 
 package com.percussion.workflow;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * An interface that defines methods for State-Roles Context. The table joins are hidden from the
  * user.
@@ -24,10 +27,8 @@ package com.percussion.workflow;
  * @author Rammohan Vangapalli
  * @version 1.0
  * @since 2.0
+ * @deprecated
  */
-import java.util.List;
-import java.util.Map;
-
 @Deprecated
 public interface IPSStateRolesContext {
   /**
@@ -106,20 +107,14 @@ public interface IPSStateRolesContext {
    * Gets the number of roles assgined for the current state. This is more than 1 formultiple
    * assignments.
    *
-   * @author Ram
-   * @version 1.0
-   * @param none
-   * @return role count as int
+   * @return the role count as an int.
    */
   public int getStateRoleCount();
 
   /**
    * Indicates whether the context has any entries.
    *
-   * @author Ram
-   * @version 1.0
-   * @param none
-   * @return <CODE>true</CODE> if empty, else <CODE>false</CODE>
+   * @return <CODE>true</CODE> if empty, else <CODE>false</CODE>.
    */
   public boolean isEmpty();
 }

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/IPSTransitionNotificationsContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/IPSTransitionNotificationsContext.java
@@ -52,12 +52,13 @@ public interface IPSTransitionNotificationsContext {
    * Return value indicating which state role recipients should receive notification: none,
    * from-state, to-state or both (for the current notification data set).
    *
-   * <ul>
-   *   <li>NO_STATE_ROLE_RECIPIENTS for No State Role recipients
-   *   <li>ONLY_NEW_STATE_ROLE_RECIPIENTS for To State Role recipients only
-   *   <li>ONLY_OLD_STATE_ROLE_RECIPIENTS for From State Role recipients only
-   *   <li>OLD_AND_NEW_STATE_ROLE_RECIPIENTS for Both To and From State Role recipients
-   * </ul>
+   * @return one of:
+   *     <ul>
+   *       <li>{@link #NO_STATE_ROLE_RECIPIENTS} for No State Role recipients
+   *       <li>{@link #ONLY_NEW_STATE_ROLE_RECIPIENTS} for To State Role recipients only
+   *       <li>{@link #ONLY_OLD_STATE_ROLE_RECIPIENTS} for From State Role recipients only
+   *       <li>{@link #OLD_AND_NEW_STATE_ROLE_RECIPIENTS} for Both To and From State Role recipients
+   *     </ul>
    */
   public int getStateRoleRecipientTypes();
 

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentAdhocUsersContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentAdhocUsersContext.java
@@ -68,6 +68,7 @@ public class PSContentAdhocUsersContext implements IPSContentAdhocUsersContext {
    * @param connection database connection - must not be <CODE>null</CODE>
    * @throws SQLException if an SQL error occurs
    * @throws IllegalArgumentException if the connection is <CODE>null</CODE>
+   * @throws PSRoleException if a workflow role error occurs while loading the adhoc users
    */
   @Deprecated // TODO: This class needs refactored to use spring  hibernate
   public PSContentAdhocUsersContext(int contentID, Connection connection)
@@ -410,6 +411,13 @@ public class PSContentAdhocUsersContext implements IPSContentAdhocUsersContext {
     return m_adhocAnonymousUserNames.size();
   }
 
+  /**
+   * Returns the role IDs from the supplied list that have no adhoc users assigned. The input list
+   * is not modified.
+   *
+   * @param roleIDList list of role IDs to check, may be <code>null</code> or empty.
+   * @return a new list containing the role IDs that have no adhoc users, never <code>null</code>.
+   */
   public List<Integer> getEmptyAdhocRoles(List<Integer> roleIDList) {
     List<Integer> emptyAdhocRoles = new ArrayList<>();
     Integer roleID;
@@ -426,6 +434,12 @@ public class PSContentAdhocUsersContext implements IPSContentAdhocUsersContext {
     return emptyAdhocRoles;
   }
 
+  /**
+   * Determines whether the given role has any adhoc users assigned.
+   *
+   * @param roleID the role ID to check.
+   * @return <code>true</code> if the role has adhoc users assigned, otherwise <code>false</code>.
+   */
   public boolean hasAdhocUsers(int roleID) {
     return (m_adhocRoleIDtoAdhocTypeMap.containsKey(roleID));
   }

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentTypesContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentTypesContext.java
@@ -23,6 +23,10 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+/**
+ * Concrete implementation of {@link IPSContentTypesContext} that loads content type metadata from
+ * the database.
+ */
 @Deprecated
 public class PSContentTypesContext implements IPSContentTypesContext {
   private boolean invokedStandalone = false;
@@ -38,6 +42,15 @@ public class PSContentTypesContext implements IPSContentTypesContext {
   String m_sContentTypeQueryRequest = "";
   String m_sContentTypeUpdateRequest = "";
 
+  /**
+   * Constructs a content types context for the supplied content type by loading its row from the
+   * database.
+   *
+   * @param connection the database connection to use, must not be <code>null</code>.
+   * @param contentTypeID the ID of the content type to load.
+   * @throws SQLException if an SQL error occurs while loading the row.
+   * @throws PSEntryNotFoundException if no row exists for the supplied content type ID.
+   */
   public PSContentTypesContext(Connection connection, int contentTypeID)
       throws SQLException, PSEntryNotFoundException {
     this.contentTypeID = contentTypeID;

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSCreateTranslations.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSCreateTranslations.java
@@ -56,6 +56,10 @@ import org.w3c.dom.*;
  * @author RammohanVangapalli
  */
 public class PSCreateTranslations implements IPSWorkflowAction {
+
+  /** Default constructor for the extension framework. */
+  public PSCreateTranslations() {}
+
   /* (non-Javadoc)
    * @see com.percussion.extension.IPSWorkflowAction#performAction(
    * com.percussion.extension.IPSWorkFlowContext,

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExecuteWorkflowActions.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExecuteWorkflowActions.java
@@ -47,6 +47,10 @@ import org.w3c.dom.Document;
  */
 public class PSExecuteWorkflowActions implements IPSResultDocumentProcessor {
 
+  /** Default constructor for the extension framework. */
+  public PSExecuteWorkflowActions() {}
+
+
   /** The fully qualified name of this extension. */
   private String m_fullExtensionName = "";
 
@@ -88,10 +92,10 @@ public class PSExecuteWorkflowActions implements IPSResultDocumentProcessor {
    *
    * @param params the parameters for this extension. Should be <CODE>null</CODE> or of size 0,
    *     because this extension does not have any parameters.
-   * @param requestContext the context of the request associated with this extension
+   * @param requestContext the context of the request associated with this extension. If there are
+   *     transition workflow action extensions to be performed, the following two private objects
+   *     must be present:
    *     <ul>
-   *       If there are transition workflow action extensions to be performed, the following two
-   *       private objects must be present:
    *       <li>workflow context - key <CODE>
    *                         IPSWorkFlowContext.WORKFLOW_CONTEXT_PRIVATE_OBJECT
    *                         </CODE>

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExecuteWorkflowActions.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExecuteWorkflowActions.java
@@ -99,9 +99,11 @@ public class PSExecuteWorkflowActions implements IPSResultDocumentProcessor {
    *       <li>workflow context - key <CODE>
    *                         IPSWorkFlowContext.WORKFLOW_CONTEXT_PRIVATE_OBJECT
    *                         </CODE>
+   *       </li>
    *       <li>workflow action extensions list - key <CODE>
    *                         IPSWorkflowAction.WORKFLOW_ACTIONS_PRIVATE_OBJECT
    *                         </CODE>
+   *       </li>
    *     </ul>
    *
    * @param resultDoc the result XML document (may be <CODE>null</CODE> because it will be ignored)

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAddEditAuthFlag.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAddEditAuthFlag.java
@@ -49,6 +49,10 @@ import org.w3c.dom.Element;
  */
 public class PSExitAddEditAuthFlag implements IPSResultDocumentProcessor {
 
+  /** Default constructor for the extension framework. */
+  public PSExitAddEditAuthFlag() {}
+
+
   private static final Logger log = LogManager.getLogger(PSExitAddEditAuthFlag.class);
 
   /*

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAddPossibleTransitions.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAddPossibleTransitions.java
@@ -39,7 +39,17 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 
+/**
+ * Result-document processor exit that augments the supplied result document with the workflow
+ * transitions that are permitted for the current item. See the {@link
+ * IPSResultDocumentProcessor} contract for the parameters and return value of {@link
+ * #processResultDocument(Object[], IPSRequestContext, Document)}.
+ */
 public class PSExitAddPossibleTransitions implements IPSResultDocumentProcessor {
+
+  /** Default constructor for the extension framework. */
+  public PSExitAddPossibleTransitions() {}
+
   /**
    * This is an inner class to encapsulate the parameters. We cannot keep these as class variables
    * due to threading issues. We instantiate this object in the main processrequest method (called
@@ -502,23 +512,45 @@ public class PSExitAddPossibleTransitions implements IPSResultDocumentProcessor 
   /** Element and attribute names for the workflow information node. */
   public static final String ELEMENT_WORKFLOWINFO = "workflowinfo";
 
+  /** Content ID attribute name. */
   public static final String ATTRIB_CONTENTID = "contentid";
+
+  /** Workflow ID attribute name. */
   public static final String ATTRIB_WORKFLOWID = "workflowid";
+
+  /** Workflow name attribute name. */
   public static final String ATTRIB_WORKFLOWNAME = "workflowname";
 
+  /** Transition ID attribute name. */
   public static final String ATTRIB_TRANSITIONID = "transitionid";
 
+  /** User name element name. */
   public static final String ELEMENT_USERNAME = "username";
+
+  /** Assignment type attribute name. */
   public static final String ATTRIB_ASSIGNMENTTYPE = "assignmenttype";
 
+  /** Current state element name. */
   public static final String ELEMENT_CURRENTSTATE = "currentstate";
+
+  /** State ID attribute name. */
   public static final String ATTRIB_STATEID = "stateid";
+
+  /** Publishable attribute name. */
   public static final String ATTRIB_PUBLISHABLE = "publishable";
 
+  /** Check-out status element name. */
   public static final String ELEMENT_CHECKOUTSTATUS = "checkoutstatus";
+
+  /** Check-out user name attribute name. */
   public static final String ATTRIB_CHECKOUTUSERNAME = "checkoutusername";
 
+  /** Assigned roles container element name. */
   public static final String ELEMENT_ASSIGNEDROLES = "assignedroles";
+
+  /** Single assigned role element name. */
   public static final String ELEMENT_ASSIGNEDROLE = "assignedrole";
+
+  /** Role ID attribute name. */
   public static final String ATTRIB_ROLEID = "roleid";
 }

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAddPossibleTransitionsEx.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAddPossibleTransitionsEx.java
@@ -53,7 +53,16 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 
+/**
+ * Extended result-document processor exit that augments the supplied result document with the
+ * workflow transitions that are permitted for the current item, including hidden form parameters
+ * for action links. See {@link IPSResultDocumentProcessor} for the contract of {@link
+ * #processResultDocument(Object[], IPSRequestContext, Document)}.
+ */
 public class PSExitAddPossibleTransitionsEx implements IPSResultDocumentProcessor {
+
+  /** Default constructor for the extension framework. */
+  public PSExitAddPossibleTransitionsEx() {}
 
   private static final Logger log = LogManager.getLogger(PSExitAddPossibleTransitionsEx.class);
 
@@ -1103,8 +1112,13 @@ public class PSExitAddPossibleTransitionsEx implements IPSResultDocumentProcesso
   /** Element and attribute names for the workflow information node. */
   public static final String ELEMENT_WORKFLOWINFO = "BasicInfo";
 
+  /** Content ID attribute name. */
   public static final String ATTRIB_CONTENTID = "contentId";
+
+  /** Workflow ID attribute name. */
   public static final String ATTRIB_WORKFLOWID = "workflowId";
+
+  /** Name of the hidden form parameters node attached to action links. */
   public static final String HIDDEN_PARAMS_NAME = "HiddenFormParams";
 
   // element/attribute names for ActionLink and its children
@@ -1118,10 +1132,19 @@ public class PSExitAddPossibleTransitionsEx implements IPSResultDocumentProcesso
   private static final String DISABLED_ATTRIB = "isDisabled";
 
   // The next 4 values are the button's label as seen by the end user
+  /** Label for the check-in button. */
   private static final String CHECKIN_BUTTON_LABEL = "Check-in";
+
+  /** Label for the check-out button. */
   private static final String CHECKOUT_BUTTON_LABEL = "Check-out";
+
+  /** Label for the force check-in button. */
   private static final String FORCE_CHECKIN_BUTTON_LABEL = "Force Check-in";
+
+  /** Label for the edit button. */
   private static final String EDIT_BUTTON_LABEL = "Edit";
+
+  /** Label for the preview button. */
   private static final String PREVIEW_BUTTON_LABEL = "Preview";
 
   /** XML attribute value that represents true */
@@ -1133,13 +1156,25 @@ public class PSExitAddPossibleTransitionsEx implements IPSResultDocumentProcesso
   /** XML attribute value that represents false */
   private static final String ATTRIB_HIDE = "hide";
 
+  /** User name element name. */
   public static final String ELEMENT_USERNAME = "UserName";
+
+  /** Assignment type attribute name. */
   public static final String ATTRIB_ASSIGNMENTTYPE = "assignmentType";
+
+  /** Check-out user name attribute name. */
   public static final String ATTRIB_CHECKOUTUSERNAME = "CheckOutUserName";
+
+  /** Adhoc role type attribute name. */
   public static final String ATTRIB_ADHOCTYPE = "adhocType";
 
+  /** Assigned roles container element name. */
   public static final String ELEMENT_ASSIGNEDROLES = "AssignedRoles";
+
+  /** Single assigned role element name. */
   public static final String ELEMENT_ASSIGNEDROLE = "Role";
+
+  /** Role ID attribute name. */
   public static final String ATTRIB_ROLEID = "roleId";
 
   /** The internal name of the command handler that processes workflow actions. */

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAuthenticateUser.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAuthenticateUser.java
@@ -43,7 +43,15 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * Pre-processor exit that authenticates the current user against the workflow role requirements of
+ * the request, populating authorization flags used by downstream processing.
+ */
 public class PSExitAuthenticateUser implements IPSRequestPreProcessor {
+
+  /** Default constructor for the extension framework. */
+  public PSExitAuthenticateUser() {}
+
   Logger log = LogManager.getLogger(IPSConstants.WORKFLOW_LOG);
 
   /**

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitDeleteWfCtypeAssociations.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitDeleteWfCtypeAssociations.java
@@ -54,6 +54,9 @@ import org.apache.logging.log4j.Logger;
  */
 public class PSExitDeleteWfCtypeAssociations implements IPSRequestPreProcessor {
 
+  /** Default constructor for the extension framework. */
+  public PSExitDeleteWfCtypeAssociations() {}
+
   public void preProcessRequest(Object[] params, IPSRequestContext request)
       throws PSAuthorizationException,
           PSRequestValidationException,

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitDisallowUpdatePublished.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitDisallowUpdatePublished.java
@@ -41,6 +41,10 @@ import org.apache.logging.log4j.Logger;
  * extension is to restrict updating a document in workflow when it is in state that is publishable.
  */
 public class PSExitDisallowUpdatePublished implements IPSRequestPreProcessor {
+
+  /** Default constructor for the extension framework. */
+  public PSExitDisallowUpdatePublished() {}
+
   private static final Logger ms_log = LogManager.getLogger(PSExitDisallowUpdatePublished.class);
   /* Set the parameter count to not initialized */
   private static int ms_correctParamCount = NOT_INITIALIZED;
@@ -63,9 +67,10 @@ public class PSExitDisallowUpdatePublished implements IPSRequestPreProcessor {
    * This overrides the method in the original interface and is called by the server while
    * processign the request.
    *
-   * @param params - array of objects that are parameters to the extension
-   * @param request - request context (IPSRequestContext)
-   * @throws PSExtensionProcessingException
+   * @param params the array of objects that are parameters to the extension.
+   * @param request the request context (IPSRequestContext).
+   * @throws PSExtensionProcessingException if the request cannot be processed, for example because
+   *     the content item is in a publishable state.
    */
   public void preProcessRequest(Object[] params, IPSRequestContext request)
       throws PSExtensionProcessingException, PSParameterMismatchException {

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitGetAllowedTransitions.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitGetAllowedTransitions.java
@@ -44,6 +44,10 @@ import org.w3c.dom.Element;
  */
 public class PSExitGetAllowedTransitions extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
+
+  /** Default constructor for the extension framework. */
+  public PSExitGetAllowedTransitions() {}
+
   public boolean canModifyStyleSheet() {
     return false;
   }

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitNextNumber.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitNextNumber.java
@@ -36,6 +36,10 @@ import org.apache.logging.log4j.Logger;
 
 /** This extension returns the value of a counter obtained from a database stored procedure. */
 public class PSExitNextNumber implements IPSRequestPreProcessor {
+
+  /** Default constructor for the extension framework. */
+  public PSExitNextNumber() {}
+
   private static final String GLOBAL_KEY = "RXKEYGLOBAL";
 
   /* Set the parameter count to not initialized */

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitNextNumberMaxPP.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitNextNumberMaxPP.java
@@ -36,6 +36,10 @@ import org.apache.logging.log4j.Logger;
 @Deprecated
 public class PSExitNextNumberMaxPP implements IPSRequestPreProcessor {
 
+  /** Default constructor for the extension framework. */
+  public PSExitNextNumberMaxPP() {}
+
+
   private static PSExitNextNumber newNextNumberExt = new PSExitNextNumber();
   private static final Logger log = LogManager.getLogger(IPSConstants.WORKFLOW_LOG);
 

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitNotifyAssignees.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitNotifyAssignees.java
@@ -101,6 +101,10 @@ import org.w3c.dom.Document;
 
 /** This exit sends mail notifications to the assigned roles for the new state after transition. */
 public class PSExitNotifyAssignees implements IPSResultDocumentProcessor {
+
+  /** Default constructor for the extension framework. */
+  public PSExitNotifyAssignees() {}
+
   private static final Logger m_log = LogManager.getLogger(IPSConstants.WORKFLOW_LOG);
 
   /** The fully qualified name of this extension. */

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java
@@ -55,6 +55,10 @@ import java.util.Optional;
  * transition is placed into private objects in the request context.
  */
 public class PSExitPerformTransition implements IPSRequestPreProcessor {
+
+  /** Default constructor for the extension framework. */
+  public PSExitPerformTransition() {}
+
   /**
    * This is an inner class to encapsulate the parameters. We cannot keep these as class variables
    * due to threading issues. We instantiate this object in the main processrequest method (called
@@ -244,6 +248,8 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
    *             <li>a PSEntryNotFoundException is caught because an expected data base entry does
    *                 not exist
    *           </ul>
+   *         </li>
+   *     </ul>
    */
   public void preProcessRequest(Object[] params, IPSRequestContext request)
       throws PSExtensionProcessingException {

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPrepareQueryFilters.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPrepareQueryFilters.java
@@ -26,7 +26,16 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.StringTokenizer;
 
+/**
+ * Pre-processor exit that prepares the request's HTML parameters for downstream workflow-related
+ * query filters, splitting any role list parameter into the individual role names expected by
+ * subsequent processing.
+ */
 public class PSExitPrepareQueryFilters implements IPSRequestPreProcessor {
+
+  /** Default constructor for the extension framework. */
+  public PSExitPrepareQueryFilters() {}
+
   /*role delimiter (in role list) */
   private static final String ROLE_DELIMITER = ",";
 

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitUpdateHistory.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitUpdateHistory.java
@@ -53,6 +53,10 @@ import org.w3c.dom.Element;
 
 /** Updates the status history context for this transition or checkout or checkin action. */
 public class PSExitUpdateHistory implements IPSResultDocumentProcessor {
+
+  /** Default constructor for the extension framework. */
+  public PSExitUpdateHistory() {}
+
   /** The fully qualified name of this extension. */
   private String m_fullExtensionName = "";
 

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSGetAssignees.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSGetAssignees.java
@@ -42,6 +42,9 @@ import org.w3c.dom.Text;
  */
 public class PSGetAssignees extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
 
+  /** Default constructor for the extension framework. */
+  public PSGetAssignees() {}
+
   private static final Logger log = LogManager.getLogger(PSGetAssignees.class);
 
   public Object processUdf(Object[] params, IPSRequestContext request)

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSGetAssignmentType.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSGetAssignmentType.java
@@ -37,7 +37,7 @@ import org.w3c.dom.Element;
  * <p>This UDF evaluates the assignment type to an image given the contentid of the item and image
  * url options. Assignment value (which is a number) is evaluated based on the current state of the
  * workflow of the item. Currently supported assignment types are defined in {@link
- * com.percussion.workflow.PSWorkflowUtils}. The UDF takes the content id as the first parameter and
+ * PSWorkFlowUtils}. The UDF takes the content id as the first parameter and
  * the rest are the image url options for each possible assignmenttype in asending order by value.
  *
  * <p>The image urls can either be standard Applet Url in the syntax of "../app/resource.gif" or the
@@ -47,6 +47,9 @@ import org.w3c.dom.Element;
  * images match the normal icon images in the content explorer.
  */
 public class PSGetAssignmentType extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
+
+  /** Default constructor for the extension framework. */
+  public PSGetAssignmentType() {}
 
   private static final Logger log = LogManager.getLogger(PSGetAssignmentType.class);
 

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSGetCheckOutStatusUdf.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSGetCheckOutStatusUdf.java
@@ -37,6 +37,10 @@ import com.percussion.server.IPSRequestContext;
  * @see PSWorkFlowUtils
  */
 public class PSGetCheckOutStatusUdf extends PSSimpleJavaUdfExtension {
+
+  /** Default constructor for the extension framework. */
+  public PSGetCheckOutStatusUdf() {}
+
   /* ************ IPSUdfProcessor Interface Implementation ************ */
 
   /**

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSGetCheckoutStatus.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSGetCheckoutStatus.java
@@ -58,6 +58,10 @@ import org.apache.logging.log4j.Logger;
  * images match the normal icon images in the content explorer.
  */
 public class PSGetCheckoutStatus extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
+
+  /** Default constructor for the extension framework. */
+  public PSGetCheckoutStatus() {}
+
   /**
    * Determines the image url to use.
    *
@@ -147,5 +151,6 @@ public class PSGetCheckoutStatus extends PSSimpleJavaUdfExtension implements IPS
     return result;
   }
 
+  /** Logger for this class. */
   protected static final Logger log = LogManager.getLogger(IPSConstants.WORKFLOW_LOG);
 }

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSGetUserCheckoutStatus.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSGetUserCheckoutStatus.java
@@ -26,6 +26,10 @@ import com.percussion.server.IPSRequestContext;
  * first param is the checked out user name, not the content id of the item.
  */
 public class PSGetUserCheckoutStatus extends PSGetCheckoutStatus {
+
+  /** Default constructor for the extension framework. */
+  public PSGetUserCheckoutStatus() {}
+
   /**
    * See base class for more info. The only difference is that this method expects the first
    * parameter to be the checkedout user name. May be <code>null</code> or empty.

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSGetWorkflowActionList.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSGetWorkflowActionList.java
@@ -35,6 +35,10 @@ import org.w3c.dom.Element;
 
 /** Adds a list of all installed workflow action extensions to the result XML document. */
 public class PSGetWorkflowActionList implements IPSResultDocumentProcessor {
+
+  /** Default constructor for the extension framework. */
+  public PSGetWorkflowActionList() {}
+
   /*
    * Flag to indicate indicating that this exit has not been initialized yet.
    */

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSNotificationsContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSNotificationsContext.java
@@ -45,6 +45,7 @@ public class PSNotificationsContext extends PSAbstractWorkflowContext
    * @throws SQLException if an error occurs
    * @throws NamingException if a datasource cannot be resolved
    * @throws IllegalArgumentException if the connection is <CODE>null</CODE>
+   * @throws PSEntryNotFoundException if no notification row is found for the supplied IDs.
    */
   public PSNotificationsContext(int workflowID, int notificationID, Connection connection)
       throws SQLException, PSEntryNotFoundException, NamingException {

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSPostExitHandler.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSPostExitHandler.java
@@ -63,8 +63,6 @@ public class PSPostExitHandler implements IPSResultDocumentProcessor {
    * @param request the current request context, may be <code>null</code>.
    * @param resDoc the result XML document, may be <code>null</code>.
    * @return the supplied result document, possibly <code>null</code>.
-   * @throws PSParameterMismatchException never thrown.
-   * @throws PSExtensionProcessingException never thrown.
    */
   public Document processResultDocument(Object[] params, IPSRequestContext request, Document resDoc)
       throws PSParameterMismatchException, PSExtensionProcessingException {
@@ -123,7 +121,7 @@ public class PSPostExitHandler implements IPSResultDocumentProcessor {
    * Logs the contents of the supplied request context (application name, request URL, CGI
    * variables, HTML parameters and response cookies) to the workflow log for debugging.
    *
-   * @param request the request context to log, may be <code>null</code>.
+   * @param request the request context to log, must not be <code>null</code>.
    */
   public static void printRequestContext(IPSRequestContext request) {
     log.info("");

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSPostExitHandler.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSPostExitHandler.java
@@ -34,6 +34,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 
+/**
+ * Base class for result document post-exit handlers used by the workflow debugging extension. Logs
+ * details of the request, its input XML document and the result document for debugging purposes.
+ */
 public class PSPostExitHandler implements IPSResultDocumentProcessor {
   private static final Logger log = LogManager.getLogger(PSPostExitHandler.class);
 
@@ -50,7 +54,18 @@ public class PSPostExitHandler implements IPSResultDocumentProcessor {
     // nothing to initialize
   }
 
-  /** This is the main request processing handler */
+  /**
+   * This is the main request processing handler. It logs details of the request, its input XML
+   * document and the result document to the workflow log for debugging purposes, and returns the
+   * supplied result document unchanged.
+   *
+   * @param params the parameters for this extension, unused.
+   * @param request the current request context, may be <code>null</code>.
+   * @param resDoc the result XML document, may be <code>null</code>.
+   * @return the supplied result document, possibly <code>null</code>.
+   * @throws PSParameterMismatchException never thrown.
+   * @throws PSExtensionProcessingException never thrown.
+   */
   public Document processResultDocument(Object[] params, IPSRequestContext request, Document resDoc)
       throws PSParameterMismatchException, PSExtensionProcessingException {
     log.info("");
@@ -104,6 +119,12 @@ public class PSPostExitHandler implements IPSResultDocumentProcessor {
     return resDoc;
   }
 
+  /**
+   * Logs the contents of the supplied request context (application name, request URL, CGI
+   * variables, HTML parameters and response cookies) to the workflow log for debugging.
+   *
+   * @param request the request context to log, may be <code>null</code>.
+   */
   public static void printRequestContext(IPSRequestContext request) {
     log.info("");
     log.info("Contents of the Request Context...");
@@ -132,6 +153,11 @@ public class PSPostExitHandler implements IPSResultDocumentProcessor {
     printMap(request.getResponseCookies());
   }
 
+  /**
+   * Logs the contents of the supplied map to the workflow log for debugging.
+   *
+   * @param map the map to log, may be <code>null</code>.
+   */
   public static void printMap(Map map) {
     if (null == map) {
       log.info("Map containing the list is null");
@@ -151,6 +177,12 @@ public class PSPostExitHandler implements IPSResultDocumentProcessor {
     }
   }
 
+  /**
+   * Logs a single name/value pair to the workflow log for debugging.
+   *
+   * @param value the value to log, may be <code>null</code>.
+   * @param name the name to associate with the value, may be <code>null</code>.
+   */
   public static void printString(String value, String name) {
     log.info("{} = {}", name, value);
     log.info("");

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSStateRolesContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSStateRolesContext.java
@@ -145,6 +145,12 @@ public class PSStateRolesContext implements IPSStateRolesContext {
     return m_StateRoleIDs;
   }
 
+  /**
+   * Gets a list of state role names corresponding to the state role IDs in {@link
+   * #getStateRoleIDs()}.
+   *
+   * @return a new list of role names, never <code>null</code>.
+   */
   public List<String> getStateRoleNames() {
     return new ArrayList<>(m_stateRoleNameMap.values());
   }

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSTransitionException.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSTransitionException.java
@@ -18,6 +18,9 @@ package com.percussion.workflow;
 
 import com.percussion.error.PSException;
 
+/**
+ * Exception thrown when an error occurs while performing a workflow transition.
+ */
 public class PSTransitionException extends PSException {
   /**
    * Construct an exception for messages taking locale and msgCode arguments.

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSWorkflowRoleInfoStatic.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSWorkflowRoleInfoStatic.java
@@ -55,6 +55,10 @@ import org.apache.logging.log4j.Logger;
  * #WORKFLOW_ROLE_INFO_PRIVATE_OBJECT }
  */
 public class PSWorkflowRoleInfoStatic {
+
+  /** Default constructor. */
+  public PSWorkflowRoleInfoStatic() {}
+
   /* Manipulate state role information */
 
   /**
@@ -72,29 +76,23 @@ public class PSWorkflowRoleInfoStatic {
 
   /* Obtain actor and role information */
 
-  /*
-   * Get list of state roles in which a user is acting, including adhoc roles
+  /**
+   * Get list of state roles in which a user is acting, including adhoc roles.
    *
-   * @param contentID          ID of the content item
-   * @param src                context of state roles meeting the minimum
-   *                           assignment types, may not be <CODE>null</CODE>
-   *                           or empty
-   * @param userName           The user's name, cannot be <CODE>null</CODE>
-   * @param userRoleNameList   A comma-delimited list of the user's roles,
-   *                           may not be <CODE>null</CODE> or empty
-   * @param connection         database connection, may be not be
-   *                           <CODE>null</CODE>
-   * @param authUser           if true indicates that PSExitAuthenticateUser
-   *                           is the caller, false otherwise
-   *
-   * @return                   list of state roles in which a user is acting
-   *                           <CODE>null</CODE> if the user has no roles
-   *
-   * @throws                   SQLException if a SQL error occurs
-   * @throws                   IllegalArgumentException if any of the input
-   *                           parameters is not valid.
-   * @throws                   PSRoleException if the content adhoc user
-   *                           records contain invalid data
+   * @param contentID ID of the content item
+   * @param src context of state roles meeting the minimum assignment types, may not be <code>null
+   *     </code> or empty
+   * @param userName the user's name, cannot be <code>null</code>
+   * @param userRoleNames a comma-delimited list of the user's roles, may not be <code>null</code>
+   *     or empty
+   * @param connection database connection, may be not be <code>null</code>
+   * @param authUser if true indicates that {@link PSExitAuthenticateUser} is the caller, false
+   *     otherwise
+   * @return list of state roles in which a user is acting, <code>null</code> if the user has no
+   *     roles
+   * @throws SQLException if a SQL error occurs
+   * @throws IllegalArgumentException if any of the input parameters is not valid.
+   * @throws PSRoleException if the content adhoc user records contain invalid data
    */
   public static List<Integer> getActorRoles(
       int contentID,
@@ -139,23 +137,20 @@ public class PSWorkflowRoleInfoStatic {
     return actorRoles;
   }
 
-  /*
-   * Get list of state roles in which a user is acting, including adhoc roles
+  /**
+   * Get list of state roles in which a user is acting, including adhoc roles.
    *
-   * @param userName           The user's name, cannot be <CODE>null</CODE>
-   *                           or empty
-   * @param userRoleNames      A comma-delimited list of the user's roles.
-   *                           may be <CODE>null</CODE> or empty
-   * @param src                context of state roles meeting the minimum
-   *                           assignment types, cannot be <CODE>null</CODE>
-   * @param cauc               ad hoc user context for the content item
-   *                           not <CODE>null</CODE>
-   * @param authUser           if true indicates that PSExitAuthenticateUser
-   *                           is the caller, false otherwise
-   * @return                   list of state roles in which a user is acting,
-   *                           <CODE>null</CODE> if the user has no roles
-   * @throws                   IllegalArgumentException if any of the input
-   *                           parameters is not valid.
+   * @param userName the user's name, cannot be <code>null</code> or empty
+   * @param userRoleNames a comma-delimited list of the user's roles, may be <code>null</code> or
+   *     empty
+   * @param src context of state roles meeting the minimum assignment types, cannot be <code>null
+   *     </code>
+   * @param cauc ad hoc user context for the content item, not <code>null</code>
+   * @param authUser if true indicates that {@link PSExitAuthenticateUser} is the caller, false
+   *     otherwise
+   * @return list of state roles in which a user is acting, <code>null</code> if the user has no
+   *     roles
+   * @throws IllegalArgumentException if any of the input parameters is not valid.
    */
   public static List<Integer> getActorRoles(
       String userName,
@@ -1088,7 +1083,7 @@ public class PSWorkflowRoleInfoStatic {
    *     are sent, may be <code>null</code> to ignore the community filter.
    * @return a list (never <CODE>null</CODE> may be empty) containing for each role subject, either
    *     <ul>
-   *       <li>their email address(es) given by the system global email address attribute, or </
+   *       <li>their email address(es) given by the system global email address attribute, or
    *       <li>
    *       <li>their subject name
    *     </ul>
@@ -1146,7 +1141,7 @@ public class PSWorkflowRoleInfoStatic {
    *     are sent, may be <code>null</code> to ignore the community filter.
    * @return a list containing for each role subject, either
    *     <ul>
-   *       <li>their email address(es) given by the system global email address attribute, or </
+   *       <li>their email address(es) given by the system global email address attribute, or
    *       <li>
    *       <li>their subject name
    *     </ul>
@@ -1198,10 +1193,14 @@ public class PSWorkflowRoleInfoStatic {
   }
 
   /**
-   * @param princes
-   * @param contentid
-   * @param revisionid
-   * @throws Exception
+   * Filters the supplied collection of principals by the community of the supplied content item and
+   * by folder security if folder security overrides workflow security.
+   *
+   * @param princes the principals to filter, may be <code>null</code>.
+   * @param contentid the content id whose community is used as the filter.
+   * @param revisionid the revision id of the content item.
+   * @return the filtered set of principals, never <code>null</code>.
+   * @throws Exception if an error occurs while accessing role manager state.
    */
   protected static Set<IPSTypedPrincipal> filterPrincipalsByCommunityAndFolderSecurity(
       final Collection<IPSTypedPrincipal> princes, final int contentid, int revisionid)
@@ -1299,7 +1298,7 @@ public class PSWorkflowRoleInfoStatic {
    *     are sent, may be <code>null</code> to ignore the ccommunity filter.
    * @return a list (never <CODE>null</CODE> may be empty) containing for each subject, either
    *     <ul>
-   *       <li>their email address(es) given by the system global email address attribute, or </
+   *       <li>their email address(es) given by the system global email address attribute, or
    *       <li>
    *       <li>their subject name
    *     </ul>
@@ -1354,7 +1353,7 @@ public class PSWorkflowRoleInfoStatic {
    *     are sent, may be <code>null</code> to ignore the community filter.
    * @return a list either
    *     <ul>
-   *       <li>the email address(es) given by the system global email address attribute, or </
+   *       <li>the email address(es) given by the system global email address attribute, or
    *       <li>
    *       <li>the subject name
    *     </ul>

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSXMLNodeMissingException.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSXMLNodeMissingException.java
@@ -18,6 +18,9 @@ package com.percussion.workflow;
 
 import com.percussion.error.PSException;
 
+/**
+ * Exception thrown when a required XML node is missing while processing workflow data.
+ */
 public class PSXMLNodeMissingException extends PSException {
   private static final long serialVersionUID = 1L;
 

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PreviewWorkflow.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PreviewWorkflow.java
@@ -30,7 +30,14 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+/**
+ * Builds a visual representation of a workflow's states and transitions, used to preview the
+ * workflow. This class extends {@link PSPostExitHandler} so it can be wired as a result document
+ * post exit.
+ */
 public class PreviewWorkflow extends PSPostExitHandler {
+
+  /** Default constructor. */
   public PreviewWorkflow() {}
 
   /**


### PR DESCRIPTION
Resolves #1530

Documentation-only cleanup of the \extensions-workflow\ module. Resolves all 18 Javadoc errors and all 133 Javadoc source warnings (plus 1 Javadoc plugin warning). No public API contract changed; no method signatures altered; no code logic touched.

## Pre-PR build evidence

Command (standalone module build, from \modules/extensions-workflow\):

\\\ash
..\\..\\mvn-env.bat clean install -B
\\\

Result: **BUILD SUCCESS**

- 0 Javadoc errors
- 0 Javadoc plugin warnings
- 0 Javadoc source warnings
- Tests run: 0, Failures: 0, Errors: 0, Skipped: 0 (pre-existing — surefire test selection unchanged by this PR)

The remaining 121 compiler warnings (\aw type\, \	his escape\, static-qualified, \serialVersionUID\, unchecked) are pre-existing on the base branch baseline and out of scope for the Javadoc cleanup task in #1530.

## Categories of fixes

- Malformed/invalid tags: removed invalid \@return\ on a void method (PSNotifyEffect), rewrote placeholder \@param quesry\/\@param update\/\@param new\/\@param 'content type name'\/\@param 'content type description'\/\@param none\ lines as proper \@return\, removed \@author\/\@version\ misuse on methods, added \@throws\ for documented exceptions.
- Malformed HTML: fixed 4 occurrences of \, or </\ (missing closing \>\ on \</li>\) in PSWorkflowRoleInfoStatic, moved stray text out of \<ul>\ into \@param\ prose in PSExecuteWorkflowActions, added missing nested \</li></ul>\ close in PSExitPerformTransition.
- Broken references: corrected unresolved \{@link com.percussion.workflow.PSWorkflowUtils}\ to \{@link PSWorkFlowUtils}\ in PSGetAssignmentType.
- Missing comments on types/fields/methods: added class-level Javadoc to PreviewWorkflow, PSExitPrepareQueryFilters, PSExitAuthenticateUser, PSExitAddPossibleTransitions, PSExitAddPossibleTransitionsEx, PSPostExitHandler, PSTransitionException, PSXMLNodeMissingException, PSContentTypesContext, plus missing field/method Javadoc and \@deprecated\ tags on deprecated interfaces.
- Default-constructor warnings: added explicit default constructor with Javadoc to 24 classes that previously relied on an implicit one.
- Converted block comments (\/* ... */\) to Javadoc (\/** ... */\) on two overloaded \getActorRoles\ methods in PSWorkflowRoleInfoStatic.
- Reordered imports in IPSStateRolesContext and IPSContentTypesContext so the type-level Javadoc binds to the declaration.

## Erlang pre-commit review

Strict Erlang-style pre-commit review recorded at \docs/ai-generated/code-reviews/fix-1530-extensions-workflow-javadoc-erlang.md\.

- Recommendation: **approve**
- Gate: **May commit/push: yes**
- Blocking bugs: 0
- Initial pass surfaced two latent breaking changes (interface methods gaining \	hrows SQLException\); both were reverted before final build.
- Cross-platform path review: no issues (no file I/O / paths touched).

## Files

37 files changed: 36 source files in \modules/extensions-workflow/src/main/java/...\ plus the durable Erlang review report.