### PR TITLE
fix(javadoc): resolve 99 javadoc source warnings in perc-auditlog (#1626)

### DIFF
--- a/docs/ai-generated/code-reviews/1626-perc-auditlog-javadoc-erlang.md
+++ b/docs/ai-generated/code-reviews/1626-perc-auditlog-javadoc-erlang.md
@@ -1,0 +1,113 @@
+# Erlang Review — perc-auditlog Javadoc cleanup (#1626)
+
+## Summary
+
+Issue #1626 reported **0 errors + 100 source warnings** during
+`javadoc -Xdoclint:all` for the `audit-log` module (artifactId `audit-log`,
+sources under `modules/perc-auditlog/src/main/java`). The actual javadoc tool
+emitted **99 source-warning lines** before the fix (100 in the issue metric
+counts, which includes the doubled raw + formatted reporting). After this
+change every javadoc diagnostic is gone and the standalone module build is
+`BUILD SUCCESS`.
+
+The diff is documentation-only: no production logic, control flow, or API
+signatures change. The added no-arg constructor on `FileCreator` is empty
+(field initializers are static; no instance state changes).
+
+## Scope
+
+- Base: `origin/development` @ `798a5c0d8a`
+- Head: `fix/1626-perc-auditlog-javadoc` (1 commit pending — not yet pushed)
+- Files: **12** changed (all under `modules/perc-auditlog/src/main/java/`)
+  - `AbstractEvent.java`
+  - `IPSAuditEvent.java`
+  - `IPSAuditLogService.java`
+  - `PSActionOutcome.java`
+  - `PSAuditLogService.java`
+  - `PSAuthenticationEvent.java`
+  - `PSContentEvent.java`
+  - `PSUserManagementEvent.java`
+  - `PSWorkflowEvent.java`
+  - `exception/AuditException.java`
+  - `util/AuditPropertyLoader.java`
+  - `util/FileCreator.java`
+- Prior report: none
+- Memory patterns hit: none (no logic / I/O / path / security changes)
+
+## Recommendation
+
+`approve`
+
+## Gate
+
+- Blocking bugs: **0**
+- Missing behavioral tests: **N/A** (documentation-only diff; module has no
+  existing test sources and the diff adds none — appropriate for a pure
+  javadoc-touch task)
+- Non-portable path / file I/O: **N/A** (diff does not touch file I/O; the
+  existing `FileCreator` path-traversal guards and `Path`/`Paths`/`normalize`
+  usage are unchanged)
+- May commit/push: **yes**
+
+## Issues
+
+None.
+
+## Notes
+
+### What the warnings were
+
+Every public type, method, field, and enum constant in the module lacked a
+Javadoc comment, triggering `warning: no comment` from `-Xdoclint:all`. Three
+methods in `PSAuditLogService` (`logWorkflowEvent`, `logAuthenticationEvent`,
+`logUserManagementEvent`) also had `@param event` tags with no description text
+(`warning: no description for @param`). `FileCreator` had an implicit default
+constructor (only the static `generateFile` method was used externally),
+triggering `use of default constructor, which does not provide a comment`.
+
+### Per-file summary
+
+| File | Notes |
+|------|-------|
+| `AbstractEvent` | Added class-level Javadoc, getter/setter descriptions, and a constructor Javadoc. `getOutcome` / `setOutcome` use `@code null` semantics that match the existing implementation (`setOutcome` does not check `null`). |
+| `AuditException` | Added class Javadoc + Javadoc on the three public ctors. The class is now properly documented as the standard checked exception raised by the audit-log subsystem. |
+| `FileCreator` | Added class Javadoc and an explicit no-arg constructor with Javadoc. The static `generateFile` method already had Javadoc; only the constructor warning remained after the first fix pass. |
+| `AuditPropertyLoader` | Added class Javadoc and `loadProperties` description. The private constructor intentionally remains undocumented (doclint only flags public ctors). |
+| `IPSAuditEvent` | Added interface and `getAction` Javadoc. The `<T> T getAction()` generic carries the documented `@param <T>` declaration. |
+| `IPSAuditLogService` | Added per-method Javadoc on the five public API methods. The existing `/** Defines the interface for the audit log service */` on the interface itself was retained. |
+| `PSActionOutcome` | Added class Javadoc and Javadoc on each of the three enum constants (`SUCCESS`, `FAILURE`, `UNKNOWN`). |
+| `PSAuditLogService` | Added class Javadoc + Javadoc on `auditLog`, `createEvent`, `getInstance`, `generateLogFile`, `isGenerateLog`. Replaced missing `@param event` descriptions on the three event-log methods with proper sentences. |
+| `PSAuthenticationEvent` | Added class Javadoc, Javadoc on the five public constants (sessionid/roles/communityName/user-uri/security-uri), on both ctors, on the `AuthenticationEventActions` enum and each of its 4 constants, and on every getter/setter pair. |
+| `PSContentEvent` | Added class Javadoc, Javadoc on the three public constants (`CONTENTID_TAG`, `GUID_TAG`, `CONTENT_OBSERVER`), on the `ContentEventActions` enum and each of its 6 constants, on the populated ctor (6 `@param`s), on every getter/setter pair, and on the no-arg ctor. |
+| `PSUserManagementEvent` | Added class Javadoc, Javadoc on the `UserEventActions` enum and each of its 5 constants, on the populated ctor, and on `getAction`/`setAction`. |
+| `PSWorkflowEvent` | Added class Javadoc, Javadoc on the four public constants (`CONTENTID_TAG`, `GUID_TAG`, `TRANSITIONFROM_TAG`, `TRANSITIONTO_TAG`), on the `WorkflowEventActions` enum and its sole `update` constant, on the populated ctor (7 `@param`s), and on every getter/setter pair. |
+
+### Behaviour preservation
+
+- The added constructor on `FileCreator` is empty. `FileCreator` is
+  effectively used as a static utility — no static field initializers, no
+  instance state. Construction is a no-op, identical to the prior implicit
+  default.
+- All other files touched in this PR only have Javadoc additions; the existing
+  methods, fields, visibility, and parameter lists are untouched. Behaviour
+  is preserved exactly.
+
+### Cross-platform path / file I/O checklist
+
+**N/A.** The diff does not introduce or modify filesystem paths. The existing
+`FileCreator.generateFile` continues to use `Paths.get(...).toAbsolutePath().normalize()`
++ `finalPath.startsWith(basePath)` traversal guard; no changes were made to that
+logic.
+
+### Build evidence (Windows / JDK 21 / `mvnw.cmd`)
+
+- `./mvnw.cmd -f modules/perc-auditlog/pom.xml -DskipTests clean install` →
+  `BUILD SUCCESS`. `javadoc:jar (attach-javadocs)` attaches cleanly; final
+  log: 0 `MavenReportException`, 0 `error:`, 0 `warning:` lines from
+  `-Xdoclint:all`.
+- `./mvnw.cmd -f modules/perc-auditlog/pom.xml spotless:check` → `BUILD SUCCESS`
+  (12 Java files + 1 POM clean).
+- `spotless:apply` was used once mid-iteration to normalize google-java-format
+  whitespace in `AuditPropertyLoader#loadProperties` (the project uses
+  `googleJavaFormat`). All 12 in-scope files remain in scope; no out-of-scope
+  changes were introduced.

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/AbstractEvent.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/AbstractEvent.java
@@ -19,19 +19,37 @@ package com.percussion.auditlog;
 
 import com.ibm.cadf.middleware.AuditContext;
 
+/**
+ * Base {@link AuditContext} shared by every Percussion audit event. Pre-populates the observer and
+ * target resource URIs with the {@code service/bss/cms} system observer and defaults the action
+ * outcome to {@link PSActionOutcome#UNKNOWN}. Sub-classes typically mutate the action and the
+ * outcome in their own constructors before passing the event to {@link PSAuditLogService}.
+ */
 public class AbstractEvent extends AuditContext {
 
   private static final String SYSTEM_OBSERVER = "service/bss/cms";
   private String outcome;
 
+  /**
+   * Returns the action outcome recorded for this audit event.
+   *
+   * @return the outcome value, typically one of {@link PSActionOutcome}, never {@code null} after
+   *     construction.
+   */
   public String getOutcome() {
     return outcome;
   }
 
+  /**
+   * Sets the action outcome for this audit event.
+   *
+   * @param outcome the outcome value, typically one of {@link PSActionOutcome}, never {@code null}.
+   */
   public void setOutcome(String outcome) {
     this.outcome = outcome;
   }
 
+  /** Constructs an event pre-populated with the system observer and an {@code UNKNOWN} outcome. */
   public AbstractEvent() {
 
     // Set some defaults

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/IPSAuditEvent.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/IPSAuditEvent.java
@@ -17,7 +17,17 @@
 
 package com.percussion.auditlog;
 
+/**
+ * Common contract for Percussion audit event objects. Allows callers to retrieve the strongly-typed
+ * action associated with an event without knowing the concrete subtype.
+ */
 public interface IPSAuditEvent {
 
+  /**
+   * Returns the action recorded for this event.
+   *
+   * @param <T> the concrete action enum type declared by an implementing event class.
+   * @return the action, never {@code null}.
+   */
   public <T> T getAction();
 }

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/IPSAuditLogService.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/IPSAuditLogService.java
@@ -23,13 +23,45 @@ import com.ibm.cadf.model.Event;
 /** Defines the interface for the audit log service */
 public interface IPSAuditLogService {
 
+  /**
+   * Records a content lifecycle event (create, update, delete, publish/recycle) with the active
+   * audit sink.
+   *
+   * @param event the fully-populated content event to log, never {@code null}.
+   */
   public void logContentEvent(PSContentEvent event);
 
+  /**
+   * Records a workflow transition event (e.g., state changes) with the active audit sink.
+   *
+   * @param event the fully-populated workflow event to log, never {@code null}.
+   */
   public void logWorkflowEvent(PSWorkflowEvent event);
 
+  /**
+   * Records an authentication lifecycle event (login, renew, revoke, logout) with the active audit
+   * sink.
+   *
+   * @param event the fully-populated authentication event to log, never {@code null}.
+   */
   public void logAuthenticationEvent(PSAuthenticationEvent event);
 
+  /**
+   * Records a user-management event (create, update, delete, disable, revoke) with the active audit
+   * sink.
+   *
+   * @param event the fully-populated user-management event to log, never {@code null}.
+   */
   public void logUserManagementEvent(PSUserManagementEvent event);
 
+  /**
+   * Builds an IBM CADF {@link Event} from a generic audit context, action name, and outcome.
+   *
+   * @param event the source audit context carrying resource and initiator metadata, never {@code
+   *     null}.
+   * @param action the action name emitted for the resulting event, never {@code null}.
+   * @param outcome the outcome name emitted for the resulting event, never {@code null}.
+   * @return the constructed CADF event, never {@code null}.
+   */
   public Event createEvent(AuditContext event, String action, String outcome);
 }

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSActionOutcome.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSActionOutcome.java
@@ -17,8 +17,15 @@
 
 package com.percussion.auditlog;
 
+/** Standard outcome categories recorded alongside every Percussion audit event. */
 public enum PSActionOutcome {
+  /** The audited action completed without an observable error. */
   SUCCESS,
+  /** The audited action did not complete as intended; consult other event details for cause. */
   FAILURE,
+  /**
+   * Default outcome used when neither success nor failure has been determined yet, e.g., during
+   * event construction before {@code setOutcome(...)} is invoked.
+   */
   UNKNOWN
 }

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSAuditLogService.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSAuditLogService.java
@@ -31,6 +31,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * Process-wide singleton that bridges the {@link IPSAuditEvent} domain events with the IBM CADF
+ * {@link AuditMiddleware} used by the rest of the platform. Reads {@code
+ * rxconfig/Server/audit-log.properties} on first use to determine whether to emit a JSON audit log
+ * to disk via {@link FileCreator} in addition to forwarding events to the middleware.
+ */
 public class PSAuditLogService implements IPSAuditLogService {
 
   private static final Logger log = LogManager.getLogger(PSAuditLogService.class);
@@ -40,7 +46,7 @@ public class PSAuditLogService implements IPSAuditLogService {
   private static final String CONFIG_FILE_BASE = "rxconfig/Server/audit-log.properties";
   private static Boolean isGenerateLog = false;
 
-  /***
+  /**
    * Creates an Audit Log Entry for a ContentEvent
    *
    * @param event A fully populated ContentEvent
@@ -59,9 +65,10 @@ public class PSAuditLogService implements IPSAuditLogService {
     auditLog(ae);
   }
 
-  /***
-   * Logs a Workflow Event
-   * @param event
+  /**
+   * Logs a Workflow Event.
+   *
+   * @param event the fully-populated workflow event to log, never {@code null}.
    */
   public void logWorkflowEvent(PSWorkflowEvent event) {
     Event ae = createEvent((AuditContext) event, event.getAction().name(), event.getOutcome());
@@ -82,9 +89,10 @@ public class PSAuditLogService implements IPSAuditLogService {
     auditLog(ae);
   }
 
-  /***
-   * Logs an Authentication Event
-   * @param event
+  /**
+   * Logs an Authentication Event.
+   *
+   * @param event the fully-populated authentication event to log, never {@code null}.
    */
   public void logAuthenticationEvent(PSAuthenticationEvent event) {
 
@@ -92,9 +100,10 @@ public class PSAuditLogService implements IPSAuditLogService {
     auditLog(ae);
   }
 
-  /***
-   * Logs an event for User Management
-   * @param event
+  /**
+   * Logs an event for User Management.
+   *
+   * @param event the fully-populated user-management event to log, never {@code null}.
    */
   public void logUserManagementEvent(PSUserManagementEvent event) {
 
@@ -102,6 +111,12 @@ public class PSAuditLogService implements IPSAuditLogService {
     auditLog(ae);
   }
 
+  /**
+   * Forwards the given CADF event to the configured middleware sink and, when audit-log file
+   * generation is enabled, ensures the dated log file exists for the configured output directory.
+   *
+   * @param ae the CADF event to record, never {@code null}.
+   */
   public void auditLog(Event ae) {
     try {
       if (isGenerateLog() && properties != null && properties.size() > 0) {
@@ -114,6 +129,15 @@ public class PSAuditLogService implements IPSAuditLogService {
     }
   }
 
+  /**
+   * Delegates to the underlying {@link AuditMiddleware} to build a CADF {@link Event} from the
+   * supplied context, action, and outcome.
+   *
+   * @param event the source audit context, never {@code null}.
+   * @param action the action name, never {@code null}.
+   * @param outcome the outcome name, never {@code null}.
+   * @return the constructed CADF event, never {@code null}.
+   */
   public Event createEvent(AuditContext event, String action, String outcome) {
     return middleware.createEvent(action, outcome, event);
   }
@@ -134,6 +158,11 @@ public class PSAuditLogService implements IPSAuditLogService {
 
   private static PSAuditLogService instance;
 
+  /**
+   * Returns the process-wide singleton instance, constructing it on first access.
+   *
+   * @return the shared {@link PSAuditLogService} instance, never {@code null}.
+   */
   public static synchronized PSAuditLogService getInstance() {
     if (instance == null) {
       // if instance is null, initialize
@@ -144,6 +173,12 @@ public class PSAuditLogService implements IPSAuditLogService {
     return instance;
   }
 
+  /**
+   * Creates (or reuses) the dated audit-log file under the directory configured by the supplied
+   * properties and forwards the resolved file path to the underlying middleware.
+   *
+   * @param properties the audit-log configuration bundle, never {@code null}.
+   */
   public static void generateLogFile(Properties properties) {
 
     String fileName =
@@ -156,6 +191,12 @@ public class PSAuditLogService implements IPSAuditLogService {
     middleware.setOutputFilePath(fileName);
   }
 
+  /**
+   * Indicates whether the configured properties request a file-based audit log to be generated.
+   *
+   * @return {@code true} when {@code generateLog} is set to {@code true} in the loaded properties,
+   *     {@code false} otherwise.
+   */
   public static Boolean isGenerateLog() {
     if ("true".equalsIgnoreCase(properties.getProperty("generateLog"))) {
       isGenerateLog = true;

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSAuthenticationEvent.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSAuthenticationEvent.java
@@ -19,20 +19,45 @@ package com.percussion.auditlog;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+/**
+ * Audit event emitted whenever a user authenticates against the CMS — covering login, renewal,
+ * session revocation, and logout actions. Carries the session id, role claims, and community name
+ * so the downstream audit sink can attribute the action.
+ */
 public class PSAuthenticationEvent extends AbstractEvent {
 
+  /** Tag identifying the HTTP session id associated with the authentication action. */
   public static final String SESSIONID_TAG = "sessionid";
+
+  /** Tag identifying the role(s) granted as part of the authentication action. */
   public static final String ROLES_TAG = "roles";
+
+  /** Tag identifying the community the authenticated user belongs to. */
   public static final String COMMUNITYNAME_TAG = "communityName";
+
+  /** Resource URI for a single user account. */
   public static final String USER_URI = "data/security/account/user";
+
+  /** Resource URI for the system security service that records authentication events. */
   public static final String SYSTEM_SECURITY_URI = "service/bss/cms/security";
 
+  /** Constructs an empty event with the security observer pre-assigned. */
   public PSAuthenticationEvent() {
     super();
 
     this.setObserverName(SYSTEM_SECURITY_URI);
   }
 
+  /**
+   * Constructs an authentication event fully populated from the supplied servlet request and
+   * metadata.
+   *
+   * @param outcome the action outcome (typically {@code SUCCESS} or {@code FAILURE}), never {@code
+   *     null}.
+   * @param action the authentication action enum value, never {@code null}.
+   * @param request the HTTP request that triggered the event, never {@code null}.
+   * @param username the user name captured by the authentication attempt, never {@code null}.
+   */
   public PSAuthenticationEvent(
       String outcome,
       AuthenticationEventActions action,
@@ -47,10 +72,15 @@ public class PSAuthenticationEvent extends AbstractEvent {
     this.setAgentName(request.getHeader("User-Agent"));
   }
 
+  /** Enumerates the authentication lifecycle actions recorded by {@link PSAuthenticationEvent}. */
   public enum AuthenticationEventActions {
+    /** A user signed in successfully. */
     login,
+    /** An existing session was renewed or refreshed. */
     renew,
+    /** A previously issued session was explicitly revoked. */
     revoke,
+    /** The user signed out, terminating the session. */
     logout
   }
 
@@ -60,34 +90,74 @@ public class PSAuthenticationEvent extends AbstractEvent {
   private String roles;
   private String communityName;
 
+  /**
+   * Returns the action recorded for this event.
+   *
+   * @return the action, may be {@code null} when not yet set.
+   */
   public AuthenticationEventActions getAction() {
     return action;
   }
 
+  /**
+   * Sets the action recorded for this event.
+   *
+   * @param action the action to record, never {@code null}.
+   */
   public void setAction(AuthenticationEventActions action) {
     this.action = action;
   }
 
+  /**
+   * Returns the HTTP session id associated with the event.
+   *
+   * @return the session id, may be {@code null} when not set.
+   */
   public String getSessionId() {
     return sessionId;
   }
 
+  /**
+   * Sets the HTTP session id associated with the event.
+   *
+   * @param sessionId the session id, never {@code null} or empty.
+   */
   public void setSessionId(String sessionId) {
     this.sessionId = sessionId;
   }
 
+  /**
+   * Returns the role(s) granted by the authentication action, typically a comma-delimited list.
+   *
+   * @return the roles string, may be {@code null} when not set.
+   */
   public String getRoles() {
     return roles;
   }
 
+  /**
+   * Sets the role(s) granted by the authentication action.
+   *
+   * @param roles the roles string, may be {@code null}.
+   */
   public void setRoles(String roles) {
     this.roles = roles;
   }
 
+  /**
+   * Returns the community name associated with the authentication.
+   *
+   * @return the community name, may be {@code null} when not set.
+   */
   public String getCommunityName() {
     return communityName;
   }
 
+  /**
+   * Sets the community name associated with the authentication.
+   *
+   * @param communityName the community name, may be {@code null}.
+   */
   public void setCommunityName(String communityName) {
     this.communityName = communityName;
   }

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSContentEvent.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSContentEvent.java
@@ -19,24 +19,52 @@ package com.percussion.auditlog;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+/**
+ * Audit event emitted whenever content stored in the CMS changes — covering CRUD, recycling, and
+ * page publish/removal scheduling. Carries the content id and GUID so downstream consumers can
+ * locate the affected item.
+ */
 public class PSContentEvent extends AbstractEvent {
 
+  /** Tag identifying the integer content id of the affected item. */
   public static final String CONTENTID_TAG = "//percussion/contentid";
+
+  /** Tag identifying the GUID of the affected item. */
   public static final String GUID_TAG = "//percussion/guid";
+
+  /** Resource URI for the content observer. */
   public static final String CONTENT_OBSERVER = "service/bss/cms/content";
 
+  /** Enumerates the content lifecycle actions recorded by {@link PSContentEvent}. */
   public enum ContentEventActions {
+    /** A new content item was created. */
     create,
+    /** An existing content item was updated. */
     update,
+    /** An existing content item was moved to the recycle bin. */
     recycle,
+    /** An existing content item was removed permanently. */
     delete,
+    /** A page publish operation was scheduled. */
     pagePublishSchedule,
+    /** A page removal operation was scheduled. */
     pageRemovalSchedule
   }
 
   private String contentId;
   private String guid;
 
+  /**
+   * Constructs a content event pre-populated from the supplied servlet request and metadata.
+   *
+   * @param guid the GUID of the affected content item, never {@code null}.
+   * @param contentId the integer content id of the affected content item as a string, may be {@code
+   *     null} when not applicable.
+   * @param path the repository path of the affected content item, never {@code null}.
+   * @param action the content lifecycle action being recorded, never {@code null}.
+   * @param request the HTTP request that triggered the event, never {@code null}.
+   * @param outcome the outcome of the action, never {@code null}.
+   */
   public PSContentEvent(
       String guid,
       String contentId,
@@ -56,30 +84,61 @@ public class PSContentEvent extends AbstractEvent {
 
   private ContentEventActions action;
 
+  /**
+   * Returns the integer content id of the affected item as a string.
+   *
+   * @return the content id, may be {@code null} when not set.
+   */
   public String getContentId() {
     return contentId;
   }
 
+  /**
+   * Sets the integer content id of the affected item.
+   *
+   * @param contentId the content id as a string, may be {@code null}.
+   */
   public void setContentId(String contentId) {
     this.contentId = contentId;
   }
 
+  /**
+   * Returns the GUID of the affected content item.
+   *
+   * @return the GUID, may be {@code null} when not set.
+   */
   public String getGuid() {
     return guid;
   }
 
+  /**
+   * Sets the GUID of the affected content item.
+   *
+   * @param guid the GUID, may be {@code null}.
+   */
   public void setGuid(String guid) {
     this.guid = guid;
   }
 
+  /**
+   * Returns the action recorded for this event.
+   *
+   * @return the action, may be {@code null} when not yet set.
+   */
   public ContentEventActions getAction() {
     return action;
   }
 
+  /**
+   * Sets the action recorded for this event.
+   *
+   * @param action the action to record, never {@code null}.
+   */
   public void setAction(ContentEventActions action) {
     this.action = action;
   }
 
+  /** Constructs an empty event with the content observer pre-assigned. */
   public PSContentEvent() {
     super();
 

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSUserManagementEvent.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSUserManagementEvent.java
@@ -19,27 +19,55 @@ package com.percussion.auditlog;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+/**
+ * Audit event emitted for user-management administrative actions (create, update, delete, disable,
+ * revoke) initiated through the CMS console. Subclasses or callers may attach additional tags at
+ * the time the event is constructed.
+ */
 public class PSUserManagementEvent extends AbstractEvent {
   // Add any user specific tags here that would be useful to an auditor
 
+  /** Enumerates the user-management lifecycle actions recorded by {@link PSUserManagementEvent}. */
   public enum UserEventActions {
+    /** A new user account was created. */
     create,
+    /** An existing user account was updated. */
     update,
+    /** An existing user account was removed. */
     delete,
+    /** An existing user account was disabled. */
     disable,
+    /** Permissions previously granted to a user were revoked. */
     revoke
   }
 
   private UserEventActions action;
 
+  /**
+   * Returns the action recorded for this event.
+   *
+   * @return the action, may be {@code null} when not yet set.
+   */
   public UserEventActions getAction() {
     return action;
   }
 
+  /**
+   * Sets the action recorded for this event.
+   *
+   * @param action the action to record, never {@code null}.
+   */
   public void setAction(UserEventActions action) {
     this.action = action;
   }
 
+  /**
+   * Constructs a user-management event populated from the originating servlet request.
+   *
+   * @param request the HTTP request that triggered the event, never {@code null}.
+   * @param action the user-management action being recorded, never {@code null}.
+   * @param outcome the outcome of the action, never {@code null}.
+   */
   public PSUserManagementEvent(
       HttpServletRequest request, UserEventActions action, PSActionOutcome outcome) {
     super();

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSWorkflowEvent.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSWorkflowEvent.java
@@ -19,14 +19,28 @@ package com.percussion.auditlog;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+/**
+ * Audit event emitted when a workflow transition is applied to a content item. Carries the source
+ * and destination state names, the affected content id and GUID, and the user who triggered the
+ * transition.
+ */
 public class PSWorkflowEvent extends AbstractEvent {
 
+  /** Tag identifying the integer content id of the item whose workflow was updated. */
   public static final String CONTENTID_TAG = "//percussion/contentid";
+
+  /** Tag identifying the GUID of the item whose workflow was updated. */
   public static final String GUID_TAG = "//percussion/guid";
+
+  /** Tag identifying the workflow state the item transitioned away from. */
   public static final String TRANSITIONFROM_TAG = "//percussion/transitionFrom";
+
+  /** Tag identifying the workflow state the item transitioned to. */
   public static final String TRANSITIONTO_TAG = "//percussion/transitionTo";
 
+  /** Enumerates the workflow transition actions recorded by {@link PSWorkflowEvent}. */
   public enum WorkflowEventActions {
+    /** A workflow transition (update of state) was applied to a content item. */
     update
   }
 
@@ -36,6 +50,17 @@ public class PSWorkflowEvent extends AbstractEvent {
   private String transitionTo;
   private WorkflowEventActions action;
 
+  /**
+   * Constructs a workflow event populated from the originating servlet request and metadata.
+   *
+   * @param transitionFrom the source workflow state name, never {@code null}.
+   * @param transitionTo the destination workflow state name, never {@code null}.
+   * @param action the workflow transition action, never {@code null}.
+   * @param request the HTTP request that triggered the transition, never {@code null}.
+   * @param content the integer content id of the affected item as a string, never {@code null}.
+   * @param guid the GUID of the affected item, never {@code null}.
+   * @param outcome the outcome of the transition, never {@code null}.
+   */
   public PSWorkflowEvent(
       String transitionFrom,
       String transitionTo,
@@ -56,42 +81,92 @@ public class PSWorkflowEvent extends AbstractEvent {
     this.setContentId(Integer.parseInt(content));
   }
 
+  /**
+   * Returns the action recorded for this event.
+   *
+   * @return the action, may be {@code null} when not yet set.
+   */
   public WorkflowEventActions getAction() {
     return action;
   }
 
+  /**
+   * Sets the action recorded for this event.
+   *
+   * @param action the action to record, never {@code null}.
+   */
   public void setAction(WorkflowEventActions action) {
     this.action = action;
   }
 
+  /**
+   * Returns the integer content id of the item whose workflow was updated.
+   *
+   * @return the content id.
+   */
   public int getContentId() {
     return contentId;
   }
 
+  /**
+   * Sets the integer content id of the item whose workflow was updated.
+   *
+   * @param contentId the content id.
+   */
   public void setContentId(int contentId) {
     this.contentId = contentId;
   }
 
+  /**
+   * Returns the GUID of the item whose workflow was updated.
+   *
+   * @return the GUID, may be {@code null} when not set.
+   */
   public String getGuid() {
     return guid;
   }
 
+  /**
+   * Sets the GUID of the item whose workflow was updated.
+   *
+   * @param guid the GUID, may be {@code null}.
+   */
   public void setGuid(String guid) {
     this.guid = guid;
   }
 
+  /**
+   * Returns the source workflow state name recorded for this transition.
+   *
+   * @return the state name, may be {@code null} when not set.
+   */
   public String getTransitionFrom() {
     return transitionFrom;
   }
 
+  /**
+   * Sets the source workflow state name for this transition.
+   *
+   * @param transitionFrom the source state name, may be {@code null}.
+   */
   public void setTransitionFrom(String transitionFrom) {
     this.transitionFrom = transitionFrom;
   }
 
+  /**
+   * Returns the destination workflow state name recorded for this transition.
+   *
+   * @return the state name, may be {@code null} when not set.
+   */
   public String getTransitionTo() {
     return transitionTo;
   }
 
+  /**
+   * Sets the destination workflow state name for this transition.
+   *
+   * @param transitionTo the destination state name, may be {@code null}.
+   */
   public void setTransitionTo(String transitionTo) {
     this.transitionTo = transitionTo;
   }

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/exception/AuditException.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/exception/AuditException.java
@@ -17,18 +17,39 @@
 
 package com.percussion.auditlog.exception;
 
+/**
+ * Checked exception raised by the audit-log subsystem to signal that an audit event could not be
+ * recorded or delivered to the configured sink. Carries either a message, a cause, or both,
+ * mirroring the standard {@link Exception} triad.
+ */
 public class AuditException extends Exception {
 
   private static final long serialVersionUID = 1L;
 
+  /**
+   * Constructs an audit exception with both a message and an underlying cause.
+   *
+   * @param message human-readable description of the failure, may be {@code null}.
+   * @param e the underlying cause, may be {@code null}.
+   */
   public AuditException(String message, Throwable e) {
     super(message, e);
   }
 
+  /**
+   * Constructs an audit exception with the given message.
+   *
+   * @param message human-readable description of the failure, may be {@code null}.
+   */
   public AuditException(String message) {
     super(message);
   }
 
+  /**
+   * Constructs an audit exception wrapping an underlying cause.
+   *
+   * @param e the underlying cause, may be {@code null}.
+   */
   public AuditException(Throwable e) {
     super(e);
   }

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/util/AuditPropertyLoader.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/util/AuditPropertyLoader.java
@@ -25,6 +25,10 @@ import java.util.Properties;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * Utility for loading {@code audit-log.properties} from disk into an in-memory {@link Properties}
+ * bundle. Non-instantiable; all callers use the {@link #loadProperties(String)} static method.
+ */
 public class AuditPropertyLoader {
 
   private static final Logger log = LogManager.getLogger(AuditPropertyLoader.class);
@@ -33,6 +37,14 @@ public class AuditPropertyLoader {
     // Don't allow new instances
   }
 
+  /**
+   * Loads a Java {@link Properties} bundle from the given filesystem path. If the file cannot be
+   * read, a warning is logged and an empty {@link Properties} instance is returned.
+   *
+   * @param filePath absolute or classpath-relative path to the properties file, never {@code null}.
+   * @return the loaded properties; an empty (but never {@code null}) instance if the file could not
+   *     be read.
+   */
   public static Properties loadProperties(String filePath) {
     Properties prop = new Properties();
     try (InputStream input = new FileInputStream(filePath)) {

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/util/FileCreator.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/util/FileCreator.java
@@ -25,8 +25,17 @@ import org.apache.commons.lang3.time.FastDateFormat;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * Static helper that creates timestamped audit log files on disk. The {@link #generateFile} method
+ * is the sole entry point; the class itself is non-instantiable and exposes no state.
+ */
 public class FileCreator {
   private static final Logger log = LogManager.getLogger(FileCreator.class);
+
+  /** Default no-argument constructor for {@link FileCreator}. */
+  public FileCreator() {
+    // Default constructor for FileCreator.
+  }
 
   /**
    * Generates a file with the specified parameters.


### PR DESCRIPTION
Resolves #1626.

The `audit-log` module (`modules/perc-auditlog`) built SUCCESS, but JDK 21 `javadoc -Xdoclint:all` reported **99 javadoc source-warning lines** during `attach-javadocs` (the issue's metric counted 100 including the doubled raw + formatted reporting). After this change, the same command emits **0 errors and 0 warnings**.

### Root causes

Every public type, method, field, and enum constant in the module lacked a Javadoc comment. Three methods in `PSAuditLogService` (`logWorkflowEvent`, `logAuthenticationEvent`, `logUserManagementEvent`) had `@param event` tags with no description text. `FileCreator` relied on an implicit default constructor.

### Changes by file (12 files in `modules/perc-auditlog/src/main/java`)

- `AbstractEvent` — class-level Javadoc + getter/setter + constructor.
- `AuditException` — class-level Javadoc + 3 public constructors.
- `FileCreator` — class-level Javadoc + explicit no-arg constructor with Javadoc.
- `AuditPropertyLoader` — class-level Javadoc + `loadProperties` description.
- `IPSAuditEvent` — interface + `getAction` description (incl. `<T>` declaration).
- `IPSAuditLogService` — descriptions for all 5 public methods.
- `PSActionOutcome` — enum + 3 constant descriptions.
- `PSAuditLogService` — class-level Javadoc + descriptions for `auditLog`, `createEvent`, `getInstance`, `generateLogFile`, `isGenerateLog`; added missing `@param` descriptions on `logWorkflowEvent`, `logAuthenticationEvent`, `logUserManagementEvent`.
- `PSAuthenticationEvent` — class + 5 constants + 2 ctors + enum + 4 enum constants + 4 getter/setter pairs.
- `PSContentEvent` — class + 3 constants + enum + 6 enum constants + populated ctor + 4 getter/setter pairs + no-arg ctor.
- `PSUserManagementEvent` — class + enum + 5 enum constants + populated ctor + getter/setter pair.
- `PSWorkflowEvent` — class + 4 constants + enum + 1 enum constant + populated ctor + 5 getter/setter pairs.

### Behaviour preservation

The added `FileCreator` no-arg constructor is empty; `FileCreator` is effectively a static utility with no instance state, so the prior implicit default is unchanged. Every other file in this PR only adds Javadoc comments — existing methods, fields, visibility, and parameter lists are untouched, so behaviour is preserved exactly.

### Verification (Windows / JDK 21 / `mvnw.cmd`)

```
./mvnw.cmd -f modules/perc-auditlog/pom.xml -DskipTests clean install
./mvnw.cmd -f modules/perc-auditlog/pom.xml spotless:check
```

- **`clean install`** → `BUILD SUCCESS`. `attach-javadocs` runs without `MavenReportException`. Final log: 0 `error:` lines, 0 `warning:` lines from `-Xdoclint:all`.
- **`spotless:check`** → `BUILD SUCCESS` (12 Java files + 1 POM clean). `spotless:apply` was used once mid-iteration to normalize google-java-format whitespace in `AuditPropertyLoader#loadProperties`; all in-scope files remain in scope.
- **Erlang review** (`docs/ai-generated/code-reviews/1626-perc-auditlog-javadoc-erlang.md`) → `approve`. 0 blocking bugs. Cross-platform path / file I/O checklist N/A.

Co-authored-by: kilo <kilo@local>
