### PR TITLE
ci: widen in-repo Dependency Submission to development + PRs

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches: ["development", "development-8.1.x"]
   schedule:
-    # Weekly cadence is enough for Dependabot / the dependency graph on the
-    # active `development` line. Schedule events default to the repo's default
-    # branch; the JDK 21 job hardcodes `ref:` on checkout so it lands on
-    # development. The JDK 8 job skips schedule events - it stays push-only
-    # for the maintenance `development-8.1.x` line.
+    # Weekly cadence for both lines. Each job hardcodes `ref:` on checkout
+    # so schedule events (which default to the repo's default branch) land
+    # on the right branch.
     - cron: '0 6 * * 1'   # Monday 06:00 UTC
   workflow_dispatch:
 
@@ -78,6 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/development-8.1.x')
 
     steps:

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -3,6 +3,10 @@ name: Dependency Submission
 on:
   push:
     branches: ["development", "development-8.1.x"]
+  schedule:
+    # Once a day per branch. Schedule events default to the repo's default
+    # branch; each job hardcodes `ref:` on checkout so it picks its own line.
+    - cron: '0 6 * * *'
   workflow_dispatch:
 
 permissions:
@@ -18,10 +22,15 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/development')
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # For schedule/workflow_dispatch, force-checkout the right branch.
+          # On push events this matches github.ref anyway.
+          ref: development
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -66,10 +75,14 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/development-8.1.x')
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # See dep-submit-21 comment.
+          ref: development-8.1.x
 
       - name: Set up JDK 8
         uses: actions/setup-java@v4

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -3,8 +3,6 @@ name: Dependency Submission
 on:
   push:
     branches: ["development", "development-8.1.x"]
-  pull_request:
-    branches: ["development", "development-8.1.x"]
   workflow_dispatch:
 
 permissions:
@@ -20,8 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/development') ||
-      (github.event_name == 'pull_request' && github.base_ref == 'development')
+      (github.event_name == 'push' && github.ref == 'refs/heads/development')
 
     steps:
       - uses: actions/checkout@v4
@@ -69,8 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/development-8.1.x') ||
-      (github.event_name == 'pull_request' && github.base_ref == 'development-8.1.x')
+      (github.event_name == 'push' && github.ref == 'refs/heads/development-8.1.x')
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -4,9 +4,12 @@ on:
   push:
     branches: ["development", "development-8.1.x"]
   schedule:
-    # Once a day per branch. Schedule events default to the repo's default
-    # branch; each job hardcodes `ref:` on checkout so it picks its own line.
-    - cron: '0 6 * * *'
+    # Weekly cadence is enough for Dependabot / the dependency graph on the
+    # active `development` line. Schedule events default to the repo's default
+    # branch; the JDK 21 job hardcodes `ref:` on checkout so it lands on
+    # development. The JDK 8 job skips schedule events - it stays push-only
+    # for the maintenance `development-8.1.x` line.
+    - cron: '0 6 * * 1'   # Monday 06:00 UTC
   workflow_dispatch:
 
 permissions:
@@ -75,7 +78,6 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'schedule' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/development-8.1.x')
 
     steps:

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -2,7 +2,9 @@ name: Dependency Submission
 
 on:
   push:
-    branches: ["development-8.1.x"]
+    branches: ["development", "development-8.1.x"]
+  pull_request:
+    branches: ["development", "development-8.1.x"]
   workflow_dispatch:
 
 permissions:
@@ -12,8 +14,63 @@ permissions:
   actions: read
 
 jobs:
-  dependency-submission:
+  # JDK 21 build: covers the active `development` line.
+  dependency-submission-21:
+    name: dep-submit (jdk21)
     runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/development') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'development')
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+          cache: maven
+
+      - name: Create Maven Toolchains (jdk21)
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/toolchains.xml <<'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <toolchains>
+            <toolchain>
+              <type>jdk</type>
+              <provides>
+                <version>21</version>
+                <vendor>temurin</vendor>
+              </provides>
+              <configuration>
+                <jdkHome>${{ env.JAVA_HOME }}</jdkHome>
+              </configuration>
+            </toolchain>
+          </toolchains>
+          EOF
+
+      - name: Build project to install dependencies
+        run: mvn clean install -DskipTests=true -pl !modules/perc-distribution-tree
+        continue-on-error: true
+
+      - name: Submit Dependency Snapshot
+        uses: advanced-security/maven-dependency-submission-action@v4
+        with:
+          ignore-maven-wrapper: true
+          # The action will now pick up the toolchain from ~/.m2/toolchains.xml automatically
+          maven-args: "-B -DskipTests -fn -pl !modules/perc-distribution-tree"
+
+  # JDK 8 build: covers the maintenance `development-8.1.x` line.
+  dependency-submission-8:
+    name: dep-submit (jdk8)
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/development-8.1.x') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'development-8.1.x')
 
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +83,7 @@ jobs:
           cache: maven
 
       # NEW STEP: Create the toolchains.xml file
