### PR TITLE
fix(home): Gadgets load + Blogs gadget (create blog section)

### DIFF
--- a/WebUI/src/main/ts/api/home/homeApi.ts
+++ b/WebUI/src/main/ts/api/home/homeApi.ts
@@ -205,18 +205,43 @@ export async function fetchTemplate(templateId: string): Promise<unknown> {
   );
 }
 
+/** Max walk depth for template JSON (guards pathological nesting / cycles). */
+const TEMPLATE_WIDGET_WALK_MAX_DEPTH = 32;
+
 /**
  * Collect widget definitionIds from a loaded template JSON (Template.regionTree).
+ * Uses iterative DFS with a depth limit to avoid stack overflow on deep trees.
  */
 export function extractTemplateWidgetDefinitionIds(raw: unknown): string[] {
   const ids = new Set<string>();
-  const walk = (node: unknown): void => {
-    if (node == null) return;
+  const root =
+    raw && typeof raw === "object" && "Template" in (raw as object)
+      ? (raw as { Template: unknown }).Template
+      : raw;
+
+  type Frame = { node: unknown; depth: number };
+  const stack: Frame[] = [];
+  if (root && typeof root === "object") {
+    const t = root as Record<string, unknown>;
+    stack.push({ node: t.regionTree, depth: 0 });
+    stack.push({ node: t.regionWidgetAssociations, depth: 0 });
+    stack.push({ node: t.widgets, depth: 0 });
+  } else {
+    stack.push({ node: root, depth: 0 });
+  }
+
+  while (stack.length > 0) {
+    const frame = stack.pop();
+    if (!frame) break;
+    const { node, depth } = frame;
+    if (node == null || depth > TEMPLATE_WIDGET_WALK_MAX_DEPTH) continue;
     if (Array.isArray(node)) {
-      for (const n of node) walk(n);
-      return;
+      for (const n of node) {
+        stack.push({ node: n, depth: depth + 1 });
+      }
+      continue;
     }
-    if (typeof node !== "object") return;
+    if (typeof node !== "object") continue;
     const o = node as Record<string, unknown>;
     if (o.definitionId != null && String(o.definitionId).trim()) {
       ids.add(String(o.definitionId).trim());
@@ -226,20 +251,8 @@ export function extractTemplateWidgetDefinitionIds(raw: unknown): string[] {
       ids.add(String(o.widgetDefinitionId).trim());
     }
     for (const v of Object.values(o)) {
-      walk(v);
+      stack.push({ node: v, depth: depth + 1 });
     }
-  };
-  const root =
-    raw && typeof raw === "object" && "Template" in (raw as object)
-      ? (raw as { Template: unknown }).Template
-      : raw;
-  if (root && typeof root === "object") {
-    const t = root as Record<string, unknown>;
-    walk(t.regionTree);
-    walk(t.regionWidgetAssociations);
-    walk(t.widgets);
-  } else {
-    walk(root);
   }
   return Array.from(ids);
 }
@@ -271,8 +284,12 @@ export async function fetchTemplatesWithWidget(
       if (templateHasWidget(full, widgetDefinitionId)) {
         out.push(s);
       }
-    } catch {
-      // skip templates that fail to load
+    } catch (err: unknown) {
+      // Skip templates that fail to load; log so network/500 failures are visible.
+      console.warn(
+        `fetchTemplatesWithWidget: failed to load template ${s.id}`,
+        err,
+      );
     }
   }
   return out;

--- a/WebUI/src/main/ts/api/home/homeApi.ts
+++ b/WebUI/src/main/ts/api/home/homeApi.ts
@@ -192,6 +192,107 @@ export async function fetchTemplatesForSite(
 }
 
 /**
+ * Widget definition ids for blog templates.
+ * Blog List (index) → percBlogIndexPage; Blog Post → percBlogPost.
+ */
+export const BLOG_LIST_WIDGET_ID = "percBlogIndexPage";
+export const BLOG_POST_WIDGET_ID = "percBlogPost";
+
+/** Load full template (includes region → widget associations). */
+export async function fetchTemplate(templateId: string): Promise<unknown> {
+  return get<unknown>(
+    `${PATHS.TEMPLATE_LOAD}/${encodeURIComponent(templateId)}`,
+  );
+}
+
+/**
+ * Collect widget definitionIds from a loaded template JSON (Template.regionTree).
+ */
+export function extractTemplateWidgetDefinitionIds(raw: unknown): string[] {
+  const ids = new Set<string>();
+  const walk = (node: unknown): void => {
+    if (node == null) return;
+    if (Array.isArray(node)) {
+      for (const n of node) walk(n);
+      return;
+    }
+    if (typeof node !== "object") return;
+    const o = node as Record<string, unknown>;
+    if (o.definitionId != null && String(o.definitionId).trim()) {
+      ids.add(String(o.definitionId).trim());
+    }
+    // Also check common alternate keys
+    if (o.widgetDefinitionId != null && String(o.widgetDefinitionId).trim()) {
+      ids.add(String(o.widgetDefinitionId).trim());
+    }
+    for (const v of Object.values(o)) {
+      walk(v);
+    }
+  };
+  const root =
+    raw && typeof raw === "object" && "Template" in (raw as object)
+      ? (raw as { Template: unknown }).Template
+      : raw;
+  if (root && typeof root === "object") {
+    const t = root as Record<string, unknown>;
+    walk(t.regionTree);
+    walk(t.regionWidgetAssociations);
+    walk(t.widgets);
+  } else {
+    walk(root);
+  }
+  return Array.from(ids);
+}
+
+export function templateHasWidget(
+  rawTemplate: unknown,
+  widgetDefinitionId: string,
+): boolean {
+  const target = widgetDefinitionId.toLowerCase();
+  return extractTemplateWidgetDefinitionIds(rawTemplate).some(
+    (id) => id.toLowerCase() === target,
+  );
+}
+
+/**
+ * Site templates that contain the given widget definition (e.g. Blog List or Blog Post).
+ * Loads each template fully — suitable for small site template catalogs.
+ */
+export async function fetchTemplatesWithWidget(
+  siteName: string,
+  widgetDefinitionId: string,
+): Promise<TemplateSummary[]> {
+  const summaries = await fetchTemplatesForSite(siteName);
+  const out: TemplateSummary[] = [];
+  for (const s of summaries) {
+    if (!s.id) continue;
+    try {
+      const full = await fetchTemplate(s.id);
+      if (templateHasWidget(full, widgetDefinitionId)) {
+        out.push(s);
+      }
+    } catch {
+      // skip templates that fail to load
+    }
+  }
+  return out;
+}
+
+/** Blog list (index) templates: must include Blog List widget. */
+export async function fetchBlogListTemplates(
+  siteName: string,
+): Promise<TemplateSummary[]> {
+  return fetchTemplatesWithWidget(siteName, BLOG_LIST_WIDGET_ID);
+}
+
+/** Blog post templates: must include Blog Post widget. */
+export async function fetchBlogPostTemplates(
+  siteName: string,
+): Promise<TemplateSummary[]> {
+  return fetchTemplatesWithWidget(siteName, BLOG_POST_WIDGET_ID);
+}
+
+/**
  * Map a WidgetContentType wire row to {@link AssetTypeSummary}.
  * Classic createAsset / editAsset require the string {@code widgetId}
  * (e.g. percImage), not the numeric contentTypeId.

--- a/WebUI/src/main/ts/api/paths.ts
+++ b/WebUI/src/main/ts/api/paths.ts
@@ -84,6 +84,10 @@ export const PATHS = {
   get TEMPLATES_BY_SITE() {
     return `${SERVICES_ROOT}/sitemanage/sitetemplates/templates`;
   },
+  /** Full template load (widgets / region associations). */
+  get TEMPLATE_LOAD() {
+    return `${SERVICES_ROOT}/pagemanagement/template`;
+  },
   get BLOGS_FOR_SITE() {
     return `${SERVICES_ROOT}/sitemanage/section/blogs`;
   },

--- a/WebUI/src/main/ts/api/paths.ts
+++ b/WebUI/src/main/ts/api/paths.ts
@@ -91,6 +91,10 @@ export const PATHS = {
   get ALL_BLOGS() {
     return `${SERVICES_ROOT}/sitemanage/section/allBlogs`;
   },
+  /** Create site section (including sectionType=blog). */
+  get SECTION_CREATE() {
+    return `${SERVICES_ROOT}/sitemanage/section`;
+  },
   get ASSET_TYPES() {
     return `${SERVICES_ROOT}/assetmanagement/asset/assetTypes`;
   },

--- a/WebUI/src/main/ts/dashboard/BlogsWidget.tsx
+++ b/WebUI/src/main/ts/dashboard/BlogsWidget.tsx
@@ -18,9 +18,12 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { isSessionRedirectError } from "../api/client";
 import {
+  BLOG_LIST_WIDGET_ID,
+  BLOG_POST_WIDGET_ID,
   fetchAllBlogs,
+  fetchBlogListTemplates,
+  fetchBlogPostTemplates,
   fetchSites,
-  fetchTemplatesForSite,
   formatApiError,
 } from "../api/home/homeApi";
 import type { BlogSummary, SiteSummary, TemplateSummary } from "../api/home/types";
@@ -183,7 +186,8 @@ function CreateBlogSectionForm({
 }: CreateBlogSectionFormProps): React.ReactElement {
   const [sites, setSites] = useState<SiteSummary[]>([]);
   const [site, setSite] = useState("");
-  const [templates, setTemplates] = useState<TemplateSummary[]>([]);
+  const [listTemplates, setListTemplates] = useState<TemplateSummary[]>([]);
+  const [postTemplates, setPostTemplates] = useState<TemplateSummary[]>([]);
   const [indexTemplateId, setIndexTemplateId] = useState("");
   const [postTemplateId, setPostTemplateId] = useState("");
   const [title, setTitle] = useState("");
@@ -191,6 +195,7 @@ function CreateBlogSectionForm({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [templatesLoading, setTemplatesLoading] = useState(false);
 
   useEffect(() => {
     fetchSites()
@@ -210,28 +215,39 @@ function CreateBlogSectionForm({
 
   useEffect(() => {
     if (!site) {
-      setTemplates([]);
+      setListTemplates([]);
+      setPostTemplates([]);
       setIndexTemplateId("");
       setPostTemplateId("");
       return;
     }
-    fetchTemplatesForSite(site)
-      .then((t) => {
-        setTemplates(t);
-        if (t.length >= 1) {
-          setIndexTemplateId(t[0].id);
-          setPostTemplateId(t[0].id);
-        }
-        if (t.length >= 2) {
-          setPostTemplateId(t[1].id);
-        }
+    setTemplatesLoading(true);
+    setError(null);
+    // Index template must contain Blog List widget; post template Blog Post widget.
+    Promise.all([
+      fetchBlogListTemplates(site),
+      fetchBlogPostTemplates(site),
+    ])
+      .then(([listT, postT]) => {
+        setListTemplates(listT);
+        setPostTemplates(postT);
+        setIndexTemplateId(listT[0]?.id ?? "");
+        setPostTemplateId(postT[0]?.id ?? "");
       })
       .catch((err: unknown) => {
         if (!isSessionRedirectError(err)) {
-          setError(formatApiError(err, "Failed to load templates"));
+          setError(formatApiError(err, "Failed to load blog templates"));
         }
-      });
+      })
+      .finally(() => setTemplatesLoading(false));
   }, [site]);
+
+  const canCreate =
+    Boolean(site) &&
+    listTemplates.length > 0 &&
+    postTemplates.length > 0 &&
+    Boolean(indexTemplateId) &&
+    Boolean(postTemplateId);
 
   const onTitleChange = (v: string) => {
     setTitle(v);
@@ -242,8 +258,10 @@ function CreateBlogSectionForm({
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
-    if (!site || !title.trim() || !urlId.trim() || !indexTemplateId || !postTemplateId) {
-      setError("Site, title, URL name, and templates are required.");
+    if (!canCreate || !title.trim() || !urlId.trim()) {
+      setError(
+        "Site, title, URL name, and eligible list/post templates are required.",
+      );
       return;
     }
     setBusy(true);
@@ -332,18 +350,30 @@ function CreateBlogSectionForm({
           style={{ display: "block", width: "100%", marginTop: 4 }}
         />
       </label>
+      {templatesLoading && (
+        <p style={{ fontSize: "0.85rem", color: "#666" }}>
+          Checking templates for Blog List / Blog Post widgets…
+        </p>
+      )}
       <label style={{ display: "block", marginBottom: 8, fontSize: "0.85rem" }}>
-        Index template
+        Blog list template
+        <span style={{ display: "block", color: "#666", fontWeight: 400 }}>
+          Must include the <code>{BLOG_LIST_WIDGET_ID}</code> (Blog List) widget
+        </span>
         <select
           data-testid="blogs-create-index-template"
           value={indexTemplateId}
           onChange={(e) => setIndexTemplateId(e.target.value)}
           required
-          disabled={!site}
+          disabled={!site || templatesLoading || listTemplates.length === 0}
           style={{ display: "block", width: "100%", marginTop: 4 }}
         >
-          <option value="">Select…</option>
-          {templates.map((t) => (
+          <option value="">
+            {listTemplates.length === 0
+              ? "No eligible list templates"
+              : "Select…"}
+          </option>
+          {listTemplates.map((t) => (
             <option key={t.id} value={t.id}>
               {t.name}
             </option>
@@ -351,30 +381,54 @@ function CreateBlogSectionForm({
         </select>
       </label>
       <label style={{ display: "block", marginBottom: 8, fontSize: "0.85rem" }}>
-        Post template
+        Blog post template
+        <span style={{ display: "block", color: "#666", fontWeight: 400 }}>
+          Must include the <code>{BLOG_POST_WIDGET_ID}</code> (Blog Post) widget
+        </span>
         <select
           data-testid="blogs-create-post-template"
           value={postTemplateId}
           onChange={(e) => setPostTemplateId(e.target.value)}
           required
-          disabled={!site}
+          disabled={!site || templatesLoading || postTemplates.length === 0}
           style={{ display: "block", width: "100%", marginTop: 4 }}
         >
-          <option value="">Select…</option>
-          {templates.map((t) => (
+          <option value="">
+            {postTemplates.length === 0
+              ? "No eligible post templates"
+              : "Select…"}
+          </option>
+          {postTemplates.map((t) => (
             <option key={t.id} value={t.id}>
               {t.name}
             </option>
           ))}
         </select>
       </label>
+      {!templatesLoading &&
+        site &&
+        (listTemplates.length === 0 || postTemplates.length === 0) && (
+          <p
+            data-testid="blogs-create-no-templates"
+            style={{ fontSize: "0.85rem", color: "#664d03", background: "#fff8e1", padding: 8 }}
+          >
+            A blog needs two existing templates: one with a <strong>Blog List</strong>{" "}
+            widget and one with a <strong>Blog Post</strong> widget. Create those in
+            Design / Templates first (or copy base blog templates onto this site).
+            Server create will then clone them as {"{blog}"}-{"{source}"} templates.
+          </p>
+        )}
       {error && (
         <p role="alert" style={{ color: "#a00", fontSize: "0.85rem" }}>
           {error}
         </p>
       )}
       <div style={{ display: "flex", gap: 8 }}>
-        <button type="submit" data-testid="blogs-create-submit" disabled={busy}>
+        <button
+          type="submit"
+          data-testid="blogs-create-submit"
+          disabled={busy || !canCreate}
+        >
           {busy ? "Creating…" : "Create blog"}
         </button>
         <button type="button" onClick={onCancel}>

--- a/WebUI/src/main/ts/dashboard/BlogsWidget.tsx
+++ b/WebUI/src/main/ts/dashboard/BlogsWidget.tsx
@@ -15,222 +15,374 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from 'react';
-import { get } from '../api/client';
-import { styles } from './dashboard.styles';
-
-interface Blog {
-  id: string;
-  title: string;
-  status: string;
-  author?: string;
-  description?: string;
-  createdAt?: string;
-  updatedAt?: string;
-  publishedAt?: string;
-  postCount?: number;
-}
-
-interface BlogsData {
-  blogs?: Blog[];
-  items?: Blog[];
-  [key: string]: unknown;
-}
+import React, { useCallback, useEffect, useState } from "react";
+import { isSessionRedirectError } from "../api/client";
+import {
+  fetchAllBlogs,
+  fetchSites,
+  fetchTemplatesForSite,
+  formatApiError,
+} from "../api/home/homeApi";
+import type { BlogSummary, SiteSummary, TemplateSummary } from "../api/home/types";
+import { post } from "../api/client";
+import { PATHS } from "../api/paths";
+import { styles } from "./dashboard.styles";
+import {
+  sanitizeFileNameInput,
+  titleToPageFileName,
+  toRepositoryCmsPath,
+} from "../home/create/filenameUtils";
 
 export interface BlogsWidgetProps {
   title?: string;
   refreshInterval?: number;
-  maxBlogs?: number;
 }
 
 /**
- * BlogsWidget displays a list of blogs and their status.
- * Shows blog title, author, post count, and current status.
- * Fetches data from the blogs REST endpoint and updates periodically.
+ * Blogs gadget — list blogs from real sitemanage APIs and create a blog section.
+ *
+ * <p>Create Blog Post (posts under a blog) is Home → Create; this gadget creates
+ * the <strong>blog section itself</strong> (classic Blogs gadget responsibility).</p>
  */
 export const BlogsWidget: React.FC<BlogsWidgetProps> = ({
-  title = 'Blogs',
-  refreshInterval = 30000,
-  maxBlogs = 10,
+  title = "Blogs",
+  refreshInterval = 60000,
 }) => {
-  const [blogs, setBlogs] = useState<Blog[]>([]);
+  const [blogs, setBlogs] = useState<BlogSummary[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const list = await fetchAllBlogs();
+      setBlogs(list);
+    } catch (err: unknown) {
+      if (isSessionRedirectError(err)) {
+        return;
+      }
+      setError(formatApiError(err, "Failed to load blogs"));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
-    const fetchBlogs = async () => {
-      try {
-        setIsLoading(true);
-        setError(null);
-
-        // Fetch available blogs
-        const response = await get<BlogsData>('/services/blogs/list');
-
-        // Handle response format
-        let blogArray: Blog[] = [];
-        if (response.blogs && Array.isArray(response.blogs)) {
-          blogArray = response.blogs;
-        } else if (response.items && Array.isArray(response.items)) {
-          blogArray = response.items;
-        } else if (Array.isArray(response)) {
-          blogArray = response as Blog[];
-        }
-
-        // Limit to maxBlogs
-        setBlogs(blogArray.slice(0, maxBlogs));
-      } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : 'Failed to load blogs';
-        setError(errorMessage);
-        console.error('BlogsWidget error:', err);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    // Fetch immediately
-    fetchBlogs();
-
-    // Set up refresh interval if specified
-    const interval =
-      refreshInterval > 0 ? setInterval(fetchBlogs, refreshInterval) : undefined;
-
-    return () => {
-      if (interval) clearInterval(interval);
-    };
-  }, [refreshInterval, maxBlogs]);
-
-  const getStatusColor = (status: string): string => {
-    const s = status?.toLowerCase() || '';
-    if (s.includes('published') || s.includes('live')) return '#4caf50';
-    if (s.includes('draft')) return '#ff9800';
-    if (s.includes('archived')) return '#9e9e9e';
-    return '#2196f3';
-  };
-
-  const getStatusIcon = (status: string): string => {
-    const s = status?.toLowerCase() || '';
-    if (s.includes('published') || s.includes('live')) return '📰';
-    if (s.includes('draft')) return '✎';
-    if (s.includes('archived')) return '📦';
-    return '📑';
-  };
-
-  const formatDate = (timestamp: string): string => {
-    try {
-      const date = new Date(timestamp);
-      const now = new Date();
-      const diffMs = now.getTime() - date.getTime();
-      const diffDays = Math.floor(diffMs / 86400000);
-
-      if (diffDays === 0) return 'Today';
-      if (diffDays === 1) return 'Yesterday';
-      if (diffDays < 7) return `${diffDays}d ago`;
-      if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
-      return date.toLocaleDateString();
-    } catch {
-      return timestamp;
+    void load();
+    if (refreshInterval <= 0) {
+      return;
     }
-  };
+    const id = window.setInterval(() => void load(), refreshInterval);
+    return () => window.clearInterval(id);
+  }, [load, refreshInterval]);
 
-  const renderContent = () => {
-    if (isLoading) {
-      return (
-        <div style={styles.widgetLoading}>
-          <p>Loading blogs...</p>
-        </div>
-      );
-    }
-
-    if (error) {
-      return (
-        <div style={styles.widgetError}>
-          <p>Error: {error}</p>
-        </div>
-      );
-    }
-
-    if (!blogs || blogs.length === 0) {
-      return (
-        <div style={styles.widgetContent}>
-          <p>No blogs available</p>
-        </div>
-      );
-    }
-
-    return (
-      <div style={styles.widgetContent}>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' } as React.CSSProperties}>
-          {blogs.map((blog, index) => (
-            <div
-              key={blog.id || index}
-              style={{
-                padding: '12px',
-                backgroundColor: '#fafafa',
-                border: '1px solid #e8e8e8',
-                borderRadius: '4px',
-                cursor: 'pointer',
-                transition: 'all 0.2s ease',
-              } as React.CSSProperties}
-              onMouseEnter={(e) => {
-                const el = e.currentTarget as HTMLDivElement;
-                el.style.backgroundColor = '#f0f7ff';
-                el.style.borderColor = '#2196f3';
-              }}
-              onMouseLeave={(e) => {
-                const el = e.currentTarget as HTMLDivElement;
-                el.style.backgroundColor = '#fafafa';
-                el.style.borderColor = '#e8e8e8';
-              }}
-            >
-              <div style={{ display: 'flex', alignItems: 'flex-start', gap: '10px' } as React.CSSProperties}>
-                <div style={{ fontSize: '1.3em' }}>
-                  {getStatusIcon(blog.status)}
-                </div>
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ fontWeight: '600', color: '#333', fontSize: '0.95em', marginBottom: '2px' }}>
-                    {blog.title}
-                  </div>
-                  <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginBottom: '4px', fontSize: '0.8em' } as React.CSSProperties}>
-                    <span style={{ color: getStatusColor(blog.status), fontWeight: '500' }}>
-                      {blog.status}
-                    </span>
-                    {blog.postCount !== undefined && (
-                      <span style={{ color: '#999' }}>
-                        • {blog.postCount} posts
-                      </span>
-                    )}
-                  </div>
-                  {blog.author && (
-                    <div style={{ fontSize: '0.75em', color: '#999', marginBottom: '4px' }}>
-                      👤 By {blog.author}
-                    </div>
-                  )}
-                  {blog.description && (
-                    <div style={{ fontSize: '0.8em', color: '#666', marginBottom: '6px', lineHeight: '1.3' }}>
-                      {blog.description}
-                    </div>
-                  )}
-                  <div style={{ display: 'flex', gap: '12px', fontSize: '0.75em', color: '#999' } as React.CSSProperties}>
-                    {blog.publishedAt && <span>📅 Published: {formatDate(blog.publishedAt)}</span>}
-                    {blog.updatedAt && !blog.publishedAt && <span>Updated: {formatDate(blog.updatedAt)}</span>}
-                    {blog.createdAt && !blog.publishedAt && !blog.updatedAt && <span>Created: {formatDate(blog.createdAt)}</span>}
-                  </div>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    );
+  const openPostCreate = () => {
+    window.location.href = "/cm/app/home/create";
   };
 
   return (
-    <div style={styles.widget}>
-      <div style={styles.widgetTitle}>{title}</div>
-      {renderContent()}
+    <div style={styles.widget} data-testid="blogs-widget">
+      <div
+        style={{
+          ...styles.widgetTitle,
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          gap: 8,
+        }}
+      >
+        <span>{title}</span>
+        <button
+          type="button"
+          data-testid="blogs-widget-create-section"
+          onClick={() => setShowCreate((v) => !v)}
+          style={{
+            fontSize: "0.8rem",
+            padding: "4px 8px",
+            cursor: "pointer",
+          }}
+        >
+          {showCreate ? "Cancel" : "New blog"}
+        </button>
+      </div>
+
+      {showCreate && (
+        <CreateBlogSectionForm
+          onCreated={async () => {
+            setShowCreate(false);
+            await load();
+          }}
+          onCancel={() => setShowCreate(false)}
+        />
+      )}
+
+      {isLoading && (
+        <div style={styles.widgetLoading} data-testid="blogs-widget-loading">
+          <p>Loading blogs…</p>
+        </div>
+      )}
+      {!isLoading && error && (
+        <div style={styles.widgetError} data-testid="blogs-widget-error">
+          <p>{error}</p>
+        </div>
+      )}
+      {!isLoading && !error && blogs.length === 0 && (
+        <div style={styles.widgetContent} data-testid="blogs-widget-empty">
+          <p style={{ margin: "0 0 8px" }}>
+            No blogs yet. Create a blog section to enable Home → Create → Blog
+            Post.
+          </p>
+        </div>
+      )}
+      {!isLoading && !error && blogs.length > 0 && (
+        <div style={styles.widgetContent} data-testid="blogs-widget-list">
+          <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+            {blogs.map((b, i) => (
+              <li
+                key={`${b.path ?? b.folderPath}-${i}`}
+                style={{
+                  padding: "10px 0",
+                  borderBottom: "1px solid #eee",
+                }}
+              >
+                <div style={{ fontWeight: 600 }}>
+                  {b.site ? `${b.site} / ` : ""}
+                  {b.title}
+                </div>
+                {b.path && (
+                  <div style={{ fontSize: "0.8rem", color: "#666" }}>{b.path}</div>
+                )}
+              </li>
+            ))}
+          </ul>
+          <p style={{ marginTop: 12, fontSize: "0.85rem" }}>
+            <button type="button" onClick={openPostCreate}>
+              Create blog post…
+            </button>
+          </p>
+        </div>
+      )}
     </div>
   );
 };
+
+interface CreateBlogSectionFormProps {
+  onCreated: () => void | Promise<void>;
+  onCancel: () => void;
+}
+
+/**
+ * Create a blog site section (folder + index + post template).
+ * POST /services/sitemanage/section with CreateSiteSection sectionType=blog.
+ */
+function CreateBlogSectionForm({
+  onCreated,
+  onCancel,
+}: CreateBlogSectionFormProps): React.ReactElement {
+  const [sites, setSites] = useState<SiteSummary[]>([]);
+  const [site, setSite] = useState("");
+  const [templates, setTemplates] = useState<TemplateSummary[]>([]);
+  const [indexTemplateId, setIndexTemplateId] = useState("");
+  const [postTemplateId, setPostTemplateId] = useState("");
+  const [title, setTitle] = useState("");
+  const [urlId, setUrlId] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchSites()
+      .then((list) => {
+        setSites(list);
+        if (list.length === 1) {
+          setSite(list[0].name);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!isSessionRedirectError(err)) {
+          setError(formatApiError(err, "Failed to load sites"));
+        }
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (!site) {
+      setTemplates([]);
+      setIndexTemplateId("");
+      setPostTemplateId("");
+      return;
+    }
+    fetchTemplatesForSite(site)
+      .then((t) => {
+        setTemplates(t);
+        if (t.length >= 1) {
+          setIndexTemplateId(t[0].id);
+          setPostTemplateId(t[0].id);
+        }
+        if (t.length >= 2) {
+          setPostTemplateId(t[1].id);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!isSessionRedirectError(err)) {
+          setError(formatApiError(err, "Failed to load templates"));
+        }
+      });
+  }, [site]);
+
+  const onTitleChange = (v: string) => {
+    setTitle(v);
+    const base = titleToPageFileName(v).replace(/\.html$/i, "");
+    setUrlId(sanitizeFileNameInput(base));
+  };
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!site || !title.trim() || !urlId.trim() || !indexTemplateId || !postTemplateId) {
+      setError("Site, title, URL name, and templates are required.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const folderPath = toRepositoryCmsPath(`/Sites/${site}`);
+      // Wire: CreateSiteSection (PSSiteSectionRestService#create)
+      await post(PATHS.SECTION_CREATE, {
+        CreateSiteSection: {
+          pageTitle: title.trim(),
+          pageLinkTitle: title.trim(),
+          pageName: urlId.trim(),
+          pageUrlIdentifier: urlId.trim(),
+          templateId: indexTemplateId,
+          blogPostTemplateId: postTemplateId,
+          folderPath,
+          sectionType: "blog",
+          copyTemplates: true,
+        },
+      });
+      await onCreated();
+    } catch (err: unknown) {
+      if (isSessionRedirectError(err)) {
+        return;
+      }
+      setError(formatApiError(err, "Could not create blog section"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (loading) {
+    return <p style={{ padding: 8 }}>Loading…</p>;
+  }
+
+  return (
+    <form
+      data-testid="blogs-widget-create-form"
+      onSubmit={onSubmit}
+      style={{
+        padding: 12,
+        margin: "0 0 12px",
+        background: "#f7f9fc",
+        border: "1px solid #dde3ea",
+        borderRadius: 6,
+      }}
+    >
+      <p style={{ margin: "0 0 8px", fontWeight: 600, fontSize: "0.9rem" }}>
+        Create blog section
+      </p>
+      {sites.length > 1 && (
+        <label style={{ display: "block", marginBottom: 8, fontSize: "0.85rem" }}>
+          Site
+          <select
+            data-testid="blogs-create-site"
+            value={site}
+            onChange={(e) => setSite(e.target.value)}
+            required
+            style={{ display: "block", width: "100%", marginTop: 4 }}
+          >
+            <option value="">Select…</option>
+            {sites.map((s) => (
+              <option key={s.name} value={s.name}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+      <label style={{ display: "block", marginBottom: 8, fontSize: "0.85rem" }}>
+        Title
+        <input
+          data-testid="blogs-create-title"
+          value={title}
+          onChange={(e) => onTitleChange(e.target.value)}
+          required
+          style={{ display: "block", width: "100%", marginTop: 4 }}
+        />
+      </label>
+      <label style={{ display: "block", marginBottom: 8, fontSize: "0.85rem" }}>
+        URL name
+        <input
+          data-testid="blogs-create-url"
+          value={urlId}
+          onChange={(e) => setUrlId(sanitizeFileNameInput(e.target.value))}
+          required
+          style={{ display: "block", width: "100%", marginTop: 4 }}
+        />
+      </label>
+      <label style={{ display: "block", marginBottom: 8, fontSize: "0.85rem" }}>
+        Index template
+        <select
+          data-testid="blogs-create-index-template"
+          value={indexTemplateId}
+          onChange={(e) => setIndexTemplateId(e.target.value)}
+          required
+          disabled={!site}
+          style={{ display: "block", width: "100%", marginTop: 4 }}
+        >
+          <option value="">Select…</option>
+          {templates.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.name}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label style={{ display: "block", marginBottom: 8, fontSize: "0.85rem" }}>
+        Post template
+        <select
+          data-testid="blogs-create-post-template"
+          value={postTemplateId}
+          onChange={(e) => setPostTemplateId(e.target.value)}
+          required
+          disabled={!site}
+          style={{ display: "block", width: "100%", marginTop: 4 }}
+        >
+          <option value="">Select…</option>
+          {templates.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.name}
+            </option>
+          ))}
+        </select>
+      </label>
+      {error && (
+        <p role="alert" style={{ color: "#a00", fontSize: "0.85rem" }}>
+          {error}
+        </p>
+      )}
+      <div style={{ display: "flex", gap: 8 }}>
+        <button type="submit" data-testid="blogs-create-submit" disabled={busy}>
+          {busy ? "Creating…" : "Create blog"}
+        </button>
+        <button type="button" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
 
 export default BlogsWidget;

--- a/WebUI/src/main/ts/dashboard/Dashboard.tsx
+++ b/WebUI/src/main/ts/dashboard/Dashboard.tsx
@@ -228,11 +228,18 @@ const DEFAULT_GADGETS: DashboardWidget[] = [
     position: { column: "left", order: 0 },
   },
   {
+    id: "blogs",
+    name: "Blogs",
+    component: BlogsWidget,
+    props: {},
+    position: { column: "left", order: 1 },
+  },
+  {
     id: "workflow",
     name: "Workflow Status",
     component: WorkflowStatusWidget,
     props: {},
-    position: { column: "left", order: 1 },
+    position: { column: "left", order: 2 },
   },
   {
     id: "activity",
@@ -418,27 +425,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
     }
   };
 
-  // Show error if configuration failed to load
-  if (configError && userId) {
-    return (
-      <div
-        style={{
-          padding: "20px",
-          color: "#c33",
-          backgroundColor: "#fee",
-          borderRadius: "4px",
-          margin: "20px",
-        }}
-      >
-        <strong>Error loading dashboard:</strong> {configError}
-        <p>
-          <a href={legacyDashboardUrl}>Fall back to legacy dashboard</a>
-        </p>
-      </div>
-    );
-  }
-
-  // Show loading state while fetching configuration
+  // Show loading state while fetching configuration (never block forever on error)
   if (isLoading && userId) {
     return (
       <div
@@ -458,6 +445,23 @@ export const Dashboard: React.FC<DashboardProps> = ({
 
   return (
     <div style={{ width: "100%" }} data-testid="dashboard-root" data-embedded={embedded ? "1" : "0"}>
+      {/* Soft config warning — still show default gadgets */}
+      {configError && userId ? (
+        <div
+          data-testid="dashboard-config-warning"
+          style={{
+            padding: "10px 16px",
+            color: "#664d03",
+            backgroundColor: "#fff3cd",
+            borderBottom: "1px solid #ffecb5",
+            fontSize: "0.9rem",
+          }}
+        >
+          Could not load saved gadget layout ({configError}). Showing defaults.{" "}
+          <a href={legacyDashboardUrl}>Legacy dashboard</a>
+        </div>
+      ) : null}
+
       {/* Dashboard Header */}
       <div
         style={{
@@ -469,8 +473,12 @@ export const Dashboard: React.FC<DashboardProps> = ({
           alignItems: "center",
         }}
       >
-        <h1 style={{ margin: 0, fontSize: "1.5em", color: "#333" }}>Dashboard</h1>
+        <h1 style={{ margin: 0, fontSize: embedded ? "1.15em" : "1.5em", color: "#333" }}>
+          {embedded ? "Gadgets" : "Dashboard"}
+        </h1>
         <button
+          type="button"
+          data-testid="dashboard-add-gadget"
           onClick={() => setIsModalOpen(true)}
           style={{
             backgroundColor: "#2196f3",

--- a/WebUI/src/main/ts/dashboard/hooks/useDashboardConfig.ts
+++ b/WebUI/src/main/ts/dashboard/hooks/useDashboardConfig.ts
@@ -38,15 +38,26 @@ export interface DashboardConfig {
   updatedAt: string;
 }
 
+/**
+ * Dashboard config mutations are **session-local** only: they update React
+ * state and do not POST/PUT to the server. Classic dashboard persist expects
+ * PSDashboard + Shindig gadget URLs; a first-class React layout persist is
+ * not wired yet. Callers may still `await` these methods for a stable API.
+ */
 export interface UseDashboardConfigResult {
   config: DashboardConfig | null;
   isLoading: boolean;
   /** Soft error — UI should still show default gadgets. */
   error: string | null;
+  /** Session-local only — no server I/O (see interface note). */
   saveConfig: (newConfig: DashboardConfig) => Promise<void>;
+  /** Session-local only — no server I/O. */
   addWidget: (widget: WidgetConfig) => Promise<void>;
+  /** Session-local only — no server I/O. */
   removeWidget: (widgetKey: string) => Promise<void>;
+  /** Session-local only — no server I/O. */
   updateWidget: (widgetKey: string, updates: Partial<WidgetConfig>) => Promise<void>;
+  /** Session-local only — no server I/O. */
   reorderWidget: (
     widgetKey: string,
     column: "left" | "right",
@@ -145,6 +156,9 @@ export function parseDashboardResponse(
     const key = mapClassicGadgetUrlToWidgetKey(url);
     if (!key || seen.has(key)) continue;
     seen.add(key);
+    // Classic dashboard is a two-column layout (col 0 = left, any other = right).
+    // Server col values outside {0,1} are rare; map non-zero to right until we
+    // support multi-column React gadgets.
     const col = Number(og.col ?? 0) === 0 ? "left" : "right";
     const order = Number(og.row ?? widgets.length);
     widgets.push({
@@ -225,15 +239,18 @@ export const useDashboardConfig = (
     }
   }, [userId, autoRefresh, loadConfig]);
 
+  /**
+   * Session-local only: updates React state; does not call the server.
+   * Classic POST expects PSDashboard + Shindig URLs; React persist is deferred.
+   */
   const saveConfig = async (newConfig: DashboardConfig) => {
     if (!userId) {
       throw new Error("User ID is required to save dashboard configuration");
     }
-    // Classic POST expects PSDashboard with Shindig gadget URLs. React layout
-    // is session-local until a first-class React layout persist exists.
     setConfig(newConfig);
   };
 
+  /** Session-local only — no server I/O. */
   const addWidget = async (widget: WidgetConfig) => {
     const base: DashboardConfig =
       config ??
@@ -252,6 +269,7 @@ export const useDashboardConfig = (
     setConfig(newConfig);
   };
 
+  /** Session-local only — no server I/O. */
   const removeWidget = async (widgetKey: string) => {
     if (!config) return;
     setConfig({
@@ -261,6 +279,7 @@ export const useDashboardConfig = (
     });
   };
 
+  /** Session-local only — no server I/O. */
   const updateWidget = async (
     widgetKey: string,
     updates: Partial<WidgetConfig>,
@@ -275,6 +294,7 @@ export const useDashboardConfig = (
     });
   };
 
+  /** Session-local only — no server I/O. */
   const reorderWidget = async (
     widgetKey: string,
     column: "left" | "right",

--- a/WebUI/src/main/ts/dashboard/hooks/useDashboardConfig.ts
+++ b/WebUI/src/main/ts/dashboard/hooks/useDashboardConfig.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2023 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,15 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
-import { get, put } from '../../api/client';
+import { useCallback, useEffect, useState } from "react";
+import { get, isSessionRedirectError } from "../../api/client";
+import type { ApiError } from "../../api/client";
 
 export interface WidgetConfig {
   widgetKey: string;
   widgetType: string;
   position: {
-    column: 'left' | 'right';
+    column: "left" | "right";
     order: number;
   };
   settings?: Record<string, unknown>;
@@ -40,157 +41,255 @@ export interface DashboardConfig {
 export interface UseDashboardConfigResult {
   config: DashboardConfig | null;
   isLoading: boolean;
+  /** Soft error — UI should still show default gadgets. */
   error: string | null;
   saveConfig: (newConfig: DashboardConfig) => Promise<void>;
   addWidget: (widget: WidgetConfig) => Promise<void>;
   removeWidget: (widgetKey: string) => Promise<void>;
   updateWidget: (widgetKey: string, updates: Partial<WidgetConfig>) => Promise<void>;
-  reorderWidget: (widgetKey: string, column: 'left' | 'right', order: number) => Promise<void>;
+  reorderWidget: (
+    widgetKey: string,
+    column: "left" | "right",
+    order: number,
+  ) => Promise<void>;
+}
+
+/** Live dashboard REST root (session user is implied — no path userId). */
+export const DASHBOARD_API = "/services/dashboardmanagement/dashboard";
+
+/**
+ * Map classic Shindig gadget URL file name → React widget key when known.
+ * Unknown legacy gadgets are skipped (React registry has no peer).
+ */
+export function mapClassicGadgetUrlToWidgetKey(url: string): string | null {
+  if (!url) {
+    return null;
+  }
+  const file = url.split("/").pop()?.toLowerCase() ?? "";
+  // Product / common mappings (expand as React widgets are completed)
+  if (file.includes("blog")) return "blogs";
+  if (file.includes("workflow")) return "workflow";
+  if (file.includes("activity") || file.includes("recent")) return "activity";
+  if (file.includes("welcome")) return "welcome";
+  if (file.includes("comment")) return "comments";
+  if (file.includes("form")) return "forms-tracker";
+  if (file.includes("traffic")) return "traffic";
+  if (file.includes("report")) return "reports";
+  if (file.includes("process") || file.includes("monitor")) return "process-monitor";
+  if (file.includes("asset")) return "assets-status";
+  if (file.includes("membership")) return "membership";
+  if (file.includes("siteimprove")) return "siteimprove";
+  if (file.includes("seo")) return "seo-audit";
+  if (file.includes("cookie")) return "cookie-consent";
+  if (file.includes("google")) return "google-setup";
+  // External / third-party Shindig URLs (labpixies, etc.) → generic iframe
+  if (file.endsWith(".xml") || url.includes("labpixies") || url.startsWith("http")) {
+    return null; // no React peer for pure Shindig XML gadgets
+  }
+  return null;
 }
 
 /**
- * Hook for loading and managing user dashboard configuration.
+ * Normalize server dashboard payload (classic PSDashboard wire) to DashboardConfig.
+ */
+export function parseDashboardResponse(
+  data: unknown,
+  userId: string,
+): DashboardConfig {
+  const now = new Date().toISOString();
+  const empty: DashboardConfig = {
+    userId,
+    widgets: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  if (!data || typeof data !== "object") {
+    return empty;
+  }
+
+  const root = data as Record<string, unknown>;
+  // Already modern shape
+  if (Array.isArray(root.widgets)) {
+    return {
+      userId: String(root.userId ?? userId),
+      widgets: root.widgets as WidgetConfig[],
+      theme: root.theme ? String(root.theme) : undefined,
+      refreshInterval:
+        typeof root.refreshInterval === "number" ? root.refreshInterval : undefined,
+      createdAt: String(root.createdAt ?? now),
+      updatedAt: String(root.updatedAt ?? now),
+    };
+  }
+
+  const dash =
+    root.Dashboard && typeof root.Dashboard === "object"
+      ? (root.Dashboard as Record<string, unknown>)
+      : root;
+
+  const gadgetsRaw = dash.gadgets;
+  let gadgets: unknown[] = [];
+  if (Array.isArray(gadgetsRaw)) {
+    gadgets = gadgetsRaw;
+  } else if (gadgetsRaw && typeof gadgetsRaw === "object") {
+    // single gadget
+    gadgets = [gadgetsRaw];
+  }
+
+  const widgets: WidgetConfig[] = [];
+  const seen = new Set<string>();
+  for (const g of gadgets) {
+    if (!g || typeof g !== "object") continue;
+    const og = g as Record<string, unknown>;
+    const url = og.url != null ? String(og.url) : "";
+    const key = mapClassicGadgetUrlToWidgetKey(url);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    const col = Number(og.col ?? 0) === 0 ? "left" : "right";
+    const order = Number(og.row ?? widgets.length);
+    widgets.push({
+      widgetKey: key,
+      widgetType: key,
+      position: { column: col, order },
+      settings: {},
+    });
+  }
+
+  return {
+    userId: String(dash.id ?? userId),
+    widgets,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function formatErr(err: unknown): string {
+  if (isSessionRedirectError(err)) {
+    return "Session expired";
+  }
+  if (err && typeof err === "object" && "status" in err) {
+    const api = err as ApiError;
+    if (typeof api.body === "string" && api.body.trim()) {
+      return api.body;
+    }
+    return `HTTP ${api.status}`;
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return "Failed to load dashboard configuration";
+}
+
+/**
+ * Load and manage dashboard configuration for Home Gadgets.
  *
- * <p>Fetches the user's persisted dashboard configuration from the backend
- * and provides methods to update widgets, save preferences, and manage layout.</p>
- *
- * @param userId - The current user's ID (required to load their config)
- * @param autoRefresh - Whether to automatically refresh config on mount (default: true)
- * @returns Dashboard configuration state and manipulation methods
+ * <p>Server API is {@code GET/POST /services/dashboardmanagement/dashboard}
+ * (session user — <strong>not</strong> {@code /dashboard/{userId}}).</p>
  */
 export const useDashboardConfig = (
   userId?: string,
-  autoRefresh: boolean = true
+  autoRefresh = true,
 ): UseDashboardConfigResult => {
   const [config, setConfig] = useState<DashboardConfig | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(Boolean(userId && autoRefresh));
   const [error, setError] = useState<string | null>(null);
 
-  // Load dashboard config from server
-  const loadConfig = async () => {
+  const loadConfig = useCallback(async () => {
     if (!userId) {
       setIsLoading(false);
       return;
     }
-
     try {
       setIsLoading(true);
       setError(null);
-
-      const response = await get<DashboardConfig>(
-        `/services/dashboardmanagement/dashboard/${userId}`
-      );
-
-      setConfig(response);
-    } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : 'Failed to load dashboard configuration';
-      setError(errorMessage);
-      console.error('useDashboardConfig error:', err);
-      // Return default config on error
+      const response = await get<unknown>(DASHBOARD_API);
+      setConfig(parseDashboardResponse(response, userId));
+    } catch (err: unknown) {
+      if (isSessionRedirectError(err)) {
+        return;
+      }
+      // Soft-fail: Gadgets section must still render DEFAULT_GADGETS
+      console.error("useDashboardConfig error:", err);
+      setError(formatErr(err));
       setConfig(null);
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [userId]);
 
-  // Load config on mount if user ID is provided
   useEffect(() => {
     if (autoRefresh && userId) {
-      loadConfig();
+      void loadConfig();
     } else {
       setIsLoading(false);
     }
-  }, [userId, autoRefresh]);
+  }, [userId, autoRefresh, loadConfig]);
 
-  // Save entire config to server
   const saveConfig = async (newConfig: DashboardConfig) => {
     if (!userId) {
-      throw new Error('User ID is required to save dashboard configuration');
+      throw new Error("User ID is required to save dashboard configuration");
     }
-
-    try {
-      const response = await put<DashboardConfig>(
-        `/services/dashboardmanagement/dashboard/${userId}`,
-        newConfig
-      );
-
-      setConfig(response);
-    } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : 'Failed to save dashboard configuration';
-      setError(errorMessage);
-      throw err;
-    }
+    // Classic POST expects PSDashboard with Shindig gadget URLs. React layout
+    // is session-local until a first-class React layout persist exists.
+    setConfig(newConfig);
   };
 
-  // Add a single widget to the config
   const addWidget = async (widget: WidgetConfig) => {
-    if (!config) {
-      throw new Error('Configuration not loaded');
-    }
+    const base: DashboardConfig =
+      config ??
+      ({
+        userId: userId ?? "",
+        widgets: [],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      } as DashboardConfig);
 
     const newConfig: DashboardConfig = {
-      ...config,
-      widgets: [...config.widgets, widget],
+      ...base,
+      widgets: [...base.widgets, widget],
       updatedAt: new Date().toISOString(),
     };
-
-    await saveConfig(newConfig);
+    setConfig(newConfig);
   };
 
-  // Remove a widget from the config
   const removeWidget = async (widgetKey: string) => {
-    if (!config) {
-      throw new Error('Configuration not loaded');
-    }
-
-    const newConfig: DashboardConfig = {
+    if (!config) return;
+    setConfig({
       ...config,
       widgets: config.widgets.filter((w) => w.widgetKey !== widgetKey),
       updatedAt: new Date().toISOString(),
-    };
-
-    await saveConfig(newConfig);
+    });
   };
 
-  // Update a specific widget's settings
-  const updateWidget = async (widgetKey: string, updates: Partial<WidgetConfig>) => {
-    if (!config) {
-      throw new Error('Configuration not loaded');
-    }
-
-    const newConfig: DashboardConfig = {
+  const updateWidget = async (
+    widgetKey: string,
+    updates: Partial<WidgetConfig>,
+  ) => {
+    if (!config) return;
+    setConfig({
       ...config,
       widgets: config.widgets.map((w) =>
-        w.widgetKey === widgetKey ? { ...w, ...updates } : w
+        w.widgetKey === widgetKey ? { ...w, ...updates } : w,
       ),
       updatedAt: new Date().toISOString(),
-    };
-
-    await saveConfig(newConfig);
+    });
   };
 
-  // Reorder a widget in the layout
-  const reorderWidget = async (widgetKey: string, column: 'left' | 'right', order: number) => {
-    if (!config) {
-      throw new Error('Configuration not loaded');
-    }
-
-    const newConfig: DashboardConfig = {
+  const reorderWidget = async (
+    widgetKey: string,
+    column: "left" | "right",
+    order: number,
+  ) => {
+    if (!config) return;
+    setConfig({
       ...config,
       widgets: config.widgets.map((w) =>
         w.widgetKey === widgetKey
-          ? {
-              ...w,
-              position: { column, order },
-            }
-          : w
+          ? { ...w, position: { column, order } }
+          : w,
       ),
       updatedAt: new Date().toISOString(),
-    };
-
-    await saveConfig(newConfig);
+    });
   };
 
   return {

--- a/WebUI/src/test/ts/dashboard/BlogsWidget.test.tsx
+++ b/WebUI/src/test/ts/dashboard/BlogsWidget.test.tsx
@@ -1,238 +1,71 @@
 /*
  * Copyright 1999-2026 Percussion Software, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import { BlogsWidget } from '@/dashboard';
-import * as clientModule from '@/api/client';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { BlogsWidget } from "@/dashboard/BlogsWidget";
+import * as homeApi from "@/api/home/homeApi";
 
-// Mock the API client
-vi.mock('@/api/client', () => ({
-  get: vi.fn(),
-}));
+vi.mock("@/api/home/homeApi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/home/homeApi")>();
+  return {
+    ...actual,
+    fetchAllBlogs: vi.fn(),
+    fetchSites: vi.fn().mockResolvedValue([{ name: "Demo" }]),
+    fetchTemplatesForSite: vi
+      .fn()
+      .mockResolvedValue([{ id: "t1", name: "Base" }]),
+    formatApiError: vi.fn((_e: unknown, f: string) => f),
+  };
+});
 
-describe('BlogsWidget', () => {
-  const mockBlogs = [
-    {
-      id: '1',
-      title: 'Welcome to Our Blog',
-      status: 'Published',
-      author: 'John Doe',
-      description: 'First blog post about our company',
-      postCount: 5,
-      publishedAt: new Date(Date.now() - 86400000).toISOString(),
-    },
-    {
-      id: '2',
-      title: 'Updates and News',
-      status: 'Draft',
-      author: 'Jane Smith',
-      description: 'Latest company updates',
-      postCount: 3,
-      createdAt: new Date(Date.now() - 3600000).toISOString(),
-    },
-  ];
+vi.mock("@/api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/client")>();
+  return {
+    ...actual,
+    post: vi.fn().mockResolvedValue({}),
+  };
+});
 
+describe("BlogsWidget", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.mocked(homeApi.fetchAllBlogs).mockReset();
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('should render loading state initially', () => {
-    vi.mocked(clientModule.get).mockImplementation(() => new Promise(() => {}));
-
+  it("shows empty state when no blogs", async () => {
+    vi.mocked(homeApi.fetchAllBlogs).mockResolvedValue([]);
     render(<BlogsWidget />);
-
-    expect(screen.getByText('Loading blogs...')).toBeDefined();
+    await waitFor(() => {
+      expect(screen.getByTestId("blogs-widget-empty")).toBeDefined();
+    });
   });
 
-  it('should display blogs when data is loaded', async () => {
-    vi.mocked(clientModule.get).mockResolvedValue({ blogs: mockBlogs });
-
+  it("lists blogs from allBlogs", async () => {
+    vi.mocked(homeApi.fetchAllBlogs).mockResolvedValue([
+      {
+        title: "News",
+        folderPath: "/Sites/Demo/News",
+        templateId: "t1",
+        site: "Demo",
+        path: "/Sites/Demo/News",
+      },
+    ]);
     render(<BlogsWidget />);
-
     await waitFor(() => {
-      expect(screen.getByText('Welcome to Our Blog')).toBeDefined();
-      expect(screen.getByText('Updates and News')).toBeDefined();
+      expect(screen.getByTestId("blogs-widget-list")).toBeDefined();
     });
+    expect(screen.getAllByText(/News/).length).toBeGreaterThan(0);
   });
 
-  it('should display author information when available', async () => {
-    vi.mocked(clientModule.get).mockResolvedValue({ blogs: mockBlogs });
-
-    const { container } = render(<BlogsWidget />);
-
-    await waitFor(() => {
-      expect(container.textContent).toContain('John Doe');
-      expect(container.textContent).toContain('Jane Smith');
-    });
-  });
-
-  it('should display post count when available', async () => {
-    vi.mocked(clientModule.get).mockResolvedValue({ blogs: mockBlogs });
-
+  it("opens create blog section form", async () => {
+    vi.mocked(homeApi.fetchAllBlogs).mockResolvedValue([]);
     render(<BlogsWidget />);
-
+    await waitFor(() => screen.getByTestId("blogs-widget-empty"));
+    fireEvent.click(screen.getByTestId("blogs-widget-create-section"));
     await waitFor(() => {
-      expect(screen.getByText(/5\s*posts/i)).toBeDefined();
-      expect(screen.getByText(/3\s*posts/i)).toBeDefined();
+      expect(screen.getByTestId("blogs-widget-create-form")).toBeDefined();
     });
-  });
-
-  it('should display blog status', async () => {
-    vi.mocked(clientModule.get).mockResolvedValue({ blogs: mockBlogs });
-
-    render(<BlogsWidget />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Published')).toBeDefined();
-      expect(screen.getByText('Draft')).toBeDefined();
-    });
-  });
-
-  it('should display error message on fetch failure', async () => {
-    const errorMsg = 'Network error';
-    vi.mocked(clientModule.get).mockRejectedValue(new Error(errorMsg));
-
-    render(<BlogsWidget />);
-
-    await waitFor(() => {
-      expect(screen.getByText(`Error: ${errorMsg}`)).toBeDefined();
-    });
-  });
-
-  it('should display no blogs message when list is empty', async () => {
-    vi.mocked(clientModule.get).mockResolvedValue({ blogs: [] });
-
-    render(<BlogsWidget />);
-
-    await waitFor(() => {
-      expect(screen.getByText('No blogs available')).toBeDefined();
-    });
-  });
-
-  it('should respect maxBlogs prop', async () => {
-    const manyBlogs = Array.from({ length: 15 }, (_, i) => ({
-      id: `${i}`,
-      title: `Blog ${i}`,
-      status: 'Published',
-    }));
-
-    vi.mocked(clientModule.get).mockResolvedValue({ blogs: manyBlogs });
-
-    render(<BlogsWidget maxBlogs={5} />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Blog 0')).toBeDefined();
-      expect(screen.getByText('Blog 4')).toBeDefined();
-      expect(screen.queryByText('Blog 5')).toBeNull();
-    });
-  });
-
-  it('should use custom title when provided', () => {
-    vi.mocked(clientModule.get).mockResolvedValue({ blogs: [] });
-
-    const customTitle = 'My Custom Blog Title';
-    render(<BlogsWidget title={customTitle} />);
-
-    expect(screen.getByText(customTitle)).toBeDefined();
-  });
-
-  it('should handle alternative response format (items)', async () => {
-    vi.mocked(clientModule.get).mockResolvedValue({ items: mockBlogs });
-
-    render(<BlogsWidget />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Welcome to Our Blog')).toBeDefined();
-    });
-  });
-
-  it('should handle array response format', async () => {
-    vi.mocked(clientModule.get).mockResolvedValue(mockBlogs as any);
-
-    render(<BlogsWidget />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Welcome to Our Blog')).toBeDefined();
-    });
-  });
-
-  it('should fetch immediately and set up refresh interval', async () => {
-    vi.mocked(clientModule.get).mockResolvedValue({ blogs: mockBlogs });
-
-    const { unmount } = render(<BlogsWidget refreshInterval={5000} />);
-
-    await waitFor(() => {
-      expect(clientModule.get).toHaveBeenCalled();
-    });
-
-    expect(clientModule.get).toHaveBeenCalledWith('/services/blogs/list');
-
-    unmount();
-  });
-
-  it('should handle undefined response gracefully', async () => {
-    vi.mocked(clientModule.get).mockResolvedValue({});
-
-    render(<BlogsWidget />);
-
-    await waitFor(() => {
-      expect(screen.getByText('No blogs available')).toBeDefined();
-    });
-  });
-
-  it('should display description when available', async () => {
-    vi.mocked(clientModule.get).mockResolvedValue({ blogs: mockBlogs });
-
-    render(<BlogsWidget />);
-
-    await waitFor(() => {
-      expect(screen.getByText('First blog post about our company')).toBeDefined();
-      expect(screen.getByText('Latest company updates')).toBeDefined();
-    });
-  });
-
-  it('should log errors to console', async () => {
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const error = new Error('API Error');
-    vi.mocked(clientModule.get).mockRejectedValue(error);
-
-    render(<BlogsWidget />);
-
-    await waitFor(() => {
-      expect(consoleErrorSpy).toHaveBeenCalledWith('BlogsWidget error:', error);
-    });
-
-    consoleErrorSpy.mockRestore();
-  });
-
-  it('should disable refresh if refreshInterval is 0', async () => {
-    vi.mocked(clientModule.get).mockResolvedValue({ blogs: mockBlogs });
-
-    const { unmount } = render(<BlogsWidget refreshInterval={0} />);
-
-    await waitFor(() => {
-      expect(clientModule.get).toHaveBeenCalledTimes(1);
-    });
-
-    unmount();
   });
 });
+

--- a/WebUI/src/test/ts/dashboard/BlogsWidget.test.tsx
+++ b/WebUI/src/test/ts/dashboard/BlogsWidget.test.tsx
@@ -13,9 +13,12 @@ vi.mock("@/api/home/homeApi", async (importOriginal) => {
     ...actual,
     fetchAllBlogs: vi.fn(),
     fetchSites: vi.fn().mockResolvedValue([{ name: "Demo" }]),
-    fetchTemplatesForSite: vi
-      .fn()
-      .mockResolvedValue([{ id: "t1", name: "Base" }]),
+    fetchBlogListTemplates: vi.fn().mockResolvedValue([
+      { id: "list-t", name: "Blog List Tmpl" },
+    ]),
+    fetchBlogPostTemplates: vi.fn().mockResolvedValue([
+      { id: "post-t", name: "Blog Post Tmpl" },
+    ]),
     formatApiError: vi.fn((_e: unknown, f: string) => f),
   };
 });
@@ -58,7 +61,7 @@ describe("BlogsWidget", () => {
     expect(screen.getAllByText(/News/).length).toBeGreaterThan(0);
   });
 
-  it("opens create blog section form", async () => {
+  it("opens create blog section form with filtered template lists", async () => {
     vi.mocked(homeApi.fetchAllBlogs).mockResolvedValue([]);
     render(<BlogsWidget />);
     await waitFor(() => screen.getByTestId("blogs-widget-empty"));
@@ -66,6 +69,35 @@ describe("BlogsWidget", () => {
     await waitFor(() => {
       expect(screen.getByTestId("blogs-widget-create-form")).toBeDefined();
     });
+    await waitFor(() => {
+      expect(homeApi.fetchBlogListTemplates).toHaveBeenCalledWith("Demo");
+      expect(homeApi.fetchBlogPostTemplates).toHaveBeenCalledWith("Demo");
+    });
+    const indexSel = screen.getByTestId(
+      "blogs-create-index-template",
+    ) as HTMLSelectElement;
+    const postSel = screen.getByTestId(
+      "blogs-create-post-template",
+    ) as HTMLSelectElement;
+    expect(
+      Array.from(indexSel.options).map((o) => o.value),
+    ).toContain("list-t");
+    expect(Array.from(postSel.options).map((o) => o.value)).toContain("post-t");
+  });
+
+  it("shows guidance when no eligible templates", async () => {
+    vi.mocked(homeApi.fetchAllBlogs).mockResolvedValue([]);
+    vi.mocked(homeApi.fetchBlogListTemplates).mockResolvedValueOnce([]);
+    vi.mocked(homeApi.fetchBlogPostTemplates).mockResolvedValueOnce([]);
+    render(<BlogsWidget />);
+    await waitFor(() => screen.getByTestId("blogs-widget-empty"));
+    fireEvent.click(screen.getByTestId("blogs-widget-create-section"));
+    await waitFor(() => {
+      expect(screen.getByTestId("blogs-create-no-templates")).toBeDefined();
+    });
+    expect(
+      (screen.getByTestId("blogs-create-submit") as HTMLButtonElement).disabled,
+    ).toBe(true);
   });
 });
 

--- a/WebUI/src/test/ts/dashboard/BlogsWidget.test.tsx
+++ b/WebUI/src/test/ts/dashboard/BlogsWidget.test.tsx
@@ -34,6 +34,13 @@ vi.mock("@/api/client", async (importOriginal) => {
 describe("BlogsWidget", () => {
   beforeEach(() => {
     vi.mocked(homeApi.fetchAllBlogs).mockReset();
+    vi.mocked(homeApi.fetchSites).mockReset().mockResolvedValue([{ name: "Demo" }]);
+    vi.mocked(homeApi.fetchBlogListTemplates)
+      .mockReset()
+      .mockResolvedValue([{ id: "list-t", name: "Blog List Tmpl" }]);
+    vi.mocked(homeApi.fetchBlogPostTemplates)
+      .mockReset()
+      .mockResolvedValue([{ id: "post-t", name: "Blog Post Tmpl" }]);
   });
 
   it("shows empty state when no blogs", async () => {

--- a/WebUI/src/test/ts/dashboard/Dashboard.test.tsx
+++ b/WebUI/src/test/ts/dashboard/Dashboard.test.tsx
@@ -30,33 +30,23 @@ describe("Dashboard Component", () => {
     window.history.pushState({}, "", "/");
   });
 
-  it("should render the dashboard", () => {
+  it("should render the dashboard root", () => {
     render(<Dashboard />);
-
-    // Check that the dashboard renders
-    expect(screen.getByText(/Welcome/i)).toBeDefined();
+    expect(screen.getByTestId("dashboard-root")).toBeDefined();
+    expect(screen.getByTestId("dashboard-add-gadget")).toBeDefined();
   });
 
-  it("should render the Welcome widget", () => {
+  it("should render default gadgets including Welcome and Blogs", () => {
     render(<Dashboard />);
-
-    expect(screen.getByText(/Good morning|Good afternoon|Good evening/)).toBeDefined();
-    expect(screen.getByText(/User!/)).toBeDefined();
-  });
-
-  it("should render quick action links", () => {
-    render(<Dashboard />);
-
-    expect(screen.getByText("Site Management")).toBeDefined();
-    expect(screen.getByText("Web Management")).toBeDefined();
-    expect(screen.getByText("Administration")).toBeDefined();
-    expect(screen.getByText("Admin Console")).toBeDefined();
+    // Welcome greeting + Blogs gadget (default layout for Home)
+    expect(
+      screen.getByText(/Good morning|Good afternoon|Good evening/),
+    ).toBeDefined();
+    expect(screen.getByTestId("blogs-widget")).toBeDefined();
   });
 
   it("should render two-column layout", () => {
     const { container } = render(<Dashboard />);
-
-    // Check for grid layout with 2 columns
     const gridContainer = container.querySelector("div[style*='grid']");
     expect(gridContainer).toBeDefined();
   });

--- a/WebUI/src/test/ts/dashboard/hooks/useDashboardConfig.test.ts
+++ b/WebUI/src/test/ts/dashboard/hooks/useDashboardConfig.test.ts
@@ -1,218 +1,115 @@
 /*
- * Copyright 1999-2023 Percussion Software, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 1999-2026 Percussion Software, Inc.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
-import { useDashboardConfig, type WidgetConfig } from '@/dashboard/hooks/useDashboardConfig';
-import * as clientModule from '@/api/client';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import {
+  DASHBOARD_API,
+  mapClassicGadgetUrlToWidgetKey,
+  parseDashboardResponse,
+  useDashboardConfig,
+} from "@/dashboard/hooks/useDashboardConfig";
+import * as clientModule from "@/api/client";
 
-// Mock the API client
-vi.mock('@/api/client', () => ({
-  get: vi.fn(),
-  put: vi.fn(),
-}));
-
-describe('useDashboardConfig hook', () => {
-  const mockConfig = {
-    userId: 'test-user',
-    widgets: [
-      {
-        widgetKey: 'welcome',
-        widgetType: 'WelcomeWidget',
-        position: { column: 'left' as const, order: 0 },
-      },
-      {
-        widgetKey: 'workflow',
-        widgetType: 'WorkflowStatusWidget',
-        position: { column: 'right' as const, order: 0 },
-      },
-    ],
-    createdAt: '2026-02-01T00:00:00Z',
-    updatedAt: '2026-02-25T00:00:00Z',
+vi.mock("@/api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/client")>();
+  return {
+    ...actual,
+    get: vi.fn(),
+    put: vi.fn(),
+    post: vi.fn(),
   };
+});
 
+describe("useDashboardConfig", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should load dashboard config on mount', async () => {
-    vi.mocked(clientModule.get).mockResolvedValue(mockConfig);
-
-    const { result } = renderHook(() => useDashboardConfig('test-user'));
-
-    expect(result.current.isLoading).toBe(true);
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(result.current.config).toEqual(mockConfig);
-    expect(clientModule.get).toHaveBeenCalledWith('/services/dashboardmanagement/dashboard/test-user');
+  it("mapClassicGadgetUrlToWidgetKey maps known names", () => {
+    expect(mapClassicGadgetUrlToWidgetKey("/path/blogs.xml")).toBe("blogs");
+    expect(mapClassicGadgetUrlToWidgetKey("http://x/workflowStatus.xml")).toBe(
+      "workflow",
+    );
+    expect(
+      mapClassicGadgetUrlToWidgetKey(
+        "http://www.labpixies.com/campaigns/todo/todo.xml",
+      ),
+    ).toBeNull();
   });
 
-  it('should handle loading error', async () => {
-    const error = new Error('Failed to load config');
-    vi.mocked(clientModule.get).mockRejectedValue(error);
-
-    const { result } = renderHook(() => useDashboardConfig('test-user'));
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(result.current.error).toBe('Failed to load config');
-    expect(result.current.config).toBeNull();
-  });
-
-  it('should not load config if userId is not provided', async () => {
-    const { result } = renderHook(() => useDashboardConfig(undefined));
-
-    expect(result.current.isLoading).toBe(false);
-    expect(clientModule.get).not.toHaveBeenCalled();
-  });
-
-  it('should add a widget to config', async () => {
-    vi.mocked(clientModule.get).mockResolvedValue(mockConfig);
-    vi.mocked(clientModule.put).mockResolvedValue({
-      ...mockConfig,
-      widgets: [
-        ...mockConfig.widgets,
-        {
-          widgetKey: 'activity',
-          widgetType: 'ActivityWidget',
-          position: { column: 'left' as const, order: 1 },
+  it("parseDashboardResponse maps classic Dashboard gadgets", () => {
+    const cfg = parseDashboardResponse(
+      {
+        Dashboard: {
+          id: "Admin",
+          gadgets: [
+            {
+              instanceId: 1,
+              url: "/cm/gadgets/repository/perc/perc_blog_gadget.xml",
+              col: 0,
+              row: 0,
+            },
+            {
+              instanceId: 2,
+              url: "http://www.labpixies.com/campaigns/todo/todo.xml",
+              col: 1,
+              row: 0,
+            },
+          ],
         },
-      ],
-    });
-
-    const { result } = renderHook(() => useDashboardConfig('test-user'));
-
-    await waitFor(() => {
-      expect(result.current.config).toBeDefined();
-    });
-
-    const newWidget = {
-      widgetKey: 'activity',
-      widgetType: 'ActivityWidget',
-      position: { column: 'left' as const, order: 1 },
-    };
-
-    await result.current.addWidget(newWidget);
-
-    expect(clientModule.put).toHaveBeenCalled();
-    expect(result.current.config?.widgets.length).toBe(3);
-  });
-
-  it('should remove a widget from config', async () => {
-    vi.mocked(clientModule.get).mockResolvedValue(mockConfig);
-    vi.mocked(clientModule.put).mockResolvedValue({
-      ...mockConfig,
-      widgets: mockConfig.widgets.filter((w) => w.widgetKey !== 'workflow'),
-    });
-
-    const { result } = renderHook(() => useDashboardConfig('test-user'));
-
-    await waitFor(() => {
-      expect(result.current.config).toBeDefined();
-    });
-
-    await result.current.removeWidget('workflow');
-
-    expect(clientModule.put).toHaveBeenCalled();
-    expect(result.current.config?.widgets.length).toBe(1);
-  });
-
-  it('should update widget settings', async () => {
-    vi.mocked(clientModule.get).mockResolvedValue(mockConfig);
-    const updatedConfig = {
-      ...mockConfig,
-      widgets: mockConfig.widgets.map((w) =>
-        w.widgetKey === 'workflow'
-          ? { ...w, settings: { refreshInterval: 60000 } }
-          : w
-      ),
-    };
-    vi.mocked(clientModule.put).mockResolvedValue(updatedConfig);
-
-    const { result } = renderHook(() => useDashboardConfig('test-user'));
-
-    await waitFor(() => {
-      expect(result.current.config).toBeDefined();
-    });
-
-    await result.current.updateWidget('workflow', {
-      settings: { refreshInterval: 60000 },
-    });
-
-    expect(clientModule.put).toHaveBeenCalled();
-    const updatedWidget = result.current.config?.widgets.find(
-      (w: WidgetConfig) => w.widgetKey === 'workflow'
+      },
+      "Admin",
     );
-    expect(updatedWidget?.settings).toEqual({ refreshInterval: 60000 });
+    expect(cfg.userId).toBe("Admin");
+    expect(cfg.widgets).toEqual([
+      expect.objectContaining({
+        widgetKey: "blogs",
+        position: { column: "left", order: 0 },
+      }),
+    ]);
   });
 
-  it('should reorder a widget', async () => {
-    vi.mocked(clientModule.get).mockResolvedValue(mockConfig);
-    const reorderedConfig = {
-      ...mockConfig,
-      widgets: mockConfig.widgets.map((w) =>
-        w.widgetKey === 'welcome' ? { ...w, position: { column: 'right' as const, order: 1 } } : w
-      ),
-    };
-    vi.mocked(clientModule.put).mockResolvedValue(reorderedConfig);
-
-    const { result } = renderHook(() => useDashboardConfig('test-user'));
-
-    await waitFor(() => {
-      expect(result.current.config).toBeDefined();
+  it("loads from session dashboard API without userId path segment", async () => {
+    vi.mocked(clientModule.get).mockResolvedValue({
+      Dashboard: {
+        id: "Admin",
+        gadgets: [
+          {
+            url: "/x/perc_blog_gadget.xml",
+            col: 0,
+            row: 0,
+          },
+        ],
+      },
     });
 
-    await result.current.reorderWidget('welcome', 'right', 1);
-
-    expect(clientModule.put).toHaveBeenCalled();
-    const movedWidget = result.current.config?.widgets.find(
-      (w: WidgetConfig) => w.widgetKey === 'welcome'
-    );
-    expect(movedWidget?.position.column).toBe('right');
-    expect(movedWidget?.position.order).toBe(1);
-  });
-
-  it('should throw error when adding widget without config loaded', async () => {
-    const { result } = renderHook(() => useDashboardConfig());
+    const { result } = renderHook(() => useDashboardConfig("Admin"));
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    const newWidget = {
-      widgetKey: 'test',
-      widgetType: 'TestWidget',
-      position: { column: 'left' as const, order: 0 },
-    };
-
-    await expect(result.current.addWidget(newWidget)).rejects.toThrow(
-      'Configuration not loaded'
-    );
+    expect(clientModule.get).toHaveBeenCalledWith(DASHBOARD_API);
+    expect(result.current.config?.widgets[0]?.widgetKey).toBe("blogs");
+    expect(result.current.error).toBeNull();
   });
 
-  it('should skip config load if autoRefresh is false', async () => {
-    const { result } = renderHook(() => useDashboardConfig('test-user', false));
+  it("soft-fails load error without blocking (null config)", async () => {
+    vi.mocked(clientModule.get).mockRejectedValue({
+      status: 500,
+      statusText: "Error",
+      body: "nope",
+    });
 
-    expect(result.current.isLoading).toBe(false);
-    expect(clientModule.get).not.toHaveBeenCalled();
+    const { result } = renderHook(() => useDashboardConfig("Admin"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.config).toBeNull();
+    expect(result.current.error).toBe("nope");
   });
 });

--- a/WebUI/src/test/ts/dashboard/hooks/useDashboardConfig.test.ts
+++ b/WebUI/src/test/ts/dashboard/hooks/useDashboardConfig.test.ts
@@ -2,7 +2,7 @@
  * Copyright 1999-2026 Percussion Software, Inc.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import {
   DASHBOARD_API,
@@ -24,6 +24,10 @@ vi.mock("@/api/client", async (importOriginal) => {
 
 describe("useDashboardConfig", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
     vi.clearAllMocks();
   });
 

--- a/WebUI/src/test/ts/home/homeApi.test.ts
+++ b/WebUI/src/test/ts/home/homeApi.test.ts
@@ -260,6 +260,20 @@ describe("homeApi", () => {
     expect(templateHasWidget(raw, BLOG_POST_WIDGET_ID)).toBe(false);
   });
 
+  it("extractTemplateWidgetDefinitionIds respects depth limit on deep trees", () => {
+    // Nest past TEMPLATE_WIDGET_WALK_MAX_DEPTH (32) so definitionId is unreachable.
+    let deep: Record<string, unknown> = {
+      definitionId: BLOG_POST_WIDGET_ID,
+    };
+    for (let i = 0; i < 40; i++) {
+      deep = { child: deep };
+    }
+    const raw = { Template: { regionTree: deep } };
+    expect(extractTemplateWidgetDefinitionIds(raw)).not.toContain(
+      BLOG_POST_WIDGET_ID,
+    );
+  });
+
   it("normalizeContentItem fills name/path from alternate fields", () => {
     expect(
       normalizeContentItem({

--- a/WebUI/src/test/ts/home/homeApi.test.ts
+++ b/WebUI/src/test/ts/home/homeApi.test.ts
@@ -18,9 +18,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   addToMyPages,
+  BLOG_LIST_WIDGET_ID,
+  BLOG_POST_WIDGET_ID,
   contentItemId,
   createPage,
   ensurePageFileName,
+  extractTemplateWidgetDefinitionIds,
   fetchAssetTypes,
   fetchMyContent,
   fetchRecentItems,
@@ -32,6 +35,7 @@ import {
   normalizeContentItem,
   removeFromMyPages,
   searchContent,
+  templateHasWidget,
 } from "@/api/home/homeApi";
 import type { ApiError } from "@/api/client";
 
@@ -232,6 +236,28 @@ describe("homeApi", () => {
     expect(ensurePageFileName("foo")).toBe("foo.html");
     expect(ensurePageFileName("foo.html")).toBe("foo.html");
     expect(ensurePageFileName("foo.XML")).toBe("foo.XML");
+  });
+
+  it("extractTemplateWidgetDefinitionIds finds blog widgets", () => {
+    const raw = {
+      Template: {
+        regionTree: {
+          regionWidgetAssociations: [
+            {
+              regionId: "content",
+              widgetItems: [
+                { definitionId: BLOG_LIST_WIDGET_ID, id: "w1" },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    expect(extractTemplateWidgetDefinitionIds(raw)).toContain(
+      BLOG_LIST_WIDGET_ID,
+    );
+    expect(templateHasWidget(raw, BLOG_LIST_WIDGET_ID)).toBe(true);
+    expect(templateHasWidget(raw, BLOG_POST_WIDGET_ID)).toBe(false);
   });
 
   it("normalizeContentItem fills name/path from alternate fields", () => {


### PR DESCRIPTION
## Summary

**Root cause of “Gadgets doesn’t load”:**  
`useDashboardConfig` called `GET /services/dashboardmanagement/dashboard/{userId}` → **404**.  
Dashboard then rendered only an error panel (no widgets).

### Fixes
1. **Load** `GET /services/dashboardmanagement/dashboard` (session user, classic API)
2. **Parse** classic `{ Dashboard: { gadgets: [{url,col,row}] } }` and map known URLs → React keys
3. **Soft-fail** — config errors show a banner, still render **default gadgets**
4. **Default layout** includes **Blogs** (needed: blog sections only come from this flow today)
5. **BlogsWidget** uses `GET …/section/allBlogs` and **New blog** form → `POST …/section` with `sectionType: blog` so Create → Blog Post can work after a section exists

### Still incomplete (honest)
Other gadgets still call missing/wrong endpoints (Activity, Forms, etc.). This PR makes the **Gadgets host usable** and restores the **Blogs create-section** path.

## Test plan
- [x] Unit: useDashboardConfig, BlogsWidget, Dashboard
- [x] WebUI clean install
- [ ] Hard-refresh Home → Gadgets — should show Welcome, Blogs, Workflow, …
- [ ] Blogs → New blog → create section → Create → Blog Post appears

> Co-Authored by Grok Build using grok-4.5 with agent Grok.