### PR TITLE
fix(javadoc): resolve 6 errors + 200 warnings in extensions-sfp (#1601)

### DIFF
--- a/docs/ai-generated/code-reviews/1601-extensions-sfp-javadoc-erlang.md
+++ b/docs/ai-generated/code-reviews/1601-extensions-sfp-javadoc-erlang.md
@@ -1,0 +1,84 @@
+# Erlang Review — Issue #1601 extensions-sfp Javadoc
+
+## Summary
+
+Documentation-only fix for the `extensions-sfp` module: 3 Javadoc HTML errors
+and 100 unique Javadoc warnings (200 plugin-emitted lines) eliminated. No
+production-code behavior changes; no new compiler warnings; clean install +
+Spotless check pass on the module.
+
+## Scope
+
+- Base: `origin/development` (commit `ea85629c2f`)
+- Head: feature branch `fix/1601-javadoc-issues-extensions-sfp`
+- Files: 25 changed in `modules/extensions-sfp/src/main/java/**`
+- Prior report: none
+- Memory patterns hit: none (pure Javadoc cleanup; no I/O, no security, no
+  behavioral change)
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Blocking bugs: 0
+- May commit/push: **yes**
+
+## Issues
+
+None.
+
+## Specific changes
+
+- `PSSiteFolderContentListBaseExit.java` — fixed the 3 HTML errors. The
+  `<ol start="0">` was wrongly closed by `</ul>`; replaced with `<ul>` and
+  removed a stray second `</ul>`. Also added a class-level description
+  (resolves "no main description" warning).
+- `IPSDTDPublisherEdition.java` — added 42 Javadoc comments to the public
+  static final `ELEM_*` / `ATTR_*` constants that previously had none.
+- `PSCalendarMonthModel.java`, `PSRecurringEvent.java`, `PSExpandRecurringEvents.java`,
+  `PSSiteFolderContentListLinkGenerator.java`, `PSSiteFolderCListBase.java`,
+  `PSRelationshipHelper.java`, etc. — added missing `@param` / `@throws`
+  descriptions, supplied a leading main description on methods whose only
+  tag was `@return`, and removed the empty `<p>` tags in
+  `PSSiteFolderAssembly.java` / `PSSimpleSqlQuery.java`.
+- Added explicit `public <ClassName>()` constructors with a one-line Javadoc
+  to 11 classes that previously relied on an implicit default constructor
+  (`PSAutoGenerateFileName`, `PSAutoSiteItemFilter`, `PSCopyValueToRequest`,
+  `PSAppendPurgedOrMovedItems`, `PSBuildRelationshipsFromIdsExit`,
+  `PSExtractIdsFromSlotExit`, `PSMakeCalendar`, `PSSite`,
+  `PSSiteFolderAssembly`, `PSSiteFolderContentListBaseExit`,
+  `PSSiteFolderContentListBulkExit`, `PSSiteFolderContentListExit`,
+  `PSSiteFolderContentListLinkGenerator`, `PSCalendarMonthModel`,
+  `PSExpandRecurringEvents`).
+
+## Cross-platform / path review
+
+Not applicable — diff touches Javadoc text only. No new file I/O or path
+construction.
+
+## Build evidence
+
+- `cmd /c ..\..\mvnw.cmd clean install` on `modules/extensions-sfp` (JDK 21):
+  BUILD SUCCESS, jar + javadoc.jar produced, `Tests run: 4, Failures: 0,
+  Errors: 0, Skipped: 4` (skipped count is pre-existing for the
+  `PSCalendarMonthModelTest`).
+- `cmd /c ..\..\mvnw.cmd spotless:check` on `modules/extensions-sfp`: clean.
+- `mvnw.cmd javadoc:javadoc`: `3 errors` and `100 warnings` reduced to
+  `0 errors` and `0 warnings` (verified via `Select-String -Pattern
+  "warning:|error:"` returning 0 unique lines on `tmp/sfp-final-build.log`).
+- Pre-existing compiler WARNINGs (raw `HashMap`, `Iterator` types) in
+  `PSAutoGenerateFileName.java`, `PSExpandRecurringEvents.java`,
+  `PSCalendarMonthModel.java`, `PSChildRelationshipBuilder.java` are
+  unchanged from the baseline and are out of scope for this Javadoc issue.
+
+## Notes
+
+- Per AGENTS.md "Pre-PR Spotless formatting (HARD GATE)", an unrelated
+  Spotless reformat of `docker-compose.yml` was observed during a root-level
+  spotless run and was reverted; this PR contains only the
+  `extensions-sfp`-scoped changes.
+- Per AGENTS.md "Pre-PR Maven verification (HARD GATE)", the build was run
+  module-standalone (`cd modules/extensions-sfp && ../mvnw.cmd clean
+  install`), not as a full reactor build.

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/PSAutoGenerateFileName.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/PSAutoGenerateFileName.java
@@ -47,6 +47,11 @@ public class PSAutoGenerateFileName extends PSDefaultExtension
 
   private static final Logger log = LogManager.getLogger(PSAutoGenerateFileName.class);
 
+  /** Default constructor for PSAutoGenerateFileName. */
+  public PSAutoGenerateFileName() {
+    // default constructor
+  }
+
   /**
    * Required by the interface. Always return <code>false</code>.
    *
@@ -69,8 +74,9 @@ public class PSAutoGenerateFileName extends PSDefaultExtension
    *     </code>.
    * @param doc The input document that is passed, never used.
    * @return The result document same as the input result document.
-   * @throws PSParameterMismatchException
-   * @throws PSExtensionProcessingException
+   * @throws PSParameterMismatchException if fewer than three parameters are supplied, or if any
+   *     required parameter is empty
+   * @throws PSExtensionProcessingException if an error occurs while processing the extension
    */
   public Document processResultDocument(Object[] params, IPSRequestContext request, Document doc)
       throws PSParameterMismatchException, PSExtensionProcessingException {

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/PSCopyValueToRequest.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/PSCopyValueToRequest.java
@@ -24,6 +24,11 @@ import com.percussion.server.IPSRequestContext;
 /** UDF to set the supplied parameter (name-value pair) into the request as HTML paramater. */
 public class PSCopyValueToRequest extends PSDefaultExtension implements IPSUdfProcessor {
 
+  /** Default constructor for PSCopyValueToRequest. */
+  public PSCopyValueToRequest() {
+    // default constructor
+  }
+
   /**
    * Implementation of the interface method. A new HTML parameter is set in the request context. The
    * name of the parameter is the first member of the parameter array and the value is the second
@@ -33,7 +38,8 @@ public class PSCopyValueToRequest extends PSDefaultExtension implements IPSUdfPr
    *     non-empty members.
    * @param request - IPSRequestContext request object, must not be <code>null</code>.
    * @return Object always "0" to be ignored.
-   * @throws PSConversionException
+   * @throws PSConversionException if fewer than two parameters are supplied, or if either parameter
+   *     is null or empty
    */
   public Object processUdf(Object[] params, IPSRequestContext request)
       throws PSConversionException {

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSCalendarMonthModel.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSCalendarMonthModel.java
@@ -44,6 +44,17 @@ import org.apache.logging.log4j.Logger;
  */
 public class PSCalendarMonthModel extends PSJexlUtilBase {
 
+  /** Default constructor required by Jexl utility framework. */
+  public PSCalendarMonthModel() {
+    // default constructor
+  }
+
+  /**
+   * Assigns the calendar to the month containing the specified date.
+   *
+   * @param date date within month to assign
+   * @return this calendar month model, never {@code null}
+   */
   @IPSJexlMethod(
       description = "Assigns the calendar to the month containing the specified date.",
       params = {
@@ -58,6 +69,12 @@ public class PSCalendarMonthModel extends PSJexlUtilBase {
     return model;
   }
 
+  /**
+   * Assigns the specified calendar for computing month information.
+   *
+   * @param cal calendar to use for computing month information
+   * @return this calendar month model, never {@code null}
+   */
   @IPSJexlMethod(
       description = "Assigns the specified calendar for computing month information.",
       params = {
@@ -75,6 +92,13 @@ public class PSCalendarMonthModel extends PSJexlUtilBase {
     return model;
   }
 
+  /**
+   * Assigns the calendar to the month containing the specified date.
+   *
+   * @param format format of date to assign
+   * @param date date within month to assign
+   * @return this calendar month model, never {@code null}
+   */
   @IPSJexlMethod(
       description = "Assigns the calendar to the month containing the specified date.",
       params = {
@@ -99,6 +123,8 @@ public class PSCalendarMonthModel extends PSJexlUtilBase {
   }
 
   /**
+   * Gets the number of weeks in the assigned month.
+   *
    * @return the number of weeks in the assigned month
    */
   public int getWeeks() {
@@ -107,6 +133,8 @@ public class PSCalendarMonthModel extends PSJexlUtilBase {
   }
 
   /**
+   * Gets the last day of the assigned month.
+   *
    * @return the last day of the assigned month
    */
   public int getLastDay() {
@@ -114,6 +142,8 @@ public class PSCalendarMonthModel extends PSJexlUtilBase {
   }
 
   /**
+   * Gets the day of the week for the first day of the assigned month.
+   *
    * @return the day of the week for the first day of the assigned month
    */
   public int getFirstDayOfWeek() {
@@ -122,6 +152,8 @@ public class PSCalendarMonthModel extends PSJexlUtilBase {
   }
 
   /**
+   * Gets the day of the week for the last day of the assigned month.
+   *
    * @return the day of the week for the last day of the assigned month
    */
   public int getLastDayOfWeek() {
@@ -130,8 +162,9 @@ public class PSCalendarMonthModel extends PSJexlUtilBase {
   }
 
   /**
-   * @return a calendar set to midnight on the first day of the assigned month, never <code>null
-   *     </code>
+   * Gets a calendar set to midnight on the first day of the assigned month.
+   *
+   * @return a calendar set to midnight on the first day of the assigned month, never {@code null}
    */
   public Calendar getStartDate() {
     PSCalendarMonthModel model = getModel();
@@ -144,15 +177,19 @@ public class PSCalendarMonthModel extends PSJexlUtilBase {
   }
 
   /**
-   * @return the date of the first day of the assigned month, formatted as <code>yyyy-MM-dd</code>
+   * Gets the date of the first day of the assigned month.
+   *
+   * @return the date of the first day of the assigned month, formatted as {@code yyyy-MM-dd}
    */
   public String getStart() {
     return getModel().m_formatter.format(getStartDate().getTime());
   }
 
   /**
+   * Gets a calendar set to the final millisecond of the last day of the assigned month.
+   *
    * @return a calendar set to the final millisecond of the last day of the assigned month, never
-   *     <code>null</code>
+   *     {@code null}
    */
   public Calendar getEndDate() {
     PSCalendarMonthModel model = getModel();
@@ -164,7 +201,9 @@ public class PSCalendarMonthModel extends PSJexlUtilBase {
   }
 
   /**
-   * @return the date of the last day of the assigned month, formatted as <code>yyyy-MM-dd</code>
+   * Gets the date of the last day of the assigned month.
+   *
+   * @return the date of the last day of the assigned month, formatted as {@code yyyy-MM-dd}
    */
   public String getEnd() {
     return getModel().m_formatter.format(getEndDate().getTime());

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSExpandRecurringEvents.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSExpandRecurringEvents.java
@@ -45,6 +45,11 @@ import org.w3c.dom.NodeList;
 public class PSExpandRecurringEvents extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
 
+  /** Default constructor for PSExpandRecurringEvents. */
+  public PSExpandRecurringEvents() {
+    // default constructor
+  }
+
   private static final Logger log = LogManager.getLogger(PSExpandRecurringEvents.class);
 
   /**
@@ -62,9 +67,9 @@ public class PSExpandRecurringEvents extends PSDefaultExtension
    * end date string. Both will be parsed as Date objects and return as a new object array.
    *
    * @param params parameter array as explained above, must not be <code>null</code> or empty.
-   * @return @throws PSParameterMismatchException
-   * @throws PSParameterMismatchException
-   * @throws PSExtensionProcessingException
+   * @return object array containing the parsed calendar start and end {@link Date} objects
+   * @throws PSParameterMismatchException if a required parameter is missing
+   * @throws PSExtensionProcessingException if fewer than two parameters are supplied
    */
   private static Object[] parseParameters(Object[] params)
       throws PSParameterMismatchException, PSExtensionProcessingException {
@@ -125,11 +130,11 @@ public class PSExpandRecurringEvents extends PSDefaultExtension
    *     </ol>
    *
    * @param request the current request context, never <code>null</code>.
-   * @param resultDoc
-   * @return @throws com.percussion.extension.PSParameterMismatchException if either required
-   *     parameter is not supplied, or cannot be parsed as a Date.
-   * @throws PSParameterMismatchException
-   * @throws com.percussion.extension.PSExtensionProcessingException
+   * @param resultDoc the result document being processed, never <code>null</code>
+   * @return the modified result document with the expanded recurring event instances
+   * @throws PSParameterMismatchException if either required parameter is not supplied, or cannot be
+   *     parsed as a Date.
+   * @throws PSExtensionProcessingException if an error occurs while processing the extension
    */
   public Document processResultDocument(
       Object[] params, IPSRequestContext request, Document resultDoc)
@@ -237,7 +242,7 @@ public class PSExpandRecurringEvents extends PSDefaultExtension
    * <p>This method is protected so it can be overridden by the test framework, to allow testing the
    * rest of the class without a running Rhythmyx server.
    *
-   * @param request
+   * @param request the current request context, never <code>null</code>
    * @return a newly constructed <code>Holidays</code> object, never <code>null</code>
    */
   protected PSHolidays loadHolidays(IPSRequestContext request) {

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSMakeCalendar.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSMakeCalendar.java
@@ -44,6 +44,12 @@ import org.w3c.dom.NodeList;
  *     com.percussion.fastforward.calendar.PSCalendarMonthModel PSCalendarMonthModel} instead.
  */
 public class PSMakeCalendar implements IPSResultDocumentProcessor {
+
+  /** Default constructor for PSMakeCalendar. */
+  public PSMakeCalendar() {
+    // default constructor
+  }
+
   /*
    * (non-Javadoc)
    *

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSRecurringEvent.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSRecurringEvent.java
@@ -292,7 +292,8 @@ public class PSRecurringEvent {
   /**
    * Set the day of wee occurrence.
    *
-   * @param dayOfWeekOccurrence
+   * @param dayOfWeekOccurrence the week-of-month occurrence of the day of week (1 to 5), where 5
+   *     represents the last occurrence of that day-of-week in the month.
    */
   public void setDayOfWeekOccurrence(int dayOfWeekOccurrence) {
     // todo validation of dayOfWeekOccurrence
@@ -302,7 +303,7 @@ public class PSRecurringEvent {
   /**
    * Set day of month.
    *
-   * @param dayOfMonth
+   * @param dayOfMonth the day of the month (1 to 31) on which the event recurs
    */
   public void setDayOfMonth(int dayOfMonth) {
     // todo validation of dayOfMonth
@@ -312,7 +313,7 @@ public class PSRecurringEvent {
   /**
    * Gets the date of the specified recurrence of this event.
    *
-   * @param recurrence
+   * @param recurrence the zero-based recurrence index to compute the date for
    * @return a calendar (with the default time zone and locale) set to the date of the specified
    *     recurrence of this event, or <code>null</code> if the date of the recurrence is greater
    *     than the end date of this event.
@@ -383,6 +384,8 @@ public class PSRecurringEvent {
   }
 
   /**
+   * Gets the start date of the event.
+   *
    * @return start date of the event.
    */
   public Date getStartDate() {
@@ -474,7 +477,7 @@ public class PSRecurringEvent {
     /**
      * Just calls the super class version.
      *
-     * @param s
+     * @param s the detail message describing the unknown node type
      */
     public UnknownNodeTypeException(String s) {
       super(s);
@@ -491,7 +494,7 @@ public class PSRecurringEvent {
     /**
      * Just calls the super class version.
      *
-     * @param s
+     * @param s the detail message describing the illegal value
      */
     public IllegalValueException(String s) {
       super(s);

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/relationship/PSBuildRelationshipsFromIdsExit.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/relationship/PSBuildRelationshipsFromIdsExit.java
@@ -45,6 +45,12 @@ import org.w3c.dom.Document;
  */
 public class PSBuildRelationshipsFromIdsExit extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
+
+  /** Default constructor for PSBuildRelationshipsFromIdsExit. */
+  public PSBuildRelationshipsFromIdsExit() {
+    // default constructor
+  }
+
   /**
    * @return <code>false</code> always.
    */

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/relationship/PSChildRelationshipBase.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/relationship/PSChildRelationshipBase.java
@@ -71,6 +71,7 @@ public abstract class PSChildRelationshipBase {
    * Finds the definition for a slot given its name, using the assembly service.
    *
    * @param templateName name of the template to find. not <code>null</code>, must exist.
+   * @param type the type used to scope the template lookup, never <code>null</code>
    * @return the template definition for the specified name, never <code>null</code>
    * @throws PSAssemblyException if the template is not found
    */
@@ -90,6 +91,7 @@ public abstract class PSChildRelationshipBase {
    * @param slot slot whose relationships will be queried, assumed not <code>null</code>
    * @return the set of relationships for the specified slot with the specified dependent item.
    *     never <code>null</code>, may be emptty.
+   * @throws PSCmsException if an error occurs while querying the relationships
    */
   protected PSRelationshipSet getRelationships(int dependentContentId, IPSTemplateSlot slot)
       throws PSCmsException {

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/relationship/PSExtractIdsFromSlotExit.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/relationship/PSExtractIdsFromSlotExit.java
@@ -40,6 +40,11 @@ import org.apache.logging.log4j.Logger;
  */
 public class PSExtractIdsFromSlotExit extends PSDefaultExtension implements IPSUdfProcessor {
 
+  /** Default constructor for PSExtractIdsFromSlotExit. */
+  public PSExtractIdsFromSlotExit() {
+    // default constructor
+  }
+
   /**
    * Returns a list of the owner content ids from the relationships in the slot identified by the
    * "slotname" parameter that have the request's content item as their dependent.

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/IPSDTDPublisherEdition.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/IPSDTDPublisherEdition.java
@@ -99,47 +99,124 @@ public interface IPSDTDPublisherEdition {
   /*
    * Element names
    */
+  /** The name of the root element of the publisher edition XML document. */
   public static final String ELEM_ROOT = "psxpub:pubdata";
+
+  /** The name of the destination site element. */
   public static final String ELEM_SITE = "destsite";
+
+  /** The name of the content list element. */
   public static final String ELEM_CONTENTLIST = "contentlist";
+
+  /** The name of the content item element. */
   public static final String ELEM_CONTENTITEM = "contentitem";
+
+  /** The name of the content title element. */
   public static final String ELEM_CONTENTTITLE = "title";
+
+  /** The name of the content URL element. */
   public static final String ELEM_CONTENTURL = "contenturl";
+
+  /** The name of the delivery element. */
   public static final String ELEM_DELIVERY = "delivery";
+
+  /** The name of the location element. */
   public static final String ELEM_LOCATION = "location";
+
+  /** The name of the modify date element. */
   public static final String ELEM_MODIFYDATE = "modifydate";
+
+  /** The name of the modify user element. */
   public static final String ELEM_MODIFYUSER = "modifyuser";
+
+  /** The name of the expire date element. */
   public static final String ELEM_EXPIREDATE = "expiredate";
+
+  /** The name of the content type element. */
   public static final String ELEM_CONTENTTYPE = "contenttype";
+
+  /** The name of the publisher configuration element. */
   public static final String ELEM_CONFIG = "publisherconfig";
+
+  /** The name of a publisher configuration parameter element. */
   public static final String ELEM_PARAM = "param";
+
+  /** The name of the custom properties container element. */
   public static final String ELEM_CUSTOMPROPERTIES = "customproperties";
+
   /*
    * Attribute names
    */
+  /** The XML namespace attribute name used by the publisher edition document. */
   public static final String ATTR_NS = "xmlns:psxpub";
+
+  /** The user identifier attribute name on the destination site element. */
   public static final String ATTR_USERID = "userid";
+
+  /** The password attribute name on the destination site element. */
   public static final String ATTR_PASSWORD = "password";
+
+  /** The IP address attribute name on the destination site element. */
   public static final String ATTR_IPADDRESS = "ipaddress";
+
+  /** The port attribute name on the destination site element. */
   public static final String ATTR_PORT = "port";
+
+  /** The root directory attribute name on the destination site element. */
   public static final String ATTR_ROOTDIR = "rootdir";
+
+  /** The name attribute name on the destination site element. */
   public static final String ATTR_NAME = "name";
+
+  /** The edition identifier attribute name on the content list element. */
   public static final String ATTR_EDITIONID = "editionid";
+
+  /** The source site identifier attribute name. */
   public static final String ATTR_SRCSITEID = "srcsiteid";
+
+  /** The recovery publication status identifier attribute name. */
   public static final String ATTR_RECOVERYPUBSTATUSID = "recoverypubstatusid";
+
+  /** The site identifier attribute name on the destination site element. */
   public static final String ATTR_SITEID = "siteid";
+
+  /** The publisher identifier attribute name on the content list element. */
   public static final String ATTR_PUBLISHERID = "publisherid";
+
+  /** The publication identifier attribute name on the content list element. */
   public static final String ATTR_PUBLICATIONID = "publicationid";
+
+  /** The publication status identifier attribute name on the content list element. */
   public static final String ATTR_PUBSTATUSID = "pubstatusid";
+
+  /** The delivery type attribute name on the content list element. */
   public static final String ATTR_DELIVERYTYPE = "deliverytype";
+
+  /** The unpublish attribute name on the content item element. */
   public static final String ATTR_UNPUBLISH = "unpublish";
+
+  /** The content identifier attribute name on the content item element. */
   public static final String ATTR_CONTENTID = "contentid";
+
+  /** The revision attribute name on the content item element. */
   public static final String ATTR_REVISION = "revision";
+
+  /** The context attribute name on the content list element. */
   public static final String ATTR_CONTEXT = "context";
+
+  /** The variant identifier attribute name on the content item element. */
   public static final String ATTR_VARIANTID = "variantid";
+
+  /** The content list identifier attribute name on the content list element. */
   public static final String ATTR_CLISTID = "clistid";
+
+  /** The page index attribute name on the content list element. */
   public static final String ATTR_PAGEINDEX = "pageindex";
+
+  /** The is-last-page attribute name on the content list element. */
   public static final String ATTR_ISLASTPAGE = "islastpage";
+
+  /** The elapsed time attribute name on the content list element. */
   public static final String ATTR_ELAPSETIME = "elapsetime";
 
   /**

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSAppendPurgedOrMovedItems.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSAppendPurgedOrMovedItems.java
@@ -83,6 +83,12 @@ import org.w3c.dom.NodeList;
  */
 public class PSAppendPurgedOrMovedItems extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
+
+  /** Default constructor for PSAppendPurgedOrMovedItems. */
+  public PSAppendPurgedOrMovedItems() {
+    // default constructor
+  }
+
   // see IPSResultDocumentProcessor
   public boolean canModifyStyleSheet() {
     return false;

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSAutoSiteItemFilter.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSAutoSiteItemFilter.java
@@ -46,6 +46,11 @@ import org.w3c.dom.Node;
  */
 public class PSAutoSiteItemFilter extends PSDefaultExtension implements IPSResultDocumentProcessor {
 
+  /** Default constructor for PSAutoSiteItemFilter. */
+  public PSAutoSiteItemFilter() {
+    // default constructor
+  }
+
   /**
    * Implements the interface method. Modifies the result document to filter out items that are not
    * in the site with specified siteid. The request context must have the HTML parameter {@link
@@ -57,8 +62,8 @@ public class PSAutoSiteItemFilter extends PSDefaultExtension implements IPSResul
    * @param resultDoc if <code>null</code> returned as it is.
    * @return Document result document filtered for the items that are not in the site specified,
    *     <code>null</code> only if the original document is <code>null</code>.
-   * @throws PSParameterMismatchException
-   * @throws PSExtensionProcessingException
+   * @throws PSParameterMismatchException if the parameters are invalid
+   * @throws PSExtensionProcessingException if an error occurs while processing the extension
    */
   public Document processResultDocument(
       Object[] params, IPSRequestContext request, Document resultDoc)
@@ -160,7 +165,7 @@ public class PSAutoSiteItemFilter extends PSDefaultExtension implements IPSResul
    * @param parentFolderPath paranet folder path, must not be <code>null</code>
    * @return <code>true</code> if test based on the above description succeeds, <code>false</code>
    *     otherwise.
-   * @throws PSCmsException
+   * @throws PSCmsException if an error occurs while resolving folder relationships
    */
   private boolean isValid(Element currElement, IPSRequestContext request, String parentFolderPath)
       throws PSCmsException {

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSContentList.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSContentList.java
@@ -40,8 +40,8 @@ public class PSContentList {
    * Ctor that takes the publish context and delivery type. Calls {@link #PSContentList(String,
    * String, int, int, int)}with default values (-1) for the last three parameters.
    *
-   * @param context
-   * @param deliveryType
+   * @param context publish context, allows <code>null</code> or empty
+   * @param deliveryType delivery type string, may be <code>null</code> or empty
    */
   public PSContentList(String context, String deliveryType) {
     m_context = context;
@@ -222,6 +222,8 @@ public class PSContentList {
   }
 
   /**
+   * Gets the number of content items in this content list.
+   *
    * @return the size of the content list.
    */
   public int size() {

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSContentListItem.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSContentListItem.java
@@ -389,6 +389,8 @@ public class PSContentListItem implements Comparable {
   }
 
   /**
+   * Gets the content id of the item.
+   *
    * @return contentid of the item, never <code>null</code> or empty.
    */
   public String getContentId() {
@@ -410,6 +412,8 @@ public class PSContentListItem implements Comparable {
   }
 
   /**
+   * Gets the variant id of the item.
+   *
    * @return variantid of the item, never <code>null</code> or empty.
    */
   public String getVariantId() {
@@ -417,6 +421,8 @@ public class PSContentListItem implements Comparable {
   }
 
   /**
+   * Gets the last modified date of the item.
+   *
    * @return Last modified date of the item, may be <code>null</code>.
    */
   public Date getLastModifiedDate() {
@@ -424,6 +430,8 @@ public class PSContentListItem implements Comparable {
   }
 
   /**
+   * Gets the unpublish attribute of the item.
+   *
    * @return Unpublish attribute of the item, may be <code>null</code> or empty.
    */
   public String getUnpublishValue() {
@@ -431,6 +439,8 @@ public class PSContentListItem implements Comparable {
   }
 
   /**
+   * Indicates whether the content URL has been recorded as a null link.
+   *
    * @return If the Url is null then return <code>true</code> otherwise <code>false</code>.
    */
   public boolean isContentUrlNull() {

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSimpleSqlQuery.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSimpleSqlQuery.java
@@ -55,8 +55,6 @@ import org.apache.logging.log4j.Logger;
  * <p>This class makes no attempt to handle complex datatypes. Longs, CLOBs, Blobs, etc. are not
  * handled.
  *
- * <p>
- *
  * @author DavidBenua
  */
 public class PSSimpleSqlQuery {
@@ -70,7 +68,7 @@ public class PSSimpleSqlQuery {
    * @param params a list of Objects that represent the placeholders in the SQL. Never <code>null
    *     </code>. May be <code>empty</code>.
    * @return a List of Object[] representing the rows of the result set.
-   * @throws SQLException
+   * @throws SQLException if an error occurs executing the query
    */
   public static List doQuery(String query, List params) throws SQLException {
     List resultList = new ArrayList();
@@ -104,8 +102,8 @@ public class PSSimpleSqlQuery {
    *
    * @param ir the internal request.
    * @return a List of Object[] representing the rows of the result set.
-   * @throws PSInternalRequestCallException
-   * @throws SQLException
+   * @throws PSInternalRequestCallException if the internal request fails
+   * @throws SQLException if an error occurs executing the query
    */
   public static List doQuery(IPSInternalRequest ir)
       throws PSInternalRequestCallException, SQLException {
@@ -140,7 +138,7 @@ public class PSSimpleSqlQuery {
    * @param params a List of Objects that represent the parameters.
    * @return an Object[] that represents the first row returned from the query. May be <code>null
    *     </code>.
-   * @throws SQLException
+   * @throws SQLException if an error occurs executing the query
    */
   public static Object[] doSingleRowQuery(String query, List params) throws SQLException {
     Connection conn = null;
@@ -171,8 +169,8 @@ public class PSSimpleSqlQuery {
    *
    * @param ir the Internal Request.
    * @return an Object[] representing the columns returned by the query. May be <code>null</code>
-   * @throws SQLException
-   * @throws PSInternalRequestCallException
+   * @throws SQLException if an error occurs executing the query
+   * @throws PSInternalRequestCallException if the internal request fails
    */
   public static Object[] doSingleRowQuery(IPSInternalRequest ir)
       throws SQLException, PSInternalRequestCallException {

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSite.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSite.java
@@ -45,12 +45,18 @@ import org.w3c.dom.NodeList;
  * @author James Schultz
  */
 public class PSSite {
+
+  /** Default constructor for PSSite. */
+  public PSSite() {
+    // default constructor
+  }
+
   /**
    * Uses the site id parameter to lookup the site folder root path stored in the RXSITES table.
    *
    * @param siteid Id of the site whose site folder root will be returned. if provided null, null
    *     will be returned
-   * @param request
+   * @param request the current request context, never <code>null</code>
    * @return the site folder root of the supplied site, may be null or empty.
    */
   public static String lookupFolderRootForSite(String siteid, IPSRequestContext request) {

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderAssembly.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderAssembly.java
@@ -43,8 +43,6 @@ import org.apache.logging.log4j.Logger;
  * that is from the same site as the current site or a different one. Three site combinations exist
  * and the generated location for each combination follows the following pattern:
  *
- * <p>
- *
  * <ol>
  *   <li><i>Single Site with Multiple Sections: </i>An item has link to an item from a different
  *       section of the same site folder tree (originating siteid and current siteid are the same)
@@ -63,6 +61,12 @@ import org.apache.logging.log4j.Logger;
  */
 public class PSSiteFolderAssembly extends PSDefaultExtension
     implements IPSAssemblyLocation, IPSUdfProcessor {
+
+  /** Default constructor for PSSiteFolderAssembly. */
+  public PSSiteFolderAssembly() {
+    // default constructor
+  }
+
   /**
    * Implementation of the UDF interface method. Generates a publishing location as described in the
    * class description. The request context must have valid {@link IPSHtmlParameters#SYS_CONTENTID
@@ -72,7 +76,7 @@ public class PSSiteFolderAssembly extends PSDefaultExtension
    * @param params parameters for the extension as registered by teh extension.
    * @param request request context object, must not be <code>null</code>.
    * @return location path for the item in the request context, not <code>null</code>, may be empty.
-   * @throws PSConversionException
+   * @throws PSConversionException if an error occurs while converting parameter values
    */
   public Object processUdf(Object[] params, IPSRequestContext request)
       throws PSConversionException {

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderCListBase.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderCListBase.java
@@ -279,9 +279,10 @@ public abstract class PSSiteFolderCListBase {
    *     not be <code>null</code> or empty.
    * @return A content list XML document. Never <code>null</code> but will be empty if member
    *     variables are not initialized.
-   * @throws PSUnknownNodeTypeException
-   * @throws PSCmsException
-   * @throws PSExtensionProcessingException
+   * @throws PSUnknownNodeTypeException if an unknown node type is encountered while building the
+   *     content list
+   * @throws PSCmsException if an error occurs while accessing CMS data
+   * @throws PSExtensionProcessingException if an error occurs while processing the extension
    */
   public synchronized Document buildContentList(
       final String siteFolderPath,
@@ -512,9 +513,10 @@ public abstract class PSSiteFolderCListBase {
    * @param appendFolderName determines if the folder name will be appended to the path used in
    *     location schemes: true to add the name, false to ignore the name. Generally, only false on
    *     the first call to this method.
-   * @throws PSUnknownNodeTypeException
-   * @throws PSCmsException
-   * @throws PSExtensionProcessingException
+   * @throws PSUnknownNodeTypeException if an unknown node type is encountered while generating
+   *     content items
+   * @throws PSCmsException if an error occurs while accessing CMS data
+   * @throws PSExtensionProcessingException if an error occurs while processing the extension
    */
   protected abstract void generateContentItems(
       String parentFolderPath,
@@ -656,6 +658,7 @@ public abstract class PSSiteFolderCListBase {
   /** Resource for looking up content and/or variants for this site. */
   protected String m_contentResourceName;
 
+  /** The log instance for this class, never <code>null</code>. */
   protected final Logger log = LogManager.getLogger(PSSiteFolderCListBase.class);
 
   /** Caches the sys_casGeneratePubLocation UDF used to build pub locations */
@@ -697,6 +700,10 @@ public abstract class PSSiteFolderCListBase {
    */
   protected int m_maxDisplayedPageLinks;
 
+  /**
+   * Folder include mode controlling which sub-folders are included in the generated content list,
+   * defaults to <code>all</code>. Never <code>null</code>.
+   */
   protected String m_folderIncludeMode = "all";
 
   /**

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderCListBulk.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderCListBulk.java
@@ -95,8 +95,6 @@ public class PSSiteFolderCListBulk extends PSSiteFolderCListBase {
    * <p>Construct a site folder content list builder that will use the specified request for
    * obtaining request parameters, logging, and making internal requests.
    *
-   * <p>
-   *
    * @param request the current request context, used to obtain request parameters, logging, and
    *     making internal requests. Not <code>null</code>.
    * @param isIncremental <code>true</code> to generate an incremental publishing content list,

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListBaseExit.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListBaseExit.java
@@ -38,9 +38,18 @@ import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 
 /**
+ * Base class for site folder content list exits that produce a content list XML document for a
+ * given site. Concrete subclasses assemble content items for delivery based on parameters passed to
+ * the exit.
+ *
  * @author James Schultz
  */
 public abstract class PSSiteFolderContentListBaseExit implements IPSResultDocumentProcessor {
+
+  /** Default constructor for PSSiteFolderContentListBaseExit. */
+  public PSSiteFolderContentListBaseExit() {
+    // default constructor
+  }
 
   private static final Logger log = LogManager.getLogger(PSSiteFolderContentListBaseExit.class);
 
@@ -54,8 +63,10 @@ public abstract class PSSiteFolderContentListBaseExit implements IPSResultDocume
   }
 
   /**
-   * @param params values passed by the application invoking the exit
-   *     <ol start="0">
+   * Builds the site folder content list XML for the request's current site.
+   *
+   * @param params values passed by the application invoking the exit. Indexes (zero based):
+   *     <ul>
    *       <li>filenameContext: id of the context used to generate content items delivery locations.
    *           Defaults to the context of the current request.
    *       <li>deliveryType: determines the value of the deliverytype attribute of the contentlist
@@ -67,17 +78,17 @@ public abstract class PSSiteFolderContentListBaseExit implements IPSResultDocume
    *           pagination mode; unlimited number of items)
    *       <li>contentResourceName: Content items and its variants lookup resource name, default
    *           resource will be provided by the derived classes
-   *     </ul>
-   *     <li>NonStandardParamsToPass: Comma separated list of all non standard HTML parameters to
-   *         pass on from request to the content URL for each item in the content list
+   *       <li>NonStandardParamsToPass: Comma separated list of all non standard HTML parameters to
+   *           pass on from request to the content URL for each item in the content list
    *     </ul>
    *
-   * @param request
-   * @param resultDoc
-   * @throws com.percussion.extension.PSParameterMismatchException if the current request does not
-   *     contain a sys_siteid parameter, if no site folder root is registered to that site, or if
-   *     the filenameContext parameter is mot provided.
-   * @throws PSExtensionProcessingException
+   * @param request the current request context, must not be {@code null}
+   * @param resultDoc the result document being processed; must not be {@code null}
+   * @return the result document, populated with the site folder content list
+   * @throws PSParameterMismatchException if the current request does not contain a sys_siteid
+   *     parameter, if no site folder root is registered to that site, or if the filenameContext
+   *     parameter is not provided.
+   * @throws PSExtensionProcessingException if an error occurs while processing the extension
    */
   public Document processResultDocument(
       Object[] params, IPSRequestContext request, Document resultDoc)

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListBulkExit.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListBulkExit.java
@@ -26,6 +26,12 @@ import java.util.Set;
  * @see PSSiteFolderCListBulk
  */
 public class PSSiteFolderContentListBulkExit extends PSSiteFolderContentListBaseExit {
+
+  /** Default constructor for PSSiteFolderContentListBulkExit. */
+  public PSSiteFolderContentListBulkExit() {
+    // default constructor
+  }
+
   // implements the abstract method getSiteFolderCListObject()
   protected PSSiteFolderCListBase getSiteFolderCListInstance(
       IPSRequestContext request,

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListExit.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListExit.java
@@ -26,6 +26,12 @@ import java.util.Set;
  *     PSSiteFolderContentListBulkExit} instead.
  */
 public class PSSiteFolderContentListExit extends PSSiteFolderContentListBaseExit {
+
+  /** Default constructor for PSSiteFolderContentListExit. */
+  public PSSiteFolderContentListExit() {
+    // default constructor
+  }
+
   // implements the abstract method getSiteFolderCListObject()
   protected PSSiteFolderCListBase getSiteFolderCListInstance(
       IPSRequestContext request,

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListLinkGenerator.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListLinkGenerator.java
@@ -37,19 +37,26 @@ import org.apache.logging.log4j.Logger;
 
 /** Defines methods to generate various types of assembly locations. */
 public class PSSiteFolderContentListLinkGenerator {
+
+  /** Default constructor for PSSiteFolderContentListLinkGenerator. */
+  public PSSiteFolderContentListLinkGenerator() {
+    // default constructor
+  }
+
   /**
    * Generates an absolute URL to the assembler resource for the specified variant, using the
    * Rhythmyx server's external name and port. The URL will contain request parameters for
    * sys_contentid, sys_revision, sys_authtype, sys_context, sys_variantid, sys_siteid, and
    * rx_folder (containing the content id of the site folder of the item being assembled).
    *
-   * @param contentId
-   * @param revision
-   * @param variantId
-   * @param variantAssemblerBase
+   * @param contentId the id of the content item being assembled, never <code>null</code>
+   * @param revision the revision of the content item being assembled, never <code>null</code>
+   * @param variantId the id of the variant to assemble, never <code>null</code>
+   * @param variantAssemblerBase the base path of the assembler resource for the variant, never
+   *     <code>null</code>
    * @param folderId the ID of the site folder than contains the item. If provided, this value will
    *     be included in the URL as "sys_folderid"
-   * @param request
+   * @param request the current request context, never <code>null</code>
    * @param protocol the URL protocol to use when creating content URLs, never <code>null</code> or
    *     empty
    * @param host the host name or ip address to use when creating content URLs, never <code>null
@@ -134,12 +141,12 @@ public class PSSiteFolderContentListLinkGenerator {
    * Generates the publishing location for the specified content item's variant in the specified
    * context. Calls the sys_casGeneratePubLocation exit to do the heavy lifting.
    *
-   * @param contentId
-   * @param revision
-   * @param variantId
-   * @param context
-   * @param folderPath
-   * @param request
+   * @param contentId the id of the content item being published, never <code>null</code>
+   * @param revision the revision of the content item being published, never <code>null</code>
+   * @param variantId the id of the variant to publish, never <code>null</code>
+   * @param context the publishing context, never <code>null</code>
+   * @param folderPath the publishing folder path, never <code>null</code>
+   * @param request the current request context, never <code>null</code>
    * @return the publishing location produced by the scheme generator registered for the specified
    *     variant/context. Never <code>null</code>, will be empty if an error occurs while calling
    *     the generator (or if no generator is registered for the variant/context).
@@ -161,13 +168,13 @@ public class PSSiteFolderContentListLinkGenerator {
    * Generates the publishing location for the specified content item's variant in the specified
    * context. Calls the sys_casGeneratePubLocation exit to do the heavy lifting.
    *
-   * @param contentId
-   * @param revision
-   * @param variantId
-   * @param context
-   * @param folderPath
-   * @param folderId
-   * @param request
+   * @param contentId the id of the content item being published, never <code>null</code>
+   * @param revision the revision of the content item being published, never <code>null</code>
+   * @param variantId the id of the variant to publish, never <code>null</code>
+   * @param context the publishing context, never <code>null</code>
+   * @param folderPath the publishing folder path, never <code>null</code>
+   * @param folderId the id of the site folder that contains the item, may be <code>null</code>
+   * @param request the current request context, never <code>null</code>
    * @return the publishing location produced by the scheme generator registered for the specified
    *     variant/context. Never <code>null</code>, will be empty if an error occurs while calling
    *     the generator (or if no generator is registered for the variant/context).
@@ -206,7 +213,7 @@ public class PSSiteFolderContentListLinkGenerator {
    * return a trivial XML document; the URL is used as the assembly URL when an item has no
    * publishable variants because the publisher requires a valid content URL.
    *
-   * @param request
+   * @param request the current request context, never <code>null</code>
    * @return a URL to a resource named "null.xml" in the same application as the origining request,
    *     never null.
    */

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSqlInList.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSqlInList.java
@@ -32,7 +32,7 @@ public class PSSqlInList extends ArrayList implements List {
   /**
    * Creates a list with a specificied capacity. The created object is {@link #TYPE_LITERAL}.
    *
-   * @param initialCapacity
+   * @param initialCapacity the initial capacity of the underlying list
    */
   public PSSqlInList(int initialCapacity) {
     super(initialCapacity);
@@ -47,7 +47,7 @@ public class PSSqlInList extends ArrayList implements List {
    * Creates a list containing the members of the specified collection. The created object is {@link
    * #TYPE_LITERAL}.
    *
-   * @param c
+   * @param c the collection whose members will populate this list, never <code>null</code>
    */
   public PSSqlInList(Collection c) {
     super(c);

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/utils/PSRelationshipHelper.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/utils/PSRelationshipHelper.java
@@ -194,9 +194,9 @@ public class PSRelationshipHelper {
   /**
    * Gets a folder summary by path.
    *
-   * @param pathname
+   * @param pathname the folder path, never <code>null</code> or empty
    * @return the folder summary or <code>null</code>
-   * @throws PSCmsException
+   * @throws PSCmsException if an error occurs while loading the folder summary
    */
   public PSComponentSummary getSummaryByPath(String pathname) throws PSCmsException {
     getRelationshipProcessor();
@@ -233,9 +233,9 @@ public class PSRelationshipHelper {
    *
    * @param pathname the full path. Must not be empty or <code>null</code>.
    * @return the specified folder, or <code>null</code> if the folder cannot be found.
-   * @throws PSUnknownNodeTypeException
-   * @throws PSCmsException
-   * @throws PSExtensionProcessingException
+   * @throws PSUnknownNodeTypeException if the folder definition is not a recognized node type
+   * @throws PSCmsException if an error occurs while loading the folder
+   * @throws PSExtensionProcessingException if an error occurs while processing the extension
    */
   public PSFolder getFolderByPath(String pathname)
       throws PSUnknownNodeTypeException, PSCmsException, PSExtensionProcessingException {
@@ -278,9 +278,9 @@ public class PSRelationshipHelper {
    *
    * @param locator locator of the folder to get, must not be <code>null</code>.
    * @return the folder, or <code>null</code> if the folder cannot be found.
-   * @throws PSUnknownNodeTypeException
-   * @throws PSCmsException
-   * @throws PSExtensionProcessingException
+   * @throws PSUnknownNodeTypeException if the folder definition is not a recognized node type
+   * @throws PSCmsException if an error occurs while loading the folder
+   * @throws PSExtensionProcessingException if an error occurs while processing the extension
    */
   public PSFolder getFolder(PSLocator locator)
       throws PSUnknownNodeTypeException, PSCmsException, PSExtensionProcessingException {
@@ -318,9 +318,9 @@ public class PSRelationshipHelper {
    *
    * @param loc the locator to check, must not be <code>null</code>.
    * @return the locator with current revision filled if missing, never <code>null</code>.
-   * @throws PSCmsException
-   * @throws PSUnknownNodeTypeException
-   * @throws PSExtensionProcessingException
+   * @throws PSCmsException if an error occurs while resolving the current revision
+   * @throws PSUnknownNodeTypeException if the supplied locator is not a recognized node type
+   * @throws PSExtensionProcessingException if an error occurs while processing the extension
    */
   public PSLocator validateLocator(PSLocator loc)
       throws PSCmsException, PSUnknownNodeTypeException, PSExtensionProcessingException {
@@ -411,7 +411,7 @@ public class PSRelationshipHelper {
    * @param folder Locator of the descendent folder to check, must not be <code>null</code>.
    * @return <code>true</code> if the folder descends from the specified root, <code>false</code>
    *     otherwise.
-   * @throws PSCmsException
+   * @throws PSCmsException if an error occurs while querying the folder relationships
    */
   public boolean isFolderDescendent(PSLocator root, PSLocator folder) throws PSCmsException {
     getRelationshipProcessor();
@@ -452,9 +452,9 @@ public class PSRelationshipHelper {
    *
    * @param locator the content item or folder, must not be <code>null</code>.
    * @return a Set of PSFolders objects. Never <code>null</code> may be <code>empty</code>
-   * @throws PSCmsException
-   * @throws PSUnknownNodeTypeException
-   * @throws PSExtensionProcessingException
+   * @throws PSCmsException if an error occurs while loading the site folders
+   * @throws PSUnknownNodeTypeException if the folder definition is not a recognized node type
+   * @throws PSExtensionProcessingException if an error occurs while processing the extension
    */
   public Set getSiteFolders(PSLocator locator)
       throws PSUnknownNodeTypeException, PSCmsException, PSExtensionProcessingException {
@@ -469,9 +469,9 @@ public class PSRelationshipHelper {
    *
    * @param locator the content item or folder to search, must not be <code>null</code>.
    * @return a Set of PSFolder objects that contain this item.
-   * @throws PSUnknownNodeTypeException
-   * @throws PSCmsException
-   * @throws PSExtensionProcessingException
+   * @throws PSUnknownNodeTypeException if the folder definition is not a recognized node type
+   * @throws PSCmsException if an error occurs while loading the folders
+   * @throws PSExtensionProcessingException if an error occurs while processing the extension
    */
   public Set getFolders(PSLocator locator)
       throws PSUnknownNodeTypeException, PSCmsException, PSExtensionProcessingException {
@@ -487,9 +487,9 @@ public class PSRelationshipHelper {
    * @param locator the item or folder to search for, must not be <code>null</code>.
    * @param allFolders if <code>true</code> return all folders. Otherwise only return site folders.
    * @return a Set of PSFolder objects.
-   * @throws PSUnknownNodeTypeException
-   * @throws PSCmsException
-   * @throws PSExtensionProcessingException
+   * @throws PSUnknownNodeTypeException if the folder definition is not a recognized node type
+   * @throws PSCmsException if an error occurs while loading the folders
+   * @throws PSExtensionProcessingException if an error occurs while processing the extension
    */
   private Set getFoldersCommon(PSLocator locator, boolean allFolders)
       throws PSUnknownNodeTypeException, PSCmsException, PSExtensionProcessingException {
@@ -524,9 +524,9 @@ public class PSRelationshipHelper {
    * @param slotName the specified slot name, must not be <code>null</code> or empty.
    * @return a List of PSComponentSummary objects representing the slot contents. May be <code>empty
    *     </code> but never <code>null</code>
-   * @throws PSCmsException
+   * @throws PSCmsException if an error occurs while loading the slot contents
    * @throws PSExtensionProcessingException when the slot cannot be found.
-   * @throws PSUnknownNodeTypeException
+   * @throws PSUnknownNodeTypeException if the slot definition is not a recognized node type
    */
   public List getSlotContents(PSLocator item, String slotName)
       throws PSExtensionProcessingException, PSCmsException, PSUnknownNodeTypeException {
@@ -554,9 +554,9 @@ public class PSRelationshipHelper {
    * @param slot the specified slot, must not be <code>null</code>.
    * @return a List of PSComponentSummary objects representing the slot contents. May be <code>empty
    *     </code> but never <code>null</code>
-   * @throws PSCmsException
-   * @throws PSUnknownNodeTypeException
-   * @throws PSExtensionProcessingException
+   * @throws PSCmsException if an error occurs while loading the slot contents
+   * @throws PSUnknownNodeTypeException if the slot definition is not a recognized node type
+   * @throws PSExtensionProcessingException if an error occurs while processing the extension
    */
   public List getSlotContents(PSLocator item, PSSlotType slot)
       throws PSCmsException, PSUnknownNodeTypeException, PSExtensionProcessingException {
@@ -585,7 +585,7 @@ public class PSRelationshipHelper {
    * @param category the relationship category, may be <code>null</code> or empty.
    * @param relationship the name of the relationship, may be <code>null</code> or empty.
    * @return the parent items. May be <code>empty</code> but never <code>null</code>
-   * @throws PSCmsException
+   * @throws PSCmsException if an error occurs while loading the parent items
    */
   public PSComponentSummaries getParentItems(PSLocator item, String category, String relationship)
       throws PSCmsException {


### PR DESCRIPTION
## Summary

Documentation-only fix for the `extensions-sfp` module. The Maven build succeeded but Javadoc generation reported **6 errors** (3 unique HTML errors + their plugin-emitted detail lines) and **200 warnings** (100 unique Javadoc source warnings + their plugin-emitted detail lines). After this PR the module generates a clean Javadoc JAR.

## Errors fixed

| File | Issue |
| --- | --- |
| `modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListBaseExit.java` | `<ol start="0">` was wrongly closed by stray `</ul>` end tags in the `processResultDocument` params Javadoc (3 HTML errors: 2 unexpected `</ul>` end tags + 1 unclosed `ol` element) |

## Warnings fixed (100 unique)

- Added missing Javadoc to **42 undocumented public static final constants** in `IPSDTDPublisherEdition` (`ELEM_*` / `ATTR_*`).
- Added main descriptions, `@param` descriptions, and `@throws` descriptions to dozens of methods in `PSCalendarMonthModel`, `PSRecurringEvent`, `PSExpandRecurringEvents`, `PSSiteFolderContentListLinkGenerator`, `PSSiteFolderCListBase`, `PSRelationshipHelper`, etc.
- Added an explicit no-op default constructor with Javadoc to 15 classes that previously relied on the implicit default constructor (which triggered the `use of default constructor, which does not provide a comment` warning).
- Removed empty `<p>` tags in `PSSiteFolderAssembly` and `PSSimpleSqlQuery`.

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Javadoc error/warning count | `../mvnw.cmd javadoc:javadoc` | **0 errors, 0 warnings** |
| Module clean install | `cd modules/extensions-sfp && ../mvnw.cmd clean install` | **BUILD SUCCESS** — Tests run: 4, Failures: 0, Errors: 0, Skipped: 4 |
| Spotless | `../mvnw.cmd spotless:check` | **clean** |
| Erlang pre-commit review | see `docs/ai-generated/code-reviews/1601-extensions-sfp-javadoc-erlang.md` | **approve** (no blocking bugs) |

No new compiler warnings were introduced; pre-existing raw-type `HashMap` / `Iterator` warnings in `PSAutoGenerateFileName`, `PSExpandRecurringEvents`, `PSCalendarMonthModel`, `PSChildRelationshipBuilder` are unchanged from baseline and out of scope for this Javadoc issue.

## Files

25 changed files in `modules/extensions-sfp/src/main/java/**` — all documentation/Javadoc-only.

```
docs/ai-generated/code-reviews/1601-extensions-sfp-javadoc-erlang.md  |  91 ++++++++
modules/extensions-sfp/.../fastforward/PSAutoGenerateFileName.java    |  10 +-
modules/extensions-sfp/.../fastforward/PSCopyValueToRequest.java      |   8 +-
modules/extensions-sfp/.../fastforward/calendar/PSCalendarMonthModel.java |  49 +++-
modules/extensions-sfp/.../fastforward/calendar/PSExpandRecurringEvents.java |  23 ++-
modules/extensions-sfp/.../fastforward/calendar/PSMakeCalendar.java   |   6 +
modules/extensions-sfp/.../fastforward/calendar/PSRecurringEvent.java |  13 +-
modules/extensions-sfp/.../fastforward/relationship/PSBuildRelationshipsFromIdsExit.java |   6 +
modules/extensions-sfp/.../fastforward/relationship/PSChildRelationshipBase.java |   2 +
modules/extensions-sfp/.../fastforward/relationship/PSExtractIdsFromSlotExit.java |   5 +
modules/extensions-sfp/.../fastforward/sfp/IPSDTDPublisherEdition.java |  77 +++++
modules/extensions-sfp/.../fastforward/sfp/PSAppendPurgedOrMovedItems.java |   6 +
modules/extensions-sfp/.../fastforward/sfp/PSAutoSiteItemFilter.java |  11 +-
modules/extensions-sfp/.../fastforward/sfp/PSContentList.java        |   6 +-
modules/extensions-sfp/.../fastforward/sfp/PSContentListItem.java    |  10 +
modules/extensions-sfp/.../fastforward/sfp/PSSimpleSqlQuery.java     |  14 +-
modules/extensions-sfp/.../fastforward/sfp/PSSite.java               |   8 +-
modules/extensions-sfp/.../fastforward/sfp/PSSiteFolderAssembly.java |  10 +-
modules/extensions-sfp/.../fastforward/sfp/PSSiteFolderCListBase.java |  19 +-
modules/extensions-sfp/.../fastforward/sfp/PSSiteFolderCListBulk.java |   2 -
modules/extensions-sfp/.../fastforward/sfp/PSSiteFolderContentListBaseExit.java |  33 ++-
modules/extensions-sfp/.../fastforward/sfp/PSSiteFolderContentListBulkExit.java |   6 +
modules/extensions-sfp/.../fastforward/sfp/PSSiteFolderContentListExit.java |   6 +
modules/extensions-sfp/.../fastforward/sfp/PSSiteFolderContentListLinkGenerator.java |  45 ++--
modules/extensions-sfp/.../fastforward/sfp/PSSqlInList.java          |   4 +-
modules/extensions-sfp/.../fastforward/utils/PSRelationshipHelper.java |  54 ++--
26 files changed, 411 insertions(+), 106 deletions(-)
```

## Closes

Closes #1601
