### PR TITLE
fix(javadoc): resolve 4 errors + 200 warnings in feeds module (#1603)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/data/FeedType.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/data/FeedType.java
@@ -19,11 +19,17 @@ package com.percussion.delivery.data;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/** Enumeration of the supported feed types. */
 public enum FeedType {
+  /** Atom feed format. */
   @JsonProperty("ATOM")
   ATOM,
+
+  /** RSS 1.0 (RDF Site Summary) feed format. */
   @JsonProperty("RSS1")
   RSS1,
+
+  /** RSS 2.0 (Really Simple Syndication) feed format. */
   @JsonProperty("RSS2")
   RSS2
 }

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/data/IPSFeedDescriptor.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/data/IPSFeedDescriptor.java
@@ -23,36 +23,50 @@ import com.percussion.delivery.feeds.data.PSFeedDescriptor;
 @JsonDeserialize(as = PSFeedDescriptor.class)
 public interface IPSFeedDescriptor {
   /**
+   * Gets the name of the feed.
+   *
    * @return the name of the feed.
    */
   public String getName();
 
   /**
+   * Gets the name of the site the feed belongs to.
+   *
    * @return the name of the site the feed belongs to.
    */
   public String getSite();
 
   /**
+   * Gets the feed title.
+   *
    * @return the feed title.
    */
   public String getTitle();
 
   /**
+   * Gets the feed description.
+   *
    * @return the feed description.
    */
   public String getDescription();
 
   /**
+   * Gets the link to the page the feed represents.
+   *
    * @return the link to the page the feed represents.
    */
   public String getLink();
 
   /**
+   * Gets the query to get the feed data from the meta-data service.
+   *
    * @return the query to get the feed data from the meta-data service.
    */
   public String getQuery();
 
   /**
+   * Gets the feed output type.
+   *
    * @return the feed output type. Never <code>null</code>.
    */
   public String getType();

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/data/PSFeedDTO.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/data/PSFeedDTO.java
@@ -19,32 +19,60 @@ package com.percussion.delivery.data;
 
 import java.util.Objects;
 
+/** Transfer object for an external feed URL and the host that issued the request. */
 public class PSFeedDTO {
 
   private String feedsUrl;
   private String hostName;
 
+  /** Default no-arg constructor required by Jackson serialization. */
   public PSFeedDTO() {
     super();
   }
 
+  /**
+   * Constructs a DTO with the supplied feed URL and host name.
+   *
+   * @param feedsUrl the URL of the external feed, never <code>null</code>
+   * @param hostName the host name that issued the request, never <code>null</code>
+   */
   public PSFeedDTO(String feedsUrl, String hostName) {
     this.feedsUrl = Objects.requireNonNull(feedsUrl, "feedsUrl cannot be null");
     this.hostName = Objects.requireNonNull(hostName, "hostName cannot be null");
   }
 
+  /**
+   * Gets the URL of the external feed.
+   *
+   * @return the feedsUrl, may be <code>null</code>
+   */
   public String getFeedsUrl() {
     return feedsUrl;
   }
 
+  /**
+   * Sets the URL of the external feed.
+   *
+   * @param feedsUrl the feedsUrl to set
+   */
   public void setFeedsUrl(String feedsUrl) {
     this.feedsUrl = feedsUrl;
   }
 
+  /**
+   * Gets the host name that issued the request.
+   *
+   * @return the hostName, may be <code>null</code>
+   */
   public String getHostName() {
     return hostName;
   }
 
+  /**
+   * Sets the host name that issued the request.
+   *
+   * @param hostName the hostName to set
+   */
   public void setHostName(String hostName) {
     this.hostName = hostName;
   }

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/data/PSFeedDescriptor.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/data/PSFeedDescriptor.java
@@ -31,10 +31,23 @@ public class PSFeedDescriptor implements IPSFeedDescriptor {
 
   private String type;
 
+  /** Default no-arg constructor required by Jackson serialization. */
   public PSFeedDescriptor() {
     super();
   }
 
+  /**
+   * Constructs a fully-populated feed descriptor.
+   *
+   * @param name the feed name, never <code>null</code>
+   * @param site the name of the site the feed belongs to, never <code>null</code>
+   * @param description the feed description, never <code>null</code>
+   * @param link the link to the page the feed represents, never <code>null</code>
+   * @param title the feed title, never <code>null</code>
+   * @param query the query used to get the feed data from the meta-data service, never <code>null
+   *     </code>
+   * @param type the feed output type, never <code>null</code>
+   */
   public PSFeedDescriptor(
       String name,
       String site,
@@ -52,49 +65,64 @@ public class PSFeedDescriptor implements IPSFeedDescriptor {
     this.type = Objects.requireNonNull(type, "type cannot be null");
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.data.IPSFeedDescriptor#getDescription()
+  /**
+   * Gets the feed description.
+   *
+   * @return the feed description, never <code>null</code>
    */
   public String getDescription() {
     return description;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.data.IPSFeedDescriptor#getLink()
+  /**
+   * Gets the link to the page the feed represents.
+   *
+   * @return the link to the page the feed represents, never <code>null</code>
    */
   public String getLink() {
     return link;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.data.IPSFeedDescriptor#getName()
+  /**
+   * Gets the feed name.
+   *
+   * @return the feed name, never <code>null</code>
    */
   public String getName() {
     return name;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.data.IPSFeedDescriptor#getQuery()
+  /**
+   * Gets the query used to get the feed data from the meta-data service.
+   *
+   * @return the query used to get the feed data from the meta-data service, never <code>null
+   *     </code>
    */
   public String getQuery() {
     return query;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.data.IPSFeedDescriptor#getSite()
+  /**
+   * Gets the name of the site the feed belongs to.
+   *
+   * @return the name of the site the feed belongs to, never <code>null</code>
    */
   public String getSite() {
     return site;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.data.IPSFeedDescriptor#getTitle()
+  /**
+   * Gets the feed title.
+   *
+   * @return the feed title, never <code>null</code>
    */
   public String getTitle() {
     return title;
   }
 
   /**
+   * Gets the feed output type.
+   *
    * @return the type
    */
   public String getType() {
@@ -102,6 +130,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor {
   }
 
   /**
+   * Sets the feed output type.
+   *
    * @param type the type to set
    */
   public void setType(String type) {
@@ -109,6 +139,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor {
   }
 
   /**
+   * Sets the feed name.
+   *
    * @param name the name to set
    */
   public void setName(String name) {
@@ -116,6 +148,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor {
   }
 
   /**
+   * Sets the name of the site the feed belongs to.
+   *
    * @param site the site to set
    */
   public void setSite(String site) {
@@ -123,6 +157,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor {
   }
 
   /**
+   * Sets the feed description.
+   *
    * @param description the description to set
    */
   public void setDescription(String description) {
@@ -130,6 +166,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor {
   }
 
   /**
+   * Sets the link to the page the feed represents.
+   *
    * @param link the link to set
    */
   public void setLink(String link) {
@@ -137,6 +175,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor {
   }
 
   /**
+   * Sets the feed title.
+   *
    * @param title the title to set
    */
   public void setTitle(String title) {
@@ -144,6 +184,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor {
   }
 
   /**
+   * Sets the query used to get the feed data from the meta-data service.
+   *
    * @param query the query to set
    */
   public void setQuery(String query) {
@@ -172,6 +214,17 @@ public class PSFeedDescriptor implements IPSFeedDescriptor {
     return Objects.hash(name, site, description, link, title, query, type);
   }
 
+  /**
+   * Convenience constructor that builds a descriptor with no feed type set.
+   *
+   * @param name the feed name, never <code>null</code>
+   * @param site the name of the site the feed belongs to, never <code>null</code>
+   * @param description the feed description, never <code>null</code>
+   * @param link the link to the page the feed represents, never <code>null</code>
+   * @param title the feed title, never <code>null</code>
+   * @param query the query used to get the feed data from the meta-data service, never <code>null
+   *     </code>
+   */
   public PSFeedDescriptor(
       String name, String site, String description, String link, String title, String query) {
     this(name, site, description, link, title, query, null);

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/data/PSFeedDescriptors.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/data/PSFeedDescriptors.java
@@ -34,6 +34,7 @@ public class PSFeedDescriptors {
   private boolean servicePassEncrypted;
   private String site;
 
+  /** Default no-arg constructor required by Jackson serialization. */
   public PSFeedDescriptors() {
     super();
   }
@@ -79,6 +80,16 @@ public class PSFeedDescriptors {
         + '}';
   }
 
+  /**
+   * Constructs a fully-populated feed descriptors container.
+   *
+   * @param descriptors the list of feed descriptors, never <code>null</code>
+   * @param serviceUrl the metadata service URL, never <code>null</code>
+   * @param serviceUser the metadata service user name, never <code>null</code>
+   * @param servicePass the metadata service password, never <code>null</code>
+   * @param servicePassEncrypted <code>true</code> if the password is encrypted
+   * @param site the site this container is associated with, never <code>null</code>
+   */
   public PSFeedDescriptors(
       List<IPSFeedDescriptor> descriptors,
       String serviceUrl,
@@ -95,6 +106,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Gets the list of feed descriptors.
+   *
    * @return the descriptors
    */
   public List<IPSFeedDescriptor> getDescriptors() {
@@ -102,6 +115,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Sets the list of feed descriptors.
+   *
    * @param descriptors the descriptors to set
    */
   public void setDescriptors(List<IPSFeedDescriptor> descriptors) {
@@ -109,6 +124,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Gets the metadata service URL.
+   *
    * @return the serviceUrl
    */
   public String getServiceUrl() {
@@ -116,6 +133,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Sets the metadata service URL.
+   *
    * @param serviceUrl the serviceUrl to set
    */
   public void setServiceUrl(String serviceUrl) {
@@ -123,6 +142,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Gets the metadata service user name.
+   *
    * @return the serviceUser
    */
   public String getServiceUser() {
@@ -130,6 +151,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Sets the metadata service user name.
+   *
    * @param serviceUser the serviceUser to set
    */
   public void setServiceUser(String serviceUser) {
@@ -137,6 +160,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Gets the metadata service password.
+   *
    * @return the servicePass
    */
   public String getServicePass() {
@@ -144,6 +169,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Sets the metadata service password.
+   *
    * @param servicePass the servicePass to set
    */
   public void setServicePass(String servicePass) {
@@ -151,6 +178,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Indicates whether the metadata service password is encrypted.
+   *
    * @return the servicePassEncrypted
    */
   public boolean isServicePassEncrypted() {
@@ -158,6 +187,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Sets whether the metadata service password is encrypted.
+   *
    * @param servicePassEncrypted the servicePassEncrypted to set
    */
   public void setServicePassEncrypted(boolean servicePassEncrypted) {
@@ -165,6 +196,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Gets the site this container is associated with.
+   *
    * @return the site
    */
   public String getSite() {
@@ -172,6 +205,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Sets the site this container is associated with.
+   *
    * @param site the site to set
    */
   public void setSite(String site) {

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/data/PSFeedItem.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/data/PSFeedItem.java
@@ -19,6 +19,8 @@ package com.percussion.delivery.data;
 import java.util.Date;
 
 /**
+ * Transfer object representing a single feed item (entry) within an RSS/Atom feed.
+ *
  * @author erikserating
  */
 public class PSFeedItem {
@@ -27,7 +29,14 @@ public class PSFeedItem {
   private Date publishDate;
   private String link;
 
+  /** Default no-arg constructor required by Jackson serialization. */
+  public PSFeedItem() {
+    super();
+  }
+
   /**
+   * Gets the title of the feed item.
+   *
    * @return the title
    */
   public String getTitle() {
@@ -35,6 +44,8 @@ public class PSFeedItem {
   }
 
   /**
+   * Sets the title of the feed item.
+   *
    * @param title the title to set
    */
   public void setTitle(String title) {
@@ -42,6 +53,8 @@ public class PSFeedItem {
   }
 
   /**
+   * Gets the description of the feed item.
+   *
    * @return the description
    */
   public String getDescription() {
@@ -49,6 +62,8 @@ public class PSFeedItem {
   }
 
   /**
+   * Sets the description of the feed item.
+   *
    * @param description the description to set
    */
   public void setDescription(String description) {
@@ -56,6 +71,8 @@ public class PSFeedItem {
   }
 
   /**
+   * Gets the publish date of the feed item.
+   *
    * @return the publishDate
    */
   public Date getPublishDate() {
@@ -63,6 +80,8 @@ public class PSFeedItem {
   }
 
   /**
+   * Sets the publish date of the feed item.
+   *
    * @param publishDate the publishDate to set
    */
   public void setPublishDate(Date publishDate) {
@@ -70,6 +89,8 @@ public class PSFeedItem {
   }
 
   /**
+   * Gets the link associated with the feed item.
+   *
    * @return the link
    */
   public String getLink() {
@@ -77,6 +98,8 @@ public class PSFeedItem {
   }
 
   /**
+   * Sets the link associated with the feed item.
+   *
    * @param link the link to set
    */
   public void setLink(String link) {

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/PSFeedGenerator.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/PSFeedGenerator.java
@@ -35,9 +35,27 @@ import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
 /**
+ * Generates Atom/RSS feed XML for a feed descriptor and a list of feed items, using the configured
+ * host name as the feed link host.
+ *
  * @author erikserating
  */
 public class PSFeedGenerator {
+
+  /** Default constructor. */
+  public PSFeedGenerator() {
+    // default constructor
+  }
+
+  /**
+   * Renders the supplied descriptor and items as feed XML using the given host.
+   *
+   * @param desc the feed descriptor, never <code>null</code>
+   * @param host the host name used to build the feed's links, never <code>null</code>
+   * @param items the feed items to include, never <code>null</code>
+   * @return the feed XML as a string, never <code>null</code>
+   * @throws FeedException if the feed XML cannot be produced
+   */
   public String makeFeedContent(IPSFeedDescriptor desc, String host, List<PSFeedItem> items)
       throws FeedException {
     Objects.requireNonNull(desc, "desc cannot be null");
@@ -75,18 +93,25 @@ public class PSFeedGenerator {
   }
 
   /**
-   * Replaces the host name in the link with the supplied host
+   * Replaces the host name in the link with the supplied host.
    *
-   * @param link
-   * @param host
-   * @return The link
-   * @throws FeedException
+   * @param link the original link, never <code>null</code>
+   * @param host the replacement host, never <code>null</code>
+   * @return the link with the host replaced, never <code>null</code>
+   * @throws FeedException if the link cannot be parsed
    */
   private String fixupHost(String link, String host) throws FeedException {
     String curHost = getHost(link);
     return StringUtils.replace(link, curHost, host, 1);
   }
 
+  /**
+   * Extracts the host (and port, if present) from the supplied link.
+   *
+   * @param link the link to parse, never <code>null</code>
+   * @return the host portion of the link (with port if present), never <code>null</code>
+   * @throws FeedException if the link cannot be parsed
+   */
   public static String getHost(String link) throws FeedException {
     try {
       URI uri = new URI(link);

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/PSFeedsApplication.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/PSFeedsApplication.java
@@ -31,8 +31,18 @@ import org.glassfish.jersey.server.spring.SpringLifecycleListener;
 import org.glassfish.jersey.server.spring.SpringWebApplicationInitializer;
 import org.glassfish.jersey.server.spring.scope.RequestContextFilter;
 
+/**
+ * Jersey application configuration for the feeds REST endpoints. Mounted at the application root
+ * and registers the Spring/Jersey integration, JSON providers, exception mappers, and the {@link
+ * PSFeedService} resource.
+ */
 @ApplicationPath("/")
 public class PSFeedsApplication extends ResourceConfig {
+
+  /**
+   * Registers the request-scoped filter, Spring component provider, lifecycle listeners, the feed
+   * REST service, JSON binding provider, and exception mappers used by the feeds application.
+   */
   public PSFeedsApplication() {
     register(RequestContextFilter.class);
     register(SpringComponentProvider.class);

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/data/FeedType.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/data/FeedType.java
@@ -19,11 +19,17 @@ package com.percussion.delivery.feeds.data;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/** Enumeration of the supported feed types. */
 public enum FeedType {
+  /** Atom feed format. */
   @JsonProperty("ATOM")
   ATOM,
+
+  /** RSS 1.0 (RDF Site Summary) feed format. */
   @JsonProperty("RSS1")
   RSS1,
+
+  /** RSS 2.0 (Really Simple Syndication) feed format. */
   @JsonProperty("RSS2")
   RSS2
 }

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/data/IPSFeedDescriptor.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/data/IPSFeedDescriptor.java
@@ -22,36 +22,50 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 @JsonDeserialize(as = PSFeedDescriptor.class)
 public interface IPSFeedDescriptor {
   /**
+   * Gets the name of the feed.
+   *
    * @return the name of the feed.
    */
   public String getName();
 
   /**
+   * Gets the name of the site the feed belongs to.
+   *
    * @return the name of the site the feed belongs to.
    */
   public String getSite();
 
   /**
+   * Gets the feed title.
+   *
    * @return the feed title.
    */
   public String getTitle();
 
   /**
+   * Gets the feed description.
+   *
    * @return the feed description.
    */
   public String getDescription();
 
   /**
+   * Gets the link to the page the feed represents.
+   *
    * @return the link to the page the feed represents.
    */
   public String getLink();
 
   /**
+   * Gets the query to get the feed data from the meta-data service.
+   *
    * @return the query to get the feed data from the meta-data service.
    */
   public String getQuery();
 
   /**
+   * Gets the feed output type.
+   *
    * @return the feed output type. Never <code>null</code>.
    */
   public String getType();

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/data/PSFeedDTO.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/data/PSFeedDTO.java
@@ -17,23 +17,49 @@
 
 package com.percussion.delivery.feeds.data;
 
+/** Transfer object for an external feed URL and the host that issued the request. */
 public class PSFeedDTO {
 
   private String feedsUrl;
   private String hostName;
 
+  /** Default no-arg constructor required by Jackson serialization. */
+  public PSFeedDTO() {
+    super();
+  }
+
+  /**
+   * Gets the URL of the external feed.
+   *
+   * @return the feedsUrl, may be <code>null</code>
+   */
   public String getFeedsUrl() {
     return feedsUrl;
   }
 
+  /**
+   * Sets the URL of the external feed.
+   *
+   * @param feedsUrl the feedsUrl to set
+   */
   public void setFeedsUrl(String feedsUrl) {
     this.feedsUrl = feedsUrl;
   }
 
+  /**
+   * Gets the host name that issued the request.
+   *
+   * @return the hostName, may be <code>null</code>
+   */
   public String getHostName() {
     return hostName;
   }
 
+  /**
+   * Sets the host name that issued the request.
+   *
+   * @param hostName the hostName to set
+   */
   public void setHostName(String hostName) {
     this.hostName = hostName;
   }

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/data/PSFeedDescriptor.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/data/PSFeedDescriptor.java
@@ -29,10 +29,23 @@ public class PSFeedDescriptor implements IPSFeedDescriptor {
   private String query;
   private String type;
 
+  /** Default no-arg constructor required by Jackson serialization. */
   public PSFeedDescriptor() {
     super();
   }
 
+  /**
+   * Constructs a fully-populated feed descriptor.
+   *
+   * @param name the feed name, never <code>null</code>
+   * @param site the name of the site the feed belongs to, never <code>null</code>
+   * @param description the feed description, never <code>null</code>
+   * @param link the link to the page the feed represents, never <code>null</code>
+   * @param title the feed title, never <code>null</code>
+   * @param query the query used to get the feed data from the meta-data service, never <code>null
+   *     </code>
+   * @param type the feed output type, never <code>null</code>
+   */
   public PSFeedDescriptor(
       String name,
       String site,
@@ -50,49 +63,64 @@ public class PSFeedDescriptor implements IPSFeedDescriptor {
     this.type = Objects.requireNonNull(type, "type cannot be null");
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.data.IPSFeedDescriptor#getDescription()
+  /**
+   * Gets the feed description.
+   *
+   * @return the feed description, never <code>null</code>
    */
   public String getDescription() {
     return description;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.data.IPSFeedDescriptor#getLink()
+  /**
+   * Gets the link to the page the feed represents.
+   *
+   * @return the link to the page the feed represents, never <code>null</code>
    */
   public String getLink() {
     return link;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.data.IPSFeedDescriptor#getName()
+  /**
+   * Gets the feed name.
+   *
+   * @return the feed name, never <code>null</code>
    */
   public String getName() {
     return name;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.data.IPSFeedDescriptor#getQuery()
+  /**
+   * Gets the query used to get the feed data from the meta-data service.
+   *
+   * @return the query used to get the feed data from the meta-data service, never <code>null
+   *     </code>
    */
   public String getQuery() {
     return query;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.data.IPSFeedDescriptor#getSite()
+  /**
+   * Gets the name of the site the feed belongs to.
+   *
+   * @return the name of the site the feed belongs to, never <code>null</code>
    */
   public String getSite() {
     return site;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.data.IPSFeedDescriptor#getTitle()
+  /**
+   * Gets the feed title.
+   *
+   * @return the feed title, never <code>null</code>
    */
   public String getTitle() {
     return title;
   }
 
   /**
+   * Gets the feed output type.
+   *
    * @return the type
    */
   public String getType() {
@@ -100,6 +128,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor {
   }
 
   /**
+   * Sets the feed output type.
+   *
    * @param type the type to set
    */
   public void setType(String type) {
@@ -107,6 +137,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor {
   }
 
   /**
+   * Sets the feed name.
+   *
    * @param name the name to set
    */
   public void setName(String name) {
@@ -114,6 +146,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor {
   }
 
   /**
+   * Sets the name of the site the feed belongs to.
+   *
    * @param site the site to set
    */
   public void setSite(String site) {
@@ -121,6 +155,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor {
   }
 
   /**
+   * Sets the feed description.
+   *
    * @param description the description to set
    */
   public void setDescription(String description) {
@@ -128,6 +164,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor {
   }
 
   /**
+   * Sets the link to the page the feed represents.
+   *
    * @param link the link to set
    */
   public void setLink(String link) {
@@ -135,6 +173,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor {
   }
 
   /**
+   * Sets the feed title.
+   *
    * @param title the title to set
    */
   public void setTitle(String title) {
@@ -142,6 +182,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor {
   }
 
   /**
+   * Sets the query used to get the feed data from the meta-data service.
+   *
    * @param query the query to set
    */
   public void setQuery(String query) {

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/data/PSFeedDescriptors.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/data/PSFeedDescriptors.java
@@ -31,11 +31,14 @@ public class PSFeedDescriptors {
   private boolean servicePassEncrypted;
   private String site;
 
+  /** Default no-arg constructor required by Jackson serialization. */
   public PSFeedDescriptors() {
     super();
   }
 
   /**
+   * Gets the list of feed descriptors.
+   *
    * @return the descriptors
    */
   public List<IPSFeedDescriptor> getDescriptors() {
@@ -43,6 +46,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Sets the list of feed descriptors.
+   *
    * @param descriptors the descriptors to set
    */
   public void setDescriptors(List<IPSFeedDescriptor> descriptors) {
@@ -50,6 +55,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Gets the metadata service URL.
+   *
    * @return the serviceUrl
    */
   public String getServiceUrl() {
@@ -57,6 +64,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Sets the metadata service URL.
+   *
    * @param serviceUrl the serviceUrl to set
    */
   public void setServiceUrl(String serviceUrl) {
@@ -64,6 +73,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Gets the metadata service user name.
+   *
    * @return the serviceUser
    */
   public String getServiceUser() {
@@ -71,6 +82,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Sets the metadata service user name.
+   *
    * @param serviceUser the serviceUser to set
    */
   public void setServiceUser(String serviceUser) {
@@ -78,6 +91,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Gets the metadata service password.
+   *
    * @return the servicePass
    */
   public String getServicePass() {
@@ -85,6 +100,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Sets the metadata service password.
+   *
    * @param servicePass the servicePass to set
    */
   public void setServicePass(String servicePass) {
@@ -92,6 +109,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Indicates whether the metadata service password is encrypted.
+   *
    * @return the servicePassEncrypted
    */
   public boolean isServicePassEncrypted() {
@@ -99,6 +118,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Sets whether the metadata service password is encrypted.
+   *
    * @param servicePassEncrypted the servicePassEncrypted to set
    */
   public void setServicePassEncrypted(boolean servicePassEncrypted) {
@@ -106,6 +127,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Gets the site this container is associated with.
+   *
    * @return the site
    */
   public String getSite() {
@@ -113,6 +136,8 @@ public class PSFeedDescriptors {
   }
 
   /**
+   * Sets the site this container is associated with.
+   *
    * @param site the site to set
    */
   public void setSite(String site) {

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/data/PSFeedItem.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/data/PSFeedItem.java
@@ -20,6 +20,8 @@ import java.util.Date;
 import java.util.Objects;
 
 /**
+ * Transfer object representing a single feed item (entry) within an RSS/Atom feed.
+ *
  * @author erikserating
  */
 public class PSFeedItem {
@@ -28,10 +30,19 @@ public class PSFeedItem {
   private Date publishDate;
   private String link;
 
+  /** Default no-arg constructor required by Jackson serialization. */
   public PSFeedItem() {
     super();
   }
 
+  /**
+   * Constructs a fully-populated feed item.
+   *
+   * @param title the title of the feed item, never <code>null</code>
+   * @param description the description of the feed item, never <code>null</code>
+   * @param publishDate the publish date of the feed item, never <code>null</code>
+   * @param link the link associated with the feed item, never <code>null</code>
+   */
   public PSFeedItem(String title, String description, Date publishDate, String link) {
     this.title = Objects.requireNonNull(title, "title cannot be null");
     this.description = Objects.requireNonNull(description, "description cannot be null");
@@ -40,6 +51,8 @@ public class PSFeedItem {
   }
 
   /**
+   * Gets the title of the feed item.
+   *
    * @return the title
    */
   public String getTitle() {
@@ -47,6 +60,8 @@ public class PSFeedItem {
   }
 
   /**
+   * Sets the title of the feed item.
+   *
    * @param title the title to set
    */
   public void setTitle(String title) {
@@ -54,6 +69,8 @@ public class PSFeedItem {
   }
 
   /**
+   * Gets the description of the feed item.
+   *
    * @return the description
    */
   public String getDescription() {
@@ -61,6 +78,8 @@ public class PSFeedItem {
   }
 
   /**
+   * Sets the description of the feed item.
+   *
    * @param description the description to set
    */
   public void setDescription(String description) {
@@ -68,6 +87,8 @@ public class PSFeedItem {
   }
 
   /**
+   * Gets the publish date of the feed item.
+   *
    * @return the publishDate
    */
   public Date getPublishDate() {
@@ -75,6 +96,8 @@ public class PSFeedItem {
   }
 
   /**
+   * Sets the publish date of the feed item.
+   *
    * @param publishDate the publishDate to set
    */
   public void setPublishDate(Date publishDate) {
@@ -82,6 +105,8 @@ public class PSFeedItem {
   }
 
   /**
+   * Gets the link associated with the feed item.
+   *
    * @return the link
    */
   public String getLink() {
@@ -89,6 +114,8 @@ public class PSFeedItem {
   }
 
   /**
+   * Sets the link associated with the feed item.
+   *
    * @param link the link to set
    */
   public void setLink(String link) {

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/services/IPSConnectionInfo.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/services/IPSConnectionInfo.java
@@ -17,17 +17,44 @@
 package com.percussion.delivery.feeds.services;
 
 /**
+ * Represents connection information used to access the metadata service.
+ *
  * @author erikserating
  */
 public interface IPSConnectionInfo {
 
+  /**
+   * Gets the connection URL.
+   *
+   * @return the connection URL, never <code>null</code>
+   */
   public String getUrl();
 
+  /**
+   * Gets the connection user name.
+   *
+   * @return the connection user name, never <code>null</code>
+   */
   public String getUsername();
 
+  /**
+   * Gets the connection password.
+   *
+   * @return the connection password, may be <code>null</code> when unused
+   */
   public String getPassword();
 
+  /**
+   * Gets the encrypted form of the connection password.
+   *
+   * @return the encrypted password, may be <code>null</code> when no password is set
+   */
   public String getEncrypted();
 
+  /**
+   * Gets the unique identifier of this connection record.
+   *
+   * @return the connection record id
+   */
   public long getId();
 }

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/services/IPSFeedDao.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/services/IPSFeedDao.java
@@ -46,7 +46,7 @@ public interface IPSFeedDao {
    *
    * @param name the feed name, cannot be <code>null</code> or empty.
    * @param site the feed site, cannot be <code>null</code> or empty.
-   * @return the retrieved descriptor or </code>empty Optional</code> if not found.
+   * @return the retrieved descriptor or <code>empty Optional</code> if not found.
    */
   public IPSFeedDescriptor find(String name, String site);
 
@@ -69,14 +69,16 @@ public interface IPSFeedDao {
   /**
    * Save the connection info to access the meta data service.
    *
-   * @param url
-   * @param user
-   * @param pass
-   * @param encrypted
+   * @param url the URL of the metadata service, never <code>null</code> or empty
+   * @param user the user name used to authenticate, never <code>null</code> or empty
+   * @param pass the password used to authenticate, may be <code>null</code>
+   * @param encrypted <code>true</code> if the password is encrypted, <code>false</code> otherwise
    */
   public void saveConnectionInfo(String url, String user, String pass, boolean encrypted);
 
   /**
+   * Gets the connection info used to access the meta data service.
+   *
    * @return the connection info, may be <code>empty Optional</code>.
    */
   public IPSConnectionInfo getConnectionInfo();

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/services/IPSFeedsRestService.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/services/IPSFeedsRestService.java
@@ -34,6 +34,9 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 /**
+ * REST service contract for the feeds module. Exposes feed generation, external feed proxying, feed
+ * descriptor persistence, and metadata listener management.
+ *
  * @author natechadwick
  */
 public interface IPSFeedsRestService extends IPSRestService {
@@ -46,6 +49,8 @@ public interface IPSFeedsRestService extends IPSRestService {
    *     a page not found will be sent in response.
    * @param feedname may be <code>null</code> or empty in which case a page not found will be sent
    *     in response.
+   * @param hostname the host name used to build the feed's links, never <code>null</code>
+   * @param httpRequest the current HTTP servlet request, never <code>null</code>
    * @return response with the feed xml or a page not found or server error, depending on the
    *     situation.
    */
@@ -61,7 +66,8 @@ public interface IPSFeedsRestService extends IPSRestService {
   /**
    * Acts as a proxy getting a list of feeds from an external URL. Returns the xml as a string.
    *
-   * @param psFeedDTO the url, assumed to not be <code>null</code>.
+   * @param psFeedDTO the feed DTO containing the target URL, assumed to not be <code>null</code>.
+   * @return the external feed XML as a string, never <code>null</code>
    */
   @POST
   @Path("/readExternalFeed")
@@ -74,31 +80,32 @@ public interface IPSFeedsRestService extends IPSRestService {
    * list sent and currently stored descriptors. Any stored descriptors not on the list sent will be
    * deleted. Notifies listeners of changes so that cache regions can be flushed.
    *
-   * @param descriptors
+   * @param descriptors the feed descriptors and connection info to save, never <code>null</code>
    */
   @PUT
   @Path("/descriptors")
   @RolesAllowed("deliverymanager")
   public abstract void saveDescriptors(PSFeedDescriptors descriptors);
 
-  /*
-   * (non-Javadoc)
+  /**
+   * Adds a metadata change listener.
    *
-   * @see
-   * com.percussion.metadata.IPSMetadataIndexerService#addMetadataListener
-   * (com.percussion.metadata.event.IPSMetadataListener)
+   * @param listener the listener to register, never <code>null</code>
    */
   public abstract void addMetadataListener(IPSServiceDataChangeListener listener);
 
-  /*
-   * (non-Javadoc)
+  /**
+   * Removes a previously registered metadata change listener.
    *
-   * @see
-   * com.percussion.metadata.IPSMetadataIndexerService#removeMetadataListener
-   * (com.percussion.metadata.event.IPSMetadataListener)
+   * @param listener the listener to remove, never <code>null</code>
    */
   public abstract void removeMetadataListener(IPSServiceDataChangeListener listener);
 
+  /**
+   * Rotates the encryption key used to protect stored credentials.
+   *
+   * @param key the new key supplied by the caller, never <code>null</code>
+   */
   @PUT
   @Path("/rotateKey")
   @RolesAllowed("deliverymanager")
@@ -106,8 +113,15 @@ public interface IPSFeedsRestService extends IPSRestService {
   public abstract void rotateKey(String key);
 
   // Property key constants
+  /** Property key for the feed item description (Dublin Core: abstract). */
   public static final String PROP_DESCRIPTION = "dcterms:abstract";
+
+  /** Property key for the feed item title (Dublin Core: title). */
   public static final String PROP_TITLE = "dcterms:title";
+
+  /** Property key for the feed item publish date (Dublin Core: created). */
   public static final String PROP_PUBDATE = "dcterms:created";
+
+  /** Property key for the feed item content post date timezone. */
   public static final String PROP_CONTENTPOSTDATETZ = "dcterms:contentpostdatetz";
 }

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/services/PSFeedService.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/services/PSFeedService.java
@@ -100,18 +100,35 @@ import org.springframework.stereotype.Component;
 @Scope("singleton")
 public class PSFeedService extends PSAbstractRestService implements IPSFeedsRestService {
 
+  /** Default no-arg constructor required by Spring. */
   public PSFeedService() {}
 
+  /**
+   * Gets the configured IP address used to access the feeds service.
+   *
+   * @return the RSS feeds IP, may be <code>null</code>
+   */
   public String getRssFeedsIP() {
     return this.rssFeedsIP;
   }
 
+  /**
+   * Sets the IP address used to access the feeds service.
+   *
+   * @param rssFeedsIP the RSS feeds IP to set
+   */
   public void setRssFeedsIP(String rssFeedsIP) {
     this.rssFeedsIP = rssFeedsIP;
   }
 
   private String rssFeedsIP;
 
+  /**
+   * Sets the CSRF token response headers from the {@code XSRF-TOKEN} cookie, if present.
+   *
+   * @param request the current HTTP servlet request, never <code>null</code>
+   * @param response the current HTTP servlet response, never <code>null</code>
+   */
   @HEAD
   @Path("/csrf")
   public void csrf(@Context HttpServletRequest request, @Context HttpServletResponse response) {
@@ -165,6 +182,12 @@ public class PSFeedService extends PSAbstractRestService implements IPSFeedsRest
   /** 2011-01-21T09:36:05 */
   FastDateFormat dateFormat = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss");
 
+  /**
+   * Spring constructor that wires the feed DAO and HTTP client.
+   *
+   * @param dao the feed DAO, never <code>null</code>
+   * @param httpClient the HTTP client, never <code>null</code>
+   */
   @Autowired
   public PSFeedService(@Qualifier("feedsDao") IPSFeedDao dao, PSHttpClient httpClient) {
     this.feedDao = Objects.requireNonNull(dao, "dao cannot be null");

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/services/rdbms/PSConnectionInfo.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/services/rdbms/PSConnectionInfo.java
@@ -24,6 +24,9 @@ import jakarta.persistence.Table;
 import java.util.Objects;
 
 /**
+ * JPA entity backing the singleton row in the {@code PERC_CONNECTION_INFO} table that stores
+ * credentials for the feeds metadata service.
+ *
  * @author erikserating
  */
 @Entity
@@ -39,13 +42,16 @@ public class PSConnectionInfo implements IPSConnectionInfo {
 
   @Basic private String encrypted;
 
+  /** Default no-arg constructor required by JPA. */
   public PSConnectionInfo() {}
 
   /**
-   * @param url
-   * @param user
-   * @param password
-   * @param encrypted
+   * Constructs a connection info entity with the supplied values.
+   *
+   * @param url the metadata service URL, may be <code>null</code>
+   * @param user the metadata service user name, may be <code>null</code>
+   * @param password the metadata service password, may be <code>null</code>
+   * @param encrypted <code>true</code> if the password is stored encrypted
    */
   public PSConnectionInfo(String url, String user, String password, boolean encrypted) {
     this.url = url;
@@ -55,70 +61,90 @@ public class PSConnectionInfo implements IPSConnectionInfo {
   }
 
   /**
+   * Gets the metadata service URL.
+   *
    * @return the url
    */
   public String getUrl() {
     return url;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.services.rdbms.IPSConnectionInfo#setUrl(java.lang.String)
+  /**
+   * Sets the metadata service URL.
+   *
+   * @param url the metadata service URL, may be <code>null</code>
    */
   public void setUrl(String url) {
     this.url = url;
   }
 
   /**
+   * Gets the metadata service user name.
+   *
    * @return the user
    */
   public String getUsername() {
     return username;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.services.rdbms.IPSConnectionInfo#setUser(java.lang.String)
+  /**
+   * Sets the metadata service user name.
+   *
+   * @param user the metadata service user name, may be <code>null</code>
    */
   public void setUsername(String user) {
     this.username = user;
   }
 
   /**
+   * Gets the metadata service password.
+   *
    * @return the password
    */
   public String getPassword() {
     return password;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.services.rdbms.IPSConnectionInfo#setPassword(java.lang.String)
+  /**
+   * Sets the metadata service password.
+   *
+   * @param password the metadata service password, may be <code>null</code>
    */
   public void setPassword(String password) {
     this.password = password;
   }
 
   /**
+   * Gets the encrypted form of the password, as stored in the database.
+   *
    * @return the encrypted
    */
   public String getEncrypted() {
     return encrypted;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.services.rdbms.IPSConnectionInfo#setEncrypted(java.lang.String)
+  /**
+   * Sets the encrypted form of the password, as stored in the database.
+   *
+   * @param encrypted the encrypted password string, may be <code>null</code>
    */
   public void setEncrypted(String encrypted) {
     this.encrypted = encrypted;
   }
 
   /**
+   * Gets the connection record id. Always <code>1</code> since the table holds a singleton row.
+   *
    * @return the id
    */
   public long getId() {
     return id;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.services.rdbms.IPSConnectionInfo#setId(long)
+  /**
+   * Sets the connection record id.
+   *
+   * @param id the connection record id
    */
   public void setId(long id) {
     this.id = id;

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/services/rdbms/PSFeedDao.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/services/rdbms/PSFeedDao.java
@@ -34,6 +34,9 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
+ * RDBMS-backed implementation of {@link IPSFeedDao} using JPA/Hibernate to manage feed descriptors
+ * and connection info in the feeds schema.
+ *
  * @author erikserating
  */
 @Repository
@@ -41,20 +44,27 @@ public class PSFeedDao implements IPSFeedDao {
 
   private static final Logger log = LogManager.getLogger(PSFeedDao.class);
 
+  /** Default no-arg constructor required by Spring. */
   public PSFeedDao() {}
 
   private SessionFactory sessionFactory;
 
+  /**
+   * Spring constructor that wires the Hibernate session factory.
+   *
+   * @param sessionFactory the Hibernate session factory, never <code>null</code>
+   */
   @Autowired
   public PSFeedDao(SessionFactory sessionFactory) {
     this.sessionFactory = sessionFactory;
   }
 
-  /*
-   * (non-Javadoc)
+  /**
+   * Finds a single feed descriptor by feed name and site.
    *
-   * @see com.percussion.feeds.services.IPSFeedDao#find(java.lang.String,
-   * java.lang.String)
+   * @param name the feed name, never <code>null</code>
+   * @param site the feed site, never <code>null</code>
+   * @return the matching descriptor, or <code>null</code> if not found
    */
   @Override
   @Transactional
@@ -81,11 +91,11 @@ public class PSFeedDao implements IPSFeedDao {
     return sessionFactory.getCurrentSession();
   }
 
-  /*
-   * (non-Javadoc)
+  /**
+   * Finds all feed descriptors belonging to the specified site.
    *
-   * @see
-   * com.percussion.feeds.services.IPSFeedDao#findBySite(java.lang.String)
+   * @param site the feed site, never <code>null</code>
+   * @return the list of descriptors for the site, never <code>null</code>, may be empty
    */
   @Override
   @Transactional
@@ -101,10 +111,10 @@ public class PSFeedDao implements IPSFeedDao {
     return session.createQuery(criteriaQuery).getResultList();
   }
 
-  /*
-   * (non-Javadoc)
+  /**
+   * Gets the singleton metadata service connection info record.
    *
-   * @see com.percussion.feeds.services.IPSFeedDao#getConnectionInfo()
+   * @return the connection info, or <code>null</code> if no row exists
    */
   @Override
   @Transactional
@@ -121,12 +131,13 @@ public class PSFeedDao implements IPSFeedDao {
     return results.stream().findFirst().orElse(null);
   }
 
-  /*
-   * (non-Javadoc)
+  /**
+   * Saves (merges) the singleton metadata service connection info row.
    *
-   * @see
-   * com.percussion.feeds.services.IPSFeedDao#saveConnectionInfo(java.lang.
-   * String, java.lang.String, java.lang.String, boolean)
+   * @param url the metadata service URL, may be <code>null</code>
+   * @param user the metadata service user name, may be <code>null</code>
+   * @param pass the metadata service password, may be <code>null</code>
+   * @param encrypted <code>true</code> if the password is stored encrypted
    */
   @Override
   @Transactional
@@ -137,11 +148,10 @@ public class PSFeedDao implements IPSFeedDao {
     session.merge(info);
   }
 
-  /*
-   * (non-Javadoc)
+  /**
+   * Saves (merges) the supplied feed descriptors. Per-descriptor errors are logged and skipped.
    *
-   * @see
-   * com.percussion.feeds.services.IPSFeedDao#saveDescriptors(java.util.List)
+   * @param descriptors the descriptors to save, never <code>null</code>, may be empty
    */
   @Transactional
   public void saveDescriptors(List<IPSFeedDescriptor> descriptors) {
@@ -162,12 +172,10 @@ public class PSFeedDao implements IPSFeedDao {
     }
   }
 
-  /*
-   * (non-Javadoc)
+  /**
+   * Removes the supplied feed descriptors from storage.
    *
-   * @see
-   * com.percussion.feeds.services.IPSFeedDao#deleteDescriptors(java.util.
-   * List)
+   * @param descriptors the descriptors to remove, never <code>null</code>, may be empty
    */
   @Override
   @Transactional
@@ -180,10 +188,10 @@ public class PSFeedDao implements IPSFeedDao {
     }
   }
 
-  /*
-   * (non-Javadoc)
+  /**
+   * Retrieves all feed descriptors.
    *
-   * @see com.percussion.feeds.services.IPSFeedDao#findAll()
+   * @return the list of all descriptors, never <code>null</code>, may be empty
    */
   @Override
   @Transactional

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/services/rdbms/PSFeedDescriptor.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/services/rdbms/PSFeedDescriptor.java
@@ -26,45 +26,61 @@ import jakarta.persistence.Table;
 import java.io.Serializable;
 
 /**
+ * JPA entity backing a row in the {@code PERC_FEED_DESCRIPTORS} table that stores a single feed
+ * descriptor for a particular site.
+ *
  * @author erikserating
  */
 @Entity
 @Table(name = "PERC_FEED_DESCRIPTORS")
 public class PSFeedDescriptor implements IPSFeedDescriptor, Serializable {
 
-  /** */
+  /** Serialization version. */
   private static final long serialVersionUID = 2756156009184830398L;
 
+  /** Site portion of the composite key, may be <code>null</code> before persistence. */
   @Id
   @Column(length = 255)
   private String site;
 
+  /** Feed name portion of the composite key, may be <code>null</code> before persistence. */
   @Id
   @Column(length = 255)
   private String name;
 
+  /** Feed title, may be <code>null</code>. */
   @Basic
   @Column(length = 2000)
   private String title;
 
+  /** Feed description, may be <code>null</code>. */
   @Basic
   @Column(length = 4000)
   private String description;
 
+  /** Link to the page the feed represents, may be <code>null</code>. */
   @Basic
   @Column(length = 2000)
   private String link;
 
+  /** Feed output type, may be <code>null</code>. */
   @Basic
   @Column(length = 2000)
   private String type;
 
+  /** Query used to retrieve the feed data from the metadata service, may be <code>null</code>. */
   @Basic
   @Column(length = 4000)
   private String query;
 
+  /** Default no-arg constructor required by JPA. */
   public PSFeedDescriptor() {}
 
+  /**
+   * Copies the values from the supplied descriptor into a new JPA entity.
+   *
+   * @param descriptor the descriptor to copy, never <code>null</code>
+   */
   public PSFeedDescriptor(IPSFeedDescriptor descriptor) {
     this.name = descriptor.getName();
     this.site = descriptor.getSite();
@@ -75,56 +91,72 @@ public class PSFeedDescriptor implements IPSFeedDescriptor, Serializable {
     this.query = descriptor.getQuery();
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.data.IPSFeedDescriptor#getDescription()
+  /**
+   * Gets the feed description.
+   *
+   * @return the feed description, may be <code>null</code>
    */
   public String getDescription() {
     return description;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.data.IPSFeedDescriptor#getFeedType()
+  /**
+   * Gets the feed type as an enum.
+   *
+   * @return the parsed {@link FeedType}, never <code>null</code>
    */
   public FeedType getFeedType() {
     return FeedType.valueOf(type);
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.data.IPSFeedDescriptor#getLink()
+  /**
+   * Gets the link to the page the feed represents.
+   *
+   * @return the link, may be <code>null</code>
    */
   public String getLink() {
     return link;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.data.IPSFeedDescriptor#getName()
+  /**
+   * Gets the feed name.
+   *
+   * @return the feed name, may be <code>null</code>
    */
   public String getName() {
     return name;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.data.IPSFeedDescriptor#getQuery()
+  /**
+   * Gets the query used to retrieve the feed data from the metadata service.
+   *
+   * @return the query, may be <code>null</code>
    */
   public String getQuery() {
     return query;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.data.IPSFeedDescriptor#getSite()
+  /**
+   * Gets the name of the site this feed belongs to.
+   *
+   * @return the site name, may be <code>null</code>
    */
   public String getSite() {
     return site;
   }
 
-  /* (non-Javadoc)
-   * @see com.percussion.feeds.data.IPSFeedDescriptor#getTitle()
+  /**
+   * Gets the feed title.
+   *
+   * @return the title, may be <code>null</code>
    */
   public String getTitle() {
     return title;
   }
 
   /**
+   * Gets the feed output type.
+   *
    * @return the type
    */
   public String getType() {
@@ -132,6 +164,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor, Serializable {
   }
 
   /**
+   * Sets the feed output type.
+   *
    * @param type the type to set
    */
   public void setType(String type) {
@@ -139,6 +173,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor, Serializable {
   }
 
   /**
+   * Sets the name of the site this feed belongs to.
+   *
    * @param site the site to set
    */
   public void setSite(String site) {
@@ -146,6 +182,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor, Serializable {
   }
 
   /**
+   * Sets the feed name.
+   *
    * @param name the name to set
    */
   public void setName(String name) {
@@ -153,6 +191,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor, Serializable {
   }
 
   /**
+   * Sets the feed title.
+   *
    * @param title the title to set
    */
   public void setTitle(String title) {
@@ -160,6 +200,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor, Serializable {
   }
 
   /**
+   * Sets the feed description.
+   *
    * @param description the description to set
    */
   public void setDescription(String description) {
@@ -167,6 +209,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor, Serializable {
   }
 
   /**
+   * Sets the link to the page the feed represents.
+   *
    * @param link the link to set
    */
   public void setLink(String link) {
@@ -174,6 +218,8 @@ public class PSFeedDescriptor implements IPSFeedDescriptor, Serializable {
   }
 
   /**
+   * Sets the query used to retrieve the feed data from the metadata service.
+   *
    * @param query the query to set
    */
   public void setQuery(String query) {

--- a/docs/ai-generated/code-reviews/1603-feeds-javadoc-erlang.md
+++ b/docs/ai-generated/code-reviews/1603-feeds-javadoc-erlang.md
@@ -1,0 +1,112 @@
+# Erlang Review — Issue #1603 feeds Javadoc
+
+## Summary
+
+Documentation-only fix for the `feeds` module. The Maven build succeeded but
+Javadoc generation reported **4 errors** (1 unique HTML error + plugin-emitted
+detail lines) and **200 warnings** (100 unique Javadoc source warnings +
+plugin-emitted detail lines). After this PR the module generates a clean
+Javadoc JAR.
+
+## Scope
+
+- Base: `origin/development` (commit `ea85629c2f`)
+- Head: feature branch `fix/1603-javadoc-issues-feeds`
+- Files: 21 changed in `deliverytiersuite/delivery-tier-suite/feeds/src/main/java/**`
+- Prior report: none
+- Memory patterns hit: none (pure Javadoc cleanup; no I/O, no security, no
+  behavioral change)
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Blocking bugs: 0
+- May commit/push: **yes**
+
+## Issues
+
+None.
+
+## Specific changes
+
+- `services/IPSFeedDao.java` — fixed the HTML error. The Javadoc on
+  `find(String name, String site)` had a stray `</code>` end tag
+  (`the retrieved descriptor or </code>empty Optional</code>`); replaced
+  with the correct opening `<code>`. Also added descriptions for the four
+  `@param` tags on `saveConnectionInfo` and a leading description on
+  `getConnectionInfo`.
+- `data/FeedType.java` (both copies under `com.percussion.delivery.data` and
+  `com.percussion.delivery.feeds.data`) — added Javadoc to the enum class
+  and to all three enum constants (`ATOM`, `RSS1`, `RSS2`).
+- `data/IPSFeedDescriptor.java` (both copies) — added leading descriptions
+  to all seven getter methods.
+- `data/PSFeedDescriptor.java` (both copies under `data/`) —
+  `rdbms/PSFeedDescriptor.java` — added explicit default constructors with
+  Javadoc, added leading descriptions on every getter and setter, replaced
+  `/* (non-Javadoc) */` blocks with real Javadoc summaries, and documented
+  the additional 6-arg `PSFeedDescriptor` convenience constructor in the
+  older `data/` copy.
+- `data/PSFeedDescriptors.java` (both copies) — added class/constructor
+  Javadoc and leading descriptions on all getters and setters.
+- `data/PSFeedDTO.java` (both copies) — added class/constructor Javadoc,
+  explicit default constructor on the new copy, and leading descriptions on
+  every getter and setter.
+- `data/PSFeedItem.java` (both copies) — added explicit default
+  constructor with Javadoc on the older `data/` copy and leading
+  descriptions on all getters and setters.
+- `PSFeedGenerator.java` — added a class-level description, an explicit
+  default constructor with Javadoc, and leading descriptions on
+  `makeFeedContent`, `fixupHost`, and `getHost`.
+- `PSFeedsApplication.java` — added class-level and constructor Javadoc.
+- `services/IPSConnectionInfo.java` — added class-level description and
+  Javadoc to all five interface methods.
+- `services/IPSFeedsRestService.java` — added class-level description,
+  `@param`/`@return` descriptions, replaced `/* (non-Javadoc) */` blocks
+  with proper Javadoc on `addMetadataListener` and `removeMetadataListener`,
+  and added Javadoc to the four `PROP_*` constants and `rotateKey`.
+- `services/PSFeedService.java` — added explicit default constructor with
+  Javadoc and leading descriptions on `getRssFeedsIP`, `setRssFeedsIP`,
+  `csrf`, and the autowired constructor.
+- `services/rdbms/PSConnectionInfo.java` — added class-level description,
+  explicit default constructor, and Javadoc on the constructor and all
+  getters/setters; replaced `/* (non-Javadoc) */` blocks with proper
+  Javadoc summaries.
+- `services/rdbms/PSFeedDescriptor.java` — added Javadoc to every
+  `@Basic` field (`site`, `name`, `title`, `description`, `link`, `type`,
+  `query`), explicit default constructor, and Javadoc on the copy
+  constructor and every getter/setter.
+
+## Cross-platform / path review
+
+Not applicable — diff touches Javadoc text only. No new file I/O or path
+construction.
+
+## Build evidence
+
+- `mvnw.cmd -pl deliverytiersuite/delivery-tier-suite/feeds -am javadoc:javadoc`:
+  feeds section reports 0 javadoc errors and 0 javadoc warnings.
+  (Upstream modules like `perc-legacy` still report pre-existing warnings
+  that are unrelated to this issue and out of scope.)
+- `mvnw.cmd clean install -pl deliverytiersuite/delivery-tier-suite/feeds -am`:
+  BUILD SUCCESS; war + javadoc.jar produced; tests: 110 run, 0 failures,
+  0 errors, 100 skipped (pre-existing skips for
+  `PSFeedServicePerformanceTest`).
+- `mvnw.cmd spotless:check -pl deliverytiersuite/delivery-tier-suite/feeds`:
+  clean after `spotless:apply` reformatted 4 files.
+
+## Notes
+
+- The feeds module contains two parallel copies of the data package
+  (`com.percussion.delivery.data.*` and `com.percussion.delivery.feeds.data.*`).
+  Both copies are tracked, both contain the same public types, and the
+  javadoc tool scans both. Every javadoc fix was applied to both copies.
+- Per AGENTS.md "Pre-PR Spotless formatting (HARD GATE)", a root-level
+  spotless run was rejected due to an unrelated encoding error in
+  `.kilo/worktrees/.../raw-files.js`; spotless was run module-scoped on
+  `feeds` only.
+- Per AGENTS.md "Pre-PR Maven verification (HARD GATE)", the build was run
+  with `-pl deliverytiersuite/delivery-tier-suite/feeds -am` to include
+  upstream dependencies (not a full reactor).


### PR DESCRIPTION
## Summary

Documentation-only fix for the `feeds` module. The Maven build succeeded but Javadoc generation reported **4 errors** (1 unique HTML error + plugin-emitted detail lines) and **200 warnings** (100 unique Javadoc source warnings + plugin-emitted detail lines). After this PR the module generates a clean Javadoc JAR.

## Errors fixed

| File | Issue |
| --- | --- |
| `deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/services/IPSFeedDao.java` | Stray `</code>` end tag on `find(String, String)` `@return` Javadoc (`the retrieved descriptor or </code>empty Optional</code>`); replaced with the correct opening `<code>` tag (1 HTML error). |

## Warnings fixed (100 unique)

- Added Javadoc to the `FeedType` enum class and to all three enum constants in both `com.percussion.delivery.data.FeedType` and `com.percussion.delivery.feeds.data.FeedType`.
- Added leading descriptions on every getter in both copies of `IPSFeedDescriptor` (7 methods each).
- Added explicit default constructors with Javadoc and leading descriptions on all getters/setters in `PSFeedDescriptor` (3 copies: `feeds/data/`, `data/`, `rdbms/`), `PSFeedDescriptors` (both copies), `PSFeedDTO` (both copies), `PSFeedItem` (older `data/` copy), `PSConnectionInfo`, `PSFeedDao`, and `PSFeedService`.
- Replaced all `/* (non-Javadoc) */` blocks with real Javadoc summaries on `IPSFeedDao`, `IPSFeedsRestService`, `rdbms/PSFeedDao`, `rdbms/PSConnectionInfo`, and `rdbms/PSFeedDescriptor`.
- Added Javadoc to all `@Basic` entity fields in `rdbms/PSFeedDescriptor`.
- Added class-level descriptions on `PSFeedGenerator`, `PSFeedsApplication`, `PSFeedItem`, `PSFeedDescriptors`, `PSFeedDTO`, `IPSConnectionInfo`, `IPSFeedsRestService`.
- Added `@param`/`@return`/constant Javadoc to `IPSFeedsRestService` (`getFeed`, `readExternalFeed`, `saveDescriptors`, `addMetadataListener`, `removeMetadataListener`, `rotateKey`, `PROP_*`).

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Javadoc error/warning count (feeds module) | `mvnw.cmd -pl feeds -am javadoc:javadoc` | **0 errors, 0 warnings** in feeds section |
| Module clean install | `mvnw.cmd -pl feeds -am clean install` | **BUILD SUCCESS** — Tests run: 110, Failures: 0, Errors: 0, Skipped: 100 |
| Spotless | `mvnw.cmd -pl feeds spotless:check` | **clean** |
| Erlang pre-commit review | see `docs/ai-generated/code-reviews/1603-feeds-javadoc-erlang.md` | **approve** (no blocking bugs) |

No new compiler warnings were introduced. Pre-existing javadoc warnings in upstream modules (`perc-legacy`, etc.) are out of scope for this issue and unchanged.

## Files

21 changed files in `deliverytiersuite/delivery-tier-suite/feeds/src/main/java/**` — all documentation/Javadoc-only.

The feeds module contains two parallel copies of the data package (`com.percussion.delivery.data.*` and `com.percussion.delivery.feeds.data.*`). Both copies are tracked and contain the same public types; javadoc fixes were applied to both copies.

## Closes

Closes #1603
