### PR TITLE
fix: Home functional recovery + install/H2 slot deploy fixes

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/searchApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/searchApi.ts
@@ -93,13 +93,13 @@ export async function searchExtended(
     return {
       children: [],
       totalCount: 0,
-      startIndex: criteria.startIndex ?? 0,
+      startIndex: criteria.startIndex ?? 1,
     };
   }
   return {
     children: envelope.childrenInPage ?? [],
     totalCount: envelope.childrenCount,
-    startIndex: envelope.startIndex ?? criteria.startIndex ?? 0,
+    startIndex: envelope.startIndex ?? criteria.startIndex ?? 1,
   };
 }
 

--- a/WebUI/src/main/ts/api/home/homeApi.ts
+++ b/WebUI/src/main/ts/api/home/homeApi.ts
@@ -18,6 +18,8 @@
 import { get, post } from "../client";
 import type { ApiError } from "../client";
 import { PATHS } from "../paths";
+import { searchExtended } from "../contentExplorer/searchApi";
+import type { PSSearchCriteria } from "../contentExplorer/types";
 import type {
   AssetTypeSummary,
   BlogSummary,
@@ -39,7 +41,7 @@ export async function fetchRecentItems(
     url += `/${encodeURIComponent(site)}`;
   }
   const data = await get<unknown>(url);
-  return normalizeList(data);
+  return normalizeList(data).map(normalizeContentItem);
 }
 
 /**
@@ -47,7 +49,7 @@ export async function fetchRecentItems(
  */
 export async function fetchMyContent(): Promise<ContentListItem[]> {
   const data = await get<unknown>(PATHS.MY_CONTENT);
-  return normalizeList(data);
+  return normalizeList(data).map(normalizeContentItem);
 }
 
 /** All sites for Library root. */
@@ -76,7 +78,7 @@ export async function fetchFolderChildren(
   const data = await get<unknown>(
     `${PATHS.PATH_FOLDER}${encodeURI(normalized)}`,
   );
-  return normalizeList(data) as FolderChild[];
+  return normalizeList(data).map(normalizeContentItem) as FolderChild[];
 }
 
 /** Templates for a site (classic getTemplates). */
@@ -191,12 +193,98 @@ export async function createPageAndPath(
   return joinFolderAndName(req.folderPath, req.name);
 }
 
-/** Run extended finder search. */
+/**
+ * Run extended finder search (same REST as Content Explorer US5).
+ *
+ * <p>Must wrap body under {@code SearchCriteria} and unwrap
+ * {@code PagedItemPropertiesList.childrenInPage}. A bare criteria object
+ * or flat array unwrap silently yields empty Home Search results.</p>
+ */
 export async function searchContent(
-  criteria: Record<string, unknown>,
+  criteria: PSSearchCriteria | Record<string, unknown>,
 ): Promise<ContentListItem[]> {
-  const data = await post<unknown>(PATHS.FINDER_SEARCH_EXTENDED, criteria);
-  return normalizeList(data);
+  const query =
+    typeof criteria.query === "string"
+      ? criteria.query
+      : typeof (criteria as { searchText?: unknown }).searchText === "string"
+        ? String((criteria as { searchText: string }).searchText)
+        : "";
+  const maxResults =
+    typeof criteria.maxResults === "number" ? criteria.maxResults : 50;
+  // Server rejects startIndex < 1 (IllegalArgumentException).
+  const startIndex =
+    typeof criteria.startIndex === "number" && criteria.startIndex >= 1
+      ? criteria.startIndex
+      : 1;
+  const folderPath =
+    typeof criteria.folderPath === "string" ? criteria.folderPath : undefined;
+
+  // formatId is required by PSSearchService.searchForIds (classic finder uses
+  // the active display format; Home defaults to system list format id 9).
+  const formatId =
+    typeof criteria.formatId === "number" ? criteria.formatId : 9;
+
+  const searchCriteria: PSSearchCriteria = {
+    query: query.trim(),
+    maxResults,
+    startIndex,
+    folderPath,
+    formatId,
+    searchType:
+      typeof criteria.searchType === "string" ? criteria.searchType : undefined,
+    sortColumn:
+      typeof criteria.sortColumn === "string" ? criteria.sortColumn : undefined,
+    sortOrder:
+      typeof criteria.sortOrder === "string" ? criteria.sortOrder : undefined,
+  };
+
+  const results = await searchExtended(searchCriteria);
+  return results.children.map((row) =>
+    normalizeContentItem({
+      id: row.id,
+      name: row.name ?? row.title,
+      title: row.title ?? row.name,
+      path: row.folderPath ?? (row as { path?: string }).path,
+      type: row.type,
+      ...row,
+    }),
+  );
+}
+
+/**
+ * Normalize PSItemProperties / PathItem-style rows so Home sections always
+ * have display {@code name} and openable {@code path}/{@code id}.
+ */
+export function normalizeContentItem(
+  raw: ContentListItem | Record<string, unknown>,
+): ContentListItem {
+  const o = raw as ContentListItem & {
+    contentId?: string;
+    folderPath?: string;
+    title?: string;
+    name?: string;
+    path?: string;
+    id?: string;
+  };
+  const path =
+    (o.path != null && String(o.path).trim()) ||
+    (o.folderPath != null && String(o.folderPath).trim()) ||
+    undefined;
+  const id =
+    (o.id != null && String(o.id)) ||
+    (o.contentId != null && String(o.contentId)) ||
+    undefined;
+  const name =
+    (o.name != null && String(o.name).trim()) ||
+    (o.title != null && String(o.title).trim()) ||
+    undefined;
+  return {
+    ...o,
+    id,
+    name,
+    title: o.title != null ? String(o.title) : name,
+    path,
+  };
 }
 
 /**
@@ -242,6 +330,14 @@ function normalizeList(data: unknown): ContentListItem[] {
   }
   if (data && typeof data === "object") {
     const obj = data as Record<string, unknown>;
+    // Search wire: { PagedItemPropertiesList: { childrenInPage: [...] } }
+    const paged = obj.PagedItemPropertiesList;
+    if (paged && typeof paged === "object") {
+      const children = (paged as { childrenInPage?: unknown }).childrenInPage;
+      if (Array.isArray(children)) {
+        return children as ContentListItem[];
+      }
+    }
     for (const key of [
       "RecentItemList",
       "ItemProperties",
@@ -250,13 +346,24 @@ function normalizeList(data: unknown): ContentListItem[] {
       "results",
       "PathItem",
       "children",
+      "childrenInPage",
       "resultPage",
       "FolderItem",
       "childFolders",
+      "PagedItemList",
     ]) {
       const v = obj[key];
       if (Array.isArray(v)) {
         return v as ContentListItem[];
+      }
+      // Nested list wrappers (e.g. PagedItemList.childrenInPage)
+      if (v && typeof v === "object") {
+        const nested = v as Record<string, unknown>;
+        for (const nk of ["childrenInPage", "children", "ItemProperties", "PathItem"]) {
+          if (Array.isArray(nested[nk])) {
+            return nested[nk] as ContentListItem[];
+          }
+        }
       }
     }
     for (const v of Object.values(obj)) {

--- a/WebUI/src/main/ts/contentExplorer/SearchPanel.tsx
+++ b/WebUI/src/main/ts/contentExplorer/SearchPanel.tsx
@@ -109,7 +109,7 @@ export function SearchPanel(props: SearchPanelProps): React.JSX.Element {
       const results = await search({
         ...initialCriteria,
         query: trimmed,
-        startIndex: initialCriteria.startIndex ?? 0,
+        startIndex: initialCriteria.startIndex ?? 1,
         maxResults: initialCriteria.maxResults ?? 25,
       });
       setStatus({ kind: "ready", query: trimmed, results });

--- a/WebUI/src/main/ts/home/create/CreateWizard.tsx
+++ b/WebUI/src/main/ts/home/create/CreateWizard.tsx
@@ -16,7 +16,12 @@
  */
 
 import React, { useEffect, useState } from "react";
