### PR TITLE
feat(developer): workflows catalog browse (P0.17 / SY-04 read)

### DIFF
--- a/WebUI/src/main/ts/api/developer/types.ts
+++ b/WebUI/src/main/ts/api/developer/types.ts
@@ -560,6 +560,8 @@ export interface WorkflowDef {
   stagingRoleNames?: string;
   defaultWorkflow?: boolean;
   workflowSteps?: WorkflowStepSummary[];
+  /** Developer surface honesty; defaults filled by workflowsApi when absent. */
+  designGaps?: string[];
 }
 
 

--- a/WebUI/src/main/ts/api/developer/types.ts
+++ b/WebUI/src/main/ts/api/developer/types.ts
@@ -543,4 +543,23 @@ export interface RelationshipTypeDef {
   designGaps?: string[];
 }
 
+/** Workflow step from workflowmanagement PSUiWorkflow. */
+export interface WorkflowStepSummary {
+  stepName?: string;
+  permissionNames?: string[];
+  stepRoles?: { roleName?: string; roleId?: number }[];
+}
+
+/**
+ * Workflow catalog row from GET /services/workflowmanagement/workflows
+ * (PSUiWorkflow — SY-04 association browse).
+ */
+export interface WorkflowDef {
+  workflowName?: string;
+  workflowDescription?: string;
+  stagingRoleNames?: string;
+  defaultWorkflow?: boolean;
+  workflowSteps?: WorkflowStepSummary[];
+}
+
 

--- a/WebUI/src/main/ts/api/developer/workflowsApi.ts
+++ b/WebUI/src/main/ts/api/developer/workflowsApi.ts
@@ -6,23 +6,47 @@ import { get } from "../client";
 import { PATHS } from "../paths";
 import type { WorkflowDef } from "./types";
 
