### PR TITLE
fix(i18n): dedupe DeveloperUi.tmx searches/views entries

### DIFF
--- a/modules/perc-i18n/src/main/resources/i18n/DeveloperUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/DeveloperUi.tmx
@@ -1711,22 +1711,26 @@
         </tu>
         <tu tuid="perc.ui.developer@Display format id">
             <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_COL_DF / DEV_MSG.VW_COL_DF</note>
+            <note xml:lang="en-us">DEV_MSG.SR_COL_DF</note>
+            <note xml:lang="en-us">DEV_MSG.VW_COL_DF</note>
             <tuv xml:lang="en-us"><seg>Display format id</seg></tuv>
         </tu>
         <tu tuid="perc.ui.developer@Max results">
             <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_COL_MAX / DEV_MSG.VW_COL_MAX</note>
+            <note xml:lang="en-us">DEV_MSG.SR_COL_MAX</note>
+            <note xml:lang="en-us">DEV_MSG.VW_COL_MAX</note>
             <tuv xml:lang="en-us"><seg>Max results</seg></tuv>
         </tu>
         <tu tuid="perc.ui.developer@Case sensitive">
             <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_COL_CASE / DEV_MSG.VW_COL_CASE</note>
+            <note xml:lang="en-us">DEV_MSG.SR_COL_CASE</note>
+            <note xml:lang="en-us">DEV_MSG.VW_COL_CASE</note>
             <tuv xml:lang="en-us"><seg>Case sensitive</seg></tuv>
         </tu>
         <tu tuid="perc.ui.developer@Custom">
             <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_KIND_CUSTOM / DEV_MSG.VW_KIND_CUSTOM</note>
+            <note xml:lang="en-us">DEV_MSG.SR_KIND_CUSTOM</note>
+            <note xml:lang="en-us">DEV_MSG.VW_KIND_CUSTOM</note>
             <tuv xml:lang="en-us"><seg>Custom</seg></tuv>
         </tu>
         <tu tuid="perc.ui.developer@User">
@@ -1736,7 +1740,8 @@
         </tu>
         <tu tuid="perc.ui.developer@Standard">
             <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_KIND_STANDARD / DEV_MSG.VW_KIND_STANDARD</note>
+            <note xml:lang="en-us">DEV_MSG.SR_KIND_STANDARD</note>
+            <note xml:lang="en-us">DEV_MSG.VW_KIND_STANDARD</note>
             <tuv xml:lang="en-us"><seg>Standard</seg></tuv>
         </tu>
         <tu tuid="perc.ui.developer@Loading search…">
@@ -1751,7 +1756,8 @@
         </tu>
         <tu tuid="perc.ui.developer@Field criteria">
             <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_FIELDS / DEV_MSG.VW_FIELDS</note>
+            <note xml:lang="en-us">DEV_MSG.SR_FIELDS</note>
+            <note xml:lang="en-us">DEV_MSG.VW_FIELDS</note>
             <tuv xml:lang="en-us"><seg>Field criteria</seg></tuv>
         </tu>
         <tu tuid="perc.ui.developer@Search field conditions. Criterion editing is not exposed yet.">
@@ -1761,7 +1767,8 @@
         </tu>
         <tu tuid="perc.ui.developer@Operator">
             <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_COL_OP / DEV_MSG.VW_COL_OP</note>
+            <note xml:lang="en-us">DEV_MSG.SR_COL_OP</note>
+            <note xml:lang="en-us">DEV_MSG.VW_COL_OP</note>
             <tuv xml:lang="en-us"><seg>Operator</seg></tuv>
         </tu>
         <tu tuid="perc.ui.developer@Search create / update / delete not supported via this API">

--- a/modules/perc-i18n/src/main/resources/i18n/DeveloperUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/DeveloperUi.tmx
@@ -1711,7 +1711,73 @@
         </tu>
         <tu tuid="perc.ui.developer@Display format id">
             <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_COL_DF</note>
