### PR TITLE
docs(developer): capture PR review follow-ups and tech debt

### DIFF
--- a/docs/ai-generated/tasks/developer-module-p0/README.md
+++ b/docs/ai-generated/tasks/developer-module-p0/README.md
@@ -6,6 +6,7 @@
 | **FR source** | [`docs/developer-module/workbench-functional-inventory.md`](../../developer-module/workbench-functional-inventory.md) §15 P0 |
 | **Pipeline track** | [`docs/developer-module/data-pipeline-engine-inventory.md`](../../developer-module/data-pipeline-engine-inventory.md) (parallel; not blocking P0) |
 | **Related** | [design-templates-item-types](../design-templates-item-types/README.md) (CM1 template library — complementary, not a substitute) |
+| **Review follow-ups** | [review-followups-tech-debt.md](./review-followups-tech-debt.md) — deferred PR-review items (not FR roadmap) |
 
 ## P0 scope (from FR)
 
@@ -36,13 +37,16 @@
 - [x] **P0.6** Pipelines list `GET /services/pipelines` — classic **XML Application** summaries (not Slice A IR) + SPA panel; optional `?name=` / `?limit=` / `?offset=`  
 - [x] Gap map: [content-type-api-gaps.md](./content-type-api-gaps.md)  
 - [x] Vitest coverage for shell + catalogs  
+- [x] Review-deferral backlog: [review-followups-tech-debt.md](./review-followups-tech-debt.md)  
 
 ## Next slices (separate PRs)
 
 1. Template/slot/CT detail editors (write + field rules)  
 2. Keyword create/edit; community roles + ACL dialogs  
 3. Pipelines track Slice A (IR + SQL runtime + JSON I/O + classic import)  
-4. Server runtime map for data pipelines
+4. Server runtime map for data pipelines  
+
+Cross-cutting review debt (typed JSON errors, structured designGaps, source viewer, panel migration) is **not** listed above — see [review-followups-tech-debt.md](./review-followups-tech-debt.md).
 
 ## Product locks
 

