### PR TITLE
feat(developer): object ACL read viewer on CT and template detail (P0.5d)

### DIFF
--- a/WebUI/src/main/ts/api/developer/aclApi.ts
+++ b/WebUI/src/main/ts/api/developer/aclApi.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { get } from "../client";
+import { PATHS } from "../paths";
+import type { ObjectAcl } from "./types";
+
+/**
+ * GET /services/acls/object/{objectGuid}
+ *
+ * <p>Returns the design-time ACL for a securable object. 404 when no ACL exists.
+ */
+export async function getAclForObject(objectGuid: string): Promise<ObjectAcl> {
+  const key = encodeURIComponent(objectGuid);
+  return get<ObjectAcl>(`${PATHS.ACLS}/object/${key}`);
+}

--- a/WebUI/src/main/ts/api/developer/types.ts
+++ b/WebUI/src/main/ts/api/developer/types.ts
@@ -190,9 +190,36 @@ export interface CommunityRoleSummary {
   roleGuid?: RestGuid;
 }
 
-/** Community detail including associated roles (read-only for this slice). */
+/** Community detail including associated roles. */
 export interface CommunityDetail extends CommunitySummary {
   roleList?: CommunityRoleSummary[] | { CommunityRole?: CommunityRoleSummary[] };
+}
+
+/** Design-time object ACL entry (from `/services/acls/object/{guid}`). */
+export interface ObjectAclPermission {
+  id?: number;
+  permission?: string;
+  permissions?: string[] | { Permission?: string[] };
+}
+
+export interface ObjectAclEntry {
+  id?: number;
+  name?: string;
+  aclId?: number;
+  principal?: { name?: string; type?: string };
+  type?: { name?: string; type?: string };
+  permissions?: ObjectAclPermission[] | { UserAccessLevel?: ObjectAclPermission[] };
+}
+
+export interface ObjectAcl {
+  id?: number;
+  name?: string;
+  description?: string;
+  objectId?: number;
+  objectType?: number;
+  guid?: RestGuid;
+  objectGuid?: RestGuid;
+  aclEntries?: ObjectAclEntry[] | { AclEntry?: ObjectAclEntry[] };
 }
 
 /** Classic XML Application / pipeline package summary. */

