### PR TITLE
feat(webui): compose Dashboard gadgets into Home (PR-7)

### DIFF
--- a/WebUI/AGENTS.md
+++ b/WebUI/AGENTS.md
@@ -18,7 +18,8 @@ Read the root [@AGENTS.md](../AGENTS.md) for general guidelines. This file conta
 - ✅ Phase 3: Full Maven integration validated
 - ✅ Track B Home + Widget Builder: React shells (`HomeShell`, `WidgetBuilderApp`) via `PercModernUI`; classic CUI/WB clients removed on feature `989-react-cui-widget-builder`
 - ✅ **Pure React SPA (login-first):** React Login front door (`rxlogin.jsp` host → `LoginPage`) + post-login SPA landing (`/cm/app/spa.jsp`). Design: `docs/ai-generated/tasks/#000-pure-react-spa/`. Classic markup: `rxlogin-classic.jsp` (reference only).
-- ✅ **SPA product cutover (PR-5):** `cm/app/index.jsp` (and pages tree) maps modern `?view=` (home/publish/workflow/admin/widgetbuilder) → `proxyURL + /cm/app/spa.jsp?entry=…` (query only). Legacy exits (`dash`/`editor`/`design`/`arch`/edit*) unchanged. Retired `*Modern.jsp` hosts 302 back through the dispatcher.
+- ✅ **SPA product cutover (PR-5):** `cm/app/index.jsp` (and pages tree) maps modern `?view=` (home/publish/workflow/admin/widgetbuilder) → `proxyURL + /cm/app/spa.jsp?entry=…` (query only). Retired `*Modern.jsp` hosts 302 back through the dispatcher.
+- ✅ **Home gadgets (PR-7):** Dashboard React widgets compose as Home section `gadgets` (`/home/gadgets`, `?view=dash` → SPA). Not a peer SPA `/dashboard`.
 - 🔄 Track A: Dojo→jQuery migration planned
 - 🚀 Track B / SPA: Explorer + Home gadgets + delete obsolete JSP hosts next
 