-function asArray<T>(payload: unknown): T[] {
-  if (payload == null) return [];
-  if (Array.isArray(payload)) return payload as T[];
+/** Honest design gaps for the Developer SY-04 browse surface (not full workflow admin). */
+export const WORKFLOW_DESIGN_GAPS: string[] = [
+  "Full workflow graph design is not exposed in the Developer catalog",
+  "Workflow create / update / delete is not supported from this Developer surface",
+  "Content type workflow association is edited on the content type detail panel",
+];
+
+/**
+ * Parse workflowmanagement metadata list.
+ * Production payload is either a bare JSON array or a root object with a
+ * {@code Workflow} property (PSUiWorkflowList / @JsonRootName("Workflow")).
+ */
+function parseWorkflowList(payload: unknown): WorkflowDef[] {
+  if (payload == null) {
+    return [];
+  }
+  if (Array.isArray(payload)) {
+    return payload as WorkflowDef[];
+  }
   if (typeof payload === "object") {
     const obj = payload as Record<string, unknown>;
-    const raw =
-      obj.Workflow ??
-      obj.workflow ??
-      obj.WorkflowList ??
-      obj.PSUiWorkflowList ??
-      obj.entries ??
-      obj.EnumVals ??
-      obj.enumVals;
-    if (raw == null) return [];
-    return Array.isArray(raw) ? (raw as T[]) : [raw as T];
+    const raw = obj.Workflow ?? obj.workflow;
+    if (Array.isArray(raw)) {
+      return raw as WorkflowDef[];
+    }
+    if (raw != null && typeof raw === "object") {
+      return [raw as WorkflowDef];
+    }
+    throw new Error(
+      "Unexpected workflow list payload (expected array or Workflow wrapper)",
+    );
   }
-  return [];
+  throw new Error("Unexpected workflow list payload type");
+}
+
+function withGaps(w: WorkflowDef): WorkflowDef {
+  return {
+    ...w,
+    designGaps:
+      w.designGaps && w.designGaps.length > 0 ? w.designGaps : [...WORKFLOW_DESIGN_GAPS],
+  };
 }
 
 /**
@@ -31,7 +55,7 @@ function asArray<T>(payload: unknown): T[] {
  */
 export async function listWorkflows(): Promise<WorkflowDef[]> {
   const payload = await get<unknown>(PATHS.WORKFLOW_METADATA);
-  return asArray<WorkflowDef>(payload);
+  return parseWorkflowList(payload).map(withGaps);
 }
 
 /**
@@ -40,5 +64,6 @@ export async function listWorkflows(): Promise<WorkflowDef[]> {
 export async function getWorkflowDetail(name: string): Promise<WorkflowDef> {
   const key = encodeURIComponent(name);
   // PATHS.WORKFLOWS already ends with '/'
-  return get<WorkflowDef>(`${PATHS.WORKFLOWS}${key}`);
+  const detail = await get<WorkflowDef>(`${PATHS.WORKFLOWS}${key}`);
+  return withGaps(detail ?? {});
 }

--- a/WebUI/src/main/ts/api/developer/workflowsApi.ts
+++ b/WebUI/src/main/ts/api/developer/workflowsApi.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { get } from "../client";
+import { PATHS } from "../paths";
+import type { WorkflowDef } from "./types";
+
+function asArray<T>(payload: unknown): T[] {
+  if (payload == null) return [];
+  if (Array.isArray(payload)) return payload as T[];
+  if (typeof payload === "object") {
+    const obj = payload as Record<string, unknown>;
+    const raw =
+      obj.Workflow ??
+      obj.workflow ??
+      obj.WorkflowList ??
+      obj.PSUiWorkflowList ??
+      obj.entries ??
+      obj.EnumVals ??
+      obj.enumVals;
+    if (raw == null) return [];
+    return Array.isArray(raw) ? (raw as T[]) : [raw as T];
+  }
+  return [];
+}
+
+/**
+ * GET /services/workflowmanagement/workflows/metadata
+ * (existing stepped-workflow catalog; Developer SY-04 browse surface)
+ */
+export async function listWorkflows(): Promise<WorkflowDef[]> {
+  const payload = await get<unknown>(PATHS.WORKFLOW_METADATA);
+  return asArray<WorkflowDef>(payload);
+}
+
+/**
+ * GET /services/workflowmanagement/workflows/{name}
+ */
+export async function getWorkflowDetail(name: string): Promise<WorkflowDef> {
+  const key = encodeURIComponent(name);
+  // PATHS.WORKFLOWS already ends with '/'
+  return get<WorkflowDef>(`${PATHS.WORKFLOWS}${key}`);
+}

--- a/WebUI/src/main/ts/api/developer/workflowsApi.ts
+++ b/WebUI/src/main/ts/api/developer/workflowsApi.ts
@@ -13,10 +13,19 @@ export const WORKFLOW_DESIGN_GAPS: string[] = [
   "Content type workflow association is edited on the content type detail panel",
 ];
 
+/** Known envelope keys for list payloads (PSUiWorkflowList @JsonRootName + historical aliases). */
+const LIST_WRAPPER_KEYS = [
+  "Workflow",
+  "workflow",
+  "WorkflowList",
+  "PSUiWorkflowList",
+  "entries",
+] as const;
+
 /**
  * Parse workflowmanagement metadata list.
- * Production payload is either a bare JSON array or a root object with a
- * {@code Workflow} property (PSUiWorkflowList / @JsonRootName("Workflow")).
+ * Accepts a bare JSON array or a known list wrapper object. Unknown object shapes throw
+ * so the UI surfaces an error instead of a silent empty catalog.
  */
 function parseWorkflowList(payload: unknown): WorkflowDef[] {
   if (payload == null) {
@@ -27,15 +36,18 @@ function parseWorkflowList(payload: unknown): WorkflowDef[] {
   }
   if (typeof payload === "object") {
     const obj = payload as Record<string, unknown>;
-    const raw = obj.Workflow ?? obj.workflow;
-    if (Array.isArray(raw)) {
-      return raw as WorkflowDef[];
-    }
-    if (raw != null && typeof raw === "object") {
-      return [raw as WorkflowDef];
+    for (const key of LIST_WRAPPER_KEYS) {
+      const raw = obj[key];
+      if (raw == null) continue;
+      if (Array.isArray(raw)) {
+        return raw as WorkflowDef[];
+      }
+      if (typeof raw === "object") {
+        return [raw as WorkflowDef];
+      }
     }
     throw new Error(
-      "Unexpected workflow list payload (expected array or Workflow wrapper)",
+      "Unexpected workflow list payload (expected array or known Workflow wrapper)",
     );
   }
   throw new Error("Unexpected workflow list payload type");
@@ -64,6 +76,14 @@ export async function listWorkflows(): Promise<WorkflowDef[]> {
 export async function getWorkflowDetail(name: string): Promise<WorkflowDef> {
   const key = encodeURIComponent(name);
   // PATHS.WORKFLOWS already ends with '/'
-  const detail = await get<WorkflowDef>(`${PATHS.WORKFLOWS}${key}`);
-  return withGaps(detail ?? {});
+  const detail = await get<WorkflowDef | null | undefined>(`${PATHS.WORKFLOWS}${key}`);
+  if (detail == null || typeof detail !== "object") {
+    throw new Error("Workflow not found or empty response");
+  }
+  const workflowName =
+    typeof detail.workflowName === "string" ? detail.workflowName.trim() : "";
+  if (!workflowName) {
+    throw new Error("Workflow response missing workflowName");
+  }
+  return withGaps(detail);
 }

--- a/WebUI/src/main/ts/app/deepLinks/allowlists.ts
+++ b/WebUI/src/main/ts/app/deepLinks/allowlists.ts
@@ -97,6 +97,7 @@ export const DEVELOPER_SECTIONS = [
   "views",
   "extensions",
   "relationship-types",
+  "workflows",
   "communities",
   "pipelines",
 ] as const;
@@ -134,6 +135,9 @@ const DEVELOPER_SECTION_ALIASES: Record<string, DeveloperSection> = {
   relationshiptypes: "relationship-types",
   relationships: "relationship-types",
   "rel-types": "relationship-types",
+  workflows: "workflows",
+  workflow: "workflows",
+  wfs: "workflows",
   cxviews: "views",
   pipeline: "pipelines",
   applications: "pipelines",

--- a/WebUI/src/main/ts/developer/DeveloperShell.tsx
+++ b/WebUI/src/main/ts/developer/DeveloperShell.tsx
@@ -38,6 +38,7 @@ import { SystemDefPanel } from "./SystemDefPanel";
 import { SlotsPanel } from "./SlotsPanel";
 import { TemplatesPanel } from "./TemplatesPanel";
 import { ViewsPanel } from "./ViewsPanel";
+import { WorkflowsPanel } from "./WorkflowsPanel";
 
 export type { DeveloperSection };
 
@@ -56,6 +57,7 @@ const SECTION_LABEL: Record<DeveloperSection, string> = {
   views: DEV_MSG.TAB_VIEWS,
   extensions: DEV_MSG.TAB_EXTENSIONS,
   "relationship-types": DEV_MSG.TAB_RELATIONSHIP_TYPES,
+  workflows: DEV_MSG.TAB_WORKFLOWS,
   communities: DEV_MSG.TAB_COMMUNITIES,
   pipelines: DEV_MSG.TAB_PIPELINES,
 };
@@ -178,6 +180,8 @@ export const DeveloperShell: React.FC<DeveloperShellProps> = ({
           <ExtensionsPanel />
         ) : active === "relationship-types" ? (
           <RelationshipTypesPanel />
+        ) : active === "workflows" ? (
+          <WorkflowsPanel />
         ) : active === "communities" ? (
           <CommunitiesPanel />
         ) : (

--- a/WebUI/src/main/ts/developer/WorkflowDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/WorkflowDetailPanel.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import React, { useEffect, useState } from "react";
+import { getWorkflowDetail } from "../api/developer/workflowsApi";
+import type { WorkflowDef } from "../api/developer/types";
+import { backButton, errorAlert, metaGrid, monoCell } from "./catalogStyles";
+import { panelErrMsg } from "./errors";
+import { DEV_MSG } from "./messages";
+
+export function WorkflowDetailPanel({
+  name,
+  onBack,
+}: {
+  name: string;
+  onBack: () => void;
+}): React.ReactElement {
+  const [detail, setDetail] = useState<WorkflowDef | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setDetail(null);
+    setError(null);
+    getWorkflowDetail(name)
+      .then((d) => {
+        if (!cancelled) setDetail(d);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(panelErrMsg(err, DEV_MSG.WF_DETAIL_ERROR));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [name]);
+
+  const steps =
+    detail != null && Array.isArray(detail.workflowSteps) ? detail.workflowSteps : [];
+
+  return (
+    <div data-testid="developer-wf-detail">
+      <button type="button" onClick={onBack} data-testid="developer-wf-back" style={backButton}>
+        ← {DEV_MSG.WF_BACK}
+      </button>
+
+      {error ? (
+        <div role="alert" data-testid="developer-wf-detail-error" style={errorAlert}>
+          {error}
+        </div>
+      ) : null}
+
+      {!error && detail == null ? (
+        <div data-testid="developer-wf-detail-loading">{DEV_MSG.WF_DETAIL_LOADING}</div>
+      ) : null}
+
+      {detail ? (
+        <>
+          <header style={{ marginBottom: "16px" }}>
+            <h2 style={{ margin: "0 0 4px" }} data-testid="developer-wf-detail-title">
+              {detail.workflowName || name}
+            </h2>
+            <dl style={metaGrid}>
+              <dt>{DEV_MSG.WF_COL_NAME}</dt>
+              <dd style={{ margin: 0, ...monoCell }}>{detail.workflowName || "—"}</dd>
+              <dt>{DEV_MSG.WF_COL_DESC}</dt>
+              <dd style={{ margin: 0 }}>{detail.workflowDescription || "—"}</dd>
+              <dt>{DEV_MSG.WF_COL_DEFAULT}</dt>
+              <dd style={{ margin: 0 }}>
+                {detail.defaultWorkflow ? DEV_MSG.WF_YES : DEV_MSG.WF_NO}
+              </dd>
+              <dt>{DEV_MSG.WF_COL_STAGING}</dt>
+              <dd style={{ margin: 0 }}>{detail.stagingRoleNames || "—"}</dd>
+            </dl>
+          </header>
+
+          <section data-testid="developer-wf-steps">
+            <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.WF_STEPS}</h3>
+            {steps.length === 0 ? (
+              <p style={{ color: "#718096" }}>{DEV_MSG.WF_NONE}</p>
+            ) : (
+              <div style={{ overflowX: "auto" }}>
+                <table
+                  data-testid="developer-wf-steps-table"
+                  style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.9rem" }}
+                >
+                  <thead>
+                    <tr style={{ textAlign: "left", borderBottom: "2px solid #e2e8f0" }}>
+                      <th style={{ padding: "8px" }}>{DEV_MSG.WF_COL_STEP}</th>
+                      <th style={{ padding: "8px" }}>{DEV_MSG.WF_COL_PERMS}</th>
+                      <th style={{ padding: "8px" }}>{DEV_MSG.WF_COL_ROLES}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {steps.map((s, i) => {
+                      const roles = Array.isArray(s.stepRoles)
+                        ? s.stepRoles
+                            .map((r) => r.roleName)
+                            .filter(Boolean)
+                            .join(", ")
+                        : "";
+                      const perms = Array.isArray(s.permissionNames)
+                        ? s.permissionNames.join(", ")
+                        : "";
+                      return (
+                        <tr
+                          key={`${s.stepName ?? "s"}-${i}`}
+                          style={{ borderBottom: "1px solid #edf2f7" }}
+                        >
+                          <td style={{ padding: "8px", fontFamily: "monospace" }}>
+                            {s.stepName || "—"}
+                          </td>
+                          <td style={{ padding: "8px" }}>{perms || "—"}</td>
+                          <td style={{ padding: "8px" }}>{roles || "—"}</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+
+          <section style={{ marginTop: "16px" }} data-testid="developer-wf-gaps">
+            <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.WF_GAPS}</h3>
+            <ul style={{ color: "#4a5568", fontSize: "0.9rem" }}>
+              <li>{DEV_MSG.WF_GAP_GRAPH}</li>
+              <li>{DEV_MSG.WF_GAP_WRITE}</li>
+              <li>{DEV_MSG.WF_GAP_CT}</li>
+            </ul>
+          </section>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/developer/WorkflowDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/WorkflowDetailPanel.tsx
@@ -124,9 +124,12 @@ export function WorkflowDetailPanel({
           <section style={{ marginTop: "16px" }} data-testid="developer-wf-gaps">
             <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.WF_GAPS}</h3>
             <ul style={{ color: "#4a5568", fontSize: "0.9rem" }}>
-              <li>{DEV_MSG.WF_GAP_GRAPH}</li>
-              <li>{DEV_MSG.WF_GAP_WRITE}</li>
-              <li>{DEV_MSG.WF_GAP_CT}</li>
+              {(detail.designGaps && detail.designGaps.length
+                ? detail.designGaps
+                : [DEV_MSG.WF_GAP_GRAPH, DEV_MSG.WF_GAP_WRITE, DEV_MSG.WF_GAP_CT]
+              ).map((g) => (
+                <li key={g}>{g}</li>
+              ))}
             </ul>
           </section>
         </>

--- a/WebUI/src/main/ts/developer/WorkflowDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/WorkflowDetailPanel.tsx
@@ -127,8 +127,8 @@ export function WorkflowDetailPanel({
               {(detail.designGaps && detail.designGaps.length
                 ? detail.designGaps
                 : [DEV_MSG.WF_GAP_GRAPH, DEV_MSG.WF_GAP_WRITE, DEV_MSG.WF_GAP_CT]
-              ).map((g) => (
-                <li key={g}>{g}</li>
+              ).map((g, i) => (
+                <li key={`${g}-${i}`}>{g}</li>
               ))}
             </ul>
           </section>

--- a/WebUI/src/main/ts/developer/WorkflowsPanel.tsx
+++ b/WebUI/src/main/ts/developer/WorkflowsPanel.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { listWorkflows } from "../api/developer/workflowsApi";
 import type { WorkflowDef } from "../api/developer/types";
 import { CatalogHint, CatalogStatus } from "./CatalogTable";
-import { monoCell, mutedCell } from "./catalogStyles";
+import { mutedCell } from "./catalogStyles";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
 import { WorkflowDetailPanel } from "./WorkflowDetailPanel";
@@ -28,7 +28,7 @@ export function WorkflowsPanel(): React.ReactElement {
       .catch((e: unknown) => {
         if (cancelled) return;
         setError(panelErrMsg(e, DEV_MSG.WF_ERROR));
-        setItems([]);
+        // Leave items null so error ≠ empty catalog (and retry can show loading).
       });
     return () => {
       cancelled = true;
@@ -37,11 +37,13 @@ export function WorkflowsPanel(): React.ReactElement {
 
   const sorted = useMemo(() => {
     if (!items) return [];
-    return [...items].sort((a, b) =>
-      (a.workflowName || "").localeCompare(b.workflowName || "", undefined, {
-        sensitivity: "base",
-      }),
-    );
+    return [...items]
+      .filter((w) => (w.workflowName || "").trim().length > 0)
+      .sort((a, b) =>
+        (a.workflowName || "").localeCompare(b.workflowName || "", undefined, {
+          sensitivity: "base",
+        }),
+      );
   }, [items]);
 
   if (selected) {
@@ -76,47 +78,40 @@ export function WorkflowsPanel(): React.ReactElement {
             </tr>
           </thead>
           <tbody>
-            {sorted.map((w, index) => {
-              const openKey = w.workflowName || "";
-              const interactive = openKey.length > 0;
+            {sorted.map((w) => {
+              const openKey = (w.workflowName || "").trim();
               const stepCount = Array.isArray(w.workflowSteps) ? w.workflowSteps.length : 0;
               return (
                 <tr
-                  key={w.workflowName || `wf-${index}`}
+                  key={openKey}
                   data-testid="developer-wf-row"
                   style={{
                     borderBottom: "1px solid #edf2f7",
-                    cursor: interactive ? "pointer" : "default",
+                    cursor: "pointer",
                   }}
-                  onClick={() => {
-                    if (interactive) setSelected(openKey);
-                  }}
+                  onClick={() => setSelected(openKey)}
                 >
                   <td style={{ padding: "8px" }}>
-                    {interactive ? (
-                      <button
-                        type="button"
-                        data-testid="developer-wf-open"
-                        aria-label={`Open ${openKey}`}
-                        onClick={(ev) => {
-                          ev.stopPropagation();
-                          setSelected(openKey);
-                        }}
-                        style={{
-                          background: "transparent",
-                          border: "none",
-                          color: "#007ea8",
-                          cursor: "pointer",
-                          font: "inherit",
-                          padding: 0,
-                          fontFamily: "monospace",
-                        }}
-                      >
-                        {w.workflowName || "—"}
-                      </button>
-                    ) : (
-                      <span style={monoCell}>{w.workflowName || "—"}</span>
-                    )}
+                    <button
+                      type="button"
+                      data-testid="developer-wf-open"
+                      aria-label={`Open ${openKey}`}
+                      onClick={(ev) => {
+                        ev.stopPropagation();
+                        setSelected(openKey);
+                      }}
+                      style={{
+                        background: "transparent",
+                        border: "none",
+                        color: "#007ea8",
+                        cursor: "pointer",
+                        font: "inherit",
+                        padding: 0,
+                        fontFamily: "monospace",
+                      }}
+                    >
+                      {openKey}
+                    </button>
                   </td>
                   <td style={{ padding: "8px", ...mutedCell }}>
                     {w.workflowDescription || ""}

--- a/WebUI/src/main/ts/developer/WorkflowsPanel.tsx
+++ b/WebUI/src/main/ts/developer/WorkflowsPanel.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import React, { useEffect, useMemo, useState } from "react";
+import { listWorkflows } from "../api/developer/workflowsApi";
+import type { WorkflowDef } from "../api/developer/types";
+import { CatalogHint, CatalogStatus } from "./CatalogTable";
+import { monoCell, mutedCell } from "./catalogStyles";
+import { panelErrMsg } from "./errors";
+import { DEV_MSG } from "./messages";
+import { WorkflowDetailPanel } from "./WorkflowDetailPanel";
+
+/**
+ * P0.17 — workflow catalog browse (SY-04) via existing workflowmanagement API.
+ */
+export function WorkflowsPanel(): React.ReactElement {
+  const [items, setItems] = useState<WorkflowDef[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    listWorkflows()
+      .then((list) => {
+        if (!cancelled) setItems(list);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setError(panelErrMsg(e, DEV_MSG.WF_ERROR));
+        setItems([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const sorted = useMemo(() => {
+    if (!items) return [];
+    return [...items].sort((a, b) =>
+      (a.workflowName || "").localeCompare(b.workflowName || "", undefined, {
+        sensitivity: "base",
+      }),
+    );
+  }, [items]);
+
+  if (selected) {
+    return <WorkflowDetailPanel name={selected} onBack={() => setSelected(null)} />;
+  }
+
+  if (error)
+    return (
+      <CatalogStatus testId="developer-wf-error" error>
+        {error}
+      </CatalogStatus>
+    );
+  if (items == null)
+    return <CatalogStatus testId="developer-wf-loading">{DEV_MSG.WF_LOADING}</CatalogStatus>;
+  if (items.length === 0)
+    return <CatalogStatus testId="developer-wf-empty">{DEV_MSG.WF_EMPTY}</CatalogStatus>;
+
+  return (
+    <div data-testid="developer-wf-panel">
+      <CatalogHint>{DEV_MSG.WF_HINT}</CatalogHint>
+      <div style={{ overflowX: "auto" }}>
+        <table
+          data-testid="developer-wf-table"
+          style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.95rem" }}
+        >
+          <thead>
+            <tr style={{ textAlign: "left", borderBottom: "2px solid #e2e8f0" }}>
+              <th style={{ padding: "8px" }}>{DEV_MSG.WF_COL_NAME}</th>
+              <th style={{ padding: "8px" }}>{DEV_MSG.WF_COL_DESC}</th>
+              <th style={{ padding: "8px" }}>{DEV_MSG.WF_COL_DEFAULT}</th>
+              <th style={{ padding: "8px" }}>{DEV_MSG.WF_COL_STEPS}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((w, index) => {
+              const openKey = w.workflowName || "";
+              const interactive = openKey.length > 0;
+              const stepCount = Array.isArray(w.workflowSteps) ? w.workflowSteps.length : 0;
+              return (
+                <tr
+                  key={w.workflowName || `wf-${index}`}
+                  data-testid="developer-wf-row"
+                  style={{
+                    borderBottom: "1px solid #edf2f7",
+                    cursor: interactive ? "pointer" : "default",
+                  }}
+                  onClick={() => {
+                    if (interactive) setSelected(openKey);
+                  }}
+                >
+                  <td style={{ padding: "8px" }}>
+                    {interactive ? (
+                      <button
+                        type="button"
+                        data-testid="developer-wf-open"
+                        aria-label={`Open ${openKey}`}
+                        onClick={(ev) => {
+                          ev.stopPropagation();
+                          setSelected(openKey);
+                        }}
+                        style={{
+                          background: "transparent",
+                          border: "none",
+                          color: "#007ea8",
+                          cursor: "pointer",
+                          font: "inherit",
+                          padding: 0,
+                          fontFamily: "monospace",
+                        }}
+                      >
+                        {w.workflowName || "—"}
+                      </button>
+                    ) : (
+                      <span style={monoCell}>{w.workflowName || "—"}</span>
+                    )}
+                  </td>
+                  <td style={{ padding: "8px", ...mutedCell }}>
+                    {w.workflowDescription || ""}
+                  </td>
+                  <td style={{ padding: "8px" }}>
+                    {w.defaultWorkflow ? DEV_MSG.WF_YES : "—"}
+                  </td>
+                  <td style={{ padding: "8px" }}>
+                    {stepCount > 0 ? String(stepCount) : "—"}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/developer/WorkflowsPanel.tsx
+++ b/WebUI/src/main/ts/developer/WorkflowsPanel.tsx
@@ -78,12 +78,12 @@ export function WorkflowsPanel(): React.ReactElement {
             </tr>
           </thead>
           <tbody>
-            {sorted.map((w) => {
+            {sorted.map((w, index) => {
               const openKey = (w.workflowName || "").trim();
               const stepCount = Array.isArray(w.workflowSteps) ? w.workflowSteps.length : 0;
               return (
                 <tr
-                  key={openKey}
+                  key={`${openKey}-${index}`}
                   data-testid="developer-wf-row"
                   style={{
                     borderBottom: "1px solid #edf2f7",

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -69,6 +69,7 @@ export const DEV_MSG_KEYS = {
   TAB_VIEWS: "perc.ui.developer@Views",
   TAB_EXTENSIONS: "perc.ui.developer@Extensions",
   TAB_RELATIONSHIP_TYPES: "perc.ui.developer@Relationship Types",
+  TAB_WORKFLOWS: "perc.ui.developer@Workflows",
   TAB_COMMUNITIES: "perc.ui.developer@Communities",
   TAB_PIPELINES: "perc.ui.developer@Pipelines",
   CT_LOADING: "perc.ui.developer@Loading content types…",
@@ -545,6 +546,33 @@ export const DEV_MSG_KEYS = {
     "perc.ui.developer@Cloning field override editor not supported via this API",
   RT_GAP_EFFECTS:
     "perc.ui.developer@Effect condition and execution-context edit not supported via this API",
+  WF_LOADING: "perc.ui.developer@Loading workflows…",
+  WF_EMPTY: "perc.ui.developer@No workflows returned.",
+  WF_ERROR: "perc.ui.developer@Could not load workflows.",
+  WF_HINT:
+    "perc.ui.developer@Workflow definitions for association and step browse (SY-04). Full graph design stays on the workflow management surface.",
+  WF_COL_NAME: "perc.ui.developer@Name",
+  WF_COL_DESC: "perc.ui.developer@Description",
+  WF_COL_DEFAULT: "perc.ui.developer@Default",
+  WF_COL_STEPS: "perc.ui.developer@Steps",
+  WF_COL_STAGING: "perc.ui.developer@Staging roles",
+  WF_COL_STEP: "perc.ui.developer@Step",
+  WF_COL_PERMS: "perc.ui.developer@Permissions",
+  WF_COL_ROLES: "perc.ui.developer@Roles",
+  WF_YES: "perc.ui.developer@Yes",
+  WF_NO: "perc.ui.developer@No",
+  WF_BACK: "perc.ui.developer@Back to list",
+  WF_DETAIL_LOADING: "perc.ui.developer@Loading workflow…",
+  WF_DETAIL_ERROR: "perc.ui.developer@Could not load workflow.",
+  WF_STEPS: "perc.ui.developer@Steps",
+  WF_NONE: "perc.ui.developer@None",
+  WF_GAPS: "perc.ui.developer@Design gaps (not in this API yet)",
+  WF_GAP_GRAPH:
+    "perc.ui.developer@Full workflow graph design is not exposed in the Developer catalog",
+  WF_GAP_WRITE:
+    "perc.ui.developer@Workflow create / update / delete is not supported from this Developer surface",
+  WF_GAP_CT:
+    "perc.ui.developer@Content type workflow association is edited on the content type detail panel",
   PLACEHOLDER_TITLE: "perc.ui.developer@Not implemented yet",
   PLACEHOLDER_BODY: "perc.ui.developer@This section is planned for Developer P0. See docs/ai-generated/tasks/developer-module-p0 and docs/developer-module.",
 } as const;

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -700,6 +700,24 @@ it("loads views catalog section", async () => {
     expect(screen.getByTestId("developer-wf-table").textContent).toContain("Simple Workflow");
   });
 
+  it("workflows tab surfaces empty and error panel states", async () => {
+    const wfApi = await import("../../../main/ts/api/developer/workflowsApi");
+    (wfApi.listWorkflows as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+    const { unmount } = render(<DeveloperShell initialSection="workflows" embedded />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-wf-empty")).toBeTruthy();
+    });
+    unmount();
+
+    (wfApi.listWorkflows as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("workflow service down"),
+    );
+    render(<DeveloperShell initialSection="workflows" embedded />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-wf-error")).toBeTruthy();
+    });
+  });
+
   it("edits content type workflow and template associations on save", async () => {
     const { updateContentTypeDetail } = await import(
       "../../../main/ts/api/developer/contentTypesApi"

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -461,6 +461,21 @@ vi.mock("../../../main/ts/api/developer/relationshipTypesApi", () => ({
   }),
 }));
 
+vi.mock("../../../main/ts/api/developer/workflowsApi", () => ({
+  listWorkflows: vi.fn().mockResolvedValue([
+    {
+      workflowName: "Simple Workflow",
+      workflowDescription: "Default",
+      defaultWorkflow: true,
+      workflowSteps: [{ stepName: "Draft" }],
+    },
+  ]),
+  getWorkflowDetail: vi.fn().mockResolvedValue({
+    workflowName: "Simple Workflow",
+    workflowSteps: [{ stepName: "Draft", permissionNames: ["Read"], stepRoles: [] }],
+  }),
+}));
+
 describe("DeveloperShell", () => {
   beforeEach(() => {
     (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
@@ -672,6 +687,17 @@ it("loads views catalog section", async () => {
       expect(screen.getByTestId("developer-rt-table")).toBeTruthy();
     });
     expect(screen.getByTestId("developer-rt-table").textContent).toContain("ActiveAssembly");
+  });
+
+  it("loads workflows catalog section", async () => {
+    render(<DeveloperShell initialSection="workflows" embedded />);
+    expect(screen.getByTestId("tab-developer-workflows").getAttribute("aria-selected")).toBe(
+      "true",
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-wf-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-wf-table").textContent).toContain("Simple Workflow");
   });
 
   it("edits content type workflow and template associations on save", async () => {

--- a/WebUI/src/test/ts/developer/WorkflowsPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/WorkflowsPanel.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WorkflowsPanel } from "../../../main/ts/developer/WorkflowsPanel";
+
+vi.mock("../../../main/ts/api/developer/workflowsApi", () => ({
+  listWorkflows: vi.fn().mockResolvedValue([
+    {
+      workflowName: "Simple Workflow",
+      workflowDescription: "Default",
+      defaultWorkflow: true,
+      workflowSteps: [{ stepName: "Draft" }],
+    },
+  ]),
+  getWorkflowDetail: vi.fn().mockResolvedValue({
+    workflowName: "Simple Workflow",
+    workflowDescription: "Default",
+    defaultWorkflow: true,
+    stagingRoleNames: "Admin;Editor",
+    workflowSteps: [
+      {
+        stepName: "Draft",
+        permissionNames: ["Read", "Write"],
+        stepRoles: [{ roleName: "Author" }],
+      },
+      {
+        stepName: "Approved",
+        permissionNames: ["Read"],
+        stepRoles: [{ roleName: "Admin" }],
+      },
+    ],
+  }),
+}));
+
+describe("WorkflowsPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+  });
+
+  it("lists workflows and opens detail", async () => {
+    render(<WorkflowsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-wf-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-wf-table").textContent).toContain("Simple Workflow");
+    fireEvent.click(screen.getByTestId("developer-wf-open"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-wf-detail")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-wf-steps-table")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("developer-wf-back"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-wf-table")).toBeTruthy();
+    });
+  });
+});

--- a/WebUI/src/test/ts/developer/WorkflowsPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/WorkflowsPanel.test.tsx
@@ -6,44 +6,59 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WorkflowsPanel } from "../../../main/ts/developer/WorkflowsPanel";
+import * as workflowsApi from "../../../main/ts/api/developer/workflowsApi";
 
 vi.mock("../../../main/ts/api/developer/workflowsApi", () => ({
-  listWorkflows: vi.fn().mockResolvedValue([
-    {
-      workflowName: "Simple Workflow",
-      workflowDescription: "Default",
-      defaultWorkflow: true,
-      workflowSteps: [{ stepName: "Draft" }],
-    },
-  ]),
-  getWorkflowDetail: vi.fn().mockResolvedValue({
-    workflowName: "Simple Workflow",
-    workflowDescription: "Default",
-    defaultWorkflow: true,
-    stagingRoleNames: "Admin;Editor",
-    workflowSteps: [
-      {
-        stepName: "Draft",
-        permissionNames: ["Read", "Write"],
-        stepRoles: [{ roleName: "Author" }],
-      },
-      {
-        stepName: "Approved",
-        permissionNames: ["Read"],
-        stepRoles: [{ roleName: "Admin" }],
-      },
-    ],
-  }),
+  listWorkflows: vi.fn(),
+  getWorkflowDetail: vi.fn(),
+  WORKFLOW_DESIGN_GAPS: [
+    "Full workflow graph design is not exposed in the Developer catalog",
+    "Workflow create / update / delete is not supported from this Developer surface",
+    "Content type workflow association is edited on the content type detail panel",
+  ],
 }));
+
+const listWorkflows = workflowsApi.listWorkflows as ReturnType<typeof vi.fn>;
+const getWorkflowDetail = workflowsApi.getWorkflowDetail as ReturnType<typeof vi.fn>;
 
 describe("WorkflowsPanel", () => {
   beforeEach(() => {
     (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
       message: (key: string) => key,
     };
+    listWorkflows.mockReset();
+    getWorkflowDetail.mockReset();
   });
 
   it("lists workflows and opens detail", async () => {
+    listWorkflows.mockResolvedValue([
+      {
+        workflowName: "Simple Workflow",
+        workflowDescription: "Default",
+        defaultWorkflow: true,
+        workflowSteps: [{ stepName: "Draft" }],
+      },
+    ]);
+    getWorkflowDetail.mockResolvedValue({
+      workflowName: "Simple Workflow",
+      workflowDescription: "Default",
+      defaultWorkflow: true,
+      stagingRoleNames: "Admin;Editor",
+      workflowSteps: [
+        {
+          stepName: "Draft",
+          permissionNames: ["Read", "Write"],
+          stepRoles: [{ roleName: "Author" }],
+        },
+        {
+          stepName: "Approved",
+          permissionNames: ["Read"],
+          stepRoles: [{ roleName: "Admin" }],
+        },
+      ],
+      designGaps: ["gap-a"],
+    });
+
     render(<WorkflowsPanel />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-wf-table")).toBeTruthy();
@@ -54,9 +69,43 @@ describe("WorkflowsPanel", () => {
       expect(screen.getByTestId("developer-wf-detail")).toBeTruthy();
     });
     expect(screen.getByTestId("developer-wf-steps-table")).toBeTruthy();
+    expect(screen.getByTestId("developer-wf-gaps").textContent).toContain("gap-a");
     fireEvent.click(screen.getByTestId("developer-wf-back"));
     await waitFor(() => {
       expect(screen.getByTestId("developer-wf-table")).toBeTruthy();
     });
+  });
+
+  it("shows loading state while list is pending", async () => {
+    let resolveList!: (v: unknown) => void;
+    listWorkflows.mockReturnValue(
+      new Promise((resolve) => {
+        resolveList = resolve;
+      }),
+    );
+    render(<WorkflowsPanel />);
+    expect(screen.getByTestId("developer-wf-loading")).toBeTruthy();
+    resolveList([]);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-wf-empty")).toBeTruthy();
+    });
+  });
+
+  it("shows empty state when API returns no workflows", async () => {
+    listWorkflows.mockResolvedValue([]);
+    render(<WorkflowsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-wf-empty")).toBeTruthy();
+    });
+  });
+
+  it("shows error state when list fails (items stay unloaded)", async () => {
+    listWorkflows.mockRejectedValue(new Error("network down"));
+    render(<WorkflowsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-wf-error")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("developer-wf-empty")).toBeNull();
+    expect(screen.queryByTestId("developer-wf-table")).toBeNull();
   });
 });

--- a/modules/perc-i18n/src/main/resources/i18n/DeveloperUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/DeveloperUi.tmx
@@ -2021,6 +2021,77 @@
             <note xml:lang="en-us">DEV_MSG.RT_GAP_EFFECTS</note>
             <tuv xml:lang="en-us"><seg>Effect condition and execution-context edit not supported via this API</seg></tuv>
         </tu>
+        <tu tuid="perc.ui.developer@Workflows">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.TAB_WORKFLOWS</note>
+            <tuv xml:lang="en-us"><seg>Workflows</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Loading workflows…">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.WF_LOADING</note>
+            <tuv xml:lang="en-us"><seg>Loading workflows…</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@No workflows returned.">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.WF_EMPTY</note>
+            <tuv xml:lang="en-us"><seg>No workflows returned.</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Could not load workflows.">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.WF_ERROR</note>
+            <tuv xml:lang="en-us"><seg>Could not load workflows.</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Workflow definitions for association and step browse (SY-04). Full graph design stays on the workflow management surface.">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.WF_HINT</note>
+            <tuv xml:lang="en-us"><seg>Workflow definitions for association and step browse (SY-04). Full graph design stays on the workflow management surface.</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Steps">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.WF_COL_STEPS</note>
+            <note xml:lang="en-us">DEV_MSG.WF_STEPS</note>
+            <tuv xml:lang="en-us"><seg>Steps</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Staging roles">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.WF_COL_STAGING</note>
+            <tuv xml:lang="en-us"><seg>Staging roles</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Step">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.WF_COL_STEP</note>
+            <tuv xml:lang="en-us"><seg>Step</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Roles">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.WF_COL_ROLES</note>
+            <tuv xml:lang="en-us"><seg>Roles</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Loading workflow…">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.WF_DETAIL_LOADING</note>
+            <tuv xml:lang="en-us"><seg>Loading workflow…</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Could not load workflow.">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.WF_DETAIL_ERROR</note>
+            <tuv xml:lang="en-us"><seg>Could not load workflow.</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Full workflow graph design is not exposed in the Developer catalog">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.WF_GAP_GRAPH</note>
+            <tuv xml:lang="en-us"><seg>Full workflow graph design is not exposed in the Developer catalog</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Workflow create / update / delete is not supported from this Developer surface">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.WF_GAP_WRITE</note>
+            <tuv xml:lang="en-us"><seg>Workflow create / update / delete is not supported from this Developer surface</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Content type workflow association is edited on the content type detail panel">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.WF_GAP_CT</note>
+            <tuv xml:lang="en-us"><seg>Content type workflow association is edited on the content type detail panel</seg></tuv>
+        </tu>
         <tu tuid="perc.ui.developer@Not implemented yet">
             <prop type="sectionname" xml:lang="en-us">Developer</prop>
             <note xml:lang="en-us">DEV_MSG.PLACEHOLDER_TITLE</note>


### PR DESCRIPTION
## Summary
P0.17 thin **read** workflow catalog for Developer (Workbench System Design / SY-04 association browse).

Reuses the existing stepped-workflow REST surface (no new backend resource):

- `GET /services/workflowmanagement/workflows/metadata` — list
- `GET /services/workflowmanagement/workflows/{name}` — detail with steps / roles / permissions

## SPA
- **Workflows** tab in Developer shell
- Detail: staging roles + steps table
- `designGaps`: full graph design, write, CT association (owned by CT detail)

## Tests
- Vitest `WorkflowsPanel` + shell section

Refs #1622