### PR TITLE
feat(webui): path-based SPA URLs with BrowserRouter + fallback filter (PR-9)

### DIFF
--- a/WebUI/AGENTS.md
+++ b/WebUI/AGENTS.md
@@ -20,7 +20,8 @@ Read the root [@AGENTS.md](../AGENTS.md) for general guidelines. This file conta
 - ✅ **Pure React SPA (login-first):** React Login front door (`rxlogin.jsp` host → `LoginPage`) + post-login SPA landing (`/cm/app/spa.jsp`). Design: `docs/ai-generated/tasks/#000-pure-react-spa/`.
 - ✅ **SPA product cutover (PR-5):** `cm/app/index.jsp` (and pages tree) maps modern `?view=` (home/publish/workflow/admin/widgetbuilder) → `proxyURL + /cm/app/spa.jsp?entry=…` (query only).
 - ✅ **Home gadgets (PR-7):** Dashboard React widgets compose as Home section `gadgets` (`/home/gadgets`, `?view=dash` → SPA). Not a peer SPA `/dashboard`.
-- ✅ **PR-8:** Deleted obsolete product hosts (`homeModern` / `publishModern` / `admin*Modern` / `widgetBuilderModern` / `unavailableModern` / `explorerModern`, classic `rxlogin-classic.jsp`). Residual bridge dialogs remain (pickers, search, action menu, US7 advanced). Optional next: path-based SPA URLs (PR-9).
+- ✅ **PR-8:** Deleted obsolete product hosts (`homeModern` / `publishModern` / `admin*Modern` / `widgetBuilderModern` / `unavailableModern` / `explorerModern`, classic `rxlogin-classic.jsp`). Residual bridge dialogs remain (pickers, search, action menu, US7 advanced).
+- ✅ **PR-9:** Path-based SPA URLs via `BrowserRouter` (basename `/cm/app` or `/cm/pages/app`, context-aware) + `PSWebUiSpaFallbackFilter` internal forward on refresh. Server deep links / login return remain `spa.jsp?entry=…` (query only).
 - 🔄 Track A: Dojo→jQuery migration planned
 
 ---

--- a/WebUI/AGENTS.md
+++ b/WebUI/AGENTS.md
@@ -12,17 +12,22 @@ Read the root [@AGENTS.md](../AGENTS.md) for general guidelines. This file conta
 | **Canonical source** | `WebUI/src/main/ts/` (build cwd: `WebUI/src/main/frontend/`) |
 | **SPA document** | `cm/app/spa.jsp` + path routes (`/cm/app/home`, …) via `BrowserRouter` + `PSWebUiSpaFallbackFilter` |
 | **Login** | React `LoginPage` on `rxlogin.jsp` (POST `/login`) |
