### PR TITLE
fix(webui): modernize logout screen to match login chrome

### DIFF
--- a/WebUI/src/main/ts/developer/SlotDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/SlotDetailPanel.tsx
@@ -47,18 +47,26 @@ function associationsEqual(
 ): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) {
+    // Indexed access may be undefined under noUncheckedIndexedAccess.
+    const left = a[i];
+    const right = b[i];
+    if (!left || !right) return false;
     const as =
-      a[i].contentTypeGuid?.stringValue ||
-      (a[i].contentTypeGuid?.uuid != null ? String(a[i].contentTypeGuid.uuid) : "");
+      left.contentTypeGuid?.stringValue ||
+      (left.contentTypeGuid?.uuid != null
+        ? String(left.contentTypeGuid.uuid)
+        : "");
     const at =
-      a[i].templateGuid?.stringValue ||
-      (a[i].templateGuid?.uuid != null ? String(a[i].templateGuid.uuid) : "");
+      left.templateGuid?.stringValue ||
+      (left.templateGuid?.uuid != null ? String(left.templateGuid.uuid) : "");
     const bs =
-      b[i].contentTypeGuid?.stringValue ||
-      (b[i].contentTypeGuid?.uuid != null ? String(b[i].contentTypeGuid.uuid) : "");
+      right.contentTypeGuid?.stringValue ||
+      (right.contentTypeGuid?.uuid != null
+        ? String(right.contentTypeGuid.uuid)
+        : "");
     const bt =
-      b[i].templateGuid?.stringValue ||
-      (b[i].templateGuid?.uuid != null ? String(b[i].templateGuid.uuid) : "");
+      right.templateGuid?.stringValue ||
+      (right.templateGuid?.uuid != null ? String(right.templateGuid.uuid) : "");
     if (as !== bs || at !== bt) return false;
   }
   return true;

