### PR TITLE
fix(webui): address late #1531 Kilo review on SPA cutover

### DIFF
--- a/WebUI/src/main/webapp/cm/app/includes/retired_modern_redirect.jsp
+++ b/WebUI/src/main/webapp/cm/app/includes/retired_modern_redirect.jsp
@@ -17,9 +17,11 @@
     }
     StringBuilder url = new StringBuilder();
     url.append(proxyURL).append("/cm/app/?view=").append(URLEncoder.encode(retiredView, "UTF-8"));
-    // Preserve deep-link params; index.jsp allowlists before building spa.jsp Location
+    // Re-forward only params that index.jsp buildSpaEntryRedirect actually consumes
+    // (then allowlists into spa.jsp?entry=…). Do not pass path/site — those are not
+    // mapped for home/publish/workflow/admin/widgetbuilder SPA entries from this host.
     String[] keys = new String[]{
-            "initialScreen", "section", "tab", "siteId", "serverId", "path", "site"
+            "initialScreen", "section", "tab", "siteId", "serverId"
     };
     for (int i = 0; i < keys.length; i++) {
         String key = keys[i];

--- a/WebUI/src/main/webapp/cm/pages/app/includes/retired_modern_redirect.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/includes/retired_modern_redirect.jsp
@@ -17,9 +17,11 @@
     }
     StringBuilder url = new StringBuilder();
     url.append(proxyURL).append("/cm/app/?view=").append(URLEncoder.encode(retiredView, "UTF-8"));
-    // Preserve deep-link params; index.jsp allowlists before building spa.jsp Location
+    // Re-forward only params that index.jsp buildSpaEntryRedirect actually consumes
+    // (then allowlists into spa.jsp?entry=…). Do not pass path/site — those are not
+    // mapped for home/publish/workflow/admin/widgetbuilder SPA entries from this host.
     String[] keys = new String[]{
-            "initialScreen", "section", "tab", "siteId", "serverId", "path", "site"
+            "initialScreen", "section", "tab", "siteId", "serverId"
     };
     for (int i = 0; i < keys.length; i++) {
         String key = keys[i];

--- a/WebUI/src/test/ts/app/spaCutover.test.ts
+++ b/WebUI/src/test/ts/app/spaCutover.test.ts
@@ -35,7 +35,9 @@ describe("PR-5 aggressive index.jsp SPA cutover", () => {
       const text = read(indexPath);
       expect(text).toContain("buildSpaEntryRedirect");
       expect(text).toContain("/cm/app/spa.jsp?");
-      expect(text).toContain('entry=").append');
+      // Intent: SPA Location query starts with entry= (avoid coupling to JSP format)
+      expect(text).toMatch(/"entry="\s*\)|entry=\s*"\s*\+/);
+      expect(text).toMatch(/URLEncoder\.encode\(\s*entry\b/);
       // Must not forward product modern views to *Modern.jsp
       expect(text).not.toMatch(
         /legacyViews\.put\("home",\s*"homeModern\.jsp"\)/,
@@ -77,6 +79,23 @@ describe("PR-5 aggressive index.jsp SPA cutover", () => {
     expect(text).toContain("WORKFLOW_TABS");
     expect(text).toContain("ADMIN_TABS");
     expect(text).toContain('"widget-builder"');
+  });
+
+  it("retired_modern_redirect only re-forwards params buildSpaEntryRedirect consumes", () => {
+    const redirect = read(
+      resolve(
+        __dirname,
+        "../../../main/webapp/cm/app/includes/retired_modern_redirect.jsp",
+      ),
+    );
+    expect(redirect).toContain('"initialScreen"');
+    expect(redirect).toContain('"section"');
+    expect(redirect).toContain('"tab"');
+    expect(redirect).toContain('"siteId"');
+    expect(redirect).toContain('"serverId"');
+    // Intentionally not re-forwarded (Kilo #1531): not mapped for these SPA entries
+    expect(redirect).not.toMatch(/"path"\s*,/);
+    expect(redirect).not.toMatch(/"site"\s*\]/);
   });
 
   it("dual-tree index.jsp files stay aligned for SPA cutover", () => {


### PR DESCRIPTION
## Summary

Follow-up for late [Kilo review comments on #1531](https://github.com/intersoftdatalabs-in/percussioncms/pull/1531) (merged before review finished).

| Thread | Mitigation |
|--------|------------|
| `retired_modern_redirect.jsp` comment / `path`+`site` | Stop re-forwarding `path`/`site` (not consumed by `buildSpaEntryRedirect` for these views); comment now matches behavior |
| Fragile `spaCutover` `entry=").append` assertion | Intent-based match on `entry=` + `URLEncoder.encode(entry…)` plus contract test for redirect keys |

## Test plan

- [x] `npm test -- --run spaCutover` (WebUI frontend) — pass
- [ ] No behavior change for normal SPA nav; retired `*Modern.jsp` deep links with `section`/`tab`/`siteId` still work

Fixes review on #1531 (post-merge).

> Co-Authored by Grok Build 0.2.112 using grok-4.5 with agent Grok.