### PR TITLE
feat(i18n): base locale flag, Arabic ar, login filter

### DIFF
--- a/WebUI/src/main/webapp/rxlogin.jsp
+++ b/WebUI/src/main/webapp/rxlogin.jsp
@@ -4,6 +4,7 @@
 <%@ page import="com.percussion.i18n.PSI18nUtils" %>
 <%@ page import="com.percussion.i18n.PSLocaleManager" %>
 <%@ page import="com.percussion.i18n.PSLocale" %>
+<%@ page import="com.percussion.i18n.PSLocaleLoginSelection" %>
 <%@ taglib uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" prefix="csrf" %>
 <%--
   React Login SPA host (product front door).
@@ -46,17 +47,11 @@
 %>
 <%
     String username = request.getParameter("j_username");
-    String locale = request.getParameter("j_locale");
+    String requestedLocale = request.getParameter("j_locale");
     String error = request.getParameter("j_error");
 
     if (username == null) {
         username = "";
-    }
-    if (locale == null) {
-        locale = PSI18nUtils.getSystemLanguage();
-    }
-    if (locale == null) {
-        locale = "en-us";
     }
 
     String loginComplete = PSServer.getServerProps().getProperty("loginAutoComplete");
@@ -77,13 +72,21 @@
         defaultRedirect = returnParam;
     }
 
+    // Login list: hide base locales when an active regional sibling exists; default en-us.
     PSLocaleManager locManager = PSLocaleManager.getInstance();
+    List<PSLocale> allLocales = new ArrayList<>();
+    Iterator<PSLocale> allIt = locManager.getLocales();
+    while (allIt.hasNext()) {
+        allLocales.add(allIt.next());
+    }
+    List<PSLocale> loginLocales = PSLocaleLoginSelection.forLoginDropdown(allLocales);
+    String locale = PSLocaleLoginSelection.resolveSelectedLocale(
+            requestedLocale, PSI18nUtils.getSystemLanguage(), loginLocales);
+
     StringBuilder localesJson = new StringBuilder();
     localesJson.append('[');
     boolean first = true;
