### PR TITLE
feat(developer): sites catalog browse (P0.18 / SY-04 read)

### DIFF
--- a/WebUI/src/main/ts/api/developer/sitesApi.ts
+++ b/WebUI/src/main/ts/api/developer/sitesApi.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { get } from "../client";
+import { PATHS } from "../paths";
+import type { SiteDef } from "./types";
+
+/** Honest design gaps for Developer SY-04 site browse (not full site design). */
+export const SITE_DESIGN_GAPS: string[] = [
+  "Site create / update / delete is not supported from this Developer surface",
+  "Full site publish and section design live outside the Developer catalog",
+  "Workflow association is browsed under the Workflows catalog",
+];
+
+const LIST_WRAPPER_KEYS = ["Site", "site", "SiteList", "sites", "entries"] as const;
+
+function parseSiteList(payload: unknown): SiteDef[] {
+  if (payload == null) {
+    return [];
+  }
+  if (Array.isArray(payload)) {
+    return payload as SiteDef[];
+  }
+  if (typeof payload === "object") {
+    const obj = payload as Record<string, unknown>;
+    for (const key of LIST_WRAPPER_KEYS) {
+      const raw = obj[key];
+      if (raw == null) continue;
+      if (Array.isArray(raw)) {
+        return raw as SiteDef[];
+      }
+      if (typeof raw === "object") {
+        return [raw as SiteDef];
+      }
+    }
+    throw new Error("Unexpected site list payload (expected array or known Site wrapper)");
+  }
+  throw new Error("Unexpected site list payload type");
+}
+
+function withGaps(s: SiteDef): SiteDef {
+  return {
+    ...s,
+    designGaps:
+      s.designGaps && s.designGaps.length > 0 ? s.designGaps : [...SITE_DESIGN_GAPS],
+  };
+}
+
+/** GET /services/sites */
+export async function listSites(): Promise<SiteDef[]> {
+  const payload = await get<unknown>(PATHS.SITES);
+  return parseSiteList(payload).map(withGaps);
+}

--- a/WebUI/src/main/ts/api/developer/types.ts
+++ b/WebUI/src/main/ts/api/developer/types.ts
@@ -564,4 +564,23 @@ export interface WorkflowDef {
   designGaps?: string[];
 }
 
+/**
+ * Site catalog row from GET /services/sites (SY-04 association browse).
+ * Optional fields may arrive as plain strings from Jackson.
+ */
+export interface SiteDef {
+  name?: string;
+  description?: string;
+  baseUrl?: string;
+  siteProtocol?: string;
+  defaultDocument?: string;
+  defaultFileExtention?: string;
+  pageBasedSite?: boolean;
+  isCanonical?: boolean;
+  canonical?: boolean;
+  guid?: RestGuid;
+  designGaps?: string[];
+}
+
+
 

