### PR TITLE
docs: codify Workbench REST rules and dev vs QA test modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -444,7 +444,7 @@ A list of child modules in this repository. Each bullet contains: Module name �
 - **webservices** — `./modules/webservices` — Legacy Rhythmyx SOAP web services API migrated from Apache Axis to CXF.
 - **perc-system** — `./system` — The core CMS module representing Rhythmyx functionality.  Contains the core XML application server and content managenent implementation.
 - **perc-service-wrapper** — `./modules/perc-service-wrapper` — Legacy module that was intended to be used for Windows service management. Currently not used in deployments.
-- **rest** — `./rest` — Public REST API (JAX-RS resources, wire DTOs, `IXxxAdaptor` interfaces). **Must not** depend on `sitemanage` (reactor cycle). See `rest/AGENTS.md`.
+- **rest** — `./rest` — Public REST API (JAX-RS resources, wire DTOs, `IXxxAdaptor` interfaces). **Must not** depend on `sitemanage` (reactor cycle). See `rest/AGENTS.md`. Workbench-replacement REST + **dev/QA test modes**: `docs/developer-module/workbench-rest-and-qa-modes.md`.
 - **perc-tinymce** — `./modules/perc-tinymce` — Packaging module for the TinyMCE rich text editor used in the CMS ui to edit content.
 - **perc-toolkit** — `./modules/perc-toolkit` — Legacy module containing
 - **perc-taxonomy** — `./modules/perc-taxonomy` — Legacy Rhythmyx module that provides taxonomy services for CMS content.
@@ -463,7 +463,7 @@ A list of child modules in this repository. Each bullet contains: Module name �
 - **Percussion CMS Common UI Bundle** — `./modules/perc-common-ui-bundle` — Minified JavaScript bundle for the Percussion CMS delivery-tier widgets (perc_common_ui.js and perc_common_ui_slim.js); built with esbuild and served as bundled web resources from this JAR.
 - **Percussion OpenAPI Generator Maven Plugin** — `./modules/perc-openapi-generator-plugin` — Maven plugin to generate OpenAPI specification from JAX-RS annotations in the `rest` module.
 - **perc-web-ui** — `./WebUI` — The main user interface for the product. UI screen changes require Playwright create/update in `modules/perc-qa-automation` (see `WebUI/AGENTS.md`).
-- **perc-qa-automation** — `./modules/perc-qa-automation` — Playwright (+ TestNG) E2E against a live CMS; required companion tests for WebUI screen work.
+- **perc-qa-automation** — `./modules/perc-qa-automation` — Playwright (+ TestNG) E2E against a live CMS; required companion tests for WebUI screen work. **Dev mode** = local install + docker bind + hot copy (no restart); **QA mode** = all-in-docker pass/fail. See `docs/developer-module/workbench-rest-and-qa-modes.md` and `modules/perc-qa-automation/AGENTS.md`.
 - **Percussion OpenAPI Web App** — `./modules/perc-openapi-webapp` — Provides the OpenAPI Swagger UI forinteracting with the products REST API's.
 - **perc-thumbnail** — `./modules/perc-thumbnail` — Responsible for generating all web page thumbnails in the application.
 - **sitemanage** — `./projects/sitemanage` — CM1 middleware + `com.percussion.apibridge` implementations of `rest` `IXxxAdaptor` interfaces. Depends on `rest`; never reverse. See `projects/sitemanage/AGENTS.md`.

--- a/WebUI/AGENTS.md
+++ b/WebUI/AGENTS.md
@@ -117,13 +117,18 @@ npm run test             # Vitest
 npm run dev              # HMR when wired to a running CMS
 ```
 
-### Hot copy to docker CMS (example)
+### Hot copy to CMS install (dev mode)
+
+**Dev mode:** CMS is a **local install** on the machine; docker **binds** to it. Copy artifacts into that install and re-run Playwright — **no restart** for typical JS/CSS/JSP.  
+**QA mode:** fully containerized stack; pass/fail only — no host-install hot copy.  
+See [`docs/developer-module/workbench-rest-and-qa-modes.md`](../docs/developer-module/workbench-rest-and-qa-modes.md).
 
 ```bash
