### PR TITLE
fix(deps): align Spring 7.0.8 / Spring Security 7.0.6 / SLF4J 2.0.18 to support spring-ldap-core 4.0.4 (supersedes #1668)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/pom.xml
@@ -31,8 +31,6 @@
         <disruptor.version>4.0.0</disruptor.version>
         <eclipse-manifest-location>META-INF</eclipse-manifest-location>
         <ehcache-core.version>3.10.8</ehcache-core.version>
-        <!-- Overrides Parent -->
-        <install.jre.version>8.222.10.1</install.jre.version>
         <javadocs.skip>false</javadocs.skip>
         <jaxb-runtime.version>4.0.6</jaxb-runtime.version>
         <jdt.version>3.18.0</jdt.version>
@@ -42,14 +40,11 @@
         <lifecycle.mapping.plugin>1.0.0</lifecycle.mapping.plugin>
         <liquibase-core.version>5.0.1</liquibase-core.version>
         <macker.version>1.0.2</macker.version>
-        <mariadb.version>3.5.7</mariadb.version>
         <morphia.version>0.104</morphia.version>
-        <postgresql.version>42.7.12</postgresql.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Jakarta EE 11 / Tomcat 11 — align with parent jakarta.servlet.api.version (#667) -->
         <servlet.api.version>6.1.0</servlet.api.version>
-        <servlet.spec>6.1.0</servlet.spec>
         <spring.security.version>7.0.6</spring.security.version>
         <sqlserver.version>13.3.1.jre11-preview</sqlserver.version>
         <supercsv.version>2.4.0</supercsv.version>

--- a/deliverytiersuite/delivery-tier-suite/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/pom.xml
@@ -50,9 +50,7 @@
         <!-- Jakarta EE 11 / Tomcat 11 — align with parent jakarta.servlet.api.version (#667) -->
         <servlet.api.version>6.1.0</servlet.api.version>
         <servlet.spec>6.1.0</servlet.spec>
-        <spring.security.version>7.0.5</spring.security.version>
-        <!-- Overrides Parent-->
-        <spring.version>7.0.7</spring.version>
+        <spring.security.version>7.0.6</spring.security.version>
         <sqlserver.version>13.3.1.jre11-preview</sqlserver.version>
         <supercsv.version>2.4.0</supercsv.version>
         <timestamp>${maven.build.timestamp}</timestamp>
@@ -230,6 +228,11 @@
                         <artifactId>micrometer-commons</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.ldap</groupId>
+                <artifactId>spring-ldap-core</artifactId>
+                <version>4.0.4</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>

--- a/deliverytiersuite/delivery-tier-suite/secure-membership/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/secure-membership/pom.xml
@@ -62,7 +62,6 @@
         <dependency>
             <groupId>org.springframework.ldap</groupId>
             <artifactId>spring-ldap-core</artifactId>
-            <version>4.0.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -236,12 +236,12 @@
         <skin.last.release.version>1.3.1</skin.last.release.version>
         <skipITs>true</skipITs>
         <skipTests>false</skipTests>
-        <slf4j.version>2.0.17</slf4j.version>
+        <slf4j.version>2.0.18</slf4j.version>
         <snakeyaml.version>2.5</snakeyaml.version>
         <solr.version>9.10.1</solr.version>
         <spotless.plugin.version>3.1.0</spotless.plugin.version>
         <!-- 5.17.x and up require Java 11 -->
-        <spring.version>7.0.7</spring.version>
+        <spring.version>7.0.8</spring.version>
         <sqlite.version>3.51.1.0</sqlite.version>
         <stax.version>1.0.1</stax.version>
         <surefireArgLine/>


### PR DESCRIPTION
## Summary

Fixes the `maven-enforcer-plugin:3.6.2:enforce` build break on
`:perc-secure-membership` that dependabot PR #1661 introduced when it bumped
`org.springframework.ldap:spring-ldap-core` from `4.0.3` -> `4.0.4`.

Coordinated fix: align the parent pom versions (the intended fix path) rather
than reverting dependabot, and remove a few redundant properties that DTS
should not have been carrying.

Two commits on `fix/bump-spring-and-slf4j-for-ldap-4-0-4` against
`origin/development`.

### Commit 1 — `b5cf4a2647` — fix(deps): align Spring / Spring Security / SLF4J

Root cause: Spring LDAP 4.0.4 transitively requires spring-core / spring-
context / spring-beans / spring-tx at `7.0.8` and slf4j-api at `2.0.18`,
which exceed the parent poms' managed versions (`7.0.7`, `2.0.17`). That
breaks the **`RequireUpperBoundDeps` (Rule 4)** gate on
`:perc-secure-membership`. Spring Security `7.0.5` pulls spring-ldap-core at
`4.0.3`, so the direct `4.0.4` pin in
`secure-membership/pom.xml` also breaks **`DependencyConvergence` (Rule 5)**.

Changes:

* `pom.xml` (root): `spring.version` `7.0.7` -> `7.0.8`, `slf4j.version`
  `2.0.17` -> `2.0.18`.
* `deliverytiersuite/delivery-tier-suite/pom.xml` (DTS):
  * `spring.security.version` `7.0.5` -> `7.0.6` (matches Spring `7.0.8`
    alignment).
  * Remove the redundant `<spring.version>7.0.7</spring.version>` DTS
    override so DTS inherits from root.
  * Add `<spring-ldap-core>` `4.0.4` to DTS `<dependencyManagement>` so both
    the direct path and the `spring-security-ldap` transitive path agree.
* `deliverytiersuite/delivery-tier-suite/secure-membership/pom.xml`: drop
  the inline `<version>4.0.4</version>` on `spring-ldap-core` so it picks up
  the managed version from DTS dependencyManagement.

### Commit 2 — `54c9edf12e` — chore(dts): drop redundant version overrides from DTS pom

Audit (user request) confirmed four more DTS `<properties>` were either
overriding root or were dead code, in addition to `spring.version` which
Commit 1 already cleaned up. Per project convention, DTS pom should only
carry properties it owns.

Removed:

* `<install.jre.version>8.222.10.1</install.jre.version>` — not referenced
  anywhere in the reactor (dead in both root and DTS).
* `<mariadb.version>3.5.7</mariadb.version>` — duplicate of root value; the
  single DTS-side reference at `delivery-tier-suite/pom.xml:317` resolves
  identically through the root pom.
* `<postgresql.version>42.7.12</postgresql.version>` — duplicate of root
  value; `delivery-tier-distribution/pom.xml:378` resolves identically
  through the root pom.
* `<servlet.spec>6.1.0</servlet.spec>` — not referenced anywhere (dead in
  both root and DTS).
* Orphan `<!-- Overrides Parent -->` comment that introduced the
  `install.jre` block.

Remaining DTS `<properties>` are either DTS-only artifacts (jaxb-runtime,
jdt, jersey, jrds, liquibase-core, macker, morphia, sqlserver, supercsv,
tomcat, commons-collections, disruptor, xml-apis, servlet-api), DTS-only
build-time configs (build.profile.id, eclipse-manifest-location,
javadocs.skip, lifecycle.mapping.plugin, timestamp), or the property DTS
exclusively owns (`spring.security.version`).

## Supersedes

* PR #1668 — the earlier revert-only attempt. Should be closed in favor of
  this coordinated version bump + cleanup.

## Verification

Ran from repo root (`mvnw.cmd`, JDK 21).

### Full DTS reactor — `mvnw.cmd -f deliverytiersuite\delivery-tier-suite\pom.xml clean install`

`BUILD SUCCESS` after both commits. All 7 enforcer rules pass on every one
of the 12 modules (`delivery-tier-suite` aggregator + `perc-shared-app`,
`tomcat-common`, `common`, `comments`, `feeds`, `forms`, `membership`,
`metadata`, `polls`, `secure-membership`, `delivery-tier-distribution`).
Surefire runs the secure-membership suite with no failures. No new compiler
/ enforcer / surefire warnings; Javadoc warnings on this module are
pre-existing baseline (missing comments on public members of
`AuthFormProcessingFilter`, `PSLdapMembershipAuthProvider`,
`PSLdapUserDetailsMapper`, `PSMembershipAuthProvider`,
`PSMembershipAuthUtils`, `PSMembershipConfiguration`,
`PSMembershipLoginHandler`, `PSMembershipLogoutHandler`,
`PSCacheControlFilter`) and are unrelated to this PR.

### Standalone per-module installs

* `cd deliverytiersuite/delivery-tier-suite/secure-membership & ../../../../mvnw.cmd clean install`
  -> BUILD SUCCESS, all 7 enforcer rules passing.
* `cd deliverytiersuite/delivery-tier-suite & mvnw.cmd -N clean install`
  -> parent-pom install OK, no warnings.

## Out of scope (called out for followup)

* `org.springframework.ldap:spring-ldap-core` (or `org.springframework.ldap:*`
  wholesale) could be added to `.github/dependabot.yml` ignore list. We did
  not touch dependabot config here; add as a follow-up PR if patch bumps
  reopen the same class of conflict in future.
* The unrelated Spotless baseline debt in the repo (>5k lines of formatting
  diffs across unrelated files) is intentionally **not** folded into this
  PR. Per root `AGENTS.md` -> **Pre-PR Spotless formatting**, this PR
  touches only `.pom.xml` files, which are not in any Spotless glob, so it
  adds zero formatting debt. A dedicated `chore: Spotless cleanup` PR is the
  correct venue for the baseline diff.

> Co-Authored by Kilo MiniMax-M3 using MiniMax M3 with agent kilo.
