### PR TITLE
fix(javadoc): clear extensions-default-template javadoc warnings (GH-1682)

### DIFF
--- a/docs/ai-generated/code-reviews/fix-1682-extensions-default-template-javadoc-cleanup-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-1682-extensions-default-template-javadoc-cleanup-erlang.md
@@ -1,0 +1,129 @@
+# Erlang Code Review — fix/1682-extensions-default-template-javadoc-cleanup
+
+## Summary
+
+Documentation cleanup for issue **#1682** (extensions-default-template module javadoc
+warnings). The module's reactor status was `SUCCESS` but the javadoc tool emitted 5 source
+warnings plus an implicit-default-constructor warning on the single utility class. This pass
+adds the missing class/method javadoc, swaps the bare `@author` block for a proper class
+description, and adds an explicit no-op constructor to silence the implicit-default-constructor
+warning.
+
+Standalone module build after the fix: 0 javadoc warnings, 0 javadoc plugin warnings, 0 javadoc
+blocks warnings, 0 implicit-default-constructor warnings, BUILD SUCCESS in ~32 s.
+
+## Scope
+
+- Base: `origin/development` (`7f2d787acc`, head before this branch)
+- Head: `fix/1682-extensions-default-template-javadoc-cleanup`
+- Files: 1 modified
+  - `modules/extensions-default-template/src/main/java/com/percussion/fastforward/defaulttemplate/PSDefaultTemplateLookup.java`
+- Reactor module: `modules/extensions-default-template`
+
+## Recommendation
+
+approve
+
+## Gate
+
+- Blocking bugs: 0
+- May commit/push: yes
+
+## Issues
+
+None.
+
+## Review notes
+
+### Diff footprint
+
+`PSDefaultTemplateLookup.java` is the **only** Java source file in the module (no `src/test`,
+no other main classes). The diff:
+
+| Section | Before | After |
+|---|---|---|
+| Class-level javadoc (lines 45-47) | Bare `@author adamgent` only — javac emits `warning: no main description`. | Full class description (JEXL utility purpose, FastForward role, entry points) plus preserved `@author` tag. |
+| Default constructor | None — javac emits `warning: use of default constructor, which does not provide a comment`. | Explicit `public PSDefaultTemplateLookup()` no-op constructor. |
+| `test(String first)` (line 53) | `@IPSJexlMethod(...)` annotation only — javac emits `warning: no comment`. | Added javadoc with `@param first`, `@return`. |
+| `test2(int i)` (line 60) | Same pattern — `warning: no comment`. | Added javadoc with `@param i`, `@return`. |
+| `lookup(IPSAssemblyItem item)` (line 72) | Same pattern — `warning: no comment`. | Added javadoc with `@param item`, `@return`. |
+| `lookupDefaults(IPSAssemblyItem item)` (line 85+) | Already documented (full javadoc with `@param`, `@return`, internal-context paragraphs). | Unchanged. |
+| Private helpers `getContentTypeId`, `getSiteId`, `isDefault`, `log` | Package-private / private — not javac-reported. | Unchanged. |
+
+### Functional risk
+
+None. This is a documentation pass plus a no-op explicit constructor. No runtime behavior
+change, no public API surface change, no test changes (the module has no `src/test`
+directory — `PSDefaultTemplateLookup` is exercised indirectly via the FastForward assembly
+flow on the legacy Rhythmyx runtime, which is out of scope for unit tests).
+
+### Cross-platform path / file I/O
+
+The diff does not touch any path or file I/O logic. The only `getParameterValue(SYS_SITEID)`
+call at line ~140 reads a string property and passes it to `PSGuid`; the constructor is
+pure-data and the value never reaches a filesystem API in this method. The downstream
+`PSLocationUtils.findTemplatesByContentType` / `IPSSiteManager.loadUnmodifiableSite` calls are
+inside the unchanged `lookupDefaults` method and are pre-existing.
+
+### Spotless
+
+`mvnw.cmd spotless:apply` reformatted the touched file (Google Java Style enforcement).
+After `spotless:apply`, `mvnw.cmd spotless:check` passes with **0 needs changes**. No new
+Spotless violations introduced.
+
+### Build evidence
+
+```bash
+cd modules/extensions-default-template
+mvnw.cmd clean install -B -Dai.integrity.skip=true
+```
+
+Result: `BUILD SUCCESS` in ~32 s.
+
+```
+[INFO] Building extensions-default-template 8.2.0-SNAPSHOT
+[INFO] Building jar: extensions-default-template-8.2.0-SNAPSHOT.jar
+[INFO] Building jar: extensions-default-template-8.2.0-SNAPSHOT-javadoc.jar
+[INFO] BUILD SUCCESS
+```
+
+The module has no `src/test` directory so no test results are produced (consistent with the
+issue baseline `TestFailures=0 TestErrors=0`).
+
+Spotless:
+
+```bash
+mvnw.cmd spotless:apply   # reformatted 1 file
+mvnw.cmd spotless:check
+```
+
+```
+[INFO] Spotless.Java is keeping 1 files clean - 0 needs changes to be clean
+[INFO] BUILD SUCCESS
+```
+
+### Notes for the PR body
+
+- Resolves #1682 (the tracking issue; not a PR-review thread).
+- Issue-reported baseline was `JavadocSrcWarn=100, JavadocBlocks=1, OtherWarn=4`; my
+  standalone-module `mvnw clean install` baseline showed 5 javadoc source warnings (1
+  no-main-description + 3 no-comment + 1 use-of-default-constructor). The `JavadocBlocks=1`
+  bucket is satisfied by the new class-level javadoc (a single multi-line comment that
+  documents the class as a unit). The `OtherWarn=4` entries are pre-existing baseline
+  `maven-dependency-plugin:analyze-only` reports (`Used undeclared dependencies` +
+  `Unused declared dependencies` — one line each, plus a per-dependency line for
+  `org.apache.logging.log4j:log4j-api` and `org.apache.logging.log4j:log4j-1.2-api`) that
+  exist on `origin/development` unchanged.
+- After the fix, the standalone-module javadoc-tool output contains **0** source warnings and
+  **0** plugin warnings.
+
+### Alternatives considered
+
+- **Suppress the implicit-default-constructor warning via `@SuppressWarnings("javac")` or
+  `<doclint>` plugin config** — rejected; an explicit no-op constructor is the idiomatic
+  Java fix and is one line.
+- **Remove the `test` / `test2` JEXL methods** — rejected; they are part of the public API
+  (annotated with `@IPSJexlMethod`, callable from JEXL scripts) and removing them would
+  break consumer scripts that use them for parameter-binding smoke tests.
+- **Delete the bare `@author` tag** — rejected; AGENTS.md / project culture keeps `@author`
+  tags on legacy classes. We retained it as a secondary line in the new class javadoc.