+# Paths: use your DEV_PERCUSSION_INSTALL (e.g. /opt/Percussion or C:\Installs\…)
 cp WebUI/target/generated-webui/cm/modern/assets/perc-modern-ui.js \
-   /opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/perc-modern-ui.js
+   "$DEV_PERCUSSION_INSTALL/jetty/base/webapps/Rhythmyx/cm/modern/assets/perc-modern-ui.js"
 cp WebUI/target/generated-webui/cm/modern/assets/perc-modern-ui.css \
-   /opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/assets/perc-modern-ui.css
+   "$DEV_PERCUSSION_INSTALL/jetty/base/webapps/Rhythmyx/cm/modern/assets/perc-modern-ui.css"
 # Path routes: spa.jsp + filter are on the server; rebuild WAR or copy JSP/filter classes as needed
 ```
 

--- a/docs/developer-module/README.md
+++ b/docs/developer-module/README.md
@@ -8,6 +8,7 @@ Tool-agnostic reverse engineering of the Rhythmyx 7.3.2 **Workbench** (Eclipse D
 
 |                                     File                                     |                                                                                          Description                                                                                           |
 |------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [workbench-rest-and-qa-modes.md](./workbench-rest-and-qa-modes.md)           | **Direction of record:** clean REST for Workbench replacement (SOAP as reference); **dev mode** (local install + docker bind + hot copy) vs **QA mode** (all-in-docker pass/fail)             |
 | [workbench-functional-inventory.md](./workbench-functional-inventory.md)     | Primary inventory + functional requirements: IA, object catalog, module FR, cross-cutting platform needs, prioritization, appendices                                                           |
 | [data-pipeline-engine-inventory.md](./data-pipeline-engine-inventory.md)     | **XML Application / E2Designer data pipeline engine** — full stage inventory (tanks, mapper, selector, updater, txn, hooks, value system) + modernization brief (JSON, datasources, hooks, IR) |
 | [data-pipeline-server-runtime-map.md](./data-pipeline-server-runtime-map.md) | **Server runtime map** in this repo — `PSApplicationHandler` → `PSQueryHandler` / `PSUpdateHandler` (+ reuse vs reimplement notes for Slice A)                                                 |
@@ -28,7 +29,7 @@ Tool-agnostic reverse engineering of the Rhythmyx 7.3.2 **Workbench** (Eclipse D
 2. **Server runtime map** — [data-pipeline-server-runtime-map.md](./data-pipeline-server-runtime-map.md) (done as docs; use before estimating engine reuse)
 3. **Pipeline Slice A (parallel or next)** — pipeline IR + SQL runtime + JSON I/O + hooks + classic app import
 
-**Slice progress (todo list):** [issue #1622](https://github.com/intersoftdatalabs-in/percussioncms/issues/1622) — update the issue task list when PRs merge; do not thrash the P0 README checklist on every PR.
+**Slice progress:** post-P0 tracker [issue #1690](https://github.com/intersoftdatalabs-in/percussioncms/issues/1690) (P0 checklist [#1622](https://github.com/intersoftdatalabs-in/percussioncms/issues/1622) is closed). Do not thrash markdown checklists on every PR.
 
 Implementation notes and **PR review deferrals / tech debt** live under  
 [`docs/ai-generated/tasks/developer-module-p0/`](../ai-generated/tasks/developer-module-p0/)  

--- a/docs/developer-module/workbench-rest-and-qa-modes.md
+++ b/docs/developer-module/workbench-rest-and-qa-modes.md
@@ -1,0 +1,125 @@
+# Workbench replacement REST + Dev / QA test modes
+
+| Field | Value |
+|-------|--------|
+| **Status** | **Direction of record** for agents and humans |
+| **Audience** | Anyone adding Developer-module (Workbench replacement) APIs or Playwright against CMS |
+| **Related** | [rest/AGENTS.md](../../rest/AGENTS.md), [sitemanage/AGENTS.md](../../projects/sitemanage/AGENTS.md), [perc-qa-automation/AGENTS.md](../../modules/perc-qa-automation/AGENTS.md), [adaptor-design-ws-audit.md](../ai-generated/tasks/developer-module-p0/adaptor-design-ws-audit.md) |
+
+---
+
+## 1. Workbench replacement REST (HARD RULES)
+
+Classic design tools went **SOAP → design webservices (`IPS*DesignWs` / `*DesignSOAPImpl`) → system**.  
+The modern SPA must **not** reimplement Workbench by gluing partial sitemanage “already REST-like” product APIs just because they are convenient.
+
+### Required shape
+
+```text
+Workbench / SOAP design operations  (behavioral reference)
+        │
+        ▼
+Clean public REST  (rest module: resource + wire DTOs + IXxxAdaptor)
+        │
+        ▼
+Thin sitemanage apibridge  (@PSSiteManageBean implements IXxxAdaptor)
+        │
+        ▼
+Same backing capabilities SOAP used
+  (prefer IPS*DesignWs / assembly design WS / system design WS when they exist)
+        │
+        ▼
+perc-system / objectstore / services
+```
+
+| Layer | Module | Role |
+|-------|--------|------|
+| HTTP + OpenAPI + DTOs | **`rest`** | New, intentional Workbench-replacement surface |
+| Adaptor interface | **`rest`** | Contract only — **no** sitemanage dependency |
+| Adaptor impl | **`sitemanage` apibridge** | Thin map to design/system call sites |
+| Domain truth for design objects | **webservices design APIs + system** | Same stack Workbench trusted |
+
+### DO
+
+1. Design the **REST contract** for the FR (list/detail/save/lock gaps explicit).
+2. Use **SOAP / `IPS*DesignWs` method lists** as the reference for operations, locks, and failure modes.
+3. Implement adaptors that call those design/system APIs when they exist (see audit matrix).
+4. Keep sitemanage as **glue**, not a second design product.
+5. Document `designGaps[]` when REST is thinner than Workbench.
+
+### DO NOT
+
+1. **Lazy-wire** an existing sitemanage/CM1 endpoint into Developer because it “looks REST.”
+2. Invent a **parallel domain stack** (new DAO / random managers) that Workbench never used for that design object **when** a design WS already owns it.
+3. Put design-object business logic only in the SPA or only in rest without a clear system/design backend.
+4. Depend **rest → sitemanage** (reactor cycle).
+
+### Not every surface is design-WS
+
+Some catalogs have **no** SOAP design twin (e.g. CE control managers, extension registry, server config files). Those are **ALT** paths: still **clean REST + thin adaptor**, backend = the real system owner, documented in the audit — not “use a random sitemanage REST.”
+
+---
+
+## 2. Test environments: **dev mode** vs **QA mode**
+
+Two supported modes. Agents must know which they are in. **Developers/agents do not invent one-off “copy jars by hand forever” workflows** as the product process — they use these modes; **automation owns packaging and full installs**.
+
+### Dev mode (fast iteration)
+
+**Purpose:** day-to-day feature + Playwright development on a real CMS tree.
+
+| Piece | Expectation |
+|-------|-------------|
+| CMS | **Local install on the developer machine** (e.g. `C:\Installs\…`, `/opt/Percussion`) |
+| Docker | **Binds/mounts that install** (or otherwise uses that tree) — not a throwaway empty container as the only copy of the product |
+| Code changes | Build → **copy artifacts into the install webapp** (hot deploy) |
+| Server restart | **Not required** for typical JS/CSS/JSP (and other hot-copy paths); see WebUI / perc-qa-automation hot-deploy tables |
+| Tests | Playwright against `DEV_PERCUSSION_INSTALL` / discovered URL (e.g. `localhost:9992`) |
+| Loop | edit → build/copy → **re-run test** (cache-buster on SPA URLs when needed) |
+
+**Agent rules (dev mode):**
+
+1. Set `DEV_PERCUSSION_INSTALL` (or rely on project `.env`); never hardcode another machine’s path in committed files.
+2. Prefer **hot copy** over full reinstall for UI/rest jar iteration when docs allow.
+3. **Do not** treat “I didn’t manually redeploy” as an acceptable reason to skip Playwright for a screen change — use the install + hot copy path.
+4. Full reinstall of a local install is **ops/automation**, not the default every PR.
+
+### QA mode (contained pass/fail)
+
+**Purpose:** clean, reproducible gate — “does this revision work?”
+
+| Piece | Expectation |
+|-------|-------------|
+| CMS | **Fully contained in Docker** (image/stack owns the install) |
+| Host install | Not required for the test run |
+| Code under test | Built into the image / stack under test (or the pipeline’s defined artifact path) |
+| Tests | Playwright (or suite) runs **against that stack only** |
+| Outcome | **Pass or fail** — no “works on my July-29 folder” caveat |
+
+**Agent rules (QA mode):**
+
+1. Do not assume a host bind mount or `C:\Installs\…`.
+2. Do not ask the developer to copy jars into a personal install to “make QA green.”
+3. Failures are **product or pipeline** defects; file issues, don’t invent local-only workarounds as the fix.
+
+### What is *not* a supported long-term process
+
+- “Merged to `development` so the shared QA box should magically update” without **automation**.
+- “Agents must remember to copy `rest.jar` and restart Jetty” as the primary workflow.
+- Using **dev-mode local install drift** as the only CI signal for Workbench-replacement APIs.
+
+**Automation (target):** pipelines (or `perc-devctl` / matrix scripts) own **build → package → install or image → start → Playwright**. Dev mode remains the fast loop; QA mode remains the contained gate.
+
+---
+
+## 3. Pointers for agents
+
+| Need | Doc |
+|------|-----|
+| REST adaptor layout | `rest/AGENTS.md`, `projects/sitemanage/AGENTS.md` |
+| Which adaptors hit design WS | `docs/ai-generated/tasks/developer-module-p0/adaptor-design-ws-audit.md` |
+| Playwright + hot copy | `modules/perc-qa-automation/AGENTS.md`, `WebUI/AGENTS.md` |
+| FR parity | `docs/developer-module/workbench-functional-inventory.md` |
+| Progress tracker | GitHub **#1690** (post-P0); closed **#1622** was P0 |
+
+When adding a Workbench-replacement API or Playwright coverage, **read this file first** and state **dev mode** vs **QA mode** in the PR body.

--- a/modules/perc-qa-automation/AGENTS.md
+++ b/modules/perc-qa-automation/AGENTS.md
@@ -239,9 +239,20 @@ npm test -- --config=playwright.config.js
 npm test -- --debug
 ```
 
