### PR TITLE
feat(developer): content type workflow and template association edit (P0.2e)

### DIFF
--- a/WebUI/src/main/ts/api/developer/contentTypesApi.ts
+++ b/WebUI/src/main/ts/api/developer/contentTypesApi.ts
@@ -22,6 +22,7 @@ import type {
   ContentTypeFieldSummary,
   ContentTypeListEnvelope,
   ContentTypeSummary,
+  NamedObjectRef,
 } from "./types";
 
 /**
@@ -76,12 +77,18 @@ export type ContentTypeUpdateBody = {
   description?: string;
   enabled?: boolean;
   fields?: Pick<ContentTypeFieldSummary, "name" | "searchable" | "required" | "occurrence">[];
+  /** Omit to leave unchanged; non-null list is a full replace. */
+  allowedWorkflows?: NamedObjectRef[];
+  defaultWorkflow?: NamedObjectRef | null;
+  /** Omit to leave unchanged; non-null list is a full replace. */
+  allowedTemplates?: NamedObjectRef[];
 };
 
 /**
  * PUT /services/contenttypes/{idOrName} — design lock + save + release.
  *
- * <p>Server locks for the current session user, applies mutable fields, saves, and releases.
+ * <p>Server locks for the current session user, applies mutable fields (meta, field flags,
+ * optional workflow/template association full-replace), saves, and releases.
  */
 export async function updateContentTypeDetail(
   idOrName: string,

--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -19,10 +19,12 @@ import React, { useEffect, useState } from "react";
 import {
   getContentTypeDetail,
   updateContentTypeDetail,
+  type ContentTypeUpdateBody,
 } from "../api/developer/contentTypesApi";
 import type {
   ContentTypeDetail,
   ContentTypeFieldSummary,
+  NamedObjectRef,
 } from "../api/developer/types";
 import { ObjectAclSection } from "./ObjectAclSection";
 import { panelErrMsg } from "./errors";
@@ -35,6 +37,14 @@ const inputStyle: React.CSSProperties = {
   font: "inherit",
   width: "100%",
   boxSizing: "border-box",
+};
+
+const smallBtnStyle: React.CSSProperties = {
+  background: "transparent",
+  border: "1px solid #cbd5e0",
+  borderRadius: "4px",
+  padding: "4px 8px",
+  cursor: "pointer",
 };
 
 type FieldDraft = {
@@ -60,6 +70,45 @@ function toDrafts(fields: ContentTypeFieldSummary[] | undefined): Record<string,
   return out;
 }
 
+function cloneRefs(list: NamedObjectRef[] | undefined): NamedObjectRef[] {
+  return (list || []).map((r) => ({
+    name: r.name,
+    label: r.label,
+    isDefault: r.isDefault,
+    guid: r.guid ? { ...r.guid } : undefined,
+  }));
+}
+
+function refKey(r: NamedObjectRef, index: number): string {
+  if (r.name) return `name:${r.name}`;
+  if (r.guid?.stringValue) return `guid:${r.guid.stringValue}`;
+  if (r.guid?.uuid != null) return `uuid:${r.guid.uuid}`;
+  return `idx:${index}`;
+}
+
+function refsEqual(a: NamedObjectRef[], b: NamedObjectRef[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (refKey(a[i], i) !== refKey(b[i], i)) return false;
+    if (!!a[i].isDefault !== !!b[i].isDefault) return false;
+  }
+  return true;
+}
+
+function toRefPayload(list: NamedObjectRef[]): NamedObjectRef[] {
+  return list.map((r) => {
+    const out: NamedObjectRef = {};
+    if (r.name) out.name = r.name;
+    if (r.guid?.stringValue || r.guid?.uuid != null) {
+      out.guid = {};
+      if (r.guid.stringValue) out.guid.stringValue = r.guid.stringValue;
+      if (r.guid.uuid != null) out.guid.uuid = r.guid.uuid;
+    }
+    if (r.isDefault) out.isDefault = true;
+    return out;
+  });
+}
+
 export function ContentTypeDetailPanel({
   idOrName,
   onBack,
@@ -75,6 +124,10 @@ export function ContentTypeDetailPanel({
   const [description, setDescription] = useState("");
   const [enabled, setEnabled] = useState(true);
   const [fieldDrafts, setFieldDrafts] = useState<Record<string, FieldDraft>>({});
+  const [workflows, setWorkflows] = useState<NamedObjectRef[]>([]);
+  const [templates, setTemplates] = useState<NamedObjectRef[]>([]);
+  const [newWfName, setNewWfName] = useState("");
+  const [newTplName, setNewTplName] = useState("");
 
   useEffect(() => {
     let cancelled = false;
@@ -89,6 +142,21 @@ export function ContentTypeDetailPanel({
         setDescription(d.description || "");
         setEnabled(d.enabled !== false);
         setFieldDrafts(toDrafts(d.fields));
+        const wfs = cloneRefs(d.allowedWorkflows);
+        // Ensure default flag matches defaultWorkflow when server omits isDefault
+        if (d.defaultWorkflow) {
+          const defKey = refKey(d.defaultWorkflow, -1);
+          for (const w of wfs) {
+            w.isDefault = refKey(w, -1) === defKey || w.name === d.defaultWorkflow.name;
+          }
+          if (wfs.length > 0 && !wfs.some((w) => w.isDefault)) {
+            wfs[0].isDefault = true;
+          }
+        }
+        setWorkflows(wfs);
+        setTemplates(cloneRefs(d.allowedTemplates));
+        setNewWfName("");
+        setNewTplName("");
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -110,22 +178,97 @@ export function ContentTypeDetailPanel({
       if (!d || !i) return false;
       return d.searchable !== i.searchable || d.required !== i.required;
     });
+
+  const initialWorkflows = (() => {
+    const wfs = cloneRefs(detail?.allowedWorkflows);
+    if (detail?.defaultWorkflow) {
+      const defKey = refKey(detail.defaultWorkflow, -1);
+      for (const w of wfs) {
+        w.isDefault = refKey(w, -1) === defKey || w.name === detail.defaultWorkflow.name;
+      }
+      if (wfs.length > 0 && !wfs.some((w) => w.isDefault)) {
+        wfs[0].isDefault = true;
+      }
+    }
+    return wfs;
+  })();
+  const initialTemplates = cloneRefs(detail?.allowedTemplates);
+  const workflowsDirty = detail != null && !refsEqual(workflows, initialWorkflows);
+  const templatesDirty = detail != null && !refsEqual(templates, initialTemplates);
+
   const dirty =
     detail != null &&
     (label !== (detail.label || "") ||
       description !== (detail.description || "") ||
       enabled !== (detail.enabled !== false) ||
-      fieldsDirty);
+      fieldsDirty ||
+      workflowsDirty ||
+      templatesDirty);
 
-  function toggleField(
-    key: string,
-    prop: "searchable" | "required",
-  ) {
+  function toggleField(key: string, prop: "searchable" | "required") {
     setFieldDrafts((prev) => {
       const cur = prev[key];
       if (!cur) return prev;
       return { ...prev, [key]: { ...cur, [prop]: !cur[prop] } };
     });
+    setNotice(null);
+  }
+
+  function removeWorkflow(index: number) {
+    setWorkflows((prev) => {
+      const next = prev.filter((_, i) => i !== index);
+      if (next.length > 0 && !next.some((w) => w.isDefault)) {
+        next[0] = { ...next[0], isDefault: true };
+      }
+      return next;
+    });
+    setNotice(null);
+  }
+
+  function addWorkflow() {
+    const name = newWfName.trim();
+    if (!name) return;
+    if (workflows.some((w) => (w.name || "").toLowerCase() === name.toLowerCase())) {
+      setNewWfName("");
+      return;
+    }
+    setWorkflows((prev) => [
+      ...prev,
+      { name, label: name, isDefault: prev.length === 0 },
+    ]);
+    setNewWfName("");
+    setNotice(null);
+  }
+
+  function setDefaultWorkflow(index: number) {
+    setWorkflows((prev) => prev.map((w, i) => ({ ...w, isDefault: i === index })));
+    setNotice(null);
+  }
+
+  function removeTemplate(index: number) {
+    setTemplates((prev) => prev.filter((_, i) => i !== index));
+    setNotice(null);
+  }
+
+  function addTemplate() {
+    const raw = newTplName.trim();
+    if (!raw) return;
+    const looksLikeGuid = /^\d+-\d+(-\d+)?$/.test(raw);
+    const exists = templates.some((t) => {
+      if (looksLikeGuid) return t.guid?.stringValue === raw;
+      return (t.name || "").toLowerCase() === raw.toLowerCase();
+    });
+    if (exists) {
+      setNewTplName("");
+      return;
+    }
+    setTemplates((prev) => [
+      ...prev,
+      looksLikeGuid
+        ? { guid: { stringValue: raw }, name: raw, label: raw }
+        : { name: raw, label: raw },
+    ]);
+    setNewTplName("");
     setNotice(null);
   }
 
@@ -148,17 +291,42 @@ export function ContentTypeDetailPanel({
           searchable: d.searchable,
           required: d.required,
         }));
-      const saved = await updateContentTypeDetail(idOrName, {
+
+      const body: ContentTypeUpdateBody = {
         label,
         description,
         enabled,
         fields: fieldPatches,
-      });
+      };
+      if (workflowsDirty) {
+        body.allowedWorkflows = toRefPayload(workflows);
+        const def = workflows.find((w) => w.isDefault) || workflows[0];
+        if (def) {
+          body.defaultWorkflow = toRefPayload([def])[0];
+        }
+      }
+      if (templatesDirty) {
+        body.allowedTemplates = toRefPayload(templates);
+      }
+
+      const saved = await updateContentTypeDetail(idOrName, body);
       setDetail(saved);
       setLabel(saved.label || "");
       setDescription(saved.description || "");
       setEnabled(saved.enabled !== false);
       setFieldDrafts(toDrafts(saved.fields));
+      const wfs = cloneRefs(saved.allowedWorkflows);
+      if (saved.defaultWorkflow) {
+        const defKey = refKey(saved.defaultWorkflow, -1);
+        for (const w of wfs) {
+          w.isDefault = refKey(w, -1) === defKey || w.name === saved.defaultWorkflow.name;
+        }
+        if (wfs.length > 0 && !wfs.some((w) => w.isDefault)) {
+          wfs[0].isDefault = true;
+        }
+      }
+      setWorkflows(wfs);
+      setTemplates(cloneRefs(saved.allowedTemplates));
       setNotice(DEV_MSG.CT_SAVED);
     } catch (err: unknown) {
       setError(panelErrMsg(err, DEV_MSG.CT_SAVE_ERROR));
@@ -281,71 +449,208 @@ export function ContentTypeDetailPanel({
             </section>
           ) : null}
 
-          <section
-            style={{ marginBottom: "16px" }}
-            data-testid="developer-ct-workflows"
-          >
+          <section style={{ marginBottom: "16px" }} data-testid="developer-ct-workflows">
             <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.CT_WORKFLOWS}</h3>
-            {detail.defaultWorkflow ? (
-              <p style={{ fontSize: "0.9rem", marginTop: 0 }}>
-                <strong>{DEV_MSG.CT_DEFAULT_WF}:</strong>{" "}
-                {detail.defaultWorkflow.label || detail.defaultWorkflow.name}
+            <p style={{ color: "#4a5568", fontSize: "0.9rem" }}>{DEV_MSG.CT_WORKFLOWS_HINT}</p>
+            {workflows.length === 0 ? (
+              <p style={{ color: "#718096" }} data-testid="developer-ct-wf-empty">
+                {DEV_MSG.CT_NONE}
               </p>
-            ) : null}
-            {(detail.allowedWorkflows || []).length === 0 ? (
-              <p style={{ color: "#718096" }}>{DEV_MSG.CT_NONE}</p>
             ) : (
-              <ul>
-                {(detail.allowedWorkflows || []).map((w) => (
-                  <li key={w.name || w.guid?.stringValue || w.label}>
-                    {w.label || w.name}
-                    {w.isDefault ? " (default)" : ""}
-                    {w.name ? (
-                      <span
-                        style={{
-                          fontFamily: "monospace",
-                          color: "#718096",
-                          marginLeft: "8px",
-                          fontSize: "0.85rem",
-                        }}
-                      >
-                        {w.name}
+              <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+                {workflows.map((w, i) => (
+                  <li
+                    key={refKey(w, i)}
+                    data-testid={`developer-ct-wf-row-${i}`}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 12,
+                      padding: "6px 0",
+                      borderBottom: "1px solid #edf2f7",
+                    }}
+                  >
+                    <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                      <input
+                        type="radio"
+                        name="ct-default-wf"
+                        data-testid={`developer-ct-wf-default-${i}`}
+                        checked={!!w.isDefault}
+                        disabled={busy}
+                        onChange={() => setDefaultWorkflow(i)}
+                        aria-label={`${DEV_MSG.CT_SET_DEFAULT} ${w.label || w.name}`}
+                      />
+                      <span style={{ fontSize: "0.85rem", color: "#4a5568" }}>
+                        {DEV_MSG.CT_SET_DEFAULT}
                       </span>
-                    ) : null}
+                    </label>
+                    <span>
+                      {w.label || w.name}
+                      {w.name ? (
+                        <span
+                          style={{
+                            fontFamily: "monospace",
+                            color: "#718096",
+                            marginLeft: "8px",
+                            fontSize: "0.85rem",
+                          }}
+                        >
+                          {w.name}
+                        </span>
+                      ) : null}
+                    </span>
+                    <button
+                      type="button"
+                      data-testid={`developer-ct-wf-remove-${i}`}
+                      aria-label={`Remove workflow ${w.name || w.label}`}
+                      disabled={busy}
+                      onClick={() => removeWorkflow(i)}
+                      style={{ ...smallBtnStyle, marginLeft: "auto", cursor: busy ? "not-allowed" : "pointer" }}
+                    >
+                      {DEV_MSG.CT_ASSOC_REMOVE}
+                    </button>
                   </li>
                 ))}
               </ul>
             )}
+            <div
+              style={{
+                marginTop: "12px",
+                display: "grid",
+                gridTemplateColumns: "1fr auto",
+                gap: "8px",
+                alignItems: "end",
+              }}
+            >
+              <div>
+                <label htmlFor="ct-wf-add" style={{ display: "block", marginBottom: 4 }}>
+                  {DEV_MSG.CT_WORKFLOWS}
+                </label>
+                <input
+                  id="ct-wf-add"
+                  data-testid="developer-ct-wf-add-name"
+                  style={inputStyle}
+                  placeholder={DEV_MSG.CT_WF_NAME_PLACEHOLDER}
+                  value={newWfName}
+                  onChange={(e) => setNewWfName(e.target.value)}
+                  disabled={busy}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      addWorkflow();
+                    }
+                  }}
+                />
+              </div>
+              <button
+                type="button"
+                data-testid="developer-ct-wf-add"
+                disabled={busy || !newWfName.trim()}
+                onClick={addWorkflow}
+                style={{
+                  ...smallBtnStyle,
+                  padding: "8px 12px",
+                  cursor: busy || !newWfName.trim() ? "not-allowed" : "pointer",
+                }}
+              >
+                {DEV_MSG.CT_ASSOC_ADD}
+              </button>
+            </div>
           </section>
 
-          <section
-            style={{ marginBottom: "16px" }}
-            data-testid="developer-ct-templates"
-          >
+          <section style={{ marginBottom: "16px" }} data-testid="developer-ct-templates">
             <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.CT_TEMPLATES}</h3>
-            {(detail.allowedTemplates || []).length === 0 ? (
-              <p style={{ color: "#718096" }}>{DEV_MSG.CT_NONE}</p>
+            <p style={{ color: "#4a5568", fontSize: "0.9rem" }}>{DEV_MSG.CT_TEMPLATES_HINT}</p>
+            {templates.length === 0 ? (
+              <p style={{ color: "#718096" }} data-testid="developer-ct-tpl-empty">
+                {DEV_MSG.CT_NONE}
+              </p>
             ) : (
-              <ul>
-                {(detail.allowedTemplates || []).map((t) => (
-                  <li key={t.name || t.guid?.stringValue || t.label}>
-                    {t.label || t.name}
-                    {t.name ? (
-                      <span
-                        style={{
-                          fontFamily: "monospace",
-                          color: "#718096",
-                          marginLeft: "8px",
-                          fontSize: "0.85rem",
-                        }}
-                      >
-                        {t.name}
-                      </span>
-                    ) : null}
+              <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+                {templates.map((t, i) => (
+                  <li
+                    key={refKey(t, i)}
+                    data-testid={`developer-ct-tpl-row-${i}`}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 12,
+                      padding: "6px 0",
+                      borderBottom: "1px solid #edf2f7",
+                    }}
+                  >
+                    <span>
+                      {t.label || t.name}
+                      {t.name ? (
+                        <span
+                          style={{
+                            fontFamily: "monospace",
+                            color: "#718096",
+                            marginLeft: "8px",
+                            fontSize: "0.85rem",
+                          }}
+                        >
+                          {t.name}
+                        </span>
+                      ) : null}
+                    </span>
+                    <button
+                      type="button"
+                      data-testid={`developer-ct-tpl-remove-${i}`}
+                      aria-label={`Remove template ${t.name || t.label}`}
+                      disabled={busy}
+                      onClick={() => removeTemplate(i)}
+                      style={{ ...smallBtnStyle, marginLeft: "auto", cursor: busy ? "not-allowed" : "pointer" }}
+                    >
+                      {DEV_MSG.CT_ASSOC_REMOVE}
+                    </button>
                   </li>
                 ))}
               </ul>
             )}
+            <div
+              style={{
+                marginTop: "12px",
+                display: "grid",
+                gridTemplateColumns: "1fr auto",
+                gap: "8px",
+                alignItems: "end",
+              }}
+            >
+              <div>
+                <label htmlFor="ct-tpl-add" style={{ display: "block", marginBottom: 4 }}>
+                  {DEV_MSG.CT_TEMPLATES}
+                </label>
+                <input
+                  id="ct-tpl-add"
+                  data-testid="developer-ct-tpl-add-name"
+                  style={inputStyle}
+                  placeholder={DEV_MSG.CT_TPL_NAME_PLACEHOLDER}
+                  value={newTplName}
+                  onChange={(e) => setNewTplName(e.target.value)}
+                  disabled={busy}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      addTemplate();
+                    }
+                  }}
+                />
+              </div>
+              <button
+                type="button"
+                data-testid="developer-ct-tpl-add"
+                disabled={busy || !newTplName.trim()}
+                onClick={addTemplate}
+                style={{
+                  ...smallBtnStyle,
+                  padding: "8px 12px",
+                  cursor: busy || !newTplName.trim() ? "not-allowed" : "pointer",
+                }}
+              >
+                {DEV_MSG.CT_ASSOC_ADD}
+              </button>
+            </div>
           </section>
 
           <section style={{ marginBottom: "16px" }}>

--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -86,6 +86,9 @@ function refKey(r: NamedObjectRef, index: number): string {
   return `idx:${index}`;
 }
 
+/** Canonical Percussion GUID shape: type-host-uuid (three numeric groups). */
+const PERC_GUID_RE = /^\d+-\d+-\d+$/;
+
 function refsEqual(a: NamedObjectRef[], b: NamedObjectRef[]): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) {
@@ -93,6 +96,26 @@ function refsEqual(a: NamedObjectRef[], b: NamedObjectRef[]): boolean {
     if (!!a[i].isDefault !== !!b[i].isDefault) return false;
   }
   return true;
+}
+
+/**
+ * Align isDefault flags with server defaultWorkflow (or first row when missing).
+ */
+function withDefaultFlags(
+  list: NamedObjectRef[] | undefined,
+  defaultWorkflow?: NamedObjectRef | null,
+): NamedObjectRef[] {
+  const wfs = cloneRefs(list);
+  if (defaultWorkflow) {
+    const defKey = refKey(defaultWorkflow, -1);
+    for (const w of wfs) {
+      w.isDefault = refKey(w, -1) === defKey || w.name === defaultWorkflow.name;
+    }
+  }
+  if (wfs.length > 0 && !wfs.some((w) => w.isDefault)) {
+    wfs[0] = { ...wfs[0], isDefault: true };
+  }
+  return wfs;
 }
 
 function toRefPayload(list: NamedObjectRef[]): NamedObjectRef[] {
@@ -142,18 +165,7 @@ export function ContentTypeDetailPanel({
         setDescription(d.description || "");
         setEnabled(d.enabled !== false);
         setFieldDrafts(toDrafts(d.fields));
-        const wfs = cloneRefs(d.allowedWorkflows);
-        // Ensure default flag matches defaultWorkflow when server omits isDefault
-        if (d.defaultWorkflow) {
-          const defKey = refKey(d.defaultWorkflow, -1);
-          for (const w of wfs) {
-            w.isDefault = refKey(w, -1) === defKey || w.name === d.defaultWorkflow.name;
-          }
-          if (wfs.length > 0 && !wfs.some((w) => w.isDefault)) {
-            wfs[0].isDefault = true;
-          }
-        }
-        setWorkflows(wfs);
+        setWorkflows(withDefaultFlags(d.allowedWorkflows, d.defaultWorkflow));
         setTemplates(cloneRefs(d.allowedTemplates));
         setNewWfName("");
         setNewTplName("");
@@ -179,19 +191,7 @@ export function ContentTypeDetailPanel({
       return d.searchable !== i.searchable || d.required !== i.required;
     });
 
-  const initialWorkflows = (() => {
-    const wfs = cloneRefs(detail?.allowedWorkflows);
-    if (detail?.defaultWorkflow) {
-      const defKey = refKey(detail.defaultWorkflow, -1);
-      for (const w of wfs) {
-        w.isDefault = refKey(w, -1) === defKey || w.name === detail.defaultWorkflow.name;
-      }
-      if (wfs.length > 0 && !wfs.some((w) => w.isDefault)) {
-        wfs[0].isDefault = true;
-      }
-    }
-    return wfs;
-  })();
+  const initialWorkflows = withDefaultFlags(detail?.allowedWorkflows, detail?.defaultWorkflow);
   const initialTemplates = cloneRefs(detail?.allowedTemplates);
   const workflowsDirty = detail != null && !refsEqual(workflows, initialWorkflows);
   const templatesDirty = detail != null && !refsEqual(templates, initialTemplates);
@@ -253,7 +253,7 @@ export function ContentTypeDetailPanel({
   function addTemplate() {
     const raw = newTplName.trim();
     if (!raw) return;
-    const looksLikeGuid = /^\d+-\d+(-\d+)?$/.test(raw);
+    const looksLikeGuid = PERC_GUID_RE.test(raw);
     const exists = templates.some((t) => {
       if (looksLikeGuid) return t.guid?.stringValue === raw;
       return (t.name || "").toLowerCase() === raw.toLowerCase();
@@ -315,17 +315,7 @@ export function ContentTypeDetailPanel({
       setDescription(saved.description || "");
       setEnabled(saved.enabled !== false);
       setFieldDrafts(toDrafts(saved.fields));
-      const wfs = cloneRefs(saved.allowedWorkflows);
-      if (saved.defaultWorkflow) {
-        const defKey = refKey(saved.defaultWorkflow, -1);
-        for (const w of wfs) {
-          w.isDefault = refKey(w, -1) === defKey || w.name === saved.defaultWorkflow.name;
-        }
-        if (wfs.length > 0 && !wfs.some((w) => w.isDefault)) {
-          wfs[0].isDefault = true;
-        }
-      }
-      setWorkflows(wfs);
+      setWorkflows(withDefaultFlags(saved.allowedWorkflows, saved.defaultWorkflow));
       setTemplates(cloneRefs(saved.allowedTemplates));
       setNotice(DEV_MSG.CT_SAVED);
     } catch (err: unknown) {

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -46,7 +46,7 @@ export const DEV_MSG = {
   CT_COL_DESCRIPTION: "Description",
   CT_COL_ID: "Id",
   CT_HINT:
-    "Select a content type to view fields and edit label, description, enabled, and field search/required flags.",
+    "Select a content type to view fields and edit label, description, enabled, field flags, workflows, and templates.",
   CT_BACK: "Back to list",
   CT_DETAIL_LOADING: "Loading content type…",
   CT_DETAIL_ERROR: "Could not load content type detail.",
@@ -79,8 +79,17 @@ export const DEV_MSG = {
   CT_RULE_IN_XFORM: "in-xform",
   CT_RULE_OUT_XFORM: "out-xform",
   CT_WORKFLOWS: "Allowed workflows",
+  CT_WORKFLOWS_HINT:
+    "Full replace on save when changed. Add by workflow name; set default with the radio.",
   CT_DEFAULT_WF: "Default workflow",
   CT_TEMPLATES: "Allowed templates",
+  CT_TEMPLATES_HINT:
+    "Full replace on save when changed. Add by template name or GUID string.",
+  CT_ASSOC_ADD: "Add",
+  CT_ASSOC_REMOVE: "Remove",
+  CT_WF_NAME_PLACEHOLDER: "Workflow name",
+  CT_TPL_NAME_PLACEHOLDER: "Template name or GUID",
+  CT_SET_DEFAULT: "Default",
   CT_NONE: "None",
   YES: "Yes",
   NO: "No",

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -84,11 +84,11 @@ export const DEV_MSG = {
   CT_DEFAULT_WF: "Default workflow",
   CT_TEMPLATES: "Allowed templates",
   CT_TEMPLATES_HINT:
-    "Full replace on save when changed. Add by template name or GUID string.",
+    "Full replace on save when changed. Add by template name or GUID (type-host-uuid, e.g. 0-10-347).",
   CT_ASSOC_ADD: "Add",
   CT_ASSOC_REMOVE: "Remove",
   CT_WF_NAME_PLACEHOLDER: "Workflow name",
-  CT_TPL_NAME_PLACEHOLDER: "Template name or GUID",
+  CT_TPL_NAME_PLACEHOLDER: "Template name or GUID (0-10-347)",
   CT_SET_DEFAULT: "Default",
   CT_NONE: "None",
   YES: "Yes",

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -83,6 +83,13 @@ vi.mock("../../../main/ts/api/developer/contentTypesApi", () => ({
         occurrence: "optional",
       },
     ],
+    allowedWorkflows:
+      body.allowedWorkflows ??
+      [{ name: "Simple Workflow", label: "Simple Workflow", isDefault: true }],
+    defaultWorkflow:
+      body.defaultWorkflow ??
+      { name: "Simple Workflow", label: "Simple Workflow", isDefault: true },
+    allowedTemplates: body.allowedTemplates ?? [{ name: "perc.page", label: "Page" }],
     designGaps: [],
   })),
 }));
@@ -334,6 +341,61 @@ describe("DeveloperShell", () => {
     expect(body.fields).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: "page_title", searchable: true }),
+      ]),
+    );
+    // Field-only save must not wipe associations
+    expect(body.allowedWorkflows).toBeUndefined();
+    expect(body.allowedTemplates).toBeUndefined();
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-notice").textContent).toMatch(/saved/i);
+    });
+  });
+
+  it("edits content type workflow and template associations on save", async () => {
+    const { updateContentTypeDetail } = await import(
+      "../../../main/ts/api/developer/contentTypesApi"
+    );
+    (updateContentTypeDetail as ReturnType<typeof vi.fn>).mockClear();
+    render(<DeveloperShell embedded />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-row"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-wf-row-0")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("developer-ct-wf-add-name"), {
+      target: { value: "Standard Workflow" },
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-wf-add"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-wf-row-1")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("developer-ct-tpl-add-name"), {
+      target: { value: "perc.page.summary" },
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-tpl-add"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-tpl-row-1")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(updateContentTypeDetail).toHaveBeenCalled();
+    });
+    const body = (updateContentTypeDetail as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1];
+    expect(body.allowedWorkflows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Simple Workflow" }),
+        expect.objectContaining({ name: "Standard Workflow" }),
+      ]),
+    );
+    expect(body.defaultWorkflow).toEqual(
+      expect.objectContaining({ name: "Simple Workflow" }),
+    );
+    expect(body.allowedTemplates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "perc.page" }),
+        expect.objectContaining({ name: "perc.page.summary" }),
       ]),
     );
     await waitFor(() => {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -28,6 +28,8 @@ import com.percussion.design.objectstore.PSField;
 import com.percussion.design.objectstore.PSFieldSet;
 import com.percussion.design.objectstore.PSFieldTranslation;
 import com.percussion.design.objectstore.PSUISet;
+import com.percussion.design.objectstore.PSWorkflowInfo;
+import com.percussion.rest.Guid;
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeDetail;
 import com.percussion.rest.contenttypes.ContentTypeField;
@@ -36,6 +38,7 @@ import com.percussion.rest.contenttypes.IContentTypesAdaptor;
 import com.percussion.rest.contenttypes.NamedObjectRef;
 import com.percussion.services.assembly.IPSAssemblyService;
 import com.percussion.services.assembly.IPSAssemblyTemplate;
+import com.percussion.services.assembly.PSAssemblyException;
 import com.percussion.services.assembly.PSAssemblyServiceLocator;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.contentmgr.IPSContentMgr;
@@ -204,10 +207,12 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
             + " expressions and control properties are not");
     gaps.add("Item-level pre/post exits not exposed");
     gaps.add(
-        "Create / delete not supported; update uses design lock for label/description/enabled"
-            + " and field searchable/occurrence");
+        "Create / delete not supported; update uses design lock for label/description/enabled,"
+            + " field searchable/occurrence, workflows (+ default), and templates");
     gaps.add("Shared/system field inclusion editing not supported");
