### PR TITLE
fix(webui): resolve TS2307 'Cannot find module react-router' in tsc --noEmit

### DIFF
--- a/WebUI/src/main/frontend/tsconfig.json
+++ b/WebUI/src/main/frontend/tsconfig.json
@@ -22,7 +22,8 @@
       "react-dom": ["node_modules/@types/react-dom"],
       "react/jsx-runtime": ["node_modules/@types/react/jsx-runtime"],
       "react-dom/*": ["node_modules/@types/react-dom/*"],
-      "*": ["node_modules/*"]
+      "*": ["node_modules/*"],
+      "react-router": ["./node_modules/react-router/dist/production/index.d.ts"]
     },
     "typeRoots": ["./node_modules/@types"]
   },

--- a/WebUI/src/main/frontend/tsconfig.json
+++ b/WebUI/src/main/frontend/tsconfig.json
@@ -23,7 +23,7 @@
       "react/jsx-runtime": ["node_modules/@types/react/jsx-runtime"],
       "react-dom/*": ["node_modules/@types/react-dom/*"],
       "*": ["node_modules/*"],
-      "react-router": ["./node_modules/react-router/dist/production/index.d.ts"]
+      "react-router": ["node_modules/react-router/dist/production/index.d.ts"]
     },
     "typeRoots": ["./node_modules/@types"]
   },

--- a/docs/ai-generated/code-reviews/fix-perc-web-ui-npm-build-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-perc-web-ui-npm-build-erlang.md
@@ -1,0 +1,69 @@
+# Erlang Code Review — fix/perc-web-ui-npm-build
+
+## Summary
+
+Build fix for `perc-web-ui` (WebUI) — the `npm run build:modern` step (`tsc --noEmit && vite build`) was failing on the current `origin/development` tip with 11 `TS2307: Cannot find module 'react-router'` errors. Root cause: the `react-router` v8.3.0 package was added in PR #1539 and started being imported in PR #1542, but the package ships its type declarations only via the `exports.types` subpath condition and not via a root-level `types` field. TypeScript 5.9 with `paths: "*": ["node_modules/*"]` was bypassing the `exports` field, falling back to legacy package-root field resolution, and never finding `react-router/dist/production/index.d.ts`. One-line fix: explicit `paths` mapping for `react-router` to its types file. Standalone module build is now green.
+
+## Scope
+
+- Base: `origin/development` (24ee28acf4)
+- Head: `fix/perc-web-ui-npm-build` (uncommitted)
+- Files: 1 changed (`WebUI/src/main/frontend/tsconfig.json`, +1 line)
+- Prior report: none
+- Memory patterns hit: `docs.ts.paths-bypass-exports-field`
+
+## Recommendation
+
+approve
+
+## Gate
+
+- Blocking bugs: 0
+- May commit/push: yes
+
+## Issues
+
+None.
+
+## Review notes
+
+### Reproduction
+- `cd WebUI && ..\..\mvn-env.bat clean install -B` on `origin/development` → BUILD FAILURE in `frontend-maven-plugin:npm-build-modern` (`tsc --noEmit && vite build`). npm step exit value 2.
+- `tsc --noEmit` produced exactly 11 errors of the form `error TS2307: Cannot find module 'react-router' or its corresponding type declarations.` across the SPA shell, route shims and feature placeholder files imported in PRs #1531/#1542.
+
+### Diagnosis
+- `react-router@8.3.0` package.json has no root-level `types`, `typings`, `main`, or `typesVersions` field; types are exposed solely through `exports[".types"]` pointing at `./dist/production/index.d.ts`.
+- TypeScript 5.9 with `moduleResolution: "bundler"` honours `exports` during a normal node-modules walk, but the `tsconfig.json` here uses a catch-all `paths: "*": ["node_modules/*"]` rule. Trace (`tsc --noEmit --traceResolution`) confirmed TS falls back to the legacy package-root field walk (looking for `typesVersions` / `typings` / `types` / `main`) and never reads the `exports` block.
+- Secondary contributor: source files live at `WebUI/src/main/ts/`, `node_modules` at `WebUI/src/main/frontend/node_modules/` (sibling layout). Node resolution walks UP from source, so it cannot find the package without an explicit hint even if `exports` is read.
+
+### Fix
+- Added `paths` entry `"react-router": ["./node_modules/react-router/dist/production/index.d.ts"]` (kept the existing catch-all `"*"` mapping so no other package changes). The direct `.d.ts` file path bypasses the broken `exports` walk and gives TS the exact type entry point.
+- Considered alternatives:
+  - Symlink `WebUI/src/main/ts/node_modules/react-router` → real install — rejected, fragile and platform-specific.
+  - Move `node_modules` closer to `ts/` — rejected, large dir restructuring outside this issue's scope.
+  - Switch to `moduleResolution: "nodenext"` — rejected, would force `.js` extensions on hundreds of relative imports (verified locally — produced ~12 follow-on errors in SiteCopyWizard/HomeShell/index.ts).
+  - Add a `@types/react-router` shadow package — rejected, ugly workaround and unnecessary.
+  - Switch `paths` wildcard to a per-package style for *every* package — rejected, far more invasive than needed.
+
+### Verification
+- `cd WebUI && ..\..\mvn-env.bat clean install -B` → **BUILD SUCCESS** (~3 min cold; full module + 11 tests pass).
+- `tsc --noEmit` standalone: 0 errors.
+- `vite build` standalone: 0 errors, generated `target/generated-webui/cm/modern/assets/perc-modern-ui.{js,css}` plus the expected vendor chunks.
+- `Tests run: 11, Failures: 0, Errors: 0, Skipped: 0` (PSWebUiSpaFallbackFilterTest 7 + GadgetRegistryTest 4).
+- No new warnings introduced; existing warnings are pre-existing dependency relocations (jakarta artefacts, etc.) unrelated to the diff.
+
+### Diff footprint
+- One file, +1 line. No code changes, no API changes, no test changes. Risk surface is minimal.
+
+### Cross-platform path / file I/O
+- Diff is TypeScript config only; no file I/O, paths, installers, or packaging touched.
+- Cross-platform path review: no issues.
+
+## Pre-PR command evidence
+
+```bash
+cd WebUI
+..\..\mvn-env.bat clean install -B
+```
+
+Result: `BUILD SUCCESS`. `tsc --noEmit` clean. `vite build` clean. 11 tests pass, 0 failures. No new warnings.