-## Fast iteration against the dev CMS (no container restart)
+## Two modes: **dev** vs **QA** (HARD RULES)
 
-When the dev CMS is running via the docker compose stack at `localhost:9992` (see `docker-compose.yml` + `docker/scripts/perc-devctl.py`), **JS / TS / JSP changes do NOT require a container restart** — rebuild and copy the artifact. See the WebUI AGENTS.md "Hot Deployment" section for the full iteration cost table. Quick reference for QA work:
+Full product rules: [`docs/developer-module/workbench-rest-and-qa-modes.md`](../../docs/developer-module/workbench-rest-and-qa-modes.md).
+
+| Mode | CMS | Docker | Change loop | Outcome |
+|------|-----|--------|-------------|---------|
+| **Dev mode** (fast) | **Local install on the dev machine** | **Binds** to that install (or uses that tree) | Build → **copy into install** → re-run Playwright — **no restart** for typical hot-copy paths | Iterate on specs + product |
+| **QA mode** (gate) | **Fully contained in Docker** | Stack owns the install | Image/stack built from the revision under test | **Pass or fail** — no host install drift |
+
+**Automation owns** full build → install/image → start → test. Agents must **not** treat manual “redeploy jars forever” as the primary process. Dev mode = local install + bind + hot copy; QA mode = all-in-docker.
+
+### Dev mode: fast iteration (no container restart)
+
+When the CMS is a **local install** used by docker bind/mount (or equivalent) at e.g. `localhost:9992` (see `docker-compose.yml` + `docker/scripts/perc-devctl.py`), **JS / TS / JSP changes do NOT require a restart** — rebuild and copy the artifact into the install webapp. See the WebUI AGENTS.md hot-deploy section. Quick reference:
 
 ```bash
 # 1. Edit spec file in modules/perc-qa-automation/frontend/tests/

--- a/projects/sitemanage/AGENTS.md
+++ b/projects/sitemanage/AGENTS.md
@@ -48,6 +48,16 @@ Package: `com.percussion.apibridge`
 This package is the **only** place that should implement public REST adaptor interfaces from
 `com.percussion.rest.*`.
 
+### Workbench replacement (HARD RULES)
+
+apibridge is **thin glue**, not a second Workbench. Prefer **design webservices**
+(`IPSContentDesignWs`, `IPSUiDesignWs`, `IPSAssemblyDesignWs`, …) when implementing
+Developer/Workbench-replacement catalogs — same backends SOAP used. Do **not** wire
+partial CM1/sitemanage product REST “because it’s already REST-like.”
+
+Canonical rules: [`docs/developer-module/workbench-rest-and-qa-modes.md`](../../docs/developer-module/workbench-rest-and-qa-modes.md).  
+Audit matrix: [`docs/ai-generated/tasks/developer-module-p0/adaptor-design-ws-audit.md`](../../docs/ai-generated/tasks/developer-module-p0/adaptor-design-ws-audit.md).
+
 ```text
 rest JAX-RS Resource
         │  injects interface
