### PR TITLE
fix(rest): Spring test adaptors for keywords/pipelines/slots context

### DIFF
--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestKeywordsAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestKeywordsAdaptor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.test.apibridge;
+
+import com.percussion.rest.keywords.IKeywordsAdaptor;
+import com.percussion.rest.keywords.KeywordSummary;
+import java.net.URI;
+import java.util.List;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring test stub for {@link IKeywordsAdaptor}. Required after {@code KeywordsResource} switched
+ * to constructor injection so the rest module ApplicationContext can start.
+ */
+@Component
+@Lazy
+public class TestKeywordsAdaptor implements IKeywordsAdaptor {
+
+  @Override
+  public List<KeywordSummary> listKeywords(URI baseUri, boolean includeChoices) {
+    return List.of();
+  }
+
+  @Override
+  public KeywordSummary getKeyword(URI baseUri, String idOrValue) {
+    return null;
+  }
+
+  @Override
+  public KeywordSummary createKeyword(URI baseUri, KeywordSummary body) {
+    return null;
+  }
+
+  @Override
+  public KeywordSummary updateKeyword(URI baseUri, String id, KeywordSummary body) {
+    return null;
+  }
+
+  @Override
+  public void deleteKeyword(URI baseUri, String id) {
+    // no-op for tests
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestPipelinesAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestPipelinesAdaptor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.test.apibridge;
+
+import com.percussion.rest.pipelines.ApplicationSummary;
+import com.percussion.rest.pipelines.IPipelinesAdaptor;
+import java.net.URI;
+import java.util.List;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring test stub for {@link IPipelinesAdaptor}. Required for ApplicationContext load after
+ * constructor injection on {@code PipelinesResource}.
+ */
+@Component
+@Lazy
+public class TestPipelinesAdaptor implements IPipelinesAdaptor {
+
+  @Override
+  public List<ApplicationSummary> listApplications(
+      URI baseUri, String nameFilter, int limit, int offset) {
+    return List.of();
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestSlotsAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestSlotsAdaptor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.test.apibridge;
+
+import com.percussion.rest.slots.ISlotsAdaptor;
+import com.percussion.rest.slots.SlotDetail;
+import com.percussion.rest.slots.SlotSummary;
+import java.net.URI;
+import java.util.List;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring test stub for {@link ISlotsAdaptor}. Required for ApplicationContext load after
+ * constructor injection on {@code SlotsResource}.
+ */
+@Component
+@Lazy
+public class TestSlotsAdaptor implements ISlotsAdaptor {
+
+  @Override
+  public List<SlotSummary> listSlots(URI baseUri) {
+    return List.of();
+  }
+
+  @Override
+  public SlotDetail getSlot(URI baseUri, String idOrName) {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Full ``rest`` module ``mvnw test`` was failing with **11 ApplicationContext errors** after constructor injection on catalog resources:

```
No qualifying bean of type IKeywordsAdaptor / IPipelinesAdaptor / ISlotsAdaptor
```

### Fix
Add Spring ``@Component`` test stubs (same pattern as ``TestTemplatesAdaptor``):
- ``TestKeywordsAdaptor``
- ``TestPipelinesAdaptor``
- ``TestSlotsAdaptor``

### Verification
```
cd rest && ../mvnw.cmd test
Tests run: 69, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

> Co-Authored by Grok Build using grok-4.5 with agent main.