### PR TITLE
feat(deps): migrate runtime Jackson 2.x to Jackson 3.1.5 (#1706)

### DIFF
--- a/WebUI/pom.xml
+++ b/WebUI/pom.xml
@@ -229,11 +229,11 @@
             <version>1.1.2</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
+            <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+            <groupId>tools.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
         </dependency>
         <dependency>
@@ -241,7 +241,7 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
+            <groupId>tools.jackson.module</groupId>
             <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
         </dependency>
         <dependency>

--- a/deliverytiersuite/delivery-tier-suite/comments/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/comments/pom.xml
@@ -37,7 +37,7 @@
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+            <groupId>tools.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
         </dependency>
         <dependency>
@@ -79,8 +79,8 @@
             <artifactId>spring-tx</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/PSCommentsApplication.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/PSCommentsApplication.java
@@ -18,7 +18,7 @@
 
 package com.percussion.delivery;
 
-import com.fasterxml.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
+import tools.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
 import com.percussion.delivery.comments.services.PSCommentsRestService;
 import com.percussion.delivery.exceptions.PSJsonMappingErrorResponse;
 import com.percussion.delivery.exceptions.PSUncaughtError;

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/IPSComment.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/IPSComment.java
@@ -17,7 +17,7 @@
  */
 package com.percussion.delivery.comments.data;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 import java.util.Date;
 import java.util.Set;
 
@@ -96,7 +96,7 @@ public interface IPSComment {
    *
    * @return the created date for this comment. Never <code>null</code> or empty.
    */
-  @JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.class)
+  @JsonSerialize(using = com.percussion.delivery.services.PSCustomDateSerializer.class)
   Date getCreatedDate();
 
   /**

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSCommentCriteria.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSCommentCriteria.java
@@ -17,7 +17,8 @@
  */
 package com.percussion.delivery.comments.data;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.delivery.comments.data.IPSComment.APPROVAL_STATE;
 import java.io.IOException;
 import org.apache.logging.log4j.LogManager;
@@ -290,11 +291,11 @@ public class PSCommentCriteria {
    */
   public String toJSON() {
     String ret = "";
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
 
     try {
       ret = mapper.writeValueAsString(this);
-    } catch (IOException e) {
+    } catch (Exception e) {
       log.warn("Error deserializing to JSON.", e);
     }
     return ret;

--- a/deliverytiersuite/delivery-tier-suite/comments/src/test/java/com/percussion/delivery/comments/services/PSCommentsRestServiceBaseTest.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/test/java/com/percussion/delivery/comments/services/PSCommentsRestServiceBaseTest.java
@@ -18,8 +18,9 @@ package com.percussion.delivery.comments.services;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
 import com.percussion.delivery.comments.data.PSCommentCriteria;
 import com.percussion.delivery.multitenant.PSTenantSecurityFilter;
 import com.percussion.delivery.test.utils.FakeRegistrant;
@@ -104,7 +105,7 @@ public abstract class PSCommentsRestServiceBaseTest extends JerseyTest {
     WebTarget webTarget = client.target(MOD_STATE_PUT_URL);
     Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON);
 
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
     ObjectNode setState = mapper.createObjectNode();
     setState.put("site", "testsite");
     setState.put("state", "REJECTED");
@@ -133,7 +134,7 @@ public abstract class PSCommentsRestServiceBaseTest extends JerseyTest {
 
     // Load up 1 comment per tenant.
     int i = 1;
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
     for (FakeRegistrant p : this.tenants) {
 
       Client client = ClientBuilder.newClient();

--- a/deliverytiersuite/delivery-tier-suite/common/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/common/pom.xml
@@ -40,12 +40,12 @@
             <version>1.6.8</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
+            <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>

--- a/deliverytiersuite/delivery-tier-suite/common/src/main/java/com/percussion/delivery/exceptions/PSJsonMappingErrorResponse.java
+++ b/deliverytiersuite/delivery-tier-suite/common/src/main/java/com/percussion/delivery/exceptions/PSJsonMappingErrorResponse.java
@@ -17,7 +17,7 @@
 
 package com.percussion.delivery.exceptions;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
+import tools.jackson.databind.DatabindException;
 import com.percussion.security.error.PSExceptionUtils;
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.core.Response;
@@ -27,12 +27,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * Maps Jackson {@link JsonMappingException}s into a generic 500 plain-text response, logging the
+ * Maps Jackson {@link DatabindException}s into a generic 500 plain-text response, logging the
  * original error for diagnostics.
  */
 @Provider
 @Priority(1)
-public class PSJsonMappingErrorResponse implements ExceptionMapper<JsonMappingException> {
+public class PSJsonMappingErrorResponse implements ExceptionMapper<DatabindException> {
 
   /** Default constructor. */
   public PSJsonMappingErrorResponse() {}
@@ -48,7 +48,7 @@ public class PSJsonMappingErrorResponse implements ExceptionMapper<JsonMappingEx
    * @return a response mapped from the supplied exception.
    */
   @Override
-  public Response toResponse(JsonMappingException exception) {
+  public Response toResponse(DatabindException exception) {
     log.error(PSExceptionUtils.getMessageForLog(exception));
     log.debug(PSExceptionUtils.getDebugMessageForLog(exception));
     return Response.status(500)

--- a/deliverytiersuite/delivery-tier-suite/common/src/main/java/com/percussion/delivery/jaxrs/PSExceptionMapper.java
+++ b/deliverytiersuite/delivery-tier-suite/common/src/main/java/com/percussion/delivery/jaxrs/PSExceptionMapper.java
@@ -17,8 +17,8 @@
 
 package com.percussion.delivery.jaxrs;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DatabindException;
 import com.percussion.security.error.PSExceptionUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.WebApplicationException;
@@ -59,10 +59,10 @@ public class PSExceptionMapper implements ExceptionMapper<Exception> {
 
     String clientMsg;
     Status status;
-    if (e instanceof JsonMappingException) {
+    if (e instanceof DatabindException) {
       clientMsg = "Invalid request. JSON property is not of an expected type";
       status = Response.Status.BAD_REQUEST;
-    } else if (e instanceof JsonParseException) {
+    } else if (e instanceof JacksonException) {
       clientMsg = "Invalid request.  Invalid JSON object";
       status = Response.Status.BAD_REQUEST;
     } else if (e instanceof WebApplicationException) {

--- a/deliverytiersuite/delivery-tier-suite/common/src/main/java/com/percussion/delivery/services/PSCustomDateSerializer.java
+++ b/deliverytiersuite/delivery-tier-suite/common/src/main/java/com/percussion/delivery/services/PSCustomDateSerializer.java
@@ -16,11 +16,11 @@
  */
 package com.percussion.delivery.services;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import java.io.IOException;
 import org.apache.commons.lang3.time.FastDateFormat;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
 /**
  * Custom date serializer to put the serialized date into a non numeric format. Uses the date format
@@ -28,30 +28,17 @@ import org.apache.commons.lang3.time.FastDateFormat;
  *
  * @author erikserating
  */
-public class PSCustomDateSerializer extends JsonSerializer<Object> {
+public class PSCustomDateSerializer extends ValueSerializer<Object> {
 
   private final FastDateFormat formatter = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
-  /**
-   * Default constructor. The {@link SerializerProvider} argument is not currently used by this
-   * implementation; it is a placeholder for future enhancements such as locale-aware formatting.
-   */
   public PSCustomDateSerializer() {}
 
-  /**
-   * Serializes the supplied date value as a string using {@code yyyy-MM-dd'T'HH:mm:ss.SSSZ}.
-   *
-   * @param value the value to serialize; expected to be a {@link java.util.Date}.
-   * @param gen the Jackson generator to write to, never <code>null</code>.
-   * @param provider the serializer provider, reserved for future use.
-   * @throws IOException if writing to the generator fails.
-   */
   @Override
   public void serialize(
-      Object value, JsonGenerator gen, @SuppressWarnings("unused") SerializerProvider provider)
-      throws IOException {
+      Object value, JsonGenerator gen, @SuppressWarnings("unused") SerializationContext provider)
+      throws JacksonException {
     String formattedDate = formatter.format(value);
-
     gen.writeString(formattedDate);
   }
 }

--- a/deliverytiersuite/delivery-tier-suite/common/src/test/java/com/percussion/delivery/test/utils/properties/PSPropertyGroupTest.java
+++ b/deliverytiersuite/delivery-tier-suite/common/src/test/java/com/percussion/delivery/test/utils/properties/PSPropertyGroupTest.java
@@ -16,14 +16,11 @@
  */
 package com.percussion.delivery.test.utils.properties;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.percussion.delivery.utils.properties.PSPropertyDefinition;
 import com.percussion.delivery.utils.properties.PSPropertyGroupDefinition;
-import java.io.IOException;
-import java.io.StringWriter;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * @author natechadwick
@@ -31,8 +28,7 @@ import org.junit.jupiter.api.Test;
 public class PSPropertyGroupTest {
 
   @Test
-  public void testJSON() throws IOException {
-
+  public void testJSON() {
     PSPropertyGroupDefinition basic = new PSPropertyGroupDefinition();
     basic.setDisplayName("Basic");
     basic.setName("basic");
@@ -53,16 +49,7 @@ public class PSPropertyGroupTest {
     p2.setName("p2");
     basic.getProperties().add(p2);
 
-    ObjectMapper m = new ObjectMapper();
-    JsonFactory jf = new JsonFactory();
-    StringWriter sw = new StringWriter();
-
-    JsonGenerator jg = jf.createJsonGenerator(sw);
-
-    jg.useDefaultPrettyPrinter();
-
-    m.writeValue(jg, basic);
-
-    System.out.print(sw.toString());
+    var mapper = JsonMapper.builder().enable(SerializationFeature.INDENT_OUTPUT).build();
+    System.out.print(mapper.writeValueAsString(basic));
   }
 }

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml
@@ -272,7 +272,7 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <groupId>tools.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
         </dependency>
         <dependency>

--- a/deliverytiersuite/delivery-tier-suite/feeds/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/feeds/pom.xml
@@ -45,7 +45,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+            <groupId>tools.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
         </dependency>
         <dependency>
@@ -53,8 +53,8 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/data/IPSFeedDescriptor.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/data/IPSFeedDescriptor.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.delivery.data;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import com.percussion.delivery.feeds.data.PSFeedDescriptor;
 
 /** A feed descriptor contains meta data needed to create a feed. */

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/data/PSFeedDescriptors.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/data/PSFeedDescriptors.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.delivery.data;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import com.percussion.delivery.feeds.data.IPSFeedDescriptor;
 import com.percussion.delivery.feeds.data.PSFeedDescriptor;
 import java.util.ArrayList;

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/PSFeedsApplication.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/PSFeedsApplication.java
@@ -17,7 +17,7 @@
 
 package com.percussion.delivery.feeds;
 
-import com.fasterxml.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
+import tools.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
 import com.percussion.delivery.exceptions.PSJsonMappingErrorResponse;
 import com.percussion.delivery.exceptions.PSUncaughtError;
 import com.percussion.delivery.feeds.services.PSFeedService;

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/data/IPSFeedDescriptor.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/data/IPSFeedDescriptor.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.delivery.feeds.data;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /** A feed descriptor contains meta data needed to create a feed. */
 @JsonDeserialize(as = PSFeedDescriptor.class)

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/data/PSFeedDescriptors.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/data/PSFeedDescriptors.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.delivery.feeds.data;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/deliverytiersuite/delivery-tier-suite/forms/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/forms/pom.xml
@@ -136,7 +136,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+            <groupId>tools.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
         </dependency>
         <!-- Add missing dependencies for Hibernate 6 and Spring 6 -->

--- a/deliverytiersuite/delivery-tier-suite/forms/src/main/java/com/percussion/delivery/forms/PSFormsApplication.java
+++ b/deliverytiersuite/delivery-tier-suite/forms/src/main/java/com/percussion/delivery/forms/PSFormsApplication.java
@@ -17,7 +17,7 @@
 
 package com.percussion.delivery.forms;
 
-import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
+import tools.jackson.jakarta.rs.json.JacksonJsonProvider;
 import com.percussion.delivery.exceptions.PSJsonMappingErrorResponse;
 import com.percussion.delivery.exceptions.PSUncaughtError;
 import com.percussion.delivery.forms.impl.PSFormRestService;

--- a/deliverytiersuite/delivery-tier-suite/membership/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/membership/pom.xml
@@ -110,11 +110,11 @@
         </dependency>
         <!-- JSON Processing -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+            <groupId>tools.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
         </dependency>
         <!-- Test Dependencies -->

--- a/deliverytiersuite/delivery-tier-suite/membership/src/main/java/com/percussion/PSMembershipApplication.java
+++ b/deliverytiersuite/delivery-tier-suite/membership/src/main/java/com/percussion/PSMembershipApplication.java
@@ -19,7 +19,7 @@ package com.percussion;
 
 // REFACTORED: CP-JAVA11
 
-import com.fasterxml.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
+import tools.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
 import com.percussion.delivery.exceptions.PSJsonMappingErrorResponse;
 import com.percussion.delivery.exceptions.PSUncaughtError;
 import com.percussion.generickey.utils.services.impl.PSGenericKeyRestService;

--- a/deliverytiersuite/delivery-tier-suite/membership/src/main/java/com/percussion/membership/data/PSUserSummary.java
+++ b/deliverytiersuite/delivery-tier-suite/membership/src/main/java/com/percussion/membership/data/PSUserSummary.java
@@ -17,7 +17,7 @@
 
 package com.percussion.membership.data;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 import com.percussion.delivery.services.PSCustomDateSerializer;
 import com.percussion.membership.data.IPSMembership.PSMemberStatus;
 import java.util.Date;

--- a/deliverytiersuite/delivery-tier-suite/metadata/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/metadata/pom.xml
@@ -74,8 +74,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
+            <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -119,7 +119,7 @@
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+            <groupId>tools.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
         </dependency>
         <dependency>
@@ -128,8 +128,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/PSMetadataApplication.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/PSMetadataApplication.java
@@ -17,7 +17,7 @@
 
 package com.percussion.delivery.metadata;
 
-import com.fasterxml.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
+import tools.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
 import com.percussion.delivery.exceptions.PSJsonMappingErrorResponse;
 import com.percussion.delivery.exceptions.PSUncaughtError;
 import com.percussion.delivery.metadata.impl.PSMetadataExtractorRestService;

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/PSMetadataQueryServiceTest.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/PSMetadataQueryServiceTest.java
@@ -18,8 +18,9 @@ package com.percussion.delivery.metadata;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.github.javafaker.Faker;
 import com.percussion.delivery.metadata.IPSMetadataProperty.VALUETYPE;
 import com.percussion.delivery.metadata.data.PSMetadataBlogResult;
@@ -1600,7 +1601,7 @@ public class PSMetadataQueryServiceTest {
   @Test
   public void testSortByCreatedDateDesc() {
     PSMetadataQuery query = new PSMetadataQuery();
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
     try {
       query =
           mapper.readValue(
@@ -1642,7 +1643,7 @@ public class PSMetadataQueryServiceTest {
   @Test
   public void testSortByCreatedDateAsc() {
     PSMetadataQuery query = new PSMetadataQuery();
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
     try {
       query =
           mapper.readValue(
@@ -1690,7 +1691,7 @@ public class PSMetadataQueryServiceTest {
   @Test
   public void testSortByLinkTextASC() {
     PSMetadataQuery query = new PSMetadataQuery();
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
     try {
       query =
           mapper.readValue(
@@ -1722,7 +1723,7 @@ public class PSMetadataQueryServiceTest {
         }
       }
 
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
       fail(e.getMessage());
@@ -1736,7 +1737,7 @@ public class PSMetadataQueryServiceTest {
   @Test
   public void testSortByLinkTextDesc() {
     PSMetadataQuery query = new PSMetadataQuery();
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
     try {
       query =
           mapper.readValue(

--- a/deliverytiersuite/delivery-tier-suite/polls/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/polls/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>jersey-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+            <groupId>tools.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
         </dependency>
         <dependency>

--- a/deliverytiersuite/delivery-tier-suite/polls/src/main/java/com/percussion/delivery/polls/PSPollsApplication.java
+++ b/deliverytiersuite/delivery-tier-suite/polls/src/main/java/com/percussion/delivery/polls/PSPollsApplication.java
@@ -18,7 +18,7 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.delivery.polls;
 
-import com.fasterxml.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
+import tools.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
 import com.percussion.delivery.exceptions.PSJsonMappingErrorResponse;
 import com.percussion.delivery.exceptions.PSUncaughtError;
 import com.percussion.delivery.polls.services.PSPollsRestService;

--- a/deliverytiersuite/delivery-tier-suite/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/pom.xml
@@ -71,12 +71,12 @@
                 <version>${jakarta.transaction.api.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+                <groupId>tools.jackson.jakarta.rs</groupId>
                 <artifactId>jackson-jakarta-rs-json-provider</artifactId>
                 <version>${jakarta.jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
+                <groupId>tools.jackson.module</groupId>
                 <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
                 <version>${jakarta.jackson.version}</version>
             </dependency>
@@ -323,7 +323,7 @@
                 <version>${jersey.version}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>com.fasterxml.jackson.module</groupId>
+                        <groupId>tools.jackson.module</groupId>
                         <artifactId>jackson-module-jaxb-annotations</artifactId>
                     </exclusion>
                 </exclusions>

--- a/docs/ai-generated/tasks/plan-jackson3Migration.md
+++ b/docs/ai-generated/tasks/plan-jackson3Migration.md
@@ -1,10 +1,15 @@
 # Plan: Migrate to Jackson 3
 
-Migrate Percussion CMS from Jackson 2.21.1 to Jackson 3.1 (LTS). This involves changing Maven groupId (`com.fasterxml.jackson` → `tools.jackson`), Java package imports, converting ObjectMapper to immutable builder pattern, updating renamed classes/methods, removing embedded Java 8 modules, and adjusting for changed defaults. An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/java/jackson/upgradejackson_2_3) exists to automate much of the mechanical work.
+**Tracking issue:** [#1706](https://github.com/intersoftdatalabs-in/percussioncms/issues/1706) — `[8.2] Migrate runtime Jackson 2.x → Jackson 3.x (LTS)`  
+**Branch (WIP):** `feature/1706-jackson3-migration`
+
+Migrate Percussion CMS from Jackson 2.x to Jackson 3.1 (LTS). This involves changing Maven groupId (`com.fasterxml.jackson` → `tools.jackson`), Java package imports, converting ObjectMapper to immutable builder pattern, updating renamed classes/methods, removing embedded Java 8 modules, and adjusting for changed defaults. An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/java/jackson/upgradejackson_2_3) exists to automate much of the mechanical work.
+
+**Status (2026-07-31):** Path C (OpenAPI isolation) partially complete. Runtime still Jackson **2.22.1**. Full 3.x migration **not** started — often confused with Path C completion.
 
 ## Current State
 
-- Jackson 2.21.1 across the codebase (annotations 2.21, Jakarta variants 2.20.1)
+- Jackson 2.22.1 across the codebase (annotations ~2.22, Jakarta variants 2.20.1)
 - 100+ files with Jackson imports, 150+ annotation usages
 - 10 Jackson Maven artifacts declared
 - 50+ direct `new ObjectMapper()` instantiations

--- a/docs/ai-generated/tasks/plan-jackson3Migration.md
+++ b/docs/ai-generated/tasks/plan-jackson3Migration.md
@@ -5,11 +5,12 @@
 
 Migrate Percussion CMS from Jackson 2.x to Jackson 3.1 (LTS). This involves changing Maven groupId (`com.fasterxml.jackson` → `tools.jackson`), Java package imports, converting ObjectMapper to immutable builder pattern, updating renamed classes/methods, removing embedded Java 8 modules, and adjusting for changed defaults. An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/java/jackson/upgradejackson_2_3) exists to automate much of the mechanical work.
 
-**Status (2026-07-31):** Path C (OpenAPI isolation) partially complete. Runtime still Jackson **2.22.1**. Full 3.x migration **not** started — often confused with Path C completion.
+**Status (2026-07-31):** Runtime migration to Jackson **3.1.5** implemented on branch `feature/1706-jackson3-migration` (single PR). Path C OpenAPI isolation remains the Swagger gate completed earlier.
 
-## Current State
+## Current State (post-migration)
 
-- Jackson 2.22.1 across the codebase (annotations ~2.22, Jakarta variants 2.20.1)
+- Jackson **3.1.5** (`tools.jackson.*`) across the monorepo; `jackson-annotations` stays **2.21** on `com.fasterxml.jackson.core` by Jackson 3 design
+- Java 8 modules (`jackson-datatype-jdk8` / `jsr310` / `parameter-names`) removed — built into databind
 - 100+ files with Jackson imports, 150+ annotation usages
 - 10 Jackson Maven artifacts declared
 - 50+ direct `new ObjectMapper()` instantiations

--- a/modules/CMLight-Main-cactus-tests/src/test/java/com/percussion/search/PSSearchQueryTest.java
+++ b/modules/CMLight-Main-cactus-tests/src/test/java/com/percussion/search/PSSearchQueryTest.java
@@ -32,7 +32,6 @@ import java.util.Map;
 
 
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.Disabled;

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExpandedOption.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSExpandedOption.java
@@ -93,14 +93,14 @@ public class PSExpandedOption implements IPSClientObjects {
     Element el = null;
 
     // create temp text node
-    Text textNode = null;
+    Text StringNode = null;
 
     Iterator iter = m_paths.iterator();
     while (iter.hasNext()) {
       el = doc.createElement(ELEM_PATH);
-      textNode = doc.createTextNode((String) iter.next());
+      StringNode = doc.createTextNode((String) iter.next());
 
-      el.appendChild(textNode);
+      el.appendChild(StringNode);
       root.appendChild(el);
     }
     return root;

--- a/modules/perc-openapi-generator-plugin/pom.xml
+++ b/modules/perc-openapi-generator-plugin/pom.xml
@@ -62,8 +62,8 @@
         </dependency>
         <!-- JSON processing -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
         <!-- Logging -->

--- a/modules/perc-toolkit/pom.xml
+++ b/modules/perc-toolkit/pom.xml
@@ -134,8 +134,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSORemoteContentTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSORemoteContentTools.java
@@ -16,7 +16,8 @@
 
 package com.percussion.pso.jexl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.extension.IPSJexlExpression;
 import com.percussion.extension.IPSJexlMethod;
 import com.percussion.extension.IPSJexlParam;
@@ -49,7 +50,7 @@ public class PSORemoteContentTools extends PSJexlUtilBase implements IPSJexlExpr
   private static final int SC_NOT_MODIFIED = 304;
   private static final HttpClient HTTP_CLIENT =
       HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
 
   public PSORemoteContentTools() {
     super();

--- a/modules/utils/src/main/java/com/percussion/xml/PSXmlDocumentBuilder.java
+++ b/modules/utils/src/main/java/com/percussion/xml/PSXmlDocumentBuilder.java
@@ -880,8 +880,8 @@ public class PSXmlDocumentBuilder {
       value = normalize(value);
     }
 
-    Text textNode = node.getOwnerDocument().createTextNode(value);
-    node.appendChild(textNode);
+    Text StringNode = node.getOwnerDocument().createTextNode(value);
+    node.appendChild(StringNode);
 
     return node;
   }

--- a/pom.xml
+++ b/pom.xml
@@ -132,13 +132,15 @@
         <httpcomponents.core.version>4.4.16</httpcomponents.core.version>
         <httpcomponents.version>4.5.14</httpcomponents.version>
         <install.jre.version>8.222.10.1</install.jre.version>
-        <jackson.annotation.api.version>2.22</jackson.annotation.api.version>
-        <jackson.version>2.22.1</jackson.version>
+        <!-- Jackson 3.x runtime (tools.jackson); annotations stay on 2.x com.fasterxml by design -->
+        <jackson.annotation.api.version>2.21</jackson.annotation.api.version>
+        <jackson.version>3.1.5</jackson.version>
         <jakarta.activation.version>2.1.4</jakarta.activation.version>
         <jakarta.annotation.api.version>3.0.0</jakarta.annotation.api.version>
         <jakarta.el.api.version>6.0.1</jakarta.el.api.version>
         <jakarta.inject.version>2.0.1</jakarta.inject.version>
-        <jakarta.jackson.version>2.20.1</jakarta.jackson.version>
+        <!-- Align Jakarta-RS / xmlbind modules with core Jackson 3 line -->
+        <jakarta.jackson.version>${jackson.version}</jakarta.jackson.version>
         <jakarta.jms.api.version>3.1.0</jakarta.jms.api.version>
         <jakarta.json.api.version>2.1.3</jakarta.json.api.version>
         <jakarta.mail.api.version>2.1.5</jakarta.mail.api.version>
@@ -665,7 +667,7 @@
                 <version>${swagger.version}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>com.fasterxml.jackson.module</groupId>
+                        <groupId>tools.jackson.module</groupId>
                         <artifactId>jackson-module-jaxb-annotations</artifactId>
                     </exclusion>
                 </exclusions>
@@ -676,7 +678,7 @@
                 <version>${swagger.version}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>com.fasterxml.jackson.module</groupId>
+                        <groupId>tools.jackson.module</groupId>
                         <artifactId>jackson-module-jaxb-annotations</artifactId>
                     </exclusion>
                 </exclusions>
@@ -1655,22 +1657,22 @@
                 <version>${commons.file.upload.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
+                <groupId>tools.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <groupId>tools.jackson.jaxrs</groupId>
                 <artifactId>jackson-jaxrs-json-provider</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+                <groupId>tools.jackson.jakarta.rs</groupId>
                 <artifactId>jackson-jakarta-rs-json-provider</artifactId>
                 <version>${jakarta.jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
+                <groupId>tools.jackson.module</groupId>
                 <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
                 <version>${jakarta.jackson.version}</version>
             </dependency>
@@ -1680,7 +1682,7 @@
                 <version>${jackson.annotation.api.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
+                <groupId>tools.jackson.module</groupId>
                 <artifactId>jackson-module-jaxb-annotations</artifactId>
                 <version>${jackson.version}</version>
                 <exclusions>
@@ -1705,28 +1707,13 @@
                 <version>${jaxb.api.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
+                <groupId>tools.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <groupId>tools.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-xml</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jsr310</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-parameter-names</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jdk8</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>

--- a/projects/sitemanage/pom.xml
+++ b/projects/sitemanage/pom.xml
@@ -247,38 +247,26 @@
             <artifactId>spring-context-support</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
+            <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
+            <groupId>tools.jackson.module</groupId>
             <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
             <version>${jakarta.jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+            <groupId>tools.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
             <version>${jakarta.jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-parameter-names</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jettison</groupId>

--- a/projects/sitemanage/src/main/java/com/percussion/analytics/service/impl/PSAnalyticsProviderService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/analytics/service/impl/PSAnalyticsProviderService.java
@@ -18,7 +18,7 @@ package com.percussion.analytics.service.impl;
 
 import static com.percussion.share.service.exception.PSParameterValidationUtils.validateParameters;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import tools.jackson.core.JacksonException;
 import com.percussion.analytics.data.PSAnalyticsProviderConfig;
 import com.percussion.analytics.error.IPSAnalyticsErrorMessageHandler;
 import com.percussion.analytics.error.PSAnalyticsProviderException;
@@ -88,11 +88,11 @@ public class PSAnalyticsProviderService implements IPSAnalyticsProviderService {
 
     config.setPassword(ePwd);
 
-    var objectMapper = new com.fasterxml.jackson.databind.ObjectMapper();
+    var objectMapper = new tools.jackson.databind.ObjectMapper();
     String objectToJson = null;
     try {
       objectToJson = objectMapper.writeValueAsString(config);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       log.error("Exception occurred while parsing -> {}", PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
     }
@@ -115,7 +115,7 @@ public class PSAnalyticsProviderService implements IPSAnalyticsProviderService {
     if (metadata == null) return null;
     var json = metadata.getData();
     if (StringUtils.isBlank(json)) return null;
-    var objectMapper = new com.fasterxml.jackson.databind.ObjectMapper();
+    var objectMapper = new tools.jackson.databind.ObjectMapper();
     try {
       config = objectMapper.readValue(json, PSAnalyticsProviderConfig.class);
 
@@ -146,7 +146,7 @@ public class PSAnalyticsProviderService implements IPSAnalyticsProviderService {
 
       config.setPassword(pwd);
       config.setUserid(userID);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       log.error("Error parsing Analytics configuration: {}", e.getMessage());
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
       var builder = validateParameters("json file");

--- a/projects/sitemanage/src/main/java/com/percussion/category/data/LocalDateDeserializer.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/data/LocalDateDeserializer.java
@@ -18,28 +18,27 @@
 
 package com.percussion.category.data;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.percussion.share.service.exception.PSDataServiceException;
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 
 /** Jackson deserializer for LocalDateTime. Handles ISO-8601 and common variants. */
-public class LocalDateDeserializer extends JsonDeserializer<LocalDateTime> {
+public class LocalDateDeserializer extends ValueDeserializer<LocalDateTime> {
 
   private static final Logger log = LogManager.getLogger(LocalDateDeserializer.class);
 
   @Override
   public LocalDateTime deserialize(JsonParser parser, DeserializationContext ctxt)
-      throws IOException {
+      throws JacksonException {
     var dateInStringFormat = parser.getText();
     try {
-      // Try ISO_LOCAL_DATE_TIME first
       return Optional.ofNullable(dateInStringFormat)
           .map(String::trim)
           .filter(s -> !s.isEmpty())
@@ -48,7 +47,6 @@ public class LocalDateDeserializer extends JsonDeserializer<LocalDateTime> {
                 try {
                   return LocalDateTime.parse(s, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
                 } catch (Exception e) {
-                  // Try fallback: replace single-digit hour/min/sec with padded zero
                   var fixed =
                       s.replaceAll("T(\\d:)", "T0$1")
                           .replaceAll(":(\\d:)", ":0$1")

--- a/projects/sitemanage/src/main/java/com/percussion/category/data/LocalDateSerializer.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/data/LocalDateSerializer.java
@@ -19,22 +19,19 @@
 
 package com.percussion.category.data;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
 /** Jackson serializer for LocalDateTime. */
-public class LocalDateSerializer extends JsonSerializer<LocalDateTime> {
+public class LocalDateSerializer extends ValueSerializer<LocalDateTime> {
   @Override
   public void serialize(
-      LocalDateTime localDateTime,
-      JsonGenerator jsonGenerator,
-      SerializerProvider serializerProvider)
-      throws IOException {
-    // Use ISO_LOCAL_DATE_TIME for consistency
+      LocalDateTime localDateTime, JsonGenerator jsonGenerator, SerializationContext ctxt)
+      throws JacksonException {
     jsonGenerator.writeString(localDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/category/data/PSCategory.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/data/PSCategory.java
@@ -20,8 +20,9 @@
 package com.percussion.category.data;
 
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.share.data.PSAbstractDataObject;
 import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
@@ -107,9 +108,9 @@ public class PSCategory extends PSAbstractDataObject implements Cloneable {
    */
   public String toJSON() {
     try {
-      var mapper = new ObjectMapper();
+      var mapper = JsonMapper.builder().build();
       return mapper.writeValueAsString(this);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       System.out.println(e.getMessage());
       return null;
     }

--- a/projects/sitemanage/src/main/java/com/percussion/category/data/PSCategoryNode.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/data/PSCategoryNode.java
@@ -20,10 +20,11 @@
 package com.percussion.category.data;
 
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 import com.percussion.share.data.PSAbstractDataObject;
 import jakarta.xml.bind.annotation.*;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
@@ -343,9 +344,9 @@ public class PSCategoryNode extends PSAbstractDataObject
    */
   public String toJSON() {
     try {
-      var mapper = new ObjectMapper();
+      var mapper = JsonMapper.builder().build();
       return mapper.writeValueAsString(this);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       System.out.println(e.getMessage());
       return null;
     }

--- a/projects/sitemanage/src/main/java/com/percussion/category/marshaller/PSCategoryMarshaller.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/marshaller/PSCategoryMarshaller.java
@@ -19,11 +19,9 @@
 
 package com.percussion.category.marshaller;
 
-import com.fasterxml.jackson.databind.AnnotationIntrospector;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.dataformat.xml.jaxb.XmlJaxbAnnotationIntrospector;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector;
 import com.percussion.category.data.PSCategory;
 import com.percussion.category.data.PSCategoryFileLockData;
 import com.percussion.server.PSServer;
@@ -142,17 +140,14 @@ public class PSCategoryMarshaller {
 
   public static String marshalToJson(PSCategory category) {
     try (var writer = new StringWriter()) {
-      var mapper = new ObjectMapper();
-      mapper.registerModule(new JavaTimeModule());
-      mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-
-      AnnotationIntrospector introspector =
-          new XmlJaxbAnnotationIntrospector(mapper.getTypeFactory());
-      mapper.getSerializationConfig().withAppendedAnnotationIntrospector(introspector);
-
+      var mapper =
+          JsonMapper.builder()
+              .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+              .annotationIntrospector(new JakartaXmlBindAnnotationIntrospector())
+              .build();
       mapper.writeValue(writer, category);
       return writer.toString();
-    } catch (IOException e) {
+    } catch (Exception e) {
       log.debug("Cannot convert category object to JSON string", e);
       throw new RuntimeException("Error processing category data", e);
     }

--- a/projects/sitemanage/src/main/java/com/percussion/category/marshaller/PSCategoryUnMarshaller.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/marshaller/PSCategoryUnMarshaller.java
@@ -19,11 +19,10 @@
 
 package com.percussion.category.marshaller;
 
-import com.fasterxml.jackson.databind.AnnotationIntrospector;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.dataformat.xml.jaxb.XmlJaxbAnnotationIntrospector;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector;
 import com.percussion.category.data.PSCategory;
 import com.percussion.category.data.PSCategoryNode;
 import com.percussion.category.transformer.PSCategoryXmlTransform;
@@ -108,15 +107,14 @@ public class PSCategoryUnMarshaller {
       return null;
     }
     try (Reader reader = new StringReader(categoryJson)) {
-      var mapper = new ObjectMapper();
-      mapper.registerModule(new JavaTimeModule());
-      mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-      mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
-      AnnotationIntrospector introspector =
-          new XmlJaxbAnnotationIntrospector(mapper.getTypeFactory());
-      mapper.getDeserializationConfig().withAppendedAnnotationIntrospector(introspector);
+      var mapper =
+          JsonMapper.builder()
+              .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+              .enable(SerializationFeature.INDENT_OUTPUT)
+              .annotationIntrospector(new JakartaXmlBindAnnotationIntrospector())
+              .build();
       return mapper.readValue(categoryJson, PSCategory.class);
-    } catch (IOException e) {
+    } catch (Exception e) {
       log.error("Error parsing category JSON: " + categoryJson, e);
       throw new RuntimeException("Unexpected error processing categories", e);
     }

--- a/projects/sitemanage/src/main/java/com/percussion/category/marshaller/PSJAXBContextResolver.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/marshaller/PSJAXBContextResolver.java
@@ -19,13 +19,6 @@
 
 package com.percussion.category.marshaller;
 
-import com.fasterxml.jackson.databind.AnnotationIntrospector;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
-import com.fasterxml.jackson.databind.type.TypeFactory;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector;
 import com.percussion.category.data.PSCategory;
 import com.percussion.category.data.PSCategoryNode;
 import com.percussion.category.data.PSDateAdapter;
@@ -34,6 +27,13 @@ import jakarta.ws.rs.ext.ContextResolver;
 import jakarta.xml.bind.JAXBException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import tools.jackson.databind.AnnotationIntrospector;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector;
 
 @PSSiteManageBean("categoryContextResolver")
 public class PSJAXBContextResolver implements ContextResolver<ObjectMapper> {
@@ -43,15 +43,15 @@ public class PSJAXBContextResolver implements ContextResolver<ObjectMapper> {
   private static final Logger log = LogManager.getLogger(PSJAXBContextResolver.class);
 
   public PSJAXBContextResolver() throws JAXBException {
-    this.objectMapper = new ObjectMapper();
-    objectMapper.registerModule(new JavaTimeModule());
-    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-    objectMapper
-        .configure(SerializationFeature.INDENT_OUTPUT, true)
-        .setAnnotationIntrospector(
-            AnnotationIntrospector.pair(
-                new JacksonAnnotationIntrospector(),
-                new JakartaXmlBindAnnotationIntrospector(TypeFactory.defaultInstance())));
+    this.objectMapper =
+        JsonMapper.builder()
+            .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .annotationIntrospector(
+                AnnotationIntrospector.pair(
+                    new JacksonAnnotationIntrospector(),
+                    new JakartaXmlBindAnnotationIntrospector()))
+            .build();
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/category/service/impl/PSCategoryService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/service/impl/PSCategoryService.java
@@ -18,8 +18,9 @@
 
 package com.percussion.category.service.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.category.dao.IPSCategoryDao;
 import com.percussion.category.data.PSCategory;
 import com.percussion.category.data.PSCategoryLockInfo;
@@ -221,9 +222,9 @@ public class PSCategoryService implements IPSCategoryService {
     }
     PSCategory categoryWithJson = null;
     try {
-      var mapper = new ObjectMapper();
+      var mapper = JsonMapper.builder().build();
       categoryWithJson = mapper.readValue(categoryString, PSCategory.class);
-    } catch (JsonProcessingException ex) {
+    } catch (JacksonException ex) {
       log.error("Error while parsing json to {} Error: {}", categoryString, ex.getMessage());
       log.debug(ex.getMessage(), ex);
     }
@@ -241,9 +242,9 @@ public class PSCategoryService implements IPSCategoryService {
     }
     PSCategory categoryWithJson = null;
     try {
-      var mapper = new ObjectMapper();
+      var mapper = JsonMapper.builder().build();
       categoryWithJson = mapper.readValue(categoryString, PSCategory.class);
-    } catch (JsonProcessingException ex) {
+    } catch (JacksonException ex) {
       log.error("Error while parsing json to {} Error: {}", categoryString, ex.getMessage());
       log.debug(ex.getMessage(), ex);
     }

--- a/projects/sitemanage/src/main/java/com/percussion/cloudservice/impl/PSCloudService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/cloudservice/impl/PSCloudService.java
@@ -17,7 +17,8 @@
 
 package com.percussion.cloudservice.impl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.cloudservice.IPSCloudService;
 import com.percussion.cloudservice.data.PSCloudLicenseType;
 import com.percussion.cloudservice.data.PSCloudServiceInfo;
@@ -54,7 +55,7 @@ public class PSCloudService implements IPSCloudService {
   protected static final String PAGE_THUMB_ROOT = "/rx_resources/images/TemplateImages/";
   protected static final String PAGE_THUMB_SUFFIX = "-page.jpg";
   protected static final String CLOUD_SERVICE_TYPE_CM1 = "CM1";
-  protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  protected static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
 
   protected IPSFolderHelper folderHelper;
   protected IPSRenderService renderService;

--- a/projects/sitemanage/src/main/java/com/percussion/comments/service/impl/PSCommentsService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/comments/service/impl/PSCommentsService.java
@@ -19,7 +19,8 @@ package com.percussion.comments.service.impl;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.Validate.notNull;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.comments.data.PSComment;
 import com.percussion.comments.data.PSCommentIds;
 import com.percussion.comments.data.PSCommentList;
@@ -208,7 +209,7 @@ public class PSCommentsService implements IPSCommentsService {
       try {
         var deliveryClient = new PSDeliveryClient();
         deliveryClient.setLicenseOverride(licenseId);
-        var mapper = new ObjectMapper();
+        var mapper = JsonMapper.builder().build();
         var responseMapObj =
             deliveryClient.getJsonObject(
                 new PSDeliveryActionOptions(
@@ -314,7 +315,7 @@ public class PSCommentsService implements IPSCommentsService {
       deliveryClient.push(
           new PSDeliveryActionOptions(
               server, COMMENT_DEFAULT_MODERATION_STATE_PATH, HttpMethodType.PUT, true),
-          new ObjectMapper().writeValueAsString(setState));
+          JsonMapper.builder().build().writeValueAsString(setState));
     } catch (Exception e) {
       log.error(
           "An unknown error occurred while retrieving the default moderation setting. Error: {}",
@@ -346,7 +347,7 @@ public class PSCommentsService implements IPSCommentsService {
       if ("APPROVED".equals(moderationState) || "REJECTED".equals(moderationState)) {
         var returnObject = new java.util.LinkedHashMap<String, Object>();
         returnObject.put("defaultModerationState", moderationState);
-        return new ObjectMapper().writeValueAsString(returnObject);
+        return JsonMapper.builder().build().writeValueAsString(returnObject);
       } else {
         log.error("Unknown default moderation state: {}", moderationState);
         throw new WebApplicationException(Response.serverError().build());
@@ -473,7 +474,7 @@ public class PSCommentsService implements IPSCommentsService {
     try {
       var deliveryClient = new PSDeliveryClient();
       deliveryClient.setLicenseOverride(licenseId);
-      var mapper = new ObjectMapper();
+      var mapper = JsonMapper.builder().build();
 
       Map<String, Object> responseMap =
           (Map<String, Object>)

--- a/projects/sitemanage/src/main/java/com/percussion/integrations/siteimprove/rest/PSSiteimprove.java
+++ b/projects/sitemanage/src/main/java/com/percussion/integrations/siteimprove/rest/PSSiteimprove.java
@@ -18,7 +18,8 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.integrations.siteimprove.rest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.integrations.siteimprove.data.PSSiteImproveCredentials;
 import com.percussion.integrations.siteimprove.data.PSSiteImproveSiteConfigurations;
 import com.percussion.metadata.data.PSMetadata;
@@ -154,7 +155,7 @@ public class PSSiteimprove {
         addSiteImproveTaskToPreExistingEditions(credentials.getSiteName());
         var metadataKey = SITEIMPROVE_CREDENTIALS_BASE_KEY + credentials.getSiteName();
         metadataService.save(
-            new PSMetadata(metadataKey, new ObjectMapper().writeValueAsString(jsonMap)));
+            new PSMetadata(metadataKey, JsonMapper.builder().build().writeValueAsString(jsonMap)));
         // CMS-8189: Upgraded jquery unable to parse if response is empty string. Advisable to
         // return "204 - No content" to avoid jquery parser error for json.
         return Response.noContent().build();
@@ -194,7 +195,7 @@ public class PSSiteimprove {
           "isSiteImproveEnabled", publishSettings.getIsSiteImproveEnabled().orElse(false));
       metadataService.save(
           new PSMetadata(
-              siteConfigKey, new ObjectMapper().writeValueAsString(publishSettingsJSON)));
+              siteConfigKey, JsonMapper.builder().build().writeValueAsString(publishSettingsJSON)));
       // CMS-8189: Upgraded jquery unable to parse if response is empty string. Advisable to return
       // "204 - No content" to avoid jquery parser error for json.
       return Response.noContent().build();

--- a/projects/sitemanage/src/main/java/com/percussion/integrations/siteimprove/task/impl/PSSiteimproveEditionTask.java
+++ b/projects/sitemanage/src/main/java/com/percussion/integrations/siteimprove/task/impl/PSSiteimproveEditionTask.java
@@ -18,7 +18,8 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.integrations.siteimprove.task.impl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.google.common.collect.Iterators;
 import com.percussion.extension.IPSExtensionDef;
 import com.percussion.integrations.siteimprove.data.PSSiteImproveSiteConfigurations;
@@ -234,7 +235,7 @@ public class PSSiteimproveEditionTask implements IPSEditionTask {
 
   /** Obtain the token and site name from a metadata JSON. */
   private Map<String, String> obtainToken(String credentialsData) throws Exception {
-    var mapper = new ObjectMapper();
+    var mapper = JsonMapper.builder().build();
     var credentialsJSON = mapper.readValue(credentialsData, java.util.LinkedHashMap.class);
     var credentials = new HashMap<String, String>();
     if (!credentialsJSON.containsKey(SITE_NAME)) {
@@ -259,7 +260,7 @@ public class PSSiteimproveEditionTask implements IPSEditionTask {
   /** Parse metadata JSON for our Siteimprove configuration settings. */
   private PSSiteImproveSiteConfigurations obtainSiteConfiguration(String siteConfigurationData)
       throws Exception {
-    var mapper = new ObjectMapper();
+    var mapper = JsonMapper.builder().build();
     var siteConfigurationJson =
         mapper.readValue(siteConfigurationData, java.util.LinkedHashMap.class);
     if (!siteConfigurationJson.containsKey(DO_PRODUCTION)) {

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemService.java
@@ -22,7 +22,8 @@ import static com.percussion.webservices.PSWebserviceUtils.getStateById;
 import static com.percussion.webservices.PSWebserviceUtils.getWorkflow;
 import static java.util.Arrays.asList;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.assetmanagement.dao.IPSAssetDao;
 import com.percussion.assetmanagement.data.PSAsset;
 import com.percussion.assetmanagement.data.PSReportFailedToRunException;
@@ -563,7 +564,7 @@ public class PSItemService implements IPSItemService {
           "An unexpected error occurred while fetching the site impact details for the asset.", e);
     }
     try {
-      ObjectMapper mapper = new ObjectMapper();
+      ObjectMapper mapper = JsonMapper.builder().build();
       return mapper.writeValueAsString(result);
     } catch (Exception e) {
       log.error("Error serializing site impact data: {}", PSExceptionUtils.getMessageForLog(e));

--- a/projects/sitemanage/src/main/java/com/percussion/licensemanagement/service/impl/PSLicenseService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/licensemanagement/service/impl/PSLicenseService.java
@@ -20,7 +20,8 @@ package com.percussion.licensemanagement.service.impl;
 
 import static org.apache.commons.lang3.Validate.notNull;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.delivery.service.IPSDeliveryInfoService;
 import com.percussion.licensemanagement.data.PSLicenseStatus;
 import com.percussion.licensemanagement.data.PSModuleLicense;
@@ -90,13 +91,13 @@ public class PSLicenseService implements IPSLicenseService {
       throws PSLicenseServiceException {
     notNull(moduleLicense);
     validateModuleLicense(moduleLicense);
-    var mapper = new ObjectMapper();
+    var mapper = JsonMapper.builder().build();
     try {
       var moduleLicenses = findAllModuleLicenses();
       moduleLicenses.addModuleLicense(moduleLicense);
       metadataService.save(
           new PSMetadata(MODULE_LICENSE_METADATA_KEY, mapper.writeValueAsString(moduleLicenses)));
-    } catch (IOException | IPSGenericDao.LoadException | IPSGenericDao.SaveException e) {
+    } catch (Exception e) {
       log.error(e);
       throw new PSLicenseServiceException(PSLicenseServiceException.ERROR_SAVING_LICENSES);
     }
@@ -115,13 +116,13 @@ public class PSLicenseService implements IPSLicenseService {
       throws PSLicenseServiceException {
     notNull(moduleLicense);
     validateModuleLicense(moduleLicense);
-    var mapper = new ObjectMapper();
+    var mapper = JsonMapper.builder().build();
     try {
       var moduleLicenses = findAllModuleLicenses();
       moduleLicenses.removeModuleLicense(moduleLicense);
       metadataService.save(
           new PSMetadata(MODULE_LICENSE_METADATA_KEY, mapper.writeValueAsString(moduleLicenses)));
-    } catch (IOException | IPSGenericDao.LoadException | IPSGenericDao.SaveException e) {
+    } catch (Exception e) {
       log.error(e);
       throw new PSLicenseServiceException(PSLicenseServiceException.ERROR_SAVING_LICENSES);
     }
@@ -163,7 +164,7 @@ public class PSLicenseService implements IPSLicenseService {
     if (StringUtils.isBlank(moduleLicense.getName().orElse(""))
         || StringUtils.isBlank(moduleLicense.getKey().orElse(""))
         || StringUtils.isBlank(moduleLicense.getHandshake().orElse(""))) {
-      var mapper = new ObjectMapper();
+      var mapper = JsonMapper.builder().build();
       try {
         log.error(
             "Supplied module license is invalid. " + mapper.writeValueAsString(moduleLicense));
@@ -209,10 +210,10 @@ public class PSLicenseService implements IPSLicenseService {
       return null;
     }
     PSModuleLicenses mls;
-    var mapper = new ObjectMapper();
+    var mapper = JsonMapper.builder().build();
     try {
       mls = mapper.readValue(jsonStr, PSModuleLicenses.class);
-    } catch (IOException e) {
+    } catch (Exception e) {
       log.error(e);
       throw new PSLicenseServiceException(PSLicenseServiceException.ERROR_FINDING_LICENSE);
     }

--- a/projects/sitemanage/src/main/java/com/percussion/membership/service/impl/PSMembershipService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/membership/service/impl/PSMembershipService.java
@@ -21,7 +21,8 @@
  */
 package com.percussion.membership.service.impl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.delivery.client.IPSDeliveryClient.HttpMethodType;
 import com.percussion.delivery.client.IPSDeliveryClient.PSDeliveryActionOptions;
 import com.percussion.delivery.client.PSDeliveryClient;
@@ -117,7 +118,7 @@ public class PSMembershipService implements IPSMembershipService {
       accountJson.put("action", account.getAction().orElse(""));
       deliveryClient.push(
           new PSDeliveryActionOptions(server, url, HttpMethodType.PUT, true),
-          new ObjectMapper().writeValueAsString(accountJson));
+          JsonMapper.builder().build().writeValueAsString(accountJson));
 
       return getUsers(site);
     } catch (Exception e) {
@@ -178,12 +179,12 @@ public class PSMembershipService implements IPSMembershipService {
       accountJson.put("groups", userGroup.getGroups().orElse(""));
       deliveryClient.push(
           new PSDeliveryActionOptions(server, url, HttpMethodType.PUT, true),
-          new ObjectMapper().writeValueAsString(accountJson));
+          JsonMapper.builder().build().writeValueAsString(accountJson));
 
       return getUsers(site);
     } catch (IPSPubServerService.PSPubServerServiceException
         | PSNotFoundException
-        | com.fasterxml.jackson.core.JsonProcessingException e) {
+        | tools.jackson.core.JacksonException e) {
       log.warn("Error updating group account.  Error: {}", e.getMessage());
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
       throw new WebApplicationException(e, Response.serverError().build());

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/PSPageUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/assembler/PSPageUtils.java
@@ -27,7 +27,8 @@ import static org.apache.commons.lang3.Validate.isTrue;
 import static org.apache.commons.lang3.Validate.notEmpty;
 import static org.apache.commons.lang3.Validate.notNull;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.analytics.service.IPSAnalyticsProviderService;
 import com.percussion.category.data.PSCategory;
 import com.percussion.category.data.PSCategoryNode;
@@ -1017,7 +1018,7 @@ public class PSPageUtils extends PSJexlUtilBase {
       returns = "Map of key/value pairs")
   public Map<String, String> parseSoProMetadata(String metadata) {
     try {
-      ObjectMapper mapper = new ObjectMapper();
+      ObjectMapper mapper = JsonMapper.builder().build();
 
       Map<String, String> jsonObject = mapper.readValue(metadata, Map.class);
       Map<String, String> map = new ConcurrentHashMap<>();
@@ -2018,7 +2019,7 @@ public class PSPageUtils extends PSJexlUtilBase {
 
       // Get the persisted drop down field value.
 
-      var mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+      var mapper = new tools.jackson.databind.ObjectMapper();
       List<Map<String, Object>> jsonArray = mapper.readValue(fieldValue, java.util.ArrayList.class);
 
       // Get the categories from the category xml, so that the relevant
@@ -2047,7 +2048,7 @@ public class PSPageUtils extends PSJexlUtilBase {
         }
       }
       return new TreeMap<>(templateMap);
-    } catch (PSDataServiceException | com.fasterxml.jackson.core.JsonProcessingException e) {
+    } catch (PSDataServiceException | tools.jackson.core.JacksonException e) {
       log.error(
           LOG_ERROR_DEFAULT, "getCategoryDropDownValues", PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
@@ -2358,7 +2359,7 @@ public class PSPageUtils extends PSJexlUtilBase {
       returns = "A Map instance")
   public Map<String, Object> createJsonObject(String jsonString) {
     try {
-      ObjectMapper mapper = new ObjectMapper();
+      ObjectMapper mapper = JsonMapper.builder().build();
 
       Map<String, Object> result = mapper.readValue(jsonString, Map.class);
       return result;

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSTemplateSummary.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSTemplateSummary.java
@@ -19,7 +19,7 @@
 package com.percussion.pagemanagement.data;
 
 import com.fasterxml.jackson.annotation.JsonRootName;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 import com.percussion.share.data.PSAbstractPersistantObject;
 import jakarta.xml.bind.annotation.*;
 import net.sf.oval.constraint.NotEmpty;

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSWidgetService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSWidgetService.java
@@ -17,7 +17,8 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.pagemanagement.service.impl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.metadata.service.IPSMetadataService;
 import com.percussion.pagemanagement.dao.IPSWidgetDao;
 import com.percussion.pagemanagement.data.PSWidgetDefinition;
@@ -125,13 +126,13 @@ public class PSWidgetService implements IPSWidgetService {
       if (md != null) {
         var data = md.getData();
         if (StringUtils.isNotBlank(data)) {
-          var mapper = new ObjectMapper();
+          var mapper = JsonMapper.builder().build();
           try {
             var jsonArray = mapper.readValue(data, java.util.ArrayList.class);
             for (var item : jsonArray) {
               disabledWidgets.add((String) item);
             }
-          } catch (IOException e) {
+          } catch (Exception e) {
             log.warn("Error parsing disabled widgets configuration", e);
           }
         }

--- a/projects/sitemanage/src/main/java/com/percussion/patch/PSSaveAssetsMaintenanceProcess.java
+++ b/projects/sitemanage/src/main/java/com/percussion/patch/PSSaveAssetsMaintenanceProcess.java
@@ -20,7 +20,8 @@ package com.percussion.patch;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.assetmanagement.data.PSAsset;
 import com.percussion.assetmanagement.service.IPSAssetService;
 import com.percussion.assetmanagement.service.impl.PSAssetService;
@@ -286,7 +287,7 @@ public class PSSaveAssetsMaintenanceProcess
 
   public void loadFailedAssetsFromFile(File f) {
     assetListSet = new HashSet<>();
-    var objectMapper = new ObjectMapper();
+    var objectMapper = JsonMapper.builder().build();
     try {
       addAssets(
           (Set<ItemWrapper>)
@@ -563,7 +564,7 @@ public class PSSaveAssetsMaintenanceProcess
       file.mkdirs();
     }
     log.info("Logging Assets to {}", assetsLogFilePath);
-    var objectMapper = new ObjectMapper();
+    var objectMapper = JsonMapper.builder().build();
     objectMapper.writeValue(new File(PathUtils.getRxDir(null), assetsLogFilePath), assetListSet);
   }
 
@@ -573,7 +574,7 @@ public class PSSaveAssetsMaintenanceProcess
       file.mkdirs();
     }
     log.info("Logging Pages to {}", pagesLogFilePath);
-    var objectMapper = new ObjectMapper();
+    var objectMapper = JsonMapper.builder().build();
     objectMapper.writeValue(new File(PathUtils.getRxDir(null), pagesLogFilePath), qualifiedPages);
   }
 
@@ -710,7 +711,7 @@ public class PSSaveAssetsMaintenanceProcess
 
   private void loadPagesFromFile(File readFile) {
     qualifiedPages = new HashSet<>();
-    var objectMapper = new ObjectMapper();
+    var objectMapper = JsonMapper.builder().build();
     try {
       qualifiedPages.addAll(
           (Set<ItemWrapper>)

--- a/projects/sitemanage/src/main/java/com/percussion/pubserver/impl/PSPubServerRestService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pubserver/impl/PSPubServerRestService.java
@@ -18,7 +18,8 @@
 package com.percussion.pubserver.impl;
 
 import com.amazonaws.regions.Regions;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.delivery.service.IPSDeliveryInfoService;
 import com.percussion.delivery.service.PSDeliveryInfoServiceLocator;
 import com.percussion.delivery.service.impl.PSDeliveryInfoService;
@@ -186,22 +187,22 @@ public class PSPubServerRestService {
   @GET
   @Path("/availableDrivers")
   @Produces(MediaType.TEXT_PLAIN)
-  public String getAvailableDrivers() throws com.fasterxml.jackson.core.JsonProcessingException {
-    return new ObjectMapper().writeValueAsString(service.getAvailableDrivers());
+  public String getAvailableDrivers() throws tools.jackson.core.JacksonException {
+    return JsonMapper.builder().build().writeValueAsString(service.getAvailableDrivers());
   }
 
   /** Gets available EC2 bucket regions. */
   @GET
   @Path("/availableRegions")
   @Produces(MediaType.TEXT_PLAIN)
-  public String getAvailableRegions() throws com.fasterxml.jackson.core.JsonProcessingException {
+  public String getAvailableRegions() throws tools.jackson.core.JacksonException {
     var regions = Regions.values();
     if (regions != null) {
       var regionNames = new String[regions.length];
       for (int i = 0; i < regions.length; i++) {
         regionNames[i] = regions[i].getName();
       }
-      return new ObjectMapper().writeValueAsString(regionNames);
+      return JsonMapper.builder().build().writeValueAsString(regionNames);
     }
     return null;
   }
@@ -211,12 +212,12 @@ public class PSPubServerRestService {
   @Path("/availablePublishingServer/{publishServerType}")
   @Produces(MediaType.TEXT_PLAIN)
   public String getAvailablePublishingServer(@PathParam("publishServerType") String publishServer)
-      throws com.fasterxml.jackson.core.JsonProcessingException {
+      throws tools.jackson.core.JacksonException {
     var psDeliveryInfoService =
         (PSDeliveryInfoService) PSDeliveryInfoServiceLocator.getDeliveryInfoService();
     var serverList = psDeliveryInfoService.getAdminUrls(publishServer);
     serverList.add(IPSPubServerService.DEFAULT_DTS);
-    return new ObjectMapper().writeValueAsString(serverList.toArray());
+    return JsonMapper.builder().build().writeValueAsString(serverList.toArray());
   }
 
   /** Checks if the current instance is an EC2 instance. */
@@ -261,8 +262,8 @@ public class PSPubServerRestService {
   @Path("/availableDeliveryServers")
   @Produces(MediaType.TEXT_PLAIN)
   public String getAvailableDeliveryServers()
-      throws com.fasterxml.jackson.core.JsonProcessingException {
+      throws tools.jackson.core.JacksonException {
     IPSDeliveryInfoService svc = PSDeliveryInfoServiceLocator.getDeliveryInfoService();
-    return new ObjectMapper().writeValueAsString(svc.findAll());
+    return JsonMapper.builder().build().writeValueAsString(svc.findAll());
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/redirect/service/impl/PSRedirectService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/redirect/service/impl/PSRedirectService.java
@@ -18,7 +18,8 @@
 
 package com.percussion.redirect.service.impl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.licensemanagement.data.PSModuleLicense;
 import com.percussion.licensemanagement.service.IPSLicenseService;
 import com.percussion.licensemanagement.service.impl.PSLicenseService;
@@ -128,7 +129,7 @@ public class PSRedirectService implements IPSRedirectService {
 
   private String getDataAsString(PSRedirectValidationData data) {
     var temp = "";
-    var mapper = new ObjectMapper();
+    var mapper = JsonMapper.builder().build();
     try {
       temp = mapper.writeValueAsString(data);
     } catch (Exception e) {

--- a/projects/sitemanage/src/main/java/com/percussion/share/data/PSRestResponse.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/data/PSRestResponse.java
@@ -48,8 +48,8 @@ public class PSRestResponse {
       res.put(DEFAULT_MESSAGE, DEFAULT_ERROR_MESSAGE);
     }
     try {
-      result = new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(res);
-    } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+      result = new tools.jackson.databind.ObjectMapper().writeValueAsString(res);
+    } catch (tools.jackson.core.JacksonException e) {
       result = "{\"message\":\"Error\"}";
     }
   }

--- a/projects/sitemanage/src/main/java/com/percussion/share/web/service/PSJsonProcessingExceptionMapper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/web/service/PSJsonProcessingExceptionMapper.java
@@ -18,7 +18,7 @@
 
 package com.percussion.share.web.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import tools.jackson.core.JacksonException;
 import com.percussion.share.service.exception.PSErrorUtils;
 import com.percussion.share.validation.PSErrors;
 import jakarta.ws.rs.Produces;
@@ -30,23 +30,23 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 /**
- * Maps {@link JsonProcessingException} to a serializable error object. Sunny Sal says: "JSON
+ * Maps {@link JacksonException} to a serializable error object. Sunny Sal says: "JSON
  * parsing failed? Let's keep it classy and JSON-y!"
  */
 @Provider
 @Component
 @Produces(MediaType.APPLICATION_JSON)
 public class PSJsonProcessingExceptionMapper
-    extends PSAbstractExceptionMapper<JsonProcessingException>
-    implements ExceptionMapper<JsonProcessingException> {
+    extends PSAbstractExceptionMapper<JacksonException>
+    implements ExceptionMapper<JacksonException> {
 
   private static final String ERROR_MESSAGE = "JSON error: ";
 
   /** The log instance to use for this class, never {@code null}. */
-  private static final Logger log = LogManager.getLogger(JsonProcessingException.class);
+  private static final Logger log = LogManager.getLogger(JacksonException.class);
 
   @Override
-  protected PSErrors createErrors(JsonProcessingException exception) {
+  protected PSErrors createErrors(JacksonException exception) {
     var errorMessage = exception.getClass().getName();
     if (log.isDebugEnabled()) {
       log.debug(errorMessage, exception);

--- a/projects/sitemanage/src/main/java/com/percussion/share/web/service/PSRuntimeExceptionMapper.java
+++ b/projects/sitemanage/src/main/java/com/percussion/share/web/service/PSRuntimeExceptionMapper.java
@@ -17,7 +17,7 @@
  */
 package com.percussion.share.web.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import tools.jackson.core.JacksonException;
 import com.percussion.cms.IPSConstants;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.share.service.exception.IPSValidationException;
@@ -82,7 +82,7 @@ public class PSRuntimeExceptionMapper extends PSAbstractExceptionMapper<RuntimeE
     if (exception instanceof IllegalArgumentException) {
       return Status.BAD_REQUEST;
     }
-    if (exception.getCause() instanceof JsonProcessingException) {
+    if (exception.getCause() instanceof JacksonException) {
       return Status.BAD_REQUEST;
     }
     return super.getStatus(exception);

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/json/JacksonContextResolver.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/json/JacksonContextResolver.java
@@ -20,28 +20,27 @@ package com.percussion.sitemanage.json;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.databind.AnnotationIntrospector;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
-import com.fasterxml.jackson.databind.type.TypeFactory;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector;
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import com.percussion.system.utils.PSSiteManageBean;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.ContextResolver;
 import jakarta.ws.rs.ext.Provider;
+import tools.jackson.databind.AnnotationIntrospector;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.cfg.EnumFeature;
+import tools.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector;
 
 /**
  * JacksonContextResolver is picked up by Jackson automatically via the Provider annotation. It
- * modifies the serialization behavior of objects passed in. Only classes in the same package and
- * subpackages are affected.
+ * modifies the serialization behavior of objects passed in.
+ *
+ * <p>Configured via Jackson 3 immutable {@link JsonMapper} builder (Optional / java.time built-in).
  */
 @Provider
 @PSSiteManageBean("jacksonContextResolver")
@@ -49,28 +48,25 @@ import jakarta.ws.rs.ext.Provider;
 @Produces({MediaType.APPLICATION_JSON, "text/json"})
 public class JacksonContextResolver implements ContextResolver<ObjectMapper> {
 
-  private static final ObjectMapper MAPPER = new ObjectMapper();
-
-  static {
-    MAPPER
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        .enable(SerializationFeature.INDENT_OUTPUT)
-        .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-        .configure(SerializationFeature.WRAP_ROOT_VALUE, true)
-        .configure(DeserializationFeature.UNWRAP_ROOT_VALUE, true)
-        .configure(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS, false)
-        .configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true)
-        .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE, true)
-        .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.PUBLIC_ONLY)
-        .setAnnotationIntrospector(
-            AnnotationIntrospector.pair(
-                new JakartaXmlBindAnnotationIntrospector(TypeFactory.defaultInstance()),
-                new JacksonAnnotationIntrospector()))
-        .registerModule(new ParameterNamesModule())
-        .registerModule(new Jdk8Module())
-        .registerModule(new JavaTimeModule())
-        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-  }
+  private static final ObjectMapper MAPPER =
+      JsonMapper.builder()
+          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+          .enable(SerializationFeature.INDENT_OUTPUT)
+          .changeDefaultPropertyInclusion(
+              incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
+          .enable(SerializationFeature.WRAP_ROOT_VALUE)
+          .enable(DeserializationFeature.UNWRAP_ROOT_VALUE)
+          .disable(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)
+          .enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)
+          .enable(EnumFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+          .changeDefaultVisibility(
+              vc -> vc.withFieldVisibility(JsonAutoDetect.Visibility.PUBLIC_ONLY))
+          .annotationIntrospector(
+              AnnotationIntrospector.pair(
+                  new JakartaXmlBindAnnotationIntrospector(),
+                  new JacksonAnnotationIntrospector()))
+          .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+          .build();
 
   public JacksonContextResolver() {
     // Default constructor
@@ -78,13 +74,6 @@ public class JacksonContextResolver implements ContextResolver<ObjectMapper> {
 
   @Override
   public ObjectMapper getContext(Class<?> objectType) {
-    // Only use this configuration for classes in the same package and subpackages.
-    // If you want to restrict, uncomment the following:
-    // if
-    // (objectType.getPackage().getName().startsWith(JacksonContextResolver.class.getPackage().getName())) {
-    //     return MAPPER;
-    // }
-    // return null;
     return MAPPER;
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteDataService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/service/impl/PSSiteDataService.java
@@ -27,11 +27,11 @@ import static com.percussion.utils.service.impl.PSSiteConfigUtils.updateSiteConf
 import static org.apache.commons.lang3.Validate.notEmpty;
 import static org.apache.commons.lang3.Validate.notNull;
 
-import com.fasterxml.jackson.core.JsonGenerationException;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectWriter;
 import com.percussion.assetmanagement.dao.IPSAssetDao;
 import com.percussion.assetmanagement.data.PSAsset;
 import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
@@ -373,10 +373,10 @@ public class PSSiteDataService extends PSAbstractDataService<PSSite, PSSiteSumma
     String jsonString = site.getGenerateSiteMapOptions();
     PSGenerateSiteMapOptions psGenerateSiteMapOptions = null;
     if (StringUtils.isNotBlank(jsonString)) {
-      ObjectMapper mapper = new ObjectMapper();
+      ObjectMapper mapper = JsonMapper.builder().build();
       try {
         psGenerateSiteMapOptions = mapper.readValue(jsonString, PSGenerateSiteMapOptions.class);
-      } catch (JsonProcessingException e) {
+      } catch (JacksonException e) {
         log.warn(
             "Failed to parse generateSiteMapOptions JSON for site {}, using defaults. Error: {}",
             site.getName(),
@@ -540,12 +540,12 @@ public class PSSiteDataService extends PSAbstractDataService<PSSite, PSSiteSumma
     site.setSiteBeforeBodyCloseContent(props.getSiteBeforeBodyCloseContent().orElse(null));
     site.setMobilePreviewEnabled(props.isMobilePreviewEnabled());
     site.setGenerateSitemap(props.isGenerateSiteMap());
-    ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+    ObjectWriter ow = JsonMapper.builder().build().writer().withDefaultPrettyPrinter();
     String json = null;
     try {
       json = ow.writeValueAsString(props.getGenerateSiteMapOptions());
 
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new RuntimeException(e);
     }
     site.setGenerateSiteMapOptions(json);
@@ -1264,7 +1264,7 @@ public class PSSiteDataService extends PSAbstractDataService<PSSite, PSSiteSumma
     for (PSSiteSummary siteSum : sums) {
       siteNames.add(siteSum.getName());
     }
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
 
     for (File file : fileList) {
       PSSaasSiteConfig saasSiteConfig = loadSiteConfig(file.getName(), mapper);
@@ -1310,7 +1310,7 @@ public class PSSiteDataService extends PSAbstractDataService<PSSite, PSSiteSumma
     if (!map.containsKey(siteName)) {
       return null;
     }
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JsonMapper.builder().build();
     return loadSiteConfig(map.get(siteName), mapper);
   }
 
@@ -1331,17 +1331,12 @@ public class PSSiteDataService extends PSAbstractDataService<PSSite, PSSiteSumma
                 + fileName);
     try {
       saasSiteConfig = mapper.readValue(file, PSSaasSiteConfig.class);
-    } catch (JsonGenerationException e) {
+    } catch (JacksonException e) {
       log.error(
-          "The site config file {} is not a valid json file. Error: {}",
+          "The site config file {} is not valid JSON or does not map. Error: {}",
           file.getName(),
           PSExceptionUtils.getMessageForLog(e));
-    } catch (JsonMappingException e) {
-      log.error(
-          "The site config file {} does not map to the java class. Error: {}",
-          file.getName(),
-          PSExceptionUtils.getMessageForLog(e));
-    } catch (IOException e) {
+    } catch (Exception e) {
       log.error(
           "Exception occurred while reading saas site configuration file {}. Error: {}",
           file.getName(),

--- a/projects/sitemanage/src/main/java/com/percussion/sitemanage/task/impl/PSSiteMapGeneratorTask.java
+++ b/projects/sitemanage/src/main/java/com/percussion/sitemanage/task/impl/PSSiteMapGeneratorTask.java
@@ -17,8 +17,9 @@
 
 package com.percussion.sitemanage.task.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.cms.IPSConstants;
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.extension.IPSExtensionDef;
@@ -110,10 +111,10 @@ public class PSSiteMapGeneratorTask implements IPSEditionTask {
       var jsonString = site.getGenerateSiteMapOptions();
       PSGenerateSiteMapOptions psGenerateSiteMapOptions = null;
       if (jsonString != null && !jsonString.trim().isEmpty()) {
-        var mapper = new ObjectMapper();
+        var mapper = JsonMapper.builder().build();
         try {
           psGenerateSiteMapOptions = mapper.readValue(jsonString, PSGenerateSiteMapOptions.class);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
           log.warn(
               "Failed to parse generateSiteMapOptions JSON, using defaults. Error: {}",
               PSExceptionUtils.getMessageForLog(e));

--- a/projects/sitemanage/src/test/java/com/percussion/metadata/web/service/PSMetadataServiceRestClient.java
+++ b/projects/sitemanage/src/test/java/com/percussion/metadata/web/service/PSMetadataServiceRestClient.java
@@ -18,7 +18,8 @@
 
 package com.percussion.metadata.web.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.dashboardmanagement.data.PSDashboardConfiguration;
 import com.percussion.dashboardmanagement.data.PSGadget;
 import com.percussion.metadata.data.PSMetadata;
@@ -43,8 +44,8 @@ public class PSMetadataServiceRestClient extends PSDataServiceRestClient<PSMetad
   }
 
   public void save(Map<String, Object> obj)
-      throws com.fasterxml.jackson.core.JsonProcessingException {
-    POST(getPath(), new ObjectMapper().writeValueAsString(obj));
+      throws tools.jackson.core.JacksonException {
+    POST(getPath(), JsonMapper.builder().build().writeValueAsString(obj));
   }
 
   public List<PSGadget> getCurrentGadgets() {
@@ -52,7 +53,7 @@ public class PSMetadataServiceRestClient extends PSDataServiceRestClient<PSMetad
     try {
       var response = GET(concatPath(getPath(), GADGETS_KEY));
       var metadata = PSSerializerUtils.unmarshal(response, PSMetadata.class);
-      var mapper = new ObjectMapper();
+      var mapper = JsonMapper.builder().build();
       var dataMap = mapper.readValue(metadata.getData(), java.util.Map.class);
       var dashboardConfigMap = (java.util.Map<String, Object>) dataMap.get("DashboardConfig");
       config = mapper.convertValue(dashboardConfigMap, PSDashboardConfiguration.class);
@@ -85,7 +86,7 @@ public class PSMetadataServiceRestClient extends PSDataServiceRestClient<PSMetad
 
   private Map<String, Object> getMetadataJsonForSpecificGadgetSettings(
       PSDashboardConfiguration dashboardConfig)
-      throws com.fasterxml.jackson.core.JsonProcessingException {
+      throws tools.jackson.core.JacksonException {
     var userConfig = new LinkedHashMap<String, Object>();
     for (var gad : dashboardConfig.getGadgets()) {
       var specificGadgetSettings = new LinkedHashMap<String, Object>();
@@ -97,7 +98,7 @@ public class PSMetadataServiceRestClient extends PSDataServiceRestClient<PSMetad
     var userPrefJson = new LinkedHashMap<String, Object>();
     userPrefJson.put("userprefs", userConfig);
 
-    var mapper = new ObjectMapper();
+    var mapper = JsonMapper.builder().build();
     var metadata =
         new PSMetadata(GADGETS_PREFS_KEY, "\"" + mapper.writeValueAsString(userPrefJson) + "\"");
     var metadataJson = new LinkedHashMap<String, Object>();
@@ -106,9 +107,9 @@ public class PSMetadataServiceRestClient extends PSDataServiceRestClient<PSMetad
   }
 
   private Map<String, Object> getMetadataJson(PSDashboardConfiguration dashboardConfig)
-      throws com.fasterxml.jackson.core.JsonProcessingException {
+      throws tools.jackson.core.JacksonException {
     var dashboardConfigJson = new LinkedHashMap<String, Object>();
-    var mapper = new ObjectMapper();
+    var mapper = JsonMapper.builder().build();
     dashboardConfigJson.put("DashboardConfig", mapper.convertValue(dashboardConfig, Object.class));
 
     var metadata =

--- a/projects/sitemanage/src/test/java/com/percussion/share/web/service/PSRuntimeExceptionMapperJacksonNullTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/share/web/service/PSRuntimeExceptionMapperJacksonNullTest.java
@@ -19,7 +19,7 @@ package com.percussion.share.web.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import tools.jackson.core.JacksonException;
 import jakarta.ws.rs.core.Response;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
@@ -51,7 +51,7 @@ class PSRuntimeExceptionMapperJacksonNullTest {
   @Test
   void jacksonCauseIsBadRequest() throws Exception {
     RuntimeException wrap =
-        new RuntimeException("wrap", new JsonProcessingException("bad json") {});
+        new RuntimeException("wrap", new JacksonException("bad json") {});
     assertEquals(Response.Status.BAD_REQUEST, statusOf(wrap));
   }
 }

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -148,18 +148,18 @@
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
+            <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+            <groupId>tools.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
             <version>${jackson.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/rest/src/main/java/com/percussion/rest/JacksonContextResolver.java
+++ b/rest/src/main/java/com/percussion/rest/JacksonContextResolver.java
@@ -17,34 +17,38 @@
 
 package com.percussion.rest;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.ContextResolver;
 import jakarta.ws.rs.ext.Provider;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * @author stephenbolton
  *     <p>This is picked up by Jackson automatically by the Provider annotation It will modify the
  *     serialization behavior of the objects passed in we test that the class has the same ancestor
  *     package as this class to ensure we do not modify behavior for other parts of the system
+ *
+ *     <p>Jackson 3 embeds Optional / java.time support in databind — no Jdk8Module or JavaTimeModule
+ *     registration required. Many rest DTOs expose {@code Optional} getters (e.g. ContentType name);
+ *     without that support, catalog tables serialize empty (hideFromMenu-only payloads).
  */
 // REFACTORED: CP-JAVA11
 @Provider
 @Produces(MediaType.APPLICATION_JSON)
 public class JacksonContextResolver implements ContextResolver<ObjectMapper> {
-  private static final ObjectMapper objectMapper = new ObjectMapper();
-
-  static {
-    objectMapper
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
-        .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-        .configure(SerializationFeature.WRAP_ROOT_VALUE, true)
-        .configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true)
-        .configure(DeserializationFeature.UNWRAP_ROOT_VALUE, true);
-  }
+  private static final ObjectMapper objectMapper =
+      JsonMapper.builder()
+          .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+          .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+          .enable(SerializationFeature.WRAP_ROOT_VALUE)
+          .enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)
+          .enable(DeserializationFeature.UNWRAP_ROOT_VALUE)
+          .build();
 
   @Override
   public ObjectMapper getContext(Class<?> objectType) {

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.rest.contenttypes.ContentType;
+import com.percussion.rest.templates.TemplateSummary;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Jackson 3 databind unwraps {@code Optional} DTO getters by default (no Jdk8Module). Content-type
+ * and template catalogs must serialize names for the Developer SPA tables.
+ */
+@Tag("UnitTest")
+class JacksonContextResolverOptionalTest {
+
+  private final ObjectMapper mapper = new JacksonContextResolver().getContext(ContentType.class);
+
+  @Test
+  void contentType_serializesNameLabelNotOnlyHideFromMenu() {
+    ContentType ct = new ContentType();
+    ct.setName("percPage");
+    ct.setLabel("Page");
+    ct.setDescription("Page content type");
+    ct.setHideFromMenu(false);
+
+    String json = mapper.writeValueAsString(ct);
+    assertTrue(json.contains("percPage"), json);
+    assertTrue(json.contains("Page"), json);
+    assertTrue(json.contains("\"name\""), json);
+  }
+
+  @Test
+  void templateSummary_serializesNameNotOnlyId() {
+    TemplateSummary t = new TemplateSummary();
+    t.setTemplateId(1018);
+    t.setTemplateName("perc.page");
+    t.setTemplateLabel("Page");
+
+    String json = mapper.writeValueAsString(t);
+    assertTrue(json.contains("perc.page"), json);
+    assertTrue(json.contains("Page"), json);
+    assertTrue(json.contains("1018"), json);
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/MainTest.java
+++ b/rest/src/test/java/com/percussion/rest/MainTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
+import tools.jackson.jakarta.rs.json.JacksonJsonProvider;
 import com.percussion.rest.errors.RestExceptionMapper;
 import com.percussion.utils.testing.PSTestNetUtils;
 import jakarta.ws.rs.Path;
@@ -67,7 +67,7 @@ public class MainTest {
     WebTarget target =
         builder
             .build()
-            .register(com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider.class)
+            .register(tools.jackson.jakarta.rs.json.JacksonJsonProvider.class)
             .target(endpoint)
             .path(address);
 

--- a/rest/src/test/java/com/percussion/rest/MainTestJacksonBeansTest.java
+++ b/rest/src/test/java/com/percussion/rest/MainTestJacksonBeansTest.java
@@ -22,9 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.jakarta.rs.json.JacksonJsonProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/rest/src/test/java/com/percussion/rest/assets/AssetSerialDeserialTests.java
+++ b/rest/src/test/java/com/percussion/rest/assets/AssetSerialDeserialTests.java
@@ -19,10 +19,11 @@ package com.percussion.rest.assets;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
 import java.util.Date;
 import org.junit.jupiter.api.Test;
 
@@ -46,12 +47,13 @@ public class AssetSerialDeserialTests {
   }
 
   @Test
-  public void testSerialize() throws JsonProcessingException {
-    var mapper = new ObjectMapper();
-    mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, true);
-    mapper.configure(DeserializationFeature.UNWRAP_ROOT_VALUE, true);
+  public void testSerialize() throws JacksonException {
+    var mapper =
+        JsonMapper.builder()
+            .enable(SerializationFeature.WRAP_ROOT_VALUE)
+            .enable(DeserializationFeature.UNWRAP_ROOT_VALUE)
+            .build();
     var a = getTestAsset();
-    assertTrue(mapper.canSerialize(Asset.class));
     var assetString = mapper.writeValueAsString(a);
 
     assertNotNull(assetString);

--- a/rest/src/test/java/com/percussion/rest/displayformat/TestDisplayFormat.java
+++ b/rest/src/test/java/com/percussion/rest/displayformat/TestDisplayFormat.java
@@ -19,7 +19,8 @@ package com.percussion.rest.displayformat;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +33,7 @@ public class TestDisplayFormat {
     f.setDisplayName("DisplayNameTest");
     f.setInternalName("InternalNameTest");
 
-    var mapper = new ObjectMapper();
+    var mapper = JsonMapper.builder().build();
     var json = mapper.writeValueAsString(f);
     System.out.println(json);
 

--- a/system/Testing/Extensions/src/com/percussion/extensions/testing/DatabasePublisherTestPostExit.java
+++ b/system/Testing/Extensions/src/com/percussion/extensions/testing/DatabasePublisherTestPostExit.java
@@ -41,7 +41,6 @@ import com.percussion.server.PSServer;
 import com.percussion.tablefactory.PSJdbcDbmsDef;
 import com.percussion.xml.PSXmlDocumentBuilder;
 
-import com.percussion.tablefactory.PSJdbcDbmsDef;
 import com.percussion.tablefactory.PSJdbcTableFactory;
 
 import java.io.ByteArrayInputStream;

--- a/system/Tools/ImageWidgetService/src/com/percussion/widgets/image/web/impl/BinaryUploadController.java
+++ b/system/Tools/ImageWidgetService/src/com/percussion/widgets/image/web/impl/BinaryUploadController.java
@@ -17,7 +17,8 @@
 
 package com.percussion.widgets.image.web.impl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.server.PSServer;
 import com.percussion.system.utils.PSBaseBean;
 import com.percussion.widgets.image.data.CachedImageMetaData;
@@ -136,7 +137,7 @@ public class BinaryUploadController {
      */
     protected List<Object> buildResults(HttpServletRequest request) throws PSBinaryUploadException {
         var results = new ArrayList<Object>();
-        var mapper = new ObjectMapper();
+        var mapper = JsonMapper.builder().build();
 
         if (!(request instanceof MultipartHttpServletRequest)) {
             throw new PSBinaryUploadException("Request is not a multipart request");

--- a/system/Tools/ImageWidgetService/src/com/percussion/widgets/image/web/impl/ImageRequestController.java
+++ b/system/Tools/ImageWidgetService/src/com/percussion/widgets/image/web/impl/ImageRequestController.java
@@ -17,7 +17,8 @@
 
 package com.percussion.widgets.image.web.impl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.widgets.image.data.CachedImageMetaData;
 import com.percussion.widgets.image.services.ImageCacheManager;
 import org.apache.commons.lang3.StringUtils;
@@ -83,7 +84,7 @@ public class ImageRequestController extends ParameterizableViewController implem
 
             var imageData = imageDataOpt.get();
             var cachedMetadata = new CachedImageMetaData(imageData, imageKey);
-            var mapper = new ObjectMapper();
+            var mapper = JsonMapper.builder().build();
             var json = mapper.convertValue(cachedMetadata, java.util.Map.class);
 
             mav.addObject(modelObjectName, json);

--- a/system/Tools/ImageWidgetService/src/com/percussion/widgets/image/web/impl/ImageResizeController.java
+++ b/system/Tools/ImageWidgetService/src/com/percussion/widgets/image/web/impl/ImageResizeController.java
@@ -17,7 +17,8 @@
 
 package com.percussion.widgets.image.web.impl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.system.utils.PSBaseBean;
 import com.percussion.widgets.image.data.CachedImageMetaData;
@@ -78,7 +79,7 @@ public class ImageResizeController {
     @PostMapping
     public ModelAndView handle(@ModelAttribute("results") ResizeImageBean bean, BindingResult result) {
         var mav = new ModelAndView(viewName);
-        var mapper = new ObjectMapper();
+        var mapper = JsonMapper.builder().build();
 
         try {
             var validationError = validateResizeBean(bean);

--- a/system/Tools/ImageWidgetService/src/com/percussion/widgets/image/web/impl/JSONView.java
+++ b/system/Tools/ImageWidgetService/src/com/percussion/widgets/image/web/impl/JSONView.java
@@ -17,8 +17,9 @@
 
 package com.percussion.widgets.image.web.impl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.SerializationFeature;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -248,11 +249,11 @@ public class JSONView extends AbstractView implements View {
      */
     private String convertToJson(Object obj, boolean debug) {
         try {
-            var mapper = new ObjectMapper();
+            var builder = JsonMapper.builder();
             if (debug) {
-                mapper.enable(SerializationFeature.INDENT_OUTPUT);
+                builder.enable(SerializationFeature.INDENT_OUTPUT);
             }
-            return mapper.writeValueAsString(obj);
+            return builder.build().writeValueAsString(obj);
         } catch (Exception e) {
             log.warn("Error converting object to JSON: {}", e.getMessage());
             return "{}";

--- a/system/business/src/com/percussion/delivery/client/PSDeliveryClient.java
+++ b/system/business/src/com/percussion/delivery/client/PSDeliveryClient.java
@@ -17,7 +17,8 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.delivery.client;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.delivery.data.PSDeliveryInfo;
 import com.percussion.proxyconfig.data.PSProxyConfig;
 import com.percussion.proxyconfig.service.IPSProxyConfigService;
@@ -237,7 +238,7 @@ public class PSDeliveryClient implements IPSDeliveryClient
             return new java.util.HashMap<String, Object>();
         }
         try {
-            var mapper = new ObjectMapper();
+            var mapper = JsonMapper.builder().build();
             return mapper.readValue(jsonStr, Object.class);
         }
         catch (Exception ex) {

--- a/system/business/src/com/percussion/share/dao/PSSerializerUtils.java
+++ b/system/business/src/com/percussion/share/dao/PSSerializerUtils.java
@@ -17,7 +17,8 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.share.dao;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.security.xml.PSSecureXMLUtils;
 import com.percussion.security.xml.PSXmlSecurityOptions;
@@ -250,7 +251,7 @@ public class PSSerializerUtils
             if (json == null || json.isBlank()) {
                 return null;
             }
-            var mapper = new ObjectMapper();
+            var mapper = JsonMapper.builder().build();
             String wrappedJson = '[' + json + ']';
             var array = mapper.readValue(wrappedJson, List.class);
             if (array.isEmpty()) {
@@ -281,7 +282,7 @@ public class PSSerializerUtils
      */
     public static String getJsonFromObject(Object obj) {
         try {
-            var mapper = new ObjectMapper();
+            var mapper = JsonMapper.builder().build();
             var wrappedList = Collections.singletonList(obj);
             String jsonList = mapper.writeValueAsString(wrappedList);
             // Remove surrounding [ and ]

--- a/system/pom.xml
+++ b/system/pom.xml
@@ -520,8 +520,8 @@
 			<artifactId>jackson-annotations</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
+			<groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.percussion</groupId>

--- a/system/src/main/java/com/percussion/data/PSResultSetXmlConverter.java
+++ b/system/src/main/java/com/percussion/data/PSResultSetXmlConverter.java
@@ -1646,8 +1646,8 @@ public class PSResultSetXmlConverter implements IPSResultSetConverter {
 
           if (m_dataSource != null) {
             nodeData.m_curValue = curValue.toString();
-            Text textNode = doc.createTextNode(PSXmlDocumentBuilder.normalize(curValue.toString()));
-            elementNode.appendChild(textNode);
+            Text StringNode = doc.createTextNode(PSXmlDocumentBuilder.normalize(curValue.toString()));
+            elementNode.appendChild(StringNode);
           }
         }
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSDisplayTextLiteral.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSDisplayTextLiteral.java
@@ -105,8 +105,8 @@ public class PSDisplayTextLiteral extends PSLiteral implements IPSMutatableRepla
   public Element toXml(Document doc) {
     if (null == doc) throw new IllegalArgumentException("Must provide a valid Document");
     Element root = doc.createElement(XML_NODE_NAME);
-    Text textNode = doc.createTextNode(PSXmlDocumentBuilder.normalize(m_value));
-    root.appendChild(textNode);
+    Text StringNode = doc.createTextNode(PSXmlDocumentBuilder.normalize(m_value));
+    root.appendChild(StringNode);
     root.setAttribute("displayText", m_displayValue);
     return root;
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSRelationshipPropertyData.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSRelationshipPropertyData.java
@@ -207,9 +207,9 @@ public class PSRelationshipPropertyData implements Serializable {
     String isPersisted = m_isPersisted ? PSRelationship.XML_TRUE : PSRelationship.XML_FALSE;
     propEl.setAttribute(XML_ATTR_ISPERSISTED, isPersisted);
     propEl.setAttribute(XML_ATTR_NAME, String.valueOf(m_propertyName));
-    Text textNode =
+    Text StringNode =
         propEl.getOwnerDocument().createTextNode(m_propertyValue == null ? "" : m_propertyValue);
-    propEl.appendChild(textNode);
+    propEl.appendChild(StringNode);
 
     return propEl;
   }

--- a/system/src/main/java/com/percussion/fastforward/managednav/PSNavLink.java
+++ b/system/src/main/java/com/percussion/fastforward/managednav/PSNavLink.java
@@ -455,8 +455,8 @@ public class PSNavLink {
     if (m_folderId != 0) parentElem.setAttribute(XML_ATTR_FOLDERID, String.valueOf(m_folderId));
 
     Document parentDoc = parentElem.getOwnerDocument();
-    Node textNode = parentDoc.createTextNode(m_uri);
-    parentElem.appendChild(textNode);
+    Node StringNode = parentDoc.createTextNode(m_uri);
+    parentElem.appendChild(StringNode);
 
     return parentElem;
   }

--- a/system/src/main/java/com/percussion/fastforward/managednav/PSNavXMLUtils.java
+++ b/system/src/main/java/com/percussion/fastforward/managednav/PSNavXMLUtils.java
@@ -482,7 +482,7 @@ public class PSNavXMLUtils {
    */
   public static void replaceNodeText(Element elem, String value) {
     Document parentDoc = elem.getOwnerDocument();
-    Node textNode = parentDoc.createTextNode(value);
+    Node StringNode = parentDoc.createTextNode(value);
     NodeList nlist = elem.getChildNodes();
     for (int i = 0; i < nlist.getLength(); i++) {
       Node child = nlist.item(i);
@@ -497,7 +497,7 @@ public class PSNavXMLUtils {
           continue;
       }
     }
-    elem.appendChild(textNode);
+    elem.appendChild(StringNode);
   }
 
   /** Name of the query to use for Nav Theme overrides. */

--- a/system/src/main/java/com/percussion/system/utils/PSDocVersionConverter.java
+++ b/system/src/main/java/com/percussion/system/utils/PSDocVersionConverter.java
@@ -355,8 +355,8 @@ public class PSDocVersionConverter {
       } // end of loop
 
       Element typeNode = doc.createElement("type");
-      Text textNode = doc.createTextNode(type);
-      typeNode.appendChild(textNode);
+      Text StringNode = doc.createTextNode(type);
+      typeNode.appendChild(StringNode);
       extDefNode.insertBefore(typeNode, paramDefNode);
 
       // create <PSXJavaExtensionDef> without child
@@ -473,8 +473,8 @@ public class PSDocVersionConverter {
       } // end of loop
 
       Element typeNode = doc.createElement("type");
-      Text textNode = doc.createTextNode(ms_type1); // UDF_PROC is type 1
-      typeNode.appendChild(textNode);
+      Text StringNode = doc.createTextNode(ms_type1); // UDF_PROC is type 1
+      typeNode.appendChild(StringNode);
       extDefNode.insertBefore(typeNode, paramDefNode);
 
       // create <PSXScriptExtensionDef> without child

--- a/system/webservices/src/com/percussion/webservices/system/impl/PSSystemDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/system/impl/PSSystemDesignWs.java
@@ -69,7 +69,6 @@ import com.percussion.webservices.system.IPSSystemDesignWs;
 import com.percussion.webservices.system.IPSSystemWs;
 import com.percussion.webservices.system.PSSystemWsLocator;
 import com.percussion.security.shim.acl.NotOwnerException;
-import com.percussion.services.system.data.PSSharedProperty;
 import org.apache.commons.lang3.StringUtils;
 import com.percussion.webservices.ExceptionUtils;
 import org.springframework.transaction.annotation.Transactional;

--- a/system/webservices/src/com/percussion/webservices/transformation/converter/PSErrorsExceptionConverter.java
+++ b/system/webservices/src/com/percussion/webservices/transformation/converter/PSErrorsExceptionConverter.java
@@ -27,7 +27,6 @@ import com.percussion.webservices.faults.PSErrorsFaultServiceCall;
 import com.percussion.webservices.faults.PSErrorsFaultServiceCallError;
 import com.percussion.webservices.faults.PSErrorsFaultServiceCallSuccess;
 import com.percussion.webservices.faults.PSLockFaultBean;
-import com.percussion.webservices.faults.PSError;
 
 import java.util.Map;
 


### PR DESCRIPTION
## Summary
Full monorepo **runtime** migration from Jackson **2.22** to Jackson **3.1.5** (LTS), tracked by **#1706**.

Path C (OpenAPI webapp / swagger-jaxrs2 out of main app) was prep only; this PR is the actual Jackson major upgrade.

## What changed
- Parent `jackson.version` → **3.1.5**; `tools.jackson.*` groupIds for core/databind/dataformat/module/jaxrs
- `jackson-annotations` remains `com.fasterxml.jackson.core` **2.21** (Jackson 3 design)
- Removed `jackson-datatype-jdk8`, `jackson-datatype-jsr310`, `jackson-module-parameter-names` (built into databind)
- Java packages → `tools.jackson.*` (annotations stay `com.fasterxml.jackson.annotation`)
- Class renames: `ValueSerializer` / `ValueDeserializer`, `JacksonException` / `DatabindException`, `DateTimeFeature`, `EnumFeature`, ...
- Immutable `JsonMapper.builder()...build()` for ContextResolvers and call sites
- DTS Applications, serializers, exception mappers updated
- Unit tests: Optional DTO serialization + asset ser/deser on rest

## Verification (local)
| Module | Result |
|--------|--------|
| `rest` clean install + unit tests | pass |
| `projects/sitemanage` install -DskipTests | pass |
| `system` install -DskipTests | pass |
| DTS common/metadata/feeds/polls/comments/membership/forms install -DskipTests | pass |

## Follow-up
- Full reactor / CI green on PR
- Deploy smoke: REST JSON root wrap, dates, Optional catalogs (content types / templates)
- Close #1706 when merged

Refs #1706