--- a/WebUI/src/main/ts/api/paths.ts
+++ b/WebUI/src/main/ts/api/paths.ts
@@ -285,6 +285,10 @@ export const PATHS = {
   get PIPELINES() {
     return `${SERVICES_ROOT}/pipelines`;
   },
+  /** Object ACL catalog (design-time security). */
+  get ACLS() {
+    return `${SERVICES_ROOT}/acls`;
+  },
   /** Workflow management (workflowmanagement) — Feature 993 */
   get WORKFLOWS() {
     return `${SERVICES_ROOT}/workflowmanagement/workflows/`;

--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -22,6 +22,7 @@ import {
 } from "../api/client";
 import { getContentTypeDetail } from "../api/developer/contentTypesApi";
 import type { ContentTypeDetail } from "../api/developer/types";
+import { ObjectAclSection } from "./ObjectAclSection";
 import { DEV_MSG } from "./messages";
 
 function errorMessage(err: unknown): string {
@@ -300,6 +301,11 @@ export function ContentTypeDetailPanel({
               </table>
             </div>
           </section>
+
+          <ObjectAclSection
+            objectGuid={detail.guid?.stringValue}
+            testIdPrefix="developer-ct-acl"
+          />
 
           {detail.designGaps && detail.designGaps.length > 0 ? (
             <section data-testid="developer-ct-gaps">

--- a/WebUI/src/main/ts/developer/ObjectAclSection.tsx
+++ b/WebUI/src/main/ts/developer/ObjectAclSection.tsx
@@ -1,0 +1,208 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useState } from "react";
+import { getAclForObject } from "../api/developer/aclApi";
+import type {
+  ObjectAcl,
+  ObjectAclEntry,
+  ObjectAclPermission,
+} from "../api/developer/types";
+import { isSessionRedirectError, type ApiError } from "../api/client";
+import { errorAlert } from "./catalogStyles";
+import { DEV_MSG } from "./messages";
+
+function asEntries(acl: ObjectAcl | null): ObjectAclEntry[] {
+  if (!acl?.aclEntries) return [];
+  if (Array.isArray(acl.aclEntries)) return acl.aclEntries;
+  const env = acl.aclEntries as { AclEntry?: ObjectAclEntry[] };
+  return Array.isArray(env.AclEntry) ? env.AclEntry : [];
+}
+
+function asPermissions(entry: ObjectAclEntry): string[] {
+  const raw = entry.permissions;
+  if (!raw) return [];
+  let list: ObjectAclPermission[] = [];
+  if (Array.isArray(raw)) list = raw;
+  else if (Array.isArray((raw as { UserAccessLevel?: ObjectAclPermission[] }).UserAccessLevel)) {
+    list = (raw as { UserAccessLevel: ObjectAclPermission[] }).UserAccessLevel;
+  }
+  const out: string[] = [];
+  for (const p of list) {
+    if (!p) continue;
+    if (p.permission) out.push(String(p.permission));
+    const nested = p.permissions;
+    if (Array.isArray(nested)) {
+      for (const n of nested) out.push(String(n));
+    } else if (nested && Array.isArray((nested as { Permission?: string[] }).Permission)) {
+      for (const n of (nested as { Permission: string[] }).Permission) out.push(String(n));
+    }
+  }
+  return out.length ? [...new Set(out)] : [];
+}
+
+function entryLabel(e: ObjectAclEntry): string {
+  return (
+    e.name ||
+    e.principal?.name ||
+    e.type?.name ||
+    (e.id != null ? `entry-${e.id}` : "—")
+  );
+}
+
+/**
+ * Read-only object ACL viewer for Developer detail panels (SE-04 read path).
+ * Edit/save remains a later slice.
+ */
+export function ObjectAclSection({
+  objectGuid,
+  testIdPrefix = "developer-acl",
+}: {
+  objectGuid: string | null | undefined;
+  testIdPrefix?: string;
+}): React.ReactElement {
+  const [acl, setAcl] = useState<ObjectAcl | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [missing, setMissing] = useState(false);
+
+  useEffect(() => {
+    if (!objectGuid) {
+      setAcl(null);
+      setError(null);
+      setMissing(false);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setMissing(false);
+    setAcl(null);
+    getAclForObject(objectGuid)
+      .then((a) => {
+        if (cancelled) return;
+        setAcl(a);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setLoading(false);
+        if (isSessionRedirectError(err)) {
+          setError(DEV_MSG.SESSION_REDIRECT);
+          return;
+        }
+        const api = err as ApiError;
+        if (api && typeof api.status === "number" && api.status === 404) {
+          setMissing(true);
+          return;
+        }
+        const status =
+          api && typeof api.status === "number" ? ` (${api.status})` : "";
+        const msg = err instanceof Error && err.message ? ` ${err.message}` : "";
+        setError(`${DEV_MSG.ACL_ERROR}${status}${msg}`);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [objectGuid]);
+
+  if (!objectGuid) {
+    return (
+      <section style={{ marginBottom: "16px" }} data-testid={`${testIdPrefix}-section`}>
+        <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.ACL_TITLE}</h3>
+        <p style={{ color: "#718096" }}>{DEV_MSG.ACL_NO_GUID}</p>
+      </section>
+    );
+  }
+
+  const entries = asEntries(acl);
+
+  return (
+    <section style={{ marginBottom: "16px" }} data-testid={`${testIdPrefix}-section`}>
+      <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.ACL_TITLE}</h3>
+      <p style={{ color: "#4a5568", fontSize: "0.9rem" }}>{DEV_MSG.ACL_HINT}</p>
+
+      {loading ? (
+        <div data-testid={`${testIdPrefix}-loading`}>{DEV_MSG.ACL_LOADING}</div>
+      ) : null}
+
+      {error ? (
+        <div role="alert" data-testid={`${testIdPrefix}-error`} style={errorAlert}>
+          {error}
+        </div>
+      ) : null}
+
+      {missing && !loading ? (
+        <p data-testid={`${testIdPrefix}-empty`} style={{ color: "#718096" }}>
+          {DEV_MSG.ACL_EMPTY}
+        </p>
+      ) : null}
+
+      {acl && !loading ? (
+        <>
+          <div
+            style={{ fontFamily: "monospace", color: "#4a5568", fontSize: "0.85rem" }}
+            data-testid={`${testIdPrefix}-meta`}
+          >
+            {acl.name || "ACL"}
+            {acl.id != null ? ` · id ${acl.id}` : ""}
+            {acl.guid?.stringValue ? ` · ${acl.guid.stringValue}` : ""}
+          </div>
+          {entries.length === 0 ? (
+            <p style={{ color: "#718096" }}>{DEV_MSG.ACL_NO_ENTRIES}</p>
+          ) : (
+            <div style={{ overflowX: "auto", marginTop: "8px" }}>
+              <table
+                data-testid={`${testIdPrefix}-table`}
+                style={{
+                  width: "100%",
+                  borderCollapse: "collapse",
+                  fontSize: "0.95rem",
+                }}
+              >
+                <thead>
+                  <tr style={{ textAlign: "left", borderBottom: "2px solid #e2e8f0" }}>
+                    <th style={{ padding: "8px" }}>{DEV_MSG.ACL_COL_ENTRY}</th>
+                    <th style={{ padding: "8px" }}>{DEV_MSG.ACL_COL_TYPE}</th>
+                    <th style={{ padding: "8px" }}>{DEV_MSG.ACL_COL_PERMS}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {entries.map((e, i) => (
+                    <tr
+                      key={e.id ?? `${entryLabel(e)}-${i}`}
+                      style={{ borderBottom: "1px solid #edf2f7" }}
+                    >
+                      <td style={{ padding: "8px" }}>{entryLabel(e)}</td>
+                      <td style={{ padding: "8px", fontFamily: "monospace" }}>
+                        {e.type?.type || e.type?.name || e.principal?.type || "—"}
+                      </td>
+                      <td style={{ padding: "8px", fontFamily: "monospace" }}>
+                        {asPermissions(e).join(", ") || "—"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/WebUI/src/main/ts/developer/TemplateDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/TemplateDetailPanel.tsx
@@ -21,6 +21,7 @@ import type { TemplateDetail } from "../api/developer/types";
 import { monoCell, mutedCell } from "./catalogStyles";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
+import { ObjectAclSection } from "./ObjectAclSection";
 
 const metaGrid: React.CSSProperties = {
   display: "grid",
@@ -228,6 +229,11 @@ export function TemplateDetailPanel({
               </pre>
             </section>
           ) : null}
+
+          <ObjectAclSection
+            objectGuid={detail.guid?.stringValue}
+            testIdPrefix="developer-tpl-acl"
+          />
 
           {(detail.designGaps || []).length > 0 ? (
             <section data-testid="developer-tpl-gaps">

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -21,6 +21,17 @@ export const DEV_MSG = {
   INTRO:
     "Design-time tools for content types, assembly, and related CMS objects. Replaces the classic Workbench / Design surfaces.",
   SESSION_REDIRECT: "Session expired — redirecting to login…",
+  ACL_TITLE: "Object ACL",
+  ACL_HINT:
+    "Design-time access control entries for this object (read-only). Add/edit ACL remains a later slice.",
+  ACL_LOADING: "Loading ACL…",
+  ACL_ERROR: "Could not load object ACL.",
+  ACL_EMPTY: "No ACL defined for this object.",
+  ACL_NO_GUID: "Object GUID not available — cannot load ACL.",
+  ACL_NO_ENTRIES: "ACL has no entries.",
+  ACL_COL_ENTRY: "Principal / name",
+  ACL_COL_TYPE: "Type",
+  ACL_COL_PERMS: "Permissions",
   TAB_CONTENT_TYPES: "Content Types",
   TAB_TEMPLATES: "Templates",
   TAB_SLOTS: "Slots",

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -21,6 +21,7 @@ vi.mock("../../../main/ts/api/developer/contentTypesApi", () => ({
     label: "Page",
     description: "A page",
     enabled: true,
+    guid: { stringValue: "0-2-301", uuid: 301 },
     fields: [
       {
         name: "sys_title",
@@ -43,6 +44,28 @@ vi.mock("../../../main/ts/api/developer/contentTypesApi", () => ({
     allowedTemplates: [{ name: "perc.page", label: "Page" }],
     designGaps: [
       "Field rule flags are exposed (validation/visibility/transforms present); full rule expressions and control properties are not",
+    ],
+  }),
+}));
+
+vi.mock("../../../main/ts/api/developer/aclApi", () => ({
+  getAclForObject: vi.fn().mockResolvedValue({
+    id: 1,
+    name: "object-acl",
+    guid: { stringValue: "0-4-1", uuid: 1 },
+    aclEntries: [
+      {
+        id: 10,
+        name: "Default",
+        type: { type: "ROLE", name: "Default" },
+        permissions: [{ permission: "READ" }, { permission: "UPDATE" }],
+      },
+      {
+        id: 11,
+        name: "Admin",
+        type: { type: "ROLE", name: "Admin" },
+        permissions: [{ permission: "OWNER" }],
+      },
     ],
   }),
 }));
@@ -86,6 +109,7 @@ vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
     name: "perc.page",
     label: "Page",
     description: "Default page",
+    guid: { stringValue: "0-10-1", uuid: 1 },
     assembler: "Java/JEXL",
     outputFormat: "Page",
     templateType: "Shared",
@@ -213,6 +237,9 @@ describe("DeveloperShell", () => {
     expect(screen.getByTestId("developer-ct-field-occurrence").textContent).toBe("required");
     expect(screen.getByTestId("developer-ct-workflows")).toBeTruthy();
     expect(screen.getByTestId("developer-ct-templates")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-acl-table")).toBeTruthy();
+    });
     expect(screen.getByTestId("developer-ct-gaps")).toBeTruthy();
     fireEvent.click(screen.getByTestId("developer-ct-back"));
     await waitFor(() => {
@@ -303,6 +330,9 @@ describe("DeveloperShell", () => {
     expect(screen.getByTestId("developer-tpl-bindings")).toBeTruthy();
     expect(screen.getByTestId("developer-tpl-slots")).toBeTruthy();
     expect(screen.getByTestId("developer-tpl-source")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-acl-table")).toBeTruthy();
+    });
     expect(screen.getByTestId("developer-tpl-gaps")).toBeTruthy();
     fireEvent.click(screen.getByTestId("developer-tpl-back"));
     await waitFor(() => {

--- a/docs/ai-generated/tasks/developer-module-p0/README.md
+++ b/docs/ai-generated/tasks/developer-module-p0/README.md
@@ -38,9 +38,9 @@
 - [x] **P0.4b** Template detail `GET /services/templates/{idOrName}` — bindings, slots, source, designGaps + SPA detail  
 - [x] **P0.4c** Slot detail `GET /services/slots/{idOrName}` (finder + associations) + SPA detail  
 - [x] **P0.5** Communities list via `GET /services/communities/find?name=*` + SPA panel  
-- [x] **P0.5b** Community detail `GET /services/communities/{idOrName}` — roles + SPA detail (role/ACL edit later)  
+- [x] **P0.5b** Community detail `GET /services/communities/{idOrName}` — roles + SPA detail  
 - [x] **P0.5c** Community role membership edit `GET /roles` + `PUT /{id}/roles` + SPA checkboxes  
-
+- [x] **P0.5d** Object ACL **read** view on CT + template detail via existing `GET /services/acls/object/{guid}`  
 - [x] **P0.6** Pipelines list `GET /services/pipelines` — classic **XML Application** summaries (not Slice A IR) + SPA panel; optional `?name=` / `?limit=` / `?offset=`  
 - [x] Gap map: [content-type-api-gaps.md](./content-type-api-gaps.md)  
 - [x] Vitest coverage for shell + catalogs  

--- a/rest/src/main/java/com/percussion/rest/acls/AclResource.java
+++ b/rest/src/main/java/com/percussion/rest/acls/AclResource.java
@@ -171,7 +171,15 @@ public class AclResource {
   @Path("/object/{objectGuid}")
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
-  public Acl loadAclForObject(@PathParam("objectGuid") String objectGuid) {
+  @Operation(
+      summary = "Load ACL for object",
+      description =
+          "Returns the design-time ACL for a securable object GUID (template, content type,"
+              + " etc.). Used by the Developer module ACL viewer.")
+  public Acl loadAclForObject(
+      @Parameter(description = "Object GUID stringValue", required = true)
+          @PathParam("objectGuid")
+          String objectGuid) {
     try {
       return adaptor.loadAclForObject(new Guid(objectGuid));
     } catch (NotFoundException n) {


### PR DESCRIPTION
## Summary

P0.5d **object ACL read viewer** for the Developer module (SE-04 read path). Reuses the existing REST surface — no new domain API.

### SPA
- Shared ``ObjectAclSection`` component
- Embedded on **Content Type** detail and **Template** detail when object GUID is present
- Handles loading / 404 (no ACL) / error states
- ACL **edit** remains a follow-up (save via existing ``PUT /acls/bulk``)

### API client
- ``GET /services/acls/object/{objectGuid}`` via ``aclApi.getAclForObject``
- OpenAPI summary added on ``AclResource.loadAclForObject``

## Test plan
- [x] WebUI ``DeveloperShell.test.tsx`` **6/6** (CT + template detail show ACL table)
- [ ] Manual: open a content type and a template; confirm ACL entries or empty state

## Pre-PR verification
```
WebUI: vitest DeveloperShell.test.tsx — 6/6 pass
```

> Co-Authored by Grok Build using grok-4.5 with agent main.