### PR TITLE
fix(home): Create path, HQL, Recent TX, Velocity tools for Home acceptance

### DIFF
--- a/WebUI/src/main/ts/api/home/homeApi.ts
+++ b/WebUI/src/main/ts/api/home/homeApi.ts
@@ -29,7 +29,11 @@ import type {
   SiteSummary,
   TemplateSummary,
 } from "./types";
-import { joinFolderAndName, normalizeCmsPath } from "../../home/create/filenameUtils";
+import {
+  joinFolderAndName,
+  normalizeCmsPath,
+  toRepositoryCmsPath,
+} from "../../home/create/filenameUtils";
 
 /** Recent content items (type typically {@code item}). */
 export async function fetchRecentItems(
@@ -169,7 +173,8 @@ export async function fetchBlogsForSite(
  * folderPath should be the parent folder (classic passes path with leading slash).
  */
 export async function createPage(req: CreatePageRequest): Promise<unknown> {
-  const folderPath = normalizeCmsPath(req.folderPath);
+  // Page REST validates via contentWs.getIdByPath, which requires //Sites/...
+  const folderPath = toRepositoryCmsPath(req.folderPath);
   const body = {
     Page: {
       name: req.name,

--- a/WebUI/src/main/ts/home/create/filenameUtils.ts
+++ b/WebUI/src/main/ts/home/create/filenameUtils.ts
@@ -39,7 +39,12 @@ export function sanitizeFileNameInput(fileName: string): string {
     .replace(/[\\/:*?"<>|#;%']/g, "");
 }
 
-/** Ensure CMS path uses a single leading slash (classic getNormalizedPath). */
+/**
+ * Ensure CMS path uses a single leading slash (classic CUI getNormalizedPath).
+ * Used for UI navigation, path REST URLs under {@code /path/folder/...}, and
+ * editor open links — not for page-create POST bodies (see
+ * {@link toRepositoryCmsPath}).
+ */
 export function normalizeCmsPath(path: string): string {
   let p = path.trim();
   if (!p) {
@@ -52,6 +57,22 @@ export function normalizeCmsPath(path: string): string {
     p = `/${p}`;
   }
   return p.replace(/\/+/g, "/");
+}
+
+/**
+ * Repository folder form required by content WS / page create
+ * ({@code getIdByPath} rejects paths that do not start with {@code //}).
+ *
+ * <p>Classic CUI does the same: normalize to {@code /Sites/...} then
+ * re-prefix as {@code "/" + folderPath} → {@code //Sites/...} before
+ * {@code perc_page_manager.createPage}.
+ */
+export function toRepositoryCmsPath(path: string): string {
+  const normalized = normalizeCmsPath(path);
+  if (!normalized) {
+    return normalized;
+  }
+  return normalized.startsWith("//") ? normalized : `/${normalized}`;
 }
 
 export function joinFolderAndName(folderPath: string, name: string): string {

--- a/WebUI/src/test/ts/home/filenameUtils.test.ts
+++ b/WebUI/src/test/ts/home/filenameUtils.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeCmsPath,
   titleToBlogFileName,
   titleToPageFileName,
+  toRepositoryCmsPath,
 } from "@/home/create/filenameUtils";
 
 describe("filenameUtils", () => {
@@ -23,5 +24,11 @@ describe("filenameUtils", () => {
     expect(normalizeCmsPath("//Sites/a")).toBe("/Sites/a");
     expect(joinFolderAndName("/Sites/a", "page")).toBe("/Sites/a/page");
     expect(joinFolderAndName("/Sites/a/", "page")).toBe("/Sites/a/page");
+  });
+
+  it("converts UI paths to repository // form for page create", () => {
+    expect(toRepositoryCmsPath("/Sites/Demo")).toBe("//Sites/Demo");
+    expect(toRepositoryCmsPath("//Sites/Demo")).toBe("//Sites/Demo");
+    expect(toRepositoryCmsPath("Sites/Demo")).toBe("//Sites/Demo");
   });
 });

--- a/WebUI/src/test/ts/home/homeApi.test.ts
+++ b/WebUI/src/test/ts/home/homeApi.test.ts
@@ -17,6 +17,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
+  createPage,
   fetchMyContent,
   fetchRecentItems,
   fetchSites,
@@ -145,6 +146,25 @@ describe("homeApi", () => {
       String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body),
     );
     expect(body.SearchCriteria.query).toBe("legacy");
+  });
+
+  it("createPage posts repository // folderPath (getIdByPath requires it)", async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({ Page: { id: "1", name: "p" } }),
+    );
+    await createPage({
+      name: "about.html",
+      title: "About",
+      linkTitle: "About",
+      templateId: "t1",
+      folderPath: "/Sites/Demo",
+    });
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/pagemanagement/page");
+    const body = JSON.parse(String(init.body));
+    expect(body.Page.folderPath).toBe("//Sites/Demo");
+    expect(body.Page.addToRecent).toBe(true);
   });
 
   it("normalizeContentItem fills name/path from alternate fields", () => {

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSPageChangeHandler.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSPageChangeHandler.java
@@ -269,11 +269,14 @@ public class PSPageChangeHandler implements IPSPageChangeListener {
       var newSummary = generatePageSummary(page.getId());
       if (pageFields.containsKey(PAGE_SUMMARY_FIELD_NAME)) {
         var intg = (new Guid(page.getId())).getUuid();
+        // getFirstPublishDate returns Optional — never put Optional.toString()
+        // ("Optional.empty") into date fields; PSDateValue rejects that format.
         var postDate = cmsObjectMgr.getFirstPublishDate(intg);
         if (page.getFields() != null
             && page.getFields().get("sys_contentpostdate") == null
-            && postDate != null) {
-          page.getFields().put("sys_contentpostdate", postDate.toString());
+            && postDate != null
+            && postDate.isPresent()) {
+          page.getFields().put("sys_contentpostdate", postDate.get().toString());
         }
         pageFields.put(PAGE_SUMMARY_FIELD_NAME, newSummary);
         contentItemDao.save(page);

--- a/projects/sitemanage/src/main/java/com/percussion/recent/service/impl/PSRecentService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/recent/service/impl/PSRecentService.java
@@ -48,8 +48,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * Service implementation for managing recent items, templates, folders, and asset types. Provides
@@ -74,9 +77,24 @@ public class PSRecentService implements IPSRecentService {
 
   @Autowired private IPSSiteTemplateService siteTemplateService;
 
+  private TransactionTemplate requiresNewReadOnly;
+
   private static final Logger log = LogManager.getLogger(IPSConstants.CONTENTREPOSITORY_LOG);
 
-  /** Finds recent items for the current user, optionally ignoring archived items. */
+  @Autowired
+  public void setTransactionManager(PlatformTransactionManager transactionManager) {
+    requiresNewReadOnly = new TransactionTemplate(transactionManager);
+    requiresNewReadOnly.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    requiresNewReadOnly.setReadOnly(true);
+  }
+
+  /**
+   * Finds recent items for the current user, optionally ignoring archived items.
+   *
+   * <p>Lookups run in {@link Propagation#REQUIRES_NEW} so a Hibernate failure on one stale
+   * recent id cannot mark this transaction rollback-only (which previously caused
+   * {@code UnexpectedRollbackException} on Home Recent even after the failure was caught).
+   */
   @Override
   public List<PSItemProperties> findRecentItem(boolean ignoreArchivedItems) {
     var user = PSWebserviceUtils.getUserName();
@@ -84,34 +102,89 @@ public class PSRecentService implements IPSRecentService {
     var items = new ArrayList<PSItemProperties>();
     var toDelete = new ArrayList<String>();
     for (var entry : recentEntries) {
-      PSItemProperties itemProps = null;
-      try {
-        itemProps = folderHelper.findItemPropertiesById(entry);
-        if (itemProps != null) {
-          // Don't return archived items and items with no path on home page.
-          if (ignoreArchivedItems
-              && (PSWorkflowHelper.WF_STATE_ARCHIVE.equals(itemProps.getStatus())
-                  || itemProps.getPath() == null)) {
-            continue;
-          }
-          items.add(itemProps);
-        } else {
-          log.debug("Removing recent item find returned null : {}", entry);
+      ItemLookupResult lookup = findItemPropertiesIsolated(entry);
+      if (lookup.properties != null) {
+        var itemProps = lookup.properties;
+        // Don't return archived items and items with no path on home page.
+        if (ignoreArchivedItems
+            && (PSWorkflowHelper.WF_STATE_ARCHIVE.equals(itemProps.getStatus())
+                || itemProps.getPath() == null)) {
+          continue;
         }
-      } catch (Exception e) {
-        log.debug(
-            "Removing error entry from recent item list {}, Error: {}",
-            entry,
-            PSExceptionUtils.getMessageForLog(e));
-      }
-      if (itemProps == null) {
+        items.add(itemProps);
+      } else if (lookup.missing) {
+        // Only drop entries that are confirmed gone — not load failures
+        // (those used to mark the list empty and wipe recent on every Home load).
+        log.debug("Removing recent item find returned null : {}", entry);
         toDelete.add(entry);
+      } else {
+        log.debug("Keeping recent item after lookup failure : {}", entry);
       }
     }
     if (!toDelete.isEmpty()) {
       recentService.deleteRecent(user, null, RecentType.ITEM, toDelete);
     }
     return items;
+  }
+
+  /** Result of an isolated recent-item lookup. */
+  private static final class ItemLookupResult {
+    final PSItemProperties properties;
+    /** True when the item is known missing (null without exception). */
+    final boolean missing;
+
+    ItemLookupResult(PSItemProperties properties, boolean missing) {
+      this.properties = properties;
+      this.missing = missing;
+    }
+
+    static ItemLookupResult found(PSItemProperties props) {
+      return new ItemLookupResult(props, false);
+    }
+
+    static ItemLookupResult notFound() {
+      return new ItemLookupResult(null, true);
+    }
+
+    static ItemLookupResult failed() {
+      return new ItemLookupResult(null, false);
+    }
+  }
+
+  /**
+   * Load item properties in a nested transaction so failures do not poison the outer TX.
+   *
+   * @param entry content id / guid string from recent storage
+   * @return lookup result distinguishing missing items from load failures
+   */
+  private ItemLookupResult findItemPropertiesIsolated(String entry) {
+    if (requiresNewReadOnly == null) {
+      // Fallback when no TX manager (unit tests): same-thread lookup.
+      try {
+        PSItemProperties props = folderHelper.findItemPropertiesById(entry);
+        return props != null ? ItemLookupResult.found(props) : ItemLookupResult.notFound();
+      } catch (Exception e) {
+        log.debug(
+            "Recent item lookup failed for {}, Error: {}",
+            entry,
+            PSExceptionUtils.getMessageForLog(e));
+        return ItemLookupResult.failed();
+      }
+    }
+    return requiresNewReadOnly.execute(
+        status -> {
+          try {
+            PSItemProperties props = folderHelper.findItemPropertiesById(entry);
+            return props != null ? ItemLookupResult.found(props) : ItemLookupResult.notFound();
+          } catch (Exception e) {
+            log.debug(
+                "Recent item lookup failed for {}, Error: {}",
+                entry,
+                PSExceptionUtils.getMessageForLog(e));
+            status.setRollbackOnly();
+            return ItemLookupResult.failed();
+          }
+        });
   }
 
   /** Finds recent templates for the current user and site. */

--- a/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSContentItemDao.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/dao/impl/PSContentItemDao.java
@@ -367,8 +367,22 @@ public class PSContentItemDao implements IPSContentItemDao {
               f.addValue(fv);
             } else {
               if (value != null) {
-                fv = f.createFieldValue((String) value);
-                f.addValue(fv);
+                // Coerce non-String (e.g. Optional) and skip blank / unparseable date noise
+                // such as "Optional.empty" that would abort the entire save.
+                String text =
+                    value instanceof String ? (String) value : String.valueOf(value);
+                if (text.isBlank()
+                    || "Optional.empty".equals(text)
+                    || text.startsWith("Optional[")) {
+                  f.clearValues();
+                } else {
+                  try {
+                    fv = f.createFieldValue(text);
+                    f.addValue(fv);
+                  } catch (IllegalArgumentException badValue) {
+                    f.clearValues();
+                  }
+                }
               } else {
                 f.clearValues();
               }

--- a/system/services/src/com/percussion/services/assembly/impl/PSAssemblyService.java
+++ b/system/services/src/com/percussion/services/assembly/impl/PSAssemblyService.java
@@ -289,7 +289,14 @@ public class PSAssemblyService implements IPSAssemblyService
          sw.start();
          if (notification.getType().equals(EventType.CONTENT_CHANGED))
          {
-            var ccid = (IPSGuid) notification.getTarget();
+            // Callers pass either IPSGuid (content repository) or String id
+            // (e.g. PSPageChangeHandler). Accept both so page create does not
+            // fail the content-changed listener with ClassCastException.
+            var ccid = toGuid(notification.getTarget());
+            if (ccid == null)
+            {
+               return;
+            }
             synchronized (ContentCacheKey.class)
             {
                var keys = ContentCacheKey.getAndClearKeys(ccid);
@@ -304,13 +311,58 @@ public class PSAssemblyService implements IPSAssemblyService
          }
          else if (notification.getType().equals(EventType.OBJECT_INVALIDATION))
          {
-            var guid = (IPSGuid) notification.getTarget();
+            var guid = toGuid(notification.getTarget());
+            if (guid == null)
+            {
+               return;
+            }
             short type = guid.getType();
             if (ms_invalidatefor.contains(type))
             {
                cache.clear(CONTENT_REGION);
             }
          }
+      }
+
+      /**
+       * Resolve notification target to a GUID. Supports {@link IPSGuid} and
+       * string forms (legacy content guids such as {@code 16777215-101-12345}).
+       */
+      private static IPSGuid toGuid(Object target)
+      {
+         if (target == null)
+         {
+            return null;
+         }
+         if (target instanceof IPSGuid)
+         {
+            return (IPSGuid) target;
+         }
+         if (target instanceof String)
+         {
+            String s = ((String) target).trim();
+            if (s.isEmpty())
+            {
+               return null;
+            }
+            try
+            {
+               // Prefer legacy content guid parse for page/item ids
+               return new PSLegacyGuid(s);
+            }
+            catch (Exception e)
+            {
+               try
+               {
+                  return new PSGuid(s);
+               }
+               catch (Exception e2)
+               {
+                  return null;
+               }
+            }
+         }
+         return null;
       }
    }
 

--- a/system/services/src/com/percussion/services/content/impl/PSContentService.java
+++ b/system/services/src/com/percussion/services/content/impl/PSContentService.java
@@ -460,11 +460,12 @@ public class PSContentService implements IPSContentService {
       }
 
       try {
+         // Hibernate 6 HQL: entity property names (dependentId, configId), not SQL columns
          var queryString =
             "SELECT pfp FROM PSFolderProperty pfp, PSRelationshipData prd " +
             "WHERE pfp.propertyName = :property " +
-            "AND pfp.contentID = prd.dependent_id " +
-            "AND prd.config_id != :recycledId";
+            "AND pfp.contentID = prd.dependentId " +
+            "AND prd.configId != :recycledId";
 
          TypedQuery<PSFolderProperty> query = entityManager.createQuery(queryString, PSFolderProperty.class);
          query.setParameter("property", property);

--- a/system/services/src/com/percussion/services/relationship/impl/PSRelationshipService.java
+++ b/system/services/src/com/percussion/services/relationship/impl/PSRelationshipService.java
@@ -644,8 +644,10 @@ public class PSRelationshipService implements IPSRelationshipService {
    public List<PSRelationshipData> findByDependentId(int dependentId) {
       Session session = getSession();
 
+      // Hibernate 6 HQL: property name dependentId (not column dependent_id)
       Query query = session
-              .createQuery("from PSRelationshipData " + " where dependent_id =  " + dependentId);
+              .createQuery("from PSRelationshipData where dependentId = :dependentId")
+              .setParameter("dependentId", dependentId);
       return  query.list();
    }
 
@@ -956,8 +958,12 @@ public class PSRelationshipService implements IPSRelationshipService {
    public List<PSRelationshipData> findByDependentIdConfigId(int dependentId, int configId) {
       Session session = getSession();
 
+      // Hibernate 6 HQL: property names dependentId / configId (not SQL columns)
       Query query = session
-              .createQuery("from PSRelationshipData " + " where dependent_id =  " + dependentId +" and config_id = " + configId);
+              .createQuery(
+                  "from PSRelationshipData where dependentId = :dependentId and configId = :configId")
+              .setParameter("dependentId", dependentId)
+              .setParameter("configId", configId);
       return query.list();
 
    }

--- a/system/services/src/com/percussion/services/utils/jexl/PSServiceJexlEvaluatorBase.java
+++ b/system/services/src/com/percussion/services/utils/jexl/PSServiceJexlEvaluatorBase.java
@@ -26,9 +26,24 @@ import com.percussion.utils.jexl.PSJexlEvaluator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.velocity.tools.ToolManager;
+import org.apache.velocity.tools.config.ConfigurationUtils;
+import org.apache.velocity.tools.config.EasyFactoryConfiguration;
+import org.apache.velocity.tools.config.FactoryConfiguration;
+import org.apache.velocity.tools.generic.CollectionTool;
+import org.apache.velocity.tools.generic.ComparisonDateTool;
+import org.apache.velocity.tools.generic.ContextTool;
+import org.apache.velocity.tools.generic.DisplayTool;
+import org.apache.velocity.tools.generic.EscapeTool;
+import org.apache.velocity.tools.generic.LinkTool;
+import org.apache.velocity.tools.generic.LoopTool;
+import org.apache.velocity.tools.generic.MathTool;
+import org.apache.velocity.tools.generic.NumberTool;
+import org.apache.velocity.tools.generic.RenderTool;
+import org.apache.velocity.tools.generic.SortTool;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -157,13 +172,80 @@ public class PSServiceJexlEvaluatorBase extends PSJexlEvaluator implements IPSEx
             throw new FileNotFoundException("Velocity tools configuration not found: " + toolsPath);
         }
 
-        var manager = new ToolManager();
-        // ToolManager has differing overloads across versions; prefer String path to avoid
-        // ambiguous conversion problems during compilation.
-        manager.configure(toolsPath.toString());
+        var manager = new ToolManager(false, false);
+        FactoryConfiguration config = loadVelocityToolsConfig(toolsPath);
+        manager.configure(config);
 
         ms_log.info("Successfully configured ToolManager with tools from: {}", toolsPath);
         return manager;
+    }
+
+    /**
+     * Load Velocity Tools 3.x factory config from product tools.xml.
+     *
+     * <p>Velocity Tools 3 XML config uses Commons Digester3. On Jetty the digester SAX parser
+     * may be null ({@code Digester.getParser() == null}), so {@code ConfigurationUtils.read}
+     * and {@code getDefaultTools()} both fail. Prefer product tools.xml when digester works;
+     * otherwise build a programmatic toolbox (no digester) so assembly/preview/search indexing
+     * can still run.
+     */
+    private FactoryConfiguration loadVelocityToolsConfig(Path toolsPath) {
+        ClassLoader previous = Thread.currentThread().getContextClassLoader();
+        ClassLoader webappLoader = PSServiceJexlEvaluatorBase.class.getClassLoader();
+        try {
+            if (webappLoader != null) {
+                Thread.currentThread().setContextClassLoader(webappLoader);
+            }
+            try {
+                URL toolsUrl = toolsPath.toUri().toURL();
+                FactoryConfiguration productConfig = ConfigurationUtils.read(toolsUrl);
+                if (productConfig != null) {
+                    return productConfig;
+                }
+                ms_log.warn(
+                    "Velocity tools.xml at {} could not be parsed (null config); "
+                        + "using programmatic tool defaults.",
+                    toolsPath);
+            } catch (Exception e) {
+                ms_log.warn(
+                    "Failed to load Velocity tools.xml at {}: {}. Using programmatic tool defaults.",
+                    toolsPath,
+                    e.toString());
+            }
+            return createProgrammaticVelocityToolsConfig();
+        } finally {
+            Thread.currentThread().setContextClassLoader(previous);
+        }
+    }
+
+    /**
+     * Digester-free Velocity Tools config used when tools.xml cannot be parsed under Jetty.
+     * Covers the common generic tools referenced by product templates.
+     */
+    private static FactoryConfiguration createProgrammaticVelocityToolsConfig() {
+        EasyFactoryConfiguration config = new EasyFactoryConfiguration(false);
+        config.number("TOOLS_VERSION", "3.1");
+        config.toolbox("application")
+            .tool(MathTool.class)
+            .tool(NumberTool.class)
+            .tool(ComparisonDateTool.class)
+            .tool(DisplayTool.class)
+            .tool(EscapeTool.class)
+            .tool(CollectionTool.class)
+            .tool(SortTool.class);
+        config.toolbox("request")
+            .tool(ContextTool.class)
+            .tool(LinkTool.class)
+            .tool(LoopTool.class)
+            .tool(RenderTool.class);
+        // Product list helper (replacement for dropped ListTool) when on classpath
+        try {
+            Class<?> listTool = Class.forName("com.percussion.extension.PSVelocityListTool");
+            config.toolbox("application").tool("list", listTool);
+        } catch (ClassNotFoundException ignored) {
+            // optional
+        }
+        return config;
     }
 
     /**


### PR DESCRIPTION
## Summary

Continues Home functional recovery on native H2 after Demo site create (merged #1563).

- **Home Create:** `createPage` posts repository `//Sites/...` folder paths (`getIdByPath` requires `//`). UI still uses single-slash for path REST.
- **Hibernate 6 HQL:** `dependentId` / `configId` property names in `PSContentService` and `PSRelationshipService` (blogs/folder props no longer 500).
- **Recent:** isolate item lookups in `REQUIRES_NEW` so a failed load cannot mark Home Recent rollback-only; only delete confirmed-missing entries.
- **Velocity tools:** Digester3 cannot parse product `tools.xml` on Jetty (`getParser()==null`); fall back to programmatic toolbox so assembly can configure.
- **Page summary:** do not write `Optional.empty` into `sys_contentpostdate`.
- **Content-changed notification:** accept String page ids as well as `IPSGuid` (stops ClassCast on page create).

## Verification

Standalone clean install:
- `cd system && ../mvn-env.sh clean install -Dai.integrity.skip=true` → BUILD SUCCESS
- `cd projects/sitemanage && ../../mvn-env.sh clean install -Dai.integrity.skip=true` → BUILD SUCCESS
- WebUI Home vitest: 33 passed

Live `/opt/Percussion` smoke (after hot-deploy):
- Library sites/folder: 200 (Demo + created pages)
- Create page with `//Sites/Demo`: 200
- Blogs: 200 (was 500)
- Recent/Search APIs: 200 (empty search index still a follow-up — preview path still hits UnexpectedRollback in some cases)

## Follow-ups

- Search index still empty until assembly/preview fully succeeds for indexing (further TX/binding issues).
- Recent list still empty in smoke (add/find path needs more live debugging).
- Related backlog: #1561 dual JDBC/ORM stack.

## Test plan

- [ ] Create page from Home Create wizard on Demo site
- [ ] Library shows Demo and new pages
- [ ] Blogs section loads without 500
- [ ] Recent/Search: no 500; search results once index populates
- [ ] Gadgets dashboard config loads

> Co-Authored by Grok Build using grok-4.5 with agent coding.