### PR DESCRIPTION
\]\ — the package.json has no root-level \	ypes\ / \	ypings\ / \main\ field.
- \WebUI/src/main/frontend/tsconfig.json\ has the catch-all \\paths\: { \*\: [\node_modules/*\] }\. That forces TypeScript into legacy package-root field resolution and bypasses the subpath \exports\ walk.
- Source files live at \WebUI/src/main/ts/\ and \
ode_modules\ at \WebUI/src/main/frontend/node_modules/\ (sibling directories), so the ordinary node_modules walk from a source file does not even reach the package.

## Fix

Add one explicit \paths\ mapping pointing the \eact-router\ specifier at its main type declaration file:

\\\json
\react-router\: [\./node_modules/react-router/dist/production/index.d.ts\]
\\\

The catch-all \\*\\ mapping is kept so no other package changes. The point at the exact \.d.ts\ file works around the bypass — TS reads the entry file directly, no \exports\ traversal required.

## Alternatives considered and rejected

- \moduleResolution: nodenext\ — requires \.js\ extensions on hundreds of relative imports (verified locally, ~12 new errors in SiteCopyWizard/HomeShell/index.ts).
- A \
ode_modules\ symlink from \WebUI/src/main/ts/\ to the install — fragile, platform-specific, not portable to Windows.
- A shadow \@types/react-router\ package — unnecessary workaround and creates a divergence between tsc and the real package types.
- Switching every \paths\ entry to per-package — far more invasive than this one-line fix.

## Pre-PR build evidence (standalone module, from \WebUI/\)

\\\ash
cd WebUI
..\\..\\mvn-env.bat clean install -B
\\\

Result: **BUILD SUCCESS**

- \	sc --noEmit\: 0 errors
- \ite build\: 0 errors, emitted \	arget/generated-webui/cm/modern/assets/perc-modern-ui.js\ and \.css\ along with the expected vendor chunks
- \Tests run: 11, Failures: 0, Errors: 0, Skipped: 0\
  - \com.percussion.webui.filter.PSWebUiSpaFallbackFilterTest\: 7/7
  - \com.percussion.webui.gadget.servlets.GadgetRegistryTest\: 4/4
- No new warnings; the only warnings are pre-existing dependency relocations (jakarta artefacts, etc.).

## Files

- \WebUI/src/main/frontend/tsconfig.json\ — 1 line added (\+1/-0\)
- \docs/ai-generated/code-reviews/fix-perc-web-ui-npm-build-erlang.md\ — durable Erlang review record (recommendation: approve, gate: May commit/push: yes, blocking bugs: 0).

No public API changes. No runtime code changes. Surgical, low-risk build fix.