### PR TITLE
chore(webui): upgrade to react-router 8.3.0 (security)

### DIFF
--- a/WebUI/package-lock.json
+++ b/WebUI/package-lock.json
@@ -25,9 +25,9 @@
         "js-cookie": "^3.0.7",
         "moment": "^2.30.1",
         "mousetrap": "^1.6.5",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
-        "react-router-dom": "^7.18.1",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-router": "^8.3.0",
         "recharts": "^3.7.0",
         "underscore": "^1.13.7"
       },
@@ -1387,18 +1387,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2991,24 +2984,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-is": {
@@ -3042,41 +3035,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/recharts": {
@@ -3205,12 +3181,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {

--- a/WebUI/package.json
+++ b/WebUI/package.json
@@ -31,9 +31,9 @@
     "js-cookie": "^3.0.7",
     "moment": "^2.30.1",
     "mousetrap": "^1.6.5",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "react-router-dom": "^7.18.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-router": "^8.3.0",
     "recharts": "^3.7.0",
     "underscore": "^1.13.7"
   },

--- a/WebUI/src/main/frontend/REACT-ROUTER-GUIDE.md
+++ b/WebUI/src/main/frontend/REACT-ROUTER-GUIDE.md
@@ -78,7 +78,7 @@ src/main/ts/
 ### App.tsx
 
 ```typescript
-import { RouterProvider } from 'react-router-dom';
+import { RouterProvider } from 'react-router';
 import { router } from '../router';
 
 export const App: React.FC = () => {
@@ -97,7 +97,7 @@ Instead of manually managing Layout, Navigation, and pages, the Router handles t
 Updated to use React Router's `useNavigate` hook:
 
 ```typescript
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 export const Navigation: React.FC<{ items: NavItem[] }> = ({ items }) => {
   const navigate = useNavigate();

--- a/WebUI/src/main/frontend/package-lock.json
+++ b/WebUI/src/main/frontend/package-lock.json
@@ -25,9 +25,9 @@
         "js-cookie": "^3.0.7",
         "moment": "^2.30.1",
         "mousetrap": "^1.6.5",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
-        "react-router-dom": "^7.18.1",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-router": "^8.3.0",
         "recharts": "^3.7.0",
         "underscore": "^1.13.7"
       },
@@ -1410,18 +1410,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3040,24 +3033,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-is": {
@@ -3091,41 +3084,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/recharts": {
@@ -3268,12 +3244,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {

--- a/WebUI/src/main/frontend/package.json
+++ b/WebUI/src/main/frontend/package.json
@@ -31,9 +31,9 @@
     "js-cookie": "^3.0.7",
     "moment": "^2.30.1",
     "mousetrap": "^1.6.5",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "react-router-dom": "^7.18.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-router": "^8.3.0",
     "recharts": "^3.7.0",
     "underscore": "^1.13.7"
   },

--- a/WebUI/src/main/ts/app/App.tsx
+++ b/WebUI/src/main/ts/app/App.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, { useEffect } from "react";
-import { HashRouter, useNavigate } from "react-router-dom";
+import { HashRouter, useNavigate } from "react-router";
 import { ThemeProvider } from "../ui-themes/ThemeProvider";
 import { BootstrapProvider } from "./bootstrap/BootstrapContext";
 import type { SpaBootstrap } from "./bootstrap/types";

