### PR TITLE
fix(webui): ship endonyms for login locale dropdown

### DIFF
--- a/WebUI/src/main/ts/login/localeLabels.ts
+++ b/WebUI/src/main/ts/login/localeLabels.ts
@@ -25,13 +25,39 @@
  * dropdown only changes application chrome, not the names of every locale
  * option (see GH-1608).</p>
  *
- * <p>Native names come from {@link Intl.DisplayNames} using the option's own
- * language tag as the viewer. When the browser does not provide
- * {@link Intl.DisplayNames}, the server-supplied English fallback is used
- * verbatim.</p>
+ * <p>Ship locales use a static endonym map so the list looks clean even when
+ * {@link Intl.DisplayNames} is missing, incomplete, or returns the English
+ * server {@code displayName}. Other / customer locales still prefer
+ * {@link Intl.DisplayNames}, then the server fallback.</p>
  */
 
 const viewerCache: Map<string, Intl.DisplayNames | null> = new Map();
+
+/**
+ * Endonym text after the {@code "code - "} prefix for product-shipped locales.
+ * Keys are normalized BCP-47 (lowercase hyphen). Keep in sync with RXLOCALE
+ * seed + login filter matrix.
+ */
+export const SHIP_LOCALE_ENDONYMS: Readonly<Record<string, string>> = {
+  ar: "العربية",
+  "de-de": "Deutsch (Deutschland)",
+  "en-gb": "English (United Kingdom)",
+  "en-us": "English (United States)",
+  es: "español",
+  "es-cl": "español (Chile)",
+  "es-es": "español (España)",
+  "es-mx": "español (México)",
+  "fr-ca": "français (Canada)",
+  "fr-fr": "français (France)",
+  hi: "हिन्दी",
+  "hi-in": "हिन्दी (भारत)",
+  "it-it": "italiano (Italia)",
+  "ja-jp": "日本語 (日本)",
+  "nl-nl": "Nederlands (Nederland)",
+  "pt-br": "português (Brasil)",
+  "pt-pt": "português (Portugal)",
+  "tr-tr": "Türkçe (Türkiye)",
+};
 
 /**
  * Normalize a locale tag to lowercase BCP-47 with hyphen separator.
@@ -116,11 +142,18 @@ export function localeLabel(
   const codeOut = norm || code;
   const fallbackOut = fallback || codeOut;
 
+  // Prefer curated ship-matrix endonyms so the login list is complete and
+  // stable across browsers / incomplete ICU data.
+  const ship = SHIP_LOCALE_ENDONYMS[norm];
+  if (ship) {
+    return `${codeOut} - ${ship}`;
+  }
+
   const parts = norm.split("-");
   const langCode = parts[0] || norm;
   const regionCode = parts.length > 1 ? parts[parts.length - 1] : "";
 
-  // Endonym: name the language in its own language, not the UI locale.
+  // Customer / unknown codes: endonym via Intl when available.
   const langDN = getDisplayNames(langCode, "language");
   const langName = safeOf(langDN, langCode);
   if (!langName) {

--- a/WebUI/src/test/ts/login/LoginPage.test.tsx
+++ b/WebUI/src/test/ts/login/LoginPage.test.tsx
@@ -148,7 +148,7 @@ describe("LoginPage", () => {
     expect(after.some((t) => /espagnol/.test(t))).toBe(false);
   });
 
-  it("falls back to server displayName when Intl.DisplayNames is unavailable", () => {
+  it("keeps ship endonyms when Intl.DisplayNames is unavailable", () => {
     const original = (Intl as unknown as { DisplayNames?: unknown })
       .DisplayNames;
     // @ts-expect-error simulate runtime without DisplayNames
@@ -161,9 +161,10 @@ describe("LoginPage", () => {
       const options = Array.from(select.options).map(
         (o) => o.textContent ?? "",
       );
+      // Curated SHIP_LOCALE_ENDONYMS — not English server displayName.
       expect(options).toContain("en-us - English (United States)");
-      expect(options).toContain("fr-fr - French (France)");
-      expect(options).toContain("es - Spanish");
+      expect(options).toContain("fr-fr - français (France)");
+      expect(options).toContain("es - español");
     } finally {
       (Intl as unknown as { DisplayNames?: unknown }).DisplayNames = original;
     }

--- a/WebUI/src/test/ts/login/localeLabels.test.ts
+++ b/WebUI/src/test/ts/login/localeLabels.test.ts
@@ -20,6 +20,7 @@ import {
   __resetLocaleLabelsCache,
   localeLabel,
   normalizeTag,
+  SHIP_LOCALE_ENDONYMS,
 } from "../../../main/ts/login/localeLabels";
 
 describe("login/localeLabels", () => {
@@ -50,21 +51,24 @@ describe("login/localeLabels", () => {
   });
 
   describe("localeLabel", () => {
-    it("uses fallback when Intl.DisplayNames is unavailable", () => {
+    it("ship endonyms still work when Intl.DisplayNames is unavailable", () => {
       const original = (Intl as unknown as { DisplayNames?: unknown })
         .DisplayNames;
       // @ts-expect-error simulate runtime without DisplayNames
       delete Intl.DisplayNames;
       try {
+        // Curated map does not depend on Intl.
         expect(localeLabel("fr-fr", "en-us", "French (France)")).toBe(
-          "fr-fr - French (France)",
+          "fr-fr - français (France)",
         );
+        // Unknown codes still use the English server fallback.
+        expect(localeLabel("zz", "en-us", "Made Up")).toBe("zz - Made Up");
       } finally {
         (Intl as unknown as { DisplayNames?: unknown }).DisplayNames = original;
       }
     });
 
-    it("uses fallback when Intl.DisplayNames.of throws", () => {
+    it("ship endonyms still work when Intl.DisplayNames.of throws", () => {
       const original = Intl.DisplayNames;
       // @ts-expect-error stub ctor that throws
       Intl.DisplayNames = function () {
@@ -72,7 +76,7 @@ describe("login/localeLabels", () => {
       };
       try {
         expect(localeLabel("ja-jp", "en-us", "Japanese (Japan)")).toBe(
-          "ja-jp - Japanese (Japan)",
+          "ja-jp - 日本語 (日本)",
         );
       } finally {
         Intl.DisplayNames = original;
@@ -104,6 +108,31 @@ describe("login/localeLabels", () => {
       const deHi = localeLabel("de-de", "hi-in", "German (Germany)");
       expect(deEn).toMatch(/^de-de - Deutsch/);
       expect(deHi).toBe(deEn);
+    });
+
+    it("uses curated ship endonyms for the product locale matrix", () => {
+      expect(localeLabel("ar", "en-us", "Arabic")).toBe("ar - العربية");
+      expect(localeLabel("ja-jp", "en-us", "Japanese (Japan)")).toBe(
+        "ja-jp - 日本語 (日本)",
+      );
+      expect(localeLabel("tr-tr", "en-us", "Turkish (Turkey)")).toBe(
+        "tr-tr - Türkçe (Türkiye)",
+      );
+      expect(localeLabel("hi-in", "en-us", "Hindi (India)")).toBe(
+        "hi-in - हिन्दी (भारत)",
+      );
+      // Server English fallback is ignored when a ship endonym exists.
+      expect(localeLabel("de-de", "en-us", "German (Germany)")).toBe(
+        "de-de - Deutsch (Deutschland)",
+      );
+    });
+
+    it("covers every key in SHIP_LOCALE_ENDONYMS", () => {
+      for (const [code, endonym] of Object.entries(SHIP_LOCALE_ENDONYMS)) {
+        expect(localeLabel(code, "en-us", "EnglishFallback")).toBe(
+          `${code} - ${endonym}`,
+        );
+      }
     });
 
     it("falls back to server displayName for unknown codes", () => {


### PR DESCRIPTION
## Summary

Login locale options that were falling through to English server `displayName` (or incomplete `Intl.DisplayNames`) now use a curated **endonym** map for the product ship matrix:

| Code | Endonym (after `code - `) |
|------|---------------------------|
| ar | العربية |
| de-de | Deutsch (Deutschland) |
| en-us / en-gb | English (…) |
| es / es-* | español (…) |
| fr-fr / fr-ca | français (…) |
| hi / hi-in | हिन्दी (…) |
| it-it, ja-jp, nl-nl, pt-*, tr-tr | native |

Customer / unknown locales still use `Intl.DisplayNames` then server fallback.

## Test plan

- [ ] Open login; confirm every option is `code - <native name>` (not bare English for ja/hi/ar/tr/…).
- [ ] Change UI locale; option labels stay stable (GH-1608).
- Vitest: `src/test/ts/login` — localeLabels + LoginPage green.

> Co-Authored by Grok Build 0.2.114 using grok-4.5 with agent Grok.