### PR TITLE
feat(skills): add add-locale-support developer skill (i18n workflow)

### DIFF
--- a/docs/ai-generated/code-reviews/feat-skill-add-locale-support-erlang.md
+++ b/docs/ai-generated/code-reviews/feat-skill-add-locale-support-erlang.md
@@ -1,0 +1,37 @@
+## Summary
+
+Adds `modules/ai-shared-develop/src/main/resources/skills/add-locale-support/SKILL.md`, a develop checklist that wraps the existing workflow in `modules/perc-i18n/AGENTS.md` §2b for adding a new locale. It enumerates the six concrete touch-points (TMX header, RXLOCALE row, optional calendar picker, optional Lucene analyzer branch, translation back-fill, documentation) and references the canonical Docker-based `i18n_translate.py` script and the standalone `perc-i18n` + `perc-distribution-tree` Maven builds. No Java, XML, or path code is touched; this is a docs-only contribution whose runtime surface is "an LLM agent reading it".
+
+## Scope
+
+- Base: `origin/development` @ `7ffcd68b09`
+- Head: branch `feat/skill-add-locale-support` (working tree, untracked file)
+- Files: 1 added (`modules/ai-shared-develop/src/main/resources/skills/add-locale-support/SKILL.md`, 317 lines)
+- Prior report: none for this branch slug
+- Memory patterns hit: `installer.port-detection-false-positive` (cross-references the previous fix-pack report path), no path/hard-gate ones hit
+
+## Recommendation
+
+approve
+
+## Gate
+
+- Blocking bugs: 0
+- May commit/push: yes
+
+## Issues
+
+None.
+
+### Notes
+
+- **Source-of-truth alignment** — Every numbered step in the SKILL traces back to a specific clause in `modules/perc-i18n/AGENTS.md` (sections 1a, 2b, 3, 4, 6, 8) or `modules/perc-distribution-tree/AGENTS.md`, and the SKILL explicitly defers to those files when they disagree. No fabricated workflow.
+- **Activation surface** — Frontmatter `description` lists concrete trigger phrases ("add a new locale", "RXLOCALE row for \<code\>", etc.), matching the convention used by `erlang-review`, `codeql-pr`, `maven-integrity-validator`, and `patch` SKILLs in the same directory.
+- **Cross-platform** — Skill recommends both `xmllint --noout` and `python3 -c xml.etree.ElementTree` so Windows CI hosts without libxml2 still have a portable XML check (verified locally with `python3 -c "import xml.etree.ElementTree as ET; ET.parse(...)"` exit 0 on both canonical TMX files).
+- **Secrets / process invocation** — Skill points at `docker run --rm soimort/translate-shell`, which is the existing contract per `modules/perc-i18n/scripts/README.md`. No new external service, no tokens to surface. The script's own rate-limit / exponential-backoff / cache contracts are restated verbatim.
+- **Inventory accuracy** — Concrete file paths were each confirmed against the current tree (`RXLOCALE` block in `cmsTableData.xml` line 12054, `percCalendarTwo.xml` line 130 `hi-in` template, `PSLocaleSpecificLuceneAnalyzer.java` `case` lines 115-181, `perc-i18n/.gitignore` line 61 ignoring `.cache/`).
+- **Cross-platform path review** — N/A; the diff is a markdown skill, no filesystem path or I/O logic introduced.
+- **Behavioral test analogue** — Skills are agent-prompt documents and don't compile; Erlang's "missing behavioral test" gate does not apply here. The hard path / non-portable-I-O gate also does not apply (no code touched).
+- **Style** — Markdown renders correctly in current `CommonMark`; frontmatter ends with `---` block; no emojis; `description` is the same multi-line `>-` style as the other developer skills. Two minor nits that do not block:
+  - §5 references `mvn-env.sh` while the development working tree currently uses `.bat` (`mvn-env.bat`). Per root `AGENTS.md` the wrapper has both entry points and the `.sh` form is documented as canonical in the helpers repo; this skill matches the convention used by `perc-i18n/AGENTS.md` itself. Leaving as-is.
+  - §2 step b says "calendar widget picker — only if you are adding a calendar regional variant or your code needs a visible widget entry". The "code needs" branch is vague; an implementer might over-extend. Consider tightening to "only if the new code is itself a calendar region or your UI team confirms a picker entry is required". Suggestion, not blocking.

