### PR TITLE
test(qa): Playwright Basic auth + Developer catalog smoke

### DIFF
--- a/WebUI/src/main/ts/api/client.ts
+++ b/WebUI/src/main/ts/api/client.ts
@@ -49,6 +49,36 @@ export function isSessionRedirectError(err: unknown): boolean {
   return err instanceof SessionRedirectError;
 }
 
+/** True when {@code err} is a thrown {@link ApiError} (plain object, not Error). */
+export function isApiError(err: unknown): err is ApiError {
+  return (
+    !!err &&
+    typeof err === "object" &&
+    typeof (err as ApiError).status === "number"
+  );
+}
+
+/**
+ * Human-readable message for SPA error chrome.
+ *
+ * <p>{@link handleResponse} throws a plain {@link ApiError} object (not an
+ * {@code Error}). {@code String(err)} therefore becomes {@code "[object Object]"}
+ * — always use this helper (or equivalent) before displaying API failures.</p>
+ */
+export function formatApiError(err: unknown, fallback = "Request failed"): string {
+  if (isSessionRedirectError(err)) {
+    return fallback;
+  }
+  if (err instanceof Error && err.message) {
+    return err.message;
+  }
+  if (isApiError(err)) {
+    const st = err.statusText ? ` ${err.statusText}` : "";
+    return `${fallback} (HTTP ${err.status}${st})`.trim();
+  }
+  return fallback;
+}
+
 function buildHeaders(extra: HeadersInit = {}, preferJson = true): Headers {
   const headers = new Headers(extra);
   if (!headers.has("Content-Type") && preferJson) {

--- a/WebUI/src/main/ts/contentExplorer/ExplorerTree.tsx
+++ b/WebUI/src/main/ts/contentExplorer/ExplorerTree.tsx
@@ -23,6 +23,7 @@
  */
 
 import React, { useEffect, useState, useCallback, useMemo } from "react";
+import { formatApiError } from "../api/client";
 import { findChildren } from "../api/contentExplorer/pathApi";
 import type { PSPathItem } from "../api/contentExplorer/types";
 import { message } from "../i18n/message";
@@ -91,7 +92,7 @@ export function ExplorerTree({
         [path]: { loaded: true, loading: false, error: null, children },
       }));
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
+      const msg = formatApiError(err, message(EXPLORER_MSG.TREE_LOAD_ERROR));
       setNodes((prev) => ({
         ...prev,
         [path]: { loaded: true, loading: false, error: msg, children: [] },
@@ -183,10 +184,11 @@ export function ExplorerTree({
   }, [nodes, rootState.error]);
 
   if (error) {
+    // Not role=tree: axe aria-required-children fails when there are no treeitems.
     return (
-      <div style={treeStyle} role="tree" data-testid="explorer-tree">
-        <div style={errorStateStyle} role="alert">
-          {message(EXPLORER_MSG.TREE_LOAD_ERROR)}: {error}
+      <div style={treeStyle} data-testid="explorer-tree">
+        <div style={errorStateStyle} role="alert" data-testid="explorer-tree-error">
+          {error}
         </div>
       </div>
     );
@@ -194,8 +196,10 @@ export function ExplorerTree({
 
   if (rootState.loaded && rootState.children.length === 0) {
     return (
-      <div style={treeStyle} role="tree" data-testid="explorer-tree">
-        <div style={emptyStateStyle}>{message(EXPLORER_MSG.TREE_EMPTY)}</div>
+      <div style={treeStyle} data-testid="explorer-tree">
+        <div style={emptyStateStyle} data-testid="explorer-tree-empty">
+          {message(EXPLORER_MSG.TREE_EMPTY)}
+        </div>
       </div>
     );
   }

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-1622-explorer-root-folders.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-1622-explorer-root-folders.spec.js
@@ -27,7 +27,8 @@
  *   <li>REST: root {@code path/folder/} returns 200 with well-known roots</li>
  *   <li>REST: double-slash {@code path/folder//Sites} must not be the
  *       client contract (assert correct Sites URL works)</li>
- *   <li>UI: explorer tree is non-empty after shell mount</li>
+ *   <li>UI: explorer tree is non-empty after shell mount (requires WebUI
+ *       with encodePath fix deployed to the CMS install)</li>
  * </ul>
  *
  * <p>Run against a live CMS (e.g. {@code C:\Installs\8.2-july-29} or docker):</p>
@@ -38,7 +39,11 @@
  */
 
 const { test, expect } = require("@playwright/test");
-const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+const {
+  loginAsAdmin,
+  BASE_URL,
+  adminBasicAuthHeaders,
+} = require("../helpers/auth");
 
 const EXPLORER_URL = `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${Date.now()}`;
 const PATH_FOLDER = `${BASE_URL}/Rhythmyx/services/pathmanagement/path/folder`;
@@ -48,28 +53,21 @@ test.describe("GH-1622 explorer root folders (encodePath / no double-slash)", ()
     request,
   }) => {
     test.setTimeout(30_000);
-    // Session cookie from login is not required for this assertion when
-    // basic-auth header is accepted; fall back to cookie via storage if needed.
-    const root = await request.get(`${PATH_FOLDER}/`, {
-      headers: { RX_USEBASICAUTH: "true" },
-    });
+    const headers = adminBasicAuthHeaders();
+    const root = await request.get(`${PATH_FOLDER}/`, { headers });
     expect(
       root.status(),
       `GET ${PATH_FOLDER}/ should be 200 (double-slash form is 400)`
     ).toBe(200);
 
-    const sites = await request.get(`${PATH_FOLDER}/Sites`, {
-      headers: { RX_USEBASICAUTH: "true" },
-    });
+    const sites = await request.get(`${PATH_FOLDER}/Sites`, { headers });
     // Sites may be empty on a fresh install, but the path must be valid.
     expect(
       sites.status(),
       `GET ${PATH_FOLDER}/Sites must not 400 (folder//Sites was the bug)`
     ).toBe(200);
 
-    const bad = await request.get(`${PATH_FOLDER}//Sites`, {
-      headers: { RX_USEBASICAUTH: "true" },
-    });
+    const bad = await request.get(`${PATH_FOLDER}//Sites`, { headers });
     // Document the server contract the SPA must avoid.
     expect(bad.status()).toBe(400);
   });
@@ -84,6 +82,18 @@ test.describe("GH-1622 explorer root folders (encodePath / no double-slash)", ()
 
     const tree = page.locator('[data-testid="explorer-tree"]');
     await expect(tree).toBeVisible({ timeout: 15_000 });
+
+    // Surface API/load failures explicitly (install lag still has folder// → 400).
+    // Prefer data-testid after WebUI fix; also match older alert chrome.
+    const treeErr = page.locator(
+      '[data-testid="explorer-tree-error"], [data-testid="explorer-tree"] [role="alert"]'
+    );
+    if ((await treeErr.count()) > 0 && (await treeErr.first().isVisible())) {
+      const text = await treeErr.first().innerText();
+      throw new Error(
+        `Explorer tree failed to load: ${text}. If the network URL was path/folder//, redeploy WebUI with encodePath fix (#1680).`
+      );
+    }
 
     // Root children render as tree-node-* rows (paths like /Sites/, /Assets/).
     const nodes = tree.locator('[data-testid^="tree-node-"]');

--- a/modules/perc-qa-automation/frontend/tests/developer-catalog-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-catalog-smoke.spec.js
@@ -1,0 +1,134 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Smoke: Developer module SPA + catalog REST health (Refs #1690).
+ *
+ * <p>Catches the common post-P0 failure mode: SPA shell mounts but catalog
+ * endpoints 500 / return unusable payloads, or the CMS install is behind
+ * {@code development} (new REST resources not deployed).</p>
+ *
+ * <pre>
+ *   cd modules/perc-qa-automation/frontend
+ *   npm test -- tests/developer-catalog-smoke.spec.js
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const {
+  loginAsAdmin,
+  BASE_URL,
+  adminBasicAuthHeaders,
+} = require("./helpers/auth");
+
+const DEVELOPER_URL = `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=developer&_=${Date.now()}`;
+
+/** Catalog REST paths used by Developer shell sections (thin read catalogs). */
+const CATALOG_ENDPOINTS = [
+  { name: "contenttypes", path: "/Rhythmyx/services/contenttypes", critical: true },
+  { name: "templates", path: "/Rhythmyx/services/templates", critical: true },
+  { name: "slots", path: "/Rhythmyx/services/slots", critical: true },
+  { name: "keywords", path: "/Rhythmyx/services/keywords", critical: true },
+  { name: "locales", path: "/Rhythmyx/services/locales", critical: false },
+  { name: "searches", path: "/Rhythmyx/services/searches", critical: false },
+  { name: "views", path: "/Rhythmyx/services/views", critical: false },
+  { name: "extensions", path: "/Rhythmyx/services/extensions/catalog", critical: false },
+  { name: "cecontrols", path: "/Rhythmyx/services/cecontrols", critical: false },
+  { name: "serverconfigs", path: "/Rhythmyx/services/serverconfigs", critical: false },
+  { name: "sites", path: "/Rhythmyx/services/sites", critical: false },
+  { name: "relationshiptypes", path: "/Rhythmyx/services/relationshiptypes", critical: false },
+];
+
+test.describe("Developer catalog smoke (#1690)", () => {
+  test("SPA Developer shell mounts and content-types table is usable", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+    await page.goto(DEVELOPER_URL, { waitUntil: "networkidle" });
+
+    const shell = page.locator('[data-testid="perc-developer-shell"]');
+    await expect(shell).toBeVisible({ timeout: 20_000 });
+
+    // Default section: content types list
+    const table = page.locator('[data-testid="developer-ct-table"]');
+    await expect(table).toBeVisible({ timeout: 20_000 });
+
+    // Fail hard if the panel is in error chrome
+    const err = page.locator('[data-testid="developer-ct-error"]');
+    if ((await err.count()) > 0) {
+      const text = await err.innerText();
+      throw new Error(`Developer content-types panel error: ${text}`);
+    }
+
+    // Rows should expose a real name/label, not only "—" placeholders from
+    // empty DTOs (seen when list JSON only carries hideFromMenu flags).
+    const openBtns = table.locator('[data-testid="developer-ct-open"]');
+    const rowCount = await table.locator("tbody tr").count();
+    expect(rowCount, "content type table should have at least one row").toBeGreaterThan(
+      0,
+    );
+
+    const bodyText = await table.innerText();
+    // If every cell is an em dash, the REST payload is useless for the SPA.
+    const onlyPlaceholders =
+      !/[A-Za-z]{2,}/.test(bodyText.replace(/Label|Name|Id|Description|Select/gi, ""));
+    expect(
+      onlyPlaceholders,
+      "content type rows look empty (labels/names missing from API/DTO) — redeploy rest/WebUI or fix ContentType list mapping",
+    ).toBe(false);
+
+    if ((await openBtns.count()) > 0) {
+      await expect(openBtns.first()).toBeVisible();
+    }
+  });
+
+  test("catalog REST endpoints return 2xx with Basic auth", async ({ request }) => {
+    test.setTimeout(120_000);
+    const headers = adminBasicAuthHeaders();
+    const failures = [];
+
+    for (const ep of CATALOG_ENDPOINTS) {
+      const res = await request.get(`${BASE_URL}${ep.path}`, { headers });
+      const status = res.status();
+      if (status < 200 || status >= 300) {
+        failures.push({
+          name: ep.name,
+          path: ep.path,
+          status,
+          critical: ep.critical,
+        });
+      }
+    }
+
+    const criticalFails = failures.filter((f) => f.critical);
+    const softFails = failures.filter((f) => !f.critical);
+
+    // Soft fails (P0.7+ catalogs) still report — install often lags development.
+    if (softFails.length) {
+      console.warn(
+        "[developer-catalog-smoke] non-critical catalog HTTP failures (often means install not redeployed):\n" +
+          softFails.map((f) => `  ${f.status} ${f.name} ${f.path}`).join("\n"),
+      );
+    }
+
+    expect(
+      criticalFails,
+      `Critical catalog REST failures (redeploy rest/sitemanage or fix 5xx):\n` +
+        criticalFails.map((f) => `  ${f.status} ${f.name} ${f.path}`).join("\n"),
+    ).toEqual([]);
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/helpers/auth.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/auth.js
@@ -201,6 +201,34 @@ async function loginAsContributor(page) {
   await login(page, USERNAME_CONTRIBUTOR, CONTRIBUTOR_PASSWORD);
 }
 
+/**
+ * Headers for CMS REST calls that opt into Basic auth.
+ *
+ * <p>{@code RX_USEBASICAUTH: true} alone is <strong>not</strong> enough — the
+ * server still expects an {@code Authorization: Basic …} header. Specs that
+ * only set the RX flag get HTTP 401 against a stock 8.2 install.</p>
+ *
+ * @param {string} username
+ * @param {string} password
+ * @returns {Record<string, string>}
+ */
+function basicAuthHeaders(username, password) {
+  if (!password) {
+    throw new Error(
+      `basicAuthHeaders: password for ${username} is missing (set .env or DEV_PERCUSSION_INSTALL)`
+    );
+  }
+  const token = Buffer.from(`${username}:${password}`, "utf8").toString("base64");
+  return {
+    RX_USEBASICAUTH: "true",
+    Authorization: `Basic ${token}`,
+  };
+}
+
+function adminBasicAuthHeaders() {
+  return basicAuthHeaders(ADMIN_USERNAME, ADMIN_PASSWORD);
+}
+
 module.exports = {
   BASE_URL: PERCUSSION_URL,
   DTS_URL,
@@ -213,4 +241,6 @@ module.exports = {
   loginAsAdmin,
   loginAsEditor,
   loginAsContributor,
+  basicAuthHeaders,
+  adminBasicAuthHeaders,
 };


### PR DESCRIPTION
## Summary
First slice of **#1690** Playwright QA execution against live CMS `C:\Installs\8.2-july-29` (port 9992).

## Findings (install under test)
| Area | Result |
|------|--------|
| Login | **OK** |
| Explorer REST `folder/` (with Basic auth) | **OK** |
| Explorer SPA tree | **FAIL** — still requests `path/folder//` → 400 (**WebUI not redeployed** with #1680) |
| `contenttypes` JSON | **200** but rows are `{hideFromMenu}` only → SPA shows `—` |
| `templates` | **200** sparse (`templateId` only in sample) |
| `slots`, `keywords`, `locales`, `searches`, `views`, `extensions`, `cecontrols`, `serverconfigs`, `relationshiptypes` | **500** (install lag / not redeployed) |
| `sites` | **200** empty list |

## This PR
1. **`adminBasicAuthHeaders`** — `RX_USEBASICAUTH` alone is not enough; add `Authorization: Basic …`
2. **bug-1622** REST uses real Basic auth; UI asserts surface tree error text (redeploy hint for #1680)
3. **`developer-catalog-smoke.spec.js`** — SPA shell + CT table usability + catalog REST 2xx matrix
4. **`formatApiError`** in `client.ts` + ExplorerTree uses it (no more `[object Object]`); empty/error tree drops invalid `role=tree` without treeitems

## How to run
```bash
cd modules/perc-qa-automation/frontend
# set DEV_PERCUSSION_INSTALL in ../.env
npx playwright install chromium   # once
npx playwright test tests/login.spec.js tests/bugs/bug-1622-explorer-root-folders.spec.js tests/developer-catalog-smoke.spec.js
```

## After merge / next
1. **Redeploy** `development` WebUI + rest/sitemanage to the install
2. Re-run the smoke suite — expect green once catalogs + encodePath are live
3. Fix any remaining product 500s / empty DTO mapping under #1690

Refs #1690