### PR TITLE
fix(webui): explorer folder tree 400 from double-slash path encoding

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
@@ -87,11 +87,17 @@ interface PSPathItemResponse {
  * JAX-RS serializes ArrayList subclasses as a JSON object with a key
  * matching the DTO's local element name).</p>
  */
-export async function findChildren(path: string): Promise<PSPathItem[]> {
+/** Join a pathmanagement base URL with an encodePath suffix (no double slash). */
+function joinPathUrl(base: string, path: string): string {
   const safe = encodePath(path);
-  const res = await get<PSPathItemListResponse>(
-    `${PATHS.PATH_FOLDER}/${safe}`,
+  return safe ? `${base}/${safe}` : `${base}/`;
+}
+
+export async function findChildren(path: string): Promise<PSPathItem[]> {
+  const res = await get<PSPathItemListResponse | PSPathItem[]>(
+    joinPathUrl(PATHS.PATH_FOLDER, path),
   );
+  if (Array.isArray(res)) return res;
   return res?.PathItem ?? [];
 }
 
@@ -109,7 +115,6 @@ export async function paginatedFolder(
   path: string,
   params: PaginatedFolderParams,
 ): Promise<PSPagedResult> {
-  const safe = encodePath(path);
   const q = new URLSearchParams();
   q.set("startIndex", String(params.startIndex));
   q.set("maxResults", String(params.maxResults));
@@ -120,7 +125,7 @@ export async function paginatedFolder(
   if (params.category) q.set("category", params.category);
   if (params.type) q.set("type", params.type);
   const res = await get<PSPagedItemListResponse>(
-    `${PATHS.PATH_PAGINATED_FOLDER}/${safe}?${q.toString()}`,
+    `${joinPathUrl(PATHS.PATH_PAGINATED_FOLDER, path)}?${q.toString()}`,
   );
   // Normalize wire shape (childrenInPage + childrenCount + startIndex
   // under "PagedItemList") into the client-facing shape (children +
@@ -137,8 +142,7 @@ export async function paginatedFolder(
 }
 
 export async function findItemByPath(path: string): Promise<PSPathItem> {
-  const safe = encodePath(path);
-  const res = await get<PSPathItemResponse>(`${PATHS.PATH_ITEM}/${safe}`);
+  const res = await get<PSPathItemResponse>(joinPathUrl(PATHS.PATH_ITEM, path));
   return res?.PathItem ?? ({} as PSPathItem);
 }
 
@@ -153,9 +157,8 @@ export async function addNewFolder(
   path: string,
   name: string,
 ): Promise<PSPathItem> {
-  const safe = encodePath(path);
   const res = await get<PSPathItemResponse>(
-    `${PATHS.PATH_ADD_NEW_FOLDER}/${safe}?name=${encodeURIComponent(name)}`,
+    `${joinPathUrl(PATHS.PATH_ADD_NEW_FOLDER, path)}?name=${encodeURIComponent(name)}`,
   );
   return res?.PathItem ?? ({} as PSPathItem);
 }
@@ -172,8 +175,7 @@ export async function moveItem(body: PSMoveFolderItem): Promise<void> {
 }
 
 export async function deleteItem(path: string): Promise<void> {
-  const safe = encodePath(path);
-  await post<PSPathItemResponse>(`${PATHS.PATH_DELETE_ITEM}/${safe}`);
+  await post<PSPathItemResponse>(joinPathUrl(PATHS.PATH_DELETE_ITEM, path));
 }
 
 export async function folderProperties(
@@ -191,23 +193,30 @@ export async function saveFolderProperties(
 }
 
 export async function validatePath(path: string): Promise<string> {
-  const safe = encodePath(path);
-  return get<string>(`${PATHS.PATH_VALIDATE}/${safe}`);
+  return get<string>(joinPathUrl(PATHS.PATH_VALIDATE, path));
 }
 
 export async function lastExisting(path: string): Promise<string> {
-  const safe = encodePath(path);
-  return get<string>(`${PATHS.PATH_LAST_EXISTING}/${safe}`);
+  return get<string>(joinPathUrl(PATHS.PATH_LAST_EXISTING, path));
 }
 
 /**
- * Encode each `/`-separated path segment with {@link encodeURIComponent}.
- * The `/` separator is preserved by joining — server JAX-RS expects the
- * multi-segment `{path:.*}` pattern to remain readable.
+ * Encode each `/`-separated path segment with {@link encodeURIComponent} for
+ * use as the JAX-RS `{path:.*}` suffix under `/pathmanagement/path/folder/…`.
+ *
+ * <p><strong>Leading/trailing slashes are stripped.</strong> Callers pass CMS
+ * paths like {@code /Sites/} or {@code /} (from {@code PSPathItem.path}); the
+ * server endpoint is mounted as {@code /folder/{path:.*}} and rejects a path
+ * that starts with {@code /} (HTTP 400 "Invalid path") — so the wire form must
+ * be {@code folder/Sites} or {@code folder/} (empty), never {@code folder//Sites}.
  */
 export function encodePath(path: string): string {
+  if (path == null || path === "") {
+    return "";
+  }
   return path
     .split("/")
+    .filter((seg) => seg.length > 0)
     .map((seg) => encodeURIComponent(seg))
     .join("/");
 }

--- a/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/pathApi.ts
@@ -79,25 +79,35 @@ interface PSPathItemResponse {
 }
 
 /**
+ * Join a pathmanagement base URL with an {@link encodePath} suffix.
+ *
+ * <p>{@code base} must already be the resource root <em>without</em> a
+ * trailing slash (e.g. {@code …/path/folder}); this helper appends exactly
+ * one {@code /} then the encoded suffix. An empty suffix (CMS root {@code /})
+ * yields {@code base/} so the server sees {@code folder/}, never
+ * {@code folder//} or {@code folder//Sites}.</p>
+ *
+ * <p>Exported for unit tests that lock the double-slash regression.</p>
+ */
+export function joinPathUrl(base: string, path: string): string {
+  const safe = encodePath(path);
+  return safe ? `${base}/${safe}` : `${base}/`;
+}
+
+/**
  * List folder children (small folders). For large folders use
  * {@link paginatedFolder}.
  *
  * <p>Server response shape: {@code {"PathItem": [...]}} (the
  * {@code PSPathItemList} DTO is an {@code ArrayList<PSPathItem>} subclass;
  * JAX-RS serializes ArrayList subclasses as a JSON object with a key
- * matching the DTO's local element name).</p>
+ * matching the DTO's local element name — Evidence Over Invention: do not
+ * invent alternate bare-array wire shapes).</p>
  */
-/** Join a pathmanagement base URL with an encodePath suffix (no double slash). */
-function joinPathUrl(base: string, path: string): string {
-  const safe = encodePath(path);
-  return safe ? `${base}/${safe}` : `${base}/`;
-}
-
 export async function findChildren(path: string): Promise<PSPathItem[]> {
-  const res = await get<PSPathItemListResponse | PSPathItem[]>(
+  const res = await get<PSPathItemListResponse>(
     joinPathUrl(PATHS.PATH_FOLDER, path),
   );
-  if (Array.isArray(res)) return res;
   return res?.PathItem ?? [];
 }
 
@@ -211,7 +221,7 @@ export async function lastExisting(path: string): Promise<string> {
  * be {@code folder/Sites} or {@code folder/} (empty), never {@code folder//Sites}.
  */
 export function encodePath(path: string): string {
-  if (path == null || path === "") {
+  if (path === "") {
     return "";
   }
   return path

--- a/WebUI/src/test/ts/contentExplorer/pathApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/pathApi.test.ts
@@ -15,7 +15,17 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { encodePath, paginatedFolder } from "../../../main/ts/api/contentExplorer/pathApi";
+import {
+  addNewFolder,
+  deleteItem,
+  encodePath,
+  findChildren,
+  findItemByPath,
+  joinPathUrl,
+  lastExisting,
+  paginatedFolder,
+  validatePath,
+} from "../../../main/ts/api/contentExplorer/pathApi";
 import { mockFetch } from "./setup";
 
 describe("encodePath", () => {
@@ -47,12 +57,28 @@ describe("encodePath", () => {
   });
 });
 
+describe("joinPathUrl", () => {
+  const base = "/Rhythmyx/services/pathmanagement/path/folder";
+
+  it("appends a single trailing slash for CMS root paths", () => {
+    expect(joinPathUrl(base, "/")).toBe(`${base}/`);
+    expect(joinPathUrl(base, "")).toBe(`${base}/`);
+    expect(joinPathUrl(base, "///")).toBe(`${base}/`);
+  });
+
+  it("never produces a double slash before the first segment", () => {
+    expect(joinPathUrl(base, "/Sites/")).toBe(`${base}/Sites`);
+    expect(joinPathUrl(base, "/Sites/Foo")).toBe(`${base}/Sites/Foo`);
+    expect(joinPathUrl(base, "Sites/Foo")).toBe(`${base}/Sites/Foo`);
+  });
+});
 
 describe("paginatedFolder", () => {
   it("builds the paginated URL with required pagination params", async () => {
     const fn = mockFetch(async (input) => {
       const url = typeof input === "string" ? input : (input as Request).url;
       expect(url).toContain("/pathmanagement/path/paginatedFolder/Sites/Foo");
+      expect(url).not.toContain("paginatedFolder//");
       expect(url).toContain("startIndex=0");
       expect(url).toContain("maxResults=50");
       return new Response(
@@ -103,5 +129,70 @@ describe("paginatedFolder", () => {
     await expect(
       paginatedFolder("/Sites/Foo", { startIndex: 0, maxResults: 50 }),
     ).rejects.toMatchObject({ status: 403 });
+  });
+});
+
+describe("pathmanagement URL shape (no double-slash)", () => {
+  function mockJson(body: unknown = { PathItem: [] }): { lastUrl: () => string } {
+    let last = "";
+    mockFetch(async (input) => {
+      last = typeof input === "string" ? input : (input as Request).url;
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    return { lastUrl: () => last };
+  }
+
+  it("findChildren root uses folder/ not folder//", async () => {
+    const cap = mockJson({
+      PathItem: [{ name: "Sites", path: "/Sites/" }],
+    });
+    await findChildren("/");
+    expect(cap.lastUrl()).toMatch(/\/path\/folder\/$/);
+    expect(cap.lastUrl()).not.toContain("folder//");
+  });
+
+  it("findChildren Sites strips leading slash", async () => {
+    const cap = mockJson({ PathItem: [] });
+    await findChildren("/Sites/");
+    expect(cap.lastUrl()).toContain("/path/folder/Sites");
+    expect(cap.lastUrl()).not.toContain("folder//Sites");
+  });
+
+  it("findItemByPath joins without double slash", async () => {
+    const cap = mockJson({ PathItem: { name: "Foo", path: "/Sites/Foo" } });
+    await findItemByPath("/Sites/Foo");
+    expect(cap.lastUrl()).toContain("/path/item/Sites/Foo");
+    expect(cap.lastUrl()).not.toContain("item//Sites");
+  });
+
+  it("addNewFolder joins path and query without double slash", async () => {
+    const cap = mockJson({ PathItem: { name: "New", path: "/Sites/New" } });
+    await addNewFolder("/Sites/", "New");
+    expect(cap.lastUrl()).toContain("/path/addNewFolder/Sites?name=New");
+    expect(cap.lastUrl()).not.toContain("addNewFolder//");
+  });
+
+  it("deleteItem joins without double slash", async () => {
+    const cap = mockJson({});
+    await deleteItem("/Sites/Foo");
+    expect(cap.lastUrl()).toContain("/path/delete/Sites/Foo");
+    expect(cap.lastUrl()).not.toContain("delete//");
+  });
+
+  it("validatePath joins without double slash", async () => {
+    const cap = mockJson("ok");
+    await validatePath("/Sites/");
+    expect(cap.lastUrl()).toContain("/path/validate/Sites");
+    expect(cap.lastUrl()).not.toContain("validate//");
+  });
+
+  it("lastExisting joins without double slash", async () => {
+    const cap = mockJson("/Sites");
+    await lastExisting("/Sites/Missing");
+    expect(cap.lastUrl()).toContain("/path/lastExisting/Sites/Missing");
+    expect(cap.lastUrl()).not.toContain("lastExisting//");
   });
 });

--- a/WebUI/src/test/ts/contentExplorer/pathApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/pathApi.test.ts
@@ -19,21 +19,24 @@ import { encodePath, paginatedFolder } from "../../../main/ts/api/contentExplore
 import { mockFetch } from "./setup";
 
 describe("encodePath", () => {
-  it("preserves the multi-segment shape for CMS paths", () => {
-    expect(encodePath("/Sites/Foo/Bar")).toBe("/Sites/Foo/Bar");
+  it("strips leading/trailing slashes for the folder/{path:.*} URL suffix", () => {
+    // Wire form must be "Sites/Foo/Bar", never "/Sites/…" (that becomes folder//Sites → 400).
+    expect(encodePath("/Sites/Foo/Bar")).toBe("Sites/Foo/Bar");
     expect(encodePath("Sites/Foo/Bar")).toBe("Sites/Foo/Bar");
+    expect(encodePath("/Sites/")).toBe("Sites");
   });
 
   it("encodes spaces and special characters per segment", () => {
     expect(encodePath("/Folder With Space/Child")).toBe(
-      "/Folder%20With%20Space/Child",
+      "Folder%20With%20Space/Child",
     );
-    expect(encodePath("/A&B/C D")).toBe("/A%26B/C%20D");
+    expect(encodePath("/A&B/C D")).toBe("A%26B/C%20D");
   });
 
-  it("handles the empty / root path", () => {
-    expect(encodePath("/")).toBe("/");
+  it("handles the empty / root path as empty suffix (folder/)", () => {
+    expect(encodePath("/")).toBe("");
     expect(encodePath("")).toBe("");
+    expect(encodePath("///")).toBe("");
   });
 
   it("encodes each segment independently so the slash separator is preserved", () => {
@@ -43,6 +46,7 @@ describe("encodePath", () => {
     expect(out).toBe("a/b/c");
   });
 });
+
 
 describe("paginatedFolder", () => {
   it("builds the paginated URL with required pagination params", async () => {

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-1622-explorer-root-folders.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-1622-explorer-root-folders.spec.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regression: Content Explorer root folder tree empty (GH-1622 / encodePath).
+ *
+ * <p>encodePath used to preserve leading slashes on CMS paths like
+ * {@code /} and {@code /Sites/}, producing {@code folder//} and
+ * {@code folder//Sites} which the pathmanagement service rejects with
+ * HTTP 400. The React tree then rendered with no children.</p>
+ *
+ * <p>Coverage:</p>
+ * <ul>
+ *   <li>REST: root {@code path/folder/} returns 200 with well-known roots</li>
+ *   <li>REST: double-slash {@code path/folder//Sites} must not be the
+ *       client contract (assert correct Sites URL works)</li>
+ *   <li>UI: explorer tree is non-empty after shell mount</li>
+ * </ul>
+ *
+ * <p>Run against a live CMS (e.g. {@code C:\Installs\8.2-july-29} or docker):</p>
+ * <pre>
+ *   cd modules/perc-qa-automation/frontend
+ *   npm test -- tests/bugs/bug-1622-explorer-root-folders.spec.js
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+
+const EXPLORER_URL = `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${Date.now()}`;
+const PATH_FOLDER = `${BASE_URL}/Rhythmyx/services/pathmanagement/path/folder`;
+
+test.describe("GH-1622 explorer root folders (encodePath / no double-slash)", () => {
+  test("REST: root folder/ returns well-known children (not folder//)", async ({
+    request,
+  }) => {
+    test.setTimeout(30_000);
+    // Session cookie from login is not required for this assertion when
+    // basic-auth header is accepted; fall back to cookie via storage if needed.
+    const root = await request.get(`${PATH_FOLDER}/`, {
+      headers: { RX_USEBASICAUTH: "true" },
+    });
+    expect(
+      root.status(),
+      `GET ${PATH_FOLDER}/ should be 200 (double-slash form is 400)`,
+    ).toBe(200);
+
+    const sites = await request.get(`${PATH_FOLDER}/Sites`, {
+      headers: { RX_USEBASICAUTH: "true" },
+    });
+    // Sites may be empty on a fresh install, but the path must be valid.
+    expect(
+      sites.status(),
+      `GET ${PATH_FOLDER}/Sites must not 400 (folder//Sites was the bug)`,
+    ).toBe(200);
+
+    const bad = await request.get(`${PATH_FOLDER}//Sites`, {
+      headers: { RX_USEBASICAUTH: "true" },
+    });
+    // Document the server contract the SPA must avoid.
+    expect(bad.status()).toBe(400);
+  });
+
+  test("UI: Content Explorer tree is not empty at root", async ({ page }) => {
+    test.setTimeout(60_000);
+    await loginAsAdmin(page);
+    await page.goto(EXPLORER_URL, { waitUntil: "networkidle" });
+
+    const shell = page.locator('[data-testid="content-explorer-shell"]');
+    await expect(shell).toBeVisible({ timeout: 15_000 });
+
+    const tree = page.locator('[data-testid="explorer-tree"]');
+    await expect(tree).toBeVisible({ timeout: 15_000 });
+
+    // Root children render as tree-node-* rows (paths like /Sites/, /Assets/).
+    const nodes = tree.locator('[data-testid^="tree-node-"]');
+    await expect(nodes.first()).toBeVisible({ timeout: 15_000 });
+    const count = await nodes.count();
+    expect(count, "explorer tree should list root folders").toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Problem
Modern Content Explorer loads no folders (or fails to expand them).

## Root cause
`encodePath` kept a leading `/` from `PSPathItem.path` values (`/`, `/Sites/`). Combined with template joins this produced:

| CMS path | Wire URL | Result |
|----------|----------|--------|
| `/` | `…/path/folder//` | **400** Invalid path |
| `/Sites/` | `…/path/folder//Sites/` | **400** Invalid path |

Server: `PSPathService.findChildren` validates with `SecureStringUtils.isValidCMSPathString` and rejects paths that start with `/`.

## Fix
- Strip empty segments in `encodePath` so `/Sites/Foo` → `Sites/Foo` and `/` → `""`
- Join URLs with `joinPathUrl` (empty → trailing slash only; base must not include trailing `/`)
- Kilo review follow-up: restored `findChildren` JSDoc, removed undocumented bare-array unwrap, exported `joinPathUrl` for tests, expanded Vitest URL-shape coverage, Playwright regression

## Evidence (local `C:\Installs\8.2-july-29`)
- Auth as Admin (`var/config/generated/passwords`)
- `GET …/path/folder/` → 200, PathItem: Sites, Assets, Design, Search, Recycling
- `GET …/path/folder//Sites/` → 400
- `GET …/path/folder/Sites` → 200 (empty children — **no sites** installed yet)
- `GET …/path/folder/Design` → 200 with children

## Note
After this fix, root and Design expand. **Sites/Assets may still look empty** on a fresh install with zero sites — create a site to populate Sites.

## Tests
- Vitest: `npx vitest run src/test/ts/contentExplorer/pathApi.test.ts` — **16 passed**
- Playwright: `modules/perc-qa-automation/frontend/tests/bugs/bug-1622-explorer-root-folders.spec.js` (REST double-slash contract + non-empty tree). **Not run in agent push** (needs live CMS); run against install when available:

`ash
cd modules/perc-qa-automation/frontend
npm test -- tests/bugs/bug-1622-explorer-root-folders.spec.js
`

Refs #1622