### PR TITLE
fix(home): Create Asset widgetId + Blog allBlogs and file names

### DIFF
--- a/WebUI/src/main/ts/api/home/homeApi.ts
+++ b/WebUI/src/main/ts/api/home/homeApi.ts
@@ -194,6 +194,41 @@ export async function fetchTemplatesForSite(
   return [];
 }
 
+/**
+ * Map a WidgetContentType wire row to {@link AssetTypeSummary}.
+ * Classic createAsset / editAsset require the string {@code widgetId}
+ * (e.g. percImage), not the numeric contentTypeId.
+ */
+export function mapAssetType(raw: unknown): AssetTypeSummary {
+  const o = (raw ?? {}) as Record<string, unknown>;
+  const widgetId =
+    o.widgetId != null && String(o.widgetId).trim()
+      ? String(o.widgetId).trim()
+      : o.id != null && String(o.id).trim()
+        ? String(o.id).trim()
+        : "";
+  const label =
+    o.widgetLabel != null
+      ? String(o.widgetLabel)
+      : o.label != null
+        ? String(o.label)
+        : undefined;
+  const name =
+    label ||
+    (o.contentTypeName != null ? String(o.contentTypeName) : undefined) ||
+    (o.name != null ? String(o.name) : undefined) ||
+    widgetId;
+  return {
+    id: widgetId,
+    name,
+    label,
+    contentTypeId:
+      o.contentTypeId != null ? String(o.contentTypeId) : undefined,
+    contentTypeName:
+      o.contentTypeName != null ? String(o.contentTypeName) : undefined,
+  };
+}
+
 /** Asset widget types (classic getAssetTypes). */
 export async function fetchAssetTypes(
   filterDisabled = true,
@@ -210,14 +245,38 @@ export async function fetchAssetTypes(
   } else if (Array.isArray(data)) {
     list = data;
   }
-  return list.map((t) => {
-    const o = t as Record<string, unknown>;
-    return {
-      id: String(o.contentTypeId ?? o.widgetId ?? o.id ?? ""),
-      name: String(o.name ?? o.label ?? o.id ?? ""),
-      label: o.label ? String(o.label) : undefined,
-    };
-  });
+  return list.map(mapAssetType).filter((t) => Boolean(t.id));
+}
+
+function mapBlogSummary(
+  raw: unknown,
+  siteFallback?: string,
+): BlogSummary {
+  const o = (raw ?? {}) as Record<string, unknown>;
+  const path = String(o.path ?? "");
+  // Wire path is typically the blog section/page path; posts go in that folder.
+  let folderPath =
+    o.folderPath != null && String(o.folderPath).trim()
+      ? String(o.folderPath).trim()
+      : path && path.includes("/")
+        ? path.substring(0, path.lastIndexOf("/"))
+        : path;
+  folderPath = normalizeCmsPath(folderPath);
+  // Site from path /Sites/{site}/... when not provided
+  let site = siteFallback;
+  if (!site && folderPath.toLowerCase().startsWith("/sites/")) {
+    const parts = folderPath.split("/").filter(Boolean);
+    if (parts.length >= 2) {
+      site = parts[1];
+    }
+  }
+  return {
+    title: String(o.title ?? o.name ?? "Blog"),
+    folderPath,
+    templateId: String(o.blogPostTemplateId ?? o.templateId ?? ""),
+    site,
+    path: path || undefined,
+  };
 }
 
 /** Blogs for a site (classic getBlogsForSite). */
@@ -234,21 +293,41 @@ export async function fetchBlogsForSite(
   } else if (Array.isArray(data)) {
     list = data;
   }
