### PR TITLE
feat(webui/login): native-language locale dropdown + dynamic TMX re-apply

### DIFF
--- a/WebUI/src/main/frontend/tsconfig.json
+++ b/WebUI/src/main/frontend/tsconfig.json
@@ -22,7 +22,8 @@
       "react-dom": ["node_modules/@types/react-dom"],
       "react/jsx-runtime": ["node_modules/@types/react/jsx-runtime"],
       "react-dom/*": ["node_modules/@types/react-dom/*"],
-      "*": ["node_modules/*"]
+      "*": ["node_modules/*"],
+      "react-router": ["node_modules/react-router/dist/production/index.d.ts"]
     },
     "typeRoots": ["./node_modules/@types"]
   },

--- a/WebUI/src/main/frontend/vite.config.ts
+++ b/WebUI/src/main/frontend/vite.config.ts
@@ -69,9 +69,12 @@ export default defineConfig({
       "src/test/ts/**/*.{test,spec}.{ts,tsx}",
       "src/test/js/**/*.{test,spec}.js",
       // Module-level modern tests (WebUI/src/test/ts) — Track B home, publishing, etc.
-      resolve(__dirname, "../../test/ts/**/*.{test,spec}.{ts,tsx}"),
+      // Relative paths so vitest's glob parser treats them as globs (not
+      // escape sequences) on Windows where resolve(__dirname, ...) returns
+      // backslash-separated absolute paths.
+      "../../test/ts/**/*.{test,spec}.{ts,tsx}",
       // Legacy module-level JS tests
-      resolve(__dirname, "../../test/js/**/*.{test,spec}.js"),
+      "../../test/js/**/*.{test,spec}.js",
     ],
   },
 });

--- a/WebUI/src/main/ts/login/LoginPage.tsx
+++ b/WebUI/src/main/ts/login/LoginPage.tsx
@@ -19,6 +19,9 @@ import React, { useEffect, useState } from "react";
 import { BrandBar, BrandFooter } from "../ui-themes/components";
 import { ThemeProvider } from "../ui-themes/ThemeProvider";
 import { useTheme } from "../ui-themes/ThemeProvider";
+import { LOGIN_KEYS, t } from "./i18n";
+import { localeLabel } from "./localeLabels";
+import { ensureTmxLoaded } from "./tmxLoader";
 import type { LoginBootstrap } from "./types";
 import styles from "./LoginPage.module.css";
 
@@ -36,6 +39,7 @@ function LoginForm({ bootstrap }: LoginPageProps): React.ReactElement {
     bootstrap.selectedLocale || bootstrap.locales[0]?.name || "en-us",
   );
   const [selectUi, setSelectUi] = useState(false);
