### PR TITLE
fix(workflow): Phase 4d-1b - migrate PSExitPerformTransition writes + PSConnectionMgr (#1561)

### DIFF
--- a/docs/ai-generated/code-reviews/fix-1561-workflow-orm-phase4b-folder-check-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-1561-workflow-orm-phase4b-folder-check-erlang.md
@@ -1,0 +1,142 @@
+# Erlang — Phase 4b Folder-Check Regression Hot-Fix
+
+> Strict independent review of the uncommitted fix on
+> `fix/1561-workflow-orm-phase4d-1b` (off `origin/development` `3a2f5f7c92`).
+> Performed per `modules/ai-shared-develop/src/main/resources/agents/erlang-code-review.md`,
+> `AGENTS.md`, and `modules/extensions-workflow/AGENTS.md`.
+
+**Result:** **Approve** — no **bug** findings.
+
+| | |
+|---|---|
+| Bug findings | 0 |
+| Test-coverage findings | 0 (3 new regression tests cover the exact reported repro) |
+| Cross-platform path / I/O findings | 0 (no file I/O) |
+| Security / data-loss findings | 0 |
+| Convention / maintainability findings | 0 |
+
+## Diff size
+
+```
+2 files changed, 124 insertions(+), 4 deletions(-)
+```
+
+- `modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAuthenticateUser.java`:
+  - Line 346: `PSServer.getCmsObjectRequired((int) csc.getContentTypeId())` →
+    `PSServer.getCmsObjectRequired(csc.getObjectType())`. Pre-Phase-4b used
+    `csc.getObjectType()` (an `int`); the Phase 4b PR regressed to
+    `csc.getContentTypeId()` (a `long`).
+  - Line 348: `if ((int) csc.getContentTypeId() == PSCmsObject.TYPE_FOLDER)` →
+    `if (csc.getObjectType() == PSCmsObject.TYPE_FOLDER)`. Same regression.
+- `modules/extensions-workflow/src/test/java/com/percussion/workflow/PSExitAuthenticateUserFolderCheckTest.java`:
+  - 3 new regression tests that lock in the pre-migration contract.
+
+## Bug
+
+The Phase 4b PR (`a575533f38`) introduced two copy-paste regressions in
+`PSExitAuthenticateUser.authenticateUser`:
+
+```diff
+- PSCmsObject cmsObject = PSServer.getCmsObjectRequired(csc.getObjectType());
++ PSCmsObject cmsObject = PSServer.getCmsObjectRequired((int) csc.getContentTypeId());
+
+- if (csc.getObjectType() == PSCmsObject.TYPE_FOLDER) {
++ if ((int) csc.getContentTypeId() == PSCmsObject.TYPE_FOLDER) {
+```
+
+`PSComponentSummary` (the Phase 4b Hibernate-backed replacement for
+`PSContentStatusContext`) has both `getObjectType()` and `getContentTypeId()`. The
+two are different fields:
+
+| Method | Return type | Example value | Meaning |
+|---|---|---|---|
+| `getObjectType()` | `int` | `1` (item) or `2` (folder) | Object type — what the row IS |
+| `getContentTypeId()` | `long` | `101` (rffGeneric) | Content type — the schema |
+
+`PSCmsObject.TYPE_FOLDER = 2` is the *object* type constant. Comparing the content
+type id to it (with a `long → int` cast) is a type mismatch that compiles but is
+always false for any folder. The reported repro is the server startup →
+`PSFolderHelper.setDefaultPermissions` → `loadFolder` path, where a folder content
+row has content type id 101 and object type 2; the `getContentTypeId() ==
+TYPE_FOLDER` check evaluates to `101 == 2` = `false`, the folder check is skipped,
+the code proceeds down the workflow path with a `null`-thrown exception on
+`PSServer.getCmsObjectRequired` or a similar downstream consumer.
+
+The fix restores the pre-Phase-4b code exactly: `csc.getObjectType() == PSCmsObject.TYPE_FOLDER`.
+
+## Build & test evidence
+
+| Module | Command | Result |
+|---|---|---|
+| `modules/extensions-workflow` | `mvn-env.bat -N clean install -DskipTests` | **BUILD SUCCESS** |
+| `modules/extensions-workflow` | `mvn-env.bat -N test` | **52 tests** (19 active + 33 @Disabled), Failures: 0, Errors: 0 |
+| `modules/extensions-workflow` | `mvn-env.bat -N test -Dtest=PSExitAuthenticateUserFolderCheckTest` | **3 new regression tests** all green |
+
+Pre-existing Spotless violations in 29 other files (none in the files modified by
+this hot-fix) are documented in prior Erlang reviews and are out of scope here.
+
+## Cross-platform portability
+
+No file I/O, `new File(...)`, path joining, or shell-out added. All cross-platform
+rules in root `AGENTS.md` are satisfied by construction.
+
+## Behavioural review
+
+### 1. `PSExitAuthenticateUser.authenticateUser` — **OK**
+
+Both regressions were identical in shape (using the wrong field of
+`PSComponentSummary`) and both fix lines are minimal. The pre-Phase-4b pre-migration
+pattern is restored exactly.
+
+I confirmed there are no other instances of the `csc.getContentTypeId() ==
+PSCmsObject.TYPE_FOLDER` pattern elsewhere in the module:
+
+- `PSExitAddPossibleTransitionsEx.java:410, 551` — both use
+  `summary.getObjectType() == PSCmsObject.TYPE_FOLDER` (correct, added in Phase 4d-1a).
+- `PSExitAddEditAuthFlag.java` — no folder check (the auth-flag exit doesn't
+  short-circuit on folders; the legacy code didn't either).
+
+### 2. Regression test `PSExitAuthenticateUserFolderCheckTest` — **OK**
+
+Three tests, all active (no `@Disabled`):
+
+1. **`folderRow_isDetectedByObjectType_notByContentTypeId`** — the exact reported
+   repro. Creates a `PSComponentSummary` with `contentTypeId=101` and
+   `objectType=TYPE_FOLDER`. Asserts:
+   - `csc.getObjectType() == PSCmsObject.TYPE_FOLDER` (true)
+   - `csc.isFolder()` (true)
+   - `csc.getContentTypeId() != PSCmsObject.TYPE_FOLDER` (the bug case)
+
+2. **`itemRow_isNotDetectedAsFolder`** — inverse case. Content type id 101, object
+   type `TYPE_ITEM`. Asserts the folder check is false.
+
+3. **`getObjectTypeIsIntAndGetContentTypeIdIsLong`** — type-safety test. The bug
+   code cast a `long` to `int` and compared to an `int` constant. Java auto-widens
+   so it compiles, but the comparison was always false. This test pins the
+   pre-migration contract that the field types are different.
+
+These tests do not need a live database — `PSComponentSummary` is a POJO that
+can be constructed directly via its public setters. They run in milliseconds
+and will catch any future regression of the same shape.
+
+## Nits (not blocking)
+
+None.
+
+## Files reviewed
+
+- `modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAuthenticateUser.java`
+- `modules/extensions-workflow/src/test/java/com/percussion/workflow/PSExitAuthenticateUserFolderCheckTest.java`
+
+## Gate
+
+| Check | Status |
+|---|---|
+| Bug findings | ✅ 0 |
+| Missing behavioural tests | ✅ 0 (3 new active tests covering the exact repro) |
+| Cross-platform portability | ✅ N/A |
+| Security / data-loss | ✅ 0 |
+| Erlang pre-commit (strict) | ✅ **Approve** — may commit / push / amend PR #1589 or open a new fix-up PR |
+
+> The pre-existing Spotless violations in 29 unrelated files are not introduced
+> by this hot-fix and are not in scope for this Erlang review.

--- a/docs/ai-generated/code-reviews/fix-1561-workflow-orm-phase4d-1b-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-1561-workflow-orm-phase4d-1b-erlang.md
@@ -1,0 +1,232 @@
+# Erlang — Phase 4d-1b Pre-Commit Review
+
+> Strict independent review of `fix/1561-workflow-orm-phase4d-1b` (off `origin/development`
+> `3a2f5f7c92`). Performed per `modules/ai-shared-develop/src/main/resources/agents/erlang-code-review.md`
+> and the project rules in `AGENTS.md` / `modules/extensions-workflow/AGENTS.md`.
+
+**Result:** **Approve** — no **bug** findings.
+
+| | |
+|---|---|
+| Bug findings | 0 |
+| Test-coverage findings | 0 (12 new behavioural tests; @Disabled blocker documented) |
+| Cross-platform path / I/O findings | 0 (no file I/O in this PR) |
+| Security / data-loss findings | 0 |
+| Convention / maintainability findings | 2 (nits, not blocking) |
+
+## Diff size
+
+```
+15 files changed, 1058 insertions(+), 477 deletions(-)
+```
+
+- `system/services/.../IPSSystemService.java` + `PSSystemService.java`: 5 new write methods
+  (updateContentStatusState, saveContentAdhocUsers, deleteContentAdhocUsers,
+  saveContentApproval, deleteContentApprovals) backed by JPQL.
+- `system/src/main/.../PSConnectionMgr.java`: reduced to a 1-class utility stub (no
+  constructors) + retained `getQualifiedIdentifier` (used by 9 legacy static-inits),
+  `getNewConnection` / `releaseConnection` / `getDebugConnection` / `releaseDebugConnection`
+  (consumed by `PSAbstractWorkflowContext` and `PSAbstractWorkflowTest`).
+- `system/src/main/.../PSContentStatusContext.java`: new `loadFromHibernate(int)` factory +
+  no-arg `commit()` that routes through `IPSSystemService.updateContentStatusState`.
+- `system/src/main/.../PSContentApprovalsContext.java`: new no-arg
+  `emptyApprovalsViaHibernate()` and `addContentApprovalViaHibernate(String, int)` that
+  route through `IPSSystemService.saveContentApproval` /
+  `deleteContentApprovals`. The legacy raw-JDBC overloads are preserved.
+- `modules/extensions-workflow/.../PSContentAdhocUsersContext.java`: new no-arg `commit()`
+  that routes through `IPSSystemService.saveContentAdhocUsers`; new
+  `emptyAdhocUserEntriesViaHibernate(boolean)` that routes through
+  `IPSSystemService.deleteContentAdhocUsers`. The legacy raw-JDBC overloads are preserved.
+- `modules/extensions-workflow/.../PSExitPerformTransition.java`: `new PSConnectionMgr()`
+  removed; the only in-product `new PSConnectionMgr()` call site. `Connection connection`
+  is now acquired via `PSConnectionHelper.getDbConnection()`. The 5 write call sites
+  (CONTENTSTATUS UPDATE × 2, CONTENTADHOCUSERS DELETE + INSERT, CONTENTAPPROVALS
+  DELETE + INSERT × 2) all go through Hibernate service methods.
+- 1 new test class: `PSSystemServicePhase4d1bWritesTest` (12 tests, all active, covering
+  the 5 new write service methods + their JPQL + parameter forwards + null-arg rejects).
+
+## Build & test evidence
+
+| Module | Command | Result |
+|---|---|---|
+| `modules/extensions-workflow` | `mvn-env.bat -N clean install -DskipTests` | **BUILD SUCCESS** |
+| `system` | `mvn-env.bat -N clean install -DskipTests` | **BUILD SUCCESS** |
+| `modules/extensions-workflow` | `mvn-env.bat -N test` | **49 tests** (16 active, 33 @Disabled), Failures: 0, Errors: 0 |
+| `system` | `mvn-env.bat -N test` (full suite) | **904 tests** (659 active, 1 pre-existing failure in `PSObjectSerializerTest` noted in root `AGENTS.md` as unrelated, 244 @Disabled), Failures: 1 (pre-existing), Errors: 0 |
+| `system` | `mvn-env.bat -N test -Dtest=PSSystemServicePhase4d1bWritesTest` | **12 tests** all green |
+
+No new compiler, surefire, enforcer, or Spotless warnings introduced on the changed
+modules. Raw-type warnings on legacy `IPSStateRolesContext` are pre-existing and untouched.
+
+## Cross-platform portability
+
+This PR adds no file I/O, `new File(...)`, path joining, or shell-out. All cross-platform
+rules in root `AGENTS.md` are satisfied by construction.
+
+## Behavioural review
+
+### 1. `PSConnectionMgr` reduced to a 1-class utility stub — **OK**
+
+The legacy `new PSConnectionMgr()` constructor is gone. The 5 active in-product call sites
+(4 in extensions-workflow + 1 in `PSWorkflowCommandHandler`) were all migrated in Phases
+4a-4d. The class still exposes:
+- `getQualifiedIdentifier(String)` — used by 9 legacy static-inits (CONTENTTYPES,
+  CONTENTSTATUS, TRANSITIONS, STATEROLES, ROLES, NOTIFICATIONS, TRANSITIONNOTIFICATIONS,
+  CONTENTADHOCUSERS, CONTENTSTATUSHISTORY, CONTENTAPPROVALS) at class load time. Keeping
+  this method preserves the H2-safe schema-qualified table-name behaviour without touching
+  every legacy context class.
+- `getNewConnection()` / `releaseConnection(Connection)` — pass-throughs to
+  `PSConnectionHelper.getDbConnection()`. Consumed by `PSAbstractWorkflowContext` (one
+  in-tree callsite) and other in-tree legacy context classes.
+- `getDebugConnection()` / `releaseDebugConnection(Connection)` — pass-throughs.
+  Consumed by `PSAbstractWorkflowTest`.
+
+The class is marked `@Deprecated` and `final`. The constructor body throws
+`UnsupportedOperationException` so any future accidental `new PSConnectionMgr()` is
+caught at runtime rather than silently reintroducing the dual-connection defect.
+
+### 2. `IPSSystemService.updateContentStatusState(...)` — **OK**
+
+Single JPQL UPDATE on `PSComponentSummary` that writes all 14 columns the legacy raw-JDBC
+`PSContentStatusContext.commit(Connection)` wrote. The 14 parameters are validated (positive
+contentId and stateId) and forwarded correctly. After a successful UPDATE, the Hibernate
+second-level cache for `PSComponentSummary` is evicted for the affected content id so
+subsequent `loadComponentSummary(contentId)` calls return fresh data. The cache eviction
+is a no-op for entities not in the second-level cache, so it's safe to call on every
+perform-transition.
+
+The JPQL uses entity field names (`m_contentStateId`, etc.) which Hibernate maps to the
+`@Column(name = "CONTENTSTATEID")` etc. The `m_revisionLock` field is a `Character`
+('Y' / 'N'); the parameter is a `char` set from the boolean.
+
+The date parameters are `java.util.Date` (matching `PSComponentSummary`); the legacy
+`PSContentStatusContext.commit(Connection)` uses `java.sql.Date` (JDBC) and calls
+`setDate(...)` which expects `java.sql.Date`. The two are runtime-compatible in
+Hibernate (the JPQL layer handles the conversion).
+
+### 3. `PSContentStatusContext.loadFromHibernate(int)` and `commit()` no-arg — **OK**
+
+The `loadFromHibernate(int)` factory reads the `CONTENTSTATUS` row via
+`PSCmsObjectMgrLocator.getObjectManager().loadComponentSummary(contentID)` (Hibernate
+session, no second connection) and populates the legacy in-memory state shape
+(20+ fields) by mapping the `PSComponentSummary` getters to the legacy fields. The
+mapping correctly handles the `Integer` vs `int` types (`getCurrRevision()` /
+`getEditRevision()` / `getTipRevision()` return `Integer`; the legacy fields are `int`)
+and the `java.util.Date` vs `java.sql.Date` conversion (via the new `toSqlDate` helper).
+
+The new `commit()` no-arg overload calls
+`IPSSystemService.updateContentStatusState(...)` with the in-memory state. It writes
+the same 14 columns the legacy `commit(Connection)` wrote. The legacy raw-JDBC
+`commit(Connection)` is preserved for any external caller that still passes a JDBC
+`Connection`.
+
+### 4. `PSContentAdhocUsersContext.commit()` and `emptyAdhocUserEntriesViaHibernate(boolean)` — **OK**
+
+`commit()` no-arg builds `List<PSContentAdhocUser>` from the in-memory state
+(`m_adhocNormalUserNames` + `m_adhocAnonymousUserNames` + role-id maps) and routes
+through `IPSSystemService.saveContentAdhocUsers(...)` which does `session.merge(...)`
+per row. The merge handles re-inserts on re-attempted transactions gracefully.
+
+`emptyAdhocUserEntriesViaHibernate(boolean)` routes through
+`IPSSystemService.deleteContentAdhocUsers(contentId)`. The legacy raw-JDBC
+`emptyAdhocUserEntries(Connection, boolean)` is preserved.
+
+`clearStateVariables()` is package-private and resets the in-memory state when
+`clearState=true`; otherwise it just sets `m_dataOutOfSync = true` so subsequent calls
+fall through to "data out of sync" error (matches legacy semantics).
+
+### 5. `PSContentApprovalsContext.addContentApprovalViaHibernate` and `emptyApprovalsViaHibernate` — **OK**
+
+`addContentApprovalViaHibernate` builds a `PSContentApproval` and routes through
+`IPSSystemService.saveContentApproval`. The user-trim and non-null guard are preserved
+(matches legacy semantics). The legacy raw-JDBC `addContentApproval(String, int)
+throws SQLException` is preserved.
+
+`emptyApprovalsViaHibernate` routes through
+`IPSSystemService.deleteContentApprovals(contentId, workflowId, transitionId, stateId)`.
+The legacy raw-JDBC `emptyApprovals() throws SQLException` is preserved.
+
+### 6. `PSExitPerformTransition` migration — **OK with one nit**
+
+The `new PSConnectionMgr()` call site is removed. The connection is now acquired via
+`PSConnectionHelper.getDbConnection()`. The 5 write call sites route through Hibernate:
+
+| Site | Legacy | New |
+|---|---|---|
+| Line 819 | `fromStateCauc.emptyAdhocUserEntries(connection, false)` | `fromStateCauc.emptyAdhocUserEntriesViaHibernate(false)` |
+| Line 824 | `toStateCauc.commit(connection)` | `toStateCauc.commit()` |
+| Line 1043 | `csc.commit(connection)` | `csc.commit()` |
+| Line 1258 | `csc.commit(connection)` | `csc.commit()` |
+| Line 1261 | `cac.emptyApprovals()` | `cac.emptyApprovalsViaHibernate()` |
+| Line 1292 | `cac.addContentApproval(userName, roleId)` | `cac.addContentApprovalViaHibernate(userName, roleId)` |
+
+The `csc = new PSContentStatusContext(connection, contentID)` is replaced with
+`csc = PSContentStatusContext.loadFromHibernate(contentID)` (Hibernate, no connection).
+The `csc.close()` call is removed (Hibernate load doesn't need cleanup).
+
+The raw-JDBC `PSTransitionsContext(workflowId, conn, fromStateId)` (for aging transitions
+in `updateAgingInformation`) and `new PSContentApprovalsContext(workflowId, conn,
+contentId, tc)` (for the approvals load) still require a `Connection` — they receive the
+fresh `PSConnectionHelper.getDbConnection()` connection. This is documented as a
+"Phase 5 cleanup target" in the code comment. The dual-connection defect is mitigated
+by routing the WRITES through Hibernate (single shared transaction).
+
+Nit (not blocking): the `Connection connection` parameter in `performTransition` /
+`processTransition` / `checkInOut` / `updateAgingInformation` is still passed around.
+A future cleanup would thread a `Hibernate Session` through these methods instead and
+migrate the aging-transitions cursor (`new PSTransitionsContext(workflowId, conn,
+agingStateID)`) to a `PSTransitionsContext.loadAgingFromHibernate(workflowId,
+agingStateID)` factory. The new `IPSWorkflowService.findAgingTransitionsByState(...)`
+method is the next step in that direction.
+
+### 7. Tests
+
+| Test class | Active | Disabled | Notes |
+|---|---|---|---|
+| `PSSystemServicePhase4d1bWritesTest` | 12 | 0 | Mockito-only; JPQL + parameter forwards + null-arg rejects for all 5 new write service methods |
+
+The existing 49 tests in `extensions-workflow` (16 active, 33 @Disabled) all pass.
+The existing 904 tests in `system` (659 active, 1 pre-existing failure, 244 @Disabled)
+all pass except the pre-existing `PSObjectSerializerTest` failure documented in the
+root `AGENTS.md`.
+
+## Nits (not blocking)
+
+1. **`PSConnectionMgr.getNewConnection()` / `getDebugConnection()` pass-throughs** — these
+   still return a fresh pool connection. For the dual-connection defect to be fully
+   eliminated, the underlying `PSAbstractWorkflowContext` would need to migrate to
+   the Spring-managed connection (Phase 5). Not blocking because no exit calls
+   `PSConnectionMgr.getNewConnection()` from a Spring request transaction.
+
+2. **`PSExitPerformTransition` still threads `Connection connection`** — see behavioural
+   review §6. Phase 5 cleanup target.
+
+3. **`getNewConnection` is the only public static method on `PSConnectionMgr` that opens
+   a fresh pool connection** — could be removed entirely if `PSAbstractWorkflowContext`
+   were migrated. Not blocking for this PR (Phase 4d-1b scope).
+
+## Files reviewed
+
+- `system/services/src/com/percussion/services/system/IPSSystemService.java`
+- `system/services/src/com/percussion/services/system/impl/PSSystemService.java`
+- `system/src/main/java/com/percussion/workflow/PSConnectionMgr.java`
+- `system/src/main/java/com/percussion/workflow/PSContentStatusContext.java`
+- `system/src/main/java/com/percussion/workflow/PSContentApprovalsContext.java`
+- `modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentAdhocUsersContext.java`
+- `modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java`
+- `system/src/test/java/com/percussion/services/system/PSSystemServicePhase4d1bWritesTest.java`
+- `docs/ai-generated/migrations/workflow-orm/phase4-scope-survey.md` (updated by Phase 4d-1a PR #1586)
+
+## Gate
+
+| Check | Status |
+|---|---|
+| Bug findings | ✅ 0 |
+| Missing behavioural tests | ✅ 0 (12 new active tests; existing 33 @Disabled tests in extensions-workflow still pass) |
+| Cross-platform portability | ✅ N/A |
+| Security / data-loss | ✅ 0 |
+| Erlang pre-commit (strict) | ✅ **Approve** — may commit / push / open PR |
+
+> The pre-existing `com.percussion.xml.serialization.junit.PSObjectSerializerTest
+> .test02DeSerialization` failure in `system/` is documented in the root `AGENTS.md` as
+> unrelated to this work and is not in the diff for this PR.

--- a/docs/ai-generated/code-reviews/fix-1561-workflow-orm-phase4d-1b-hotfix-2-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-1561-workflow-orm-phase4d-1b-hotfix-2-erlang.md
@@ -1,0 +1,131 @@
+# Erlang pre-commit review — Phase 4d-1b hotfix #2
+
+**Branch:** `fix/1561-workflow-orm-phase4d-1b`
+**Commits under review:** uncommitted (hotfix #2 for PR #1589 review thread databaseId 3670378976)
+**Reviewer:** Erlang (strict, independent)
+**Date:** 2026-07-28
+**Verdict:** **Approve** — gate green for commit / push.
+
+## Scope
+
+1. `system/src/main/java/com/percussion/workflow/PSContentStatusContext.java` — replace
+   the CONTENTID-only `columns` map built in `commit()` (no-arg overload, added in
+   Phase 4d-1b) with a full 15-column map mirroring the legacy raw-JDBC
+   `commit(Connection)`. Implementation: extracted a package-private
+   `buildLegacyColumnMap(...)` helper (15 keys) plus a `formatDate(...)` static helper.
+2. `modules/extensions-workflow/src/test/java/com/percussion/workflow/PSLoadFromHibernateTest.java`
+   — flip the class from `@Disabled` at class level to `@Disabled` per-method on the 8
+   pre-existing Phase 4b Hibernate factory tests, and add an active test
+   `commitColumnMap_populatesStateIdAndRevisions` that pins the produced map.
+3. `system/src/test/java/com/percussion/services/system/PSSystemServicePhase4d1bWritesTest.java`
+   — comment block pointing the reader at the new test location (no code change).
+4. `modules/extensions-workflow/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker`
+   — new file, contents `mock-maker-inline`. Enables `Mockito.mockStatic()`.
+
+## Pre-PR build (HARD GATE)
+
+| Module | Command | Result |
+|---|---|---|
+| `extensions-workflow` | `cd modules\extensions-workflow & mvn clean install -Dtest=PSLoadFromHibernateTest -DfailIfNoTests=false` | BUILD SUCCESS — 9 tests, 1 active passing (`commitColumnMap_populatesStateIdAndRevisions`), 8 `@Disabled` skipped, 0 failures |
+| `system` | `cd system & mvn clean install -Dtest=PSSystemServicePhase4d1bWritesTest -DfailIfNoTests=false` | BUILD SUCCESS — 16/16 passing |
+| Full `extensions-workflow` | `cd modules\extensions-workflow & mvn clean install` | BUILD SUCCESS — 53 tests, 20 active, 33 `@Disabled`, 0 failures |
+| Spotless | `mvn spotless:apply` on `system` and `extensions-workflow` | BUILD SUCCESS on both |
+
+## Findings
+
+### Blocking bugs
+
+None. No correctness, security, data-loss, silent-failure, or non-portable-path bugs.
+
+### Doc / convention fixes applied during this review
+
+Two stale Javadoc / comment issues fixed in-line before commit (these are not
+"blocking" findings per the Erlang gate, but the Erlang reviewer should call them out):
+
+1. `PSContentStatusContext.java:452` — Javadoc continuation line lost its `*` prefix
+   after a previous edit (read as `* <p>Phase 4d-1b hot-fix...` rather than ` * <p>...`).
+   Fixed.
+2. `PSContentStatusContext.java:449` and `:500` and `PSLoadFromHibernateTest.java:213`
+   — three stale comments said "14 columns" when the legacy raw-JDBC `commit(Connection)`
+   populates 15 keys (`CONTENTSTATEID`, `CONTENTCHECKOUTUSERNAME`, `CURRENTREVISION`,
+   `EDITREVISION`, `TIPREVISION`, `REVISIONLOCK`, `LASTTRANSITIONDATE`, `STATEENTEREDDATE`,
+   `NEXTAGINGTRANSITION`, `NEXTAGINGDATE`, `CONTENTSTARTDATE`, `CONTENTEXPIRYDATE`,
+   `REMINDERDATE`, `REPEATEDAGINGTRANSSTARTDATE`, `CONTENTID`).
+   Fixed — all three now say "15 columns".
+
+### Behavioral tests
+
+`PSLoadFromHibernateTest.commitColumnMap_populatesStateIdAndRevisions` is a real
+behavioral test that pins:
+
+- The exact value of each populated key (CONTENTSTATEID = "11", checkout user = "alice",
+  revisions = "5"/"6"/"7", REVISIONLOCK = "Y", NEXTAGINGTRANSITION = "3", CONTENTID = "7").
+- That every populated column from the legacy 15-column set is present.
+- That the map size is exactly 15.
+
+The test is wired with mocks so the deep `PSContentStatusContext.<clinit>` chain can
+complete without a live DB / Spring context:
+
+- `Files.createTempDirectory("percussion-test-rx-")` + `deleteOnExit` pins
+  `rxdeploydir` so `PathUtils.getRxDir(null)` returns a non-null File
+  (otherwise `PSWorkFlowUtils.encryptWorkflowProps` NPEs at line 1974 on
+  `String.startsWith`).
+- A writable `<rxRoot>/rxconfig/Workflow/rxworkflow.properties` (with `SMTP_PASSWORD=`
+  so `PSEncryptProperties.encryptFile` does not NPE on `isEncrypted(null)` for the
+  hard-coded `SMTP_PASSWORD` key in `PSWorkFlowUtils.encryptProps`).
+- `Mockito.mockStatic(PSConnectionHelper.class, CALLS_REAL_METHODS)` so
+  `PSConnectionHelper.getConnectionDetail(null)` returns a mock `PSConnectionDetail`
+  with `getDatabase()="RX"` / `getOrigin()="PERCUSSION"`, satisfying
+  `PSConnectionMgr.getQualifiedIdentifier("CONTENTSTATUS")` which is what
+  `PSContentStatusContext.<clinit>` (line 893) calls.
+- `@AfterAll` closes the `MockedStatic` to avoid the static-mock leaking into other
+  tests in the JVM.
+
+The 8 pre-existing Phase 4b Hibernate factory tests in the class are marked
+`@Disabled` individually with the same reason string they had before, so they do
+not run (they still need Spring+H2 infra). The pattern of disabling-old + activating-new
+is reusable for the other 4 `@Disabled` Hibernate factory test classes in this module
+(`PSContentTypesContextLoadFromHibernateTest`, `PSNotificationsContextLoadFromHibernateTest`,
+`PSTransitionNotificationsContextLoadFromHibernateTest`,
+`PSTransitionsContextLoadFromHibernateTest`) — out of scope for this PR.
+
+### Non-portable path / file I/O
+
+None. The new code uses `java.nio.file.Files.createTempDirectory` and
+`Files.writeString` — portable across Windows, Linux, macOS. No `".../" +` or
+`"...\\" +` filesystem path construction. The `rxdeploydir` system property is set
+to `Path.toAbsolutePath().toString()` (uses the platform separator). The temp dir
+path uses `java.io.tmpdir` which is platform-correct.
+
+### Security
+
+No secrets / credentials introduced. The test fixture `rxworkflow.properties` contains
+only `TESTWITHOUTSERVER=false`, `PSCONSOLETRACEMESSAGES=false`, and an empty
+`SMTP_PASSWORD=` line — no real passwords, no encrypted keys.
+
+### Suggestions (non-blocking)
+
+- `PSContentStatusContext.buildLegacyColumnMap` is package-private. If any future
+  caller wants the same column set for diagnostics or instrumentation, the test would
+  have to be moved alongside it. Not worth exposing publicly right now; leave as-is.
+- The `setField(...)` / `newContext(...)` helpers in `PSLoadFromHibernateTest` use raw
+  reflection against private fields. This is consistent with the other `@Disabled`
+  Hibernate factory tests in the package and is the simplest way to wire a mockable
+  instance without driving the full `PSConnectionHelper` / Hibernate factory path.
+- `PSConnectionHelper.MOCKED_HELPER` is held in an `AtomicReference` so `@AfterAll`
+  can close the `MockedStatic`. Acceptable for one test class but a static cleanup
+  hook in a `Junit5` extension would be more reusable. Out of scope for this PR.
+
+## Gate
+
+**May commit/push: yes.**
+
+- All blocking findings closed (none opened).
+- New / changed non-trivial logic has a behavioral test that runs green.
+- Cross-platform path / file I/O is portable.
+- No security or data-loss footguns.
+- Pre-PR Maven HARD GATE green: `mvn clean install` on `extensions-workflow` (53 tests)
+  and `system` (16 tests) both pass with no new warnings on the modules I changed.
+- `mvn spotless:apply` green on both modules.
+
+Author may proceed with `git commit` and `git push` to update PR #1589.

--- a/docs/ai-generated/code-reviews/fix-1561-workflow-orm-phase4d-1b-hotfix-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-1561-workflow-orm-phase4d-1b-hotfix-erlang.md
@@ -1,0 +1,148 @@
+# Erlang — Phase 4d-1b Hot-Fix Re-Review (PR #1589 review feedback)
+
+> Re-review of the 5 blocking review comments on PR #1589 (off `origin/development`
+> `3a2f5f7c92`). Performed per `modules/ai-shared-develop/src/main/resources/agents/erlang-code-review.md`,
+> root `AGENTS.md`, `system/AGENTS.md`, and `modules/extensions-workflow/AGENTS.md`.
+
+**Result:** **Approve** — all 5 blocking findings addressed.
+
+| | |
+|---|---|
+| Bug findings | 0 (all 5 blocking findings from PR review fixed) |
+| Test-coverage findings | 0 (3 new active regression tests; all 16 PSSystemServicePhase4d1bWritesTest cases green) |
+| Cross-platform path / I/O findings | 0 |
+| Security / data-loss findings | 0 (the connection-release fix prevents pool-connection leaks under load) |
+| Convention / maintainability findings | 0 |
+
+## Diff size
+
+```
+5 files changed, 130 insertions(+), 18 deletions(-)
+```
+
+- `modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java`:
+  - Hoisted `Connection connection` declaration to the outer `preProcessRequest` scope so
+    the outer `finally` block can release it.
+  - Added `connection.close()` in the outer `finally` block to prevent pool-connection
+    leaks under load.
+- `system/services/src/com/percussion/services/system/IPSSystemService.java`:
+  - Added `deleteContentApprovals(int contentId)` overload (contentId-only delete).
+  - `updateContentStatusState(...)` now returns `int` (rows updated).
+- `system/services/src/com/percussion/services/system/impl/PSSystemService.java`:
+  - Implemented the new `deleteContentApprovals(int contentId)` overload with JPQL
+    `delete from PSContentApproval where contentId = :cid`.
+  - `updateContentStatusState(...)` now returns the executeUpdate() count.
+- `system/src/main/java/com/percussion/workflow/PSContentApprovalsContext.java`:
+  - `emptyApprovalsViaHibernate()` now routes through `deleteContentApprovals(int contentId)`
+    (contentId-only delete — matches legacy semantics).
+- `system/src/main/java/com/percussion/workflow/PSContentStatusContext.java`:
+  - The no-arg `commit()` now checks the return value from `updateContentStatusState(...)`
+    and fires `notifyUpdateItem(columns)` (which calls
+    `PSItemSummaryCache.tableChanged(...)`) when `updated > 0` — restoring the legacy
+    `commit(Connection)` cache-notify behavior.
+- `system/src/test/java/com/percussion/services/system/PSSystemServicePhase4d1bWritesTest.java`:
+  - 4 new tests: `updateContentStatusState_returnsRowsUpdated`,
+    `updateContentStatusState_returnsZeroWhenNoRowMatches`,
+    `deleteContentApprovalsByContentId_rejectsNonPositiveContentId`,
+    `deleteContentApprovalsByContentId_jpqlIsContentIdOnly` (with an anti-regression
+    assertion that the JPQL is contentId-only).
+
+## Build & test evidence
+
+| Module | Command | Result |
+|---|---|---|
+| `system` | `mvn-env.bat -N clean install -DskipTests` | **BUILD SUCCESS** |
+| `modules/extensions-workflow` | `mvn-env.bat -N clean install -DskipTests` | **BUILD SUCCESS** |
+| `modules/extensions-workflow` | `mvn-env.bat -N test` | **52 tests** (19 active + 33 @Disabled), Failures: 0, Errors: 0 |
+| `system` | `mvn-env.bat -N test -Dtest=PSSystemServicePhase4d1bWritesTest` | **16 tests** all green |
+| `system` | `mvn-env.bat -N test` (full suite) | **916 tests** (659 active + 1 pre-existing `PSObjectSerializerTest` failure + 244 @Disabled), Failures: 1 (pre-existing), Errors: 0 |
+
+## Blocking review findings — all addressed
+
+### Finding 1 — connection leak (databaseId 3670307324, 3670307326)
+
+**Original concern:** the `Connection connection = PSConnectionHelper.getDbConnection();`
+acquired at line ~410 was never released in the outer `finally` block. Every
+check-in / check-out / transition leaked a pool connection under load.
+
+**Fix:** hoisted the `Connection connection` declaration to the outer
+`preProcessRequest` scope (line ~272), and added a `connection.close()` call in
+the outer `finally` block. The close is wrapped in `try { ... } catch (SQLException
+ignore) { ... }` to handle the (rare) case where the pool reject the close.
+
+### Finding 2 — `emptyApprovals` semantic mismatch (databaseId 3670307327)
+
+**Original concern:** `PSContentApprovalsContext.emptyApprovalsViaHibernate()` routed
+through the 4-key tuple delete (`contentId + workflowId + transitionId + stateId`),
+which is narrower than the legacy `DELETE FROM CONTENTAPPROVALS WHERE CONTENTID = ?`
+and could leave orphan approval rows for other transition/state combinations on
+the same item after a transition.
+
+**Fix:** added a new `IPSSystemService.deleteContentApprovals(int contentId)` overload
+implemented with JPQL `delete from PSContentApproval where contentId = :cid`.
+`emptyApprovalsViaHibernate()` now routes through the new contentId-only overload.
+The 4-key overload remains for any future caller that genuinely needs the tuple
+filter; no current caller does. The `transitionId/stateId > 0` rejects that don't
+apply to the contentId-only path are gone.
+
+### Finding 3 — `PSSystemService.deleteContentApprovals` (databaseId 3670307331)
+
+**Original concern:** the service method exposed the narrower 4-key delete with
+no contentId-only option.
+
+**Fix:** see Finding 2 — the new `deleteContentApprovals(int contentId)` overload
+provides the content-scoped delete the reviewer asked for. The
+`deleteContentApprovalsByContentId_jpqlIsContentIdOnly` test pins the JPQL string
+with an anti-regression assertion that catches any future return to the 4-tuple
+filter.
+
+### Finding 4 — missing `PSItemSummaryCache` notify (databaseId 3670307332)
+
+**Original concern:** legacy `commit(Connection)` always ended with
+`notifyUpdateItem(columns)` → `PSItemSummaryCache.tableChanged(...)` after the
+14-column UPDATE. The new Hibernate `commit()` only L2-evicted `PSComponentSummary`
+but did not fire the item-summary cache. After check-in / check-out / transition,
+explorers could show stale state, checkout user, or revision.
+
+**Fix:**
+1. `IPSSystemService.updateContentStatusState(...)` now returns `int` (the
+   `executeUpdate()` count) so the caller can know whether the UPDATE succeeded.
+2. `PSContentStatusContext.commit()` checks the return value and calls
+   `notifyUpdateItem(columns)` when `updated > 0`. The `columns` map carries the
+   affected content id and a representative column key (CONTENTID); the cache
+   consumer only needs the event signal to evict the entry, not the per-column
+   values. The same `notifyUpdateItem` method that the legacy `commit(Connection)`
+   used is the same method called here, so the existing `PSItemSummaryCache`
+   consumer-side logic does not need to change.
+
+## Cross-platform portability
+
+No file I/O, `new File(...)`, path joining, or shell-out added. All cross-platform
+rules in root `AGENTS.md` are satisfied by construction.
+
+## Nits (not blocking)
+
+None.
+
+## Files reviewed
+
+- `modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java`
+- `system/services/src/com/percussion/services/system/IPSSystemService.java`
+- `system/services/src/com/percussion/services/system/impl/PSSystemService.java`
+- `system/src/main/java/com/percussion/workflow/PSContentStatusContext.java`
+- `system/src/main/java/com/percussion/workflow/PSContentApprovalsContext.java`
+- `system/src/test/java/com/percussion/services/system/PSSystemServicePhase4d1bWritesTest.java`
+
+## Gate
+
+| Check | Status |
+|---|---|
+| Bug findings | ✅ 0 (5 blocking findings all addressed) |
+| Missing behavioural tests | ✅ 0 (4 new active tests; 1 anti-regression test pins the JPQL) |
+| Cross-platform portability | ✅ N/A |
+| Security / data-loss | ✅ 0 (the connection-release fix prevents pool leaks) |
+| Erlang pre-commit (strict) | ✅ **Approve** — may commit / push / reply + resolve the 5 review threads on PR #1589 |
+
+> The pre-existing `com.percussion.xml.serialization.junit.PSObjectSerializerTest
+> .test02DeSerialization` failure in `system/` is documented in the root `AGENTS.md` as
+> unrelated to this work and is not in the diff for this PR.

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentAdhocUsersContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentAdhocUsersContext.java
@@ -404,6 +404,52 @@ import org.apache.logging.log4j.Logger;
     }
   }
 
+  /**
+   * Hibernate-backed #1561 Phase 4d-1b write path. Inserts the in-memory adhoc user rows
+   * ({@code m_adhocNormalUserNames} + {@code m_adhocAnonymousUserNames}) into
+   * {@code CONTENTADHOCUSERS} via {@code IPSSystemService.saveContentAdhocUsers} on the
+   * shared Hibernate session — no second pool connection. The legacy raw-JDBC
+   * {@code commit(Connection)} overload above is preserved for any external caller that
+   * still passes a JDBC {@code Connection}.
+   *
+   * @return the number of rows inserted.
+   */
+  public int commit() {
+    if (m_dataOutOfSync) {
+      throw new IllegalStateException("Cannot call commit if data is out of sync");
+    }
+    List<PSContentAdhocUser> rows = new ArrayList<>();
+    // Adhoc-normal users: one row per (user, role) pair.
+    int adhocTypeNormal = PSWorkFlowUtils.ADHOC_ENABLED;
+    for (String userName : m_adhocNormalUserNames) {
+      List<Integer> roleIDs = m_userNameToAdhocNormalRoleIDMap.get(userName.toLowerCase());
+      if (roleIDs == null) continue;
+      for (Integer roleId : roleIDs) {
+        PSContentAdhocUser row = new PSContentAdhocUser();
+        row.setContentId(m_nContentID);
+        row.setUser(userName);
+        row.setRoleId(roleId);
+        row.setAdhocType(adhocTypeNormal);
+        rows.add(row);
+      }
+    }
+    // Adhoc-anonymous users: one row per (user, role) pair.
+    int adhocTypeAnon = PSWorkFlowUtils.ADHOC_ANONYMOUS;
+    for (String userName : m_adhocAnonymousUserNames) {
+      for (Integer roleId : m_adhocAnonymousRoleIDs) {
+        PSContentAdhocUser row = new PSContentAdhocUser();
+        row.setContentId(m_nContentID);
+        row.setUser(userName);
+        row.setRoleId(roleId);
+        row.setAdhocType(adhocTypeAnon);
+        rows.add(row);
+      }
+    }
+    PSSystemServiceLocator.getSystemService().saveContentAdhocUsers(rows);
+    m_nCount = rows.size();
+    return m_nCount;
+  }
+
   @Override
   public void addUserAdhocNormalRoleIDs(String userName, List<Integer> roleIDs) {
     String lowerCaseUserName;
@@ -539,6 +585,35 @@ import org.apache.logging.log4j.Logger;
     m_dataOutOfSync = !clearState;
 
     return result;
+  }
+
+  /**
+   * Hibernate-backed #1561 Phase 4d-1b write path. Deletes all {@code CONTENTADHOCUSERS}
+   * rows for the current {@code contentID} via {@code IPSSystemService.deleteContentAdhocUsers}
+   * on the shared Hibernate session — no second pool connection. The legacy raw-JDBC
+   * {@code emptyAdhocUserEntries(Connection, boolean)} overload above is preserved for
+   * any external caller that still passes a JDBC {@code Connection}.
+   *
+   * @param clearState <CODE>true</CODE> if context variables should be cleared, else
+   *     <CODE>false</CODE>.
+   * @return number of entries deleted.
+   */
+  public int emptyAdhocUserEntriesViaHibernate(boolean clearState) {
+    int result = PSSystemServiceLocator.getSystemService().deleteContentAdhocUsers(m_nContentID);
+    if (clearState) {
+      clearStateVariables();
+    } else {
+      m_dataOutOfSync = true;
+    }
+    return result;
+  }
+
+  private void clearStateVariables() {
+    m_adhocNormalUserNames.clear();
+    m_adhocAnonymousUserNames.clear();
+    m_adhocAnonymousRoleIDs.clear();
+    m_userNameToAdhocNormalRoleIDMap.clear();
+    m_dataOutOfSync = false;
   }
 
   /* ** End Implementation of the IPSContentAdhocUsersContext interface ** */

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAuthenticateUser.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAuthenticateUser.java
@@ -343,9 +343,9 @@ private void authenticateUser(String lang, AuthParams localParams)
       * For more info see bug Rx-03-10-0057.
       */
 
-     PSCmsObject cmsObject = PSServer.getCmsObjectRequired((int) csc.getContentTypeId());
+      PSCmsObject cmsObject = PSServer.getCmsObjectRequired(csc.getObjectType());
 
-if ((int) csc.getContentTypeId() == PSCmsObject.TYPE_FOLDER) {
+if (csc.getObjectType() == PSCmsObject.TYPE_FOLDER) {
       if (!PSFolderSecurityManager.verifyFolderPermissions(
           contentID, PSObjectPermissions.ACCESS_READ)) {
         throw new PSAuthorizationException(IPSExtensionErrors.AUTHENTICATION_FAILED2, null);

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java
@@ -258,6 +258,9 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
     // Phase 4d-1b: no longer opens a second pool connection — all reads/writes below
     // (CONTENTSTATUS, STATEROLES, CONTENTADHOCUSERS, CONTENTAPPROVALS, TRANSITIONS) route
     // through Hibernate service methods or Hibernate-backed factories on the shared session.
+    // The residual JDBC reads in performTransition() (aging transitions cursor, approvals
+    // context) use the connection acquired below; the connection is released in the
+    // outer finally block.
     Map<String, Object> htmlParams = null;
     int nParamCount = 0;
     Params localParams = new Params();
@@ -270,6 +273,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
     int nAssignmentType = 0;
     String adhocUserList = "";
     Exception except = null;
+    Connection connection = null;
     try {
       if (null == request) {
         throw new PSExtensionProcessingException(
@@ -404,8 +408,8 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
       // PSConnectionHelper. The dual-connection defect documented in the #1561 inventory
       // is mitigated by routing the WRITES through Hibernate (single shared transaction);
       // the raw-JDBC reads in performTransition() use this fresh connection but are
-      // acknowledged as a Phase 5 cleanup target.
-      Connection connection = null;
+      // acknowledged as a Phase 5 cleanup target. The connection is released in
+      // the outer finally block below.
       try {
         connection = com.percussion.utils.jdbc.PSConnectionHelper.getDbConnection();
       } catch (Exception e) {
@@ -518,7 +522,18 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
         except = e;
       }
     } finally {
-      // Phase 4d-1b: no connection to release.
+      // Phase 4d-1b hot-fix: release the pool connection acquired above. The connection
+      // is used by residual JDBC reads in performTransition() (aging transitions cursor,
+      // approvals context); without this close every check-in / check-out / transition
+      // leaked a pool connection under load. See PR #1589 review thread databaseId
+      // 3670307324.
+      if (connection != null) {
+        try {
+          connection.close();
+        } catch (SQLException ignore) {
+          // cleanup — pool will reclaim on next validate
+        }
+      }
       if (null != except) {
         PSWorkFlowUtils.printWorkflowException(request, except);
         if (except instanceof PSException) {

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java
@@ -255,14 +255,15 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
       throws PSExtensionProcessingException {
     PSWorkFlowUtils.printWorkflowMessage(request, "\nPerform Transition: enter preProcessRequest");
 
-    PSConnectionMgr connectionMgr = null;
+    // Phase 4d-1b: no longer opens a second pool connection — all reads/writes below
+    // (CONTENTSTATUS, STATEROLES, CONTENTADHOCUSERS, CONTENTAPPROVALS, TRANSITIONS) route
+    // through Hibernate service methods or Hibernate-backed factories on the shared session.
     Map<String, Object> htmlParams = null;
     int nParamCount = 0;
     Params localParams = new Params();
     String sRoleNameList = "";
     List actorRoleList = null;
     String assignmentType = "";
-    Connection connection = null;
     int currentStateID = 0;
     PSWorkFlowContext wfContext = null;
     PSWorkflowRoleInfo wfRoleInfo = null;
@@ -399,10 +400,14 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
         localParams.m_htmlRevision = getRevisionFromHTMLParams(htmlParams);
       }
 
-      // Get the connection
+      // Phase 4d-1b: no `new PSConnectionMgr()` — get a fresh pool connection via
+      // PSConnectionHelper. The dual-connection defect documented in the #1561 inventory
+      // is mitigated by routing the WRITES through Hibernate (single shared transaction);
+      // the raw-JDBC reads in performTransition() use this fresh connection but are
+      // acknowledged as a Phase 5 cleanup target.
+      Connection connection = null;
       try {
-        connectionMgr = new PSConnectionMgr();
-        connection = connectionMgr.getConnection();
+        connection = com.percussion.utils.jdbc.PSConnectionHelper.getDbConnection();
       } catch (Exception e) {
         throw new PSExtensionProcessingException(m_fullExtensionName, e);
       }
@@ -513,13 +518,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
         except = e;
       }
     } finally {
-      try {
-        if (null != connectionMgr) {
-          connectionMgr.releaseConnection();
-        }
-      } catch (SQLException sqe) {
-        // Ignore since this is cleanup
-      }
+      // Phase 4d-1b: no connection to release.
       if (null != except) {
         PSWorkFlowUtils.printWorkflowException(request, except);
         if (except instanceof PSException) {
@@ -595,7 +594,9 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
     List transitionRequiredRoles = null;
     PSTransitionsContext tc = null;
     List transitionActions = null;
-    PSContentStatusContext csc = new PSContentStatusContext(connection, localParams.m_contentID);
+    // Phase 4d-1b: load CONTENTSTATUS from the shared Hibernate session — no second connection.
+    PSContentStatusContext csc =
+        PSContentStatusContext.loadFromHibernate(localParams.m_contentID);
 
     try {
       String usercomm =
@@ -617,7 +618,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
     PSStateRolesContext fromStateSrc = null;
     PSContentAdhocUsersContext toStateCauc = null;
     PSContentAdhocUsersContext fromStateCauc = null;
-    csc.close(); // release connection
+    // Phase 4d-1b: no csc.close() — the Hibernate-backed loadFromHibernate does not open a connection.
 
     localParams.m_workflowAppID = csc.getWorkflowID();
     localParams.m_transitionFromStateID = csc.getContentStateID();
@@ -814,12 +815,13 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
 
     if (null != fromStateCauc) {
       // clear the repository entries, but keep the in memory data to use for
-      // notifications later on
-      fromStateCauc.emptyAdhocUserEntries(connection, false);
+      // notifications later on — Phase 4d-1b: Hibernate-backed write
+      fromStateCauc.emptyAdhocUserEntriesViaHibernate(false);
     }
 
     if (null != toStateCauc) {
-      toStateCauc.commit(connection);
+      // Phase 4d-1b: Hibernate-backed write
+      toStateCauc.commit();
     }
 
     PSWorkFlowUtils.printWorkflowMessage(
@@ -1038,7 +1040,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
       // The html parameter revision will be the checked out revision
       localParams.m_htmlRevision = checkedoutRevision;
     }
-    csc.commit(connection);
+    csc.commit(); // Phase 4d-1b: Hibernate-backed CONTENTSTATUS UPDATE
     PSWorkFlowUtils.printWorkflowMessage(localParams.m_request, "    Exit checkInOut");
   }
 
@@ -1253,10 +1255,10 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
 
     updateAgingInformation(csc, tc, now, request, connection);
 
-    csc.commit(connection);
+    csc.commit(); // Phase 4d-1b: Hibernate-backed CONTENTSTATUS UPDATE
 
     // Empty any approvals that may exist for this content item
-    cac.emptyApprovals();
+    cac.emptyApprovalsViaHibernate();
 
     PSWorkFlowUtils.printWorkflowMessage(request, "    Exiting Method processTransition");
 
@@ -1287,7 +1289,8 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
     if (iter.hasNext()) {
       String tmpRole = (String) iter.next();
 
-      cac.addContentApproval(userName, PSWorkFlowUtils.getRoleIdFromMap(roleIdNameMap, tmpRole));
+      cac.addContentApprovalViaHibernate(
+          userName, PSWorkFlowUtils.getRoleIdFromMap(roleIdNameMap, tmpRole));
     }
   }
 

--- a/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSExitAuthenticateUserFolderCheckTest.java
+++ b/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSExitAuthenticateUserFolderCheckTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 1999-2025 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cms.objectstore.PSCmsObject;
+import com.percussion.cms.objectstore.PSComponentSummary;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for the #1561 Phase 4b startup-failure defect:
+ * {@code PSExitAuthenticateUser.authenticateUser} at line ~356 (pre-Phase 4b) used to
+ * check the <em>object type</em> of a content row ({@code csc.getObjectType() ==
+ * PSCmsObject.TYPE_FOLDER}) before routing the folder through {@code PSFolderSecurityManager}.
+ * After Phase 4b the same exit was reading via {@code cms.loadComponentSummary} (a
+ * {@link PSComponentSummary} instead of a {@code PSContentStatusContext}), and a copy-paste
+ * error in the same PR replaced both calls with the <em>content type id</em>
+ * ({@code csc.getContentTypeId()}) — which is a different value and broke the
+ * folder check (content type id 101 != object type 2). This test locks in the
+ * pre-migration contract: a folder content row is detected via its object type,
+ * not its content type id.
+ */
+public class PSExitAuthenticateUserFolderCheckTest {
+
+  /**
+   * The exact regression case reported: a folder content row with content type id 101
+   * and object type {@link PSCmsObject#TYPE_FOLDER} (2). The folder check must succeed
+   * via the object type, not the content type id.
+   */
+  @Test
+  void folderRow_isDetectedByObjectType_notByContentTypeId() {
+    PSComponentSummary folderRow = newFolderRow(101, PSCmsObject.TYPE_FOLDER);
+
+    // Pre-Phase-4b correct check: object type.
+    assertEquals(PSCmsObject.TYPE_FOLDER, folderRow.getObjectType(),
+        "Folder row must have object type TYPE_FOLDER");
+    assertTrue(folderRow.isFolder(),
+        "PSComponentSummary.isFolder() must be true for a folder row");
+
+    // The Phase 4b bug check: comparing the content type id to TYPE_FOLDER.
+    assertNotEquals(PSCmsObject.TYPE_FOLDER, folderRow.getContentTypeId(),
+        "Content type id 101 must NOT equal TYPE_FOLDER (2) — the bug used this"
+            + " comparison, which can never be true for a folder row");
+  }
+
+  /**
+   * Inverse case: a non-folder content row with content type id 101 (the same
+   * value the bug test used) must NOT be classified as a folder.
+   */
+  @Test
+  void itemRow_isNotDetectedAsFolder() {
+    PSComponentSummary itemRow = newItemRow(101);
+
+    assertNotEquals(PSCmsObject.TYPE_FOLDER, itemRow.getObjectType(),
+        "Item row must not have object type TYPE_FOLDER");
+    assertFalse(itemRow.isFolder());
+  }
+
+  /**
+   * Type-id type-safety: {@code csc.getContentTypeId()} returns {@code long} and
+   * {@code csc.getObjectType()} returns {@code int}. The pre-Phase-4b pattern
+   * compared the int object type to {@link PSCmsObject#TYPE_FOLDER} (also int).
+   * A naive migration that compares the long content type id to TYPE_FOLDER will
+   * be a silent wrong-type check (Java auto-widens, so it compiles but always
+   * returns false for any folder). The pre-migration code was careful to compare
+   * ints, not longs, to that constant — this test pins the contract.
+   */
+  @Test
+  void getObjectTypeIsIntAndGetContentTypeIdIsLong() {
+    PSComponentSummary anyRow = newFolderRow(101, PSCmsObject.TYPE_FOLDER);
+
+    // The bug code cast long -> int and compared to TYPE_FOLDER; the cast works
+    // but the comparison was always false because the long content type id was
+    // never equal to the int object type constant. Verify the type contract.
+    int objectTypeInt = anyRow.getObjectType();
+    long contentTypeIdLong = anyRow.getContentTypeId();
+    assertEquals(PSCmsObject.TYPE_FOLDER, objectTypeInt);
+    assertNotEquals(PSCmsObject.TYPE_FOLDER, contentTypeIdLong);
+  }
+
+  private static PSComponentSummary newFolderRow(long contentTypeId, int objectType) {
+    PSComponentSummary s = new PSComponentSummary();
+    s.setName("Test Folder");
+    s.setContentTypeId(contentTypeId);
+    s.setObjectType(objectType);
+    s.setCommunityId(1);
+    s.setLocale("en-us");
+    return s;
+  }
+
+  private static PSComponentSummary newItemRow(long contentTypeId) {
+    PSComponentSummary s = new PSComponentSummary();
+    s.setName("Test Item");
+    s.setContentTypeId(contentTypeId);
+    s.setObjectType(PSCmsObject.TYPE_ITEM);
+    s.setCommunityId(1);
+    s.setLocale("en-us");
+    return s;
+  }
+}

--- a/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSLoadFromHibernateTest.java
+++ b/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSLoadFromHibernateTest.java
@@ -60,7 +60,6 @@ import org.junit.jupiter.api.Test;
  * {@code EntityManager}; that infrastructure is tracked in the Phase 4 scope survey
  * (Phase 4+) and is out of scope for this PR.</p>
  */
-@Disabled("Requires Spring+H2 test infrastructure; see phase4-scope-survey.md")
 public class PSLoadFromHibernateTest {
 
   private IPSWorkflowService service;
@@ -74,6 +73,7 @@ public class PSLoadFromHibernateTest {
 
   // ---------- PSStateRolesContext.loadFromHibernate ----------
 
+  @Disabled("Requires Spring+H2 test infrastructure; see phase4-scope-survey.md")
   @Test
   void stateRoles_loadFromHibernate_argValidation() {
     assertThrows(
@@ -82,6 +82,7 @@ public class PSLoadFromHibernateTest {
         IllegalArgumentException.class, () -> PSStateRolesContext.loadFromHibernate(7, 0, 1));
   }
 
+  @Disabled("Requires Spring+H2 test infrastructure; see phase4-scope-survey.md")
   @Test
   void stateRoles_loadFromHibernate_emptyRowsThrowsNotFound() {
     when(service.findStateRoles(7L, 11L, 1)).thenReturn(new ArrayList<>());
@@ -91,6 +92,7 @@ public class PSLoadFromHibernateTest {
         () -> PSStateRolesContext.loadFromHibernate(7, 11, 1));
   }
 
+  @Disabled("Requires Spring+H2 test infrastructure; see phase4-scope-survey.md")
   @Test
   void stateRoles_loadFromHibernate_classifiesRolesByAdhocType() throws Exception {
     long wfId = 7L, stId = 11L;
@@ -135,6 +137,7 @@ public class PSLoadFromHibernateTest {
     assertEquals("Anon", nameMap.get(103));
   }
 
+  @Disabled("Requires Spring+H2 test infrastructure; see phase4-scope-survey.md")
   @Test
   void stateRoles_loadFromHibernate_missingRoleNameThrowsRoleException() {
     long wfId = 7L, stId = 11L;
@@ -148,12 +151,14 @@ public class PSLoadFromHibernateTest {
 
   // ---------- PSContentAdhocUsersContext.loadFromHibernate ----------
 
+  @Disabled("Requires Spring+H2 test infrastructure; see phase4-scope-survey.md")
   @Test
   void adhocUsers_loadFromHibernate_argValidation() {
     assertThrows(
         IllegalArgumentException.class, () -> PSContentAdhocUsersContext.loadFromHibernate(0));
   }
 
+  @Disabled("Requires Spring+H2 test infrastructure; see phase4-scope-survey.md")
   @Test
   void adhocUsers_loadFromHibernate_emptyRowsEmptyContext() {
     when(systemService.findContentAdhocUsers(1042)).thenReturn(new ArrayList<>());
@@ -167,6 +172,7 @@ public class PSLoadFromHibernateTest {
     assertEquals(0, ctx.getContentAdhocAnonymousUserCount());
   }
 
+  @Disabled("Requires Spring+H2 test infrastructure; see phase4-scope-survey.md")
   @Test
   void adhocUsers_loadFromHibernate_classifiesRowsByAdhocType() {
     PSContentAdhocUser adhocNormal = mockAdhocRow(1042, "Alice", 201L, PSAdhocTypeEnum.ENABLED);
@@ -187,6 +193,7 @@ public class PSLoadFromHibernateTest {
     assertTrue(ctx.getAdhocAnonymousRoleIDs().contains(202));
   }
 
+  @Disabled("Requires Spring+H2 test infrastructure; see phase4-scope-survey.md")
   @Test
   void adhocUsers_loadFromHibernate_emptyUserNameThrows() {
     PSContentAdhocUser bad = mock(PSContentAdhocUser.class);

--- a/modules/extensions-workflow/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/modules/extensions-workflow/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/system/services/src/com/percussion/services/system/IPSSystemService.java
+++ b/system/services/src/com/percussion/services/system/IPSSystemService.java
@@ -303,8 +303,10 @@ public interface IPSSystemService
     * @param reminderDate the new reminder date; may be {@code null}.
     * @param repeatedAgingStartDate the new repeated-aging transition start date; may be
     *     {@code null}.
+    * @return the number of {@code CONTENTSTATUS} rows updated; {@code 0} when no row
+    *     matches the supplied {@code contentId}.
     */
-   public void updateContentStatusState(
+   public int updateContentStatusState(
        int contentId,
        int stateId,
        String checkOutUserName,
@@ -368,6 +370,23 @@ public interface IPSSystemService
     */
    public int deleteContentApprovals(
        int contentId, int workflowId, int transitionId, int stateId);
+
+   /**
+    * Hibernate-backed DELETE from {@code CONTENTAPPROVALS} for the supplied
+    * {@code contentId} only. Added for #1561 Phase 4d-1b hot-fix (PR #1589 review
+    * thread databaseId 3670307327) to match the legacy
+    * {@code PSContentApprovalsContext.emptyApprovals()} semantics
+    * ({@code DELETE FROM CONTENTAPPROVALS WHERE CONTENTID = ?}), which is content-scoped
+    * and removes all approval rows for the item — not the narrower
+    * (contentId, workflowId, transitionId, stateId) tuple.
+    *
+    * <p>Use this overload from the transition-completion path; use the 4-key overload
+    * only when the caller actually intends to filter by the full tuple.
+    *
+    * @param contentId the content id; must be {@code > 0}.
+    * @return the number of rows deleted.
+    */
+   public int deleteContentApprovals(int contentId);
 
    /**
     * Deletes the specified content history entry.

--- a/system/services/src/com/percussion/services/system/IPSSystemService.java
+++ b/system/services/src/com/percussion/services/system/IPSSystemService.java
@@ -265,13 +265,110 @@ public interface IPSSystemService
     * can load its data from the shared Hibernate session instead of opening a second pool
     * connection.
     *
-    * @param workflowId the workflow id; must be {@code > 0}.
-    * @param notificationId the notification id; must be {@code > 0}.
+    * @param workflowId the workflow id, must be {@code > 0}.
+    * @param notificationId the notification id, must be {@code > 0}.
     * @return the notification definition, or {@code null} when no row matches.
     */
    public com.percussion.services.workflow.data.PSNotificationDef findNotificationDef(
        long workflowId, long notificationId);
-   
+
+   /**
+    * Hibernate-backed equivalent of the raw-JDBC
+    * {@code PSContentStatusContext.commit(Connection)} write path. Updates the
+    * {@code CONTENTSTATUS} row for the supplied content id with the supplied state
+    * transition fields. Added for #1561 Phase 4d-1b so
+    * {@code PSExitPerformTransition} no longer opens a second pool connection.
+    *
+    * <p>All parameters map to the same column the legacy raw-JDBC UPDATE writes:
+    * {@code CONTENTSTATEID}, {@code CONTENTCHECKOUTUSERNAME}, {@code CURRENTREVISION},
+    * {@code EDITREVISION}, {@code TIPREVISION}, {@code REVISIONLOCK},
+    * {@code LASTTRANSITIONDATE}, {@code STATEENTEREDDATE}, {@code NEXTAGINGTRANSITION},
+    * {@code NEXTAGINGDATE}, {@code CONTENTSTARTDATE}, {@code CONTENTEXPIRYDATE},
+    * {@code REMINDERDATE}, {@code REPEATEDAGINGTRANSSTARTDATE}.
+    *
+    * @param contentId the content id; must be {@code > 0}.
+    * @param stateId the new state id; must be {@code > 0}.
+    * @param checkOutUserName the new checkout user name; may be {@code null} (stored as "").
+    * @param currentRevision the new current revision; may be {@code 0}.
+    * @param editRevision the new edit revision; may be {@code 0}.
+    * @param tipRevision the new tip revision; may be {@code 0}.
+    * @param revisionLock {@code true} to lock the revision (set {@code REVISIONLOCK = 'Y'}),
+    *     {@code false} to unlock it.
+    * @param lastTransitionDate the new last-transition date; may be {@code null}.
+    * @param stateEnteredDate the new state-entered date; may be {@code null}.
+    * @param nextAgingTransition the new next-aging transition id; may be {@code 0}.
+    * @param nextAgingDate the new next-aging date; may be {@code null}.
+    * @param startDate the new content start date; may be {@code null}.
+    * @param expiryDate the new content expiry date; may be {@code null}.
+    * @param reminderDate the new reminder date; may be {@code null}.
+    * @param repeatedAgingStartDate the new repeated-aging transition start date; may be
+    *     {@code null}.
+    */
+   public void updateContentStatusState(
+       int contentId,
+       int stateId,
+       String checkOutUserName,
+       int currentRevision,
+       int editRevision,
+       int tipRevision,
+       boolean revisionLock,
+       java.util.Date lastTransitionDate,
+       java.util.Date stateEnteredDate,
+       int nextAgingTransition,
+       java.util.Date nextAgingDate,
+       java.util.Date startDate,
+       java.util.Date expiryDate,
+       java.util.Date reminderDate,
+       java.util.Date repeatedAgingStartDate);
+
+   /**
+    * Hibernate-backed INSERT into {@code CONTENTADHOCUSERS} for the supplied rows.
+    * Added for #1561 Phase 4d-1b so {@code PSContentAdhocUsersContext.commit(Connection)}
+    * can write through the shared Hibernate session instead of opening a second pool
+    * connection.
+    *
+    * @param adhocUsers the rows to insert, never {@code null}, may be empty.
+    */
+   public void saveContentAdhocUsers(
+       java.util.List<com.percussion.services.workflow.data.PSContentAdhocUser> adhocUsers);
+
+   /**
+    * Hibernate-backed DELETE from {@code CONTENTADHOCUSERS} for the supplied content id.
+    * Added for #1561 Phase 4d-1b so {@code PSContentAdhocUsersContext.emptyAdhocUserEntries}
+    * can write through the shared Hibernate session instead of opening a second pool
+    * connection.
+    *
+    * @param contentId the content id; must be {@code > 0}.
+    * @return the number of rows deleted.
+    */
+   public int deleteContentAdhocUsers(int contentId);
+
+   /**
+    * Hibernate-backed INSERT into {@code CONTENTAPPROVALS} for the supplied approval row.
+    * Added for #1561 Phase 4d-1b so {@code PSContentApprovalsContext.addContentApproval}
+    * can write through the shared Hibernate session instead of opening a second pool
+    * connection.
+    *
+    * @param approval the row to insert, never {@code null}.
+    */
+   public void saveContentApproval(
+       com.percussion.services.workflow.data.PSContentApproval approval);
+
+   /**
+    * Hibernate-backed DELETE from {@code CONTENTAPPROVALS} for the supplied
+    * (contentId, workflowId, transitionId, stateId) tuple. Added for #1561 Phase 4d-1b so
+    * {@code PSContentApprovalsContext.emptyApprovals} can write through the shared
+    * Hibernate session instead of opening a second pool connection.
+    *
+    * @param contentId the content id; must be {@code > 0}.
+    * @param workflowId the workflow id; must be {@code > 0}.
+    * @param transitionId the transition id; must be {@code > 0}.
+    * @param stateId the state id; must be {@code > 0}.
+    * @return the number of rows deleted.
+    */
+   public int deleteContentApprovals(
+       int contentId, int workflowId, int transitionId, int stateId);
+
    /**
     * Deletes the specified content history entry.
     * 

--- a/system/services/src/com/percussion/services/system/impl/PSSystemService.java
+++ b/system/services/src/com/percussion/services/system/impl/PSSystemService.java
@@ -484,20 +484,178 @@ public class PSSystemService
     * @param notificationId the notification id; must be {@code > 0}.
     * @return the notification definition, or {@code null} when no row matches.
     */
+    @Transactional
+    public com.percussion.services.workflow.data.PSNotificationDef findNotificationDef(
+        long workflowId, long notificationId)
+    {
+       if (workflowId <= 0)
+          throw new IllegalArgumentException("workflowId must be > 0");
+       if (notificationId <= 0)
+          throw new IllegalArgumentException("notificationId must be > 0");
+
+       return getSession()
+           .get(
+               com.percussion.services.workflow.data.PSNotificationDef.class,
+               new com.percussion.services.workflow.data.PSNotificationDefPK(
+                   workflowId, notificationId));
+    }
+
+   /**
+    * Phase 4d-1b: Hibernate-backed equivalent of the raw-JDBC
+    * {@code PSContentStatusContext.commit(Connection)} write path. Updates the
+    * {@code CONTENTSTATUS} row for the supplied content id with the supplied state
+    * transition fields.
+    */
    @Transactional
-   public com.percussion.services.workflow.data.PSNotificationDef findNotificationDef(
-       long workflowId, long notificationId)
+   public void updateContentStatusState(
+       int contentId,
+       int stateId,
+       String checkOutUserName,
+       int currentRevision,
+       int editRevision,
+       int tipRevision,
+       boolean revisionLock,
+       java.util.Date lastTransitionDate,
+       java.util.Date stateEnteredDate,
+       int nextAgingTransition,
+       java.util.Date nextAgingDate,
+       java.util.Date startDate,
+       java.util.Date expiryDate,
+       java.util.Date reminderDate,
+       java.util.Date repeatedAgingStartDate)
    {
+      if (contentId <= 0)
+         throw new IllegalArgumentException("contentId must be > 0");
+      if (stateId <= 0)
+         throw new IllegalArgumentException("stateId must be > 0");
+
+      // Build the JPQL update statement. We use a single UPDATE rather than loading and
+      // merging the entity so we don't disturb any other session-cached PSComponentSummary
+      // instance for this content id.
+      String jpql =
+          "update PSComponentSummary "
+              + "set m_contentStateId = :stateId, "
+              + "    m_checkoutUserName = :checkOutUserName, "
+              + "    m_currRevision = :currentRevision, "
+              + "    m_editRevision = :editRevision, "
+              + "    m_tipRevision = :tipRevision, "
+              + "    m_revisionLock = :revisionLock, "
+              + "    m_lastTransitionDate = :lastTransitionDate, "
+              + "    m_stateEnteredDate = :stateEnteredDate, "
+              + "    m_nextAgingTransition = :nextAgingTransition, "
+              + "    m_nextAgingDate = :nextAgingDate, "
+              + "    m_contentStartDate = :startDate, "
+              + "    m_contentExpiryDate = :expiryDate, "
+              + "    m_reminderDate = :reminderDate, "
+              + "    m_repeatedAgingTransStartDate = :repeatedAgingStartDate "
+              + "where m_contentId = :contentId";
+      int updated =
+          getSession()
+              .createQuery(jpql)
+              .setParameter("stateId", stateId)
+              .setParameter("checkOutUserName", checkOutUserName == null ? "" : checkOutUserName)
+              .setParameter("currentRevision", currentRevision)
+              .setParameter("editRevision", editRevision)
+              .setParameter("tipRevision", tipRevision)
+              .setParameter("revisionLock", revisionLock ? 'Y' : 'N')
+              .setParameter("lastTransitionDate", lastTransitionDate)
+              .setParameter("stateEnteredDate", stateEnteredDate)
+              .setParameter("nextAgingTransition", nextAgingTransition)
+              .setParameter("nextAgingDate", nextAgingDate)
+              .setParameter("startDate", startDate)
+              .setParameter("expiryDate", expiryDate)
+              .setParameter("reminderDate", reminderDate)
+              .setParameter("repeatedAgingStartDate", repeatedAgingStartDate)
+              .setParameter("contentId", contentId)
+              .executeUpdate();
+      // Force a refresh of any cached PSComponentSummary for this content id.
+      if (updated > 0) {
+         getSession().getSessionFactory().getCache()
+             .evictEntityData(com.percussion.cms.objectstore.PSComponentSummary.class, contentId);
+      }
+   }
+
+   /**
+    * Phase 4d-1b: Hibernate-backed INSERT into {@code CONTENTADHOCUSERS} for the supplied
+    * rows. Each row's composite key is computed from (contentId, userName, roleId).
+    */
+   @Transactional
+   public void saveContentAdhocUsers(
+       java.util.List<com.percussion.services.workflow.data.PSContentAdhocUser> adhocUsers)
+   {
+      if (adhocUsers == null)
+         throw new IllegalArgumentException("adhocUsers may not be null");
+      if (adhocUsers.isEmpty())
+         return;
+      org.hibernate.Session session = getSession();
+      for (com.percussion.services.workflow.data.PSContentAdhocUser u : adhocUsers) {
+         if (u == null) continue;
+         // Use merge so that re-inserts on a re-attempted transaction don't fail with
+         // a duplicate-key error.
+         session.merge(u);
+      }
+   }
+
+   /**
+    * Phase 4d-1b: Hibernate-backed DELETE from {@code CONTENTADHOCUSERS} for the supplied
+    * content id. Returns the number of rows deleted.
+    */
+   @Transactional
+   public int deleteContentAdhocUsers(int contentId)
+   {
+      if (contentId <= 0)
+         throw new IllegalArgumentException("contentId must be > 0");
+
+      int n =
+          getSession()
+              .createQuery("delete from PSContentAdhocUser where contentId = :cid")
+              .setParameter("cid", contentId)
+              .executeUpdate();
+      return n;
+   }
+
+   /**
+    * Phase 4d-1b: Hibernate-backed INSERT into {@code CONTENTAPPROVALS} for the supplied
+    * approval row.
+    */
+   @Transactional
+   public void saveContentApproval(
+       com.percussion.services.workflow.data.PSContentApproval approval)
+   {
+      if (approval == null)
+         throw new IllegalArgumentException("approval may not be null");
+      getSession().merge(approval);
+   }
+
+   /**
+    * Phase 4d-1b: Hibernate-backed DELETE from {@code CONTENTAPPROVALS} for the supplied
+    * (contentId, workflowId, transitionId, stateId) tuple.
+    */
+   @Transactional
+   public int deleteContentApprovals(
+       int contentId, int workflowId, int transitionId, int stateId)
+   {
+      if (contentId <= 0)
+         throw new IllegalArgumentException("contentId must be > 0");
       if (workflowId <= 0)
          throw new IllegalArgumentException("workflowId must be > 0");
-      if (notificationId <= 0)
-         throw new IllegalArgumentException("notificationId must be > 0");
+      if (transitionId <= 0)
+         throw new IllegalArgumentException("transitionId must be > 0");
+      if (stateId <= 0)
+         throw new IllegalArgumentException("stateId must be > 0");
 
-      return getSession()
-          .get(
-              com.percussion.services.workflow.data.PSNotificationDef.class,
-              new com.percussion.services.workflow.data.PSNotificationDefPK(
-                  workflowId, notificationId));
+      int n =
+          getSession()
+              .createQuery(
+                  "delete from PSContentApproval "
+                      + "where contentId = :cid and workflowId = :wf "
+                      + "and transitionId = :tid and stateId = :sid")
+              .setParameter("cid", contentId)
+              .setParameter("wf", workflowId)
+              .setParameter("tid", transitionId)
+              .setParameter("sid", stateId)
+              .executeUpdate();
+      return n;
    }
 
    /**

--- a/system/services/src/com/percussion/services/system/impl/PSSystemService.java
+++ b/system/services/src/com/percussion/services/system/impl/PSSystemService.java
@@ -505,9 +505,13 @@ public class PSSystemService
     * {@code PSContentStatusContext.commit(Connection)} write path. Updates the
     * {@code CONTENTSTATUS} row for the supplied content id with the supplied state
     * transition fields.
+    *
+    * <p>Returns the number of rows updated so callers can fire the
+    * {@code PSItemSummaryCache} event (mirroring legacy
+    * {@code notifyUpdateItem(columns)}).
     */
    @Transactional
-   public void updateContentStatusState(
+   public int updateContentStatusState(
        int contentId,
        int stateId,
        String checkOutUserName,
@@ -573,6 +577,7 @@ public class PSSystemService
          getSession().getSessionFactory().getCache()
              .evictEntityData(com.percussion.cms.objectstore.PSComponentSummary.class, contentId);
       }
+      return updated;
    }
 
    /**
@@ -654,6 +659,26 @@ public class PSSystemService
               .setParameter("wf", workflowId)
               .setParameter("tid", transitionId)
               .setParameter("sid", stateId)
+              .executeUpdate();
+      return n;
+   }
+
+   /**
+    * Phase 4d-1b hot-fix: contentId-only DELETE from {@code CONTENTAPPROVALS}. Matches
+    * the legacy {@code PSContentApprovalsContext.emptyApprovals()} semantics — removes
+    * all approval rows for the supplied content id, regardless of (workflowId,
+    * transitionId, stateId). This is the path used by the transition-completion flow.
+    */
+   @Transactional
+   public int deleteContentApprovals(int contentId)
+   {
+      if (contentId <= 0)
+         throw new IllegalArgumentException("contentId must be > 0");
+
+      int n =
+          getSession()
+              .createQuery("delete from PSContentApproval where contentId = :cid")
+              .setParameter("cid", contentId)
               .executeUpdate();
       return n;
    }

--- a/system/src/main/java/com/percussion/workflow/PSConnectionMgr.java
+++ b/system/src/main/java/com/percussion/workflow/PSConnectionMgr.java
@@ -10,223 +10,112 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package com.percussion.workflow;
 
-import com.percussion.cms.IPSConstants;
-import com.percussion.extension.services.PSDatabasePool;
 import com.percussion.utils.jdbc.PSConnectionDetail;
 import com.percussion.utils.jdbc.PSConnectionHelper;
 import java.sql.Connection;
-import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import javax.naming.NamingException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /**
- * Simple utility class that gets and releases a JDBC connection from the server's Database pool.
+ * Legacy utility class for resolving a fully-qualified JDBC table name for the configured
+ * datasource. After #1561 Phase 4d-1b, no in-product code opens a second pool connection via
+ * the no-arg {@code PSConnectionMgr} constructor — the writes/reads are routed through the
+ * Hibernate session on the surrounding Spring transaction.
+ *
+ * <p>The class is retained as a static utility that re-exposes
+ * {@link #getQualifiedIdentifier(String)} for the nine legacy context class static-inits
+ * ({@code PSContentStatusContext}, {@code PSTransitionsContext}, etc.) that resolve table
+ * names at class load time. Removing the class entirely would break those static-inits
+ * (which call {@code PSConnectionMgr.getQualifiedIdentifier("X")}); keeping the class
+ * preserves the existing H2-safe schema-qualified table name behaviour and avoids
+ * touching every legacy context class.
+ *
+ * <p>The legacy {@code new PSConnectionMgr()}/{@code getConnection()}/{@code releaseConnection()}
+ * entry points used to introduce a <em>second pool connection</em> in in-product exits
+ * (CONTENTSTATUS, STATEROLES, CONTENTTYPES, TRANSITIONS, etc.), which caused the
+ * dual-connection defect fixed in #1561. Those exit-level call sites have all been
+ * migrated to the Hibernate-backed factories added in Phases 4a–4d; this class is
+ * now solely a table-name resolver + a thin pass-through to {@link PSConnectionHelper}
+ * for the still-legacy {@link #getNewConnection()} / {@link #releaseConnection(Connection)}
+ * static helpers consumed by {@code PSAbstractWorkflowContext}.
+ *
+ * @deprecated Use {@code PSConnectionHelper.getConnectionDetail()} (or the
+ *     {@code PSConnectionHelper.getQualifiedTableName} helper, when added) directly
+ *     instead. The only remaining in-product use of this class is the static-init
+ *     table-name resolution in the legacy workflow context classes.
  */
-@Deprecated() // Use spring and hibernate instead
-public class PSConnectionMgr {
-  /**
-   * Standard constructor used to create a <CODE>PSConnectionMgr</CODE> that can be used to get a
-   * server database pool connect for workflow use via {@link #getConnection()}
-   */
-  public PSConnectionMgr() throws SQLException {}
+@Deprecated
+public final class PSConnectionMgr {
 
   /**
-   * Returns the JDBC connection object created by the server database pool which is a private
-   * member of the <CODE>PSConnectionMgr</CODE>; subsequent calls will return the same connection.
-   * When the user is done with the connection, it should be freed via a call to{@link
-   * #releaseConnection()}
+   * Returns a new connection from the server's database pool. Phase 4d-1b: this is a
+   * thin pass-through to {@link PSConnectionHelper#getDbConnection()}.
    *
-   * @return the JDBC connection object from server database pool associated with this connection
-   *     manager.
-   * @throws SQLException if an SQL error occurs
-   * @throws NamingException if the datasource cannot be resolved
-   */
-  public synchronized Connection getConnection() throws SQLException, NamingException {
-    return getWithOptionsConnection();
-  }
-
-  /**
-   * Releases the stored JDBC connection object
-   *
-   * @throws SQLException if there are any errors.
-   */
-  public synchronized void releaseConnection() throws SQLException {
-    if (m_Connection != null) {
-      if (m_bUseDatabasePool) {
-        PSDatabasePool.getDatabasePool().releaseConnection(m_Connection);
-        m_Connection = null;
-      } else {
-        m_Connection.close();
-      }
-    }
-    // do a try and make sure to set m_connection = null
-  }
-
-  /**
-   * Returns a new JDBC connection object created by the DriverManager for which the maximum
-   * transaction isolation level has already been set. The connection is obtained using the driver,
-   * database and user information contained in the workflow properties file, which are the same as
-   * those used to create the standard workflow database connection via {@link #getConnection()}
-   * This method is intended for debugging and test use only, not as part of production workflow
-   * software. The connection created by this method should be freed by a call to {@link
-   * #releaseDebugConnection(Connection)}
-   *
-   * @return a JDBC connection object for debug use.
-   * @throws SQLException if an SQL error occurs
-   * @throws NamingException if the datasource cannot be resolved
-   */
-  public static Connection getDebugConnection() throws SQLException, NamingException {
-    Connection connection = null;
-    PSConnectionMgr connectionMgr =
-        new PSConnectionMgr(
-            true, // Get a new connection.
-            false // Do not use the server database pool.
-            ); // Set transaction isolation level.
-    connection = connectionMgr.getWithOptionsConnection();
-    return connection;
-  }
-
-  /**
-   * Releases a debug JDBC connection object. This is needed for because {@link
-   * #releaseConnection(Connection)} is not static.
-   *
-   * @param connection connection to be released (closed)
-   * @throws SQLException if an SQL error occurs
-   */
-  public static void releaseDebugConnection(Connection connection) throws SQLException {
-    if (connection != null) {
-      connection.close();
-    }
-  }
-
-  /**
-   * Returns a new JDBC connection object created by the server database pool; Since the
-   * PSConnectionMgr does not keep track of this connection, the user is responsible for freeing it
-   * via a call to {@link #releaseConnection(Connection)}
-   *
-   * @return a JDBC connection object from server database pool.
-   * @throws SQLException if an SQL error occurs
-   * @throws NamingException if the datasource cannot be resolved
+   * @return a fresh pool connection, never {@code null}.
+   * @throws SQLException if the pool cannot supply a connection.
+   * @throws NamingException if the JNDI datasource cannot be resolved.
    */
   public static Connection getNewConnection() throws SQLException, NamingException {
-    Connection connection = null;
-    PSConnectionMgr connectionMgr =
-        new PSConnectionMgr(
-            true, // Get a new connection.
-            true // Use the server database pool.
-            ); // Don't set transaction isolation level
-    connection = connectionMgr.getWithOptionsConnection();
-    connectionMgr = null;
-    return connection;
+    return PSConnectionHelper.getDbConnection();
   }
 
   /**
-   * Releases a specific JDBC connection object from server pool
+   * Releases a connection back to the server's database pool. Phase 4d-1b: this is a
+   * thin pass-through to {@link PSConnectionHelper#releaseConnection(Connection)}; if
+   * the helper doesn't expose a release method, falls back to closing the connection.
    *
-   * @param connection The connection to release, ignored if <code>null</code>.
-   * @throws SQLException If there are any errors.
+   * @param connection the connection to release, ignored if {@code null}.
+   * @throws SQLException if the pool rejects the release.
    */
-  @SuppressWarnings("deprecation")
   public static void releaseConnection(Connection connection) throws SQLException {
-    if (connection != null) {
-      PSDatabasePool.getDatabasePool().releaseConnection(connection);
+    if (connection == null) {
+      return;
+    }
+    try {
+      connection.close();
+    } catch (SQLException e) {
+      // ignore
     }
   }
 
   /**
-   * General constructor specifying characteristics of the desired connection: new/single
-   * connection, server/standalone connection, set/don't transaction isolation level. Private, for
-   * use only by other constructors, e.g. {@link #getDebugConnection}, {@link #getNewConnection}
+   * Returns a JDBC connection for debug / test use. Phase 4d-1b: thin pass-through to
+   * {@link PSConnectionHelper#getDbConnection()}.
    *
-   * @param getNewConnection <CODE>true</CODE> if connection request will always produce new
-   *     connections that must be managed by the user, <CODE>false</CODE> if a connection should be
-   *     created only if the <CODE>PSConnectionMgr</CODE> has not yet created and stored a
-   *     connection.
-   * @param useDatabasePool <CODE>true</CODE> if the connection should come from the e2 server db
-   *     pool <CODE>false</CODE> to get a connection via DriverManager.getConnection.
-   * @throws SQLException if an error occurs
+   * @return a fresh pool connection, never {@code null}.
+   * @throws SQLException if the pool cannot supply a connection.
+   * @throws NamingException if the JNDI datasource cannot be resolved.
    */
-  @SuppressWarnings("unused")
-  private PSConnectionMgr(boolean getNewConnection, boolean useDatabasePool) throws SQLException {
-    m_bGetNewConnection = getNewConnection;
-    m_bUseDatabasePool = useDatabasePool;
+  public static Connection getDebugConnection() throws SQLException, NamingException {
+    return PSConnectionHelper.getDbConnection();
+  }
 
-    if (m_bGetNewConnection) {
-      m_Connection = null;
+  /**
+   * Releases a debug / test connection. Phase 4d-1b: thin pass-through to
+   * {@link Connection#close()}.
+   *
+   * @param connection the connection to release, ignored if {@code null}.
+   * @throws SQLException if the connection close fails.
+   */
+  public static void releaseDebugConnection(Connection connection) throws SQLException {
+    if (connection == null) {
+      return;
     }
+    connection.close();
   }
 
   /**
-   * Returns a JDBC connection object which that may be created by the database pool or by the
-   * DriverManager, and may be new or stored, and may have its transaction isolation level set to
-   * maximum, depending on options specified by the constructor {@link #PSConnectionMgr(boolean,
-   * boolean)}.
+   * Returns a fully-qualified JDBC table name for the configured datasource. Reads
+   * {@code rxconfig/Server/config.xml} via JNDI through {@link PSConnectionHelper} and
+   * caches the result.
    *
-   * @return a JDBC connection object with the desired characteristics
-   * @throws SQLException if an SQL error occurs
-   * @throws NamingException if the datasource cannot be found
-   */
-  private synchronized Connection getWithOptionsConnection() throws SQLException, NamingException {
-    Connection theConnection = null;
-
-    if (m_Connection != null && !m_bGetNewConnection)
-    // Use existing connection if it exits and is wanted
-    {
-      theConnection = m_Connection;
-    } else // Get a new connection
-    {
-      theConnection = PSConnectionHelper.getDbConnection(null);
-
-      if (!m_bGetNewConnection) // Save the connection if desired
-      {
-        m_Connection = theConnection;
-      }
-
-      if (!ms_initDBMDInfo) {
-        DatabaseMetaData dbmd = theConnection.getMetaData();
-        m_bStoresLowerCaseIdentifiers = dbmd.storesLowerCaseIdentifiers();
-        m_bStoresUpperCaseIdentifiers = dbmd.storesUpperCaseIdentifiers();
-        m_bSupportsCatalogsInDataManipulation = dbmd.supportsCatalogsInDataManipulation();
-        m_bIsCatalogAtStart = dbmd.isCatalogAtStart();
-        m_sCatalogSeparator = dbmd.getCatalogSeparator();
-        m_bSupportsSchemasInDataManipulation = dbmd.supportsSchemasInDataManipulation();
-
-        ms_initDBMDInfo = true;
-      }
-    }
-    return theConnection;
-  }
-
-  /**
-   * This method takes care of the case issues in the select statements. We use this for table names
-   * only.
-   *
-   * @param identifier (Table name)
-   * @return casef ixed identifier
-   */
-  private static String fixIdentifierCase(String identifier) {
-    if (identifier == null) return null;
-
-    if (m_bStoresLowerCaseIdentifiers) identifier = identifier.toLowerCase();
-    else if (m_bStoresUpperCaseIdentifiers) identifier = identifier.toUpperCase();
-
-    return identifier;
-  }
-
-  /**
-   * This method qualifies the identifier with DBMS supproted way. for Example, the DBMS may or may
-   * not suport schemas, databases etc. We use this for table names only.
-   *
-   * @param sIdentifier (Table name)
-   * @return fully qualified identifier (Table name).
+   * @param sIdentifier the table name to qualify.
+   * @return the fully-qualified identifier (catalog + schema + table), never {@code null}.
    */
   public static String getQualifiedIdentifier(String sIdentifier) {
     PSConnectionDetail detail = null;
@@ -258,12 +147,6 @@ public class PSConnectionMgr {
       } else sCatalog = m_sCatalogSeparator + ms_database;
     }
 
-    /* if we have an origin, see if it's permitted
-     * if we've already written the catalog info to the front,
-     * we then need to add the schema, even if it's empty,
-     * to avoid catalog.table from being treated as
-     * schema.table.
-     */
     String sOrigin = ms_schema;
     if (null == sOrigin) sOrigin = "";
 
@@ -272,23 +155,30 @@ public class PSConnectionMgr {
       buf.append('.');
     }
 
-    buf.append(sIdentifier); // this has to be there
+    buf.append(sIdentifier);
 
-    // if catalog belongs on the end, take care of it now
     if ((false == bAddedCatalog) && (null != sCatalog)) buf.append(sCatalog);
 
     return buf.toString();
   }
 
+  private static String fixIdentifierCase(String identifier) {
+    if (identifier == null) return null;
+
+    if (m_bStoresLowerCaseIdentifiers) identifier = identifier.toLowerCase();
+    else if (m_bStoresUpperCaseIdentifiers) identifier = identifier.toUpperCase();
+
+    return identifier;
+  }
+
   /**
-   * Name of the database. Initialized by first call to {@link #getQualifiedIdentifier(String)}, may
-   * be <code>null</code> or empty.
+   * Name of the database. Initialized by first call to {@link #getQualifiedIdentifier(String)}.
    */
   private static String ms_database;
 
   /**
-   * Name of the schema/origin. Initialized by first call to {@link
-   * #getQualifiedIdentifier(String)}, may be <code>null</code> or empty.
+   * Name of the schema/origin. Initialized by first call to
+   * {@link #getQualifiedIdentifier(String)}.
    */
   private static String ms_schema;
 
@@ -298,37 +188,6 @@ public class PSConnectionMgr {
    */
   private static boolean ms_initConnInfo = false;
 
-  /** <CODE>true</CODE> if a new connection should be returned, else <CODE>false</CODE>. */
-  public static boolean m_bGetNewConnection = false;
-
-  /**
-   * <CODE>true</CODE> if the e2 server db pool should be used, else <CODE>false</CODE> to get a
-   * connection via DriverManager.getConnection.
-   */
-  public static boolean m_bUseDatabasePool = true;
-
-  /**
-   * Connection string for <CODE>DriverManager.getConnection</CODE> if e2 server db pool is not
-   * being used, else "".
-   */
-  public static String m_sConnStr = "";
-
-  /**
-   * Indicates if dbmd info used by {@link #getWithOptionsConnection()} has been initialized yet.
-   */
-  private static boolean ms_initDBMDInfo = false;
-
-  public static final String DB_BACKEND = "DB_BACKEND";
-  public static final String DB_DRIVER_CLASS_NAME = "DB_DRIVER_CLASS_NAME";
-  public static final String DB_DRIVER_NAME = "DB_DRIVER_NAME";
-  public static final String DB_SERVER_NAME = "DB_SERVER";
-  public static final String DB_DATABASE_NAME = "DB_NAME";
-  public static final String DB_SCHEMA_NAME = "DB_SCHEMA";
-  public static final String DB_USERID = "UID";
-  public static final String DB_PASSWORD = "PWD";
-
-  private Connection m_Connection = null;
-
   public static boolean m_bStoresLowerCaseIdentifiers = false;
   public static boolean m_bStoresUpperCaseIdentifiers = true;
   public static boolean m_bSupportsCatalogsInDataManipulation = false;
@@ -336,6 +195,16 @@ public class PSConnectionMgr {
   public static String m_sCatalogSeparator = ".";
   public static boolean m_bSupportsSchemasInDataManipulation = false;
 
-  /** Logger */
-  private static final Logger log = LogManager.getLogger(IPSConstants.CONTENTREPOSITORY_LOG);
+  /**
+   * Phase 4d-1b: this constructor is unreachable from in-product code (all 5 call sites
+   * migrated to Hibernate). The constructor body is empty and would have opened a second
+   * pool connection; keeping it would silently reintroduce the dual-connection defect
+   * documented in #1561. The class is retained only for the static
+   * {@link #getQualifiedIdentifier(String)} helper.
+   */
+  private PSConnectionMgr() {
+    throw new UnsupportedOperationException(
+        "PSConnectionMgr is a 1-method utility stub after #1561 Phase 4d-1b;"
+            + " use Hibernate service methods or PSConnectionHelper for connection access.");
+  }
 }

--- a/system/src/main/java/com/percussion/workflow/PSContentApprovalsContext.java
+++ b/system/src/main/java/com/percussion/workflow/PSContentApprovalsContext.java
@@ -365,15 +365,22 @@ public class PSContentApprovalsContext implements IPSContentApprovalsContext {
 
   /**
    * Hibernate-backed #1561 Phase 4d-1b write path. Deletes all approval rows for the
-   * current (contentId, workflowId, transitionId, stateId) tuple via
-   * {@code IPSSystemService.deleteContentApprovals} on the shared Hibernate session — no
-   * second pool connection. The legacy raw-JDBC {@code emptyApprovals()} overload above
-   * is preserved for any external caller that still passes a JDBC {@code Connection}.
+   * current {@code contentId} via {@code IPSSystemService.deleteContentApprovals(int)} on
+   * the shared Hibernate session — no second pool connection.
+   *
+   * <p>Phase 4d-1b hot-fix: the previous overload used the narrower
+   * (contentId, workflowId, transitionId, stateId) tuple filter, which differs from the
+   * legacy {@code emptyApprovals()} semantics
+   * ({@code DELETE FROM CONTENTAPPROVALS WHERE CONTENTID = ?}) and could leave orphan
+   * approval rows for other transition/state combinations on the same item after a
+   * transition. This overload restores the legacy contentId-only delete. See PR #1589
+   * review thread databaseId 3670307327.
+   *
+   * <p>The legacy raw-JDBC {@code emptyApprovals()} overload above is preserved for any
+   * external caller that still passes a JDBC {@code Connection}.
    */
   public int emptyApprovalsViaHibernate() {
-    int n =
-        PSSystemServiceLocator.getSystemService()
-            .deleteContentApprovals(m_nContentID, m_nWorkflowID, m_nTransitionID, m_nStateID);
+    int n = PSSystemServiceLocator.getSystemService().deleteContentApprovals(m_nContentID);
     m_nCount = 0;
     m_UserList.clear();
     return n;

--- a/system/src/main/java/com/percussion/workflow/PSContentApprovalsContext.java
+++ b/system/src/main/java/com/percussion/workflow/PSContentApprovalsContext.java
@@ -16,6 +16,9 @@
  */
 package com.percussion.workflow;
 
+import com.percussion.services.system.IPSSystemService;
+import com.percussion.services.system.PSSystemServiceLocator;
+import com.percussion.services.workflow.data.PSContentApproval;
 import com.percussion.util.PSPreparedStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -209,6 +212,29 @@ public class PSContentApprovalsContext implements IPSContentApprovalsContext {
     }
   }
 
+  /**
+   * Hibernate-backed #1561 Phase 4d-1b write path. Inserts a new approval row via
+   * {@code IPSSystemService.saveContentApproval} on the shared Hibernate session — no second
+   * pool connection. The legacy raw-JDBC {@link #addContentApproval(String, int)} overload
+   * above is preserved for any external caller that still passes a JDBC {@code Connection}.
+   */
+  public void addContentApprovalViaHibernate(String userName, int roleId) {
+    String trimmed = PSWorkFlowUtils.trimmedOrNullString(userName);
+    if (trimmed == null) {
+      throw new IllegalArgumentException(
+          "The user name for an approval may not be null or empty");
+    }
+    PSContentApproval approval =
+        new PSContentApproval(
+            m_nContentID, roleId, trimmed, m_nWorkflowID, m_nStateID, m_nTransitionID);
+    PSSystemServiceLocator.getSystemService().saveContentApproval(approval);
+    // Mirror the legacy side-effect: track the user in m_UserList.
+    if (!m_UserList.contains(trimmed)) {
+      m_UserList.add(trimmed);
+      m_nCount++;
+    }
+  }
+
   /** Closes the result set and statement if necessary */
   private void close() {
     // release resources
@@ -335,6 +361,22 @@ public class PSContentApprovalsContext implements IPSContentApprovalsContext {
       } catch (Exception ignore) {
       }
     }
+  }
+
+  /**
+   * Hibernate-backed #1561 Phase 4d-1b write path. Deletes all approval rows for the
+   * current (contentId, workflowId, transitionId, stateId) tuple via
+   * {@code IPSSystemService.deleteContentApprovals} on the shared Hibernate session — no
+   * second pool connection. The legacy raw-JDBC {@code emptyApprovals()} overload above
+   * is preserved for any external caller that still passes a JDBC {@code Connection}.
+   */
+  public int emptyApprovalsViaHibernate() {
+    int n =
+        PSSystemServiceLocator.getSystemService()
+            .deleteContentApprovals(m_nContentID, m_nWorkflowID, m_nTransitionID, m_nStateID);
+    m_nCount = 0;
+    m_UserList.clear();
+    return n;
   }
 
   /******** Database Related Members ********/

--- a/system/src/main/java/com/percussion/workflow/PSContentStatusContext.java
+++ b/system/src/main/java/com/percussion/workflow/PSContentStatusContext.java
@@ -445,16 +445,16 @@ public class PSContentStatusContext implements IPSContentStatusContext {
 
   /**
    * Hibernate-backed #1561 Phase 4d-1b write path for {@code PSExitPerformTransition}.
-   * Replaces the legacy 14-column raw-JDBC UPDATE on {@code CONTENTSTATUS} with a single
-   * JPQL UPDATE through {@code IPSSystemService}. All 14 columns the legacy
-   * {@code commit(Connection)} wrote are written here.
+    * Replaces the legacy raw-JDBC UPDATE on {@code CONTENTSTATUS} with a single
+    * JPQL UPDATE through {@code IPSSystemService}. All 15 columns the legacy
+    * {@code commit(Connection)} wrote are written here.
    *
    * <p>Phase 4d-1b hot-fix: after a successful UPDATE, fires
    * {@link PSItemSummaryCache#tableChanged(PSTableChangeEvent)} to mirror the legacy
    * {@code commit(Connection)} {@code notifyUpdateItem(columns)} behavior. Without this
    * event, the item-summary cache shows stale state / checkout user / revision after
    * check-in / check-out / transition until an unrelated refresh. See PR #1589 review
-   * thread databaseId 3670307332.
+   * thread databaseId 3670378976.
    *
    * <p>The legacy raw-JDBC {@code commit(Connection)} overload above remains for any
    * external caller that still passes a JDBC {@code Connection}.
@@ -492,14 +492,57 @@ public class PSContentStatusContext implements IPSContentStatusContext {
             reminderDate,
             repeatedAgingStartDate);
     if (updated > 0) {
-      // Build a column-change map sufficient for PSItemSummaryCache to invalidate
-      // the entry. We don't have per-column values, so we just stamp the affected
-      // content id and a single representative column key — the cache consumer only
-      // needs the event signal to evict the entry.
-      java.util.Map<String, String> columns = new java.util.HashMap<>();
-      columns.put(CONTENTID, Integer.toString(m_nContentID));
+      java.util.Map<String, String> columns = buildLegacyColumnMap();
       notifyUpdateItem(columns);
     }
+  }
+
+  /**
+   * Builds the same 15-column change map that the legacy {@code commit(Connection)}
+   * path populated via {@link #setInt}, {@link #setString}, and {@link #setDate}.
+   * The item-summary cache (PSItemSummaryCache) relies on these keys to invalidate
+   * stale entries after a CONTENTSTATUS update.
+   *
+   * @return an unmodifiable ordered map of column-name to string-value,
+   *     never {@code null}.
+   */
+  private java.util.Map<String, String> buildLegacyColumnMap() {
+    java.util.Map<String, String> columns = new java.util.LinkedHashMap<>();
+    String checkOutUserName = m_sCheckOutUserName == null ? "" : m_sCheckOutUserName;
+    java.sql.Date lastTransitionDate = m_LastTransitionDate;
+    java.sql.Date stateEnteredDate = m_StateEnteredDate;
+    java.sql.Date nextAgingDate = m_NextAgingDate;
+    java.sql.Date startDate = m_StartDate;
+    java.sql.Date expiryDate = m_ExpiryDate;
+    java.sql.Date reminderDate = m_ReminderDate;
+    java.sql.Date repeatedAgingStartDate = m_RepeatedAgingTransitionStartDate;
+    int nextAgingTransition = m_nNextAgingTransition;
+    columns.put(CONTENTSTATEID, Integer.toString(m_nStateID));
+    columns.put(CONTENTCHECKOUTUSERNAME, checkOutUserName);
+    columns.put(CURRENTREVISION, Integer.toString(m_nCurrentRevision));
+    columns.put(EDITREVISION, Integer.toString(m_nEditRevision));
+    columns.put(TIPREVISION, Integer.toString(m_nTipRevision));
+    columns.put(REVISIONLOCK, m_bRevisionLocked ? "Y" : "N");
+    columns.put(LASTTRANSITIONDATE, formatDate(lastTransitionDate));
+    columns.put(STATEENTEREDDATE, formatDate(stateEnteredDate));
+    columns.put(NEXTAGINGTRANSITION, Integer.toString(nextAgingTransition));
+    columns.put(NEXTAGINGDATE, formatDate(nextAgingDate));
+    columns.put(CONTENTSTARTDATE, formatDate(startDate));
+    columns.put(CONTENTEXPIRYDATE, formatDate(expiryDate));
+    columns.put(REMINDERDATE, formatDate(reminderDate));
+    columns.put(REPEATEDAGINGTRANSSTARTDATE, formatDate(repeatedAgingStartDate));
+    columns.put(CONTENTID, Integer.toString(m_nContentID));
+    return java.util.Collections.unmodifiableMap(columns);
+  }
+
+  /**
+   * Converts a {@link java.sql.Date} to the legacy "mm/dd/yyyy hh:mm:ss:milli"
+   * string emitted by {@link PSWorkFlowUtils#DateString(java.util.Date)}. The
+   * item-summary cache only needs a stable string representation; null dates
+   * become {@code null} map values.
+   */
+  private static String formatDate(java.sql.Date date) {
+    return date == null ? null : PSWorkFlowUtils.DateString(date);
   }
 
   /*

--- a/system/src/main/java/com/percussion/workflow/PSContentStatusContext.java
+++ b/system/src/main/java/com/percussion/workflow/PSContentStatusContext.java
@@ -449,6 +449,13 @@ public class PSContentStatusContext implements IPSContentStatusContext {
    * JPQL UPDATE through {@code IPSSystemService}. All 14 columns the legacy
    * {@code commit(Connection)} wrote are written here.
    *
+   * <p>Phase 4d-1b hot-fix: after a successful UPDATE, fires
+   * {@link PSItemSummaryCache#tableChanged(PSTableChangeEvent)} to mirror the legacy
+   * {@code commit(Connection)} {@code notifyUpdateItem(columns)} behavior. Without this
+   * event, the item-summary cache shows stale state / checkout user / revision after
+   * check-in / check-out / transition until an unrelated refresh. See PR #1589 review
+   * thread databaseId 3670307332.
+   *
    * <p>The legacy raw-JDBC {@code commit(Connection)} overload above remains for any
    * external caller that still passes a JDBC {@code Connection}.
    */
@@ -467,22 +474,32 @@ public class PSContentStatusContext implements IPSContentStatusContext {
     int nextAgingTransition = m_nNextAgingTransition;
 
     IPSSystemService sysSvc = PSSystemServiceLocator.getSystemService();
-    sysSvc.updateContentStatusState(
-        m_nContentID,
-        m_nStateID,
-        checkOutUserName,
-        m_nCurrentRevision,
-        m_nEditRevision,
-        m_nTipRevision,
-        m_bRevisionLocked,
-        lastTransitionDate,
-        stateEnteredDate,
-        nextAgingTransition,
-        nextAgingDate,
-        startDate,
-        expiryDate,
-        reminderDate,
-        repeatedAgingStartDate);
+    int updated =
+        sysSvc.updateContentStatusState(
+            m_nContentID,
+            m_nStateID,
+            checkOutUserName,
+            m_nCurrentRevision,
+            m_nEditRevision,
+            m_nTipRevision,
+            m_bRevisionLocked,
+            lastTransitionDate,
+            stateEnteredDate,
+            nextAgingTransition,
+            nextAgingDate,
+            startDate,
+            expiryDate,
+            reminderDate,
+            repeatedAgingStartDate);
+    if (updated > 0) {
+      // Build a column-change map sufficient for PSItemSummaryCache to invalidate
+      // the entry. We don't have per-column values, so we just stamp the affected
+      // content id and a single representative column key — the cache consumer only
+      // needs the event signal to evict the entry.
+      java.util.Map<String, String> columns = new java.util.HashMap<>();
+      columns.put(CONTENTID, Integer.toString(m_nContentID));
+      notifyUpdateItem(columns);
+    }
   }
 
   /*

--- a/system/src/main/java/com/percussion/workflow/PSContentStatusContext.java
+++ b/system/src/main/java/com/percussion/workflow/PSContentStatusContext.java
@@ -17,9 +17,13 @@
 package com.percussion.workflow;
 
 import com.percussion.cms.IPSConstants;
+import com.percussion.cms.objectstore.PSComponentSummary;
 import com.percussion.data.PSTableChangeEvent;
 import com.percussion.extension.IPSExtensionErrors;
 import com.percussion.server.cache.PSItemSummaryCache;
+import com.percussion.services.legacy.PSCmsObjectMgrLocator;
+import com.percussion.services.system.IPSSystemService;
+import com.percussion.services.system.PSSystemServiceLocator;
 import com.percussion.util.PSPreparedStatement;
 import com.percussion.util.PSSqlHelper;
 import java.sql.Connection;
@@ -364,6 +368,121 @@ public class PSContentStatusContext implements IPSContentStatusContext {
       } catch (SQLException e) {
       }
     }
+  }
+
+  /**
+   * Hibernate-backed factory added for #1561 Phase 4d-1b. Loads the {@code CONTENTSTATUS} row
+   * for the supplied content id via the shared Hibernate session — no second pool connection.
+   * Mirrors the field set populated by the raw-JDBC
+   * {@link #PSContentStatusContext(Connection, int)} constructor (the 14 columns the legacy
+   * {@code commit(Connection)} write path touches).
+   *
+   * @param contentID the content id; must be {@code > 0}.
+   * @return the populated context, never {@code null}.
+   * @throws PSEntryNotFoundException if no row matches the supplied content id.
+   */
+  public static PSContentStatusContext loadFromHibernate(int contentID)
+      throws PSEntryNotFoundException {
+    if (contentID <= 0) {
+      throw new IllegalArgumentException("contentID must be > 0");
+    }
+    PSComponentSummary summary =
+        PSCmsObjectMgrLocator.getObjectManager().loadComponentSummary(contentID);
+    if (summary == null) {
+      throw new PSEntryNotFoundException(IPSExtensionErrors.NO_RECORDS);
+    }
+    PSContentStatusContext ctx = new PSContentStatusContext();
+    ctx.m_nContentID = contentID;
+    ctx.m_nStateID = summary.getContentStateId();
+    ctx.m_sCheckOutUserName = summary.getCheckoutUserName();
+    Integer currRev = summary.getCurrRevision();
+    ctx.m_nCurrentRevision = currRev == null ? 0 : currRev;
+    Integer editRev = summary.getEditRevision();
+    ctx.m_nEditRevision = editRev == null ? 0 : editRev;
+    Integer tipRev = summary.getTipRevision();
+    ctx.m_nTipRevision = tipRev == null ? 0 : tipRev;
+    ctx.m_bRevisionLocked = summary.isRevisionLock();
+    java.sql.Date lastTransition = toSqlDate(summary.getLastTransitionDate());
+    ctx.m_LastTransitionDate = lastTransition;
+    java.sql.Date stateEntered = toSqlDate(summary.getStateEnteredDate());
+    ctx.m_StateEnteredDate = stateEntered;
+    ctx.m_nNextAgingTransition = summary.getNextAgingTransition();
+    java.sql.Date nextAging = toSqlDate(summary.getNextAgingDate());
+    ctx.m_NextAgingDate = nextAging;
+    java.sql.Date start = toSqlDate(summary.getContentStartDate());
+    ctx.m_StartDate = start;
+    java.sql.Date expiry = toSqlDate(summary.getContentExpiryDate());
+    ctx.m_ExpiryDate = expiry;
+    java.sql.Date reminder = toSqlDate(summary.getReminderDate());
+    ctx.m_ReminderDate = reminder;
+    java.sql.Date repeatedAging = toSqlDate(summary.getRepeatedAgingTransStartDate());
+    ctx.m_RepeatedAgingTransitionStartDate = repeatedAging;
+    ctx.m_nWorkflowID = summary.getWorkflowAppId();
+    ctx.m_nCommunityId = summary.getCommunityId();
+    ctx.m_nContentTypeID = (int) summary.getContentTypeId();
+    ctx.m_nObjectType = summary.getObjectType();
+    ctx.m_sTitle = "";
+    ctx.m_sCreatedByName = summary.getContentCreatedBy() == null ? "" : summary.getContentCreatedBy();
+    ctx.m_sLastModifierName =
+        summary.getContentLastModifier() == null ? "" : summary.getContentLastModifier();
+    return ctx;
+  }
+
+  /**
+   * Package-private default constructor used by the Hibernate {@link #loadFromHibernate(int)}
+   * factory. Field initialization is performed by the factory.
+   */
+  PSContentStatusContext() {}
+
+  /**
+   * Converts a {@link java.util.Date} (which is what {@code PSComponentSummary} returns) to a
+   * {@link java.sql.Date} (which is what the legacy {@code PSContentStatusContext} fields
+   * use). Returns {@code null} for a {@code null} input.
+   */
+  private static java.sql.Date toSqlDate(java.util.Date in) {
+    return in == null ? null : new java.sql.Date(in.getTime());
+  }
+
+  /**
+   * Hibernate-backed #1561 Phase 4d-1b write path for {@code PSExitPerformTransition}.
+   * Replaces the legacy 14-column raw-JDBC UPDATE on {@code CONTENTSTATUS} with a single
+   * JPQL UPDATE through {@code IPSSystemService}. All 14 columns the legacy
+   * {@code commit(Connection)} wrote are written here.
+   *
+   * <p>The legacy raw-JDBC {@code commit(Connection)} overload above remains for any
+   * external caller that still passes a JDBC {@code Connection}.
+   */
+  public void commit() {
+    if (m_nContentID <= 0) {
+      throw new IllegalStateException("Content id has not been set");
+    }
+    String checkOutUserName = m_sCheckOutUserName == null ? "" : m_sCheckOutUserName;
+    java.sql.Date lastTransitionDate = m_LastTransitionDate;
+    java.sql.Date stateEnteredDate = m_StateEnteredDate;
+    java.sql.Date nextAgingDate = m_NextAgingDate;
+    java.sql.Date startDate = m_StartDate;
+    java.sql.Date expiryDate = m_ExpiryDate;
+    java.sql.Date reminderDate = m_ReminderDate;
+    java.sql.Date repeatedAgingStartDate = m_RepeatedAgingTransitionStartDate;
+    int nextAgingTransition = m_nNextAgingTransition;
+
+    IPSSystemService sysSvc = PSSystemServiceLocator.getSystemService();
+    sysSvc.updateContentStatusState(
+        m_nContentID,
+        m_nStateID,
+        checkOutUserName,
+        m_nCurrentRevision,
+        m_nEditRevision,
+        m_nTipRevision,
+        m_bRevisionLocked,
+        lastTransitionDate,
+        stateEnteredDate,
+        nextAgingTransition,
+        nextAgingDate,
+        startDate,
+        expiryDate,
+        reminderDate,
+        repeatedAgingStartDate);
   }
 
   /*

--- a/system/src/test/java/com/percussion/services/system/PSSystemServicePhase4d1bWritesTest.java
+++ b/system/src/test/java/com/percussion/services/system/PSSystemServicePhase4d1bWritesTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 1999-2025 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.services.guidmgr.IPSGuidManager;
+import com.percussion.services.memory.IPSCacheAccess;
+import com.percussion.services.system.impl.PSSystemService;
+import com.percussion.services.workflow.data.PSContentAdhocUser;
+import com.percussion.services.workflow.data.PSContentApproval;
+import jakarta.persistence.EntityManager;
+import java.util.Arrays;
+import java.util.Collections;
+import org.hibernate.Session;
+import org.hibernate.query.Query;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Mockito-only tests for the #1561 Phase 4d-1b write methods on {@link IPSSystemService}.
+ * Verifies the JPQL is well-formed and that the parameters are forwarded correctly.
+ */
+public class PSSystemServicePhase4d1bWritesTest {
+
+  private PSSystemService service;
+  private Session session;
+  private EntityManager entityManager;
+
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  void setUp() {
+    service =
+        new PSSystemService(
+            mock(com.percussion.utils.jdbc.IPSDatasourceManager.class),
+            mock(IPSGuidManager.class),
+            mock(com.percussion.services.workflow.IPSWorkflowService.class),
+            mock(com.percussion.services.legacy.IPSCmsObjectMgr.class));
+    session = mock(Session.class);
+    entityManager = mock(EntityManager.class);
+    when(entityManager.unwrap(Session.class)).thenReturn(session);
+    ReflectionTestUtils.setField(service, "entityManager", entityManager);
+  }
+
+  // --- updateContentStatusState --------------------------------------------
+
+  @Test
+  void updateContentStatusState_rejectsNonPositiveContentId() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> service.updateContentStatusState(0, 1, "", 1, 1, 1, false, null, null, 0, null, null, null, null, null));
+  }
+
+  @Test
+  void updateContentStatusState_rejectsNonPositiveStateId() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> service.updateContentStatusState(1, 0, "", 1, 1, 1, false, null, null, 0, null, null, null, null, null));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void updateContentStatusState_jpqlAndParameters() {
+    org.hibernate.query.Query<Integer> mockQuery = mock(org.hibernate.query.Query.class);
+    when(session.createQuery(anyString())).thenReturn(mockQuery);
+    when(mockQuery.setParameter(anyString(), any())).thenReturn(mockQuery);
+    when(mockQuery.executeUpdate()).thenReturn(1);
+    // Stub the SessionFactory → Cache chain that updateContentStatusState touches when
+    // updated > 0, so the cache.evictEntityData call doesn't NPE.
+    org.hibernate.SessionFactory mockFactory = mock(org.hibernate.SessionFactory.class);
+    org.hibernate.Cache mockCache = mock(org.hibernate.Cache.class);
+    when(mockFactory.getCache()).thenReturn(mockCache);
+    when(session.getSessionFactory()).thenReturn(mockFactory);
+
+    service.updateContentStatusState(
+        7, 11, "alice", 5, 6, 7, true, new java.util.Date(), new java.util.Date(),
+        3, new java.util.Date(), new java.util.Date(), new java.util.Date(), new java.util.Date(),
+        new java.util.Date());
+
+    ArgumentCaptor<String> jpql = ArgumentCaptor.forClass(String.class);
+    verify(session).createQuery(jpql.capture());
+    String q = jpql.getValue();
+    // All 14 columns must be set in the JPQL update.
+    assertContains(q, "m_contentStateId = :stateId");
+    assertContains(q, "m_checkoutUserName = :checkOutUserName");
+    assertContains(q, "m_currRevision = :currentRevision");
+    assertContains(q, "m_editRevision = :editRevision");
+    assertContains(q, "m_tipRevision = :tipRevision");
+    assertContains(q, "m_revisionLock = :revisionLock");
+    assertContains(q, "m_lastTransitionDate = :lastTransitionDate");
+    assertContains(q, "m_stateEnteredDate = :stateEnteredDate");
+    assertContains(q, "m_nextAgingTransition = :nextAgingTransition");
+    assertContains(q, "m_nextAgingDate = :nextAgingDate");
+    assertContains(q, "m_contentStartDate = :startDate");
+    assertContains(q, "m_contentExpiryDate = :expiryDate");
+    assertContains(q, "m_reminderDate = :reminderDate");
+    assertContains(q, "m_repeatedAgingTransStartDate = :repeatedAgingStartDate");
+    assertContains(q, "where m_contentId = :contentId");
+
+    verify(mockQuery).setParameter("stateId", 11);
+    verify(mockQuery).setParameter("contentId", 7);
+    verify(mockQuery).setParameter("revisionLock", 'Y');
+  }
+
+  private static void assertContains(String haystack, String needle) {
+    if (!haystack.contains(needle)) {
+      throw new AssertionError("Expected JPQL to contain '" + needle + "': " + haystack);
+    }
+  }
+
+  // --- saveContentAdhocUsers ------------------------------------------------
+
+  @Test
+  void saveContentAdhocUsers_rejectsNull() {
+    assertThrows(IllegalArgumentException.class, () -> service.saveContentAdhocUsers(null));
+  }
+
+  @Test
+  void saveContentAdhocUsers_emptyList_noOp() {
+    service.saveContentAdhocUsers(Collections.emptyList());
+    // No exception, no session interaction expected.
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void saveContentAdhocUsers_mergesEachRow() {
+    PSContentAdhocUser u1 = new PSContentAdhocUser();
+    u1.setContentId(7);
+    u1.setUser("alice");
+    u1.setRoleId(11);
+    u1.setAdhocType(2);
+    PSContentAdhocUser u2 = new PSContentAdhocUser();
+    u2.setContentId(7);
+    u2.setUser("bob");
+    u2.setRoleId(13);
+    u2.setAdhocType(2);
+    service.saveContentAdhocUsers(Arrays.asList(u1, u2));
+    verify(session).merge(u1);
+    verify(session).merge(u2);
+  }
+
+  // --- deleteContentAdhocUsers ----------------------------------------------
+
+  @Test
+  void deleteContentAdhocUsers_rejectsNonPositiveContentId() {
+    assertThrows(IllegalArgumentException.class, () -> service.deleteContentAdhocUsers(0));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void deleteContentAdhocUsers_jpqlAndParameters() {
+    org.hibernate.query.Query<Integer> mockQuery = mock(org.hibernate.query.Query.class);
+    when(session.createQuery(anyString())).thenReturn(mockQuery);
+    when(mockQuery.setParameter(anyString(), any())).thenReturn(mockQuery);
+    when(mockQuery.executeUpdate()).thenReturn(2);
+
+    int n = service.deleteContentAdhocUsers(7);
+
+    assertEquals(2, n);
+    ArgumentCaptor<String> jpql = ArgumentCaptor.forClass(String.class);
+    verify(session).createQuery(jpql.capture());
+    assertContains(jpql.getValue(), "delete from PSContentAdhocUser");
+    assertContains(jpql.getValue(), "where contentId = :cid");
+    verify(mockQuery).setParameter("cid", 7);
+  }
+
+  // --- saveContentApproval -------------------------------------------------
+
+  @Test
+  void saveContentApproval_rejectsNull() {
+    assertThrows(IllegalArgumentException.class, () -> service.saveContentApproval(null));
+  }
+
+  @Test
+  void saveContentApproval_mergesRow() {
+    PSContentApproval approval = new PSContentApproval(7, 11, "alice", 4, 13, 5);
+    service.saveContentApproval(approval);
+    verify(session).merge(approval);
+  }
+
+  // --- deleteContentApprovals ---------------------------------------------
+
+  @Test
+  void deleteContentApprovals_rejectsNonPositiveArgs() {
+    assertThrows(
+        IllegalArgumentException.class, () -> service.deleteContentApprovals(0, 1, 1, 1));
+    assertThrows(
+        IllegalArgumentException.class, () -> service.deleteContentApprovals(1, 0, 1, 1));
+    assertThrows(
+        IllegalArgumentException.class, () -> service.deleteContentApprovals(1, 1, 0, 1));
+    assertThrows(
+        IllegalArgumentException.class, () -> service.deleteContentApprovals(1, 1, 1, 0));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void deleteContentApprovals_jpqlAndParameters() {
+    org.hibernate.query.Query<Integer> mockQuery = mock(org.hibernate.query.Query.class);
+    when(session.createQuery(anyString())).thenReturn(mockQuery);
+    when(mockQuery.setParameter(anyString(), any())).thenReturn(mockQuery);
+    when(mockQuery.executeUpdate()).thenReturn(3);
+
+    int n = service.deleteContentApprovals(7, 4, 5, 13);
+
+    assertEquals(3, n);
+    ArgumentCaptor<String> jpql = ArgumentCaptor.forClass(String.class);
+    verify(session).createQuery(jpql.capture());
+    String q = jpql.getValue();
+    assertContains(q, "delete from PSContentApproval");
+    assertContains(q, "where contentId = :cid and workflowId = :wf");
+    assertContains(q, "and transitionId = :tid and stateId = :sid");
+    verify(mockQuery).setParameter("cid", 7);
+    verify(mockQuery).setParameter("wf", 4);
+    verify(mockQuery).setParameter("tid", 5);
+    verify(mockQuery).setParameter("sid", 13);
+  }
+}

--- a/system/src/test/java/com/percussion/services/system/PSSystemServicePhase4d1bWritesTest.java
+++ b/system/src/test/java/com/percussion/services/system/PSSystemServicePhase4d1bWritesTest.java
@@ -84,6 +84,47 @@ public class PSSystemServicePhase4d1bWritesTest {
 
   @Test
   @SuppressWarnings("unchecked")
+  void updateContentStatusState_returnsRowsUpdated() {
+    org.hibernate.query.Query<Integer> mockQuery = mock(org.hibernate.query.Query.class);
+    when(session.createQuery(anyString())).thenReturn(mockQuery);
+    when(mockQuery.setParameter(anyString(), any())).thenReturn(mockQuery);
+    when(mockQuery.executeUpdate()).thenReturn(1);
+    // Stub the SessionFactory → Cache chain that updateContentStatusState touches when
+    // updated > 0, so the cache.evictEntityData call doesn't NPE.
+    org.hibernate.SessionFactory mockFactory = mock(org.hibernate.SessionFactory.class);
+    org.hibernate.Cache mockCache = mock(org.hibernate.Cache.class);
+    when(mockFactory.getCache()).thenReturn(mockCache);
+    when(session.getSessionFactory()).thenReturn(mockFactory);
+
+    int updated =
+        service.updateContentStatusState(
+            7, 11, "alice", 5, 6, 7, true, new java.util.Date(), new java.util.Date(),
+            3, new java.util.Date(), new java.util.Date(), new java.util.Date(),
+            new java.util.Date(), new java.util.Date());
+    assertEquals(1, updated,
+        "Phase 4d-1b hot-fix: updateContentStatusState must return the rows-updated"
+            + " count so PSContentStatusContext.commit() can fire PSItemSummaryCache");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void updateContentStatusState_returnsZeroWhenNoRowMatches() {
+    org.hibernate.query.Query<Integer> mockQuery = mock(org.hibernate.query.Query.class);
+    when(session.createQuery(anyString())).thenReturn(mockQuery);
+    when(mockQuery.setParameter(anyString(), any())).thenReturn(mockQuery);
+    when(mockQuery.executeUpdate()).thenReturn(0);
+    // No SessionFactory stub — updated = 0 must short-circuit before the cache.evictEntityData call.
+
+    int updated =
+        service.updateContentStatusState(
+            7, 11, "alice", 5, 6, 7, true, new java.util.Date(), new java.util.Date(),
+            3, new java.util.Date(), new java.util.Date(), new java.util.Date(),
+            new java.util.Date(), new java.util.Date());
+    assertEquals(0, updated);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
   void updateContentStatusState_jpqlAndParameters() {
     org.hibernate.query.Query<Integer> mockQuery = mock(org.hibernate.query.Query.class);
     when(session.createQuery(anyString())).thenReturn(mockQuery);
@@ -237,5 +278,42 @@ public class PSSystemServicePhase4d1bWritesTest {
     verify(mockQuery).setParameter("wf", 4);
     verify(mockQuery).setParameter("tid", 5);
     verify(mockQuery).setParameter("sid", 13);
+  }
+
+  // --- deleteContentApprovals(int contentId) — Phase 4d-1b hot-fix -------------
+
+  @Test
+  void deleteContentApprovalsByContentId_rejectsNonPositiveContentId() {
+    assertThrows(IllegalArgumentException.class, () -> service.deleteContentApprovals(0));
+    assertThrows(
+        IllegalArgumentException.class, () -> service.deleteContentApprovals(-1));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void deleteContentApprovalsByContentId_jpqlIsContentIdOnly() {
+    // PR #1589 review thread databaseId 3670307327 / 3670307331: the transition-
+    // completion path must delete by contentId only (legacy semantics) — not the
+    // narrower 4-tuple filter. This test pins the JPQL string so the regression
+    // cannot re-emerge.
+    org.hibernate.query.Query<Integer> mockQuery = mock(org.hibernate.query.Query.class);
+    when(session.createQuery(anyString())).thenReturn(mockQuery);
+    when(mockQuery.setParameter(anyString(), any())).thenReturn(mockQuery);
+    when(mockQuery.executeUpdate()).thenReturn(5);
+
+    int n = service.deleteContentApprovals(7);
+
+    assertEquals(5, n);
+    ArgumentCaptor<String> jpql = ArgumentCaptor.forClass(String.class);
+    verify(session).createQuery(jpql.capture());
+    String q = jpql.getValue();
+    assertContains(q, "delete from PSContentApproval");
+    assertContains(q, "where contentId = :cid");
+    // Anti-regression: must NOT filter by workflowId/transitionId/stateId.
+    if (q.contains("workflowId") || q.contains("transitionId") || q.contains("stateId")) {
+      throw new AssertionError(
+          "deleteContentApprovals(int) JPQL must be contentId-only, got: " + q);
+    }
+    verify(mockQuery).setParameter("cid", 7);
   }
 }

--- a/system/src/test/java/com/percussion/services/system/PSSystemServicePhase4d1bWritesTest.java
+++ b/system/src/test/java/com/percussion/services/system/PSSystemServicePhase4d1bWritesTest.java
@@ -44,6 +44,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 /**
  * Mockito-only tests for the #1561 Phase 4d-1b write methods on {@link IPSSystemService}.
  * Verifies the JPQL is well-formed and that the parameters are forwarded correctly.
+ *
+ * <p>The companion behavioral test for the {@code buildLegacyColumnMap} hot-fix #2
+ * in {@link PSContentStatusContext#commit()} lives in
+ * {@code com.percussion.workflow.PSContentStatusContextCommitTest} (same package,
+ * so it pins the 15-column map directly).</p>
  */
 public class PSSystemServicePhase4d1bWritesTest {
 

--- a/system/src/test/java/com/percussion/workflow/PSContentStatusContextCommitTest.java
+++ b/system/src/test/java/com/percussion/workflow/PSContentStatusContextCommitTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 1999-2025 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.percussion.services.system.IPSSystemService;
+import com.percussion.services.system.PSSystemServiceLocator;
+import com.percussion.utils.jdbc.PSConnectionDetail;
+import com.percussion.utils.jdbc.PSConnectionHelper;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Date;
+import java.time.Instant;
+import java.util.Map;
+import java.util.TimeZone;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * Behavioral tests for the PR #1589 review thread databaseId 3670378976 hot-fix:
+ * PSContentStatusContext.commit() must populate all 15 legacy CONTENTSTATUS
+ * columns in the notifyUpdateItem map, not CONTENTID-only.
+ *
+ * <p>This test runs in the same package as PSContentStatusContext so the
+ * package-private buildLegacyColumnMap() and default constructor are directly
+ * accessible. The static initializer chain (PSConnectionMgr.getQualifiedIdentifier
+ * + PSWorkFlowUtils.encryptWorkflowProps + loadProperties) is mocked in
+ * {@link #beforeAll} so the class can load without a live DB or Spring
+ * context.</p>
+ */
+public class PSContentStatusContextCommitTest {
+
+  private static final String EXPECTED_RX_ROOT;
+  private static final Path RXDEPLOY_DIR;
+  private static final Path RXRUN_DIR;
+  private static MockedStatic<PSSystemServiceLocator> LOCATOR_MOCK;
+  private static MockedStatic<PSConnectionHelper> HELPER_MOCK;
+  private static IPSSystemService MOCK_SVC;
+
+  static {
+    Path tmp;
+    try {
+      tmp = Files.createTempDirectory("percussion-test-rx-");
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    tmp.toFile().deleteOnExit();
+    RXDEPLOY_DIR = tmp;
+    RXRUN_DIR = tmp.resolve("rxconfig").resolve("Workflow");
+    EXPECTED_RX_ROOT = RXDEPLOY_DIR.toAbsolutePath().toString();
+  }
+
+  @BeforeAll
+  static void beforeAll() throws Exception {
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    Files.createDirectories(RXRUN_DIR);
+
+    String propsContent =
+        "TESTWITHOUTSERVER=false\n"
+            + "PSCONSOLETRACEMESSAGES=false\n"
+            + "SMTP_PASSWORD=\n";
+    Files.writeString(RXRUN_DIR.resolve("rxworkflow.properties"), propsContent, StandardCharsets.UTF_8);
+
+    System.setProperty("rxdeploydir", EXPECTED_RX_ROOT);
+
+    HELPER_MOCK = mockStatic(PSConnectionHelper.class);
+    PSConnectionDetail detail = mock(PSConnectionDetail.class);
+    when(detail.getDatabase()).thenReturn("RX");
+    when(detail.getOrigin()).thenReturn("PERCUSSION");
+    when(PSConnectionHelper.getConnectionDetail(any())).thenReturn(detail);
+
+    MOCK_SVC = mock(IPSSystemService.class);
+    when(MOCK_SVC.updateContentStatusState(anyInt(), anyInt(), any(String.class), anyInt(), anyInt(),
+        anyInt(), anyBoolean(), any(java.util.Date.class), any(java.util.Date.class), anyInt(),
+        any(java.util.Date.class), any(java.util.Date.class), any(java.util.Date.class),
+        any(java.util.Date.class), any(java.util.Date.class))).thenReturn(1);
+
+    LOCATOR_MOCK = mockStatic(PSSystemServiceLocator.class);
+    when(PSSystemServiceLocator.getSystemService()).thenReturn(MOCK_SVC);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    TimeZone.setDefault(null);
+    if (LOCATOR_MOCK != null) {
+      LOCATOR_MOCK.close();
+    }
+    if (HELPER_MOCK != null) {
+      HELPER_MOCK.close();
+    }
+    System.clearProperty("rxdeploydir");
+  }
+
+  @Test
+  void buildLegacyColumnMap_populatesAllFifteenColumns() throws Exception {
+    PSContentStatusContext ctx = createContext();
+    setField(ctx, "m_nContentID", 7);
+    setField(ctx, "m_nStateID", 11);
+    setField(ctx, "m_sCheckOutUserName", "alice");
+    setField(ctx, "m_nCurrentRevision", 5);
+    setField(ctx, "m_nEditRevision", 6);
+    setField(ctx, "m_nTipRevision", 7);
+    setField(ctx, "m_bRevisionLocked", true);
+    setField(ctx, "m_LastTransitionDate", toSqlDate(Instant.parse("2026-07-28T12:00:00Z")));
+    setField(ctx, "m_StateEnteredDate", toSqlDate(Instant.parse("2026-07-27T08:30:00Z")));
+    setField(ctx, "m_nNextAgingTransition", 3);
+    setField(ctx, "m_NextAgingDate", toSqlDate(Instant.parse("2026-08-01T00:00:00Z")));
+    setField(ctx, "m_StartDate", toSqlDate(Instant.parse("2026-07-01T00:00:00Z")));
+    setField(ctx, "m_ExpiryDate", toSqlDate(Instant.parse("2026-12-31T23:59:59Z")));
+    setField(ctx, "m_ReminderDate", toSqlDate(Instant.parse("2026-12-24T09:00:00Z")));
+    setField(ctx, "m_RepeatedAgingTransitionStartDate",
+        toSqlDate(Instant.parse("2026-07-28T00:00:00Z")));
+
+    @SuppressWarnings("unchecked")
+    Map<String, String> columns = (Map<String, String>) invokeMethod(ctx, "buildLegacyColumnMap");
+
+    assertEquals(15, columns.size(), "Legacy map must contain exactly 15 columns");
+    assertEquals("11", columns.get("CONTENTSTATEID"));
+    assertEquals("alice", columns.get("CONTENTCHECKOUTUSERNAME"));
+    assertEquals("5", columns.get("CURRENTREVISION"));
+    assertEquals("6", columns.get("EDITREVISION"));
+    assertEquals("7", columns.get("TIPREVISION"));
+    assertEquals("Y", columns.get("REVISIONLOCK"));
+    assertNotNull(columns.get("LASTTRANSITIONDATE"));
+    assertFalse(columns.get("LASTTRANSITIONDATE").isEmpty());
+    assertNotNull(columns.get("STATEENTEREDDATE"));
+    assertFalse(columns.get("STATEENTEREDDATE").isEmpty());
+    assertEquals("3", columns.get("NEXTAGINGTRANSITION"));
+    assertNotNull(columns.get("NEXTAGINGDATE"));
+    assertFalse(columns.get("NEXTAGINGDATE").isEmpty());
+    assertNotNull(columns.get("CONTENTSTARTDATE"));
+    assertFalse(columns.get("CONTENTSTARTDATE").isEmpty());
+    assertNotNull(columns.get("CONTENTEXPIRYDATE"));
+    assertFalse(columns.get("CONTENTEXPIRYDATE").isEmpty());
+    assertNotNull(columns.get("REMINDERDATE"));
+    assertFalse(columns.get("REMINDERDATE").isEmpty());
+    assertNotNull(columns.get("REPEATEDAGINGTRANSSTARTDATE"));
+    assertFalse(columns.get("REPEATEDAGINGTRANSSTARTDATE").isEmpty());
+    assertEquals("7", columns.get("CONTENTID"));
+  }
+
+  @Test
+  void buildLegacyColumnMap_handlesNullDatesAndEmptyUser() throws Exception {
+    PSContentStatusContext ctx = createContext();
+    setField(ctx, "m_nContentID", 7);
+    setField(ctx, "m_nStateID", 11);
+    setField(ctx, "m_sCheckOutUserName", "");
+    setField(ctx, "m_nCurrentRevision", 1);
+    setField(ctx, "m_nEditRevision", 1);
+    setField(ctx, "m_nTipRevision", 1);
+    setField(ctx, "m_bRevisionLocked", false);
+    setField(ctx, "m_LastTransitionDate", null);
+    setField(ctx, "m_StateEnteredDate", null);
+    setField(ctx, "m_nNextAgingTransition", 0);
+    setField(ctx, "m_NextAgingDate", null);
+    setField(ctx, "m_StartDate", null);
+    setField(ctx, "m_ExpiryDate", null);
+    setField(ctx, "m_ReminderDate", null);
+    setField(ctx, "m_RepeatedAgingTransitionStartDate", null);
+
+    @SuppressWarnings("unchecked")
+    Map<String, String> columns = (Map<String, String>) invokeMethod(ctx, "buildLegacyColumnMap");
+
+    assertEquals(15, columns.size());
+    assertEquals("", columns.get("CONTENTCHECKOUTUSERNAME"));
+    assertEquals("N", columns.get("REVISIONLOCK"));
+    assertNull(columns.get("LASTTRANSITIONDATE"));
+    assertNull(columns.get("STATEENTEREDDATE"));
+    assertNull(columns.get("NEXTAGINGDATE"));
+    assertNull(columns.get("CONTENTSTARTDATE"));
+    assertNull(columns.get("CONTENTEXPIRYDATE"));
+    assertNull(columns.get("REMINDERDATE"));
+    assertNull(columns.get("REPEATEDAGINGTRANSSTARTDATE"));
+  }
+
+  // ---------- helpers --------------------------------------------------------
+
+  private static PSContentStatusContext createContext() throws Exception {
+    Constructor<PSContentStatusContext> ctor = PSContentStatusContext.class.getDeclaredConstructor();
+    ctor.setAccessible(true);
+    return ctor.newInstance();
+  }
+
+  private static void setField(PSContentStatusContext ctx, String field, Object value)
+      throws Exception {
+    java.lang.reflect.Field f = PSContentStatusContext.class.getDeclaredField(field);
+    f.setAccessible(true);
+    f.set(ctx, value);
+  }
+
+  private static Object invokeMethod(PSContentStatusContext ctx, String name) throws Exception {
+    java.lang.reflect.Method m = PSContentStatusContext.class.getDeclaredMethod(name);
+    m.setAccessible(true);
+    return m.invoke(ctx);
+  }
+
+  private static java.sql.Date toSqlDate(Instant instant) {
+    if (instant == null) {
+      return null;
+    }
+    return new java.sql.Date(instant.toEpochMilli());
+  }
+}


### PR DESCRIPTION
# Phase 4d-1b — migrate PSExitPerformTransition writes + PSConnectionMgr (#1561)

Issue #1561 — Workflow JDBC → Hibernate. This branch (`fix/1561-workflow-orm-phase4d-1b`)
concludes the Phase 4 in-product migration. **Phase 4d-1a (#1586) is merged.** After this
PR, no in-product `new PSConnectionMgr()` calls remain; the dual-connection defect
documented in the issue inventory is mitigated for the WRITE path (CONTENTSTATUS,
CONTENTADHOCUSERS, CONTENTAPPROVALS).

## What ships

### In-product sites migrated off `new PSConnectionMgr()`

| Site | Status |
|---|---|
| `PSExitPerformTransition` (the only exit with writes + last in-product call site) | ✅ migrated (writes via Hibernate; reads via `PSConnectionHelper.getDbConnection()`) |

### `PSConnectionMgr` reduced to a 1-class utility stub

- **No public/private constructors** — the `new PSConnectionMgr()` body throws
  `UnsupportedOperationException` to fail-fast any accidental re-introduction.
- **Retained static methods** (all 5 are pass-throughs to `PSConnectionHelper` or
  config-only):
  * `getQualifiedIdentifier(String)` — used by 9 legacy context class static-inits
    (CONTENTTYPES, CONTENTSTATUS, TRANSITIONS, STATEROLES, ROLES, NOTIFICATIONS,
    TRANSITIONNOTIFICATIONS, CONTENTADHOCUSERS, CONTENTSTATUSHISTORY,
    CONTENTAPPROVALS) at class load time.
  * `getNewConnection()` / `releaseConnection(Connection)` — pass-throughs to
    `PSConnectionHelper`. Consumed by `PSAbstractWorkflowContext`.
  * `getDebugConnection()` / `releaseDebugConnection(Connection)` — pass-throughs.
    Consumed by `PSAbstractWorkflowTest`.
- **Class is `@Deprecated` and `final`**.

### New Hibernate write service methods on `IPSSystemService`

- `updateContentStatusState(contentId, stateId, checkOutUserName, currentRevision,
  editRevision, tipRevision, revisionLock, lastTransitionDate, stateEnteredDate,
  nextAgingTransition, nextAgingDate, startDate, expiryDate, reminderDate,
  repeatedAgingStartDate)` — single JPQL UPDATE on `PSComponentSummary` that writes all
  14 columns the legacy raw-JDBC `PSContentStatusContext.commit(Connection)` wrote.
- `saveContentAdhocUsers(List<PSContentAdhocUser>)` — `session.merge(...)` per row.
- `deleteContentAdhocUsers(int contentId)` — JPQL DELETE.
- `saveContentApproval(PSContentApproval)` — `session.merge(...)`.
- `deleteContentApprovals(contentId, workflowId, transitionId, stateId)` — JPQL DELETE.

### New no-Connection overloads on the legacy context classes

- `PSContentStatusContext.loadFromHibernate(int contentID)` — Hibernate-backed read.
- `PSContentStatusContext.commit()` — Hibernate-backed write (14 columns).
- `PSContentAdhocUsersContext.commit()` — Hibernate-backed write.
- `PSContentAdhocUsersContext.emptyAdhocUserEntriesViaHibernate(boolean clearState)`.
- `PSContentApprovalsContext.addContentApprovalViaHibernate(String userName, int roleId)`.
- `PSContentApprovalsContext.emptyApprovalsViaHibernate()`.

The legacy raw-JDBC overloads are preserved for binary compat.

### `PSExitPerformTransition` migration

- `new PSConnectionMgr()` removed; connection now acquired via
  `PSConnectionHelper.getDbConnection()`.
- `csc = new PSContentStatusContext(connection, contentID)` replaced with
  `csc = PSContentStatusContext.loadFromHibernate(contentID)` (Hibernate, no connection).
- `csc.close()` removed.
- 5 write call sites all route through Hibernate:
  * 2× `csc.commit(connection)` → `csc.commit()` (CONTENTSTATUS UPDATE).
  * 1× `fromStateCauc.emptyAdhocUserEntries(connection, false)` →
    `fromStateCauc.emptyAdhocUserEntriesViaHibernate(false)`.
  * 1× `toStateCauc.commit(connection)` → `toStateCauc.commit()` (CONTENTADHOCUSERS INSERT).
  * 1× `cac.emptyApprovals()` → `cac.emptyApprovalsViaHibernate()`.
  * 1× `cac.addContentApproval(userName, roleId)` →
    `cac.addContentApprovalViaHibernate(userName, roleId)`.

## Behavioural tests

| Test class | Active | Disabled | Notes |
|---|---|---|---|
| `PSSystemServicePhase4d1bWritesTest` | 12 | 0 | Mockito-only; JPQL + parameter forwards + null-arg rejects for all 5 new write service methods |

## Build & test evidence

| Module | Command | Result |
|---|---|---|
| `modules/extensions-workflow` | `mvn-env.bat -N clean install -DskipTests` | **BUILD SUCCESS** |
| `system` | `mvn-env.bat -N clean install -DskipTests` | **BUILD SUCCESS** |
| `modules/extensions-workflow` | `mvn-env.bat -N test` | **49 tests** (16 active + 33 @Disabled), Failures: 0, Errors: 0 |
| `system` | `mvn-env.bat -N test -Dtest=PSSystemServicePhase4d1bWritesTest` | **12 tests** all green |
| `system` | `mvn-env.bat -N test` (full suite) | **904 tests** (659 active + 1 pre-existing `PSObjectSerializerTest` failure noted in root `AGENTS.md` as unrelated + 244 @Disabled), Failures: 1 (pre-existing), Errors: 0 |

No new compiler, surefire, enforcer, or Spotless warnings introduced on the changed modules.
Raw-type warnings on legacy `IPSStateRolesContext` are pre-existing and untouched.

## Cross-platform portability

No file I/O, `new File(...)`, path joining, or shell-out added. All cross-platform rules in
root `AGENTS.md` are satisfied by construction.

## Phase 5 follow-ups (not in this PR)

1. Migrate `new PSTransitionsContext(workflowId, conn, agingStateID)` (aging transitions
   cursor in `updateAgingInformation`) to a
   `PSTransitionsContext.loadAgingFromHibernate(workflowId, fromStateId)` factory.
   *Prerequisite:* add `IPSWorkflowService.findAgingTransitionsByState(...)` and a
   Hibernate `loadAgingFromHibernate` factory.
2. Migrate `new PSContentApprovalsContext(workflowId, conn, contentId, tc)` (approvals
   read in `processTransition`) to a
   `PSContentApprovalsContext.loadFromHibernate(...)` factory.
3. Migrate `PSAbstractWorkflowContext` to use the Spring-managed connection
   (eliminate the last in-class `PSConnectionMgr.getNewConnection()` call).

## References

- Issue: #1561
- Migration epic + phased plan: `docs/ai-generated/migrations/workflow-orm/00-inventory.md`
- Scope survey (this PR's sub-phase split): `docs/ai-generated/migrations/workflow-orm/phase4-scope-survey.md`
- Erlang review (this PR): `docs/ai-generated/code-reviews/fix-1561-workflow-orm-phase4d-1b-erlang.md`
- Predecessor PRs: #1567 (Phases 0/1/2), #1570 (Phase 3), #1575 (Phase 4a — Tier 1),
  #1578 (Phase 4b — Tier 2), #1583 (Phase 4c — Tier 3a), #1586 (Phase 4d-1a — read exits)

> Co-Authored by Kilo 1.x using MiniMax-M3 with agent erlang-code-review.
