### PR TITLE
docs(webui): tighten no-jQuery SPA lock in AGENTS and plan

### DIFF
--- a/WebUI/AGENTS.md
+++ b/WebUI/AGENTS.md
@@ -60,7 +60,7 @@ These are **not** peer product UIs. Agents may touch them only for security/hotf
 | Layer | Tech | Policy |
 |-------|------|--------|
 | Residual bridge dialogs / embeds | React via `PercModernUI.mount` on old JSPs | Delete when SPA owns the job; **no new mounts** |
-| WebUI legacy pages | jQuery / Backbone | No new features |
+| WebUI legacy pages | jQuery / Backbone | No new features; **never** depend on from `src/main/ts` |
 | Contributor UI leftovers | Knockout | No new features |
 | Active Assembly / residual `ps.*` | Historical Dojo-shaped code + shims | No new Dojo; replace with React when editor wave runs |
 | Package Manager | GWT | Legacy until React wave |
@@ -139,6 +139,7 @@ cp WebUI/target/generated-webui/cm/modern/assets/perc-modern-ui.css \
 - Styles: CSS modules preferred; theme tokens via `ui-themes`
 - Tests: Vitest for non-trivial logic; update tests with every behavior change
 - SPA routing: `app/routes.tsx` + deep-link allowlists; server entry allowlists stay in lockstep
+- **No jQuery** — see product lock #2. If a legacy page used `$('…')` or FancyTree, reimplement in React or use a non-jQuery primitive.
 
 ### Java (WebUI)
 
@@ -150,6 +151,7 @@ cp WebUI/target/generated-webui/cm/modern/assets/perc-modern-ui.css \
 - **Do not** add product features
 - **Do not** add Dojo
 - **Do not** add new `PercModernUI.mount` hosts
+- **Do not** pull jQuery into the modern SPA bundle or TS sources
 - Security/hotfix only, or delete after React acceptance
 
 ---
@@ -182,8 +184,9 @@ Follow the **screen checklist** in the unified UI plan. Home must pass on a **re
 | Ship SPA React features | Dual-mode / classic peer UIs |
 | Fix Home until functional | Declare “done” because shell renders |
 | Delete obsolete hosts after acceptance | New bridge product pages |
-| Align allowlists (TS + JSP/filter) | New Dojo / Knockout / jQuery product code |
-| Document acceptance evidence | Invent REST APIs without checking existing `api/` + `rest` module |
+| Align allowlists (TS + JSP/filter) | **jQuery / `$` / jQuery plugins in `src/main/ts` or modern bundle** |
+| Document acceptance evidence | New Dojo / Knockout product code |
+| Typed `api/*` + React UI | Wrap jQuery widgets in React “for speed” |
 
 ---
 

--- a/docs/ai-generated/tasks/#000-unified-ui-plan/unified-ui-plan.md
+++ b/docs/ai-generated/tasks/#000-unified-ui-plan/unified-ui-plan.md
@@ -147,17 +147,19 @@ Same rule: **feature checklist per screen**, then delete legacy peer.
 ### DO
 
 - Implement features in **React + TypeScript** under `WebUI/src/main/ts/`.
-- Use SPA routes and existing REST + CSRF + TMX patterns.
+- Use SPA routes and existing REST + CSRF + TMX patterns (**no jQuery**).
 - For each screen: **acceptance checklist** + Vitest for non-trivial logic + real CMS smoke.
 - Prefer fixing broken SPA behavior over wiring another jQuery page.
-- After a surface is **Accepted**, delete obsolete hosts/scripts for that surface in the same or immediate follow-up PR.
+- After a surface is **Accepted**, delete obsolete hosts/scripts (including jQuery packs for that surface) in the same or immediate follow-up PR.
 
 ### DO NOT
 
 - Add dual-mode flags or “keep classic as production peer.”
 - Add new `PercModernUI.mount` product pages.
+- **Import or depend on jQuery from the SPA / modern bundle / `src/main/ts`.**
+- Wrap jQuery widgets in React or call `$.perc_*` from TypeScript.
 - Add new Dojo or new Knockout features.
-- Expand jQuery except critical security/hotfix on a surface not yet replaced.
+- Expand jQuery except critical security/hotfix on a **legacy** surface not yet replaced.
 - Call a route “done” because the shell renders.
 
 ### Residual bridge / legacy code
@@ -218,9 +220,10 @@ Infra PRs (login shell, cutover, path URLs) stay; **value is measured by accepte
 | ID | Decision |
 |----|----------|
 | KD-R1 | Product UI = React + TypeScript SPA only |
-| KD-R2 | No dual mode / no soft feature-flag cutover |
-| KD-R3 | No new PercModernUI product hosts |
-| KD-R4 | Shell ≠ done; feature acceptance required |
-| KD-R5 | Home first, then Publish → Explorer → Admin → Workflow → WB |
-| KD-R6 | Track A Dojo→jQuery as product strategy is retired; vendor Dojo already gone |
-| KD-R7 | Server redirects stay query `entry` contract; client uses path URLs |
+| KD-R2 | **No jQuery in the new UI** (modern bundle / `src/main/ts`); jQuery is delete-bound legacy only |
+| KD-R3 | No dual mode / no soft feature-flag cutover |
+| KD-R4 | No new PercModernUI product hosts |
+| KD-R5 | Shell ≠ done; feature acceptance required |
+| KD-R6 | Home first, then Publish → Explorer → Admin → Workflow → WB |
+| KD-R7 | Track A Dojo→jQuery as product strategy is retired; vendor Dojo already gone |
+| KD-R8 | Server redirects stay query `entry` contract; client uses path URLs |


### PR DESCRIPTION
## Summary

Small follow-up to the no-jQuery product lock that landed with PR-9 (#1542). Strengthens agent guidance so the ban is hard to miss when implementing SPA screens.

### Changes

- **`WebUI/AGENTS.md`**
  - Legacy jQuery pages: never depend on from `src/main/ts`
  - Stack / residual rules: no jQuery in modern SPA bundle or TS
  - Prefer table: ban `$` / jQuery plugins and “wrap jQuery in React for speed”
- **`docs/ai-generated/tasks/#000-unified-ui-plan/unified-ui-plan.md`**
  - DO / DO NOT: no jQuery import, no `$.perc_*`, delete jQuery packs after acceptance
  - Key decisions: **KD-R2 = no jQuery in the new UI**; prior KD-R2–R7 renumbered to KD-R3–R8

Docs only — no Maven clean install required.

## Test plan

- [x] Diff-only review of AGENTS + plan consistency
- [ ] Skim KD table / Prefer table for agent discoverability

> Co-Authored by Grok Build using grok-4.5 with agent Grok.