### PR TITLE
fix(workflow): isolate CONTENTSTATUS notify-map test from static init

### DIFF
--- a/system/src/main/java/com/percussion/workflow/PSContentStatusContext.java
+++ b/system/src/main/java/com/percussion/workflow/PSContentStatusContext.java
@@ -495,8 +495,9 @@ public class PSContentStatusContext implements IPSContentStatusContext {
   }
 
   /**
-   * Builds the same 15-column change map that the legacy {@code commit(Connection)} path populated
-   * via setInt/setString/setDate for item-summary cache notify.
+   * Single seam from Hibernate {@link #commit()} to {@link PSContentStatusNotifyMap}: maps
+   * instance CONTENTSTATUS fields into the 15-column notify map (legacy setInt/setString/setDate
+   * order). Kept as a private method so commit() stays readable; not used outside this class.
    */
   private java.util.Map<String, String> buildLegacyColumnMap() {
     return PSContentStatusNotifyMap.build(

--- a/system/src/main/java/com/percussion/workflow/PSContentStatusContext.java
+++ b/system/src/main/java/com/percussion/workflow/PSContentStatusContext.java
@@ -492,57 +492,31 @@ public class PSContentStatusContext implements IPSContentStatusContext {
             reminderDate,
             repeatedAgingStartDate);
     if (updated > 0) {
-      java.util.Map<String, String> columns = buildLegacyColumnMap();
-      notifyUpdateItem(columns);
+      notifyUpdateItem(buildLegacyColumnMap());
     }
   }
 
   /**
    * Builds the same 15-column change map that the legacy {@code commit(Connection)}
-   * path populated via {@link #setInt}, {@link #setString}, and {@link #setDate}.
-   * The item-summary cache (PSItemSummaryCache) relies on these keys to invalidate
-   * stale entries after a CONTENTSTATUS update.
-   *
-   * @return an unmodifiable ordered map of column-name to string-value,
-   *     never {@code null}.
+   * path populated via setInt/setString/setDate for item-summary cache notify.
    */
   private java.util.Map<String, String> buildLegacyColumnMap() {
-    java.util.Map<String, String> columns = new java.util.LinkedHashMap<>();
-    String checkOutUserName = m_sCheckOutUserName == null ? "" : m_sCheckOutUserName;
-    java.sql.Date lastTransitionDate = m_LastTransitionDate;
-    java.sql.Date stateEnteredDate = m_StateEnteredDate;
-    java.sql.Date nextAgingDate = m_NextAgingDate;
-    java.sql.Date startDate = m_StartDate;
-    java.sql.Date expiryDate = m_ExpiryDate;
-    java.sql.Date reminderDate = m_ReminderDate;
-    java.sql.Date repeatedAgingStartDate = m_RepeatedAgingTransitionStartDate;
-    int nextAgingTransition = m_nNextAgingTransition;
-    columns.put(CONTENTSTATEID, Integer.toString(m_nStateID));
-    columns.put(CONTENTCHECKOUTUSERNAME, checkOutUserName);
-    columns.put(CURRENTREVISION, Integer.toString(m_nCurrentRevision));
-    columns.put(EDITREVISION, Integer.toString(m_nEditRevision));
-    columns.put(TIPREVISION, Integer.toString(m_nTipRevision));
-    columns.put(REVISIONLOCK, m_bRevisionLocked ? "Y" : "N");
-    columns.put(LASTTRANSITIONDATE, formatDate(lastTransitionDate));
-    columns.put(STATEENTEREDDATE, formatDate(stateEnteredDate));
-    columns.put(NEXTAGINGTRANSITION, Integer.toString(nextAgingTransition));
-    columns.put(NEXTAGINGDATE, formatDate(nextAgingDate));
-    columns.put(CONTENTSTARTDATE, formatDate(startDate));
-    columns.put(CONTENTEXPIRYDATE, formatDate(expiryDate));
-    columns.put(REMINDERDATE, formatDate(reminderDate));
-    columns.put(REPEATEDAGINGTRANSSTARTDATE, formatDate(repeatedAgingStartDate));
-    columns.put(CONTENTID, Integer.toString(m_nContentID));
-    return java.util.Collections.unmodifiableMap(columns);
-  }
-
-  /**
-   * Converts a {@link java.sql.Date} to the legacy "mm/dd/yyyy hh:mm:ss:milli"
-   * string emitted by {@link PSWorkFlowUtils#DateString(java.util.Date)}. The
-   * item-summary cache only needs a stable string representation; null dates
-   * become {@code null} map values.
-   */
-  private static String formatDate(java.sql.Date date) {
-    return date == null ? null : PSWorkFlowUtils.DateString(date);
+    return PSContentStatusNotifyMap.build(
+        m_nContentID,
+        m_nStateID,
+        m_sCheckOutUserName,
+        m_nCurrentRevision,
+        m_nEditRevision,
+        m_nTipRevision,
+        m_bRevisionLocked,
+        m_LastTransitionDate,
+        m_StateEnteredDate,
+        m_nNextAgingTransition,
+        m_NextAgingDate,
+        m_StartDate,
+        m_ExpiryDate,
+        m_ReminderDate,
+        m_RepeatedAgingTransitionStartDate);
   }
 
   /*

--- a/system/src/main/java/com/percussion/workflow/PSContentStatusContext.java
+++ b/system/src/main/java/com/percussion/workflow/PSContentStatusContext.java
@@ -371,11 +371,10 @@ public class PSContentStatusContext implements IPSContentStatusContext {
   }
 
   /**
-   * Hibernate-backed factory added for #1561 Phase 4d-1b. Loads the {@code CONTENTSTATUS} row
-   * for the supplied content id via the shared Hibernate session — no second pool connection.
-   * Mirrors the field set populated by the raw-JDBC
-   * {@link #PSContentStatusContext(Connection, int)} constructor (the 14 columns the legacy
-   * {@code commit(Connection)} write path touches).
+   * Hibernate-backed factory added for #1561 Phase 4d-1b. Loads the {@code CONTENTSTATUS} row for
+   * the supplied content id via the shared Hibernate session — no second pool connection. Mirrors
+   * the field set populated by the raw-JDBC {@link #PSContentStatusContext(Connection, int)}
+   * constructor (the 14 columns the legacy {@code commit(Connection)} write path touches).
    *
    * @param contentID the content id; must be {@code > 0}.
    * @return the populated context, never {@code null}.
@@ -422,7 +421,8 @@ public class PSContentStatusContext implements IPSContentStatusContext {
     ctx.m_nContentTypeID = (int) summary.getContentTypeId();
     ctx.m_nObjectType = summary.getObjectType();
     ctx.m_sTitle = "";
-    ctx.m_sCreatedByName = summary.getContentCreatedBy() == null ? "" : summary.getContentCreatedBy();
+    ctx.m_sCreatedByName =
+        summary.getContentCreatedBy() == null ? "" : summary.getContentCreatedBy();
     ctx.m_sLastModifierName =
         summary.getContentLastModifier() == null ? "" : summary.getContentLastModifier();
     return ctx;
@@ -436,28 +436,26 @@ public class PSContentStatusContext implements IPSContentStatusContext {
 
   /**
    * Converts a {@link java.util.Date} (which is what {@code PSComponentSummary} returns) to a
-   * {@link java.sql.Date} (which is what the legacy {@code PSContentStatusContext} fields
-   * use). Returns {@code null} for a {@code null} input.
+   * {@link java.sql.Date} (which is what the legacy {@code PSContentStatusContext} fields use).
+   * Returns {@code null} for a {@code null} input.
    */
   private static java.sql.Date toSqlDate(java.util.Date in) {
     return in == null ? null : new java.sql.Date(in.getTime());
   }
 
   /**
-   * Hibernate-backed #1561 Phase 4d-1b write path for {@code PSExitPerformTransition}.
-    * Replaces the legacy raw-JDBC UPDATE on {@code CONTENTSTATUS} with a single
-    * JPQL UPDATE through {@code IPSSystemService}. All 15 columns the legacy
-    * {@code commit(Connection)} wrote are written here.
+   * Hibernate-backed #1561 Phase 4d-1b write path for {@code PSExitPerformTransition}. Replaces the
+   * legacy raw-JDBC UPDATE on {@code CONTENTSTATUS} with a single JPQL UPDATE through {@code
+   * IPSSystemService}. All 15 columns the legacy {@code commit(Connection)} wrote are written here.
    *
-   * <p>Phase 4d-1b hot-fix: after a successful UPDATE, fires
-   * {@link PSItemSummaryCache#tableChanged(PSTableChangeEvent)} to mirror the legacy
-   * {@code commit(Connection)} {@code notifyUpdateItem(columns)} behavior. Without this
-   * event, the item-summary cache shows stale state / checkout user / revision after
-   * check-in / check-out / transition until an unrelated refresh. See PR #1589 review
-   * thread databaseId 3670378976.
+   * <p>Phase 4d-1b hot-fix: after a successful UPDATE, fires {@link
+   * PSItemSummaryCache#tableChanged(PSTableChangeEvent)} to mirror the legacy {@code
+   * commit(Connection)} {@code notifyUpdateItem(columns)} behavior. Without this event, the
+   * item-summary cache shows stale state / checkout user / revision after check-in / check-out /
+   * transition until an unrelated refresh. See PR #1589 review thread databaseId 3670378976.
    *
-   * <p>The legacy raw-JDBC {@code commit(Connection)} overload above remains for any
-   * external caller that still passes a JDBC {@code Connection}.
+   * <p>The legacy raw-JDBC {@code commit(Connection)} overload above remains for any external
+   * caller that still passes a JDBC {@code Connection}.
    */
   public void commit() {
     if (m_nContentID <= 0) {
@@ -497,8 +495,8 @@ public class PSContentStatusContext implements IPSContentStatusContext {
   }
 
   /**
-   * Builds the same 15-column change map that the legacy {@code commit(Connection)}
-   * path populated via setInt/setString/setDate for item-summary cache notify.
+   * Builds the same 15-column change map that the legacy {@code commit(Connection)} path populated
+   * via setInt/setString/setDate for item-summary cache notify.
    */
   private java.util.Map<String, String> buildLegacyColumnMap() {
     return PSContentStatusNotifyMap.build(
@@ -938,21 +936,27 @@ public class PSContentStatusContext implements IPSContentStatusContext {
   /** Portion of SQL update string specifying which status record fields to update. */
   private static final String WHERESTRING = " WHERE " + TABLE_CSC + ".CONTENTID=?";
 
-  /** Column names for CONTENTSTATUS table */
-  private static final String CONTENTID = "CONTENTID";
+  /**
+   * Column names for CONTENTSTATUS table. Canonical string literals live on {@link
+   * PSContentStatusNotifyMap}; aliases here keep the legacy setInt/setString/setDate call sites
+   * readable without duplicating the literals.
+   */
+  private static final String CONTENTID = PSContentStatusNotifyMap.CONTENTID;
 
-  private static final String CONTENTSTATEID = "CONTENTSTATEID";
-  private static final String CONTENTCHECKOUTUSERNAME = "CONTENTCHECKOUTUSERNAME";
-  private static final String CURRENTREVISION = "CURRENTREVISION";
-  private static final String EDITREVISION = "EDITREVISION";
-  private static final String TIPREVISION = "TIPREVISION";
-  private static final String REVISIONLOCK = "REVISIONLOCK";
-  private static final String LASTTRANSITIONDATE = "LASTTRANSITIONDATE";
-  private static final String STATEENTEREDDATE = "STATEENTEREDDATE";
-  private static final String NEXTAGINGTRANSITION = "NEXTAGINGTRANSITION";
-  private static final String NEXTAGINGDATE = "NEXTAGINGDATE";
-  private static final String CONTENTSTARTDATE = "CONTENTSTARTDATE";
-  private static final String CONTENTEXPIRYDATE = "CONTENTEXPIRYDATE";
-  private static final String REMINDERDATE = "REMINDERDATE";
-  private static final String REPEATEDAGINGTRANSSTARTDATE = "REPEATEDAGINGTRANSSTARTDATE";
+  private static final String CONTENTSTATEID = PSContentStatusNotifyMap.CONTENTSTATEID;
+  private static final String CONTENTCHECKOUTUSERNAME =
+      PSContentStatusNotifyMap.CONTENTCHECKOUTUSERNAME;
+  private static final String CURRENTREVISION = PSContentStatusNotifyMap.CURRENTREVISION;
+  private static final String EDITREVISION = PSContentStatusNotifyMap.EDITREVISION;
+  private static final String TIPREVISION = PSContentStatusNotifyMap.TIPREVISION;
+  private static final String REVISIONLOCK = PSContentStatusNotifyMap.REVISIONLOCK;
+  private static final String LASTTRANSITIONDATE = PSContentStatusNotifyMap.LASTTRANSITIONDATE;
+  private static final String STATEENTEREDDATE = PSContentStatusNotifyMap.STATEENTEREDDATE;
+  private static final String NEXTAGINGTRANSITION = PSContentStatusNotifyMap.NEXTAGINGTRANSITION;
+  private static final String NEXTAGINGDATE = PSContentStatusNotifyMap.NEXTAGINGDATE;
+  private static final String CONTENTSTARTDATE = PSContentStatusNotifyMap.CONTENTSTARTDATE;
+  private static final String CONTENTEXPIRYDATE = PSContentStatusNotifyMap.CONTENTEXPIRYDATE;
+  private static final String REMINDERDATE = PSContentStatusNotifyMap.REMINDERDATE;
+  private static final String REPEATEDAGINGTRANSSTARTDATE =
+      PSContentStatusNotifyMap.REPEATEDAGINGTRANSSTARTDATE;
 }

--- a/system/src/main/java/com/percussion/workflow/PSContentStatusNotifyMap.java
+++ b/system/src/main/java/com/percussion/workflow/PSContentStatusNotifyMap.java
@@ -23,11 +23,15 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Builds the 15-column CONTENTSTATUS change map used by {@link
- * PSContentStatusContext#commit()} for item-summary cache notify events.
+ * Builds the 15-column CONTENTSTATUS change map used by {@link PSContentStatusContext#commit()} for
+ * item-summary cache notify events.
  *
- * <p>Kept free of JDBC / Spring / {@link PSWorkFlowUtils} static initializers so unit
- * tests can pin the map shape without a live server or rxdeploydir.
+ * <p>Kept free of JDBC / Spring / {@link PSWorkFlowUtils} static initializers so unit tests can pin
+ * the map shape without a live server or rxdeploydir.
+ *
+ * <p>Canonical home for the 15 CONTENTSTATUS notify column-name constants. Callers such as {@link
+ * PSContentStatusContext} must reference these rather than re-declaring string literals so a future
+ * schema change touches a single file.
  */
 final class PSContentStatusNotifyMap {
 
@@ -50,8 +54,21 @@ final class PSContentStatusNotifyMap {
   private PSContentStatusNotifyMap() {}
 
   /**
-   * Same 15 columns the legacy {@code PSContentStatusContext.commit(Connection)} path put
-   * into {@code notifyUpdateItem} via setInt/setString/setDate.
+   * Same 15 columns the legacy {@code PSContentStatusContext.commit(Connection)} path put into
+   * {@code notifyUpdateItem} via setInt/setString/setDate.
+   *
+   * <p><strong>Argument order</strong> mirrors the legacy {@code setInt}/{@code setString}/ {@code
+   * setDate} call sequence in {@link PSContentStatusContext#commit(java.sql.Connection)} (state,
+   * checkout user, current/edit/tip revision, revision lock, last-transition date, state-entered
+   * date, next-aging transition/date, start/expiry/reminder/repeated-aging dates, then content id
+   * last). Keep that order greppable against the JDBC path; swapping positional ints (e.g. edit vs
+   * tip revision) fails silently.
+   *
+   * <p><strong>Null date values are intentional:</strong> date columns whose input is {@code null}
+   * are stored as map values of {@code null} (not {@code ""}), matching legacy {@code setDate(...)}
+   * which puts {@code null} into the notify map when the column date is unset. Do not "fix" null
+   * map values to empty string — that would change the notify contract for {@link
+   * com.percussion.server.cache.PSItemSummaryCache}.
    *
    * @return unmodifiable ordered map, never {@code null}
    */
@@ -92,9 +109,19 @@ final class PSContentStatusNotifyMap {
   }
 
   /**
-   * Legacy {@code mm/dd/yyyy hh:mm:ss:milli} shape (same as {@link
-   * PSWorkFlowUtils#DateString(Date)} for non-null dates). Null dates stay {@code null} so
-   * the map matches legacy {@code setDate} (which does not call DateString for null).
+   * Legacy {@code mm/dd/yyyy H:MM:SS:milli} shape using {@link Calendar#HOUR} (0–11), matching
+   * {@link PSWorkFlowUtils#DateString(Date)} for non-null dates.
+   *
+   * <p><strong>Intentional duplication:</strong> this method deliberately does <em>not</em> call
+   * {@code PSWorkFlowUtils.DateString} so this class stays free of {@code PSWorkFlowUtils}'s
+   * static-initializer chain (JDBC / Spring / rxdeploydir). Keep both implementations in lockstep
+   * if the format ever changes; do not "dedupe" by calling {@code DateString} from here without
+   * re-evaluating the ExceptionInInitializerError isolation that motivated this helper (see PR
+   * #1589 / #1595).
+   *
+   * <p>Null dates stay {@code null} (not {@code ""}) so the map matches legacy {@code setDate}
+   * which does not call {@code DateString} for null inputs — distinct from {@link
+   * PSWorkFlowUtils#DateString(Date)}, which returns {@code ""} for null.
    */
   static String formatDate(Date date) {
     if (date == null) {

--- a/system/src/main/java/com/percussion/workflow/PSContentStatusNotifyMap.java
+++ b/system/src/main/java/com/percussion/workflow/PSContentStatusNotifyMap.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 1999-2025 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.workflow;
+
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Builds the 15-column CONTENTSTATUS change map used by {@link
+ * PSContentStatusContext#commit()} for item-summary cache notify events.
+ *
+ * <p>Kept free of JDBC / Spring / {@link PSWorkFlowUtils} static initializers so unit
+ * tests can pin the map shape without a live server or rxdeploydir.
+ */
+final class PSContentStatusNotifyMap {
+
+  static final String CONTENTID = "CONTENTID";
+  static final String CONTENTSTATEID = "CONTENTSTATEID";
+  static final String CONTENTCHECKOUTUSERNAME = "CONTENTCHECKOUTUSERNAME";
+  static final String CURRENTREVISION = "CURRENTREVISION";
+  static final String EDITREVISION = "EDITREVISION";
+  static final String TIPREVISION = "TIPREVISION";
+  static final String REVISIONLOCK = "REVISIONLOCK";
+  static final String LASTTRANSITIONDATE = "LASTTRANSITIONDATE";
+  static final String STATEENTEREDDATE = "STATEENTEREDDATE";
+  static final String NEXTAGINGTRANSITION = "NEXTAGINGTRANSITION";
+  static final String NEXTAGINGDATE = "NEXTAGINGDATE";
+  static final String CONTENTSTARTDATE = "CONTENTSTARTDATE";
+  static final String CONTENTEXPIRYDATE = "CONTENTEXPIRYDATE";
+  static final String REMINDERDATE = "REMINDERDATE";
+  static final String REPEATEDAGINGTRANSSTARTDATE = "REPEATEDAGINGTRANSSTARTDATE";
+
+  private PSContentStatusNotifyMap() {}
+
+  /**
+   * Same 15 columns the legacy {@code PSContentStatusContext.commit(Connection)} path put
+   * into {@code notifyUpdateItem} via setInt/setString/setDate.
+   *
+   * @return unmodifiable ordered map, never {@code null}
+   */
+  static Map<String, String> build(
+      int contentId,
+      int stateId,
+      String checkOutUserName,
+      int currentRevision,
+      int editRevision,
+      int tipRevision,
+      boolean revisionLocked,
+      Date lastTransitionDate,
+      Date stateEnteredDate,
+      int nextAgingTransition,
+      Date nextAgingDate,
+      Date startDate,
+      Date expiryDate,
+      Date reminderDate,
+      Date repeatedAgingStartDate) {
+    Map<String, String> columns = new LinkedHashMap<>();
+    String user = checkOutUserName == null ? "" : checkOutUserName;
+    columns.put(CONTENTSTATEID, Integer.toString(stateId));
+    columns.put(CONTENTCHECKOUTUSERNAME, user);
+    columns.put(CURRENTREVISION, Integer.toString(currentRevision));
+    columns.put(EDITREVISION, Integer.toString(editRevision));
+    columns.put(TIPREVISION, Integer.toString(tipRevision));
+    columns.put(REVISIONLOCK, revisionLocked ? "Y" : "N");
+    columns.put(LASTTRANSITIONDATE, formatDate(lastTransitionDate));
+    columns.put(STATEENTEREDDATE, formatDate(stateEnteredDate));
+    columns.put(NEXTAGINGTRANSITION, Integer.toString(nextAgingTransition));
+    columns.put(NEXTAGINGDATE, formatDate(nextAgingDate));
+    columns.put(CONTENTSTARTDATE, formatDate(startDate));
+    columns.put(CONTENTEXPIRYDATE, formatDate(expiryDate));
+    columns.put(REMINDERDATE, formatDate(reminderDate));
+    columns.put(REPEATEDAGINGTRANSSTARTDATE, formatDate(repeatedAgingStartDate));
+    columns.put(CONTENTID, Integer.toString(contentId));
+    return Collections.unmodifiableMap(columns);
+  }
+
+  /**
+   * Legacy {@code mm/dd/yyyy hh:mm:ss:milli} shape (same as {@link
+   * PSWorkFlowUtils#DateString(Date)} for non-null dates). Null dates stay {@code null} so
+   * the map matches legacy {@code setDate} (which does not call DateString for null).
+   */
+  static String formatDate(Date date) {
+    if (date == null) {
+      return null;
+    }
+    Calendar calendar = Calendar.getInstance();
+    calendar.setTime(date);
+    StringBuilder buf = new StringBuilder();
+    buf.append((calendar.get(Calendar.MONTH) + 1)).append('/');
+    buf.append(calendar.get(Calendar.DAY_OF_MONTH)).append('/');
+    buf.append(calendar.get(Calendar.YEAR)).append(' ');
+    buf.append(calendar.get(Calendar.HOUR)).append(':');
+    buf.append(calendar.get(Calendar.MINUTE)).append(':');
+    buf.append(calendar.get(Calendar.SECOND)).append(':');
+    buf.append(calendar.get(Calendar.MILLISECOND));
+    return buf.toString();
+  }
+}

--- a/system/src/test/java/com/percussion/workflow/PSContentStatusContextCommitTest.java
+++ b/system/src/test/java/com/percussion/workflow/PSContentStatusContextCommitTest.java
@@ -19,23 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.percussion.services.system.IPSSystemService;
-import com.percussion.services.system.PSSystemServiceLocator;
-import com.percussion.utils.jdbc.PSConnectionDetail;
-import com.percussion.utils.jdbc.PSConnectionHelper;
-import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.sql.Date;
 import java.time.Instant;
 import java.util.Map;
@@ -43,190 +28,108 @@ import java.util.TimeZone;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 
 /**
- * Behavioral tests for the PR #1589 review thread databaseId 3670378976 hot-fix:
- * PSContentStatusContext.commit() must populate all 15 legacy CONTENTSTATUS
- * columns in the notifyUpdateItem map, not CONTENTID-only.
+ * Behavioral tests for the PR #1589 hot-fix #2 notify map: Hibernate {@code
+ * PSContentStatusContext.commit()} must populate all 15 legacy CONTENTSTATUS columns for
+ * item-summary cache invalidation (not CONTENTID-only).
  *
- * <p>This test runs in the same package as PSContentStatusContext so the
- * package-private buildLegacyColumnMap() and default constructor are directly
- * accessible. The static initializer chain (PSConnectionMgr.getQualifiedIdentifier
- * + PSWorkFlowUtils.encryptWorkflowProps + loadProperties) is mocked in
- * {@link #beforeAll} so the class can load without a live DB or Spring
- * context.</p>
+ * <p>Tests {@link PSContentStatusNotifyMap} only — pure map building with no JDBC, Spring,
+ * {@code PSConnectionMgr}, or {@code PSWorkFlowUtils} static initializers — so the suite
+ * does not hit {@code ExceptionInInitializerError} when other tests have already poisoned
+ * those class statics.
  */
 public class PSContentStatusContextCommitTest {
 
-  private static final String EXPECTED_RX_ROOT;
-  private static final Path RXDEPLOY_DIR;
-  private static final Path RXRUN_DIR;
-  private static MockedStatic<PSSystemServiceLocator> LOCATOR_MOCK;
-  private static MockedStatic<PSConnectionHelper> HELPER_MOCK;
-  private static IPSSystemService MOCK_SVC;
-
-  static {
-    Path tmp;
-    try {
-      tmp = Files.createTempDirectory("percussion-test-rx-");
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-    tmp.toFile().deleteOnExit();
-    RXDEPLOY_DIR = tmp;
-    RXRUN_DIR = tmp.resolve("rxconfig").resolve("Workflow");
-    EXPECTED_RX_ROOT = RXDEPLOY_DIR.toAbsolutePath().toString();
-  }
+  private static TimeZone previousTz;
 
   @BeforeAll
-  static void beforeAll() throws Exception {
+  static void beforeAll() {
+    previousTz = TimeZone.getDefault();
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-    Files.createDirectories(RXRUN_DIR);
-
-    String propsContent =
-        "TESTWITHOUTSERVER=false\n"
-            + "PSCONSOLETRACEMESSAGES=false\n"
-            + "SMTP_PASSWORD=\n";
-    Files.writeString(RXRUN_DIR.resolve("rxworkflow.properties"), propsContent, StandardCharsets.UTF_8);
-
-    System.setProperty("rxdeploydir", EXPECTED_RX_ROOT);
-
-    HELPER_MOCK = mockStatic(PSConnectionHelper.class);
-    PSConnectionDetail detail = mock(PSConnectionDetail.class);
-    when(detail.getDatabase()).thenReturn("RX");
-    when(detail.getOrigin()).thenReturn("PERCUSSION");
-    when(PSConnectionHelper.getConnectionDetail(any())).thenReturn(detail);
-
-    MOCK_SVC = mock(IPSSystemService.class);
-    when(MOCK_SVC.updateContentStatusState(anyInt(), anyInt(), any(String.class), anyInt(), anyInt(),
-        anyInt(), anyBoolean(), any(java.util.Date.class), any(java.util.Date.class), anyInt(),
-        any(java.util.Date.class), any(java.util.Date.class), any(java.util.Date.class),
-        any(java.util.Date.class), any(java.util.Date.class))).thenReturn(1);
-
-    LOCATOR_MOCK = mockStatic(PSSystemServiceLocator.class);
-    when(PSSystemServiceLocator.getSystemService()).thenReturn(MOCK_SVC);
   }
 
   @AfterAll
   static void afterAll() {
-    TimeZone.setDefault(null);
-    if (LOCATOR_MOCK != null) {
-      LOCATOR_MOCK.close();
+    if (previousTz != null) {
+      TimeZone.setDefault(previousTz);
     }
-    if (HELPER_MOCK != null) {
-      HELPER_MOCK.close();
-    }
-    System.clearProperty("rxdeploydir");
   }
 
   @Test
-  void buildLegacyColumnMap_populatesAllFifteenColumns() throws Exception {
-    PSContentStatusContext ctx = createContext();
-    setField(ctx, "m_nContentID", 7);
-    setField(ctx, "m_nStateID", 11);
-    setField(ctx, "m_sCheckOutUserName", "alice");
-    setField(ctx, "m_nCurrentRevision", 5);
-    setField(ctx, "m_nEditRevision", 6);
-    setField(ctx, "m_nTipRevision", 7);
-    setField(ctx, "m_bRevisionLocked", true);
-    setField(ctx, "m_LastTransitionDate", toSqlDate(Instant.parse("2026-07-28T12:00:00Z")));
-    setField(ctx, "m_StateEnteredDate", toSqlDate(Instant.parse("2026-07-27T08:30:00Z")));
-    setField(ctx, "m_nNextAgingTransition", 3);
-    setField(ctx, "m_NextAgingDate", toSqlDate(Instant.parse("2026-08-01T00:00:00Z")));
-    setField(ctx, "m_StartDate", toSqlDate(Instant.parse("2026-07-01T00:00:00Z")));
-    setField(ctx, "m_ExpiryDate", toSqlDate(Instant.parse("2026-12-31T23:59:59Z")));
-    setField(ctx, "m_ReminderDate", toSqlDate(Instant.parse("2026-12-24T09:00:00Z")));
-    setField(ctx, "m_RepeatedAgingTransitionStartDate",
-        toSqlDate(Instant.parse("2026-07-28T00:00:00Z")));
-
-    @SuppressWarnings("unchecked")
-    Map<String, String> columns = (Map<String, String>) invokeMethod(ctx, "buildLegacyColumnMap");
+  void buildLegacyColumnMap_populatesAllFifteenColumns() {
+    Map<String, String> columns =
+        PSContentStatusNotifyMap.build(
+            7,
+            11,
+            "alice",
+            5,
+            6,
+            7,
+            true,
+            toSqlDate(Instant.parse("2026-07-28T12:00:00Z")),
+            toSqlDate(Instant.parse("2026-07-27T08:30:00Z")),
+            3,
+            toSqlDate(Instant.parse("2026-08-01T00:00:00Z")),
+            toSqlDate(Instant.parse("2026-07-01T00:00:00Z")),
+            toSqlDate(Instant.parse("2026-12-31T23:59:59Z")),
+            toSqlDate(Instant.parse("2026-12-24T09:00:00Z")),
+            toSqlDate(Instant.parse("2026-07-28T00:00:00Z")));
 
     assertEquals(15, columns.size(), "Legacy map must contain exactly 15 columns");
-    assertEquals("11", columns.get("CONTENTSTATEID"));
-    assertEquals("alice", columns.get("CONTENTCHECKOUTUSERNAME"));
-    assertEquals("5", columns.get("CURRENTREVISION"));
-    assertEquals("6", columns.get("EDITREVISION"));
-    assertEquals("7", columns.get("TIPREVISION"));
-    assertEquals("Y", columns.get("REVISIONLOCK"));
-    assertNotNull(columns.get("LASTTRANSITIONDATE"));
-    assertFalse(columns.get("LASTTRANSITIONDATE").isEmpty());
-    assertNotNull(columns.get("STATEENTEREDDATE"));
-    assertFalse(columns.get("STATEENTEREDDATE").isEmpty());
-    assertEquals("3", columns.get("NEXTAGINGTRANSITION"));
-    assertNotNull(columns.get("NEXTAGINGDATE"));
-    assertFalse(columns.get("NEXTAGINGDATE").isEmpty());
-    assertNotNull(columns.get("CONTENTSTARTDATE"));
-    assertFalse(columns.get("CONTENTSTARTDATE").isEmpty());
-    assertNotNull(columns.get("CONTENTEXPIRYDATE"));
-    assertFalse(columns.get("CONTENTEXPIRYDATE").isEmpty());
-    assertNotNull(columns.get("REMINDERDATE"));
-    assertFalse(columns.get("REMINDERDATE").isEmpty());
-    assertNotNull(columns.get("REPEATEDAGINGTRANSSTARTDATE"));
-    assertFalse(columns.get("REPEATEDAGINGTRANSSTARTDATE").isEmpty());
-    assertEquals("7", columns.get("CONTENTID"));
+    assertEquals("11", columns.get(PSContentStatusNotifyMap.CONTENTSTATEID));
+    assertEquals("alice", columns.get(PSContentStatusNotifyMap.CONTENTCHECKOUTUSERNAME));
+    assertEquals("5", columns.get(PSContentStatusNotifyMap.CURRENTREVISION));
+    assertEquals("6", columns.get(PSContentStatusNotifyMap.EDITREVISION));
+    assertEquals("7", columns.get(PSContentStatusNotifyMap.TIPREVISION));
+    assertEquals("Y", columns.get(PSContentStatusNotifyMap.REVISIONLOCK));
+    assertNotNull(columns.get(PSContentStatusNotifyMap.LASTTRANSITIONDATE));
+    assertFalse(columns.get(PSContentStatusNotifyMap.LASTTRANSITIONDATE).isEmpty());
+    assertNotNull(columns.get(PSContentStatusNotifyMap.STATEENTEREDDATE));
+    assertFalse(columns.get(PSContentStatusNotifyMap.STATEENTEREDDATE).isEmpty());
+    assertEquals("3", columns.get(PSContentStatusNotifyMap.NEXTAGINGTRANSITION));
+    assertNotNull(columns.get(PSContentStatusNotifyMap.NEXTAGINGDATE));
+    assertFalse(columns.get(PSContentStatusNotifyMap.NEXTAGINGDATE).isEmpty());
+    assertNotNull(columns.get(PSContentStatusNotifyMap.CONTENTSTARTDATE));
+    assertFalse(columns.get(PSContentStatusNotifyMap.CONTENTSTARTDATE).isEmpty());
+    assertNotNull(columns.get(PSContentStatusNotifyMap.CONTENTEXPIRYDATE));
+    assertFalse(columns.get(PSContentStatusNotifyMap.CONTENTEXPIRYDATE).isEmpty());
+    assertNotNull(columns.get(PSContentStatusNotifyMap.REMINDERDATE));
+    assertFalse(columns.get(PSContentStatusNotifyMap.REMINDERDATE).isEmpty());
+    assertNotNull(columns.get(PSContentStatusNotifyMap.REPEATEDAGINGTRANSSTARTDATE));
+    assertFalse(columns.get(PSContentStatusNotifyMap.REPEATEDAGINGTRANSSTARTDATE).isEmpty());
+    assertEquals("7", columns.get(PSContentStatusNotifyMap.CONTENTID));
   }
 
   @Test
-  void buildLegacyColumnMap_handlesNullDatesAndEmptyUser() throws Exception {
-    PSContentStatusContext ctx = createContext();
-    setField(ctx, "m_nContentID", 7);
-    setField(ctx, "m_nStateID", 11);
-    setField(ctx, "m_sCheckOutUserName", "");
-    setField(ctx, "m_nCurrentRevision", 1);
-    setField(ctx, "m_nEditRevision", 1);
-    setField(ctx, "m_nTipRevision", 1);
-    setField(ctx, "m_bRevisionLocked", false);
-    setField(ctx, "m_LastTransitionDate", null);
-    setField(ctx, "m_StateEnteredDate", null);
-    setField(ctx, "m_nNextAgingTransition", 0);
-    setField(ctx, "m_NextAgingDate", null);
-    setField(ctx, "m_StartDate", null);
-    setField(ctx, "m_ExpiryDate", null);
-    setField(ctx, "m_ReminderDate", null);
-    setField(ctx, "m_RepeatedAgingTransitionStartDate", null);
-
-    @SuppressWarnings("unchecked")
-    Map<String, String> columns = (Map<String, String>) invokeMethod(ctx, "buildLegacyColumnMap");
+  void buildLegacyColumnMap_handlesNullDatesAndEmptyUser() {
+    Map<String, String> columns =
+        PSContentStatusNotifyMap.build(
+            7, 11, "", 1, 1, 1, false, null, null, 0, null, null, null, null, null);
 
     assertEquals(15, columns.size());
-    assertEquals("", columns.get("CONTENTCHECKOUTUSERNAME"));
-    assertEquals("N", columns.get("REVISIONLOCK"));
-    assertNull(columns.get("LASTTRANSITIONDATE"));
-    assertNull(columns.get("STATEENTEREDDATE"));
-    assertNull(columns.get("NEXTAGINGDATE"));
-    assertNull(columns.get("CONTENTSTARTDATE"));
-    assertNull(columns.get("CONTENTEXPIRYDATE"));
-    assertNull(columns.get("REMINDERDATE"));
-    assertNull(columns.get("REPEATEDAGINGTRANSSTARTDATE"));
+    assertEquals("", columns.get(PSContentStatusNotifyMap.CONTENTCHECKOUTUSERNAME));
+    assertEquals("N", columns.get(PSContentStatusNotifyMap.REVISIONLOCK));
+    assertNull(columns.get(PSContentStatusNotifyMap.LASTTRANSITIONDATE));
+    assertNull(columns.get(PSContentStatusNotifyMap.STATEENTEREDDATE));
+    assertNull(columns.get(PSContentStatusNotifyMap.NEXTAGINGDATE));
+    assertNull(columns.get(PSContentStatusNotifyMap.CONTENTSTARTDATE));
+    assertNull(columns.get(PSContentStatusNotifyMap.CONTENTEXPIRYDATE));
+    assertNull(columns.get(PSContentStatusNotifyMap.REMINDERDATE));
+    assertNull(columns.get(PSContentStatusNotifyMap.REPEATEDAGINGTRANSSTARTDATE));
   }
 
-  // ---------- helpers --------------------------------------------------------
-
-  private static PSContentStatusContext createContext() throws Exception {
-    Constructor<PSContentStatusContext> ctor = PSContentStatusContext.class.getDeclaredConstructor();
-    ctor.setAccessible(true);
-    return ctor.newInstance();
+  @Test
+  void formatDate_nullSafeAndNonEmptyForInstant() {
+    assertNull(PSContentStatusNotifyMap.formatDate(null));
+    String s = PSContentStatusNotifyMap.formatDate(toSqlDate(Instant.parse("2026-07-28T12:00:00Z")));
+    assertNotNull(s);
+    assertFalse(s.isEmpty());
+    // mm/dd/yyyy … shape
+    assertTrue(s.contains("/"));
   }
 
-  private static void setField(PSContentStatusContext ctx, String field, Object value)
-      throws Exception {
-    java.lang.reflect.Field f = PSContentStatusContext.class.getDeclaredField(field);
-    f.setAccessible(true);
-    f.set(ctx, value);
-  }
-
-  private static Object invokeMethod(PSContentStatusContext ctx, String name) throws Exception {
-    java.lang.reflect.Method m = PSContentStatusContext.class.getDeclaredMethod(name);
-    m.setAccessible(true);
-    return m.invoke(ctx);
-  }
-
-  private static java.sql.Date toSqlDate(Instant instant) {
-    if (instant == null) {
-      return null;
-    }
-    return new java.sql.Date(instant.toEpochMilli());
+  private static Date toSqlDate(Instant instant) {
+    return new Date(instant.toEpochMilli());
   }
 }

--- a/system/src/test/java/com/percussion/workflow/PSContentStatusContextCommitTest.java
+++ b/system/src/test/java/com/percussion/workflow/PSContentStatusContextCommitTest.java
@@ -124,14 +124,19 @@ public class PSContentStatusContextCommitTest {
   void formatDate_nullSafeAndNonEmptyForInstant() {
     // Intentional: null → null (not ""), distinct from PSWorkFlowUtils.DateString(null) → "".
     assertNull(PSContentStatusNotifyMap.formatDate(null));
+    // 14:05 UTC → Calendar.HOUR is 2 (0–11 clock, same as PSWorkFlowUtils.DateString — not HOUR_OF_DAY).
     String s =
-        PSContentStatusNotifyMap.formatDate(toSqlDate(Instant.parse("2026-07-28T12:00:00Z")));
+        PSContentStatusNotifyMap.formatDate(toSqlDate(Instant.parse("2026-07-28T14:05:00Z")));
     assertNotNull(s);
-    assertFalse(s.isEmpty());
-    // mm/dd/yyyy … shape (Calendar.HOUR 0–11, same as PSWorkFlowUtils.DateString)
-    assertTrue(s.contains("/"));
+    assertTrue(
+        s.startsWith("7/28/2026 2:"),
+        "expected mm/dd/yyyy H:… with Calendar.HOUR 0–11 for 14:05 UTC, got: " + s);
   }
 
+  /**
+   * Epoch millis → {@link Date}; format assertions rely on {@code TimeZone.setDefault(UTC)} in
+   * {@link #beforeAll} (and reset in {@link #afterAll}). Do not change only one of those pieces.
+   */
   private static Date toSqlDate(Instant instant) {
     return new Date(instant.toEpochMilli());
   }

--- a/system/src/test/java/com/percussion/workflow/PSContentStatusContextCommitTest.java
+++ b/system/src/test/java/com/percussion/workflow/PSContentStatusContextCommitTest.java
@@ -34,10 +34,9 @@ import org.junit.jupiter.api.Test;
  * PSContentStatusContext.commit()} must populate all 15 legacy CONTENTSTATUS columns for
  * item-summary cache invalidation (not CONTENTID-only).
  *
- * <p>Tests {@link PSContentStatusNotifyMap} only — pure map building with no JDBC, Spring,
- * {@code PSConnectionMgr}, or {@code PSWorkFlowUtils} static initializers — so the suite
- * does not hit {@code ExceptionInInitializerError} when other tests have already poisoned
- * those class statics.
+ * <p>Tests {@link PSContentStatusNotifyMap} only — pure map building with no JDBC, Spring, {@code
+ * PSConnectionMgr}, or {@code PSWorkFlowUtils} static initializers — so the suite does not hit
+ * {@code ExceptionInInitializerError} when other tests have already poisoned those class statics.
  */
 public class PSContentStatusContextCommitTest {
 
@@ -103,6 +102,8 @@ public class PSContentStatusContextCommitTest {
 
   @Test
   void buildLegacyColumnMap_handlesNullDatesAndEmptyUser() {
+    // Null date inputs must remain null map values (legacy setDate / PSItemSummaryCache
+    // contract) — never coerced to "".
     Map<String, String> columns =
         PSContentStatusNotifyMap.build(
             7, 11, "", 1, 1, 1, false, null, null, 0, null, null, null, null, null);
@@ -121,11 +122,13 @@ public class PSContentStatusContextCommitTest {
 
   @Test
   void formatDate_nullSafeAndNonEmptyForInstant() {
+    // Intentional: null → null (not ""), distinct from PSWorkFlowUtils.DateString(null) → "".
     assertNull(PSContentStatusNotifyMap.formatDate(null));
-    String s = PSContentStatusNotifyMap.formatDate(toSqlDate(Instant.parse("2026-07-28T12:00:00Z")));
+    String s =
+        PSContentStatusNotifyMap.formatDate(toSqlDate(Instant.parse("2026-07-28T12:00:00Z")));
     assertNotNull(s);
     assertFalse(s.isEmpty());
-    // mm/dd/yyyy … shape
+    // mm/dd/yyyy … shape (Calendar.HOUR 0–11, same as PSWorkFlowUtils.DateString)
     assertTrue(s.contains("/"));
   }
 


### PR DESCRIPTION
## Summary

Fixes full-suite failure introduced with #1589 hot-fix #2:

```
PSContentStatusContextCommitTest.buildLegacyColumnMap_populatesAllFifteenColumns
  » ExceptionInInitializer (at invokeMethod)
```

The test constructed `PSContentStatusContext` and called `buildLegacyColumnMap`, which pulled `PSWorkFlowUtils.DateString` and forced class static initializers (`PSConnectionMgr.getQualifiedIdentifier`, `encryptWorkflowProps` / rxdeploydir). That is brittle under a 900+ test suite when other tests have already touched those statics.

## Fix

- New package-private `PSContentStatusNotifyMap` — pure 15-column map builder + date format (same shape as legacy `setDate` / `DateString` for non-null dates; null → null map value).
- `PSContentStatusContext.commit()` delegates to it (behavior unchanged for production notify path).
- Tests rewritten against the helper only (no mockStatic, no temp rxdeploydir).

## Evidence

```bash
cd system && ../mvnw -Dai.integrity.skip=true \
  -Dtest=PSContentStatusContextCommitTest,PSSystemServicePhase4d1bWritesTest test
# Tests run: 19, Failures: 0, Errors: 0
# PSContentStatusContextCommitTest: 3 tests, ~0.4s
```

## Test plan

- [x] `PSContentStatusContextCommitTest` green
- [x] `PSSystemServicePhase4d1bWritesTest` green  
- [ ] Full `system` module test suite (or CI) green

Related: #1589 / #1561

> Co-Authored by Grok Build using grok-4.5 with agent Grok.