### PR TITLE
fix(docker): tear down matrix-started external DBs after smoke (#1516)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -101,9 +101,29 @@ python3 docker/scripts/matrix-install-smoke.py --product cms --db postgresql --k
 TEST_CMS_URL=http://localhost:9993 TEST_DB_TYPE=postgresql \
   npm test --prefix modules/perc-qa-automation/frontend -- tests/install.spec.js
 
+# Destroy cells but keep external DBs for a follow-up matrix run
+python3 docker/scripts/matrix-install-smoke.py --product cms --db postgresql --keep-db
+
+# Force-stop every external DB used by this matrix (including pre-existing)
+python3 docker/scripts/matrix-install-smoke.py --product cms --db postgresql,mysql --stop-db
+
 # Dry-run (no docker)
 python3 docker/scripts/matrix-install-smoke.py --product cms --db h2 --dry-run --skip-image-build
 ```
+
+### External DB teardown policy (#1516)
+
+Matrix cells (`perc-matrix-*`) are destroyed after each cell unless `--keep`.
+External compose DBs (`percussion-postgres` / `percussion-mysql` / `percussion-sqlserver`) follow a separate ownership rule:
+
+| Flag | Cells | External DBs |
+|------|-------|--------------|
+| **Default** | Destroyed | Stop services **this process started** (`compose stop`; no volume wipe) |
+| `--keep` | Left running | Left running (Layer 2 / debugging) |
+| `--keep-db` | Destroyed (unless `--keep`) | Left running (reuse across runs) |
+| `--stop-db` | Destroyed (unless `--keep`) | Stop **all** external DBs used by the matrix, even if pre-existing |
+
+If a DB container was already running before the harness (e.g. long-lived dev stack), the default path **reuses** it and **does not** stop it at the end. Use `--stop-db` only when you intentionally want those containers stopped. Never uses `compose down -v` by default (named volumes / operator data are preserved).
 
 ### DTS packaging notes (HTTP 9980)
 

--- a/docker/scripts/matrix-install-smoke.py
+++ b/docker/scripts/matrix-install-smoke.py
@@ -13,6 +13,21 @@ Layer 1 harness:
   4. Probe login / health URL from the host
   5. Record JSON + RESULT line under ``docker/logs/``
   6. Destroy the cell unless ``--keep``
+  7. Stop external DBs this process started (unless ``--keep`` / ``--keep-db``)
+
+DB lifecycle (#1516)
+--------------------
+External compose DBs (``percussion-postgres`` / ``-mysql`` / ``-sqlserver``) are
+started only when not already running. After the matrix report is written:
+
+* **Default** — stop services this process brought up (``compose stop``, no ``-v``).
+* ``--keep`` — leave cells **and** DBs up (Playwright Layer 2 / debugging).
+* ``--keep-db`` — destroy cells (unless ``--keep``) but leave external DBs running.
+* ``--stop-db`` — stop every external DB used by this matrix, even if pre-existing
+  (destructive; does not remove volumes).
+
+Operator-owned DBs that were already running before the harness are left alone
+unless ``--stop-db`` is set.
 
 Usage
 -----
@@ -29,6 +44,9 @@ Usage
 
     # Leave stack up for Playwright Layer 2
     python3 docker/scripts/matrix-install-smoke.py --product cms --db postgresql --keep
+
+    # Destroy cells but reuse DBs for the next matrix run
+    python3 docker/scripts/matrix-install-smoke.py --product cms --db postgresql --keep-db
 
     # Dry-run (no docker/mvn)
     python3 docker/scripts/matrix-install-smoke.py --product cms --db h2 --dry-run
@@ -54,7 +72,7 @@ import urllib.request
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 LOG = logging.getLogger("matrix-install-smoke")
 
@@ -114,8 +132,64 @@ DB_SERVICES: Dict[str, Dict[str, str]] = {
     },
 }
 
+# Compose service name → stable container_name from docker-compose.yml
+CONTAINER_BY_SERVICE: Dict[str, str] = {
+    "postgres": "percussion-postgres",
+    "mysql": "percussion-mysql",
+    "sqlserver": "percussion-sqlserver",
+}
+
 PRODUCTS = ("cms", "dts")
 DB_TYPES = tuple(DB_SERVICES.keys())
+
+
+def db_container_name(service: str) -> str:
+    """Return the Docker container name for a compose DB service."""
+    return CONTAINER_BY_SERVICE.get(service, f"percussion-{service}")
+
+
+def external_db_types(db_types: Iterable[str]) -> Set[str]:
+    """Return matrix DB keys that use an external compose service (not H2)."""
+    out: Set[str] = set()
+    for db_type in db_types:
+        meta = DB_SERVICES.get(db_type) or {}
+        if meta.get("service"):
+            out.add(db_type)
+    return out
+
+
+def select_dbs_to_stop(
+    *,
+    started_by_matrix: Iterable[str],
+    used_external: Iterable[str],
+    keep: bool,
+    keep_db: bool,
+    stop_db: bool,
+) -> Set[str]:
+    """Decide which external DB types to stop after a matrix run (pure policy).
+
+    Parameters
+    ----------
+    started_by_matrix
+        DB types this process actually brought up via ``compose up``.
+    used_external
+        External DB types selected for the matrix (pre-existing or started).
+    keep
+        Leave cells and DBs up (Layer 2).
+    keep_db
+        Leave DBs up even when cells are destroyed.
+    stop_db
+        Hard-stop every used external DB, including pre-existing ones.
+
+    ``--keep`` and ``--keep-db`` always win over ``--stop-db``.
+    Never includes H2 (no external container).
+    """
+    if keep or keep_db:
+        return set()
+    used = set(used_external)
+    if stop_db:
+        return used
+    return set(started_by_matrix) & used
 
 
 @dataclass
@@ -351,20 +425,26 @@ def start_db(
     db_type: str,
     *,
     dry_run: bool,
-) -> None:
+) -> Optional[bool]:
+    """Start an external compose DB for ``db_type`` if needed.
+
+    Returns
+    -------
+    Optional[bool]
+        ``None`` if ``db_type`` has no external compose service (e.g. H2).
+        ``True`` if this invocation brought the service up (or would under
+        ``--dry-run``).
+        ``False`` if the container was already running (operator-owned / reused).
+    """
     meta = DB_SERVICES[db_type]
     profile = meta.get("profile") or ""
     service = meta.get("service") or ""
     if not profile or not service:
-        return
+        return None
     # Attach DB container to matrix network with a DNS alias matching the
     # compose service name (e.g. "postgres") so cells can use DB_HOST=postgres.
-    container_by_service = {
-        "postgres": "percussion-postgres",
-        "mysql": "percussion-mysql",
-        "sqlserver": "percussion-sqlserver",
-    }
-    container = container_by_service.get(service, f"percussion-{service}")
+    container = db_container_name(service)
+    started_by_matrix = False
 
     # If compose DB is already running (common on long-lived dev hosts), skip
     # ``compose up`` so a host port clash (e.g. local Postgres on 5432) does not
@@ -384,6 +464,7 @@ def start_db(
             service,
         ]
         _run(argv, dry_run=dry_run, check=not dry_run)
+        started_by_matrix = True
 
     _run(
         [
@@ -398,6 +479,53 @@ def start_db(
         dry_run=dry_run,
         check=False,
     )
+    return started_by_matrix
+
+
+def stop_external_dbs(
+    compose_file: Path,
+    db_types: Iterable[str],
+    *,
+    dry_run: bool,
+) -> None:
+    """Stop external compose DB services (no volume wipe).
+
+    Disconnects each container from ``perc-matrix-net`` best-effort, then
+    ``docker compose … stop <service>`` (not ``down -v``).
+    """
+    for db_type in sorted(set(db_types)):
+        meta = DB_SERVICES.get(db_type) or {}
+        profile = meta.get("profile") or ""
+        service = meta.get("service") or ""
+        if not profile or not service:
+            continue
+        container = db_container_name(service)
+        LOG.info("Stopping matrix external DB %s (%s)", db_type, container)
+        _run(
+            [
+                "docker",
+                "network",
+                "disconnect",
+                MATRIX_NETWORK,
+                container,
+            ],
+            dry_run=dry_run,
+            check=False,
+        )
+        _run(
+            [
+                "docker",
+                "compose",
+                "-f",
+                str(compose_file),
+                "--profile",
+                profile,
+                "stop",
+                service,
+            ],
+            dry_run=dry_run,
+            check=False,
+        )
 
 
 def _docker_container_running(name: str) -> bool:
@@ -468,6 +596,8 @@ def run_cell(
     probe_timeout: int,
     dry_run: bool,
     log_dir: Path,
+    started_dbs: Optional[Set[str]] = None,
+    engaged_dbs: Optional[Set[str]] = None,
 ) -> CellResult:
     started = time.time()
     name = cell_container_name(cell)
@@ -492,7 +622,12 @@ def run_cell(
     LOG.info("Cell %s using jar %s (%s bytes)", cell.cell_id, jar, jar.stat().st_size if jar.is_file() else 0)
 
     destroy_container(name, dry_run=dry_run)
-    start_db(repo_root, compose_file, cell.db_type, dry_run=dry_run)
+    ownership = start_db(repo_root, compose_file, cell.db_type, dry_run=dry_run)
+    if ownership is not None:
+        if engaged_dbs is not None:
+            engaged_dbs.add(cell.db_type)
+        if ownership and started_dbs is not None:
+            started_dbs.add(cell.db_type)
 
     run_argv = build_docker_run_argv(
         image=MATRIX_IMAGE_TAG,
@@ -604,7 +739,27 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--keep",
         action="store_true",
-        help="Leave the last/each cell container running for Playwright Layer 2",
+        help=(
+            "Leave cell containers running for Playwright Layer 2; "
+            "also leaves external DBs up (implies no DB teardown)"
+        ),
+    )
+    db_life = p.add_mutually_exclusive_group()
+    db_life.add_argument(
+        "--keep-db",
+        action="store_true",
+        help=(
+            "Leave external DB containers running after the matrix finishes "
+            "(cells still destroyed unless --keep). Opt-in to previous default."
+        ),
+    )
+    db_life.add_argument(
+        "--stop-db",
+        action="store_true",
+        help=(
+            "Stop every external DB used by this matrix, including containers "
+            "that were already running before the run (destructive; no volume wipe)"
+        ),
     )
     p.add_argument(
         "--probe-timeout",
@@ -647,52 +802,89 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return EXIT_INVOCATION
 
     cells = expand_matrix(products, dbs)
+    # Engaged = external DBs we actually start_db()'d for a cell (not merely selected).
+    engaged_external: Set[str] = set()
+    started_by_matrix: Set[str] = set()
     report = MatrixReport(started_at=datetime.now(timezone.utc).isoformat())
+    exit_code = EXIT_OK
 
     if not args.dry_run and shutil.which("docker") is None:
         LOG.error("docker not found on PATH")
         print("RESULT:FAIL STEP:matrix LOG:")
         return EXIT_INVOCATION
 
-    ensure_network(MATRIX_NETWORK, dry_run=args.dry_run)
-    if not args.skip_image_build:
-        try:
-            build_matrix_image(repo_root, dry_run=args.dry_run)
-        except subprocess.CalledProcessError as exc:
-            LOG.error("matrix image build failed: %s", exc)
-            print("RESULT:FAIL STEP:matrix-image LOG:")
-            return EXIT_CELL_FAILED
+    try:
+        ensure_network(MATRIX_NETWORK, dry_run=args.dry_run)
+        if not args.skip_image_build:
+            try:
+                build_matrix_image(repo_root, dry_run=args.dry_run)
+            except subprocess.CalledProcessError as exc:
+                LOG.error("matrix image build failed: %s", exc)
+                print("RESULT:FAIL STEP:matrix-image LOG:")
+                exit_code = EXIT_CELL_FAILED
+                return exit_code
 
-    for cell in cells:
-        LOG.info("=== matrix cell %s ===", cell.cell_id)
-        result = run_cell(
-            cell,
-            repo_root=repo_root,
-            compose_file=compose_file,
+        for cell in cells:
+            LOG.info("=== matrix cell %s ===", cell.cell_id)
+            result = run_cell(
+                cell,
+                repo_root=repo_root,
+                compose_file=compose_file,
+                keep=args.keep,
+                probe_timeout=args.probe_timeout,
+                dry_run=args.dry_run,
+                log_dir=log_dir,
+                started_dbs=started_by_matrix,
+                engaged_dbs=engaged_external,
+            )
+            report.results.append(result)
+            LOG.info(
+                "Cell %s → %s (%0.1fs) %s",
+                result.cell_id,
+                result.status,
+                result.duration_seconds,
+                result.detail,
+            )
+
+        report.finished_at = datetime.now(timezone.utc).isoformat()
+        report_path = log_dir / f"matrix-results-{_ts()}.json"
+        report_path.write_text(
+            json.dumps(report.to_dict(), indent=2) + "\n", encoding="utf-8"
+        )
+
+        failed = [r for r in report.results if r.status == "fail"]
+        if failed:
+            print(f"RESULT:FAIL STEP:matrix LOG:{report_path}")
+            exit_code = EXIT_CELL_FAILED
+        else:
+            print(f"RESULT:OK STEP:matrix LOG:{report_path}")
+            exit_code = EXIT_OK
+        return exit_code
+    finally:
+        # Always attempt DB teardown after cells (pass or fail), unless opted out.
+        # Only consider DBs this run actually engaged (start_db called).
+        to_stop = select_dbs_to_stop(
+            started_by_matrix=started_by_matrix,
+            used_external=engaged_external,
             keep=args.keep,
-            probe_timeout=args.probe_timeout,
-            dry_run=args.dry_run,
-            log_dir=log_dir,
+            keep_db=args.keep_db,
+            stop_db=args.stop_db,
         )
-        report.results.append(result)
-        LOG.info(
-            "Cell %s → %s (%0.1fs) %s",
-            result.cell_id,
-            result.status,
-            result.duration_seconds,
-            result.detail,
-        )
-
-    report.finished_at = datetime.now(timezone.utc).isoformat()
-    report_path = log_dir / f"matrix-results-{_ts()}.json"
-    report_path.write_text(json.dumps(report.to_dict(), indent=2) + "\n", encoding="utf-8")
-
-    failed = [r for r in report.results if r.status == "fail"]
-    if failed:
-        print(f"RESULT:FAIL STEP:matrix LOG:{report_path}")
-        return EXIT_CELL_FAILED
-    print(f"RESULT:OK STEP:matrix LOG:{report_path}")
-    return EXIT_OK
+        if to_stop:
+            LOG.info(
+                "Tearing down external DBs: %s",
+                ", ".join(sorted(to_stop)),
+            )
+            stop_external_dbs(compose_file, to_stop, dry_run=args.dry_run)
+        elif engaged_external and (args.keep or args.keep_db):
+            LOG.info(
+                "Leaving external DBs running (%s)",
+                "--keep" if args.keep else "--keep-db",
+            )
+        elif engaged_external and not started_by_matrix and not args.stop_db:
+            LOG.info(
+                "Leaving pre-existing external DBs running (not started by this matrix run)"
+            )
 
 
 if __name__ == "__main__":

--- a/docker/scripts/test_matrix_install_smoke.py
+++ b/docker/scripts/test_matrix_install_smoke.py
@@ -210,22 +210,140 @@ class ProbeUrlTests(unittest.TestCase):
         )
 
 
+class DbOwnershipAndTeardownTests(unittest.TestCase):
+    """Pure policy tests for #1516 external DB lifecycle (no live Docker)."""
+
+    def test_db_container_name_mapping(self):
+        self.assertEqual(smoke.db_container_name("postgres"), "percussion-postgres")
+        self.assertEqual(smoke.db_container_name("mysql"), "percussion-mysql")
+        self.assertEqual(smoke.db_container_name("sqlserver"), "percussion-sqlserver")
+        self.assertEqual(smoke.db_container_name("other"), "percussion-other")
+
+    def test_external_db_types_skips_h2(self):
+        self.assertEqual(
+            smoke.external_db_types(["h2", "postgresql", "mysql", "sqlserver"]),
+            {"postgresql", "mysql", "sqlserver"},
+        )
+        self.assertEqual(smoke.external_db_types(["h2"]), set())
+
+    def test_default_stops_only_started_by_matrix(self):
+        self.assertEqual(
+            smoke.select_dbs_to_stop(
+                started_by_matrix={"postgresql"},
+                used_external={"postgresql", "mysql"},
+                keep=False,
+                keep_db=False,
+                stop_db=False,
+            ),
+            {"postgresql"},
+        )
+
+    def test_default_stops_nothing_when_all_preexisting(self):
+        self.assertEqual(
+            smoke.select_dbs_to_stop(
+                started_by_matrix=set(),
+                used_external={"postgresql", "mysql"},
+                keep=False,
+                keep_db=False,
+                stop_db=False,
+            ),
+            set(),
+        )
+
+    def test_keep_leaves_all_dbs(self):
+        self.assertEqual(
+            smoke.select_dbs_to_stop(
+                started_by_matrix={"postgresql", "mysql"},
+                used_external={"postgresql", "mysql"},
+                keep=True,
+                keep_db=False,
+                stop_db=False,
+            ),
+            set(),
+        )
+
+    def test_keep_db_leaves_dbs_without_keep(self):
+        self.assertEqual(
+            smoke.select_dbs_to_stop(
+                started_by_matrix={"postgresql"},
+                used_external={"postgresql"},
+                keep=False,
+                keep_db=True,
+                stop_db=False,
+            ),
+            set(),
+        )
+
+    def test_stop_db_stops_all_used_including_preexisting(self):
+        self.assertEqual(
+            smoke.select_dbs_to_stop(
+                started_by_matrix={"postgresql"},
+                used_external={"postgresql", "mysql", "sqlserver"},
+                keep=False,
+                keep_db=False,
+                stop_db=True,
+            ),
+            {"postgresql", "mysql", "sqlserver"},
+        )
+
+    def test_keep_overrides_stop_db(self):
+        self.assertEqual(
+            smoke.select_dbs_to_stop(
+                started_by_matrix={"postgresql"},
+                used_external={"postgresql"},
+                keep=True,
+                keep_db=False,
+                stop_db=True,
+            ),
+            set(),
+        )
+
+    def test_keep_db_overrides_stop_db_via_mutex_policy(self):
+        # CLI makes these mutually exclusive; policy still prefers keep_db.
+        self.assertEqual(
+            smoke.select_dbs_to_stop(
+                started_by_matrix={"mysql"},
+                used_external={"mysql"},
+                keep=False,
+                keep_db=True,
+                stop_db=True,
+            ),
+            set(),
+        )
+
+    def test_started_unknown_to_used_is_ignored(self):
+        # Defensive: only stop DBs that were part of this matrix selection.
+        self.assertEqual(
+            smoke.select_dbs_to_stop(
+                started_by_matrix={"postgresql", "mysql"},
+                used_external={"postgresql"},
+                keep=False,
+                keep_db=False,
+                stop_db=False,
+            ),
+            {"postgresql"},
+        )
+
+
 class DryRunCliTests(unittest.TestCase):
+    def _stub_repo(self, root: Path) -> None:
+        target = root / "modules" / "perc-distribution-tree" / "target"
+        target.mkdir(parents=True)
+        # Exact customer-shipped assembly name (not *-SNAPSHOT.jar).
+        (target / "perc-distribution-tree.jar").write_bytes(b"stub-jar-content")
+        (root / "docker" / "logs").mkdir(parents=True)
+        (root / "docker" / "matrix").mkdir(parents=True)
+        (root / "docker" / "matrix" / "Dockerfile").write_text(
+            "FROM scratch\n", encoding="utf-8"
+        )
+        (root / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+
     def test_dry_run_exits_zero_for_h2(self):
         # dry-run still needs a jar on disk for resolve in run_cell —
         # dry-run path resolves jar before docker; create a stub tree.
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
-            target = root / "modules" / "perc-distribution-tree" / "target"
-            target.mkdir(parents=True)
-            # Exact customer-shipped assembly name (not *-SNAPSHOT.jar).
-            (target / "perc-distribution-tree.jar").write_bytes(b"stub-jar-content")
-            (root / "docker" / "logs").mkdir(parents=True)
-            (root / "docker" / "matrix").mkdir(parents=True)
-            (root / "docker" / "matrix" / "Dockerfile").write_text(
-                "FROM scratch\n", encoding="utf-8"
-            )
-            (root / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+            self._stub_repo(root)
             rc = smoke.main(
                 [
                     "--repo-root",
@@ -239,6 +357,30 @@ class DryRunCliTests(unittest.TestCase):
                 ]
             )
             self.assertEqual(rc, 0)
+
+    def test_dry_run_postgresql_exits_zero(self):
+        """External DB path exercises start/stop planning without live Docker."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            self._stub_repo(root)
+            rc = smoke.main(
+                [
+                    "--repo-root",
+                    str(root),
+                    "--product",
+                    "cms",
+                    "--db",
+                    "postgresql",
+                    "--dry-run",
+                    "--skip-image-build",
+                ]
+            )
+            self.assertEqual(rc, 0)
+
+    def test_keep_db_and_stop_db_are_mutually_exclusive(self):
+        with self.assertRaises(SystemExit) as ctx:
+            smoke._build_parser().parse_args(["--keep-db", "--stop-db"])
+        self.assertNotEqual(ctx.exception.code, 0)
 
 
 if __name__ == "__main__":

--- a/docs/ai-generated/code-reviews/1516-matrix-install-smoke-db-teardown-erlang.md
+++ b/docs/ai-generated/code-reviews/1516-matrix-install-smoke-db-teardown-erlang.md
@@ -1,0 +1,68 @@
+# Erlang review: #1516 matrix-install-smoke DB teardown
+
+**Date:** 2026-07-27  
+**Branch:** `feature/matrix-install-smoke-db-teardown`  
+**Base:** `origin/development`  
+**Reviewer persona:** Erlang (pre-commit / pre-PR)
+
+## Summary
+
+The harness now tracks which external compose DBs it started vs reused, and tears
+down only matrix-owned services by default after the cell loop (success or fail).
+CLI opts (`--keep`, `--keep-db`, `--stop-db`) match issue #1516. Pure decision
+logic is unit-tested; docker CLI remains subprocess argv lists (spec 994 style).
+
+## Scope
+
+| Path | Change |
+|------|--------|
+| `docker/scripts/matrix-install-smoke.py` | Ownership, `select_dbs_to_stop`, `stop_external_dbs`, CLI, `main` finally |
+| `docker/scripts/test_matrix_install_smoke.py` | Policy + dry-run + mutex tests |
+| `docker/README.md` | Teardown policy table and examples |
+
+- Uncommitted diff vs `HEAD` (no prior commits on branch).
+- Prior reports: `1500-matrix-smoke-*.md` (parent harness); no prior #1516 report.
+- Memory patterns: portable Python + docker CLI; no shell-only entry; ownership
+  must not destroy operator-owned resources by default.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs | None found |
+| Behavioral unit tests for new logic | Present (`select_dbs_to_stop`, ownership mapping, CLI mutex, dry-run PG path) |
+| Cross-platform path / file I/O | Clean — `pathlib.Path`, `str(compose_file)` to docker only; no hardcoded FS separators |
+| May commit/push | **yes** |
+
+Cross-platform path review: no new filesystem path string joins; temp dirs in
+tests use `tempfile` + `Path`; docker network/compose args are logical names.
+
+## Issues
+
+### suggestion
+
+1. **`select_dbs_to_stop` docstring vs call site**  
+   Docstring describes `used_external` as “selected for the matrix”; `main`
+   passes **engaged** DBs only (those for which `start_db` ran). Behavior is
+   correct and safer; consider renaming the parameter to `engaged_external` in
+   a follow-up for clarity. Non-blocking.
+
+### nit
+
+1. **`start_db(..., repo_root)`** still unused (pre-existing). Harmless.
+
+2. **`--keep` + `--stop-db`** allowed together; policy prefers `--keep`. Fine;
+   optional help note later.
+
+## Verification
+
+```text
+python -m pytest docker/scripts/test_matrix_install_smoke.py -v
+# 25 passed
+```
+
+Maven clean install: **N/A** (Python/docs only; no module `pom.xml` / sources).


### PR DESCRIPTION
## Summary

- After `matrix-install-smoke` finishes (pass or fail), stop external compose DBs that **this process started** (`compose stop`; no volume wipe).
- Reuse pre-existing operator-owned DB containers by default and leave them running unless `--stop-db`.
- Add `--keep-db` (leave DBs, destroy cells) and `--stop-db` (hard-stop all engaged external DBs); `--keep` still leaves cells **and** DBs for Playwright Layer 2.
- Document teardown policy in `docker/README.md` and harness help; unit tests cover ownership decision logic without live Docker.

Closes #1516

## Test plan

- [x] `python -m pytest docker/scripts/test_matrix_install_smoke.py -v` — **25 passed**
- [x] `python docker/scripts/matrix-install-smoke.py --help` shows `--keep-db` / `--stop-db`
- [ ] Optional live smoke: `--product cms --db postgresql` then confirm `percussion-postgres` is stopped when matrix started it
- [ ] Optional: pre-start postgres, run matrix without `--stop-db`, confirm container left running
- [ ] Optional: `--keep` leaves cell + DB; `--keep-db` destroys cell but leaves DB

## Pre-PR verification

- **Maven clean install:** N/A — Python/docs only (no module `pom.xml` / Java sources changed).
- **Erlang pre-commit:** approve — `docs/ai-generated/code-reviews/1516-matrix-install-smoke-db-teardown-erlang.md`
- **Unit tests:** `docker/scripts/test_matrix_install_smoke.py` (25 passed)

> Co-Authored by Grok Build (xAI) Grok 4.5 using grok-4.5 with agent Grok.