### PR TITLE
fix(developer): KeywordsAdaptor via IPSContentDesignWs

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/KeywordsAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/KeywordsAdaptor.java
@@ -10,7 +10,6 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
@@ -21,68 +20,96 @@ import com.percussion.rest.keywords.IKeywordsAdaptor;
 import com.percussion.rest.keywords.KeywordChoiceSummary;
 import com.percussion.rest.keywords.KeywordNotFoundException;
 import com.percussion.rest.keywords.KeywordSummary;
+import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
-import com.percussion.services.content.IPSContentService;
-import com.percussion.services.content.PSContentException;
-import com.percussion.services.content.PSContentServiceLocator;
 import com.percussion.services.content.data.PSKeyword;
 import com.percussion.services.content.data.PSKeywordChoice;
 import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.system.utils.PSSiteManageBean;
 import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSErrorsException;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.content.PSContentWsLocator;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-/** Keyword design catalog + create/update/delete for the Developer module. */
+/**
+ * Keyword design catalog for Developer REST.
+ *
+ * <p>Workbench parity: routes through {@link IPSContentDesignWs} (same design web service
+ * {@code ContentDesignSOAPImpl} uses) — find / load / create / save / delete with design locks —
+ * not a parallel path via {@code IPSContentService} alone.
+ */
 @PSSiteManageBean
 public class KeywordsAdaptor implements IKeywordsAdaptor {
 
   private static final Logger log = LogManager.getLogger(KeywordsAdaptor.class);
 
-  private final IPSContentService contentService;
+  private final IPSContentDesignWs designWs;
 
   public KeywordsAdaptor() {
-    this(PSContentServiceLocator.getContentService());
+    this(PSContentWsLocator.getContentDesignWebservice());
   }
 
-  /** Package-visible for unit tests that inject a fake content service. */
-  KeywordsAdaptor(IPSContentService contentService) {
-    this.contentService = contentService;
-  }
-
-  private IPSContentService svc() {
-    return contentService;
+  /** Package-visible for unit tests that inject a fake design web service. */
+  KeywordsAdaptor(IPSContentDesignWs designWs) {
+    this.designWs = designWs;
   }
 
   @Override
   public List<KeywordSummary> listKeywords(URI baseUri, boolean includeChoices) {
-    // baseUri reserved for HATEOAS link building (interface contract)
-    List<PSKeyword> keywords = svc().findKeywordsByLabel(null, "label");
-    List<KeywordSummary> out = new ArrayList<>();
-    for (PSKeyword kw : keywords) {
-      if (kw == null || !isKeywordDef(kw)) {
-        continue;
+    try {
+      List<IPSCatalogSummary> summaries = designWs.findKeywords(null);
+      if (summaries == null || summaries.isEmpty()) {
+        return List.of();
       }
-      out.add(toSummary(kw, includeChoices));
+      List<IPSGuid> guids = new ArrayList<>();
+      for (IPSCatalogSummary sum : summaries) {
+        if (sum != null && sum.getGUID() != null) {
+          guids.add(sum.getGUID());
+        }
+      }
+      if (guids.isEmpty()) {
+        return List.of();
+      }
+      List<PSKeyword> loaded =
+          designWs.loadKeywords(guids, false, false, currentSession(), currentUser());
+      List<KeywordSummary> out = new ArrayList<>();
+      if (loaded != null) {
+        for (PSKeyword kw : loaded) {
+          if (kw == null || !isKeywordDef(kw)) {
+            continue;
+          }
+          out.add(toSummary(kw, includeChoices));
+        }
+      }
+      out.sort(
+          Comparator.comparing(
+              KeywordSummary::getLabel, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
+      return out;
+    } catch (PSErrorResultsException e) {
+      log.error("Failed to list keywords via content design WS", e);
+      throw new IllegalStateException("Failed to list keywords", e);
+    } catch (RuntimeException e) {
+      log.error("Failed to list keywords via content design WS", e);
+      throw e;
     }
-    out.sort(
-        Comparator.comparing(
-            KeywordSummary::getLabel, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
-    return out;
   }
 
   @Override
   public KeywordSummary getKeyword(URI baseUri, String idOrValue) {
-    // baseUri reserved for HATEOAS link building (interface contract)
     if (StringUtils.isBlank(idOrValue)) {
       return null;
     }
-    PSKeyword kw = resolveKeyword(svc(), idOrValue.trim());
+    PSKeyword kw = resolveKeyword(idOrValue.trim());
     return kw == null ? null : toSummary(kw, true);
   }
 
@@ -91,25 +118,31 @@ public class KeywordsAdaptor implements IKeywordsAdaptor {
     if (body == null || StringUtils.isBlank(body.getLabel())) {
       throw new IllegalArgumentException("label is required");
     }
-    IPSContentService svc = svc();
+    requireSessionUserForWrite();
     String label = body.getLabel().trim();
-    assertLabelUnique(svc, label, null);
+    assertLabelUnique(label, null);
+    String session = currentSession();
+    String user = currentUser();
     try {
-      PSKeyword kw = svc.createKeyword(label, body.getDescription());
+      List<PSKeyword> created =
+          designWs.createKeywords(Collections.singletonList(label), session, user);
+      if (created == null || created.isEmpty() || created.get(0) == null) {
+        throw new IllegalStateException("Design WS createKeywords returned empty");
+      }
+      PSKeyword kw = created.get(0);
+      if (body.getDescription() != null) {
+        kw.setDescription(body.getDescription());
+      }
       if (body.getSequence() != null) {
         kw.setSequence(body.getSequence());
       }
       applyChoices(kw, body.getChoices());
-      svc.saveKeyword(kw);
-      try {
-        PSKeyword reloaded = svc.loadKeyword(kw.getGUID(), "sequence");
-        return toSummary(reloaded, true);
-      } catch (PSContentException e) {
-        log.debug("Could not reload keyword after create: {}", e.getMessage());
-        return toSummary(kw, true);
-      }
+      designWs.saveKeywords(Collections.singletonList(kw), true, session, user);
+      return reloadSummary(kw.getGUID());
+    } catch (PSErrorsException e) {
+      log.error("Failed to create keyword via content design WS", e);
+      throw new IllegalStateException("Failed to create keyword", e);
     } catch (IllegalArgumentException e) {
-      // Surface service uniqueness/validation as 400
       throw e;
     }
   }
@@ -122,31 +155,45 @@ public class KeywordsAdaptor implements IKeywordsAdaptor {
     if (body == null) {
       throw new IllegalArgumentException("body is required");
     }
-    IPSContentService svc = svc();
-    PSKeyword kw = loadById(svc, id.trim());
-    if (kw == null) {
-      return null;
+    requireSessionUserForWrite();
+    IPSGuid g = parseKeywordGuid(id.trim());
+    if (g == null) {
+      throw new IllegalArgumentException("Invalid keyword id: " + id);
     }
-    if (StringUtils.isNotBlank(body.getLabel())) {
-      String newLabel = body.getLabel().trim();
-      assertLabelUnique(svc, newLabel, kw.getGUID());
-      kw.setLabel(newLabel);
-    }
-    if (body.getDescription() != null) {
-      kw.setDescription(body.getDescription());
-    }
-    if (body.getSequence() != null) {
-      kw.setSequence(body.getSequence());
-    }
-    if (body.getChoices() != null) {
-      applyChoices(kw, body.getChoices());
-    }
-    svc.saveKeyword(kw);
+    String session = currentSession();
+    String user = currentUser();
     try {
-      return toSummary(svc.loadKeyword(kw.getGUID(), "sequence"), true);
-    } catch (PSContentException e) {
-      log.debug("Could not reload keyword after update: {}", e.getMessage());
-      return toSummary(kw, true);
+      List<PSKeyword> loaded =
+          designWs.loadKeywords(Collections.singletonList(g), true, false, session, user);
+      if (loaded == null || loaded.isEmpty() || loaded.get(0) == null) {
+        return null;
+      }
+      PSKeyword kw = loaded.get(0);
+      if (StringUtils.isNotBlank(body.getLabel())) {
+        String newLabel = body.getLabel().trim();
+        assertLabelUnique(newLabel, kw.getGUID());
+        kw.setLabel(newLabel);
+      }
+      if (body.getDescription() != null) {
+        kw.setDescription(body.getDescription());
+      }
+      if (body.getSequence() != null) {
+        kw.setSequence(body.getSequence());
+      }
+      if (body.getChoices() != null) {
+        applyChoices(kw, body.getChoices());
+      }
+      designWs.saveKeywords(Collections.singletonList(kw), true, session, user);
+      return reloadSummary(kw.getGUID());
+    } catch (PSErrorResultsException e) {
+      if (isNotFound(e)) {
+        return null;
+      }
+      log.error("Failed to load keyword for update via design WS: {}", id, e);
+      throw new IllegalStateException("Failed to update keyword", e);
+    } catch (PSErrorsException e) {
+      log.error("Failed to save keyword via content design WS: {}", id, e);
+      throw new IllegalStateException("Failed to update keyword", e);
     }
   }
 
@@ -155,34 +202,59 @@ public class KeywordsAdaptor implements IKeywordsAdaptor {
     if (StringUtils.isBlank(id)) {
       throw new IllegalArgumentException("id is required");
     }
-    IPSContentService svc = svc();
+    requireSessionUserForWrite();
     IPSGuid g = parseKeywordGuid(id.trim());
     if (g == null) {
       throw new IllegalArgumentException("Invalid keyword id: " + id);
     }
+    String session = currentSession();
+    String user = currentUser();
+    // Ensure exists (design load)
     try {
-      svc.loadKeyword(g, null);
-    } catch (PSContentException e) {
+      designWs.loadKeywords(Collections.singletonList(g), false, false, session, user);
+    } catch (PSErrorResultsException e) {
       throw new KeywordNotFoundException("Keyword not found: " + id);
     }
-    svc.deleteKeyword(g);
+    try {
+      designWs.deleteKeywords(Collections.singletonList(g), false, session, user);
+    } catch (PSErrorsException e) {
+      log.error("Failed to delete keyword via content design WS: {}", id, e);
+      throw new IllegalStateException("Failed to delete keyword", e);
+    }
   }
 
-  /**
-   * Ensure no other keyword definition uses the same label (case-insensitive).
-   *
-   * @param excludeGuid when updating, the current keyword GUID to ignore
-   */
-  private static void assertLabelUnique(IPSContentService svc, String label, IPSGuid excludeGuid) {
-    List<PSKeyword> matches = svc.findKeywordsByLabel(label, null);
+  private KeywordSummary reloadSummary(IPSGuid guid) {
+    if (guid == null) {
+      return null;
+    }
+    try {
+      List<PSKeyword> loaded =
+          designWs.loadKeywords(
+              Collections.singletonList(guid), false, false, currentSession(), currentUser());
+      if (loaded != null && !loaded.isEmpty() && loaded.get(0) != null) {
+        return toSummary(loaded.get(0), true);
+      }
+    } catch (PSErrorResultsException e) {
+      log.debug("Could not reload keyword after write: {}", e.getMessage());
+    }
+    return null;
+  }
+
+  private void assertLabelUnique(String label, IPSGuid excludeGuid) {
+    List<IPSCatalogSummary> matches = designWs.findKeywords(label);
     if (matches == null) {
       return;
     }
-    for (PSKeyword existing : matches) {
-      if (existing == null || !isKeywordDef(existing)) {
+    for (IPSCatalogSummary existing : matches) {
+      if (existing == null) {
         continue;
       }
-      if (!label.equalsIgnoreCase(StringUtils.defaultString(existing.getLabel()))) {
+      String name = existing.getName();
+      String sumLabel = existing.getLabel();
+      boolean labelMatch =
+          label.equalsIgnoreCase(StringUtils.defaultString(name))
+              || label.equalsIgnoreCase(StringUtils.defaultString(sumLabel));
+      if (!labelMatch) {
         continue;
       }
       if (excludeGuid != null
@@ -198,32 +270,72 @@ public class KeywordsAdaptor implements IKeywordsAdaptor {
     return kw.getKeywordType() == null || PSKeyword.KEYWORD_TYPE.equals(kw.getKeywordType());
   }
 
-  private static PSKeyword resolveKeyword(IPSContentService svc, String idOrValue) {
+  private PSKeyword resolveKeyword(String idOrValue) {
     if (StringUtils.isNumeric(idOrValue) || idOrValue.contains("-")) {
-      PSKeyword byId = loadById(svc, idOrValue);
-      if (byId != null) {
-        return byId;
+      IPSGuid g = parseKeywordGuid(idOrValue);
+      if (g != null) {
+        try {
+          List<PSKeyword> loaded =
+              designWs.loadKeywords(
+                  Collections.singletonList(g), false, false, currentSession(), currentUser());
+          if (loaded != null && !loaded.isEmpty() && loaded.get(0) != null) {
+            return loaded.get(0);
+          }
+        } catch (PSErrorResultsException e) {
+          log.debug("Keyword id not found {}: {}", idOrValue, e.getMessage());
+        }
       }
     }
-    // Match by value among keyword defs
-    List<PSKeyword> all = svc.findKeywordsByLabel(null, null);
-    for (PSKeyword kw : all) {
-      if (kw != null && isKeywordDef(kw) && idOrValue.equals(kw.getValue())) {
-        return kw;
+    // Match by value or label among all defs loaded via design WS
+    try {
+      List<IPSCatalogSummary> summaries = designWs.findKeywords(null);
+      if (summaries == null || summaries.isEmpty()) {
+        return null;
       }
+      List<IPSGuid> guids = new ArrayList<>();
+      for (IPSCatalogSummary sum : summaries) {
+        if (sum != null && sum.getGUID() != null) {
+          guids.add(sum.getGUID());
+        }
+      }
+      if (guids.isEmpty()) {
+        return null;
+      }
+      List<PSKeyword> loaded =
+          designWs.loadKeywords(guids, false, false, currentSession(), currentUser());
+      if (loaded == null) {
+        return null;
+      }
+      for (PSKeyword kw : loaded) {
+        if (kw == null || !isKeywordDef(kw)) {
+          continue;
+        }
+        if (idOrValue.equals(kw.getValue()) || idOrValue.equalsIgnoreCase(kw.getLabel())) {
+          return kw;
+        }
+      }
+    } catch (PSErrorResultsException e) {
+      log.debug("Keyword resolve failed for {}: {}", idOrValue, e.getMessage());
     }
     return null;
   }
 
-  private static PSKeyword loadById(IPSContentService svc, String id) {
-    IPSGuid g = parseKeywordGuid(id);
-    if (g == null) {
-      return null;
-    }
-    try {
-      return svc.loadKeyword(g, "sequence");
-    } catch (PSContentException e) {
-      return null;
+  private static boolean isNotFound(PSErrorResultsException e) {
+    return e != null && e.getErrors() != null && !e.getErrors().isEmpty() && e.getResults().isEmpty();
+  }
+
+  private static String currentSession() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
+  }
+
+  private static String currentUser() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
+  }
+
+  private static void requireSessionUserForWrite() {
+    if (StringUtils.isBlank(currentSession()) || StringUtils.isBlank(currentUser())) {
+      throw new IllegalStateException(
+          "session and user are required for keyword design create/update/delete (IPSContentDesignWs)");
     }
   }
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/KeywordsAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/KeywordsAdaptor.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -142,8 +143,6 @@ public class KeywordsAdaptor implements IKeywordsAdaptor {
     } catch (PSErrorsException e) {
       log.error("Failed to create keyword via content design WS", e);
       throw new IllegalStateException("Failed to create keyword", e);
-    } catch (IllegalArgumentException e) {
-      throw e;
     }
   }
 
@@ -186,7 +185,7 @@ public class KeywordsAdaptor implements IKeywordsAdaptor {
       designWs.saveKeywords(Collections.singletonList(kw), true, session, user);
       return reloadSummary(kw.getGUID());
     } catch (PSErrorResultsException e) {
-      if (isNotFound(e)) {
+      if (isNotFound(e, g)) {
         return null;
       }
       log.error("Failed to load keyword for update via design WS: {}", id, e);
@@ -320,8 +319,20 @@ public class KeywordsAdaptor implements IKeywordsAdaptor {
     return null;
   }
 
-  private static boolean isNotFound(PSErrorResultsException e) {
-    return e != null && e.getErrors() != null && !e.getErrors().isEmpty() && e.getResults().isEmpty();
+  /**
+   * True when the design WS reported an error for the specific requested keyword GUID and did not
+   * return a result for that GUID. Partial multi-id results are not treated as not-found for other
+   * ids.
+   */
+  static boolean isNotFound(PSErrorResultsException e, IPSGuid requested) {
+    if (e == null || requested == null) {
+      return false;
+    }
+    Map<IPSGuid, Object> errors = e.getErrors();
+    Map<IPSGuid, Object> results = e.getResults();
+    boolean errored = errors != null && errors.containsKey(requested);
+    boolean hasResult = results != null && results.containsKey(requested);
+    return errored && !hasResult;
   }
 
   private static String currentSession() {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/KeywordsAdaptorDesignWsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/KeywordsAdaptorDesignWsTest.java
@@ -5,27 +5,36 @@
 package com.percussion.apibridge;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.percussion.rest.keywords.KeywordChoiceSummary;
+import com.percussion.rest.keywords.KeywordNotFoundException;
 import com.percussion.rest.keywords.KeywordSummary;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.content.data.PSKeyword;
 import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfoBase;
+import com.percussion.webservices.PSErrorResultsException;
 import com.percussion.webservices.content.IPSContentDesignWs;
 import java.util.Collections;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -37,6 +46,18 @@ import org.mockito.ArgumentCaptor;
 @Tag("UnitTest")
 class KeywordsAdaptorDesignWsTest {
 
+  @BeforeEach
+  void setRequestInfo() {
+    PSRequestInfoBase.initRequestInfo(Collections.emptyMap());
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_JSESSIONID, "test-session");
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_USER, "test-user");
+  }
+
+  @AfterEach
+  void clearRequestInfo() {
+    PSRequestInfoBase.resetRequestInfo();
+  }
+
   @Test
   void listKeywords_usesFindAndLoadOnDesignWs() throws Exception {
     IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
@@ -47,7 +68,6 @@ class KeywordsAdaptorDesignWsTest {
     PSKeyword kw = new PSKeyword();
     kw.setLabel("Colors");
     kw.setValue("colors");
-    // GUID on PSKeyword is typically set by service; use reflection-free: mock load return only
 
     when(designWs.findKeywords(isNull())).thenReturn(List.of(sum));
     when(designWs.loadKeywords(anyList(), eq(false), eq(false), any(), any()))
@@ -77,5 +97,190 @@ class KeywordsAdaptorDesignWsTest {
     assertNotNull(list);
     assertTrue(list.isEmpty());
     verify(designWs).findKeywords(null);
+    verify(designWs, never()).loadKeywords(anyList(), anyBoolean(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void createKeyword_usesCreateAndSaveOnDesignWs() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    IPSGuid guid = new PSGuid(PSTypeEnum.KEYWORD_DEF, 7L);
+    PSKeyword created = new PSKeyword();
+    created.setGUID(guid);
+    created.setLabel("NewKw");
+    created.setValue("newkw");
+
+    when(designWs.findKeywords("NewKw")).thenReturn(Collections.emptyList());
+    when(designWs.createKeywords(eq(List.of("NewKw")), eq("test-session"), eq("test-user")))
+        .thenReturn(List.of(created));
+    when(designWs.loadKeywords(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(created));
+
+    KeywordSummary body = new KeywordSummary();
+    body.setLabel("NewKw");
+    body.setDescription("desc");
+    body.setSequence(3);
+    KeywordChoiceSummary choice = new KeywordChoiceSummary();
+    choice.setLabel("Red");
+    choice.setValue("red");
+    body.setChoices(List.of(choice));
+
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+    KeywordSummary out = adaptor.createKeyword(null, body);
+
+    assertNotNull(out);
+    assertEquals("NewKw", out.getLabel());
+    verify(designWs).createKeywords(eq(List.of("NewKw")), eq("test-session"), eq("test-user"));
+    verify(designWs).saveKeywords(anyList(), eq(true), eq("test-session"), eq("test-user"));
+  }
+
+  @Test
+  void createKeyword_duplicateLabel_throwsBeforeCreate() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    IPSCatalogSummary existing = mock(IPSCatalogSummary.class);
+    when(existing.getName()).thenReturn("Colors");
+    when(existing.getLabel()).thenReturn("Colors");
+    when(existing.getGUID()).thenReturn(new PSGuid(PSTypeEnum.KEYWORD_DEF, 1L));
+    when(designWs.findKeywords("Colors")).thenReturn(List.of(existing));
+
+    KeywordSummary body = new KeywordSummary();
+    body.setLabel("Colors");
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createKeyword(null, body));
+    assertTrue(ex.getMessage().contains("already in use"));
+    verify(designWs, never()).createKeywords(anyList(), any(), any());
+  }
+
+  @Test
+  void updateKeyword_loadsWithLockAndSaves() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    IPSGuid guid = new PSGuid(PSTypeEnum.KEYWORD_DEF, 9L);
+    PSKeyword kw = new PSKeyword();
+    kw.setGUID(guid);
+    kw.setLabel("Old");
+    kw.setValue("old");
+
+    when(designWs.loadKeywords(eq(List.of(guid)), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(kw));
+    when(designWs.findKeywords("Updated")).thenReturn(Collections.emptyList());
+    when(designWs.loadKeywords(eq(List.of(guid)), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(kw));
+
+    KeywordSummary body = new KeywordSummary();
+    body.setLabel("Updated");
+    body.setDescription("d");
+
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+    KeywordSummary out = adaptor.updateKeyword(null, String.valueOf(guid.getUUID()), body);
+
+    assertNotNull(out);
+    verify(designWs).loadKeywords(eq(List.of(guid)), eq(true), eq(false), any(), any());
+    verify(designWs).saveKeywords(anyList(), eq(true), eq("test-session"), eq("test-user"));
+  }
+
+  @Test
+  void updateKeyword_notFoundViaIsNotFound_returnsNull() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    IPSGuid guid = new PSGuid(PSTypeEnum.KEYWORD_DEF, 11L);
+    PSErrorResultsException err = new PSErrorResultsException();
+    err.addError(guid, "missing");
+    when(designWs.loadKeywords(eq(List.of(guid)), eq(true), eq(false), any(), any())).thenThrow(err);
+
+    KeywordSummary body = new KeywordSummary();
+    body.setLabel("X");
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+
+    assertNull(adaptor.updateKeyword(null, String.valueOf(guid.getUUID()), body));
+    verify(designWs, never()).saveKeywords(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void deleteKeyword_loadsThenDeletesOnDesignWs() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    IPSGuid guid = new PSGuid(PSTypeEnum.KEYWORD_DEF, 5L);
+    PSKeyword kw = new PSKeyword();
+    kw.setGUID(guid);
+    when(designWs.loadKeywords(eq(List.of(guid)), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(kw));
+
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+    adaptor.deleteKeyword(null, String.valueOf(guid.getUUID()));
+
+    verify(designWs).loadKeywords(eq(List.of(guid)), eq(false), eq(false), any(), any());
+    verify(designWs).deleteKeywords(eq(List.of(guid)), eq(false), eq("test-session"), eq("test-user"));
+  }
+
+  @Test
+  void deleteKeyword_missingOnLoad_throwsKeywordNotFound() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    IPSGuid guid = new PSGuid(PSTypeEnum.KEYWORD_DEF, 6L);
+    when(designWs.loadKeywords(eq(List.of(guid)), eq(false), eq(false), any(), any()))
+        .thenThrow(new PSErrorResultsException());
+
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+    assertThrows(
+        KeywordNotFoundException.class,
+        () -> adaptor.deleteKeyword(null, String.valueOf(guid.getUUID())));
+    verify(designWs, never()).deleteKeywords(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void getKeyword_byNumericId_usesLoadKeywords() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    IPSGuid guid = new PSGuid(PSTypeEnum.KEYWORD_DEF, 42L);
+    PSKeyword kw = new PSKeyword();
+    kw.setGUID(guid);
+    kw.setLabel("Colors");
+    kw.setValue("colors");
+    when(designWs.loadKeywords(eq(List.of(guid)), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(kw));
+
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+    KeywordSummary out = adaptor.getKeyword(null, "42");
+
+    assertNotNull(out);
+    assertEquals("Colors", out.getLabel());
+    verify(designWs).loadKeywords(eq(List.of(guid)), eq(false), eq(false), any(), any());
+  }
+
+  @Test
+  void getKeyword_byLabel_loadsAllAndMatches() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    IPSGuid guid = new PSGuid(PSTypeEnum.KEYWORD_DEF, 3L);
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    when(sum.getGUID()).thenReturn(guid);
+    PSKeyword kw = new PSKeyword();
+    kw.setGUID(guid);
+    kw.setLabel("Seasons");
+    kw.setValue("seasons");
+
+    when(designWs.findKeywords(isNull())).thenReturn(List.of(sum));
+    when(designWs.loadKeywords(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(kw));
+
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+    KeywordSummary out = adaptor.getKeyword(null, "Seasons");
+
+    assertNotNull(out);
+    assertEquals("seasons", out.getValue());
+  }
+
+  @Test
+  void isNotFound_requiresErrorForRequestedGuidOnly() {
+    IPSGuid requested = new PSGuid(PSTypeEnum.KEYWORD_DEF, 1L);
+    IPSGuid other = new PSGuid(PSTypeEnum.KEYWORD_DEF, 2L);
+
+    PSErrorResultsException partial = new PSErrorResultsException();
+    partial.addError(other, "fail");
+    partial.addResult(requested, new Object());
+    assertFalse(KeywordsAdaptor.isNotFound(partial, requested));
+
+    PSErrorResultsException missing = new PSErrorResultsException();
+    missing.addError(requested, "missing");
+    assertTrue(KeywordsAdaptor.isNotFound(missing, requested));
+
+    assertFalse(KeywordsAdaptor.isNotFound(null, requested));
+    assertFalse(KeywordsAdaptor.isNotFound(missing, null));
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/KeywordsAdaptorDesignWsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/KeywordsAdaptorDesignWsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.rest.keywords.KeywordSummary;
+import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.content.data.PSKeyword;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Keywords REST adaptor must call content <em>design</em> web service (Workbench path), not only
+ * {@code IPSContentService}.
+ */
+@Tag("UnitTest")
+class KeywordsAdaptorDesignWsTest {
+
+  @Test
+  void listKeywords_usesFindAndLoadOnDesignWs() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    IPSGuid guid = new PSGuid(PSTypeEnum.KEYWORD_DEF, 42L);
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    when(sum.getGUID()).thenReturn(guid);
+
+    PSKeyword kw = new PSKeyword();
+    kw.setLabel("Colors");
+    kw.setValue("colors");
+    // GUID on PSKeyword is typically set by service; use reflection-free: mock load return only
+
+    when(designWs.findKeywords(isNull())).thenReturn(List.of(sum));
+    when(designWs.loadKeywords(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(kw));
+
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+    List<KeywordSummary> list = adaptor.listKeywords(null, false);
+
+    assertEquals(1, list.size());
+    assertEquals("Colors", list.get(0).getLabel());
+    verify(designWs).findKeywords(null);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<IPSGuid>> ids = ArgumentCaptor.forClass(List.class);
+    verify(designWs).loadKeywords(ids.capture(), eq(false), eq(false), any(), any());
+    assertEquals(1, ids.getValue().size());
+    assertEquals(guid, ids.getValue().get(0));
+  }
+
+  @Test
+  void listKeywords_emptyFind_returnsEmptyWithoutLoad() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    when(designWs.findKeywords(isNull())).thenReturn(Collections.emptyList());
+
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+    List<KeywordSummary> list = adaptor.listKeywords(null, true);
+
+    assertNotNull(list);
+    assertTrue(list.isEmpty());
+    verify(designWs).findKeywords(null);
+  }
+}


### PR DESCRIPTION
## Summary
Retarget **Keywords** Developer REST to the Workbench design path:

`KeywordsResource` → `KeywordsAdaptor` → **`IPSContentDesignWs`** (`findKeywords` / `loadKeywords` / `createKeywords` / `saveKeywords` / `deleteKeywords`)

Previously the adaptor called **`IPSContentService` directly**, bypassing design locks and the SOAP design API.

## Design WS mapping
| REST op | Design WS |
|---------|-----------|
| list | `findKeywords` + `loadKeywords` (lock=false) |
| get | load by guid or find+match value/label |
| create | `createKeywords` + mutate + `saveKeywords`(release) |
| update | `loadKeywords`(lock) + `saveKeywords`(release) |
| delete | `deleteKeywords` |

Session/user from `PSRequestInfo` (same pattern as searches / content types).

## Tests
```
cd projects/sitemanage
../../mvnw test -Dtest=KeywordsAdaptorDesignWsTest
# 2 passed
```

## Parent
Part of #1700 (BYPASS retarget list). Next: locales, system/shared def, slots.

Refs #1700 #1690