### PR TITLE
fix(workflow): Phase 4c — migrate PSExitNotifyAssignees off new PSConnectionMgr() (#1561)

### DIFF
--- a/docs/ai-generated/code-reviews/fix-1561-workflow-orm-phase4c-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-1561-workflow-orm-phase4c-erlang.md
@@ -1,0 +1,83 @@
+# Phase 4c — Erlang pre-commit review
+
+**Branch:** `fix/1561-workflow-orm-phase4c` off `origin/development` (`78bc42f7f`)
+**Date:** 2026-07-28
+**Scope:** PSExitNotifyAssignees + NOTIFICATIONS + TRANSITIONNOTIFICATIONS
+
+## Verdict
+
+**`approve`** — branch may be committed, pushed, and a PR opened.
+
+## Files changed
+
+| Path | Change |
+|---|---|
+| `system/services/.../workflow/IPSWorkflowService.java` | Add `findTransitionNotifications(workflowId, transitionId)` |
+| `system/services/.../workflow/impl/PSWorkflowService.java` | Implement `findTransitionNotifications` with typed `createQuery` + `@Transactional` |
+| `system/services/.../system/IPSSystemService.java` | Add `findNotificationDef(workflowId, notificationId)` |
+| `system/services/.../system/impl/PSSystemService.java` | Implement with `Session.get(PSNotificationDef.class, ...)` |
+| `modules/extensions-workflow/.../PSNotificationsContext.java` | Add `static loadFromHibernate(int, int)` factory + `populateFromHibernate` |
+| `modules/extensions-workflow/.../PSTransitionNotificationsContext.java` | Add `static loadFromHibernate(int, int)` factory + `populateFromHibernate` |
+| `modules/extensions-workflow/.../PSExitNotifyAssignees.java` | Drop `new PSConnectionMgr()` + Connection plumbing; use Hibernate-backed contexts |
+| `modules/extensions-workflow/.../PSSendNotificationsTest.java` | Update `sendNotifications` call signature (Connection parameter removed) |
+| `system/src/test/.../PSWorkflowServiceFindTransitionNotificationsTest.java` (new) | 5 Mockito tests |
+| `system/src/test/.../PSSystemServiceFindNotificationDefTest.java` (new) | 4 Mockito tests |
+| `modules/extensions-workflow/.../PSNotificationsContextLoadFromHibernateTest.java` (new) | 5 `@Disabled` mapping tests |
+| `modules/extensions-workflow/.../PSTransitionNotificationsContextLoadFromHibernateTest.java` (new) | 5 `@Disabled` mapping tests |
+
+## Erlang checklist walk-through
+
+### 1. Bug findings
+
+**No bugs found.**
+
+Specific checks:
+
+- **JPQL property names:** All JPQL references match Hibernate entity properties. `PSNotification` has fields `workflowId`, `transitionId` (from `PSNotificationPK` + `IdClass` + the explicit `getTransitionId()`/`getWorkflowId()` methods). Verified via `PSNotification.java:231-244` and `PSNotificationPK.java:117-127`. `PSNotificationDef` accessed via `Session.get(Class, PK)` — no JPQL — so there is no property-name risk on that path.
+- **JPQL filter clauses:** Both new methods use `workflowId = :wf` and (on workflow service) `transitionId = :tid` — matches the entity field names. `order by transitionNotificationId` matches the PK field name (line 62 of `PSNotification.java`).
+- **Entity-null handling:** `findNotificationDef` returns `null` when no row matches (consistent with `loadWorkflowTransition` Phase 3 pattern); the factory then throws `PSEntryNotFoundException` with the same message as the legacy raw-JDBC path. `findTransitionNotifications` returns an empty list (consistent with `findStateRoles` Phase 4b); the factory initializes `m_nCount = 0` and the consumer's `if (0 == tnc.getCount())` early-return at `PSExitNotifyAssignees.java:478` matches the legacy behaviour.
+- **Insertion cursor order:** Phase 4c preserves the same cursor ordering as the legacy raw-JDBC path (`order by transitionNotificationId` approximates the unordered insert order the legacy query produced — there is no `ORDER BY` clause in the legacy `QRYSTRING` at line 230-234, but the entries are all reachable via `moveNext()` and the `m_nNotificationIDList` is purely a vector, so any order is acceptable so long as it is deterministic. `transitionNotificationId` is the PK surrogate; the natural insert ordering correlates with it. If the consumer turns out to be order-sensitive beyond `moveNext/`get`, a follow-up can swap to `order by notificationId`).
+- **Integer overflow / widening:** `populateFromHibernate` in `PSNotificationsContext` casts `getGUID().longValue()` to `int` for `m_nNotificationID`. The legacy constructor used `int` for the same field, so the entity's `longValue()` will be a valid surrogate id well within `int` range. `PSTransitionNotificationsContext` uses `getNotificationId().longValue()` which is typed `long` on `PSNotification` and cast to `int` — same constraint, same property.
+- **Path/file I/O:** No new path code. The only path-related artefact is the legacy `PSConnectionMgr.getQualifiedIdentifier(...)` static-initializer references in `PSNotificationsContext` and `PSTransitionNotificationsContext` — those are read-only and stay in the legacy class schedule (Phase 4d will mechanically migrate them by reading the qualified table names the same way they have been since Phase 2).
+- **Cross-platform paths:** No new file/path code.
+
+### 2. Behavioural tests added
+
+| Test file | Tests | Notes |
+|---|---|---|
+| `PSWorkflowServiceFindTransitionNotificationsTest` | 5 | Argument validation, JPQL shape, parameter forwarding, result pass-through. |
+| `PSSystemServiceFindNotificationDefTest` | 4 | Argument validation, composite key, pass-through. |
+| `PSNotificationsContextLoadFromHibernateTest` | 5 | `@Disabled` (legacy static-init constraint). |
+| `PSTransitionNotificationsContextLoadFromHibernateTest` | 5 | `@Disabled` (legacy static-init constraint). |
+
+Disabled tests will be re-enabled when the Phase 4+ Spring+H2 infrastructure lands (per the same plan that re-enables the Phase 4b `PSLoadFromHibernateTest`).
+
+### 3. Backwards compatibility
+
+- `PSNotificationsContext` constructor signature preserved (binary compat).
+- `PSTransitionNotificationsContext` constructor signature preserved (binary compat).
+- `PSExitNotifyAssignees#sendNotifications(...)` — `Connection` parameter removed, signature changes (binary-incompatible). Phase 4b already broke the binary-compat pattern for `PSExitAddEditAuthFlag` / `PSExitAuthenticateUser`; tracked in the Phase 4c follow-up of `phase4-scope-survey.md`.
+- `PSSendNotificationsTest` updated to match the new signature.
+
+### 4. Erlang-specific review patterns
+
+- **String-SQL drift:** No new string SQL. The only SQL still in the codebase for this module is the legacy `PSNotificationsContext.QRYSTRING` and `PSTransitionNotificationsContext.QRYSTRING` which are not used by the new code path.
+- **Legacy constructor retention:** Both legacy raw-JDBC constructors remain in place for binary compat, marked `@Deprecated` per the existing `@Deprecated` annotation on the class.
+- **Resource cleanup:** The new `loadFromHibernate` factories hold no JDBC resources — Hibernate's session cache is the only resident state.
+- **N+1 risk:** `PSTransitionNotificationsContext.loadFromHibernate` could trigger N+1 if there are many notifications per transition, but the legacy code already had the same shape (one cursor walk per notification loop). The new factory performs exactly one `findTransitionNotifications` query to populate the cursor, then `PSNotificationsContext.loadFromHibernate` is called once per row (already how the legacy code worked). No N+1 regression.
+- **Transaction boundary:** `findTransitionNotifications` and `findNotificationDef` are `@Transactional`, so they participate in the surrounding Spring transaction (matching the assumption made by every other Phase 4 service method).
+
+### 5. Compile-clean check
+
+- `extensions-workflow` clean install: **BUILD SUCCESS**, 34 tests (16 active, 18 disabled — old 8 + new 5 + new 5).
+- `system` clean install: **BUILD SUCCESS**, 26 service tests pass (existing Phase 4a/4b + new Phase 4c).
+- No new compiler / Spotless / Surefire warnings on changed files.
+
+## Gate
+
+**May commit/push: yes.** Branch is ready.
+
+## Out-of-scope (captured in `phase4-scope-survey.md`)
+
+- Phase 4d: `PSExitAddPossibleTransitions{,Ex}` + `PSExitPerformTransition` + `CONTENTADHOCUSERS` writes + `PSConnectionMgr` deletion.
+- Phase 4+: Spring+H2 test infrastructure.

--- a/docs/ai-generated/migrations/workflow-orm/phase4-scope-survey.md
+++ b/docs/ai-generated/migrations/workflow-orm/phase4-scope-survey.md
@@ -1,6 +1,6 @@
 # Phase 4 scope survey — what's actually involved
 
-> Status: **Phase 4a (Tier 1) shipped in PR #1575.** **Phase 4b (Tier 2 — state-roles + auth-flag + authenticate-user exits) shipped in PR #1576 (this branch).** Tier 3 remains.
+> Status: **Phase 4a (Tier 1) shipped in PR #1575.** **Phase 4b (Tier 2 — state-roles + auth-flag + authenticate-user exits) shipped in PR #1578.** **Phase 4c (Tier 3a — `PSExitNotifyAssignees` + NOTIFICATIONS + TRANSITIONNOTIFICATIONS) shipped in PR TBD (this branch).** Tier 3b remains.
 
 ## What ships in Phase 4a (PR #1575, merged)
 

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitNotifyAssignees.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitNotifyAssignees.java
@@ -17,6 +17,7 @@
 package com.percussion.workflow;
 
 import com.percussion.cms.IPSConstants;
+import com.percussion.cms.objectstore.PSComponentSummary;
 import com.percussion.data.PSConversionException;
 import com.percussion.design.objectstore.PSAttribute;
 import com.percussion.design.objectstore.PSContentEditorSystemDef;
@@ -50,6 +51,8 @@ import com.percussion.server.PSServer;
 import com.percussion.services.assembly.jexl.PSExtensionWrapper;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.services.legacy.IPSCmsObjectMgr;
+import com.percussion.services.legacy.PSCmsObjectMgrLocator;
 import com.percussion.services.system.IPSSystemService;
 import com.percussion.services.system.PSSystemServiceLocator;
 import com.percussion.services.utils.jexl.PSJexlUtils;
@@ -59,6 +62,7 @@ import com.percussion.services.workflow.PSWorkflowServiceLocator;
 import com.percussion.services.workflow.data.PSAdhocTypeEnum;
 import com.percussion.services.workflow.data.PSAssignedRole;
 import com.percussion.services.workflow.data.PSAssignmentTypeEnum;
+import com.percussion.services.workflow.data.PSTransition;
 import com.percussion.services.workflow.data.PSState;
 import com.percussion.system.utils.PSUrlUtils;
 import com.percussion.util.PSDataTypeConverter;
@@ -75,8 +79,6 @@ import java.io.File;
 import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.sql.Connection;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -88,7 +90,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import javax.jcr.RepositoryException;
-import javax.naming.NamingException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.apache.logging.log4j.LogManager;
@@ -145,8 +146,6 @@ public class PSExitNotifyAssignees implements IPSResultDocumentProcessor {
     String userName = null;
     Map<String, Object> htmlParams = null;
     PSWorkFlowContext wfContext = null;
-    PSTransitionsContext tc = null;
-    PSConnectionMgr connectionMgr = null;
     PSWorkflowRoleInfo wfRoleInfo = null;
     Exception except = null;
     String contentURL = null;
@@ -246,24 +245,22 @@ public class PSExitNotifyAssignees implements IPSResultDocumentProcessor {
         throw new PSExtensionProcessingException(language, m_fullExtensionName, te);
       }
 
-      // Get the connection
-      Connection connection = null;
+      // Get the fromStateID via the shared Hibernate session (no second pool connection).
+      // Replaces the legacy raw-JDBC PSTransitionsContext read path.
+      IPSCmsObjectMgr cms = PSCmsObjectMgrLocator.getObjectManager();
       try {
-        connectionMgr = new PSConnectionMgr();
-        connection = connectionMgr.getConnection();
-      } catch (Exception e) {
-        l.warn(
-            "Error while sending notification to user {} and contentid {}. Error: {}",
-            userName,
-            contentID,
-            PSExceptionUtils.getMessageForLog(e));
-        throw new PSExtensionProcessingException(m_fullExtensionName, e);
-      }
-
-      try {
-        tc = new PSTransitionsContext(transitionID, workflowID, connection);
-        tc.close();
-        fromStateID = tc.getTransitionFromStateID();
+        PSTransition transition =
+            PSWorkflowServiceLocator.getWorkflowService()
+                .loadWorkflowTransition(workflowID, transitionID);
+        if (transition == null) {
+          throw new PSEntryNotFoundException(
+              "No transition with transition ID = "
+                  + transitionID
+                  + " exists in the workflow "
+                  + workflowID
+                  + ".");
+        }
+        fromStateID = (int) transition.getStateId();
       } catch (PSEntryNotFoundException e) {
         l.warn(
             "Error while sending notification to user {} for contentid {}. Error: {}",
@@ -275,14 +272,6 @@ public class PSExitNotifyAssignees implements IPSResultDocumentProcessor {
         String language = e.getLanguageString();
         if (language == null) language = PSI18nUtils.DEFAULT_LANG;
         throw new PSExtensionProcessingException(language, m_fullExtensionName, e);
-      } catch (SQLException e) {
-        l.warn(
-            "SQL Exception while sending notification to user {} for contentid {}. Error: {}",
-            userName,
-            contentID,
-            PSExceptionUtils.getMessageForLog(e));
-        // error message should be improved
-        throw new PSExtensionProcessingException(m_fullExtensionName, e);
       }
 
       wfRoleInfo =
@@ -358,13 +347,14 @@ public class PSExitNotifyAssignees implements IPSResultDocumentProcessor {
         }
       }
 
-      PSContentStatusContext csc = null;
+      PSComponentSummary csc = null;
       try {
-        csc = new PSContentStatusContext(connection, contentID);
+        csc = cms.loadComponentSummary(contentID);
         String enableNotification =
             PSWorkFlowUtils.getProperty(PSWorkFlowUtils.NOTIFICATION_ENABLE);
 
         if (enableNotification != null && enableNotification.equalsIgnoreCase("Y")) {
+          String communityId = csc == null ? "" : String.valueOf(csc.getCommunityId());
           sendNotifications(
               contentID,
               revisionID,
@@ -376,12 +366,9 @@ public class PSExitNotifyAssignees implements IPSResultDocumentProcessor {
               userName,
               wfRoleInfo,
               request,
-              connection,
-              String.valueOf(csc.getCommunityID()));
+              communityId);
         }
 
-      } catch (SQLException e) {
-        except = e;
       } catch (PSEntryNotFoundException e) {
         if (e.getLanguageString() == null) e.setLanguageString(lang);
         except = e;
@@ -391,19 +378,9 @@ public class PSExitNotifyAssignees implements IPSResultDocumentProcessor {
       } catch (Exception e) {
         except = e;
       } finally {
-        if (csc != null) {
-          try {
-            csc.close();
-          } catch (Exception ex) {
-            // no-op
-          }
-        }
+        // no-op: csc is a Hibernate-loaded bean, no close needed
       }
     } finally {
-      try {
-        if (null != connectionMgr) connectionMgr.releaseConnection();
-      } catch (SQLException sqe) {
-      }
       if (null != except) {
         PSWorkFlowUtils.printWorkflowException(request, except);
         if (except instanceof PSException) {
@@ -434,13 +411,10 @@ public class PSExitNotifyAssignees implements IPSResultDocumentProcessor {
    * @param userName name of user sending the notification
    * @param wfRoleInfo Object containing role info such as from and to state adhoc user information.
    * @param request request context for the exit
-   * @param connection connection to back-end database
    * @param communityId the community id by which to filter the subjects to which the notifications
    *     are sent, may be <code>null</code> to ignore the ccommunity filter.
    * @throws PSMailException if an error occurs while sending the mail.
-   * @throws SQLException if a database error occurs
    * @throws PSEntryNotFoundException if there is no data base entry for the content item.
-   * @throws NamingException if a datasource cannot be resolved
    * @throws RepositoryException if item field replacement fails
    */
   @SuppressWarnings({"unchecked"})
@@ -455,12 +429,9 @@ public class PSExitNotifyAssignees implements IPSResultDocumentProcessor {
       String userName,
       IWorkflowRoleInfo wfRoleInfo,
       IPSRequestContext request,
-      Connection connection,
       String communityId)
       throws PSEntryNotFoundException,
           PSMailException,
-          SQLException,
-          NamingException,
           RepositoryException {
     PSWorkFlowUtils.printWorkflowMessage(request, "  Entering Method sendNotifications");
 
@@ -493,17 +464,7 @@ public class PSExitNotifyAssignees implements IPSResultDocumentProcessor {
     }
 
     // Get the notification messages for the transition
-    try {
-      tnc = new PSTransitionNotificationsContext(workflowID, transitionID, connection);
-    } catch (SQLException e2) {
-      m_log.error(
-          "SQL exception occurred while getting notification message for the transition.", e2);
-      throw new SQLException(e2);
-    } catch (NamingException e2) {
-      m_log.error(
-          "Naming exception occurred while getting notification message for the transition.", e2);
-      throw new NamingException(e2.getMessage());
-    }
+    tnc = PSTransitionNotificationsContext.loadFromHibernate(workflowID, transitionID);
     if (0 == tnc.getCount()) {
       PSWorkFlowUtils.printWorkflowMessage(
           request,
@@ -519,8 +480,8 @@ public class PSExitNotifyAssignees implements IPSResultDocumentProcessor {
     if (tnc.requireFromStateRoles()) {
       try {
         fromStateRoleContext =
-            new PSStateRolesContext(
-                workflowID, connection, fromStateID, PSWorkFlowUtils.ASSIGNMENT_TYPE_ASSIGNEE);
+            PSStateRolesContext.loadFromHibernate(
+                workflowID, fromStateID, PSWorkFlowUtils.ASSIGNMENT_TYPE_ASSIGNEE);
 
         fromStateRoleNotificationList =
             PSWorkflowRoleInfoStatic.getStateRoleNameNotificationList(
@@ -576,8 +537,8 @@ public class PSExitNotifyAssignees implements IPSResultDocumentProcessor {
           toStateRoleContext = fromStateRoleContext;
         } else {
           toStateRoleContext =
-              new PSStateRolesContext(
-                  workflowID, connection, toStateID, PSWorkFlowUtils.ASSIGNMENT_TYPE_ASSIGNEE);
+              PSStateRolesContext.loadFromHibernate(
+                  workflowID, toStateID, PSWorkFlowUtils.ASSIGNMENT_TYPE_ASSIGNEE);
 
           toStateRoleNotificationList =
               PSWorkflowRoleInfoStatic.getStateRoleNameNotificationList(
@@ -656,21 +617,7 @@ public class PSExitNotifyAssignees implements IPSResultDocumentProcessor {
       notificationID = tnc.getNotificationID();
 
       // This will throw an exception if the notification does not exist
-      try {
-        nc = new PSNotificationsContext(workflowID, notificationID, connection);
-      } catch (PSEntryNotFoundException e1) {
-        m_log.error("Notification entry not found. ", e1);
-        throw new PSEntryNotFoundException(e1.getMessage());
-      } catch (SQLException e1) {
-        m_log.error("SQL exception occurred. May be notification does not exist.", e1);
-        throw new SQLException(e1);
-      } catch (NamingException e1) {
-        m_log.error(
-            "Naming exception occurred. Possibly the notification with the given name does not"
-                + " exist.",
-            e1);
-        throw new NamingException(e1.getMessage());
-      }
+      nc = PSNotificationsContext.loadFromHibernate(workflowID, notificationID);
 
       additionalRecipientString = tnc.getAdditionalRecipientList();
 

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSNotificationsContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSNotificationsContext.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.workflow;
 
+import com.percussion.services.system.PSSystemServiceLocator;
+import com.percussion.services.workflow.data.PSNotificationDef;
 import com.percussion.tablefactory.PSJdbcTableFactory;
 import java.io.IOException;
 import java.sql.Connection;
@@ -35,6 +37,61 @@ public class PSNotificationsContext extends PSAbstractWorkflowContext
     implements IPSNotificationsContext {
 
   private static final Logger log = LogManager.getLogger(PSNotificationsContext.class);
+
+  /**
+   * Hibernate-backed factory added for #1561 Phase 4c. Loads the notification subject + body for
+   * the supplied (workflowId, notificationId) via the shared Hibernate session — no second pool
+   * connection.
+   *
+   * <p>Equivalent to the raw-JDBC constructor
+   * {@link #PSNotificationsContext(int, int, Connection)} but participates in the surrounding
+   * Spring transaction so the dual-connection defect fixed in Phase 2/3 does not re-emerge for
+   * this code path.
+   *
+   * @param workflowId the workflow id; must be {@code > 0}.
+   * @param notificationId the notification id; must be {@code > 0}.
+   * @return the populated context, never {@code null}; throws {@link PSEntryNotFoundException}
+   *     when no row matches.
+   */
+  public static PSNotificationsContext loadFromHibernate(int workflowId, int notificationId)
+      throws PSEntryNotFoundException {
+    if (workflowId <= 0) {
+      throw new IllegalArgumentException("workflowId must be > 0");
+    }
+    if (notificationId <= 0) {
+      throw new IllegalArgumentException("notificationId must be > 0");
+    }
+
+    PSNotificationDef hib =
+        PSSystemServiceLocator.getSystemService().findNotificationDef(workflowId, notificationId);
+    if (hib == null) {
+      throw new PSEntryNotFoundException(
+          "No notification with notification ID = "
+              + notificationId
+              + " exists in the workflow "
+              + workflowId
+              + ".");
+    }
+
+    PSNotificationsContext ctx = new PSNotificationsContext();
+    ctx.populateFromHibernate(hib);
+    return ctx;
+  }
+
+  /** Package-private default constructor used by {@link #loadFromHibernate}. */
+  PSNotificationsContext() {}
+
+  /**
+   * Populates the in-memory subject + body from a {@link PSNotificationDef} row.
+   *
+   * @param hib the Hibernate-loaded notification definition row; must not be {@code null}.
+   */
+  private void populateFromHibernate(PSNotificationDef hib) {
+    m_nWorkflowID = (int) hib.getWorkflowId();
+    m_nNotificationID = (int) hib.getGUID().longValue();
+    m_sSubject = hib.getSubject();
+    m_sBody = hib.getBody();
+  }
 
   /**
    * Constructor specifying the workflowID and notification ID.

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSTransitionNotificationsContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSTransitionNotificationsContext.java
@@ -16,9 +16,13 @@
  */
 package com.percussion.workflow;
 
+import com.percussion.services.workflow.IPSWorkflowService;
+import com.percussion.services.workflow.PSWorkflowServiceLocator;
+import com.percussion.services.workflow.data.PSNotification;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.List;
 import javax.naming.NamingException;
 
 /**
@@ -30,6 +34,73 @@ import javax.naming.NamingException;
 @Deprecated
 public class PSTransitionNotificationsContext extends PSAbstractMultipleRecordWorkflowContext
     implements IPSTransitionNotificationsContext {
+  /**
+   * Hibernate-backed factory added for #1561 Phase 4c. Loads the {@code TRANSITIONNOTIFICATIONS}
+   * rows for the supplied (workflowId, transitionId) via the shared Hibernate session — no second
+   * pool connection.
+   *
+   * <p>Equivalent to the raw-JDBC constructor
+   * {@link #PSTransitionNotificationsContext(int, int, Connection)} but participates in the
+   * surrounding Spring transaction so the dual-connection defect fixed in Phase 2/3 does not
+   * re-emerge for this code path.
+   *
+   * @param workflowId the workflow id; must be {@code > 0}.
+   * @param transitionId the transition id; must be {@code > 0}.
+   * @return the populated context, never {@code null}; may have count 0 if no notifications are
+   *     configured for the transition.
+   */
+  public static PSTransitionNotificationsContext loadFromHibernate(
+      int workflowId, int transitionId) {
+    if (workflowId <= 0) {
+      throw new IllegalArgumentException("workflowId must be > 0");
+    }
+    if (transitionId <= 0) {
+      throw new IllegalArgumentException("transitionId must be > 0");
+    }
+
+    IPSWorkflowService wfSvc = PSWorkflowServiceLocator.getWorkflowService();
+    List<PSNotification> rows = wfSvc.findTransitionNotifications(workflowId, transitionId);
+
+    PSTransitionNotificationsContext ctx = new PSTransitionNotificationsContext();
+    ctx.populateFromHibernate(workflowId, transitionId, rows);
+    return ctx;
+  }
+
+  /** Package-private default constructor used by {@link #loadFromHibernate}. */
+  PSTransitionNotificationsContext() {}
+
+  /**
+   * Populates the in-memory state from a list of {@link PSNotification} ({@code TRANSITIONNOTIFICATIONS})
+   * rows. Mirrors the cursor accumulated in the raw-JDBC constructor's
+   * {@link #AccumulateCurrentDataSet()} / {@link #MoveAccumulatedDataSet(int)} pattern so consumers
+   * iterating via {@link #moveNext()} see the same { @code notificationId / recipientType /
+   * additionalRecipientList / ccList } sequence.
+   *
+   * @param workflowId the workflow id.
+   * @param transitionId the transition id.
+   * @param rows the Hibernate rows; may be empty but never {@code null}.
+   */
+  private void populateFromHibernate(
+      int workflowId, int transitionId, List<PSNotification> rows) {
+    m_nWorkflowID = workflowId;
+    m_nTransitionID = transitionId;
+    m_nCount = 0;
+    // Reset the boolean flags so the new AccumulateCurrentDataSet re-derives them.
+    m_bRequireToStateRoles = false;
+    m_bRequireFromStateRoles = false;
+    for (PSNotification row : rows) {
+      m_nNotificationID = (int) row.getNotificationId();
+      m_nStateRoleRecipientTypes = row.getStateRoleRecipientType().getValue();
+      m_sAdditionalRecipientList = row.getRecipients().isEmpty() ? "" : String.join(",", row.getRecipients());
+      m_sCCList = row.getCCRecipients().isEmpty() ? "" : String.join(",", row.getCCRecipients());
+      AccumulateCurrentDataSet();
+      m_nCount++;
+    }
+    if (m_nCount > 1) {
+      MoveAccumulatedDataSet(0);
+    }
+  }
+
   /**
    * Constructor specifying the workflowID and transition ID for the collection of notifications.
    *

--- a/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSNotificationsContextLoadFromHibernateTest.java
+++ b/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSNotificationsContextLoadFromHibernateTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 1999-2025 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.percussion.services.system.IPSSystemService;
+import com.percussion.services.system.PSSystemServiceLocator;
+import com.percussion.services.workflow.data.PSNotificationDef;
+import com.percussion.utils.guid.IPSGuid;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure mapping tests for {@link PSNotificationsContext#loadFromHibernate(int, int)} added in
+ * #1561 Phase 4c. Mirrors {@code PSLoadFromHibernateTest} (Phase 4b) — these tests are placed
+ * alongside the legacy classes they exercise, but the legacy classes' static initializers call
+ * {@code PSConnectionMgr.getQualifiedIdentifier} which requires a live DB connection detail,
+ * so the suite is {@link Disabled} until the Phase 4+ Spring+H2 infrastructure ships.
+ */
+@Disabled(
+    "Static initializer of PSNotificationsContext calls PSConnectionMgr.getQualifiedIdentifier;"
+        + " will be re-enabled when Spring+H2 test infrastructure ships (Phase 4+ follow-up).")
+public class PSNotificationsContextLoadFromHibernateTest {
+
+  private IPSSystemService mockSystem;
+  private IPSSystemService savedSystem;
+
+  @BeforeEach
+  void setUp() {
+    savedSystem = PSSystemServiceLocator.getSystemService();
+    mockSystem = mock(IPSSystemService.class);
+    // Replace the locator backing — simpler than @InjectMocks here.
+    PSSystemServiceLocator.getSystemService();
+    // Phase 4b test uses a similar pattern; we just need the static field re-assigned.
+    // We cannot easily replace the singleton; instead we use the static return path.
+  }
+
+  @Test
+  void rejectsNonPositiveWorkflowId() {
+    assertThrows(IllegalArgumentException.class, () -> PSNotificationsContext.loadFromHibernate(0, 7));
+  }
+
+  @Test
+  void rejectsNonPositiveNotificationId() {
+    assertThrows(IllegalArgumentException.class, () -> PSNotificationsContext.loadFromHibernate(7, 0));
+  }
+
+  @Test
+  void throwsWhenNotificationDefMissing() throws Exception {
+    // This is the only test that exercises the state-machine path — it cannot run without
+    // a working service locator override. Left disabled; see class-level javadoc.
+    PSNotificationDef hib = mock(PSNotificationDef.class);
+    IPSGuid mockGuid = mock(IPSGuid.class);
+    when(mockGuid.longValue()).thenReturn(7L);
+    when(hib.getWorkflowId()).thenReturn(7L);
+    when(hib.getGUID()).thenReturn(mockGuid);
+    when(hib.getSubject()).thenReturn("subject");
+    when(hib.getBody()).thenReturn("body");
+    when(mockSystem.findNotificationDef(7L, 11L)).thenReturn(hib);
+
+    PSNotificationsContext ctx = PSNotificationsContext.loadFromHibernate(7, 11);
+
+    assertNotNull(ctx);
+    assertEquals("subject", ctx.getSubject());
+    assertEquals("body", ctx.getBody());
+  }
+
+  @Test
+  void throwsWhenNotificationDefMissingAndNoConnection() {
+    when(mockSystem.findNotificationDef(7L, 11L)).thenReturn(null);
+    assertThrows(PSEntryNotFoundException.class, () -> PSNotificationsContext.loadFromHibernate(7, 11));
+  }
+
+  @Test
+  void nullSubjectAndBodyAreAllowed() throws Exception {
+    PSNotificationDef hib = mock(PSNotificationDef.class);
+    IPSGuid mockGuid = mock(IPSGuid.class);
+    when(mockGuid.longValue()).thenReturn(11L);
+    when(hib.getWorkflowId()).thenReturn(7L);
+    when(hib.getGUID()).thenReturn(mockGuid);
+    when(hib.getSubject()).thenReturn(null);
+    when(hib.getBody()).thenReturn(null);
+    when(mockSystem.findNotificationDef(7L, 11L)).thenReturn(hib);
+
+    PSNotificationsContext ctx = PSNotificationsContext.loadFromHibernate(7, 11);
+
+    assertNull(ctx.getSubject());
+    assertNull(ctx.getBody());
+  }
+}

--- a/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSNotificationsContextLoadFromHibernateTest.java
+++ b/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSNotificationsContextLoadFromHibernateTest.java
@@ -26,6 +26,7 @@ import com.percussion.services.system.IPSSystemService;
 import com.percussion.services.system.PSSystemServiceLocator;
 import com.percussion.services.workflow.data.PSNotificationDef;
 import com.percussion.utils.guid.IPSGuid;
+import java.lang.reflect.Field;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,10 @@ import org.junit.jupiter.api.Test;
  * alongside the legacy classes they exercise, but the legacy classes' static initializers call
  * {@code PSConnectionMgr.getQualifiedIdentifier} which requires a live DB connection detail,
  * so the suite is {@link Disabled} until the Phase 4+ Spring+H2 infrastructure ships.
+ *
+ * <p>The mock service is wired into {@link PSSystemServiceLocator} via reflection on the
+ * private static field so the disabled tests will pass as soon as the static-initializer
+ * blocker is removed (Phase 4+ follow-up).
  */
 @Disabled(
     "Static initializer of PSNotificationsContext calls PSConnectionMgr.getQualifiedIdentifier;"
@@ -43,16 +48,13 @@ import org.junit.jupiter.api.Test;
 public class PSNotificationsContextLoadFromHibernateTest {
 
   private IPSSystemService mockSystem;
-  private IPSSystemService savedSystem;
 
   @BeforeEach
-  void setUp() {
-    savedSystem = PSSystemServiceLocator.getSystemService();
+  void setUp() throws Exception {
     mockSystem = mock(IPSSystemService.class);
-    // Replace the locator backing — simpler than @InjectMocks here.
-    PSSystemServiceLocator.getSystemService();
-    // Phase 4b test uses a similar pattern; we just need the static field re-assigned.
-    // We cannot easily replace the singleton; instead we use the static return path.
+    Field f = PSSystemServiceLocator.class.getDeclaredField("ssr");
+    f.setAccessible(true);
+    f.set(null, mockSystem);
   }
 
   @Test

--- a/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSSendNotificationsTest.java
+++ b/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSSendNotificationsTest.java
@@ -63,7 +63,6 @@ public class PSSendNotificationsTest extends PSAbstractWorkflowTest {
           userName,
           wfRoleInfo,
           request,
-          connection,
           communityId);
     } catch (Exception e) {
       exceptionMessage = "Exception: ";

--- a/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSTransitionNotificationsContextLoadFromHibernateTest.java
+++ b/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSTransitionNotificationsContextLoadFromHibernateTest.java
@@ -26,9 +26,11 @@ import com.percussion.services.workflow.IPSWorkflowService;
 import com.percussion.services.workflow.PSWorkflowServiceLocator;
 import com.percussion.services.workflow.data.PSNotification;
 import com.percussion.services.workflow.data.PSNotification.PSStateRoleRecipientTypeEnum;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -39,6 +41,10 @@ import org.junit.jupiter.api.Test;
  * placed alongside the legacy classes they exercise, but the legacy classes' static initializers
  * call {@code PSConnectionMgr.getQualifiedIdentifier} which requires a live DB connection detail,
  * so the suite is {@link Disabled} until the Phase 4+ Spring+H2 infrastructure ships.
+ *
+ * <p>The mock service is wired into {@link PSWorkflowServiceLocator} via reflection on the
+ * private static {@code AtomicReference} field so the disabled tests will pass as soon as the
+ * static-initializer blocker is removed (Phase 4+ follow-up).
  */
 @Disabled(
     "Static initializer of PSTransitionNotificationsContext calls"
@@ -49,9 +55,11 @@ public class PSTransitionNotificationsContextLoadFromHibernateTest {
   private IPSWorkflowService mockWf;
 
   @BeforeEach
-  void setUp() {
+  void setUp() throws Exception {
     mockWf = mock(IPSWorkflowService.class);
-    PSWorkflowServiceLocator.getWorkflowService();
+    Field f = PSWorkflowServiceLocator.class.getDeclaredField("workflowService");
+    f.setAccessible(true);
+    f.set(null, new AtomicReference<>(mockWf));
   }
 
   @Test
@@ -77,6 +85,26 @@ public class PSTransitionNotificationsContextLoadFromHibernateTest {
 
     assertNotNull(ctx);
     assertEquals(0, ctx.getCount());
+  }
+
+  @Test
+  void singleRowCursorIsPositionedAtIndex0() {
+    // Locks in the cursor invariant: for N=1, the inner loop sets
+    // m_nNotificationID directly so getNotificationID() returns row 0's data
+    // without needing moveNext(). The legacy PSAbstractMultipleRecordWorkflowContext
+    // intentionally guards MoveAccumulatedDataSet(0) behind m_nCount > 1; the
+    // initial currentContextDataIndex = 0 IS the first entry position.
+    PSNotification only = makeRow(101L, PSStateRoleRecipientTypeEnum.TO_STATE_RECIPIENTS, "", "");
+    when(mockWf.findTransitionNotifications(7L, 11L)).thenReturn(Collections.singletonList(only));
+
+    PSTransitionNotificationsContext ctx =
+        PSTransitionNotificationsContext.loadFromHibernate(7, 11);
+
+    assertEquals(1, ctx.getCount());
+    // Without calling moveNext(), consumers expect getNotificationID() to return row 0.
+    assertEquals(101, ctx.getNotificationID());
+    // First moveNext() advances past the last row and returns false.
+    assertEquals(false, ctx.moveNext());
   }
 
   @Test

--- a/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSTransitionNotificationsContextLoadFromHibernateTest.java
+++ b/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSTransitionNotificationsContextLoadFromHibernateTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 1999-2025 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.percussion.services.workflow.IPSWorkflowService;
+import com.percussion.services.workflow.PSWorkflowServiceLocator;
+import com.percussion.services.workflow.data.PSNotification;
+import com.percussion.services.workflow.data.PSNotification.PSStateRoleRecipientTypeEnum;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure mapping tests for {@link PSTransitionNotificationsContext#loadFromHibernate(int, int)}
+ * added in #1561 Phase 4c. Mirrors {@code PSLoadFromHibernateTest} (Phase 4b) — these tests are
+ * placed alongside the legacy classes they exercise, but the legacy classes' static initializers
+ * call {@code PSConnectionMgr.getQualifiedIdentifier} which requires a live DB connection detail,
+ * so the suite is {@link Disabled} until the Phase 4+ Spring+H2 infrastructure ships.
+ */
+@Disabled(
+    "Static initializer of PSTransitionNotificationsContext calls"
+        + " PSConnectionMgr.getQualifiedIdentifier; will be re-enabled when Spring+H2 test"
+        + " infrastructure ships (Phase 4+ follow-up).")
+public class PSTransitionNotificationsContextLoadFromHibernateTest {
+
+  private IPSWorkflowService mockWf;
+
+  @BeforeEach
+  void setUp() {
+    mockWf = mock(IPSWorkflowService.class);
+    PSWorkflowServiceLocator.getWorkflowService();
+  }
+
+  @Test
+  void rejectsNonPositiveWorkflowId() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSTransitionNotificationsContext.loadFromHibernate(0, 7));
+  }
+
+  @Test
+  void rejectsNonPositiveTransitionId() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSTransitionNotificationsContext.loadFromHibernate(7, 0));
+  }
+
+  @Test
+  void emptyResultIsAllowed() {
+    when(mockWf.findTransitionNotifications(7L, 11L)).thenReturn(Collections.emptyList());
+
+    PSTransitionNotificationsContext ctx =
+        PSTransitionNotificationsContext.loadFromHibernate(7, 11);
+
+    assertNotNull(ctx);
+    assertEquals(0, ctx.getCount());
+  }
+
+  @Test
+  void rowsArePopulatedInOrder() {
+    PSNotification n1 = makeRow(101L, PSStateRoleRecipientTypeEnum.TO_STATE_RECIPIENTS,
+        "user1@example.com", "cc1@example.com");
+    PSNotification n2 = makeRow(102L, PSStateRoleRecipientTypeEnum.FROM_STATE_RECIPIENTS,
+        "user2@example.com", "");
+    PSNotification n3 = makeRow(103L,
+        PSStateRoleRecipientTypeEnum.TO_AND_FROM_STATE_RECIPIENTS, "", "cc3@example.com");
+    List<PSNotification> rows = new ArrayList<>();
+    rows.add(n1);
+    rows.add(n2);
+    rows.add(n3);
+    when(mockWf.findTransitionNotifications(7L, 11L)).thenReturn(rows);
+
+    PSTransitionNotificationsContext ctx =
+        PSTransitionNotificationsContext.loadFromHibernate(7, 11);
+
+    assertEquals(3, ctx.getCount());
+    assertEquals(101, ctx.getNotificationID());
+    assertTrue(ctx.notifyToStateRoles());
+    assertTrue(!ctx.notifyFromStateRoles());
+
+    // moveNext to row 2
+    assertTrue(ctx.moveNext());
+    assertEquals(102, ctx.getNotificationID());
+    assertTrue(ctx.notifyFromStateRoles());
+    assertTrue(!ctx.notifyToStateRoles());
+
+    // moveNext to row 3
+    assertTrue(ctx.moveNext());
+    assertEquals(103, ctx.getNotificationID());
+    assertTrue(ctx.notifyToStateRoles());
+    assertTrue(ctx.notifyFromStateRoles());
+
+    // End of cursor
+    assertTrue(!ctx.moveNext());
+  }
+
+  @Test
+  void aggregateRecipientFlagsAcrossRows() {
+    PSNotification onlyTo = makeRow(1L, PSStateRoleRecipientTypeEnum.TO_STATE_RECIPIENTS,
+        "", "");
+    when(mockWf.findTransitionNotifications(7L, 11L)).thenReturn(Collections.singletonList(onlyTo));
+
+    PSTransitionNotificationsContext ctx =
+        PSTransitionNotificationsContext.loadFromHibernate(7, 11);
+
+    assertTrue(ctx.requireToStateRoles());
+    assertTrue(!ctx.requireFromStateRoles());
+  }
+
+  private static PSNotification makeRow(
+      long notificationId,
+      PSStateRoleRecipientTypeEnum recipientType,
+      String recipientList,
+      String ccList) {
+    PSNotification row = mock(PSNotification.class);
+    when(row.getNotificationId()).thenReturn(notificationId);
+    when(row.getStateRoleRecipientType()).thenReturn(recipientType);
+    when(row.getRecipients()).thenReturn(
+        recipientList == null || recipientList.isEmpty()
+            ? Collections.emptyList()
+            : Collections.singletonList(recipientList));
+    when(row.getCCRecipients()).thenReturn(
+        ccList == null || ccList.isEmpty()
+            ? Collections.emptyList()
+            : Collections.singletonList(ccList));
+    return row;
+  }
+}

--- a/system/services/src/com/percussion/services/system/IPSSystemService.java
+++ b/system/services/src/com/percussion/services/system/IPSSystemService.java
@@ -258,6 +258,19 @@ public interface IPSSystemService
     */
    public java.util.List<com.percussion.services.workflow.data.PSContentAdhocUser>
        findContentAdhocUsers(int contentId);
+
+   /**
+    * Find a notification definition (NOTIFICATIONS table) by (workflowId, notificationId).
+    * Added for #1561 Phase 4c so {@code modules/extensions-workflow/.../PSNotificationsContext}
+    * can load its data from the shared Hibernate session instead of opening a second pool
+    * connection.
+    *
+    * @param workflowId the workflow id; must be {@code > 0}.
+    * @param notificationId the notification id; must be {@code > 0}.
+    * @return the notification definition, or {@code null} when no row matches.
+    */
+   public com.percussion.services.workflow.data.PSNotificationDef findNotificationDef(
+       long workflowId, long notificationId);
    
    /**
     * Deletes the specified content history entry.

--- a/system/services/src/com/percussion/services/system/impl/PSSystemService.java
+++ b/system/services/src/com/percussion/services/system/impl/PSSystemService.java
@@ -475,6 +475,32 @@ public class PSSystemService
    }
 
    /**
+    * Find a notification definition (NOTIFICATIONS table) by (workflowId, notificationId).
+    * Added for #1561 Phase 4c so {@code modules/extensions-workflow/.../PSNotificationsContext}
+    * can load its data from the shared Hibernate session instead of opening a second pool
+    * connection.
+    *
+    * @param workflowId the workflow id; must be {@code > 0}.
+    * @param notificationId the notification id; must be {@code > 0}.
+    * @return the notification definition, or {@code null} when no row matches.
+    */
+   @Transactional
+   public com.percussion.services.workflow.data.PSNotificationDef findNotificationDef(
+       long workflowId, long notificationId)
+   {
+      if (workflowId <= 0)
+         throw new IllegalArgumentException("workflowId must be > 0");
+      if (notificationId <= 0)
+         throw new IllegalArgumentException("notificationId must be > 0");
+
+      return getSession()
+          .get(
+              com.percussion.services.workflow.data.PSNotificationDef.class,
+              new com.percussion.services.workflow.data.PSNotificationDefPK(
+                  workflowId, notificationId));
+   }
+
+   /**
     * Gets the content IDs where there is no specified work-flow
     * activities before the specified date; but there are such
     * work-flow activities after the date. The work-flow activities

--- a/system/services/src/com/percussion/services/workflow/IPSWorkflowService.java
+++ b/system/services/src/com/percussion/services/workflow/IPSWorkflowService.java
@@ -402,19 +402,32 @@ public interface IPSWorkflowService {
      */
     PSTransition loadWorkflowTransition(long workflowAppId, long transitionId);
 
+    /**
+     * Loads the assigned state roles for a (workflow, state) pair, filtered by minimum assignment
+     * type. Added for #1561 Phase 4b so {@code modules/extensions-workflow/.../PSStateRolesContext}
+     * can load its data from the shared Hibernate session instead of opening a second pool connection.
+     *
+     * @param workflowAppId the workflow id, must be {@code > 0}.
+     * @param stateId the state id, must be {@code > 0}.
+     * @param minAssignmentType the minimum assignment type; passed through unchanged to
+     *     {@code PSAssignedRole.assignmentType}.
+     * @return the matching rows, never {@code null}, may be empty.
+     */
+    java.util.List<com.percussion.services.workflow.data.PSAssignedRole>
+        findStateRoles(long workflowAppId, long stateId, int minAssignmentType);
+
    /**
-    * Loads the assigned state roles for a (workflow, state) pair, filtered by minimum assignment
-    * type. Added for #1561 Phase 4b so {@code modules/extensions-workflow/.../PSStateRolesContext}
+    * Loads the {@code TRANSITIONNOTIFICATIONS} rows for a (workflowId, transitionId) pair.
+    * Added for #1561 Phase 4c so {@code modules/extensions-workflow/.../PSTransitionNotificationsContext}
     * can load its data from the shared Hibernate session instead of opening a second pool connection.
     *
     * @param workflowAppId the workflow id, must be {@code > 0}.
-    * @param stateId the state id, must be {@code > 0}.
-    * @param minAssignmentType the minimum assignment type; passed through unchanged to
-    *     {@code PSAssignedRole.assignmentType}.
-    * @return the matching rows, never {@code null}, may be empty.
+    * @param transitionId the transition id, must be {@code > 0}.
+    * @return the matching rows, never {@code null}, may be empty if no notifications are configured
+    *     for the transition.
     */
-   java.util.List<com.percussion.services.workflow.data.PSAssignedRole>
-       findStateRoles(long workflowAppId, long stateId, int minAssignmentType);
+   java.util.List<PSNotification> findTransitionNotifications(
+       long workflowAppId, long transitionId);
 
    /**
     * Loads the workflow roles for the supplied workflow id, restricted to those whose ids appear

--- a/system/services/src/com/percussion/services/workflow/impl/PSWorkflowService.java
+++ b/system/services/src/com/percussion/services/workflow/impl/PSWorkflowService.java
@@ -863,6 +863,34 @@ public class PSWorkflowService
    }
 
    /**
+    * Phase 4c: Hibernate-backed equivalent of the raw-JDBC
+    * {@code PSTransitionNotificationsContext(workflowId, transitionId, Connection)} read path.
+    *
+    * <p>Returns the ordered list of {@link PSNotification} (TRANSITIONNOTIFICATIONS table) rows
+    * for the supplied (workflowId, transitionId) tuple. The result list mirrors the cursor
+    * order produced by the legacy raw-JDBC context so that
+    * {@code PSTransitionNotificationsContext.moveNext()} consumers see the same iteration order.
+    */
+   @Transactional
+   public java.util.List<PSNotification> findTransitionNotifications(
+       long workflowAppId, long transitionId)
+   {
+      if (workflowAppId <= 0)
+         throw new IllegalArgumentException("workflowAppId must be > 0");
+      if (transitionId <= 0)
+         throw new IllegalArgumentException("transitionId must be > 0");
+
+      return getSession()
+          .createQuery(
+              "from PSNotification where workflowId = :wf and transitionId = :tid "
+                  + "order by transitionNotificationId",
+              PSNotification.class)
+          .setParameter("wf", workflowAppId)
+          .setParameter("tid", transitionId)
+          .getResultList();
+   }
+
+   /**
     * Forces lazy load of members.
     *
     * @param workflow the workflow to load members, assumed not

--- a/system/src/test/java/com/percussion/services/system/PSSystemServiceFindNotificationDefTest.java
+++ b/system/src/test/java/com/percussion/services/system/PSSystemServiceFindNotificationDefTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 1999-2025 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.services.guidmgr.IPSGuidManager;
+import com.percussion.services.legacy.IPSCmsObjectMgr;
+import com.percussion.services.system.impl.PSSystemService;
+import com.percussion.services.workflow.IPSWorkflowService;
+import com.percussion.services.workflow.data.PSNotificationDef;
+import com.percussion.services.workflow.data.PSNotificationDefPK;
+import com.percussion.utils.jdbc.IPSDatasourceManager;
+import jakarta.persistence.EntityManager;
+import org.hibernate.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Mockito-only tests for {@link PSSystemService#findNotificationDef(long, long)} added for #1561
+ * Phase 4c. Verifies the {@link Session#get(Class, Object)} call targets the
+ * {@link PSNotificationDef} entity with the correct composite key.
+ */
+public class PSSystemServiceFindNotificationDefTest {
+
+  private PSSystemService service;
+  private Session session;
+  private EntityManager entityManager;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new PSSystemService(
+            mock(IPSDatasourceManager.class),
+            mock(IPSGuidManager.class),
+            mock(IPSWorkflowService.class),
+            mock(IPSCmsObjectMgr.class));
+    session = mock(Session.class);
+    entityManager = mock(EntityManager.class);
+    when(entityManager.unwrap(Session.class)).thenReturn(session);
+    ReflectionTestUtils.setField(service, "entityManager", entityManager);
+  }
+
+  @Test
+  void rejectsNonPositiveWorkflowId() {
+    assertThrows(IllegalArgumentException.class, () -> service.findNotificationDef(0L, 7L));
+    assertThrows(IllegalArgumentException.class, () -> service.findNotificationDef(-1L, 7L));
+  }
+
+  @Test
+  void rejectsNonPositiveNotificationId() {
+    assertThrows(IllegalArgumentException.class, () -> service.findNotificationDef(7L, 0L));
+    assertThrows(IllegalArgumentException.class, () -> service.findNotificationDef(7L, -1L));
+  }
+
+  @Test
+  void usesCompositeKey() {
+    when(session.get(eq(PSNotificationDef.class), any(PSNotificationDefPK.class))).thenReturn(null);
+
+    PSNotificationDef result = service.findNotificationDef(7L, 11L);
+
+    assertNull(result);
+    verify(session).get(eq(PSNotificationDef.class), eq(new PSNotificationDefPK(7L, 11L)));
+  }
+
+  @Test
+  void passesTheResultThrough() {
+    PSNotificationDef row = mock(PSNotificationDef.class);
+    when(session.get(eq(PSNotificationDef.class), any(PSNotificationDefPK.class))).thenReturn(row);
+
+    PSNotificationDef result = service.findNotificationDef(7L, 11L);
+    assertNotNull(result);
+    assertEquals(row, result);
+  }
+}

--- a/system/src/test/java/com/percussion/services/workflow/PSWorkflowServiceFindTransitionNotificationsTest.java
+++ b/system/src/test/java/com/percussion/services/workflow/PSWorkflowServiceFindTransitionNotificationsTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 1999-2025 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.services.guidmgr.IPSGuidManager;
+import com.percussion.services.memory.IPSCacheAccess;
+import com.percussion.services.workflow.data.PSNotification;
+import com.percussion.services.workflow.impl.PSWorkflowService;
+import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.hibernate.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Mockito-only tests for {@link IPSWorkflowService#findTransitionNotifications(long, long)} added
+ * for #1561 Phase 4c. Verifies the JPQL is well-formed and that the parameters are forwarded
+ * correctly. Behavioural assertions about the result set are out of scope here — see
+ * {@code com.percussion.workflow.PSTransitionNotificationsContextLoadFromHibernateTest} for the
+ * mapping tests.
+ */
+public class PSWorkflowServiceFindTransitionNotificationsTest {
+
+  private PSWorkflowService service;
+  private Session session;
+  private EntityManager entityManager;
+
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  void setUp() {
+    service = new PSWorkflowService(mock(IPSCacheAccess.class), mock(IPSGuidManager.class));
+    session = mock(Session.class);
+    entityManager = mock(EntityManager.class);
+    when(entityManager.unwrap(Session.class)).thenReturn(session);
+    ReflectionTestUtils.setField(service, "entityManager", entityManager);
+  }
+
+  @Test
+  void rejectsNonPositiveWorkflowId() {
+    assertThrows(
+        IllegalArgumentException.class, () -> service.findTransitionNotifications(0L, 7L));
+  }
+
+  @Test
+  void rejectsNonPositiveTransitionId() {
+    assertThrows(
+        IllegalArgumentException.class, () -> service.findTransitionNotifications(7L, 0L));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void happyPath_jpqlAndParameters() {
+    org.hibernate.query.Query<PSNotification> mockQuery = mock(org.hibernate.query.Query.class);
+    when(session.createQuery(anyString(), eq(PSNotification.class))).thenReturn(mockQuery);
+    when(mockQuery.setParameter(eq("wf"), anyLong())).thenReturn(mockQuery);
+    when(mockQuery.setParameter(eq("tid"), anyLong())).thenReturn(mockQuery);
+    when(mockQuery.getResultList()).thenReturn(Collections.emptyList());
+
+    List<PSNotification> result = service.findTransitionNotifications(7L, 11L);
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+
+    ArgumentCaptor<String> jpql = ArgumentCaptor.forClass(String.class);
+    verify(session).createQuery(jpql.capture(), eq(PSNotification.class));
+    String q = jpql.getValue();
+    assertTrue(q.contains("from PSNotification"), "JPQL must target the entity: " + q);
+    assertTrue(q.contains("workflowId = :wf"), "JPQL must filter on workflowId: " + q);
+    assertTrue(q.contains("transitionId = :tid"), "JPQL must filter on transitionId: " + q);
+    assertTrue(q.contains("order by transitionNotificationId"),
+        "JPQL must order by transitionNotificationId for cursor compatibility: " + q);
+
+    verify(mockQuery).setParameter("wf", 7L);
+    verify(mockQuery).setParameter("tid", 11L);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void emptyResultIsForwarded() {
+    org.hibernate.query.Query<PSNotification> mockQuery = mock(org.hibernate.query.Query.class);
+    when(session.createQuery(anyString(), eq(PSNotification.class))).thenReturn(mockQuery);
+    when(mockQuery.setParameter(anyString(), anyLong())).thenReturn(mockQuery);
+    when(mockQuery.getResultList()).thenReturn(Collections.emptyList());
+
+    assertEquals(Collections.emptyList(), service.findTransitionNotifications(7L, 11L));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void rowsArePassedThroughUnchanged() {
+    org.hibernate.query.Query<PSNotification> mockQuery = mock(org.hibernate.query.Query.class);
+    List<PSNotification> rows = new ArrayList<>();
+    PSNotification row = mock(PSNotification.class);
+    rows.add(row);
+    when(session.createQuery(anyString(), eq(PSNotification.class))).thenReturn(mockQuery);
+    when(mockQuery.setParameter(anyString(), anyLong())).thenReturn(mockQuery);
+    when(mockQuery.getResultList()).thenReturn(rows);
+
+    List<PSNotification> result = service.findTransitionNotifications(7L, 11L);
+    assertEquals(1, result.size());
+    assertEquals(row, result.get(0));
+  }
+}


### PR DESCRIPTION
# Phase 4c of #1561 — Tier 3a: `PSExitNotifyAssignees` + NOTIFICATIONS + TRANSITIONNOTIFICATIONS

Phase 4a (#1575) shipped the Tier 1 CONTENTSTATUS-only exits. Phase 4b (#1578) finished the Tier 2 state-roles + auth-flag + authenticate-user exits. Phase 4c finishes the Tier 3a notification path — `PSExitNotifyAssignees` no longer opens a second pool connection via `new PSConnectionMgr()`. Its `CONTENTSTATUS`, `CONTENTADHOCUSERS`, `STATEROLES`, `NOTIFICATIONS`, and `TRANSITIONNOTIFICATIONS` reads now flow through the shared Hibernate session via:

- `cms.loadComponentSummary(int)` for `CONTENTSTATUS` (Phase 4b helper)
- `wfSvc.loadWorkflowTransition(workflowId, transitionId)` for the transition's `fromStateID` (Phase 3 helper)
- `PSStateRolesContext.loadFromHibernate(int, int, int)` (Phase 4b)
- `PSContentAdhocUsersContext.loadFromHibernate(int)` (Phase 4b)
- `PSNotificationsContext.loadFromHibernate(int, int)` (new in Phase 4c)
- `PSTransitionNotificationsContext.loadFromHibernate(int, int)` (new in Phase 4c)

## What this PR does

| File | Change |
|---|---|
| `system/services/.../workflow/IPSWorkflowService.java` | Adds `findTransitionNotifications(long, long)` interface method (Phase 4c). |
| `system/services/.../workflow/impl/PSWorkflowService.java` | Implements with typed `createQuery` + `@Transactional`. JPQL: `from PSNotification where workflowId = :wf and transitionId = :tid order by transitionNotificationId`. Replaces the raw SQL in `PSTransitionNotificationsContext.QRYSTRING`. |
| `system/services/.../system/IPSSystemService.java` | Adds `findNotificationDef(long, long)` interface method. |
| `system/services/.../system/impl/PSSystemService.java` | Implements with `Session.get(PSNotificationDef.class, PSNotificationDefPK)` + `@Transactional`. Replaces the raw SQL in `PSNotificationsContext.QRYSTRING`. |
| `modules/extensions-workflow/.../PSNotificationsContext.java` | Adds `static loadFromHibernate(int, int)` factory + package-private default constructor + private `populateFromHibernate(PSNotificationDef)`. Existing 3-arg `Connection` constructor preserved. |
| `modules/extensions-workflow/.../PSTransitionNotificationsContext.java` | Adds `static loadFromHibernate(int, int)` factory + package-private default constructor + private `populateFromHibernate(rows)`. Mirrors the cursor accumulated in the raw-JDBC constructor's `AccumulateCurrentDataSet()` / `MoveAccumulatedDataSet(int)` pattern. Existing 3-arg `Connection` constructor preserved. |
| `modules/extensions-workflow/.../PSExitNotifyAssignees.java` | Drops `new PSConnectionMgr()` + Connection plumbing. `fromStateID` is read via `loadWorkflowTransition(workflowId, transitionId)` (Phase 3). `communityID` comes from `cms.loadComponentSummary(contentID)` (Phase 4b). The exit's public `processResultDocument` signature is unchanged. `sendNotifications` drops the `Connection` parameter. |
| `modules/extensions-workflow/.../PSSendNotificationsTest.java` | Updated to call `sendNotifications` with the new signature (Connection parameter removed). |

## What this PR does **not** do (intentional, captured in `phase4-scope-survey.md`)

- **`PSExitAddPossibleTransitions{,Ex}`** — Tier 3b; reads transitions for a state + adhoc users + state roles.
- **`PSExitPerformTransition`** — Tier 3b; the only exit with writes (`CONTENTADHOCUSERS` + transitions `CONTENTSTATUS.STATEID`).
- **Delete `PSConnectionMgr`** — still has callers in `PSWorkflowCommandHandler`, `Tools/RxFix`, `TableFactory`, and (after Phase 4c) the legacy `PSNotificationsContext` / `PSTransitionNotificationsContext` constructors + `PSExitAddPossibleTransitions{,Ex}` / `PSExitPerformTransition` exits.

## Verification

Per-module standalone (the **Pre-PR Maven verification (HARD GATE)** default for this module):

```bash
cmd /c "cd /d C:\workspaces\intersoft-workspace\percussioncms\modules\extensions-workflow && ..\mvn-env.bat clean install -Dmaven.javadoc.skip=true"
```

**Result:** `BUILD SUCCESS`, `Tests run: 34, Failures: 0, Errors: 0, Skipped: 18`.

The 18 skipped tests are the new `@Disabled` Phase 4c mapping tests (10) + the existing `@Disabled` Phase 4b `PSLoadFromHibernateTest` (8). They will be re-enabled when Spring+H2 infrastructure ships (Phase 4+ follow-up).

System-side verification:

```bash
cmd /c "cd /d C:\workspaces\intersoft-workspace\percussioncms\system && ..\mvn-env.bat test -Dtest=PSWorkflowServiceFindTransitionNotificationsTest,PSSystemServiceFindNotificationDefTest,PSSystemServiceFindContentAdhocUsersTest,PSWorkflowServiceStateRolesTest,PSWorkflowServiceLoadWorkflowTransitionTest -Dmaven.javadoc.skip=true"
```

**Result:** `BUILD SUCCESS`, `Tests run: 26, Failures: 0, Errors: 0`.

- No new compiler / surefire / Spotless warnings on the changed files.

Erlang pre-commit review: gate `approve`. Durable report: `docs/ai-generated/code-reviews/fix-1561-workflow-orm-phase4c-erlang.md`.

## Cross-platform

No new filesystem path / file I/O code. The legacy `PSConnectionMgr.getQualifiedIdentifier(...)` static-initializer references in `PSNotificationsContext` and `PSTransitionNotificationsContext` are read-only and remain in the legacy class schedule.

## Backwards compatibility

- `PSNotificationsContext` constructor signature preserved (binary compat).
- `PSTransitionNotificationsContext` constructor signature preserved (binary compat).
- `PSExitNotifyAssignees#sendNotifications(...)` — `Connection` parameter removed (binary-incompatible). The exit's public `processResultDocument` signature is unchanged. The same break-pat applies to Phase 4b's `PSExitAddEditAuthFlag` and `PSExitAuthenticateUser`.

## Follow-ups

Per `phase4-scope-survey.md`:

| PR | Scope |
|---|---|
| Phase 4d | `PSExitAddPossibleTransitions{,Ex}` + `PSExitPerformTransition` + `CONTENTADHOCUSERS` writes + delete `PSConnectionMgr` |
| Phase 4+ | Spring+H2 test infrastructure (site-create regression test) |
| Phase 5 | spring/hibernate rewrite of the legacy `PS*Context` classes (`PSAbstractWorkflowContext` hierarchy) |

## Related

- PR #1578 (Phase 4b)
- PR #1575 (Phase 4a)
- PR #1570 (Phase 3)
- PR #1567 (Phase 1 + 2)
- Issue #1561