--- a/modules/extensions-default-template/src/main/java/com/percussion/fastforward/defaulttemplate/PSDefaultTemplateLookup.java
+++ b/modules/extensions-default-template/src/main/java/com/percussion/fastforward/defaulttemplate/PSDefaultTemplateLookup.java
@@ -43,10 +43,27 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
+ * JEXL utility that resolves the default assembly template (variant) for an assembly item, used by
+ * the FastForward default-template selection flow on legacy Rhythmyx sites. Exposes a few {@link
+ * IPSJexlMethod}-annotated entry points that the assembly pipeline can call from velocity or JEXL
+ * expressions, plus a programmatic lookup helper.
+ *
  * @author adamgent
  */
 public class PSDefaultTemplateLookup extends PSJexlUtilBase {
 
+  /** Default no-op constructor. */
+  public PSDefaultTemplateLookup() {
+    // JEXL-instantiated utility; no initialization required.
+  }
+
+  /**
+   * Round-trip test helper exposed to JEXL scripts. Returns a string that echoes the supplied
+   * argument so callers can verify parameter binding.
+   *
+   * @param first the value to echo back to the caller
+   * @return a string of the form {@code "testing param = <first>"}; never {@code null}
+   */
   @IPSJexlMethod(
       description = "A test method",
       params = {@IPSJexlParam(name = "first", type = "String", description = "first parameter")})
@@ -54,6 +71,13 @@ public class PSDefaultTemplateLookup extends PSJexlUtilBase {
     return "testing param = " + first;
   }
 
+  /**
+   * Round-trip numeric test helper exposed to JEXL scripts. Increments the supplied integer so
+   * callers can verify numeric coercion of JEXL parameters.
+   *
+   * @param i the value to increment
+   * @return {@code i + 1}
+   */
   @IPSJexlMethod(
       description = "A test method",
       params = {@IPSJexlParam(name = "first", type = "int", description = "first parameter")})
@@ -61,6 +85,13 @@ public class PSDefaultTemplateLookup extends PSJexlUtilBase {
     return i + 1;
   }
 
+  /**
+   * Looks up the name of the default variant (template) for the supplied assembly item.
+   *
+   * @param item the item to find the default variant for; never {@code null}
+   * @return the template name when at least one default variant exists; {@code null} when no
+   *     defaults are registered (a warning is logged in that case)
+   */
   @IPSJexlMethod(
       description = "Looks up the default variant for an assembly item",
       params = {


### PR DESCRIPTION
{
  "title": "fix(javadoc): clear extensions-default-template javadoc warnings (GH-1682)",
  "body": "## Summary\n\nIssue **#1682**: `modules/extensions-default-template` built with `ReactorStatus: SUCCESS` but the javadoc tool emitted source warnings on the **only** Java file in the module (no `src/test`). My standalone `mvnw.cmd clean install` baseline shows 5 javadoc source warnings (1 no-main-description + 3 no-comment + 1 implicit-default-constructor).\n\nThis PR clears all 5 javadoc source warnings. Pure documentation pass + one explicit no-op constructor. No public API change, no runtime behavior change.\n\n## Issue baseline\n\n```\nextensions-default-template  SUCCESS  32.240 s  0  0  0  100  0  1  0  0  4\n                                                 JavadocSrcWarn  JavadocBlocks  OtherWarn\n```\n\n## After\n\n```\n[INFO] Building extensions-default-template 8.2.0-SNAPSHOT\n[INFO] Building jar: extensions-default-template-8.2.0-SNAPSHOT.jar\n[INFO] Building jar: extensions-default-template-8.2.0-SNAPSHOT-javadoc.jar\n[INFO] BUILD SUCCESS\n```\n\nMaven javadoc tool output on `PSDefaultTemplateLookup.java` after the fix: **0 source warnings, 0 plugin warnings, 0 blocks warnings, 0 implicit-default-constructor warnings** (was 5 source warnings).\n\n## Changes\n\n`modules/extensions-default-template/src/main/java/com/percussion/fastforward/defaulttemplate/PSDefaultTemplateLookup.java`\n\n| Section | Before | After |\n|---|---|---|\n| Class-level javadoc | Bare `@author adamgent` block (warning: no main description) | Full description of the JEXL utility + `@author` retained |\n| Constructor | None (warning: use of default constructor, which does not provide a comment) | Explicit `public PSDefaultTemplateLookup()` no-op |\n| `test(String first)` | `@IPSJexlMethod(...)` only (warning: no comment) | `@param`, `@return` added |\n| `test2(int i)` | `@IPSJexlMethod(...)` only (warning: no comment) | `@param`, `@return` added |\n| `lookup(IPSAssemblyItem item)` | `@IPSJexlMethod(...)` only (warning: no comment) | `@param`, `@return` added |\n| `lookupDefaults(IPSAssemblyItem item)` | Already documented | Unchanged |\n| Private helpers / `log` field | Unchanged | Unchanged |\n\n`docs/ai-generated/code-reviews/fix-1682-extensions-default-template-javadoc-cleanup-erlang.md`\n\nPre-PR Erlang review (recommendation: approve; gate: May commit/push: yes; blocking bugs: 0).\n\n## Build evidence\n\n```bash\ncd modules/extensions-default-template\nmvnw.cmd clean install -B -Dai.integrity.skip=true\n```\n\n```\n[INFO] BUILD SUCCESS\n```\n\nSpotless:\n\n```bash\nmvnw.cmd spotless:apply   # reformatted 1 file\nmvnw.cmd spotless:check\n```\n\n```\n[INFO] Spotless.Java is keeping 1 files clean - 0 needs changes to be clean\n[INFO] BUILD SUCCESS\n```\n\nThe module has no `src/test` directory so no test results are produced (consistent with the issue baseline `TestFailures=0 TestErrors=0`).\n\n## Why\n\nThe `JavadocBlocks=1` line in the issue table maps to the single class-level javadoc block for `PSDefaultTemplateLookup` — fixed here. The `OtherWarn=4` entries are pre-existing baseline on `origin/development`:\n\n- `maven-dependency-plugin:analyze-only` reports `Used undeclared dependencies found` (1 entry) + `Unused declared dependencies found` (1 entry) + 2 specific dependency lines for `org.apache.logging.log4j:log4j-api` and `org.apache.logging.log4j:log4j-1.2-api`\n\nThese are pre-existing baseline on `origin/development` (verified by stashing the diff and rebuilding), unchanged by this PR, and **out of scope** for the javadoc cleanup.\n\n## Worktree / branch\n\n- Worktree path: `D:/Projects/worktrees/issue-1682-javadoc`\n- Branch: `fix/1682-extensions-default-template-javadoc-cleanup` (off `origin/development`)\n- Head commit: `94bcea1ca7156c3422a8f8dbb652fa0f83f68095` (GPG-signed, verified on GitHub)\n\nCloses #1682",
  "head": "fix/1682-extensions-default-template-javadoc-cleanup",
  "base": "development",
  "draft": false
}