### PR TITLE
fix(h2): enable Demo site create — JDBC/ORM and post-save reload

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/services/impl/PSDeployService.java
+++ b/deployer/src/main/java/com/percussion/deployer/services/impl/PSDeployService.java
@@ -42,10 +42,14 @@ import com.percussion.services.filter.PSFilterServiceLocator;
 import com.percussion.services.filter.data.PSItemFilter;
 import com.percussion.services.sitemgr.IPSSite;
 import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.jdbc.PSConnectionHelper;
+import com.percussion.utils.jdbc.PSJdbcConnectionDiagnostics;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.hibernate.SessionFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Propagation;
@@ -62,6 +66,8 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Transactional(propagation = Propagation.REQUIRED, rollbackFor = Exception.class)
 public class PSDeployService implements IPSDeployService {
+  private static final Logger log = LogManager.getLogger(PSDeployService.class);
+
   private SessionFactory sessionFactory;
 
   public SessionFactory getSessionFactory() {
@@ -152,6 +158,7 @@ public class PSDeployService implements IPSDeployService {
     Objects.requireNonNull(depHandler, "dependency handler may not be null");
 
     var dh = (PSFilterDefDependencyHandler) depHandler;
+    String filterName = null;
     try {
       // Always deserialize package payload into a fresh (non-managed) object.
       var packageFilter = dh.generateFilterFromFile(tok, archive, dep, depFile, ctx, null);
@@ -165,7 +172,7 @@ public class PSDeployService implements IPSDeployService {
       // Only FILTER_MISSING means first install; blank names and other PSFilterException
       // codes must not be swallowed (Kilo review / unique-constraint mask).
       com.percussion.services.filter.IPSItemFilter existingByName = null;
-      String filterName = packageFilter.getName();
+      filterName = packageFilter.getName();
       try {
         existingByName = filterSvc.findFilterByName(filterName);
       } catch (IllegalArgumentException e) {
@@ -214,7 +221,30 @@ public class PSDeployService implements IPSDeployService {
         dh.saveFilter(packageFilter, null);
       }
     } catch (PSDeployException e) {
+      logJdbcDiagnosticsOnFilterFailure(dep, filterName, e);
       throw new PSDeployServiceException(e);
+    } catch (RuntimeException e) {
+      // Hibernate/H2 VALUE keyword failures surface here (Baseline perc_public filter).
+      logJdbcDiagnosticsOnFilterFailure(dep, filterName, e);
+      throw e;
+    }
+  }
+
+  private void logJdbcDiagnosticsOnFilterFailure(
+      PSDependency dep, String filterName, Exception cause) {
+    try (var conn = PSConnectionHelper.getDbConnection()) {
+      log.error(
+          "Filter dependency install failed (depId={}, filterName={}): {} | JDBC: {}",
+          dep != null ? dep.getDependencyId() : null,
+          filterName,
+          cause != null ? cause.toString() : null,
+          PSJdbcConnectionDiagnostics.describeConnection(conn));
+    } catch (Exception diagEx) {
+      log.error(
+          "Filter dependency install failed (depId={}): {}; JDBC diagnostics unavailable: {}",
+          dep != null ? dep.getDependencyId() : null,
+          cause != null ? cause.toString() : null,
+          diagEx.toString());
     }
   }
 

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentAdhocUsersContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentAdhocUsersContext.java
@@ -565,43 +565,24 @@ public class PSContentAdhocUsersContext implements IPSContentAdhocUsersContext {
   /** static constant string that represents the unqualified table name. */
   private static final String CONTENTADHOCUSERS = "CONTENTADHOCUSERS";
 
-  /** static constant string that represents the qualified table name. */
+  /**
+   * Qualified table name only. Do not use as a column qualifier — {@code schema.table.column} fails
+   * on H2 ({@code Column "PUBLIC" not found}).
+   */
   private static final String TABLE_CAU = PSConnectionMgr.getQualifiedIdentifier(CONTENTADHOCUSERS);
 
-  /** SQL query string is constructed based on fully qualified table name(s). */
+  /** SQL query — unqualified column names for H2-safe schema-qualified table names. */
   private static final String QRYSTRING =
-      "SELECT "
-          + TABLE_CAU
-          + ".USERNAME, "
-          + TABLE_CAU
-          + ".ADHOCTYPE, "
-          + TABLE_CAU
-          + ".ROLEID "
-          + "FROM "
-          + TABLE_CAU
-          + " WHERE ("
-          + TABLE_CAU
-          + ".CONTENTID=?)";
+      "SELECT USERNAME, ADHOCTYPE, ROLEID FROM " + TABLE_CAU + " WHERE (CONTENTID=?)";
 
-  /** SQL string to insert a data base record for a new approval. */
+  /** SQL insert — unqualified column names for H2-safe schema-qualified table names. */
   private static final String INSERTSTRING =
-      "INSERT INTO "
-          + TABLE_CAU
-          + "( "
-          + TABLE_CAU
-          + ".CONTENTID, "
-          + TABLE_CAU
-          + ".USERNAME, "
-          + TABLE_CAU
-          + ".ADHOCTYPE ,"
-          + TABLE_CAU
-          + ".ROLEID) "
-          + "VALUES(?,?,?,?)";
+      "INSERT INTO " + TABLE_CAU + " (CONTENTID, USERNAME, ADHOCTYPE, ROLEID) VALUES(?,?,?,?)";
 
   /**
    * SQL string to delete all data base record for approvals for given content item with a given
    * initial state.
    */
   private static final String DELETESTRING =
-      "DELETE FROM " + TABLE_CAU + " WHERE ( " + TABLE_CAU + ".CONTENTID=?)";
+      "DELETE FROM " + TABLE_CAU + " WHERE (CONTENTID=?)";
 }

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentStatusHistoryContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentStatusHistoryContext.java
@@ -684,94 +684,31 @@ public class PSContentStatusHistoryContext implements IPSContentStatusHistoryCon
   /** Number of database records found */
   private int m_nCount = 0;
 
-  /** static constant string that represents the qualified table name. */
+  /**
+   * Qualified table name only (e.g. {@code PUBLIC.CONTENTSTATUSHISTORY} on H2). Do <strong>not</strong>
+   * use this as a column qualifier — {@code schema.table.column} is rejected by H2 as {@code Column
+   * "PUBLIC" not found}. Columns in the statements below are unqualified.
+   */
   private static String TABLE_CSHC = PSConnectionMgr.getQualifiedIdentifier("CONTENTSTATUSHISTORY");
 
   /** SQL query string to get data base records for the content status history. */
   private static final String QRYSTRING =
-      "SELECT "
-          + TABLE_CSHC
-          + ".SESSIONID , "
-          + TABLE_CSHC
-          + ".CONTENTSTATUSHISTORYID , "
-          + TABLE_CSHC
-          + ".CONTENTID , "
-          + TABLE_CSHC
-          + ".STATEID , "
-          + TABLE_CSHC
-          + ".ACTOR , "
-          + TABLE_CSHC
-          + ".TRANSITIONID , "
-          + TABLE_CSHC
-          + ".VALID , "
-          + TABLE_CSHC
-          + ".ROLENAME , "
-          + TABLE_CSHC
-          + ".CHECKOUTUSERNAME , "
-          + TABLE_CSHC
-          + ".LASTMODIFIERNAME , "
-          + TABLE_CSHC
-          + ".LASTMODIFIEDDATE , "
-          + TABLE_CSHC
-          + ".EVENTTIME , "
-          + TABLE_CSHC
-          + ".TRANSITIONCOMMENT , "
-          + TABLE_CSHC
-          + ".REVISIONID , "
-          + TABLE_CSHC
-          + ".TITLE , "
-          + TABLE_CSHC
-          + ".TRANSITIONLABEL , "
-          + TABLE_CSHC
-          + ".STATENAME "
+      "SELECT SESSIONID, CONTENTSTATUSHISTORYID, CONTENTID, STATEID, ACTOR, TRANSITIONID, VALID, "
+          + "ROLENAME, CHECKOUTUSERNAME, LASTMODIFIERNAME, LASTMODIFIEDDATE, EVENTTIME, "
+          + "TRANSITIONCOMMENT, REVISIONID, TITLE, TRANSITIONLABEL, STATENAME "
           + "FROM "
           + TABLE_CSHC
-          + " WHERE ("
-          + TABLE_CSHC
-          + ".WORKFLOWAPPID=? AND "
-          + TABLE_CSHC
-          + ".CONTENTID=?)";
+          + " WHERE (WORKFLOWAPPID=? AND CONTENTID=?)";
 
-  /** SQL insert string to insert a new data base record for the content status history. */
+  /**
+   * SQL insert for a new content status history row. Columns are unqualified so schema-qualified
+   * table names (H2 {@code PUBLIC.CONTENTSTATUSHISTORY}) remain valid.
+   */
   private static final String INSERTSTRING =
       "INSERT INTO "
           + TABLE_CSHC
-          + " ("
-          + TABLE_CSHC
-          + ".WORKFLOWAPPID , "
-          + TABLE_CSHC
-          + ".SESSIONID , "
-          + TABLE_CSHC
-          + ".CONTENTSTATUSHISTORYID , "
-          + TABLE_CSHC
-          + ".CONTENTID , "
-          + TABLE_CSHC
-          + ".STATEID , "
-          + TABLE_CSHC
-          + ".ACTOR , "
-          + TABLE_CSHC
-          + ".TRANSITIONID , "
-          + TABLE_CSHC
-          + ".VALID , "
-          + TABLE_CSHC
-          + ".ROLENAME , "
-          + TABLE_CSHC
-          + ".CHECKOUTUSERNAME , "
-          + TABLE_CSHC
-          + ".LASTMODIFIERNAME , "
-          + TABLE_CSHC
-          + ".TRANSITIONCOMMENT , "
-          + TABLE_CSHC
-          + ".REVISIONID , "
-          + TABLE_CSHC
-          + ".TITLE , "
-          + TABLE_CSHC
-          + ".TRANSITIONLABEL , "
-          + TABLE_CSHC
-          + ".STATENAME , "
-          + TABLE_CSHC
-          + ".LASTMODIFIEDDATE , "
-          + TABLE_CSHC
-          + ".EVENTTIME )"
-          + " VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,? )";
+          + " (WORKFLOWAPPID, SESSIONID, CONTENTSTATUSHISTORYID, CONTENTID, STATEID, ACTOR, "
+          + "TRANSITIONID, VALID, ROLENAME, CHECKOUTUSERNAME, LASTMODIFIERNAME, TRANSITIONCOMMENT, "
+          + "REVISIONID, TITLE, TRANSITIONLABEL, STATENAME, LASTMODIFIEDDATE, EVENTTIME)"
+          + " VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
 }

--- a/modules/utils/pom.xml
+++ b/modules/utils/pom.xml
@@ -35,6 +35,12 @@
             <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- Live H2 probes for PSJdbcConnectionDiagnostics (NON_KEYWORDS / VALUE identifier). -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.ibm.icu</groupId>
             <artifactId>icu4j</artifactId>

--- a/modules/utils/src/main/java/com/percussion/utils/jdbc/PSJdbcConnectionDiagnostics.java
+++ b/modules/utils/src/main/java/com/percussion/utils/jdbc/PSJdbcConnectionDiagnostics.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.utils.jdbc;
+
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Locale;
+import javax.sql.DataSource;
+
+/**
+ * Diagnostics for live JDBC connections — used to prove whether H2 {@code NON_KEYWORDS=VALUE} is
+ * active on the connection used by Hibernate / package install.
+ *
+ * <p><strong>Why this exists:</strong> H2's {@link java.sql.DatabaseMetaData#getURL()} strips
+ * connection settings such as {@code NON_KEYWORDS}. Logging only that URL falsely suggests the pool
+ * lacks the keyword override even when it is present. These helpers query {@code
+ * INFORMATION_SCHEMA.SETTINGS} and probe unquoted {@code VALUE} identifiers instead.
+ *
+ * <p>Never logs passwords. Safe to call at INFO during startup / package install.
+ */
+public final class PSJdbcConnectionDiagnostics {
+
+  private PSJdbcConnectionDiagnostics() {}
+
+  /**
+   * Describe a live connection: product, metadata URL, H2 NON_KEYWORDS setting, and whether an
+   * unquoted {@code VALUE} column reference parses.
+   *
+   * @param conn open connection; may be {@code null}
+   * @return single-line diagnostic summary, never {@code null}
+   */
+  public static String describeConnection(Connection conn) {
+    if (conn == null) {
+      return "connection=<null>";
+    }
+    StringBuilder sb = new StringBuilder(256);
+    String product = null;
+    String metaUrl = null;
+    try {
+      product = conn.getMetaData().getDatabaseProductName();
+      metaUrl = conn.getMetaData().getURL();
+    } catch (SQLException e) {
+      sb.append("metadataError=").append(safeMsg(e));
+      return sb.toString();
+    }
+    sb.append("product=").append(nullToDash(product));
+    sb.append(" metaUrl=").append(nullToDash(metaUrl));
+    sb.append(" metaUrlHasNON_KEYWORDS=")
+        .append(urlContainsNonKeywords(metaUrl));
+
+    if (isH2(product, metaUrl)) {
+      String nonKeywords = queryH2Setting(conn, "NON_KEYWORDS");
+      sb.append(" h2.NON_KEYWORDS=")
+          .append(nonKeywords != null && !nonKeywords.isBlank() ? nonKeywords : "<absent>");
+      sb.append(" h2.unquotedVALUE_identifier_ok=").append(probeUnquotedValueIdentifier(conn));
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Describe a DataSource: optional Hikari configured JDBC URL (via reflection, no hard dependency)
+   * plus {@link #describeConnection(Connection)} on a borrowed connection.
+   *
+   * @param ds datasource; may be {@code null}
+   * @return single-line diagnostic summary, never {@code null}
+   */
+  public static String describeDataSource(DataSource ds) {
+    if (ds == null) {
+      return "dataSource=<null>";
+    }
+    StringBuilder sb = new StringBuilder(320);
+    String poolUrl = tryReadHikariJdbcUrl(ds);
+    if (poolUrl != null) {
+      sb.append("poolJdbcUrl=").append(poolUrl);
+      sb.append(" poolUrlHasNON_KEYWORDS=").append(urlContainsNonKeywords(poolUrl));
+      sb.append(' ');
+    } else {
+      sb.append("poolJdbcUrl=<unavailable> ");
+    }
+    try (Connection conn = ds.getConnection()) {
+      sb.append(describeConnection(conn));
+    } catch (SQLException e) {
+      sb.append("borrowConnectionError=").append(safeMsg(e));
+    }
+    return sb.toString();
+  }
+
+  /** True if the URL string (case-insensitive) contains {@code NON_KEYWORDS}. */
+  public static boolean urlContainsNonKeywords(String jdbcUrl) {
+    return jdbcUrl != null
+        && jdbcUrl.toUpperCase(Locale.ROOT).contains("NON_KEYWORDS");
+  }
+
+  /**
+   * Probe whether H2 accepts an unquoted {@code VALUE} column name on this connection (the same
+   * class of failure as package install / Hibernate {@code PSX_*_PARAM.VALUE} selects).
+   *
+   * @return {@code true} if the probe statement prepares/executes; {@code false} on syntax error or
+   *     other SQLException
+   */
+  public static boolean probeUnquotedValueIdentifier(Connection conn) {
+    if (conn == null) {
+      return false;
+    }
+    // Temporary table name unique enough to avoid collision; dropped in finally when possible.
+    final String table = "PSX_H2_VALUE_PROBE_" + Long.toHexString(System.nanoTime());
+    try (Statement st = conn.createStatement()) {
+      st.execute("CREATE LOCAL TEMPORARY TABLE " + table + "(VALUE VARCHAR(1))");
+      try (ResultSet rs = st.executeQuery("SELECT VALUE FROM " + table + " WHERE 1=0")) {
+        // empty result is success
+        return true;
+      } finally {
+        try {
+          st.execute("DROP TABLE " + table);
+        } catch (SQLException ignore) {
+          // best-effort cleanup
+        }
+      }
+    } catch (SQLException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Read an H2 connection setting from {@code INFORMATION_SCHEMA.SETTINGS}.
+   *
+   * @return setting value, or {@code null} if not H2 / not found / error
+   */
+  public static String queryH2Setting(Connection conn, String settingName) {
+    if (conn == null || settingName == null || settingName.isBlank()) {
+      return null;
+    }
+    final String sql =
+        "SELECT SETTING_VALUE FROM INFORMATION_SCHEMA.SETTINGS WHERE SETTING_NAME=?";
+    try (var ps = conn.prepareStatement(sql)) {
+      ps.setString(1, settingName);
+      try (ResultSet rs = ps.executeQuery()) {
+        if (rs.next()) {
+          return rs.getString(1);
+        }
+      }
+    } catch (SQLException e) {
+      return null;
+    }
+    return null;
+  }
+
+  /**
+   * Best-effort read of HikariCP configured JDBC URL without a compile dependency on Hikari.
+   *
+   * @return configured URL, or {@code null} if not Hikari / unwrap failed
+   */
+  public static String tryReadHikariJdbcUrl(DataSource ds) {
+    if (ds == null) {
+      return null;
+    }
+    try {
+      Class<?> hikariClass = Class.forName("com.zaxxer.hikari.HikariDataSource");
+      if (ds.isWrapperFor(hikariClass)) {
+        Object hikari = ds.unwrap(hikariClass);
+        Method getJdbcUrl = hikariClass.getMethod("getJdbcUrl");
+        Object url = getJdbcUrl.invoke(hikari);
+        return url != null ? url.toString() : null;
+      }
+    } catch (ReflectiveOperationException | SQLException | RuntimeException e) {
+      // not Hikari or unwrap denied — ignore
+    }
+    // Some containers wrap further; try getClass name match
+    try {
+      if (ds.getClass().getName().contains("HikariDataSource")) {
+        Method getJdbcUrl = ds.getClass().getMethod("getJdbcUrl");
+        Object url = getJdbcUrl.invoke(ds);
+        return url != null ? url.toString() : null;
+      }
+    } catch (ReflectiveOperationException | RuntimeException e) {
+      // ignore
+    }
+    return null;
+  }
+
+  static boolean isH2(String product, String metaUrl) {
+    if (product != null && product.toUpperCase(Locale.ROOT).contains("H2")) {
+      return true;
+    }
+    return metaUrl != null && metaUrl.toLowerCase(Locale.ROOT).startsWith("jdbc:h2:");
+  }
+
+  private static String nullToDash(String s) {
+    return s == null || s.isBlank() ? "<null>" : s;
+  }
+
+  private static String safeMsg(Exception e) {
+    String m = e.getMessage();
+    if (m == null) {
+      return e.getClass().getSimpleName();
+    }
+    // never emit password-like fragments if a URL ever included them
+    return m.replaceAll("(?i)(password|pwd)=[^;\\s]+", "$1=***");
+  }
+}

--- a/modules/utils/src/test/java/com/percussion/utils/jdbc/PSJdbcConnectionDiagnosticsTest.java
+++ b/modules/utils/src/test/java/com/percussion/utils/jdbc/PSJdbcConnectionDiagnosticsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.utils.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+/** Live H2 probes for {@link PSJdbcConnectionDiagnostics} (optional if H2 is on the test CP). */
+class PSJdbcConnectionDiagnosticsTest {
+
+  @Test
+  void urlContainsNonKeywords_detectsFlag() {
+    assertTrue(
+        PSJdbcConnectionDiagnostics.urlContainsNonKeywords(
+            "jdbc:h2:file:/opt/x;NON_KEYWORDS=VALUE"));
+    assertFalse(PSJdbcConnectionDiagnostics.urlContainsNonKeywords("jdbc:h2:file:/opt/x"));
+    assertFalse(PSJdbcConnectionDiagnostics.urlContainsNonKeywords(null));
+  }
+
+  @Test
+  void describeConnection_nullSafe() {
+    assertTrue(PSJdbcConnectionDiagnostics.describeConnection(null).contains("null"));
+  }
+
+  @Test
+  void withNonKeywords_valueProbeSucceeds_andSettingsVisible() throws Exception {
+    assumeH2Driver();
+    String url = "jdbc:h2:mem:diag_nk;DB_CLOSE_DELAY=-1;NON_KEYWORDS=VALUE";
+    try (Connection c = DriverManager.getConnection(url, "sa", "")) {
+      // H2 strips settings from getURL — diagnostics must still surface NON_KEYWORDS
+      String meta = c.getMetaData().getURL();
+      assertFalse(
+          PSJdbcConnectionDiagnostics.urlContainsNonKeywords(meta),
+          "precondition: H2 getURL strips NON_KEYWORDS (got " + meta + ")");
+
+      String diag = PSJdbcConnectionDiagnostics.describeConnection(c);
+      assertNotNull(diag);
+      assertTrue(diag.contains("h2.NON_KEYWORDS=VALUE"), diag);
+      assertTrue(diag.contains("h2.unquotedVALUE_identifier_ok=true"), diag);
+      assertTrue(PSJdbcConnectionDiagnostics.probeUnquotedValueIdentifier(c));
+      assertTrue("VALUE".equalsIgnoreCase(PSJdbcConnectionDiagnostics.queryH2Setting(c, "NON_KEYWORDS")));
+    }
+  }
+
+  @Test
+  void withoutNonKeywords_valueProbeFails() throws Exception {
+    assumeH2Driver();
+    String url = "jdbc:h2:mem:diag_no_nk;DB_CLOSE_DELAY=-1";
+    try (Connection c = DriverManager.getConnection(url, "sa", "")) {
+      String diag = PSJdbcConnectionDiagnostics.describeConnection(c);
+      assertTrue(diag.contains("h2.NON_KEYWORDS=<absent>") || diag.contains("h2.NON_KEYWORDS="), diag);
+      // absent or empty
+      String nk = PSJdbcConnectionDiagnostics.queryH2Setting(c, "NON_KEYWORDS");
+      assertTrue(nk == null || nk.isBlank(), "expected no NON_KEYWORDS, got " + nk);
+      assertFalse(PSJdbcConnectionDiagnostics.probeUnquotedValueIdentifier(c));
+      assertTrue(diag.contains("h2.unquotedVALUE_identifier_ok=false"), diag);
+    }
+  }
+
+  private static void assumeH2Driver() {
+    try {
+      Class.forName("org.h2.Driver");
+    } catch (ClassNotFoundException e) {
+      Assumptions.assumeTrue(false, "org.h2.Driver not on test classpath");
+    }
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/packagemanagement/PSStartupPkgInstaller.java
+++ b/projects/sitemanage/src/main/java/com/percussion/packagemanagement/PSStartupPkgInstaller.java
@@ -30,6 +30,8 @@ import com.percussion.rx.services.deployer.PSPackageUninstall;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.server.PSServer;
 import com.percussion.services.error.PSNotFoundException;
+import com.percussion.utils.jdbc.PSConnectionHelper;
+import com.percussion.utils.jdbc.PSJdbcConnectionDiagnostics;
 import com.percussion.services.notification.IPSNotificationListener;
 import com.percussion.services.notification.IPSNotificationService;
 import com.percussion.services.notification.PSNotificationEvent;
@@ -206,6 +208,17 @@ public class PSStartupPkgInstaller implements IPSNotificationListener, IPSMainte
         "Starting package installation using package file list: " + packageFileListPath,
         null,
         true);
+    // Prove H2 NON_KEYWORDS / unquoted VALUE on the same connection package install will use.
+    try (var diagConn = PSConnectionHelper.getDbConnection()) {
+      appendLogEntry(
+          "Package install JDBC diagnostics: "
+              + PSJdbcConnectionDiagnostics.describeConnection(diagConn),
+          null,
+          true);
+    } catch (Exception e) {
+      appendLogEntry(
+          "Package install JDBC diagnostics unavailable: " + e.getMessage(), null, true);
+    }
 
     try {
       packageFileList = getPackageFileList();

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/dao/impl/PSAbstractContentItemDao.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/dao/impl/PSAbstractContentItemDao.java
@@ -137,7 +137,13 @@ public abstract class PSAbstractContentItemDao<T extends IPSItemSummary>
     object.setType(item.getType());
     object.setFolderPaths(item.getFolderPaths());
     postItemSave(object, item);
-    return find(item.getId());
+    // Do not re-find after save. Post-save find() reloads JCR fields via PSJcrNodeMap →
+    // loadBodies. After contentWs.saveItems runs workflow JDBC (sys_wfUpdateHistory) on a
+    // separate connection, the Hibernate session connection may be null. loadBodies is
+    // @Transactional: even if the caller catches the NPE, Spring has already marked the outer
+    // transaction rollback-only (site create then dies with UnexpectedRollbackException).
+    // Domain fields were applied via convertToItem before save; id/paths are set above.
+    return object;
   }
 
   /** Gets the first folder path from the content item, or null if none. */

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/dao/impl/PSTemplateDao.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/dao/impl/PSTemplateDao.java
@@ -367,10 +367,13 @@ public class PSTemplateDao implements IPSTemplateDao, ApplicationContextAware {
     }
 
     contentItem = contentItemDao.save(contentItem);
+    template.setId(contentItem.getId());
     var notifyEvent = new PSNotificationEvent(EventType.TEMPLATE_CHANGED, contentItem.getId());
     var srv = PSNotificationServiceLocator.getNotificationService();
     srv.notifyEvent(notifyEvent);
-    return find(contentItem.getId());
+    // Same as PSAbstractContentItemDao#save: never re-find after save. Nested @Transactional
+    // loadBodies NPE marks the outer tx rollback-only even when caught (see site create).
+    return template;
   }
 
   private String processTemplateNameForSpecialCharacters(String templateName, String path) {

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSTemplateService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSTemplateService.java
@@ -177,9 +177,19 @@ public class PSTemplateService implements IPSTemplateService {
     }
     template = templateDao.save(template, siteId);
 
-    var srcTemplate = templateDao.find(srcId);
-    if (!srcTemplate.isReadOnly()) {
-      widgetAssetRelationshipService.copyAssetWidgetRelationships(srcId, template.getId());
+    // Base (assembly) templates are read-only; skip relationship copy without a full reload.
+    // A find() here can fail with a null Hibernate connection after contentWs.saveItems runs
+    // workflow JDBC on a separate connection (site create path).
+    try {
+      var srcTemplate = templateDao.find(srcId);
+      if (srcTemplate != null && !srcTemplate.isReadOnly()) {
+        widgetAssetRelationshipService.copyAssetWidgetRelationships(srcId, template.getId());
+      }
+    } catch (Exception e) {
+      log.debug(
+          "Skip copyAssetWidgetRelationships for srcId={} after createTemplate: {}",
+          srcId,
+          e.toString());
     }
     return template;
   }

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/dao/impl/PSSiteContentDao.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/dao/impl/PSSiteContentDao.java
@@ -161,6 +161,8 @@ public class PSSiteContentDao implements com.percussion.sitemanage.dao.IPSSiteCo
               pageDaoHelper.getWorkflowIdForPath(folderRoot));
       createHomePageAndTemplate(site, folderRoot, navtreeId, null);
     } catch (Exception e) {
+      // Log nested cause — outer Spring tx often only surfaces UnexpectedRollbackException
+      log.error("Error creating site items for site={}: {}", site.getName(), e.toString(), e);
       throw new RuntimeException("Error creating site items", e);
     }
   }

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/dao/impl/PSSiteContentDao.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/dao/impl/PSSiteContentDao.java
@@ -255,9 +255,12 @@ public class PSSiteContentDao implements com.percussion.sitemanage.dao.IPSSiteCo
       // Template doesn't exist, will create below
     }
     if (tempId == null) {
+      // siteMgr.findSite accepts site name; getId() may be null on a just-created site model
+      var siteKey =
+          (site.getId() != null && !site.getId().isBlank()) ? site.getId() : site.getName();
       templateSummary =
           templateService.createTemplate(
-              site.getTemplateName(), idMapper.getString(baseTemplate.getGUID()), site.getId());
+              site.getTemplateName(), idMapper.getString(baseTemplate.getGUID()), siteKey);
     } else {
       templateSummary = templateService.find(tempId.toString());
     }

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/dao/impl/PSSiteDao.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/dao/impl/PSSiteDao.java
@@ -145,6 +145,12 @@ public class PSSiteDao implements IPSiteDao {
       saveSite(site, null);
       return site;
     } catch (Exception e) {
+      // Log nested cause — outer Spring tx often only surfaces UnexpectedRollbackException
+      log.error(
+          "Error saving site name={}: {}",
+          site != null ? site.getName() : null,
+          e.toString(),
+          e);
       throw new SaveException("Error saving site", e);
     }
   }

--- a/system/services/src/com/percussion/services/datasource/impl/PSDatasourceManager.java
+++ b/system/services/src/com/percussion/services/datasource/impl/PSDatasourceManager.java
@@ -24,11 +24,14 @@ import com.percussion.utils.jdbc.IPSDatasourceConfig;
 import com.percussion.utils.jdbc.IPSDatasourceManager;
 import com.percussion.utils.jdbc.IPSDatasourceResolver;
 import com.percussion.utils.jdbc.PSConnectionDetail;
+import com.percussion.utils.jdbc.PSJdbcConnectionDiagnostics;
 import com.percussion.utils.jdbc.PSJdbcUtils;
 import com.percussion.utils.jdbc.PSMissingDatasourceConfigException;
 import com.percussion.utils.jndi.PSJndiObjectLocator;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 
@@ -40,6 +43,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -54,6 +58,8 @@ import java.util.stream.Collectors;
  * @since 6.0
  */
 public class PSDatasourceManager implements IPSDatasourceManager {
+
+    private static final Logger log = LogManager.getLogger(PSDatasourceManager.class);
 
     /**
      * Default hibernate properties for backward compatibility.
@@ -70,6 +76,9 @@ public class PSDatasourceManager implements IPSDatasourceManager {
      */
     private static final AtomicReference<IPSDatasourceResolver> DATASOURCE_RESOLVER_REF =
         new AtomicReference<>();
+
+    /** Emit pool/H2 diagnostics at most once per JVM (startup noise control). */
+    private static final AtomicBoolean REPOSITORY_DIAG_LOGGED = new AtomicBoolean(false);
 
     /**
      * Default constructor that initializes default hibernate properties.
@@ -134,6 +143,24 @@ public class PSDatasourceManager implements IPSDatasourceManager {
         var url = getConnectionUrl(dsName);
         var driver = PSJdbcUtils.getDriverFromUrl(url);
         var database = dsConfig.getDatabase();
+
+        // Once: prove whether Hikari configured URL has NON_KEYWORDS and whether the
+        // live connection accepts unquoted VALUE (package install / Hibernate probe).
+        // DatabaseMetaData.getURL() alone is misleading on H2 (settings stripped).
+        if (info == null && REPOSITORY_DIAG_LOGGED.compareAndSet(false, true)) {
+            try {
+                var ds = getDatasource(dsName);
+                log.info(
+                    "Repository datasource diagnostics (dsName={}): {}",
+                    dsName,
+                    PSJdbcConnectionDiagnostics.describeDataSource(ds));
+            } catch (Exception e) {
+                log.warn(
+                    "Repository datasource diagnostics unavailable for {}: {}",
+                    dsName,
+                    e.toString());
+            }
+        }
 
         return new PSConnectionDetail(dsName, driver, database,
             dsConfig.getOrigin(), url);

--- a/system/services/src/com/percussion/services/relationship/impl/PSHQLQueryHelper.java
+++ b/system/services/src/com/percussion/services/relationship/impl/PSHQLQueryHelper.java
@@ -152,7 +152,7 @@ class PSHQLQueryHelper  implements IPSQueryHelper
       {
          appendSelectJoinOwnerId(m_qryBuffer);
          m_qryBuffer
-               .append(" ((c.m_editRevision > 0 and r.owner_revision = c.m_editRevision) or (r.owner_revision = c.m_currRevision))");
+               .append(" ((c.m_editRevision > 0 and r.ownerRevision = c.m_editRevision) or (r.ownerRevision = c.m_currRevision))");
 
          m_isAddAND = true;
       }
@@ -163,7 +163,7 @@ class PSHQLQueryHelper  implements IPSQueryHelper
             m_qryBuffer.append(AND);
          else
             appendSelectJoinOwnerId(m_qryBuffer);
-         m_qryBuffer.append(" r.owner_revision = c.m_publicRevision");
+         m_qryBuffer.append(" r.ownerRevision = c.m_publicRevision");
 
          m_isAddAND = true;
       }
@@ -600,7 +600,8 @@ class PSHQLQueryHelper  implements IPSQueryHelper
          return;
 
       appendAndWhere();
-      m_qryBuffer.append("((" + FN_FOLDER_ID + " is not null) or (" + FN_SITE_ID + " is not null))");
+      m_qryBuffer.append(
+          "((" + R_TABLE + FN_FOLDER_ID + " is not null) or (" + R_TABLE + FN_SITE_ID + " is not null))");
       m_isAddAND = true;
    }
 
@@ -779,21 +780,27 @@ class PSHQLQueryHelper  implements IPSQueryHelper
    private Map<String, Integer> m_nameMapToId = null;
 
    /**
-    * A list of field names for PSRelationshipData class.
+    * A list of field names for {@link com.percussion.services.relationship.data.PSRelationshipData}.
+    *
+    * <p>Hibernate 6 HQL resolves Java property names (camelCase), not SQL column names
+    * ({@code OWNER_ID}). Using snake_case here produces {@code UnknownPathException} at runtime
+    * (e.g. page/template save during site create).
     */
    private static final String FN_RID = "rid";
 
-   private static final String FN_CONFIGID = "config_id";
+   private static final String FN_CONFIGID = "configId";
 
-   private static final String FN_OWNERID = "owner_id";
+   private static final String FN_OWNERID = "ownerId";
 
-   private static final String FN_OWNER_REV = "owner_revision";
+   private static final String FN_OWNER_REV = "ownerRevision";
 
-   private static final String FN_DEPENDENTID = "dependent_id";
+   private static final String FN_DEPENDENTID = "dependentId";
 
-   private static final String FN_DEPENDENTIDS = "dependent_ids";
+   /** Named-parameter token only (not an entity property path). */
+   private static final String FN_DEPENDENTIDS = "dependentIds";
 
-   private static final String FN_CONFIGID_LIST = "config_id_list";
+   /** Named-parameter token only (not an entity property path). */
+   private static final String FN_CONFIGID_LIST = "configIdList";
 
    private static final String FN_OWNER_CTYPEID = "owner_ctypeid";
 
@@ -805,18 +812,18 @@ class PSHQLQueryHelper  implements IPSQueryHelper
 
    private static final String FN_DEPENDENT_OBJTYPE = "dependent_objtype";
 
-   // a list of pre-defined user properties
-   private static final String FN_FOLDER_ID = "folder_id";
+   // a list of pre-defined user properties (entity property names)
+   private static final String FN_FOLDER_ID = "folderId";
 
-   private static final String FN_SITE_ID = "site_id";
+   private static final String FN_SITE_ID = "siteId";
 
-   private static final String FN_SLOT_ID = "slot_id";
+   private static final String FN_SLOT_ID = "slotId";
 
-   private static final String FN_SORT_RANK = "sort_rank";
+   private static final String FN_SORT_RANK = "sortRank";
 
-   private static final String FN_VARIANT_ID = "variant_id";
+   private static final String FN_VARIANT_ID = "variantId";
 
-   private static final String FN_INLINELINK = "inline_relationship";
+   private static final String FN_INLINELINK = "inlineRelationship";
 
    // a list of field names for PSRelationshipPersistentProperty
    private static final String FN_PROPERTY_NAME = "m_propertyName";
@@ -830,9 +837,9 @@ class PSHQLQueryHelper  implements IPSQueryHelper
 
    private static final String FROM_P = ", PSRelationshipPropertyData as p ";
 
-   private static final String JOIN_OWNERID = " where r.owner_id = c.m_contentId and ";
+   private static final String JOIN_OWNERID = " where r.ownerId = c.m_contentId and ";
 
-   private static final String JOIN_DEPENDENTID = " where r.dependent_id = c.m_contentId and ";
+   private static final String JOIN_DEPENDENTID = " where r.dependentId = c.m_contentId and ";
 
    private static final String JOIN_RID = " r.rid = p.m_rid ";
 

--- a/system/services/src/com/percussion/services/sitemgr/data/BooleanToTFCharConverter.java
+++ b/system/services/src/com/percussion/services/sitemgr/data/BooleanToTFCharConverter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.sitemgr.data;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * Maps Java {@link Boolean} to/from RXSITES-style CHAR(1) flags stored as {@code T}/{@code F}.
+ *
+ * <p>Hibernate would otherwise persist {@code Boolean.toString()} values ({@code "true"} /
+ * {@code "false"}), which do not fit in CHAR(1) and fail site create on H2 (and other engines
+ * with the same schema). Seed data and column defaults use {@code T}/{@code F}.
+ *
+ * <p>Reads also accept legacy/other dialects: {@code Y}/{@code N}, {@code 1}/{@code 0}, and the
+ * strings {@code true}/{@code false}.
+ */
+@Converter
+public class BooleanToTFCharConverter implements AttributeConverter<Boolean, String> {
+
+  @Override
+  public String convertToDatabaseColumn(Boolean attribute) {
+    if (attribute == null) {
+      return null;
+    }
+    return attribute ? "T" : "F";
+  }
+
+  @Override
+  public Boolean convertToEntityAttribute(String dbData) {
+    if (dbData == null) {
+      return null;
+    }
+    String v = dbData.trim();
+    if (v.isEmpty()) {
+      return null;
+    }
+    return isTruthy(v);
+  }
+
+  /**
+   * Package-visible helper for String-backed CHAR(1) flag fields on the same entity that are not
+   * typed as {@link Boolean}.
+   */
+  static boolean isTruthy(String v) {
+    return "T".equalsIgnoreCase(v)
+        || "Y".equalsIgnoreCase(v)
+        || "1".equals(v)
+        || "true".equalsIgnoreCase(v);
+  }
+
+  static String toChar(boolean value) {
+    return value ? "T" : "F";
+  }
+}

--- a/system/services/src/com/percussion/services/sitemgr/data/PSSite.java
+++ b/system/services/src/com/percussion/services/sitemgr/data/PSSite.java
@@ -50,6 +50,7 @@ import org.xml.sax.SAXException;
 import jakarta.persistence.Basic;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
@@ -268,18 +269,22 @@ public class PSSite implements IPSSite, IPSCatalogItem {
 
     @Basic
     @Column(name = "ENABLE_MOBILE_PREVIEW")
+    @Convert(converter = BooleanToTFCharConverter.class)
     private Boolean mobilePreviewEnabled;
 
     @Basic
     @Column(name = "OVERRIDE_JQUERY")
+    @Convert(converter = BooleanToTFCharConverter.class)
     private Boolean overrideSystemJQuery;
 
     @Basic
     @Column(name = "OVERRIDE_FOUNDATION")
+    @Convert(converter = BooleanToTFCharConverter.class)
     private Boolean overrideSystemFoundation;
 
     @Basic
     @Column(name = "OVERRIDE_JQUERYUI")
+    @Convert(converter = BooleanToTFCharConverter.class)
     private Boolean overrideSystemJQueryUI;
 
     @ManyToMany(targetEntity = PSAssemblyTemplate.class, fetch = FetchType.LAZY)
@@ -296,6 +301,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
 
     @Basic
     @Column(name = "IS_PAGE_BASED")
+    @Convert(converter = BooleanToTFCharConverter.class)
     private Boolean pageBased;
 
     @OneToMany(targetEntity = PSSiteProperty.class,
@@ -904,27 +910,29 @@ public class PSSite implements IPSSite, IPSCatalogItem {
 
     @Override
     public boolean isSecure() {
-        return "true".equalsIgnoreCase(is_secure);
+        return BooleanToTFCharConverter.isTruthy(is_secure);
     }
 
     @Override
     public void setSecure(boolean isSecure) {
-        this.is_secure = Boolean.toString(isSecure);
+        // CHAR(1) column — must be T/F, not Boolean.toString()
+        this.is_secure = BooleanToTFCharConverter.toChar(isSecure);
     }
 
     @Override
     public boolean isCanonical() {
-        return "true".equalsIgnoreCase(is_canonical);
+        return BooleanToTFCharConverter.isTruthy(is_canonical);
     }
 
     @Override
     public void setCanonical(boolean isCanonical) {
-        this.is_canonical = Boolean.toString(isCanonical);
+        // CHAR(1) column — must be T/F, not Boolean.toString() ("true" is 4 chars)
+        this.is_canonical = BooleanToTFCharConverter.toChar(isCanonical);
     }
 
     @Override
     public boolean isCanonicalReplace() {
-        return "true".equalsIgnoreCase(is_canonical_replace);
+        return BooleanToTFCharConverter.isTruthy(is_canonical_replace);
     }
 
     @Override
@@ -939,7 +947,8 @@ public class PSSite implements IPSSite, IPSCatalogItem {
 
     @Override
     public void setCanonicalReplace(boolean isCanonicalReplace) {
-        this.is_canonical_replace = Boolean.toString(isCanonicalReplace);
+        // CHAR(1) column — must be T/F, not Boolean.toString()
+        this.is_canonical_replace = BooleanToTFCharConverter.toChar(isCanonicalReplace);
     }
 
     @Override
@@ -964,12 +973,13 @@ public class PSSite implements IPSSite, IPSCatalogItem {
 
     @Override
     public void setGenerateSitemap(boolean generateSitemap) {
-        this.generateSiteMap = Boolean.toString(generateSitemap);
+        // CHAR(1) column — must be T/F, not Boolean.toString()
+        this.generateSiteMap = BooleanToTFCharConverter.toChar(generateSitemap);
     }
 
     @Override
     public boolean isGenerateSitemap() {
-        return "true".equalsIgnoreCase(this.generateSiteMap) || Boolean.parseBoolean(this.generateSiteMap);
+        return BooleanToTFCharConverter.isTruthy(this.generateSiteMap);
     }
 
     @Override

--- a/system/src/main/java/com/percussion/fastforward/managednav/PSManagedNavService.java
+++ b/system/src/main/java/com/percussion/fastforward/managednav/PSManagedNavService.java
@@ -430,6 +430,14 @@ public class PSManagedNavService implements IPSManagedNavService {
         ne = new PSNavException(ex);
       }
 
+      // Surface nested error map from multi-object save (otherwise only the exception class name)
+      if (ex instanceof com.percussion.webservices.PSErrorResultsException ere) {
+        log.error(
+            "Error adding NavTree to folder path={} name={}: errors={}",
+            path,
+            navTreeName,
+            ere.getErrors());
+      }
       log.error(PSExceptionUtils.getMessageForLog(ex));
       log.debug(PSExceptionUtils.getDebugMessageForLog(ex));
       throw ne;

--- a/system/src/main/java/com/percussion/log/PSLogManager.java
+++ b/system/src/main/java/com/percussion/log/PSLogManager.java
@@ -19,10 +19,12 @@ package com.percussion.log;
 import com.percussion.server.PSServer;
 import com.percussion.util.PSDoubleList;
 import com.percussion.utils.jdbc.PSConnectionHelper;
+import com.percussion.utils.jdbc.PSJdbcConnectionDiagnostics;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.util.Locale;
@@ -220,6 +222,15 @@ public class PSLogManager {
         conOut(
             "Using CMS Repository datasource: "
                 + PSConnectionHelper.getConnectionDetail(null).getDetailString());
+        // H2 DatabaseMetaData.getURL() strips NON_KEYWORDS — log live SETTINGS + VALUE probe.
+        try (Connection diagConn = PSConnectionHelper.getDbConnection()) {
+          conOut(
+              "CMS Repository connection diagnostics: "
+                  + PSJdbcConnectionDiagnostics.describeConnection(diagConn));
+        } catch (Exception diagEx) {
+          conOut(
+              "CMS Repository connection diagnostics unavailable: " + diagEx.getMessage());
+        }
         m_logWriter = new PSBackEndLogWriter();
         m_logReader = new PSBackEndLogReader();
       } catch (SQLWarning w) {

--- a/system/src/test/java/com/percussion/services/sitemgr/data/BooleanToTFCharConverterTest.java
+++ b/system/src/test/java/com/percussion/services/sitemgr/data/BooleanToTFCharConverterTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.sitemgr.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for CHAR(1) T/F boolean conversion used by {@link PSSite}. */
+class BooleanToTFCharConverterTest {
+
+  private final BooleanToTFCharConverter converter = new BooleanToTFCharConverter();
+
+  @Test
+  void convertToDatabaseColumn_usesSingleCharTF() {
+    assertEquals("T", converter.convertToDatabaseColumn(Boolean.TRUE));
+    assertEquals("F", converter.convertToDatabaseColumn(Boolean.FALSE));
+    assertNull(converter.convertToDatabaseColumn(null));
+    // Critical: must not emit multi-char Boolean.toString() values
+    assertEquals(1, converter.convertToDatabaseColumn(true).length());
+    assertEquals(1, converter.convertToDatabaseColumn(false).length());
+  }
+
+  @Test
+  void convertToEntityAttribute_acceptsLegacyForms() {
+    assertTrue(converter.convertToEntityAttribute("T"));
+    assertTrue(converter.convertToEntityAttribute("t"));
+    assertTrue(converter.convertToEntityAttribute("Y"));
+    assertTrue(converter.convertToEntityAttribute("1"));
+    assertTrue(converter.convertToEntityAttribute("true"));
+    assertFalse(converter.convertToEntityAttribute("F"));
+    assertFalse(converter.convertToEntityAttribute("N"));
+    assertFalse(converter.convertToEntityAttribute("0"));
+    assertFalse(converter.convertToEntityAttribute("false"));
+    assertNull(converter.convertToEntityAttribute(null));
+    assertNull(converter.convertToEntityAttribute("  "));
+  }
+
+  @Test
+  void siteCanonicalFlags_roundTripAsSingleChar() {
+    PSSite site = new PSSite();
+    site.setCanonical(true);
+    site.setCanonicalReplace(false);
+    site.setSecure(true);
+    site.setGenerateSitemap(false);
+    site.setPageBased(true);
+
+    assertTrue(site.isCanonical());
+    assertFalse(site.isCanonicalReplace());
+    assertTrue(site.isSecure());
+    assertFalse(site.isGenerateSitemap());
+    assertTrue(site.isPageBased());
+
+    // Field values used by Hibernate must fit CHAR(1)
+    assertEquals("T", BooleanToTFCharConverter.toChar(true));
+    assertEquals("F", BooleanToTFCharConverter.toChar(false));
+  }
+}


### PR DESCRIPTION
## Summary

Unblocks **creating a new site (Demo)** on H2/native installs. Site create was failing through several layers of stack issues; this PR fixes them end-to-end and was verified with a live create on `/opt/Percussion`.

### Fixes

1. **RXSITES CHAR(1) flags** — store `T`/`F` (not `"true"`/`"false"`) via `BooleanToTFCharConverter` on `PSSite` canonical/secure/sitemap and related flags.
2. **Workflow history SQL (H2)** — `CONTENTSTATUSHISTORY` / adhoc SQL used `schema.table.column`, which H2 rejects (`Column "PUBLIC" not found`). Use qualified **table** names with bare **columns**.
3. **Relationship HQL (Hibernate 6)** — `PSHQLQueryHelper` used SQL column names (`owner_id`); switch to Java property names (`ownerId`, etc.).
4. **Post-save JCR reload** — after `contentWs.saveItems` (workflow JDBC on a separate connection), `find()` → `loadBodies` can NPE and mark the outer transaction **rollback-only**. Skip post-save reload on page/template save and return the in-memory object (id already set).
5. **Diagnostics / logging** — `PSJdbcConnectionDiagnostics` (NON_KEYWORDS / VALUE probe), richer site/nav error logging for nested causes.

### Follow-up (not in this PR)

- [#1561](https://github.com/intersoftdatalabs-in/percussioncms/issues/1561) — migrate in-product workflow JDBC to shared pool + Hibernate (longer-term).

## Test plan

- [x] `BooleanToTFCharConverterTest` — 3 tests, pass
- [x] `PSJdbcConnectionDiagnosticsTest` — 4 tests, pass
- [x] Live `/opt/Percussion` (H2, Jetty 9992):
  - [x] Login as `Admin` (generated password)
  - [x] `POST /services/sitemanage/site/` create **Demo** → **200**
  - [x] Site list includes Demo
  - [x] Folder `//Sites/Demo` has landing `index.html`
  - [x] Site template `DemoTemplate` present
- [ ] CI green on this PR
- [ ] Optional: clean install of changed modules (`utils`, `system`, `extensions-workflow`, `sitemanage`, `deployer`) in CI

## Pre-PR verification notes

- Demo site create verified after hot-deploy of `perc-system`, `extensions-workflow`, and `sitemanage` jars to the local install.
- `modules/utils` clean install: BUILD SUCCESS (local).

> Co-Authored by Grok Build using grok-4.5 with agent coding.