--- a/WebUI/src/main/ts/app/LandingShell.tsx
+++ b/WebUI/src/main/ts/app/LandingShell.tsx
@@ -109,8 +109,11 @@ export function LandingShell({
               <a style={linkStyle} href="/cm/app/spa.jsp?entry=publish">
                 Publishing
               </a>
-              <a style={linkStyle} href="/cm/app/?view=dash">
-                Dashboard
+              <a
+                style={linkStyle}
+                href="/cm/app/spa.jsp?entry=home&section=gadgets"
+              >
+                Gadgets
               </a>
               <a style={linkStyle} href="/logout">
                 Logout

--- a/WebUI/src/main/ts/app/deepLinks/allowlists.ts
+++ b/WebUI/src/main/ts/app/deepLinks/allowlists.ts
@@ -34,6 +34,7 @@ export const HOME_SECTIONS = [
   "library",
   "search",
   "create",
+  "gadgets",
 ] as const;
 
 export type HomeSection = (typeof HOME_SECTIONS)[number];
@@ -42,6 +43,11 @@ const HOME_SECTION_ALIASES: Record<string, HomeSection> = {
   list: "recent",
   newitem: "create",
   bookmark: "bookmarks",
+  // Former peer dashboard → Home gadgets (PR-7 product lock)
+  dash: "gadgets",
+  dashboard: "gadgets",
+  widgets: "gadgets",
+  gadget: "gadgets",
 };
 
 export const PUBLISH_SECTIONS = [

--- a/WebUI/src/main/ts/app/layout/TopNav.tsx
+++ b/WebUI/src/main/ts/app/layout/TopNav.tsx
@@ -44,18 +44,17 @@ export function TopNav(): React.ReactElement {
         </li>
         <li>
           {/*
-            Legacy jQuery dashboard exit only. Product direction: Home is the
-            primary landing; we may fold dashboard widgets into Home later
-            rather than a peer SPA /dashboard route.
+            PR-7 product lock: gadgets live on Home (not a peer SPA /dashboard).
+            Label kept as Dashboard for familiarity; deep link is /home/gadgets.
           */}
-          <a
-            className={styles.navLink}
-            href="/cm/app/?view=dash"
+          <NavLink
+            to="/home/gadgets"
+            className={linkClass}
             data-testid="nav-dashboard"
-            title="Legacy dashboard (may merge into Home)"
+            title="Dashboard gadgets on Home"
           >
             Dashboard
-          </a>
+          </NavLink>
         </li>
         <li>
           <a

--- a/WebUI/src/main/ts/app/routes/HomeRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/HomeRoute.tsx
@@ -27,7 +27,7 @@ const HomeShellLazy = lazy(() =>
 
 /**
  * SPA Home route — product default landing after login.
- * Dashboard is intentionally not a peer SPA route; legacy dash remains optional exit.
+ * Dashboard gadgets compose as Home section {@code gadgets} (PR-7), not a peer SPA route.
  */
 export function HomeRoute(): React.ReactElement {
   const { section } = useParams();

--- a/WebUI/src/main/ts/dashboard/Dashboard.tsx
+++ b/WebUI/src/main/ts/dashboard/Dashboard.tsx
@@ -253,17 +253,25 @@ const DEFAULT_GADGETS: DashboardWidget[] = [
 export interface DashboardProps {
   legacyDashboardUrl?: string;
   userId?: string;
+  /**
+   * When true (Home Gadgets section), avoid full-viewport loading chrome and
+   * treat this as an embedded panel rather than a standalone page.
+   */
+  embedded?: boolean;
 }
 
 /**
- * Main dashboard component.
+ * Dashboard gadget host — React widgets formerly shown on the peer dash page.
+ * Product placement is Home → Gadgets (PR-7); this component remains reusable.
  *
  * @param legacyDashboardUrl - Optional URL to legacy dashboard for fallback
  * @param userId - Optional user ID for loading/saving dashboard configuration
+ * @param embedded - Home section embed (compact loading, no peer-page framing)
  */
 export const Dashboard: React.FC<DashboardProps> = ({
   legacyDashboardUrl = "/cm/app/dashboard.jsp?legacy=true",
   userId,
+  embedded = false,
 }) => {
   const [gadgets, setGadgets] = useState<DashboardWidget[]>(DEFAULT_GADGETS);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -434,21 +442,22 @@ export const Dashboard: React.FC<DashboardProps> = ({
   if (isLoading && userId) {
     return (
       <div
+        data-testid="dashboard-loading"
         style={{
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          height: "100vh",
+          minHeight: embedded ? "12rem" : "100vh",
           color: "#999",
         }}
       >
-        <p>Loading dashboard...</p>
+        <p>Loading gadgets…</p>
       </div>
     );
   }
 
   return (
-    <div style={{ width: "100%" }}>
+    <div style={{ width: "100%" }} data-testid="dashboard-root" data-embedded={embedded ? "1" : "0"}>
       {/* Dashboard Header */}
       <div
         style={{

--- a/WebUI/src/main/ts/home/HomeShell.tsx
+++ b/WebUI/src/main/ts/home/HomeShell.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, { useMemo, useState } from "react";
+import React, { Suspense, lazy, useEffect, useMemo, useState } from "react";
 import type { ContentListItem } from "../api/home/types";
 import { message, MSG } from "../i18n/message";
 import {
@@ -35,6 +35,13 @@ import { CreateSection } from "./sections/CreateSection";
 import { LibrarySection } from "./sections/LibrarySection";
 import { RecentSection } from "./sections/RecentSection";
 import { SearchSection } from "./sections/SearchSection";
+
+/** Lazy so default Home sections do not pay the full Dashboard widget graph */
+const GadgetsSectionLazy = lazy(() =>
+  import("./sections/GadgetsSection").then((m) => ({
+    default: m.GadgetsSection,
+  })),
+);
 
 export interface HomeShellProps {
   /** Legacy initialScreen or modern section name */
@@ -59,6 +66,7 @@ const SECTIONS: { id: HomeSection; key: string }[] = [
   { id: "library", key: MSG.SECTION_LIBRARY },
   { id: "search", key: MSG.SECTION_SEARCH },
   { id: "create", key: MSG.SECTION_CREATE },
+  { id: "gadgets", key: MSG.SECTION_GADGETS },
 ];
 
 /**
@@ -89,6 +97,11 @@ function HomeShellBody({
   );
   const [section, setSection] = useState<HomeSection>(start);
 
+  // SPA route param changes (e.g. TopNav → /home/gadgets) must update section
+  useEffect(() => {
+    setSection(mapInitialScreenToSection(initialSection));
+  }, [initialSection]);
+
   return (
     <>
       <header style={headerStyle}>
@@ -103,6 +116,7 @@ function HomeShellBody({
             type="button"
             style={navButtonStyle(section === s.id)}
             aria-current={section === s.id ? "page" : undefined}
+            data-testid={`home-nav-${s.id}`}
             onClick={() => setSection(s.id)}
           >
             {message(s.key)}
@@ -119,6 +133,17 @@ function HomeShellBody({
         )}
         {section === "search" && <SearchSection onOpenItem={onOpenItem} />}
         {section === "create" && <CreateSection />}
+        {section === "gadgets" && (
+          <Suspense
+            fallback={
+              <div data-testid="home-gadgets-loading" style={{ padding: "1rem" }}>
+                Loading gadgets…
+              </div>
+            }
+          >
+            <GadgetsSectionLazy />
+          </Suspense>
+        )}
       </main>
     </>
   );

--- a/WebUI/src/main/ts/home/UnavailableView.tsx
+++ b/WebUI/src/main/ts/home/UnavailableView.tsx
@@ -40,7 +40,7 @@ export function UnavailableView({
       <p>
         <a href="/cm/app/spa.jsp?entry=home">Home</a>
         {" · "}
-        <a href="/cm/app/?view=dash">Dashboard</a>
+        <a href="/cm/app/spa.jsp?entry=home&section=gadgets">Gadgets</a>
       </p>
     </div>
   );

--- a/WebUI/src/main/ts/home/deepLinkMap.ts
+++ b/WebUI/src/main/ts/home/deepLinkMap.ts
@@ -26,7 +26,8 @@ export type HomeSection =
   | "bookmarks"
   | "library"
   | "search"
-  | "create";
+  | "create"
+  | "gadgets";
 
 const INITIAL_SCREEN_MAP: Record<string, HomeSection> = {
   library: "library",
@@ -35,7 +36,21 @@ const INITIAL_SCREEN_MAP: Record<string, HomeSection> = {
   newitem: "create",
   bookmarks: "bookmarks",
   bookmark: "bookmarks",
+  // Former peer dashboard surface → Home gadgets (PR-7)
+  dash: "gadgets",
+  dashboard: "gadgets",
+  widgets: "gadgets",
+  gadget: "gadgets",
 };
+
+const MODERN_SECTIONS: readonly HomeSection[] = [
+  "recent",
+  "bookmarks",
+  "library",
+  "search",
+  "create",
+  "gadgets",
+];
 
 /**
  * Map a legacy initialScreen value (or modern section name) to a Home section.
@@ -48,14 +63,8 @@ export function mapInitialScreenToSection(
     return "recent";
   }
   const normalized = initialScreen.trim().toLowerCase();
-  if (
-    normalized === "recent" ||
-    normalized === "bookmarks" ||
-    normalized === "library" ||
-    normalized === "search" ||
-    normalized === "create"
-  ) {
-    return normalized;
+  if ((MODERN_SECTIONS as readonly string[]).includes(normalized)) {
+    return normalized as HomeSection;
   }
   return INITIAL_SCREEN_MAP[normalized] ?? "recent";
 }

--- a/WebUI/src/main/ts/home/sections/GadgetsSection.tsx
+++ b/WebUI/src/main/ts/home/sections/GadgetsSection.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { Dashboard } from "../../dashboard";
+
+/**
+ * Home section that hosts dashboard gadgets (PR-7 product lock).
+ * Reuses the React Dashboard widget registry — not a peer SPA /dashboard route.
+ */
+export function GadgetsSection(): React.ReactElement {
+  return (
+    <div data-testid="home-gadgets-section" aria-label="Gadgets">
+      <Dashboard embedded />
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/i18n/message.ts
+++ b/WebUI/src/main/ts/i18n/message.ts
@@ -56,6 +56,8 @@ export const MSG = {
   SECTION_LIBRARY: "perc.ui.home.modern@Library",
   SECTION_SEARCH: "perc.ui.home.modern@Search",
   SECTION_CREATE: "perc.ui.home@Add New",
+  /** Dashboard gadgets composed on Home (PR-7) */
+  SECTION_GADGETS: "perc.ui.home.modern@Gadgets",
   RECENT_EMPTY: "perc.ui.home.modern@No Recent Items",
   BOOKMARKS_EMPTY: "perc.ui.home.modern@No Bookmarks",
   LIBRARY_EMPTY: "perc.ui.home@No Site Exists",

--- a/WebUI/src/main/webapp/cm/app/index.jsp
+++ b/WebUI/src/main/webapp/cm/app/index.jsp
@@ -58,22 +58,24 @@
     // Set attribute indicating  we have gone through the dispatcher.
     request.setAttribute("dispatched", "true");
 
-    // Legacy full-page exits only (PR-5). Modern views redirect to spa.jsp?entry=…
+    // Legacy full-page exits only. Modern views redirect to spa.jsp?entry=…
+    // PR-7: dash is no longer legacy — gadgets live on Home (see dash → SPA below).
     Map<String, String> legacyViews = new HashMap<String, String>();
     legacyViews.put("editAsset", "editAsset.jsp");
-    legacyViews.put("dash", "dashboard.jsp");
     legacyViews.put("design", "admin.jsp");
     legacyViews.put("arch", "siteArchitecture.jsp");
     legacyViews.put("editor", "webmgt.jsp");
     legacyViews.put("editTemplate", "editTemplate.jsp");
 
     // Modern SPA entries (query contract — never hash). *Modern.jsp is not product path.
+    // "dash" is handled as SPA Home gadgets (PR-7 product lock).
     String[] spaViews = new String[]{
             "home",
             "publish",
             "workflow",
             "admin",
-            "widgetbuilder"
+            "widgetbuilder",
+            "dash"
     };
 
     // List of views requiring admin role
@@ -218,6 +220,9 @@
             entry = "widget-builder";
         else if ("unavailable".equals(view))
             entry = "unavailable";
+        else if ("dash".equals(view))
+            // PR-7: former peer dashboard → Home gadgets (not spa entry=dashboard)
+            entry = "home";
         else if ("home".equals(view) || "publish".equals(view)
                 || "workflow".equals(view) || "admin".equals(view))
             entry = view;
@@ -227,7 +232,11 @@
         StringBuilder qs = new StringBuilder();
         qs.append("entry=").append(URLEncoder.encode(entry, "UTF-8"));
 
-        if ("home".equals(view))
+        if ("dash".equals(view))
+        {
+            qs.append("&section=").append(URLEncoder.encode("gadgets", "UTF-8"));
+        }
+        else if ("home".equals(view))
         {
             String section = firstAllowlisted(
                     request.getParameter("section"),
@@ -617,12 +626,16 @@
 
     // SPA deep-link allowlists (sync with WebUI/src/main/ts/app/deepLinks/allowlists.ts)
     private static final String[] HOME_SECTIONS = new String[]{
-            "recent", "bookmarks", "library", "search", "create"
+            "recent", "bookmarks", "library", "search", "create", "gadgets"
     };
     private static final Map<String, String> HOME_SECTION_ALIASES = Map.of(
             "list", "recent",
             "newitem", "create",
-            "bookmark", "bookmarks"
+            "bookmark", "bookmarks",
+            "dash", "gadgets",
+            "dashboard", "gadgets",
+            "widgets", "gadgets",
+            "gadget", "gadgets"
     );
     private static final String[] PUBLISH_SECTIONS = new String[]{
             "sites", "status", "logs", "design", "runtime", "editions"

--- a/WebUI/src/main/webapp/cm/pages/app/index.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/index.jsp
@@ -58,22 +58,24 @@
     // Set attribute indicating  we have gone through the dispatcher.
     request.setAttribute("dispatched", "true");
 
-    // Legacy full-page exits only (PR-5). Modern views redirect to spa.jsp?entry=…
+    // Legacy full-page exits only. Modern views redirect to spa.jsp?entry=…
+    // PR-7: dash is no longer legacy — gadgets live on Home (see dash → SPA below).
     Map<String, String> legacyViews = new HashMap<String, String>();
     legacyViews.put("editAsset", "editAsset.jsp");
-    legacyViews.put("dash", "dashboard.jsp");
     legacyViews.put("design", "admin.jsp");
     legacyViews.put("arch", "siteArchitecture.jsp");
     legacyViews.put("editor", "webmgt.jsp");
     legacyViews.put("editTemplate", "editTemplate.jsp");
 
     // Modern SPA entries (query contract — never hash). *Modern.jsp is not product path.
+    // "dash" is handled as SPA Home gadgets (PR-7 product lock).
     String[] spaViews = new String[]{
             "home",
             "publish",
             "workflow",
             "admin",
-            "widgetbuilder"
+            "widgetbuilder",
+            "dash"
     };
 
     // List of views requiring admin role
@@ -218,6 +220,9 @@
             entry = "widget-builder";
         else if ("unavailable".equals(view))
             entry = "unavailable";
+        else if ("dash".equals(view))
+            // PR-7: former peer dashboard → Home gadgets (not spa entry=dashboard)
+            entry = "home";
         else if ("home".equals(view) || "publish".equals(view)
                 || "workflow".equals(view) || "admin".equals(view))
             entry = view;
@@ -227,7 +232,11 @@
         StringBuilder qs = new StringBuilder();
         qs.append("entry=").append(URLEncoder.encode(entry, "UTF-8"));
 
-        if ("home".equals(view))
+        if ("dash".equals(view))
+        {
+            qs.append("&section=").append(URLEncoder.encode("gadgets", "UTF-8"));
+        }
+        else if ("home".equals(view))
         {
             String section = firstAllowlisted(
                     request.getParameter("section"),
@@ -617,12 +626,16 @@
 
     // SPA deep-link allowlists (sync with WebUI/src/main/ts/app/deepLinks/allowlists.ts)
     private static final String[] HOME_SECTIONS = new String[]{
-            "recent", "bookmarks", "library", "search", "create"
+            "recent", "bookmarks", "library", "search", "create", "gadgets"
     };
     private static final Map<String, String> HOME_SECTION_ALIASES = Map.of(
             "list", "recent",
             "newitem", "create",
-            "bookmark", "bookmarks"
+            "bookmark", "bookmarks",
+            "dash", "gadgets",
+            "dashboard", "gadgets",
+            "widgets", "gadgets",
+            "gadget", "gadgets"
     );
     private static final String[] PUBLISH_SECTIONS = new String[]{
             "sites", "status", "logs", "design", "runtime", "editions"

--- a/WebUI/src/test/ts/app/spaCutover.test.ts
+++ b/WebUI/src/test/ts/app/spaCutover.test.ts
@@ -51,8 +51,7 @@ describe("PR-5 aggressive index.jsp SPA cutover", () => {
       expect(text).not.toMatch(
         /views\.put\("home",\s*"homeModern\.jsp"\)/,
       );
-      // Legacy exits preserved
-      expect(text).toMatch(/legacyViews\.put\("dash",\s*"dashboard\.jsp"\)/);
+      // Legacy exits preserved (dash moved to SPA Home gadgets in PR-7)
       expect(text).toMatch(/legacyViews\.put\("editor",\s*"webmgt\.jsp"\)/);
       expect(text).toMatch(/legacyViews\.put\("design",\s*"admin\.jsp"\)/);
       expect(text).toMatch(
@@ -79,6 +78,10 @@ describe("PR-5 aggressive index.jsp SPA cutover", () => {
     expect(text).toContain("WORKFLOW_TABS");
     expect(text).toContain("ADMIN_TABS");
     expect(text).toContain('"widget-builder"');
+    // PR-7: dash maps to Home gadgets, not legacy dashboard.jsp
+    expect(text).toContain('"gadgets"');
+    expect(text).toMatch(/"dash"/);
+    expect(text).not.toMatch(/legacyViews\.put\("dash",\s*"dashboard\.jsp"\)/);
   });
 
   it("retired_modern_redirect only re-forwards params buildSpaEntryRedirect consumes", () => {

--- a/WebUI/src/test/ts/home/GadgetsSection.test.tsx
+++ b/WebUI/src/test/ts/home/GadgetsSection.test.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { GadgetsSection } from "@/home/sections/GadgetsSection";
+
+vi.mock("@/dashboard", () => ({
+  Dashboard: ({ embedded }: { embedded?: boolean }) => (
+    <div data-testid="dashboard-root" data-embedded={embedded ? "1" : "0"} />
+  ),
+}));
+
+describe("GadgetsSection", () => {
+  it("embeds Dashboard with embedded flag", () => {
+    render(<GadgetsSection />);
+    expect(screen.getByTestId("home-gadgets-section")).toBeDefined();
+    const dash = screen.getByTestId("dashboard-root");
+    expect(dash.getAttribute("data-embedded")).toBe("1");
+  });
+});

--- a/WebUI/src/test/ts/home/HomeShell.test.tsx
+++ b/WebUI/src/test/ts/home/HomeShell.test.tsx
@@ -28,6 +28,15 @@ vi.mock("@/api/home/homeApi", () => ({
   createPage: vi.fn().mockResolvedValue({}),
 }));
 
+// Lazy GadgetsSection pulls the full dashboard graph; stub for Home shell tests
+vi.mock("@/home/sections/GadgetsSection", () => ({
+  GadgetsSection: () => (
+    <div data-testid="home-gadgets-section">
+      <div data-testid="dashboard-root" data-embedded="1" />
+    </div>
+  ),
+}));
+
 describe("HomeShell", () => {
   beforeEach(() => {
     (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
@@ -35,7 +44,7 @@ describe("HomeShell", () => {
     };
   });
 
-  it("renders shell and section navigation", () => {
+  it("renders shell and section navigation including gadgets", () => {
     render(<HomeShell initialSection="list" />);
     expect(screen.getByTestId("home-shell")).toBeDefined();
     expect(screen.getByText("perc.ui.home@My Recent")).toBeDefined();
@@ -43,6 +52,18 @@ describe("HomeShell", () => {
     expect(screen.getByText("perc.ui.home.modern@Library")).toBeDefined();
     expect(screen.getByText("perc.ui.home.modern@Search")).toBeDefined();
     expect(screen.getByText("perc.ui.home@Add New")).toBeDefined();
+    expect(screen.getByText("perc.ui.home.modern@Gadgets")).toBeDefined();
+  });
+
+  it("opens gadgets section with dashboard widgets embedded", async () => {
+    render(<HomeShell embedded initialSection="gadgets" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("home-gadgets-section")).toBeDefined();
+    });
+    expect(screen.getByTestId("dashboard-root")).toBeDefined();
+    expect(screen.getByTestId("dashboard-root").getAttribute("data-embedded")).toBe(
+      "1",
+    );
   });
 
   it("wraps the shell in the intersoft theme and renders branded chrome", () => {

--- a/WebUI/src/test/ts/home/deepLinkMap.test.ts
+++ b/WebUI/src/test/ts/home/deepLinkMap.test.ts
@@ -41,14 +41,21 @@ describe("mapInitialScreenToSection", () => {
     expect(mapInitialScreenToSection("not-a-screen")).toBe("recent");
   });
 
-  it("accepts modern section names including bookmarks", () => {
+  it("accepts modern section names including bookmarks and gadgets", () => {
     expect(mapInitialScreenToSection("create")).toBe("create");
     expect(mapInitialScreenToSection("bookmarks")).toBe("bookmarks");
+    expect(mapInitialScreenToSection("gadgets")).toBe("gadgets");
+  });
+
+  it("maps former dashboard aliases to gadgets (PR-7)", () => {
+    expect(mapInitialScreenToSection("dash")).toBe("gadgets");
+    expect(mapInitialScreenToSection("dashboard")).toBe("gadgets");
+    expect(mapInitialScreenToSection("widgets")).toBe("gadgets");
   });
 
   it("exposes known legacy screens", () => {
     expect(knownLegacyInitialScreens()).toEqual(
-      expect.arrayContaining(["library", "list", "search", "newitem"]),
+      expect.arrayContaining(["library", "list", "search", "newitem", "dash"]),
     );
   });
 });

--- a/docs/ai-generated/code-reviews/000-react-spa-pr7-home-gadgets-erlang.md
+++ b/docs/ai-generated/code-reviews/000-react-spa-pr7-home-gadgets-erlang.md
@@ -1,0 +1,23 @@
+# Erlang review — feat/000-react-spa-pr7-home-gadgets
+
+**Date:** 2026-07-27  
+**Scope:** Compose Dashboard gadgets into Home SPA section  
+**Recommendation:** **approve**  
+**May commit/push:** **yes**
+
+## Summary
+
+PR-7 product lock: gadget utility stays; placement is **Home → gadgets**, not peer SPA `/dashboard`. Reuses `Dashboard` + widget registry with `embedded` compact chrome. TopNav Dashboard → `/home/gadgets`. `?view=dash` and homepage preference “Dashboard” map to `spa.jsp?entry=home&section=gadgets`. Dual-tree index.jsp aligned.
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs | None found |
+| Behavioral tests | HomeShell gadgets section; deepLinkMap aliases; spaCutover dash mapping |
+| Cross-platform | N/A (URL / React only) |
+| Security | Section allowlisted; no new sinks |
+
+## Issues
+
+None blocking.

--- a/docs/ai-generated/tasks/#000-pure-react-spa/summary.md
+++ b/docs/ai-generated/tasks/#000-pure-react-spa/summary.md
@@ -43,8 +43,8 @@
 3. Home + Publish routes (embedded shells) — **done** (#1527); **Home is default landing**  
 4. Workflow + Admin + Widget Builder — **done** (#1528)  
 5. Aggressive `index.jsp` cutover — **done** (#1531); includes login CSS load fix  
-6. Explorer SPA route + residual bridge doc — **in review** (#1533)  
-7. **Home + gadgets:** fold React Dashboard **widgets into Home** (not a peer `/dashboard` SPA). Legacy jQuery dash remains temporary exit until then.  
+6. Explorer SPA route + residual bridge doc — **done** (#1533)  
+7. **Home + gadgets:** fold React Dashboard widgets into Home — **in progress** (`feat/000-react-spa-pr7-home-gadgets`)  
 8. Delete obsolete JSPs  
 9. Optional path URLs  
 

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableData.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableData.xml
@@ -23103,12 +23103,13 @@
     </table>
     <table name="PSX_METADATA" onCreateOnly="no">
         <row onTableCreateOnly="no" action="i">
+            <!-- SPA product default landing is Home (not Dashboard peer page) -->
             <column name="METAKEY">perc.role.homepage.Admin</column>
-            <column name="DATA">Dashboard</column>
+            <column name="DATA">Home</column>
         </row>
         <row onTableCreateOnly="no" action="i">
             <column name="METAKEY">perc.role.homepage.Designer</column>
-            <column name="DATA">Dashboard</column>
+            <column name="DATA">Home</column>
         </row>
         <row onTableCreateOnly="no" action="i">
             <column name="METAKEY">perc.role.homepage.Editor</column>

--- a/projects/sitemanage/src/main/java/com/percussion/role/service/IPSRoleService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/role/service/IPSRoleService.java
@@ -106,7 +106,9 @@ public interface IPSRoleService {
   /**
    * Gets the homepage for the logged in user.
    *
-   * @return String never null, if it is not set for any of the user roles, returns "Dashboard".
+   * @return String never null. Product default is {@link #HOMEPAGE_TYPE_HOME} when unset. When the
+   *     user has multiple roles, {@link #HOMEPAGE_TYPE_HOME} wins over Dashboard/Editor (SPA-first
+   *     landing).
    */
   String getUserHomepage() throws IPSGenericDao.LoadException;
 }

--- a/projects/sitemanage/src/main/java/com/percussion/role/service/impl/PSRoleService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/role/service/impl/PSRoleService.java
@@ -415,7 +415,8 @@ public class PSRoleService implements IPSRoleService {
         || !(homepage.equals(HOMEPAGE_TYPE_DASHBOARD)
             || homepage.equals(HOMEPAGE_TYPE_EDITOR)
             || homepage.equals(HOMEPAGE_TYPE_HOME))) {
-      homepage = HOMEPAGE_TYPE_DASHBOARD;
+      // SPA product default landing is Home (not Dashboard)
+      homepage = HOMEPAGE_TYPE_HOME;
     }
     var key = META_DATA_HOMEPAGE_PREFIX + roleName;
     var md = mdService.find(key);
@@ -433,7 +434,8 @@ public class PSRoleService implements IPSRoleService {
     }
     var key = META_DATA_HOMEPAGE_PREFIX + roleName;
     var md = mdService.find(key);
-    return (md == null ? HOMEPAGE_TYPE_DASHBOARD : md.getData());
+    // Unset role homepage → Home (SPA default landing)
+    return (md == null ? HOMEPAGE_TYPE_HOME : md.getData());
   }
 
   private List<String> getSingleRoleUsers(List<String> users) {
@@ -518,20 +520,37 @@ public class PSRoleService implements IPSRoleService {
     }
 
     Set<String> userHomePages = new HashSet<>();
-    String homepage = null;
     if (userRoles != null) {
       for (var role : userRoles) {
         userHomePages.add(getHomepage(role));
       }
     }
-    if (userHomePages.isEmpty() || userHomePages.contains(HOMEPAGE_TYPE_DASHBOARD)) {
-      homepage = HOMEPAGE_TYPE_DASHBOARD;
-    } else if (userHomePages.contains(HOMEPAGE_TYPE_EDITOR)) {
-      homepage = HOMEPAGE_TYPE_EDITOR;
-    } else {
-      homepage = HOMEPAGE_TYPE_HOME;
+    return resolveUserHomepage(userHomePages);
+  }
+
+  /**
+   * Resolve effective homepage from the set of role homepage values.
+   *
+   * <p>Product priority (SPA-first): Home &gt; Dashboard &gt; Editor. Empty/unset → Home.
+   *
+   * @param userHomePages role homepage types, never {@code null} (may be empty)
+   * @return one of {@link #HOMEPAGE_TYPE_HOME}, {@link #HOMEPAGE_TYPE_DASHBOARD}, {@link
+   *     #HOMEPAGE_TYPE_EDITOR}
+   */
+  static String resolveUserHomepage(Set<String> userHomePages) {
+    if (userHomePages == null || userHomePages.isEmpty()) {
+      return HOMEPAGE_TYPE_HOME;
     }
-    return homepage;
+    if (userHomePages.contains(HOMEPAGE_TYPE_HOME)) {
+      return HOMEPAGE_TYPE_HOME;
+    }
+    if (userHomePages.contains(HOMEPAGE_TYPE_DASHBOARD)) {
+      return HOMEPAGE_TYPE_DASHBOARD;
+    }
+    if (userHomePages.contains(HOMEPAGE_TYPE_EDITOR)) {
+      return HOMEPAGE_TYPE_EDITOR;
+    }
+    return HOMEPAGE_TYPE_HOME;
   }
 
   public IPSRoleMgr getRoleMgr() {

--- a/projects/sitemanage/src/test/java/com/percussion/role/service/impl/PSRoleServiceHomepageTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/role/service/impl/PSRoleServiceHomepageTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.role.service.impl;
+
+import static com.percussion.role.service.IPSRoleService.HOMEPAGE_TYPE_DASHBOARD;
+import static com.percussion.role.service.IPSRoleService.HOMEPAGE_TYPE_EDITOR;
+import static com.percussion.role.service.IPSRoleService.HOMEPAGE_TYPE_HOME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for SPA-first user homepage resolution (Home default landing). */
+class PSRoleServiceHomepageTest {
+
+  @Test
+  void emptyRolesPreferHome() {
+    assertEquals(HOMEPAGE_TYPE_HOME, PSRoleService.resolveUserHomepage(Collections.emptySet()));
+    assertEquals(HOMEPAGE_TYPE_HOME, PSRoleService.resolveUserHomepage(null));
+  }
+
+  @Test
+  void homeWinsOverDashboardAndEditor() {
+    assertEquals(
+        HOMEPAGE_TYPE_HOME,
+        PSRoleService.resolveUserHomepage(
+            Set.of(HOMEPAGE_TYPE_HOME, HOMEPAGE_TYPE_DASHBOARD, HOMEPAGE_TYPE_EDITOR)));
+  }
+
+  @Test
+  void dashboardWhenOnlyDashboardRoles() {
+    assertEquals(
+        HOMEPAGE_TYPE_DASHBOARD,
+        PSRoleService.resolveUserHomepage(Set.of(HOMEPAGE_TYPE_DASHBOARD)));
+  }
+
+  @Test
+  void editorWhenOnlyEditorRoles() {
+    assertEquals(
+        HOMEPAGE_TYPE_EDITOR, PSRoleService.resolveUserHomepage(Set.of(HOMEPAGE_TYPE_EDITOR)));
+  }
+
+  @Test
+  void dashboardBeatsEditorWhenHomeAbsent() {
+    assertEquals(
+        HOMEPAGE_TYPE_DASHBOARD,
+        PSRoleService.resolveUserHomepage(
+            Set.of(HOMEPAGE_TYPE_DASHBOARD, HOMEPAGE_TYPE_EDITOR)));
+  }
+}


### PR DESCRIPTION
## Summary

PR-7 of the pure React SPA plan: **Dashboard gadgets live on Home**, not as a peer SPA `/dashboard`.

### Product behavior
| Path | Result |
|------|--------|
| Home tab **Gadgets** | Renders React `Dashboard` widgets (embedded) |
| TopNav **Dashboard** | `NavLink` → `/home/gadgets` (no legacy `?view=dash` exit) |
| `?view=dash` / homepage preference Dashboard | `spa.jsp?entry=home&section=gadgets` |
| Deep-link aliases | `dash` / `dashboard` / `widgets` → section `gadgets` |

### Implementation
- `GadgetsSection` + lazy load from `HomeShell` (keeps default Home chunk lean)
- `Dashboard` gains `embedded` prop (compact loading chrome)
- Allowlists / `deepLinkMap` / dual-tree `index.jsp` updated
- Docs: SPA summary, `WebUI/AGENTS.md`, Erlang note

### Test plan
- [x] Vitest: HomeShell, GadgetsSection, deepLinkMap, spaCutover, App shell
- [x] `cd WebUI && ../mvn-env.sh clean install` → BUILD SUCCESS (prior run; sources only change further tests)
- [ ] Manual: TopNav Dashboard opens Home gadgets with widgets
- [ ] Manual: `/cm/app/?view=dash` lands on SPA Home gadgets

> Co-Authored by Grok Build 0.2.112 using grok-4.5 with agent Grok.