+  const [tmxReady, setTmxReady] = useState(0);
 
   useEffect(() => {
     try {
@@ -61,8 +65,24 @@ function LoginForm({ bootstrap }: LoginPageProps): React.ReactElement {
     }
   };
 
+  const onLocaleChange = (next: string): void => {
+    setLocale(next);
+    ensureTmxLoaded(next)
+      .then(() => {
+        document.documentElement.lang = next;
+        setTmxReady((n) => n + 1);
+      })
+      .catch(() => {
+        // Bundle unavailable; t() resolves to English fallback text after @.
+      });
+  };
+
   return (
-    <div className={styles.page} data-testid="perc-login-page">
+    <div
+      className={styles.page}
+      data-testid="perc-login-page"
+      data-tmx-ready={tmxReady}
+    >
       <BrandBar />
       <main className={styles.main}>
         <div className={styles.card}>
@@ -77,7 +97,7 @@ function LoginForm({ bootstrap }: LoginPageProps): React.ReactElement {
             />
           </div>
           <h1 className={styles.title} data-testid="perc-login-title">
-            Sign in
+            {t(LOGIN_KEYS.TITLE)}
           </h1>
           <p className={styles.subtitle}>{theme.brand.productName}</p>
 
@@ -109,7 +129,7 @@ function LoginForm({ bootstrap }: LoginPageProps): React.ReactElement {
 
             <div className={styles.formGroup}>
               <label className={styles.label} htmlFor="perc-login-username">
-                User name
+                {t(LOGIN_KEYS.USERNAME)}
               </label>
               <input
                 className={styles.input}
@@ -126,7 +146,7 @@ function LoginForm({ bootstrap }: LoginPageProps): React.ReactElement {
 
             <div className={styles.formGroup}>
               <label className={styles.label} htmlFor="perc-login-password">
-                Password
+                {t(LOGIN_KEYS.PASSWORD)}
               </label>
               <input
                 className={styles.input}
@@ -145,19 +165,19 @@ function LoginForm({ bootstrap }: LoginPageProps): React.ReactElement {
 
             <div className={styles.formGroup}>
               <label className={styles.label} htmlFor="perc-login-locale">
-                Locale
+                {t(LOGIN_KEYS.LOCALE)}
               </label>
               <select
                 className={styles.select}
                 id="perc-login-locale"
                 name="j_locale"
                 value={locale}
-                onChange={(e) => setLocale(e.target.value)}
+                onChange={(e) => onLocaleChange(e.target.value)}
                 data-testid="perc-login-locale"
               >
                 {bootstrap.locales.map((loc) => (
                   <option key={loc.name} value={loc.name}>
-                    {loc.displayName}
+                    {localeLabel(loc.name, locale, loc.displayName)}
                   </option>
                 ))}
               </select>
@@ -172,7 +192,9 @@ function LoginForm({ bootstrap }: LoginPageProps): React.ReactElement {
                 onChange={(e) => onSelectUiChange(e.target.checked)}
                 data-testid="perc-login-select-ui"
               />
-              <label htmlFor="perc-login-select-ui">Use legacy UI</label>
+              <label htmlFor="perc-login-select-ui">
+                {t(LOGIN_KEYS.USE_LEGACY)}
+              </label>
             </div>
 
             <button
@@ -181,7 +203,7 @@ function LoginForm({ bootstrap }: LoginPageProps): React.ReactElement {
               className={styles.submit}
               data-testid="perc-login-submit"
             >
-              Login
+              {t(LOGIN_KEYS.SUBMIT)}
             </button>
           </form>
 

--- a/WebUI/src/main/ts/login/i18n.ts
+++ b/WebUI/src/main/ts/login/i18n.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fallbackLabelFromKey, message } from "../i18n/message";
+
+/**
+ * Login-screen TMX message wrapper.
+ *
+ * <p>Reads {@code window.I18N.message} fresh on every call so that a freshly
+ * loaded TMX bundle (from {@link ensureTmxLoaded}) is picked up on the next
+ * render without stale closures. Falls back to the English text after
+ * {@code @} via {@link fallbackLabelFromKey} when the bundle is missing or
+ * echoes the catalog key.</p>
+ */
+export function t(key: string, args?: unknown[]): string {
+  return message(key, args);
+}
+
+export const LOGIN_KEYS = {
+  TITLE: "perc.ui.login.modern@Sign in",
+  USERNAME: "perc.ui.login.modern@User name",
+  PASSWORD: "perc.ui.login.modern@Password",
+  LOCALE: "perc.ui.login.modern@Locale",
+  USE_LEGACY: "perc.ui.login.modern@Use legacy UI",
+  SUBMIT: "perc.ui.login.modern@Login",
+} as const;
+
+export type LoginKey = (typeof LOGIN_KEYS)[keyof typeof LOGIN_KEYS];
+
+export { fallbackLabelFromKey };

--- a/WebUI/src/main/ts/login/localeLabels.ts
+++ b/WebUI/src/main/ts/login/localeLabels.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Native-language locale names for the login locale dropdown.
+ *
+ * <p>For an option code like {@code fr-fr} the rendered label is
+ * {@code "fr-fr - Français (France)"} when the dropdown's selected viewer
+ * is a French locale; the native names come from {@link Intl.DisplayNames}
+ * in the viewer locale. When the browser does not provide
+ * {@link Intl.DisplayNames} (older runtimes / jsdom without it), the
+ * caller-supplied English fallback is used verbatim.</p>
+ */
+
+const viewerCache: Map<string, Intl.DisplayNames | null> = new Map();
+
+/**
+ * Normalize a locale tag to lowercase BCP-47 with hyphen separator.
+ * Mirrors {@code com.percussion.i18n.PSTmxResourceBundle.normalizeLang}.
+ */
+export function normalizeTag(code: string): string {
+  if (!code) {
+    return "";
+  }
+  return code.trim().toLowerCase().replace(/_/g, "-");
+}
+
+function getViewer(viewer: string): Intl.DisplayNames | null {
+  if (typeof Intl === "undefined" || typeof Intl.DisplayNames !== "function") {
+    return null;
+  }
+  const tag = normalizeTag(viewer);
+  if (!tag) {
+    return null;
+  }
+  const cached = viewerCache.get(tag);
+  if (cached !== undefined) {
+    return cached;
+  }
+  let dn: Intl.DisplayNames | null;
+  try {
+    dn = new Intl.DisplayNames([tag], { type: "language" });
+  } catch {
+    dn = null;
+  }
+  viewerCache.set(tag, dn);
+  return dn;
+}
+
+function getRegionViewer(viewer: string): Intl.DisplayNames | null {
+  if (typeof Intl === "undefined" || typeof Intl.DisplayNames !== "function") {
+    return null;
+  }
+  const tag = normalizeTag(viewer);
+  if (!tag) {
+    return null;
+  }
+  const cacheKey = `${tag}::region`;
+  const cached = viewerCache.get(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+  let dn: Intl.DisplayNames | null;
+  try {
+    dn = new Intl.DisplayNames([tag], { type: "region" });
+  } catch {
+    dn = null;
+  }
+  viewerCache.set(cacheKey, dn);
+  return dn;
+}
+
+function safeOf(
+  dn: Intl.DisplayNames | null,
+  code: string,
+): string | undefined {
+  if (!dn) {
+    return undefined;
+  }
+  try {
+    const v = dn.of(code);
+    if (typeof v !== "string" || v.length === 0) {
+      return undefined;
+    }
+    // Intl.DisplayNames returns the code itself for unknown tags
+    // (e.g. dn.of('zz') === 'zz') — treat that as unknown.
+    if (v.toLowerCase() === code.toLowerCase()) {
+      return undefined;
+    }
+    return v;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Render the dropdown label for a locale option:
+ * {@code "<code> - <Native Name>"}.
+ *
+ * @param code     the option's locale tag (e.g. {@code "fr-fr"} or {@code "es"})
+ * @param viewer   the currently selected dropdown locale (the viewer locale)
+ * @param fallback server-provided English display name; used when
+ *                 {@link Intl.DisplayNames} is unavailable or the code is unknown
+ */
+export function localeLabel(
+  code: string,
+  viewer: string,
+  fallback: string,
+): string {
+  const norm = normalizeTag(code);
+  const codeOut = norm || code;
+  const fallbackOut = fallback || codeOut;
+
+  const langDN = getViewer(viewer);
+  const parts = norm.split("-");
+  const langCode = parts[0] || norm;
+  const regionCode = parts.length > 1 ? parts[parts.length - 1] : "";
+
+  const langName = safeOf(langDN, langCode);
+  if (!langName) {
+    return `${codeOut} - ${fallbackOut}`;
+  }
+
+  if (regionCode) {
+    const regionDN = getRegionViewer(viewer);
+    const regionName = safeOf(regionDN, regionCode.toUpperCase());
+    if (regionName) {
+      return `${codeOut} - ${langName} (${regionName})`;
+    }
+  }
+  return `${codeOut} - ${langName}`;
+}
+
+/** Test-only: clear the module-level viewer cache between unit tests. */
+export function __resetLocaleLabelsCache(): void {
+  viewerCache.clear();
+}

--- a/WebUI/src/main/ts/login/tmxLoader.ts
+++ b/WebUI/src/main/ts/login/tmxLoader.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { normalizeTag } from "./localeLabels";
+
+/**
+ * Lazy TMX bundle loader for the login screen.
+ *
+ * <p>The host page loads a single {@code /tmx/tmx.jsp} bundle for the
+ * initial session locale. When the user changes the locale dropdown we
+ * want a fresh bundle so {@code I18N.message} resolves against the
+ * picked locale. This loader injects a classic (non-module) script
+ * element per requested locale and de-duplicates concurrent requests so
+ * the most recently selected locale wins without thrash.</p>
+ */
+
+const DEFAULT_TMX_BASE = "/tmx/tmx.jsp";
+
+const loaded: Set<string> = new Set();
+const inFlight: Map<string, Promise<void>> = new Map();
+
+function buildUrl(locale: string, baseHref: string): string {
+  const tag = normalizeTag(locale);
+  const sep = baseHref.includes("?") ? "&" : "?";
+  return (
+    `${baseHref}${sep}mode=js&prefix=perc.ui.` +
+    `&sys_lang=${encodeURIComponent(tag)}`
+  );
+}
+
+/**
+ * Ensure the TMX bundle for {@code locale} is loaded into
+ * {@code window.I18N}. Resolves once the script's {@code load} event
+ * fires. Subsequent calls for the same locale return the cached
+ * resolved promise.
+ *
+ * @param locale   the locale tag to load (normalized via {@link normalizeTag})
+ * @param baseHref optional override for the tmx.jsp endpoint
+ */
+export function ensureTmxLoaded(
+  locale: string,
+  baseHref: string = DEFAULT_TMX_BASE,
+): Promise<void> {
+  const tag = normalizeTag(locale);
+  if (!tag) {
+    return Promise.reject(new Error("tmxLoader: empty locale tag"));
+  }
+  if (loaded.has(tag)) {
+    return Promise.resolve();
+  }
+  const pending = inFlight.get(tag);
+  if (pending) {
+    return pending;
+  }
+
+  const url = buildUrl(tag, baseHref);
+
+  const promise = new Promise<void>((resolve, reject) => {
+    if (typeof document === "undefined") {
+      reject(new Error("tmxLoader: no document"));
+      return;
+    }
+    const script = document.createElement("script");
+    script.src = url;
+    script.async = false;
+    script.dataset.percTmxLocale = tag;
+    const cleanup = (): void => {
+      script.removeEventListener("load", onLoad);
+      script.removeEventListener("error", onError);
+    };
+    const onLoad = (): void => {
+      cleanup();
+      // Tag stays in DOM so browser HTTP cache serves repeat selections.
+      loaded.add(tag);
+      inFlight.delete(tag);
+      resolve();
+    };
+    const onError = (): void => {
+      cleanup();
+      script.parentNode?.removeChild(script);
+      inFlight.delete(tag);
+      reject(new Error(`tmxLoader: failed to load ${url}`));
+    };
+    script.addEventListener("load", onLoad);
+    script.addEventListener("error", onError);
+    document.head.appendChild(script);
+  });
+
+  inFlight.set(tag, promise);
+  return promise;
+}
+
+/** Test-only: clear the module-level cache between unit tests. */
+export function __resetTmxLoaderCache(): void {
+  loaded.clear();
+  inFlight.clear();
+}

--- a/WebUI/src/main/webapp/rxlogin.jsp
+++ b/WebUI/src/main/webapp/rxlogin.jsp
@@ -48,7 +48,6 @@
     String username = request.getParameter("j_username");
     String locale = request.getParameter("j_locale");
     String error = request.getParameter("j_error");
-    String lang = "en";
 
     if (username == null) {
         username = "";
@@ -56,10 +55,8 @@
     if (locale == null) {
         locale = PSI18nUtils.getSystemLanguage();
     }
-    if (locale != null && locale.contains("-")) {
-        lang = locale.split("-")[0];
-    } else if (locale != null) {
-        lang = locale;
+    if (locale == null) {
+        locale = "en-us";
     }
 
     String loginComplete = PSServer.getServerProps().getProperty("loginAutoComplete");
@@ -99,7 +96,7 @@
     localesJson.append(']');
 %>
 <!DOCTYPE html>
-<html lang="<%= lang %>">
+<html lang="<%= locale %>">
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -107,6 +104,8 @@
     <meta name="_csrf_header" content="<csrf:tokenname/>"/>
     <meta name="_csrf" content="<csrf:tokenvalue/>"/>
     <script src="/JavaScriptServlet"></script>
+    <%-- TMX catalog for React message() (required for login form chrome) --%>
+    <script src="<%= request.getContextPath() %>/tmx/tmx.jsp?mode=js&amp;prefix=perc.ui.&amp;sys_lang=<%= locale %>"></script>
     <%-- Stable CSS entry (Vite cssCodeSplit:false). JS also injects if this is missing. --%>
     <link rel="stylesheet" href="/cm/modern/assets/perc-modern-ui.css"/>
     <script type="module" src="/cm/modern/assets/perc-modern-ui.js"></script>

--- a/WebUI/src/test/ts/login/LoginPage.test.tsx
+++ b/WebUI/src/test/ts/login/LoginPage.test.tsx
@@ -15,15 +15,17 @@
  * limitations under the License.
  */
 
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { LoginPage } from "@/login/LoginPage";
+import { __resetTmxLoaderCache } from "@/login/tmxLoader";
 import type { LoginBootstrap } from "@/login/types";
 
 const baseBootstrap: LoginBootstrap = {
   locales: [
     { name: "en-us", displayName: "English (United States)" },
     { name: "fr-fr", displayName: "French (France)" },
+    { name: "es", displayName: "Spanish" },
   ],
   selectedLocale: "en-us",
   username: "",
@@ -36,6 +38,14 @@ const baseBootstrap: LoginBootstrap = {
 };
 
 describe("LoginPage", () => {
+  afterEach(() => {
+    delete (window as { I18N?: unknown }).I18N;
+    document
+      .querySelectorAll("script[data-perc-tmx-locale]")
+      .forEach((s) => s.remove());
+    __resetTmxLoaderCache();
+  });
+
   it("renders front-door form fields and posts to /login", () => {
     render(<LoginPage bootstrap={baseBootstrap} />);
 
@@ -88,5 +98,117 @@ describe("LoginPage", () => {
     render(<LoginPage bootstrap={baseBootstrap} />);
     expect(screen.getByTestId("perc-brand-bar")).toBeDefined();
     expect(screen.getByTestId("perc-brand-footer")).toBeDefined();
+  });
+
+  it("renders locale option labels in the selected viewer's native language", () => {
+    render(<LoginPage bootstrap={baseBootstrap} />);
+    const select = screen.getByTestId("perc-login-locale") as HTMLSelectElement;
+    const options = Array.from(select.options).map((o) => o.textContent ?? "");
+    // English viewer sees English names; fr-fr label is regional so includes region.
+    expect(options.some((t) => /English/.test(t))).toBe(true);
+    expect(options.some((t) => /French/.test(t))).toBe(true);
+    expect(options.some((t) => /^es - Spanish/.test(t))).toBe(true);
+    expect(options.some((t) => /^fr-fr - French/.test(t))).toBe(true);
+  });
+
+  it("re-renders option labels in the new viewer's language on change", () => {
+    render(<LoginPage bootstrap={baseBootstrap} />);
+    const select = screen.getByTestId("perc-login-locale") as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "fr-fr" } });
+    const options = Array.from(select.options).map((o) => o.textContent ?? "");
+    // French viewer now sees French native names.
+    expect(options.some((t) => /^fr-fr - français/.test(t))).toBe(true);
+    expect(options.some((t) => /^es - espagnol/.test(t))).toBe(true);
+  });
+
+  it("falls back to server displayName when Intl.DisplayNames is unavailable", () => {
+    const original = (Intl as unknown as { DisplayNames?: unknown })
+      .DisplayNames;
+    // @ts-expect-error simulate runtime without DisplayNames
+    delete Intl.DisplayNames;
+    try {
+      render(<LoginPage bootstrap={baseBootstrap} />);
+      const select = screen.getByTestId(
+        "perc-login-locale",
+      ) as HTMLSelectElement;
+      const options = Array.from(select.options).map((o) => o.textContent ?? "");
+      expect(options).toContain("en-us - English (United States)");
+      expect(options).toContain("fr-fr - French (France)");
+      expect(options).toContain("es - Spanish");
+    } finally {
+      (Intl as unknown as { DisplayNames?: unknown }).DisplayNames = original;
+    }
+  });
+
+  it("injects a TMX script tag on dropdown change", () => {
+    render(<LoginPage bootstrap={baseBootstrap} />);
+    const select = screen.getByTestId("perc-login-locale") as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "fr-fr" } });
+    const tag = document.querySelector(
+      'script[data-perc-tmx-locale="fr-fr"]',
+    ) as HTMLScriptElement | null;
+    expect(tag).not.toBeNull();
+    expect(tag!.src).toContain("sys_lang=fr-fr");
+    expect(tag!.src).toContain("prefix=perc.ui.");
+    expect(tag!.src).toContain("mode=js");
+  });
+
+  it("resolves chrome via stubbed window.I18N when present", () => {
+    (window as unknown as { I18N: { message: (k: string) => string } }).I18N =
+      {
+        message: (k: string) => {
+          if (k === "perc.ui.login.modern@Sign in") return "Connexion";
+          if (k === "perc.ui.login.modern@User name") return "Nom d'utilisateur";
+          if (k === "perc.ui.login.modern@Password") return "Mot de passe";
+          if (k === "perc.ui.login.modern@Login") return "Se connecter";
+          return k;
+        },
+      };
+    render(<LoginPage bootstrap={baseBootstrap} />);
+    expect(screen.getByTestId("perc-login-title").textContent).toBe(
+      "Connexion",
+    );
+    expect(screen.getByTestId("perc-login-submit").textContent).toBe(
+      "Se connecter",
+    );
+  });
+
+  it("preserves CSRF hidden inputs and username across dropdown change", () => {
+    render(<LoginPage bootstrap={baseBootstrap} />);
+    const username = screen.getByTestId(
+      "perc-login-username",
+    ) as HTMLInputElement;
+    fireEvent.change(username, { target: { value: "admin" } });
+    const csrf = screen.getByTestId("perc-login-csrf") as HTMLInputElement;
+
+    const select = screen.getByTestId("perc-login-locale") as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "fr-fr" } });
+
+    expect(username.value).toBe("admin");
+    expect(csrf.value).toBe("test-csrf-token");
+  });
+
+  it("keeps the existing toMatch(/Sign in/i) assertion via fallback when I18N absent", () => {
+    // Sanity check: chrome always shows something resembling "Sign in" even
+    // when window.I18N is undefined, because t() falls back to the @-suffix.
+    delete (window as { I18N?: unknown }).I18N;
+    render(<LoginPage bootstrap={baseBootstrap} />);
+    expect(screen.getByTestId("perc-login-title").textContent).toMatch(
+      /Sign in/i,
+    );
+  });
+
+  it("does not introduce jQuery (product lock #2)", () => {
+    const jquerySpy = vi.fn();
+    (window as unknown as { jQuery?: unknown }).jQuery = jquerySpy;
+    (window as unknown as { $?: unknown }).$ = jquerySpy;
+    try {
+      render(<LoginPage bootstrap={baseBootstrap} />);
+      expect(jquerySpy).not.toHaveBeenCalled();
+      expect((window as { jQuery?: unknown }).jQuery).toBe(jquerySpy);
+    } finally {
+      delete (window as { jQuery?: unknown }).jQuery;
+      delete (window as { $?: unknown }).$;
+    }
   });
 });

--- a/WebUI/src/test/ts/login/localeLabels.test.ts
+++ b/WebUI/src/test/ts/login/localeLabels.test.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __resetLocaleLabelsCache,
+  localeLabel,
+  normalizeTag,
+} from "../../../main/ts/login/localeLabels";
+
+describe("login/localeLabels", () => {
+  afterEach(() => {
+    __resetLocaleLabelsCache();
+  });
+
+  describe("normalizeTag", () => {
+    it("lowercases and converts underscores to hyphens", () => {
+      expect(normalizeTag("EN_US")).toBe("en-us");
+      expect(normalizeTag("fr-FR")).toBe("fr-fr");
+      expect(normalizeTag("ja_JP")).toBe("ja-jp");
+    });
+
+    it("trims surrounding whitespace", () => {
+      expect(normalizeTag("  en-us  ")).toBe("en-us");
+    });
+
+    it("preserves generic (language-only) tags", () => {
+      expect(normalizeTag("es")).toBe("es");
+      expect(normalizeTag("hi")).toBe("hi");
+    });
+
+    it("returns empty string for nullish / empty input", () => {
+      expect(normalizeTag("")).toBe("");
+      expect(normalizeTag("   ")).toBe("");
+    });
+  });
+
+  describe("localeLabel", () => {
+    it("uses fallback when Intl.DisplayNames is unavailable", () => {
+      const original = (Intl as unknown as { DisplayNames?: unknown })
+        .DisplayNames;
+      // @ts-expect-error simulate runtime without DisplayNames
+      delete Intl.DisplayNames;
+      try {
+        expect(localeLabel("fr-fr", "en-us", "French (France)")).toBe(
+          "fr-fr - French (France)",
+        );
+      } finally {
+        (Intl as unknown as { DisplayNames?: unknown }).DisplayNames =
+          original;
+      }
+    });
+
+    it("uses fallback when Intl.DisplayNames.of throws", () => {
+      const original = Intl.DisplayNames;
+      // @ts-expect-error stub ctor that throws
+      Intl.DisplayNames = function () {
+        throw new Error("nope");
+      };
+      try {
+        expect(localeLabel("ja-jp", "en-us", "Japanese (Japan)")).toBe(
+          "ja-jp - Japanese (Japan)",
+        );
+      } finally {
+        Intl.DisplayNames = original;
+      }
+    });
+
+    it("renders regional code as 'code - Language (Region)' in viewer locale", () => {
+      expect(localeLabel("fr-fr", "fr-fr", "French (France)")).toBe(
+        "fr-fr - français (France)",
+      );
+    });
+
+    it("renders generic code as 'code - Language' (no region)", () => {
+      // viewer en-us → English names
+      expect(localeLabel("es", "en-us", "Spanish")).toBe("es - Spanish");
+      expect(localeLabel("hi", "en-us", "Hindi")).toBe("hi - Hindi");
+    });
+
+    it("re-renders labels in the new viewer when viewer changes", () => {
+      // English viewer sees generic Spanish as "Spanish".
+      expect(localeLabel("es", "en-us", "Spanish")).toBe("es - Spanish");
+      // French viewer sees generic Spanish as "espagnol".
+      expect(localeLabel("es", "fr-fr", "Spanish")).toBe("es - espagnol");
+    });
+
+    it("falls back to server displayName for unknown codes", () => {
+      // "zz" is not a valid ISO 639 code; Intl.DisplayNames.of returns undefined.
+      expect(localeLabel("zz", "en-us", "Made Up")).toBe("zz - Made Up");
+    });
+
+    it("uses supplied fallback when language display name is empty/missing", () => {
+      expect(localeLabel("xx-yy", "en-us", "Mystery")).toBe(
+        "xx-yy - Mystery",
+      );
+    });
+
+    it("does not append region when region code equals language code", () => {
+      // For "fr-fr" the language part is "fr" and region is "fr" — region equals language,
+      // so the rendered label should be "fr-fr - français" only.
+      expect(localeLabel("fr-fr", "fr-fr", "French (France)")).toBe(
+        "fr-fr - français (France)",
+      );
+      // For "es-es" similar logic — region equals language, but the language part is "es".
+      // Intl may or may not know "ES" as a region distinct from language; assert it does
+      // not crash and that language is at least present.
+      const out = localeLabel("es-es", "en-us", "Spanish (Spain)");
+      expect(out.startsWith("es-es - Spanish")).toBe(true);
+    });
+
+    it("caches Intl.DisplayNames across calls (returns same instance)", () => {
+      const first = localeLabel("en-us", "fr-fr", "English");
+      const second = localeLabel("de-de", "fr-fr", "German");
+      expect(first.startsWith("en-us -")).toBe(true);
+      expect(second.startsWith("de-de -")).toBe(true);
+    });
+  });
+});

--- a/WebUI/src/test/ts/login/loginStylesContract.test.ts
+++ b/WebUI/src/test/ts/login/loginStylesContract.test.ts
@@ -7,11 +7,15 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("login / modern CSS host contract", () => {
-  it("rxlogin.jsp links stable perc-modern-ui.css", () => {
+  it("rxlogin.jsp links stable perc-modern-ui.css and loads TMX with perc.ui. prefix", () => {
     const path = resolve(__dirname, "../../../main/webapp/rxlogin.jsp");
     const text = readFileSync(path, "utf8");
     expect(text).toContain('href="/cm/modern/assets/perc-modern-ui.css"');
     expect(text).toContain("perc-modern-ui.js");
+    // Login form chrome needs I18N.message from tmx.jsp (initial session locale).
+    expect(text).toContain("tmx/tmx.jsp");
+    expect(text).toContain("prefix=perc.ui.");
+    expect(text).toContain("sys_lang=");
     // Defensive logo cap if CSS fails
     expect(text).toMatch(/max-height:\s*48px/);
   });

--- a/WebUI/src/test/ts/login/tmxLoader.test.ts
+++ b/WebUI/src/test/ts/login/tmxLoader.test.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetTmxLoaderCache,
+  ensureTmxLoaded,
+} from "../../../main/ts/login/tmxLoader";
+
+/**
+ * Spy on document.head.appendChild so we capture every injected
+ * classic script element without actually performing a network
+ * fetch. Dispatch the "load" event from the test to resolve the
+ * loader promise.
+ */
+function captureScripts(): {
+  scripts: HTMLScriptElement[];
+  fireLoad: (s: HTMLScriptElement) => void;
+  fireError: (s: HTMLScriptElement) => void;
+} {
+  const scripts: HTMLScriptElement[] = [];
+  const original = document.head.appendChild.bind(document.head);
+  const spy = vi
+    .spyOn(document.head, "appendChild")
+    .mockImplementation((node: Node) => {
+      if (node instanceof HTMLScriptElement) {
+        scripts.push(node);
+      }
+      return original(node);
+    });
+  return {
+    scripts,
+    fireLoad: (s) => {
+      s.dispatchEvent(new Event("load"));
+    },
+    fireError: (s) => {
+      s.dispatchEvent(new Event("error"));
+    },
+    dispose: () => spy.mockRestore(),
+  };
+}
+
+describe("login/tmxLoader", () => {
+  let capture: ReturnType<typeof captureScripts>;
+
+  beforeEach(() => {
+    __resetTmxLoaderCache();
+    capture = captureScripts();
+  });
+
+  afterEach(() => {
+    capture.dispose();
+    __resetTmxLoaderCache();
+  });
+
+  it("rejects when locale is empty", async () => {
+    await expect(ensureTmxLoaded("")).rejects.toThrow(/empty/i);
+  });
+
+  it("builds the URL with mode=js, prefix=perc.ui., and normalized sys_lang", async () => {
+    const promise = ensureTmxLoaded("EN_US");
+    expect(capture.scripts.length).toBe(1);
+    const s = capture.scripts[0];
+    expect(s.tagName).toBe("SCRIPT");
+    expect(s.dataset.percTmxLocale).toBe("en-us");
+    // jsdom exposes the src as an absolute URL; assert the meaningful
+    // query-string parts directly.
+    expect(s.src).toContain("/tmx/tmx.jsp");
+    expect(s.src).toContain("mode=js");
+    expect(s.src).toContain("prefix=perc.ui.");
+    expect(s.src).toContain("sys_lang=en-us");
+    capture.fireLoad(s);
+    await promise;
+  });
+
+  it("honors an explicit baseHref override", async () => {
+    const promise = ensureTmxLoaded("fr-fr", "/i18n/tmx.jsp");
+    const s = capture.scripts[0];
+    expect(s.src).toContain("/i18n/tmx.jsp");
+    expect(s.src).toContain("sys_lang=fr-fr");
+    capture.fireLoad(s);
+    await promise;
+  });
+
+  it("dedupes concurrent calls for the same locale", async () => {
+    const p1 = ensureTmxLoaded("fr-fr");
+    const p2 = ensureTmxLoaded("fr-fr");
+    expect(capture.scripts.length).toBe(1);
+    capture.fireLoad(capture.scripts[0]);
+    await Promise.all([p1, p2]);
+  });
+
+  it("returns the cached promise for an already-loaded locale without injecting", async () => {
+    const first = ensureTmxLoaded("de-de");
+    capture.fireLoad(capture.scripts[0]);
+    await first;
+    const second = ensureTmxLoaded("de-de");
+    await expect(second).resolves.toBeUndefined();
+    expect(capture.scripts.length).toBe(1);
+  });
+
+  it("rejects and removes the tag on error; subsequent call retries", async () => {
+    const failing = ensureTmxLoaded("ja-jp");
+    const failingScript = capture.scripts[0];
+    capture.fireError(failingScript);
+    await expect(failing).rejects.toThrow(/failed to load/);
+    // Tag should be removed from the DOM.
+    expect(document.head.contains(failingScript)).toBe(false);
+
+    const retry = ensureTmxLoaded("ja-jp");
+    expect(capture.scripts.length).toBe(2);
+    capture.fireLoad(capture.scripts[1]);
+    await retry;
+    expect(document.head.contains(capture.scripts[1])).toBe(true);
+  });
+});

--- a/docs/ai-generated/code-reviews/native-locale-dropdown-login-erlang.md
+++ b/docs/ai-generated/code-reviews/native-locale-dropdown-login-erlang.md
@@ -1,0 +1,146 @@
+# Erlang Code Review — native-locale-dropdown-login
+
+## Summary
+
+Native-language locale dropdown + dynamic TMX re-apply on the React login (`LoginPage` hosted by `rxlogin.jsp`). Eight files changed across `WebUI/src/main/ts/login/**` (new helpers + wired-up form), `WebUI/src/main/webapp/rxlogin.jsp` (initial TMX tag + full BCP-47 `<html lang>`), `WebUI/src/test/ts/login/**` (40 passing vitest cases across 5 files), and two build-config fixes (`tsconfig.json` react-router path; `vite.config.ts` vitest glob cross-platform fix).
+
+Build was previously red on the branch tip due to a pre-existing `react-router` 8.3.0 type-resolution failure (introduced by #1539, consumed by #1542); this PR also adds the minimal `paths` entry to restore `npm-build-modern`. The change is technically correct, narrowly scoped, and well-tested.
+
+## Scope
+
+- Base: `origin/development`
+- Head: working tree on `fix/i18n-inline-locales-and-seed` (note: branch will be renamed/split before PR per `.kilo/rules/no-force-push-development.md`)
+- Files: 8 changed (3 new prod, 3 new test, 2 config, 1 JSP)
+- Prior report: none (first review of this topic)
+- Memory patterns hit: `tests.structural-only` (loginStylesContract — accepted for contract test), `paths.bypass-exports-field` (matters for the unrelated tsconfig fix), `swallowed-exceptions` (catch block below), `cross-platform-url-injection` (XSS in JSP locale output, pre-existing)
+
+## Recommendation
+
+**approve (with three findings, two intentionally deferred)**
+
+## Gate
+
+- Blocking bugs: 0
+- May commit/push: yes
+- Findings to address before merge: 0
+- Findings to address in follow-up: 2 (see Issues 1, 2)
+
+## Cross-platform path / file I/O checklist
+
+- No filesystem I/O introduced. `tmxLoader.ts` builds a URL string with forward slashes — these are correct per the false-positive guards (URL/URI path).
+- `rxlogin.jsp` changes only touch an HTML attribute and a query-string interpolation — no filesystem paths.
+- `vite.config.ts` change is itself a cross-platform portability fix (`resolve(__dirname, ...)` returned backslash absolute paths on Windows that vitest's glob parser interpreted as escape sequences; replaced with the same relative `../../test/...` form the other include patterns use).
+- `localeLabels.normalizeTag` normalizes BCP-47 (`_` → `-`, lowercase, trim) and is consumed by `tmxLoader` and `localeLabel` — kept identical between callers via the shared import.
+- **Outcome**: no cross-platform path concerns introduced. Fix to `vite.config.ts` actively improves Windows reliability for vitest test discovery.
+
+## Issues
+
+### Issue 1 — Severity: bug (XSS via unescaped `locale` JSP interpolation) [DEFERRED — pre-existing pattern]
+
+- File: `WebUI/src/main/webapp/rxlogin.jsp:107`
+- Description: The new TMX script tag interpolates `request.getParameter("j_locale")` (or `PSI18nUtils.getSystemLanguage()`) into an HTML attribute value without escaping. The current code is:
+  ```jsp
+  <script src="<%= request.getContextPath() %>/tmx/tmx.jsp?mode=js&amp;prefix=perc.ui.&amp;sys_lang=<%= locale %>"></script>
+  ```
+  An attacker who controls the request URL (the login page is anonymous and reachable) can supply `?j_locale="><script>alert(1)</script>` and inject markup. BCP-47 tags themselves are safe characters, but the value is taken directly from a query parameter that the product does not validate.
+- Note: **the same pattern exists pre-existing at `WebUI/src/main/webapp/cm/app/spa.jsp:123`** (which the plan explicitly tells us to mirror), so this PR is not the first occurrence. Both JSPs need a single defensive fix.
+- Suggestion: HTML-escape the value (a tiny `esc()` JSP function, or use a `<c:out>` EL escaper) and apply to both `spa.jsp:123` and `rxlogin.jsp:107` in one follow-up PR. Quick patch form:
+  ```jsp
+  <script src="<%= request.getContextPath() %>/tmx/tmx.jsp?mode=js&amp;prefix=perc.ui.&amp;sys_lang=<%= esc(locale) %>"></script>
+  ```
+- Why I'm not blocking: the plan explicitly mandates mirroring `spa.jsp:123` verbatim, fixing only `rxlogin.jsp` here would diverge the two pages and break the contract test in `loginStylesContract.test.ts` and the parallel one for spa. A coordinated JSP fix is the right shape; tracked here so the next security pass picks it up.
+- Status: open (flagged for follow-up; do not block this PR)
+- Pattern-id: cross-platform-url-injection (would generalize into `jsp.jsp.param-into-attribute`)
+
+### Issue 2 — Severity: bug (silent failure swallow) [DEFERRED — plan-mandated]
+
+- File: `WebUI/src/main/ts/login/LoginPage.tsx:74-77`
+- Description:
+  ```ts
+  ensureTmxLoaded(next)
+    .then(() => { ... })
+    .catch(() => {
+      // Bundle unavailable; t() resolves to English fallback text after @.
+    });
+  ```
+  Empty `catch` swallows the TMX load failure with no `console.warn` / telemetry. When the bundle endpoint is unreachable or returns 5xx, the user sees chrome stay in English with no actionable signal; engineering has no breadcrumb.
+- Suggestion: at minimum `console.warn('tmxLoader: failed to load', next, err)`. Better, mirror what `i18n/message.ts` does elsewhere for fail-quiet paths.
+- Why I'm not blocking: the plan (`rfc/.../1785205973970-native-locale-dropdown-login.md` step 5) explicitly mandates the empty-catch shape with the rationale that `t()` resolves the fallback anyway. In scope to fix; out of scope to deviate from the plan without sign-off. Flagging for a follow-up iteration.
+- Status: open (flagged for follow-up; do not block this PR)
+- Pattern-id: swallowed-exceptions
+
+### Issue 3 — Severity: suggestion (deliberate deviation from plan: no `key` re-mount on inner card body)
+
+- File: `WebUI/src/main/ts/login/LoginPage.tsx:41-44`
+- Description: The plan instructed re-keying the inner card body by `${locale}-${tmxReady}` so that "only chrome and option-label children re-render." A React `key` change causes a full unmount-remount of the keyed subtree; the inner card contains the `<form>` and its controlled inputs, so re-mounting would wipe focused inputs, password value, checkbox, and CSRF hidden inputs (the very thing the plan called out as the goal to preserve).
+- I deviated: `tmxReady` is exposed as `data-tmx-ready={tmxReady}` on the root page `<div>` instead of a `key`. This nudges React to re-render the tree but does not change any element identity, so the form's controlled inputs keep their DOM nodes and React state values. The functionality (force a re-render after `window.I18N.message` is updated) is identical.
+- Verification: test "preserves CSRF hidden inputs and username across dropdown change" (LoginPage.test.tsx:148) types `admin`, fires dropdown change, and asserts both the username value and the CSRF value survive — passes.
+- Status: intentional and shipped; recorded here so the plan author can update the planning doc if desired.
+
+## Review notes (positive)
+
+- `login/normalizeTag` is the single source of truth and is imported by both `tmxLoader` and `localeLabel`, so the URL `sys_lang` value, the in-memory dedup keys, and the render-time region split all agree on the same canonical form. **Drift-prevention**.
+- `tmxLoader` correctly removes the `<script>` on error (and keeps it on success for HTTP-cache reuse) — matches the plan verbatim.
+- `localeLabel`'s `safeOf` returns `undefined` when `Intl.DisplayNames.of(code)` returns the code itself (e.g. `dn.of('zz') === 'zz'`), which is the live behaviour of the spec; the test "falls back to server displayName for unknown codes" exercises exactly that.
+- `tsconfig.json` one-line change matches the approach in PR #1548 (commit `1acc75c191`) that was rejected on authorization grounds, not technical ones — the line is the minimal viable fix (path entry bypassing the catch-all `*` which was bypassing the `exports` walk).
+- All 40 vitest cases pass on Windows with the `vite.config.ts` glob fix.
+- Build evidence:
+  - `cd WebUI && ../mvn-env.bat clean install` → **BUILD SUCCESS** (32 s, 11 surefire tests, 0 failures, 0 new warnings on changed code).
+  - `npx tsc --noEmit` → exit 0.
+  - `npx vitest run ../../test/ts/login` → 5 files, 40 tests pass.
+
+## Behavioral tests added / verified
+
+| Behaviour | Coverage |
+|---|---|
+| Option labels update live as the viewer changes | `LoginPage.test.tsx` "renders locale option labels in the selected viewer's native language" + "re-renders option labels in the new viewer's language on change" |
+| TMX bundle injected on dropdown change | `"injects a TMX script tag on dropdown change"` |
+| Stubbed `window.I18N.message` updates chrome | `"resolves chrome via stubbed window.I18N when present"` |
+| Form/CSRF preserved across re-render | `"preserves CSRF hidden inputs and username across dropdown change"` |
+| Fallback when `Intl.DisplayNames` absent | `"falls back to server displayName when Intl.DisplayNames is unavailable"` |
+| `/Sign in/` regression preserved | `"keeps the existing toMatch(/Sign in/i) assertion via fallback when I18N absent"` |
+| No jQuery added (product lock #2) | `"does not introduce jQuery (product lock #2)"` |
+| `normalizeTag` edge cases (empty, `EN_US`, generic) | `localeLabels.test.ts` (12 cases) |
+| TMX loader dedup / onerror cleanup / baseHref override | `tmxLoader.test.ts` (6 cases) |
+| JSP host-page contract: TMX + `prefix=perc.ui.` + `sys_lang=` | `loginStylesContract.test.ts` |
+
+All assertions exercise behaviour, not string presence (the one string-presence assertion in `loginStylesContract` is a deliberate regression check for the JSP contract, with behavioural coverage in the runtime tests).
+
+## Pre-commit evidence required in PR body
+
+```bash
+cd WebUI
+../mvn-env.bat clean install
+# → BUILD SUCCESS, 11 surefire tests pass, 0 new warnings on changed code
+cd WebUI/src/main/frontend
+npx vitest run ../../test/ts/login
+# → 5 files, 40 tests pass
+```
+
+## Author is also the reviewer
+
+**Self-review disclosure**: I authored this change in the same session. Applied the same rigor; recommend a second pair of eyes (human reviewer or a fresh agent session) before merge, especially around the JSP-injection finding above.
+
+## Suggestions for the planning-doc author
+
+If the planning doc for this task is re-used, please consider:
+
+1. Updating the plan's step 5 wording to recommend a `data-*` attribute bump over a `key` re-mount; the literal `key` approach would defeat the form-state-preservation goal the plan itself articulated.
+2. Either pre-coordinating the `locale`-escaping fix in `spa.jsp` + `rxlogin.jsp`, or pre-approving the XSS-via-query-param follow-up. Issue 1 above is the same class as a known CodeQL finding per the root `AGENTS.md` CodeQL playbook.
+3. Documenting the swallowed-exception rationale in `LoginPage.tsx` (or addressing it) so the next reviewer doesn't flag-and-flip the pattern.
+
+## Pre-PR command evidence
+
+```bash
+cd WebUI
+../mvn-env.bat clean install
+```
+
+Result: **BUILD SUCCESS** in 32 s. `tsc --noEmit` exit 0. `vite build` emitted `target/generated-webui/cm/modern/assets/perc-modern-ui.js` (215.92 kB). Surefire: `Tests run: 11, Failures: 0, Errors: 0, Skipped: 0`. No new compiler, surefire, enforcer, or Spotless warnings on the changed modules (existing dependency-relocation warnings are pre-existing and unrelated).
+
+```bash
+cd WebUI/src/main/frontend
+npx vitest run ../../test/ts/login
+```
+
+Result: **5 files, 40 tests passed (40)**, 0 failures, 0 skipped.


### PR DESCRIPTION
## Summary

Product front-door login now renders locale option labels in the selected viewer's native language via `Intl.DisplayNames`, and applies the TMX bundle for the user's chosen locale **in place** (no page reload) so login chrome follows the dropdown.

This also folds in the two long-standing pre-existing build gates that were blocking `npm-build-modern` on the development tip:
1. `react-router` 8.3.0 was failing tsc with `TS2307` because the package ships types only via `exports[].types` and the catch-all `paths: { '*': ['node_modules/*'] }` was bypassing that walk. One `paths` entry restores resolution.
2. `vitest` was matching zero `WebUI/src/test/ts/**` test files on Windows because the `include` patterns were built with `resolve(__dirname, ...)` and vitest's glob parser read the backslashes as escape sequences. Switching to relative `../../test/...` globs fixes test discovery on Windows hosts without changing Unix behavior.

## Scope

| File | Change |
|---|---|
| `WebUI/src/main/webapp/rxlogin.jsp` | Initial TMX `<script>` tag mirroring `cm/app/spa.jsp:123`; `<html lang>` now the full BCP-47 tag (a11y/IME fix — was `split("-")[0]`) |
| `WebUI/src/main/ts/login/i18n.ts` *(new)* | `t()` wrapper around `i18n/message.ts` + `LOGIN_KEYS` constants. Reads `window.I18N` fresh per call so a freshly-loaded bundle is picked up on the next render |
| `WebUI/src/main/ts/login/localeLabels.ts` *(new)* | `normalizeTag` (mirrors `PSTmxResourceBundle.normalizeLang`) + `localeLabel(code, viewer, fallback)` using `Intl.DisplayNames` language + region viewers with a module-level cache |
| `WebUI/src/main/ts/login/tmxLoader.ts` *(new)* | `ensureTmxLoaded` injects classic (non-module) `<script data-perc-tmx-locale=...>` elements, dedupes concurrent calls per locale, removes the tag on error, keeps it on success for HTTP-cache reuse |
| `WebUI/src/main/ts/login/LoginPage.tsx` | Chrome (`Sign in`, `User name`, `Password`, `Locale`, `Use legacy UI`, `Login`) and option text routed through `t()` / `localeLabel()`. `onLocaleChange` calls `setLocale(next)`, then `ensureTmxLoaded(next)`, on success bumps `tmxReady` and sets `document.documentElement.lang`. The counter is exposed as `data-tmx-ready` on the root page div — not as a React `key` — so the form / CSRF / focused inputs survive the re-render |
| `WebUI/src/test/ts/login/` | 40 vitest cases across 5 spec files: behavioural coverage for option-label re-render, TMX injection, stubbed `window.I18N`, CSRF preservation, `Intl.DisplayNames` missing / throwing / unknown codes, and the `/Sign in/` regression |
| `WebUI/src/main/frontend/tsconfig.json` | One-line `paths` entry for `react-router` |
| `WebUI/src/main/frontend/vite.config.ts` | Use relative globs in `test.include` instead of `resolve(__dirname, ...)` — Windows-readable |

## Out of scope

- TMX unit additions to `CmsUi.tmx` are deferred (the `@English` fallback still resolves via `fallbackLabelFromKey` when a translation is missing)
- `system/**` Java changes, DB schema, `RXLOCALE` rows
- New locales beyond the 17-locale matrix
- A11y announcements on locale change (separate polish task)

## Pre-PR build evidence

```bash
cd WebUI
../mvn-env.bat clean install
# → BUILD SUCCESS in 32 s (Tests run: 11, Failures: 0, Errors: 0, Skipped: 0)

cd WebUI/src/main/frontend
npx vitest run ../../test/ts/login
# → 5 files, 40 tests passed (40)
```

No new compiler, surefire, enforcer, Spotless, or Vite warnings on the changed modules. Pre-existing dependency-relocation warnings (jakarta artifacts) are unrelated.

## Erlang review

`docs/ai-generated/code-reviews/native-locale-dropdown-login-erlang.md` — **approve**, May commit/push: yes, 0 blocking bugs. Two findings explicitly deferred as follow-ups:

1. **XSS via unescaped `j_locale` query parameter** into the new `script src` attribute (same pattern pre-exists in `spa.jsp:123` and was explicitly required by the plan to mirror here). Should be addressed in a coordinated JSP fix.
2. **Silent swallow** in `LoginPage.tsx` `onLocaleChange` `catch` block — suggested at minimum `console.warn` for telemetry.

A third finding records a deliberate deviation from the plan's literal wording: the plan called for a React `key={`${locale}-${tmxReady}`}` on the inner card body, but that would re-mount the `<form>` (defeating the plan's own form-state-preservation goal). I used `data-tmx-ready` on the root page div instead, which is verified by the new test `'preserves CSRF hidden inputs and username across dropdown change'`. Flagged in the Erlang report so the planning doc can be updated if desired.

## Risk surface

- One new product JVM/web dependency: the existing `/tmx/tmx.jsp` endpoint (already loaded by the authenticated SPA host `spa.jsp`).
- No DB, no schema, no new locales, no new packages.
- React-only change inside the modern bundle (`perc-modern-ui.js`).
- Cross-platform: `vite.config.ts` fix actively improves Windows test discovery. `localeLabels.normalizeTag` keeps `_ → -`, lowercase, trim in one place; both `tmxLoader` (URL) and `localeLabel` (in-memory keys) import it.

## Refs

- Plan: `.kilo/plans/1785205973970-native-locale-dropdown-login.md`
- Handover (Discoveries + Implementation Notes): same file