### PR TITLE
fix(home): Activity + Pages By Status gadgets (real sitemanage APIs)

### DIFF
--- a/WebUI/src/main/ts/api/dashboard/gadgetApi.ts
+++ b/WebUI/src/main/ts/api/dashboard/gadgetApi.ts
@@ -1,0 +1,298 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Real sitemanage-backed APIs for Home Gadgets widgets.
+ *
+ * <p>Classic Shindig gadgets called these paths via {@code perc_path_constants}.
+ * Invented React paths such as {@code /services/activity/contentactivity?limit=}
+ * and {@code /services/dashboardmanagement/gadget/workflow-status} do not exist.</p>
+ */
+
+import { get, post } from "../client";
+import { PATHS } from "../paths";
+import { fetchSites } from "../home/homeApi";
+
+/** Classic duration types for content activity. */
+export type ActivityDurationType = "days" | "weeks" | "months" | "years";
+
+/** One row from {@code PSContentActivity}. */
+export interface ContentActivityRow {
+  siteName?: string;
+  name: string;
+  path?: string;
+  publishedItems: number;
+  pendingItems: number;
+  newItems: number;
+  updatedItems: number;
+  archivedItems: number;
+}
+
+/** One page/item property row from {@code PSItemProperties}. */
+export interface ItemPropertiesRow {
+  id?: string;
+  name?: string;
+  status?: string;
+  workflow?: string;
+  path?: string;
+  type?: string;
+  lastModifier?: string;
+  lastModifiedDate?: string;
+}
+
+/** Aggregated status bucket for Pages By Status. */
+export interface WorkflowStatusBucket {
+  /** Workflow state name (e.g. Draft, Pending). */
+  state: string;
+  count: number;
+  /** Sample item names for display (capped). */
+  sampleNames: string[];
+}
+
+export interface PagesByStatusResult {
+  path: string;
+  workflow: string;
+  buckets: WorkflowStatusBucket[];
+  totalItems: number;
+}
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return v && typeof v === "object" ? (v as Record<string, unknown>) : null;
+}
+
+/**
+ * Unwrap Jackson root-name list envelopes used by sitemanage
+ * (e.g. {@code { ContentActivity: [...] }} or a bare array).
+ */
+export function unwrapNamedList(data: unknown, rootName: string): unknown[] {
+  if (Array.isArray(data)) {
+    return data;
+  }
+  const obj = asRecord(data);
+  if (!obj) {
+    return [];
+  }
+  const named = obj[rootName];
+  if (Array.isArray(named)) {
+    return named;
+  }
+  if (named && typeof named === "object") {
+    return [named];
+  }
+  // Some responses nest under the same key as a map of arrays
+  for (const v of Object.values(obj)) {
+    if (Array.isArray(v)) {
+      return v;
+    }
+  }
+  return [];
+}
+
+function num(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export function normalizeContentActivityRow(
+  raw: unknown,
+): ContentActivityRow | null {
+  const o = asRecord(raw);
+  if (!o) {
+    return null;
+  }
+  const name = o.name != null ? String(o.name).trim() : "";
+  if (!name) {
+    return null;
+  }
+  return {
+    siteName: o.siteName != null ? String(o.siteName) : undefined,
+    name,
+    path: o.path != null ? String(o.path) : undefined,
+    publishedItems: num(o.publishedItems),
+    pendingItems: num(o.pendingItems),
+    newItems: num(o.newItems),
+    updatedItems: num(o.updatedItems),
+    archivedItems: num(o.archivedItems),
+  };
+}
+
+/**
+ * Content activity for a path and duration window.
+ * Classic: POST {@code /activitymanagement/activity/contentactivity}.
+ *
+ * @param path - CMS path, e.g. {@code /Sites/} or {@code /Sites/Demo}
+ * @param durationType - days | weeks | months | years
+ * @param duration - integer duration as string (classic wire)
+ */
+export async function fetchContentActivity(
+  path: string,
+  durationType: ActivityDurationType = "days",
+  duration: string | number = 30,
+): Promise<ContentActivityRow[]> {
+  const body = {
+    ContentActivityRequest: {
+      path,
+      durationType,
+      duration: String(duration),
+    },
+  };
+  const data = await post<unknown>(PATHS.ACTIVITY_CONTENT, body);
+  return unwrapNamedList(data, "ContentActivity")
+    .map(normalizeContentActivityRow)
+    .filter((r): r is ContentActivityRow => r != null);
+}
+
+/**
+ * Resolve a sensible default activity path: first site under {@code /Sites/},
+ * or {@code /Sites/} when no sites exist.
+ */
+export async function resolveDefaultActivityPath(): Promise<string> {
+  try {
+    const sites = await fetchSites();
+    const name = sites[0]?.name?.trim();
+    if (name) {
+      return `/Sites/${name}`;
+    }
+  } catch {
+    /* fall through */
+  }
+  return "/Sites/";
+}
+
+/**
+ * Default workflow label from {@code GET .../workflows/metadata/default}.
+ * {@code PSEnumVals.entries[0].value} is the workflow label/name.
+ */
+export async function fetchDefaultWorkflowName(): Promise<string | null> {
+  const data = await get<unknown>(PATHS.WORKFLOW_METADATA_DEFAULT);
+  const obj = asRecord(data);
+  if (!obj) {
+    return null;
+  }
+  // { EnumVals: { entries: [...] } } or flat { entries: [...] }
+  const root = asRecord(obj.EnumVals) ?? obj;
+  const entries = root.entries;
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return null;
+  }
+  const first = asRecord(entries[0]);
+  if (!first) {
+    return null;
+  }
+  const value = first.value != null ? String(first.value).trim() : "";
+  return value || null;
+}
+
+export function normalizeItemPropertiesRow(
+  raw: unknown,
+): ItemPropertiesRow | null {
+  const o = asRecord(raw);
+  if (!o) {
+    return null;
+  }
+  return {
+    id: o.id != null ? String(o.id) : undefined,
+    name: o.name != null ? String(o.name) : undefined,
+    status: o.status != null ? String(o.status) : undefined,
+    workflow: o.workflow != null ? String(o.workflow) : undefined,
+    path: o.path != null ? String(o.path) : undefined,
+    type: o.type != null ? String(o.type) : undefined,
+    lastModifier: o.lastModifier != null ? String(o.lastModifier) : undefined,
+    lastModifiedDate:
+      o.lastModifiedDate != null ? String(o.lastModifiedDate) : undefined,
+  };
+}
+
+/**
+ * Items under path in a workflow (all states when {@code state} is empty).
+ * Classic: POST {@code /pathmanagement/path/item/wfState}.
+ */
+export async function fetchItemsByWorkflowState(
+  path: string,
+  workflow: string,
+  state = "",
+): Promise<ItemPropertiesRow[]> {
+  const body = {
+    ItemByWfStateRequest: {
+      path,
+      workflow,
+      state: state ?? "",
+    },
+  };
+  const data = await post<unknown>(PATHS.PATH_ITEM_BY_WF_STATE, body);
+  return unwrapNamedList(data, "ItemProperties")
+    .map(normalizeItemPropertiesRow)
+    .filter((r): r is ItemPropertiesRow => r != null);
+}
+
+/**
+ * Aggregate items by workflow status for the Pages By Status gadget.
+ */
+export function groupItemsByStatus(
+  items: ItemPropertiesRow[],
+  sampleLimit = 3,
+): WorkflowStatusBucket[] {
+  const map = new Map<string, { count: number; sampleNames: string[] }>();
+  for (const item of items) {
+    const state = (item.status && item.status.trim()) || "Unknown";
+    let bucket = map.get(state);
+    if (!bucket) {
+      bucket = { count: 0, sampleNames: [] };
+      map.set(state, bucket);
+    }
+    bucket.count += 1;
+    if (
+      bucket.sampleNames.length < sampleLimit &&
+      item.name &&
+      item.name.trim()
+    ) {
+      bucket.sampleNames.push(item.name.trim());
+    }
+  }
+  return Array.from(map.entries())
+    .map(([state, v]) => ({
+      state,
+      count: v.count,
+      sampleNames: v.sampleNames,
+    }))
+    .sort((a, b) => b.count - a.count || a.state.localeCompare(b.state));
+}
+
+/**
+ * Load Pages By Status for the first site + default workflow.
+ */
+export async function fetchPagesByStatusSummary(options?: {
+  path?: string;
+  workflow?: string;
+}): Promise<PagesByStatusResult> {
+  let path = options?.path?.trim() || "";
+  if (!path) {
+    path = await resolveDefaultActivityPath();
+  }
+  let workflow = options?.workflow?.trim() || "";
+  if (!workflow) {
+    workflow = (await fetchDefaultWorkflowName()) || "Default Workflow";
+  }
+  const items = await fetchItemsByWorkflowState(path, workflow, "");
+  const buckets = groupItemsByStatus(items);
+  return {
+    path,
+    workflow,
+    buckets,
+    totalItems: items.length,
+  };
+}