-    gaps.add("Workflow/template associations are read-only (no add/remove via this API)");
+    gaps.add(
+        "Workflow/template associations: full replace when lists are supplied on PUT; omit lists"
+            + " to leave unchanged");
     gaps.add("Field display labels and control properties are not writable via this API");
     if (!controlsResolved) {
       gaps.add("Display control/label resolution failed for this content type");
@@ -251,11 +256,25 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       PSItemDefinition def = locked.get(0);
       applyMetaUpdates(def, body);
       applyFieldUpdates(def, body.getFields());
+      applyWorkflowUpdates(def, body);
+      boolean needTemplates = body.getAllowedTemplates() != null;
       try {
-        designSvc.saveContentTypes(Collections.singletonList(def), true, session, user);
+        // Keep design lock when template associations still need a separate save.
+        designSvc.saveContentTypes(
+            Collections.singletonList(def), !needTemplates, session, user);
       } catch (PSErrorsException e) {
         log.error("Failed to save content type {}: {}", idOrName, e.getMessage(), e);
         throw new IllegalStateException("Failed to save content type", e);
+      }
+      if (needTemplates) {
+        try {
+          List<IPSGuid> templateGuids = resolveTemplateGuids(body.getAllowedTemplates());
+          designSvc.saveAssociatedTemplates(ctGuid, templateGuids, true, session, user);
+        } catch (PSErrorsException e) {
+          log.error(
+              "Failed to save template associations for {}: {}", idOrName, e.getMessage(), e);
+          throw new IllegalStateException("Failed to save template associations", e);
+        }
       }
       // Prefer re-read via item def cache after save
       PSItemDefinition reloaded = resolveItemDef(idOrName.trim());
@@ -269,6 +288,147 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       log.error("Failed to update content type {}: {}", idOrName, e.getMessage(), e);
       throw new IllegalStateException("Failed to update content type", e);
     }