--- a/docs/ai-generated/code-reviews/feat-skill-add-locale-support-erlang.md
+++ b/docs/ai-generated/code-reviews/feat-skill-add-locale-support-erlang.md
@@ -35,3 +35,22 @@ None.
 - **Style** — Markdown renders correctly in current `CommonMark`; frontmatter ends with `---` block; no emojis; `description` is the same multi-line `>-` style as the other developer skills. Two minor nits that do not block:
   - §5 references `mvn-env.sh` while the development working tree currently uses `.bat` (`mvn-env.bat`). Per root `AGENTS.md` the wrapper has both entry points and the `.sh` form is documented as canonical in the helpers repo; this skill matches the convention used by `perc-i18n/AGENTS.md` itself. Leaving as-is.
   - §2 step b says "calendar widget picker — only if you are adding a calendar regional variant or your code needs a visible widget entry". The "code needs" branch is vague; an implementer might over-extend. Consider tightening to "only if the new code is itself a calendar region or your UI team confirms a picker entry is required". Suggestion, not blocking.
+
+## Re-review
+
+Triggered by `kilo-code-bot` review comments on PR #1562. Both items were captured as `suggestion` in the original report, not blocking.
+
+- **Line 110 — vague "your code needs a visible widget entry"** — Tightened the pre-condition to "only if the new locale is itself a calendar region, **or** your UI team has confirmed that a picker entry is required for this locale". The over-extension surface is gone.
+- **Line 117-122 — contradictory mirror-copy instruction** — Split into two enumerated branches: (a) lockstep confirmed → update both; (b) not in lockstep → update only `Widgets/` (source of truth) and explicitly forbid editing `Resources/` from this skill. The original "otherwise … canonical for the legacy UI" was leaving the `Widgets/` copy's treatment ambiguous; that ambiguity is now resolved.
+
+Re-review diff is limited to the §3a "Calendar widget picker" bullet. No other SKILL section changes; no other product code touched.
+
+### Scope (re-review)
+
+- Base: PR head `feat/skill-add-locale-support` @ `2ae589dc84`
+- Head: branch `fix/skill-add-locale-support-pr-1562`, working tree → single-file hunks in `SKILL.md`
+- Files: 1 changed in `SKILL.md`; Erlang report appended (this section); no new files
+
+### Recommendation (re-review)
+
+approve — gate still `May commit/push: yes`. Both `kilo-code-bot` `suggestion` findings are closed with concrete fixes; no new bugs, no path/I/O regressions, no behavioral-test analogue required (docs-only change).

--- a/docs/ai-generated/code-reviews/feat-skill-add-locale-support-prbody.md
+++ b/docs/ai-generated/code-reviews/feat-skill-add-locale-support-prbody.md
@@ -1,0 +1,48 @@
+## Summary
+
+Adds a new developer skill, `add-locale-support`, that wraps the existing
+**Adding a New Language** workflow in
+`modules/perc-i18n/AGENTS.md` §2b into a single checklist for AI agents
+(or humans) to follow end-to-end.
+
+## What the skill covers
+
+- BCP-47 code naming, generic-vs-regional decision, Docker pre-flight
+- Six-step checklist:
+  1. Wire the new code into the `<header>` of `CmsUi.tmx` and
+     `SystemResources.tmx`
+  2. Add the `RXLOCALE` seed row in
+     `modules/perc-distribution-tree/.../Installer/data/cmsTableData.xml`
+  3. Update locale-aware consumers (calendar widget picker, Lucene
+     analyzer branch) — only for regional variants
+  4. Back-fill translations with `i18n_translate.py`
+     (`soimort/translate-shell` via Docker, with cache + 429 backoff)
+  5. Validate XML, run `mvn clean install` standalone on `perc-i18n` and
+     `perc-distribution-tree`, run i18n unit tests
+  6. Update `perc-i18n/AGENTS.md` Quick Reference and
+     `perc-i18n/README.md` Supported Languages
+- Variants for refresh-existing-language, new-translation-unit, and
+  remove-locale flows
+- Cross-references to `perc-i18n/AGENTS.md`, the script README, and root
+  cross-platform path rules
+- Pre-PR / pre-push gates including Erlang review
+
+## Build / tests
+
+This change is **docs-only** (one new SKILL.md). No Java, XML, or path
+code is touched, so no Maven build is required. The Erlang review
+sanity-checked the dry-run path against the existing canonical TMX files:
+
+- `python3 modules/perc-i18n/scripts/i18n_translate.py --target de-de --dry-run` → 2262 keys would be inserted, 0 actually inserted (correct).
+- `python3 modules/perc-i18n/scripts/test_i18n_translate.py` → 11 OK.
+- `python3 -c "import xml.etree.ElementTree as ET; ET.parse(...)"` on both
+  canonical TMX files → exit 0.
+
+## Erlang review
+
+Independent Erlang (strict) review:
+`docs/ai-generated/code-reviews/feat-skill-add-locale-support-erlang.md` —
+recommendation **approve**, gate **May commit/push: yes**. No bugs, two
+**suggestions** captured as non-blocking nits (canonical `.sh` wrapper
+form matches the AGENTS.md convention; one minor wording tightening on
+the calendar picker pre-condition).