-import { fetchBlogsForSite, fetchSites } from "../../api/home/homeApi";
+import { isSessionRedirectError } from "../../api/client";
+import {
+  fetchBlogsForSite,
+  fetchSites,
+  formatApiError,
+} from "../../api/home/homeApi";
 import { message, MSG } from "../../i18n/message";
 import { errorStyle } from "../home.styles";
 import { AssetWizard } from "./AssetWizard";
@@ -58,8 +63,11 @@ export function CreateWizard(): React.ReactElement {
         }
         setHasBlogs(found);
       })
-      .catch(() => {
-        setError(message(MSG.ERROR_GENERIC));
+      .catch((err: unknown) => {
+        if (isSessionRedirectError(err)) {
+          return;
+        }
+        setError(formatApiError(err, message(MSG.ERROR_GENERIC)));
         setHasSites(false);
       });
   }, []);

--- a/WebUI/src/main/ts/home/sections/BookmarksSection.tsx
+++ b/WebUI/src/main/ts/home/sections/BookmarksSection.tsx
@@ -16,7 +16,8 @@
  */
 
 import React, { useEffect, useState } from "react";
-import { fetchMyContent } from "../../api/home/homeApi";
+import { isSessionRedirectError } from "../../api/client";
+import { fetchMyContent, formatApiError } from "../../api/home/homeApi";
 import type { ContentListItem } from "../../api/home/types";
 import { message, MSG } from "../../i18n/message";
 import { errorStyle, listItemStyle, listStyle } from "../home.styles";