+  }
+
+  /**
+   * Apply default workflow id and/or allowed-workflow inclusion list.
+   *
+   * <p>{@code allowedWorkflows == null} leaves associations unchanged. Non-null list is a full
+   * replace (empty clears). When a default is set, it is forced into the allowed list.
+   */
+  private void applyWorkflowUpdates(PSItemDefinition def, ContentTypeDetail body) {
+    if (body.getDefaultWorkflow() != null) {
+      int wfId = resolveWorkflowUuid(body.getDefaultWorkflow(), "defaultWorkflow");
+      def.getContentEditor().setWorkflowId(wfId);
+    }
+    if (body.getAllowedWorkflows() == null) {
+      return;
+    }
+    List<Integer> wfIds = new ArrayList<>();
+    int i = 0;
+    for (NamedObjectRef ref : body.getAllowedWorkflows()) {
+      if (ref == null) {
+        throw new IllegalArgumentException("allowedWorkflows[" + i + "] is null");
+      }
+      int id = resolveWorkflowUuid(ref, "allowedWorkflows[" + i + "]");
+      if (!wfIds.contains(id)) {
+        wfIds.add(id);
+      }
+      i++;
+    }
+    int defaultId = def.getContentEditor().getWorkflowId();
+    if (defaultId > 0 && !wfIds.contains(defaultId)) {
+      wfIds.add(defaultId);
+    }
+    def.getContentEditor()
+        .setWorkflowInfo(
+            new PSWorkflowInfo(PSWorkflowInfo.TYPE_INCLUSIONARY, new ArrayList<>(wfIds)));
+  }
+
+  private int resolveWorkflowUuid(NamedObjectRef ref, String field) {
+    if (ref.getGuid() != null) {
+      int fromGuid = uuidFromRestGuid(ref.getGuid(), PSTypeEnum.WORKFLOW, field);
+      if (fromGuid > 0) {
+        return fromGuid;
+      }
+    }
+    if (StringUtils.isNotBlank(ref.getName())) {
+      IPSWorkflowService wfSvc = PSWorkflowServiceLocator.getWorkflowService();
+      List<PSWorkflow> found = wfSvc.findWorkflowsByName(ref.getName().trim());
+      if (found == null || found.isEmpty()) {
+        throw new IllegalArgumentException(field + " workflow not found: " + ref.getName());
+      }
+      return found.get(0).getGUID().getUUID();
+    }
+    throw new IllegalArgumentException(field + " requires name or guid");
+  }
+
+  private List<IPSGuid> resolveTemplateGuids(List<NamedObjectRef> refs) {
+    List<IPSGuid> out = new ArrayList<>();
+    if (refs == null) {
+      return out;
+    }
+    int i = 0;
+    for (NamedObjectRef ref : refs) {
+      if (ref == null) {
+        throw new IllegalArgumentException("allowedTemplates[" + i + "] is null");
+      }
+      out.add(resolveTemplateGuid(ref, "allowedTemplates[" + i + "]"));
+      i++;
+    }
+    return out;
+  }
+
+  private IPSGuid resolveTemplateGuid(NamedObjectRef ref, String field) {
+    IPSAssemblyService asm = PSAssemblyServiceLocator.getAssemblyService();
+    if (ref.getGuid() != null) {
+      String sv = ref.getGuid().getStringValue().orElse(null);
+      if (StringUtils.isNotBlank(sv)) {
+        try {
+          IPSGuid g = ApiUtils.convertGuid(ref.getGuid());
+          // Normalize type if untyped numeric guid
+          if (g.getType() == 0) {
+            g = new PSGuid(PSTypeEnum.TEMPLATE, g.getUUID());
+          }
+          try {
+            asm.loadTemplate(g, false);
+          } catch (PSAssemblyException e) {
+            throw new IllegalArgumentException(field + " template not found: " + sv, e);
+          }
+          return g;
+        } catch (IllegalArgumentException e) {
+          throw e;
+        } catch (Exception e) {
+          throw new IllegalArgumentException(field + " invalid template guid: " + sv, e);
+        }
+      }
+      int uuid = ref.getGuid().getUuid();
+      if (uuid > 0) {
+        IPSGuid g = new PSGuid(PSTypeEnum.TEMPLATE, uuid);
+        try {
+          asm.loadTemplate(g, false);
+        } catch (PSAssemblyException e) {
+          throw new IllegalArgumentException(field + " template not found uuid=" + uuid, e);
+        }
+        return g;
+      }
+    }
+    if (StringUtils.isNotBlank(ref.getName())) {
+      try {
+        IPSAssemblyTemplate t = asm.findTemplateByName(ref.getName().trim());
+        if (t == null || t.getGUID() == null) {
+          throw new IllegalArgumentException(field + " template not found: " + ref.getName());
+        }
+        return t.getGUID();
+      } catch (PSAssemblyException e) {
+        throw new IllegalArgumentException(field + " template not found: " + ref.getName(), e);
+      }
+    }
+    throw new IllegalArgumentException(field + " requires name or guid");
+  }
+
+  /**
+   * Prefer stringValue guid form, then uuid field. Returns 0 when guid cannot contribute a
+   * positive uuid (caller may fall through to name).
+   */
+  private int uuidFromRestGuid(Guid guid, PSTypeEnum expectedType, String field) {
+    if (guid == null) {
+      return 0;
+    }
+    String sv = guid.getStringValue().orElse(null);
+    if (StringUtils.isNotBlank(sv)) {
+      try {
+        IPSGuid g = ApiUtils.convertGuid(guid);
+        if (g.getType() == 0) {
+          g = new PSGuid(expectedType, g.getUUID());
+        }
+        return g.getUUID();
+      } catch (Exception e) {
+        throw new IllegalArgumentException(field + " invalid guid: " + sv, e);
+      }
+    }
+    int uuid = guid.getUuid();
+    return uuid > 0 ? uuid : 0;
   }
 
   private void applyMetaUpdates(PSItemDefinition def, ContentTypeDetail body) {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -27,6 +27,7 @@ import com.percussion.design.objectstore.PSDisplayMapping;
 import com.percussion.design.objectstore.PSField;
 import com.percussion.design.objectstore.PSFieldSet;
 import com.percussion.design.objectstore.PSFieldTranslation;
+import com.percussion.design.objectstore.PSSystemValidationException;
 import com.percussion.design.objectstore.PSUISet;
 import com.percussion.design.objectstore.PSWorkflowInfo;
 import com.percussion.rest.Guid;
@@ -195,6 +196,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
 
     IPSGuid ctGuid = new PSGuid(PSTypeEnum.NODEDEF, def.getTypeId());
     int defaultWfId = def.getContentEditor() != null ? def.getContentEditor().getWorkflowId() : -1;
+    // Always set non-null lists on GET so wire shape stays [] not omitted (NON_NULL include).
     detail.setAllowedWorkflows(loadWorkflows(ctGuid, defaultWfId));
     if (defaultWfId > 0) {
       detail.setDefaultWorkflow(toWorkflowRef(defaultWfId, true));
@@ -212,7 +214,10 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     gaps.add("Shared/system field inclusion editing not supported");
     gaps.add(
         "Workflow/template associations: full replace when lists are supplied on PUT; omit lists"
-            + " to leave unchanged");
+            + " to leave unchanged; empty allowedWorkflows clears associations");
+    gaps.add(
+        "Template association save is a separate design write after content-type save; if it"
+            + " fails, meta/field/workflow changes may already be committed");
     gaps.add("Field display labels and control properties are not writable via this API");
     if (!controlsResolved) {
       gaps.add("Display control/label resolution failed for this content type");
@@ -260,6 +265,8 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       boolean needTemplates = body.getAllowedTemplates() != null;
       try {
         // Keep design lock when template associations still need a separate save.
+        // Note: content-type save and template association save are sequential design writes
+        // without a shared rollback — template failure after CT save is partial success.
         designSvc.saveContentTypes(
             Collections.singletonList(def), !needTemplates, session, user);
       } catch (PSErrorsException e) {
@@ -272,8 +279,14 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
           designSvc.saveAssociatedTemplates(ctGuid, templateGuids, true, session, user);
         } catch (PSErrorsException e) {
           log.error(
-              "Failed to save template associations for {}: {}", idOrName, e.getMessage(), e);
-          throw new IllegalStateException("Failed to save template associations", e);
+              "Failed to save template associations for {} (content type already saved): {}",
+              idOrName,
+              e.getMessage(),
+              e);
+          throw new IllegalStateException(
+              "Content type meta/fields/workflows saved, but template associations failed —"
+                  + " retry template update",
+              e);
         }
       }
       // Prefer re-read via item def cache after save