+            <note xml:lang="en-us">DEV_MSG.SR_COL_DF / DEV_MSG.VW_COL_DF</note>
+            <tuv xml:lang="en-us"><seg>Display format id</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Max results">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SR_COL_MAX / DEV_MSG.VW_COL_MAX</note>
+            <tuv xml:lang="en-us"><seg>Max results</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Case sensitive">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SR_COL_CASE / DEV_MSG.VW_COL_CASE</note>
+            <tuv xml:lang="en-us"><seg>Case sensitive</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Custom">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SR_KIND_CUSTOM / DEV_MSG.VW_KIND_CUSTOM</note>
+            <tuv xml:lang="en-us"><seg>Custom</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@User">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SR_KIND_USER</note>
+            <tuv xml:lang="en-us"><seg>User</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Standard">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SR_KIND_STANDARD / DEV_MSG.VW_KIND_STANDARD</note>
+            <tuv xml:lang="en-us"><seg>Standard</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Loading search…">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SR_DETAIL_LOADING</note>
+            <tuv xml:lang="en-us"><seg>Loading search…</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Could not load search.">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SR_DETAIL_ERROR</note>
+            <tuv xml:lang="en-us"><seg>Could not load search.</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Field criteria">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SR_FIELDS / DEV_MSG.VW_FIELDS</note>
+            <tuv xml:lang="en-us"><seg>Field criteria</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Search field conditions. Criterion editing is not exposed yet.">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SR_FIELDS_HINT</note>
+            <tuv xml:lang="en-us"><seg>Search field conditions. Criterion editing is not exposed yet.</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Operator">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SR_COL_OP / DEV_MSG.VW_COL_OP</note>
+            <tuv xml:lang="en-us"><seg>Operator</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Search create / update / delete not supported via this API">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SR_GAP_WRITE</note>
+            <tuv xml:lang="en-us"><seg>Search create / update / delete not supported via this API</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Search field criterion editing not supported via this API">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SR_GAP_FIELDS</note>
+            <tuv xml:lang="en-us"><seg>Search field criterion editing not supported via this API</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Views are a separate catalog (Developer Views / UI-07)">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SR_GAP_VIEWS</note>
+            <tuv xml:lang="en-us"><seg>Views are a separate catalog (Developer Views / UI-07)</seg></tuv>
         </tu>
         <tu tuid="perc.ui.developer@Views">
             <prop type="sectionname" xml:lang="en-us">Developer</prop>
@@ -1738,84 +1804,6 @@
             <note xml:lang="en-us">DEV_MSG.VW_HINT</note>
             <tuv xml:lang="en-us"><seg>Content Explorer view definitions. Open a row for field criteria. Create/edit is a later slice.</seg></tuv>
         </tu>