-    Iterator<PSLocale> locales = locManager.getLocales();
-    while (locales.hasNext()) {
-        PSLocale loc = locales.next();
+    for (PSLocale loc : loginLocales) {
         if (!first) {
             localesJson.append(',');
         }

--- a/WebUI/src/test/ts/login/loginStylesContract.test.ts
+++ b/WebUI/src/test/ts/login/loginStylesContract.test.ts
@@ -18,6 +18,10 @@ describe("login / modern CSS host contract", () => {
     expect(text).toContain("sys_lang=");
     // Defensive logo cap if CSS fails
     expect(text).toMatch(/max-height:\s*48px/);
+    // Server-side base-locale filter + default en-us
+    expect(text).toContain("PSLocaleLoginSelection");
+    expect(text).toContain("forLoginDropdown");
+    expect(text).toContain("resolveSelectedLocale");
   });
 
   it("spa.jsp hosts link stable perc-modern-ui.css and TMX (both trees)", () => {

--- a/docs/ai-generated/code-reviews/feat-base-locales-and-arabic-erlang.md
+++ b/docs/ai-generated/code-reviews/feat-base-locales-and-arabic-erlang.md
@@ -1,0 +1,36 @@
+# Erlang review: feat/base-locales-and-arabic
+
+**Date:** 2026-07-29  
+**Scope:** Uncommitted branch vs `origin/development`  
+**Intent:** RXLOCALE ISBASE flag, Arabic base locale, login base-hiding filter, TMX policy docs.
+
+## Summary
+
+Adds `ISBASE` to schema/entity/seed, Arabic `ar` as base, server-side login
+locale filter (`PSLocaleLoginSelection`), TMX header + fallback tests, docs.
+Does not invent bare `en`/`fr`/… base rows (confirmed plan scope).
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+## Issues
+
+| Severity | Finding | Status |
+|----------|---------|--------|
+| nit | Arabic TMX body not fully back-filled — header only; missing segs fall back to en-us | open (documented follow-up) |
+| nit | Existing DBs get ISBASE default 0; upgrade `action=u` for es/hi only | open (acceptable) |
+
+## Cross-platform path checklist
+
+No new filesystem path construction. Clean.
+
+## Tests observed
+
+- `PSLocaleLoginSelectionTest`, `PSLocaleTest` ISBASE
+- `PSTmxResourceBundleTest` including Arabic fallback
+- Vitest login host contract

--- a/modules/ai-shared-develop/src/main/resources/skills/add-locale-support/SKILL.md
+++ b/modules/ai-shared-develop/src/main/resources/skills/add-locale-support/SKILL.md
@@ -37,11 +37,12 @@ removing an existing locale (different playbook — see §7).
    `hi-in`, `pt-br`. Tags like `de_DE`, `EN_us`, `ja-JP` all normalize at
    runtime via `PSTmxResourceBundle.normalizeLang(...)`, but every new
    piece of content must use the canonical form.
-2. **Is it a generic code (`es`, `hi`) or a regional variant?** Generic
-   codes catch-fall any untagged region; regional variants (`es-mx`)
-   override only that region. Decide which matrix slots it occupies; do
-   not introduce a code outside the canonical 17-locale matrix without
-   first updating the `RXLOCALE` table.
+2. **Is it a generic / base code (`es`, `hi`, `ar`) or a regional
+   variant?** Base codes (`RXLOCALE.ISBASE=1`) hold shared translations;
+   regionals hold dialect overrides only. Login hides a base when any
+   active regional sibling exists (`PSLocaleLoginSelection`). Do not
+   introduce a code outside the canonical 18-locale matrix without first
+   updating the `RXLOCALE` table (including `ISBASE`).
 3. **Is Docker on PATH?** The translation pipeline (`i18n_translate.py`)
    shells out to `docker run --rm soimort/translate-shell`. Confirm
    `docker info` exits 0 before starting; failure is a tooling issue, not
@@ -84,11 +85,12 @@ line 12054). Schema:
     <column name="SORTORDER"><gaps-of-10></column>
     <column name="DESCRIPTION"><English sentence describing region/scope></column>
     <column name="STATUS">1</column>
+    <column name="ISBASE"><1 for language-only base; 0 for regional></column>
     <column name="VERSION">0</column>
 </row>
 ```
 
-Conventions observed in the existing 17-row block:
+Conventions observed in the existing seed block:
 
 - `SORTORDER` increments by 10 per family (`10`, `20`, `30`…) and by 1
   inside regional variants (`40`, `41`, `42`, `43` for `es*`).
@@ -96,6 +98,8 @@ Conventions observed in the existing 17-row block:
   reused.
 - `STATUS=1` makes the locale visible by default. Use `0` only when the
   locale must ship seeded but hidden.
+- `ISBASE=1` for language-only base codes (`ar`, `es`, `hi`); `0` for
+  regionals. Schema: `cmsTableDef.xml` column `ISBASE`.
 - Avoid backslashes / special XML characters in `DISPLAYNAME` /
   `DESCRIPTION`.
 
@@ -224,9 +228,9 @@ Pipeline invariants:
 Per `perc-i18n/AGENTS.md` rule 8:
 
 1. `modules/perc-i18n/AGENTS.md` — append to the **Quick Reference**
-   17-locale matrix (keep alphabetical order; preserve the `es` / `hi`
-   generic-and-regional commentary).
-2. `modules/perc-i18n/README.md` — update the **Canonical 17-Locale
+   18-locale matrix (keep alphabetical order; preserve base vs regional
+   and login-filter commentary).
+2. `modules/perc-i18n/README.md` — update the **Canonical 18-Locale
    Matrix** table; add the new code to the right family row.
 3. If you added a Lucene branch or a calendar widget entry, link to the
    relevant file from the PR description (no separate docs file needed

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableData.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableData.xml
@@ -12059,6 +12059,7 @@
             <column name="SORTORDER">10</column>
             <column name="DESCRIPTION">English language used in United States of America</column>
             <column name="STATUS">1</column>
+            <column name="ISBASE">0</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">
@@ -12068,6 +12069,7 @@
             <column name="SORTORDER">20</column>
             <column name="DESCRIPTION">English language used in United Kingdom</column>
             <column name="STATUS">1</column>
+            <column name="ISBASE">0</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">
@@ -12077,6 +12079,7 @@
             <column name="SORTORDER">30</column>
             <column name="DESCRIPTION">German language used in Germany</column>
             <column name="STATUS">1</column>
+            <column name="ISBASE">0</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">
@@ -12086,6 +12089,7 @@
             <column name="SORTORDER">40</column>
             <column name="DESCRIPTION">General Spanish language locale (covers all es-* variants)</column>
             <column name="STATUS">1</column>
+            <column name="ISBASE">1</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">
@@ -12095,6 +12099,7 @@
             <column name="SORTORDER">41</column>
             <column name="DESCRIPTION">Spanish language used in Chile</column>
             <column name="STATUS">1</column>
+            <column name="ISBASE">0</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">
@@ -12104,6 +12109,7 @@
             <column name="SORTORDER">42</column>
             <column name="DESCRIPTION">Spanish language used in Spain (canonical Castilian)</column>
             <column name="STATUS">1</column>
+            <column name="ISBASE">0</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">
@@ -12113,6 +12119,7 @@
             <column name="SORTORDER">43</column>
             <column name="DESCRIPTION">Spanish language used in Mexico</column>
             <column name="STATUS">1</column>
+            <column name="ISBASE">0</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">
@@ -12122,6 +12129,7 @@
             <column name="SORTORDER">50</column>
             <column name="DESCRIPTION">French language used in Canada</column>
             <column name="STATUS">1</column>
+            <column name="ISBASE">0</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">
@@ -12131,6 +12139,7 @@
             <column name="SORTORDER">51</column>
             <column name="DESCRIPTION">French language used in France</column>
             <column name="STATUS">1</column>
+            <column name="ISBASE">0</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">
@@ -12140,6 +12149,7 @@
             <column name="SORTORDER">60</column>
             <column name="DESCRIPTION">Hindi language (generic, no region)</column>
             <column name="STATUS">1</column>
+            <column name="ISBASE">1</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">
@@ -12149,6 +12159,7 @@
             <column name="SORTORDER">61</column>
             <column name="DESCRIPTION">Hindi language used in India (canonical regional form)</column>
             <column name="STATUS">1</column>
+            <column name="ISBASE">0</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">
@@ -12158,6 +12169,7 @@
             <column name="SORTORDER">70</column>
             <column name="DESCRIPTION">Italian language used in Italy</column>
             <column name="STATUS">1</column>
+            <column name="ISBASE">0</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">
@@ -12167,6 +12179,7 @@
             <column name="SORTORDER">80</column>
             <column name="DESCRIPTION">Japanese language used in Japan</column>
             <column name="STATUS">1</column>
+            <column name="ISBASE">0</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">
@@ -12176,6 +12189,7 @@
             <column name="SORTORDER">90</column>
             <column name="DESCRIPTION">Dutch language used in Netherlands</column>
             <column name="STATUS">1</column>
+            <column name="ISBASE">0</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">
@@ -12185,6 +12199,7 @@
             <column name="SORTORDER">100</column>
             <column name="DESCRIPTION">Portuguese language used in Brazil</column>
             <column name="STATUS">1</column>
+            <column name="ISBASE">0</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">
@@ -12194,6 +12209,7 @@
             <column name="SORTORDER">101</column>
             <column name="DESCRIPTION">Portuguese language used in Portugal</column>
             <column name="STATUS">1</column>
+            <column name="ISBASE">0</column>
             <column name="VERSION">0</column>
         </row>
         <row onTableCreateOnly="no" action="i">
@@ -12203,6 +12219,38 @@
             <column name="SORTORDER">110</column>
             <column name="DESCRIPTION">Turkish language used in Turkey</column>
             <column name="STATUS">1</column>
+            <column name="ISBASE">0</column>
+            <column name="VERSION">0</column>
+        </row>
+        <row onTableCreateOnly="no" action="i">
+            <column name="LOCALEID">18</column>
+            <column name="LANGUAGESTRING">ar</column>
+            <column name="DISPLAYNAME">Arabic</column>
+            <column name="SORTORDER">5</column>
+            <column name="DESCRIPTION">Arabic language (generic base locale)</column>
+            <column name="STATUS">1</column>
+            <column name="ISBASE">1</column>
+            <column name="VERSION">0</column>
+        </row>
+        <!-- Upgrade existing installs: set base flags and ensure Arabic row -->
+        <row action="u" onTableCreateOnly="no">
+            <column name="LOCALEID">4</column>
+            <column name="LANGUAGESTRING">es</column>
+            <column name="DISPLAYNAME">Spanish</column>
+            <column name="SORTORDER">40</column>
+            <column name="DESCRIPTION">General Spanish language locale (covers all es-* variants)</column>
+            <column name="STATUS">1</column>
+            <column name="ISBASE">1</column>
+            <column name="VERSION">0</column>
+        </row>
+        <row action="u" onTableCreateOnly="no">
+            <column name="LOCALEID">10</column>
+            <column name="LANGUAGESTRING">hi</column>
+            <column name="DISPLAYNAME">Hindi</column>
+            <column name="SORTORDER">60</column>
+            <column name="DESCRIPTION">Hindi language (generic, no region)</column>
+            <column name="STATUS">1</column>
+            <column name="ISBASE">1</column>
             <column name="VERSION">0</column>
         </row>
     </table>

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableDef.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableDef.xml
@@ -3059,6 +3059,13 @@
                 <size/>
                 <allowsnull>yes</allowsnull>
             </column>
+            <!-- 1 = language-only / base locale (e.g. es, hi, ar); 0 = regional or non-base -->
+            <column name="ISBASE">
+                <jdbctype>INTEGER</jdbctype>
+                <size/>
+                <allowsnull>yes</allowsnull>
+                <defaultvalue>0</defaultvalue>
+            </column>
             <column name="VERSION">
                 <jdbctype>INTEGER</jdbctype>
                 <size/>

--- a/modules/perc-i18n/AGENTS.md
+++ b/modules/perc-i18n/AGENTS.md
@@ -14,8 +14,8 @@ The `perc-i18n` module is the **canonical source for all i18n resources** in Per
 
 All TMX files are centralized in `src/main/resources/i18n/`:
 - **ResourceBundle.tmx** - Master resource bundle
-- **CmsUi.tmx** - UI translations (17-locale matrix, see Quick Reference)
-- **SystemResources.tmx** - System/editor resources (same 17-locale matrix)
+- **CmsUi.tmx** - UI translations (18-locale matrix, see Quick Reference)
+- **SystemResources.tmx** - System/editor resources (same 18-locale matrix)
 
 **Legacy locations are deprecated:**
 - ~~`system/config/I18n/`~~ (TMX files removed)
@@ -39,16 +39,23 @@ All TMX files are centralized in `src/main/resources/i18n/`:
   line and the inline `<tuv xml:lang="...">` attribute still work
   because both are normalized on read, but new content must use the
   canonical form.
-- **Canonical 17-locale set**: `en-us`, `en-gb`, `de-de`, `es`,
+- **Canonical 18-locale set**: `ar`, `de-de`, `en-gb`, `en-us`, `es`,
   `es-cl`, `es-es`, `es-mx`, `fr-ca`, `fr-fr`, `hi`, `hi-in`,
-  `it-it`, `ja-jp`, `nl-nl`, `pt-br`, `pt-pt`, `tr-tr`. `es` is the
-  generic Spanish catch-all; `hi` is generic Hindi; both stay in the
-  matrix alongside their regional siblings. Do not introduce a code
-  outside this set without updating `RXLOCALE` in
-  `modules/perc-distribution-tree/.../cmsTableData.xml` first.
-- **Header `<prop type="supportedlanguage">` lines must match the 17
+  `it-it`, `ja-jp`, `nl-nl`, `pt-br`, `pt-pt`, `tr-tr`. Base /
+  language-only codes (`ar`, `es`, `hi`) have `RXLOCALE.ISBASE=1`.
+  Product string fallback when no locale is set is always **`en-us`**.
+  Do not introduce a code outside this set without updating `RXLOCALE`
+  in `modules/perc-distribution-tree/.../cmsTableData.xml` first.
+- **Header `<prop type="supportedlanguage">` lines must match the 18
   codes above in alphabetical order.** The header is the source of
   truth for "what languages ship out of the box".
+- **Base vs regional TMX storage:** store shared translations under the
+  base language tag (`es`, `hi`, `ar`). Regional tags store **only
+  dialect overrides**. Lookup is `regional → base → en-us` via
+  `PSTmxResourceBundle.languageLookupChain`.
+- **Login dropdown:** server-side `PSLocaleLoginSelection` hides a base
+  locale when any active regional sibling exists (e.g. hide `es` when
+  `es-es` is active; show `ar` when no `ar-*` exists).
 - **Per-key translations are owned by `i18n_translate.py`.** Do not
   hand-edit translated `<seg>` text in a TMX file; re-run the script
   (see section 1b). Hand-edits are only acceptable for English source
@@ -111,7 +118,9 @@ and cross-platform guarantees.
    `CmsUi.tmx` and `SystemResources.tmx` (alphabetical position).
 2. Add a new row in `RXLOCALE` in
    `modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableData.xml`
-   with `STATUS=1` (visible by default) and a sensible `SORTORDER`.
+   with `STATUS=1` (visible by default), a sensible `SORTORDER`, and
+   `ISBASE=1` for language-only / base codes (no region) or `ISBASE=0`
+   for regionals. Schema column is defined in `cmsTableDef.xml`.
 3. If the new code is a regional variant (e.g. `xx-yy` where `xx`
    already exists), update locale-aware consumers:
    - `modules/perc-packages/.../perc.widget.calendar/percCalendarTwo.xml`
@@ -277,19 +286,22 @@ If seeing `PSTmxResourceBundle` errors:
 |        File         |         Purpose         |   Languages   |          Location          |
 |---------------------|-------------------------|---------------|----------------------------|
 | ResourceBundle.tmx  | Master bundle (seed)    | en-us         | `src/main/resources/i18n/` |
-| CmsUi.tmx           | UI labels/strings       | 17-locale matrix (see below) | `src/main/resources/i18n/` |
-| SystemResources.tmx | System/editor resources | 17-locale matrix (see below) | `src/main/resources/i18n/` |
+| CmsUi.tmx           | UI labels/strings       | 18-locale matrix (see below) | `src/main/resources/i18n/` |
+| SystemResources.tmx | System/editor resources | 18-locale matrix (see below) | `src/main/resources/i18n/` |
 
-**17-locale matrix** (alphabetical, BCP-47 lowercase hyphen):
+**18-locale matrix** (alphabetical, BCP-47 lowercase hyphen):
 
-`en-us`, `en-gb`, `de-de`, `es`, `es-cl`, `es-es`, `es-mx`,
+`ar`, `de-de`, `en-gb`, `en-us`, `es`, `es-cl`, `es-es`, `es-mx`,
 `fr-ca`, `fr-fr`, `hi`, `hi-in`, `it-it`, `ja-jp`, `nl-nl`,
 `pt-br`, `pt-pt`, `tr-tr`.
 
-`es` and `hi` are the generic (language-only) catch-alls;
-`es-es` / `hi-in` are the canonical regional variants. The runtime
-loader normalizes incoming tags so `EN_US`, `en-US`, `es_ES`,
-`ja-JP`, etc. all resolve to their canonical bucket.
+**Base locales** (`RXLOCALE.ISBASE=1`): `ar`, `es`, `hi`. Regionals
+store dialect overrides; TMX lookup is `regional → base → en-us`.
+Login hides a base locale when any active regional sibling exists
+(`PSLocaleLoginSelection`). Default login/string fallback: **`en-us`**.
+
+The runtime loader normalizes incoming tags so `EN_US`, `en-US`,
+`es_ES`, `ja-JP`, etc. all resolve to their canonical bucket.
 
 **Developer tooling** (outside the JAR; in `scripts/`):
 

--- a/modules/perc-i18n/README.md
+++ b/modules/perc-i18n/README.md
@@ -44,7 +44,7 @@ All translation memory exchange (TMX) files are maintained in this module:
 
 - **Purpose**: UI-specific translations for the CMS interface
 - **Scope**: Content Manager UI components, dialogs, and labels
-- **Supported Languages**: the 17-locale matrix below
+- **Supported Languages**: the 18-locale matrix below
 - **Naming Convention**: Keys follow pattern `perc.ui.(IDENTIFIER).(TYPE)@(MESSAGE/KEY)`
 
 ### SystemResources.tmx
@@ -52,25 +52,34 @@ All translation memory exchange (TMX) files are maintained in this module:
 - **Purpose**: System and content editor resources
 - **Scope**: Content editor actions, system messages, and resource definitions
 - **Key Examples**: `psx.ce.action@Check-in`, `psx.ce.action@Update`
-- **Supported Languages**: the 17-locale matrix below
+- **Supported Languages**: the 18-locale matrix below
 
-### Canonical 17-Locale Matrix
+### Canonical 18-Locale Matrix
 
 Both `CmsUi.tmx` and `SystemResources.tmx` declare the same set of
 languages in their `<header>` `<prop type="supportedlanguage">` lines:
 
 | Family    | Codes                                              |
 |-----------|----------------------------------------------------|
-| English   | `en-us`, `en-gb`                                   |
-| Spanish   | `es` (generic), `es-cl`, `es-es`, `es-mx`          |
+| Arabic    | `ar` (base)                                        |
+| English   | `en-us` (default fallback), `en-gb`                |
+| Spanish   | `es` (base), `es-cl`, `es-es`, `es-mx`             |
 | French    | `fr-ca`, `fr-fr`                                   |
 | German    | `de-de`                                            |
-| Hindi     | `hi` (generic), `hi-in`                            |
+| Hindi     | `hi` (base), `hi-in`                               |
 | Italian   | `it-it`                                            |
 | Japanese  | `ja-jp`                                            |
 | Dutch     | `nl-nl`                                            |
 | Portuguese| `pt-br`, `pt-pt`                                   |
 | Turkish   | `tr-tr`                                            |
+
+**Base locales** (`RXLOCALE.ISBASE=1`): `ar`, `es`, `hi`. Prefer storing
+shared translations under the base tag; regionals hold dialect
+overrides only. Lookup chain: regional → base → `en-us`.
+
+**Login:** `PSLocaleLoginSelection` hides a base locale when an active
+regional sibling exists (e.g. `es` is hidden while `es-es` is active;
+`ar` is shown while no `ar-*` exists). Default when unset: **`en-us`**.
 
 Locale tags are normalized to BCP-47 lowercase hyphen form by
 `PSTmxResourceBundle.normalizeLang(...)`. Per-locale sibling TMX

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSLocaleHandler.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSLocaleHandler.java
@@ -572,6 +572,24 @@ public class PSLocaleHandler implements IPSActionHandler {
     colList.add(new PSJdbcColumnData(COL_DESCRIPTION, desc));
     colList.add(new PSJdbcColumnData(COL_SORT_ORDER, sortOrder));
     colList.add(new PSJdbcColumnData(COL_STATUS, String.valueOf(status)));
+    // Preserve base flag on replace when the row already exists; new rows default to non-base.
+    // Integer 1 = base / language-only (see RXLOCALE.ISBASE). Avoid referencing system.PSLocale
+    // here (would create a module cycle).
+    String isBase = "0";
+    if (exists && rowData != null) {
+      PSJdbcColumnData existingBase = rowData.getColumn(COL_IS_BASE);
+      if (existingBase != null
+          && existingBase.getValue() != null
+          && !existingBase.getValue().isEmpty()) {
+        isBase = existingBase.getValue();
+      }
+    } else if (languageString != null
+        && !languageString.contains("-")
+        && !languageString.contains("_")) {
+      // Language-only codes (es, hi, ar) default to base when newly created.
+      isBase = "1";
+    }
+    colList.add(new PSJdbcColumnData(COL_IS_BASE, isBase));
     rowList.add(new PSJdbcRowData(colList.iterator(), PSJdbcRowData.ACTION_REPLACE));
 
     // save it
@@ -738,6 +756,11 @@ public class PSLocaleHandler implements IPSActionHandler {
    * definitions.
    */
   public static final String COL_STATUS = "STATUS";
+
+  /**
+   * Constant for the name of the ISBASE column (1 = language-only / base locale).
+   */
+  public static final String COL_IS_BASE = "ISBASE";
 
   /**
    * Constant for the name of the LOCALEID column in the repository table containing locale

--- a/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
@@ -28,9 +28,10 @@
 
 -->
     <header>
-        <prop type="supportedlanguage">en-us</prop>
-        <prop type="supportedlanguage">en-gb</prop>
+        <prop type="supportedlanguage">ar</prop>
         <prop type="supportedlanguage">de-de</prop>
+        <prop type="supportedlanguage">en-gb</prop>
+        <prop type="supportedlanguage">en-us</prop>
         <prop type="supportedlanguage">es</prop>
         <prop type="supportedlanguage">es-cl</prop>
         <prop type="supportedlanguage">es-es</prop>

--- a/modules/perc-i18n/src/main/resources/i18n/SystemResources.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/SystemResources.tmx
@@ -6,9 +6,10 @@
 -->
 <tmx version="1.4">
    <header>
-      <prop type="supportedlanguage">en-us</prop>
-      <prop type="supportedlanguage">en-gb</prop>
+      <prop type="supportedlanguage">ar</prop>
       <prop type="supportedlanguage">de-de</prop>
+      <prop type="supportedlanguage">en-gb</prop>
+      <prop type="supportedlanguage">en-us</prop>
       <prop type="supportedlanguage">es</prop>
       <prop type="supportedlanguage">es-cl</prop>
       <prop type="supportedlanguage">es-es</prop>

--- a/modules/perc-i18n/src/test/java/com/percussion/i18n/PSTmxResourceBundleTest.java
+++ b/modules/perc-i18n/src/test/java/com/percussion/i18n/PSTmxResourceBundleTest.java
@@ -239,6 +239,36 @@ public class PSTmxResourceBundleTest {
         "Hola", PSTmxResourceBundle.getInstance().getString("k@hello", "es-es"));
   }
 
+  /**
+   * Arabic base locale: exact hit, then missing key falls back to en-us (product default).
+   */
+  @Test
+  public void getString_arabicBaseAndDefaultFallback() throws Exception {
+    Document doc = parse(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<tmx version=\"1.4\"><header>"
+            + "<prop type=\"supportedlanguage\">ar</prop>"
+            + "<prop type=\"supportedlanguage\">en-us</prop>"
+            + "</header><body>"
+            + "<tu tuid=\"perc.ui.login.modern@Sign in\">"
+            + "<tuv xml:lang=\"en-us\"><seg>Sign in</seg></tuv>"
+            + "<tuv xml:lang=\"ar\"><seg>تسجيل الدخول</seg></tuv>"
+            + "</tu>"
+            + "<tu tuid=\"k@only-en\">"
+            + "<tuv xml:lang=\"en-us\"><seg>EnglishOnly</seg></tuv>"
+            + "</tu>"
+            + "</body></tmx>");
+    PSTmxResourceBundle.getInstance().addResourcesToCacheForTest(doc);
+
+    assertEquals(
+        "تسجيل الدخول",
+        PSTmxResourceBundle.getInstance()
+            .getString("perc.ui.login.modern@Sign in", "ar"));
+    assertEquals(
+        "EnglishOnly",
+        PSTmxResourceBundle.getInstance().getString("k@only-en", "ar"));
+  }
+
   private static Document parse(String xml) throws Exception {
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     factory.setNamespaceAware(true);

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-1608-1609-login-locale.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-1608-1609-login-locale.spec.js
@@ -80,8 +80,10 @@ test.describe("Login locale (GH-1608 / GH-1609)", () => {
     const target = await pickHindiTag(select);
     expect(
       target,
-      "install must expose hi-in or hi in the login locale dropdown",
+      // Base hi is hidden when hi-in is active (PSLocaleLoginSelection).
+      "install must expose hi-in in the login locale dropdown",
     ).toBeTruthy();
+    expect(target).toBe("hi-in");
 
     const readyBefore = await page
       .getByTestId("perc-login-page")

--- a/system/src/main/java/com/percussion/i18n/PSLocale.java
+++ b/system/src/main/java/com/percussion/i18n/PSLocale.java
@@ -72,6 +72,7 @@ public class PSLocale implements IPSCatalogSummary {
     m_displayName = displayName;
     m_description = description;
     m_status = status;
+    m_isBase = IS_BASE_FALSE;
   }
 
   /** No arg constructor used for Hibernate */
@@ -132,6 +133,20 @@ public class PSLocale implements IPSCatalogSummary {
     if (!validateStatus(m_status)) {
       Object[] args = {COL_STATUS, status == null ? "null" : status};
       throw new PSDataExtractionException(IPSLocaleErrors.INVALID_COLUMN_VALUE, args);
+    }
+
+    // Optional for backward-compatible row shapes; missing / invalid => not base.
+    m_isBase = IS_BASE_FALSE;
+    PSJdbcColumnData isBaseCol = rowData.getColumn(PSLocaleHandler.COL_IS_BASE);
+    if (isBaseCol != null && isBaseCol.getValue() != null && !isBaseCol.getValue().isEmpty()) {
+      try {
+        m_isBase =
+            Integer.parseInt(isBaseCol.getValue().trim()) == IS_BASE_TRUE
+                ? IS_BASE_TRUE
+                : IS_BASE_FALSE;
+      } catch (NumberFormatException e) {
+        m_isBase = IS_BASE_FALSE;
+      }
     }
   }
 
@@ -216,6 +231,24 @@ public class PSLocale implements IPSCatalogSummary {
   }
 
   /**
+   * Whether this locale is a language-only / base locale (e.g. {@code es}, {@code ar}).
+   * Base locales may be omitted from the login dropdown when active regional
+   * siblings exist; see {@link PSLocaleLoginSelection}.
+   *
+   * @return <code>true</code> if this is a base locale.
+   */
+  public boolean isBaseLocale() {
+    return m_isBase != null && m_isBase.intValue() == IS_BASE_TRUE;
+  }
+
+  /**
+   * @param isBase <code>true</code> to mark as base / language-only locale.
+   */
+  public void setBaseLocale(boolean isBase) {
+    m_isBase = isBase ? IS_BASE_TRUE : IS_BASE_FALSE;
+  }
+
+  /**
    * Serializes this object's state to its XML representation. Format is:
    *
    * <pre><code>
@@ -224,6 +257,7 @@ public class PSLocale implements IPSCatalogSummary {
    *       languageString CDATA #REQUIRED
    *       displayName CDATA #REQUIRED
    *       status CDATA #REQUIRED
+   *       isBase CDATA #IMPLIED
    *    >
    *    &lt;ELEMENT Description (#PCDATA)>
    * </code></pre>
@@ -239,6 +273,7 @@ public class PSLocale implements IPSCatalogSummary {
     root.setAttribute(ATTR_LANGUAGE_STRING, m_languageString);
     root.setAttribute(ATTR_DISPLAY_NAME, m_displayName);
     root.setAttribute(ATTR_STATUS, STATUS_ENUM[m_status]);
+    root.setAttribute(ATTR_IS_BASE, isBaseLocale() ? "true" : "false");
     if (m_version != null) root.setAttribute(ATTR_VERSION, m_version.toString());
 
     if (m_description != null)
@@ -289,6 +324,15 @@ public class PSLocale implements IPSCatalogSummary {
     if (descEl != null) {
       m_description = PSXmlTreeWalker.getElementData(descEl);
     }
+
+    // Optional attribute for backward-compatible XML; default false.
+    String isBase = source.getAttribute(ATTR_IS_BASE);
+    boolean base =
+        isBase != null
+            && (isBase.equalsIgnoreCase("true")
+                || isBase.equals("1")
+                || isBase.equalsIgnoreCase("yes"));
+    m_isBase = base ? IS_BASE_TRUE : IS_BASE_FALSE;
   }
 
   /**
@@ -421,6 +465,12 @@ public class PSLocale implements IPSCatalogSummary {
   /** Constant to indicate locale's status is active. */
   public static final int STATUS_ACTIVE = 1;
 
+  /** Integer column value meaning this row is a base / language-only locale. */
+  public static final int IS_BASE_TRUE = 1;
+
+  /** Integer column value meaning this row is not a base locale. */
+  public static final int IS_BASE_FALSE = 0;
+
   /**
    * Enumeration of status strings, uses the <code>STATUS_xxx</code> constant value as an index into
    * the array to retrieve its corresponding string representation. This must be maintained if a new
@@ -471,6 +521,15 @@ public class PSLocale implements IPSCatalogSummary {
   @Column(name = "STATUS")
   private int m_status = STATUS_UNDEFINED;
 
+  /**
+   * Whether this is a base / language-only locale ({@link #IS_BASE_TRUE} / {@link #IS_BASE_FALSE}).
+   * Defaults to non-base. Not part of {@link #equals(Object)} — language string remains identity
+   * for catalog equality.
+   */
+  @Basic
+  @Column(name = "ISBASE")
+  private Integer m_isBase = IS_BASE_FALSE;
+
   @Version
   @Column(name = "VERSION")
   private Integer m_version = null;
@@ -485,6 +544,7 @@ public class PSLocale implements IPSCatalogSummary {
   private static final String EL_DESCRIPTION = "Description";
   private static final String ATTR_STATUS = "status";
   private static final String ATTR_VERSION = "version";
+  private static final String ATTR_IS_BASE = "isBase";
 
   // private constants to specify column names expected in the row data when
   // constructing from the repository

--- a/system/src/main/java/com/percussion/i18n/PSLocaleLoginSelection.java
+++ b/system/src/main/java/com/percussion/i18n/PSLocaleLoginSelection.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.i18n;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Server-side helpers for the login locale dropdown and default selection.
+ *
+ * <p>Login shows active regional locales always. A base / language-only locale
+ * ({@link PSLocale#isBaseLocale()}) is shown only when no active regional sibling
+ * exists for the same language family (e.g. hide {@code es} when {@code es-es}
+ * is active; show {@code ar} when no {@code ar-*} regionals exist).
+ *
+ * <p>When no locale is requested, the product default is {@link
+ * PSI18nUtils#DEFAULT_LANG} ({@code en-us}).
+ */
+public final class PSLocaleLoginSelection {
+
+  private PSLocaleLoginSelection() {}
+
+  /**
+   * Filter locales for the login dropdown.
+   *
+   * @param all all locales from the repository; may be {@code null}
+   * @return active locales that should appear on login, never {@code null}; order preserved from
+   *     the input iteration
+   */
+  public static List<PSLocale> forLoginDropdown(Iterable<PSLocale> all) {
+    List<PSLocale> active = new ArrayList<>();
+    if (all == null) {
+      return active;
+    }
+    for (PSLocale loc : all) {
+      if (loc != null && loc.getStatus() == PSLocale.STATUS_ACTIVE) {
+        active.add(loc);
+      }
+    }
+
+    Set<String> activeTags = new HashSet<>();
+    for (PSLocale loc : active) {
+      String tag = normalizeTag(loc.getLanguageString());
+      if (tag != null) {
+        activeTags.add(tag);
+      }
+    }
+
+    List<PSLocale> result = new ArrayList<>();
+    for (PSLocale loc : active) {
+      if (shouldShowOnLogin(loc, activeTags)) {
+        result.add(loc);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Resolve the selected login locale: prefer {@code requested} if it is in the allowed login list,
+   * else system language if allowed, else {@code en-us}.
+   *
+   * @param requested candidate from the request (may be null/empty)
+   * @param systemLanguage system default language (may be null/empty)
+   * @param loginLocales already-filtered login list (may be null)
+   * @return never null/empty; defaults to {@link PSI18nUtils#DEFAULT_LANG}
+   */
+  public static String resolveSelectedLocale(
+      String requested, String systemLanguage, Collection<PSLocale> loginLocales) {
+    Set<String> allowed = new HashSet<>();
+    if (loginLocales != null) {
+      for (PSLocale loc : loginLocales) {
+        if (loc != null && loc.getLanguageString() != null) {
+          allowed.add(normalizeTag(loc.getLanguageString()));
+        }
+      }
+    }
+
+    String req = normalizeTag(requested);
+    if (req != null && (allowed.isEmpty() || allowed.contains(req))) {
+      return req;
+    }
+    String sys = normalizeTag(systemLanguage);
+    if (sys != null && (allowed.isEmpty() || allowed.contains(sys))) {
+      return sys;
+    }
+    String def = normalizeTag(PSI18nUtils.DEFAULT_LANG);
+    return def != null ? def : "en-us";
+  }
+
+  /**
+   * Whether a single active locale should appear on login given the set of all active language
+   * tags.
+   */
+  static boolean shouldShowOnLogin(PSLocale loc, Set<String> activeTags) {
+    if (loc == null || loc.getStatus() != PSLocale.STATUS_ACTIVE) {
+      return false;
+    }
+    if (!loc.isBaseLocale()) {
+      return true;
+    }
+    String base = normalizeTag(loc.getLanguageString());
+    if (base == null || base.isEmpty()) {
+      return false;
+    }
+    String prefix = base + "-";
+    for (String tag : activeTags) {
+      if (tag != null && tag.startsWith(prefix)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Lowercase BCP-47 with hyphens; null/blank → null. */
+  static String normalizeTag(String tag) {
+    if (tag == null) {
+      return null;
+    }
+    String t = tag.trim().toLowerCase(Locale.ROOT).replace('_', '-');
+    return t.isEmpty() ? null : t;
+  }
+}

--- a/system/src/test/java/com/percussion/i18n/PSLocaleLoginSelectionTest.java
+++ b/system/src/test/java/com/percussion/i18n/PSLocaleLoginSelectionTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link PSLocaleLoginSelection}. */
+@Tag("UnitTest")
+public class PSLocaleLoginSelectionTest {
+
+  @Test
+  public void hidesBaseWhenRegionalSiblingsActive() {
+    PSLocale es = locale("es", true, PSLocale.STATUS_ACTIVE);
+    PSLocale esEs = locale("es-es", false, PSLocale.STATUS_ACTIVE);
+    PSLocale esMx = locale("es-mx", false, PSLocale.STATUS_ACTIVE);
+    PSLocale ar = locale("ar", true, PSLocale.STATUS_ACTIVE);
+    PSLocale enUs = locale("en-us", false, PSLocale.STATUS_ACTIVE);
+
+    List<PSLocale> login =
+        PSLocaleLoginSelection.forLoginDropdown(Arrays.asList(enUs, es, esEs, esMx, ar));
+    List<String> codes =
+        login.stream().map(PSLocale::getLanguageString).collect(Collectors.toList());
+
+    assertTrue(codes.contains("en-us"));
+    assertTrue(codes.contains("es-es"));
+    assertTrue(codes.contains("es-mx"));
+    assertTrue(codes.contains("ar"), "base with no regionals must show");
+    assertFalse(codes.contains("es"), "base es hidden when es-* active");
+  }
+
+  @Test
+  public void showsBaseWhenNoActiveRegionals() {
+    PSLocale hi = locale("hi", true, PSLocale.STATUS_ACTIVE);
+    PSLocale hiIn = locale("hi-in", false, PSLocale.STATUS_INACTIVE);
+
+    List<PSLocale> login = PSLocaleLoginSelection.forLoginDropdown(Arrays.asList(hi, hiIn));
+    List<String> codes =
+        login.stream().map(PSLocale::getLanguageString).collect(Collectors.toList());
+
+    assertTrue(codes.contains("hi"), "inactive regional must not hide base");
+    assertFalse(codes.contains("hi-in"));
+  }
+
+  @Test
+  public void hidesBaseWhenRegionalSiblingActive_hi() {
+    PSLocale hi = locale("hi", true, PSLocale.STATUS_ACTIVE);
+    PSLocale hiIn = locale("hi-in", false, PSLocale.STATUS_ACTIVE);
+
+    List<PSLocale> login = PSLocaleLoginSelection.forLoginDropdown(Arrays.asList(hi, hiIn));
+    List<String> codes =
+        login.stream().map(PSLocale::getLanguageString).collect(Collectors.toList());
+
+    assertFalse(codes.contains("hi"));
+    assertTrue(codes.contains("hi-in"));
+  }
+
+  @Test
+  public void omitsInactiveLocales() {
+    PSLocale ar = locale("ar", true, PSLocale.STATUS_INACTIVE);
+    PSLocale enUs = locale("en-us", false, PSLocale.STATUS_ACTIVE);
+
+    List<PSLocale> login = PSLocaleLoginSelection.forLoginDropdown(Arrays.asList(ar, enUs));
+    assertEquals(1, login.size());
+    assertEquals("en-us", login.get(0).getLanguageString());
+  }
+
+  @Test
+  public void resolveSelectedPrefersRequestedWhenAllowed() {
+    List<PSLocale> login =
+        Arrays.asList(
+            locale("en-us", false, PSLocale.STATUS_ACTIVE),
+            locale("ar", true, PSLocale.STATUS_ACTIVE));
+    assertEquals(
+        "ar", PSLocaleLoginSelection.resolveSelectedLocale("ar", "en-us", login));
+  }
+
+  @Test
+  public void resolveSelectedFallsBackToEnUs() {
+    List<PSLocale> login =
+        Arrays.asList(
+            locale("en-us", false, PSLocale.STATUS_ACTIVE),
+            locale("de-de", false, PSLocale.STATUS_ACTIVE));
+    assertEquals(
+        "en-us",
+        PSLocaleLoginSelection.resolveSelectedLocale(null, null, login));
+    assertEquals(
+        "en-us",
+        PSLocaleLoginSelection.resolveSelectedLocale("xx-yy", "yy-zz", login));
+  }
+
+  @Test
+  public void resolveSelectedUsesSystemWhenRequestedMissing() {
+    List<PSLocale> login =
+        Arrays.asList(
+            locale("en-us", false, PSLocale.STATUS_ACTIVE),
+            locale("de-de", false, PSLocale.STATUS_ACTIVE));
+    assertEquals(
+        "de-de",
+        PSLocaleLoginSelection.resolveSelectedLocale(null, "de-de", login));
+  }
+
+  private static PSLocale locale(String code, boolean base, int status) {
+    PSLocale loc = new PSLocale(code, code, null, status);
+    loc.setBaseLocale(base);
+    return loc;
+  }
+}

--- a/system/src/test/java/com/percussion/i18n/PSLocaleTest.java
+++ b/system/src/test/java/com/percussion/i18n/PSLocaleTest.java
@@ -128,11 +128,45 @@ public class PSLocaleTest {
     System.out.println(PSXmlDocumentBuilder.toString(el));
     localeXml = new PSLocale(el);
     assertEquals(locale1, localeXml);
+    assertTrue(!localeXml.isBaseLocale());
 
     doc = PSXmlDocumentBuilder.createXmlDocument();
     el = locale2.toXml(doc);
     localeXml = new PSLocale(el);
     assertEquals(locale2, localeXml);
+  }
+
+  @Test
+  public void testIsBaseLocaleXmlAndRow() throws Exception {
+    PSLocale ar = new PSLocale("ar", "Arabic", "Arabic base", PSLocale.STATUS_ACTIVE);
+    ar.setBaseLocale(true);
+    assertTrue(ar.isBaseLocale());
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element el = ar.toXml(doc);
+    PSLocale fromXml = new PSLocale(el);
+    assertTrue(fromXml.isBaseLocale());
+    assertEquals("ar", fromXml.getLanguageString());
+
+    List cols = new ArrayList();
+    cols.add(new PSJdbcColumnData("LANGUAGESTRING", "es"));
+    cols.add(new PSJdbcColumnData("DISPLAYNAME", "Spanish"));
+    cols.add(new PSJdbcColumnData("DESCRIPTION", "base"));
+    cols.add(new PSJdbcColumnData("STATUS", "1"));
+    cols.add(new PSJdbcColumnData("ISBASE", "1"));
+    PSLocale fromRow =
+        new PSLocale(new PSJdbcRowData(cols.iterator(), PSJdbcRowData.ACTION_INSERT));
+    assertTrue(fromRow.isBaseLocale());
+
+    // Missing ISBASE column defaults to false
+    List colsNoBase = new ArrayList();
+    colsNoBase.add(new PSJdbcColumnData("LANGUAGESTRING", "en-us"));
+    colsNoBase.add(new PSJdbcColumnData("DISPLAYNAME", "English"));
+    colsNoBase.add(new PSJdbcColumnData("DESCRIPTION", null));
+    colsNoBase.add(new PSJdbcColumnData("STATUS", "1"));
+    PSLocale noBase =
+        new PSLocale(new PSJdbcRowData(colsNoBase.iterator(), PSJdbcRowData.ACTION_INSERT));
+    assertTrue(!noBase.isBaseLocale());
   }
 
   /**


### PR DESCRIPTION
## Summary

- Add `RXLOCALE.ISBASE` column and map it on `PSLocale` (`isBaseLocale` / seed + upgrade rows).
- Seed **Arabic** (`ar`) as an active **base** locale; mark existing language-only locales `es` and `hi` as base.
- Server-side login dropdown filter (`PSLocaleLoginSelection`): hide a base locale when any active regional sibling exists; resolve selected locale with fallback to **`en-us`**.
- Wire `rxlogin.jsp` to the filter; React still renders the list it receives.
- TMX headers include `ar`; document base+override storage policy (regional → base → `en-us`). Full Arabic body back-fill is optional follow-up (`i18n_translate.py --target ar`).
- Tests: `PSLocaleLoginSelectionTest`, `PSLocale` ISBASE, TMX Arabic fallback, login host contract, Playwright locale expectation (`hi-in` not bare `hi`).

### Login list behavior (examples)

| Shown | Hidden while regionals active |
|--------|-------------------------------|
| `en-us`, regionals, **`ar`** | `es`, `hi` |

## Pre-PR gates

### Erlang
- Report: `docs/ai-generated/code-reviews/feat-base-locales-and-arabic-erlang.md`
- **Recommendation: approve**

### Spotless / formatting
- In-scope Java/TS/MD/JSP only; no monorepo-wide Spotless dump.

### Builds / tests (standalone)
| Check | Result |
|--------|--------|
| `cd modules/perc-i18n && ../../mvnw clean install` | BUILD SUCCESS (prior session) |
| `PSTmxResourceBundleTest` | 8 tests, 0 failures |
| `PSLocaleTest` + `PSLocaleLoginSelectionTest` | pass |
| Vitest `loginStylesContract.test.ts` | 4 pass |

### Explicitly out of scope
- Bare base rows for `en` / `fr` / `de` / … (regionals-only families stay as-is; no break).
- Full Arabic machine-translation of every TUV (header + fallback only; run translate script as follow-up if desired).
- Mass collapse of existing regional TMX into base+delta.

## Test plan

- [ ] Fresh install / tablefactory: `ISBASE` present; `ar` row; `es`/`hi` `ISBASE=1`.
- [ ] Login: `ar` listed; `es`/`hi` not listed when regionals active; default selection `en-us` when unset.
- [ ] Select `ar` → session language `ar`; missing strings fall back to English.
- [ ] Select `es-mx` / `hi-in` → works; sparse keys still resolve via base language in TMX chain.
- [ ] Optional: `python3 modules/perc-i18n/scripts/i18n_translate.py --target ar` and review diff.

> Co-Authored by Grok Build 0.2.114 using grok-4.5 with agent Grok.