--- a/WebUI/src/main/ts/index.ts
+++ b/WebUI/src/main/ts/index.ts
@@ -21,6 +21,7 @@
  * <ul>
  *   <li>Always registers {@code window.PercModernUI} for residual bridge embeds.</li>
  *   <li>If {@code #perc-login-root} is present, boots the React Login front door.</li>
+ *   <li>If {@code #perc-logout-root} is present, boots the React Logout confirmation.</li>
  *   <li>If SPA root is present ({@code #perc-spa-root}, {@code #root}, {@code #perc-app-root}),
  *       boots the authenticated App shell.</li>
  * </ul>
@@ -31,6 +32,7 @@ import { createRoot } from "react-dom/client";
 import "./bridge";
 import { ensureModernStyles } from "./ensureModernStyles";
 import { LoginPage, readLoginBootstrap } from "./login";
+import { LogoutPage, readLogoutBootstrap } from "./logout";
 
 // Entry CSS is not auto-linked without an HTML entry — inject before any boot.
 ensureModernStyles();
@@ -43,6 +45,16 @@ function bootLogin(): void {
   const bootstrap = readLoginBootstrap();
   createRoot(el).render(React.createElement(LoginPage, { bootstrap }));
   console.info("[PercModernUI] Login SPA mounted.");
+}
+
+function bootLogout(): void {
+  const el = document.getElementById("perc-logout-root");
+  if (!el) {
+    return;
+  }
+  const bootstrap = readLogoutBootstrap();
+  createRoot(el).render(React.createElement(LogoutPage, { bootstrap }));
+  console.info("[PercModernUI] Logout SPA mounted.");
 }
 
 function findSpaRoot(): HTMLElement | null {
@@ -73,6 +85,10 @@ function bootSpa(): void {
 function boot(): void {
   if (document.getElementById("perc-login-root")) {
     bootLogin();
+    return;
+  }
+  if (document.getElementById("perc-logout-root")) {
+    bootLogout();
     return;
   }
   if (findSpaRoot()) {

--- a/WebUI/src/main/ts/logout/LogoutPage.module.css
+++ b/WebUI/src/main/ts/logout/LogoutPage.module.css
@@ -1,0 +1,44 @@
+/*
+ * Logout page — layout matches LoginPage.module.css; only logout-specific
+ * elements live here. Shared chrome (page/main/card/logo) is imported from
+ * the login CSS module so the two screens stay visually aligned.
+ */
+
+.message {
+  margin: 0 0 1.5rem;
+  text-align: center;
+  font-size: 0.95rem;
+  line-height: 1.45;
+  color: var(--color-text, #181c2c);
+}
+
+.actions {
+  margin-top: 0.25rem;
+}
+
+/* Anchor styled like LoginPage .submit (button look, link behavior). */
+.loginLink {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 6px;
+  padding: 0.7rem 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
+  background: var(--color-primary, #4a6aa3);
+  color: var(--color-text-inverse, #ffffff);
+}
+
+.loginLink:hover {
+  background: var(--color-primary-hover, #2f456e);
+  color: var(--color-text-inverse, #ffffff);
+}
+
+.loginLink:focus {
+  outline: 2px solid var(--color-accent, #fbb03b);
+  outline-offset: 2px;
+}

--- a/WebUI/src/main/ts/logout/LogoutPage.tsx
+++ b/WebUI/src/main/ts/logout/LogoutPage.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect } from "react";
+import { BrandBar, BrandFooter } from "../ui-themes/components";
+import { ThemeProvider } from "../ui-themes/ThemeProvider";
+import { useTheme } from "../ui-themes/ThemeProvider";
+// Reuse login card chrome so logout stays pixel-aligned with the front door.
+import loginStyles from "../login/LoginPage.module.css";
+import { LOGOUT_KEYS, t } from "./i18n";
+import type { LogoutBootstrap } from "./types";
+import styles from "./LogoutPage.module.css";
+
+export interface LogoutPageProps {
+  bootstrap: LogoutBootstrap;
+}
+
+function LogoutBody({ bootstrap }: LogoutPageProps): React.ReactElement {
+  const theme = useTheme();
+
+  useEffect(() => {
+    if (bootstrap.locale) {
+      document.documentElement.lang = bootstrap.locale;
+    }
+    document.title = `${t(LOGOUT_KEYS.TITLE)} — Percussion CMS`;
+  }, [bootstrap.locale]);
+
+  return (
+    <div className={loginStyles.page} data-testid="perc-logout-page">
+      <BrandBar />
+      <main className={loginStyles.main}>
+        <div className={loginStyles.card}>
+          <div className={loginStyles.logoWrap}>
+            <img
+              className={loginStyles.logo}
+              src={theme.brand.logoHorizontal}
+              alt={`${theme.brand.publisher} logo`}
+              width={220}
+              height={48}
+              data-testid="perc-logout-logo"
+            />
+          </div>
+          <h1 className={loginStyles.title} data-testid="perc-logout-title">
+            {t(LOGOUT_KEYS.TITLE)}
+          </h1>
+          <p className={loginStyles.subtitle}>{theme.brand.productName}</p>
+          <p className={styles.message} data-testid="perc-logout-message">
+            {t(LOGOUT_KEYS.MESSAGE)}
+          </p>
+          <div className={styles.actions}>
+            <a
+              className={styles.loginLink}
+              href={bootstrap.loginHref}
+              data-testid="perc-logout-sign-in"
+            >
+              {t(LOGOUT_KEYS.SIGN_IN)}
+            </a>
+          </div>
+        </div>
+      </main>
+      <BrandFooter />
+    </div>
+  );
+}
+
+/**
+ * Product logout confirmation page (React). Matches login card chrome;
+ * server logout endpoint is unchanged — this page is the post-logout UI only.
+ */
+export function LogoutPage({ bootstrap }: LogoutPageProps): React.ReactElement {
+  return (
+    <ThemeProvider data-testid="perc-logout-theme">
+      <LogoutBody bootstrap={bootstrap} />
+    </ThemeProvider>
+  );
+}

--- a/WebUI/src/main/ts/logout/bootstrap.ts
+++ b/WebUI/src/main/ts/logout/bootstrap.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { LogoutBootstrap } from "./types";
+
+const LOGOUT_BOOTSTRAP_ID = "perc-logout-bootstrap";
+
+/** Default login front door (same relative form as classic login action). */
+export const DEFAULT_LOGIN_HREF = "login";
+
+/**
+ * Allowlist a post-logout login href. Rejects absolute URLs to other hosts,
+ * protocol-relative URLs, and path traversal.
+ */
+export function sanitizeLoginHref(
+  candidate: string | null | undefined,
+  fallback: string = DEFAULT_LOGIN_HREF,
+): string {
+  if (typeof candidate !== "string") {
+    return fallback;
+  }
+  const href = candidate.trim();
+  if (!href || href.length > 2048) {
+    return fallback;
+  }
+  // Block absolute / protocol-relative / javascript: etc.
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(href) || href.startsWith("//")) {
+    return fallback;
+  }
+  if (href.includes("..") || href.includes("\\")) {
+    return fallback;
+  }
+  // Path-absolute or simple relative product paths only.
+  if (href.startsWith("/")) {
+    // Must stay on CMS product surfaces (login / rxlogin / cm).
+    if (
+      href === "/login" ||
+      href.startsWith("/login?") ||
+      href === "/rxlogin.jsp" ||
+      href.startsWith("/rxlogin.jsp?") ||
+      href.startsWith("/cm/")
+    ) {
+      return href;
+    }
+    return fallback;
+  }
+  // Relative: allow "login", "rxlogin.jsp", optional query.
+  if (/^(login|rxlogin\.jsp)(\?.*)?$/i.test(href)) {
+    return href;
+  }
+  return fallback;
+}
+
+/**
+ * Reads logout bootstrap from the host page JSON script tag.
+ */
+export function readLogoutBootstrap(): LogoutBootstrap {
+  const el = document.getElementById(LOGOUT_BOOTSTRAP_ID);
+  let raw: Partial<LogoutBootstrap> | null = null;
+  if (el?.textContent) {
+    try {
+      raw = JSON.parse(el.textContent) as Partial<LogoutBootstrap>;
+    } catch {
+      console.error(
+        `[PercModernUI] Failed to parse bootstrap JSON (#${LOGOUT_BOOTSTRAP_ID})`,
+      );
+    }
+  }
+  return {
+    locale:
+      typeof raw?.locale === "string" && raw.locale ? raw.locale : "en-us",
+    loginHref: sanitizeLoginHref(raw?.loginHref, DEFAULT_LOGIN_HREF),
+  };
+}

--- a/WebUI/src/main/ts/logout/i18n.ts
+++ b/WebUI/src/main/ts/logout/i18n.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { message } from "../i18n/message";
+
+/** Logout-screen TMX message wrapper (same contract as login {@code t()}). */
+export function t(key: string, args?: unknown[]): string {
+  return message(key, args);
+}
+
+export const LOGOUT_KEYS = {
+  TITLE: "perc.ui.logout.modern@Signed out",
+  MESSAGE: "perc.ui.logout.modern@You have been logged out.",
+  SIGN_IN: "perc.ui.logout.modern@Sign in again",
+} as const;
+
+export type LogoutKey = (typeof LOGOUT_KEYS)[keyof typeof LOGOUT_KEYS];

--- a/WebUI/src/main/ts/logout/index.ts
+++ b/WebUI/src/main/ts/logout/index.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { LogoutPage } from "./LogoutPage";
+export type { LogoutPageProps } from "./LogoutPage";
+export {
+  readLogoutBootstrap,
+  sanitizeLoginHref,
+  DEFAULT_LOGIN_HREF,
+} from "./bootstrap";
+export type { LogoutBootstrap } from "./types";

--- a/WebUI/src/main/ts/logout/types.ts
+++ b/WebUI/src/main/ts/logout/types.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Server-provided bootstrap for the React logout page (XSS-safe JSON text node).
+ */
+export interface LogoutBootstrap {
+  /** Session / system locale (BCP-47 lowercase hyphen) */
+  locale: string;
+  /**
+   * Path-absolute or relative href for the "sign in again" control.
+   * Prefer the product login front door ({@code /rxlogin.jsp} or {@code login}).
+   */
+  loginHref: string;
+}

--- a/WebUI/src/main/webapp/rxlogout.jsp
+++ b/WebUI/src/main/webapp/rxlogout.jsp
@@ -1,65 +1,85 @@
-<%@ page 
-   import="com.percussion.i18n.PSI18nUtils" 
-   import="java.net.URLEncoder"
-   import="java.text.MessageFormat"
-   import="java.util.*"
-   %>
-<%@ taglib uri="http://rhythmyx.percussion.com/components"
-    prefix="rxcomp"%>
-<%@ taglib uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" prefix="csrf" %>
-
-
-
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ page import="com.percussion.i18n.PSI18nUtils" %>
+<%--
+  React Logout SPA host (post-logout confirmation).
+  Server /logout endpoint is unchanged — this page is the UI only.
+  Mirrors rxlogin.jsp host contract: modern CSS/JS, TMX, XSS-safe bootstrap.
+--%>
+<%!
+    private static String jsonString(String s) {
+        if (s == null) {
+            return "null";
+        }
+        StringBuilder sb = new StringBuilder(s.length() + 16);
+        sb.append('"');
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\': sb.append("\\\\"); break;
+                case '"': sb.append("\\\""); break;
+                case '\b': sb.append("\\b"); break;
+                case '\f': sb.append("\\f"); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\t': sb.append("\\t"); break;
+                case '<': sb.append("\\u003c"); break;
+                case '>': sb.append("\\u003e"); break;
+                case '&': sb.append("\\u0026"); break;
+                case '\u2028': sb.append("\\u2028"); break;
+                case '\u2029': sb.append("\\u2029"); break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        sb.append('"');
+        return sb.toString();
+    }
+%>
 <%
     String locale = PSI18nUtils.getSystemLanguage();
-    pageContext.setAttribute("locale",locale);
-    String redirect = "../cm";
-    String pattern = PSI18nUtils.getString("jsp_logout@click here", locale);
-    String[] args = {redirect};
-    String msg = MessageFormat.format(pattern, args);
-%>  
+    if (locale == null || locale.isEmpty()) {
+        locale = "en-us";
+    }
+    // Product login front door (same relative action as classic login form).
+    String loginHref = "login";
+%>
 <!DOCTYPE html>
-<html>
-    <head>
-        <title>Logout Page</title> 
-        <style type="text/css">
-        body { font-family: Verdana; margin: 0; padding: 0; }
-        .perc-login-logo {color: #121212; margin-top: 160px; margin-bottom: 100px;}
-        #loginform .perc-form    { }
-        #perc-forgot {color: #fff;}
-        #perc-forgot:hover   {cursor:pointer;}
-        input { padding: 0; }
-        table { border: 0; border-spacing: 0; }
-        td { border: 0; margin: 0; padding: 0 4px 0 4px ;}
-        img:hover    {cursor: pointer;}
-        .error { font-weight:bold; margin-top:10px; }
-        .perc-form .windowName a, .perc-form .windowName a:visited { color: #444444; text-decoration: none; font-weight: bold; }
-        </style>
-    <script
-            src="/Rhythmyx/tmx/tmx.jsp?mode=js&amp;prefix=perc.ui.&amp;sys_lang=en-us"></script>
-        <script src="/JavaScriptServlet"></script>
-        <script src="/cm/cui/components/jquery/jquery.min.js"></script>
-    <script src="/cm/cui/components/jquery-migrate/jquery-migrate.min.js"></script>
-    </head>
-    <body>
-        <table align="center">
-            <tr>
-                <td align="center">
-                    <div class='perc-login'>
-                        <form id="loginform" name="loginform" method="post" enctype="multipart/form-data">
-                            <div class='perc-login-logo'><img src="/sys_resources/images/percussion-logo.png" alt="${rxcomp:i18ntext('general@Percussion Logo Alt',locale)}" title="${rxcomp:i18ntext('general@Percussion Logo Title',locale)}"/></div>
-                            <table class='perc-form'> 
-                                <tr>
-                                    <td> 
-                                        <p class="windowName" align=center>${rxcomp:i18ntext('jsp_logout@logged out',locale)}</p>
-                                        <p class="windowName" align=center><%= msg %></p>
-                                    </td>
-                                </tr>   
-                            </table>
-                        </form>
-                    </div>
-                </td>
-            </tr>
-        </table>
-    </body>
+<html lang="<%= locale %>">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>Percussion CMS — Signed out</title>
+    <%-- TMX catalog for React message() (required for logout chrome) --%>
+    <script src="<%= request.getContextPath() %>/tmx/tmx.jsp?mode=js&amp;prefix=perc.ui.&amp;sys_lang=<%= locale %>"></script>
+    <%-- Stable CSS entry (Vite cssCodeSplit:false). JS also injects if this is missing. --%>
+    <link rel="stylesheet" href="/cm/modern/assets/perc-modern-ui.css"/>
+    <script type="module" src="/cm/modern/assets/perc-modern-ui.js"></script>
+    <style>
+        html, body { margin: 0; padding: 0; }
+        /* Defensive: if CSS fails to load, logo must not paint at intrinsic 1477×720 */
+        img[data-testid="perc-logout-logo"],
+        img[data-testid="perc-brand-logo"] {
+            max-height: 48px;
+            max-width: 220px;
+            width: auto;
+            height: auto;
+            object-fit: contain;
+        }
+        img[data-testid="perc-brand-logo"] {
+            max-height: 32px;
+            max-width: 160px;
+        }
+    </style>
+</head>
+<body>
+<script type="application/json" id="perc-logout-bootstrap">{
+  "locale":<%= jsonString(locale) %>,
+  "loginHref":<%= jsonString(loginHref) %>
+}</script>
+<div id="perc-logout-root" data-testid="perc-logout-root"></div>
+</body>
 </html>

--- a/WebUI/src/test/ts/logout/LogoutPage.test.tsx
+++ b/WebUI/src/test/ts/logout/LogoutPage.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LogoutPage } from "@/logout/LogoutPage";
+import type { LogoutBootstrap } from "@/logout/types";
+
+const baseBootstrap: LogoutBootstrap = {
+  locale: "en-us",
+  loginHref: "login",
+};
+
+describe("LogoutPage", () => {
+  it("renders modern logout chrome matching login card structure", () => {
+    render(<LogoutPage bootstrap={baseBootstrap} />);
+
+    expect(screen.getByTestId("perc-logout-page")).toBeDefined();
+    expect(screen.getByTestId("perc-logout-title").textContent).toMatch(
+      /Signed out/i,
+    );
+    expect(screen.getByTestId("perc-logout-message").textContent).toMatch(
+      /logged out/i,
+    );
+    expect(screen.getByTestId("perc-brand-bar")).toBeDefined();
+    expect(screen.getByTestId("perc-brand-footer")).toBeDefined();
+    expect(screen.getByTestId("perc-logout-logo")).toBeDefined();
+  });
+
+  it("links Sign in again to the allowlisted login href", () => {
+    render(
+      <LogoutPage bootstrap={{ locale: "en-us", loginHref: "/rxlogin.jsp" }} />,
+    );
+    const link = screen.getByTestId("perc-logout-sign-in") as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("/rxlogin.jsp");
+    expect(link.textContent).toMatch(/Sign in again/i);
+  });
+
+  it("does not render jQuery legacy markup or form post", () => {
+    render(<LogoutPage bootstrap={baseBootstrap} />);
+    expect(document.querySelector("#loginform")).toBeNull();
+    expect(document.querySelector("table.perc-form")).toBeNull();
+  });
+});

--- a/WebUI/src/test/ts/logout/bootstrap.test.ts
+++ b/WebUI/src/test/ts/logout/bootstrap.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_LOGIN_HREF,
+  readLogoutBootstrap,
+  sanitizeLoginHref,
+} from "@/logout/bootstrap";
+
+describe("sanitizeLoginHref", () => {
+  it("accepts relative login front doors", () => {
+    expect(sanitizeLoginHref("login")).toBe("login");
+    expect(sanitizeLoginHref("rxlogin.jsp")).toBe("rxlogin.jsp");
+    expect(sanitizeLoginHref("login?return=/cm/app/spa.jsp?entry=home")).toBe(
+      "login?return=/cm/app/spa.jsp?entry=home",
+    );
+  });
+
+  it("accepts path-absolute product paths", () => {
+    expect(sanitizeLoginHref("/login")).toBe("/login");
+    expect(sanitizeLoginHref("/rxlogin.jsp")).toBe("/rxlogin.jsp");
+    expect(sanitizeLoginHref("/cm/app/spa.jsp?entry=home")).toBe(
+      "/cm/app/spa.jsp?entry=home",
+    );
+  });
+
+  it("rejects open redirects and traversal", () => {
+    expect(sanitizeLoginHref("https://evil.example/phish")).toBe(
+      DEFAULT_LOGIN_HREF,
+    );
+    expect(sanitizeLoginHref("//evil.example/phish")).toBe(DEFAULT_LOGIN_HREF);
+    expect(sanitizeLoginHref("javascript:alert(1)")).toBe(DEFAULT_LOGIN_HREF);
+    expect(sanitizeLoginHref("../etc/passwd")).toBe(DEFAULT_LOGIN_HREF);
+    expect(sanitizeLoginHref("/admin/secret")).toBe(DEFAULT_LOGIN_HREF);
+    expect(sanitizeLoginHref("")).toBe(DEFAULT_LOGIN_HREF);
+    expect(sanitizeLoginHref(null)).toBe(DEFAULT_LOGIN_HREF);
+  });
+});
+
+describe("readLogoutBootstrap", () => {
+  afterEach(() => {
+    document.getElementById("perc-logout-bootstrap")?.remove();
+  });
+
+  it("returns defaults when bootstrap is missing", () => {
+    const boot = readLogoutBootstrap();
+    expect(boot.locale).toBe("en-us");
+    expect(boot.loginHref).toBe(DEFAULT_LOGIN_HREF);
+  });
+
+  it("reads and sanitizes host JSON", () => {
+    const el = document.createElement("script");
+    el.id = "perc-logout-bootstrap";
+    el.type = "application/json";
+    el.textContent = JSON.stringify({
+      locale: "fr-fr",
+      loginHref: "/rxlogin.jsp",
+    });
+    document.body.appendChild(el);
+
+    const boot = readLogoutBootstrap();
+    expect(boot.locale).toBe("fr-fr");
+    expect(boot.loginHref).toBe("/rxlogin.jsp");
+  });
+
+  it("falls back when loginHref is hostile", () => {
+    const el = document.createElement("script");
+    el.id = "perc-logout-bootstrap";
+    el.type = "application/json";
+    el.textContent = JSON.stringify({
+      locale: "en-us",
+      loginHref: "https://evil.example/",
+    });
+    document.body.appendChild(el);
+
+    expect(readLogoutBootstrap().loginHref).toBe(DEFAULT_LOGIN_HREF);
+  });
+});

--- a/WebUI/src/test/ts/logout/logoutStylesContract.test.ts
+++ b/WebUI/src/test/ts/logout/logoutStylesContract.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("logout / modern CSS host contract", () => {
+  it("rxlogout.jsp links stable perc-modern-ui.css and loads TMX with perc.ui. prefix", () => {
+    const path = resolve(__dirname, "../../../main/webapp/rxlogout.jsp");
+    const text = readFileSync(path, "utf8");
+    expect(text).toContain('href="/cm/modern/assets/perc-modern-ui.css"');
+    expect(text).toContain("perc-modern-ui.js");
+    expect(text).toContain("tmx/tmx.jsp");
+    expect(text).toContain("prefix=perc.ui.");
+    expect(text).toContain("sys_lang=");
+    expect(text).toContain('id="perc-logout-root"');
+    expect(text).toContain('id="perc-logout-bootstrap"');
+    // Defensive logo cap if CSS fails
+    expect(text).toMatch(/max-height:\s*48px/);
+    // No legacy jQuery host
+    expect(text).not.toContain("jquery.min.js");
+    expect(text).not.toContain("jquery-migrate");
+  });
+
+  it("logout reuses login card logo size caps", () => {
+    const path = resolve(
+      __dirname,
+      "../../../main/ts/login/LoginPage.module.css",
+    );
+    const text = readFileSync(path, "utf8");
+    expect(text).toMatch(/max-height:\s*48px/);
+    expect(text).toMatch(/max-width:\s*min\(220px/);
+    expect(text).toContain("object-fit: contain");
+  });
+
+  it("modern bundle entry boots logout root", () => {
+    const path = resolve(__dirname, "../../../main/ts/index.ts");
+    const text = readFileSync(path, "utf8");
+    expect(text).toContain("perc-logout-root");
+    expect(text).toContain("bootLogout");
+    expect(text).toContain('from "./logout"');
+  });
+});

--- a/docs/ai-generated/code-reviews/fix-logout-screen-modern-styling-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-logout-screen-modern-styling-erlang.md
@@ -1,0 +1,59 @@
+# Erlang review: fix/logout-screen-modern-styling
+
+**Date:** 2026-07-29  
+**Scope:** Uncommitted worktree branch vs `origin/development`  
+**Intent:** Modernize post-logout UI (`rxlogout.jsp`) to match React login chrome.
+
+## Summary
+
+Logout is re-hosted as a React page (same BrandBar/card/footer CSS as login),
+with a thin JSP host, TMX keys, Vitest coverage, and a Playwright smoke spec.
+Server `/logout` endpoint is unchanged. Open-redirect risk on the “Sign in
+again” href is mitigated by `sanitizeLoginHref`.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No blocking bugs. Behavioral unit tests cover sanitization and page chrome;
+Playwright covers the product screen (HARD GATE for WebUI screens).
+
+## Cross-platform path checklist
+
+- No new filesystem path construction in product code.
+- Host contract tests use `path.resolve` / `node:fs` (portable).
+- Playwright uses URL paths only (`/Rhythmyx/logout`).
+
+**Outcome:** clean.
+
+## Issues
+
+| Severity | Finding | Status |
+|----------|---------|--------|
+| nit | `jsonString` duplicated from `rxlogin.jsp` — acceptable parity with login host | open (non-blocking) |
+| nit | New TMX keys only have en-us / es / hi (same as `perc.ui.login.modern@*`) — remaining locales can be filled via `i18n_translate.py` later | open (non-blocking) |
+| nit | Absolute `/cm/modern/assets/*` asset URLs match login; context-path-only installs rely on reverse-proxy norms already assumed by login | open (non-blocking) |
+
+## Memory patterns hit
+
+- XSS-safe bootstrap JSON (login host pattern)
+- Allowlist redirects / open-redirect hygiene
+- Playwright required for product UI screen changes
+
+## Tests observed
+
+- Vitest: `src/test/ts/logout/*` — 12 tests green
+- Playwright: `modules/perc-qa-automation/frontend/tests/logout.spec.js` (live CMS)
+- `cd modules/perc-i18n && ../../mvnw clean install` — BUILD SUCCESS
+- `cd WebUI && ../mvnw clean install` — BUILD SUCCESS after unblocking baseline
+  `SlotDetailPanel.tsx` `noUncheckedIndexedAccess` TS2532 (not introduced by logout)
+
+## Build-unblock note
+
+`WebUI/src/main/ts/developer/SlotDetailPanel.tsx` failed `tsc --noEmit` on
+`origin/development` (indexed access possibly undefined). Minimal local
+bindings added so the modern UI package can build; no behavioral change.

--- a/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
@@ -18450,5 +18450,26 @@ Documentación' href='https://percussioncmshelp.intsof.com/'&gt;percussioncmshel
         <tuv xml:lang="es"><seg>Iniciar sesión</seg></tuv>
         <tuv xml:lang="hi"><seg>लॉग इन करें</seg></tuv>
     </tu>
+    <tu tuid="perc.ui.logout.modern@Signed out">
+        <prop type="sectionname" xml:lang="en-us">Logout</prop>
+        <note xml:lang="en-us">Modern logout page title</note>
+        <tuv xml:lang="en-us"><seg>Signed out</seg></tuv>
+        <tuv xml:lang="es"><seg>Sesión cerrada</seg></tuv>
+        <tuv xml:lang="hi"><seg>साइन आउट</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.logout.modern@You have been logged out.">
+        <prop type="sectionname" xml:lang="en-us">Logout</prop>
+        <note xml:lang="en-us">Modern logout confirmation message</note>
+        <tuv xml:lang="en-us"><seg>You have been logged out.</seg></tuv>
+        <tuv xml:lang="es"><seg>Se te ha cerrado la sesión.</seg></tuv>
+        <tuv xml:lang="hi"><seg>आप लॉग आउट हो चुके हैं।</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.logout.modern@Sign in again">
+        <prop type="sectionname" xml:lang="en-us">Logout</prop>
+        <note xml:lang="en-us">Modern logout CTA to return to login</note>
+        <tuv xml:lang="en-us"><seg>Sign in again</seg></tuv>
+        <tuv xml:lang="es"><seg>Iniciar sesión de nuevo</seg></tuv>
+        <tuv xml:lang="hi"><seg>फिर से साइन इन करें</seg></tuv>
+    </tu>
     </body>
 </tmx>

--- a/modules/perc-qa-automation/frontend/tests/logout.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/logout.spec.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Smoke test: post-logout screen uses the modern UI chrome (same styling
+ * contract as login) and offers a sign-in control back to the front door.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+test.describe("Logout screen", () => {
+  test("shows modern signed-out chrome after /logout", async ({ page }) => {
+    test.setTimeout(45_000);
+    await loginAsAdmin(page);
+
+    await page.goto(`${BASE_URL}/Rhythmyx/logout`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    // Modern host mounts React into #perc-logout-root
+    await expect(page.getByTestId("perc-logout-root")).toBeAttached({
+      timeout: 15_000,
+    });
+    await expect(page.getByTestId("perc-logout-page")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByTestId("perc-logout-title")).toContainText(
+      /signed out/i,
+    );
+    await expect(page.getByTestId("perc-logout-message")).toContainText(
+      /logged out/i,
+    );
+    await expect(page.getByTestId("perc-brand-bar")).toBeVisible();
+    await expect(page.getByTestId("perc-logout-logo")).toBeVisible();
+
+    const signIn = page.getByTestId("perc-logout-sign-in");
+    await expect(signIn).toBeVisible();
+    await expect(signIn).toHaveAttribute("href", /login|rxlogin/i);
+
+    // No legacy jQuery logout chrome
+    await expect(page.locator("table.perc-form")).toHaveCount(0);
+  });
+
+  test("sign in again returns to the login front door", async ({ page }) => {
+    test.setTimeout(45_000);
+    await page.goto(`${BASE_URL}/Rhythmyx/logout`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(page.getByTestId("perc-logout-sign-in")).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.getByTestId("perc-logout-sign-in").click();
+
+    await expect(page).toHaveURL(/login|rxlogin/i, { timeout: 15_000 });
+    // Login modern root (or form) should appear
+    const loginRoot = page.getByTestId("perc-login-root");
+    const loginPage = page.getByTestId("perc-login-page");
+    await expect(loginRoot.or(loginPage)).toBeVisible({ timeout: 15_000 });
+  });
+});


### PR DESCRIPTION
## Summary

- Modernize `rxlogout.jsp` to the same React host contract as `rxlogin.jsp` (`perc-modern-ui` CSS/JS, TMX `perc.ui.` prefix, XSS-safe bootstrap).
- Add `LogoutPage` React module reusing login card chrome (`BrandBar`, themed card, logo caps, `BrandFooter`) and a primary **Sign in again** CTA.
- Sanitize post-logout `loginHref` (reject open redirects / traversal).
- Add `perc.ui.logout.modern@*` TMX keys in `CmsUi.tmx`.
- Vitest unit/contract tests + Playwright smoke (`logout.spec.js`).
- Unblock WebUI modern `tsc` build: fix baseline `SlotDetailPanel` `noUncheckedIndexedAccess` TS2532 errors on `origin/development`.

## Pre-PR gates

### Erlang review
- Report: `docs/ai-generated/code-reviews/fix-logout-screen-modern-styling-erlang.md`
- **Recommendation: approve** — May commit/push: yes

### Spotless
- `./mvnw -pl WebUI spotless:apply` then `spotless:check` attempted with Node on PATH.
- In-scope TS/JS prettied via Prettier 2.x-compatible write.
- Spotless also rewrote **out-of-scope** baseline files (WebUI Java filter tests, READMEs, legacy JS, etc.); those were **restored and not committed** per monorepo Spotless split rule (feature PR stays in-scope only).

### Maven clean install (standalone)
| Module | Command | Result |
|--------|---------|--------|
| `modules/perc-i18n` | `cd modules/perc-i18n && ../../mvnw clean install` | **BUILD SUCCESS** |
| `WebUI` | `cd WebUI && ../mvnw clean install` | **BUILD SUCCESS** |
| `modules/perc-qa-automation` | `cd modules/perc-qa-automation && ../../mvnw clean install` | **BUILD SUCCESS** |

### Unit tests
- `npx vitest run src/test/ts/logout` — **12 passed**

## Test plan

- [ ] After deploy, open `/Rhythmyx/logout` (or log out from SPA user menu).
- [ ] Confirm BrandBar, logo (capped size), “Signed out” title, message, and “Sign in again” button match login visual language.
- [ ] Click **Sign in again** → lands on login front door (`/login` / `rxlogin.jsp`).
- [ ] Confirm no legacy jQuery table chrome / `table.perc-form`.
- [ ] Optional: run Playwright `frontend/tests/logout.spec.js` against a live CMS.

> Co-Authored by Grok Build 0.2.114 using grok-4.5 with agent Grok.