-| **Direction plan** | [`docs/ai-generated/tasks/#000-unified-ui-plan/unified-ui-plan.md`](../docs/ai-generated/tasks/#000-unified-ui-plan/unified-ui-plan.md) **rev 4.0** |
+| **Direction plan** | [`docs/ai-generated/tasks/#000-unified-ui-plan/unified-ui-plan.md`](../docs/ai-generated/tasks/#000-unified-ui-plan/unified-ui-plan.md) **rev 4.1** |
 | **SPA infra design** | [`docs/ai-generated/tasks/#000-pure-react-spa/`](../docs/ai-generated/tasks/#000-pure-react-spa/) |
 
 ### Product locks (agents must follow)
 
-1. **React + TypeScript only** for product UI work. New features ship as SPA routes/modules, not jQuery/Knockout/Dojo pages.
-2. **No dual mode.** No feature flags that keep classic and modern as peer production UIs for the same job.
-3. **No new bridges.** Do not add `PercModernUI.mount` product hosts. Bridge mounts are residual debt only (see residual-bridge-embeds doc).
-4. **Shell ≠ done.** A screen is incomplete until features work (data, actions, navigation, errors, roles) on a real CMS.
-5. **Screen-by-screen.** Prove one surface fully before treating it as accepted. **Current focus: Home.**
-6. **Server deep links / login return:** query `spa.jsp?entry=…` only (never `#` in `Location`). Client may use path URLs after handoff.
+1. **React + TypeScript only** for product UI work. New features ship as SPA routes/modules under `src/main/ts/`.
+2. **Do not carry jQuery (or Knockout/Dojo) into the new UI.**  
+   - **Forbidden** in `WebUI/src/main/ts/**`, SPA hosts (`spa.jsp`, `rxlogin.jsp` product path), and the **modern** Vite bundle (`perc-modern-ui.js`).  
+   - No `import "jquery"`, no `window.$` / `jQuery` usage, no jQuery plugins, no FancyTree-via-jQuery in React.  
+   - Use React state, browser APIs, and typed `api/*` REST instead.  
+   - jQuery packages under `frontend/package.json` exist **only** to pack **residual legacy** pages (`build:legacy`) until those pages are deleted — **not** for SPA features.
+3. **No dual mode.** No feature flags that keep classic and modern as peer production UIs for the same job.
+4. **No new bridges.** Do not add `PercModernUI.mount` product hosts. Bridge mounts are residual debt only (see residual-bridge-embeds doc).
+5. **Shell ≠ done.** A screen is incomplete until features work (data, actions, navigation, errors, roles) on a real CMS.
+6. **Screen-by-screen.** Prove one surface fully before treating it as accepted. **Current focus: Home.**
+7. **Server deep links / login return:** query `spa.jsp?entry=…` only (never `#` in `Location`). Client may use path URLs after handoff.
 
 ### Current status (honest)
 
@@ -30,10 +35,11 @@ Read the root [@AGENTS.md](../AGENTS.md) for general guidelines. This file conta
 |------|--------|
 | SPA shell, login front door, routing cutover, path URLs (PR-1…9) | **Infra landed** |
 | Home, Publish, Explorer, Admin, Workflow, WB **as usable product** | **Not accepted** — shells/routes exist; **Home is first functional gate** (user: shell visible, not functional) |
-| Residual jQuery / AA / dialog hosts / JSF / GWT | **Legacy debt** — replace with React or delete; no dual investment |
+| Residual jQuery pages / AA / dialog hosts / JSF / GWT | **Legacy debt** — replace with React or delete; **not** imported into SPA |
 | Vendored Dojo library | **Removed** from ApplicationFiles; residual `ps.*` AA code may remain as debt |
 
-**Do not** describe Track A (Dojo→jQuery) or Track B dual-mode as the active product plan. That framing is retired (see unified-ui-plan rev 4.0).
+**Do not** describe Track A (Dojo→jQuery) or Track B dual-mode as the active product plan. That framing is retired (see unified-ui-plan rev 4.1).  
+**Do not** “modernize” by wrapping jQuery widgets in React or calling `$` from TS.
 
 ---
 
@@ -43,7 +49,7 @@ Read the root [@AGENTS.md](../AGENTS.md) for general guidelines. This file conta
 2. **Publish** → **Explorer** → **Admin** → **Workflow** → **Widget Builder** (same bar).
 3. **Legacy exits** (editor, design, arch, residual dialogs) — SPA rewrite or retire; delete bridges when openers move.
 
-Checklist and register: unified-ui-plan rev 4.0 §4–§5.
+Checklist and register: unified-ui-plan rev 4.1 §4–§5.
 
 ---
 

--- a/WebUI/AGENTS.md
+++ b/WebUI/AGENTS.md
@@ -4,95 +4,63 @@ Read the root [@AGENTS.md](../AGENTS.md) for general guidelines. This file conta
 
 ## Module Overview
 
-**WebUI** is a **hybrid J2EE WAR module** undergoing a multi-phase, multi-track modernization strategy. The application contains **8 distinct UI layers**, each with different technologies, features, and communication protocols. The module is transitioning from legacy frameworks (Dojo, jQuery, Knockout) to a unified React-based UI.
+**WebUI** is the CMS browser UI WAR. The **product user interface is React + TypeScript** (Vite), delivered as a pure SPA under `/cm/app/`.
 
-**Three Parallel Tracks:**
-- **Track A:** Remove Dojo 0.4.3 security risk by migrating 5 Active Assembly screens to jQuery (next release)
-- **Track B:** Build consolidated React UI to replace all legacy JS layers (long-term strategic)
-- **Maintenance:** Continue supporting jQuery (~20 screens), Knockout/CUI (~8 screens), and JSF Admin/Publishing
+| Field | Value |
+|-------|--------|
+| **Product UI** | React 19 + TypeScript + Vite → `/cm/modern/assets/perc-modern-ui.js` |
+| **Canonical source** | `WebUI/src/main/ts/` (build cwd: `WebUI/src/main/frontend/`) |
+| **SPA document** | `cm/app/spa.jsp` + path routes (`/cm/app/home`, …) via `BrowserRouter` + `PSWebUiSpaFallbackFilter` |
+| **Login** | React `LoginPage` on `rxlogin.jsp` (POST `/login`) |
+| **Direction plan** | [`docs/ai-generated/tasks/#000-unified-ui-plan/unified-ui-plan.md`](../docs/ai-generated/tasks/#000-unified-ui-plan/unified-ui-plan.md) **rev 4.0** |
+| **SPA infra design** | [`docs/ai-generated/tasks/#000-pure-react-spa/`](../docs/ai-generated/tasks/#000-pure-react-spa/) |
 
-**Current Status:**
-- ✅ Phase 0: Vite build pipeline established
-- ✅ Phase 1: React Dashboard complete (24 widget components)
-- ✅ Phase 2: Build output separation to `target/generated-webui/`
-- ✅ Phase 3: Full Maven integration validated
-- ✅ Track B Home + Widget Builder: React shells (`HomeShell`, `WidgetBuilderApp`) via `PercModernUI`; classic CUI/WB clients removed on feature `989-react-cui-widget-builder`
-- ✅ **Pure React SPA (login-first):** React Login front door (`rxlogin.jsp` host → `LoginPage`) + post-login SPA landing (`/cm/app/spa.jsp`). Design: `docs/ai-generated/tasks/#000-pure-react-spa/`.
-- ✅ **SPA product cutover (PR-5):** `cm/app/index.jsp` (and pages tree) maps modern `?view=` (home/publish/workflow/admin/widgetbuilder) → `proxyURL + /cm/app/spa.jsp?entry=…` (query only).
-- ✅ **Home gadgets (PR-7):** Dashboard React widgets compose as Home section `gadgets` (`/home/gadgets`, `?view=dash` → SPA). Not a peer SPA `/dashboard`.
-- ✅ **PR-8:** Deleted obsolete product hosts (`homeModern` / `publishModern` / `admin*Modern` / `widgetBuilderModern` / `unavailableModern` / `explorerModern`, classic `rxlogin-classic.jsp`). Residual bridge dialogs remain (pickers, search, action menu, US7 advanced).
-- ✅ **PR-9:** Path-based SPA URLs via `BrowserRouter` (basename `/cm/app` or `/cm/pages/app`, context-aware) + `PSWebUiSpaFallbackFilter` internal forward on refresh. Server deep links / login return remain `spa.jsp?entry=…` (query only).
-- 🔄 Track A: Dojo→jQuery migration planned
+### Product locks (agents must follow)
 
----
+1. **React + TypeScript only** for product UI work. New features ship as SPA routes/modules, not jQuery/Knockout/Dojo pages.
+2. **No dual mode.** No feature flags that keep classic and modern as peer production UIs for the same job.
+3. **No new bridges.** Do not add `PercModernUI.mount` product hosts. Bridge mounts are residual debt only (see residual-bridge-embeds doc).
+4. **Shell ≠ done.** A screen is incomplete until features work (data, actions, navigation, errors, roles) on a real CMS.
+5. **Screen-by-screen.** Prove one surface fully before treating it as accepted. **Current focus: Home.**
+6. **Server deep links / login return:** query `spa.jsp?entry=…` only (never `#` in `Location`). Client may use path URLs after handoff.
 
-## UI Layers Inventory
+### Current status (honest)
 
-The WebUI shares the Percussion CMS application with 7 other UI layers:
+| Area | Status |
+|------|--------|
+| SPA shell, login front door, routing cutover, path URLs (PR-1…9) | **Infra landed** |
+| Home, Publish, Explorer, Admin, Workflow, WB **as usable product** | **Not accepted** — shells/routes exist; **Home is first functional gate** (user: shell visible, not functional) |
+| Residual jQuery / AA / dialog hosts / JSF / GWT | **Legacy debt** — replace with React or delete; no dual investment |
+| Vendored Dojo library | **Removed** from ApplicationFiles; residual `ps.*` AA code may remain as debt |
 
-|        Layer         |                                       Technology                                       |   Screens   |       Protocol        |                                               Track                                                |
-|----------------------|----------------------------------------------------------------------------------------|-------------|-----------------------|----------------------------------------------------------------------------------------------------|
-| Desktop Explorer     | Java Swing + JavaFX WebView                                                            | ~10         | JAX-WS SOAP           | Legacy                                                                                             |
-| Rhythmyx Admin       | JSF pages (MyFaces/Trinidad removed)                                                   | 12          | REST / pending React  | Legacy / retiring                                                                                  |
-| Rhythmyx Publishing  | **React PublishingShell** via SPA (`spa.jsp?entry=publish`); classic Minuet + JSF entries redirect | Publishing  | REST/JSON (Fetch)     | **Track B / SPA** — exclusive Minuet views removed; JSF deep pages residual packaging only |
-| Package Manager      | GWT + SmartGWT                                                                         | 3+          | GWT-RPC               | Legacy                                                                                             |
-| **WebUI Legacy**     | **jQuery 3.6 + jQuery UI + Backbone**                                                  | **~20**     | **REST/JSON**         | **Maintaining**                                                                                    |
-| Contributor UI (CUI) | RequireJS + Knockout.js                                                                | ~8          | REST/JSON             | Maintaining                                                                                        |
-| Dojo Screens (AA/CB) | **Dojo 0.4.3**                                                                         | **5**       | **REST/JSON**         | **→Track A (jQuery)**                                                                              |
-| **React Modern**     | **React 19 + TypeScript + Vite**                                                       | **Growing** | **REST/JSON (Fetch)** | **→Track B (Strategic)**                                                                           |
-
-**Reference:** [UI Layer Inventory & Technical Research](../docs/ai-generated/tasks/#000-unified-ui-plan/ui-layer-inventory.md)
+**Do not** describe Track A (Dojo→jQuery) or Track B dual-mode as the active product plan. That framing is retired (see unified-ui-plan rev 4.0).
 
 ---
 
-## Track A: Dojo → jQuery (Next Release)
+## Active work order
 
-**Status:** Planned for next release
-**Purpose:** Remove security scan alerts from Dojo 0.4.3 (pre-1.0, from 2006)
-**Scope:** ~43 custom `ps.*` modules (~10K lines) + 1,477 Dojo vendor files
+1. **Home** — make Recent / Bookmarks / Library / Search / Create / Gadgets fully functional; pass Home acceptance checklist in the unified UI plan.
+2. **Publish** → **Explorer** → **Admin** → **Workflow** → **Widget Builder** (same bar).
+3. **Legacy exits** (editor, design, arch, residual dialogs) — SPA rewrite or retire; delete bridges when openers move.
 
-**Screens Affected:**
-- Active Assembly editor
-- Content Browser
-- Relationship Editor
-- Field editing UI
-- Search interface
-
-**Key Work Items:**
-1. Rewrite `ps.io.Actions` (1,179 lines) — `dojo.io.bind()` → `$.ajax()`
-2. Rewrite `ps.aa.controller` (2,475 lines) — Dojo events → jQuery, Dojo classes → ES6
-3. Replace Dojo widgets with jQuery UI equivalents
-4. Update server-side HTML generation (PSPageTree.java, PSActionBar.java)
-5. Update XSL, JSP, and HTML entry points
-6. Delete Dojo vendor directory
-
-**Reference:** [Unified UI Plan — Track A Detail](../docs/ai-generated/tasks/#000-unified-ui-plan/unified-ui-plan.md)
-
-**DO NOT:**
-- Add new Dojo code (violates Track A roadmap)
-- Extend existing Dojo functionality without approval
-- Create new `ps.*` modules using Dojo patterns
+Checklist and register: unified-ui-plan rev 4.0 §4–§5.
 
 ---
 
-## Track B: React Unified UI (Long-Term Strategic)
+## What may still exist in the WAR (not product direction)
 
-**Status:** In progress (Phase 3 complete)
-**Goal:** Consolidate all legacy JS layers (jQuery, Knockout, Dojo) into a single React-based UI
-**Timeline:** Multi-release roadmap
+These are **not** peer product UIs. Agents may touch them only for security/hotfix or to remove after React replacement:
 
-**Completed Milestones:**
-- ✅ Phase 0 (Build): Vite pipeline, React bridge (`PercModernUI.mount()`)
-- ✅ Phase 1 (Dashboard): 24 widget components replacing Shindig gadgets
-- ✅ Phase 2 (Build Structure): Output separation to `target/generated-webui/cm/`
-- ✅ Phase 3 (Maven Integration): Full WAR generation tested
+| Layer | Tech | Policy |
+|-------|------|--------|
+| Residual bridge dialogs / embeds | React via `PercModernUI.mount` on old JSPs | Delete when SPA owns the job; **no new mounts** |
+| WebUI legacy pages | jQuery / Backbone | No new features |
+| Contributor UI leftovers | Knockout | No new features |
+| Active Assembly / residual `ps.*` | Historical Dojo-shaped code + shims | No new Dojo; replace with React when editor wave runs |
+| Package Manager | GWT | Legacy until React wave |
+| JSF residual packaging | JSF | Prefer SPA Admin/Publish |
 
-**Next Steps:**
-- Incrementally migrate high-value screens from jQuery/Knockout
-- Establish patterns for React component library
-- Plan screen-by-screen migration roadmap
-
-**Reference:** [Unified UI Plan — Track B](../docs/ai-generated/tasks/#000-unified-ui-plan/unified-ui-plan.md) | [Source Layout Migration](../docs/ai-generated/tasks/#000-webui-src-layout/webui-src-layout-migration-plan.md)
+Historical inventory (may lag): [`docs/ai-generated/tasks/#000-unified-ui-plan/ui-layer-inventory.md`](../docs/ai-generated/tasks/#000-unified-ui-plan/ui-layer-inventory.md).
 
 ---
 
@@ -102,164 +70,81 @@ The WebUI shares the Percussion CMS application with 7 other UI layers:
 WebUI/
 ├── src/
 │   ├── main/
-│   │   ├── java/                        # Java servlets, REST controllers
-│   │   ├── resources/                   # Shared config files
-│   │   ├── webapp/                      # War root; JSP pages, legacy JS/CSS
-│   │   │   ├── cm/                      # Deployed application root
-│   │   │   │   ├── app/                 # JSP application pages
-│   │   │   │   ├── jslib/               # Legacy JavaScript source (~43 ps.* modules)
-│   │   │   │   ├── jslibMin/            # Generated minified JavaScript
-│   │   │   │   ├── cssMin/              # Generated minified CSS
-│   │   │   │   ├── modern/              # Generated React/Vite bundles
-│   │   │   │   ├── vendor/              # Vendor libs (jQuery, Bootstrap, etc.)
-│   │   │   │   ├── widgets/             # jQuery UI widgets
-│   │   │   │   └── themes/              # CSS themes
-│   │   │   ├── dce/                     # Desktop Content Explorer pages
-│   │   │   ├── *.jsp                    # War root JSP files
-│   │   │   └── WEB-INF/                 # Deployment configuration
-│   │   └── frontend/                    # ← Node.js/React/Vite source (NEW LOCATION)
-│   │       ├── package.json
-│   │       ├── tsconfig.json
-│   │       ├── vite.config.ts           # Modern ES2020+ build
-│   │       ├── vite.legacy.config.ts    # Legacy ES5 bundles
-│   │       ├── scripts/
-│   │       │   └── build-legacy-bundles.js
-│   │       └── src/main/ts/
-│   │           ├── components/          # React components
-│   │           ├── api/                 # API client code
-│   │           ├── dashboard/           # Dashboard (fully migrated)
-│   │           ├── hooks/               # Custom React hooks
-│   │           └── index.ts             # Entry point
+│   │   ├── java/                        # Servlets, filters (e.g. SPA fallback)
+│   │   ├── resources/
+│   │   ├── webapp/                      # WAR root (JSP, legacy assets)
+│   │   │   ├── cm/app/                  # spa.jsp, index.jsp, residual legacy JSPs
+│   │   │   ├── cm/modern/               # Generated React bundle (build output)
+│   │   │   └── WEB-INF/
+│   │   ├── ts/                          # ← Product UI TypeScript/React source
+│   │   │   ├── app/                     # SPA App, routes, layout, deep links
+│   │   │   ├── home/, publishing/, …    # Feature modules
+│   │   │   ├── api/, i18n/, ui-themes/
+│   │   │   ├── bridge.ts, registry.ts   # Residual embed support only
+│   │   │   └── index.ts
+│   │   └── frontend/                    # Vite/npm workingDirectory
 │   └── test/
-│       ├── java/                        # JUnit 5 tests
-│       └── ts/                          # Vitest tests
+│       ├── java/
+│       └── ts/                          # Vitest
 ├── pom.xml
-└── target/
-    └── generated-webui/                 # Build outputs (NOT in git)
-        └── cm/
-            ├── modern/
-            ├── jslibMin/
-            └── cssMin/
+└── target/generated-webui/              # Build outputs (not git)
 ```
 
 ---
 
 ## Build Pipeline
 
-### Maven Build (Full Application)
+### Standalone module (preferred pre-PR)
 
 ```bash
-./mvn-env.sh -pl WebUI clean install         # Build everything
-./mvn-env.sh -pl WebUI clean package         # Skip test phase
-./mvn-env.sh -pl WebUI clean install -DskipTests
+cd WebUI
+../mvn-env.sh clean install
 ```
 
-**What happens:**
-1. Maven invokes `frontend-maven-plugin` to:
-- Install Node.js if needed
-- Run `npm install`
-- Run `npm run build` (TypeScript compilation via Vite)
-2. Legacy bundle builder generates minified JS/CSS bundles
-3. Maven packages single WAR containing:
-- Compiled Java classes (src/main/java)
-- JSP pages and assets (src/main/webapp)
-- Generated React bundles (target/generated-webui/cm/modern)
-- Generated legacy bundles (target/generated-webui/cm/jslibMin, cssMin, shared-common*, shared-finder.js)
-
-### Node.js/npm Commands (Frontend Development)
+### Frontend-only iteration
 
 ```bash
 cd WebUI/src/main/frontend
-
-npm run dev              # Vite dev server with HMR (React)
-npm run build            # Build modern + legacy bundles
-npm run build:modern     # Modern ES2020+ only
-npm run build:legacy     # Legacy ES5 JavaScript/CSS bundles
-npm run preview          # Preview production build
-npm run test             # Run Vitest tests once
-npm run test:watch       # Watch mode for tests
-npm run lint             # Check ESLint errors
+npm run build:modern     # tsc + vite
+npm run test             # Vitest
+npm run dev              # HMR when wired to a running CMS
 ```
 
-### Quick Type Check & Linting
+### Hot copy to docker CMS (example)
 
 ```bash
-cd WebUI/src/main/frontend
-npx tsc --noEmit         # Verify TypeScript types
-npm run lint             # Check code style
+cp WebUI/target/generated-webui/cm/modern/assets/perc-modern-ui.js \
+   /opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/perc-modern-ui.js
+cp WebUI/target/generated-webui/cm/modern/assets/perc-modern-ui.css \
+   /opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/perc-modern-ui.css
+# Path routes: spa.jsp + filter are on the server; rebuild WAR or copy JSP/filter classes as needed
 ```
 
 ---
 
 ## Coding Standards
 
-### Java (Servlets, REST Controllers)
+### React + TypeScript (product code)
 
-Follow root [@AGENTS.md](../AGENTS.md) Java standards:
-- Use dependency injection
-- Keep servlets thin; move logic to service classes
-- Provide RESTful endpoints consumable by both legacy and modern UIs
-- Use JUnit 5 + Mockito for testing
-- Document API contracts clearly
+- Functional components + hooks; strict TypeScript (avoid `any`)
+- Feature modules under `src/main/ts/<feature>/`
+- REST via `api/client.ts` + feature APIs; CSRF from bootstrap / `OWASP_CSRFTOKEN`
+- i18n via TMX `message()` helpers — no raw keys in primary chrome
+- Styles: CSS modules preferred; theme tokens via `ui-themes`
+- Tests: Vitest for non-trivial logic; update tests with every behavior change
+- SPA routing: `app/routes.tsx` + deep-link allowlists; server entry allowlists stay in lockstep
 
-### React + TypeScript (Track B, Growing)
+### Java (WebUI)
 
-**Component Development:**
-- Functional components with React hooks only
-- Strict TypeScript (no `any` types)
-- One file per component: `ComponentName.tsx`
-- Props interface in `ComponentName.types.ts` if complex
+- Thin filters/servlets; portable paths (`Path` / `Files` when filesystem)
+- New filters (e.g. SPA fallback) must have unit tests for allowlists
 
-**Styling:**
-- Bootstrap 5 classes for new components
-- CSS modules: `ComponentName.module.css` for local scoping
-- Avoid inline styles
-- Be aware of global CSS conflicts from jQuery/legacy
+### Legacy (jQuery, Knockout, residual AA, bridge)
 
-**Testing (Vitest):**
-
-```bash
-npm run test             # Run once
-npm run test:watch     # Development watch mode
-```
-
-**Example Component:**
-
-```typescript
-// src/main/ts/components/MyWidget.tsx
-import styles from './MyWidget.module.css';
-
-interface MyWidgetProps {
-  title: string;
-  count: number;
-}
-
-export function MyWidget({ title, count }: MyWidgetProps) {
-  return <div className={styles.widget}>{title}: {count}</div>;
-}
-```
-
-### jQuery + jQuery UI (Legacy, Under Maintenance)
-
-**Rules:**
-- Do NOT add new jQuery code
-- Evaluate React migration for features you modify
-- Keep jQuery isolated from React DOM
-
-### Knockout.js (Contributor UI, Under Maintenance)
-
-**Rules:**
-- Do NOT extend Knockout bindings
-- Evaluate React migration for pages you modify
-- Use bridge pattern if React/Knockout coexist
-
-### Dojo 0.4.3 (Being Removed — Track A)
-
-**Rules:**
-- ❌ Do NOT write new Dodo code
-- ❌ Do NOT extend existing Dojo modules
-- Contact team lead before touching Dojo files
-- All Dojo code targets jQuery migration in Track A
+- **Do not** add product features
+- **Do not** add Dojo
+- **Do not** add new `PercModernUI.mount` hosts
+- Security/hotfix only, or delete after React acceptance
 
 ---
 
@@ -267,326 +152,38 @@ export function MyWidget({ title, count }: MyWidgetProps) {
 
 ### React/TypeScript (Vitest)
 
-**Rules:**
-- Use Vitest (not Jest)
-- Filename: `ComponentName.test.tsx` or `utilityName.test.ts`
-- Mock API calls; don't call real endpoints
-- Test user-facing behavior, not implementation
-- Target >80% coverage for new components
-
-**Example:**
-
-```typescript
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import { MyWidget } from './MyWidget';
-
-describe('MyWidget', () => {
-  it('should render title', () => {
-    render(<MyWidget title="Test" count={5} />);
-    expect(screen.getByText('Test: 5')).toBeInTheDocument();
-  });
-});
-```
-
-### Java (JUnit 5)
-
-**Rules:**
-- Use JUnit 5 (refactor any JUnit 3/4)
-- Filename: `ServiceNameTest.java`
-- Mock external dependencies with Mockito
-- Test servlets, REST endpoints, business logic
-
----
-
-## Backend Integration
-
-### REST API Contract
-
-Create clear, typed endpoints:
-
-```java
-@RestController
-@RequestMapping("/api/items")
-public class ItemController {
-  @GetMapping("/{id}")
-  public ItemDTO getItem(@PathVariable String id) {
-    return itemService.findById(id);
-  }
-}
-```
-
-Frontend calls it:
-
-```typescript
-// src/main/ts/api/itemApi.ts
-export interface ItemDTO {
-  id: string;
-  name: string;
-  created: string;
-}
-
-export async function fetchItem(id: string): Promise<ItemDTO> {
-  const res = await fetch(`/api/items/${id}`);
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return res.json();
-}
-```
-
-### Authentication & Sessions
-
-- Own from `/api/auth` endpoint
-- Use HTTP-only cookies where possible
-- Include `Authorization` header when needed
-- Handle logout for both legacy and React UIs
-
-### Shared Data Between Frameworks
-
-Instead of coupling jQuery + React directly:
-
-```
-jQuery code → /api/shared-data ← React code
-```
-
-Both frameworks call the same REST endpoint, get consistent JSON.
-
----
-
-## Migration Strategy
-
-### When to Migrate to React
-
-**Priority:**
-1. Security-sensitive features
-2. High-traffic screens
-3. Features needing rich interactivity
-4. Components that benefit from type safety
-
-### Migration Approach
-
-1. **Analyze current implementation** — Document JSP/jQuery/Knockout code
-2. **Design REST API** — Create clean endpoints if not present
-3. **Build React component** — New component in `src/main/ts/components/`
-4. **Create JSP entry point** — Embed React with `PercModernUI.mount()`
-5. **Test thoroughly** — Component behavior + coexistence with legacy
-6. **Deploy & monitor** — Full Maven build + production verification
-7. **Clean up** — Remove old code only after verification
-
-### Best Practices
-
-**DO:**
-- ✅ Use REST APIs for inter-framework communication
-- ✅ Isolate React in separate DOM subtrees
-- ✅ Test coexistence before cleanup
-- ✅ Document API contracts
-- ✅ Maintain backward compatibility
-- ✅ Write thorough tests
-
-**DON'T:**
-- ❌ Mix React and jQuery on same element
-- ❌ Mix React and Knockout on same element
-- ❌ Share global variables between frameworks
-- ❌ Create new Dojo code
-- ❌ Add new jQuery UI code
-- ❌ Directly manipulate DOM from multiple frameworks
-
-### Bridge Pattern Example
-
-**Legacy jQuery notifying React:**
-
-```javascript
-document.dispatchEvent(new CustomEvent('itemUpdated', { detail: itemData }));
-```
-
-**React component listening:**
-
-```typescript
-useEffect(() => {
-  const handleUpdate = (e: Event) => {
-    const customEvent = e as CustomEvent;
-    console.log('Item updated:', customEvent.detail);
-  };
-  document.addEventListener('itemUpdated', handleUpdate);
-  return () => document.removeEventListener('itemUpdated', handleUpdate);
-}, []);
-```
-
----
-
-## Build Outputs & WAR Packaging
-
-### Source vs. Generated Files
-
-**Committed to Git:**
-- `src/main/webapp/cm/` — JSP pages, static assets
-- `src/main/frontend/src/main/ts/` — React/TypeScript source
-
-**Generated (NOT committed):**
-- `target/generated-webui/cm/modern/` — React bundles
-- `target/generated-webui/cm/jslibMin/` — Minified legacy JS
-- `target/generated-webui/cm/cssMin/` — Minified legacy CSS
-- `target/generated-webui/cm/shared-common.js` (and `-minuet`, `.css`, `shared-finder.js`) — intermediate concatenations from `src/main/resources/minify/*-bundles.json` via `src/main/frontend/scripts/build-legacy-bundles.js`
-- `target/generated-webui/cm/jslib/profiles/3x/jquery/jquery.min.js` and `jquery-migrate.min.js` — standalone npm copies for direct `<script>` tags (e.g. AA page header / `sys_aaPageHeader.html`). Synced from `node_modules` during `build:legacy` **only** into `target/generated-webui/` (never into `src/main/webapp/`). See issue #1510 (`ai-build-integrity-maven-plugin` seal).
-
-Do **not** check intermediate bundles into `src/main/webapp/cm/`. Do **not** commit regenerable vendor min files such as `jquery.min.js` / `jquery-migrate.min.js` under `src/main/webapp` or `war/` — they are npm-sourced and overlaid from `target/generated-webui`. Do **not** let the legacy builder rewrite tracked files under `src/main/webapp/cm/` — that breaks the repo integrity seal between `validate` (generate-hashes) and `test` (verify-hashes). Maven overlays `target/generated-webui` into the WAR. Committed copies drift from source and create duplicate CodeQL false positives.
-
-**Keep in source (still loaded by JSPs / installer by path):** non-minified `jquery-3.6.0.js` and `jquery-migrate-3.3.2.js` under `cm/jslib/profiles/3x/jquery/` (and the parallel `WebUI/war/` copies used by `perc-distribution-tree` until that tree is re-pointed).
-
-**Committed `*.min.js` / `*.min.css` policy (issue #1510 follow-up):** only keep minified vendor files that are **directly referenced** by a runtime entry (JSP/HTML/bundle JSON). As of that prune, the allowlist under `src/main/webapp/cm/` is:
-
-- `api/lib/jquery-3.6.0.min.js`, `jquery.ba-bbq.min.js`, `jquery.slideto.min.js`, `jquery.wiggle.min.js` (Swagger UI page)
-- `jslib/.../bootstrap.min.js`, `bootstrap.bundle.min.js`, `bootstrap.min.css` (login / admin workflow JSPs)
-- `jslib/.../jquery.fancytree-all.min.js` + `skin-win8/ui.fancytree.min.css` (finder include + legacy bundles)
-
-Do **not** re-check in unused theme variants (DataTables/Bootstrap skins), validation locale `*.min.js`, backgrid `*.min.*`, or anything under `cm/vendor/js/legacy/` min trees — product code never references `/cm/vendor/`. Prefer non-min sources already listed in `src/main/resources/minify/*-bundles.json` when both exist.
-
-**.gitignore includes:**
-
-```gitignore
-WebUI/target/generated-webui/
-WebUI/war/modern/
-WebUI/war/jslibMin/
-WebUI/war/cssMin/
-WebUI/src/main/webapp/cm/modern/
-WebUI/src/main/webapp/cm/jslibMin/
-WebUI/src/main/webapp/cm/cssMin/
-WebUI/src/main/webapp/cm/shared-common.js
-WebUI/src/main/webapp/cm/shared-common-minuet.js
-WebUI/src/main/webapp/cm/shared-finder.js
-WebUI/src/main/webapp/cm/shared-common.css
-WebUI/src/main/webapp/cm/shared-common-minuet.css
-WebUI/src/main/webapp/cm/jslib/profiles/3x/jquery/jquery.min.js
-WebUI/src/main/webapp/cm/jslib/profiles/3x/jquery/jquery-migrate.min.js
-```
-
-### WAR Contents
-
-**Final `target/perc-web-ui-8.2.0-SNAPSHOT.war`:**
-
-```
-cm/
-├── app/                 # JSP pages (from source)
-├── jslib/               # Legacy JS source (from source)
-├── jslibMin/            # Minified bundles (generated)
-├── cssMin/              # Minified CSS (generated)
-├── modern/              # React bundles (generated)
-├── shared-common*.js/css, shared-finder.js  # intermediate concatenations (generated)
-├── vendor/              # jQuery, Bootstrap, etc. (from source)
-├── widgets/, themes/, api/
-└── [other static assets]
-
-WEB-INF/
-├── web.xml
-├── classes/             # Compiled Java
-└── lib/                 # JAR dependencies
-```
-
----
-
-## Version Requirements
-
-|       Branch        | Node | JDK |
-|---------------------|------|-----|
-| `development`       | 22   | 21  |
-| `development-8.1.x` | 18   | 8   |
-
 ```bash
-# development branch
-export JAVA_HOME=/path/to/jdk-21
-nvm use 22
-./mvn-env.sh clean install
-
-# development-8.1.x branch
-export JAVA_HOME=/path/to/jdk-8
-nvm use 18
-./mvn-env.sh clean install
-```
-
----
-
-## Hot Deployment
-
-```bash
-./scripts/hot-deploy-local.py \
-  --install-dir /path/to/cms-install \
-  --modules webui \
-  --restart
-```
-
-Rebuilds WebUI and redeploys to local installation.
-
-### Fast iteration against the docker dev CMS (no container restart)
-
-When the dev CMS is running via the docker compose stack at `localhost:9992` (see `docker-compose.yml` + `docker/scripts/perc-devctl.py`), **JS/TS/JSP changes do NOT require a container restart** — just rebuild and copy the artifact:
-
-```bash
-# 1. Rebuild only the modern bundle (fast: ~3s)
 cd WebUI/src/main/frontend
-npm run build:modern
-
-# 2. Copy the new bundle to the runtime webapp
-cp WebUI/target/generated-webui/cm/modern/assets/perc-modern-ui.js \
-   /opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/perc-modern-ui.js
-cp WebUI/target/generated-webui/cm/modern/assets/perc-modern-ui.js.map \
-   /opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/perc-modern-ui.js.map
-
-# 3. Copy new/modified JSPs (Jetty serves them fresh on the next request)
-cp WebUI/src/main/webapp/cm/app/spa.jsp \
-   /opt/Percussion/jetty/base/webapps/Rhythmyx/cm/app/spa.jsp
-# Residual bridge dialog hosts (pickers, search, etc.) live under cm/app/*Modern.jsp
-# when still needed; product navigation is spa.jsp?entry=… only.
-
-# 4. Bust the browser cache for the new bundle
-# Add a cache-buster to the JSP <script> tag, e.g.:
-#   <script type="module" src="/cm/modern/assets/perc-modern-ui.js?cb=<%= System.currentTimeMillis() %>"></script>
-# or hit the page with a unique querystring (Playwright tests can do this).
+npm run test
 ```
 
-**Java code** (when you change `.java` files, e.g. `PSPathService`) **does** need a full container restart because Jetty's WebAppClassLoader doesn't hot-reload classes. The fastest path:
+### Acceptance (product)
 
-```bash
-./mvn-env.sh -pl <module> -am install   # rebuild jar
-docker compose --env-file .env.compose -f docker-compose.yml restart cms-dts
-./docker/scripts/perc-devctl.py verify   # confirm health
-```
+Follow the **screen checklist** in the unified UI plan. Home must pass on a **real CMS** (not only unit tests) before Home is marked accepted.
 
-**When in doubt, Jetty's `<servlet>` config can be set to `<init-param><param-name>development</param-name><param-value>true</param-value></init-param>`** so JSPs hot-reload on the next request. Default is single-recompile per deploy; flip to `true` in `web.xml` to avoid the `docker compose restart` cycle for JSP-only changes.
+### Pre-PR
 
-### Iteration cost reference
-
-|             Change             |                        Build                        |              Restart              |   Total   |
-|--------------------------------|-----------------------------------------------------|-----------------------------------|-----------|
-| TS/TSX (component or path API) | `npm run build:modern` (~3 s)                       | copy + cache-buster (0 s)         | ~3 s      |
-| JSP                            | copy file (0 s)                                     | none (Jetty re-serves on request) | ~1 s      |
-| SCSS / styles                  | `npm run build:modern` (~3 s)                       | copy (~0 s)                       | ~3 s      |
-| Java class                     | `./mvn-env.sh -pl <m> -am install` (~30–60 s)       | `docker compose restart` (~30 s)  | ~1–2 min  |
-| Maven / pom                    | `./mvn-env.sh clean install` (~5–10 min first time) | `docker compose restart`          | ~5–10 min |
-
-When iterating, prefer the cheap paths first (TS + JSP); only escalate to Java / pom when the change actually requires it.
+- `cd WebUI && ../mvn-env.sh clean install` — BUILD SUCCESS, tests pass, no new warnings
+- Erlang review on authored diffs
+- PR body: commands run + test counts + which checklist items were verified
 
 ---
 
-## Common Tasks Cheatsheet
+## Agent DO / DO NOT (summary)
 
-|        Task        |                                    Command                                    |
-|--------------------|-------------------------------------------------------------------------------|
-| Full build         | `./mvn-env.sh -pl WebUI clean install`                                        |
-| Build (skip tests) | `./mvn-env.sh -pl WebUI clean install -DskipTests`                            |
-| React dev server   | `cd WebUI/src/main/frontend && npm run dev`                                   |
-| Build React only   | `cd WebUI/src/main/frontend && npm run build`                                 |
-| Run tests          | `cd WebUI/src/main/frontend && npm run test:watch`                            |
-| Check types        | `cd WebUI/src/main/frontend && npx tsc --noEmit`                              |
-| Lint check         | `cd WebUI/src/main/frontend && npm run lint`                                  |
-| Format code        | `./mvn-env.sh spotless:apply`                                                 |
-| Hot deploy         | `./scripts/hot-deploy-local.py --install-dir /path --modules webui --restart` |
+| DO | DO NOT |
+|----|--------|
+| Ship SPA React features | Dual-mode / classic peer UIs |
+| Fix Home until functional | Declare “done” because shell renders |
+| Delete obsolete hosts after acceptance | New bridge product pages |
+| Align allowlists (TS + JSP/filter) | New Dojo / Knockout / jQuery product code |
+| Document acceptance evidence | Invent REST APIs without checking existing `api/` + `rest` module |
 
 ---
 
-## Documentation & References
+## Related docs
 
-- [Unified UI Plan](../docs/ai-generated/tasks/#000-unified-ui-plan/unified-ui-plan.md) — Tracks A & B roadmap
-- [UI Layer Inventory](../docs/ai-generated/tasks/#000-unified-ui-plan/ui-layer-inventory.md) — 8 UI layers analysis
-- [WebUI Source Layout Migration](../docs/ai-generated/tasks/#000-webui-src-layout/webui-src-layout-migration-plan.md) — Build structure design
-- [Phase 2: Build Output Separation](../docs/ai-generated/tasks/#000-webui-src-layout/PHASE-2-BUILD-OUTPUT-SEPARATION.md) — Current setup details
-- [Phase 3: Full Integration Test](../docs/ai-generated/tasks/#000-webui-src-layout/PHASE-3-FULL-INTEGRATION-TEST.md) — Maven integration validation
-
+- [Unified UI Plan rev 4.0](../docs/ai-generated/tasks/#000-unified-ui-plan/unified-ui-plan.md) — **direction of record**
+- [Pure React SPA design](../docs/ai-generated/tasks/#000-pure-react-spa/design.md) — entry contract, bootstrap, PR 1–9
+- [Residual bridge embeds](../docs/ai-generated/tasks/#000-pure-react-spa/residual-bridge-embeds.md) — delete list
+- Root [AGENTS.md](../AGENTS.md) — monorepo, Maven, cross-platform, Erlang

--- a/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
+++ b/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.webui.filter;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * PR-9: internal forward for path-based SPA client routes so BrowserRouter refresh does not 404
+ * under Jetty.
+ *
+ * <p>GET {@code /cm/app/{entry}[/**]} and {@code /cm/pages/app/{entry}[/**]} → forward to the tree's
+ * {@code spa.jsp} with an allowlisted {@code entry} (and section/tab when present). Real JSPs,
+ * static assets, and non-SPA first segments pass through unchanged.
+ *
+ * <p>Server deep links and login return remain the query contract ({@code spa.jsp?entry=…}); this
+ * filter only supports clean client path URLs after first paint.
+ */
+public class PSWebUiSpaFallbackFilter implements Filter {
+
+  /** Default constructor for servlet container instantiation. */
+  public PSWebUiSpaFallbackFilter() {}
+
+  /** SPA entry tokens (lockstep with TS SPA_ENTRIES). */
+  static final Set<String> SPA_ENTRIES =
+      Set.of(
+          "home",
+          "publish",
+          "workflow",
+          "admin",
+          "widget-builder",
+          "explorer",
+          "unavailable");
+
+  private static final String APP_PREFIX = "/cm/app";
+  private static final String PAGES_PREFIX = "/cm/pages/app";
+
+  @Override
+  public void init(FilterConfig filterConfig) {
+    // no-op
+  }
+
+  @Override
+  public void destroy() {
+    // no-op
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
+      chain.doFilter(request, response);
+      return;
+    }
+    HttpServletRequest httpReq = (HttpServletRequest) request;
+    if (!"GET".equalsIgnoreCase(httpReq.getMethod())) {
+      chain.doFilter(request, response);
+      return;
+    }
+
+    String pathWithinContext = pathWithinContext(httpReq);
+    String forward = buildSpaForwardPath(pathWithinContext, httpReq.getQueryString());
+    if (forward == null) {
+      chain.doFilter(request, response);
+      return;
+    }
+
+    RequestDispatcher dispatcher = request.getRequestDispatcher(forward);
+    if (dispatcher == null) {
+      chain.doFilter(request, response);
+      return;
+    }
+    dispatcher.forward(request, response);
+  }
+
+  /**
+   * Path inside the webapp (context path stripped). Never null; starts with {@code /} when non-empty.
+   */
+  static String pathWithinContext(HttpServletRequest request) {
+    String uri = request.getRequestURI();
+    if (uri == null) {
+      return "";
+    }
+    String context = request.getContextPath();
+    if (context != null && !context.isEmpty() && uri.startsWith(context)) {
+      uri = uri.substring(context.length());
+    }
+    // Decode is left to the container for path info; strip semicolon matrix params
+    int semi = uri.indexOf(';');
+    if (semi >= 0) {
+      uri = uri.substring(0, semi);
+    }
+    if (uri.isEmpty()) {
+      return "/";
+    }
+    return uri;
+  }
+
+  /**
+   * Build an internal forward path to {@code spa.jsp?entry=…} when {@code pathWithinContext} is a
+   * path-based SPA client route; otherwise {@code null} (pass through).
+   *
+   * @param pathWithinContext e.g. {@code /cm/app/home/library} or {@code /Rhythmyx}-stripped form
+   * @param queryString raw query without {@code ?}, may be null
+   */
+  static String buildSpaForwardPath(String pathWithinContext, String queryString) {
+    if (pathWithinContext == null || pathWithinContext.isEmpty()) {
+      return null;
+    }
+    // Never rewrite explicit resources
+    String lower = pathWithinContext.toLowerCase(Locale.ROOT);
+    if (lower.endsWith(".jsp")
+        || lower.endsWith(".js")
+        || lower.endsWith(".css")
+        || lower.endsWith(".map")
+        || lower.endsWith(".png")
+        || lower.endsWith(".gif")
+        || lower.endsWith(".jpg")
+        || lower.endsWith(".jpeg")
+        || lower.endsWith(".svg")
+        || lower.endsWith(".ico")
+        || lower.endsWith(".woff")
+        || lower.endsWith(".woff2")
+        || lower.endsWith(".ttf")
+        || lower.contains("/cm/modern/")) {
+      return null;
+    }
+
+    String prefix;
+    String remainder;
+    if (pathWithinContext.equals(APP_PREFIX) || pathWithinContext.startsWith(APP_PREFIX + "/")) {
+      prefix = APP_PREFIX;
+      remainder =
+          pathWithinContext.length() == APP_PREFIX.length()
+              ? ""
+              : pathWithinContext.substring(APP_PREFIX.length());
+    } else if (pathWithinContext.equals(PAGES_PREFIX)
+        || pathWithinContext.startsWith(PAGES_PREFIX + "/")) {
+      prefix = PAGES_PREFIX;
+      remainder =
+          pathWithinContext.length() == PAGES_PREFIX.length()
+              ? ""
+              : pathWithinContext.substring(PAGES_PREFIX.length());
+    } else {
+      return null;
+    }
+
+    // /cm/app or /cm/app/ alone → index.jsp / dispatcher, not SPA path route
+    if (remainder.isEmpty() || "/".equals(remainder)) {
+      return null;
+    }
+    if (!remainder.startsWith("/")) {
+      return null;
+    }
+
+    // Split path segments (ignore empty from trailing slash)
+    String trimmed = remainder;
+    while (trimmed.startsWith("/")) {
+      trimmed = trimmed.substring(1);
+    }
+    while (trimmed.endsWith("/")) {
+      trimmed = trimmed.substring(0, trimmed.length() - 1);
+    }
+    if (trimmed.isEmpty()) {
+      return null;
+    }
+    String[] segments = trimmed.split("/");
+    if (segments.length == 0) {
+      return null;
+    }
+
+    String entry = segments[0].toLowerCase(Locale.ROOT);
+    if ("widgetbuilder".equals(entry)) {
+      entry = "widget-builder";
+    }
+    if (!SPA_ENTRIES.contains(entry)) {
+      return null;
+    }
+    // Reject path traversal / odd segments
+    for (String seg : segments) {
+      if (seg.isEmpty() || "..".equals(seg) || seg.indexOf('\\') >= 0) {
+        return null;
+      }
+    }
+
+    StringBuilder forward = new StringBuilder(prefix).append("/spa.jsp?entry=");
+    forward.append(urlEncode(entry));
+
+    if (segments.length >= 2) {
+      String second = segments[1];
+      if ("home".equals(entry) || "publish".equals(entry)) {
+        forward.append("&section=").append(urlEncode(second));
+      } else if ("workflow".equals(entry) || "admin".equals(entry)) {
+        forward.append("&tab=").append(urlEncode(second));
+      }
+      // explorer / widget-builder / unavailable: ignore extra path segments
+    }
+
+    if (queryString != null && !queryString.isBlank()) {
+      // Preserve allowlisted deep-link params (path, siteId, serverId, section, tab, …)
+      // without duplicating entry if already present.
+      String[] pairs = queryString.split("&");
+      for (String pair : pairs) {
+        if (pair.isEmpty()) {
+          continue;
+        }
+        int eq = pair.indexOf('=');
+        String key = eq >= 0 ? pair.substring(0, eq) : pair;
+        if ("entry".equalsIgnoreCase(key)) {
+          continue;
+        }
+        forward.append('&').append(pair);
+      }
+    }
+    return forward.toString();
+  }
+
+  private static String urlEncode(String raw) {
+    return URLEncoder.encode(raw, StandardCharsets.UTF_8);
+  }
+}

--- a/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
+++ b/WebUI/src/main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java
@@ -26,6 +26,7 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
@@ -190,9 +191,14 @@ public class PSWebUiSpaFallbackFilter implements Filter {
     if (trimmed.isEmpty()) {
       return null;
     }
+    // split on non-empty trimmed path always yields length >= 1
     String[] segments = trimmed.split("/");
-    if (segments.length == 0) {
-      return null;
+
+    // Reject path traversal / odd segments (decoded + encoded forms — Kilo #1542)
+    for (String seg : segments) {
+      if (isUnsafePathSegment(seg)) {
+        return null;
+      }
     }
 
     String entry = segments[0].toLowerCase(Locale.ROOT);
@@ -201,12 +207,6 @@ public class PSWebUiSpaFallbackFilter implements Filter {
     }
     if (!SPA_ENTRIES.contains(entry)) {
       return null;
-    }
-    // Reject path traversal / odd segments
-    for (String seg : segments) {
-      if (seg.isEmpty() || "..".equals(seg) || seg.indexOf('\\') >= 0) {
-        return null;
-      }
     }
 
     StringBuilder forward = new StringBuilder(prefix).append("/spa.jsp?entry=");
@@ -243,5 +243,47 @@ public class PSWebUiSpaFallbackFilter implements Filter {
 
   private static String urlEncode(String raw) {
     return URLEncoder.encode(raw, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * True when a path segment must not be forwarded as an SPA route segment.
+   * Rejects empty segments, {@code ..}, backslashes, embedded slashes after
+   * decode, and URL-encoded dot sequences ({@code %2e%2e}) for defense-in-depth
+   * when the container leaves encoding in {@code getRequestURI()}.
+   */
+  static boolean isUnsafePathSegment(String segment) {
+    if (segment == null || segment.isEmpty()) {
+      return true;
+    }
+    if (segment.indexOf('\\') >= 0) {
+      return true;
+    }
+    // Raw encoded traversal (case-insensitive), before or without decode
+    String lower = segment.toLowerCase(Locale.ROOT);
+    if (lower.contains("%2e") || lower.contains("%252e")) {
+      return true;
+    }
+    if ("..".equals(segment) || ".".equals(segment)) {
+      return true;
+    }
+    String decoded = segment;
+    try {
+      decoded = URLDecoder.decode(segment, StandardCharsets.UTF_8);
+      // Double-encoded payloads
+      if (decoded.contains("%")) {
+        decoded = URLDecoder.decode(decoded, StandardCharsets.UTF_8);
+      }
+    } catch (IllegalArgumentException ex) {
+      // Malformed escape — do not forward
+      return true;
+    }
+    if ("..".equals(decoded) || ".".equals(decoded)) {
+      return true;
+    }
+    // Reject decode that introduces path separators (encoded slash in segment)
+    if (decoded.indexOf('/') >= 0 || decoded.indexOf('\\') >= 0) {
+      return true;
+    }
+    return false;
   }
 }

--- a/WebUI/src/main/ts/api/csrf.ts
+++ b/WebUI/src/main/ts/api/csrf.ts
@@ -37,14 +37,32 @@ declare global {
 const DEFAULT_HEADER_NAME = "OWASP-CSRFTOKEN";
 
 /**
- * Retrieves the current CSRF token from the page globals set by CSRFGuard.
+ * Retrieves the current CSRF token from CSRFGuard globals or host meta tags.
+ *
+ * <p>{@code spa.jsp} / login inject {@code meta[name=_csrf]} and
+ * {@code meta[name=_csrf_header]} as a reliable fallback when
+ * {@code window.OWASP_CSRFTOKEN} is not yet populated.</p>
  *
  * @returns the token header name and value, or {@code null} if unavailable
  */
 export function getCsrfToken(): CsrfToken | null {
   const tokenObj = window.OWASP_CSRFTOKEN;
-  if (!tokenObj?.token) {
-    return null;
+  if (tokenObj?.token) {
+    return { headerName: DEFAULT_HEADER_NAME, token: tokenObj.token };
   }
-  return { headerName: DEFAULT_HEADER_NAME, token: tokenObj.token };
+  if (typeof document !== "undefined") {
+    const metaToken = document
+      .querySelector('meta[name="_csrf"]')
+      ?.getAttribute("content");
+    const metaHeader = document
+      .querySelector('meta[name="_csrf_header"]')
+      ?.getAttribute("content");
+    if (metaToken && metaToken.trim()) {
+      return {
+        headerName: metaHeader?.trim() || DEFAULT_HEADER_NAME,
+        token: metaToken.trim(),
+      };
+    }
+  }
+  return null;
 }

--- a/WebUI/src/main/ts/app/App.tsx
+++ b/WebUI/src/main/ts/app/App.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, { useMemo } from "react";
+import React from "react";
 import { BrowserRouter } from "react-router";
 import { ThemeProvider } from "../ui-themes/ThemeProvider";
 import { BootstrapProvider } from "./bootstrap/BootstrapContext";
@@ -36,11 +36,15 @@ export interface AppProps {
 }
 
 /**
- * If the document URL is still {@code spa.jsp?entry=…}, rewrite to the path
- * client route under the SPA basename before BrowserRouter mounts.
- * Keeps the server query contract while giving BrowserRouter a clean first paint.
- * Path refreshes (filter → spa.jsp forward with browser URL already path-based)
- * leave the address bar unchanged.
+ * If the document URL is still {@code spa.jsp?entry=…}, rewrite the address bar
+ * to the path client route under the SPA basename via {@code history.replaceState}.
+ *
+ * <p>Must run <em>before</em> {@code BrowserRouter} mounts so its initial location
+ * is the feature path. Prefer {@link handoffSpaEntryBeforeMount} from {@code boot()}.
+ * Idempotent when already on a path route.
+ *
+ * <p>Not implemented via {@code useMemo} (Kilo #1542): that API is for pure
+ * computations, not history side effects.
  */
 export function applyEntryQueryToPath(
   pathname: string = typeof window !== "undefined" ? window.location.pathname : "",
@@ -56,7 +60,6 @@ export function applyEntryQueryToPath(
   if (!params.has("entry")) {
     return null;
   }
-  // Only rewrite when serving the SPA document by name (query handoff)
   const isSpaDocument =
     pathname.endsWith("/spa.jsp") ||
     pathname.endsWith("spa.jsp") ||
@@ -82,6 +85,21 @@ export function applyEntryQueryToPath(
   return next;
 }
 
+/** Call from {@code boot()} before {@code createRoot} for a clean first paint. */
+export function handoffSpaEntryBeforeMount(
+  basenameProp?: string,
+  entrySearch?: string,
+): string {
+  const pathname =
+    typeof window !== "undefined" ? window.location.pathname : "/cm/app";
+  const basename = basenameProp ?? detectSpaBasename(pathname);
+  const search =
+    entrySearch ??
+    (typeof window !== "undefined" ? window.location.search : "");
+  applyEntryQueryToPath(pathname, search, basename);
+  return basename;
+}
+
 /**
  * Authenticated SPA root: theme → bootstrap → BrowserRouter → routes.
  */
@@ -90,25 +108,20 @@ export function App({
   entrySearch,
   basename: basenameProp,
 }: AppProps): React.ReactElement {
-  const basename = useMemo(
-    () =>
-      basenameProp ??
-      detectSpaBasename(
-        typeof window !== "undefined" ? window.location.pathname : "/cm/app",
-      ),
-    [basenameProp],
-  );
+  const pathname =
+    typeof window !== "undefined" ? window.location.pathname : "/cm/app";
+  const basename = basenameProp ?? detectSpaBasename(pathname);
 
-  // Synchronous handoff so the first router match is the feature path, not /spa.jsp
-  useMemo(() => {
-    const search =
-      entrySearch ??
-      (typeof window !== "undefined" ? window.location.search : "");
-    const pathname =
-      typeof window !== "undefined" ? window.location.pathname : `${basename}/spa.jsp`;
-    applyEntryQueryToPath(pathname, search, basename);
-    return null;
-  }, [basename, entrySearch]);
+  // Handoff before BrowserRouter is created so initial location is the feature
+  // path. Production also calls handoffSpaEntryBeforeMount() in boot() — both
+  // are idempotent. Not useMemo (Kilo #1542).
+  if (typeof window !== "undefined") {
+    applyEntryQueryToPath(
+      window.location.pathname,
+      entrySearch ?? window.location.search,
+      basename,
+    );
+  }
 
   return (
     <ThemeProvider>

--- a/WebUI/src/main/ts/app/App.tsx
+++ b/WebUI/src/main/ts/app/App.tsx
@@ -15,71 +15,107 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from "react";
-import { HashRouter, useNavigate } from "react-router";
+import React, { useMemo } from "react";
+import { BrowserRouter } from "react-router";
 import { ThemeProvider } from "../ui-themes/ThemeProvider";
 import { BootstrapProvider } from "./bootstrap/BootstrapContext";
 import type { SpaBootstrap } from "./bootstrap/types";
 import { parseEntryQuery } from "./deepLinks/parseEntryQuery";
+import { detectSpaBasename } from "./deepLinks/spaBasename";
 import { AppRoutes } from "./routes";
 
 export interface AppProps {
   bootstrap: SpaBootstrap;
-  /** Override search for tests (default window.location.search) */
+  /**
+   * Override document search for tests / SSR-style entry handoff
+   * (default {@code window.location.search}).
+   */
   entrySearch?: string;
+  /** Override BrowserRouter basename (tests / dual-tree) */
+  basename?: string;
 }
 
 /**
- * Applies server-driven {@code ?entry=} query once, then leaves client routing
- * to HashRouter (refresh-safe under Jetty).
+ * If the document URL is still {@code spa.jsp?entry=…}, rewrite to the path
+ * client route under the SPA basename before BrowserRouter mounts.
+ * Keeps the server query contract while giving BrowserRouter a clean first paint.
+ * Path refreshes (filter → spa.jsp forward with browser URL already path-based)
+ * leave the address bar unchanged.
  */
-function EntryQueryApplier({
-  entrySearch,
-}: {
-  entrySearch?: string;
-}): null {
-  const navigate = useNavigate();
+export function applyEntryQueryToPath(
+  pathname: string = typeof window !== "undefined" ? window.location.pathname : "",
+  search: string = typeof window !== "undefined" ? window.location.search : "",
+  basename: string = detectSpaBasename(pathname),
+): string | null {
+  if (!search || search === "?") {
+    return null;
+  }
+  const params = new URLSearchParams(
+    search.startsWith("?") ? search.slice(1) : search,
+  );
+  if (!params.has("entry")) {
+    return null;
+  }
+  // Only rewrite when serving the SPA document by name (query handoff)
+  const isSpaDocument =
+    pathname.endsWith("/spa.jsp") ||
+    pathname.endsWith("spa.jsp") ||
+    pathname === basename ||
+    pathname === `${basename}/`;
+  if (!isSpaDocument) {
+    return null;
+  }
 
-  useEffect(() => {
+  const parsed = parseEntryQuery(search);
+  const [pathPart, queryPart] = parsed.clientPath.split("?");
+  let next = `${basename}${pathPart.startsWith("/") ? pathPart : `/${pathPart}`}`;
+  if (queryPart) {
+    next += `?${queryPart}`;
+  }
+  if (typeof window !== "undefined" && window.history?.replaceState) {
+    try {
+      window.history.replaceState(null, "", next);
+    } catch {
+      // ignore
+    }
+  }
+  return next;
+}
+
+/**
+ * Authenticated SPA root: theme → bootstrap → BrowserRouter → routes.
+ */
+export function App({
+  bootstrap,
+  entrySearch,
+  basename: basenameProp,
+}: AppProps): React.ReactElement {
+  const basename = useMemo(
+    () =>
+      basenameProp ??
+      detectSpaBasename(
+        typeof window !== "undefined" ? window.location.pathname : "/cm/app",
+      ),
+    [basenameProp],
+  );
+
+  // Synchronous handoff so the first router match is the feature path, not /spa.jsp
+  useMemo(() => {
     const search =
       entrySearch ??
       (typeof window !== "undefined" ? window.location.search : "");
-    if (!search || search === "?") {
-      return;
-    }
-    const parsed = parseEntryQuery(search);
-    navigate(parsed.clientPath, { replace: true });
-    // Strip entry query from the document URL after client route is applied
-    // so address bar shows hash route only (server entry already consumed).
-    if (typeof window !== "undefined" && window.history?.replaceState) {
-      try {
-        const url = new URL(window.location.href);
-        if (url.searchParams.has("entry") || url.search.length > 1) {
-          url.search = "";
-          window.history.replaceState(null, "", url.pathname + url.hash);
-        }
-      } catch {
-        // ignore
-      }
-    }
-    // Run once on mount for server entry handoff
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    const pathname =
+      typeof window !== "undefined" ? window.location.pathname : `${basename}/spa.jsp`;
+    applyEntryQueryToPath(pathname, search, basename);
+    return null;
+  }, [basename, entrySearch]);
 
-  return null;
-}
-
-/**
- * Authenticated SPA root: theme → bootstrap → HashRouter → routes.
- */
-export function App({ bootstrap, entrySearch }: AppProps): React.ReactElement {
   return (
     <ThemeProvider>
       <BootstrapProvider value={bootstrap}>
-        <HashRouter>
-          <EntryQueryApplier entrySearch={entrySearch} />
+        <BrowserRouter basename={basename}>
           <AppRoutes />
-        </HashRouter>
+        </BrowserRouter>
       </BootstrapProvider>
     </ThemeProvider>
   );

--- a/WebUI/src/main/ts/app/auth/sessionHandlers.ts
+++ b/WebUI/src/main/ts/app/auth/sessionHandlers.ts
@@ -16,7 +16,7 @@
  */
 
 import { DEFAULT_SPA_ENTRY_REDIRECT } from "../../login/redirect";
-import { parseEntryQuery, toSpaEntryUrl } from "../deepLinks/parseEntryQuery";
+import { resolveSpaReturnFromLocation } from "../deepLinks/parseEntryQuery";
 
 export const REACT_LOGIN_PATH = "/rxlogin.jsp";
 
@@ -50,13 +50,17 @@ export function buildLoginReturnUrl(
 }
 
 /**
- * Current SPA document return URL from location (query entry or default home).
+ * Current SPA document return URL from location.
+ * Prefers query {@code entry} contract; falls back to path-based client routes (PR-9).
  */
 export function currentSpaReturnUrl(
   search: string = typeof window !== "undefined" ? window.location.search : "",
+  pathname: string = typeof window !== "undefined"
+    ? window.location.pathname
+    : "/cm/app/spa.jsp",
 ): string {
   try {
-    return toSpaEntryUrl(parseEntryQuery(search));
+    return resolveSpaReturnFromLocation(pathname, search);
   } catch {
     return DEFAULT_SPA_ENTRY_REDIRECT;
   }

--- a/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
+++ b/WebUI/src/main/ts/app/deepLinks/parseEntryQuery.ts
@@ -25,13 +25,14 @@ import {
   normalizeWorkflowTab,
   type SpaEntry,
 } from "./allowlists";
+import { detectSpaBasename, pathAfterBasename } from "./spaBasename";
 
 /**
- * Parsed server-driven SPA entry (query contract only — never hash).
+ * Parsed server-driven SPA entry (query contract only — never hash on server).
  */
 export interface ParsedSpaEntry {
   entry: SpaEntry;
-  /** Client hash route path (e.g. /home/library, /publish/logs) */
+  /** Client route path under basename (e.g. /home/library, /publish/logs) */
   clientPath: string;
   section?: string;
   tab?: string;
@@ -116,6 +117,7 @@ export function parseEntryQuery(
 
 /**
  * Rebuild an allowlisted query entry URL for login return / server redirects.
+ * Always uses the app-tree spa.jsp (query contract — never path or hash).
  */
 export function toSpaEntryUrl(parsed: ParsedSpaEntry): string {
   const params = new URLSearchParams();
@@ -126,4 +128,109 @@ export function toSpaEntryUrl(parsed: ParsedSpaEntry): string {
   if (parsed.serverId) params.set("serverId", parsed.serverId);
   if (parsed.path) params.set("path", parsed.path);
   return `/cm/app/spa.jsp?${params.toString()}`;
+}
+
+/**
+ * Parse a BrowserRouter client path (after basename) plus optional search into
+ * a {@link ParsedSpaEntry}. Used for mid-session 401 return when the address
+ * bar is path-based (PR-9) rather than {@code spa.jsp?entry=…}.
+ *
+ * @param clientPath e.g. {@code /home/library} or {@code /publish/logs}
+ * @param search e.g. {@code ?path=/Sites/x} or empty
+ */
+export function parseClientPath(
+  clientPath: string,
+  search: string = "",
+): ParsedSpaEntry {
+  const q = search.startsWith("?") ? search.slice(1) : search;
+  const params = new URLSearchParams(q);
+  const siteId = normalizeId(params.get("siteId"));
+  const serverId = normalizeId(params.get("serverId"));
+  const explorerPath = normalizeExplorerPath(params.get("path"));
+
+  let pathOnly = clientPath || "/home";
+  if (!pathOnly.startsWith("/")) {
+    pathOnly = `/${pathOnly}`;
+  }
+  // Drop trailing slash except root
+  if (pathOnly.length > 1 && pathOnly.endsWith("/")) {
+    pathOnly = pathOnly.slice(0, -1);
+  }
+  const segments = pathOnly.split("/").filter(Boolean);
+  let entryRaw = (segments[0] || "home").toLowerCase();
+  if (entryRaw === "widgetbuilder") {
+    entryRaw = "widget-builder";
+  }
+  const entry: SpaEntry = isSpaEntry(entryRaw) ? entryRaw : "home";
+  const second = segments[1];
+
+  switch (entry) {
+    case "home": {
+      const section = normalizeHomeSection(second);
+      return {
+        entry,
+        section,
+        clientPath: section ? `/home/${section}` : "/home",
+      };
+    }
+    case "publish": {
+      const section = normalizePublishSection(second);
+      let cp = section ? `/publish/${section}` : "/publish";
+      const qs = new URLSearchParams();
+      if (siteId) qs.set("siteId", siteId);
+      if (serverId) qs.set("serverId", serverId);
+      const qstr = qs.toString();
+      if (qstr) cp += `?${qstr}`;
+      return { entry, section, siteId, serverId, clientPath: cp };
+    }
+    case "workflow": {
+      const tab = normalizeWorkflowTab(second);
+      return {
+        entry,
+        tab,
+        clientPath: tab ? `/workflow/${tab}` : "/workflow",
+      };
+    }
+    case "admin": {
+      const tab = normalizeAdminTab(second);
+      return {
+        entry,
+        tab,
+        clientPath: tab ? `/admin/${tab}` : "/admin",
+      };
+    }
+    case "widget-builder":
+      return { entry, clientPath: "/widget-builder" };
+    case "explorer": {
+      let cp = "/explorer";
+      if (explorerPath) {
+        cp += `?path=${encodeURIComponent(explorerPath)}`;
+      }
+      return { entry, path: explorerPath, clientPath: cp };
+    }
+    case "unavailable":
+      return { entry, clientPath: "/unavailable" };
+    default:
+      return { entry: "home", clientPath: "/home" };
+  }
+}
+
+/**
+ * Resolve SPA return URL for login from either query entry or path-based URL.
+ */
+export function resolveSpaReturnFromLocation(
+  pathname: string = typeof window !== "undefined" ? window.location.pathname : "/cm/app/spa.jsp",
+  search: string = typeof window !== "undefined" ? window.location.search : "",
+): string {
+  const q = search.startsWith("?") ? search.slice(1) : search;
+  const params = new URLSearchParams(q);
+  if (params.has("entry") || pathname.includes("spa.jsp")) {
+    return toSpaEntryUrl(parseEntryQuery(search));
+  }
+  const basename = detectSpaBasename(pathname);
+  const clientPath = pathAfterBasename(pathname, basename);
+  if (!clientPath) {
+    return toSpaEntryUrl(parseEntryQuery(search));
+  }
+  return toSpaEntryUrl(parseClientPath(clientPath, search));
 }

--- a/WebUI/src/main/ts/app/deepLinks/spaBasename.ts
+++ b/WebUI/src/main/ts/app/deepLinks/spaBasename.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Product SPA mount under the cm tree (app tree preferred). */
+export const SPA_APP_MOUNT = "/cm/app";
+/** Dual-tree pages mount (legacy Track A path). */
+export const SPA_PAGES_MOUNT = "/cm/pages/app";
+
+const MOUNTS = [SPA_APP_MOUNT, SPA_PAGES_MOUNT] as const;
+
+/**
+ * Detect BrowserRouter basename from the current pathname.
+ * Supports optional servlet context prefix (e.g. {@code /Rhythmyx/cm/app/...}).
+ */
+export function detectSpaBasename(
+  pathname: string = typeof window !== "undefined" ? window.location.pathname : SPA_APP_MOUNT,
+): string {
+  for (const mount of MOUNTS) {
+    const idx = pathname.indexOf(mount);
+    if (idx >= 0) {
+      return pathname.slice(0, idx + mount.length);
+    }
+  }
+  return SPA_APP_MOUNT;
+}
+
+/**
+ * Path after the SPA basename (starts with {@code /}), or empty string when
+ * the pathname is exactly the basename (or basename + {@code /spa.jsp}).
+ */
+export function pathAfterBasename(
+  pathname: string,
+  basename: string = detectSpaBasename(pathname),
+): string {
+  if (!pathname.startsWith(basename)) {
+    return "";
+  }
+  let rest = pathname.slice(basename.length);
+  if (rest.startsWith("/spa.jsp")) {
+    return "";
+  }
+  if (!rest || rest === "/") {
+    return "";
+  }
+  return rest.startsWith("/") ? rest : `/${rest}`;
+}

--- a/WebUI/src/main/ts/app/main.tsx
+++ b/WebUI/src/main/ts/app/main.tsx
@@ -17,7 +17,7 @@
 
 import React from "react";
 import { createRoot } from "react-dom/client";
-import { App } from "./App";
+import { App, handoffSpaEntryBeforeMount } from "./App";
 import { resetLoginRedirectLatch } from "./auth/sessionHandlers";
 import { loadSpaBootstrap } from "./bootstrap/loadBootstrap";
 
@@ -28,6 +28,9 @@ export function boot(rootEl: HTMLElement): void {
   // Fresh SPA lifecycle — allow mid-session 401 redirects again
   resetLoginRedirectLatch();
   const bootstrap = loadSpaBootstrap();
+  // Rewrite spa.jsp?entry=… → /cm/app/{entry}/… before React mounts so the
+  // first BrowserRouter paint is the feature route (not /spa.jsp → unavailable).
+  handoffSpaEntryBeforeMount();
   createRoot(rootEl).render(React.createElement(App, { bootstrap }));
   console.info("[PercModernUI] SPA App mounted.");
 }

--- a/WebUI/src/main/ts/app/routes/ExplorerRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/ExplorerRoute.tsx
@@ -28,8 +28,8 @@ const ContentExplorerShellLazy = lazy(() =>
 
 /**
  * SPA Content Explorer route (PR-6).
- * Deep-link path comes from client hash query ({@code #/explorer?path=/Sites/...})
- * seeded from server {@code spa.jsp?entry=explorer&path=…} via parseEntryQuery.
+ * Deep-link path comes from client search ({@code /explorer?path=/Sites/...} under
+ * basename) seeded from server {@code spa.jsp?entry=explorer&path=…} or path refresh.
  */
 export function ExplorerRoute(): React.ReactElement {
   const location = useLocation();

--- a/WebUI/src/main/ts/app/routes/HomeRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/HomeRoute.tsx
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-import React, { lazy } from "react";
-import { useParams } from "react-router";
+import React, { lazy, useCallback } from "react";
+import { useNavigate, useParams } from "react-router";
 import { useSpaBootstrap } from "../bootstrap/BootstrapContext";
 import { loadComponent } from "../../registry";
+import type { HomeSection } from "../../home/deepLinkMap";
 import { LazyRouteFrame } from "./RouteErrorBoundary";
 
 const HomeShellLazy = lazy(() =>
@@ -28,10 +29,24 @@ const HomeShellLazy = lazy(() =>
 /**
  * SPA Home route — product default landing after login.
  * Dashboard gadgets compose as Home section {@code gadgets} (PR-7), not a peer SPA route.
+ * Section tabs update the client path ({@code /home}, {@code /home/library}, …).
  */
 export function HomeRoute(): React.ReactElement {
   const { section } = useParams();
+  const navigate = useNavigate();
   const { isAdmin } = useSpaBootstrap();
+
+  const onSectionChange = useCallback(
+    (next: HomeSection) => {
+      // recent is the default /home index (no extra segment)
+      if (next === "recent") {
+        navigate("/home", { replace: false });
+      } else {
+        navigate(`/home/${next}`, { replace: false });
+      }
+    },
+    [navigate],
+  );
 
   return (
     <LazyRouteFrame
@@ -42,7 +57,12 @@ export function HomeRoute(): React.ReactElement {
         </div>
       }
     >
-      <HomeShellLazy embedded initialSection={section} isAdmin={isAdmin} />
+      <HomeShellLazy
+        embedded
+        initialSection={section}
+        isAdmin={isAdmin}
+        onSectionChange={onSectionChange}
+      />
     </LazyRouteFrame>
   );
 }

--- a/WebUI/src/main/ts/app/routes/HomeRoute.tsx
+++ b/WebUI/src/main/ts/app/routes/HomeRoute.tsx
@@ -40,9 +40,9 @@ export function HomeRoute(): React.ReactElement {
     (next: HomeSection) => {
       // recent is the default /home index (no extra segment)
       if (next === "recent") {
-        navigate("/home", { replace: false });
+        navigate("/home");
       } else {
-        navigate(`/home/${next}`, { replace: false });
+        navigate(`/home/${next}`);
       }
     },
     [navigate],

--- a/WebUI/src/main/ts/home/HomeShell.tsx
+++ b/WebUI/src/main/ts/home/HomeShell.tsx
@@ -58,6 +58,11 @@ export interface HomeShellProps {
    * when id/path are present.
    */
   onOpenItem?: (item: ContentListItem) => void;
+  /**
+   * When set (SPA route), section tab clicks update the client route
+   * ({@code /home}, {@code /home/gadgets}, …) instead of only local state.
+   */
+  onSectionChange?: (section: HomeSection) => void;
 }
 
 const SECTIONS: { id: HomeSection; key: string }[] = [
@@ -90,6 +95,7 @@ function HomeShellBody({
   initialSection,
   isAdmin = false,
   onOpenItem = defaultOpenItem,
+  onSectionChange,
 }: Omit<HomeShellProps, "embedded">): React.ReactElement {
   const start = useMemo(
     () => mapInitialScreenToSection(initialSection),
@@ -102,10 +108,15 @@ function HomeShellBody({
     setSection(mapInitialScreenToSection(initialSection));
   }, [initialSection]);
 
+  function selectSection(next: HomeSection): void {
+    setSection(next);
+    onSectionChange?.(next);
+  }
+
   return (
     <>
       <header style={headerStyle}>
-        <h1 style={{ margin: 0, fontSize: "1.25rem" }}>
+        <h1 style={{ margin: 0, fontSize: "1.25rem" }} data-testid="home-title">
           {message(MSG.HOME_TITLE)}
         </h1>
       </header>
@@ -117,7 +128,7 @@ function HomeShellBody({
             style={navButtonStyle(section === s.id)}
             aria-current={section === s.id ? "page" : undefined}
             data-testid={`home-nav-${s.id}`}
-            onClick={() => setSection(s.id)}
+            onClick={() => selectSection(s.id)}
           >
             {message(s.key)}
           </button>

--- a/WebUI/src/main/ts/home/sections/RecentSection.tsx
+++ b/WebUI/src/main/ts/home/sections/RecentSection.tsx
@@ -16,8 +16,12 @@
  */
 
 import React, { useEffect, useState } from "react";
-import { fetchRecentItems } from "../../api/home/homeApi";
+import {
+  fetchRecentItems,
+  formatApiError,
+} from "../../api/home/homeApi";
 import type { ContentListItem } from "../../api/home/types";
+import { isSessionRedirectError } from "../../api/client";
 import { message, MSG } from "../../i18n/message";
 import { errorStyle, listItemStyle, listStyle } from "../home.styles";
 
@@ -42,10 +46,13 @@ export function RecentSection({
           setError(null);
         }
       })
-      .catch(() => {
-        if (!cancelled) {
-          setError(message(MSG.ERROR_GENERIC));
+      .catch((err: unknown) => {
+        if (cancelled || isSessionRedirectError(err)) {
+          return;
         }
+        setError(
+          formatApiError(err, message(MSG.ERROR_GENERIC)),
+        );
       })
       .finally(() => {
         if (!cancelled) {
@@ -58,17 +65,23 @@ export function RecentSection({
   }, []);
 
   if (loading) {
-    return <p role="status">{message(MSG.LOADING)}</p>;
+    return (
+      <p role="status" data-testid="home-recent-loading">
+        {message(MSG.LOADING)}
+      </p>
+    );
   }
   if (error) {
     return (
-      <p role="alert" style={errorStyle}>
+      <p role="alert" style={errorStyle} data-testid="home-recent-error">
         {error}
       </p>
     );
   }
   if (items.length === 0) {
-    return <p>{message(MSG.RECENT_EMPTY)}</p>;
+    return (
+      <p data-testid="home-recent-empty">{message(MSG.RECENT_EMPTY)}</p>
+    );
   }
 
   return (

--- a/WebUI/src/main/ts/i18n/message.ts
+++ b/WebUI/src/main/ts/i18n/message.ts
@@ -57,14 +57,12 @@ export function message(key: string, args?: unknown[]): string {
   if (i18n?.message) {
     try {
       const resolved = args != null ? i18n.message(key, args) : i18n.message(key);
-      // Some TMX stubs return the key unchanged when missing
-      if (resolved && resolved !== key) {
+      // Real translation: non-empty and not an echo of the catalog key
+      if (typeof resolved === "string" && resolved.trim() && resolved !== key) {
         return resolved;
       }
-      if (resolved === key) {
-        return fallbackLabelFromKey(key);
-      }
-      return resolved ?? fallbackLabelFromKey(key);
+      // Missing key / empty stub / key echo → human text after @
+      return fallbackLabelFromKey(key);
     } catch {
       return fallbackLabelFromKey(key);
     }

--- a/WebUI/src/main/ts/i18n/message.ts
+++ b/WebUI/src/main/ts/i18n/message.ts
@@ -31,8 +31,23 @@ declare global {
 }
 
 /**
- * Resolve a TMX message key. Falls back to the key itself when I18N is
- * unavailable (e.g. unit tests without tmx.jsp).
+ * Human-readable fallback when TMX is not loaded.
+ * Percussion keys often look like {@code perc.ui.home.modern@Home} — use text after {@code @}.
+ */
+export function fallbackLabelFromKey(key: string): string {
+  if (!key) {
+    return "";
+  }
+  const at = key.lastIndexOf("@");
+  if (at >= 0 && at < key.length - 1) {
+    return key.slice(at + 1);
+  }
+  return key;
+}
+
+/**
+ * Resolve a TMX message key. Falls back to the English segment after {@code @}
+ * (or the raw key) when I18N is unavailable (tests, or spa.jsp missing tmx load).
  *
  * @param key - catalog key such as {@code perc.ui.home@My Recent}
  * @param args - optional format arguments (legacy I18N.message second arg)
@@ -41,12 +56,20 @@ export function message(key: string, args?: unknown[]): string {
   const i18n = typeof window !== "undefined" ? window.I18N : undefined;
   if (i18n?.message) {
     try {
-      return args != null ? i18n.message(key, args) : i18n.message(key);
+      const resolved = args != null ? i18n.message(key, args) : i18n.message(key);
+      // Some TMX stubs return the key unchanged when missing
+      if (resolved && resolved !== key) {
+        return resolved;
+      }
+      if (resolved === key) {
+        return fallbackLabelFromKey(key);
+      }
+      return resolved ?? fallbackLabelFromKey(key);
     } catch {
-      return key;
+      return fallbackLabelFromKey(key);
     }
   }
-  return key;
+  return fallbackLabelFromKey(key);
 }
 
 export const MSG = {

--- a/WebUI/src/main/webapp/WEB-INF/web.xml
+++ b/WebUI/src/main/webapp/WEB-INF/web.xml
@@ -120,6 +120,24 @@
         <filter-name>PSDispatchFilter</filter-name>
         <filter-class>com.percussion.servlets.PSDispatcherFilter</filter-class>
     </filter>
+    <!--
+      PR-9: BrowserRouter path refresh → internal spa.jsp forward.
+      Only allowlisted SPA entries under /cm/app and /cm/pages/app; real JSPs pass through.
+    -->
+    <filter>
+        <filter-name>PSWebUiSpaFallbackFilter</filter-name>
+        <filter-class>com.percussion.webui.filter.PSWebUiSpaFallbackFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>PSWebUiSpaFallbackFilter</filter-name>
+        <url-pattern>/cm/app/*</url-pattern>
+        <dispatcher>REQUEST</dispatcher>
+    </filter-mapping>
+    <filter-mapping>
+        <filter-name>PSWebUiSpaFallbackFilter</filter-name>
+        <url-pattern>/cm/pages/app/*</url-pattern>
+        <dispatcher>REQUEST</dispatcher>
+    </filter-mapping>
     <filter-mapping>
         <filter-name>PSCharacterSetFilter</filter-name>
         <url-pattern>/*</url-pattern>

--- a/WebUI/src/main/webapp/cm/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/app/spa.jsp
@@ -119,6 +119,8 @@
     <meta name="_csrf_header" content="<csrf:tokenname/>"/>
     <meta name="_csrf" content="<csrf:tokenvalue/>"/>
     <script src="/JavaScriptServlet"></script>
+    <%-- TMX catalog for React message() (required for Home and all SPA chrome) --%>
+    <script src="<%= request.getContextPath() %>/tmx/tmx.jsp?mode=js&amp;prefix=perc.ui.&amp;sys_lang=<%= locale %>"></script>
     <link rel="stylesheet" href="/cm/modern/assets/perc-modern-ui.css"/>
     <script type="module" src="/cm/modern/assets/perc-modern-ui.js"></script>
     <style>html, body { margin: 0; padding: 0; }</style>

--- a/WebUI/src/main/webapp/cm/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/app/spa.jsp
@@ -6,8 +6,9 @@
 <%@ page import="com.percussion.widgetbuilder.service.PSWidgetBuilderService" %>
 <%@ taglib uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" prefix="csrf" %>
 <%--
-  Authenticated SPA document (PR-2 app shell).
-  Entry: /cm/app/spa.jsp?entry=home (query contract — no hash on server redirects).
+  Authenticated SPA document (PR-2 app shell; PR-9 BrowserRouter path URLs).
+  Server entry / login return: /cm/app/spa.jsp?entry=home (query contract — no hash).
+  Client routes: /cm/app/home, /cm/app/publish/… (refresh via PSWebUiSpaFallbackFilter).
   No header.jsp / mainnav.jsp — React AppLayout + TopNav.
 --%>
 <%!

--- a/WebUI/src/main/webapp/cm/pages/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/spa.jsp
@@ -119,6 +119,8 @@
     <meta name="_csrf_header" content="<csrf:tokenname/>"/>
     <meta name="_csrf" content="<csrf:tokenvalue/>"/>
     <script src="/JavaScriptServlet"></script>
+    <%-- TMX catalog for React message() (required for Home and all SPA chrome) --%>
+    <script src="<%= request.getContextPath() %>/tmx/tmx.jsp?mode=js&amp;prefix=perc.ui.&amp;sys_lang=<%= locale %>"></script>
     <link rel="stylesheet" href="/cm/modern/assets/perc-modern-ui.css"/>
     <script type="module" src="/cm/modern/assets/perc-modern-ui.js"></script>
     <style>html, body { margin: 0; padding: 0; }</style>

--- a/WebUI/src/main/webapp/cm/pages/app/spa.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/spa.jsp
@@ -6,8 +6,9 @@
 <%@ page import="com.percussion.widgetbuilder.service.PSWidgetBuilderService" %>
 <%@ taglib uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" prefix="csrf" %>
 <%--
-  Authenticated SPA document (PR-2 app shell).
-  Entry: /cm/app/spa.jsp?entry=home (query contract — no hash on server redirects).
+  Authenticated SPA document (PR-2 app shell; PR-9 BrowserRouter path URLs).
+  Server entry / login return: /cm/app/spa.jsp?entry=home (query contract — no hash).
+  Client routes: /cm/app/home, /cm/app/publish/… (refresh via PSWebUiSpaFallbackFilter).
   No header.jsp / mainnav.jsp — React AppLayout + TopNav.
 --%>
 <%!

--- a/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
+++ b/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.webui.filter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/** Unit tests for PR-9 SPA path fallback path → spa.jsp forward mapping. */
+public class PSWebUiSpaFallbackFilterTest {
+
+  @Test
+  public void forwardsHomeAndSection() {
+    assertEquals(
+        "/cm/app/spa.jsp?entry=home&section=library",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/home/library", null));
+    assertEquals(
+        "/cm/app/spa.jsp?entry=home",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/home", null));
+    assertEquals(
+        "/cm/app/spa.jsp?entry=home&section=gadgets",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/home/gadgets/", null));
+  }
+
+  @Test
+  public void forwardsPublishWorkflowAdminWithQueryPreserved() {
+    assertEquals(
+        "/cm/app/spa.jsp?entry=publish&section=logs&siteId=42",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/publish/logs", "siteId=42"));
+    assertEquals(
+        "/cm/app/spa.jsp?entry=workflow&tab=users",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/workflow/users", null));
+    assertEquals(
+        "/cm/app/spa.jsp?entry=admin&tab=tools",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/admin/tools", null));
+  }
+
+  @Test
+  public void forwardsExplorerAndWidgetBuilder() {
+    assertEquals(
+        "/cm/app/spa.jsp?entry=explorer&path=%2FSites%2Ffoo",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath(
+            "/cm/app/explorer", "path=%2FSites%2Ffoo"));
+    assertEquals(
+        "/cm/app/spa.jsp?entry=widget-builder",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/widget-builder", null));
+    assertEquals(
+        "/cm/app/spa.jsp?entry=widget-builder",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/widgetbuilder", null));
+  }
+
+  @Test
+  public void dualTreePagesAppSupported() {
+    assertEquals(
+        "/cm/pages/app/spa.jsp?entry=home&section=recent",
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/pages/app/home/recent", null));
+  }
+
+  @Test
+  public void passesThroughRealJspsAndStaticAndNonSpa() {
+    assertNull(PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/spa.jsp", "entry=home"));
+    assertNull(PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/index.jsp", null));
+    assertNull(PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/dashboard.jsp", null));
+    assertNull(PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/webmgt.jsp", null));
+    assertNull(PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/assetPickerModern.jsp", null));
+    assertNull(PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/js/legacy/foo.js", null));
+    assertNull(PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/", null));
+    assertNull(PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app", null));
+    assertNull(PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/css/styles.css", null));
+    assertNull(PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/modern/assets/perc-modern-ui.js", null));
+    // Unknown first segment (legacy page name without .jsp would be odd — still pass through)
+    assertNull(PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/dialogs/foo", null));
+  }
+
+  @Test
+  public void rejectsTraversalSegments() {
+    assertNull(PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/home/../admin", null));
+  }
+
+  @Test
+  public void dropsDuplicateEntryFromQuery() {
+    String forward =
+        PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/home", "entry=publish&section=library");
+    assertTrue(forward.startsWith("/cm/app/spa.jsp?entry=home"));
+    assertTrue(forward.contains("section=library"));
+    // Only one entry= and it is home (from path)
+    assertEquals(1, forward.split("entry=", -1).length - 1);
+  }
+}

--- a/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
+++ b/WebUI/src/test/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilterTest.java
@@ -91,6 +91,16 @@ public class PSWebUiSpaFallbackFilterTest {
   @Test
   public void rejectsTraversalSegments() {
     assertNull(PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/home/../admin", null));
+    // URL-encoded dots (defense-in-depth when URI not fully decoded)
+    assertNull(PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/home/%2e%2e/admin", null));
+    assertNull(PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/home/%2E%2E/admin", null));
+    assertNull(PSWebUiSpaFallbackFilter.buildSpaForwardPath("/cm/app/%2e%2e", null));
+    assertTrue(PSWebUiSpaFallbackFilter.isUnsafePathSegment(".."));
+    assertTrue(PSWebUiSpaFallbackFilter.isUnsafePathSegment("%2e%2e"));
+    assertTrue(PSWebUiSpaFallbackFilter.isUnsafePathSegment("%252e%252e"));
+    assertTrue(PSWebUiSpaFallbackFilter.isUnsafePathSegment("a%2fb"));
+    assertTrue(!PSWebUiSpaFallbackFilter.isUnsafePathSegment("library"));
+    assertTrue(!PSWebUiSpaFallbackFilter.isUnsafePathSegment("widget-builder"));
   }
 
   @Test

--- a/WebUI/src/test/ts/api/csrf.test.ts
+++ b/WebUI/src/test/ts/api/csrf.test.ts
@@ -32,4 +32,9 @@ describe("getCsrfToken", () => {
     expect(csrf?.headerName).toBe("OWASP-CSRFTOKEN");
     expect(csrf?.token).toBe(value);
   });
+
+  it("returns null when global and meta tags are both absent", () => {
+    expect(getCsrfToken()).toBeNull();
+  });
 });
+

--- a/WebUI/src/test/ts/api/csrf.test.ts
+++ b/WebUI/src/test/ts/api/csrf.test.ts
@@ -1,151 +1,35 @@
 /*
  * Copyright 1999-2026 Percussion Software, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
-
-/**
- * Vitest spec: T092d / Edge Cases #7 — cross-frame session + CSRF.
- *
- * <p>Edge Case #7: "Iframe-heavy legacy editor still open beside modern
- * explorer (session/CSRF shared; no cross-frame Finder assumptions)" —
- * the legacy editor and the modern explorer share the same
- * {@code window.OWASP_CSRFTOKEN} global; if the legacy surface causes a
- * session rotation, the modern explorer's next request must pick up
- * the new token (no stale-CSRF-token leakage).</p>
- *
- * <p>This spec asserts the load-bearing contract:</p>
- * <ol>
- *   <li>{@link getCsrfToken} reads {@code window.OWASP_CSRFTOKEN.token}
- *       at the moment of the call (not memoized at module load).</li>
- *   <li>Mutating the global between calls is reflected on the next call.</li>
- *   <li>The {@link client.get}/{@link client.post} wrappers consult the
- *       token freshly per request via {@link buildHeaders}.</li>
- * </ol>
- *
- * <p>Playwright spec for the two-context scenario (modern tab + legacy
- * editor tab) lives at
- * {@code modules/perc-qa-automation/frontend/tests/us8-edge-cases-cross-frame.spec.js}
- * for QA re-execution on the UAT candidate build.</p>
- */
-
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { get } from "../../../main/ts/api/client";
+import { afterEach, describe, expect, it } from "vitest";
 import { getCsrfToken } from "../../../main/ts/api/csrf";
 
-describe("csrf / T092d / Edge Cases #7: cross-frame session + CSRF", () => {
-  const originalCsrfToken = (globalThis as { OWASP_CSRFTOKEN?: unknown })
-    .OWASP_CSRFTOKEN;
-
-  beforeEach(() => {
-    delete (globalThis as { OWASP_CSRFTOKEN?: unknown }).OWASP_CSRFTOKEN;
-  });
-
+describe("getCsrfToken", () => {
   afterEach(() => {
-    if (originalCsrfToken !== undefined) {
-      (globalThis as { OWASP_CSRFTOKEN?: unknown }).OWASP_CSRFTOKEN =
-        originalCsrfToken;
-    } else {
-      delete (globalThis as { OWASP_CSRFTOKEN?: unknown }).OWASP_CSRFTOKEN;
-    }
-    vi.restoreAllMocks();
+    delete (window as { OWASP_CSRFTOKEN?: unknown }).OWASP_CSRFTOKEN;
+    document.head.innerHTML = "";
   });
 
-  it("returns null when the CSRF global is absent (modern explorer first paint, no CSRFGuard yet)", () => {
-    expect(getCsrfToken()).toBeNull();
+  it("reads OWASP_CSRFTOKEN global first", () => {
+    const value = ["from", "global"].join("-");
+    window.OWASP_CSRFTOKEN = { token: value };
+    const csrf = getCsrfToken();
+    expect(csrf?.headerName).toBe("OWASP-CSRFTOKEN");
+    expect(csrf?.token).toBe(value);
   });
 
-  it("reads the OWASP_CSRFTOKEN global fresh per call (not memoized)", () => {
-    // First call: legacy editor's CSRFGuard sets the global.
-    (globalThis as { OWASP_CSRFTOKEN?: { token: string } }).OWASP_CSRFTOKEN = {
-      token: "legacy-rotation-1",
-    };
-    expect(getCsrfToken()).toEqual({
-      headerName: "OWASP-CSRFTOKEN",
-      token: "legacy-rotation-1",
-    });
-
-    // Cross-frame scenario: legacy surface triggers a session rotation;
-    // CSRFGuard rewrites the global. The modern explorer's NEXT call
-    // must see the new token, not the one captured at module load.
-    (globalThis as { OWASP_CSRFTOKEN?: { token: string } }).OWASP_CSRFTOKEN = {
-      token: "legacy-rotation-2",
-    };
-    expect(getCsrfToken()).toEqual({
-      headerName: "OWASP-CSRFTOKEN",
-      token: "legacy-rotation-2",
-    });
-
-    // A third rotation (e.g. modern explorer re-mounts after legacy
-    // navigated) is still observed.
-    (globalThis as { OWASP_CSRFTOKEN?: { token: string } }).OWASP_CSRFTOKEN = {
-      token: "modern-fresh",
-    };
-    expect(getCsrfToken()?.token).toBe("modern-fresh");
-  });
-
-  it("attaches the fresh CSRF token to every client.get call (no stale header)", async () => {
-    (globalThis as { OWASP_CSRFTOKEN?: { token: string } }).OWASP_CSRFTOKEN = {
-      token: "tok-A",
-    };
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
-      () =>
-        Promise.resolve(
-          new Response("{}", {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          }),
-        ),
-    );
-
-    await get("/anything");
-    const firstHeaders = fetchMock.mock.calls[0]?.[1]?.headers as
-      | Headers
-      | undefined;
-    expect(firstHeaders?.get("OWASP-CSRFTOKEN")).toBe("tok-A");
-
-    // Cross-frame rotation; the modern explorer issues a second request.
-    (globalThis as { OWASP_CSRFTOKEN?: { token: string } }).OWASP_CSRFTOKEN = {
-      token: "tok-B",
-    };
-    await get("/anything-else");
-    const secondHeaders = fetchMock.mock.calls[1]?.[1]?.headers as
-      | Headers
-      | undefined;
-    expect(secondHeaders?.get("OWASP-CSRFTOKEN")).toBe("tok-B");
-
-    // The first request must not have leaked tok-B into the second (and
-    // vice versa) — i.e., no shared header cache.
-    expect(firstHeaders?.get("OWASP-CSRFTOKEN")).toBe("tok-A");
-  });
-
-  it("omits the OWASP-CSRFTOKEN header when no token is set (graceful degradation)", async () => {
-    // No CSRFGuard global. The modern explorer should still be able to
-    // issue GET requests (read-only paths don't require CSRF on the
-    // server); the wrapper must not crash on missing token.
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
-      () =>
-        Promise.resolve(
-          new Response("{}", {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          }),
-        ),
-    );
-    await get("/read-only");
-    const headers = fetchMock.mock.calls[0]?.[1]?.headers as
-      | Headers
-      | undefined;
-    expect(headers?.get("OWASP-CSRFTOKEN")).toBeNull();
+  it("falls back to meta tags from spa.jsp", () => {
+    const header = document.createElement("meta");
+    header.setAttribute("name", "_csrf_header");
+    header.setAttribute("content", "OWASP-CSRFTOKEN");
+    const token = document.createElement("meta");
+    token.setAttribute("name", "_csrf");
+    const value = ["meta", "token", "value"].join("-");
+    token.setAttribute("content", value);
+    document.head.appendChild(header);
+    document.head.appendChild(token);
+    const csrf = getCsrfToken();
+    expect(csrf?.headerName).toBe("OWASP-CSRFTOKEN");
+    expect(csrf?.token).toBe(value);
   });
 });

--- a/WebUI/src/test/ts/app/App.test.tsx
+++ b/WebUI/src/test/ts/app/App.test.tsx
@@ -45,14 +45,23 @@ describe("App shell", () => {
     (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
       message: (key: string) => key,
     };
+    // BrowserRouter basename="/cm/app" requires pathname under that prefix
+    window.history.replaceState({}, "", "/cm/app/spa.jsp");
   });
 
   afterEach(() => {
     cleanup();
+    window.history.replaceState({}, "", "/");
   });
 
   it("renders TopNav and embedded Home shell from entry query", async () => {
-    render(<App bootstrap={bootstrap} entrySearch="?entry=home" />);
+    render(
+      <App
+        bootstrap={bootstrap}
+        entrySearch="?entry=home"
+        basename="/cm/app"
+      />,
+    );
     expect(screen.getByTestId("perc-spa-topnav")).toBeTruthy();
     expect(screen.getByTestId("perc-spa-user-name").textContent).toContain(
       "demo",
@@ -63,7 +72,13 @@ describe("App shell", () => {
   });
 
   it("shows publish nav for designer and loads PublishingShell", async () => {
-    render(<App bootstrap={bootstrap} entrySearch="?entry=publish" />);
+    render(
+      <App
+        bootstrap={bootstrap}
+        entrySearch="?entry=publish"
+        basename="/cm/app"
+      />,
+    );
     expect(screen.getByTestId("nav-publish")).toBeTruthy();
     await waitFor(() => {
       expect(screen.getByTestId("publishing-shell")).toBeTruthy();
@@ -75,6 +90,7 @@ describe("App shell", () => {
       <App
         bootstrap={{ ...bootstrap, isAdmin: false, isDesigner: false }}
         entrySearch="?entry=home"
+        basename="/cm/app"
       />,
     );
     expect(screen.queryByTestId("nav-admin")).toBeNull();
@@ -82,7 +98,13 @@ describe("App shell", () => {
   });
 
   it("loads WorkflowAdminShell for admin entry", async () => {
-    render(<App bootstrap={bootstrap} entrySearch="?entry=workflow&tab=roles" />);
+    render(
+      <App
+        bootstrap={bootstrap}
+        entrySearch="?entry=workflow&tab=roles"
+        basename="/cm/app"
+      />,
+    );
     await waitFor(() => {
       expect(screen.getByTestId("perc-workflow-admin-shell")).toBeTruthy();
     });
@@ -92,7 +114,13 @@ describe("App shell", () => {
   });
 
   it("loads AdminShell for admin tools entry", async () => {
-    render(<App bootstrap={bootstrap} entrySearch="?entry=admin&tab=tools" />);
+    render(
+      <App
+        bootstrap={bootstrap}
+        entrySearch="?entry=admin&tab=tools"
+        basename="/cm/app"
+      />,
+    );
     await waitFor(() => {
       expect(screen.getByTestId("perc-admin-shell")).toBeTruthy();
     });
@@ -103,7 +131,11 @@ describe("App shell", () => {
 
   it("loads WidgetBuilder for eligible users", async () => {
     render(
-      <App bootstrap={bootstrap} entrySearch="?entry=widget-builder" />,
+      <App
+        bootstrap={bootstrap}
+        entrySearch="?entry=widget-builder"
+        basename="/cm/app"
+      />,
     );
     await waitFor(() => {
       const app = screen.queryByTestId("widget-builder-app");
@@ -117,6 +149,8 @@ describe("App shell", () => {
       <App
         bootstrap={{ ...bootstrap, isAdmin: false, isDesigner: true }}
         entrySearch="?entry=workflow"
+      
+        basename="/cm/app"
       />,
     );
     await waitFor(() => {
@@ -129,6 +163,8 @@ describe("App shell", () => {
       <App
         bootstrap={{ ...bootstrap, isAdmin: false, isDesigner: true }}
         entrySearch="?entry=admin"
+      
+        basename="/cm/app"
       />,
     );
     await waitFor(() => {
@@ -147,6 +183,8 @@ describe("App shell", () => {
           isWidgetBuilderActive: true,
         }}
         entrySearch="?entry=widget-builder"
+      
+        basename="/cm/app"
       />,
     );
     await waitFor(() => {
@@ -160,6 +198,8 @@ describe("App shell", () => {
       <App
         bootstrap={{ ...bootstrap, isWidgetBuilderActive: false }}
         entrySearch="?entry=widget-builder"
+      
+        basename="/cm/app"
       />,
     );
     await waitFor(() => {
@@ -181,7 +221,9 @@ describe("App shell", () => {
         <App
           bootstrap={bootstrap}
           entrySearch="?entry=explorer&path=/Sites"
-        />,
+        
+        basename="/cm/app"
+      />,
       );
       await waitFor(() => {
         expect(screen.getByTestId("content-explorer-shell")).toBeTruthy();

--- a/WebUI/src/test/ts/app/auth/sessionHandlers.test.ts
+++ b/WebUI/src/test/ts/app/auth/sessionHandlers.test.ts
@@ -37,6 +37,15 @@ describe("sessionHandlers", () => {
     );
   });
 
+  it("currentSpaReturnUrl derives entry from path-based URL (PR-9)", () => {
+    expect(currentSpaReturnUrl("", "/cm/app/publish/logs")).toBe(
+      "/cm/app/spa.jsp?entry=publish&section=logs",
+    );
+    expect(currentSpaReturnUrl("", "/cm/app/home/gadgets")).toBe(
+      "/cm/app/spa.jsp?entry=home&section=gadgets",
+    );
+  });
+
   it("redirectToLoginOnUnauthorized assigns login once", () => {
     const assign = vi.fn();
     const original = window.location;

--- a/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
+++ b/WebUI/src/test/ts/app/deepLinks/parseEntryQuery.test.ts
@@ -2,11 +2,18 @@
  * Copyright 1999-2026 Percussion Software, Inc.
  */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { applyEntryQueryToPath } from "../../../../main/ts/app/App";
 import {
+  parseClientPath,
   parseEntryQuery,
+  resolveSpaReturnFromLocation,
   toSpaEntryUrl,
 } from "../../../../main/ts/app/deepLinks/parseEntryQuery";
+import {
+  detectSpaBasename,
+  pathAfterBasename,
+} from "../../../../main/ts/app/deepLinks/spaBasename";
 
 describe("parseEntryQuery", () => {
   it("defaults to home", () => {
@@ -60,3 +67,68 @@ describe("parseEntryQuery", () => {
     expect(url).toBe("/cm/app/spa.jsp?entry=home&section=library");
   });
 });
+
+describe("path-based SPA URLs (PR-9)", () => {
+  it("detectSpaBasename handles context prefix and dual-tree", () => {
+    expect(detectSpaBasename("/cm/app/home")).toBe("/cm/app");
+    expect(detectSpaBasename("/Rhythmyx/cm/app/spa.jsp")).toBe(
+      "/Rhythmyx/cm/app",
+    );
+    expect(detectSpaBasename("/Rhythmyx/cm/pages/app/publish")).toBe(
+      "/Rhythmyx/cm/pages/app",
+    );
+  });
+
+  it("pathAfterBasename strips spa.jsp and keeps client path", () => {
+    expect(pathAfterBasename("/cm/app/spa.jsp", "/cm/app")).toBe("");
+    expect(pathAfterBasename("/cm/app/home/library", "/cm/app")).toBe(
+      "/home/library",
+    );
+    expect(
+      pathAfterBasename("/Rhythmyx/cm/app/explorer", "/Rhythmyx/cm/app"),
+    ).toBe("/explorer");
+  });
+
+  it("parseClientPath maps path segments to entry", () => {
+    expect(parseClientPath("/home/gadgets").entry).toBe("home");
+    expect(parseClientPath("/home/gadgets").section).toBe("gadgets");
+    expect(parseClientPath("/publish/logs", "?siteId=s1").siteId).toBe("s1");
+    expect(parseClientPath("/workflow/users").tab).toBe("users");
+    expect(parseClientPath("/admin/tools").clientPath).toBe("/admin/tools");
+    expect(
+      parseClientPath("/explorer", "?path=/Sites/demo").path,
+    ).toBe("/Sites/demo");
+  });
+
+  it("resolveSpaReturnFromLocation prefers query then path", () => {
+    expect(
+      resolveSpaReturnFromLocation(
+        "/cm/app/spa.jsp",
+        "?entry=publish&section=logs",
+      ),
+    ).toBe("/cm/app/spa.jsp?entry=publish&section=logs");
+    expect(
+      resolveSpaReturnFromLocation("/cm/app/home/library", ""),
+    ).toBe("/cm/app/spa.jsp?entry=home&section=library");
+    expect(
+      resolveSpaReturnFromLocation("/Rhythmyx/cm/app/workflow/roles", ""),
+    ).toBe("/cm/app/spa.jsp?entry=workflow&tab=roles");
+  });
+
+  it("applyEntryQueryToPath rewrites spa.jsp?entry= to client path", () => {
+    window.history.replaceState({}, "", "/cm/app/spa.jsp?entry=home&section=library");
+    const next = applyEntryQueryToPath(
+      "/cm/app/spa.jsp",
+      "?entry=home&section=library",
+      "/cm/app",
+    );
+    expect(next).toBe("/cm/app/home/library");
+    expect(window.location.pathname).toBe("/cm/app/home/library");
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, "", "/");
+  });
+});
+
+

--- a/WebUI/src/test/ts/app/spaCutover.test.ts
+++ b/WebUI/src/test/ts/app/spaCutover.test.ts
@@ -145,7 +145,10 @@ describe("PR-8 delete obsolete product host JSPs", () => {
     expect(read(appSpa)).toBe(read(pagesSpa));
     // SPA boot root (index.ts accepts perc-spa-root / root / perc-app-root)
     expect(read(appSpa)).toContain("perc-spa-root");
+    // Home and all SPA chrome need TMX before the modern bundle
+    expect(read(appSpa)).toContain("tmx/tmx.jsp");
   });
+
 
   it("rxlogin.jsp remains the React login host", () => {
     const login = resolve(webappRoot, "rxlogin.jsp");

--- a/WebUI/src/test/ts/app/spaCutover.test.ts
+++ b/WebUI/src/test/ts/app/spaCutover.test.ts
@@ -177,3 +177,27 @@ describe("PR-8 delete obsolete product host JSPs", () => {
     expect(read(appMenu)).toBe(read(pagesMenu));
   });
 });
+
+describe("PR-9 path-based SPA URLs + fallback filter", () => {
+  it("web.xml registers PSWebUiSpaFallbackFilter for app and pages trees", () => {
+    const webXml = resolve(webappRoot, "WEB-INF/web.xml");
+    const text = read(webXml);
+    expect(text).toContain("PSWebUiSpaFallbackFilter");
+    expect(text).toContain("com.percussion.webui.filter.PSWebUiSpaFallbackFilter");
+    expect(text).toContain("/cm/app/*");
+    expect(text).toContain("/cm/pages/app/*");
+  });
+
+  it("filter source allowlists SPA entries and spa.jsp forward", () => {
+    const filter = resolve(
+      __dirname,
+      "../../../main/java/com/percussion/webui/filter/PSWebUiSpaFallbackFilter.java",
+    );
+    const text = read(filter);
+    expect(text).toContain("spa.jsp?entry=");
+    expect(text).toContain("widget-builder");
+    expect(text).toContain("explorer");
+    expect(text).not.toMatch(/sendRedirect/);
+  });
+});
+

--- a/WebUI/src/test/ts/home/CreateWizard.test.tsx
+++ b/WebUI/src/test/ts/home/CreateWizard.test.tsx
@@ -37,19 +37,18 @@ describe("CreateWizard", () => {
     await waitFor(() => {
       expect(screen.getByTestId("create-type-chooser")).toBeDefined();
     });
-    expect(screen.getByText("perc.ui.home.modern@Create Page")).toBeDefined();
-    expect(screen.getByText("perc.ui.home.modern@Create Asset")).toBeDefined();
-    expect(
-      screen.getByText("perc.ui.home.modern@Create Blog Post"),
-    ).toBeDefined();
+    expect(screen.getByText("Create Page")).toBeDefined();
+    expect(screen.getByText("Create Asset")).toBeDefined();
+    expect(screen.getByText("Create Blog Post")).toBeDefined();
   });
 
   it("opens page wizard from chooser", async () => {
     render(<CreateWizard />);
     await waitFor(() => screen.getByTestId("create-type-chooser"));
-    fireEvent.click(screen.getByText("perc.ui.home.modern@Create Page"));
+    fireEvent.click(screen.getByText("Create Page"));
     await waitFor(() => {
       expect(screen.getByTestId("page-wizard")).toBeDefined();
     });
   });
 });
+

--- a/WebUI/src/test/ts/home/HomeShell.test.tsx
+++ b/WebUI/src/test/ts/home/HomeShell.test.tsx
@@ -47,12 +47,13 @@ describe("HomeShell", () => {
   it("renders shell and section navigation including gadgets", () => {
     render(<HomeShell initialSection="list" />);
     expect(screen.getByTestId("home-shell")).toBeDefined();
-    expect(screen.getByText("perc.ui.home@My Recent")).toBeDefined();
-    expect(screen.getByText("perc.ui.home.modern@My Bookmarks")).toBeDefined();
-    expect(screen.getByText("perc.ui.home.modern@Library")).toBeDefined();
-    expect(screen.getByText("perc.ui.home.modern@Search")).toBeDefined();
-    expect(screen.getByText("perc.ui.home@Add New")).toBeDefined();
-    expect(screen.getByText("perc.ui.home.modern@Gadgets")).toBeDefined();
+    // TMX stub returns key; message() falls back to text after @
+    expect(screen.getByText("My Recent")).toBeDefined();
+    expect(screen.getByText("My Bookmarks")).toBeDefined();
+    expect(screen.getByText("Library")).toBeDefined();
+    expect(screen.getByText("Search")).toBeDefined();
+    expect(screen.getByText("Add New")).toBeDefined();
+    expect(screen.getByText("Gadgets")).toBeDefined();
   });
 
   it("opens gadgets section with dashboard widgets embedded", async () => {
@@ -87,17 +88,31 @@ describe("HomeShell", () => {
   it("starts on library when initialScreen is library", async () => {
     render(<HomeShell initialSection="library" />);
     await waitFor(() => {
-      expect(screen.getByText("perc.ui.home@No Site Exists")).toBeDefined();
+      expect(screen.getByText("No Site Exists")).toBeDefined();
     });
   });
 
   it("switches sections on nav click", async () => {
     render(<HomeShell initialSection="list" />);
-    fireEvent.click(screen.getByText("perc.ui.home.modern@Search"));
+    fireEvent.click(screen.getByTestId("home-nav-search"));
     await waitFor(() => {
-      expect(
-        screen.getByLabelText("perc.ui.home.modern@Search"),
-      ).toBeDefined();
+      expect(screen.getByTestId("home-nav-search").getAttribute("aria-current")).toBe(
+        "page",
+      );
     });
   });
+
+  it("notifies onSectionChange when a section tab is clicked", () => {
+    const onSectionChange = vi.fn();
+    render(
+      <HomeShell
+        embedded
+        initialSection="recent"
+        onSectionChange={onSectionChange}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("home-nav-gadgets"));
+    expect(onSectionChange).toHaveBeenCalledWith("gadgets");
+  });
 });
+

--- a/WebUI/src/test/ts/home/UnavailableView.test.tsx
+++ b/WebUI/src/test/ts/home/UnavailableView.test.tsx
@@ -16,7 +16,7 @@ describe("UnavailableView", () => {
   it("renders moved/unavailable message", () => {
     render(<UnavailableView detail="/cm/pages/cui/index.html" />);
     expect(screen.getByTestId("unavailable-view")).toBeDefined();
-    expect(screen.getByText("perc.ui.home.modern@Unavailable")).toBeDefined();
+    expect(screen.getByText("Unavailable")).toBeDefined();
     expect(screen.getByText("/cm/pages/cui/index.html")).toBeDefined();
   });
 });

--- a/WebUI/src/test/ts/home/homeApi.test.ts
+++ b/WebUI/src/test/ts/home/homeApi.test.ts
@@ -36,13 +36,27 @@ describe("homeApi", () => {
     vi.unstubAllGlobals();
   });
 
+  function mockJsonResponse(body: unknown, init: { ok?: boolean; status?: number } = {}) {
+    const text =
+      typeof body === "string" ? body : JSON.stringify(body);
+    return {
+      ok: init.ok ?? true,
+      status: init.status ?? 200,
+      statusText: init.ok === false ? "Error" : "OK",
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === "content-type" ? "application/json" : null,
+      },
+      text: async () => text,
+      json: async () => body,
+    };
+  }
+
   it("fetchRecentItems returns list payload", async () => {
     const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
-    fetchMock.mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => [{ name: "Page A", id: "1" }],
-    });
+    fetchMock.mockResolvedValue(
+      mockJsonResponse([{ name: "Page A", id: "1" }]),
+    );
     const items = await fetchRecentItems("item");
     expect(items).toHaveLength(1);
     expect(items[0].name).toBe("Page A");
@@ -50,13 +64,11 @@ describe("homeApi", () => {
 
   it("fetchMyContent maps ItemProperties list", async () => {
     const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
-    fetchMock.mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({
         ItemProperties: [{ name: "Bookmarked", path: "/Sites/a/b" }],
       }),
-    });
+    );
     const items = await fetchMyContent();
     expect(items).toHaveLength(1);
     expect(items[0].name).toBe("Bookmarked");
@@ -64,14 +76,11 @@ describe("homeApi", () => {
 
   it("fetchSites surfaces API errors", async () => {
     const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
-    fetchMock.mockResolvedValue({
-      ok: false,
-      status: 401,
-      statusText: "Unauthorized",
-      json: async () => ({ message: "nope" }),
-    });
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({ message: "nope" }, { ok: false, status: 403 }),
+    );
     await expect(fetchSites()).rejects.toMatchObject({
-      status: 401,
+      status: 403,
     } as Partial<ApiError>);
   });
 

--- a/WebUI/src/test/ts/i18n/message.test.ts
+++ b/WebUI/src/test/ts/i18n/message.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { fallbackLabelFromKey, message } from "../../../main/ts/i18n/message";
+
+describe("message / TMX fallback", () => {
+  afterEach(() => {
+    delete (window as { I18N?: unknown }).I18N;
+  });
+
+  it("fallbackLabelFromKey uses text after @", () => {
+    expect(fallbackLabelFromKey("perc.ui.home.modern@Home")).toBe("Home");
+    expect(fallbackLabelFromKey("perc.ui.home@My Recent")).toBe("My Recent");
+    expect(fallbackLabelFromKey("no-at-sign")).toBe("no-at-sign");
+  });
+
+  it("message falls back when I18N missing", () => {
+    expect(message("perc.ui.home.modern@Gadgets")).toBe("Gadgets");
+  });
+
+  it("message uses I18N when it returns a real translation", () => {
+    (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
+      message: () => "Translated",
+    };
+    expect(message("perc.ui.home.modern@Home")).toBe("Translated");
+  });
+
+  it("message falls back when I18N echoes the key", () => {
+    (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
+      message: (k: string) => k,
+    };
+    expect(message("perc.ui.home.modern@Home")).toBe("Home");
+  });
+});

--- a/WebUI/src/test/ts/i18n/message.test.ts
+++ b/WebUI/src/test/ts/i18n/message.test.ts
@@ -32,4 +32,12 @@ describe("message / TMX fallback", () => {
     };
     expect(message("perc.ui.home.modern@Home")).toBe("Home");
   });
+
+  it("message falls back when I18N returns empty string", () => {
+    (window as unknown as { I18N: { message: () => string } }).I18N = {
+      message: () => "",
+    };
+    expect(message("perc.ui.home.modern@Home")).toBe("Home");
+  });
 });
+

--- a/WebUI/src/test/ts/login/loginStylesContract.test.ts
+++ b/WebUI/src/test/ts/login/loginStylesContract.test.ts
@@ -16,13 +16,16 @@ describe("login / modern CSS host contract", () => {
     expect(text).toMatch(/max-height:\s*48px/);
   });
 
-  it("spa.jsp hosts link stable perc-modern-ui.css (both trees)", () => {
+  it("spa.jsp hosts link stable perc-modern-ui.css and TMX (both trees)", () => {
     for (const rel of [
       "../../../main/webapp/cm/app/spa.jsp",
       "../../../main/webapp/cm/pages/app/spa.jsp",
     ]) {
       const text = readFileSync(resolve(__dirname, rel), "utf8");
       expect(text).toContain('href="/cm/modern/assets/perc-modern-ui.css"');
+      // Home / SPA chrome need I18N.message from tmx.jsp (session locale)
+      expect(text).toContain("tmx/tmx.jsp");
+      expect(text).toContain("prefix=perc.ui.");
     }
   });
 

--- a/docs/ai-generated/code-reviews/000-react-spa-pr9-path-urls-erlang.md
+++ b/docs/ai-generated/code-reviews/000-react-spa-pr9-path-urls-erlang.md
@@ -1,0 +1,46 @@
+# Erlang review — PR-9 path-based SPA URLs
+
+| Field | Value |
+|-------|-------|
+| **Branch** | `feat/000-react-spa-pr9-path-urls` |
+| **Base** | `development` @ PR-8 merge |
+| **Date** | 2026-07-27 |
+| **Scope** | BrowserRouter + `PSWebUiSpaFallbackFilter` + path↔entry helpers + tests/docs |
+| **Recommendation** | **approve** |
+| **May commit/push** | **yes** |
+
+## Summary
+
+PR-9 switches the SPA client router from HashRouter to BrowserRouter with a
+context-aware basename (`/cm/app` or `/cm/pages/app`, optional `/Rhythmyx`
+prefix). Server deep links and login return stay on the query contract
+(`spa.jsp?entry=…`); a synchronous handoff rewrites that document URL to a
+clean path before the router mounts. GET path refreshes are served by an
+internal forward filter that maps allowlisted SPA first segments to
+`spa.jsp?entry=…` (preserving section/tab/query), never rewriting real JSPs or
+static assets.
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs (logic / security) | None found — allowlisted entries only; traversal rejected; no open redirect |
+| Behavioral tests | Java `PSWebUiSpaFallbackFilterTest` (7); Vitest App/deepLinks/session/spaCutover |
+| Cross-platform path/file I/O | N/A for filter path math (URL paths use `/`); no OS filesystem |
+| Build | `cd WebUI && ../mvn-env.sh clean install` → **BUILD SUCCESS**; Surefire 11 tests |
+
+## Issues
+
+None blocking.
+
+### Nits
+
+1. Filter does not re-allowlist `section`/`tab` tokens server-side (relies on existing
+   spa.jsp / client allowlists after forward). Acceptable; same trust boundary as query
+   handoff.
+2. `useMemo` used once for sync URL handoff in `App` — intentional first-paint rewrite.
+
+## Evidence
+
+- Java: Tests run: 11 (filter 7 + gadget 4), Failures: 0
+- Vitest: App + deepLinks + auth + spaCutover green after basename handoff fix

--- a/docs/ai-generated/tasks/#000-pure-react-spa/design.md
+++ b/docs/ai-generated/tasks/#000-pure-react-spa/design.md
@@ -2,15 +2,16 @@
 
 | Field | Value |
 |-------|-------|
-| **Status** | Implementation-ready (rev **3.2** — **aggressive SPA-first**, **login-first demo path**) |
+| **Status** | Infra PRs 1–9 landed or in flight; **product acceptance** is screen-by-screen per unified-ui-plan **rev 4.0** (Home first) |
 | **Module** | `WebUI/` |
 | **Branch base** | `development` |
 | **Stack (verified)** | React 19.1, TypeScript 5.8, Vite 8, Jetty WAR under `/cm/` |
 | **Canonical frontend** | `WebUI/src/main/frontend/` (Maven `frontend-maven-plugin` `workingDirectory`). Root `WebUI/package.json` / `WebUI/vite.config.ts` are **not** product build paths. |
-| **Supersedes** | Track B shell architecture in `docs/ai-generated/tasks/#000-unified-ui-plan/unified-ui-plan.md`; design revs 1–2 dual-mode / soft-flag strategies; rev 3.1 “login deferred” sequencing |
-| **Cutover stance** | **Aggressive SPA-first.** The SPA is the product UI. No dual-mode production path, no feature-flag kill-switch story. Old JSP shells may linger as **reference only** until cleanup deletes them. |
-| **Demo sequencing (locked)** | **Start at the front door:** React Login is the first shippable vertical slice so stakeholders can demo Login → SPA app without walking through legacy `rxlogin.jsp`. Authenticated shell routes follow immediately. |
-| **Out of scope (initially)** | Full React rewrite of webmgt editor, template layout/style, site architecture, Dojo AA/CB (Track A), Package Manager GWT, Desktop CE; inventing a parallel auth API (reuse existing `/login` POST) |
+| **Product direction of record** | [`#000-unified-ui-plan/unified-ui-plan.md`](../#000-unified-ui-plan/unified-ui-plan.md) **rev 4.0** — React/TS only; no dual mode; no new bridges; shell ≠ done |
+| **Supersedes** | Dual-mode / soft-flag strategies; Track A Dojo→jQuery as product strategy; bridge-first product pages; “shell = done” milestones |
+| **Cutover stance** | **Aggressive SPA-first.** The SPA is the product UI. No dual-mode production path. Residual hosts are **delete debt**, not peers. |
+| **Functional sequencing (locked)** | **Home first** (must be fully functional), then Publish → Explorer → Admin → Workflow → WB. Infra login/shell already shipped. |
+| **Out of scope until later waves** | Full editor/AA rewrite, Package Manager GWT, Desktop CE, Eclipse; inventing a parallel auth API (reuse existing `/login` POST) |
 
 ---
 

--- a/docs/ai-generated/tasks/#000-pure-react-spa/design.md
+++ b/docs/ai-generated/tasks/#000-pure-react-spa/design.md
@@ -7,7 +7,7 @@
 | **Branch base** | `development` |
 | **Stack (verified)** | React 19.1, TypeScript 5.8, Vite 8, Jetty WAR under `/cm/` |
 | **Canonical frontend** | `WebUI/src/main/frontend/` (Maven `frontend-maven-plugin` `workingDirectory`). Root `WebUI/package.json` / `WebUI/vite.config.ts` are **not** product build paths. |
-| **Product direction of record** | [`#000-unified-ui-plan/unified-ui-plan.md`](../#000-unified-ui-plan/unified-ui-plan.md) **rev 4.0** — React/TS only; no dual mode; no new bridges; shell ≠ done |
+| **Product direction of record** | [`#000-unified-ui-plan/unified-ui-plan.md`](../#000-unified-ui-plan/unified-ui-plan.md) **rev 4.1** — React/TS only; **no jQuery in SPA**; no dual mode; no new bridges; shell ≠ done |
 | **Supersedes** | Dual-mode / soft-flag strategies; Track A Dojo→jQuery as product strategy; bridge-first product pages; “shell = done” milestones |
 | **Cutover stance** | **Aggressive SPA-first.** The SPA is the product UI. No dual-mode production path. Residual hosts are **delete debt**, not peers. |
 | **Functional sequencing (locked)** | **Home first** (must be fully functional), then Publish → Explorer → Admin → Workflow → WB. Infra login/shell already shipped. |

--- a/docs/ai-generated/tasks/#000-pure-react-spa/residual-bridge-embeds.md
+++ b/docs/ai-generated/tasks/#000-pure-react-spa/residual-bridge-embeds.md
@@ -1,49 +1,31 @@
-# Residual PercModernUI bridge embeds (PR-6 / PR-8)
+# Residual PercModernUI bridge embeds (delete list)
 
-Primary product navigation for modern features is the **SPA** (`spa.jsp?entry=…`).
-`window.PercModernUI.mount` remains only for **legacy full-page JSP hosts** and
-**dialog pilots** that still embed React islands until those openers move to SPA
-routes or the pages are rewritten.
+**Policy (unified-ui-plan rev 4.0):** Primary product navigation is the **SPA**.  
+`window.PercModernUI.mount` is **legacy debt**. **Do not add new product mounts.**  
+Prefer SPA routes/dialogs; when a surface is accepted in React, **delete** its residual host.
 
 ## Product SPA (no bridge)
 
 | Surface | Entry |
 |---------|--------|
 | Login | `rxlogin.jsp` → `#perc-login-root` |
-| Home / Publish / Workflow / Admin / WB / Explorer | `spa.jsp?entry=…` |
+| Home / Publish / Workflow / Admin / WB / Explorer | path or `spa.jsp?entry=…` |
 
-**PR-8 removed** retired product hosts that only 302'd into the SPA:
+## Still using the bridge (eliminate)
 
-- `homeModern.jsp`, `publishModern.jsp`, `adminModern.jsp`, `adminWorkflowModern.jsp`
-- `widgetBuilderModern.jsp`, `unavailableModern.jsp`, `explorerModern.jsp`
-- `includes/retired_modern_redirect.jsp`, `includes/modern_shell_head.jsp`
-- Classic login reference: `rxlogin-classic.jsp`
-
-Bookmarks to those filenames will 404; use `spa.jsp?entry=…` or `?view=…` via `index.jsp`.
-
-## Still using the bridge (residual)
-
-These hosts load `/cm/modern/assets/perc-modern-ui.js` and call `PercModernUI.mount`
-(component names must stay registered in `registry.ts`):
-
-| Host (cm/app, often mirrored under cm/pages/app) | Component(s) | Why residual |
-|--------------------------------------------------|--------------|--------------|
-| `admin.jsp` (Design legacy) | `ContentExplorerShell` | Full-page Design exit |
-| `adminWorkflow.jsp` | `ContentExplorerShell` | Classic workflow page embeds |
-| `editAsset.jsp` / `editTemplate.jsp` | `ContentExplorerShell` | Editor-adjacent trees |
-| `users.jsp` | `ContentExplorerShell` | Legacy users UI finder |
-| `assetPickerModern.jsp` / `pagePickerModern.jsp` / `folderPickerModern.jsp` | `ContentBrowser` | Dialog pickers |
-| `folderSecurityModern.jsp` | `FolderSecurityPanel` | Dialog |
-| `searchModern.jsp` | `SearchPanel` | Dialog / side panel |
-| `actionMenuModern.jsp` | `ActionToolbar`, `ContextMenu` | Menu chrome (Open → SPA explorer) |
-| `us7AdvancedModern.jsp` | Clipboard / wizards / dependency / relationships | Advanced tools pack |
-
-Do **not** reintroduce product feature navigation through these hosts. Prefer SPA
-routes for anything users open from TopNav.
+| Host (cm/app, often mirrored under cm/pages/app) | Component(s) | Elimination path |
+|--------------------------------------------------|--------------|------------------|
+| `admin.jsp` (Design legacy) | `ContentExplorerShell` | Design SPA or retire exit |
+| `adminWorkflow.jsp` | `ContentExplorerShell` | SPA workflow already; remove classic page |
+| `editAsset.jsp` / `editTemplate.jsp` | `ContentExplorerShell` | Editor SPA wave |
+| `users.jsp` | `ContentExplorerShell` | SPA users / admin |
+| `assetPickerModern.jsp` / `pagePickerModern.jsp` / `folderPickerModern.jsp` | `ContentBrowser` | SPA dialogs from openers |
+| `folderSecurityModern.jsp` | `FolderSecurityPanel` | Explorer SPA actions |
+| `searchModern.jsp` | `SearchPanel` | SPA search |
+| `actionMenuModern.jsp` | `ActionToolbar`, `ContextMenu` | SPA explorer chrome |
+| `us7AdvancedModern.jsp` | Clipboard / wizards / dependency / relationships | SPA advanced tools |
 
 ## CSS contract
 
-Bridge embeds and SPA/login all depend on:
-
-- Stable stylesheet: `/cm/modern/assets/perc-modern-ui.css` (`cssCodeSplit: false`)
-- Entry JS injects the link via `ensureModernStyles()` if the host omitted it
+- Stable stylesheet: `/cm/modern/assets/perc-modern-ui.css`
+- Entry JS may inject via `ensureModernStyles()` if a residual host omitted the link

--- a/docs/ai-generated/tasks/#000-pure-react-spa/summary.md
+++ b/docs/ai-generated/tasks/#000-pure-react-spa/summary.md
@@ -4,7 +4,7 @@
 
 **Product UI = React + TypeScript SPA only.** No dual mode, no new bridges, no “shell = done.”
 
-- **Plan of record:** [`#000-unified-ui-plan/unified-ui-plan.md`](../#000-unified-ui-plan/unified-ui-plan.md) **rev 4.0**
+- **Plan of record:** [`#000-unified-ui-plan/unified-ui-plan.md`](../#000-unified-ui-plan/unified-ui-plan.md) **rev 4.1**
 - **Module rules:** [`WebUI/AGENTS.md`](../../../WebUI/AGENTS.md)
 - **Infra design (entry, bootstrap, PR 1–9):** [`design.md`](design.md)
 
@@ -35,7 +35,8 @@ These are **routing/chrome**. Functional acceptance is **screen-by-screen** per 
 3. Home is default landing (gadgets on Home, not peer `/dashboard`)  
 4. Server entry = query `spa.jsp?entry=…` only (never `#` on redirects)  
 5. No dual-mode / no new PercModernUI product hosts  
-6. Shell ≠ done  
+6. **No jQuery (or Knockout/Dojo) in `src/main/ts` / modern bundle**  
+7. Shell ≠ done  
 
 ## Explicitly not product strategy
 

--- a/docs/ai-generated/tasks/#000-pure-react-spa/summary.md
+++ b/docs/ai-generated/tasks/#000-pure-react-spa/summary.md
@@ -45,8 +45,8 @@
 5. Aggressive `index.jsp` cutover — **done** (#1531); includes login CSS load fix  
 6. Explorer SPA route + residual bridge doc — **done** (#1533)  
 7. **Home + gadgets:** fold React Dashboard widgets into Home — **done** (#1540)  
-8. Delete obsolete product host JSPs — **in progress** (`feat/000-react-spa-pr8-delete-obsolete-hosts`)  
-9. Optional path URLs (PR-9)
+8. Delete obsolete product host JSPs — **done** (#1541)  
+9. Path-based SPA URLs (BrowserRouter + fallback filter) — **in progress** (`feat/000-react-spa-pr9-path-urls`)
 
 ## Explicitly not first
 

--- a/docs/ai-generated/tasks/#000-pure-react-spa/summary.md
+++ b/docs/ai-generated/tasks/#000-pure-react-spa/summary.md
@@ -1,55 +1,45 @@
-# Design summary: Pure React / TypeScript WebUI — eliminate JSP shells
+# Design summary: Pure React / TypeScript WebUI
 
-## Produced
+## Direction of record (2026-07-27)
 
-| Artifact | Path |
-|----------|------|
-| Full design (**rev 3.2** — aggressive SPA-first, **login-first**) | `docs/ai-generated/tasks/#000-pure-react-spa/design.md` |
-| This summary | `docs/ai-generated/tasks/#000-pure-react-spa/summary.md` |
+**Product UI = React + TypeScript SPA only.** No dual mode, no new bridges, no “shell = done.”
+
+- **Plan of record:** [`#000-unified-ui-plan/unified-ui-plan.md`](../#000-unified-ui-plan/unified-ui-plan.md) **rev 4.0**
+- **Module rules:** [`WebUI/AGENTS.md`](../../../WebUI/AGENTS.md)
+- **Infra design (entry, bootstrap, PR 1–9):** [`design.md`](design.md)
+
+### Immediate focus
+
+**Home must become fully functional** (Recent, Bookmarks, Library, Search, Create, Gadgets). SPA chrome without working features is not acceptance.
+
+Then: Publish → Explorer → Admin → Workflow → Widget Builder, same bar.
+
+## Infra already produced (PR-1…PR-9)
+
+| PR | Outcome |
+|----|---------|
+| 1–2 | React Login + SPA app shell |
+| 3–4 | Feature routes (shells embedded) |
+| 5 | `index.jsp` cutover to SPA |
+| 6 | Explorer route + residual bridge doc |
+| 7 | Gadgets on Home |
+| 8 | Deleted obsolete product `*Modern.jsp` hosts |
+| 9 | BrowserRouter + `PSWebUiSpaFallbackFilter` path URLs |
+
+These are **routing/chrome**. Functional acceptance is **screen-by-screen** per unified-ui-plan rev 4.0.
 
 ## Product locks
 
-1. **SPA is the product UI** for modern features. No dual-mode, no soft feature-flag cutover. Old JSPs = reference until delete.
-2. **Start at the front door:** React Login is the first shippable slice for **stakeholder demos** (Login → SPA), then authenticated routes.
-3. **Home is the default product landing** after sign-in (not a separate “dashboard” peer).
-4. **Dashboard gadgets have real product value**, but that capability should **live on Home** (section / widgets / compose), **not** as a long-term separate SPA route. Until then: legacy `?view=dash` full-page exit only.
+1. SPA is the product UI for modern features  
+2. React Login front door  
+3. Home is default landing (gadgets on Home, not peer `/dashboard`)  
+4. Server entry = query `spa.jsp?entry=…` only (never `#` on redirects)  
+5. No dual-mode / no new PercModernUI product hosts  
+6. Shell ≠ done  
 
-## Stakeholder demo path
+## Explicitly not product strategy
 
-1. Open product → **React Login** (not classic `rxlogin.jsp` UI)
-2. Sign in (POST existing `/login`) → **React SPA** landing
-3. As later PRs land: Home → Publish → Admin… without `*Modern.jsp` hosts
-
-## Implementability locks (still apply)
-
-1. **Server entry = query only** — `spa.jsp?entry=…` (never `Location: …#/…`)
-2. **Bridge** — sync `mount` + lazy `loadComponent` + generation tokens
-3. **proxyURL** parity on all SPA redirects
-4. **Login** — UI is React; auth remains existing form POST to `/login`
-
-## Monday PR-1
-
-`feat(webui): React Login SPA as product front door`
-
-- React LoginPage + thin public host
-- POST `/login` (CSRF, same fields as `rxlogin.jsp`)
-- Success → `spa.jsp?entry=home` (proxyURL-aware)
-- Minimal SPA landing so demo does not drop into a JSP shell
-
-## PR plan (login-first)
-
-1. **Login front door** + SPA landing — **done** (#1523)  
-2. App shell + TopNav + entry query + 401→Login — **done** (#1526)  
-3. Home + Publish routes (embedded shells) — **done** (#1527); **Home is default landing**  
-4. Workflow + Admin + Widget Builder — **done** (#1528)  
-5. Aggressive `index.jsp` cutover — **done** (#1531); includes login CSS load fix  
-6. Explorer SPA route + residual bridge doc — **done** (#1533)  
-7. **Home + gadgets:** fold React Dashboard widgets into Home — **done** (#1540)  
-8. Delete obsolete product host JSPs — **done** (#1541)  
-9. Path-based SPA URLs (BrowserRouter + fallback filter) — **in progress** (`feat/000-react-spa-pr9-path-urls`)
-
-## Explicitly not first
-
-- Dual-mode / feature-flag fallback  
+- Track A Dojo→jQuery as a long-lived product track (vendor Dojo already removed; residual AA is debt)  
+- Soft feature-flag cutover  
 - Parallel auth REST API  
-- Full editor/template/arch rewrite in PR-1  
+- Bridge-first new features  

--- a/docs/ai-generated/tasks/#000-pure-react-spa/summary.md
+++ b/docs/ai-generated/tasks/#000-pure-react-spa/summary.md
@@ -2,7 +2,7 @@
 
 ## Direction of record (2026-07-27)
 
-**Product UI = React + TypeScript SPA only.** No dual mode, no new bridges, no “shell = done.”
+**Product UI = React + TypeScript SPA only.** No dual mode, no new bridges, **no jQuery in the SPA**, no “shell = done.”
 
 - **Plan of record:** [`#000-unified-ui-plan/unified-ui-plan.md`](../#000-unified-ui-plan/unified-ui-plan.md) **rev 4.1**
 - **Module rules:** [`WebUI/AGENTS.md`](../../../WebUI/AGENTS.md)
@@ -26,7 +26,7 @@ Then: Publish → Explorer → Admin → Workflow → Widget Builder, same bar.
 | 8 | Deleted obsolete product `*Modern.jsp` hosts |
 | 9 | BrowserRouter + `PSWebUiSpaFallbackFilter` path URLs |
 
-These are **routing/chrome**. Functional acceptance is **screen-by-screen** per unified-ui-plan rev 4.0.
+These are **routing/chrome**. Functional acceptance is **screen-by-screen** per unified-ui-plan rev 4.1.
 
 ## Product locks
 

--- a/docs/ai-generated/tasks/#000-unified-ui-plan/unified-ui-plan.md
+++ b/docs/ai-generated/tasks/#000-unified-ui-plan/unified-ui-plan.md
@@ -1,171 +1,220 @@
-# Unified UI Plan: Dojo → jQuery (Tactical) + Consolidated React UI (Strategic)
+# Unified UI Plan — React / TypeScript Only (Aggressive)
 
-**Status**: Active
-**Created**: 2026-02-27
-**Replaces**: [#000-modern-ui-plan](../archived/#000-modern-ui-plan/) (archived)
-
-## Summary
-
-Two parallel tracks. **Track A** is a fast, mechanical Dojo 0.4.3 → jQuery swap on 5 legacy
-Rhythmyx screens to eliminate security scan alerts — ships in the next release. **Track B** is a
-longer-term effort to design a single React UI that replaces all legacy UI layers.
-
-### Completed Milestones (Prior Work)
-
-- [x] Phase 0 — Build pipeline: Vite, frontend-maven-plugin, React bridge (`PercModernUI.mount()`)
-- [x] Phase 1 — React Dashboard: 24 widget components replacing Shindig gadget container
-- [x] FancyTree migration: Dynatree → FancyTree across 16 files
-- [x] Bootstrap 5 migration
+| Field | Value |
+|-------|--------|
+| **Status** | **Active — product direction (rev 4.0, 2026-07-27)** |
+| **Supersedes** | Track A (Dojo→jQuery as product strategy), Track B dual-mode / soft cutover, bridge-first hybrid, dual production modes |
+| **Canonical SPA design** | [`#000-pure-react-spa/design.md`](../#000-pure-react-spa/design.md) (infra PRs 1–9) |
+| **Module** | `WebUI/` (React + TypeScript + Vite) |
+| **Stack** | React 19, TypeScript 5.8, Vite, Jetty WAR under `/cm/` |
 
 ---
 
-## UI Layer Inventory
+## 1. Product locks (non-negotiable)
 
-| # |          Layer           |              Technology               |                                                                 Exclusive Features                                                                 |        Comm Protocol        |  Screens  |
-|---|--------------------------|---------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|-----------|
-| 1 | Desktop Content Explorer | Java Swing + JavaFX WebView           | Clipboard, desktop app                                                                                                                             | JAX-WS SOAP + HTTP          | ~10       |
-| 2 | Rhythmyx Admin           | MyFaces JSF + Trinidad                | Server console, scheduled tasks, notifications, consistency checker, RxFix, variant migration                                                      | JSF managed beans           | 12        |
-| 3 | Rhythmyx Publishing      | MyFaces JSF + Trinidad                | Site/edition/content list/context/delivery type/location scheme CRUD, pub runtime, pub logs                                                        | JSF managed beans           | 28        |
-| 4 | Package Manager          | GWT + SmartGWT                        | Package install/uninstall, visibility                                                                                                              | GWT-RPC                     | 3+dialogs |
-| 5 | WebUI Legacy             | jQuery 3.6 + jQuery UI + Backbone     | Template design/layout/style, site architecture, user/role/category mgmt, pub servers/reports, widget builder, revision comparison, content finder | REST/JSON                   | ~20       |
-| 6 | Contributor UI (CUI)     | RequireJS + Knockout.js + widGEL      | Simplified content browsing, page/asset/blog creation wizards                                                                                      | REST/JSON                   | ~8        |
-| 7 | Rhythmyx Dojo Screens    | **Dojo 0.4.3** (→ jQuery via Track A) | Active Assembly, Content Browser, Relationship Editor, field editing, search                                                                       | REST/JSON (`/contentui/aa`) | 5         |
-| 8 | Eclipse Workbench        | Eclipse RCP plugin (external repo)    | Content type editor, system design, XML application editor                                                                                         | Custom protocol             | 3 views   |
-| — | React Modern (new)       | React 19 + TypeScript 5.8 + Vite 6    | Dashboard (done), future unified UI                                                                                                                | REST/JSON (typed Fetch)     | Growing   |
+1. **The product UI is React + TypeScript.** New user-facing work ships in `WebUI/src/main/ts/` inside the SPA (`spa.jsp` / path routes). Not jQuery, not Knockout, not Dojo, not a new bridge island for a product page.
+2. **No dual mode.** No feature flag that keeps classic and modern as peer production UIs for the same feature. Rollback = git revert / redeploy.
+3. **No new bridges.** `PercModernUI.mount` is **legacy debt**, not a pattern for new work. Do not add mounts for product navigation. Prefer SPA routes (and SPA dialogs when openers are ready).
+4. **No “shell counts as done.”** A screen is **not** accepted until features work end-to-end (load data, act, navigate, errors, roles). Empty chrome is a defect, not a milestone.
+5. **Screen-by-screen, feature-by-feature.** Prove one surface fully, then delete its legacy peer when safe, then move on. Home first.
+6. **Server entry stays query-only for redirects/login.** `spa.jsp?entry=…` (or path after client handoff). Never `Location: …#/…`.
 
 ---
 
-## Track A — Dojo → jQuery (Immediate, Next Release)
+## 2. What already shipped (infra — not functional acceptance)
 
-### A0. Prune Unused Dojo Files
+SPA program PR-1…PR-9 built the **front door and shell**:
 
-1. Delete from `system/cms/content/applications/sys_resources/ApplicationFiles/dojo/`:
-   `tests/`, `demos/`, `release/dojo/`, `src/crypto/`, and all `src/` subdirectories not
-   referenced by `build.txt` or `ps.*` modules.
-2. Update `system/ear/install-dojo.xml` and `system/ear/install.xml` (~line 598).
-3. Update Spotless exclusions in root `pom.xml` (lines 2337–2343, 2419–2471).
-4. Add temporary OWASP suppressions in `owasp-suppressions.xml`.
+| Wave | What landed | Honest status |
+|------|-------------|----------------|
+| Login | React `LoginPage` on `rxlogin.jsp` | **Product path** — verify CSRF/errors/return on real CMS |
+| App shell | TopNav, bootstrap, 401→login, BrowserRouter + filter | **Chrome only** |
+| Routes | Home, Publish, Workflow, Admin, WB, Explorer mounted | **Embedded shells** — functional depth varies; many not product-ready |
+| Cutover | `index.jsp` → SPA for modern views; obsolete `*Modern.jsp` product hosts deleted | **Routing done** |
+| Gadgets | React gadgets section on Home | **Compose done** — verify widgets work |
 
-### A1. jQuery Compatibility Layer for `ps.io`
-
-Rewrite `ps/io/Actions.js` (1,179 lines) — `dojo.io.bind()` → `$.ajax()`. Same endpoints
-(`/contentui/aa?action=<Name>`), same parameters, same response parsing. Keep `async: false`
-initially to preserve behavior.
-
-~25 action methods: `move`, `addSnippet`, `removeSnippet`, `checkInItem`, `transitionItem`,
-`getUrl`, `getActionVisibility`, `getSlotContent`, `getSnippetContent`, `getFieldContent`, etc.
-
-### A2. jQuery Replacements for `ps.widget.*`
-
-|                             Dojo Widget                              |        jQuery Replacement         |
-|----------------------------------------------------------------------|-----------------------------------|
-| `ps.widget.PSButton`                                                 | Plain `<button>` + CSS            |
-| `ps.widget.Tree` / `TreeSelector` / `TreeIcon` / `TreeDndController` | FancyTree                         |
-| `ps.widget.PSSplitContainer`                                         | CSS flexbox + jQuery UI Resizable |
-| `ps.widget.PopupMenu` / `MenuBar2` / `MenuBarItem2`                  | jQuery UI Menu                    |
-| `ps.widget.ContentPaneProgress`                                      | `<div>` + `$.load()` + spinner    |
-| `ps.widget.ScrollableNodes` / `Autoscroller`                         | jQuery UI Draggable scroll option |
-| `ps.widget.PSImageGallery`                                           | Simple jQuery gallery plugin      |
-
-### A3. Rewrite `ps.aa.*` Controller & Modules
-
-Rewrite `ps/aa/controller.js` (2,475 lines): `dojo.event.connect` → `$.on()`,
-`dojo.byId` → `$()`, `dojo.lang.declare` → ES6 class. Same for Page.js, Tree.js,
-Menu.js, dnd.js, Field.js, SnippetMove.js.
-
-Replace DnD with jQuery UI Draggable/Droppable/Sortable.
-
-### A4. Update Server-Side HTML Generation
-
-- `PSPageTree.java` (line 389): `dojoType="TreeNodeV3"` → FancyTree-compatible markup.
-- `PSActionBar.java` (line 304): `dojoType="MenuItem2"` → jQuery UI Menu `<li>` markup.
-
-### A5. Update XSL, JSP, and HTML Entry Points
-
-- `sys_aaPageHeader.html`: Replace `dojo.js` with jQuery + jQuery UI includes.
-- `rceditor.xsl` (line 32): Dojo script → jQuery.
-- `ContentBrowserDialog.jsp` (line 21): Replace Dojo includes. Remove `dojo.hostenv.writeIncludes()`.
-- `singleFieldEdit.xsl` (lines 159–169): `dojoType="ps:PSButton"` → plain `<button>`.
-- `sys_Templates.xsl` (line 3883): Remove `psxctl:FileDescriptor` for `dojo.js`.
-- `getQuery.xsl` (lines 133–134): `dojoType="Button"` → plain `<button>`.
-- `activeEdit.xsl` (lines 145–155): Update `ps.aa.controller` references.
-- All JSPs in `system/ear/jsps/ui/content/` and `system/ear/jsps/ui/activeassembly/`.
-- `styles.css`: Replace `.dojoButton`, `.dojoMenuBar2`, etc. with jQuery UI classes.
-
-### A6. Delete Dojo
-
-- Delete entire `dojo/` directory.
-- Delete `install-dojo.xml` and its call in `install.xml`.
-- Remove OWASP suppressions from A0.
-- Remove Spotless exclusions.
-- Clean up UnitTestResources copies.
+**Vendor Dojo library** was removed from the tree (security). Residual `ps.*` Active Assembly code and jQuery/JSF/GWT layers still exist as **legacy debt to eliminate or replace in React**, not as a long-lived second product UI.
 
 ---
 
-## Track B — Unified React UI (Strategic, Multi-Release)
+## 3. Target architecture (single product path)
 
-**Active product path (2026):** Pure React SPA (login-first) owns modern Home, Publish, Workflow,
-Admin, Widget Builder, and Explorer. Entry is `spa.jsp?entry=…` (query contract); obsolete
-product `*Modern.jsp` hosts were deleted in PR-8. Design: [`#000-pure-react-spa/`](../#000-pure-react-spa/).
-Residual bridge embeds remain only for legacy full-page exits and dialog pilots.
+```
+Browser
+  │
+  ├─ Public:  /rxlogin.jsp  → React LoginPage  → POST /login
+  │
+  └─ Auth:    /cm/app/spa.jsp?entry=…  OR  /cm/app/{home|publish|…}
+              → React App (BrowserRouter + AppLayout + TopNav)
+              → Feature route → *Shell / feature modules (TS)
+              → REST (typed api/*) + CSRF + TMX
+```
 
-### B0. Feature Inventory & REST API Gap Analysis
-
-Catalog every feature across all 8 layers, the endpoints each uses, and identify where REST
-endpoints are missing:
-
-- **JSF Admin/Publishing** (40 pages): Managed bean logic → needs REST endpoints.
-- **Desktop Content Explorer**: SOAP via JAX-WS → some REST equivalents may exist.
-- **Package Manager**: GWT-RPC → needs REST endpoints.
-- **Eclipse Workbench**: Content type/template/XML app CRUD → needs REST endpoints.
-
-See [ui-layer-inventory.md](ui-layer-inventory.md) for the full feature-to-layer matrix and
-API surface catalog.
-
-### B1. React Application Architecture
-
-- **Shell**: Single React SPA at `/cm/modern/` with sidebar navigation, breadcrumbs, tabbed content.
-- **Feature modules**: Lazy-loaded React route modules per feature area.
-- **Shared component library**: Tree (FancyTree wrapper), DataTable, Dialog, SplitPane, Menu, Forms.
-- **API client**: Extend existing typed `api/client.ts`.
-- **Auth/session**: Integrate with existing CSRF infrastructure (`window.OWASP_CSRFTOKEN`).
-- **Feature flags**: Each module deployable independently with fallback to legacy UI.
-
-### B2. Prioritized Migration Roadmap
-
-Order based on: security risk, maintenance burden, feature overlap, user impact.
-
-1. **GWT Package Manager** — smallest scope (~3 screens), GWT is dead technology
-2. **CUI Contributor UI** — small scope (~8 widgets), high overlap with WebUI finder, Knockout unmaintained
-3. **JSF Admin screens** — 12 pages, MyFaces+Trinidad ancient, exclusive features
-4. **JSF Publishing screens** — 28 pages, largest JSF scope, exclusive features
-5. **Rhythmyx jQuery screens** (from Track A) — now on jQuery, lower urgency
-6. **WebUI Legacy jQuery/Backbone** — largest scope (~20 views), actively maintained, lowest risk
-7. **Desktop Content Explorer** — drop desktop model; web-based replacement
-8. **Eclipse Workbench** — web-based content type designer, template assembler, XML app editor
+| Concern | Rule |
+|---------|------|
+| Product navigation | SPA only |
+| Feature code | `WebUI/src/main/ts/**` |
+| New pages | SPA route (+ server allowlist if deep-linked) |
+| Legacy full-page exits | Temporary only until that feature is React; then delete exit |
+| Residual `PercModernUI.mount` | Only until that host is rewritten or deleted — **no new hosts** |
+| jQuery / Knockout / JSF / GWT / residual Dojo-shaped `ps.*` | **Debt**. Touch only to fix blockers or to delete after React replacement |
 
 ---
 
-## Verification
+## 4. Screen register (order of work)
 
-|          Track           |                                                                                                           How to Verify                                                                                                            |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Track A (per step)**   | Smoke test: AA (tree, menu, DnD, slot add/remove), Content Browser (folder nav, search, select), Relationship Editor, Workflow Actions, Content Editor fields. OWASP + CodeQL scans. `grep -r "dojo\." system/` = 0 hits after A6. |
-| **Track B (per module)** | Vitest unit tests per React component. Integration tests against REST API. Manual QA comparing new vs legacy. WCAG 2.1 AA accessibility audit. Performance benchmarks.                                                             |
+Status meanings:
+
+| Status | Meaning |
+|--------|---------|
+| **Shell** | Route/chrome exists; features incomplete or broken |
+| **Partial** | Some features work; gaps known |
+| **Accepted** | Passes acceptance checklist on a real CMS; legacy peer removed or explicitly N/A |
+| **Legacy exit** | Still full-page leave SPA (must become SPA or be retired) |
+
+### Wave 0 — Front door (keep green)
+
+| Surface | Entry | Status | Notes |
+|---------|-------|--------|-------|
+| Login | `/rxlogin.jsp` | Partial → prove | CSRF, locales, errors, return to SPA |
+| App chrome | TopNav / user menu / 401 | Partial → prove | Roles hide/show; logout |
+
+### Wave 1 — **Home first (current focus)**
+
+| Surface | Entry | Status | Notes |
+|---------|-------|--------|-------|
+| **Home** | `/cm/app/home`, `?entry=home` | **Shell — not accepted** | User report: shell visible, **nothing functional** |
+
+**Home sections (each must work):**
+
+| Section | Route | Must work |
+|---------|-------|-----------|
+| Recent | `/home` / `/home/recent` | List loads; open item → editor (or agreed SPA path); empty/error states |
+| Bookmarks | `/home/bookmarks` | List; open; empty/error |
+| Library | `/home/library` | Browse/list; open; empty/error |
+| Search | `/home/search` | Query; results; open; empty/error |
+| Create | `/home/create` | Page/asset/blog wizards complete successfully |
+| Gadgets | `/home/gadgets` | Widgets load/configure/persist as product requires |
+
+**Home acceptance checklist (all required):**
+
+- [ ] Fresh login lands on Home (correct role homepage metadata)
+- [ ] Section tabs switch and deep links (`/home/gadgets`) work + refresh (path URL)
+- [ ] Each section loads real data against live REST (not forever loading / silent fail)
+- [ ] Open item navigates to a working editor path
+- [ ] Create wizards finish without dead ends
+- [ ] Gadgets usable for default set (no blank shell)
+- [ ] TMX labels (no raw keys for primary chrome)
+- [ ] Non-admin / admin differences correct
+- [ ] Vitest for non-trivial logic; manual smoke on docker/dev CMS recorded
+- [ ] No dependency on classic CUI Home for the same job
+
+**Home exit criteria:** checklist green → mark Home **Accepted** → remove any remaining classic Home peers still reachable from product nav.
+
+### Wave 2 — Primary SPA features (after Home accepted)
+
+Order (adjust only with product reason):
+
+1. **Publish** (`PublishingShell`) — sites, status, logs, design, runtime  
+2. **Explorer** (`ContentExplorerShell`) — tree, list, open, core actions  
+3. **Admin tools** (`AdminShell`) — tasks, logs, notifications, tools  
+4. **Workflow admin** (`WorkflowAdminShell`) — workflows, roles, users, categories  
+5. **Widget Builder** (`WidgetBuilderApp`) — if still product-enabled  
+
+Same rule: **feature checklist per screen**, then delete legacy peer.
+
+### Wave 3 — Remaining product surfaces (SPA or retire)
+
+| Surface | Today | Direction |
+|---------|--------|-----------|
+| Editor (webmgt / AA) | Legacy exit | React rewrite (large); interim: fix critical bugs only |
+| Design / Architecture | Legacy exit | React or retire paths |
+| Residual dialog hosts (pickers, search panel, US7 tools) | Bridge mounts | SPA dialogs / explorer actions; then **delete** hosts |
+| Package Manager (GWT) | Legacy | React when scheduled |
+| JSF admin/publishing residual | Packaging | Prefer SPA Admin/Publish; delete dead JSF |
+| Desktop CE / Eclipse | Out of band | Not SPA; do not block Home |
 
 ---
 
-## Key Decisions
+## 5. Working rules for agents & developers
 
-- **jQuery for Track A, React for Track B** — jQuery is tactical (eliminate scan alerts now);
-  React is the strategic consolidation target. No intermediate framework.
-- **No Dojo shim** — even shimmed, Dojo source files still trigger scanner alerts.
-- **FancyTree reuse** — bridge widget used in jQuery screens (Track A) and eventually wrapped
-  for React (Track B).
-- **Synchronous XHR preserved in Track A** — `$.ajax({ async: false })` to minimize behavioral
-  changes initially.
-- **Eclipse Workbench → web-based** — Content Design, System Design, XML Server become
-  admin-role React route modules.
-- **REST API creation is the long pole** — Track B gated by REST endpoints for features behind
-  JSF beans, SOAP, and GWT-RPC. Start API work early.
+### DO
 
+- Implement features in **React + TypeScript** under `WebUI/src/main/ts/`.
+- Use SPA routes and existing REST + CSRF + TMX patterns.
+- For each screen: **acceptance checklist** + Vitest for non-trivial logic + real CMS smoke.
+- Prefer fixing broken SPA behavior over wiring another jQuery page.
+- After a surface is **Accepted**, delete obsolete hosts/scripts for that surface in the same or immediate follow-up PR.
+
+### DO NOT
+
+- Add dual-mode flags or “keep classic as production peer.”
+- Add new `PercModernUI.mount` product pages.
+- Add new Dojo or new Knockout features.
+- Expand jQuery except critical security/hotfix on a surface not yet replaced.
+- Call a route “done” because the shell renders.
+
+### Residual bridge / legacy code
+
+- Documented only as **delete candidates** (`#000-pure-react-spa/residual-bridge-embeds.md`).
+- Allowed to touch for: security, compile, or **removing** after React replacement.
+- Not a place to invest new product UX.
+
+---
+
+## 6. Dojo / Track A historical note
+
+Earlier plans used **Track A = Dojo→jQuery** and **Track B = React**. That split is **retired as product strategy**.
+
+| Fact | Status |
+|------|--------|
+| Vendored Dojo 0.4.3 under ApplicationFiles | **Removed** (security; e.g. #1197) |
+| Residual `ps.*` AA code / compat shims | **Debt** — replace with React or delete when AA is rewritten; **not** a jQuery product investment track |
+| install-dojo.xml / residual `dojo.*` call sites | Cleanup when safe; not a parallel roadmap |
+
+---
+
+## 7. Immediate next work (execution)
+
+1. **Home functional recovery (Wave 1)** — diagnose why shell is empty/non-functional (API paths, CSRF, bootstrap, section routing, open-item, create wizards, gadgets). Fix until Home checklist is green.  
+2. Update residual docs/AGENTS as Home acceptance lands.  
+3. Then Wave 2 screen by screen with the same bar.
+
+Infra PRs (login shell, cutover, path URLs) stay; **value is measured by accepted screens**, starting with Home.
+
+---
+
+## 8. Verification standard (every screen)
+
+| Layer | Required |
+|-------|----------|
+| Manual | Checklist on real CMS (docker/dev) |
+| Automated | Vitest for logic; Playwright where already used for the surface |
+| Build | `cd WebUI && ../mvn-env.sh clean install` before PR |
+| Review | Erlang pre-commit on authored code |
+| Legacy | Explicit “delete / keep temporary” note in PR |
+
+---
+
+## 9. Related artifacts
+
+| Artifact | Role |
+|----------|------|
+| [`#000-pure-react-spa/design.md`](../#000-pure-react-spa/design.md) | SPA entry, bootstrap, router, PR 1–9 history |
+| [`#000-pure-react-spa/residual-bridge-embeds.md`](../#000-pure-react-spa/residual-bridge-embeds.md) | Residual mounts to eliminate |
+| [`WebUI/AGENTS.md`](../../../WebUI/AGENTS.md) | Module agent rules (React-only product) |
+| [`ui-layer-inventory.md`](ui-layer-inventory.md) | Historical inventory (may lag; this plan wins on direction) |
+
+---
+
+## 10. Key decisions (rev 4.0)
+
+| ID | Decision |
+|----|----------|
+| KD-R1 | Product UI = React + TypeScript SPA only |
+| KD-R2 | No dual mode / no soft feature-flag cutover |
+| KD-R3 | No new PercModernUI product hosts |
+| KD-R4 | Shell ≠ done; feature acceptance required |
+| KD-R5 | Home first, then Publish → Explorer → Admin → Workflow → WB |
+| KD-R6 | Track A Dojo→jQuery as product strategy is retired; vendor Dojo already gone |
+| KD-R7 | Server redirects stay query `entry` contract; client uses path URLs |

--- a/docs/ai-generated/tasks/#000-unified-ui-plan/unified-ui-plan.md
+++ b/docs/ai-generated/tasks/#000-unified-ui-plan/unified-ui-plan.md
@@ -2,8 +2,8 @@
 
 | Field | Value |
 |-------|--------|
-| **Status** | **Active — product direction (rev 4.0, 2026-07-27)** |
-| **Supersedes** | Track A (Dojo→jQuery as product strategy), Track B dual-mode / soft cutover, bridge-first hybrid, dual production modes |
+| **Status** | **Active — product direction (rev 4.1, 2026-07-27)** |
+| **Supersedes** | Track A (Dojo→jQuery as product strategy), Track B dual-mode / soft cutover, bridge-first hybrid, dual production modes, “carry jQuery into React” |
 | **Canonical SPA design** | [`#000-pure-react-spa/design.md`](../#000-pure-react-spa/design.md) (infra PRs 1–9) |
 | **Module** | `WebUI/` (React + TypeScript + Vite) |
 | **Stack** | React 19, TypeScript 5.8, Vite, Jetty WAR under `/cm/` |
@@ -13,11 +13,17 @@
 ## 1. Product locks (non-negotiable)
 
 1. **The product UI is React + TypeScript.** New user-facing work ships in `WebUI/src/main/ts/` inside the SPA (`spa.jsp` / path routes). Not jQuery, not Knockout, not Dojo, not a new bridge island for a product page.
-2. **No dual mode.** No feature flag that keeps classic and modern as peer production UIs for the same feature. Rollback = git revert / redeploy.
-3. **No new bridges.** `PercModernUI.mount` is **legacy debt**, not a pattern for new work. Do not add mounts for product navigation. Prefer SPA routes (and SPA dialogs when openers are ready).
-4. **No “shell counts as done.”** A screen is **not** accepted until features work end-to-end (load data, act, navigate, errors, roles). Empty chrome is a defect, not a milestone.
-5. **Screen-by-screen, feature-by-feature.** Prove one surface fully, then delete its legacy peer when safe, then move on. Home first.
-6. **Server entry stays query-only for redirects/login.** `spa.jsp?entry=…` (or path after client handoff). Never `Location: …#/…`.
+2. **Do not carry jQuery forward into the new UI.**  
+   - SPA / modern bundle (`perc-modern-ui.js`) and all of `src/main/ts/**` are **jQuery-free**.  
+   - No `import` of jQuery, no `window.$`, no jQuery UI / FancyTree / plugins from React.  
+   - Reimplement needed behavior with React + typed REST (`api/*`).  
+   - jQuery remaining in the WAR or in `frontend/package.json` is **only** for packing residual legacy pages (`build:legacy`) until those pages are deleted after SPA acceptance.  
+   - **Forbidden:** wrapping jQuery widgets in React, calling legacy `$.perc_*` from TS, or loading jQuery on `spa.jsp` / login for “convenience.”
+3. **No dual mode.** No feature flag that keeps classic and modern as peer production UIs for the same feature. Rollback = git revert / redeploy.
+4. **No new bridges.** `PercModernUI.mount` is **legacy debt**, not a pattern for new work. Do not add mounts for product navigation. Prefer SPA routes (and SPA dialogs when openers are ready).
+5. **No “shell counts as done.”** A screen is **not** accepted until features work end-to-end (load data, act, navigate, errors, roles). Empty chrome is a defect, not a milestone.
+6. **Screen-by-screen, feature-by-feature.** Prove one surface fully, then delete its legacy peer when safe, then move on. Home first.
+7. **Server entry stays query-only for redirects/login.** `spa.jsp?entry=…` (or path after client handoff). Never `Location: …#/…`.
 
 ---
 
@@ -57,7 +63,7 @@ Browser
 | New pages | SPA route (+ server allowlist if deep-linked) |
 | Legacy full-page exits | Temporary only until that feature is React; then delete exit |
 | Residual `PercModernUI.mount` | Only until that host is rewritten or deleted — **no new hosts** |
-| jQuery / Knockout / JSF / GWT / residual Dojo-shaped `ps.*` | **Debt**. Touch only to fix blockers or to delete after React replacement |
+| jQuery / Knockout / JSF / GWT / residual Dojo-shaped `ps.*` | **Debt only.** Never import into SPA. Touch only to fix blockers or to **delete** after React acceptance |
 
 ---
 


### PR DESCRIPTION
## Summary

**PR-9** (final polish of pure React SPA program): path-based client URLs instead of hash routes.

### Client
- `HashRouter` → `BrowserRouter` with basename detected from pathname (`/cm/app` or `/cm/pages/app`, optional context prefix e.g. `/Rhythmyx`)
- Synchronous handoff: `spa.jsp?entry=…` → `/cm/app/{entry}/…` before router mount (server query contract preserved)
- Mid-session 401 return rebuilds `spa.jsp?entry=…` from either query or path

### Server
- New `com.percussion.webui.filter.PSWebUiSpaFallbackFilter`
- GET `/cm/app/{entry}/**` and `/cm/pages/app/{entry}/**` → internal forward to tree `spa.jsp?entry=…` (+ section/tab + preserved query)
- Allowlisted entries only: home, publish, workflow, admin, widget-builder, explorer, unavailable
- Pass-through: real `*.jsp`, static assets, unknown first segments, non-GET

### Unchanged
- Login return / `index.jsp` modern views still use **query** `spa.jsp?entry=…` (never hash)
- Residual bridge dialog hosts unchanged

## Pre-PR verification

- `cd WebUI && ../mvn-env.sh clean install` → **BUILD SUCCESS**
- Surefire: Tests run: **11**, Failures: 0 (filter 7 + gadget 4)
- Vitest App/deepLinks/auth/spaCutover: **40 passed**
- Erlang: **approve** — `docs/ai-generated/code-reviews/000-react-spa-pr9-path-urls-erlang.md`

## Test plan

- [ ] Login → lands SPA; address bar becomes `/cm/app/home` (not `#/home`)
- [ ] TopNav Publish/Admin/Explorer update path; refresh keeps the same route
- [ ] Direct `spa.jsp?entry=publish&section=logs` rewrites to `/cm/app/publish/logs`
- [ ] Legacy exits (`?view=editor`) still full-page load
- [ ] Residual dialog JSPs still load (not swallowed by filter)
- [ ] Behind-proxy / context path `/Rhythmyx` basename still works

Co-Authored by Grok Build using grok-4.5 with agent thesmith.