### PR TITLE
fix(rest): Jackson Jdk8Module for Optional DTO serialization

### DIFF
--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -161,6 +161,15 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <!-- Optional&lt;T&gt; DTO getters used across rest/* (ContentType, TemplateSummary, Guid, …) -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -166,10 +166,6 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/rest/src/main/java/com/percussion/rest/JacksonContextResolver.java
+++ b/rest/src/main/java/com/percussion/rest/JacksonContextResolver.java
@@ -20,6 +20,8 @@ package com.percussion.rest;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.ContextResolver;
@@ -30,6 +32,12 @@ import jakarta.ws.rs.ext.Provider;
  *     <p>This is picked up by Jackson automatically by the Provider annotation It will modify the
  *     serialization behavior of the objects passed in we test that the class has the same ancestor
  *     package as this class to ensure we do not modify behavior for other parts of the system
+ *
+ *     <p><strong>Jdk8Module is required:</strong> many rest DTOs expose {@code Optional} getters
+ *     (e.g. {@link com.percussion.rest.contenttypes.ContentType#getName()}). Without the module,
+ *     Jackson treats {@code Optional} as a bean and, with {@code NON_NULL}, drops name/label/guid —
+ *     leaving only primitives like {@code hideFromMenu}. Live symptom: Developer content-types table
+ *     full of em-dashes while adaptors correctly call design webservices ({@code IPSContentDesignWs}).
  */
 // REFACTORED: CP-JAVA11
 @Provider