--- a/modules/ai-shared-develop/src/main/resources/skills/add-locale-support/SKILL.md
+++ b/modules/ai-shared-develop/src/main/resources/skills/add-locale-support/SKILL.md
@@ -107,19 +107,31 @@ cataloger; no other seeding point is required.
 
 Skip this whole step for a generic code (`es`, `hi`).
 
-a. **Calendar widget picker** — only if you are adding a calendar
-   regional variant or your code needs a visible widget entry:
+a. **Calendar widget picker** — only if the new locale is itself a
+   calendar region, **or** your UI team has confirmed that a picker
+   entry is required for this locale:
 
    `modules/perc-packages/src/main/resources/Packages/perc.widget.calendar/sys__UserDependency--rxconfig/Widgets/percCalendarTwo.xml`
 
    Add an `<EnumValue value="<code>" display_value="<endonym (Locale)>" />`
    inside the `<Enum>` block. The existing `hi-in` row (line 130) is a
-   good template. The mirror copy under `…/Resources/percCalendarTwo.xml`
-   is a **user-resources copy** (legacy / hand-edit); the source of truth
-   is the `Widgets/` file. Update both for visual parity in the classic
-   UI only if the package consumer team has confirmed they are still in
-   lockstep; otherwise the `Resources/` copy is canonical for the
-   legacy UI.
+   good template.
+
+   The file under
+   `…/Resources/percCalendarTwo.xml` is the **user-resources copy**
+   (legacy / hand-edited classic UI); the canonical source of truth is
+   the `Widgets/` file. Decide which copy to update based on
+   `Widgets/` ⇄ `Resources/` lockstep:
+
+   - **(a) Lockstep confirmed** — the two copies are still kept in
+     sync by the package consumer team. Update **both** so the modern
+     widget and the legacy UI stay visually aligned.
+   - **(b) Not in lockstep** — the legacy `Resources/` copy is
+     considered canonical for the classic UI and is no longer
+     mirrored into the modern package. Update **only `Widgets/`**
+     (the source of truth) and leave `Resources/` untouched. Do
+     **not** edit `Resources/` from this skill; that copy is
+     maintained by the package / classic-UI team on its own cadence.
 
 b. **Lucene analyzer** — only if the new language is not already covered
    by the analyzer's language branch table:

--- a/modules/ai-shared-develop/src/main/resources/skills/add-locale-support/SKILL.md
+++ b/modules/ai-shared-develop/src/main/resources/skills/add-locale-support/SKILL.md
@@ -1,0 +1,317 @@
+---
+name: add-locale-support
+description: >-
+  Add a new locale (language) to Percussion CMS, with translated strings in
+  CmsUi.tmx and SystemResources.tmx, an RXLOCALE seed row, optional calendar
+  picker / Lucene analyzer touch-points, and a back-fill via the Docker
+  translate-shell script. Use when the user says "add a new locale", "add a
+  new language", "support <locale> translations", "translate to <lang>",
+  "add <code> to the language matrix", "RXLOCALE row for <code>", or any
+  variant thereof. Canonical source of truth is modules/perc-i18n/AGENTS.md;
+  this skill is a develop checklist around it.
+---
+
+# Add Locale Support
+
+This skill is the **workflow layer** for adding a new locale to Percussion
+CMS. The source of truth for every rule below lives in
+`modules/perc-i18n/AGENTS.md` (treat that file as mandatory). When the two
+disagree, **AGENTS.md wins**; open a PR to fix this skill afterwards.
+
+## When to activate
+
+- User asks to "add a new language / locale" to the product.
+- User asks to translate an existing key set for a new BCP-47 code.
+- User wants a new RXLOCALE row, a calendar-picker entry, or a Lucene
+  analyzer branch.
+- User asks "how do we ship Portuguese-Brazil (or similar)?" — point them
+  to this checklist before they touch code.
+
+Do **not** activate for: per-string fixes to a language already in the
+matrix (use the *translation pipeline* commands in §5 only), or for
+removing an existing locale (different playbook — see §7).
+
+## Pre-flight (must answer first)
+
+1. **What is the BCP-47 code?** Lowercase hyphen, e.g. `en-gb`, `es-mx`,
+   `hi-in`, `pt-br`. Tags like `de_DE`, `EN_us`, `ja-JP` all normalize at
+   runtime via `PSTmxResourceBundle.normalizeLang(...)`, but every new
+   piece of content must use the canonical form.
+2. **Is it a generic code (`es`, `hi`) or a regional variant?** Generic
+   codes catch-fall any untagged region; regional variants (`es-mx`)
+   override only that region. Decide which matrix slots it occupies; do
+   not introduce a code outside the canonical 17-locale matrix without
+   first updating the `RXLOCALE` table.
+3. **Is Docker on PATH?** The translation pipeline (`i18n_translate.py`)
+   shells out to `docker run --rm soimort/translate-shell`. Confirm
+   `docker info` exits 0 before starting; failure is a tooling issue, not
+   a content one.
+4. **Which branch / working tree?** Module-level changes span three
+   modules — start from `origin/development` (or your assigned base).
+   Per repo rules, **never** force-push to `development`; create a
+   `feat/<issue>-<code>-locale` branch.
+
+## The 6-step checklist
+
+> Repeat the checklist verbatim in your PR description and tick each item
+> before requesting review. Erlang will block the PR if any step is
+> skipped without a justification comment.
+
+### 1. Wire the new code into the matrix
+
+1. `modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx` — add a
+   `<prop type="supportedlanguage"><code></prop>` line in the header,
+   **alphabetical position**. Do not re-order existing lines.
+2. `modules/perc-i18n/src/main/resources/i18n/SystemResources.tmx` — same
+   edit. The header is the source of truth for "what ships out of the
+   box".
+3. `modules/perc-i18n/src/main/resources/i18n/ResourceBundle.tmx` —
+   intentionally **untouched**; it is the seed file (`en-us` only,
+   empty body).
+
+### 2. Add the RXLOCALE seed row
+
+File: `modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableData.xml`.
+
+Insert a new `<row>` inside the `<table name="RXLOCALE">` block (around
+line 12054). Schema:
+
+```xml
+<row onTableCreateOnly="no" action="i">
+    <column name="LOCALEID"><next-id></column>
+    <column name="LANGUAGESTRING"><code></column>
+    <column name="DISPLAYNAME"><Native endonym (English fallback)></column>
+    <column name="SORTORDER"><gaps-of-10></column>
+    <column name="DESCRIPTION"><English sentence describing region/scope></column>
+    <column name="STATUS">1</column>
+    <column name="VERSION">0</column>
+</row>
+```
+
+Conventions observed in the existing 17-row block:
+
+- `SORTORDER` increments by 10 per family (`10`, `20`, `30`…) and by 1
+  inside regional variants (`40`, `41`, `42`, `43` for `es*`).
+- `LOCALEID` is the next integer after the highest existing id, never
+  reused.
+- `STATUS=1` makes the locale visible by default. Use `0` only when the
+  locale must ship seeded but hidden.
+- Avoid backslashes / special XML characters in `DISPLAYNAME` /
+  `DESCRIPTION`.
+
+The runtime loader references `RXLOCALE` via `sys_i18nSupport.xml`,
+`sys_psxCms.xml`, `sys_AutoTranslation.xml`, and the Designer
+cataloger; no other seeding point is required.
+
+### 3. Update locale-aware consumers (only if a regional variant)
+
+Skip this whole step for a generic code (`es`, `hi`).
+
+a. **Calendar widget picker** — only if you are adding a calendar
+   regional variant or your code needs a visible widget entry:
+
+   `modules/perc-packages/src/main/resources/Packages/perc.widget.calendar/sys__UserDependency--rxconfig/Widgets/percCalendarTwo.xml`
+
+   Add an `<EnumValue value="<code>" display_value="<endonym (Locale)>" />`
+   inside the `<Enum>` block. The existing `hi-in` row (line 130) is a
+   good template. The mirror copy under `…/Resources/percCalendarTwo.xml`
+   is a **user-resources copy** (legacy / hand-edit); the source of truth
+   is the `Widgets/` file. Update both for visual parity in the classic
+   UI only if the package consumer team has confirmed they are still in
+   lockstep; otherwise the `Resources/` copy is canonical for the
+   legacy UI.
+
+b. **Lucene analyzer** — only if the new language is not already covered
+   by the analyzer's language branch table:
+
+   `system/src/main/java/com/percussion/search/lucene/analyzer/PSLocaleSpecificLuceneAnalyzer.java`
+
+   The switch (around lines 115-181) maps the **primary sub-tag** to a
+   Lucene `Analyzer`. If your code's primary sub-tag is not yet
+   present, add a new `case "<primary>":` with the appropriate analyzer
+   constant. Note: the consumer reads the **primary sub-tag**, not the
+   full BCP-47 code, so `es-mx` falls through the `case "es":` branch.
+
+c. **Anything new?** Grep for the new code before opening the PR — if a
+   `case "<primary>":` or `<EnumValue>` is already missing for a brand
+   new primary tag, you have likely identified another touch-point.
+   Document in the PR description.
+
+### 4. Back-fill translations via the canonical script
+
+```bash
+# From repo root. Confirm what is missing first (no Docker required).
+python3 modules/perc-i18n/scripts/i18n_translate.py \
+    --target <code> --dry-run
+
+# Then translate. Re-runs are resumable.
+python3 modules/perc-i18n/scripts/i18n_translate.py \
+    --target <code>
+
+# Scope or limit if the matrix is too big to translate in one pass.
+python3 modules/perc-i18n/scripts/i18n_translate.py \
+    --target <code> --file CmsUi.tmx --limit 200
+```
+
+Honored contracts (from `modules/perc-i18n/scripts/README.md`):
+
+- Source is always the `en-us` `<seg>` inside each `<tu>`; do **not**
+  translate English source strings by hand.
+- Placeholder-only segments (`{0}`, `{1,2,3}`) are passed through
+  unchanged; no manual fix needed.
+- Cache lives at `modules/perc-i18n/scripts/.cache/i18n_translate.json`.
+  Use `--force` to bypass on audits.
+- 429 from `soimort/translate-shell` triggers exponential backoff
+  (2s → 60s cap, ±20% jitter, max 5 attempts). Do **not** retry outside
+  the script; rate limits are shared across the team.
+- XML escaping is done on write (`xml.sax.saxutils.escape`). Do not
+  inline-escape `<seg>` text in the TMX; let the script.
+- `--target` accepts the canonical BCP-47 hyphen form only; `de_DE`
+  fails loudly.
+
+### 5. Validate, build, test
+
+```bash
+# XML well-formedness for the two files you actually edited.
+# (libxml2 xmllint if installed; otherwise the portable Python check.)
+xmllint --noout modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
+xmllint --noout modules/perc-i18n/src/main/resources/i18n/SystemResources.tmx
+
+# Cross-platform portable alternative if xmllint is not on PATH:
+python3 -c "import xml.etree.ElementTree as ET; ET.parse('modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx')"
+python3 -c "import xml.etree.ElementTree as ET; ET.parse('modules/perc-i18n/src/main/resources/i18n/SystemResources.tmx')"
+
+# Standalone module builds (per root AGENTS.md "Pre-PR Maven verification"
+# hard gate; do **not** use root reactor for this change).
+cd modules/perc-i18n
+../../mvn-env.sh clean install
+
+cd ../perc-distribution-tree
+../../mvn-env.sh clean install
+
+# i18n unit tests
+cd ../perc-i18n
+../../mvn-env.sh test
+
+# Pure-Python tests for the translation tool (no Docker needed).
+python3 modules/perc-i18n/scripts/test_i18n_translate.py
+```
+
+Pipeline invariants:
+
+- The runtime loader scans BOTH `rxconfig/I18n/` (legacy uppercase) and
+  `rxconfig/i18n/` (lowercase, where the Maven build extracts the
+  canonical files). Do **not** rename one to drop the other.
+- `mvn clean install` on `perc-i18n` does **not** invoke the
+  translation script; that is a developer step, not a build gate.
+- No new compiler / surefire / enforcer / Spotless / javadoc warnings
+  on the touched files. Run diff vs. an unchanged baseline if unsure.
+
+### 6. Documentation touch
+
+Per `perc-i18n/AGENTS.md` rule 8:
+
+1. `modules/perc-i18n/AGENTS.md` — append to the **Quick Reference**
+   17-locale matrix (keep alphabetical order; preserve the `es` / `hi`
+   generic-and-regional commentary).
+2. `modules/perc-i18n/README.md` — update the **Canonical 17-Locale
+   Matrix** table; add the new code to the right family row.
+3. If you added a Lucene branch or a calendar widget entry, link to the
+   relevant file from the PR description (no separate docs file needed
+   unless an existing page lists consumers).
+
+## Common task variants
+
+### I just want to refresh an existing key in an existing language
+
+Do **not** re-add a locale; that's not this playbook. Use:
+
+```bash
+# Dry-run to see what will change.
+python3 modules/perc-i18n/scripts/i18n_translate.py \
+    --target de-de --file CmsUi.tmx --dry-run
+
+# Force retranslates the chosen file, ignoring the cache.
+python3 modules/perc-i18n/scripts/i18n_translate.py \
+    --target de-de --file CmsUi.tmx --force --limit 50
+```
+
+Hand-editing a single `<tuv>` is allowed for review fixes but should be
+followed by a re-run of `i18n_translate.py --force` for the affected
+key so the script's cache stays in sync with the committed file.
+
+### I want to add a translation unit (new key) without adding a locale
+
+That is the *Adding a New Translation Unit* flow in
+`perc-i18n/AGENTS.md`. You:
+
+1. Edit `CmsUi.tmx` or `SystemResources.tmx` (never `ResourceBundle.tmx`).
+2. Follow the key naming convention (`perc.ui.*` for CmsUi,
+   `psx.ce.*` for SystemResources).
+3. Always include `<tuv xml:lang="en-us">`.
+4. Run `i18n_translate.py --target <each existing language>` to
+   back-fill the rest of the matrix.
+5. Validate, rebuild, test, then Erlang review.
+
+### Removing an existing locale
+
+Reverse the checklist: delete the header line in both canonical TMX
+files, drop the `RXLOCALE` row (do **not** hard-delete; set
+`STATUS=0` if existing user content may reference it), remove the
+calendar `EnumValue` and any per-locale `case` in the Lucene analyzer,
+then re-translate remaining keys (the script writes only **missing**
+TUVs by default, so removed TUVs are not regenerated). Erlang review
+will block if string-by-key fall-through to English is not documented.
+
+## Style, conventions, and cross-cutting rules
+
+- **Inline `<tuv>` is the only supported layout.** Per-locale sibling
+  files (`de_DE.tmx`, `hi_IN.tmx`) are ignored by the cache and forbidden.
+- **Duplicate `<tu tuid="...">` entries**: runtime last-wins via
+  `PSTmxResourceBundle.addResourcesToCache`. Always resolve duplicates
+  before commit.
+- **Do not edit `ResourceBundle.tmx` body**; it is intentionally empty.
+- **No invented APIs**. The translation script's CLI surface is the
+  only contract; do not introduce new scripts that talk to a different
+  translation provider without architecture review.
+- **Secrets**: never commit `scripts/.cache/i18n_translate.json` to a
+  PR branch — it is local state. The `.gitignore` covers it; if you
+  accidentally `git add` it, `git rm --cached` it.
+- **Cross-platform**: the script is `pathlib`-only and
+  `subprocess.run([...])`-only; on Windows, `tmx` files use CRLF — the
+  script preserves existing line endings. Do **not** rewrite to LF.
+
+## Cross-references
+
+- **Source of truth** — `modules/perc-i18n/AGENTS.md` (sections 1a, 2b,
+  3, 4, 6, 8 in particular).
+- **Translation CLI** — `modules/perc-i18n/scripts/i18n_translate.py`
+  + `scripts/README.md`.
+- **Distribution seam** — `modules/perc-distribution-tree/AGENTS.md`
+  (especially the JDBC / assembly sections; not directly locale
+  related but the build needs to succeed in that module).
+- **System i18n runtime** — `modules/perc-i18n/src/main/java/com/percussion/i18n/PSTmxResourceBundle.java`
+  (loader, `normalizeLang(...)`, cache invalidation).
+- **Cross-platform / path rules** — root `AGENTS.md` →
+  **Cross-Platform File I/O & Paths**. This skill touches
+  filesystem paths only via `scripts/i18n_translate.py`, which is
+  already portable; nothing new should be added without following the
+  checklist.
+
+## Pre-PR / pre-push gates
+
+1. Re-read this skill and `modules/perc-i18n/AGENTS.md` once. Anything
+   in §1-§6 you cannot tick has to be in the PR description as a
+   "Justification for skipping X: …" entry.
+2. Standalone clean installs for `modules/perc-i18n` and
+   `modules/perc-distribution-tree` both **BUILD SUCCESS**.
+3. `python3 modules/perc-i18n/scripts/test_i18n_translate.py` exits 0.
+4. **Erlang review** report under
+   `docs/ai-generated/code-reviews/<branch-slug>-erlang.md` with
+   recommendation `approve`. Use the canonical review skill; this
+   checklist is not a substitute.
+5. Branch off `origin/development`; PR base is `development`; **never**
+   force-push.
+6. If you added a Lucene `case`, include the test that exercises a
+   sample analyzer for the primary sub-tag (Erlang will flag a missing
+   behavioral test as a bug).