@@ -294,7 +307,9 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
    * Apply default workflow id and/or allowed-workflow inclusion list.
    *
    * <p>{@code allowedWorkflows == null} leaves associations unchanged. Non-null list is a full
-   * replace (empty clears). When a default is set, it is forced into the allowed list.
+   * replace — empty list clears associations (does not re-inject the previous default). When both
+   * {@code defaultWorkflow} and a non-empty allowed list are supplied, the default is ensured to
+   * appear in the inclusion list.
    */
   private void applyWorkflowUpdates(PSItemDefinition def, ContentTypeDetail body) {
     if (body.getDefaultWorkflow() != null) {
@@ -316,9 +331,19 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       }
       i++;
     }
-    int defaultId = def.getContentEditor().getWorkflowId();
-    if (defaultId > 0 && !wfIds.contains(defaultId)) {
-      wfIds.add(defaultId);
+    // Only force-include default when the client also set defaultWorkflow this request.
+    // Empty list = true clear (do not re-inject prior default).
+    if (body.getDefaultWorkflow() != null && !wfIds.isEmpty()) {
+      int defaultId = def.getContentEditor().getWorkflowId();
+      if (defaultId > 0 && !wfIds.contains(defaultId)) {
+        wfIds.add(defaultId);
+      }
+    } else if (!wfIds.isEmpty()) {
+      // Non-empty replace without explicit default: retarget default if orphaned
+      int defaultId = def.getContentEditor().getWorkflowId();
+      if (defaultId <= 0 || !wfIds.contains(defaultId)) {
+        def.getContentEditor().setWorkflowId(wfIds.get(0));
+      }
     }
     def.getContentEditor()
         .setWorkflowInfo(
@@ -477,13 +502,23 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
           throw new IllegalArgumentException(
               "Invalid occurrence for field " + patch.getName() + ": " + patch.getOccurrence());
         }
-        field.setOccurrenceDimension(dim, null);
+        try {
+          field.setOccurrenceDimension(dim, null);
+        } catch (PSSystemValidationException e) {
+          throw new IllegalArgumentException(
+              "Invalid occurrence for field " + patch.getName() + ": " + patch.getOccurrence(), e);
+        }
       } else if (patch.getRequired() != null) {
         int dim =
             Boolean.TRUE.equals(patch.getRequired())
                 ? PSField.OCCURRENCE_DIMENSION_REQUIRED
                 : PSField.OCCURRENCE_DIMENSION_OPTIONAL;
-        field.setOccurrenceDimension(dim, null);
+        try {
+          field.setOccurrenceDimension(dim, null);
+        } catch (PSSystemValidationException e) {
+          throw new IllegalArgumentException(
+              "Invalid required flag for field " + patch.getName(), e);
+        }
       }
     }
   }

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeDetail.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeDetail.java
@@ -27,9 +27,13 @@ import java.util.List;
 /**
  * Content type design summary for the Developer module (read + partial write).
  *
- * <p>Full field rule expressions and control properties remain Workbench / SOAP parity
- * work. Partial update supports label, description, enabled, and field searchable /
- * occurrence under a design-session lock.
+ * <p>Full field rule expressions and control properties remain Workbench / SOAP parity work.
+ * Partial update supports label, description, enabled, field searchable / occurrence, allowed
+ * workflows (+ default), and allowed templates under a design-session lock.
+ *
+ * <p>For {@code PUT}: {@code allowedWorkflows} / {@code allowedTemplates} {@code null} (omitted)
+ * leaves associations unchanged; a non-null list (including empty) is a full replace. Field
+ * patches use a different convention — empty/omitted {@code fields} means no field changes.
  */
 @XmlRootElement(name = "ContentTypeDetail")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -46,9 +50,11 @@ public class ContentTypeDetail {
   private String editorUrl;
   private List<ContentTypeField> fields = new ArrayList<>();
   private List<String> childFieldSets = new ArrayList<>();
-  private List<NamedObjectRef> allowedWorkflows = new ArrayList<>();
+  /** Null on PUT means leave unchanged; non-null is full replace. */
+  private List<NamedObjectRef> allowedWorkflows;
   private NamedObjectRef defaultWorkflow;
-  private List<NamedObjectRef> allowedTemplates = new ArrayList<>();
+  /** Null on PUT means leave unchanged; non-null is full replace. */
+  private List<NamedObjectRef> allowedTemplates;
 
   @Schema(
       description =
@@ -142,7 +148,7 @@ public class ContentTypeDetail {
   }
 
   public void setAllowedWorkflows(List<NamedObjectRef> allowedWorkflows) {
-    this.allowedWorkflows = allowedWorkflows != null ? allowedWorkflows : new ArrayList<>();
+    this.allowedWorkflows = allowedWorkflows;
   }
 
   public NamedObjectRef getDefaultWorkflow() {
@@ -158,7 +164,7 @@ public class ContentTypeDetail {
   }
 
   public void setAllowedTemplates(List<NamedObjectRef> allowedTemplates) {
-    this.allowedTemplates = allowedTemplates != null ? allowedTemplates : new ArrayList<>();
+    this.allowedTemplates = allowedTemplates;
   }
 
   public List<String> getDesignGaps() {

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeDetail.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeDetail.java
@@ -31,9 +31,12 @@ import java.util.List;
  * Partial update supports label, description, enabled, field searchable / occurrence, allowed
  * workflows (+ default), and allowed templates under a design-session lock.
  *
- * <p>For {@code PUT}: {@code allowedWorkflows} / {@code allowedTemplates} {@code null} (omitted)
- * leaves associations unchanged; a non-null list (including empty) is a full replace. Field
- * patches use a different convention — empty/omitted {@code fields} means no field changes.
+ * <p><strong>GET:</strong> adaptors always populate {@code allowedWorkflows} and {@code
+ * allowedTemplates} (empty arrays when none) so clients see stable wire shape.
+ *
+ * <p><strong>PUT:</strong> {@code allowedWorkflows} / {@code allowedTemplates} {@code null}
+ * (omitted) leaves associations unchanged; a non-null list (including empty) is a full replace.
+ * Field patches use a different convention — empty/omitted {@code fields} means no field changes.
  */
 @XmlRootElement(name = "ContentTypeDetail")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -50,10 +53,27 @@ public class ContentTypeDetail {
   private String editorUrl;
   private List<ContentTypeField> fields = new ArrayList<>();
   private List<String> childFieldSets = new ArrayList<>();
-  /** Null on PUT means leave unchanged; non-null is full replace. */
+
+  /**
+   * Workflow associations. On GET always non-null (may be empty). On PUT request body: null/omitted
+   * = leave unchanged; non-null = full replace.
+   */
+  @Schema(
+      description =
+          "Allowed workflows. GET: always present (may be []). PUT: omit/null leave unchanged;"
+              + " non-null list full replace (empty clears).")
   private List<NamedObjectRef> allowedWorkflows;
+
   private NamedObjectRef defaultWorkflow;
-  /** Null on PUT means leave unchanged; non-null is full replace. */
+
+  /**
+   * Template associations. On GET always non-null (may be empty). On PUT request body: null/omitted
+   * = leave unchanged; non-null = full replace.
+   */
+  @Schema(
+      description =
+          "Allowed templates. GET: always present (may be []). PUT: omit/null leave unchanged;"
+              + " non-null list full replace (empty clears).")
   private List<NamedObjectRef> allowedTemplates;
 
   @Schema(

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -855,9 +855,13 @@ public class ContentTypesResource {
           "Locks the content type for the current session user, applies mutable fields (label,"
               + " description, enabled, per-field searchable/occurrence, allowedWorkflows +"
               + " defaultWorkflow, allowedTemplates), saves, and releases the lock. Association"
-              + " lists: omit/null = leave unchanged; non-null list = full replace. Name/id and"
-              + " system field structure are not changed. Full rule expressions and create/delete"
-              + " remain unsupported (see designGaps).",
+              + " lists: omit/null = leave unchanged; non-null list = full replace (empty clears"
+              + " workflows/templates). GET responses always include association arrays (may be"
+              + " empty). Template associations are written after content-type save in a separate"
+              + " design call — if that fails, meta/field/workflow changes may already be"
+              + " committed (error message indicates partial success). Name/id and system field"
+              + " structure are not changed. Full rule expressions and create/delete remain"
+              + " unsupported (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -867,7 +871,11 @@ public class ContentTypesResource {
         @ApiResponse(responseCode = "400", description = "Invalid input"),
         @ApiResponse(responseCode = "404", description = "Content type not found"),
         @ApiResponse(responseCode = "409", description = "Could not acquire design lock"),
-        @ApiResponse(responseCode = "500", description = "Error")
+        @ApiResponse(
+            responseCode = "500",
+            description =
+                "Error — may indicate partial success when template association save fails after"
+                    + " content type was already saved"),
       })
   public ContentTypeDetail updateContentType(
       @PathParam("idOrName") String idOrName, ContentTypeDetail body) {

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -853,9 +853,11 @@ public class ContentTypesResource {
       summary = "Update content type design fields",
       description =
           "Locks the content type for the current session user, applies mutable fields (label,"
-              + " description, enabled, per-field searchable/occurrence), saves, and releases the"
-              + " lock. Name/id and system field structure are not changed. Full rule expressions"
-              + " and create/delete remain unsupported (see designGaps).",
+              + " description, enabled, per-field searchable/occurrence, allowedWorkflows +"
+              + " defaultWorkflow, allowedTemplates), saves, and releases the lock. Association"
+              + " lists: omit/null = leave unchanged; non-null list = full replace. Name/id and"
+              + " system field structure are not changed. Full rule expressions and create/delete"
+              + " remain unsupported (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",

--- a/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
@@ -61,9 +61,10 @@ public interface IContentTypesAdaptor {
   /**
    * Update content type design fields under a design-session lock.
    *
-   * <p>Supports label, description, enabled, and per-field {@code searchable} (and optional
-   * occurrence) for named fields. Locks for the current request user, saves, and releases the
-   * lock.
+   * <p>Supports label, description, enabled, per-field {@code searchable} (and optional
+   * occurrence), allowed workflows (+ default workflow id), and allowed templates. Association
+   * lists use full-replace semantics when non-null; omit them to leave associations unchanged.
+   * Locks for the current request user, saves, and releases the lock.
    *
    * @return updated detail, or {@code null} when not found
    */


### PR DESCRIPTION
## Summary
- **P0.2e** — write path for content type **allowed workflows** (+ default) and **allowed templates** via existing `PUT /services/contenttypes/{idOrName}`.
- Partial-update semantics: omit `allowedWorkflows` / `allowedTemplates` to leave associations unchanged; non-null list = full replace (including empty).
- Backend: apply workflow inclusion list + default id under design lock (`PSWorkflowInfo` + `setWorkflowId`); templates via `IPSContentDesignWs.saveAssociatedTemplates` (lock held across save when needed).
- SPA: CT detail add/remove workflows (name) with default radio; add/remove templates (name or GUID).
- Field-only saves still omit association lists so they do not wipe workflows/templates.

## Tests
- `npx vitest run src/test/ts/developer/DeveloperShell.test.tsx` — 10/10
- `mvn -pl rest test -Dtest=ContentTypesResourceDetailTest -Dai.integrity.skip=true` — 6/6

## Tracker
Refs #1622

## Open developer P0 PRs (independent)
- #1634 ACL permission edit
- #1637 Template bindings + slots
- #1638 Community visibility
- this PR — CT workflow/template associations