### PR TITLE
fix(javadoc): resolve 4 errors + 2 warnings in perc-checkboxtree (#1617)

### DIFF
--- a/docs/ai-generated/code-reviews/1617-perc-checkboxtree-javadoc-erlang.md
+++ b/docs/ai-generated/code-reviews/1617-perc-checkboxtree-javadoc-erlang.md
@@ -1,0 +1,67 @@
+# Erlang Review — perc-checkboxtree Javadoc cleanup (#1617)
+
+## Summary
+
+Issue #1617 asked for zero Javadoc errors and warnings in the `perc-checkboxtree`
+module. The diff is documentation-only: closes an unclosed `<code>` tag in
+`PSCheckboxTreeNode`, adds the missing `@return` tag on
+`PSCheckboxTreeApplet#getParameter(String, String)`, and adds explicit
+no-argument Javadoc'd constructors on three public classes to satisfy the
+JDK 21 `javadoc -Xdoclint:all` "use of default constructor" warning.
+
+No production logic, control flow, or API signatures change. Empty constructors
+preserve all previous behaviour; field initializers still run. Module
+`mvnw clean install -DskipTests` is green with **0 javadoc errors, 0 javadoc
+warnings** and `spotless:check` passes.
+
+## Scope
+
+- Base: `origin/development` @ `798a5c0d8a`
+- Head: `fix/1617-perc-checkboxtree-javadoc` (1 commit pending — not yet pushed)
+- Files: **4** changed (all in `modules/perc-checkboxtree/src/main/java/`)
+  - `PSCheckboxTreeApplet.java`
+  - `PSCheckboxTreeNode.java`
+  - `PSCheckboxTreeRenderer.java`
+  - `PSCheckboxTreeRootNode.java`
+- Prior report: none
+- Memory patterns hit: none (no logic / I/O / path / security changes)
+
+## Recommendation
+
+`approve`
+
+## Gate
+
+- Blocking bugs: **0**
+- Missing behavioral tests: **N/A** (no logic or behavior change; module has no
+  existing test sources and the diff adds none — appropriate for a pure
+  javadoc-touch task)
+- Non-portable path / file I/O: **N/A** (diff does not touch file I/O)
+- May commit/push: **yes**
+
+## Issues
+
+None.
+
+## Notes
+
+- The three added default constructors (`PSCheckboxTreeApplet`, `PSCheckboxTreeRenderer`,
+  `PSCheckboxTreeRootNode`) are bare and only exist to silence the
+  `doclint=all` "use of default constructor, which does not provide a comment"
+  diagnostic. They preserve prior behavior exactly: field initializers
+  (`m_parameters = null`, `m_tree = new JTree()`, `m_label = ""`, etc.) still
+  execute on instantiation. No `@Override` is needed because no parent class
+  declares the constructor; these are first explicit constructors.
+- `PSCheckboxTreeApplet#getParameter(String, String)` is `protected` and only
+  invoked internally, but still gets the `-Xdoclint:all` "no `@return`" warning
+  because Javadoc inspects every documented method regardless of visibility.
+- `<code>true<code>` → `<code>true</code>` was the actual source of two
+  reported errors (`element not closed: code`) and two warnings (`nested tag
+  not allowed: <code>`) at the same line — four diagnostics from one bug.
+- Cross-platform path / file I/O checklist: **N/A** (diff does not touch
+  filesystem paths, installers, packaging, or path assertions).
+- Build evidence:
+  - `mvnw.cmd -f modules/perc-checkboxtree/pom.xml -DskipTests clean install` → `BUILD SUCCESS`
+  - Javadoc plugin output: `attach-javadocs` produces the `-javadoc.jar` with
+    no `MavenReportException`, no `error:` lines, no `warning:` lines.
+  - `mvnw.cmd -f modules/perc-checkboxtree/pom.xml spotless:check` → `BUILD SUCCESS`.

--- a/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeApplet.java
+++ b/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeApplet.java
@@ -47,9 +47,7 @@ import javax.swing.tree.TreeSelectionModel;
  */
 public class PSCheckboxTreeApplet extends JApplet implements Runnable {
   /** Default no-argument constructor for the applet. */
-  public PSCheckboxTreeApplet() {
-    // Default constructor for the applet.
-  }
+  public PSCheckboxTreeApplet() {}
 
   /** Initialize the applet and load the tree. */
   @Override

--- a/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeApplet.java
+++ b/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeApplet.java
@@ -46,6 +46,11 @@ import javax.swing.tree.TreeSelectionModel;
  * </ol>
  */
 public class PSCheckboxTreeApplet extends JApplet implements Runnable {
+  /** Default no-argument constructor for the applet. */
+  public PSCheckboxTreeApplet() {
+    // Default constructor for the applet.
+  }
+
   /** Initialize the applet and load the tree. */
   @Override
   public void init() {
@@ -103,6 +108,8 @@ public class PSCheckboxTreeApplet extends JApplet implements Runnable {
    * @param key name of the system property, not <code>null</code> or empty.
    * @param def the default value is returned if the specified key is not found, may be <code>null
    *     </code> or empty.
+   * @return the parameter value or the default when the parameter is not found; may be <code>null
+   *     </code> if <code>def</code> is <code>null</code> and the parameter is missing.
    */
   protected String getParameter(String key, String def) {
     if (key == null || key.trim().length() == 0)

--- a/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeNode.java
+++ b/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeNode.java
@@ -52,8 +52,7 @@ public class PSCheckboxTreeNode extends DefaultMutableTreeNode {
   /**
    * Determines if this node is selecable or not.
    *
-   * @return <code>true<code> if the node can be selected, <code>false</code>
-   *    otherwise.
+   * @return <code>true</code> if the node can be selected, <code>false</code> otherwise.
    */
   public boolean isSelectable() {
     return m_selectable;

--- a/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeRenderer.java
+++ b/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeRenderer.java
@@ -27,6 +27,11 @@ import javax.swing.tree.DefaultTreeCellRenderer;
  */
 public class PSCheckboxTreeRenderer extends DefaultTreeCellRenderer
     implements IPSCheckboxTreeRenderer {
+  /** Default no-argument constructor for the renderer. */
+  public PSCheckboxTreeRenderer() {
+    // Default constructor for the renderer.
+  }
+
   /* (non-Javadoc)
    * @see javax.swing.tree.TreeCellRenderer#getTreeCellRendererComponent(
    *    javax.swing.JTree, java.lang.Object, boolean, boolean, boolean, int,

--- a/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeRenderer.java
+++ b/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeRenderer.java
@@ -28,9 +28,7 @@ import javax.swing.tree.DefaultTreeCellRenderer;
 public class PSCheckboxTreeRenderer extends DefaultTreeCellRenderer
     implements IPSCheckboxTreeRenderer {
   /** Default no-argument constructor for the renderer. */
-  public PSCheckboxTreeRenderer() {
-    // Default constructor for the renderer.
-  }
+  public PSCheckboxTreeRenderer() {}
 
   /* (non-Javadoc)
    * @see javax.swing.tree.TreeCellRenderer#getTreeCellRendererComponent(

--- a/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeRootNode.java
+++ b/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeRootNode.java
@@ -28,9 +28,7 @@ import org.w3c.dom.NodeList;
  */
 public class PSCheckboxTreeRootNode extends DefaultMutableTreeNode implements MutableTreeNode {
   /** Default no-argument constructor for the root node. */
-  public PSCheckboxTreeRootNode() {
-    // Default constructor for the root node.
-  }
+  public PSCheckboxTreeRootNode() {}
 
   /**
    * Load the xml document and populate the tree. The expected xml format is: &lt;!ELEMENT Tree

--- a/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeRootNode.java
+++ b/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeRootNode.java
@@ -27,6 +27,11 @@ import org.w3c.dom.NodeList;
  * to load the entire tree from an xml document.
  */
 public class PSCheckboxTreeRootNode extends DefaultMutableTreeNode implements MutableTreeNode {
+  /** Default no-argument constructor for the root node. */
+  public PSCheckboxTreeRootNode() {
+    // Default constructor for the root node.
+  }
+
   /**
    * Load the xml document and populate the tree. The expected xml format is: &lt;!ELEMENT Tree
    * (Node*)&gt; &lt;!ATTLIST Tree label CDATA #REQUIRED &gt; &lt;!ELEMENT Node (Node*)&gt;


### PR DESCRIPTION
Resolves #1617.

The perc-checkboxtree module built SUCCESS, but JDK 21 \javadoc -Xdoclint:all\ reported **4 errors + 2 plugin warnings + 3 source warnings** during the \ttach-javadocs\ execution. After this change, the same command emits **0 errors and 0 warnings**.

### Root causes
- \PSCheckboxTreeNode.java:55\ — \<code>true<code>\ is unclosed in the \isSelectable()\ @return, producing 2 \element not closed: code\ errors and 2 \
ested tag not allowed: <code>\ warnings (4 diagnostics from one bug).
- \PSCheckboxTreeApplet.java:107\ — \protected getParameter(String, String)\ had Javadoc but no \@return\ tag.
- \PSCheckboxTreeApplet.java:48\, \PSCheckboxTreeRenderer.java:28\, \PSCheckboxTreeRootNode.java:29\ — public classes relied on the implicit default constructor without a Javadoc comment, so \-Xdoclint:all\ flagged all three with \use of default constructor, which does not provide a comment\.

### Changes
- \PSCheckboxTreeNode.java\ — fix the unclosed \<code>\ tag.
- \PSCheckboxTreeApplet.java\ — add \@return\ tag to \getParameter(String, String)\; add explicit no-arg constructor with Javadoc on \PSCheckboxTreeApplet\.
- \PSCheckboxTreeRenderer.java\ — add explicit no-arg constructor with Javadoc on \PSCheckboxTreeRenderer\.
- \PSCheckboxTreeRootNode.java\ — add explicit no-arg constructor with Javadoc on \PSCheckboxTreeRootNode\.

The added constructors are bare (only present to silence the \-Xdoclint\ warning) and preserve the prior behaviour exactly: every class still relies on the same field initializers, and the implicit \super()\ chain continues to run.

### Verification (Windows / JDK 21 / \mvnw.cmd\)

\\\
cd modules\\perc-checkboxtree
..\\mvnw.cmd -DskipTests clean install
..\\mvnw.cmd spotless:check
\\\

- **\clean install\** → \BUILD SUCCESS\. \javadoc:jar (attach-javadocs)\ attached without \MavenReportException\. 0 error lines and 0 warning lines from \-Xdoclint:all\.
- **\spotless:check\** → \BUILD SUCCESS\ (9 Java files + 1 POM already clean).
- **Erlang review** (\docs/ai-generated/code-reviews/1617-perc-checkboxtree-javadoc-erlang.md\) → \pprove\. 0 blocking bugs. Cross-platform path / file I/O checklist: N/A (diff does not touch file I/O).

### Risk / behaviour
No production logic, API signatures, or method behaviour change. The existing \(non-Javadoc)\ style comments and \{@inheritDoc}\ patterns are intentionally left as-is — the production build only counts errors during \javadoc:jar\, and rewriting them is outside the scope of #1617.

Co-authored-by: kilo <kilo@local>