### PR TITLE
fix(secure-membership): revert spring-ldap-core 4.0.4 bump (#1661) to restore enforcer

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/secure-membership/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.springframework.ldap</groupId>
             <artifactId>spring-ldap-core</artifactId>
-            <version>4.0.4</version>
+            <version>4.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## Summary

Reverts dependabot's spring-ldap-core bump from `4.0.3` -> `4.0.4` (PR #1661, commit `2c77aa6809`) on `development`.

Spring LDAP 4.0.4 transitively requires:

* `org.springframework:spring-core` / `spring-context` / `spring-beans` / `spring-tx` at `7.0.8` (DTS parent manages these at `7.0.7`)
* `io.micrometer:micrometer-commons` / `micrometer-observation` at `1.16.6` (managed at `1.16.5`; `spring-security-ldap` already excludes these but the direct `spring-ldap-core` path bypasses the exclusion)
* `org.slf4j:slf4j-api` at `2.0.18` (managed at `2.0.17`)

That breaks **Rule 4 RequireUpperBoundDeps**. On top of that, `spring-security-ldap:7.0.5` still resolves `spring-ldap-core:4.0.3` while this module pins `4.0.4`, breaking **Rule 5 DependencyConvergence**.

Both rules are part of the project's hard-gate `maven-enforcer-plugin:3.6.2` `enforce` binding, so the build of `:perc-secure-membership` no longer succeeds out of the box on `development`.

This PR restores the `4.0.3` pin on a feature branch (no force-push) so the build is green again. The proper upgrade path is a coordinated bump of Spring / Micrometer / SLF4J in the DTS parent pom, which is intentionally out of scope here.

## Files changed

* `deliverytiersuite/delivery-tier-suite/secure-membership/pom.xml` — `spring-ldap-core` version `4.0.4` -> `4.0.3` (1 line)

## Verification

Ran from repo root (with `JAVA_HOME` on JDK 21) using the repo Maven wrapper.

### Standalone clean install of the touched module

```bash
cd deliverytiersuite/delivery-tier-suite/secure-membership
../../../../mvnw.cmd clean install
```

Result:

* **BUILD SUCCESS** (6.963 s)
* All 7 enforcer rules pass:
  * Rule 0 RequirePluginVersions
  * Rule 1 RequireJavaVersion
  * Rule 2 RequireMavenVersion
  * Rule 3 BanDuplicatePomDependencyVersions
  * **Rule 4 RequireUpperBoundDeps** (previously failing)
  * **Rule 5 DependencyConvergence** (previously failing)
  * Rule 6 BannedDependencies
* Surefire executed (no tests in this module today, no failures)
* `dependency:analyze-only` -> "No dependency problems found"

### Spotless

`./mvnw spotless:check -N` reports large baseline formatting debt across the repo (>5k lines across many unrelated files). Per `AGENTS.md` -> **Pre-PR Spotless formatting (HARD GATE)**, this PR intentionally does NOT fold unrelated Spotless hits: Spotless globs cover Java / Markdown / JS / TS, and this change touches only `pom.xml`, which is not in any Spotless glob. So this PR adds zero formatting debt; the baseline debt is already tracked separately and would belong in a dedicated `chore: Spotless cleanup` PR.

### No new warnings

The 36 Javadoc warnings emitted during the build are pre-existing baseline (missing Javadoc on public members of `AuthFormProcessingFilter.java`, `PSLdapMembershipAuthProvider.java`, `PSLdapUserDetailsMapper.java`, `PSMembershipAuthProvider.java`, `PSMembershipAuthUtils.java`, `PSMembershipConfiguration.java`, `PSMembershipLoginHandler.java`, `PSMembershipLogoutHandler.java`, `PSCacheControlFilter.java`) and are unrelated to this one-line pom edit.

## Followups (not in this PR)

* Coordinate bump of `spring.version`, `spring.security.version`, `micrometer.version`, and `slf4j.version` in `deliverytiersuite/delivery-tier-suite/pom.xml`, then re-introduce `spring-ldap-core` at a compatible release.
* Add an entry to `.github/dependabot.yml` ignoring `org.springframework.ldap:spring-ldap-core` (or the whole `org.springframework.ldap:*` group) until the coordinated upgrade, so dependabot stops opening unshippable patch bumps.

> Co-Authored by Kilo MiniMax-M3 using MiniMax M3 with agent kilo.
