### PR TITLE
fix(home): Google Setup gadget (analytics provider status)

### DIFF
--- a/WebUI/src/main/ts/api/dashboard/analyticsApi.ts
+++ b/WebUI/src/main/ts/api/dashboard/analyticsApi.ts
@@ -1,0 +1,265 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Analytics / Google Setup APIs for Home Gadgets.
+ *
+ * <p>Classic paths ({@code perc_path_constants}):
+ * {@code /analytics/provider/config}, {@code isProfileConfigured/{site}},
+ * profiles. Required before Traffic and What's Working (effectiveness) can
+ * query Google Analytics.</p>
+ *
+ * <p><strong>Never surface password/credentials in UI</strong> — REST may
+ * return an encrypted password field; strip it from all display DTOs.</p>
+ */
+
+import { del, get } from "../client";
+import { PATHS } from "../paths";
+import { fetchSites } from "../home/homeApi";
+
+/** Safe view of stored provider config (no secrets). */
+export interface AnalyticsProviderStatus {
+  /** True when a provider config row exists with a user id. */
+  configured: boolean;
+  /** Service account / user id (never password). */
+  userId: string | null;
+  /**
+   * Site → profile mapping summary from extraParams
+   * ({@code profileId|webPropertyId|apiKey}).
+   */
+  siteProfiles: SiteProfileMapping[];
+}
+
+export interface SiteProfileMapping {
+  siteName: string;
+  /** True when extraParams has a non-empty mapping for this site. */
+  mapped: boolean;
+  /** Optional profile id (first segment of mapping). */
+  profileId?: string;
+  /** Optional web property / tracking id (second segment). */
+  webPropertyId?: string;
+}
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return v && typeof v === "object" ? (v as Record<string, unknown>) : null;
+}
+
+/**
+ * Unwrap Jackson {@code providerConfig} root or flat object.
+ */
+export function unwrapProviderConfig(data: unknown): Record<string, unknown> | null {
+  if (data == null || data === "") {
+    return null;
+  }
+  const root = asRecord(data);
+  if (!root) {
+    return null;
+  }
+  const nested = asRecord(root.providerConfig);
+  if (nested) {
+    return nested;
+  }
+  // Flat wire (some Jackson configs)
+  if ("userid" in root || "uid" in root || "userId" in root || "extraParams" in root) {
+    return root;
+  }
+  return root;
+}
+
+/**
+ * Parse extraParams map: either {@code extraParamsMap}, flat {@code params},
+ * or {@code extraParams.entry[{key,value}]}.
+ */
+export function extractExtraParamsMap(
+  config: Record<string, unknown>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  const mapLike = asRecord(config.extraParamsMap) ?? asRecord(config.params);
+  if (mapLike) {
+    for (const [k, v] of Object.entries(mapLike)) {
+      if (v != null && String(v).trim()) {
+        out[k] = String(v);
+      }
+    }
+  }
+  const extra = asRecord(config.extraParams);
+  const entries = extra?.entry;
+  if (Array.isArray(entries)) {
+    for (const e of entries) {
+      const r = asRecord(e);
+      if (r?.key != null && r.value != null && String(r.value).trim()) {
+        out[String(r.key)] = String(r.value);
+      }
+    }
+  }
+  return out;
+}
+
+export function parseSiteProfileMapping(
+  siteName: string,
+  raw: string | undefined,
+): SiteProfileMapping {
+  if (!raw || !raw.trim()) {
+    return { siteName, mapped: false };
+  }
+  const parts = raw.split("|");
+  return {
+    siteName,
+    mapped: true,
+    profileId: parts[0]?.trim() || undefined,
+    webPropertyId: parts[1]?.trim() || undefined,
+  };
+}
+
+/**
+ * Normalize stored config into a password-free status object.
+ */
+export function normalizeAnalyticsProviderStatus(
+  data: unknown,
+): AnalyticsProviderStatus {
+  const config = unwrapProviderConfig(data);
+  if (!config) {
+    return { configured: false, userId: null, siteProfiles: [] };
+  }
+  const userIdRaw =
+    config.userid ?? config.uid ?? config.userId ?? null;
+  const userId =
+    userIdRaw != null && String(userIdRaw).trim()
+      ? String(userIdRaw).trim()
+      : null;
+  const extra = extractExtraParamsMap(config);
+  const siteProfiles = Object.keys(extra)
+    .sort((a, b) => a.localeCompare(b))
+    .map((site) => parseSiteProfileMapping(site, extra[site]));
+  return {
+    configured: Boolean(userId) || siteProfiles.length > 0,
+    userId,
+    siteProfiles,
+  };
+}
+
+/**
+ * Load analytics provider config status (safe for UI).
+ * Returns {@code configured: false} when no config is stored (null body).
+ */
+export async function fetchAnalyticsProviderStatus(): Promise<AnalyticsProviderStatus> {
+  try {
+    const data = await get<unknown>(PATHS.ANALYTICS_CONFIG);
+    return normalizeAnalyticsProviderStatus(data);
+  } catch (err: unknown) {
+    // Some installs may 404 when no metadata key exists
+    if (err && typeof err === "object" && "status" in err) {
+      const status = (err as { status: number }).status;
+      if (status === 404 || status === 204) {
+        return { configured: false, userId: null, siteProfiles: [] };
+      }
+    }
+    throw err;
+  }
+}
+
+/**
+ * Per-site profile flag from server
+ * ({@code GET …/isProfileConfigured/{sitename}} → "true"|"false").
+ */
+export async function isSiteAnalyticsProfileConfigured(
+  siteName: string,
+): Promise<boolean> {
+  const site = siteName.trim();
+  if (!site) {
+    return false;
+  }
+  const data = await get<unknown>(
+    `${PATHS.ANALYTICS_IS_PROFILE_CONFIGURED}/${encodeURIComponent(site)}`,
+  );
+  if (typeof data === "boolean") {
+    return data;
+  }
+  if (typeof data === "string") {
+    return data.trim().toLowerCase() === "true";
+  }
+  return Boolean(data);
+}
+
+/**
+ * Merge CMS sites with config mappings + live isProfileConfigured checks.
+ */
+export async function fetchGoogleSetupSummary(): Promise<{
+  provider: AnalyticsProviderStatus;
+  sites: Array<{
+    siteName: string;
+    profileConfigured: boolean;
+    mapping?: SiteProfileMapping;
+  }>;
+}> {
+  const provider = await fetchAnalyticsProviderStatus();
+  const mappingBySite = new Map(
+    provider.siteProfiles.map((p) => [p.siteName, p]),
+  );
+  let siteNames: string[] = [];
+  try {
+    const sites = await fetchSites();
+    siteNames = sites
+      .map((s) => s.name?.trim())
+      .filter((n): n is string => Boolean(n));
+  } catch {
+    // Fall back to keys from config only
+    siteNames = provider.siteProfiles.map((p) => p.siteName);
+  }
+  // Include mapped sites that may no longer appear in site list
+  for (const m of provider.siteProfiles) {
+    if (!siteNames.includes(m.siteName)) {
+      siteNames.push(m.siteName);
+    }
+  }
+
+  const sites: Array<{
+    siteName: string;
+    profileConfigured: boolean;
+    mapping?: SiteProfileMapping;
+  }> = [];
+
+  for (const siteName of siteNames) {
+    const mapping = mappingBySite.get(siteName);
+    let profileConfigured = Boolean(mapping?.mapped);
+    if (provider.configured) {
+      try {
+        profileConfigured = await isSiteAnalyticsProfileConfigured(siteName);
+      } catch {
+        // keep mapping-based guess
+      }
+    }
+    sites.push({
+      siteName,
+      profileConfigured,
+      mapping,
+    });
+  }
+
+  return { provider, sites };
+}
+
+/** True when provider credentials exist (Traffic/Effectiveness prerequisite). */
+export async function isAnalyticsProviderConfigured(): Promise<boolean> {
+  const status = await fetchAnalyticsProviderStatus();
+  return status.configured;
+}
+
+/** Clear stored analytics config (DELETE). */
+export async function deleteAnalyticsProviderConfig(): Promise<void> {
+  await del(PATHS.ANALYTICS_CONFIG);
+}

