### PR TITLE
fix(developer): system/shared def via IPSContentDesignWs

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SharedFieldsAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SharedFieldsAdaptor.java
@@ -25,8 +25,11 @@ import com.percussion.rest.sharedfields.ISharedFieldsAdaptor;
 import com.percussion.rest.sharedfields.SharedFieldGroupDetail;
 import com.percussion.rest.sharedfields.SharedFieldGroupSummary;
 import com.percussion.rest.sharedfields.SharedFieldSummary;
-import com.percussion.server.PSServer;
 import com.percussion.system.utils.PSSiteManageBean;
+import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.content.PSContentWsLocator;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -40,8 +43,8 @@ import org.apache.logging.log4j.Logger;
 /**
  * Read-only catalog of content-editor shared field groups ({@link PSContentEditorSharedDef}).
  *
- * <p>Uses {@link PSServer#getContentEditorSharedDef()} in production; mapping helpers are pure so
- * unit tests need no object-store singleton.
+ * <p>Workbench parity: loads via {@link IPSContentDesignWs#loadContentEditorSharedDef} (same design
+ * web service SOAP uses), not {@code PSServer.getContentEditorSharedDef()} alone.
  */
 @PSSiteManageBean
 public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
@@ -57,7 +60,20 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
   private final Supplier<PSContentEditorSharedDef> sharedDefLoader;
 
   public SharedFieldsAdaptor() {
-    this(PSServer::getContentEditorSharedDef);
+    this(
+        () -> {
+          IPSContentDesignWs designWs = PSContentWsLocator.getContentDesignWebservice();
+          try {
+            return designWs.loadContentEditorSharedDef(
+                false,
+                false,
+                (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID),
+                (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER));
+          } catch (PSErrorException e) {
+            log.error("Failed to load content editor shared def via design WS", e);
+            throw new IllegalStateException("Failed to load shared def", e);
+          }
+        });
   }
 
   /** Package-visible for unit tests that inject a fake shared def source. */

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SharedFieldsAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SharedFieldsAdaptor.java
@@ -61,24 +61,31 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
 
   public SharedFieldsAdaptor() {
     this(
-        () -> {
-          IPSContentDesignWs designWs = PSContentWsLocator.getContentDesignWebservice();
-          try {
-            return designWs.loadContentEditorSharedDef(
-                false,
-                false,
+        () ->
+            loadSharedDefFromDesignWs(
+                PSContentWsLocator.getContentDesignWebservice(),
                 (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID),
-                (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER));
-          } catch (PSErrorException e) {
-            log.error("Failed to load content editor shared def via design WS", e);
-            throw new IllegalStateException("Failed to load shared def", e);
-          }
-        });
+                (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER)));
   }
 
   /** Package-visible for unit tests that inject a fake shared def source. */
   SharedFieldsAdaptor(Supplier<PSContentEditorSharedDef> sharedDefLoader) {
     this.sharedDefLoader = sharedDefLoader;
+  }
+
+  /**
+   * Production load path used by the default constructor. Package-visible so unit tests can exercise
+   * design-WS success, {@link PSErrorException} wrapping, and absent request session/user without
+   * mocking static locators.
+   */
+  static PSContentEditorSharedDef loadSharedDefFromDesignWs(
+      IPSContentDesignWs designWs, String sessionId, String user) {
+    try {
+      return designWs.loadContentEditorSharedDef(false, false, sessionId, user);
+    } catch (PSErrorException e) {
+      log.error("Failed to load content editor shared def via design WS", e);
+      throw new IllegalStateException("Failed to load shared def", e);
+    }
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SystemDefAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SystemDefAdaptor.java
@@ -10,7 +10,6 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
@@ -23,23 +22,30 @@ import com.percussion.design.objectstore.PSFieldSet;
 import com.percussion.rest.systemdef.ISystemDefAdaptor;
 import com.percussion.rest.systemdef.SystemDefDetail;
 import com.percussion.rest.systemdef.SystemDefFieldSummary;
-import com.percussion.server.PSServer;
 import com.percussion.system.utils.PSSiteManageBean;
+import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.content.PSContentWsLocator;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Read-only content-editor system definition field catalog ({@link PSContentEditorSystemDef}).
  *
- * <p>Uses {@link PSServer#getContentEditorSystemDef()} in production; mapping helpers are pure so
- * unit tests need no object-store singleton.
+ * <p>Workbench parity: loads via {@link IPSContentDesignWs#loadContentEditorSystemDef} (same design
+ * web service SOAP uses), not {@code PSServer.getContentEditorSystemDef()} alone.
  */
 @PSSiteManageBean
 public class SystemDefAdaptor implements ISystemDefAdaptor {
+
+  private static final Logger log = LogManager.getLogger(SystemDefAdaptor.class);
 
   private static final List<String> DESIGN_GAPS =
       List.of(
@@ -50,7 +56,20 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
   private final Supplier<PSContentEditorSystemDef> systemDefLoader;
 
   public SystemDefAdaptor() {
-    this(PSServer::getContentEditorSystemDef);
+    this(
+        () -> {
+          IPSContentDesignWs designWs = PSContentWsLocator.getContentDesignWebservice();
+          try {
+            return designWs.loadContentEditorSystemDef(
+                false,
+                false,
+                (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID),
+                (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER));
+          } catch (PSErrorException e) {
+            log.error("Failed to load content editor system def via design WS", e);
+            throw new IllegalStateException("Failed to load system def", e);
+          }
+        });
   }
 
   /** Package-visible for unit tests that inject a fake system def source. */

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SystemDefAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SystemDefAdaptor.java
@@ -57,24 +57,31 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
 
   public SystemDefAdaptor() {
     this(
-        () -> {
-          IPSContentDesignWs designWs = PSContentWsLocator.getContentDesignWebservice();
-          try {
-            return designWs.loadContentEditorSystemDef(
-                false,
-                false,
+        () ->
+            loadSystemDefFromDesignWs(
+                PSContentWsLocator.getContentDesignWebservice(),
                 (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID),
-                (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER));
-          } catch (PSErrorException e) {
-            log.error("Failed to load content editor system def via design WS", e);
-            throw new IllegalStateException("Failed to load system def", e);
-          }
-        });
+                (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER)));
   }
 
   /** Package-visible for unit tests that inject a fake system def source. */
   SystemDefAdaptor(Supplier<PSContentEditorSystemDef> systemDefLoader) {
     this.systemDefLoader = systemDefLoader;
+  }
+
+  /**
+   * Production load path used by the default constructor. Package-visible so unit tests can exercise
+   * design-WS success, {@link PSErrorException} wrapping, and absent request session/user without
+   * mocking static locators.
+   */
+  static PSContentEditorSystemDef loadSystemDefFromDesignWs(
+      IPSContentDesignWs designWs, String sessionId, String user) {
+    try {
+      return designWs.loadContentEditorSystemDef(false, false, sessionId, user);
+    } catch (PSErrorException e) {
+      log.error("Failed to load content editor system def via design WS", e);
+      throw new IllegalStateException("Failed to load system def", e);
+    }
   }
 
   @Override

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SharedFieldsAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SharedFieldsAdaptorTest.java
@@ -21,8 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.percussion.design.objectstore.PSContentEditorSharedDef;
@@ -32,6 +37,8 @@ import com.percussion.design.objectstore.PSSharedFieldGroup;
 import com.percussion.rest.sharedfields.SharedFieldGroupDetail;
 import com.percussion.rest.sharedfields.SharedFieldGroupSummary;
 import com.percussion.util.PSCollection;
+import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.content.IPSContentDesignWs;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -120,5 +127,50 @@ class SharedFieldsAdaptorTest {
     assertEquals(
         "required", SharedFieldsAdaptor.mapOccurrence(PSField.OCCURRENCE_DIMENSION_REQUIRED));
     assertEquals("unknown", SharedFieldsAdaptor.mapOccurrence(-99));
+  }
+
+  @Test
+  void loadSharedDefFromDesignWs_returnsDesignWsResult() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSContentEditorSharedDef def = mock(PSContentEditorSharedDef.class);
+    when(designWs.loadContentEditorSharedDef(false, false, "sid", "admin")).thenReturn(def);
+
+    assertSame(def, SharedFieldsAdaptor.loadSharedDefFromDesignWs(designWs, "sid", "admin"));
+    verify(designWs).loadContentEditorSharedDef(false, false, "sid", "admin");
+  }
+
+  @Test
+  void loadSharedDefFromDesignWs_wrapsPsErrorException() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSErrorException cause = new PSErrorException("ws failed");
+    when(designWs.loadContentEditorSharedDef(false, false, "sid", "admin")).thenThrow(cause);
+
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class,
+            () -> SharedFieldsAdaptor.loadSharedDefFromDesignWs(designWs, "sid", "admin"));
+    assertEquals("Failed to load shared def", ex.getMessage());
+    assertSame(cause, ex.getCause());
+  }
+
+  @Test
+  void loadSharedDefFromDesignWs_passesNullSessionAndUserWhenRequestInfoAbsent() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSContentEditorSharedDef def = mock(PSContentEditorSharedDef.class);
+    when(designWs.loadContentEditorSharedDef(eq(false), eq(false), isNull(), isNull()))
+        .thenReturn(def);
+
+    assertSame(def, SharedFieldsAdaptor.loadSharedDefFromDesignWs(designWs, null, null));
+    verify(designWs).loadContentEditorSharedDef(false, false, null, null);
+  }
+
+  @Test
+  void listGroups_usesInjectedLoaderFromDefaultConstructorShape() {
+    PSContentEditorSharedDef def = mock(PSContentEditorSharedDef.class);
+    when(def.getFieldGroups()).thenReturn(new PSCollection(PSSharedFieldGroup.class).iterator());
+
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(() -> def);
+    assertNotNull(adaptor.listGroups(null));
+    assertTrue(adaptor.listGroups(null).isEmpty());
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SystemDefAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SystemDefAdaptorTest.java
@@ -20,14 +20,21 @@ package com.percussion.apibridge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.percussion.design.objectstore.PSContentEditorSystemDef;
 import com.percussion.design.objectstore.PSField;
 import com.percussion.design.objectstore.PSFieldSet;
 import com.percussion.rest.systemdef.SystemDefDetail;
+import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.content.IPSContentDesignWs;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -79,5 +86,52 @@ class SystemDefAdaptorTest {
         "zeroOrMore", SystemDefAdaptor.mapOccurrence(PSField.OCCURRENCE_DIMENSION_ZERO_OR_MORE));
     assertEquals("count", SystemDefAdaptor.mapOccurrence(PSField.OCCURRENCE_DIMENSION_COUNT));
     assertEquals("unknown", SystemDefAdaptor.mapOccurrence(-1));
+  }
+
+  @Test
+  void loadSystemDefFromDesignWs_returnsDesignWsResult() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSContentEditorSystemDef def = mock(PSContentEditorSystemDef.class);
+    when(designWs.loadContentEditorSystemDef(false, false, "sid", "admin")).thenReturn(def);
+
+    assertSame(def, SystemDefAdaptor.loadSystemDefFromDesignWs(designWs, "sid", "admin"));
+    verify(designWs).loadContentEditorSystemDef(false, false, "sid", "admin");
+  }
+
+  @Test
+  void loadSystemDefFromDesignWs_wrapsPsErrorException() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSErrorException cause = new PSErrorException("ws failed");
+    when(designWs.loadContentEditorSystemDef(false, false, "sid", "admin")).thenThrow(cause);
+
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class,
+            () -> SystemDefAdaptor.loadSystemDefFromDesignWs(designWs, "sid", "admin"));
+    assertEquals("Failed to load system def", ex.getMessage());
+    assertSame(cause, ex.getCause());
+  }
+
+  @Test
+  void loadSystemDefFromDesignWs_passesNullSessionAndUserWhenRequestInfoAbsent() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSContentEditorSystemDef def = mock(PSContentEditorSystemDef.class);
+    when(designWs.loadContentEditorSystemDef(eq(false), eq(false), isNull(), isNull()))
+        .thenReturn(def);
+
+    assertSame(def, SystemDefAdaptor.loadSystemDefFromDesignWs(designWs, null, null));
+    verify(designWs).loadContentEditorSystemDef(false, false, null, null);
+  }
+
+  @Test
+  void getSystemDef_usesInjectedLoaderFromDefaultConstructorShape() {
+    PSContentEditorSystemDef def = mock(PSContentEditorSystemDef.class);
+    when(def.getFieldSet()).thenReturn(null);
+    when(def.getCacheTimeout()).thenReturn(0);
+
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(() -> def);
+    SystemDefDetail detail = adaptor.getSystemDef(null);
+    assertNotNull(detail);
+    assertEquals(0, detail.getFieldCount());
   }
 }


### PR DESCRIPTION
## Summary
Retarget system def + shared field group catalogs to content design WS:

| Adaptor | Design WS |
|---------|-----------|
| SystemDefAdaptor | `loadContentEditorSystemDef(lock=false, …)` |
| SharedFieldsAdaptor | `loadContentEditorSharedDef(lock=false, …)` |

Replaces direct `PSServer.getContentEditorSystemDef()` / `getContentEditorSharedDef()` production loaders.

## Tests
Existing mapper unit tests: 8 passed.

Refs #1700 #1690