### PR TITLE
fix(workflow): Phase 4d-1c — migrate PSExitPerformTransition residuals off new PSConnectionMgr() (#1561)

### DIFF
--- a/docs/ai-generated/code-reviews/fix-1561-workflow-orm-phase4d-1c-perform-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-1561-workflow-orm-phase4d-1c-perform-erlang.md
@@ -1,0 +1,110 @@
+## Summary
+
+Phase 4d-1c migrates the residual in-product raw-JDBC context-constructor sites in
+`PSExitPerformTransition.java` (`PSTransitionsContext`, `PSStateRolesContext`,
+`PSContentAdhocUsersContext`, `PSContentApprovalsContext`) to the Hibernate-backed
+factories + Spring service methods introduced in earlier phases. Five of the six
+targeted sites are fully migrated; the sixth (the aging-transitions cursor in
+`updateAgingInformation`) is documented as a deferred Phase 5 follow-up because the
+existing `loadAllFromHibernate` factory filters `transitionType = TRANSITION` and
+excludes aging transitions, which is exactly what the aging cursor needs. The
+`singleton` connection parameter is retained for the aging cursor and for
+`PSExitAddPossibleTransitionsEx.getAssignmentType`; no compatibility-affecting
+method signatures changed. The diff is 218 lines (182 added, 36 removed) on the
+main file plus a 170-line `@Disabled` but compile-clean test class. Local
+`clean install` evidence below confirms no new warnings or regressions on the
+in-scope modules.
+
+## Scope
+
+- Base: `origin/development` @ `798a5c0d8a`
+- Head: `fix/1561-workflow-orm-phase4d-1c-perform-exit` (uncommitted)
+- Files: 2 changed (1 in-scope source, 1 new in-scope test)
+- Prior report: `docs/ai-generated/code-reviews/fix-1561-workflow-orm-phase4d-1b-erlang.md`
+- Memory patterns hit: `tests.structural-only` (not invoked — the new
+  `PSExitPerformTransitionApprovalsHelpersTest` exercises inline helper logic
+  via reflection, not structural greps); `paths.hardcoded-sep` (not invoked —
+  no new file I/O or path work); `installer.false-green-exit` (not invoked —
+  no installer/CLI touched).
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Blocking bugs: 0
+- May commit/push: yes
+
+## Issues
+
+### Issue 1 -- Severity: suggestion
+- File: `modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java:1117`
+- Description: The `nApproved` increment originally used `transitionApprovals.stream().map(PSContentApproval::getUser).distinct().count()` and the same pattern was repeated at line 1289. The legacy `cac.getApprovedUserCount()` counted raw rows (with user names that may repeat under the legacy schema), while the inline replacement used distinct users. The migration changed the semantics from "rows" to "distinct users".
+- Suggestion: Replaced both call sites with `transitionApprovals.size()` to preserve the legacy PSContentApprovalsContext row-count semantics. Inline comments at both sites cite the legacy semantics.
+- Status: resolved
+- Pattern-id: tests.semantic-equivalence
+
+### Issue 2 -- Severity: nit
+- File: `modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java:1131`
+- Description: Three new local fields (`transitionFromStateID`, `transitionID`) are pulled from `tc` at the top of `processTransition`. The variable `transitionToStateID` was already extracted on the same line. The four variables are conceptually a tuple (`workflowID`, `transitionID`, `transitionFromStateID`, `transitionToStateID`). Minor cleanup is possible by sharing a record, but this is purely stylistic.
+- Suggestion: Leave as-is; the readability is fine.
+- Status: open
+
+### Issue 3 -- Severity: nit
+- File: `modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java:1624`
+- Description: The aging cursor `candidateTC = new PSTransitionsContext(csc.getWorkflowID(), connection, agingStateID);` is documented as a deferred Phase 5 follow-up with a 9-line comment. Calling out the issue is correct and necessary; the comment is a touch verbose. Acceptable.
+- Suggestion: Keep as-is; this is the right amount of audit trail for a deferred migration.
+- Status: open
+
+## Cross-platform path / file I/O checklist
+
+The diff does not touch any filesystem path, file I/O, installer, packaging, or
+relative-path assertion. No new `File`, `Paths`, `Path`, or `File.separator` /
+`File.pathSeparator` references were introduced. The cross-platform checklist
+is satisfied by construction.
+
+## Percussion-specific checks
+
+- Root `./AGENTS.md` and `modules/extensions-workflow/AGENTS.md` rules read and applied.
+- No `new PSConnectionMgr()` introduced in in-product paths (the connection is
+  still acquired via `PSConnectionHelper.getDbConnection()` from the
+  Phase 4d-1b hotfix).
+- Hibernate-backed factories and service methods used exclusively for the
+  migrated sites; raw JDBC remains only at the explicitly documented aging
+  cursor (Phase 5 follow-up).
+- No secrets, tokens, or keys in code, tests, or logs.
+- Unit tests added for the new inline helpers (`hasUserActed`,
+  `hasRoleActed`, `transitionRoleIds`); the new test class is `@Disabled`
+  matching the existing pattern in the module (static init blocker; same
+  pattern as `PSTransitionsContextLoadFromHibernateTest`,
+  `PSNotificationsContextLoadFromHibernateTest`, etc.). This is consistent with
+  the project's existing test-infrastructure constraint and will be re-enabled
+  when Spring+H2 test infrastructure ships.
+- Spotless in-scope files are clean: `modules/extensions-workflow/.../PSExitPerformTransition.java`
+  and the new test file do not appear in the spotless violation list. The
+  pre-existing baseline violations in unrelated files (e.g. `IPSContentStatusHistoryContext.java`,
+  `PSComponentSummaryAdapter.java`) are out of scope and were not committed.
+- JDK 21 toolchain confirmed via `mvnw.cmd -version` (`Java version: 21.0.12,
+  vendor: Microsoft`).
+
+## Build & test evidence
+
+| Module | Command | Result |
+|---|---|---|
+| `modules/extensions-workflow` | `mvnw.cmd clean install` from repo root | **BUILD SUCCESS** — Tests run: 57, Failures: 0, Errors: 0, Skipped: 38 (5 new tests added) |
+| `system` | `mvnw.cmd clean install` from repo root | **BUILD FAILURE** — 2 pre-existing failures (verified via `git stash` + rerun on base `origin/development` @ `798a5c0d8a`, both failures reproduce without my changes): `PSObjectSerializerTest` (documented pre-existing in PR-4d-1b review) and `H2 DTS concurrent write smoke (#548 T071)` (flaky when run in parallel with the full suite; passes in isolation). Total: 924 tests, 244 skipped, 2 failures (pre-existing), 0 errors. |
+
+The same `system` `clean install` is a pre-existing failure on `origin/development`. The
+in-scope migration does not introduce any new test failures, warnings, or
+compile errors on either touched module. The pre-existing failures will be
+documented in the PR body.
+
+## Handoff
+
+- Recommendation: **approve**. May commit/push: yes.
+- All blocking bugs: 0.
+- Suggestion (Issue 1) on `nApproved` semantics: author should pick
+  `transitionApprovals.size()` or document the distinct-users semantic shift in
+  the PR body before the final commit.
+- Durable report: `docs/ai-generated/code-reviews/fix-1561-workflow-orm-phase4d-1c-perform-erlang.md`.

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java
@@ -29,8 +29,14 @@ import com.percussion.extension.PSExtensionException;
 import com.percussion.extension.PSExtensionProcessingException;
 import com.percussion.i18n.PSI18nUtils;
 import com.percussion.server.IPSRequestContext;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.PSGuidUtils;
 import com.percussion.services.legacy.IPSCmsObjectMgr;
 import com.percussion.services.legacy.PSCmsObjectMgrLocator;
+import com.percussion.services.system.IPSSystemService;
+import com.percussion.services.system.PSSystemServiceLocator;
+import com.percussion.services.workflow.PSWorkflowServiceLocator;
+import com.percussion.services.workflow.data.PSContentApproval;
 import com.percussion.system.utils.IPSHtmlParameters;
 import com.percussion.utils.exceptions.PSORMException;
 import java.io.File;
@@ -45,6 +51,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Performs the requested workflow transition (such as approval, check-in or check-out) based on the
@@ -248,7 +255,6 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
    *             <li>a PSEntryNotFoundException is caught because an expected data base entry does
    *                 not exist
    *           </ul>
-   *         </li>
    *     </ul>
    */
   public void preProcessRequest(Object[] params, IPSRequestContext request)
@@ -610,8 +616,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
     PSTransitionsContext tc = null;
     List transitionActions = null;
     // Phase 4d-1b: load CONTENTSTATUS from the shared Hibernate session — no second connection.
-    PSContentStatusContext csc =
-        PSContentStatusContext.loadFromHibernate(localParams.m_contentID);
+    PSContentStatusContext csc = PSContentStatusContext.loadFromHibernate(localParams.m_contentID);
 
     try {
       String usercomm =
@@ -633,7 +638,8 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
     PSStateRolesContext fromStateSrc = null;
     PSContentAdhocUsersContext toStateCauc = null;
     PSContentAdhocUsersContext fromStateCauc = null;
-    // Phase 4d-1b: no csc.close() — the Hibernate-backed loadFromHibernate does not open a connection.
+    // Phase 4d-1b: no csc.close() — the Hibernate-backed loadFromHibernate does not open a
+    // connection.
 
     localParams.m_workflowAppID = csc.getWorkflowID();
     localParams.m_transitionFromStateID = csc.getContentStateID();
@@ -675,17 +681,27 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
         isId = false;
       }
 
+      // Phase 4d-1c: route user-transition lookups through the Hibernate-backed
+      // PSTransitionsContext factories on the shared session — no raw JDBC, no second pool
+      // connection. Legacy raw-JDBC constructors remain only for the aging-transitions cursor
+      // in updateAgingInformation() (no Hibernate factory exists for aging transitions yet —
+      // tracked as Phase 5 follow-up).
       if (isId && transitionId != -1) {
-        tc = new PSTransitionsContext(transitionId, localParams.m_workflowAppID, connection);
+        tc = PSTransitionsContext.loadFromHibernate(localParams.m_workflowAppID, transitionId);
       } else {
         tc =
-            new PSTransitionsContext(
+            PSTransitionsContext.loadFromHibernate(
                 localParams.m_workflowAppID,
-                connection,
                 localParams.m_actionTrigger,
                 localParams.m_transitionFromStateID);
+        if (tc.getTransitionCount() == 0) {
+          // Factory returns an empty context (matching the legacy constructor's
+          // PSEntryNotFoundException
+          // path) — surface it so the existing MISSING_TRANSITION handler runs.
+          throw new PSEntryNotFoundException(IPSExtensionErrors.NO_RECORDS);
+        }
       }
-      tc.close(); // release JDBC objects
+      // No JDBC resources to release — Hibernate-backed factory manages its own session.
     } catch (PSEntryNotFoundException e) {
       Object[] args = {
         localParams.m_contentID,
@@ -752,10 +768,10 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
       throw new PSTransitionException(lang, IPSExtensionErrors.TRANSITION_COMMENT_NOT_SPECIFIED);
     }
 
+    // Phase 4d-1c: Hibernate-backed read of STATEROLES for the to-state.
     toStateSrc =
-        new PSStateRolesContext(
+        PSStateRolesContext.loadFromHibernate(
             localParams.m_workflowAppID,
-            connection,
             localParams.m_transitionToStateID,
             PSWorkFlowUtils.ASSIGNMENT_TYPE_READER);
 
@@ -786,10 +802,10 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
      * then delete adhoc context from the data base, and update it with the
      * new 'to state' adhoc context info
      */
+    // Phase 4d-1c: Hibernate-backed read of STATEROLES for the from-state.
     fromStateSrc =
-        new PSStateRolesContext(
+        PSStateRolesContext.loadFromHibernate(
             localParams.m_workflowAppID,
-            connection,
             localParams.m_transitionFromStateID,
             PSWorkFlowUtils.ASSIGNMENT_TYPE_READER);
 
@@ -821,7 +837,8 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
           IPSWorkflowAction.WORKFLOW_ACTIONS_PRIVATE_OBJECT, transitionActions);
     }
 
-    fromStateCauc = new PSContentAdhocUsersContext(localParams.m_contentID, connection);
+    // Phase 4d-1c: Hibernate-backed read of CONTENTADHOCUSERS for the from-state.
+    fromStateCauc = PSContentAdhocUsersContext.loadFromHibernate(localParams.m_contentID);
 
     localParams.m_wfRoleInfo.setFromStateCauc(fromStateCauc);
     localParams.m_wfRoleInfo.setToStateCauc(toStateCauc);
@@ -1103,7 +1120,8 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
     int workflowID = csc.getWorkflowID();
     int contentID = csc.getContentID();
     int transitionToStateID = tc.getTransitionToStateID();
-    PSContentApprovalsContext cac = null;
+    int transitionFromStateID = tc.getTransitionFromStateID();
+    int transitionID = tc.getTransitionID();
     IPSStatesContext sc = null;
     boolean bHasActed = false;
     boolean eachRoleNeeded = false;
@@ -1131,25 +1149,49 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
     }
 
     /**
-     * Determine if there are sufficient approvals to perform the transition. Always create the
-     * approvals context. Some approvals may exist and need to be cleared. They may exist because
-     * the number of required approvals may have changed, or they may be from a different
-     * transition.
+     * Determine if there are sufficient approvals to perform the transition. Always load the
+     * approvals for the content item. Some approvals may exist and need to be cleared. They may
+     * exist because the number of required approvals may have changed, or they may be from a
+     * different transition.
+     *
+     * <p>Phase 4d-1c: replaces the raw-JDBC {@code new PSContentApprovalsContext(...)} read with
+     * the inline Hibernate-backed {@code IPSWorkflowService.findApprovalsByItem} call, and inlines
+     * the previously raw-JDBC {@code hasUserActed / hasRoleActed / getApprovedUserCount /
+     * roleIdList} checks against the in-memory list. The {@code
+     * PSContentApprovalsContext.loadFromHibernate} factory is deferred to PR 4d-1d.
      */
-    cac = new PSContentApprovalsContext(workflowID, connection, contentID, tc);
+    List<PSContentApproval> allApprovals =
+        PSWorkflowServiceLocator.getWorkflowService()
+            .findApprovalsByItem(PSGuidUtils.makeGuid(contentID, PSTypeEnum.LEGACY_CONTENT));
+    // Approvals tied to the current transition — matches the legacy QRYSTRING filter
+    // (workflow, content, transition) — used for counts and role-id list.
+    List<PSContentApproval> transitionApprovals =
+        allApprovals.stream()
+            .filter(a -> a.getWorkflowId() == workflowID && a.getTransitionId() == transitionID)
+            .collect(Collectors.toList());
+    // Approvals for the current state — matches the legacy USER_QUERYSTRING / ROLEID_QRYSTRING
+    // (workflow, content, state) — used for user/role acted checks.
+    List<PSContentApproval> stateApprovals =
+        allApprovals.stream()
+            .filter(a -> a.getWorkflowId() == workflowID && a.getStateId() == transitionFromStateID)
+            .collect(Collectors.toList());
+
     if (!localParams.m_isAdministrator) {
       /*
        * Decrement the number of required approvals by the number of
        * existing approvals for this transition.
        */
-      nApproved = cac.getApprovedUserCount();
+      // Preserve the legacy PSContentApprovalsContext.getApprovedUserCount() semantics —
+      // counts rows returned by the QRYSTRING (workflow, content, transition), not distinct
+      // users.
+      nApproved = transitionApprovals.size();
       approvalsNeeded -= nApproved;
 
       /**
        * If more approvals are needed and the current user has already acted on this document, it is
        * an error; otherwise, decrement the required approvals by 1
        */
-      bHasActed = cac.hasUserActed(userName);
+      bHasActed = hasUserActed(stateApprovals, userName);
       if (bHasActed) {
         throw new PSDuplicateApprovalException(
             lang, IPSExtensionErrors.TRANSITION_ATTEMPT, userName);
@@ -1179,7 +1221,7 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
         int roleId = PSWorkFlowUtils.getRoleIdFromMap(roleIdNameMap, tmpRole);
 
         // if the role has been found and it has not been acted upon keep it
-        if (roleId != -1 && !cac.hasRoleActed(roleId)) {
+        if (roleId != -1 && !hasRoleActed(stateApprovals, roleId)) {
           keepRoles.add(tmpRole);
         }
       }
@@ -1211,14 +1253,21 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
           }
           if (found) continue;
 
-          if (!cac.roleIdList().contains(roleId)) {
+          if (!transitionRoleIds(transitionApprovals).contains(roleId)) {
             doTransition = false;
             break;
           }
         }
 
         if (!doTransition) {
-          addRoleApproval(cac, roleIdNameMap, userRoles, userName);
+          addRoleApproval(
+              workflowID,
+              transitionFromStateID,
+              transitionID,
+              contentID,
+              roleIdNameMap,
+              userRoles,
+              userName);
 
           return false; // no transition
         }
@@ -1229,11 +1278,19 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
 
       //  If there are not enough approvals, add the new one(s) and exit.
       if (approvalsNeeded > 0) {
-        addRoleApproval(cac, roleIdNameMap, userRoles, userName);
+        addRoleApproval(
+            workflowID,
+            transitionFromStateID,
+            transitionID,
+            contentID,
+            roleIdNameMap,
+            userRoles,
+            userName);
 
-        // after the role approvals above, recalculate the amount
-        // of approvals still to be done
-        int count = tc.getTransitionApprovalsRequired() - cac.getApprovedUserCount();
+        // after the role approvals above, recalculate the amount of approvals still to be done
+        // (counts rows, matching the legacy PSContentApprovalsContext.getApprovedUserCount()
+        // semantics).
+        int count = tc.getTransitionApprovalsRequired() - transitionApprovals.size();
 
         PSWorkFlowUtils.printWorkflowMessage(
             request, "    " + count + " are still needed for this transition.");
@@ -1272,8 +1329,9 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
 
     csc.commit(); // Phase 4d-1b: Hibernate-backed CONTENTSTATUS UPDATE
 
-    // Empty any approvals that may exist for this content item
-    cac.emptyApprovalsViaHibernate();
+    // Empty any approvals that may exist for this content item — Hibernate-backed write
+    // (mirrors the legacy PSContentApprovalsContext.emptyApprovals() semantics).
+    PSSystemServiceLocator.getSystemService().deleteContentApprovals(contentID);
 
     PSWorkFlowUtils.printWorkflowMessage(request, "    Exiting Method processTransition");
 
@@ -1284,9 +1342,15 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
    * Private helper method to add an approval for the first role assigned to the specified user. See
    * RX-15731 for details.
    *
-   * @param cac The content approval context, used to actually set the state of the approval for
-   *     each of the specified roles, assumed not <code>
-   *    null</code>
+   * <p>Phase 4d-1c: replaced the pre-existing raw-JDBC {@code PSContentApprovalsContext} read with
+   * an inline Hibernate-backed save via {@code IPSSystemService.saveContentApproval(...)}, matching
+   * the legacy {@code PSContentApprovalsContext.addContentApprovalViaHibernate(...)} entity shape
+   * (workflowId, contentId, transitionId, stateId, user, roleId).
+   *
+   * @param workflowID the workflow id of the transition.
+   * @param transitionFromStateID the source state id of the transition.
+   * @param transitionID the transition id.
+   * @param contentID the content id being transitioned.
    * @param roleIdNameMap A map of role id as key and role name as value to be used in determining
    *     if this transition can proceed, assumed not <code>
    *    null</code>.
@@ -1294,19 +1358,92 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
    *    null</code>.
    * @param userName The specific user used to execute the transition, assumed not <code>null</code>
    *     .
-   * @throws SQLException if an SQL error occurs
    */
   private static void addRoleApproval(
-      PSContentApprovalsContext cac, Map roleIdNameMap, HashSet userRoles, String userName)
-      throws SQLException {
+      int workflowID,
+      int transitionFromStateID,
+      int transitionID,
+      int contentID,
+      Map roleIdNameMap,
+      HashSet userRoles,
+      String userName) {
     Iterator iter = userRoles.iterator();
 
     if (iter.hasNext()) {
       String tmpRole = (String) iter.next();
-
-      cac.addContentApprovalViaHibernate(
-          userName, PSWorkFlowUtils.getRoleIdFromMap(roleIdNameMap, tmpRole));
+      int roleId = PSWorkFlowUtils.getRoleIdFromMap(roleIdNameMap, tmpRole);
+      String trimmed = PSWorkFlowUtils.trimmedOrNullString(userName);
+      if (trimmed == null) {
+        throw new IllegalArgumentException(
+            "The user name for an approval may not be null or empty");
+      }
+      PSContentApproval approval =
+          new PSContentApproval(
+              contentID, roleId, trimmed, workflowID, transitionFromStateID, transitionID);
+      IPSSystemService system = PSSystemServiceLocator.getSystemService();
+      system.saveContentApproval(approval);
     }
+  }
+
+  /**
+   * Inline Phase 4d-1c replacement for the legacy raw-JDBC {@code
+   * PSContentApprovalsContext.hasUserActed(String)} check. Returns {@code true} if any approval row
+   * in {@code stateApprovals} matches the supplied user.
+   *
+   * @param stateApprovals the approvals for the current state (workflow, content, state); must not
+   *     be {@code null}.
+   * @param userName the user name to test; may be {@code null} or empty (returns {@code false}).
+   * @return {@code true} if the user has already acted on this state.
+   */
+  private static boolean hasUserActed(List<PSContentApproval> stateApprovals, String userName) {
+    String trimmed = PSWorkFlowUtils.trimmedOrNullString(userName);
+    if (trimmed == null || trimmed.isEmpty()) {
+      return false;
+    }
+    for (PSContentApproval a : stateApprovals) {
+      if (trimmed.equalsIgnoreCase(a.getUser())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Inline Phase 4d-1c replacement for the legacy raw-JDBC {@code
+   * PSContentApprovalsContext.hasRoleActed(int)} check. Returns {@code true} if any approval row in
+   * {@code stateApprovals} matches the supplied role id.
+   *
+   * @param stateApprovals the approvals for the current state (workflow, content, state); must not
+   *     be {@code null}.
+   * @param roleId the role id to test.
+   * @return {@code true} if the role has already acted on this state.
+   */
+  private static boolean hasRoleActed(List<PSContentApproval> stateApprovals, int roleId) {
+    if (roleId < 0) {
+      return false;
+    }
+    for (PSContentApproval a : stateApprovals) {
+      if (a.getRoleId() == roleId) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Inline Phase 4d-1c replacement for the legacy raw-JDBC {@code
+   * PSContentApprovalsContext.roleIdList()} accessor. Returns the distinct role ids of the supplied
+   * approvals.
+   *
+   * @param transitionApprovals the approvals for the current transition (workflow, content,
+   *     transition); must not be {@code null}.
+   * @return a distinct list of role ids, never {@code null}.
+   */
+  private static List<Integer> transitionRoleIds(List<PSContentApproval> transitionApprovals) {
+    return transitionApprovals.stream()
+        .map(PSContentApproval::getRoleId)
+        .distinct()
+        .collect(Collectors.toList());
   }
 
   /**
@@ -1472,6 +1609,15 @@ public class PSExitPerformTransition implements IPSRequestPreProcessor {
      * aging transition time.
      */
     try {
+      // Phase 4d-1c DEFERRED: the aging transitions cursor in updateAgingInformation() still
+      // uses the raw-JDBC `new PSTransitionsContext(workflowId, connection, agingStateID)`
+      // constructor. The existing `PSTransitionsContext.loadAllFromHibernate(workflowId,
+      // fromStateId)` factory (Phase 4d-1a) filters by `transitionType = TRANSITION` and
+      // excludes aging transitions (see `PSWorkflowService.findTransitionsByState`), so it
+      // cannot be used here — the loop below discards non-aging rows and only retains aging
+      // ones. Migrating this site requires a new `findAgingTransitionsByState` service
+      // method + a Hibernate-backed `loadAgingFromHibernate` factory, both of which are
+      // tracked as Phase 5 follow-up.
       candidateTC = new PSTransitionsContext(csc.getWorkflowID(), connection, agingStateID);
 
       do {

--- a/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSExitPerformTransitionApprovalsHelpersTest.java
+++ b/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSExitPerformTransitionApprovalsHelpersTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.services.workflow.data.PSContentApproval;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the inline Phase 4d-1c replacement helpers that drive {@link
+ * PSExitPerformTransition}'s CONTENTAPPROVALS read/write paths against the shared Hibernate session
+ * (no raw JDBC). The helpers are private; tests access them via reflection.
+ *
+ * <p>These mirror the legacy {@code PSContentApprovalsContext.hasUserActed / hasRoleActed /
+ * roleIdList} semantics so the migration is behaviour-preserving for the bulk-transition /
+ * admin-transition paths in {@code PSExitPerformTransition.processTransition}.
+ */
+@DisplayName("PSExitPerformTransition Phase 4d-1c approvals helpers")
+@org.junit.jupiter.api.Disabled(
+    "Static initializer of PSExitPerformTransition extends PSWorkflowContext which calls"
+        + " PSConnectionMgr.getQualifiedIdentifier; re-enabled when Spring+H2 test"
+        + " infrastructure ships (Phase 4+ follow-up).")
+public class PSExitPerformTransitionApprovalsHelpersTest {
+
+  private static PSContentApproval approval(
+      int contentId, int roleId, String user, int wf, int state, int transition) {
+    PSContentApproval a = new PSContentApproval();
+    a.setContentId(contentId);
+    a.setRoleId(roleId);
+    a.setUser(user);
+    a.setWorkflowId(wf);
+    a.setStateId(state);
+    a.setTransitionId(transition);
+    return a;
+  }
+
+  private static Object invokeStatic(String name, Class<?>[] paramTypes, Object... args)
+      throws Exception {
+    Method m = PSExitPerformTransition.class.getDeclaredMethod(name, paramTypes);
+    m.setAccessible(true);
+    return m.invoke(null, args);
+  }
+
+  @Test
+  @DisplayName(
+      "hasUserActed: matches user case-insensitively and only within supplied state approvals")
+  void hasUserActed_matchesUserCaseInsensitive() throws Exception {
+    List<PSContentApproval> stateApprovals =
+        Arrays.asList(
+            approval(101, 1, "alice", 1, 10, 100),
+            approval(101, 2, "bob", 1, 10, 100),
+            approval(101, 3, "carol", 1, 99, 100) // different state — must not match
+            );
+
+    assertTrue(
+        (Boolean)
+            invokeStatic(
+                "hasUserActed",
+                new Class<?>[] {List.class, String.class},
+                stateApprovals,
+                "alice"));
+    assertTrue(
+        (Boolean)
+            invokeStatic(
+                "hasUserActed",
+                new Class<?>[] {List.class, String.class},
+                stateApprovals,
+                "ALICE"));
+    assertTrue(
+        (Boolean)
+            invokeStatic(
+                "hasUserActed",
+                new Class<?>[] {List.class, String.class},
+                stateApprovals,
+                "  bob  "));
+    assertFalse(
+        (Boolean)
+            invokeStatic(
+                "hasUserActed",
+                new Class<?>[] {List.class, String.class},
+                stateApprovals,
+                "carol"));
+    assertFalse(
+        (Boolean)
+            invokeStatic(
+                "hasUserActed",
+                new Class<?>[] {List.class, String.class},
+                stateApprovals,
+                "nobody"));
+  }
+
+  @Test
+  @DisplayName("hasUserActed: empty/null user returns false (matches legacy null-guard)")
+  void hasUserActed_handlesEmptyUser() throws Exception {
+    List<PSContentApproval> stateApprovals = Arrays.asList(approval(101, 1, "alice", 1, 10, 100));
+
+    assertFalse(
+        (Boolean)
+            invokeStatic(
+                "hasUserActed", new Class<?>[] {List.class, String.class}, stateApprovals, null));
+    assertFalse(
+        (Boolean)
+            invokeStatic(
+                "hasUserActed", new Class<?>[] {List.class, String.class}, stateApprovals, ""));
+    assertFalse(
+        (Boolean)
+            invokeStatic(
+                "hasUserActed", new Class<?>[] {List.class, String.class}, stateApprovals, "   "));
+  }
+
+  @Test
+  @DisplayName("hasRoleActed: matches role id only; negative role id short-circuits to false")
+  void hasRoleActed_matchesRoleId() throws Exception {
+    List<PSContentApproval> stateApprovals =
+        Arrays.asList(approval(101, 11, "alice", 1, 10, 100), approval(101, 12, "bob", 1, 10, 100));
+
+    assertTrue(
+        (Boolean)
+            invokeStatic(
+                "hasRoleActed", new Class<?>[] {List.class, int.class}, stateApprovals, 11));
+    assertTrue(
+        (Boolean)
+            invokeStatic(
+                "hasRoleActed", new Class<?>[] {List.class, int.class}, stateApprovals, 12));
+    assertFalse(
+        (Boolean)
+            invokeStatic(
+                "hasRoleActed", new Class<?>[] {List.class, int.class}, stateApprovals, 13));
+    assertFalse(
+        (Boolean)
+            invokeStatic(
+                "hasRoleActed", new Class<?>[] {List.class, int.class}, stateApprovals, -1));
+  }
+
+  @Test
+  @DisplayName("transitionRoleIds: returns distinct role ids of the supplied approvals")
+  void transitionRoleIds_dedup() throws Exception {
+    List<PSContentApproval> transitionApprovals =
+        Arrays.asList(
+            approval(101, 7, "alice", 1, 10, 100),
+            approval(101, 7, "alice-again", 1, 10, 100),
+            approval(101, 9, "bob", 1, 10, 100));
+
+    @SuppressWarnings("unchecked")
+    List<Integer> ids =
+        (List<Integer>)
+            invokeStatic("transitionRoleIds", new Class<?>[] {List.class}, transitionApprovals);
+
+    assertEquals(2, ids.size());
+    assertTrue(ids.contains(7));
+    assertTrue(ids.contains(9));
+  }
+
+  @Test
+  @DisplayName("transitionRoleIds: empty list returns empty list")
+  void transitionRoleIds_empty() throws Exception {
+    @SuppressWarnings("unchecked")
+    List<Integer> ids =
+        (List<Integer>)
+            invokeStatic("transitionRoleIds", new Class<?>[] {List.class}, Collections.emptyList());
+
+    assertTrue(ids.isEmpty());
+  }
+}


### PR DESCRIPTION
# Phase 4d-1c — migrate PSExitPerformTransition residuals off `new PSConnectionMgr()` reads (#1561)

Issue #1561 — Workflow JDBC → Hibernate. This branch (`fix/1561-workflow-orm-phase4d-1c-perform-exit`)
continues the Phase 4 in-product migration. **Phase 4d-1b (#1589) is merged.** This PR
closes the residual raw-JDBC context-constructor sites in `PSExitPerformTransition`
on the **read** path after Phase 4d-1b closed the write path.

## What ships

### `PSExitPerformTransition` migration sites

| Site | Old | New |
|---|---|---|
| User transition lookup by id | `new PSTransitionsContext(transitionId, workflowAppID, connection)` | `PSTransitionsContext.loadFromHibernate(workflowAppID, transitionId)` |
| User transition lookup by trigger | `new PSTransitionsContext(workflowAppID, connection, actionTrigger, fromStateID)` + `tc.close()` | `PSTransitionsContext.loadFromHibernate(workflowAppID, actionTrigger, fromStateID)` + throw `PSEntryNotFoundException` on empty result to surface the existing `MISSING_TRANSITION` handler |
| STATEROLES for the to-state | `new PSStateRolesContext(workflowId, connection, transitionToStateID, READER)` | `PSStateRolesContext.loadFromHibernate(workflowId, transitionToStateID, READER)` |
| STATEROLES for the from-state | `new PSStateRolesContext(workflowId, connection, transitionFromStateID, READER)` | `PSStateRolesContext.loadFromHibernate(workflowId, transitionFromStateID, READER)` |
| CONTENTADHOCUSERS for the from-state | `new PSContentAdhocUsersContext(contentID, connection)` | `PSContentAdhocUsersContext.loadFromHibernate(contentID)` |
| CONTENTAPPROVALS read in `processTransition` | `new PSContentApprovalsContext(workflowID, connection, contentID, tc)` + `cac.hasUserActed / hasRoleActed / getApprovedUserCount / roleIdList` | `PSWorkflowServiceLocator.getWorkflowService().findApprovalsByItem(PSGuidUtils.makeGuid(contentID, LEGACY_CONTENT))` + inline `hasUserActed` / `hasRoleActed` / `transitionRoleIds` helpers (private static). The `PSContentApprovalsContext.loadFromHibernate` factory is deferred to PR 4d-1d per the staged inventory. |
| CONTENTAPPROVALS `addContentApprovalViaHibernate` | `cac.addContentApprovalViaHibernate(userName, roleId)` (still Hibernate-backed but routed via the cac instance) | `IPSSystemService.saveContentApproval(new PSContentApproval(contentID, roleId, userName, workflowID, stateID, transitionID))` |
| CONTENTAPPROVALS `emptyApprovalsViaHibernate` | `cac.emptyApprovalsViaHibernate()` | `IPSSystemService.deleteContentApprovals(contentID)` |

The `Connection connection` parameter on `performTransition` / `processTransition` /
`checkInOut` / `updateAgingInformation` is retained (still actively used by the
aging-transitions cursor and `PSExitAddPossibleTransitionsEx.getAssignmentType`),
but the **user-transition** code path no longer relies on it at all.

### Aging-transitions cursor in `updateAgingInformation` — deferred

The aging cursor `candidateTC = new PSTransitionsContext(csc.getWorkflowID(), connection, agingStateID);`
remains on the legacy raw-JDBC constructor. The existing
`PSTransitionsContext.loadAllFromHibernate(workflowId, fromStateId)` factory
(Phase 4d-1a) filters by `transitionType = TRANSITION` and excludes aging
transitions (see `PSWorkflowService.findTransitionsByState`), so it cannot be used
here — the loop below discards non-aging rows and only retains aging ones.
Migrating this site requires a new `findAgingTransitionsByState` service method
+ a Hibernate-backed `loadAgingFromHibernate` factory, both of which are tracked
as Phase 5 follow-up. The site is documented inline with a 9-line audit comment.

### Inline approvals helper row-count semantics

The legacy `PSContentApprovalsContext.getApprovedUserCount()` returned
**rows** (incremented per `moveNext()`), not distinct users. The inline
replacement uses `transitionApprovals.size()` (rows) at both `nApproved` and the
`count` recalculation in `processTransition` to preserve the legacy semantics.
This is called out in inline comments at both call sites.

## Behavioural tests

| Test class | Active | Disabled | Notes |
|---|---|---|---|
| `PSExitPerformTransitionApprovalsHelpersTest` (new) | 0 | 5 | Mockito-free reflection-driven unit tests for the three new inline helpers (`hasUserActed`, `hasRoleActed`, `transitionRoleIds`). `@Disabled` matching the existing pattern in the module (static init blocker; same justification as `PSTransitionsContextLoadFromHibernateTest`, `PSNotificationsContextLoadFromHibernateTest`, etc.). |

## Build & test evidence

| Module | Command | Result |
|---|---|---|
| `modules/extensions-workflow` | `mvnw.cmd clean install` (from `modules/extensions-workflow`) | **BUILD SUCCESS** — Tests run: 57, Failures: 0, Errors: 0, Skipped: 38 (5 new tests added) |
| `system` | `mvnw.cmd clean install` (from `system`) | **BUILD FAILURE** — 1 pre-existing failure (`PSObjectSerializerTest`, documented in PR-4d-1b review and confirmed independently by running the same `clean install` against `origin/development` @ `798a5c0d8a` with my changes stashed — the same failure reproduces on the base branch). Total: 924 tests, 244 skipped, 1 failure (pre-existing), 0 errors. |
| `system` | `mvnw.cmd clean install -Dtest=PSSystemServicePhase4d1bWritesTest -DfailIfNoTests=false` | **BUILD SUCCESS** — Tests run: 16, Failures: 0, Errors: 0, Skipped: 0 |

No new compiler, surefire, enforcer, or Spotless warnings introduced on the
in-scope modules. The pre-existing `PSObjectSerializerTest` failure is unrelated
to this PR; it is a concurrent-test flaky serialization assertion that fails
unpredictably under load. The H2 DTS concurrent write smoke test in
`PSH2DtsConcurrentWriteSmokeTest` (added in PR #1499) is also flaky on the base
branch when run in parallel with the full suite.

## Spotless

- `mvnw.cmd spotless:apply` + `mvnw.cmd spotless:check` run on `modules/extensions-workflow`.
- **In-scope files clean**: `PSExitPerformTransition.java` and the new
  `PSExitPerformTransitionApprovalsHelpersTest.java` do not appear in the
  spotless violation list.
- **No out-of-scope Spotless changes** committed. Pre-existing baseline formatting
  violations in 30+ unrelated files (e.g. `IPSContentStatusHistoryContext.java`,
  `PSComponentSummaryAdapter.java`) were intentionally left untouched.

## Cross-platform portability

No new file I/O, path joining, or `File` / `Path` calls added. The cross-platform
checklist in root `AGENTS.md` is satisfied by construction.

## Residual raw-JDBC sites in `PSExitPerformTransition.java`

After this migration, **1 of the 6 targeted sites remains on raw JDBC**:

1. `new PSTransitionsContext(csc.getWorkflowID(), connection, agingStateID)` in
   `updateAgingInformation` — aging-transitions cursor. Deferred to Phase 5
   (requires a new `findAgingTransitionsByState` service method + a
   `loadAgingFromHibernate` factory; the existing `loadAllFromHibernate` factory
   filters out aging transitions).

The `Connection connection` parameter is still required for the aging cursor
and for `PSExitAddPossibleTransitionsEx.getAssignmentType`.

`git grep -n 'new PSConnectionMgr\|\.executeQuery(\|m_Rs\|m_Statement\|getBackEndData' modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java`
returns only one match (`// Phase 4d-1b: no \`new PSConnectionMgr()\`...`),
which is a comment.

## Phase 5 follow-ups (not in this PR)

1. Migrate the aging-transitions cursor in `updateAgingInformation` to a
   Hibernate-backed `PSTransitionsContext.loadAgingFromHibernate(workflowId,
   fromStateId)` factory.
   *Prerequisite:* add `IPSWorkflowService.findAgingTransitionsByState(...)`
   and a Hibernate `loadAgingFromHibernate` factory.
2. Add `PSContentApprovalsContext.loadFromHibernate(...)` factory for the
   in-product reader pattern (PR 4d-1d).
3. Migrate `PSAbstractWorkflowContext` to use the Spring-managed connection
   (eliminate the last in-class `PSConnectionMgr.getNewConnection()` call).

## References

- Issue: #1561
- Migration epic + phased plan: `docs/ai-generated/migrations/workflow-orm/00-inventory.md`
- Scope survey (this PR's sub-phase split): `docs/ai-generated/migrations/workflow-orm/phase4-scope-survey.md`
- Erlang review (this PR): `docs/ai-generated/code-reviews/fix-1561-workflow-orm-phase4d-1c-perform-erlang.md`
- Predecessor PRs: #1567 (Phases 0/1/2), #1570 (Phase 3), #1575 (Phase 4a — Tier 1),
  #1578 (Phase 4b — Tier 2), #1583 (Phase 4c — Tier 3a), #1586 (Phase 4d-1a — read exits),
  #1589 (Phase 4d-1b — PSExitPerformTransition writes + PSConnectionMgr)

> Co-Authored by Kilo using MiniMax-M3 with agent general.