@@ -56,9 +66,10 @@ rest IXxxAdaptor  (interface + wire DTOs live in rest)
         │  implemented by
         ▼
 sitemanage apibridge XxxAdaptor  (@PSSiteManageBean)
-        │  calls
+        │  calls (Workbench replacement prefer:)
         ▼
-sitemanage / perc-system domain services
+IPS*DesignWs / design system APIs  (SOAP reference)
+  or documented ALT system owners when no design-WS twin
 ```
 
 ### Conventions

--- a/rest/AGENTS.md
+++ b/rest/AGENTS.md
@@ -22,6 +22,20 @@ Source of truth for dependency versions is the root `pom.xml`:
 
 ## Design Patterns
 
+### Workbench replacement APIs (HARD RULES)
+
+For **Developer module / Workbench replacement** surfaces, do **not** lazily reuse partial
+sitemanage “already REST-like” product endpoints. Build a **clean** public REST contract here
+and use **classic SOAP / design webservices as the behavioral reference**.
+
+Full rules + dev/QA modes:
+[`docs/developer-module/workbench-rest-and-qa-modes.md`](../docs/developer-module/workbench-rest-and-qa-modes.md).
+
+```text
+SOAP / IPS*DesignWs (reference) → REST resource + DTO + IXxxAdaptor (this module)
+  → sitemanage apibridge (thin) → same design/system backends Workbench used
+```
+
 ### Adaptor Pattern (with sitemanage apibridge)
 
 The REST module uses the **Adaptor pattern**. HTTP concerns live here; **implementations live in
@@ -36,7 +50,8 @@ Adaptor Interface (rest)             e.g. IPreferenceAdaptor, IRelationshipSumma
     ↓
 Adaptor Implementation (sitemanage)  com.percussion.apibridge.*  e.g. PreferencesAdaptor
     ↓
-Domain services (sitemanage / perc-system)
+Design WS / system (prefer IPS*DesignWs when replacing Workbench)
+  or documented domain services when no design-WS twin exists
     ↓
 Database & Internal Services
 ```


### PR DESCRIPTION
## Summary
Codifies product rules so future agents do not invent one-off workflows.

### Canonical doc
`docs/developer-module/workbench-rest-and-qa-modes.md`

### Workbench replacement REST
- Clean **rest-layer** APIs for Workbench replacement
- **SOAP / design webservices** as behavioral reference
- Thin sitemanage apibridge — **not** lazy reuse of partial CM1/sitemanage “already REST” endpoints

### Test modes
| Mode | Meaning |
|------|---------|
| **Dev** | Local CMS install on the machine; docker **binds** to it; hot-copy changes; **re-run tests without restart** |
| **QA** | **All-in-docker**; contained pass/fail; no host install drift |

**Automation owns** full build/install/image — not a permanent “developer copies jars by hand” process.

### Pointers updated
Root `AGENTS.md`, `rest/AGENTS.md`, `projects/sitemanage/AGENTS.md`, `WebUI/AGENTS.md`, `modules/perc-qa-automation/AGENTS.md`, `docs/developer-module/README.md`.

Refs #1690