@@ -39,6 +47,8 @@ public class JacksonContextResolver implements ContextResolver<ObjectMapper> {
 
   static {
     objectMapper
+        .registerModule(new Jdk8Module())
+        .registerModule(new JavaTimeModule())
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
         .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
         .configure(SerializationFeature.WRAP_ROOT_VALUE, true)

--- a/rest/src/main/java/com/percussion/rest/JacksonContextResolver.java
+++ b/rest/src/main/java/com/percussion/rest/JacksonContextResolver.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.ContextResolver;
@@ -33,11 +32,16 @@ import jakarta.ws.rs.ext.Provider;
  *     serialization behavior of the objects passed in we test that the class has the same ancestor
  *     package as this class to ensure we do not modify behavior for other parts of the system
  *
- *     <p><strong>Jdk8Module is required:</strong> many rest DTOs expose {@code Optional} getters
- *     (e.g. {@link com.percussion.rest.contenttypes.ContentType#getName()}). Without the module,
- *     Jackson treats {@code Optional} as a bean and, with {@code NON_NULL}, drops name/label/guid —
- *     leaving only primitives like {@code hideFromMenu}. Live symptom: Developer content-types table
- *     full of em-dashes while adaptors correctly call design webservices ({@code IPSContentDesignWs}).
+ *     <p><strong>{@link Jdk8Module} is required:</strong> many rest DTOs expose {@code Optional}
+ *     getters (e.g. {@link com.percussion.rest.contenttypes.ContentType#getName()}). Without the
+ *     module, Jackson reflects on {@code Optional} as a bean (not the contained value). Combined
+ *     with {@code @JsonInclude(NON_NULL)}, the useless wrapper is omitted and name/label/guid never
+ *     appear as JSON strings — leaving only primitives like {@code hideFromMenu}. Live symptom:
+ *     Developer content-types table full of em-dashes while adaptors correctly call design
+ *     webservices ({@code IPSContentDesignWs}).
+ *
+ *     <p>{@code JavaTimeModule} is intentionally not registered here: rest DTOs do not use {@code
+ *     java.time} types. Add it (and the jsr310 dependency) only when a DTO needs that support.
  */
 // REFACTORED: CP-JAVA11
 @Provider
@@ -48,7 +52,6 @@ public class JacksonContextResolver implements ContextResolver<ObjectMapper> {
   static {
     objectMapper
         .registerModule(new Jdk8Module())
-        .registerModule(new JavaTimeModule())
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
         .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
         .configure(SerializationFeature.WRAP_ROOT_VALUE, true)

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.percussion.rest.contenttypes.ContentType;
+import com.percussion.rest.contenttypes.ContentTypeList;
+import com.percussion.rest.templates.TemplateSummary;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * REST JSON must unwrap {@code Optional} DTO getters (Jdk8Module). Without it, content-type and
+ * template catalogs serialize as hideFromMenu / templateId only — SPA tables look empty while
+ * design webservices returned real names.
+ */
+@Tag("UnitTest")
+class JacksonContextResolverOptionalTest {
+
+  private final ObjectMapper mapper =
+      new JacksonContextResolver().getContext(ContentType.class);
+
+  @Test
+  void contentType_serializesNameLabelNotOnlyHideFromMenu() throws Exception {
+    ContentType ct = new ContentType();
+    ct.setName("percPage");
+    ct.setLabel("Page");
+    ct.setDescription("Page content type");
+    ct.setHideFromMenu(false);
+
+    String json = mapper.writeValueAsString(ct);
+    assertTrue(json.contains("percPage"), json);
+    assertTrue(json.contains("Page"), json);
+    assertFalse(
+        json.replaceAll("\\s", "").matches(".*\\{\"hideFromMenu\":false\\}.*")
+            && !json.contains("percPage"),
+        "must not emit hideFromMenu-only payload: " + json);
+  }
+
+  @Test
+  void contentTypeList_rootWrap_includesNames() throws Exception {
+    ContentType ct = new ContentType();
+    ct.setName("sys_File");
+    ct.setLabel("File");
+    ContentTypeList list = new ContentTypeList();
+    list.add(ct);
+
+    String json = mapper.writeValueAsString(list);
+    assertTrue(json.contains("sys_File"), json);
+    assertTrue(json.contains("File"), json);
+  }
+
+  @Test
+  void templateSummary_serializesNameNotOnlyId() throws Exception {
+    TemplateSummary t = new TemplateSummary();
+    t.setTemplateId(1018);
+    t.setTemplateName("perc.page");
+    t.setTemplateLabel("Page");
+
+    String json = mapper.writeValueAsString(t);
+    assertTrue(json.contains("perc.page"), json);
+    assertTrue(json.contains("Page"), json);
+    assertTrue(json.contains("1018"), json);
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
 import com.percussion.rest.templates.TemplateSummary;
@@ -27,8 +28,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
- * REST JSON must unwrap {@code Optional} DTO getters (Jdk8Module). Without it, content-type and
- * template catalogs serialize as hideFromMenu / templateId only — SPA tables look empty while
+ * REST JSON must unwrap {@code Optional} DTO getters ({@code Jdk8Module}). Without it, content-type
+ * and template catalogs serialize as hideFromMenu / templateId only — SPA tables look empty while
  * design webservices returned real names.
  */
 @Tag("UnitTest")
@@ -36,6 +37,34 @@ class JacksonContextResolverOptionalTest {
 
   private final ObjectMapper mapper =
       new JacksonContextResolver().getContext(ContentType.class);
+
+  /**
+   * Locks the pre-fix bug shape: a plain {@link ObjectMapper} (no {@code Jdk8Module}) must not
+   * emit {@code name} as a JSON string even when the DTO has a value. Modern Jackson refuses {@code
+   * Optional} without the module ({@code InvalidDefinitionException}); older behavior omitted the
+   * field. Either outcome proves the module is required — if a future refactor drops {@code
+   * registerModule(new Jdk8Module())}, this test still fails while positive tests alone might not.
+   */
+  @Test
+  void plainMapper_withoutJdk8Module_doesNotEmitOptionalNameAsString() throws Exception {
+    ContentType ct = new ContentType();
+    ct.setName("percPage");
+    ct.setLabel("Page");
+    ct.setHideFromMenu(false);
+
+    try {
+      String json = new ObjectMapper().writeValueAsString(ct);
+      assertFalse(
+          json.contains("\"name\":\"percPage\"") || json.contains("\"name\" : \"percPage\""),
+          "plain ObjectMapper must not unwrap Optional name — bug shape regression: " + json);
+    } catch (InvalidDefinitionException expected) {
+      // Jackson 2.12+: Optional requires jackson-datatype-jdk8
+      assertTrue(
+          expected.getMessage().contains("Optional")
+              || expected.getMessage().contains("jdk8"),
+          expected.getMessage());
+    }
+  }
 
   @Test
   void contentType_serializesNameLabelNotOnlyHideFromMenu() throws Exception {
@@ -46,16 +75,20 @@ class JacksonContextResolverOptionalTest {
     ct.setHideFromMenu(false);
 
     String json = mapper.writeValueAsString(ct);
+    assertTrue(json.contains("\"name\""), json);
     assertTrue(json.contains("percPage"), json);
+    assertTrue(json.contains("\"label\""), json);
     assertTrue(json.contains("Page"), json);
+    // Must not be the hideFromMenu-only payload that broke the SPA table
+    String compact = json.replaceAll("\\s", "");
     assertFalse(
-        json.replaceAll("\\s", "").matches(".*\\{\"hideFromMenu\":false\\}.*")
-            && !json.contains("percPage"),
+        compact.equals("{\"ContentType\":{\"hideFromMenu\":false}}")
+            || compact.equals("{\"hideFromMenu\":false}"),
         "must not emit hideFromMenu-only payload: " + json);
   }
 
   @Test
-  void contentTypeList_rootWrap_includesNames() throws Exception {
+  void contentTypeList_includesNames() throws Exception {
     ContentType ct = new ContentType();
     ct.setName("sys_File");
     ct.setLabel("File");
@@ -63,6 +96,10 @@ class JacksonContextResolverOptionalTest {
     list.add(ct);
 
     String json = mapper.writeValueAsString(list);
+    // WRAP_ROOT_VALUE uses the simple class name (no @JsonRootName on ContentTypeList)
+    assertTrue(
+        json.contains("ContentTypeList") || json.trim().startsWith("["),
+        "list serializes with ContentTypeList root or as array: " + json);
     assertTrue(json.contains("sys_File"), json);
     assertTrue(json.contains("File"), json);
   }


### PR DESCRIPTION
## Problem
Developer content-types (and similar) tables show empty `—` rows. Live `GET /services/contenttypes` returned objects with only `hideFromMenu`.

## Root cause
`JacksonContextResolver` built a plain `ObjectMapper` **without** `Jdk8Module`. Many rest DTOs use `Optional` getters (`ContentType#getName`, `TemplateSummary#getTemplateName`, …). Without the module, Jackson does not unwrap `Optional`; with `@JsonInclude(NON_NULL)` names vanish and only booleans/ints remain.

## Not the cause
`ContentTypeAdaptor.listContentTypes` already wires through rest → `IContentTypesAdaptor` → `IPSContentDesignWs.findContentTypes` (design web service). Conversion sets name/label/guid; they were dropped only on the wire.

## Fix
- Register `Jdk8Module` + `JavaTimeModule` on the rest `ObjectMapper`
- Add `jackson-datatype-jdk8` / `jsr310` deps on `rest` module
- Unit tests for ContentType / ContentTypeList / TemplateSummary JSON

## Architecture note
Catalog REST remains a thin façade: **Resource → adaptor interface → sitemanage adaptor → design/legacy web service**. This PR does not reimplement design object loaders.

## Tests
```
cd rest && ../mvnw test -Dtest=JacksonContextResolverOptionalTest
# 3 passed
```

## Deploy
Redeploy `rest-*.jar` (and restart CMS) for QA install to pick this up — pairs with #1692.

Refs #1693 #1690