--- a/WebUI/src/main/ts/api/paths.ts
+++ b/WebUI/src/main/ts/api/paths.ts
@@ -141,8 +141,19 @@ export const PATHS = {
   get PATH_ITEM() {
     return `${SERVICES_ROOT}/pathmanagement/path/item`;
   },
+  /** Pages/items by workflow state (classic Pages By Status gadget). POST body. */
+  get PATH_ITEM_BY_WF_STATE() {
+    return `${SERVICES_ROOT}/pathmanagement/path/item/wfState`;
+  },
   get PATH_ITEM_ID() {
     return `${SERVICES_ROOT}/pathmanagement/path/item/id`;
+  },
+  /**
+   * Content activity metrics (classic Activity gadget).
+   * POST body: {@code ContentActivityRequest} (path, durationType, duration).
+   */
+  get ACTIVITY_CONTENT() {
+    return `${SERVICES_ROOT}/activitymanagement/activity/contentactivity`;
   },
   get PATH_ADD_NEW_FOLDER() {
     return `${SERVICES_ROOT}/pathmanagement/path/addNewFolder`;

--- a/WebUI/src/main/ts/dashboard/ActivityWidget.tsx
+++ b/WebUI/src/main/ts/dashboard/ActivityWidget.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2023 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,112 +15,78 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from 'react';
-import { get } from '../api/client';
-import { styles } from './dashboard.styles';
-
-interface ActivityEntry {
-  id: string;
-  timestamp: string;
-  type: string;
-  description: string;
-  user?: string;
-  contentName?: string;
-}
-
-interface ActivityData {
-  entries: ActivityEntry[];
-  totalCount: number;
-}
+import React, { useCallback, useEffect, useState } from "react";
+import { isSessionRedirectError } from "../api/client";
+import {
+  fetchContentActivity,
+  resolveDefaultActivityPath,
+  type ActivityDurationType,
+  type ContentActivityRow,
+} from "../api/dashboard/gadgetApi";
+import { formatApiError } from "../api/home/homeApi";
+import { styles } from "./dashboard.styles";
 
 export interface ActivityWidgetProps {
   title?: string;
-  maxEntries?: number;
+  /** CMS path (default: first site or /Sites/). */
+  path?: string;
+  durationType?: ActivityDurationType;
+  /** Duration length (default 30). */
+  duration?: number;
   refreshInterval?: number;
 }
 
 /**
- * ActivityWidget displays recent content activity and user actions.
- * Fetches data from the activity REST endpoint and shows a timeline of recent changes.
+ * Classic **Activity** gadget — content activity metrics by path/duration.
+ *
+ * <p>Server: {@code POST /services/activitymanagement/activity/contentactivity}
+ * with {@code ContentActivityRequest}. Not a user-action timeline.</p>
  */
 export const ActivityWidget: React.FC<ActivityWidgetProps> = ({
-  title = 'Recent Activity',
-  maxEntries = 10,
+  title = "Activity",
+  path: pathProp,
+  durationType = "days",
+  duration = 30,
   refreshInterval = 60000,
 }) => {
-  const [data, setData] = useState<ActivityData | null>(null);
+  const [rows, setRows] = useState<ContentActivityRow[]>([]);
+  const [resolvedPath, setResolvedPath] = useState<string>(pathProp ?? "");
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const fetchActivity = async () => {
-      try {
-        setIsLoading(true);
-        setError(null);
-
-        // Call activity REST endpoint
-        const response = await get<ActivityData>(
-          `/services/activity/contentactivity?limit=${maxEntries}`
-        );
-
-        setData(response);
-      } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : 'Failed to load activity';
-        setError(errorMessage);
-        console.error('ActivityWidget error:', err);
-      } finally {
-        setIsLoading(false);
+  const load = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const path =
+        pathProp?.trim() || (await resolveDefaultActivityPath());
+      setResolvedPath(path);
+      const data = await fetchContentActivity(path, durationType, duration);
+      setRows(data);
+    } catch (err: unknown) {
+      if (isSessionRedirectError(err)) {
+        return;
       }
-    };
+      setError(formatApiError(err, "Failed to load content activity"));
+      setRows([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [pathProp, durationType, duration]);
 
-    // Fetch immediately
-    fetchActivity();
-
-    // Set up refresh interval if specified
-    const interval =
-      refreshInterval > 0
-        ? setInterval(fetchActivity, refreshInterval)
-        : undefined;
-
-    return () => {
-      if (interval) clearInterval(interval);
-    };
-  }, [maxEntries, refreshInterval]);
-
-  const getActivityIcon = (type: string): string => {
-    const iconMap: Record<string, string> = {
-      publish: '📤',
-      revise: '✏️',
-      create: '📝',
-      delete: '🗑️',
-      update: '🔄',
-      approve: '✅',
-      reject: '❌',
-      comment: '💬',
-    };
-    return iconMap[type.toLowerCase()] || '📌';
-  };
-
-  const formatTime = (timestamp: string): string => {
-    const date = new Date(timestamp);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffMins = Math.floor(diffMs / 60000);
-    const diffHours = Math.floor(diffMs / 3600000);
-    const diffDays = Math.floor(diffMs / 86400000);
-
-    if (diffMins < 1) return 'just now';
-    if (diffMins < 60) return `${diffMins}m ago`;
-    if (diffHours < 24) return `${diffHours}h ago`;
-    if (diffDays < 7) return `${diffDays}d ago`;
-    return date.toLocaleDateString();
-  };
+  useEffect(() => {
+    void load();
+    if (refreshInterval <= 0) {
+      return;
+    }
+    const id = window.setInterval(() => void load(), refreshInterval);
+    return () => window.clearInterval(id);
+  }, [load, refreshInterval]);
 
   const renderContent = () => {
     if (isLoading) {
       return (
-        <div style={styles.widgetLoading}>
+        <div style={styles.widgetLoading} data-testid="activity-widget-loading">
           <p>Loading activity...</p>
         </div>
       );
@@ -128,66 +94,70 @@ export const ActivityWidget: React.FC<ActivityWidgetProps> = ({
 
     if (error) {
       return (
-        <div style={styles.widgetError}>
+        <div style={styles.widgetError} data-testid="activity-widget-error">
           <p>Error: {error}</p>
         </div>
       );
     }
 
-    if (!data || !data.entries || data.entries.length === 0) {
+    if (rows.length === 0) {
       return (
-        <div style={styles.widgetContent}>
-          <p>No recent activity</p>
+        <div style={styles.widgetContent} data-testid="activity-widget-empty">
+          <p>No content activity for this path and duration.</p>
+          {resolvedPath ? (
+            <p style={{ fontSize: "0.85em", color: "#666" }}>
+              Path: {resolvedPath} · last {duration} {durationType}
+            </p>
+          ) : null}
         </div>
       );
     }
 
     return (
-      <div style={styles.widgetContent}>
-        <div style={{ listStyle: 'none', padding: 0, margin: 0 } as React.CSSProperties}>
-          {data.entries.map((entry, index) => (
-            <div
-              key={entry.id || index}
+      <div style={styles.widgetContent} data-testid="activity-widget-list">
+        <p style={{ fontSize: "0.85em", color: "#666", marginTop: 0 }}>
+          {resolvedPath} · last {duration} {durationType}
+        </p>
+        <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+          {rows.map((row, index) => (
+            <li
+              key={`${row.path ?? row.name}-${index}`}
               style={{
-                padding: '10px 0',
-                borderBottom: '1px solid #e0e0e0',
-                display: 'flex',
-                gap: '10px',
-                alignItems: 'flex-start',
-              } as React.CSSProperties}
+                padding: "10px 0",
+                borderBottom: "1px solid #e0e0e0",
+              }}
             >
-              <div style={{ fontSize: '1.2em', minWidth: '24px' }}>
-                {getActivityIcon(entry.type)}
-              </div>
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <div style={{ fontWeight: 500, color: '#333', fontSize: '0.95em' }}>
-                  {entry.description}
+              <div style={{ fontWeight: 600, color: "#333" }}>{row.name}</div>
+              {row.siteName && row.siteName !== row.name ? (
+                <div style={{ fontSize: "0.8em", color: "#666" }}>
+                  Site: {row.siteName}
                 </div>
-                <div
-                  style={{
-                    fontSize: '0.8em',
-                    color: '#666',
-                    marginTop: '2px',
-                  } as React.CSSProperties}
-                >
-                  {entry.contentName && (
-                    <div>{entry.contentName}</div>
-                  )}
-                  <div style={{ color: '#999' }}>
-                    {entry.user && `by ${entry.user} • `}
-                    {formatTime(entry.timestamp)}
-                  </div>
-                </div>
+              ) : null}
+              <div
+                style={{
+                  display: "flex",
+                  flexWrap: "wrap",
+                  gap: "8px 12px",
+                  marginTop: "6px",
+                  fontSize: "0.85em",
+                  color: "#444",
+                }}
+              >
+                <span>Published: {row.publishedItems}</span>
+                <span>Pending: {row.pendingItems}</span>
+                <span>New: {row.newItems}</span>
+                <span>Updated: {row.updatedItems}</span>
+                <span>Archived: {row.archivedItems}</span>
               </div>
-            </div>
+            </li>
           ))}
-        </div>
+        </ul>
       </div>
     );
   };
 
   return (
-    <div style={styles.widget}>
+    <div style={styles.widget} data-testid="activity-widget">
       <div style={styles.widgetTitle}>{title}</div>
       {renderContent()}
     </div>

--- a/WebUI/src/main/ts/dashboard/Dashboard.tsx
+++ b/WebUI/src/main/ts/dashboard/Dashboard.tsx
@@ -75,16 +75,16 @@ const AVAILABLE_GADGETS: GadgetInfo[] = [
   },
   {
     id: "workflow",
-    name: "Workflow Status",
+    name: "Pages By Status",
     component: WorkflowStatusWidget,
-    description: "Page workflow status overview",
+    description: "Pages grouped by workflow state (classic Pages By Status)",
     category: "Content Management",
   },
   {
     id: "activity",
     name: "Activity",
     component: ActivityWidget,
-    description: "Recent content activity timeline",
+    description: "Content activity metrics by path and duration",
     // GadgetRegistry.xml group "Deprecated" (v8.1.7 #722 / #885)
     category: "Deprecated",
   },
@@ -219,6 +219,11 @@ const AVAILABLE_GADGETS: GadgetInfo[] = [
   },
 ];
 
+/**
+ * Default Home Gadgets layout — only widgets with verified sitemanage APIs.
+ * Assets By Status and other invented-endpoint shells stay in AVAILABLE_GADGETS
+ * for optional add, but are not auto-mounted (they still 500/404).
+ */
 const DEFAULT_GADGETS: DashboardWidget[] = [
   {
     id: "welcome",
@@ -236,7 +241,7 @@ const DEFAULT_GADGETS: DashboardWidget[] = [
   },
   {
     id: "workflow",
-    name: "Workflow Status",
+    name: "Pages By Status",
     component: WorkflowStatusWidget,
     props: {},
     position: { column: "left", order: 2 },
@@ -247,13 +252,6 @@ const DEFAULT_GADGETS: DashboardWidget[] = [
     component: ActivityWidget,
     props: {},
     position: { column: "right", order: 0 },
-  },
-  {
-    id: "assets-status",
-    name: "Assets By Status",
-    component: AssetsStatusWidget,
-    props: {},
-    position: { column: "right", order: 1 },
   },
 ];
 

--- a/WebUI/src/main/ts/dashboard/WorkflowStatusWidget.tsx
+++ b/WebUI/src/main/ts/dashboard/WorkflowStatusWidget.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2023 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,81 +15,75 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from 'react';
-import { get } from '../api/client';
-import { styles } from './dashboard.styles';
-
-interface WorkflowItem {
-  id: string;
-  name: string;
-  state: string;
-  count: number;
-  progress?: number;
-}
-
-interface WorkflowStatusData {
-  items: WorkflowItem[];
-  totalCount: number;
-  lastUpdated: string;
-}
+import React, { useCallback, useEffect, useState } from "react";
+import { isSessionRedirectError } from "../api/client";
+import {
+  fetchPagesByStatusSummary,
+  type PagesByStatusResult,
+} from "../api/dashboard/gadgetApi";
+import { formatApiError } from "../api/home/homeApi";
+import { styles } from "./dashboard.styles";
 
 export interface WorkflowStatusWidgetProps {
+  /** Display title (classic gadget: Pages By Status). */
   title?: string;
+  /** Optional CMS path; defaults to first site. */
+  path?: string;
+  /** Optional workflow name; defaults to system default workflow label. */
+  workflow?: string;
   refreshInterval?: number;
 }
 
 /**
- * WorkflowStatusWidget displays the current workflow statuses and task counts.
- * Fetches data from the dashboard management REST endpoint and refreshes automatically.
+ * Classic **Pages By Status** gadget (React key {@code workflow}).
+ *
+ * <p>Server: {@code POST /services/pathmanagement/path/item/wfState} with
+ * {@code ItemByWfStateRequest}. Invented path
+ * {@code /dashboardmanagement/gadget/workflow-status} does not exist.</p>
  */
 export const WorkflowStatusWidget: React.FC<WorkflowStatusWidgetProps> = ({
-  title = 'Workflow Status',
+  title = "Pages By Status",
+  path,
+  workflow,
   refreshInterval = 30000,
 }) => {
-  const [data, setData] = useState<WorkflowStatusData | null>(null);
+  const [data, setData] = useState<PagesByStatusResult | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const fetchWorkflowStatus = async () => {
-      try {
-        setIsLoading(true);
-        setError(null);
-
-        // Call dashboard gadget REST endpoint
-        const response = await get<WorkflowStatusData>(
-          '/services/dashboardmanagement/gadget/workflow-status'
-        );
-
-        setData(response);
-      } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : 'Failed to load workflow status';
-        setError(errorMessage);
-        console.error('WorkflowStatusWidget error:', err);
-      } finally {
-        setIsLoading(false);
+  const load = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const result = await fetchPagesByStatusSummary({ path, workflow });
+      setData(result);
+    } catch (err: unknown) {
+      if (isSessionRedirectError(err)) {
+        return;
       }
-    };
+      setError(formatApiError(err, "Failed to load pages by status"));
+      setData(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [path, workflow]);
 
-    // Fetch immediately
-    fetchWorkflowStatus();
-
-    // Set up refresh interval if specified
-    const interval =
-      refreshInterval > 0
-        ? setInterval(fetchWorkflowStatus, refreshInterval)
-        : undefined;
-
-    return () => {
-      if (interval) clearInterval(interval);
-    };
-  }, [refreshInterval]);
+  useEffect(() => {
+    void load();
+    if (refreshInterval <= 0) {
+      return;
+    }
+    const id = window.setInterval(() => void load(), refreshInterval);
+    return () => window.clearInterval(id);
+  }, [load, refreshInterval]);
 
   const renderContent = () => {
     if (isLoading) {
       return (
-        <div style={styles.widgetLoading}>
+        <div
+          style={styles.widgetLoading}
+          data-testid="workflow-status-loading"
+        >
           <p>Loading workflow status...</p>
         </div>
       );
@@ -97,73 +91,75 @@ export const WorkflowStatusWidget: React.FC<WorkflowStatusWidgetProps> = ({
 
     if (error) {
       return (
-        <div style={styles.widgetError}>
+        <div style={styles.widgetError} data-testid="workflow-status-error">
           <p>Error: {error}</p>
         </div>
       );
     }
 
-    if (!data || !data.items || data.items.length === 0) {
+    if (!data || data.buckets.length === 0) {
       return (
-        <div style={styles.widgetContent}>
-          <p>No active workflows</p>
+        <div style={styles.widgetContent} data-testid="workflow-status-empty">
+          <p>No pages found for this path and workflow.</p>
+          {data ? (
+            <p style={{ fontSize: "0.85em", color: "#666" }}>
+              {data.path} · {data.workflow}
+            </p>
+          ) : null}
         </div>
       );
     }
 
     return (
-      <div style={styles.widgetContent}>
-        <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-          {data.items.map((item) => (
+      <div style={styles.widgetContent} data-testid="workflow-status-list">
+        <p style={{ fontSize: "0.85em", color: "#666", marginTop: 0 }}>
+          {data.path} · {data.workflow} · {data.totalItems} page
+          {data.totalItems === 1 ? "" : "s"}
+        </p>
+        <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+          {data.buckets.map((bucket) => (
             <li
-              key={item.id}
+              key={bucket.state}
               style={{
-                padding: '8px 0',
-                borderBottom: '1px solid #e0e0e0',
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-              } as React.CSSProperties}
+                padding: "8px 0",
+                borderBottom: "1px solid #e0e0e0",
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+              }}
             >
               <div>
-                <div style={{ fontWeight: 500, color: '#333' }}>
-                  {item.name}
+                <div style={{ fontWeight: 500, color: "#333" }}>
+                  {bucket.state}
                 </div>
-                <div style={{ fontSize: '0.85em', color: '#666' }}>
-                  State: {item.state}
-                </div>
+                {bucket.sampleNames.length > 0 ? (
+                  <div style={{ fontSize: "0.85em", color: "#666" }}>
+                    {bucket.sampleNames.join(", ")}
+                    {bucket.count > bucket.sampleNames.length ? "…" : ""}
+                  </div>
+                ) : null}
               </div>
               <div
                 style={{
-                  backgroundColor: '#e8f4f8',
-                  padding: '4px 12px',
-                  borderRadius: '12px',
+                  backgroundColor: "#e8f4f8",
+                  padding: "4px 12px",
+                  borderRadius: "12px",
                   fontWeight: 600,
-                  color: '#007ea8',
-                  fontSize: '0.9em',
+                  color: "#007ea8",
+                  fontSize: "0.9em",
                 }}
               >
-                {item.count}
+                {bucket.count}
               </div>
             </li>
           ))}
         </ul>
-        <div
-          style={{
-            marginTop: '12px',
-            fontSize: '0.8em',
-            color: '#999',
-            textAlign: 'right',
-          }}
-        >
-          Updated: {new Date(data.lastUpdated).toLocaleTimeString()}
-        </div>
       </div>
     );
   };
 
   return (
-    <div style={styles.widget}>
+    <div style={styles.widget} data-testid="workflow-status-widget">
       <div style={styles.widgetTitle}>{title}</div>
       {renderContent()}
     </div>

--- a/WebUI/src/test/ts/api/dashboard/gadgetApi.test.ts
+++ b/WebUI/src/test/ts/api/dashboard/gadgetApi.test.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  fetchContentActivity,
+  fetchItemsByWorkflowState,
+  groupItemsByStatus,
+  normalizeContentActivityRow,
+  unwrapNamedList,
+} from "@/api/dashboard/gadgetApi";
+import * as client from "@/api/client";
+import { PATHS } from "@/api/paths";
+
+vi.mock("@/api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/client")>();
+  return {
+    ...actual,
+    get: vi.fn(),
+    post: vi.fn(),
+  };
+});
+
+vi.mock("@/api/home/homeApi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/home/homeApi")>();
+  return {
+    ...actual,
+    fetchSites: vi.fn().mockResolvedValue([{ name: "Demo" }]),
+  };
+});
+
+describe("gadgetApi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("unwrapNamedList handles array and root envelope", () => {
+    expect(unwrapNamedList([{ a: 1 }], "X")).toEqual([{ a: 1 }]);
+    expect(
+      unwrapNamedList({ ContentActivity: [{ name: "n" }] }, "ContentActivity"),
+    ).toEqual([{ name: "n" }]);
+    expect(
+      unwrapNamedList({ ContentActivity: { name: "solo" } }, "ContentActivity"),
+    ).toEqual([{ name: "solo" }]);
+  });
+
+  it("normalizeContentActivityRow maps counts", () => {
+    const row = normalizeContentActivityRow({
+      name: "Demo",
+      siteName: "Demo",
+      publishedItems: 10,
+      pendingItems: "2",
+      newItems: 1,
+      updatedItems: 3,
+      archivedItems: 0,
+    });
+    expect(row).toMatchObject({
+      name: "Demo",
+      publishedItems: 10,
+      pendingItems: 2,
+      newItems: 1,
+      updatedItems: 3,
+      archivedItems: 0,
+    });
+  });
+
+  it("fetchContentActivity POSTs ContentActivityRequest envelope", async () => {
+    vi.mocked(client.post).mockResolvedValue({
+      ContentActivity: [
+        {
+          name: "Demo",
+          publishedItems: 1,
+          pendingItems: 0,
+          newItems: 0,
+          updatedItems: 0,
+          archivedItems: 0,
+        },
+      ],
+    });
+    const rows = await fetchContentActivity("/Sites/Demo", "days", 30);
+    expect(client.post).toHaveBeenCalledWith(
+      PATHS.ACTIVITY_CONTENT,
+      expect.objectContaining({
+        ContentActivityRequest: {
+          path: "/Sites/Demo",
+          durationType: "days",
+          duration: "30",
+        },
+      }),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe("Demo");
+  });
+
+  it("fetchItemsByWorkflowState POSTs ItemByWfStateRequest", async () => {
+    vi.mocked(client.post).mockResolvedValue({
+      ItemProperties: [
+        { id: "1", name: "Home", status: "Draft", path: "/Sites/Demo/Home" },
+        { id: "2", name: "About", status: "Draft", path: "/Sites/Demo/About" },
+        { id: "3", name: "Live", status: "Live", path: "/Sites/Demo/Live" },
+      ],
+    });
+    const items = await fetchItemsByWorkflowState(
+      "/Sites/Demo",
+      "Default Workflow",
+      "",
+    );
+    expect(client.post).toHaveBeenCalledWith(
+      PATHS.PATH_ITEM_BY_WF_STATE,
+      expect.objectContaining({
+        ItemByWfStateRequest: {
+          path: "/Sites/Demo",
+          workflow: "Default Workflow",
+          state: "",
+        },
+      }),
+    );
+    expect(items).toHaveLength(3);
+  });
+
+  it("groupItemsByStatus aggregates counts", () => {
+    const buckets = groupItemsByStatus([
+      { name: "a", status: "Draft" },
+      { name: "b", status: "Draft" },
+      { name: "c", status: "Live" },
+    ]);
+    expect(buckets.find((b) => b.state === "Draft")?.count).toBe(2);
+    expect(buckets.find((b) => b.state === "Live")?.count).toBe(1);
+  });
+});

--- a/WebUI/src/test/ts/dashboard/ActivityWidget.test.tsx
+++ b/WebUI/src/test/ts/dashboard/ActivityWidget.test.tsx
@@ -1,163 +1,72 @@
 /*
- * Copyright 1999-2023 Percussion Software, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 1999-2026 Percussion Software, Inc.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import { ActivityWidget } from '@/dashboard';
-import * as clientModule from '@/api/client';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { ActivityWidget } from "@/dashboard/ActivityWidget";
+import * as gadgetApi from "@/api/dashboard/gadgetApi";
 
-// Mock the API client
-vi.mock('@/api/client', () => ({
-  get: vi.fn(),
-}));
+vi.mock("@/api/dashboard/gadgetApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/api/dashboard/gadgetApi")>();
+  return {
+    ...actual,
+    fetchContentActivity: vi.fn(),
+    resolveDefaultActivityPath: vi.fn().mockResolvedValue("/Sites/Demo"),
+  };
+});
 
-describe('ActivityWidget', () => {
+describe("ActivityWidget", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.mocked(gadgetApi.fetchContentActivity).mockReset();
+    vi.mocked(gadgetApi.resolveDefaultActivityPath)
+      .mockReset()
+      .mockResolvedValue("/Sites/Demo");
   });
 
-  it('should render loading state initially', () => {
-    vi.mocked(clientModule.get).mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          // Never resolve to keep loading state
-          setTimeout(() => resolve({ entries: [], totalCount: 0 }), 10000);
-        })
+  it("shows empty state when no activity rows", async () => {
+    vi.mocked(gadgetApi.fetchContentActivity).mockResolvedValue([]);
+    render(<ActivityWidget refreshInterval={0} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("activity-widget-empty")).toBeDefined();
+    });
+  });
+
+  it("renders content activity metrics", async () => {
+    vi.mocked(gadgetApi.fetchContentActivity).mockResolvedValue([
+      {
+        name: "Demo",
+        siteName: "Demo",
+        publishedItems: 5,
+        pendingItems: 2,
+        newItems: 1,
+        updatedItems: 3,
+        archivedItems: 0,
+      },
+    ]);
+    render(<ActivityWidget refreshInterval={0} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("activity-widget-list")).toBeDefined();
+    });
+    expect(screen.getByText("Demo")).toBeDefined();
+    expect(screen.getByText(/Published:\s*5/)).toBeDefined();
+    expect(screen.getByText(/Pending:\s*2/)).toBeDefined();
+    expect(gadgetApi.fetchContentActivity).toHaveBeenCalledWith(
+      "/Sites/Demo",
+      "days",
+      30,
     );
-
-    render(<ActivityWidget />);
-    expect(screen.getByText(/loading activity/i)).toBeInTheDocument();
   });
 
-  it('should render activity entries from API response', async () => {
-    const mockData = {
-      entries: [
-        {
-          id: '1',
-          timestamp: new Date().toISOString(),
-          type: 'publish',
-          description: 'Published content',
-          user: 'admin',
-          contentName: 'Homepage',
-        },
-        {
-          id: '2',
-          timestamp: new Date(Date.now() - 3600000).toISOString(),
-          type: 'revise',
-          description: 'Revised content',
-          user: 'editor',
-          contentName: 'About Page',
-        },
-      ],
-      totalCount: 2,
-    };
-
-    vi.mocked(clientModule.get).mockResolvedValue(mockData);
-
-    render(<ActivityWidget />);
-
+  it("shows error on API failure", async () => {
+    vi.mocked(gadgetApi.fetchContentActivity).mockRejectedValue(
+      new Error("boom"),
+    );
+    render(<ActivityWidget refreshInterval={0} />);
     await waitFor(() => {
-      expect(screen.getByText('Published content')).toBeInTheDocument();
-      expect(screen.getByText('Revised content')).toBeInTheDocument();
-      expect(screen.getByText('Homepage')).toBeInTheDocument();
-      expect(screen.getByText('About Page')).toBeInTheDocument();
+      expect(screen.getByTestId("activity-widget-error")).toBeDefined();
     });
-  });
-
-  it('should render error message on API failure', async () => {
-    const error = new Error('Failed to load activity');
-    vi.mocked(clientModule.get).mockRejectedValue(error);
-
-    render(<ActivityWidget />);
-
-    await waitFor(() => {
-      expect(screen.getByText(/failed to load activity/i)).toBeInTheDocument();
-    });
-  });
-
-  it('should render no recent activity message when list is empty', async () => {
-    const mockData = {
-      entries: [],
-      totalCount: 0,
-    };
-
-    vi.mocked(clientModule.get).mockResolvedValue(mockData);
-
-    render(<ActivityWidget />);
-
-    await waitFor(() => {
-      expect(screen.getByText(/no recent activity/i)).toBeInTheDocument();
-    });
-  });
-
-  it('should call API with max entries parameter', async () => {
-    const mockData = {
-      entries: [],
-      totalCount: 0,
-    };
-
-    vi.mocked(clientModule.get).mockResolvedValue(mockData);
-
-    render(<ActivityWidget maxEntries={20} />);
-
-    await waitFor(() => {
-      expect(clientModule.get).toHaveBeenCalledWith(
-        '/services/activity/contentactivity?limit=20'
-      );
-    });
-  });
-
-  it('should render custom title', async () => {
-    const mockData = {
-      entries: [],
-      totalCount: 0,
-    };
-
-    vi.mocked(clientModule.get).mockResolvedValue(mockData);
-
-    render(<ActivityWidget title="System Activity" />);
-
-    await waitFor(() => {
-      expect(screen.getByText('System Activity')).toBeInTheDocument();
-    });
-  });
-
-  it('should format time correctly', async () => {
-    const now = new Date();
-    const oneHourAgo = new Date(now.getTime() - 3600000);
-
-    const mockData = {
-      entries: [
-        {
-          id: '1',
-          timestamp: oneHourAgo.toISOString(),
-          type: 'publish',
-          description: 'Published content',
-        },
-      ],
-      totalCount: 1,
-    };
-
-    vi.mocked(clientModule.get).mockResolvedValue(mockData);
-
-    render(<ActivityWidget />);
-
-    await waitFor(() => {
-      expect(screen.getByText(/1h ago/)).toBeInTheDocument();
-    });
+    expect(screen.getByText(/boom/)).toBeDefined();
   });
 });

--- a/WebUI/src/test/ts/dashboard/WorkflowStatusWidget.test.tsx
+++ b/WebUI/src/test/ts/dashboard/WorkflowStatusWidget.test.tsx
@@ -1,138 +1,68 @@
 /*
- * Copyright 1999-2023 Percussion Software, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 1999-2026 Percussion Software, Inc.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import { WorkflowStatusWidget } from '@/dashboard';
-import * as clientModule from '@/api/client';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { WorkflowStatusWidget } from "@/dashboard/WorkflowStatusWidget";
+import * as gadgetApi from "@/api/dashboard/gadgetApi";
 
-// Mock the API client
-vi.mock('@/api/client', () => ({
-  get: vi.fn(),
-}));
+vi.mock("@/api/dashboard/gadgetApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/api/dashboard/gadgetApi")>();
+  return {
+    ...actual,
+    fetchPagesByStatusSummary: vi.fn(),
+  };
+});
 
-describe('WorkflowStatusWidget', () => {
+describe("WorkflowStatusWidget", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.mocked(gadgetApi.fetchPagesByStatusSummary).mockReset();
   });
 
-  it('should render loading state initially', () => {
-    vi.mocked(clientModule.get).mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          // Never resolve to keep loading state
-          setTimeout(() => resolve({ items: [], totalCount: 0, lastUpdated: '' }), 10000);
-        })
-    );
-
-    render(<WorkflowStatusWidget />);
-    expect(screen.getByText(/loading workflow status/i)).toBeInTheDocument();
+  it("shows empty state when no pages", async () => {
+    vi.mocked(gadgetApi.fetchPagesByStatusSummary).mockResolvedValue({
+      path: "/Sites/Demo",
+      workflow: "Default Workflow",
+      buckets: [],
+      totalItems: 0,
+    });
+    render(<WorkflowStatusWidget refreshInterval={0} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("workflow-status-empty")).toBeDefined();
+    });
   });
 
-  it('should render workflow items from API response', async () => {
-    const mockData = {
-      items: [
-        {
-          id: '1',
-          name: 'Content Review',
-          state: 'Active',
-          count: 5,
-        },
-        {
-          id: '2',
-          name: 'Site Publishing',
-          state: 'Pending',
-          count: 3,
-        },
+  it("renders status buckets", async () => {
+    vi.mocked(gadgetApi.fetchPagesByStatusSummary).mockResolvedValue({
+      path: "/Sites/Demo",
+      workflow: "Default Workflow",
+      totalItems: 3,
+      buckets: [
+        { state: "Draft", count: 2, sampleNames: ["Home", "About"] },
+        { state: "Live", count: 1, sampleNames: ["Index"] },
       ],
-      totalCount: 2,
-      lastUpdated: new Date().toISOString(),
-    };
-
-    vi.mocked(clientModule.get).mockResolvedValue(mockData);
-
-    render(<WorkflowStatusWidget />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Content Review')).toBeInTheDocument();
-      expect(screen.getByText('Site Publishing')).toBeInTheDocument();
-      expect(screen.getByText('5')).toBeInTheDocument();
-      expect(screen.getByText('3')).toBeInTheDocument();
     });
+    render(<WorkflowStatusWidget refreshInterval={0} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("workflow-status-list")).toBeDefined();
+    });
+    expect(screen.getByText("Draft")).toBeDefined();
+    expect(screen.getByText("Live")).toBeDefined();
+    expect(screen.getByText("2")).toBeDefined();
+    expect(screen.getByText("1")).toBeDefined();
+    expect(screen.getByText(/Home, About/)).toBeDefined();
   });
 
-  it('should render error message on API failure', async () => {
-    const error = new Error('Failed to fetch workflow status');
-    vi.mocked(clientModule.get).mockRejectedValue(error);
-
-    render(<WorkflowStatusWidget />);
-
+  it("shows error on API failure", async () => {
+    vi.mocked(gadgetApi.fetchPagesByStatusSummary).mockRejectedValue(
+      new Error("wf fail"),
+    );
+    render(<WorkflowStatusWidget refreshInterval={0} />);
     await waitFor(() => {
-      expect(screen.getByText(/failed to fetch workflow status/i)).toBeInTheDocument();
+      expect(screen.getByTestId("workflow-status-error")).toBeDefined();
     });
-  });
-
-  it('should render no active workflows message when list is empty', async () => {
-    const mockData = {
-      items: [],
-      totalCount: 0,
-      lastUpdated: new Date().toISOString(),
-    };
-
-    vi.mocked(clientModule.get).mockResolvedValue(mockData);
-
-    render(<WorkflowStatusWidget />);
-
-    await waitFor(() => {
-      expect(screen.getByText(/no active workflows/i)).toBeInTheDocument();
-    });
-  });
-
-  it('should call API with correct endpoint', async () => {
-    const mockData = {
-      items: [],
-      totalCount: 0,
-      lastUpdated: new Date().toISOString(),
-    };
-
-    vi.mocked(clientModule.get).mockResolvedValue(mockData);
-
-    render(<WorkflowStatusWidget />);
-
-    await waitFor(() => {
-      expect(clientModule.get).toHaveBeenCalledWith(
-        '/services/dashboardmanagement/gadget/workflow-status'
-      );
-    });
-  });
-
-  it('should render custom title', async () => {
-    const mockData = {
-      items: [],
-      totalCount: 0,
-      lastUpdated: new Date().toISOString(),
-    };
-
-    vi.mocked(clientModule.get).mockResolvedValue(mockData);
-
-    render(<WorkflowStatusWidget title="My Custom Title" />);
-
-    await waitFor(() => {
-      expect(screen.getByText('My Custom Title')).toBeInTheDocument();
-    });
+    expect(screen.getByText(/wf fail/)).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

Continues the Home Gadgets wave after #1577 (host load + Blogs).

- **Activity** gadget now calls the real classic API:
  `POST /services/activitymanagement/activity/contentactivity` with
  `ContentActivityRequest` (`path`, `durationType`, `duration`).
  UI shows content activity **metrics** (published/pending/new/updated/archived),
  matching classic behavior — not the invented “timeline” wire shape.
- **Pages By Status** (`workflow` key) calls
  `POST /services/pathmanagement/path/item/wfState` with
  `ItemByWfStateRequest`, then groups `ItemProperties` by status.
  Dropped the non-existent `/dashboardmanagement/gadget/workflow-status` path.
- Default Home layout: Welcome + Blogs + Pages By Status + Activity only
  (Assets By Status stays in the add-gadget catalog but is not auto-mounted
  until a real endpoint is wired).

## Stack

- **Base:** #1577 (`fix/home-gadgets-load`)
- Retarget to `development` after #1577 merges if preferred.

## Test plan

- [x] `cd WebUI && npm test -- --run` on gadgetApi, ActivityWidget,
  WorkflowStatusWidget, BlogsWidget, Dashboard, useDashboardConfig
  (**23 tests passed**)
- [ ] After deploy of WebUI bundle: Home → Gadgets shows Activity metrics
  for first site (or `/Sites/`) and Pages By Status buckets for default workflow
- [ ] Hard-refresh browser after WebUI deploy
- [ ] No Maven modules changed (WebUI TS only)

## Notes

Docs-only Maven clean install: **not required** (no Java modules changed).

> Co-Authored by Grok Build using grok-4.5 with agent Grok.