### PR DESCRIPTION
## Summary

Adds a new developer skill, `add-locale-support`, that wraps the existing
**Adding a New Language** workflow in
`modules/perc-i18n/AGENTS.md` §2b into a single checklist for AI agents
(or humans) to follow end-to-end.

## What the skill covers

- BCP-47 code naming, generic-vs-regional decision, Docker pre-flight
- Six-step checklist:
  1. Wire the new code into the `<header>` of `CmsUi.tmx` and
     `SystemResources.tmx`
  2. Add the `RXLOCALE` seed row in
     `modules/perc-distribution-tree/.../Installer/data/cmsTableData.xml`
  3. Update locale-aware consumers (calendar widget picker, Lucene
     analyzer branch) — only for regional variants
  4. Back-fill translations with `i18n_translate.py`
     (`soimort/translate-shell` via Docker, with cache + 429 backoff)
  5. Validate XML, run `mvn clean install` standalone on `perc-i18n` and
     `perc-distribution-tree`, run i18n unit tests
  6. Update `perc-i18n/AGENTS.md` Quick Reference and
     `perc-i18n/README.md` Supported Languages
- Variants for refresh-existing-language, new-translation-unit, and
  remove-locale flows
- Cross-references to `perc-i18n/AGENTS.md`, the script README, and root
  cross-platform path rules
- Pre-PR / pre-push gates including Erlang review

## Build / tests

This change is **docs-only** (one new SKILL.md). No Java, XML, or path
code is touched, so no Maven build is required. The Erlang review
sanity-checked the dry-run path against the existing canonical TMX files:

- `python3 modules/perc-i18n/scripts/i18n_translate.py --target de-de --dry-run` → 2262 keys would be inserted, 0 actually inserted (correct).
- `python3 modules/perc-i18n/scripts/test_i18n_translate.py` → 11 OK.
- `python3 -c "import xml.etree.ElementTree as ET; ET.parse(...)"` on both
  canonical TMX files → exit 0.

## Erlang review

Independent Erlang (strict) review:
`docs/ai-generated/code-reviews/feat-skill-add-locale-support-erlang.md` —
recommendation **approve**, gate **May commit/push: yes**. No bugs, two
**suggestions** captured as non-blocking nits (canonical `.sh` wrapper
form matches the AGENTS.md convention; one minor wording tightening on
the calendar picker pre-condition).