-  return list.map((raw) => {
-    const o = raw as Record<string, unknown>;
-    const path = String(o.path ?? "");
-    const folderPath =
-      path && path.includes("/")
-        ? path.substring(0, path.lastIndexOf("/"))
-        : String(o.folderPath ?? "");
-    return {
-      title: String(o.title ?? o.name ?? ""),
-      folderPath,
-      templateId: String(o.blogPostTemplateId ?? o.templateId ?? ""),
-      site: siteName,
-      path,
-    };
-  });
+  return list
+    .map((raw) => mapBlogSummary(raw, siteName))
+    .filter((b) => Boolean(b.templateId && b.folderPath));
+}
+
+/**
+ * All blogs across sites (single call — preferred for Home Create chooser).
+ */
+export async function fetchAllBlogs(): Promise<BlogSummary[]> {
+  const data = await get<unknown>(PATHS.ALL_BLOGS);
+  let list: unknown[] = [];
+  if (data && typeof data === "object" && "SiteBlogProperties" in data) {
+    const b = (data as { SiteBlogProperties: unknown }).SiteBlogProperties;
+    list = Array.isArray(b) ? b : b ? [b] : [];
+  } else if (Array.isArray(data)) {
+    list = data;
+  }
+  return list
+    .map((raw) => mapBlogSummary(raw))
+    .filter((b) => Boolean(b.templateId && b.folderPath));
+}
+
+/**
+ * Ensure page/blog file names end with {@code .html} when the user did not
+ * supply an extension (classic CUI page names usually include it).
+ */
+export function ensurePageFileName(name: string): string {
+  const n = String(name ?? "").trim();
+  if (!n) {
+    return n;
+  }
+  if (/\.[a-zA-Z0-9]{1,8}$/.test(n)) {
+    return n;
+  }
+  return `${n}.html`;
 }
 
 /**
@@ -258,9 +337,10 @@ export async function fetchBlogsForSite(
 export async function createPage(req: CreatePageRequest): Promise<unknown> {
   // Page REST validates via contentWs.getIdByPath, which requires //Sites/...
   const folderPath = toRepositoryCmsPath(req.folderPath);
+  const name = ensurePageFileName(req.name);
   const body = {
     Page: {
-      name: req.name,
+      name,
       title: req.title,
       templateId: req.templateId,
       linkTitle: req.linkTitle,
@@ -277,8 +357,9 @@ export async function createPage(req: CreatePageRequest): Promise<unknown> {
 export async function createPageAndPath(
   req: CreatePageRequest,
 ): Promise<string> {
-  await createPage(req);
-  return joinFolderAndName(req.folderPath, req.name);
+  const name = ensurePageFileName(req.name);
+  await createPage({ ...req, name });
+  return joinFolderAndName(req.folderPath, name);
 }
 
 /**

--- a/WebUI/src/main/ts/api/home/types.ts
+++ b/WebUI/src/main/ts/api/home/types.ts
@@ -47,9 +47,15 @@ export interface TemplateSummary {
 }
 
 export interface AssetTypeSummary {
+  /**
+   * Widget definition id used by classic createAsset / editAsset
+   * (e.g. {@code percImage}), not the numeric content type id.
+   */
   id: string;
   name: string;
   label?: string;
+  contentTypeId?: string;
+  contentTypeName?: string;
 }
 
 export interface BlogSummary {

--- a/WebUI/src/main/ts/api/paths.ts
+++ b/WebUI/src/main/ts/api/paths.ts
@@ -87,6 +87,10 @@ export const PATHS = {
   get BLOGS_FOR_SITE() {
     return `${SERVICES_ROOT}/sitemanage/section/blogs`;
   },
+  /** All blogs across sites (PSSiteSectionRestService#getAllBlogs). */
+  get ALL_BLOGS() {
+    return `${SERVICES_ROOT}/sitemanage/section/allBlogs`;
+  },
   get ASSET_TYPES() {
     return `${SERVICES_ROOT}/assetmanagement/asset/assetTypes`;
   },

--- a/WebUI/src/main/ts/home/create/AssetWizard.tsx
+++ b/WebUI/src/main/ts/home/create/AssetWizard.tsx
@@ -16,13 +16,19 @@
  */
 
 import React, { useEffect, useState } from "react";
+import { isSessionRedirectError } from "../../api/client";
 import {
   fetchAssetTypes,
   fetchFolderChildren,
+  formatApiError,
 } from "../../api/home/homeApi";
 import type { AssetTypeSummary } from "../../api/home/types";
 import { message, MSG } from "../../i18n/message";
-import { errorStyle, formRowStyle } from "../home.styles";
+import {
+  actionButtonStyle,
+  errorStyle,
+  formRowStyle,
+} from "../home.styles";
 import { normalizeCmsPath } from "./filenameUtils";
 
 export interface AssetWizardProps {
@@ -30,8 +36,8 @@ export interface AssetWizardProps {
 }
 
 /**
- * Classic asset create navigates to edit-asset with widgetId + folderPath
- * (does not POST a finished asset in the adaptor).
+ * Classic asset create navigates to editAsset with widgetId + folderPath
+ * (does not POST a finished asset body — editor creates on save).
  */
 export function AssetWizard({ onBack }: AssetWizardProps): React.ReactElement {
   const [types, setTypes] = useState<AssetTypeSummary[]>([]);
@@ -47,19 +53,34 @@ export function AssetWizard({ onBack }: AssetWizardProps): React.ReactElement {
       fetchFolderChildren("/Assets").catch(() => []),
     ])
       .then(([assetTypes, children]) => {
-        setTypes(assetTypes.filter((t) => t.id));
+        setTypes(assetTypes);
+        if (assetTypes.length === 1) {
+          setTypeId(assetTypes[0].id);
+        }
         const extra = children
           .filter(
             (c) =>
               c.folder === true ||
-              String(c.type ?? "").toLowerCase().includes("folder"),
+              String(c.type ?? "").toLowerCase().includes("folder") ||
+              String((c as { category?: string }).category ?? "")
+                .toLowerCase()
+                .includes("folder"),
           )
           .map((c) =>
-            c.path ? String(c.path) : `/Assets/${c.name ?? ""}`,
-          );
-        setFolders(["/Assets", ...extra]);
+            normalizeCmsPath(
+              c.path ? String(c.path) : `/Assets/${c.name ?? ""}`,
+            ),
+          )
+          .filter(Boolean);
+        const uniq = Array.from(new Set(["/Assets", ...extra]));
+        setFolders(uniq);
       })
-      .catch(() => setError(message(MSG.ERROR_GENERIC)))
+      .catch((err: unknown) => {
+        if (isSessionRedirectError(err)) {
+          return;
+        }
+        setError(formatApiError(err, message(MSG.ERROR_GENERIC)));
+      })
       .finally(() => setLoading(false));
   }, []);
 