@@ -41,14 +42,15 @@ export function BookmarksSection({
     fetchMyContent()
       .then((list) => {
         if (!cancelled) {
-          setItems(normalizeBookmarkRows(list));
+          setItems(list);
           setError(null);
         }
       })
-      .catch(() => {
-        if (!cancelled) {
-          setError(message(MSG.ERROR_GENERIC));
+      .catch((err: unknown) => {
+        if (cancelled || isSessionRedirectError(err)) {
+          return;
         }
+        setError(formatApiError(err, message(MSG.ERROR_GENERIC)));
       })
       .finally(() => {
         if (!cancelled) {
@@ -61,26 +63,36 @@ export function BookmarksSection({
   }, []);
 
   if (loading) {
-    return <p role="status">{message(MSG.LOADING)}</p>;
+    return (
+      <p role="status" data-testid="home-bookmarks-loading">
+        {message(MSG.LOADING)}
+      </p>
+    );
   }
   if (error) {
     return (
-      <p role="alert" style={errorStyle}>
+      <p role="alert" style={errorStyle} data-testid="home-bookmarks-error">
         {error}
       </p>
     );
   }
   if (items.length === 0) {
-    return <p>{message(MSG.BOOKMARKS_EMPTY)}</p>;
+    return (
+      <p data-testid="home-bookmarks-empty">{message(MSG.BOOKMARKS_EMPTY)}</p>
+    );
   }
 
   return (
-    <ul style={listStyle} aria-label={message(MSG.SECTION_BOOKMARKS)}>
+    <ul
+      style={listStyle}
+      aria-label={message(MSG.SECTION_BOOKMARKS)}
+      data-testid="home-bookmarks-list"
+    >
       {items.map((item, index) => {
         const label =
           item.name ||
           item.title ||
-          (item as { path?: string }).path ||
+          item.path ||
           item.id ||
           `bookmark-${index}`;
         return (
@@ -94,23 +106,4 @@ export function BookmarksSection({
       })}
     </ul>
   );
-}
-
-/** Map PSItemProperties-style rows into ContentListItem fields when needed. */
-function normalizeBookmarkRows(list: ContentListItem[]): ContentListItem[] {
-  return list.map((raw) => {
-    const o = raw as ContentListItem & {
-      id?: string;
-      contentId?: string;
-      name?: string;
-      path?: string;
-      folderPath?: string;
-    };
-    return {
-      ...o,
-      id: o.id ?? o.contentId,
-      name: o.name ?? o.title,
-      path: o.path ?? o.folderPath,
-    };
-  });
 }

--- a/WebUI/src/main/ts/home/sections/GadgetsSection.tsx
+++ b/WebUI/src/main/ts/home/sections/GadgetsSection.tsx
@@ -16,16 +16,22 @@
  */
 
 import React from "react";
+import { useSpaBootstrap } from "../../app/bootstrap/BootstrapContext";
 import { Dashboard } from "../../dashboard";
 
 /**
  * Home section that hosts dashboard gadgets (PR-7 product lock).
  * Reuses the React Dashboard widget registry — not a peer SPA /dashboard route.
+ *
+ * <p>Passes the SPA bootstrap username so dashboard layout can load/save
+ * per-user configuration. Without it, only hard-coded default gadgets render
+ * and persistence is skipped.</p>
  */
 export function GadgetsSection(): React.ReactElement {
+  const { userName } = useSpaBootstrap();
   return (
     <div data-testid="home-gadgets-section" aria-label="Gadgets">
-      <Dashboard embedded />
+      <Dashboard embedded userId={userName || undefined} />
     </div>
   );
 }

--- a/WebUI/src/main/ts/home/sections/LibrarySection.tsx
+++ b/WebUI/src/main/ts/home/sections/LibrarySection.tsx
@@ -16,7 +16,12 @@
  */
 
 import React, { useCallback, useEffect, useState } from "react";
-import { fetchFolderChildren, fetchSites } from "../../api/home/homeApi";
+import { isSessionRedirectError } from "../../api/client";
+import {
+  fetchFolderChildren,
+  fetchSites,
+  formatApiError,
+} from "../../api/home/homeApi";
 import type { ContentListItem, SiteSummary } from "../../api/home/types";
 import { message, MSG } from "../../i18n/message";
 import { errorStyle, listItemStyle, listStyle } from "../home.styles";
@@ -36,6 +41,13 @@ export function LibrarySection({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const onApiError = useCallback((err: unknown): void => {
+    if (isSessionRedirectError(err)) {
+      return;
+    }
+    setError(formatApiError(err, message(MSG.ERROR_GENERIC)));
+  }, []);
+
   const loadSites = useCallback(() => {
     setLoading(true);
     fetchSites()
@@ -43,9 +55,9 @@ export function LibrarySection({
         setSites(list);
         setError(null);
       })
-      .catch(() => setError(message(MSG.ERROR_GENERIC)))
+      .catch(onApiError)
       .finally(() => setLoading(false));
-  }, []);
+  }, [onApiError]);
 
   useEffect(() => {
     loadSites();
@@ -60,7 +72,7 @@ export function LibrarySection({
         setChildren(list);
         setError(null);
       })
-      .catch(() => setError(message(MSG.ERROR_GENERIC)))
+      .catch(onApiError)
       .finally(() => setLoading(false));
   };
 
@@ -72,7 +84,7 @@ export function LibrarySection({
         setChildren(list);
         setError(null);
       })
-      .catch(() => setError(message(MSG.ERROR_GENERIC)))
+      .catch(onApiError)
       .finally(() => setLoading(false));
   };
 

--- a/WebUI/src/main/ts/home/sections/SearchSection.tsx
+++ b/WebUI/src/main/ts/home/sections/SearchSection.tsx
@@ -16,7 +16,8 @@
  */
 
 import React, { useState } from "react";
-import { searchContent } from "../../api/home/homeApi";
+import { isSessionRedirectError } from "../../api/client";
+import { formatApiError, searchContent } from "../../api/home/homeApi";
 import type { ContentListItem } from "../../api/home/types";
 import { message, MSG } from "../../i18n/message";
 import {
@@ -40,16 +41,26 @@ export function SearchSection({
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    const q = query.trim();
+    if (!q) {
+      return;
+    }
     setLoading(true);
     setError(null);
-    searchContent({ query, searchText: query, maxResults: 50 })
+    // Wire contract: SearchCriteria.query + maxResults (see searchExtended / US5).
+    searchContent({ query: q, maxResults: 50, startIndex: 1 })
       .then((list) => setItems(list))
-      .catch(() => setError(message(MSG.ERROR_GENERIC)))
+      .catch((err: unknown) => {
+        if (isSessionRedirectError(err)) {
+          return;
+        }
+        setError(formatApiError(err, message(MSG.ERROR_GENERIC)));
+      })
       .finally(() => setLoading(false));
   };
 
   return (
-    <div>
+    <div data-testid="home-search-section">
       <form onSubmit={onSubmit}>
         <div style={formRowStyle}>
           <label htmlFor="home-search-query">
@@ -57,25 +68,40 @@ export function SearchSection({
           </label>
           <input
             id="home-search-query"
+            data-testid="home-search-input"
             type="search"
             value={query}
             onChange={(ev) => setQuery(ev.target.value)}
             placeholder={message(MSG.SEARCH_PLACEHOLDER)}
           />
         </div>
-        <button type="submit" disabled={loading || !query.trim()}>
+        <button
+          type="submit"
+          data-testid="home-search-submit"
+          disabled={loading || !query.trim()}
+        >
           {message(MSG.SEARCH_SUBMIT)}
         </button>
       </form>
-      {loading && <p role="status">{message(MSG.LOADING)}</p>}
+      {loading && (
+        <p role="status" data-testid="home-search-loading">
+          {message(MSG.LOADING)}
+        </p>
+      )}
       {error && (
-        <p role="alert" style={errorStyle}>
+        <p role="alert" style={errorStyle} data-testid="home-search-error">
           {error}
         </p>
       )}
-      {items && items.length === 0 && <p>{message(MSG.SEARCH_EMPTY)}</p>}
+      {items && items.length === 0 && (
+        <p data-testid="home-search-empty">{message(MSG.SEARCH_EMPTY)}</p>
+      )}
       {items && items.length > 0 && (
-        <ul style={listStyle} aria-label={message(MSG.SECTION_SEARCH)}>
+        <ul
+          style={listStyle}
+          aria-label={message(MSG.SECTION_SEARCH)}
+          data-testid="home-search-results"
+        >
           {items.map((item, index) => {
             const label =
               item.name || item.title || item.path || item.id || `hit-${index}`;

--- a/WebUI/src/test/ts/home/GadgetsSection.test.tsx
+++ b/WebUI/src/test/ts/home/GadgetsSection.test.tsx
@@ -4,19 +4,38 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { BootstrapProvider } from "@/app/bootstrap/BootstrapContext";
+import { DEFAULT_SPA_BOOTSTRAP } from "@/app/bootstrap/types";
 import { GadgetsSection } from "@/home/sections/GadgetsSection";
 
 vi.mock("@/dashboard", () => ({
-  Dashboard: ({ embedded }: { embedded?: boolean }) => (
-    <div data-testid="dashboard-root" data-embedded={embedded ? "1" : "0"} />
+  Dashboard: ({
+    embedded,
+    userId,
+  }: {
+    embedded?: boolean;
+    userId?: string;
+  }) => (
+    <div
+      data-testid="dashboard-root"
+      data-embedded={embedded ? "1" : "0"}
+      data-user-id={userId ?? ""}
+    />
   ),
 }));
 
 describe("GadgetsSection", () => {
-  it("embeds Dashboard with embedded flag", () => {
-    render(<GadgetsSection />);
+  it("embeds Dashboard with embedded flag and bootstrap userId", () => {
+    render(
+      <BootstrapProvider
+        value={{ ...DEFAULT_SPA_BOOTSTRAP, userName: "admin" }}
+      >
+        <GadgetsSection />
+      </BootstrapProvider>,
+    );
     expect(screen.getByTestId("home-gadgets-section")).toBeDefined();
     const dash = screen.getByTestId("dashboard-root");
     expect(dash.getAttribute("data-embedded")).toBe("1");
+    expect(dash.getAttribute("data-user-id")).toBe("admin");
   });
 });

--- a/WebUI/src/test/ts/home/homeApi.test.ts
+++ b/WebUI/src/test/ts/home/homeApi.test.ts
@@ -21,6 +21,8 @@ import {
   fetchRecentItems,
   fetchSites,
   formatApiError,
+  normalizeContentItem,
+  searchContent,
 } from "@/api/home/homeApi";
 import type { ApiError } from "@/api/client";
 
@@ -62,6 +64,24 @@ describe("homeApi", () => {
     expect(items[0].name).toBe("Page A");
   });
 
+  it("fetchRecentItems maps ItemProperties wrapper", async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({
+        ItemProperties: [
+          { id: "42", name: "Recent Page", path: "/Sites/Demo/page" },
+        ],
+      }),
+    );
+    const items = await fetchRecentItems("item");
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      id: "42",
+      name: "Recent Page",
+      path: "/Sites/Demo/page",
+    });
+  });
+
   it("fetchMyContent maps ItemProperties list", async () => {
     const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
     fetchMock.mockResolvedValue(
@@ -72,6 +92,69 @@ describe("homeApi", () => {
     const items = await fetchMyContent();
     expect(items).toHaveLength(1);
     expect(items[0].name).toBe("Bookmarked");
+    expect(items[0].path).toBe("/Sites/a/b");
+  });
+
+  it("searchContent wraps SearchCriteria and unwraps paged results", async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({
+        PagedItemPropertiesList: {
+          childrenCount: 1,
+          startIndex: 0,
+          childrenInPage: [
+            {
+              id: "9",
+              title: "Hit Title",
+              folderPath: "/Sites/Demo/hit",
+              type: "page",
+            },
+          ],
+        },
+      }),
+    );
+    const items = await searchContent({ query: "hit", maxResults: 50 });
+    expect(items).toHaveLength(1);
+    expect(items[0].name).toBe("Hit Title");
+    expect(items[0].path).toBe("/Sites/Demo/hit");
+    expect(items[0].id).toBe("9");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/searchmanagement/search/get/extendedresults");
+    const body = JSON.parse(String(init.body));
+    expect(body).toEqual({
+      SearchCriteria: {
+        query: "hit",
+        maxResults: 50,
+        startIndex: 1,
+        formatId: 9,
+      },
+    });
+  });
+
+  it("searchContent accepts legacy searchText alias", async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({
+        PagedItemPropertiesList: { childrenInPage: [] },
+      }),
+    );
+    await searchContent({ searchText: "legacy", maxResults: 10 });
+    const body = JSON.parse(
+      String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body),
+    );
+    expect(body.SearchCriteria.query).toBe("legacy");
+  });
+
+  it("normalizeContentItem fills name/path from alternate fields", () => {
+    expect(
+      normalizeContentItem({
+        contentId: "c1",
+        title: "T",
+        folderPath: "/Sites/x",
+      }),
+    ).toMatchObject({ id: "c1", name: "T", path: "/Sites/x" });
   });
 
   it("fetchSites surfaces API errors", async () => {

--- a/modules/perc-ant/pom.xml
+++ b/modules/perc-ant/pom.xml
@@ -72,6 +72,17 @@
             <artifactId>derbyshared</artifactId>
             <scope>compile</scope>
         </dependency>
+        <!-- #548: H2 must be shaded into perc-ant (same as Derby). TableFactory
+             Class.forName(org.h2.Driver) during Derby→H2 migration runs on the
+             installer system classloader (java -jar perc-ant-*.jar). ant.deps
+             jetty/base/lib/jdbc JARs are on a child Ant classloader and are not
+             visible to that Class.forName — field symptom: export 209 tables OK,
+             import fails "Unable to connect to database server: org.h2.Driver". -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>compile</scope>
+        </dependency>
         <dependency>
             <groupId>net.sourceforge.jtds</groupId>
             <artifactId>jtds</artifactId>

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSConfigureDatasource.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSConfigureDatasource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,12 +29,22 @@ import com.percussion.utils.container.jetty.PSJettyJndiDatasource;
 import com.percussion.utils.jdbc.IPSDatasourceConfig;
 import com.percussion.utils.jdbc.IPSDatasourceResolver;
 import com.percussion.utils.jdbc.PSDatasourceConfig;
+import com.percussion.utils.jdbc.PSJdbcUtils;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tools.ant.BuildException;
@@ -46,7 +56,14 @@ import org.w3c.dom.NodeList;
  * PSConfigureDatasource is a class which configures the default datasource.
  *
  * <p>The rxrepository.properties file is used to gather the appropriate information, then the JNDI
- * datasource and datasource connection are configured <br>
+ * datasource and datasource connection are configured.
+ *
+ * <p>On upgrade, {@code rxconfig/Server/config.xml} is preserved (not overwritten) and may predate
+ * product drivers such as H2 (#548) and PostgreSQL (#1500). Before configuring the datasource this
+ * task merges any missing product {@code PSXJdbcDriverConfig} entries so the selected repository
+ * driver can always be resolved.
+ *
+ * <br>
  * Example Usage: <br>
  *
  * <pre>
@@ -73,11 +90,38 @@ public class PSConfigureDatasource extends PSAction {
 
   private static final Logger log = LogManager.getLogger(PSConfigureDatasource.class);
 
+  /**
+   * Product JDBC driver catalog (driverName → className + containerTypeMapping). Order matches
+   * {@code system/config/config.xml}. Keys are lower-cased for lookup.
+   */
+  private static final Map<String, ProductJdbcDriver> PRODUCT_JDBC_DRIVERS;
+
+  static {
+    Map<String, ProductJdbcDriver> map = new LinkedHashMap<>();
+    putDriver(map, "oracle:thin", "oracle.jdbc.OracleDriver", "Oracle8");
+    putDriver(map, "jtds:sqlserver", "net.sourceforge.jtds.jdbc.Driver", "MS SQLSERVER2000");
+    putDriver(map, "db2", "com.ibm.db2.jcc.DB2Driver", "DB2");
+    putDriver(map, "mysql", "com.mysql.jdbc.Driver", "MYSQL");
+    putDriver(map, "sqlserver", "com.microsoft.sqlserver.jdbc.SQLServerDriver", "MSSQLSERVER");
+    putDriver(map, "derby", "org.apache.derby.jdbc.EmbeddedDriver", "DERBY");
+    // #548 H2 default embedded (Derby migration window retains derby entry)
+    putDriver(map, PSJdbcUtils.H2_DRIVER, PSJdbcUtils.H2_DRIVER_CLASS, "H2");
+    // #1500 PostgreSQL external repository
+    putDriver(map, PSJdbcUtils.POSTGRES_DRIVER, PSJdbcUtils.POSTGRES_DRIVER_CLASS, "POSTGRES");
+    PRODUCT_JDBC_DRIVERS = Collections.unmodifiableMap(map);
+  }
+
+  private static void putDriver(
+      Map<String, ProductJdbcDriver> map, String driverName, String className, String typeMapping) {
+    map.put(
+        driverName.toLowerCase(Locale.ROOT),
+        new ProductJdbcDriver(driverName, className, typeMapping));
+  }
+
   public void execute() {
     PSProperties props = null;
     PSJdbcDbmsDef dbmsDef = null;
     List<IPSJndiDatasource> datasources = null;
-    FileInputStream jdbcDriverIn = null;
     IPSJndiDatasource datasrc = null;
 
     try {
@@ -100,27 +144,19 @@ public class PSConfigureDatasource extends PSAction {
 
       PSLogger.logInfo("Default datasource is " + datasource);
 
-      // Load container type mapping, driver class name from config.xml
-      jdbcDriverIn = new FileInputStream(getRootDir() + File.separator + getServerConfigLocation());
-      Document driverDoc = PSXmlDocumentBuilder.createXmlDocument(jdbcDriverIn, false);
-      NodeList driverNodes = driverDoc.getElementsByTagName(PSJdbcDriverConfig.XML_NODE_NAME);
-      int len = driverNodes.getLength();
-      String containerTypeMap = "";
-      String driverClassName = "";
-      for (int i = 0; i < len; i++) {
-        Element driverNode = (Element) driverNodes.item(i);
-        PSJdbcDriverConfig dc = new PSJdbcDriverConfig(driverNode);
+      // Portable join: constant relative segments (URL-style '/' in the property is not a FS path).
+      Path configPath = Path.of(getRootDir(), "rxconfig", "Server", "config.xml");
+      String preferredClass = props.getProperty(PSJdbcDbmsDef.DB_DRIVER_CLASS_NAME_PROPERTY, "");
+      ResolvedJdbcDriver resolved =
+          ensureProductJdbcDriversAndResolve(configPath, driver, preferredClass);
 
-        if (dc.getDriverName().equalsIgnoreCase(driver)) {
-          containerTypeMap = dc.getContainerTypeMapping();
-          driverClassName = dc.getClassName();
-          break;
-        }
-      }
+      String containerTypeMap = resolved.containerTypeMapping();
+      String driverClassName = resolved.className();
 
-      if (containerTypeMap.trim().length() == 0)
+      if (containerTypeMap.trim().isEmpty() || driverClassName.trim().isEmpty()) {
         throw new Exception(
             "A matching driver configuration could not " + "be found for " + dbmsDef.getDriver());
+      }
 
       // Construct default jndi datasource and add
       // can use the same datasource implementation, save differently
@@ -156,15 +192,128 @@ public class PSConfigureDatasource extends PSAction {
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
 
       throw new BuildException(e.getLocalizedMessage());
-    } finally {
-      if (jdbcDriverIn != null) {
-        try {
-          jdbcDriverIn.close();
-        } catch (IOException e) {
-        }
-      }
     }
   }
+
+  /**
+   * Ensures {@code config.xml} contains all product {@code PSXJdbcDriverConfig} entries, then
+   * resolves class name and container type mapping for {@code driverName}.
+   *
+   * <p>Package-private for unit tests. When the install is an upgrade, {@code config.xml} is
+   * preserved and may lack H2/PostgreSQL entries introduced after the site was first installed.
+   *
+   * @param configXml path to {@code rxconfig/Server/config.xml}
+   * @param driverName repository {@code DB_DRIVER_NAME} (e.g. {@code h2})
+   * @param preferredClassName optional {@code DB_DRIVER_CLASS_NAME} from repository props; used when
+   *     creating a missing product entry for this driver
+   * @return resolved class name and container type mapping
+   * @throws Exception if the config cannot be read/written or the driver is unknown
+   */
+  static ResolvedJdbcDriver ensureProductJdbcDriversAndResolve(
+      Path configXml, String driverName, String preferredClassName) throws Exception {
+    Objects.requireNonNull(configXml, "configXml");
+    if (driverName == null || driverName.isBlank()) {
+      throw new IllegalArgumentException("driverName may not be null or empty");
+    }
+
+    Document driverDoc;
+    try (FileInputStream in = new FileInputStream(configXml.toFile())) {
+      driverDoc = PSXmlDocumentBuilder.createXmlDocument(in, false);
+    }
+
+    Element jdbcDriverConfigs = findOrCreateJdbcDriverConfigs(driverDoc);
+    boolean modified = false;
+
+    for (ProductJdbcDriver product : PRODUCT_JDBC_DRIVERS.values()) {
+      if (!hasDriverConfig(jdbcDriverConfigs, product.driverName())) {
+        String className = product.className();
+        // Prefer repository class for the driver we are configuring when supplied
+        if (product.driverName().equalsIgnoreCase(driverName)
+            && preferredClassName != null
+            && !preferredClassName.isBlank()) {
+          className = preferredClassName.trim();
+        }
+        Element el = driverDoc.createElement(PSJdbcDriverConfig.XML_NODE_NAME);
+        el.setAttribute("driverName", product.driverName());
+        el.setAttribute("className", className);
+        el.setAttribute("containerTypeMapping", product.containerTypeMapping());
+        jdbcDriverConfigs.appendChild(el);
+        modified = true;
+        PSLogger.logInfo(
+            "Added missing JDBC driver configuration for "
+                + product.driverName()
+                + " to "
+                + configXml);
+      }
+    }
+
+    if (modified) {
+      // Ensure parent directory exists (should already) and write atomically-ish
+      Path parent = configXml.getParent();
+      if (parent != null) {
+        Files.createDirectories(parent);
+      }
+      try (OutputStream out = new FileOutputStream(configXml.toFile())) {
+        PSXmlDocumentBuilder.write(driverDoc, out);
+      }
+    }
+
+    // Re-resolve from document (includes pre-existing + newly added)
+    NodeList driverNodes = driverDoc.getElementsByTagName(PSJdbcDriverConfig.XML_NODE_NAME);
+    int len = driverNodes.getLength();
+    for (int i = 0; i < len; i++) {
+      Element driverNode = (Element) driverNodes.item(i);
+      PSJdbcDriverConfig dc = new PSJdbcDriverConfig(driverNode);
+      if (dc.getDriverName().equalsIgnoreCase(driverName)) {
+        return new ResolvedJdbcDriver(dc.getClassName(), dc.getContainerTypeMapping());
+      }
+    }
+
+    // Last resort: known product map without requiring a successful XML parse of the entry
+    ProductJdbcDriver product = PRODUCT_JDBC_DRIVERS.get(driverName.toLowerCase(Locale.ROOT));
+    if (product != null) {
+      String className =
+          preferredClassName != null && !preferredClassName.isBlank()
+              ? preferredClassName.trim()
+              : product.className();
+      return new ResolvedJdbcDriver(className, product.containerTypeMapping());
+    }
+
+    return new ResolvedJdbcDriver("", "");
+  }
+
+  private static Element findOrCreateJdbcDriverConfigs(Document doc) {
+    NodeList nodes = doc.getElementsByTagName("JdbcDriverConfigs");
+    if (nodes.getLength() > 0) {
+      return (Element) nodes.item(0);
+    }
+    Element root = doc.getDocumentElement();
+    if (root == null) {
+      throw new IllegalStateException("config.xml has no document element");
+    }
+    Element created = doc.createElement("JdbcDriverConfigs");
+    root.appendChild(created);
+    PSLogger.logInfo("Created missing JdbcDriverConfigs element in server config.xml");
+    return created;
+  }
+
+  private static boolean hasDriverConfig(Element jdbcDriverConfigs, String driverName) {
+    NodeList children = jdbcDriverConfigs.getElementsByTagName(PSJdbcDriverConfig.XML_NODE_NAME);
+    for (int i = 0; i < children.getLength(); i++) {
+      Element el = (Element) children.item(i);
+      String name = el.getAttribute("driverName");
+      if (name != null && name.equalsIgnoreCase(driverName)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Immutable product driver definition. */
+  record ProductJdbcDriver(String driverName, String className, String containerTypeMapping) {}
+
+  /** Resolved driver class + container type mapping for datasource setup. */
+  record ResolvedJdbcDriver(String className, String containerTypeMapping) {}
 
   /*************************************************************************
    * Property Accessors and Mutators

--- a/modules/perc-ant/src/test/java/com/percussion/ant/install/PSConfigureDatasourceTest.java
+++ b/modules/perc-ant/src/test/java/com/percussion/ant/install/PSConfigureDatasourceTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.ant.install;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.utils.jdbc.PSJdbcUtils;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for upgrade-safe JDBC driver merge in {@link PSConfigureDatasource}. Pre-#548 installs
+ * preserve {@code config.xml} without H2/PostgreSQL entries; install must still configure H2.
+ */
+@Tag("UnitTest")
+class PSConfigureDatasourceTest {
+
+  @TempDir Path tempDir;
+
+  /** Mirrors a pre-#548 field {@code config.xml} (drivers through derby only). */
+  private static final String PRE_H2_CONFIG =
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <PSXServerConfiguration id="1" serverType="System Master">
+         <requestRoot>Rhythmyx</requestRoot>
+         <JdbcDriverConfigs>
+            <PSXJdbcDriverConfig className="oracle.jdbc.OracleDriver" containerTypeMapping="Oracle8" driverName="oracle:thin"/>
+            <PSXJdbcDriverConfig className="net.sourceforge.jtds.jdbc.Driver" containerTypeMapping="MS SQLSERVER2000" driverName="jtds:sqlserver"/>
+            <PSXJdbcDriverConfig className="com.ibm.db2.jcc.DB2Driver" containerTypeMapping="DB2" driverName="db2"/>
+            <PSXJdbcDriverConfig className="com.mysql.jdbc.Driver" containerTypeMapping="MYSQL" driverName="mysql"/>
+            <PSXJdbcDriverConfig className="com.microsoft.sqlserver.jdbc.SQLServerDriver" containerTypeMapping="MSSQLSERVER" driverName="sqlserver"/>
+            <PSXJdbcDriverConfig className="org.apache.derby.jdbc.EmbeddedDriver" containerTypeMapping="DERBY" driverName="derby"/>
+         </JdbcDriverConfigs>
+      </PSXServerConfiguration>
+      """;
+
+  @Test
+  void ensureAddsH2AndPostgresqlToPre548Config() throws Exception {
+    Path config = tempDir.resolve("config.xml");
+    Files.writeString(config, PRE_H2_CONFIG, StandardCharsets.UTF_8);
+
+    PSConfigureDatasource.ResolvedJdbcDriver resolved =
+        PSConfigureDatasource.ensureProductJdbcDriversAndResolve(
+            config, PSJdbcUtils.H2_DRIVER, PSJdbcUtils.H2_DRIVER_CLASS);
+
+    assertEquals(PSJdbcUtils.H2_DRIVER_CLASS, resolved.className());
+    assertEquals("H2", resolved.containerTypeMapping());
+
+    String written = Files.readString(config, StandardCharsets.UTF_8);
+    assertTrue(
+        written.contains("driverName=\"h2\"") || written.contains("driverName='h2'"),
+        "h2 entry must be written back to config.xml");
+    assertTrue(
+        written.contains(PSJdbcUtils.H2_DRIVER_CLASS), "h2 driver class must be in config.xml");
+    assertTrue(
+        written.contains("driverName=\"postgresql\"")
+            || written.contains("driverName='postgresql'"),
+        "postgresql entry must also be merged for #1500");
+    // Pre-existing drivers retained
+    assertTrue(written.contains("driverName=\"derby\"") || written.contains("driverName='derby'"));
+  }
+
+  @Test
+  void ensureIsIdempotentWhenDriversAlreadyPresent() throws Exception {
+    Path config = tempDir.resolve("config.xml");
+    Files.writeString(config, PRE_H2_CONFIG, StandardCharsets.UTF_8);
+
+    PSConfigureDatasource.ensureProductJdbcDriversAndResolve(
+        config, PSJdbcUtils.H2_DRIVER, PSJdbcUtils.H2_DRIVER_CLASS);
+    String afterFirst = Files.readString(config, StandardCharsets.UTF_8);
+
+    PSConfigureDatasource.ResolvedJdbcDriver second =
+        PSConfigureDatasource.ensureProductJdbcDriversAndResolve(
+            config, PSJdbcUtils.H2_DRIVER, PSJdbcUtils.H2_DRIVER_CLASS);
+    String afterSecond = Files.readString(config, StandardCharsets.UTF_8);
+
+    assertEquals(PSJdbcUtils.H2_DRIVER_CLASS, second.className());
+    assertEquals("H2", second.containerTypeMapping());
+    // No duplicate h2 elements: count occurrences
+    assertEquals(
+        countOccurrences(afterFirst, "driverName=\"h2\""),
+        countOccurrences(afterSecond, "driverName=\"h2\""));
+  }
+
+  @Test
+  void ensureResolvesPostgresqlWithPreferredClass() throws Exception {
+    Path config = tempDir.resolve("config.xml");
+    Files.writeString(config, PRE_H2_CONFIG, StandardCharsets.UTF_8);
+
+    PSConfigureDatasource.ResolvedJdbcDriver resolved =
+        PSConfigureDatasource.ensureProductJdbcDriversAndResolve(
+            config, PSJdbcUtils.POSTGRES_DRIVER, PSJdbcUtils.POSTGRES_DRIVER_CLASS);
+
+    assertEquals(PSJdbcUtils.POSTGRES_DRIVER_CLASS, resolved.className());
+    assertEquals("POSTGRES", resolved.containerTypeMapping());
+  }
+
+  @Test
+  void ensureCreatesJdbcDriverConfigsWhenMissing() throws Exception {
+    Path config = tempDir.resolve("config.xml");
+    Files.writeString(
+        config,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <PSXServerConfiguration id="1">
+           <requestRoot>Rhythmyx</requestRoot>
+        </PSXServerConfiguration>
+        """,
+        StandardCharsets.UTF_8);
+
+    PSConfigureDatasource.ResolvedJdbcDriver resolved =
+        PSConfigureDatasource.ensureProductJdbcDriversAndResolve(
+            config, PSJdbcUtils.H2_DRIVER, null);
+
+    assertEquals(PSJdbcUtils.H2_DRIVER_CLASS, resolved.className());
+    assertEquals("H2", resolved.containerTypeMapping());
+    String written = Files.readString(config, StandardCharsets.UTF_8);
+    assertTrue(written.contains("JdbcDriverConfigs"));
+    assertTrue(written.contains("driverName=\"h2\"") || written.contains("driverName='h2'"));
+  }
+
+  private static int countOccurrences(String haystack, String needle) {
+    int count = 0;
+    int idx = 0;
+    while ((idx = haystack.indexOf(needle, idx)) >= 0) {
+      count++;
+      idx += needle.length();
+    }
+    return count;
+  }
+}

--- a/modules/perc-ant/src/test/java/com/percussion/ant/install/PSMigrationEmbeddedDriversClasspathTest.java
+++ b/modules/perc-ant/src/test/java/com/percussion/ant/install/PSMigrationEmbeddedDriversClasspathTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.ant.install;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards #548 installer classpath: Derby→H2 migration uses TableFactory {@code Class.forName} on
+ * the perc-ant system classloader ({@code java -jar perc-ant-*.jar}). Both engines must resolve
+ * without relying on the Ant {@code ant.deps} child loader (jetty JDBC lib).
+ */
+class PSMigrationEmbeddedDriversClasspathTest {
+
+  @Test
+  void h2DriverLoadable() {
+    Class<?> driver =
+        assertDoesNotThrow(
+            () -> Class.forName("org.h2.Driver"),
+            "org.h2.Driver must be a compile dependency of perc-ant so the shaded installer JAR can"
+                + " import into H2 during upgrade (field failure: Unable to connect to database"
+                + " server: org.h2.Driver after Derby export)");
+    assertNotNull(driver);
+  }
+
+  @Test
+  void derbyAutoloadedDriverLoadable() {
+    // Derby 10.17+ primary entry; legacy EmbeddedDriver may be absent
+    Class<?> driver =
+        assertDoesNotThrow(
+            () -> Class.forName("org.apache.derby.iapi.jdbc.AutoloadedDriver"),
+            "Derby AutoloadedDriver must remain on perc-ant for TableFactory export from product"
+                + " managed Derby repositories");
+    assertNotNull(driver);
+  }
+}

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/install.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/install.xml
@@ -679,6 +679,13 @@
 			inheritrefs="true" />
 		<antcall target="deleteOldJdbcDrivers" inheritall="true"
 			inheritrefs="true" />
+		<!-- deleteOldJdbcDrivers removes the bundled set (including h2/derby)
+			from install.dir. Re-install current drivers before Derby→H2 migration
+			so jetty/base/lib/jdbc and ant.deps install.dir entries stay loadable
+			if the process is interrupted mid-upgrade. H2 must also be on the
+			perc-ant shade classpath (see perc-ant pom) for Class.forName. -->
+		<antcall target="install_jdbc_drivers" inheritall="true"
+			inheritrefs="true" />
 		<!-- #548: Derby→H2 before file overwrite / DB setup plugins use repository -->
 		<echo>Migrating product-managed embedded repository if still Derby
 			(#548)...</echo>

--- a/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchRestService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchRestService.java
@@ -40,6 +40,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import java.util.ArrayList;
+import java.util.HashMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.queryparser.classic.QueryParser;
@@ -83,9 +84,12 @@ public class PSSearchRestService {
       criteria.setSearchType(
           SecureStringUtils.removeInvalidSQLObjectNameCharacters(criteria.getSearchType()));
 
+      // getSearchFields() returns an unmodifiable view (or emptyMap); never mutate it.
       var fields = criteria.getSearchFields();
-      if (fields != null) {
-        fields.replaceAll((k, v) -> SecureStringUtils.sanitizeStringForHTML(fields.get(k)));
+      if (fields != null && !fields.isEmpty()) {
+        var sanitized = new HashMap<String, String>(fields);
+        sanitized.replaceAll((k, v) -> SecureStringUtils.sanitizeStringForHTML(v));
+        criteria.setSearchFields(sanitized);
       }
       if (criteria.getFolderPath() != null
           && !SecureStringUtils.isValidCMSPathString(

--- a/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/searchmanagement/service/impl/PSSearchService.java
@@ -518,10 +518,12 @@ public class PSSearchService implements IPSSearchService {
             criteria.getFormatId() + " must have a numeric value for search");
       }
     }
+    // getSearchFields() is unmodifiable — copy before validating / rewriting values.
     var fields = criteria.getSearchFields();
-    if (fields != null) {
+    if (fields != null && !fields.isEmpty()) {
+      var mutableFields = new HashMap<String, String>(fields);
       var systemFieldSet = PSServer.getContentEditorSystemDef().getFieldSet();
-      for (var field : fields.entrySet()) {
+      for (var field : mutableFields.entrySet()) {
         var f = systemFieldSet.findFieldByName(field.getKey(), false);
         if (f != null) {
           if (f.getDataType().equalsIgnoreCase(PSField.DT_INTEGER)
@@ -553,7 +555,7 @@ public class PSSearchService implements IPSSearchService {
           field.setValue(SecureStringUtils.sanitizeStringForSQLStatement(field.getValue(), type));
         }
       }
-      criteria.setSearchFields(fields);
+      criteria.setSearchFields(mutableFields);
     }
     return criteria;
   }

--- a/projects/sitemanage/src/test/java/com/percussion/searchmanagement/service/impl/PSSearchRestServiceTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/searchmanagement/service/impl/PSSearchRestServiceTest.java
@@ -41,6 +41,32 @@ class PSSearchRestServiceTest {
   }
 
   /**
+   * getSearchFields() returns an unmodifiable view; sanitize must not call
+   * replaceAll on that view (UnsupportedOperationException → Home Search 500).
+   */
+  @Test
+  void sanitizeCriteriaDoesNotMutateUnmodifiableSearchFields() {
+    PSSearchRestService restService = new PSSearchRestService(null, null, null);
+    PSSearchCriteria criteria = new PSSearchCriteria();
+    criteria.setQuery("hello");
+    criteria.setSearchFields(java.util.Map.of("sys_title", "<b>x</b>"));
+    restService.sanitizeCriteria(criteria);
+    assertEquals("hello", criteria.getQuery()); // also escaped if special chars
+    assertEquals("&lt;b&gt;x&lt;/b&gt;", criteria.getSearchFields().get("sys_title"));
+  }
+
+  @Test
+  void sanitizeCriteriaHandlesNullAndEmptySearchFields() {
+    PSSearchRestService restService = new PSSearchRestService(null, null, null);
+    PSSearchCriteria criteria = new PSSearchCriteria();
+    criteria.setQuery("q");
+    restService.sanitizeCriteria(criteria); // null fields
+    criteria.setSearchFields(java.util.Map.of());
+    restService.sanitizeCriteria(criteria); // empty fields
+    assertEquals("q", criteria.getQuery());
+  }
+
+  /**
    * Exercises {@link PSLuceneQueryEscaper#escape(String)} mid-query slash escaping used on the
    * urlDecodedQuery search path in {@code PSSearchService} (GH-878 / #889 / #914).
    */

--- a/specs/548-derby-embedded-migration/checklists/derby-migration-classpath.md
+++ b/specs/548-derby-embedded-migration/checklists/derby-migration-classpath.md
@@ -14,9 +14,15 @@
 |------------------------|----------------------------------------------|-------------------------------------------------------------|
 | Parent `pom.xml`       | `dependencyManagement` keeps `derby.version` | Coordinates for migration classpath                         |
 | `modules/TableFactory` | test + tools                                 | Export from Derby fixtures                                  |
-| `modules/perc-ant`     | compile (`PSUpgradeDerby`, migration)        | Installer tasks need EmbeddedDriver at upgrade              |
+| `modules/perc-ant`     | compile (`PSUpgradeDerby`, migration)        | **Must shade both Derby and H2** — installer is `java -jar perc-ant`; TableFactory `Class.forName` uses the system classloader, not Ant `ant.deps` child loaders (`jetty/base/lib/jdbc`). Missing H2 → import fails with `Unable to connect to database server: org.h2.Driver` after a successful Derby export. |
 | `system`               | test (migration IT)                          | Runtime upgrade uses installer classpath                    |
 | DTS services           | no live default                              | Defaults are H2; Derby only if customer still has derbydata |
+
+## Field failure (2026-07-27 /opt/Percussion)
+
+- Export: 209 tables OK (Derby present in perc-ant shade).
+- Import: `PSJdbcDbmsDef:L:474` → `ClassNotFoundException` / `LinkageError` message `org.h2.Driver`.
+- `upgrade.chain` had also run `deleteOldJdbcDrivers` (glob-deletes `h2-*.jar`) immediately before migration; re-run `install_jdbc_drivers` after that delete for disk-level recovery.
 
 ## After support window
 

--- a/system/services/src/com/percussion/services/assembly/data/PSTemplateSlot.java
+++ b/system/services/src/com/percussion/services/assembly/data/PSTemplateSlot.java
@@ -339,24 +339,29 @@ public class PSTemplateSlot
         id = 0L; // Avoid problems during restore
         this.version=null;
         // Package archives (perc.nav etc.) use unhyphenated association field names
-        // (contenttypeid/templateid/slotid). Default Betwixt/PSNameMapper expects
-        // content-type-id etc.; without that rewrite, associations restore as zeros and
-        // deploy fails with "ContentType with source ID 0".
+        // (contenttypeid/templateid/slotid). PSNameMapper / PSTemplateTypeSlotAssociation.betwixt
+        // expect hyphenated names (content-type-id etc.). Without the rewrite, associations
+        // restore as zeros and deploy fails with "ContentType with source ID 0".
+        // Both the default introspector path and a successfully loaded .betwixt must agree
+        // on hyphenated names — see PSTemplateTypeSlotAssociation.betwixt.
         PSXmlSerializationHelper.readFromXML(normalizePackageAssociationElementNames(xmlsource), this);
     }
 
     /**
      * Rewrites legacy package element names on slot-type associations to hyphenated names expected
-     * by {@link PSXmlSerializationHelper}'s name mapper.
+     * by {@link PSXmlSerializationHelper}'s name mapper and by {@code
+     * PSTemplateTypeSlotAssociation.betwixt}.
      *
      * <p>Only rewrites element open/close tags ({@code <name>} / {@code </name>} / {@code
      * <name ...>}), not bare text or attribute values such as {@code name="contenttypeid"}.
+     * Already-hyphenated tags are left unchanged.
      */
     static String normalizePackageAssociationElementNames(String xml) {
         if (xml == null || xml.isEmpty()) {
             return xml;
         }
         String out = xml;
+        // Only rewrite the unhyphenated package forms; do not touch content-type-id etc.
         out = renameElementTags(out, "contenttypeid", "content-type-id");
         out = renameElementTags(out, "templateid", "template-id");
         out = renameElementTags(out, "slotid", "slot-id");

--- a/system/services/src/com/percussion/services/assembly/data/PSTemplateTypeSlotAssociation.betwixt
+++ b/system/services/src/com/percussion/services/assembly/data/PSTemplateTypeSlotAssociation.betwixt
@@ -1,14 +1,18 @@
 <?xml version="1.0"?>
 <!--
-  Explicit property map for package slot-type-association payloads.
-  Archives use unhyphenated names (contenttypeid, templateid, slotid), not the
-  default hyphenated mapper output (content-type-id, etc.).
+  Property map for slot-type-association payloads after package-name normalize.
+
+  Package archives (perc.nav etc.) ship unhyphenated tags (contenttypeid, templateid,
+  slotid). PSTemplateSlot.fromXML rewrites those to the hyphenated names below so they
+  match PSXmlSerializationHelper's HyphenatedNameMapper. This .betwixt must use the
+  same hyphenated names: if Digester loads it, unhyphenated names here would fight the
+  rewrite and restore content/template ids as 0 (deploy fails with ContentType source ID 0).
 -->
 <info primitiveTypes="element">
   <element name="slot-type-association">
-    <element name="slotid" property="slotId"/>
-    <element name="templateid" property="templateId"/>
-    <element name="contenttypeid" property="contentTypeId"/>
+    <element name="slot-id" property="slotId"/>
+    <element name="template-id" property="templateId"/>
+    <element name="content-type-id" property="contentTypeId"/>
     <element name="version" property="version"/>
   </element>
 </info>

--- a/system/services/src/com/percussion/services/contentmgr/data/PSQuery.java
+++ b/system/services/src/com/percussion/services/contentmgr/data/PSQuery.java
@@ -377,9 +377,9 @@ public class PSQuery implements Query
       {
          rval.append(", "); //$NON-NLS-1$
       }
-      // we have to use "sys_folderid", but not "rx:sys_folderid" because this
-      // will be literally passed to HQL, but the ':' is not a valid character.
-      rval.append("f.owner_id as " + IPSHtmlParameters.SYS_FOLDERID); //$NON-NLS-1$
+      // Hibernate 6 HQL requires entity property names (ownerId), not SQL columns.
+      // Alias remains sys_folderid for callers that read the projection by that key.
+      rval.append("f.ownerId as " + IPSHtmlParameters.SYS_FOLDERID); //$NON-NLS-1$
       rval.append(")"); //$NON-NLS-1$
 
       return rval.toString();

--- a/system/services/src/com/percussion/services/contentmgr/impl/query/visitors/PSQueryTransformer.java
+++ b/system/services/src/com/percussion/services/contentmgr/impl/query/visitors/PSQueryTransformer.java
@@ -164,7 +164,8 @@ public class PSQueryTransformer extends PSQueryNodeVisitor
                   throw new InvalidQueryException(
                         "Value for jcr:path must be a string");
                }
-               left = new PSQueryNodeIdentifier("f.owner_id", PropertyType.LONG);
+               // Hibernate 6 HQL: property name ownerId (not column OWNER_ID / owner_id)
+               left = new PSQueryNodeIdentifier("f.ownerId", PropertyType.LONG);
                
                List<IPSGuid> folders = m_folderExpander
                      .expandPath((String) valuesValue);
@@ -183,7 +184,7 @@ public class PSQueryTransformer extends PSQueryNodeVisitor
                         .extractContentIds(folders));
                   m_idCollections.add(collectionId);
                   return new PSQueryNodeLiteral(
-                        "f.owner_id in (select t.pk.itemId from "
+                        "f.ownerId in (select t.pk.itemId from "
                               + "PSTempId t where t.pk.id = " + collectionId
                               + ")");
                }

--- a/system/src/test/java/com/percussion/services/assembly/data/PSTemplateSlotXmlRestoreTest.java
+++ b/system/src/test/java/com/percussion/services/assembly/data/PSTemplateSlotXmlRestoreTest.java
@@ -84,6 +84,51 @@ class PSTemplateSlotXmlRestoreTest {
     }
   }
 
+  /**
+   * toXML / modern payloads already use hyphenated association field names. fromXML must restore
+   * those without depending on the package unhyphenated rewrite.
+   */
+  @Test
+  void fromXmlRestoresHyphenatedAssociationIds() throws Exception {
+    String hyphenated =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <template-slot id="1">
+          <guid>0-5-513</guid>
+          <description>navigation image for rollovers</description>
+          <finder-arguments/>
+          <finder-name>Java/global/percussion/slotcontentfinder/sys_RelationshipContentFinder</finder-name>
+          <label>Nav Image</label>
+          <name>perc.nav.image</name>
+          <relationship-name>ActiveAssembly</relationship-name>
+          <slot-type-associations>
+            <slot-type-association id="2">
+              <slot-id>513</slot-id>
+              <template-id>550</template-id>
+              <content-type-id>313</content-type-id>
+            </slot-type-association>
+          </slot-type-associations>
+          <slottype>0</slottype>
+          <system-slot>false</system-slot>
+          <version>2</version>
+        </template-slot>
+        """;
+    PSTemplateSlot slot = new PSTemplateSlot();
+    slot.fromXML(hyphenated);
+    PSTemplateTypeSlotAssociation[] assocs = slot.getSlotTypeAssociations();
+    assertTrue(assocs != null && assocs.length >= 1, "expected at least one association");
+    boolean found = false;
+    for (PSTemplateTypeSlotAssociation a : assocs) {
+      if (a.getContentTypeId() == 313L && a.getTemplateId() == 550L) {
+        found = true;
+        break;
+      }
+    }
+    assertTrue(
+        found,
+        "expected association contentTypeId=313 templateId=550; got: " + describe(assocs));
+  }
+
   @Test
   void normalizePackageAssociationElementNamesRewritesTags() {
     String in =
@@ -101,6 +146,14 @@ class PSTemplateSlotXmlRestoreTest {
     assertTrue(out.contains("name=\"contenttypeid\""), out);
     assertTrue(out.contains("templateid=\"keep\""), out);
     assertTrue(out.contains("<content-type-id>9</content-type-id>"), out);
+  }
+
+  @Test
+  void normalizePackageAssociationElementNamesLeavesHyphenatedTagsAlone() {
+    String in =
+        "<slot-type-association><slot-id>1</slot-id><template-id>2</template-id><content-type-id>3</content-type-id></slot-type-association>";
+    String out = PSTemplateSlot.normalizePackageAssociationElementNames(in);
+    assertEquals(in, out);
   }
 
   private static String describe(PSTemplateTypeSlotAssociation[] assocs) {


### PR DESCRIPTION
## Summary

Recovers modern Home UI functionality against a live CMS install and lands related install/runtime fixes that were needed to keep the healed `/opt/Percussion` environment usable for that testing.

### Home functional recovery
- Normalize Home list/search rows (`name` / `path` / `id`) for Recent, Bookmarks, Library, and Search
- Route Home Search through Content Explorer `searchExtended` with the correct `SearchCriteria` envelope, default `formatId: 9`, and `startIndex >= 1`
- Surface session/API errors in Home sections instead of a generic catch
- Pass SPA bootstrap `userName` into embedded Dashboard gadgets
- Server: stop mutating unmodifiable `searchFields` maps in search sanitize/validate (was causing extended-search 500s)
- Server: use Hibernate 6 property names (`f.ownerId`) in contentmgr HQL so dashboard user-profile loads succeed

### Install / deploy fixes (included)
- Align slot association Betwixt map with package XML normalize
- Shade H2 into `perc-ant` for Derby→H2 upgrade import classpath
- Merge missing H2/PostgreSQL drivers into `config.xml` on upgrade

## Test plan
- [x] WebUI home Vitest suite (31 tests)
- [x] `PSSearchRestServiceTest` (6 tests)
- [x] Live smoke on `/opt/Percussion` (`StartJetty.sh`, port 9992):
  - [x] Login → `/cm/app/spa.jsp?entry=home`
  - [x] `/services/sitemanage/site/`, recent, mycontent, folder path → 200
  - [x] Search extended with `startIndex: 1` → 200
  - [x] Dashboard → 200
- [ ] CI green on this PR
- [ ] Manual browser pass: Home sections (Recent, Library, Search, Create, Gadgets, Bookmarks)

## Notes
- Deployed rebuilt `perc-system` + `sitemanage` jars and modern WebUI assets to the local install for smoke testing.
- `PSSaveAssetsMaintenanceProcess` may still log secondary H2 connection failures on that install; SPA home remains usable after login.

> Co-Authored by Grok Build using grok-4.5 with agent main.