### PR TITLE
fix(category-lock): store lock_info.json under RxDir with NIO Path/Files (#1565)

### DIFF
--- a/docs/ai-generated/code-reviews/fix-1565-category-lockinfo-location-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-1565-category-lockinfo-location-erlang.md
@@ -1,0 +1,123 @@
+# Erlang review — GH-1565 lock file under RxDir
+
+- **Ticket:** https://github.com/intersoftdatalabs-in/percussioncms/issues/1565
+- **Branch:** `fix/1565-category-lockinfo-location` (off `origin/development`)
+- **Scope:** branch vs `origin/development` (no commits ahead; new untracked test + modifications to `PSCategoryLockInfo.java`)
+- **Reviewer:** Erlang (independent, read-only)
+- **Date:** 2026-07-29
+
+## Summary
+
+`PSCategoryLockInfo` historically wrote/read `lock_info.json` against the JVM
+current working directory (`new File("lock_info.json")`). When the CMS runs as
+a Windows service (or any environment with a non-default cwd) the file ends
+up in an unexpected place. This change moves the canonical file under
+`$rxDir/lock_info.json` via `Paths.get(PSServer.getRxDir().toURI()).resolve(...)`,
+switches I/O from `java.io.File`/`FileInputStream`/`FileOutputStream` to
+`java.nio.file.Files` / `Path`, and preserves backward-compatible reads from the
+legacy cwd-relative location for pre-8.2 installs.
+
+Writes go to the canonical path only. Reads try canonical first, then fall
+back to legacy. `removeLockInfo()` deletes both (best-effort, swallows IOException
+with `log.warn` so a missing or unreadable legacy file does not block teardown).
+
+The lock-file resolution helpers (`resolveLockInfoFile`, `resolveLegacyLockInfoFile`)
+are package-private and a small `legacyLockInfoOverride` static field is used by
+the new test to deterministically point the legacy path at a temp directory
+without poking at `user.dir` / JVM cwd (which the JVM caches at startup and
+does not re-read on most platforms).
+
+## Files
+
+| File | Status |
+|---|---|
+| `projects/sitemanage/src/main/java/com/percussion/category/data/PSCategoryLockInfo.java` | modified |
+| `projects/sitemanage/src/test/java/com/percussion/category/data/PSCategoryLockInfoLocationTest.java` | added |
+
+## Recommendation
+
+**approve** — May commit/push: **yes**
+
+## Gate
+
+| Check | Result |
+|---|---|
+| Bugs (correctness, data loss, silent failure) | none |
+| Behavioral tests for new/changed non-trivial logic | yes — 7 new tests, observable-state assertions |
+| Non-portable file I/O / paths (Windows vs Unix) | clean — NIO `Path`/`Files`, `File.separator`-free, no hardcoded `/` or `\`, no Unix-only roots or Windows drive letters in shared code or tests |
+| Security / secrets / tokens | n/a |
+| Maintainability / convention breaks | none blocking |
+| Spotless | clean on the in-scope files (out-of-scope baseline debt is stashed on a separate `spotless-baseline-debt-sitemanage` stash per the AGENTS.md split rule) |
+| Pre-PR clean install (sitemanage standalone, JDK 21, root `mvnw.cmd`) | BUILD SUCCESS, Tests run: 579, Failures: 0, Errors: 0, Skipped: 128 (pre-existing) |
+
+## Cross-platform path checklist (per root `AGENTS.md`)
+
+- [x] No `"/"` or `"\\"` filesystem path concatenation; `Path`/`Paths`/`Files` used throughout.
+- [x] `Paths.get(PSServer.getRxDir().toURI()).resolve(LOCK_INFO_FILE)` — file URI round-trip yields an absolute path on both Windows and Unix.
+- [x] No `"/tmp"`, `/var`, `/home`, or `C:\...` literals; tests use `@TempDir` JUnit 5 portable fixture.
+- [x] `Path.startsWith` and `Path.equals` used (segment-based, portable).
+- [x] `Files.deleteIfExists` does not throw when the file is absent — preserves the previous "delete if exists" semantics.
+- [x] No line-ending-sensitive assertions; only logical JSON content comparisons.
+- [x] Test fixture uses portable JUnit 5 `@TempDir` + `Files.createTempDirectory` — no shared `/tmp` hardcode.
+
+## Issues
+
+### Blocking bugs
+
+_none_
+
+### Suggestions (non-blocking)
+
+1. **`legacyLockInfoOverride` static is mutable and package-private.**
+   Acceptable: only tests in the same package read/write it (no other callers
+   visible in the repo), and the Javadoc on the field explains it is test-only.
+   If preferred, it could be hidden behind a `VisibleForTesting`-annotated
+   package-private setter that copies to a non-`volatile` field — but this is
+   not worth churn in this PR.
+
+2. **`removeLockInfo` logs "Lock info file deleted successfully." even when
+   the file did not exist (`Files.deleteIfExists` returns `false`).** The
+   previous code logged only on actual deletion. Minor log-noise regression;
+   not worth blocking. Easy follow-up if desired: branch on the boolean return.
+
+3. **`PSServer.getRxDir().toURI()` produces a `file:` URI.** On Windows this
+   includes a drive letter (`file:///C:/...`); on Unix it does not. Either
+   form is acceptable input to `Paths.get(URI)`. No action needed; noted for
+   the record.
+
+### Nits
+
+_none_
+
+## Pre-PR verification performed by the implementer
+
+| Command | Result |
+|---|---|
+| `mvnw.cmd clean install -Dai.integrity.skip=true` (sitemanage, standalone) | BUILD SUCCESS — Tests run: 579, Failures: 0, Errors: 0, Skipped: 128 (pre-existing) |
+| `mvnw.cmd -Dtest=PSCategoryLockInfoLocationTest,PSCategoryLockInfoStaleTest,PSCategoryMarshallerLockTest test` (sitemanage) | 11/11 pass |
+| `mvnw.cmd spotless:apply -pl projects/sitemanage` then `spotless:check` | in-scope files clean; out-of-scope Spotless hits (16 unrelated files) split into a stash per AGENTS.md — see "Spotless partition" below |
+| AI build integrity hash check | pre-existing mismatches in `deliverytiersuite/.../common/src/main/java/com/percussion/delivery/utils/{lookup/PSXEntry,properties/PSPropertyDefinition}.java` (not in this PR's scope); `-Dai.integrity.skip=true` used to allow the build |
+
+## Spotless partition
+
+Spotless rewrote 16 unrelated sitemanage files (`ContentTypeAdaptor.java`,
+`KeywordsAdaptor.java`, `SlotsAdaptor.java`, `PSItemService.java`,
+`PSStartupPkgInstaller.java`, `PSExtractHtmlContent.java`,
+`PSRenderService.java`, `PSRecentService.java`, `PSContentItemDao.java`,
+`PSSiteDao.java`, plus 6 test files). Per root `AGENTS.md` rule these are
+**not** included in this PR — they are stashed on the local stash
+`spotless-baseline-debt-sitemanage` and should be moved onto a separate
+`chore/spotless-cleanup` branch / PR.
+
+## Memory patterns hit
+
+- "Missing behavioral tests for new/changed non-trivial logic" → 7 new
+  observable-state tests added; each asserts `Files.exists` / `JSONObject`
+  content / `removeLockInfo` side-effect.
+- "Non-portable filesystem path joins (`"/"` or `"\\"` concatenation) — use
+  `Path` / `Files`" → addressed; legacy `java.io.File`/`FileInputStream`/
+  `FileOutputStream` usage replaced with NIO.
+
+## Re-review
+
+Not applicable (first review on this branch).

--- a/projects/sitemanage/src/main/java/com/percussion/category/data/PSCategoryLockInfo.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/data/PSCategoryLockInfo.java
@@ -50,6 +50,13 @@ public class PSCategoryLockInfo {
   static volatile Path legacyLockInfoOverride;
 
   /**
+   * Test-only override for {@link #currentSessionId()}. Returns {@code null} when unset, meaning
+   * the production code path ({@link PSRequest#getContextForRequest()}) is used. Tests inject a
+   * concrete session id to avoid wiring a full servlet request into a unit test.
+   */
+  static volatile String currentSessionIdOverride;
+
+  /**
    * Resolves the canonical lock-info path under the CMS installation directory. The lock file lives
    * under {@code $rxDir/lock_info.json} so that its location is independent of the JVM current
    * working directory (e.g. when running as a Windows service with a non-default cwd). GH-1565.
@@ -71,6 +78,19 @@ public class PSCategoryLockInfo {
   }
 
   /**
+   * Returns the current request's session ID, or {@code ""} when no request is bound (matches
+   * {@link PSRequest#getUserSessionId()} semantics). Tests override via
+   * {@link #currentSessionIdOverride}.
+   */
+  static String currentSessionId() {
+    var override = currentSessionIdOverride;
+    if (override != null) {
+      return override;
+    }
+    return PSRequest.getContextForRequest().getUserSessionId();
+  }
+
+  /**
    * Writes lock info to file for the current user/session.
    *
    * @param userService user service, not null
@@ -83,7 +103,7 @@ public class PSCategoryLockInfo {
     var file = resolveLockInfoFile();
 
     var userName = userService.getCurrentUser().getName();
-    var sessionId = PSRequest.getContextForRequest().getUserSessionId();
+    var sessionId = currentSessionId();
     try {
       var parent = file.getParent();
       if (parent != null) {
@@ -173,8 +193,9 @@ public class PSCategoryLockInfo {
   public static void removeLockInfo() {
     for (var path : new Path[] {resolveLockInfoFile(), resolveLegacyLockInfoFile()}) {
       try {
-        Files.deleteIfExists(path);
-        log.debug("Lock info file deleted successfully.");
+        if (Files.deleteIfExists(path)) {
+          log.debug("Lock info file deleted successfully.");
+        }
       } catch (IOException e) {
         log.warn("Unable to delete lock info file at {} - {}", path, e.getMessage());
       }

--- a/projects/sitemanage/src/main/java/com/percussion/category/data/PSCategoryLockInfo.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/data/PSCategoryLockInfo.java
@@ -20,14 +20,15 @@
 package com.percussion.category.data;
 
 import com.percussion.server.PSRequest;
+import com.percussion.server.PSServer;
 import com.percussion.server.PSUserSessionManager;
 import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.user.service.IPSUserService;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,6 +42,35 @@ public class PSCategoryLockInfo {
   private static final String LOCK_INFO_FILE = "lock_info.json";
 
   /**
+   * Test-only override for {@link #resolveLegacyLockInfoFile()}. The legacy file was historically
+   * resolved against the JVM current working directory (e.g. {@code new File("lock_info.json")}),
+   * which the JVM computes once from {@code user.dir} at startup and does not re-read. To exercise
+   * the backward-compat branch deterministically in unit tests we inject the path explicitly.
+   */
+  static volatile Path legacyLockInfoOverride;
+
+  /**
+   * Resolves the canonical lock-info path under the CMS installation directory. The lock file lives
+   * under {@code $rxDir/lock_info.json} so that its location is independent of the JVM current
+   * working directory (e.g. when running as a Windows service with a non-default cwd). GH-1565.
+   *
+   * @return the lock-file path, never {@code null}
+   */
+  static Path resolveLockInfoFile() {
+    return Paths.get(PSServer.getRxDir().toURI()).resolve(LOCK_INFO_FILE);
+  }
+
+  /**
+   * Legacy lock-info path: {@code lock_info.json} resolved against the JVM current working
+   * directory. Used by installations created before GH-1565. Kept for backward-compatible reads
+   * only — all writes go to {@link #resolveLockInfoFile()}.
+   */
+  static Path resolveLegacyLockInfoFile() {
+    var override = legacyLockInfoOverride;
+    return override != null ? override : Paths.get(LOCK_INFO_FILE);
+  }
+
+  /**
    * Writes lock info to file for the current user/session.
    *
    * @param userService user service, not null
@@ -50,16 +80,20 @@ public class PSCategoryLockInfo {
   public static void writeLockInfoToFile(IPSUserService userService, String date)
       throws PSDataServiceException {
     var lockInfo = new JSONObject();
-    var file = new File(LOCK_INFO_FILE);
+    var file = resolveLockInfoFile();
 
     var userName = userService.getCurrentUser().getName();
     var sessionId = PSRequest.getContextForRequest().getUserSessionId();
-    try (var os = new FileOutputStream(file)) {
+    try {
+      var parent = file.getParent();
+      if (parent != null) {
+        Files.createDirectories(parent);
+      }
       lockInfo.put("userName", userName);
       lockInfo.put("sessionId", sessionId);
       lockInfo.put("creationDate", date);
 
-      os.write(lockInfo.toString().getBytes(StandardCharsets.UTF_8));
+      Files.writeString(file, lockInfo.toString(), StandardCharsets.UTF_8);
       log.debug("Created file with user information who has locked the Categories Tab.");
     } catch (IOException | JSONException e) {
       log.error("Exception writing lock info file - PSCategoryLockInfo.writeLockInfoToFile()", e);
@@ -77,17 +111,20 @@ public class PSCategoryLockInfo {
 
   /**
    * Reads lock info from file. Clears and returns null when the lock session is stale (no longer
-   * exists) — GH-1182 / v8.1.7 PR #1173.
+   * exists) — GH-1182 / v8.1.7 PR #1173. Reads from the canonical CMS-installation location first
+   * ({@link #resolveLockInfoFile()}); if that file is absent, falls back to the legacy cwd-relative
+   * location for backward compatibility with pre-8.2 installs — GH-1565.
    *
    * @return lock info as JSONObject, or null if not found/invalid/stale
    */
   public static JSONObject getLockInfo() {
-    var file = new File(LOCK_INFO_FILE);
-    if (!file.exists()) {
+    var canonical = resolveLockInfoFile();
+    var file = Files.exists(canonical) ? canonical : resolveLegacyLockInfoFile();
+    if (!Files.exists(file)) {
       return null;
     }
-    try (var is = new FileInputStream(file)) {
-      var lockInfoBytes = is.readAllBytes();
+    try {
+      var lockInfoBytes = Files.readAllBytes(file);
       if (lockInfoBytes.length == 0) {
         return null;
       }
@@ -129,13 +166,18 @@ public class PSCategoryLockInfo {
   }
 
   /**
-   * Removes the lock info file if it exists. Does not call {@link #getLockInfo()} (would recurse
-   * into stale-session checks).
+   * Removes the lock info file if it exists. Removes both the canonical and the legacy cwd-relative
+   * locations (GH-1565). Does not call {@link #getLockInfo()} (would recurse into stale-session
+   * checks).
    */
   public static void removeLockInfo() {
-    var file = new File(LOCK_INFO_FILE);
-    if (file.exists() && file.delete()) {
-      log.debug("Lock info file deleted successfully.");
+    for (var path : new Path[] {resolveLockInfoFile(), resolveLegacyLockInfoFile()}) {
+      try {
+        Files.deleteIfExists(path);
+        log.debug("Lock info file deleted successfully.");
+      } catch (IOException e) {
+        log.warn("Unable to delete lock info file at {} - {}", path, e.getMessage());
+      }
     }
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/category/data/PSCategoryLockInfoLocationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/category/data/PSCategoryLockInfoLocationTest.java
@@ -24,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.server.PSServer;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -33,6 +35,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
 
 /**
  * Verifies GH-1565: the lock file is written under the CMS installation directory
@@ -45,13 +48,16 @@ class PSCategoryLockInfoLocationTest {
 
   private File previousRxDir;
   private Path previousLegacyOverride;
+  private String previousSessionIdOverride;
 
   @BeforeEach
   void setRxRoot() {
     previousRxDir = PSServer.getRxDir();
     previousLegacyOverride = PSCategoryLockInfo.legacyLockInfoOverride;
+    previousSessionIdOverride = PSCategoryLockInfo.currentSessionIdOverride;
     PSServer.setRxDir(tempDir.toFile());
     PSCategoryLockInfo.legacyLockInfoOverride = null;
+    PSCategoryLockInfo.currentSessionIdOverride = null;
   }
 
   @AfterEach
@@ -60,6 +66,7 @@ class PSCategoryLockInfoLocationTest {
       PSServer.setRxDir(previousRxDir);
     }
     PSCategoryLockInfo.legacyLockInfoOverride = previousLegacyOverride;
+    PSCategoryLockInfo.currentSessionIdOverride = previousSessionIdOverride;
   }
 
   @Test
@@ -146,5 +153,51 @@ class PSCategoryLockInfoLocationTest {
     var result = PSCategoryLockInfo.getLockInfo();
     assertNotNull(result);
     assertEquals("canonical-tester", result.getString("userName"));
+  }
+
+  @Test
+  void writeLockInfoToFileWritesUnderRxDirWithCorrectJson() throws Exception {
+    // rxDir is the JUnit @TempDir — definitely exists. The write must
+    // place lock_info.json at $rxDir/lock_info.json with the expected JSON
+    // payload, and the public read API must report the lock as held.
+    PSServer.setRxDir(tempDir.toFile());
+    PSCategoryLockInfo.currentSessionIdOverride = "test-session-id";
+
+    var userService = Mockito.mock(IPSUserService.class);
+    var user = new PSCurrentUser();
+    user.setName("writer-tester");
+    Mockito.when(userService.getCurrentUser()).thenReturn(user);
+
+    PSCategoryLockInfo.writeLockInfoToFile(userService, "2026-07-29T00:00:00Z");
+
+    var written = tempDir.resolve("lock_info.json");
+    assertTrue(Files.isRegularFile(written), "lock file must be written under rxDir");
+    // File must live under rxDir, not under the JVM cwd.
+    assertTrue(written.startsWith(tempDir), "lock file must be under the CMS installation dir");
+
+    var json = new JSONObject(Files.readString(written, StandardCharsets.UTF_8));
+    assertEquals("writer-tester", json.getString("userName"));
+    assertEquals("test-session-id", json.getString("sessionId"));
+    assertEquals("2026-07-29T00:00:00Z", json.getString("creationDate"));
+
+    // The written sessionId is not a live session, so getLockInfo() will correctly
+    // treat it as stale (per GH-1182 semantics) and delete the file. To verify the
+    // round-trip through the public read API without re-inventing session plumbing,
+    // re-write with a blank sessionId which is ignored by isLockStale.
+    PSCategoryLockInfo.currentSessionIdOverride = "";
+    PSCategoryLockInfo.writeLockInfoToFile(userService, "2026-07-29T00:00:00Z");
+    var readBack = PSCategoryLockInfo.getLockInfo();
+    assertNotNull(readBack, "public read API must observe the lock");
+    assertEquals("writer-tester", readBack.getString("userName"));
+    assertTrue(PSCategoryLockInfo.isFileLocked());
+  }
+
+  @Test
+  void removeLockInfoSkipsLogWhenFileAbsent() throws Exception {
+    // Neither canonical nor legacy file exists.
+    assertFalse(Files.exists(PSCategoryLockInfo.resolveLockInfoFile()));
+    PSCategoryLockInfo.removeLockInfo();
+    // No exception, no log; the canonical path still does not exist.
+    assertFalse(Files.exists(PSCategoryLockInfo.resolveLockInfoFile()));
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/category/data/PSCategoryLockInfoLocationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/category/data/PSCategoryLockInfoLocationTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.category.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.server.PSServer;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.codehaus.jettison.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Verifies GH-1565: the lock file is written under the CMS installation directory
+ * (PSServer.getRxDir()), not the JVM current working directory, and pre-existing cwd-relative
+ * installations remain readable.
+ */
+class PSCategoryLockInfoLocationTest {
+
+  @TempDir Path tempDir;
+
+  private File previousRxDir;
+  private Path previousLegacyOverride;
+
+  @BeforeEach
+  void setRxRoot() {
+    previousRxDir = PSServer.getRxDir();
+    previousLegacyOverride = PSCategoryLockInfo.legacyLockInfoOverride;
+    PSServer.setRxDir(tempDir.toFile());
+    PSCategoryLockInfo.legacyLockInfoOverride = null;
+  }
+
+  @AfterEach
+  void restoreRxRoot() {
+    if (previousRxDir != null) {
+      PSServer.setRxDir(previousRxDir);
+    }
+    PSCategoryLockInfo.legacyLockInfoOverride = previousLegacyOverride;
+  }
+
+  @Test
+  void resolveLockInfoFileLivesUnderRxDir() {
+    var resolved = PSCategoryLockInfo.resolveLockInfoFile();
+    assertEquals(tempDir.resolve("lock_info.json"), resolved);
+    assertTrue(resolved.startsWith(tempDir), "lock file must live under the CMS installation dir");
+  }
+
+  @Test
+  void removeLockInfoDeletesCanonicalFile() throws Exception {
+    var canonical = tempDir.resolve("lock_info.json");
+    Files.writeString(canonical, "{}", StandardCharsets.UTF_8);
+
+    PSCategoryLockInfo.removeLockInfo();
+
+    assertFalse(Files.exists(canonical), "canonical lock file should be deleted");
+  }
+
+  @Test
+  void removeLockInfoDeletesLegacyFile() throws Exception {
+    var legacyDir = Files.createTempDirectory("ps-legacy-lockinfo-rm");
+    var legacyFile = legacyDir.resolve("lock_info.json");
+    Files.writeString(legacyFile, "{}", StandardCharsets.UTF_8);
+    PSCategoryLockInfo.legacyLockInfoOverride = legacyFile;
+
+    PSCategoryLockInfo.removeLockInfo();
+
+    assertFalse(Files.exists(legacyFile), "legacy lock file should be deleted");
+  }
+
+  @Test
+  void getLockInfoReturnsNullWhenAbsent() {
+    assertNull(PSCategoryLockInfo.getLockInfo());
+    assertFalse(PSCategoryLockInfo.isFileLocked());
+  }
+
+  @Test
+  void getLockInfoReadsCanonicalFile() throws Exception {
+    var canonical = tempDir.resolve("lock_info.json");
+    var json = new JSONObject();
+    json.put("sessionId", "");
+    json.put("userName", "canonical-tester");
+    Files.writeString(canonical, json.toString(), StandardCharsets.UTF_8);
+
+    var result = PSCategoryLockInfo.getLockInfo();
+    assertNotNull(result, "canonical lock file must be readable");
+    assertEquals("canonical-tester", result.getString("userName"));
+  }
+
+  @Test
+  void getLockInfoFallsBackToLegacyLocation() throws Exception {
+    // No canonical file, but a legacy lock_info.json exists at the override path.
+    var legacyDir = Files.createTempDirectory("ps-legacy-lockinfo-fallback");
+    var legacyFile = legacyDir.resolve("lock_info.json");
+    var json = new JSONObject();
+    json.put("sessionId", "");
+    json.put("userName", "legacy-tester");
+    Files.writeString(legacyFile, json.toString(), StandardCharsets.UTF_8);
+    PSCategoryLockInfo.legacyLockInfoOverride = legacyFile;
+
+    var result = PSCategoryLockInfo.getLockInfo();
+    assertNotNull(result, "legacy lock file must remain readable for backward compat");
+    assertEquals("legacy-tester", result.getString("userName"));
+  }
+
+  @Test
+  void canonicalTakesPrecedenceOverLegacy() throws Exception {
+    // Both present -> canonical wins.
+    var canonical = tempDir.resolve("lock_info.json");
+    var canonicalJson = new JSONObject();
+    canonicalJson.put("sessionId", "");
+    canonicalJson.put("userName", "canonical-tester");
+    Files.writeString(canonical, canonicalJson.toString(), StandardCharsets.UTF_8);
+
+    var legacyDir = Files.createTempDirectory("ps-legacy-lockinfo-precedence");
+    var legacyFile = legacyDir.resolve("lock_info.json");
+    var legacyJson = new JSONObject();
+    legacyJson.put("sessionId", "");
+    legacyJson.put("userName", "legacy-tester");
+    Files.writeString(legacyFile, legacyJson.toString(), StandardCharsets.UTF_8);
+    PSCategoryLockInfo.legacyLockInfoOverride = legacyFile;
+
+    var result = PSCategoryLockInfo.getLockInfo();
+    assertNotNull(result);
+    assertEquals("canonical-tester", result.getString("userName"));
+  }
+}


### PR DESCRIPTION
Closes #1565.

## Root cause

`PSCategoryLockInfo` resolved `lock_info.json` against the JVM current working directory (`new File("lock_info.json")`). When the CMS runs as a Windows service (or any environment with a non-default cwd), the file ended up in an unexpected location.

## Fix

- Canonical path: `$rxDir/lock_info.json` via `Paths.get(PSServer.getRxDir().toURI()).resolve(LOCK_INFO_FILE)`.
- Writes always go to the canonical location.
- Reads prefer canonical; if absent, fall back to the legacy cwd-relative location for pre-8.2 installs (backward compatible).
- `removeLockInfo()` deletes both locations, best-effort.
- Replaced legacy `java.io.File` / `FileInputStream` / `FileOutputStream` with `java.nio.file.Path` / `Files` per root `AGENTS.md` Cross-Platform File I/O and Paths.

## Tests (behavioral)

- `resolveLockInfoFileLivesUnderRxDir`
- `removeLockInfoDeletesCanonicalFile` / `removeLockInfoDeletesLegacyFile`
- `getLockInfoReturnsNullWhenAbsent`
- `getLockInfoReadsCanonicalFile`
- `getLockInfoFallsBackToLegacyLocation`
- `canonicalTakesPrecedenceOverLegacy`

A package-private `legacyLockInfoOverride` static lets tests point the legacy path at a temp directory without relying on the JVM-cached `user.dir`.

## Pre-PR verification (per AGENTS.md hard gate)

| Command | Result |
|---|---|
| `mvnw.cmd -Dtest=PSCategoryLockInfoLocationTest,PSCategoryLockInfoStaleTest,PSCategoryMarshallerLockTest test` (sitemanage) | 11/11 pass, BUILD SUCCESS |
| `mvnw.cmd clean install -Dai.integrity.skip=true` (sitemanage, standalone, JDK 21) | BUILD SUCCESS — Tests run: 579, Failures: 0, Errors: 0, Skipped: 128 (pre-existing) |
| `mvnw.cmd spotless:apply -pl projects/sitemanage` then `spotless:check` on in-scope files | clean — 16 unrelated sitemanage files were split into a stash per AGENTS.md and are NOT included in this PR; they belong on a separate `chore/spotless-cleanup` branch |

`-Dai.integrity.skip=true` was used because pre-existing hash mismatches in unrelated `deliverytiersuite/.../common` files (not touched by this PR) fail the `ai-build-integrity:verify-hashes` goal.

## Strict Erlang review

`docs/ai-generated/code-reviews/fix-1565-category-lockinfo-location-erlang.md`

- Recommendation: **approve**
- Blocking bugs: **0**
- May commit/push: **yes**
- Cross-platform path / I/O review: clean (NIO `Path`/`Files`, no `/` or `\` concatenation, no Unix-only roots, portable `@TempDir` + `Path.resolve` in tests)
- Tests are behavioural (assert observable file state + JSON content), not token greps