-      - name: Create Maven Toolchains
+      - name: Create Maven Toolchains (jdk8)
         run: |
           mkdir -p ~/.m2
           echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>


### PR DESCRIPTION
## Summary

The org-level **GitHub Advanced Security → "Automatic Dependency Submission (Maven)"** check is failing on PRs to `development` because it runs a bare `mvn validate` at the repo root against a multi-module reactor where dozens of sibling SNAPSHOTs are not installed in `~/.m2`:

```
[ERROR] Failed to execute goal on project perc-system:
Could not resolve dependencies for project com.percussion:perc-system:jar:8.2.0-SNAPSHOT
  Could not find artifact com.percussion:perc-security-acl-shim:jar:8.2.0-SNAPSHOT
  ... perc-security-utils, perc-xml-security, perc-legacy, utils, servlet-utils,
      perc-simple, webservices, tablefactory, perc-shared-test-resources,
      audit-log, auditlogger, perc-exceptions-spring, perc-i18n
```

This has nothing to do with PR content; it fails on `development` HEAD too.

## Fix

Broaden the in-repo `.github/workflows/dependency-submission.yml` so it covers both branches and runs on a **weekly** schedule for both lines. Split the single job into two guarded jobs (JDK 21 for `development`, JDK 8 for `development-8.1.x`). Each job installs only its own JDK via `actions/setup-java`, writes a matching `~/.m2/toolchains.xml`, hardcodes `ref:` on checkout so schedule/workflow_dispatch pick the right branch, and runs `mvn clean install -DskipTests=true` **before** invoking the submission action so reactor SNAPSHOTs are populated.

### Triggers (post-merge + weekly on both branches, never on PRs)

```yaml
on:
  push:
    branches: ["development", "development-8.1.x"]
  schedule:
    - cron: '0 6 * * 1'   # Monday 06:00 UTC
  workflow_dispatch:
```

`pull_request` is intentionally **not** a trigger. Each run does a full `mvn clean install -DskipTests=true` across the 66-module reactor to populate `~/.m2` before submission, which is several minutes of GH Actions time and provides no value as a PR gate. The dependency graph only needs one snapshot per merge and one per week.

### Job guards

Both jobs fire on push to their respective branch, the weekly schedule, and workflow_dispatch. Each job hardcodes `ref:` on checkout so schedule events (which otherwise default to the repo's default branch) land on the right line:

```yaml
# dep-submit (jdk21)
if: |
  github.event_name == 'workflow_dispatch' ||
  github.event_name == 'schedule' ||
  (github.event_name == 'push' && github.ref == 'refs/heads/development')
```

```yaml
# dep-submit (jdk8)
if: |
  github.event_name == 'workflow_dispatch' ||
  github.event_name == 'schedule' ||
  (github.event_name == 'push' && github.ref == 'refs/heads/development-8.1.x')
```

### Cost

- 2 scheduled runs/week (one per branch, Monday 06:00 UTC).
- Plus 1 push/merge per branch on a typical day.
- Bounded by `actions/setup-java` Maven cache + the existing Maven reactor.

## Follow-up (out of scope for this PR)

Once this lands, the org/repo-level **Settings → Code security → Automatic dependency submission** toggle should be **disabled** for this monorepo. The in-repo workflow is then the single source of truth for Maven dependency submissions on both lines. (Dependabot itself is unaffected.)

## Test plan

- [x] `git diff` reviewed — single-file YAML change, no Java/JS/TS/Markdown touched.
- [x] YAML syntax valid (both jobs parse, `if:` expressions reference existing GH context keys, `schedule:` cron is valid: `0 6 * * 1` = Monday 06:00 UTC).
- [x] Branch filter quoted consistently; JDK versions pinned (`temurin`, `21` / `8`); `ref:` hardcoded per job so schedule events land on the right branch.
- [x] No hardcoded filesystem paths; `JAVA_HOME` from `actions/setup-java` is used in the toolchains config.
- [x] No secrets, tokens, or env values exposed.
- [ ] Merge → confirm `dep-submit (jdk21)` and `dep-submit (jdk8)` both fire on the next Monday 06:00 UTC schedule and each submit a snapshot of their respective branch.
- [ ] Disable org-level GHAS auto-submission for this repo (Settings → Code security).
- [ ] Re-run on PR #1669 to confirm the failing `Automatic Dependency Submission (Maven)` check is gone (or replaced by the in-repo one).

> Co-Authored by Kilo using MiniMax-M3 with agent kilo.