-        <tu tuid="perc.ui.developer@Display format id">
-            <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.VW_COL_DF</note>
-            <note xml:lang="en-us">DEV_MSG.SR_COL_DF</note>
-            <tuv xml:lang="en-us"><seg>Display format id</seg></tuv>
-        </tu>
-        <tu tuid="perc.ui.developer@Max results">
-            <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_COL_MAX</note>
-            <note xml:lang="en-us">DEV_MSG.VW_COL_MAX</note>
-            <tuv xml:lang="en-us"><seg>Max results</seg></tuv>
-        </tu>
-        <tu tuid="perc.ui.developer@Case sensitive">
-            <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_COL_CASE</note>
-            <note xml:lang="en-us">DEV_MSG.VW_COL_CASE</note>
-            <tuv xml:lang="en-us"><seg>Case sensitive</seg></tuv>
-        </tu>
-        <tu tuid="perc.ui.developer@Custom">
-            <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_KIND_CUSTOM</note>
-            <tuv xml:lang="en-us"><seg>Custom</seg></tuv>
-        </tu>
-        <tu tuid="perc.ui.developer@User">
-            <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_KIND_USER</note>
-            <tuv xml:lang="en-us"><seg>User</seg></tuv>
-        </tu>
-        <tu tuid="perc.ui.developer@Standard">
-            <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_KIND_STANDARD</note>
-            <tuv xml:lang="en-us"><seg>Standard</seg></tuv>
-        </tu>
-        <tu tuid="perc.ui.developer@Loading search…">
-            <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_DETAIL_LOADING</note>
-            <tuv xml:lang="en-us"><seg>Loading search…</seg></tuv>
-        </tu>
-        <tu tuid="perc.ui.developer@Could not load search.">
-            <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_DETAIL_ERROR</note>
-            <tuv xml:lang="en-us"><seg>Could not load search.</seg></tuv>
-        </tu>
-        <tu tuid="perc.ui.developer@Field criteria">
-            <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_FIELDS</note>
-            <tuv xml:lang="en-us"><seg>Field criteria</seg></tuv>
-        </tu>
-        <tu tuid="perc.ui.developer@Search field conditions. Criterion editing is not exposed yet.">
-            <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_FIELDS_HINT</note>
-            <tuv xml:lang="en-us"><seg>Search field conditions. Criterion editing is not exposed yet.</seg></tuv>
-        </tu>
-        <tu tuid="perc.ui.developer@Operator">
-            <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_COL_OP</note>
-            <tuv xml:lang="en-us"><seg>Operator</seg></tuv>
-        </tu>
-        <tu tuid="perc.ui.developer@Search create / update / delete not supported via this API">
-            <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_GAP_WRITE</note>
-            <tuv xml:lang="en-us"><seg>Search create / update / delete not supported via this API</seg></tuv>
-        </tu>
-        <tu tuid="perc.ui.developer@Search field criterion editing not supported via this API">
-            <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_GAP_FIELDS</note>
-            <tuv xml:lang="en-us"><seg>Search field criterion editing not supported via this API</seg></tuv>
-        </tu>
-        <tu tuid="perc.ui.developer@Views are a separate catalog (Developer Views / UI-07)">
-            <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.SR_GAP_VIEWS</note>
-            <tuv xml:lang="en-us"><seg>Views are a separate catalog (Developer Views / UI-07)</seg></tuv>
-        </tu>
-        <tu tuid="perc.ui.developer@Standard">
-            <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.VW_KIND_STANDARD</note>
-            <tuv xml:lang="en-us"><seg>Standard</seg></tuv>
-        </tu>
         <tu tuid="perc.ui.developer@Loading view…">
             <prop type="sectionname" xml:lang="en-us">Developer</prop>
             <note xml:lang="en-us">DEV_MSG.VW_DETAIL_LOADING</note>
@@ -1826,20 +1814,10 @@
             <note xml:lang="en-us">DEV_MSG.VW_DETAIL_ERROR</note>
             <tuv xml:lang="en-us"><seg>Could not load view.</seg></tuv>
         </tu>
-        <tu tuid="perc.ui.developer@Field criteria">
-            <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.VW_FIELDS</note>
-            <tuv xml:lang="en-us"><seg>Field criteria</seg></tuv>
-        </tu>
         <tu tuid="perc.ui.developer@View field conditions. Criterion editing is not exposed yet.">
             <prop type="sectionname" xml:lang="en-us">Developer</prop>
             <note xml:lang="en-us">DEV_MSG.VW_FIELDS_HINT</note>
             <tuv xml:lang="en-us"><seg>View field conditions. Criterion editing is not exposed yet.</seg></tuv>
-        </tu>
-        <tu tuid="perc.ui.developer@Operator">
-            <prop type="sectionname" xml:lang="en-us">Developer</prop>
-            <note xml:lang="en-us">DEV_MSG.VW_COL_OP</note>
-            <tuv xml:lang="en-us"><seg>Operator</seg></tuv>
         </tu>
         <tu tuid="perc.ui.developer@View create / update / delete not supported via this API">
             <prop type="sectionname" xml:lang="en-us">Developer</prop>


### PR DESCRIPTION
## Summary
Follow-up to merged #1660 (searches) after #1662 (views): the conflict resolution left **duplicate and one broken** `DeveloperUi.tmx` translation units for shared SR/VW labels.

## Changes
- Remove broken empty `Display format id` TU (note only, no `<tuv>`)
- Deduplicate shared labels: Display format id, Max results, Case sensitive, Custom, Standard, Field criteria, Operator
- Keep unique searches (SR_*) and views (VW_*) strings
- Preserve Extensions catalog TMX from #1663

## Notes
Does not change runtime keys (tuid text is the key); cleanup is hygiene / catalog correctness.

Refs #1622