### PR TITLE
chore: Spotless cleanup (unrelated baseline formatting)

### DIFF
--- a/.kilo/rules/co-author-attribution.md
+++ b/.kilo/rules/co-author-attribution.md
@@ -1,10 +1,6 @@
 == GitHub/Git Messages (Commit, PR, Review, Comment, etc)
 
-
-
 \* In order to clearly differentiate from direct developer messages and those co-authored by agents or sub-agents, you \*MUST\* use a footer that looks like the following for agent / sub-agent assisted work:
-
-
 
 ```
 

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-1622-explorer-root-folders.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-1622-explorer-root-folders.spec.js
@@ -55,7 +55,7 @@ test.describe("GH-1622 explorer root folders (encodePath / no double-slash)", ()
     });
     expect(
       root.status(),
-      `GET ${PATH_FOLDER}/ should be 200 (double-slash form is 400)`,
+      `GET ${PATH_FOLDER}/ should be 200 (double-slash form is 400)`
     ).toBe(200);
 
     const sites = await request.get(`${PATH_FOLDER}/Sites`, {
@@ -64,7 +64,7 @@ test.describe("GH-1622 explorer root folders (encodePath / no double-slash)", ()
     // Sites may be empty on a fresh install, but the path must be valid.
     expect(
       sites.status(),
-      `GET ${PATH_FOLDER}/Sites must not 400 (folder//Sites was the bug)`,
+      `GET ${PATH_FOLDER}/Sites must not 400 (folder//Sites was the bug)`
     ).toBe(200);
 
     const bad = await request.get(`${PATH_FOLDER}//Sites`, {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ControlAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ControlAdaptor.java
@@ -129,9 +129,9 @@ public class ControlAdaptor implements IControlAdaptor {
   }
 
   /**
-   * Single path segment name only — ASCII identifier characters used by CE
-   * control names ({@code sys_EditBox}, {@code myCustomControl}). Rejects
-   * traversal, separators, and any non-identifier Unicode.
+   * Single path segment name only — ASCII identifier characters used by CE control names ({@code
+   * sys_EditBox}, {@code myCustomControl}). Rejects traversal, separators, and any non-identifier
+   * Unicode.
    */
   static boolean isSafeControlKey(String key) {
     if (key == null || key.isBlank()) {

--- a/rest/src/main/java/com/percussion/rest/cecontrols/ControlDef.java
+++ b/rest/src/main/java/com/percussion/rest/cecontrols/ControlDef.java
@@ -21,8 +21,10 @@ public class ControlDef {
   private String description;
   private String dimension;
   private String choiceSet;
+
   /** system or user */
   private String scope;
+
   private boolean deprecated;
   private String deprecatedReplacement;
   private List<ControlParameter> parameters = new ArrayList<>();

--- a/rest/src/main/java/com/percussion/rest/cecontrols/IControlAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/cecontrols/IControlAdaptor.java
@@ -12,8 +12,6 @@ public interface IControlAdaptor {
   /** List system and user CE controls. Never null. */
   List<ControlDef> listControls();
 
-  /**
-   * Resolve by control name (case-insensitive). Null if missing or unsafe key.
-   */
+  /** Resolve by control name (case-insensitive). Null if missing or unsafe key. */
   ControlDef findControlByName(String name);
 }


### PR DESCRIPTION
Baseline formatting-only Spotless diffs that were skipped during the \dd-bn-locale\ feature PR. These are 5 files in modules outside the bn locale scope, written by \./mvnw spotless:apply\ on 2026-07-31.

## Files

- \.kilo/rules/co-author-attribution.md\ (Markdown)
- \modules/perc-qa-automation/frontend/tests/bugs/bug-1622-explorer-root-folders.spec.js\ (JS)
- \projects/sitemanage/src/main/java/com/percussion/apibridge/ControlAdaptor.java\ (Java)
- \est/src/main/java/com/percussion/rest/cecontrols/ControlDef.java\ (Java)
- \est/src/main/java/com/percussion/rest/cecontrols/IControlAdaptor.java\ (Java)

## Notes

- No behavioural or product-logic changes (formatting only).
- Pair PR: \#1697\ (feat(i18n): add bn locale) — splitted out of that PR's diff to keep the feature PR narrow.
- \./mvnw spotless:apply\ ran first, then \spotless:check\ exited 0.