--- a/docs/ai-generated/tasks/developer-module-p0/review-followups-tech-debt.md
+++ b/docs/ai-generated/tasks/developer-module-p0/review-followups-tech-debt.md
@@ -1,0 +1,78 @@
+# Developer module — review follow-ups & tech debt
+
+| Field | Value |
+|-------|--------|
+| **Purpose** | Durable backlog for items **deferred from PR review** so they are not lost when threads close |
+| **Product roadmap** | Still use [README.md](./README.md) “Next slices” and [content-type-api-gaps.md](./content-type-api-gaps.md) for FR-driven work |
+| **Sources** | PR #1588 (Kilo), #1594 (Minimax/Kilo), #1596 (Minimax/Kilo), #1598 (Kilo) — thread replies only until this file |
+
+Capture rule: when a review finding is **intentionally not fixed in that PR**, add a row here (or update disposition) in the same change set if possible.
+
+---
+
+## Cross-cutting REST / API
+
+| ID | Item | Why deferred | Suggested home | Status |
+|----|------|--------------|----------------|--------|
+| REST-ERR-01 | **Typed JSON error body** for 4xx/5xx (`{ status, message, code? }` or project-standard DTO) instead of bare `WebApplicationException(e, 500)` | Sibling catalog resources use the same pattern post-#1588; fix is a **global exception mapper**, not per-resource | `rest` exception mapper + SPA `ApiError` alignment | Open |
+| REST-ERR-02 | Consistent **cause-preserving** + client-visible message across all Developer catalog resources | Partially done per-resource; should be centralized with REST-ERR-01 | Same as REST-ERR-01 | Open |
+| REST-TEST-01 | Prefer **resource unit tests with mocked adaptors** for every new `GET/POST/...` surface (200/404/400/500) | Some PRs added these (#1594, #1596 harden); make it the default checklist | `rest/src/test/...` | Open (process) |
+| REST-GAPS-01 | **`designGaps` as structured `{ code, message }`** (i18n / docs links / SPA grouping) | Free-text strings enough for P0 honesty; structured form needed for product UX | `ContentTypeDetail`, `TemplateDetail`, `SlotDetail`, pipelines if any | Open |
+| REST-GAPS-02 | Avoid **duplicating identical designGaps arrays** on every detail row if payload size becomes a concern | Currently intentional so SPA needs one call; constant list is fine | Detail DTOs or `X-Design-Gaps` / static SPA list | Open (low) |
+
+---
+
+## WebUI Developer module
+
+| ID | Item | Why deferred | Suggested home | Status |
+|----|------|--------------|----------------|--------|
+| UI-ERR-01 | Finish migrating all panels to shared **`panelErrMsg`** (`developer/errors.ts`) | Introduced on pipelines/template paths; older panels still inline ladders | All `WebUI/src/main/ts/developer/*Panel.tsx` | Open |
+| UI-STYLE-01 | Shared **catalog/theme tokens** (`catalogStyles.ts` or CSS module) for mono/muted/padding | Partial adoption; many panels still inline hex colors | `developer/catalogStyles.ts` + consumers | Open |
+| UI-TABLE-01 | Prefer **`SimpleCatalogTable`** (+ optional open button) over per-panel hand-rolled tables | Templates panel was fixed on #1596; slots/others may still diverge | `CatalogTable.tsx` + panels | Open |
+| UI-SRC-01 | Template **source viewer** enhancements: syntax highlight, line numbers, copy-to-clipboard | P0.4b only needed a readable `<pre>` | `TemplateDetailPanel` | Open |
+| UI-SRC-02 | Long binding **expression** preview (“show more”) beyond maxWidth clamp | Clamp shipped; expand UX later | `TemplateDetailPanel` | Open |
+| UI-A11Y-01 | Consistent a11y for catalog open actions (button-only, aria-labels on back/nav) | Improved on CT/templates; audit remaining panels | Developer panels | Open |
+| UI-TEST-01 | Dedicated **panel-level** tests (empty/error/success) for each catalog, not only shell tests | Pipelines + template detail have some; make default | `WebUI/src/test/ts/developer/` | Open (process) |
+
+---
+
+## Process / hygiene (review bots)
+
+| ID | Item | Why deferred | Suggested home | Status |
+|----|------|--------------|----------------|--------|
+| PROC-01 | **Erlang / pre-commit review** report when Maven modules change (`.kilo/rules` / team practice) | Fixpacks sometimes skip with explicit ack on PR; should be intentional | `docs/ai-generated/code-reviews/` + PR body | Open (process) |
+| PROC-02 | **Standalone** `rest` then `sitemanage` clean install evidence in PR body (AGENTS Pre-PR HARD GATE) | Often run reactor compile in worktrees; CI remains source of truth | PR template / AGENTS.md reminder | Open (process) |
+| PROC-03 | Do not leave **deferred review items only on GitHub threads** | This file exists to prevent that | Update this doc in the same PR or a docs follow-up | Active |
+
+---
+
+## Product slices (already in README — do not duplicate as “deferred review”)
+
+Tracked under [README.md § Next slices](./README.md):
+
+- CT field rules (read) → write/lock  
+- Keyword create/edit; community roles + ACL  
+- Pipelines Slice A (IR + SQL + JSON + import)  
+- Template/slot **editors**  
+- Server runtime map for data pipelines  
+
+API surface gaps for content types: [content-type-api-gaps.md](./content-type-api-gaps.md).
+
+---
+
+## Per-PR notes (optional pointers)
+
+| PR | Notes |
+|----|--------|
+| #1588 | Early Kilo pass; exception-cause and SPA a11y patterns |
+| #1594 | Pipelines catalog; [code-reviews/2026-07-29-pr-1594-pipelines-kilo-followup.md](../../code-reviews/2026-07-29-pr-1594-pipelines-kilo-followup.md) |
+| #1596 | Template detail; REST-ERR-01, REST-GAPS-01, UI-SRC-01 deferred on threads |
+| #1598 | CT field rule flags; unit tests for `mapOccurrence` / `hasTranslation` |
+
+---
+
+## How to use
+
+1. **New PR review deferral:** add/update a row, set Status `Open`, link PR in “Per-PR notes”.  
+2. **When fixed:** set Status `Done` and note the fixing PR.  
+3. Prefer **small dedicated PRs** for cross-cutting items (REST-ERR-01, UI-STYLE-01) rather than stacking onto feature slices.

--- a/docs/developer-module/README.md
+++ b/docs/developer-module/README.md
@@ -27,6 +27,10 @@ Tool-agnostic reverse engineering of the Rhythmyx 7.3.2 **Workbench** (Eclipse D
 2. **Pipeline Slice A (parallel or next)** — pipeline IR + SQL runtime + JSON I/O + hooks + classic app import  
 3. **Server runtime map** — locate query/update pipe request handlers in this repo before estimating engine reuse vs reimplement  
 
+Implementation task tracking and **PR review deferrals / tech debt** live under  
+[`docs/ai-generated/tasks/developer-module-p0/`](../ai-generated/tasks/developer-module-p0/)  
+(especially [review-followups-tech-debt.md](../ai-generated/tasks/developer-module-p0/review-followups-tech-debt.md)).
+
 ## How to use these docs
 
 1. Treat `workbench-functional-inventory.md` as the **parity checklist**, not a React design.  


### PR DESCRIPTION
## Summary

Review deferrals from Developer P0 PRs were only living in GitHub threads. This adds a durable backlog and links it from the module docs.

- **New:** `docs/ai-generated/tasks/developer-module-p0/review-followups-tech-debt.md` (REST-ERR-*, UI-*, PROC-* items)
- **Links:** P0 README + `docs/developer-module/README.md`

## Test plan

- [x] Docs only — no code change

> Co-Authored by Grok Build using grok-4.5 with agent Grok.