### PR TITLE
chore(deps): bump netty, jetty, and artemis for active CVE fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <ant.contrib.version>1.0b3</ant.contrib.version>
         <ant.version>1.10.14</ant.version>
         <aopalliance.version>1.0</aopalliance.version>
-        <artemis.version>2.50.0</artemis.version>
+        <artemis.version>2.52.0</artemis.version>
         <avalon.version>4.1.5</avalon.version>
         <awssdk.version>1.12.797</awssdk.version>
         <batik.version>1.19</batik.version>
@@ -164,7 +164,7 @@
         <jenkins.buildNumber>2024</jenkins.buildNumber>
         <!-- Jetty 12 EE11 Maven plugin (dev jetty:run). Runtime packaging uses perc-jetty ee11 / jetty.version. -->
         <jetty.maven.plugin.version>${jetty.version}</jetty.maven.plugin.version>
-        <jetty.version>12.1.7</jetty.version>
+        <jetty.version>12.1.11</jetty.version>
         <jfx.version>11.0.2</jfx.version>
         <json.version>20251224</json.version>
         <jsoup.version>1.22.1</jsoup.version>
@@ -213,7 +213,7 @@
         <mockito.version>5.21.0</mockito.version>
         <mssql.version>13.3.1.jre11-preview</mssql.version>
         <mysql.connector.version>8.4.0</mysql.connector.version>
-        <nettyall.version>4.2.9.Final</nettyall.version>
+        <nettyall.version>4.2.16.Final</nettyall.version>
         <ojdbc17.version>23.26.0.0.0</ojdbc17.version>
         <opencsv.version>5.12.0</opencsv.version>
         <oracle.version>12.1.0.1</oracle.version>


### PR DESCRIPTION
## Summary

Dependabot's last security-updates run (workflow run 30517313343) processed 39 security advisories for this repo and reported:

```
Lowest security fix version is
Adding dependencies as handled: (org.codehaus.plexus:plexus-utils).
No update needed for org.codehaus.plexus:plexus-utils 4.0.3
Nothing to update for Dependency Group: 'maven'
```

The action concluded `success`; the issue is that the GitHub Advisory Database has **no `patched_versions` entry** for any of those advisories, so Dependabot has no bumped version to propose.

This PR fixes the **three directly-declared dependencies** in the root `pom.xml` whose current pinned versions sit inside an active advisory's affected range AND have a known upstream fix:

| Dep | From | To | Advisory range | Upstream fix |
|---|---|---|---|---|
| `io.netty:netty-all` | `4.2.9.Final` | `4.2.16.Final` | `[4.2.0.Final, 4.2.16.Final)` | `4.2.16.Final` (Maven Central, Jul 2026) |
| `org.eclipse.jetty:jetty-*` | `12.1.7` | `12.1.11` | `[12.1.0, 12.1.8]` | latest 12.1.x patch (Maven Central, Jul 2026) |
| `org.apache.activemq:artemis-*` | `2.50.0` | `2.52.0` | `[2.50.0, 2.52.0)` | `2.52.0` (Maven Central, Mar 2026) |

All three changes are in `pom.xml` (no per-module POMs declare these).

## Verification

Pre-PR Maven clean-install per the project hard gate (per-module, JDK 21 + Maven wrapper, `JAVA_HOME` set to JDK 21):

```
cd rest    && ../mvnw.cmd clean install -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dspotless.check.skip=true   -> BUILD SUCCESS
cd system && ../mvnw.cmd clean install -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dspotless.check.skip=true -> BUILD SUCCESS
```

Both representative modules (the largest in the reactor + the JAX-RS surface) compile and install cleanly against the bumped versions. The two warnings present in the `rest` build (`non-transient instance field of a serializable class` and `possible this escape before subclass is fully initialized`) are pre-existing on `origin/development`; the bumps do not introduce any new warnings.

The remaining 35 modules in the reactor inherit these versions and were **not** individually rebuilt — that would be a full reactor `-am clean install`. Per `AGENTS.md` "Pre-PR Maven verification", the project prefers per-module standalone builds over reactor rebuilds, and the deps are only declared at the parent level, so a representative pair is the standard gate.

## Out of scope (separate issues to follow)

The other 36 advisories fall into one of two buckets and are intentionally **not** addressed in this PR:

- **`commons-configuration2 2.2 - 2.15.0`** — fully transitive (no direct declaration in any `pom.xml` in the repo). Needs a separate PR that traces the source of the transitive pull and pins it there.
- **Unmaintained / EOL libraries** with no upstream fix available:
  - `com.github.junrar:junrar` (transitive)
  - `org.codehaus.plexus:plexus-utils` 3.x (transitive; 4.0.3 is already in tree at the minify-maven-plugin config)
  - `org.java-websocket:Java-WebSocket` 1.x (transitive)
  - `org.apache.zookeeper:zookeeper` 3.x (transitive via `org.apache.solr:solr-solrj`)

These will be tracked as separate issues.

## Test plan

- [x] `git diff` reviewed — single-file, 3-line patch in `pom.xml`, no other changes.
- [x] `rest` module clean install — BUILD SUCCESS.
- [x] `system` module clean install — BUILD SUCCESS.
- [x] No new compiler warnings attributable to the bumps.
- [ ] After merge: confirm Dependabot security tab clears for `netty-all`, `jetty-*`, `artemis-server` advisories.

> Co-Authored by Kilo using MiniMax-M3 with agent kilo.