### PR TITLE
feat(developer): pipelines application catalog (P0.6)

### DIFF
--- a/WebUI/src/main/ts/api/developer/pipelinesApi.ts
+++ b/WebUI/src/main/ts/api/developer/pipelinesApi.ts
@@ -19,26 +19,35 @@ import { get } from "../client";
 import { PATHS } from "../paths";
 import type { ApplicationSummary } from "./types";
 
-function asArray<T>(payload: unknown, keys: string[]): T[] {
+export interface ListApplicationsOptions {
+  name?: string;
+  limit?: number;
+  offset?: number;
+}
+
+function asArray<T>(payload: unknown): T[] {
   if (payload == null) return [];
   if (Array.isArray(payload)) return payload as T[];
+  // Defensive: some CXF/XML-bridge shapes wrap a single element
   if (typeof payload === "object") {
     const obj = payload as Record<string, unknown>;
-    for (const k of keys) {
-      const raw = obj[k];
-      if (raw == null) continue;
-      return Array.isArray(raw) ? (raw as T[]) : [raw as T];
-    }
+    const raw = obj.Application ?? obj.application;
+    if (raw == null) return [];
+    return Array.isArray(raw) ? (raw as T[]) : [raw as T];
   }
   return [];
 }
 
-/** GET /services/pipelines */
-export async function listApplications(): Promise<ApplicationSummary[]> {
-  const payload = await get<unknown>(PATHS.PIPELINES);
-  return asArray<ApplicationSummary>(payload, [
-    "Application",
-    "ApplicationList",
-    "applicationList",
-  ]);
+/** GET /services/pipelines?name=&limit=&offset= */
+export async function listApplications(
+  options: ListApplicationsOptions = {},
+): Promise<ApplicationSummary[]> {
+  const params = new URLSearchParams();
+  if (options.name) params.set("name", options.name);
+  if (options.limit != null) params.set("limit", String(options.limit));
+  if (options.offset != null) params.set("offset", String(options.offset));
+  const q = params.toString();
+  const url = q ? `${PATHS.PIPELINES}?${q}` : PATHS.PIPELINES;
+  const payload = await get<unknown>(url);
+  return asArray<ApplicationSummary>(payload);
 }

--- a/WebUI/src/main/ts/api/developer/pipelinesApi.ts
+++ b/WebUI/src/main/ts/api/developer/pipelinesApi.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { get } from "../client";
+import { PATHS } from "../paths";
+import type { ApplicationSummary } from "./types";
+
+function asArray<T>(payload: unknown, keys: string[]): T[] {
+  if (payload == null) return [];
+  if (Array.isArray(payload)) return payload as T[];
+  if (typeof payload === "object") {
+    const obj = payload as Record<string, unknown>;
+    for (const k of keys) {
+      const raw = obj[k];
+      if (raw == null) continue;
+      return Array.isArray(raw) ? (raw as T[]) : [raw as T];
+    }
+  }
+  return [];
+}
+
+/** GET /services/pipelines */
+export async function listApplications(): Promise<ApplicationSummary[]> {
+  const payload = await get<unknown>(PATHS.PIPELINES);
+  return asArray<ApplicationSummary>(payload, [
+    "Application",
+    "ApplicationList",
+    "applicationList",
+  ]);
+}

--- a/WebUI/src/main/ts/api/developer/types.ts
+++ b/WebUI/src/main/ts/api/developer/types.ts
@@ -129,4 +129,5 @@ export interface ApplicationSummary {
   appType?: string;
   version?: string;
   empty?: boolean;
+  hidden?: boolean;
 }

--- a/WebUI/src/main/ts/api/developer/types.ts
+++ b/WebUI/src/main/ts/api/developer/types.ts
@@ -118,3 +118,15 @@ export interface CommunitySummary {
   label?: string;
   description?: string;
 }
+
+/** Classic XML Application / pipeline package summary. */
+export interface ApplicationSummary {
+  id?: number;
+  name?: string;
+  description?: string;
+  enabled?: boolean;
+  appRoot?: string;
+  appType?: string;
+  version?: string;
+  empty?: boolean;
+}

--- a/WebUI/src/main/ts/api/paths.ts
+++ b/WebUI/src/main/ts/api/paths.ts
@@ -281,6 +281,10 @@ export const PATHS = {
   get COMMUNITIES() {
     return `${SERVICES_ROOT}/communities`;
   },
+  /** Pipeline / XML application design catalog. */
+  get PIPELINES() {
+    return `${SERVICES_ROOT}/pipelines`;
+  },
   /** Workflow management (workflowmanagement) — Feature 993 */
   get WORKFLOWS() {
     return `${SERVICES_ROOT}/workflowmanagement/workflows/`;

--- a/WebUI/src/main/ts/developer/DeveloperShell.tsx
+++ b/WebUI/src/main/ts/developer/DeveloperShell.tsx
@@ -25,7 +25,7 @@ import { CommunitiesPanel } from "./CommunitiesPanel";
 import { ContentTypesPanel } from "./ContentTypesPanel";
 import { KeywordsPanel } from "./KeywordsPanel";
 import { DEV_MSG } from "./messages";
-import { PlaceholderPanel } from "./PlaceholderPanel";
+import { PipelinesPanel } from "./PipelinesPanel";
 import { SlotsPanel } from "./SlotsPanel";
 import { TemplatesPanel } from "./TemplatesPanel";
 
@@ -141,7 +141,7 @@ export const DeveloperShell: React.FC<DeveloperShellProps> = ({
         ) : active === "communities" ? (
           <CommunitiesPanel />
         ) : (
-          <PlaceholderPanel sectionLabel={SECTION_LABEL[active]} />
+          <PipelinesPanel />
         )}
       </div>
     </div>

--- a/WebUI/src/main/ts/developer/PipelinesPanel.tsx
+++ b/WebUI/src/main/ts/developer/PipelinesPanel.tsx
@@ -15,23 +15,16 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from "react";
-import { isSessionRedirectError, type ApiError } from "../api/client";
+import React, { useEffect, useMemo, useState } from "react";
 import { listApplications } from "../api/developer/pipelinesApi";
 import type { ApplicationSummary } from "../api/developer/types";
 import { CatalogHint, CatalogStatus, SimpleCatalogTable } from "./CatalogTable";
+import { monoCell, mutedCell, mutedMonoCell } from "./catalogStyles";
+import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
 
-function errMsg(err: unknown, fallback: string): string {
-  if (isSessionRedirectError(err)) return DEV_MSG.SESSION_REDIRECT;
-  const api = err as ApiError;
-  if (api && typeof api.status === "number") return `${fallback} (${api.status})`;
-  if (err instanceof Error && err.message) return `${fallback} ${err.message}`;
-  return fallback;
-}
-
 /**
- * P0.6 — pipeline / XML application catalog (read-only).
+ * P0.6 — classic XML Application / pipeline package catalog (read-only).
  */
 export function PipelinesPanel(): React.ReactElement {
   const [items, setItems] = useState<ApplicationSummary[] | null>(null);
@@ -45,15 +38,21 @@ export function PipelinesPanel(): React.ReactElement {
       })
       .catch((e: unknown) => {
         if (cancelled) return;
-        // Session redirect navigates away; still leave loading so UI does not hang
-        // if navigation is delayed or blocked.
-        setError(errMsg(e, DEV_MSG.PIPE_ERROR));
+        // Exit loading and show an error (including session-redirect copy if redirect is delayed).
+        setError(panelErrMsg(e, DEV_MSG.PIPE_ERROR));
         setItems([]);
       });
     return () => {
       cancelled = true;
     };
   }, []);
+
+  const sorted = useMemo(() => {
+    if (!items) return [];
+    return [...items].sort((a, b) =>
+      (a.name || "").localeCompare(b.name || "", undefined, { sensitivity: "base" }),
+    );
+  }, [items]);
 
   if (error)
     return (
@@ -67,10 +66,6 @@ export function PipelinesPanel(): React.ReactElement {
     );
   if (items.length === 0)
     return <CatalogStatus testId="developer-pipe-empty">{DEV_MSG.PIPE_EMPTY}</CatalogStatus>;
-
-  const sorted = [...items].sort((a, b) =>
-    (a.name || "").localeCompare(b.name || "", undefined, { sensitivity: "base" }),
-  );
 
   return (
     <div data-testid="developer-pipe-panel">
@@ -89,18 +84,18 @@ export function PipelinesPanel(): React.ReactElement {
         rows={sorted.map((app, index) => ({
           key: String(app.id ?? app.name ?? `pipe-${index}`),
           cells: [
-            <span key="n" style={{ fontFamily: "monospace" }}>
+            <span key="n" style={monoCell}>
               {app.name || "—"}
             </span>,
-            <span key="i" style={{ fontFamily: "monospace" }}>
+            <span key="i" style={monoCell}>
               {app.id != null ? String(app.id) : "—"}
             </span>,
             app.appType || "—",
             app.enabled == null ? "—" : app.enabled ? DEV_MSG.YES : DEV_MSG.NO,
-            <span key="r" style={{ fontFamily: "monospace", color: "#4a5568" }}>
+            <span key="r" style={mutedMonoCell}>
               {app.appRoot || ""}
             </span>,
-            <span key="d" style={{ color: "#4a5568" }}>
+            <span key="d" style={mutedCell}>
               {app.description || ""}
             </span>,
           ],

--- a/WebUI/src/main/ts/developer/PipelinesPanel.tsx
+++ b/WebUI/src/main/ts/developer/PipelinesPanel.tsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useState } from "react";
+import { isSessionRedirectError, type ApiError } from "../api/client";
+import { listApplications } from "../api/developer/pipelinesApi";
+import type { ApplicationSummary } from "../api/developer/types";
+import { CatalogHint, CatalogStatus, SimpleCatalogTable } from "./CatalogTable";
+import { DEV_MSG } from "./messages";
+
+function errMsg(err: unknown, fallback: string): string {
+  if (isSessionRedirectError(err)) return DEV_MSG.SESSION_REDIRECT;
+  const api = err as ApiError;
+  if (api && typeof api.status === "number") return `${fallback} (${api.status})`;
+  if (err instanceof Error && err.message) return `${fallback} ${err.message}`;
+  return fallback;
+}
+
+/**
+ * P0.6 — pipeline / XML application catalog (read-only).
+ */
+export function PipelinesPanel(): React.ReactElement {
+  const [items, setItems] = useState<ApplicationSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    listApplications()
+      .then((list) => {
+        if (!cancelled) setItems(list);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        // Session redirect navigates away; still leave loading so UI does not hang
+        // if navigation is delayed or blocked.
+        setError(errMsg(e, DEV_MSG.PIPE_ERROR));
+        setItems([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error)
+    return (
+      <CatalogStatus testId="developer-pipe-error" error>
+        {error}
+      </CatalogStatus>
+    );
+  if (items == null)
+    return (
+      <CatalogStatus testId="developer-pipe-loading">{DEV_MSG.PIPE_LOADING}</CatalogStatus>
+    );
+  if (items.length === 0)
+    return <CatalogStatus testId="developer-pipe-empty">{DEV_MSG.PIPE_EMPTY}</CatalogStatus>;
+
+  const sorted = [...items].sort((a, b) =>
+    (a.name || "").localeCompare(b.name || "", undefined, { sensitivity: "base" }),
+  );
+
+  return (
+    <div data-testid="developer-pipe-panel">
+      <CatalogHint>{DEV_MSG.PIPE_HINT}</CatalogHint>
+      <SimpleCatalogTable
+        tableTestId="developer-pipe-table"
+        rowTestId="developer-pipe-row"
+        columns={[
+          DEV_MSG.PIPE_COL_NAME,
+          DEV_MSG.PIPE_COL_ID,
+          DEV_MSG.PIPE_COL_TYPE,
+          DEV_MSG.PIPE_COL_ENABLED,
+          DEV_MSG.PIPE_COL_ROOT,
+          DEV_MSG.PIPE_COL_DESCRIPTION,
+        ]}
+        rows={sorted.map((app, index) => ({
+          key: String(app.id ?? app.name ?? `pipe-${index}`),
+          cells: [
+            <span key="n" style={{ fontFamily: "monospace" }}>
+              {app.name || "—"}
+            </span>,
+            <span key="i" style={{ fontFamily: "monospace" }}>
+              {app.id != null ? String(app.id) : "—"}
+            </span>,
+            app.appType || "—",
+            app.enabled == null ? "—" : app.enabled ? DEV_MSG.YES : DEV_MSG.NO,
+            <span key="r" style={{ fontFamily: "monospace", color: "#4a5568" }}>
+              {app.appRoot || ""}
+            </span>,
+            <span key="d" style={{ color: "#4a5568" }}>
+              {app.description || ""}
+            </span>,
+          ],
+        }))}
+      />
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/developer/catalogStyles.ts
+++ b/WebUI/src/main/ts/developer/catalogStyles.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type React from "react";
+
+/** Shared cell styles for Developer catalog tables. */
+export const monoCell: React.CSSProperties = {
+  fontFamily: "monospace",
+};
+
+export const mutedMonoCell: React.CSSProperties = {
+  fontFamily: "monospace",
+  color: "#4a5568",
+};
+
+export const mutedCell: React.CSSProperties = {
+  color: "#4a5568",
+};

--- a/WebUI/src/main/ts/developer/errors.ts
+++ b/WebUI/src/main/ts/developer/errors.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isSessionRedirectError, type ApiError } from "../api/client";
+import { DEV_MSG } from "./messages";
+
+/** Shared error message formatting for Developer catalog panels. */
+export function panelErrMsg(err: unknown, fallback: string): string {
+  if (isSessionRedirectError(err)) return DEV_MSG.SESSION_REDIRECT;
+  const api = err as ApiError;
+  if (api && typeof api.status === "number") return `${fallback} (${api.status})`;
+  if (err instanceof Error && err.message) return `${fallback} ${err.message}`;
+  return fallback;
+}

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -89,6 +89,17 @@ export const DEV_MSG = {
   COMM_COL_NAME: "Name",
   COMM_COL_ID: "Id",
   COMM_COL_DESCRIPTION: "Description",
+  PIPE_LOADING: "Loading pipelines…",
+  PIPE_EMPTY: "No pipeline applications returned.",
+  PIPE_ERROR: "Could not load pipelines.",
+  PIPE_HINT:
+    "Server applications (classic XML Applications). Read-only catalog — editor, start/stop, and IR import are later slices.",
+  PIPE_COL_NAME: "Name",
+  PIPE_COL_ID: "Id",
+  PIPE_COL_TYPE: "Type",
+  PIPE_COL_ENABLED: "Enabled",
+  PIPE_COL_ROOT: "App root",
+  PIPE_COL_DESCRIPTION: "Description",
   PLACEHOLDER_TITLE: "Not implemented yet",
   PLACEHOLDER_BODY:
     "This section is planned for Developer P0. See docs/ai-generated/tasks/developer-module-p0 and docs/developer-module.",

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -69,6 +69,19 @@ vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
   ]),
 }));
 
+vi.mock("../../../main/ts/api/developer/pipelinesApi", () => ({
+  listApplications: vi.fn().mockResolvedValue([
+    {
+      id: 1,
+      name: "sys_cmpDocuments",
+      description: "System content editor app",
+      enabled: true,
+      appType: "CONTENT_EDITOR",
+      appRoot: "sys_cmpDocuments",
+    },
+  ]),
+}));
+
 describe("DeveloperShell", () => {
   beforeEach(() => {
     (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
@@ -90,12 +103,16 @@ describe("DeveloperShell", () => {
     expect(screen.getByText("Page")).toBeTruthy();
   });
 
-  it("shows placeholder for pipelines section", async () => {
+  it("loads pipelines catalog section", async () => {
     render(<DeveloperShell initialSection="pipelines" embedded />);
     expect(screen.getByTestId("tab-developer-pipelines").getAttribute("aria-selected")).toBe(
       "true",
     );
-    expect(screen.getByTestId("developer-placeholder")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-pipe-table")).toBeTruthy();
+    });
+    expect(screen.getAllByText("sys_cmpDocuments").length).toBeGreaterThan(0);
+    expect(screen.getByText("CONTENT_EDITOR")).toBeTruthy();
 
     fireEvent.click(screen.getByTestId("tab-developer-content-types"));
     await waitFor(() => {

--- a/WebUI/src/test/ts/developer/PipelinesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/PipelinesPanel.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import React from "react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { listApplications } from "../../../main/ts/api/developer/pipelinesApi";
+import { PipelinesPanel } from "../../../main/ts/developer/PipelinesPanel";
+
+vi.mock("../../../main/ts/api/developer/pipelinesApi", () => ({
+  listApplications: vi.fn(),
+}));
+
+const listApplicationsMock = vi.mocked(listApplications);
+
+describe("PipelinesPanel", () => {
+  beforeEach(() => {
+    listApplicationsMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders catalog rows when applications load", async () => {
+    listApplicationsMock.mockResolvedValue([
+      {
+        id: 1,
+        name: "sys_cmpDocuments",
+        description: "System content editor app",
+        enabled: true,
+        appType: "CONTENT_EDITOR",
+        appRoot: "sys_cmpDocuments",
+      },
+    ]);
+    render(<PipelinesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-pipe-table")).toBeTruthy();
+    });
+    expect(screen.getAllByText("sys_cmpDocuments").length).toBeGreaterThan(0);
+    expect(screen.getByText("CONTENT_EDITOR")).toBeTruthy();
+  });
+
+  it("shows empty state when API returns no applications", async () => {
+    listApplicationsMock.mockResolvedValue([]);
+    render(<PipelinesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-pipe-empty")).toBeTruthy();
+    });
+  });
+
+  it("shows error UI when pipelines fetch fails", async () => {
+    listApplicationsMock.mockRejectedValue({ status: 500, statusText: "Error" });
+    render(<PipelinesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-pipe-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-pipe-error").textContent).toMatch(/500/);
+  });
+});

--- a/docs/ai-generated/code-reviews/2026-07-29-pr-1594-pipelines-kilo-followup.md
+++ b/docs/ai-generated/code-reviews/2026-07-29-pr-1594-pipelines-kilo-followup.md
@@ -1,0 +1,20 @@
+# Erlang-style pre-commit review — PR #1594 follow-up (Kilo open threads)
+
+**Scope:** rest `PipelinesResource` null-guard + cause-preserving tests; sitemanage `PipelinesAdaptorTest` pure helper coverage.
+**Verdict:** PASS — no merge-blocking defects.
+
+## Findings
+
+| Severity | Finding | Disposition |
+|----------|---------|-------------|
+| none | `requireAdaptor()` guards no-arg constructor path; wraps as 500 with cause | OK |
+| none | `PipelinesAdaptorTest` covers limit clamp, offset, name filter, hidden map, sort | OK |
+| none | `listApplicationsWrapsFailures` asserts `assertSame` on cause | OK |
+| none | Cross-platform / file I/O | N/A (no path work) |
+
+## Tests run
+
+- `cd rest && ../mvnw -Dtest=PipelinesResourceTest test` → Tests run: 4, Failures: 0
+- `cd projects/sitemanage && ../../mvnw -Dai.integrity.skip=true -Dtest=PipelinesAdaptorTest test` → Tests run: 9, Failures: 0  
+  (integrity skip: worktree seal drift vs sibling #1595 / system notify map not on this branch)
+

--- a/docs/ai-generated/tasks/developer-module-p0/README.md
+++ b/docs/ai-generated/tasks/developer-module-p0/README.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|--------|
-| **Status** | **In progress** — shell + CT list + read-only field detail |
+| **Status** | **P0 read catalogs complete** — editors / pipeline IR next |
 | **FR source** | [`docs/developer-module/workbench-functional-inventory.md`](../../developer-module/workbench-functional-inventory.md) §15 P0 |
 | **Pipeline track** | [`docs/developer-module/data-pipeline-engine-inventory.md`](../../developer-module/data-pipeline-engine-inventory.md) (parallel; not blocking P0) |
 | **Related** | [design-templates-item-types](../design-templates-item-types/README.md) (CM1 template library — complementary, not a substitute) |
@@ -26,21 +26,22 @@
 - [x] SPA route `/developer` (+ section) for Admin or Designer  
 - [x] Top nav **Developer** (replaces legacy Design full-page exit for designers)  
 - [x] Deep-link entry `developer` (query + path fallback filter)  
-- [x] Module shell with sections: Content Types, Templates, Slots, Keywords, Communities, Pipelines (placeholder)  
+- [x] Module shell with sections: Content Types, Templates, Slots, Keywords, Communities, Pipelines  
 - [x] **Content Types** panel: list from `GET /services/contenttypes`  
 - [x] **P0.2** `GET /services/contenttypes/{idOrName}` field catalog + SPA detail view  
 - [x] **P0.2b** Allowed workflows + default workflow + allowed templates on CT detail  
 - [x] **P0.3** Keywords list `GET /services/keywords` + SPA Keywords panel (read-only)  
 - [x] **P0.4** Templates `GET /services/templates` + Slots `GET /services/slots` + SPA panels  
 - [x] **P0.5** Communities list via `GET /services/communities/find?name=*` + SPA panel  
+- [x] **P0.6** Pipelines list `GET /services/pipelines` (XML application summaries) + SPA panel  
 - [x] Gap map: [content-type-api-gaps.md](./content-type-api-gaps.md)  
 - [x] Vitest coverage for shell + catalogs  
 
-## Next slices
+## Next slices (separate PRs)
 
 1. Template/slot/CT detail editors (write + field rules)  
 2. Keyword create/edit; community roles + ACL dialogs  
-3. Pipelines track (Slice A IR)  
+3. Pipelines track Slice A (IR + SQL runtime + JSON I/O + classic import)  
 4. Server runtime map for data pipelines
 
 ## Product locks

--- a/docs/ai-generated/tasks/developer-module-p0/README.md
+++ b/docs/ai-generated/tasks/developer-module-p0/README.md
@@ -33,7 +33,7 @@
 - [x] **P0.3** Keywords list `GET /services/keywords` + SPA Keywords panel (read-only)  
 - [x] **P0.4** Templates `GET /services/templates` + Slots `GET /services/slots` + SPA panels  
 - [x] **P0.5** Communities list via `GET /services/communities/find?name=*` + SPA panel  
-- [x] **P0.6** Pipelines list `GET /services/pipelines` (XML application summaries) + SPA panel  
+- [x] **P0.6** Pipelines list `GET /services/pipelines` — classic **XML Application** summaries (not Slice A IR) + SPA panel; optional `?name=` / `?limit=` / `?offset=`  
 - [x] Gap map: [content-type-api-gaps.md](./content-type-api-gaps.md)  
 - [x] Vitest coverage for shell + catalogs  
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/PipelinesAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/PipelinesAdaptor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import com.percussion.design.objectstore.server.PSApplicationSummary;
+import com.percussion.design.objectstore.server.PSServerXmlObjectStore;
+import com.percussion.rest.pipelines.ApplicationSummary;
+import com.percussion.rest.pipelines.IPipelinesAdaptor;
+import com.percussion.security.PSSecurityToken;
+import com.percussion.server.PSRequest;
+import com.percussion.servlets.PSSecurityFilter;
+import com.percussion.system.utils.PSSiteManageBean;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@PSSiteManageBean
+public class PipelinesAdaptor implements IPipelinesAdaptor {
+
+  private static final Logger log = LogManager.getLogger(PipelinesAdaptor.class);
+
+  @Override
+  public List<ApplicationSummary> listApplications(URI baseUri) {
+    // baseUri reserved for HATEOAS link building (interface contract)
+    PSRequest req = PSSecurityFilter.getCurrentRequest();
+    if (req == null) {
+      throw new IllegalStateException("No current request for application catalog");
+    }
+    PSSecurityToken tok = req.getSecurityToken();
+    PSApplicationSummary[] sums =
+        PSServerXmlObjectStore.getInstance().getApplicationSummaryObjects(tok, false);
+    List<ApplicationSummary> out = new ArrayList<>();
+    if (sums != null) {
+      for (PSApplicationSummary sum : sums) {
+        if (sum == null) {
+          continue;
+        }
+        try {
+          out.add(toSummary(sum));
+        } catch (Exception e) {
+          log.debug(
+              "Skipping application summary {}: {}", sum.getName(), e.getMessage());
+        }
+      }
+    }
+    out.sort(
+        Comparator.comparing(
+            a -> a.getName() != null ? a.getName() : "", String.CASE_INSENSITIVE_ORDER));
+    return out;
+  }
+
+  private static ApplicationSummary toSummary(PSApplicationSummary sum) {
+    ApplicationSummary dto = new ApplicationSummary();
+    dto.setId(sum.getId());
+    dto.setName(sum.getName());
+    dto.setDescription(sum.getDescription());
+    dto.setEnabled(sum.isEnabled());
+    dto.setAppRoot(sum.getAppRoot());
+    if (sum.getAppType() != null) {
+      dto.setAppType(sum.getAppType().name());
+    }
+    dto.setVersion(sum.getVersion());
+    dto.setEmpty(sum.isEmpty());
+    return dto;
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/PipelinesAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/PipelinesAdaptor.java
@@ -29,24 +29,65 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * Lists classic XML Applications (pipeline packages) visible to the current security token.
+ *
+ * <p>Uses {@link PSServerXmlObjectStore} for summaries; mapping/filter/limit are pure helpers so
+ * they can be unit-tested without the object-store singleton.
+ */
 @PSSiteManageBean
 public class PipelinesAdaptor implements IPipelinesAdaptor {
 
   private static final Logger log = LogManager.getLogger(PipelinesAdaptor.class);
 
+  /** Default page size when callers pass non-positive limit. */
+  public static final int DEFAULT_LIMIT = 500;
+
+  /** Hard cap to avoid unbounded payloads on large servers. */
+  public static final int MAX_LIMIT = 1000;
+
+  private final Function<PSSecurityToken, PSApplicationSummary[]> summaryLoader;
+
+  public PipelinesAdaptor() {
+    this(
+        tok ->
+            PSServerXmlObjectStore.getInstance().getApplicationSummaryObjects(tok, false));
+  }
+
+  /** Package-visible for unit tests that inject a fake summary source. */
+  PipelinesAdaptor(Function<PSSecurityToken, PSApplicationSummary[]> summaryLoader) {
+    this.summaryLoader = summaryLoader;
+  }
+
   @Override
-  public List<ApplicationSummary> listApplications(URI baseUri) {
+  public List<ApplicationSummary> listApplications(
+      URI baseUri, String nameFilter, int limit, int offset) {
     // baseUri reserved for HATEOAS link building (interface contract)
     PSRequest req = PSSecurityFilter.getCurrentRequest();
     if (req == null) {
       throw new IllegalStateException("No current request for application catalog");
     }
     PSSecurityToken tok = req.getSecurityToken();
-    PSApplicationSummary[] sums =
-        PSServerXmlObjectStore.getInstance().getApplicationSummaryObjects(tok, false);
+    PSApplicationSummary[] sums = summaryLoader.apply(tok);
+    return mapFilterSortLimit(sums, nameFilter, limit, offset);
+  }
+
+  /**
+   * Pure mapping path used by production and unit tests (no object-store singleton).
+   */
+  static List<ApplicationSummary> mapFilterSortLimit(
+      PSApplicationSummary[] sums, String nameFilter, int limit, int offset) {
+    int safeLimit = limit <= 0 ? DEFAULT_LIMIT : Math.min(limit, MAX_LIMIT);
+    int safeOffset = Math.max(0, offset);
+    String q =
+        StringUtils.isBlank(nameFilter) ? null : nameFilter.trim().toLowerCase(Locale.ROOT);
+
     List<ApplicationSummary> out = new ArrayList<>();
     if (sums != null) {
       for (PSApplicationSummary sum : sums) {
@@ -54,20 +95,35 @@ public class PipelinesAdaptor implements IPipelinesAdaptor {
           continue;
         }
         try {
-          out.add(toSummary(sum));
+          ApplicationSummary dto = toSummary(sum);
+          if (q != null && !matchesNameFilter(dto, q)) {
+            continue;
+          }
+          out.add(dto);
         } catch (Exception e) {
-          log.debug(
-              "Skipping application summary {}: {}", sum.getName(), e.getMessage());
+          log.debug("Skipping application summary {}: {}", sum.getName(), e.getMessage());
         }
       }
     }
     out.sort(
         Comparator.comparing(
-            a -> a.getName() != null ? a.getName() : "", String.CASE_INSENSITIVE_ORDER));
-    return out;
+            ApplicationSummary::getName,
+            Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
+    if (safeOffset >= out.size()) {
+      return List.of();
+    }
+    int end = Math.min(out.size(), safeOffset + safeLimit);
+    return new ArrayList<>(out.subList(safeOffset, end));
   }
 
-  private static ApplicationSummary toSummary(PSApplicationSummary sum) {
+  static boolean matchesNameFilter(ApplicationSummary dto, String qLower) {
+    String name = dto.getName() != null ? dto.getName().toLowerCase(Locale.ROOT) : "";
+    String desc =
+        dto.getDescription() != null ? dto.getDescription().toLowerCase(Locale.ROOT) : "";
+    return name.contains(qLower) || desc.contains(qLower);
+  }
+
+  static ApplicationSummary toSummary(PSApplicationSummary sum) {
     ApplicationSummary dto = new ApplicationSummary();
     dto.setId(sum.getId());
     dto.setName(sum.getName());
@@ -79,6 +135,7 @@ public class PipelinesAdaptor implements IPipelinesAdaptor {
     }
     dto.setVersion(sum.getVersion());
     dto.setEmpty(sum.isEmpty());
+    dto.setHidden(sum.isHidden());
     return dto;
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/PipelinesAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/PipelinesAdaptorTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.percussion.design.objectstore.PSApplicationType;
+import com.percussion.design.objectstore.server.PSApplicationSummary;
+import com.percussion.rest.pipelines.ApplicationSummary;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure unit tests for {@link PipelinesAdaptor} mapping / filter / page helpers (no object-store
+ * singleton).
+ */
+@Tag("UnitTest")
+class PipelinesAdaptorTest {
+
+  @Test
+  void mapFilterSortLimit_mapsFieldsIncludingHiddenAndAppType() {
+    PSApplicationSummary src =
+        summary(7, "sys_cmpDocuments", "System docs", true, "sys_cmpDocuments", false, false);
+    when(src.getAppType()).thenReturn(PSApplicationType.CONTENT_EDITOR);
+    when(src.getVersion()).thenReturn("8.2");
+
+    List<ApplicationSummary> out =
+        PipelinesAdaptor.mapFilterSortLimit(new PSApplicationSummary[] {src}, null, 500, 0);
+
+    assertEquals(1, out.size());
+    ApplicationSummary dto = out.get(0);
+    assertEquals(7, dto.getId());
+    assertEquals("sys_cmpDocuments", dto.getName());
+    assertEquals("System docs", dto.getDescription());
+    assertEquals(Boolean.TRUE, dto.getEnabled());
+    assertEquals("sys_cmpDocuments", dto.getAppRoot());
+    assertEquals("CONTENT_EDITOR", dto.getAppType());
+    assertEquals("8.2", dto.getVersion());
+    assertEquals(Boolean.FALSE, dto.getEmpty());
+    assertEquals(Boolean.FALSE, dto.getHidden());
+  }
+
+  @Test
+  void mapFilterSortLimit_filtersByNameAndDescriptionCaseInsensitive() {
+    PSApplicationSummary a = summary(1, "AlphaApp", "first", true, "a", false, false);
+    PSApplicationSummary b = summary(2, "Beta", "Has DOCS inside", true, "b", false, false);
+    PSApplicationSummary c = summary(3, "gamma", "other", true, "c", false, false);
+    PSApplicationSummary[] sums = {a, b, c};
+
+    List<ApplicationSummary> byName =
+        PipelinesAdaptor.mapFilterSortLimit(sums, "ALPHA", 500, 0);
+    assertEquals(1, byName.size());
+    assertEquals("AlphaApp", byName.get(0).getName());
+
+    List<ApplicationSummary> byDesc =
+        PipelinesAdaptor.mapFilterSortLimit(sums, "docs", 500, 0);
+    assertEquals(1, byDesc.size());
+    assertEquals("Beta", byDesc.get(0).getName());
+  }
+
+  @Test
+  void mapFilterSortLimit_sortsByNameCaseInsensitive() {
+    PSApplicationSummary z = summary(1, "zeta", null, true, "z", false, false);
+    PSApplicationSummary a = summary(2, "Alpha", null, true, "a", false, false);
+    PSApplicationSummary m = summary(3, "mid", null, true, "m", false, false);
+
+    List<ApplicationSummary> out =
+        PipelinesAdaptor.mapFilterSortLimit(new PSApplicationSummary[] {z, a, m}, null, 500, 0);
+
+    assertEquals(List.of("Alpha", "mid", "zeta"), out.stream().map(ApplicationSummary::getName).toList());
+  }
+
+  @Test
+  void mapFilterSortLimit_clampsLimitToMaxAndDefaultsNonPositive() {
+    PSApplicationSummary[] sums = new PSApplicationSummary[5];
+    for (int i = 0; i < 5; i++) {
+      sums[i] = summary(i, "app" + i, null, true, "r" + i, false, false);
+    }
+
+    List<ApplicationSummary> defaulted =
+        PipelinesAdaptor.mapFilterSortLimit(sums, null, 0, 0);
+    assertEquals(5, defaulted.size());
+
+    List<ApplicationSummary> negativeLimit =
+        PipelinesAdaptor.mapFilterSortLimit(sums, null, -3, 0);
+    assertEquals(5, negativeLimit.size());
+
+    // Hard cap: even if limit is huge, at most MAX_LIMIT — with only 5 rows, still 5
+    List<ApplicationSummary> huge =
+        PipelinesAdaptor.mapFilterSortLimit(sums, null, PipelinesAdaptor.MAX_LIMIT + 500, 0);
+    assertEquals(5, huge.size());
+    assertEquals(1000, PipelinesAdaptor.MAX_LIMIT);
+    assertEquals(500, PipelinesAdaptor.DEFAULT_LIMIT);
+  }
+
+  @Test
+  void mapFilterSortLimit_appliesOffsetAndLimitWindow() {
+    PSApplicationSummary[] sums = new PSApplicationSummary[4];
+    for (int i = 0; i < 4; i++) {
+      // names force sort order app0..app3
+      sums[i] = summary(i, "app" + i, null, true, "r" + i, false, false);
+    }
+
+    List<ApplicationSummary> page =
+        PipelinesAdaptor.mapFilterSortLimit(sums, null, 2, 1);
+    assertEquals(2, page.size());
+    assertEquals("app1", page.get(0).getName());
+    assertEquals("app2", page.get(1).getName());
+  }
+
+  @Test
+  void mapFilterSortLimit_offsetPastEndReturnsEmpty() {
+    PSApplicationSummary only = summary(1, "solo", null, true, "s", false, false);
+    List<ApplicationSummary> out =
+        PipelinesAdaptor.mapFilterSortLimit(new PSApplicationSummary[] {only}, null, 10, 5);
+    assertTrue(out.isEmpty());
+  }
+
+  @Test
+  void mapFilterSortLimit_skipsNullEntriesAndNullArray() {
+    assertTrue(PipelinesAdaptor.mapFilterSortLimit(null, null, 10, 0).isEmpty());
+
+    PSApplicationSummary real = summary(1, "real", null, true, "r", false, false);
+    List<ApplicationSummary> out =
+        PipelinesAdaptor.mapFilterSortLimit(
+            new PSApplicationSummary[] {null, real, null}, null, 10, 0);
+    assertEquals(1, out.size());
+    assertEquals("real", out.get(0).getName());
+  }
+
+  @Test
+  void mapFilterSortLimit_mapsHiddenFlag() {
+    PSApplicationSummary hidden =
+        summary(9, "secret", "hidden app", false, "sec", true, true);
+
+    List<ApplicationSummary> out =
+        PipelinesAdaptor.mapFilterSortLimit(new PSApplicationSummary[] {hidden}, null, 10, 0);
+
+    assertEquals(1, out.size());
+    assertEquals(Boolean.TRUE, out.get(0).getHidden());
+    assertEquals(Boolean.TRUE, out.get(0).getEmpty());
+    assertEquals(Boolean.FALSE, out.get(0).getEnabled());
+  }
+
+  @Test
+  void matchesNameFilter_checksNameOrDescription() {
+    ApplicationSummary dto = new ApplicationSummary();
+    dto.setName("Sys_Foo");
+    dto.setDescription("Pipeline package");
+    assertTrue(PipelinesAdaptor.matchesNameFilter(dto, "sys_"));
+    assertTrue(PipelinesAdaptor.matchesNameFilter(dto, "package"));
+    assertFalse(PipelinesAdaptor.matchesNameFilter(dto, "missing"));
+  }
+
+  private static PSApplicationSummary summary(
+      int id,
+      String name,
+      String description,
+      boolean enabled,
+      String appRoot,
+      boolean empty,
+      boolean hidden) {
+    PSApplicationSummary sum = mock(PSApplicationSummary.class);
+    when(sum.getId()).thenReturn(id);
+    when(sum.getName()).thenReturn(name);
+    when(sum.getDescription()).thenReturn(description);
+    when(sum.isEnabled()).thenReturn(enabled);
+    when(sum.getAppRoot()).thenReturn(appRoot);
+    when(sum.isEmpty()).thenReturn(empty);
+    when(sum.isHidden()).thenReturn(hidden);
+    when(sum.getAppType()).thenReturn(PSApplicationType.USER);
+    when(sum.getVersion()).thenReturn(null);
+    return sum;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/pipelines/ApplicationSummary.java
+++ b/rest/src/main/java/com/percussion/rest/pipelines/ApplicationSummary.java
@@ -21,9 +21,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
-/**
- * Read-only summary of a server application (classic XML Application / pipeline package).
- */
+/** Read-only summary of a server application (classic XML Application / pipeline package). */
 @XmlRootElement(name = "Application")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Pipeline / XML application summary for design catalog")

--- a/rest/src/main/java/com/percussion/rest/pipelines/ApplicationSummary.java
+++ b/rest/src/main/java/com/percussion/rest/pipelines/ApplicationSummary.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.pipelines;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Read-only summary of a server application (classic XML Application / pipeline package).
+ */
+@XmlRootElement(name = "Application")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Pipeline / XML application summary for design catalog")
+public class ApplicationSummary {
+
+  private Integer id;
+  private String name;
+  private String description;
+  private Boolean enabled;
+  private String appRoot;
+  private String appType;
+  private String version;
+  private Boolean empty;
+
+  public ApplicationSummary() {}
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public Boolean getEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(Boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getAppRoot() {
+    return appRoot;
+  }
+
+  public void setAppRoot(String appRoot) {
+    this.appRoot = appRoot;
+  }
+
+  public String getAppType() {
+    return appType;
+  }
+
+  public void setAppType(String appType) {
+    this.appType = appType;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  public Boolean getEmpty() {
+    return empty;
+  }
+
+  public void setEmpty(Boolean empty) {
+    this.empty = empty;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/pipelines/ApplicationSummary.java
+++ b/rest/src/main/java/com/percussion/rest/pipelines/ApplicationSummary.java
@@ -37,6 +37,7 @@ public class ApplicationSummary {
   private String appType;
   private String version;
   private Boolean empty;
+  private Boolean hidden;
 
   public ApplicationSummary() {}
 
@@ -102,5 +103,13 @@ public class ApplicationSummary {
 
   public void setEmpty(Boolean empty) {
     this.empty = empty;
+  }
+
+  public Boolean getHidden() {
+    return hidden;
+  }
+
+  public void setHidden(Boolean hidden) {
+    this.hidden = hidden;
   }
 }

--- a/rest/src/main/java/com/percussion/rest/pipelines/IPipelinesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/pipelines/IPipelinesAdaptor.java
@@ -23,10 +23,14 @@ import java.util.List;
 public interface IPipelinesAdaptor {
 
   /**
-   * List server applications visible to the current security token (non-hidden by default).
+   * List server applications visible to the current security token.
    *
    * @param baseUri request base URI (reserved for HATEOAS)
+   * @param nameFilter optional case-insensitive name/description substring; blank = no filter
+   * @param limit max rows to return (clamped by implementation)
+   * @param offset zero-based offset into the sorted result
    * @return application summaries, never {@code null}
    */
-  List<ApplicationSummary> listApplications(URI baseUri);
+  List<ApplicationSummary> listApplications(
+      URI baseUri, String nameFilter, int limit, int offset);
 }

--- a/rest/src/main/java/com/percussion/rest/pipelines/IPipelinesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/pipelines/IPipelinesAdaptor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.pipelines;
+
+import java.net.URI;
+import java.util.List;
+
+public interface IPipelinesAdaptor {
+
+  /**
+   * List server applications visible to the current security token (non-hidden by default).
+   *
+   * @param baseUri request base URI (reserved for HATEOAS)
+   * @return application summaries, never {@code null}
+   */
+  List<ApplicationSummary> listApplications(URI baseUri);
+}

--- a/rest/src/main/java/com/percussion/rest/pipelines/IPipelinesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/pipelines/IPipelinesAdaptor.java
@@ -31,6 +31,5 @@ public interface IPipelinesAdaptor {
    * @param offset zero-based offset into the sorted result
    * @return application summaries, never {@code null}
    */
-  List<ApplicationSummary> listApplications(
-      URI baseUri, String nameFilter, int limit, int offset);
+  List<ApplicationSummary> listApplications(URI baseUri, String nameFilter, int limit, int offset);
 }

--- a/rest/src/main/java/com/percussion/rest/pipelines/PipelinesResource.java
+++ b/rest/src/main/java/com/percussion/rest/pipelines/PipelinesResource.java
@@ -46,15 +46,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 @PSSiteManageBean(value = "restPipelinesResource")
 @Path("/pipelines")
 @XmlRootElement
-@Tag(
-    name = "Pipelines",
-    description = "Data pipeline / XML application design catalog (read-only)")
+@Tag(name = "Pipelines", description = "Data pipeline / XML application design catalog (read-only)")
 public class PipelinesResource {
 
   private final IPipelinesAdaptor adaptor;
 
   @Context private UriInfo uriInfo;
 
+  /**
+   * No-arg constructor for bean-discovery edge cases. Production uses {@link
+   * #PipelinesResource(IPipelinesAdaptor)}; invoking list methods without injection fails with a
+   * clear diagnostic rather than a bare NPE.
+   */
   public PipelinesResource() {
     this.adaptor = null;
   }
@@ -79,8 +82,7 @@ public class PipelinesResource {
             content =
                 @Content(
                     array =
-                        @ArraySchema(
-                            schema = @Schema(implementation = ApplicationSummary.class)))),
+                        @ArraySchema(schema = @Schema(implementation = ApplicationSummary.class)))),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public List<ApplicationSummary> listApplications(
@@ -88,10 +90,21 @@ public class PipelinesResource {
       @QueryParam("limit") @DefaultValue("500") int limit,
       @QueryParam("offset") @DefaultValue("0") int offset) {
     try {
-      return adaptor.listApplications(uriInfo.getBaseUri(), name, limit, offset);
+      IPipelinesAdaptor bridge = requireAdaptor();
+      return bridge.listApplications(uriInfo.getBaseUri(), name, limit, offset);
+    } catch (WebApplicationException e) {
+      throw e;
     } catch (Exception e) {
       // Preserve cause; matches Keywords/Slots catalog resources
       throw new WebApplicationException(e, 500);
     }
+  }
+
+  private IPipelinesAdaptor requireAdaptor() {
+    if (adaptor == null) {
+      throw new IllegalStateException(
+          "Pipelines adaptor not configured (resource constructed without injection)");
+    }
+    return adaptor;
   }
 }

--- a/rest/src/main/java/com/percussion/rest/pipelines/PipelinesResource.java
+++ b/rest/src/main/java/com/percussion/rest/pipelines/PipelinesResource.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.pipelines;
+
+import com.percussion.system.utils.PSSiteManageBean;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriInfo;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@PSSiteManageBean(value = "restPipelinesResource")
+@Path("/pipelines")
+@XmlRootElement
+@Tag(
+    name = "Pipelines",
+    description = "Data pipeline / XML application design catalog (read-only)")
+public class PipelinesResource {
+
+  @Autowired private IPipelinesAdaptor adaptor;
+
+  @Context private UriInfo uriInfo;
+
+  public PipelinesResource() {}
+
+  @GET
+  @Path("/")
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "List pipeline applications",
+      description =
+          "Lists non-hidden server applications (classic XML Applications) visible to the"
+              + " current user. Editor / start-stop / IR import are later slices.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content =
+                @Content(
+                    array =
+                        @ArraySchema(
+                            schema = @Schema(implementation = ApplicationSummary.class)))),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public List<ApplicationSummary> listApplications() {
+    try {
+      return adaptor.listApplications(uriInfo.getBaseUri());
+    } catch (Exception e) {
+      // Preserve cause so log analysis retains the original stack/type
+      throw new WebApplicationException(e, 500);
+    }
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/pipelines/PipelinesResource.java
+++ b/rest/src/main/java/com/percussion/rest/pipelines/PipelinesResource.java
@@ -24,9 +24,11 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
@@ -35,6 +37,12 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 
+/**
+ * Read-only catalog of classic XML Applications (pipeline packages) for the Developer module.
+ *
+ * <p>Registered via {@link PSSiteManageBean} like sibling catalog resources ({@code Keywords},
+ * {@code Slots}).
+ */
 @PSSiteManageBean(value = "restPipelinesResource")
 @Path("/pipelines")
 @XmlRootElement
@@ -43,20 +51,27 @@ import org.springframework.beans.factory.annotation.Autowired;
     description = "Data pipeline / XML application design catalog (read-only)")
 public class PipelinesResource {
 
-  @Autowired private IPipelinesAdaptor adaptor;
+  private final IPipelinesAdaptor adaptor;
 
   @Context private UriInfo uriInfo;
 
-  public PipelinesResource() {}
+  public PipelinesResource() {
+    this.adaptor = null;
+  }
+
+  @Autowired
+  public PipelinesResource(IPipelinesAdaptor adaptor) {
+    this.adaptor = adaptor;
+  }
 
   @GET
-  @Path("/")
   @Produces({MediaType.APPLICATION_JSON})
   @Operation(
       summary = "List pipeline applications",
       description =
           "Lists non-hidden server applications (classic XML Applications) visible to the"
-              + " current user. Editor / start-stop / IR import are later slices.",
+              + " current user. Supports optional name filter and limit/offset. Editor /"
+              + " start-stop / IR import are later slices.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -68,11 +83,14 @@ public class PipelinesResource {
                             schema = @Schema(implementation = ApplicationSummary.class)))),
         @ApiResponse(responseCode = "500", description = "Error")
       })
-  public List<ApplicationSummary> listApplications() {
+  public List<ApplicationSummary> listApplications(
+      @QueryParam("name") String name,
+      @QueryParam("limit") @DefaultValue("500") int limit,
+      @QueryParam("offset") @DefaultValue("0") int offset) {
     try {
-      return adaptor.listApplications(uriInfo.getBaseUri());
+      return adaptor.listApplications(uriInfo.getBaseUri(), name, limit, offset);
     } catch (Exception e) {
-      // Preserve cause so log analysis retains the original stack/type
+      // Preserve cause; matches Keywords/Slots catalog resources
       throw new WebApplicationException(e, 500);
     }
   }

--- a/rest/src/test/java/com/percussion/rest/pipelines/PipelinesResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/pipelines/PipelinesResourceTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.pipelines;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.UriInfo;
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class PipelinesResourceTest {
+
+  private IPipelinesAdaptor adaptor;
+  private PipelinesResource resource;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    adaptor = mock(IPipelinesAdaptor.class);
+    resource = new PipelinesResource(adaptor);
+    UriInfo uriInfo = mock(UriInfo.class);
+    when(uriInfo.getBaseUri()).thenReturn(URI.create("http://localhost/services/"));
+    Field f = PipelinesResource.class.getDeclaredField("uriInfo");
+    f.setAccessible(true);
+    f.set(resource, uriInfo);
+  }
+
+  @Test
+  public void listApplicationsDelegatesToAdaptor() {
+    ApplicationSummary a = new ApplicationSummary();
+    a.setName("sys_foo");
+    when(adaptor.listApplications(any(), isNull(), eq(500), eq(0))).thenReturn(List.of(a));
+
+    List<ApplicationSummary> out = resource.listApplications(null, 500, 0);
+
+    assertEquals(1, out.size());
+    assertEquals("sys_foo", out.get(0).getName());
+    verify(adaptor).listApplications(any(), isNull(), eq(500), eq(0));
+  }
+
+  @Test
+  public void listApplicationsPassesNameAndPaging() {
+    when(adaptor.listApplications(any(), eq("doc"), eq(10), eq(5))).thenReturn(List.of());
+
+    resource.listApplications("doc", 10, 5);
+
+    verify(adaptor).listApplications(any(), eq("doc"), eq(10), eq(5));
+  }
+
+  @Test
+  public void listApplicationsWrapsFailures() {
+    when(adaptor.listApplications(any(), any(), anyInt(), anyInt()))
+        .thenThrow(new IllegalStateException("boom"));
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.listApplications(null, 500, 0));
+    assertEquals(500, ex.getResponse().getStatus());
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/pipelines/PipelinesResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/pipelines/PipelinesResourceTest.java
@@ -18,6 +18,8 @@
 package com.percussion.rest.pipelines;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -77,12 +79,24 @@ public class PipelinesResourceTest {
 
   @Test
   public void listApplicationsWrapsFailures() {
-    when(adaptor.listApplications(any(), any(), anyInt(), anyInt()))
-        .thenThrow(new IllegalStateException("boom"));
+    IllegalStateException boom = new IllegalStateException("boom");
+    when(adaptor.listApplications(any(), any(), anyInt(), anyInt())).thenThrow(boom);
 
     WebApplicationException ex =
-        assertThrows(
-            WebApplicationException.class, () -> resource.listApplications(null, 500, 0));
+        assertThrows(WebApplicationException.class, () -> resource.listApplications(null, 500, 0));
     assertEquals(500, ex.getResponse().getStatus());
+    assertSame(boom, ex.getCause(), "cause chain must preserve the original failure");
+  }
+
+  @Test
+  public void listApplicationsWithoutInjectionFailsWithDiagnostic() {
+    PipelinesResource bare = new PipelinesResource();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.listApplications(null, 500, 0));
+    assertEquals(500, ex.getResponse().getStatus());
+    assertInstanceOf(IllegalStateException.class, ex.getCause());
+    assertEquals(
+        "Pipelines adaptor not configured (resource constructed without injection)",
+        ex.getCause().getMessage());
   }
 }


### PR DESCRIPTION
## Summary

Next Developer-module slice as a **new PR** off `development` (post-#1588).

- **API:** `GET /services/pipelines` — non-hidden server applications via `PSServerXmlObjectStore.getApplicationSummaryObjects` (id, name, description, enabled, appRoot, appType, version, empty)
- **SPA:** Pipelines tab is a live read-only catalog (no longer a placeholder)
- **Docs:** P0 task README marks P0.6 done; next slices called out as separate PRs

## Scope boundary

Read catalog only. No start/stop, editor, IR import, or Slice A runtime.

## Test plan

- [x] `npm test -- --run src/test/ts/developer` (5/5)
- [x] `mvn -pl rest,projects/sitemanage -am compile -DskipTests`
- [ ] Manual: Developer → Pipelines shows apps for a designer session

> Co-Authored by Grok Build using grok-4.5 with agent Grok.