### PR TITLE
chore: Spotless cleanup (XML comments)

### DIFF
--- a/modules/TableFactory/src/main/resources/com/percussion/tablefactory/PSJdbcDataTypeMaps.xml
+++ b/modules/TableFactory/src/main/resources/com/percussion/tablefactory/PSJdbcDataTypeMaps.xml
@@ -201,7 +201,8 @@
 		<DataType jdbc="LONGVARBINARY" native="BLOB" />
 		<DataType jdbc="BLOB" native="BLOB" />
 	</DataTypeMap>
-	<!-- PostgreSQL: external CMS repository backend (GitHub #1500). Prefer BOOLEAN / TEXT / BYTEA. -->
+	<!-- PostgreSQL: external CMS repository backend (GitHub #1500). Prefer
+		BOOLEAN / TEXT / BYTEA. -->
 	<DataTypeMap for="POSTGRES" os="" driver="postgresql">
 		<DataType jdbc="BIT" native="BOOLEAN" />
 		<DataType jdbc="BOOLEAN" native="BOOLEAN" />

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/install.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/install.xml
@@ -680,10 +680,10 @@
 		<antcall target="deleteOldJdbcDrivers" inheritall="true"
 			inheritrefs="true" />
 		<!-- deleteOldJdbcDrivers removes the bundled set (including h2/derby)
-			from install.dir. Re-install current drivers before Derby→H2 migration
-			so jetty/base/lib/jdbc and ant.deps install.dir entries stay loadable
-			if the process is interrupted mid-upgrade. H2 must also be on the
-			perc-ant shade classpath (see perc-ant pom) for Class.forName. -->
+			from install.dir. Re-install current drivers before Derby→H2 migration so
+			jetty/base/lib/jdbc and ant.deps install.dir entries stay loadable if the
+			process is interrupted mid-upgrade. H2 must also be on the perc-ant shade
+			classpath (see perc-ant pom) for Class.forName. -->
 		<antcall target="install_jdbc_drivers" inheritall="true"
 			inheritrefs="true" />
 		<!-- #548: Derby→H2 before file overwrite / DB setup plugins use repository -->

--- a/modules/perc-distribution-tree/src/main/resources/installDistributionFiles.xml
+++ b/modules/perc-distribution-tree/src/main/resources/installDistributionFiles.xml
@@ -146,10 +146,10 @@
 			</fileset>
 		</copy>
 
-		<!-- AI tools (skills, prompts, instructions, future plugins) staged into the install.
-		     sys_resources/ai-tools/ is replaced on every upgrade.
-		     rx_resources/ai-tools/ is created empty as the customer overlay — files added
-		     there by an operator survive upgrades and take precedence at runtime. -->
+		<!-- AI tools (skills, prompts, instructions, future plugins) staged into
+			the install. sys_resources/ai-tools/ is replaced on every upgrade. rx_resources/ai-tools/
+			is created empty as the customer overlay — files added there by an operator
+			survive upgrades and take precedence at runtime. -->
 		<echo>Staging AI tools into sys_resources/ai-tools/...</echo>
 		<copy todir="${assembly-directory}/sys_resources/ai-tools"
 			overwrite="true" verbose="true" force="true">

--- a/modules/perc-xml-security/src/main/resources/CustomXMLCatalog.xml
+++ b/modules/perc-xml-security/src/main/resources/CustomXMLCatalog.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
-<!--
-  Operator-custom OASIS XML Catalog. No DOCTYPE (see PercussionXMLCatalog.xml).
--->
+<!-- Operator-custom OASIS XML Catalog. No DOCTYPE (see PercussionXMLCatalog.xml). -->
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
 	prefer="system" xml:base="file://@@rxdir@@">
 	<!-- Add any custom DTD, Entity, Namespace, XSL (import, include, document)

--- a/modules/perc-xml-security/src/main/resources/PercussionXMLCatalog.xml
+++ b/modules/perc-xml-security/src/main/resources/PercussionXMLCatalog.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0"?>
-<!--
-  OASIS XML Catalog for local DTD/entity resolution (XXE mitigation).
-  No DOCTYPE: under secured SAX (no external DTD load), a DOCTYPE that
-  references the oasis-open.org catalog.dtd causes SAX parse failure, then
-  xml-resolver falls back to TR9401 text parsing and throws
-  ArrayIndexOutOfBoundsException in TextCatalogReader.
-  OASISXMLCatalogReader keys off the catalog namespace below, not DOCTYPE.
--->
+<!-- OASIS XML Catalog for local DTD/entity resolution (XXE mitigation).
+	No DOCTYPE: under secured SAX (no external DTD load), a DOCTYPE that references
+	the oasis-open.org catalog.dtd causes SAX parse failure, then xml-resolver
+	falls back to TR9401 text parsing and throws ArrayIndexOutOfBoundsException
+	in TextCatalogReader. OASISXMLCatalogReader keys off the catalog namespace
+	below, not DOCTYPE. -->
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
 	prefer="system" xml:base="file://@@rxdir@@">
 


### PR DESCRIPTION
## Summary

Separate **Spotless Cleanup** PR per root `AGENTS.md` hard gate.

While verifying Spotless on #1590 (`chore: remove mvn-env wrappers`), `./mvnw spotless:apply` rewrote **5 XML resource files** that are **not** part of that change set. Per agent process: keep feature PRs scoped; ship baseline formatting debt here.

## Files

- `modules/TableFactory/.../PSJdbcDataTypeMaps.xml`
- `modules/perc-distribution-tree/.../install.xml`
- `modules/perc-distribution-tree/.../installDistributionFiles.xml`
- `modules/perc-xml-security/.../CustomXMLCatalog.xml`
- `modules/perc-xml-security/.../PercussionXMLCatalog.xml`

Formatting only (comment wrapping / whitespace).

## Relation to #1590

- #1590 scope: agent docs, mvn-env removal, scripts — **intersection with Spotless hits: zero** after apply.
- Full-repo `spotless:check` may still fail on other debt (e.g. Prettier/`docs/index.html` needing a Node executable). Not addressed here.

## Test plan

- [ ] Diff is comment/whitespace only
- [ ] No Java / product behavior change

> Co-Authored by Grok Build using grok-4.5 with agent Grok.