### PR TITLE
docs(developer): track P0 progress on issue #1622 (stop README thrash)

### DIFF
--- a/docs/ai-generated/tasks/developer-module-p0/README.md
+++ b/docs/ai-generated/tasks/developer-module-p0/README.md
@@ -2,11 +2,25 @@
 
 | Field | Value |
 |-------|--------|
-| **Status** | **In progress** — read catalogs + keyword CRUD + template/slot detail + pipelines catalog |
+| **Status** | **In progress** — track slices on the GitHub issue (not this file) |
+| **Progress tracker** | **[#1622](https://github.com/intersoftdatalabs-in/percussioncms/issues/1622)** — living todo list (shipped / open / next) |
 | **FR source** | [`docs/developer-module/workbench-functional-inventory.md`](../../developer-module/workbench-functional-inventory.md) §15 P0 |
 | **Pipeline track** | [`docs/developer-module/data-pipeline-engine-inventory.md`](../../developer-module/data-pipeline-engine-inventory.md) (parallel; not blocking P0) |
+| **Server runtime map** | [`docs/developer-module/data-pipeline-server-runtime-map.md`](../../developer-module/data-pipeline-server-runtime-map.md) |
 | **Related** | [design-templates-item-types](../design-templates-item-types/README.md) (CM1 template library — complementary, not a substitute) |
 | **Review follow-ups** | [review-followups-tech-debt.md](./review-followups-tech-debt.md) — deferred PR-review items (not FR roadmap) |
+| **API gaps** | [content-type-api-gaps.md](./content-type-api-gaps.md) |
+
+## Why progress lives on the issue
+
+Updating "done / next" checklists in this markdown on **every** feature PR caused constant merge conflicts across parallel slices.
+
+**Convention:**
+
+1. Track slice progress **only** on [#1622](https://github.com/intersoftdatalabs-in/percussioncms/issues/1622) (GitHub task list).
+2. Feature PRs should **not** edit the shipped/next lists in this file.
+3. Link PRs to the issue (`Refs #1622` / "Part of #1622").
+4. Cross-cutting review debt still goes in [review-followups-tech-debt.md](./review-followups-tech-debt.md).
 
 ## P0 scope (from FR)
 
@@ -21,39 +35,6 @@
 | Slots | AS-01–AS-02 | P0.4 |
 | Communities + object ACL | SE-01, SE-04, §5.4 | P0.5 |
 | Locking / save / problems | §5.2–5.3 | Cross-cutting as editors land |
-
-## Done in this branch
-
-- [x] SPA route `/developer` (+ section) for Admin or Designer  
-- [x] Top nav **Developer** (replaces legacy Design full-page exit for designers)  
-- [x] Deep-link entry `developer` (query + path fallback filter)  
-- [x] Module shell with sections: Content Types, Templates, Slots, Keywords, Communities, Pipelines  
-- [x] **Content Types** panel: list from `GET /services/contenttypes`  
-- [x] **P0.2** `GET /services/contenttypes/{idOrName}` field catalog + SPA detail view  
-- [x] **P0.2b** Allowed workflows + default workflow + allowed templates on CT detail  
-- [x] **P0.2c** Field rule flags (readOnly, occurrence, hasValidation/visibility/transforms) + SPA columns  
-- [x] **P0.3** Keywords list `GET /services/keywords` + SPA Keywords panel (read-only)  
-- [x] **P0.3b** Keyword create/update/delete + SPA editor  
-- [x] **P0.4** Templates `GET /services/templates` + Slots `GET /services/slots` + SPA panels  
-- [x] **P0.4b** Template detail `GET /services/templates/{idOrName}` — bindings, slots, source, designGaps + SPA detail  
-- [x] **P0.4c** Slot detail `GET /services/slots/{idOrName}` (finder + associations) + SPA detail  
-- [x] **P0.5** Communities list via `GET /services/communities/find?name=*` + SPA panel  
-- [x] **P0.5b** Community detail `GET /services/communities/{idOrName}` — roles + SPA detail (role/ACL edit later)  
-- [x] **P0.5c** Community role membership edit `GET /roles` + `PUT /{id}/roles` + SPA checkboxes  
-
-- [x] **P0.6** Pipelines list `GET /services/pipelines` — classic **XML Application** summaries (not Slice A IR) + SPA panel; optional `?name=` / `?limit=` / `?offset=`  
-- [x] Gap map: [content-type-api-gaps.md](./content-type-api-gaps.md)  
-- [x] Vitest coverage for shell + catalogs  
-- [x] Review-deferral backlog: [review-followups-tech-debt.md](./review-followups-tech-debt.md)  
-
-## Next slices (separate PRs)
-
-1. Community object ACL dialogs  
-2. Pipelines track Slice A (IR + SQL runtime + JSON I/O + classic import)  
-3. Template/slot **editors** (write)  
-4. CT field write/lock (rules projection already shipped as P0.2c)  
-
-Cross-cutting review debt (typed JSON errors, structured designGaps, source viewer, panel migration) is **not** listed above — see [review-followups-tech-debt.md](./review-followups-tech-debt.md).
 
 ## Product locks
 

--- a/docs/ai-generated/tasks/developer-module-p0/review-followups-tech-debt.md
+++ b/docs/ai-generated/tasks/developer-module-p0/review-followups-tech-debt.md
@@ -46,15 +46,9 @@ Capture rule: when a review finding is **intentionally not fixed in that PR**, a
 
 ---
 
-## Product slices (already in README — do not duplicate as “deferred review”)
+## Product slices (not deferred review)
 
-Tracked under [README.md § Next slices](./README.md):
-
-- CT field rules (read) → write/lock  
-- Keyword create/edit; community roles + ACL  
-- Pipelines Slice A (IR + SQL + JSON + import)  
-- Template/slot **editors**  
-- Server runtime map for data pipelines  
+Tracked on **[issue #1622](https://github.com/intersoftdatalabs-in/percussioncms/issues/1622)** (living todo list). Do not maintain a parallel “next slices” checklist in README.md on every PR.
 
 API surface gaps for content types: [content-type-api-gaps.md](./content-type-api-gaps.md).
 

--- a/docs/developer-module/README.md
+++ b/docs/developer-module/README.md
@@ -28,7 +28,9 @@ Tool-agnostic reverse engineering of the Rhythmyx 7.3.2 **Workbench** (Eclipse D
 2. **Server runtime map** — [data-pipeline-server-runtime-map.md](./data-pipeline-server-runtime-map.md) (done as docs; use before estimating engine reuse)  
 3. **Pipeline Slice A (parallel or next)** — pipeline IR + SQL runtime + JSON I/O + hooks + classic app import  
 
-Implementation task tracking and **PR review deferrals / tech debt** live under  
+**Slice progress (todo list):** [issue #1622](https://github.com/intersoftdatalabs-in/percussioncms/issues/1622) — update the issue task list when PRs merge; do not thrash the P0 README checklist on every PR.
+
+Implementation notes and **PR review deferrals / tech debt** live under  
 [`docs/ai-generated/tasks/developer-module-p0/`](../ai-generated/tasks/developer-module-p0/)  
 (especially [review-followups-tech-debt.md](../ai-generated/tasks/developer-module-p0/review-followups-tech-debt.md)).
 


### PR DESCRIPTION
## Summary

Feature PRs kept editing ``docs/ai-generated/tasks/developer-module-p0/README.md`` (done/next checklists), which caused **constant merge conflicts** across parallel slices.

### Changes
- Created tracker issue **#1622** with a living GitHub task list (shipped / open / next)
- P0 README: remove thrashing checklists; link to **#1622**; keep FR scope + product locks
- ``docs/developer-module/README.md`` and review-followups point at the issue

### Convention going forward
1. Update progress **on the issue**, not the markdown checklist
2. Feature PRs should not touch the done/next lists in P0 README
3. Link PRs with ``Refs #1622``

## Test plan
- [x] Issue #1622 exists with task list
- [x] README links resolve to the issue

> Co-Authored by Grok Build using grok-4.5 with agent main.