--- a/WebUI/src/main/ts/api/paths.ts
+++ b/WebUI/src/main/ts/api/paths.ts
@@ -182,6 +182,21 @@ export const PATHS = {
   get COOKIE_CONSENT_TOTALS() {
     return `${SERVICES_ROOT}/delivery/consent/log/totals`;
   },
+  /**
+   * Google Analytics provider config (classic Google Setup gadget).
+   * GET/POST/DELETE {@code /analytics/provider/config}
+   */
+  get ANALYTICS_CONFIG() {
+    return `${SERVICES_ROOT}/analytics/provider/config`;
+  },
+  /** Whether a site has a GA profile mapping. Returns plain {@code "true"|"false"}. */
+  get ANALYTICS_IS_PROFILE_CONFIGURED() {
+    return `${SERVICES_ROOT}/analytics/provider/isProfileConfigured`;
+  },
+  /** List GA profiles (requires stored credentials). */
+  get ANALYTICS_PROFILES() {
+    return `${SERVICES_ROOT}/analytics/provider/profiles`;
+  },
   get PATH_ADD_NEW_FOLDER() {
     return `${SERVICES_ROOT}/pathmanagement/path/addNewFolder`;
   },

--- a/WebUI/src/main/ts/dashboard/Dashboard.tsx
+++ b/WebUI/src/main/ts/dashboard/Dashboard.tsx
@@ -169,8 +169,9 @@ const AVAILABLE_GADGETS: GadgetInfo[] = [
     id: "google-setup",
     name: "Google Setup",
     component: GoogleSetupWidget,
-    description: "Google integration and account configuration status",
-    category: "Integration",
+    description:
+      "Google Analytics provider status (required for Traffic / What's Working)",
+    category: "Analytics",
   },
   {
     id: "membership",

--- a/WebUI/src/main/ts/dashboard/Dashboard.tsx
+++ b/WebUI/src/main/ts/dashboard/Dashboard.tsx
@@ -267,6 +267,13 @@ const DEFAULT_GADGETS: DashboardWidget[] = [
     props: {},
     position: { column: "right", order: 2 },
   },
+  {
+    id: "google-setup",
+    name: "Google Setup",
+    component: GoogleSetupWidget,
+    props: {},
+    position: { column: "left", order: 3 },
+  },
 ];
 
 export interface DashboardProps {

--- a/WebUI/src/main/ts/dashboard/GoogleSetupWidget.tsx
+++ b/WebUI/src/main/ts/dashboard/GoogleSetupWidget.tsx
@@ -15,199 +15,249 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from 'react';
-import { get } from '../api/client';
-import { styles } from './dashboard.styles';
-
-interface GoogleService {
-  name: string;
-  enabled: boolean;
-  connected?: boolean;
-  lastSync?: string;
-  status?: string;
-}
-
-interface GoogleSetup {
-  accountConnected: boolean;
-  email?: string;
-  services: GoogleService[];
-  lastUpdate?: string;
-  syncStatus?: string;
-}
-
-interface GoogleSetupData {
-  setup?: GoogleSetup;
-  data?: GoogleSetup;
-  google?: GoogleSetup;
-  [key: string]: unknown;
-}
+import React, { useCallback, useEffect, useState } from "react";
+import { isSessionRedirectError } from "../api/client";
+import {
+  deleteAnalyticsProviderConfig,
+  fetchGoogleSetupSummary,
+} from "../api/dashboard/analyticsApi";
+import { formatApiError } from "../api/home/homeApi";
+import { styles } from "./dashboard.styles";
 
 export interface GoogleSetupWidgetProps {
   title?: string;
   refreshInterval?: number;
+  /** When true, show a Clear config control (admin). */
+  allowDelete?: boolean;
 }
 
 /**
- * GoogleSetupWidget displays Google integration status and configuration.
- * Shows connected services, sync status, and account information.
+ * Classic **Google Setup** gadget — analytics provider status for GA-backed
+ * gadgets (Traffic, What's Working / effectiveness).
+ *
+ * <p>Server:
+ * {@code GET /services/analytics/provider/config},
+ * {@code GET …/isProfileConfigured/{site}}.
+ * Invented path {@code /services/google/setup} does not exist.</p>
+ *
+ * <p>Full credential upload (JSON key multipart) remains a follow-up;
+ * this wave shows status and site profile readiness so operators know why
+ * Traffic / Effectiveness fail.</p>
  */
 export const GoogleSetupWidget: React.FC<GoogleSetupWidgetProps> = ({
-  title = 'Google Setup',
-  refreshInterval,
+  title = "Google Setup",
+  refreshInterval = 0,
+  allowDelete = false,
 }) => {
-  const [setup, setSetup] = useState<GoogleSetup | null>(null);
+  const [summary, setSummary] = useState<
+    Awaited<ReturnType<typeof fetchGoogleSetupSummary>> | null
+  >(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      setSummary(await fetchGoogleSetupSummary());
+    } catch (err: unknown) {
+      if (isSessionRedirectError(err)) {
+        return;
+      }
+      setError(formatApiError(err, "Failed to load Google Analytics setup"));
+      setSummary(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
-    const fetchSetup = async () => {
-      setIsLoading(true);
-      try {
-        const response = await get<GoogleSetupData>('/services/google/setup');
-        let setupData: GoogleSetup | null = null;
-
-        if (response.setup) {
-          setupData = response.setup;
-        } else if (response.data) {
-          setupData = response.data;
-        } else if (response.google) {
-          setupData = response.google;
-        } else if (typeof response === 'object' && !('setup' in response) && !('data' in response) && !('google' in response)) {
-          setupData = {
-            accountConnected: (response as Record<string, unknown>).accountConnected as boolean,
-            email: (response as Record<string, unknown>).email as string | undefined,
-            services: (response as Record<string, unknown>).services as GoogleService[] | undefined,
-            lastUpdate: (response as Record<string, unknown>).lastUpdate as string | undefined,
-            syncStatus: (response as Record<string, unknown>).syncStatus as string | undefined,
-          } as GoogleSetup;
-        }
-
-        setSetup(setupData);
-      } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : 'Failed to load Google setup data';
-        setError(errorMessage);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchSetup();
-    if (refreshInterval) {
-      const interval = setInterval(fetchSetup, refreshInterval * 1000);
-      return () => clearInterval(interval);
+    void load();
+    if (refreshInterval <= 0) {
+      return;
     }
-  }, [refreshInterval]);
+    const id = window.setInterval(() => void load(), refreshInterval);
+    return () => window.clearInterval(id);
+  }, [load, refreshInterval]);
 
-  const getStatusColor = (connected?: boolean): string => {
-    return connected ? '#28a745' : '#dc3545';
-  };
-
-  const getStatusIcon = (connected?: boolean): string => {
-    return connected ? '✓' : '✕';
+  const onClear = async () => {
+    if (
+      !window.confirm(
+        "Remove stored Google Analytics credentials and site profile mappings?",
+      )
+    ) {
+      return;
+    }
+    try {
+      setBusy(true);
+      await deleteAnalyticsProviderConfig();
+      await load();
+    } catch (err: unknown) {
+      if (!isSessionRedirectError(err)) {
+        setError(formatApiError(err, "Failed to clear analytics config"));
+      }
+    } finally {
+      setBusy(false);
+    }
   };
 
   if (isLoading) {
     return (
-      <div style={styles.widget}>
+      <div style={styles.widget} data-testid="google-setup-widget">
         <div style={styles.widgetTitle}>{title}</div>
-        <div style={styles.widgetLoading}>Loading Google setup data...</div>
+        <div style={styles.widgetLoading} data-testid="google-setup-loading">
+          Loading Google setup data...
+        </div>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div style={styles.widget}>
+      <div style={styles.widget} data-testid="google-setup-widget">
         <div style={styles.widgetTitle}>{title}</div>
-        <div style={styles.widgetError}>{error}</div>
+        <div style={styles.widgetError} data-testid="google-setup-error">
+          {error}
+        </div>
       </div>
     );
   }
 
-  if (!setup) {
-    return (
-      <div style={styles.widget}>
-        <div style={styles.widgetTitle}>{title}</div>
-        <div style={styles.widgetContent}>No Google setup data available</div>
-      </div>
-    );
-  }
+  const provider = summary?.provider;
+  const configured = Boolean(provider?.configured);
+  const sites = summary?.sites ?? [];
+  const readySites = sites.filter((s) => s.profileConfigured).length;
 
   return (
-    <div style={styles.widget}>
+    <div style={styles.widget} data-testid="google-setup-widget">
       <div style={styles.widgetTitle}>{title}</div>
-      <div style={styles.widgetContent}>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' } as React.CSSProperties}>
-          {/* Account Connection Status */}
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' } as React.CSSProperties}>
+      <div style={styles.widgetContent} data-testid="google-setup-content">
+        <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+          <div
+            style={{ display: "flex", alignItems: "center", gap: "8px" }}
+            data-testid="google-setup-account"
+          >
             <div
               style={{
-                fontSize: '1.2em',
-                fontWeight: '700',
-                color: getStatusColor(setup.accountConnected),
+                fontSize: "1.2em",
+                fontWeight: 700,
+                color: configured ? "#28a745" : "#dc3545",
               }}
             >
-              {getStatusIcon(setup.accountConnected)}
+              {configured ? "✓" : "✕"}
             </div>
             <div>
-              <div style={{ fontSize: '0.85em', fontWeight: '600', color: '#333' }}>
-                Account {setup.accountConnected ? 'Connected' : 'Not Connected'}
+              <div style={{ fontSize: "0.85em", fontWeight: 600, color: "#333" }}>
+                {configured
+                  ? "Analytics provider configured"
+                  : "Analytics provider not configured"}
               </div>
-              {setup.email && (
-                <div style={{ fontSize: '0.75em', color: '#666' }}>{setup.email}</div>
-              )}
+              {provider?.userId ? (
+                <div
+                  style={{ fontSize: "0.75em", color: "#666" }}
+                  data-testid="google-setup-userid"
+                >
+                  Account: {provider.userId}
+                </div>
+              ) : null}
             </div>
           </div>
 
-          {/* Services Section */}
-          {setup.services && setup.services.length > 0 && (
-            <div style={{ borderTop: '1px solid #eee', paddingTop: '8px' }}>
-              <div style={{ fontSize: '0.85em', fontWeight: '600', marginBottom: '6px', color: '#333' }}>
-                Services ({setup.services.length})
+          <div
+            style={{
+              fontSize: "0.8em",
+              color: "#555",
+              padding: "8px",
+              backgroundColor: "#f5f9fc",
+              borderRadius: "4px",
+              borderLeft: "3px solid #007ea8",
+            }}
+          >
+            Traffic and What&apos;s Working (effectiveness) use this Google
+            Analytics configuration. Without credentials and a site profile
+            mapping, those gadgets cannot load data.
+          </div>
+
+          {sites.length > 0 ? (
+            <div data-testid="google-setup-sites">
+              <div
+                style={{
+                  fontSize: "0.85em",
+                  fontWeight: 600,
+                  marginBottom: "6px",
+                  color: "#333",
+                }}
+              >
+                Site profiles ({readySites}/{sites.length} ready)
               </div>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' } as React.CSSProperties}>
-                {setup.services.map((svc, idx) => (
-                  <div
-                    key={idx}
+              <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+                {sites.map((s) => (
+                  <li
+                    key={s.siteName}
                     style={{
-                      fontSize: '0.8em',
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: '6px',
-                      padding: '4px',
-                      backgroundColor: svc.connected ? '#f0f8f0' : '#fff5f5',
-                      borderRadius: '3px',
+                      fontSize: "0.8em",
+                      display: "flex",
+                      justifyContent: "space-between",
+                      gap: "8px",
+                      padding: "4px 0",
+                      borderBottom: "1px solid #eee",
                     }}
                   >
-                    <span style={{ color: getStatusColor(svc.connected) }}>
-                      {getStatusIcon(svc.connected)}
+                    <span>{s.siteName}</span>
+                    <span
+                      style={{
+                        color: s.profileConfigured ? "#28a745" : "#999",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {s.profileConfigured
+                        ? s.mapping?.webPropertyId
+                          ? `Ready · ${s.mapping.webPropertyId}`
+                          : "Ready"
+                        : "No profile"}
                     </span>
-                    <span style={{ flex: 1 }}>{svc.name}</span>
-                    {svc.enabled && (
-                      <span style={{ fontSize: '0.7em', color: '#999' }}>Enabled</span>
-                    )}
-                  </div>
+                  </li>
                 ))}
-              </div>
+              </ul>
+            </div>
+          ) : (
+            <div style={{ fontSize: "0.8em", color: "#666" }}>
+              No sites found to check profile mappings.
             </div>
           )}
 
-          {/* Sync Status */}
-          {setup.syncStatus && (
-            <div style={{ fontSize: '0.8em', color: '#666', padding: '6px', backgroundColor: '#f9f9f9', borderRadius: '3px' }}>
-              <span style={{ fontWeight: '600' }}>Sync Status:</span> {setup.syncStatus}
+          {!configured ? (
+            <div
+              style={{ fontSize: "0.8em", color: "#666" }}
+              data-testid="google-setup-hint"
+            >
+              Configure a Google service account and map each site to a GA
+              profile (classic Google Setup or Admin). Credential upload from
+              this React gadget is a follow-up.
             </div>
-          )}
+          ) : null}
 
-          {/* Last Update */}
-          {setup.lastUpdate && (
-            <div style={{ fontSize: '0.7em', color: '#999', marginTop: '4px', paddingTop: '8px', borderTop: '1px solid #eee' }}>
-              Last updated: {setup.lastUpdate}
-            </div>
-          )}
+          {allowDelete && configured ? (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void onClear()}
+              data-testid="google-setup-clear"
+              style={{
+                alignSelf: "flex-start",
+                padding: "6px 12px",
+                fontSize: "0.85em",
+                cursor: busy ? "default" : "pointer",
+              }}
+            >
+              {busy ? "Clearing…" : "Clear analytics config"}
+            </button>
+          ) : null}
         </div>
       </div>
     </div>
   );
 };
+
+export default GoogleSetupWidget;

--- a/WebUI/src/test/ts/api/dashboard/analyticsApi.test.ts
+++ b/WebUI/src/test/ts/api/dashboard/analyticsApi.test.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  extractExtraParamsMap,
+  normalizeAnalyticsProviderStatus,
+  parseSiteProfileMapping,
+  unwrapProviderConfig,
+  fetchAnalyticsProviderStatus,
+  isSiteAnalyticsProfileConfigured,
+} from "@/api/dashboard/analyticsApi";
+import * as client from "@/api/client";
+import { PATHS } from "@/api/paths";
+
+vi.mock("@/api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/client")>();
+  return {
+    ...actual,
+    get: vi.fn(),
+    del: vi.fn(),
+  };
+});
+
+vi.mock("@/api/home/homeApi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/home/homeApi")>();
+  return {
+    ...actual,
+    fetchSites: vi.fn().mockResolvedValue([{ name: "Demo" }]),
+  };
+});
+
+describe("analyticsApi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("unwrapProviderConfig handles root and null", () => {
+    expect(unwrapProviderConfig(null)).toBeNull();
+    expect(
+      unwrapProviderConfig({ providerConfig: { userid: "sa@x.iam" } }),
+    ).toMatchObject({ userid: "sa@x.iam" });
+    expect(unwrapProviderConfig({ uid: "u1" })).toMatchObject({ uid: "u1" });
+  });
+
+  it("extractExtraParamsMap from entry list", () => {
+    const map = extractExtraParamsMap({
+      extraParams: {
+        entry: [{ key: "Demo", value: "p1|UA-1|key" }],
+      },
+    });
+    expect(map.Demo).toBe("p1|UA-1|key");
+  });
+
+  it("parseSiteProfileMapping splits pipe fields", () => {
+    expect(parseSiteProfileMapping("Demo", "prof|G-123|k")).toEqual({
+      siteName: "Demo",
+      mapped: true,
+      profileId: "prof",
+      webPropertyId: "G-123",
+    });
+    expect(parseSiteProfileMapping("X", undefined).mapped).toBe(false);
+  });
+
+  it("normalizeAnalyticsProviderStatus maps sites and omits secret fields", () => {
+    const secretKey = "pass" + "word";
+    const wire: Record<string, unknown> = {
+      userid: "svc@acct.iam.gserviceaccount.com",
+      extraParams: {
+        entry: [{ key: "Demo", value: "pid|G-99" }],
+      },
+    };
+    wire[secretKey] = "SECRET_VALUE_NOT_IN_DTO";
+    const status = normalizeAnalyticsProviderStatus({
+      providerConfig: wire,
+    });
+    expect(status.configured).toBe(true);
+    expect(status.userId).toBe("svc@acct.iam.gserviceaccount.com");
+    expect(status.siteProfiles[0]).toMatchObject({
+      siteName: "Demo",
+      mapped: true,
+      profileId: "pid",
+      webPropertyId: "G-99",
+    });
+    expect(status).not.toHaveProperty(secretKey);
+    expect(JSON.stringify(status)).not.toContain("SECRET_VALUE_NOT_IN_DTO");
+  });
+
+  it("fetchAnalyticsProviderStatus GETs analytics config", async () => {
+    vi.mocked(client.get).mockResolvedValue({
+      providerConfig: { userid: "u@x.com" },
+    });
+    const s = await fetchAnalyticsProviderStatus();
+    expect(client.get).toHaveBeenCalledWith(PATHS.ANALYTICS_CONFIG);
+    expect(s.configured).toBe(true);
+    expect(s.userId).toBe("u@x.com");
+  });
+
+  it("fetchAnalyticsProviderStatus treats 404 as not configured", async () => {
+    vi.mocked(client.get).mockRejectedValue({ status: 404, body: "" });
+    const s = await fetchAnalyticsProviderStatus();
+    expect(s.configured).toBe(false);
+  });
+
+  it("isSiteAnalyticsProfileConfigured parses text boolean", async () => {
+    vi.mocked(client.get).mockResolvedValue("true");
+    await expect(isSiteAnalyticsProfileConfigured("Demo")).resolves.toBe(true);
+    expect(client.get).toHaveBeenCalledWith(
+      `${PATHS.ANALYTICS_IS_PROFILE_CONFIGURED}/Demo`,
+    );
+  });
+});

--- a/WebUI/src/test/ts/dashboard/GoogleSetupWidget.test.tsx
+++ b/WebUI/src/test/ts/dashboard/GoogleSetupWidget.test.tsx
@@ -1,250 +1,90 @@
 /*
  * Copyright 1999-2026 Percussion Software, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 
-import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import { GoogleSetupWidget } from '@/dashboard/GoogleSetupWidget';
-import * as clientModule from '@/api/client';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { GoogleSetupWidget } from "@/dashboard/GoogleSetupWidget";
+import * as analyticsApi from "@/api/dashboard/analyticsApi";
 
-vi.mock('@/api/client', () => ({
-  get: vi.fn(),
-}));
+vi.mock("@/api/dashboard/analyticsApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/api/dashboard/analyticsApi")>();
+  return {
+    ...actual,
+    fetchGoogleSetupSummary: vi.fn(),
+    deleteAnalyticsProviderConfig: vi.fn(),
+  };
+});
 
-describe('GoogleSetupWidget', () => {
+describe("GoogleSetupWidget", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.mocked(analyticsApi.fetchGoogleSetupSummary).mockReset();
   });
 
-  test('should display loading state initially', () => {
-    vi.mocked(clientModule.get).mockImplementation(
-      () => new Promise(() => {}) // Never resolves
+  it("shows not configured state", async () => {
+    vi.mocked(analyticsApi.fetchGoogleSetupSummary).mockResolvedValue({
+      provider: { configured: false, userId: null, siteProfiles: [] },
+      sites: [{ siteName: "Demo", profileConfigured: false }],
+    });
+    render(<GoogleSetupWidget />);
+    await waitFor(() => {
+      expect(screen.getByTestId("google-setup-content")).toBeDefined();
+    });
+    expect(
+      screen.getByText(/Analytics provider not configured/i),
+    ).toBeDefined();
+    expect(screen.getByTestId("google-setup-hint")).toBeDefined();
+    expect(screen.getByText(/Traffic and What's Working/i)).toBeDefined();
+  });
+
+  it("shows configured account and site readiness", async () => {
+    vi.mocked(analyticsApi.fetchGoogleSetupSummary).mockResolvedValue({
+      provider: {
+        configured: true,
+        userId: "svc@example.iam.gserviceaccount.com",
+        siteProfiles: [
+          {
+            siteName: "Demo",
+            mapped: true,
+            profileId: "p1",
+            webPropertyId: "G-1",
+          },
+        ],
+      },
+      sites: [
+        {
+          siteName: "Demo",
+          profileConfigured: true,
+          mapping: {
+            siteName: "Demo",
+            mapped: true,
+            profileId: "p1",
+            webPropertyId: "G-1",
+          },
+        },
+      ],
+    });
+    render(<GoogleSetupWidget />);
+    await waitFor(() => {
+      expect(screen.getByTestId("google-setup-userid")).toBeDefined();
+    });
+    expect(screen.getByText(/Analytics provider configured/i)).toBeDefined();
+    expect(
+      screen.getByText(/svc@example.iam.gserviceaccount.com/),
+    ).toBeDefined();
+    expect(screen.getByText(/1\/1 ready/)).toBeDefined();
+    expect(screen.getByText(/Ready · G-1/)).toBeDefined();
+  });
+
+  it("shows error on failure", async () => {
+    vi.mocked(analyticsApi.fetchGoogleSetupSummary).mockRejectedValue(
+      new Error("analytics down"),
     );
-
     render(<GoogleSetupWidget />);
-    screen.getByText(/loading google setup/i);
-  });
-
-  test('should display connected account status', async () => {
-    const mockSetup = {
-      setup: {
-        accountConnected: true,
-        email: 'user@example.com',
-        services: [],
-      },
-    };
-
-    vi.mocked(clientModule.get).mockResolvedValueOnce(mockSetup);
-
-    render(<GoogleSetupWidget />);
-
     await waitFor(() => {
-      screen.getByText('Account Connected');
-      screen.getByText('user@example.com');
+      expect(screen.getByTestId("google-setup-error")).toBeDefined();
     });
-  });
-
-  test('should display disconnected account status', async () => {
-    const mockSetup = {
-      data: {
-        accountConnected: false,
-        services: [],
-      },
-    };
-
-    vi.mocked(clientModule.get).mockResolvedValueOnce(mockSetup);
-
-    render(<GoogleSetupWidget />);
-
-    await waitFor(() => {
-      screen.getByText('Account Not Connected');
-    });
-  });
-
-  test('should display configured Google services', async () => {
-    const mockSetup = {
-      google: {
-        accountConnected: true,
-        email: 'admin@company.com',
-        services: [
-          { name: 'Google Analytics', enabled: true, connected: true },
-          { name: 'Google Search Console', enabled: true, connected: true },
-          { name: 'Google Ads', enabled: false, connected: false },
-        ],
-      },
-    };
-
-    vi.mocked(clientModule.get).mockResolvedValueOnce(mockSetup);
-
-    render(<GoogleSetupWidget />);
-
-    await waitFor(() => {
-      screen.getByText('Services (3)');
-      screen.getByText('Google Analytics');
-      screen.getByText('Google Search Console');
-    });
-  });
-
-  test('should display sync status', async () => {
-    const mockSetup = {
-      setup: {
-        accountConnected: true,
-        services: [],
-        syncStatus: 'Last synced 2 hours ago',
-      },
-    };
-
-    vi.mocked(clientModule.get).mockResolvedValueOnce(mockSetup);
-
-    render(<GoogleSetupWidget />);
-
-    await waitFor(() => {
-      screen.getByText(/Sync Status:/);
-      screen.getByText('Last synced 2 hours ago');
-    });
-  });
-
-  test('should display error message on fetch failure', async () => {
-    vi.mocked(clientModule.get).mockRejectedValueOnce(new Error('API error'));
-
-    render(<GoogleSetupWidget />);
-
-    await waitFor(() => {
-      screen.getByText('API error');
-    });
-  });
-
-  test('should display no data message when response is empty', async () => {
-    vi.mocked(clientModule.get).mockResolvedValueOnce({});
-
-    render(<GoogleSetupWidget />);
-
-    await waitFor(() => {
-      screen.getByText(/no google setup data/i);
-    });
-  });
-
-  test('should support custom title prop', async () => {
-    const mockSetup = { setup: { accountConnected: true, services: [] } };
-    vi.mocked(clientModule.get).mockResolvedValueOnce(mockSetup);
-
-    render(<GoogleSetupWidget title="Google Integration Status" />);
-
-    await waitFor(() => {
-      screen.getByText('Google Integration Status');
-    });
-  });
-
-  test('should handle different response format variations', async () => {
-    const mockSetup = {
-      accountConnected: true,
-      email: 'test@test.com',
-      services: [],
-    };
-
-    vi.mocked(clientModule.get).mockResolvedValueOnce(mockSetup);
-
-    render(<GoogleSetupWidget />);
-
-    await waitFor(() => {
-      screen.getByText('Account Connected');
-    });
-  });
-
-  test('should call API with correct endpoint', async () => {
-    const mockSetup = { setup: { accountConnected: true, services: [] } };
-    vi.mocked(clientModule.get).mockResolvedValueOnce(mockSetup);
-
-    render(<GoogleSetupWidget />);
-
-    await waitFor(() => {
-      expect(vi.mocked(clientModule.get)).toHaveBeenCalledWith('/services/google/setup');
-    });
-  });
-
-  test('should display last update timestamp', async () => {
-    const mockSetup = {
-      setup: {
-        accountConnected: true,
-        services: [],
-        lastUpdate: '2024-02-26T10:30:00Z',
-      },
-    };
-
-    vi.mocked(clientModule.get).mockResolvedValueOnce(mockSetup);
-
-    render(<GoogleSetupWidget />);
-
-    await waitFor(() => {
-      screen.getByText(/Last updated:/);
-    });
-  });
-
-  test('should display service count in header', async () => {
-    const mockSetup = {
-      setup: {
-        accountConnected: true,
-        services: [
-          { name: 'Analytics', enabled: true, connected: true },
-          { name: 'Search Console', enabled: true, connected: true },
-        ],
-      },
-    };
-
-    vi.mocked(clientModule.get).mockResolvedValueOnce(mockSetup);
-
-    render(<GoogleSetupWidget />);
-
-    await waitFor(() => {
-      screen.getByText('Services (2)');
-    });
-  });
-
-  test('should set up refresh interval when refreshInterval prop is provided', async () => {
-    const mockSetup = { setup: { accountConnected: true, services: [] } };
-    vi.mocked(clientModule.get).mockResolvedValue(mockSetup);
-
-    vi.useFakeTimers();
-
-    render(<GoogleSetupWidget refreshInterval={30} />);
-
-    await waitFor(() => {
-      expect(vi.mocked(clientModule.get)).toHaveBeenCalledTimes(1);
-    });
-
-    vi.advanceTimersByTime(30000);
-
-    await waitFor(() => {
-      expect(vi.mocked(clientModule.get)).toHaveBeenCalledTimes(2);
-    });
-
-    vi.useRealTimers();
-  });
-
-  test('should not set up refresh interval when not provided', async () => {
-    const mockSetup = { setup: { accountConnected: true, services: [] } };
-    vi.mocked(clientModule.get).mockResolvedValue(mockSetup);
-
-    render(<GoogleSetupWidget />);
-
-    await waitFor(() => {
-      expect(vi.mocked(clientModule.get)).toHaveBeenCalledTimes(1);
-    });
-
-    await new Promise(resolve => setTimeout(resolve, 100));
-    expect(vi.mocked(clientModule.get)).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/analytics down/i)).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

Google Setup is the configuration gate for **Traffic** and **What's Working** (effectiveness). This PR wires the React gadget to real classic APIs instead of invented `/services/google/setup`.

| API | Use |
|-----|-----|
| `GET /services/analytics/provider/config` | Provider configured? user id (no secrets) |
| `GET /services/analytics/provider/isProfileConfigured/{site}` | Per-site GA profile ready |
| `DELETE …/config` | Optional clear (admin prop) |

UI shows:
- Provider configured / not configured
- Service account user id when present
- Site list with profile readiness
- Explicit note that Traffic and What's Working depend on this config

**Not in this PR:** multipart JSON key upload / full classic wizard (follow-up). Status is enough for operators to know why analytics gadgets fail.

Shared module: `WebUI/src/main/ts/api/dashboard/analyticsApi.ts` for Traffic/Effectiveness next.

## Stack

- **Base:** #1581 (`fix/home-gadgets-wave3`)
- After #1580 / #1581 merge, retarget to `development` if needed

## Test plan

- [x] `analyticsApi` + `GoogleSetupWidget` unit tests (**10 passed**)
- [ ] Deploy WebUI; Home → Gadgets shows Google Setup status
- [ ] With no config: “not configured” + Traffic/What's Working note
- [ ] With config: account id + site profile readiness
- [ ] No Maven modules changed

> Co-Authored by Grok Build using grok-4.5 with agent Grok.