@@ -70,32 +91,53 @@ export function AssetWizard({ onBack }: AssetWizardProps): React.ReactElement {
       return;
     }
     const folder = normalizeCmsPath(folderPath);
-    // Classic: goToLocation VIEW_EDIT_ASSET with widgetId + folderPath
+    // Classic: VIEW_EDIT_ASSET with widgetId (string) + folderPath.
+    // Prefer editAsset.jsp so SPA path fallback cannot swallow the view.
     const q = new URLSearchParams({
-      view: "editAsset",
       widgetId: typeId,
       folderPath: folder,
     });
-    window.location.href = `/cm/app/?${q.toString()}`;
+    window.location.href = `/cm/app/editAsset.jsp?${q.toString()}`;
   };
 
   if (loading) {
-    return <p role="status">{message(MSG.LOADING)}</p>;
+    return (
+      <p role="status" data-testid="asset-wizard-loading">
+        {message(MSG.LOADING)}
+      </p>
+    );
+  }
+
+  if (types.length === 0) {
+    return (
+      <div data-testid="asset-wizard-empty">
+        <p>
+          <button type="button" style={actionButtonStyle("ghost")} onClick={onBack}>
+            {message(MSG.CREATE_BACK)}
+          </button>
+        </p>
+        <p>{message(MSG.CREATE_NO_ASSET_TYPES)}</p>
+      </div>
+    );
   }
 
   return (
     <form data-testid="asset-wizard" onSubmit={onSubmit}>
       <p>
-        <button type="button" onClick={onBack}>
+        <button type="button" style={actionButtonStyle("ghost")} onClick={onBack}>
           {message(MSG.CREATE_BACK)}
         </button>
       </p>
       <h2 style={{ fontSize: "1.1rem" }}>{message(MSG.CREATE_TYPE_ASSET)}</h2>
+      <p style={{ color: "#555", fontSize: "0.9rem" }}>
+        {message(MSG.CREATE_ASSET_HINT)}
+      </p>
 
       <div style={formRowStyle}>
         <label htmlFor="aw-type">{message(MSG.CREATE_ASSET_TYPE)}</label>
         <select
           id="aw-type"
+          data-testid="asset-wizard-type"
           value={typeId}
           onChange={(e) => setTypeId(e.target.value)}
           required
@@ -113,6 +155,7 @@ export function AssetWizard({ onBack }: AssetWizardProps): React.ReactElement {
         <label htmlFor="aw-folder">{message(MSG.CREATE_FOLDER)}</label>
         <select
           id="aw-folder"
+          data-testid="asset-wizard-folder"
           value={folderPath}
           onChange={(e) => setFolderPath(e.target.value)}
           required
@@ -126,12 +169,18 @@ export function AssetWizard({ onBack }: AssetWizardProps): React.ReactElement {
       </div>
 
       {error && (
-        <p role="alert" style={errorStyle}>
+        <p role="alert" style={errorStyle} data-testid="asset-wizard-error">
           {error}
         </p>
       )}
 
-      <button type="submit">{message(MSG.CREATE_SUBMIT)}</button>
+      <button
+        type="submit"
+        data-testid="asset-wizard-submit"
+        style={actionButtonStyle("primary")}
+      >
+        {message(MSG.CREATE_SUBMIT)}
+      </button>
     </form>
   );
 }

--- a/WebUI/src/main/ts/home/create/BlogWizard.tsx
+++ b/WebUI/src/main/ts/home/create/BlogWizard.tsx
@@ -16,15 +16,19 @@
  */
 
 import React, { useEffect, useState } from "react";
+import { isSessionRedirectError } from "../../api/client";
 import {
   createPageAndPath,
-  fetchBlogsForSite,
-  fetchSites,
+  fetchAllBlogs,
   formatApiError,
 } from "../../api/home/homeApi";
 import type { BlogSummary } from "../../api/home/types";
 import { message, MSG } from "../../i18n/message";
-import { errorStyle, formRowStyle } from "../home.styles";
+import {
+  actionButtonStyle,
+  errorStyle,
+  formRowStyle,
+} from "../home.styles";
 import {
   sanitizeFileNameInput,
   titleToBlogFileName,
@@ -46,25 +50,19 @@ export function BlogWizard({ onBack }: BlogWizardProps): React.ReactElement {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetchSites()
-      .then(async (sites) => {
-        const all: BlogSummary[] = [];
-        for (const s of sites) {
-          try {
-            const list = await fetchBlogsForSite(s.name);
-            for (const b of list) {
-              all.push({ ...b, site: s.name });
-            }
-          } catch {
-            // continue
-          }
-        }
+    fetchAllBlogs()
+      .then((all) => {
         setBlogs(all);
         if (all.length === 1) {
           setBlogKey(blogOptionKey(all[0], 0));
         }
       })
-      .catch(() => setError(message(MSG.ERROR_GENERIC)))
+      .catch((err: unknown) => {
+        if (isSessionRedirectError(err)) {
+          return;
+        }
+        setError(formatApiError(err, message(MSG.ERROR_GENERIC)));
+      })
       .finally(() => setLoading(false));
   }, []);
 
@@ -105,6 +103,9 @@ export function BlogWizard({ onBack }: BlogWizardProps): React.ReactElement {
       });
       window.location.href = `/cm/app/?view=editor&path=${encodeURIComponent(fullPath)}`;
     } catch (err) {
+      if (isSessionRedirectError(err)) {
+        return;
+      }
       setError(formatApiError(err, message(MSG.CREATE_NOT_AUTHORIZED)));
     } finally {
       setBusy(false);
@@ -112,12 +113,16 @@ export function BlogWizard({ onBack }: BlogWizardProps): React.ReactElement {
   };
 
   if (loading) {
-    return <p role="status">{message(MSG.LOADING)}</p>;
+    return (
+      <p role="status" data-testid="blog-wizard-loading">
+        {message(MSG.LOADING)}
+      </p>
+    );
   }
   if (blogs.length === 0) {
     return (
-      <div>
-        <button type="button" onClick={onBack}>
+      <div data-testid="blog-wizard-empty">
+        <button type="button" style={actionButtonStyle("ghost")} onClick={onBack}>
           {message(MSG.CREATE_BACK)}
         </button>
         <p>{message(MSG.CREATE_NO_BLOGS)}</p>
@@ -128,16 +133,20 @@ export function BlogWizard({ onBack }: BlogWizardProps): React.ReactElement {
   return (
     <form data-testid="blog-wizard" onSubmit={onSubmit}>
       <p>
-        <button type="button" onClick={onBack}>
+        <button type="button" style={actionButtonStyle("ghost")} onClick={onBack}>
           {message(MSG.CREATE_BACK)}
         </button>
       </p>
       <h2 style={{ fontSize: "1.1rem" }}>{message(MSG.CREATE_TYPE_BLOG)}</h2>
+      <p style={{ color: "#555", fontSize: "0.9rem" }}>
+        {message(MSG.CREATE_BLOG_HINT)}
+      </p>
 
       <div style={formRowStyle}>
         <label htmlFor="bw-blog">{message(MSG.CREATE_BLOG)}</label>
         <select
           id="bw-blog"
+          data-testid="blog-wizard-blog"
           value={blogKey}
           onChange={(e) => setBlogKey(e.target.value)}
           required
@@ -156,6 +165,7 @@ export function BlogWizard({ onBack }: BlogWizardProps): React.ReactElement {
         <label htmlFor="bw-title">{message(MSG.CREATE_TITLE)}</label>
         <input
           id="bw-title"
+          data-testid="blog-wizard-title"
           value={title}
           onChange={(e) => onTitleChange(e.target.value)}
           required
@@ -166,6 +176,7 @@ export function BlogWizard({ onBack }: BlogWizardProps): React.ReactElement {
         <label htmlFor="bw-file">{message(MSG.CREATE_FILENAME)}</label>
         <input
           id="bw-file"
+          data-testid="blog-wizard-filename"
           value={fileName}
           onChange={(e) => {
             setAutofill(false);
@@ -176,12 +187,17 @@ export function BlogWizard({ onBack }: BlogWizardProps): React.ReactElement {
       </div>
 
       {error && (
-        <p role="alert" style={errorStyle}>
+        <p role="alert" style={errorStyle} data-testid="blog-wizard-error">
           {error}
         </p>
       )}
 
-      <button type="submit" disabled={busy}>
+      <button
+        type="submit"
+        data-testid="blog-wizard-submit"
+        style={actionButtonStyle("primary")}
+        disabled={busy}
+      >
         {message(MSG.CREATE_SUBMIT)}
       </button>
     </form>

--- a/WebUI/src/main/ts/home/create/CreateWizard.tsx
+++ b/WebUI/src/main/ts/home/create/CreateWizard.tsx
@@ -17,13 +17,9 @@
 
 import React, { useEffect, useState } from "react";
 import { isSessionRedirectError } from "../../api/client";
-import {
-  fetchBlogsForSite,
-  fetchSites,
-  formatApiError,
-} from "../../api/home/homeApi";
+import { fetchSites, formatApiError } from "../../api/home/homeApi";
 import { message, MSG } from "../../i18n/message";
-import { errorStyle } from "../home.styles";
+import { actionButtonStyle, errorStyle } from "../home.styles";
 import { AssetWizard } from "./AssetWizard";
 import { BlogWizard } from "./BlogWizard";
 import { PageWizard } from "./PageWizard";
@@ -37,31 +33,12 @@ export type CreateKind = "page" | "asset" | "blog" | null;
 export function CreateWizard(): React.ReactElement {
   const [kind, setKind] = useState<CreateKind>(null);
   const [hasSites, setHasSites] = useState<boolean | null>(null);
-  const [hasBlogs, setHasBlogs] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     fetchSites()
-      .then(async (sites) => {
+      .then((sites) => {
         setHasSites(sites.length > 0);
-        if (sites.length === 0) {
-          setHasBlogs(false);
-          return;
-        }
-        // Discover blogs across sites (classic addwizard)
-        let found = false;
-        for (const s of sites) {
-          try {
-            const blogs = await fetchBlogsForSite(s.name);
-            if (blogs.length > 0) {
-              found = true;
-              break;
-            }
-          } catch {
-            // ignore per-site blog failures
-          }
-        }
-        setHasBlogs(found);
       })
       .catch((err: unknown) => {
         if (isSessionRedirectError(err)) {
@@ -80,10 +57,14 @@ export function CreateWizard(): React.ReactElement {
     );
   }
   if (hasSites === null) {
-    return <p role="status">{message(MSG.LOADING)}</p>;
+    return (
+      <p role="status" data-testid="create-wizard-loading">
+        {message(MSG.LOADING)}
+      </p>
+    );
   }
   if (!hasSites) {
-    return <p>{message(MSG.NO_SITES_ADMIN)}</p>;
+    return <p data-testid="create-wizard-no-sites">{message(MSG.NO_SITES_ADMIN)}</p>;
   }
 
   if (kind === "page") {
@@ -101,17 +82,30 @@ export function CreateWizard(): React.ReactElement {
       <p>{message(MSG.CREATE_HINT)}</p>
       <p style={{ fontWeight: 600 }}>{message(MSG.CREATE_CHOOSE_TYPE)}</p>
       <div style={{ display: "flex", flexDirection: "column", gap: 10, maxWidth: 320 }}>
-        <button type="button" onClick={() => setKind("page")}>
+        <button
+          type="button"
+          data-testid="create-choose-page"
+          style={actionButtonStyle("primary")}
+          onClick={() => setKind("page")}
+        >
           {message(MSG.CREATE_TYPE_PAGE)}
         </button>
-        <button type="button" onClick={() => setKind("asset")}>
+        <button
+          type="button"
+          data-testid="create-choose-asset"
+          style={actionButtonStyle("secondary")}
+          onClick={() => setKind("asset")}
+        >
           {message(MSG.CREATE_TYPE_ASSET)}
         </button>
-        {hasBlogs ? (
-          <button type="button" onClick={() => setKind("blog")}>
-            {message(MSG.CREATE_TYPE_BLOG)}
-          </button>
-        ) : null}
+        <button
+          type="button"
+          data-testid="create-choose-blog"
+          style={actionButtonStyle("secondary")}
+          onClick={() => setKind("blog")}
+        >
+          {message(MSG.CREATE_TYPE_BLOG)}
+        </button>
       </div>
     </div>
   );

--- a/WebUI/src/main/ts/home/create/PageWizard.tsx
+++ b/WebUI/src/main/ts/home/create/PageWizard.tsx
@@ -25,11 +25,16 @@ import {
 } from "../../api/home/homeApi";
 import type { SiteSummary, TemplateSummary } from "../../api/home/types";
 import { message, MSG } from "../../i18n/message";
-import { errorStyle, formRowStyle } from "../home.styles";
+import {
+  actionButtonStyle,
+  errorStyle,
+  formRowStyle,
+} from "../home.styles";
 import {
   sanitizeFileNameInput,
   titleToPageFileName,
 } from "./filenameUtils";
+import { isSessionRedirectError } from "../../api/client";
 
 export interface PageWizardProps {
   onBack: () => void;
@@ -131,6 +136,9 @@ export function PageWizard({ onBack }: PageWizardProps): React.ReactElement {
       });
       window.location.href = `/cm/app/?view=editor&path=${encodeURIComponent(fullPath)}`;
     } catch (err) {
+      if (isSessionRedirectError(err)) {
+        return;
+      }
       setError(
         formatApiError(err, message(MSG.CREATE_NOT_AUTHORIZED)),
       );
@@ -146,7 +154,7 @@ export function PageWizard({ onBack }: PageWizardProps): React.ReactElement {
   return (
     <form data-testid="page-wizard" onSubmit={onSubmit}>
       <p>
-        <button type="button" onClick={onBack}>
+        <button type="button" style={actionButtonStyle("ghost")} onClick={onBack}>
           {message(MSG.CREATE_BACK)}
         </button>
       </p>
@@ -232,7 +240,12 @@ export function PageWizard({ onBack }: PageWizardProps): React.ReactElement {
         </p>
       )}
 
-      <button type="submit" disabled={busy}>
+      <button
+        type="submit"
+        data-testid="page-wizard-submit"
+        style={actionButtonStyle("primary")}
+        disabled={busy}
+      >
         {message(MSG.CREATE_SUBMIT)}
       </button>
     </form>

--- a/WebUI/src/main/ts/home/create/filenameUtils.ts
+++ b/WebUI/src/main/ts/home/create/filenameUtils.ts
@@ -15,22 +15,30 @@
  * limitations under the License.
  */
 
-/** Classic CUI page title → file name autofill rules. */
+/** Classic CUI page title → file name autofill rules (with .html). */
 export function titleToPageFileName(title: string): string {
-  return title
+  const base = title
     .replace(/[ _]/g, "-")
     .replace(/[^a-zA-Z0-9\-_.]/g, "")
     .replace(/[-]+/g, "-")
     .toLowerCase();
+  if (!base) {
+    return base;
+  }
+  return base.endsWith(".html") ? base : `${base}.html`;
 }
 
-/** Classic CUI blog title → file name autofill (no dots in body). */
+/** Classic CUI blog title → file name autofill (no dots in body; add .html). */
 export function titleToBlogFileName(title: string): string {
-  return title
+  const base = title
     .replace(/[ _]/g, "-")
     .replace(/[^a-zA-Z0-9\-_]/g, "")
     .replace(/[-]+/g, "-")
     .toLowerCase();
+  if (!base) {
+    return base;
+  }
+  return `${base}.html`;
 }
 
 export function sanitizeFileNameInput(fileName: string): string {

--- a/WebUI/src/main/ts/i18n/message.ts
+++ b/WebUI/src/main/ts/i18n/message.ts
@@ -113,7 +113,13 @@ export const MSG = {
   CREATE_VALIDATION: "perc.ui.home.modern@Create Validation",
   CREATE_FILE_TOO_LONG: "perc.ui.home.modern@File Name Too Long",
   CREATE_NOT_AUTHORIZED: "perc.ui.home.modern@Create Not Authorized",
-  CREATE_NO_BLOGS: "perc.ui.home.modern@No Blogs",
+  CREATE_NO_BLOGS:
+    "perc.ui.home.modern@No blogs are configured. Create a blog section on a site first.",
+  CREATE_NO_ASSET_TYPES: "perc.ui.home.modern@No asset types available",
+  CREATE_ASSET_HINT:
+    "perc.ui.home.modern@Choose a type and folder. The asset editor opens so you can finish and save.",
+  CREATE_BLOG_HINT:
+    "perc.ui.home.modern@Choose a blog, then enter a title for the new post.",
   LOADING: "perc.ui.home.modern@Loading",
   RETRY: "perc.ui.home.modern@Retry",
   ERROR_GENERIC: "perc.ui.home.modern@Error",

--- a/WebUI/src/test/ts/home/CreateWizard.test.tsx
+++ b/WebUI/src/test/ts/home/CreateWizard.test.tsx
@@ -5,25 +5,40 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { CreateWizard } from "@/home/create/CreateWizard";
+import * as homeApi from "@/api/home/homeApi";
 
-vi.mock("@/api/home/homeApi", () => ({
-  fetchSites: vi.fn().mockResolvedValue([{ name: "Demo" }]),
-  fetchBlogsForSite: vi.fn().mockResolvedValue([
-    {
-      title: "News",
-      folderPath: "/Sites/Demo/News",
-      templateId: "tmpl-1",
-      site: "Demo",
-    },
-  ]),
-  fetchTemplatesForSite: vi.fn().mockResolvedValue([
-    { id: "t1", name: "Base" },
-  ]),
-  fetchFolderChildren: vi.fn().mockResolvedValue([]),
-  fetchAssetTypes: vi.fn().mockResolvedValue([{ id: "w1", name: "Image" }]),
-  createPageAndPath: vi.fn().mockResolvedValue("/Sites/Demo/page"),
-  formatApiError: vi.fn((_e: unknown, fallback: string) => fallback),
-}));
+vi.mock("@/api/home/homeApi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/home/homeApi")>();
+  return {
+    ...actual,
+    fetchSites: vi.fn().mockResolvedValue([{ name: "Demo" }]),
+    fetchAllBlogs: vi.fn().mockResolvedValue([
+      {
+        title: "News",
+        folderPath: "/Sites/Demo/News",
+        templateId: "tmpl-1",
+        site: "Demo",
+      },
+    ]),
+    fetchBlogsForSite: vi.fn().mockResolvedValue([
+      {
+        title: "News",
+        folderPath: "/Sites/Demo/News",
+        templateId: "tmpl-1",
+        site: "Demo",
+      },
+    ]),
+    fetchTemplatesForSite: vi.fn().mockResolvedValue([
+      { id: "t1", name: "Base" },
+    ]),
+    fetchFolderChildren: vi.fn().mockResolvedValue([]),
+    fetchAssetTypes: vi.fn().mockResolvedValue([
+      { id: "percImage", name: "Image", label: "Image" },
+    ]),
+    createPageAndPath: vi.fn().mockResolvedValue("/Sites/Demo/page.html"),
+    formatApiError: vi.fn((_e: unknown, fallback: string) => fallback),
+  };
+});
 
 describe("CreateWizard", () => {
   beforeEach(() => {
@@ -37,18 +52,50 @@ describe("CreateWizard", () => {
     await waitFor(() => {
       expect(screen.getByTestId("create-type-chooser")).toBeDefined();
     });
-    expect(screen.getByText("Create Page")).toBeDefined();
-    expect(screen.getByText("Create Asset")).toBeDefined();
-    expect(screen.getByText("Create Blog Post")).toBeDefined();
+    expect(screen.getByTestId("create-choose-page")).toBeDefined();
+    expect(screen.getByTestId("create-choose-asset")).toBeDefined();
+    expect(screen.getByTestId("create-choose-blog")).toBeDefined();
   });
 
   it("opens page wizard from chooser", async () => {
     render(<CreateWizard />);
     await waitFor(() => screen.getByTestId("create-type-chooser"));
-    fireEvent.click(screen.getByText("Create Page"));
+    fireEvent.click(screen.getByTestId("create-choose-page"));
     await waitFor(() => {
       expect(screen.getByTestId("page-wizard")).toBeDefined();
     });
   });
-});
 
+  it("opens asset wizard and lists widget ids as options", async () => {
+    render(<CreateWizard />);
+    await waitFor(() => screen.getByTestId("create-type-chooser"));
+    fireEvent.click(screen.getByTestId("create-choose-asset"));
+    await waitFor(() => {
+      expect(screen.getByTestId("asset-wizard")).toBeDefined();
+    });
+    const select = screen.getByTestId("asset-wizard-type") as HTMLSelectElement;
+    const values = Array.from(select.options).map((o) => o.value);
+    expect(values).toContain("percImage");
+    expect(homeApi.fetchAssetTypes).toHaveBeenCalled();
+  });
+
+  it("opens blog wizard", async () => {
+    render(<CreateWizard />);
+    await waitFor(() => screen.getByTestId("create-type-chooser"));
+    fireEvent.click(screen.getByTestId("create-choose-blog"));
+    await waitFor(() => {
+      expect(screen.getByTestId("blog-wizard")).toBeDefined();
+    });
+    expect(homeApi.fetchAllBlogs).toHaveBeenCalled();
+  });
+
+  it("shows no-blogs empty state when none configured", async () => {
+    vi.mocked(homeApi.fetchAllBlogs).mockResolvedValueOnce([]);
+    render(<CreateWizard />);
+    await waitFor(() => screen.getByTestId("create-type-chooser"));
+    fireEvent.click(screen.getByTestId("create-choose-blog"));
+    await waitFor(() => {
+      expect(screen.getByTestId("blog-wizard-empty")).toBeDefined();
+    });
+  });
+});

--- a/WebUI/src/test/ts/home/filenameUtils.test.ts
+++ b/WebUI/src/test/ts/home/filenameUtils.test.ts
@@ -12,12 +12,12 @@ import {
 } from "@/home/create/filenameUtils";
 
 describe("filenameUtils", () => {
-  it("maps title to page file name like classic CUI", () => {
-    expect(titleToPageFileName("Hello World!")).toBe("hello-world");
+  it("maps title to page file name like classic CUI with .html", () => {
+    expect(titleToPageFileName("Hello World!")).toBe("hello-world.html");
   });
 
-  it("maps title to blog file name", () => {
-    expect(titleToBlogFileName("My_Post Title")).toBe("my-post-title");
+  it("maps title to blog file name with .html", () => {
+    expect(titleToBlogFileName("My_Post Title")).toBe("my-post-title.html");
   });
 
   it("normalizes and joins paths", () => {

--- a/WebUI/src/test/ts/home/homeApi.test.ts
+++ b/WebUI/src/test/ts/home/homeApi.test.ts
@@ -20,12 +20,15 @@ import {
   addToMyPages,
   contentItemId,
   createPage,
+  ensurePageFileName,
+  fetchAssetTypes,
   fetchMyContent,
   fetchRecentItems,
   fetchSites,
   formatApiError,
   isBookmarkableItem,
   isMyPage,
+  mapAssetType,
   normalizeContentItem,
   removeFromMyPages,
   searchContent,
@@ -170,6 +173,65 @@ describe("homeApi", () => {
     const body = JSON.parse(String(init.body));
     expect(body.Page.folderPath).toBe("//Sites/Demo");
     expect(body.Page.addToRecent).toBe(true);
+  });
+
+  it("createPage appends .html when name has no extension", async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({ Page: { id: "1", name: "about.html" } }),
+    );
+    await createPage({
+      name: "about",
+      title: "About",
+      linkTitle: "About",
+      templateId: "t1",
+      folderPath: "/Sites/Demo",
+    });
+    const body = JSON.parse(
+      String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body),
+    );
+    expect(body.Page.name).toBe("about.html");
+  });
+
+  it("mapAssetType prefers widgetId over contentTypeId", () => {
+    expect(
+      mapAssetType({
+        contentTypeId: 1075,
+        contentTypeName: "percImageAsset",
+        widgetId: "percImage",
+        widgetLabel: "Image",
+      }),
+    ).toMatchObject({
+      id: "percImage",
+      name: "Image",
+      label: "Image",
+      contentTypeId: "1075",
+    });
+  });
+
+  it("fetchAssetTypes maps WidgetContentType list", async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({
+        WidgetContentType: [
+          {
+            contentTypeId: 1075,
+            widgetId: "percImage",
+            widgetLabel: "Image",
+          },
+        ],
+      }),
+    );
+    const types = await fetchAssetTypes();
+    expect(types).toEqual([
+      expect.objectContaining({ id: "percImage", label: "Image" }),
+    ]);
+  });
+
+  it("ensurePageFileName", () => {
+    expect(ensurePageFileName("foo")).toBe("foo.html");
+    expect(ensurePageFileName("foo.html")).toBe("foo.html");
+    expect(ensurePageFileName("foo.XML")).toBe("foo.XML");
   });
 
   it("normalizeContentItem fills name/path from alternate fields", () => {


### PR DESCRIPTION
## Summary

Home **Create Asset** and **Create Blog Post** were incomplete / wrong-wired:

### Asset
- **Bug:** `fetchAssetTypes` used `contentTypeId` (numeric) as option value — classic `editAsset` needs **`widgetId`** strings (`percImage`, …)
- Labels now come from `widgetLabel`
- Opens **`/cm/app/editAsset.jsp?widgetId=…&folderPath=…`** (classic createAsset path)
- Empty asset-type list handled explicitly

### Blog
- Chooser **always** offers Blog (not only when a site already has blogs)
- Loads blogs via **`GET …/section/allBlogs`** (one call)
- Empty state when no blog sections are configured
- File names autofill with `.html`

### Page (shared)
- `ensurePageFileName` / title autofill append `.html` when missing

## Test plan

- [x] Vitest: CreateWizard, homeApi (`mapAssetType`, createPage .html), filenameUtils
- [x] `cd WebUI && ../mvn-env.sh clean install` — BUILD SUCCESS
- [x] Live: assetTypes include `percImage`; `editAsset.jsp?widgetId=percImage` 200; page create with `.html`
- [ ] Manual: Home → Create → Asset → Image → Create → asset editor
- [ ] Manual: Home → Create → Blog → empty message (no blogs on Demo) or create post if blogs exist

## Pre-PR verification

| Gate | Result |
|------|--------|
| WebUI clean install | SUCCESS |
| Unit tests | 28 pass (Create + homeApi + filenameUtils) |

> Co-Authored by Grok Build using grok-4.5 with agent Grok.