--- a/WebUI/src/main/ts/api/paths.ts
+++ b/WebUI/src/main/ts/api/paths.ts
@@ -325,10 +325,15 @@ export const PATHS = {
   get RELATIONSHIP_TYPES() {
     return `${SERVICES_ROOT}/relationshiptypes`;
   },
+  /** Site design catalog (SY-04 association browse) — rest SitesResource. */
+  get SITES() {
+    return `${SERVICES_ROOT}/sites`;
+  },
   /** Object ACL catalog (design-time security). */
   get ACLS() {
     return `${SERVICES_ROOT}/acls`;
   },
+
 
   /** Workflow management (workflowmanagement) — Feature 993 */
   get WORKFLOWS() {

--- a/WebUI/src/main/ts/app/deepLinks/allowlists.ts
+++ b/WebUI/src/main/ts/app/deepLinks/allowlists.ts
@@ -98,6 +98,7 @@ export const DEVELOPER_SECTIONS = [
   "extensions",
   "relationship-types",
   "workflows",
+  "sites",
   "communities",
   "pipelines",
 ] as const;
@@ -138,6 +139,8 @@ const DEVELOPER_SECTION_ALIASES: Record<string, DeveloperSection> = {
   workflows: "workflows",
   workflow: "workflows",
   wfs: "workflows",
+  sites: "sites",
+  site: "sites",
   cxviews: "views",
   pipeline: "pipelines",
   applications: "pipelines",

--- a/WebUI/src/main/ts/developer/DeveloperShell.tsx
+++ b/WebUI/src/main/ts/developer/DeveloperShell.tsx
@@ -34,6 +34,7 @@ import { PipelinesPanel } from "./PipelinesPanel";
 import { RelationshipTypesPanel } from "./RelationshipTypesPanel";
 import { SearchesPanel } from "./SearchesPanel";
 import { SharedFieldsPanel } from "./SharedFieldsPanel";
+import { SitesPanel } from "./SitesPanel";
 import { SystemDefPanel } from "./SystemDefPanel";
 import { SlotsPanel } from "./SlotsPanel";
 import { TemplatesPanel } from "./TemplatesPanel";
@@ -58,6 +59,7 @@ const SECTION_LABEL: Record<DeveloperSection, string> = {
   extensions: DEV_MSG.TAB_EXTENSIONS,
   "relationship-types": DEV_MSG.TAB_RELATIONSHIP_TYPES,
   workflows: DEV_MSG.TAB_WORKFLOWS,
+  sites: DEV_MSG.TAB_SITES,
   communities: DEV_MSG.TAB_COMMUNITIES,
   pipelines: DEV_MSG.TAB_PIPELINES,
 };
@@ -182,6 +184,8 @@ export const DeveloperShell: React.FC<DeveloperShellProps> = ({
           <RelationshipTypesPanel />
         ) : active === "workflows" ? (
           <WorkflowsPanel />
+        ) : active === "sites" ? (
+          <SitesPanel />
         ) : active === "communities" ? (
           <CommunitiesPanel />
         ) : (

--- a/WebUI/src/main/ts/developer/SiteDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/SiteDetailPanel.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import React from "react";
+import type { SiteDef } from "../api/developer/types";
+import { backButton, metaGrid, monoCell } from "./catalogStyles";
+import { DEV_MSG } from "./messages";
+
+export function SiteDetailPanel({
+  site,
+  onBack,
+}: {
+  site: SiteDef;
+  onBack: () => void;
+}): React.ReactElement {
+  const name = typeof site.name === "string" ? site.name : "—";
+  const gaps =
+    site.designGaps && site.designGaps.length
+      ? site.designGaps
+      : [DEV_MSG.SITE_GAP_WRITE, DEV_MSG.SITE_GAP_PUBLISH, DEV_MSG.SITE_GAP_WF];
+
+  return (
+    <div data-testid="developer-site-detail">
+      <button type="button" onClick={onBack} data-testid="developer-site-back" style={backButton}>
+        ← {DEV_MSG.SITE_BACK}
+      </button>
+
+      <header style={{ marginBottom: "16px" }}>
+        <h2 style={{ margin: "0 0 4px" }} data-testid="developer-site-detail-title">
+          {name}
+        </h2>
+        <dl style={metaGrid}>
+          <dt>{DEV_MSG.SITE_COL_NAME}</dt>
+          <dd style={{ margin: 0, ...monoCell }}>{name}</dd>
+          <dt>{DEV_MSG.SITE_COL_DESC}</dt>
+          <dd style={{ margin: 0 }}>{site.description || "—"}</dd>
+          <dt>{DEV_MSG.SITE_COL_URL}</dt>
+          <dd style={{ margin: 0, ...monoCell }}>{site.baseUrl || "—"}</dd>
+          <dt>{DEV_MSG.SITE_COL_PROTOCOL}</dt>
+          <dd style={{ margin: 0 }}>{site.siteProtocol || "—"}</dd>
+          <dt>{DEV_MSG.SITE_COL_DEFAULT_DOC}</dt>
+          <dd style={{ margin: 0, ...monoCell }}>{site.defaultDocument || "—"}</dd>
+          <dt>{DEV_MSG.SITE_COL_EXT}</dt>
+          <dd style={{ margin: 0 }}>{site.defaultFileExtention || "—"}</dd>
+          <dt>{DEV_MSG.SITE_COL_PAGE_BASED}</dt>
+          <dd style={{ margin: 0 }}>
+            {site.pageBasedSite ? DEV_MSG.SITE_YES : DEV_MSG.SITE_NO}
+          </dd>
+        </dl>
+      </header>
+
+      <section data-testid="developer-site-gaps">
+        <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.SITE_GAPS}</h3>
+        <ul style={{ color: "#4a5568", fontSize: "0.9rem" }}>
+          {gaps.map((g, i) => (
+            <li key={`${g}-${i}`}>{g}</li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/developer/SitesPanel.tsx
+++ b/WebUI/src/main/ts/developer/SitesPanel.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import React, { useEffect, useMemo, useState } from "react";
+import { listSites } from "../api/developer/sitesApi";
+import type { SiteDef } from "../api/developer/types";
+import { CatalogHint, CatalogStatus } from "./CatalogTable";
+import { mutedCell } from "./catalogStyles";
+import { panelErrMsg } from "./errors";
+import { DEV_MSG } from "./messages";
+import { SiteDetailPanel } from "./SiteDetailPanel";
+
+function siteName(s: SiteDef): string {
+  const n = s.name;
+  if (typeof n === "string") return n.trim();
+  return "";
+}
+
+/**
+ * P0.18 — site catalog browse (SY-04) via existing GET /services/sites.
+ * Detail uses list payload (resource is list-only today).
+ */
+export function SitesPanel(): React.ReactElement {
+  const [items, setItems] = useState<SiteDef[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<SiteDef | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    listSites()
+      .then((list) => {
+        if (!cancelled) setItems(list);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setError(panelErrMsg(e, DEV_MSG.SITE_ERROR));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const sorted = useMemo(() => {
+    if (!items) return [];
+    return [...items]
+      .filter((s) => siteName(s).length > 0)
+      .sort((a, b) =>
+        siteName(a).localeCompare(siteName(b), undefined, { sensitivity: "base" }),
+      );
+  }, [items]);
+
+  if (selected) {
+    return <SiteDetailPanel site={selected} onBack={() => setSelected(null)} />;
+  }
+
+  if (error)
+    return (
+      <CatalogStatus testId="developer-site-error" error>
+        {error}
+      </CatalogStatus>
+    );
+  if (items == null)
+    return (
+      <CatalogStatus testId="developer-site-loading">{DEV_MSG.SITE_LOADING}</CatalogStatus>
+    );
+  if (items.length === 0 || sorted.length === 0)
+    return <CatalogStatus testId="developer-site-empty">{DEV_MSG.SITE_EMPTY}</CatalogStatus>;
+
+  return (
+    <div data-testid="developer-site-panel">
+      <CatalogHint>{DEV_MSG.SITE_HINT}</CatalogHint>
+      <div style={{ overflowX: "auto" }}>
+        <table
+          data-testid="developer-site-table"
+          style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.95rem" }}
+        >
+          <thead>
+            <tr style={{ textAlign: "left", borderBottom: "2px solid #e2e8f0" }}>
+              <th style={{ padding: "8px" }}>{DEV_MSG.SITE_COL_NAME}</th>
+              <th style={{ padding: "8px" }}>{DEV_MSG.SITE_COL_DESC}</th>
+              <th style={{ padding: "8px" }}>{DEV_MSG.SITE_COL_URL}</th>
+              <th style={{ padding: "8px" }}>{DEV_MSG.SITE_COL_FLAGS}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((s, index) => {
+              const name = siteName(s);
+              const flags: string[] = [];
+              if (s.pageBasedSite) flags.push(DEV_MSG.SITE_FLAG_PAGE);
+              if (s.isCanonical ?? s.canonical) flags.push(DEV_MSG.SITE_FLAG_CANONICAL);
+              return (
+                <tr
+                  key={`${name}-${index}`}
+                  data-testid="developer-site-row"
+                  style={{
+                    borderBottom: "1px solid #edf2f7",
+                    cursor: "pointer",
+                  }}
+                  onClick={() => setSelected(s)}
+                >
+                  <td style={{ padding: "8px" }}>
+                    <button
+                      type="button"
+                      data-testid="developer-site-open"
+                      aria-label={`Open ${name}`}
+                      onClick={(ev) => {
+                        ev.stopPropagation();
+                        setSelected(s);
+                      }}
+                      style={{
+                        background: "transparent",
+                        border: "none",
+                        color: "#007ea8",
+                        cursor: "pointer",
+                        font: "inherit",
+                        padding: 0,
+                        fontFamily: "monospace",
+                      }}
+                    >
+                      {name}
+                    </button>
+                  </td>
+                  <td style={{ padding: "8px", ...mutedCell }}>{s.description || ""}</td>
+                  <td style={{ padding: "8px", fontFamily: "monospace", fontSize: "0.85rem" }}>
+                    {s.baseUrl || "—"}
+                  </td>
+                  <td style={{ padding: "8px", fontSize: "0.85rem" }}>
+                    {flags.length ? flags.join(", ") : "—"}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -70,6 +70,7 @@ export const DEV_MSG_KEYS = {
   TAB_EXTENSIONS: "perc.ui.developer@Extensions",
   TAB_RELATIONSHIP_TYPES: "perc.ui.developer@Relationship Types",
   TAB_WORKFLOWS: "perc.ui.developer@Workflows",
+  TAB_SITES: "perc.ui.developer@Sites",
   TAB_COMMUNITIES: "perc.ui.developer@Communities",
   TAB_PIPELINES: "perc.ui.developer@Pipelines",
   CT_LOADING: "perc.ui.developer@Loading content types…",
@@ -573,6 +574,31 @@ export const DEV_MSG_KEYS = {
     "perc.ui.developer@Workflow create / update / delete is not supported from this Developer surface",
   WF_GAP_CT:
     "perc.ui.developer@Content type workflow association is edited on the content type detail panel",
+  SITE_LOADING: "perc.ui.developer@Loading sites…",
+  SITE_EMPTY: "perc.ui.developer@No sites returned.",
+  SITE_ERROR: "perc.ui.developer@Could not load sites.",
+  SITE_HINT:
+    "perc.ui.developer@Site definitions for association browse (SY-04). Open a row for URL and defaults. Site design/write is a later surface.",
+  SITE_COL_NAME: "perc.ui.developer@Name",
+  SITE_COL_DESC: "perc.ui.developer@Description",
+  SITE_COL_URL: "perc.ui.developer@Base URL",
+  SITE_COL_FLAGS: "perc.ui.developer@Flags",
+  SITE_COL_PROTOCOL: "perc.ui.developer@Protocol",
+  SITE_COL_DEFAULT_DOC: "perc.ui.developer@Default document",
+  SITE_COL_EXT: "perc.ui.developer@Default file extension",
+  SITE_COL_PAGE_BASED: "perc.ui.developer@Page-based",
+  SITE_FLAG_PAGE: "perc.ui.developer@Page-based",
+  SITE_FLAG_CANONICAL: "perc.ui.developer@Canonical",
+  SITE_YES: "perc.ui.developer@Yes",
+  SITE_NO: "perc.ui.developer@No",
+  SITE_BACK: "perc.ui.developer@Back to list",
+  SITE_GAPS: "perc.ui.developer@Design gaps (not in this API yet)",
+  SITE_GAP_WRITE:
+    "perc.ui.developer@Site create / update / delete is not supported from this Developer surface",
+  SITE_GAP_PUBLISH:
+    "perc.ui.developer@Full site publish and section design live outside the Developer catalog",
+  SITE_GAP_WF:
+    "perc.ui.developer@Workflow association is browsed under the Workflows catalog",
   PLACEHOLDER_TITLE: "perc.ui.developer@Not implemented yet",
   PLACEHOLDER_BODY: "perc.ui.developer@This section is planned for Developer P0. See docs/ai-generated/tasks/developer-module-p0 and docs/developer-module.",
 } as const;

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -476,6 +476,18 @@ vi.mock("../../../main/ts/api/developer/workflowsApi", () => ({
   }),
 }));
 
+vi.mock("../../../main/ts/api/developer/sitesApi", () => ({
+  listSites: vi.fn().mockResolvedValue([
+    {
+      name: "Corporate",
+      description: "Main site",
+      baseUrl: "https://example.com",
+      pageBasedSite: true,
+    },
+  ]),
+  SITE_DESIGN_GAPS: [],
+}));
+
 describe("DeveloperShell", () => {
   beforeEach(() => {
     (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
@@ -716,6 +728,15 @@ it("loads views catalog section", async () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-wf-error")).toBeTruthy();
     });
+  });
+
+  it("loads sites catalog section", async () => {
+    render(<DeveloperShell initialSection="sites" embedded />);
+    expect(screen.getByTestId("tab-developer-sites").getAttribute("aria-selected")).toBe("true");
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-site-table").textContent).toContain("Corporate");
   });
 
   it("edits content type workflow and template associations on save", async () => {

--- a/WebUI/src/test/ts/developer/SitesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SitesPanel.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SitesPanel } from "../../../main/ts/developer/SitesPanel";
+import * as sitesApi from "../../../main/ts/api/developer/sitesApi";
+
+vi.mock("../../../main/ts/api/developer/sitesApi", () => ({
+  listSites: vi.fn(),
+  SITE_DESIGN_GAPS: ["gap-write", "gap-publish", "gap-wf"],
+}));
+
+const listSites = sitesApi.listSites as ReturnType<typeof vi.fn>;
+
+describe("SitesPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    listSites.mockReset();
+  });
+
+  it("lists sites and opens detail from list payload", async () => {
+    listSites.mockResolvedValue([
+      {
+        name: "Corporate",
+        description: "Main site",
+        baseUrl: "https://example.com",
+        siteProtocol: "https",
+        pageBasedSite: true,
+        designGaps: ["gap-a"],
+      },
+    ]);
+    render(<SitesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-site-table").textContent).toContain("Corporate");
+    fireEvent.click(screen.getByTestId("developer-site-open"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-detail")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-site-detail-title").textContent).toContain("Corporate");
+    expect(screen.getByTestId("developer-site-gaps").textContent).toContain("gap-a");
+    fireEvent.click(screen.getByTestId("developer-site-back"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-table")).toBeTruthy();
+    });
+  });
+
+  it("shows loading then empty", async () => {
+    let resolveList!: (v: unknown) => void;
+    listSites.mockReturnValue(
+      new Promise((resolve) => {
+        resolveList = resolve;
+      }),
+    );
+    render(<SitesPanel />);
+    expect(screen.getByTestId("developer-site-loading")).toBeTruthy();
+    resolveList([]);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-empty")).toBeTruthy();
+    });
+  });
+
+  it("shows error without treating as empty", async () => {
+    listSites.mockRejectedValue(new Error("sites down"));
+    render(<SitesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-error")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("developer-site-empty")).toBeNull();
+  });
+});

--- a/modules/perc-i18n/src/main/resources/i18n/DeveloperUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/DeveloperUi.tmx
@@ -2092,6 +2092,76 @@
             <note xml:lang="en-us">DEV_MSG.WF_GAP_CT</note>
             <tuv xml:lang="en-us"><seg>Content type workflow association is edited on the content type detail panel</seg></tuv>
         </tu>
+        <tu tuid="perc.ui.developer@Sites">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.TAB_SITES</note>
+            <tuv xml:lang="en-us"><seg>Sites</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Loading sites…">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SITE_LOADING</note>
+            <tuv xml:lang="en-us"><seg>Loading sites…</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@No sites returned.">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SITE_EMPTY</note>
+            <tuv xml:lang="en-us"><seg>No sites returned.</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Could not load sites.">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SITE_ERROR</note>
+            <tuv xml:lang="en-us"><seg>Could not load sites.</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Site definitions for association browse (SY-04). Open a row for URL and defaults. Site design/write is a later surface.">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SITE_HINT</note>
+            <tuv xml:lang="en-us"><seg>Site definitions for association browse (SY-04). Open a row for URL and defaults. Site design/write is a later surface.</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Base URL">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SITE_COL_URL</note>
+            <tuv xml:lang="en-us"><seg>Base URL</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Protocol">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SITE_COL_PROTOCOL</note>
+            <tuv xml:lang="en-us"><seg>Protocol</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Default document">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SITE_COL_DEFAULT_DOC</note>
+            <tuv xml:lang="en-us"><seg>Default document</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Default file extension">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SITE_COL_EXT</note>
+            <tuv xml:lang="en-us"><seg>Default file extension</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Page-based">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SITE_COL_PAGE_BASED</note>
+            <tuv xml:lang="en-us"><seg>Page-based</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Canonical">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SITE_FLAG_CANONICAL</note>
+            <tuv xml:lang="en-us"><seg>Canonical</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Site create / update / delete is not supported from this Developer surface">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SITE_GAP_WRITE</note>
+            <tuv xml:lang="en-us"><seg>Site create / update / delete is not supported from this Developer surface</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Full site publish and section design live outside the Developer catalog">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SITE_GAP_PUBLISH</note>
+            <tuv xml:lang="en-us"><seg>Full site publish and section design live outside the Developer catalog</seg></tuv>
+        </tu>
+        <tu tuid="perc.ui.developer@Workflow association is browsed under the Workflows catalog">
+            <prop type="sectionname" xml:lang="en-us">Developer</prop>
+            <note xml:lang="en-us">DEV_MSG.SITE_GAP_WF</note>
+            <tuv xml:lang="en-us"><seg>Workflow association is browsed under the Workflows catalog</seg></tuv>
+        </tu>
         <tu tuid="perc.ui.developer@Not implemented yet">
             <prop type="sectionname" xml:lang="en-us">Developer</prop>
             <note xml:lang="en-us">DEV_MSG.PLACEHOLDER_TITLE</note>


### PR DESCRIPTION
## Summary
P0.18 thin **read** site catalog for Developer (Workbench System Design / SY-04 association browse).

Reuses existing REST:

- `GET /services/sites` — list (`SitesResource` / `ISiteAdaptor.findAllSites`)

Detail uses the list payload (resource has no detail path yet).

## SPA
- **Sites** tab: name, description, base URL, page-based / canonical flags
- Detail: protocol, default document/extension, design gaps
- `PATHS.SITES` for `/services/sites` (distinct from `SITES_ALL` sitemanage path)

## Tests
- Vitest `SitesPanel` (list/detail, loading, empty, error) + shell section

Refs #1622