--- a/WebUI/src/main/ts/app/FeaturePlaceholder.tsx
+++ b/WebUI/src/main/ts/app/FeaturePlaceholder.tsx
@@ -16,7 +16,7 @@
  */
 
 import React from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import styles from "./layout/AppLayout.module.css";
 
 export interface FeaturePlaceholderProps {

--- a/WebUI/src/main/ts/app/layout/AppLayout.tsx
+++ b/WebUI/src/main/ts/app/layout/AppLayout.tsx
@@ -16,7 +16,7 @@
  */
 
 import React from "react";
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 import { BrandBar, BrandFooter } from "../../ui-themes/components";
 import { TopNav } from "./TopNav";
 import styles from "./AppLayout.module.css";

--- a/WebUI/src/main/ts/app/layout/TopNav.tsx
+++ b/WebUI/src/main/ts/app/layout/TopNav.tsx
@@ -16,7 +16,7 @@
  */
 
 import React from "react";
-import { NavLink } from "react-router-dom";
+import { NavLink } from "react-router";
 import { useSpaBootstrap } from "../bootstrap/BootstrapContext";
 import { UserMenu } from "./UserMenu";
 import styles from "./AppLayout.module.css";

--- a/WebUI/src/main/ts/app/routes.tsx
+++ b/WebUI/src/main/ts/app/routes.tsx
@@ -16,7 +16,7 @@
  */
 
 import React from "react";
-import { Navigate, Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router";
 import { FeaturePlaceholder } from "./FeaturePlaceholder";
 import { AppLayout } from "./layout/AppLayout";
 import { AdminRoute } from "./routes/AdminRoute";

--- a/WebUI/src/main/ts/app/routes/AdminRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/AdminRoute.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, { lazy } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { loadComponent } from "../../registry";
 import { LazyRouteFrame } from "./RouteErrorBoundary";
 import { RequireRole } from "./RequireRole";

--- a/WebUI/src/main/ts/app/routes/ExplorerRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/ExplorerRoute.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, { lazy, useMemo } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 import { normalizeExplorerPath } from "../deepLinks/allowlists";
 import { loadComponent } from "../../registry";
 import { LazyRouteFrame } from "./RouteErrorBoundary";

--- a/WebUI/src/main/ts/app/routes/HomeRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/HomeRoute.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, { lazy } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { useSpaBootstrap } from "../bootstrap/BootstrapContext";
 import { loadComponent } from "../../registry";
 import { LazyRouteFrame } from "./RouteErrorBoundary";

--- a/WebUI/src/main/ts/app/routes/PublishRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/PublishRoute.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, { lazy } from "react";
-import { useParams, useSearchParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router";
 import { useSpaBootstrap } from "../bootstrap/BootstrapContext";
 import { loadComponent } from "../../registry";
 import { LazyRouteFrame } from "./RouteErrorBoundary";

--- a/WebUI/src/main/ts/app/routes/RequireRole.tsx
+++ b/WebUI/src/main/ts/app/routes/RequireRole.tsx
@@ -16,7 +16,7 @@
  */
 
 import React from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate } from "react-router";
 import { useSpaBootstrap } from "../bootstrap/BootstrapContext";
 
 export type SpaRoleGate = "admin" | "adminOrDesigner" | "widgetBuilder";

--- a/WebUI/src/main/ts/app/routes/WorkflowRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/WorkflowRoute.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, { lazy } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { loadComponent } from "../../registry";
 import { LazyRouteFrame } from "./RouteErrorBoundary";
 import { RequireRole } from "./RequireRole";


### PR DESCRIPTION
## Summary

Upgrade WebUI modern SPA from **`react-router-dom@7.18.1`** to **`react-router@8.3.0`** to clear high-severity vulnerability reports on older React Router lines.

### Changes
- Dependency: `react-router-dom` → `react-router@^8.3.0` (v8 **removed** `react-router-dom`; APIs live on `react-router`)
- All SPA imports updated: `from \"react-router\"`
- Peer baseline: `react` / `react-dom` → `^19.2.7` (resolved **19.2.8**)
- Lockfiles updated under `WebUI/` and `WebUI/src/main/frontend/` (Maven frontend working dir)

### Notes
- We use **declarative HashRouter** mode (not Framework Mode SSR), so several Framework-only CVEs did not apply at runtime, but scanners still flag the package version.
- No route structure changes; build + App SPA tests pass.

### Test plan
- [x] `npm run build:modern` (frontend)
- [x] Vitest: `App.test`, `spaCutover`, `parseEntryQuery`
- [x] `npm ls react-router` → **8.3.0**; no router entry in remaining audit highs
- [ ] Manual: login → SPA Home nav + Explorer deep link after deploy

> Co-Authored by Grok Build 0.2.112 using grok-4.5 with agent Grok.