### PR TITLE
fix(extensions-main): resolve 100 Javadoc source warnings (#1712)

### DIFF
--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSAddAssemblerInfo.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSAddAssemblerInfo.java
@@ -107,6 +107,9 @@ import org.xml.sax.SAXException;
  * are modfied.
  */
 public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
+  /** Creates a new PSAddAssemblerInfo. */
+  public PSAddAssemblerInfo() {}
+
   // see IPSResultDocumentProcessor#canModifyStyleSheet()
   public boolean canModifyStyleSheet() {
     return false;

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSAddChildInfo.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSAddChildInfo.java
@@ -34,6 +34,8 @@ import org.w3c.dom.Element;
  * tables in an assembler without manual SQL and outer joins.
  */
 public class PSAddChildInfo extends PSDefaultExtension implements IPSResultDocumentProcessor {
+  /** Creates a new PSAddChildInfo. */
+  public PSAddChildInfo() {}
 
   /**
    * Queries the URL specified by required paramater <code>params[0]</code> (the "resource"

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSAddPortalProperties.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSAddPortalProperties.java
@@ -30,6 +30,8 @@ import org.w3c.dom.Element;
 
 /** Creates a properties element as used in portal publisher assemblers. */
 public class PSAddPortalProperties extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSAddPortalProperties. */
+  public PSAddPortalProperties() {}
 
   private static final Logger log = LogManager.getLogger(PSAddPortalProperties.class);
 

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSAuthtypeDispatcher.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSAuthtypeDispatcher.java
@@ -41,6 +41,9 @@ import org.w3c.dom.NodeList;
  * for the requested authtype is "0".
  */
 public class PSAuthtypeDispatcher extends PSDefaultExtension implements IPSResultDocumentProcessor {
+  /** Creates a new PSAuthtypeDispatcher. */
+  public PSAuthtypeDispatcher() {}
+
   /**
    * Implementation of the method from the interface.
    *

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSAutoRelatedContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSAutoRelatedContent.java
@@ -55,6 +55,9 @@ import org.w3c.dom.NodeList;
  * @version 1.0
  */
 public class PSAutoRelatedContent extends PSDefaultExtension implements IPSResultDocumentProcessor {
+  /** Creates a new PSAutoRelatedContent. */
+  public PSAutoRelatedContent() {}
+
   /**
    * Required by the interface. This exit never modifies the stylesheet.
    *

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSCacheBySessionRule.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSCacheBySessionRule.java
@@ -29,6 +29,9 @@ import java.io.File;
  * Used by server to determine if a request should be cached using the sessionid as one of the keys.
  */
 public class PSCacheBySessionRule implements IPSUdfProcessor {
+  /** Creates a new PSCacheBySessionRule. */
+  public PSCacheBySessionRule() {}
+
   // see IPSUdfProcessor doc
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {
     // noop

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSConcatAssemblyLocation.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSConcatAssemblyLocation.java
@@ -26,6 +26,9 @@ import java.io.File;
 
 /** This assembly location generator concatenates all provided parameters. */
 public class PSConcatAssemblyLocation implements IPSAssemblyLocation {
+  /** Creates a new PSConcatAssemblyLocation. */
+  public PSConcatAssemblyLocation() {}
+
   // See interface for details
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {
     m_def = def;

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSConcatWithIdAssemblyLocation.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSConcatWithIdAssemblyLocation.java
@@ -34,6 +34,9 @@ import org.apache.logging.log4j.Logger;
  * given position.
  */
 public class PSConcatWithIdAssemblyLocation implements IPSAssemblyLocation {
+  /** Creates a new PSConcatWithIdAssemblyLocation. */
+  public PSConcatWithIdAssemblyLocation() {}
+
   // See interface for details
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {
     m_def = def;

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSCreatePortalPropertyList.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSCreatePortalPropertyList.java
@@ -28,6 +28,9 @@ import org.w3c.dom.Element;
 
 /** Creates a properties element as used in portal publisher assemblers. */
 public class PSCreatePortalPropertyList extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSCreatePortalPropertyList. */
+  public PSCreatePortalPropertyList() {}
+
   /**
    * Creates the <code>Properties</code> element as specified in the sys_PortalPublisher.dtd for the
    * supplied parameters.

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSDatabasePublisher.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSDatabasePublisher.java
@@ -46,6 +46,8 @@ import org.w3c.dom.Text;
  * sys_DatabasePublisher.dtd out of input documents conforming to the markup.dtd.
  */
 public class PSDatabasePublisher implements IPSResultDocumentProcessor {
+  /** Creates a new PSDatabasePublisher. */
+  public PSDatabasePublisher() {}
 
   private static final Logger log = LogManager.getLogger(PSDatabasePublisher.class);
 

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSDefaultAssemblyLocation.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSDefaultAssemblyLocation.java
@@ -31,6 +31,8 @@ import org.apache.logging.log4j.Logger;
 
 /** The default location generator for content assemblers. */
 public class PSDefaultAssemblyLocation implements IPSAssemblyLocation {
+  /** Creates a new PSDefaultAssemblyLocation. */
+  public PSDefaultAssemblyLocation() {}
 
   private static final Logger log = LogManager.getLogger(IPSConstants.ASSEMBLY_LOG);
 

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSFixAssemblyUrlForRevision.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSFixAssemblyUrlForRevision.java
@@ -42,8 +42,6 @@ import org.w3c.dom.Text;
  * sys_casSupport/casSupport_1 or any custom authtype resource that needs corrections for tha last
  * public revision. It takes two optional parameters:
  *
- * <p>
- *
  * <ol>
  *   <li>Name of the element in the result XML document whose value represents of the link URL to be
  *       corrected for last public revision. If the name specifed starts with "@", then the link URL
@@ -61,6 +59,9 @@ import org.w3c.dom.Text;
  */
 public class PSFixAssemblyUrlForRevision extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
+  /** Creates a new PSFixAssemblyUrlForRevision. */
+  public PSFixAssemblyUrlForRevision() {}
+
   /**
    * Implementation of the interface method, always return <code>false</code>.
    *
@@ -170,8 +171,6 @@ public class PSFixAssemblyUrlForRevision extends PSDefaultExtension
    * contentid of the related item is parsed from the supplied URL. The following scheme is used to
    * corerct teh URL:
    *
-   * <p>
-   *
    * <ul>
    *   <li>If the URL does not have a {@link IPSHtmlParameters#SYS_CONTENTID contentid}parameter,
    *       then the URL is returned as it is.
@@ -196,7 +195,7 @@ public class PSFixAssemblyUrlForRevision extends PSDefaultExtension
    * @return the fixed related content url, <code>null</code> if this url should be skipped.
    * @throws PSInternalRequestCallException for errors caused doing internal lookups.
    * @throws PSNotFoundException if a required resource is not found while making lookup requests.
-   * @throws PSRequestParsingException
+   * @throws PSRequestParsingException if the request cannot be parsed.
    */
   public static String fixRelatedContentUrl(
       IPSRequestContext request,

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSGenerateAssemblerLink.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSGenerateAssemblerLink.java
@@ -37,6 +37,9 @@ import org.w3c.dom.Document;
  * (similar to the SYS_MAKEINTLINK UDF).
  */
 public class PSGenerateAssemblerLink extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSGenerateAssemblerLink. */
+  public PSGenerateAssemblerLink() {}
+
   /**
    * Generates an internal URL to the assembler for the specified variant. The assembler resource
    * name is obtained by querying the sys_casSupport application.
@@ -178,9 +181,10 @@ public class PSGenerateAssemblerLink extends PSSimpleJavaUdfExtension {
    * Gets the base URL for the assembler resource associated with the supplied variant ID. Makes an
    * internal request to a system query resource to obtain the URL.
    *
-   * @param variantid
-   * @param request
-   * @return @throws PSConversionException
+   * @param variantid the variant id for which to obtain the assembler URL.
+   * @param request the request context.
+   * @return the base URL of the assembler resource.
+   * @throws PSConversionException if an error occurs making the internal request.
    */
   protected String getAssemblyBaseUrl(String variantid, IPSRequestContext request)
       throws PSConversionException {

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSGeneratePubLocation.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSGeneratePubLocation.java
@@ -87,6 +87,9 @@ import org.apache.logging.log4j.Logger;
  * RXLOCATIONSCHEME.
  */
 public class PSGeneratePubLocation extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSGeneratePubLocation. */
+  public PSGeneratePubLocation() {}
+
   /** Commons logging logger for this class */
   private static final Logger log = LogManager.getLogger(PSGeneratePubLocation.class);
 
@@ -591,7 +594,7 @@ public class PSGeneratePubLocation extends PSSimpleJavaUdfExtension {
    * @return an array of PSExtensionParamValue objects with all parameters found, never <code>null
    *     </code>, might be empty.
    * @throws SQLException if any SQL operation fails.
-   * @throws NamingException
+   * @throws NamingException if a naming lookup fails.
    */
   protected PSExtensionParamValue[] getExitParameters(
       IPSLocationScheme scheme, int contentid, int revision) throws SQLException, NamingException {

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSGenericAssembly.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSGenericAssembly.java
@@ -40,6 +40,8 @@ import org.w3c.dom.Node;
  * for the parameters supported by this exit.
  */
 public class PSGenericAssembly extends PSDefaultExtension implements IPSAssemblyLocation {
+  /** Creates a new PSGenericAssembly. */
+  public PSGenericAssembly() {}
 
   private static final Logger log = LogManager.getLogger(IPSConstants.ASSEMBLY_LOG);
 

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSGetSiteBaseUrl.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSGetSiteBaseUrl.java
@@ -52,6 +52,9 @@ import org.apache.logging.log4j.Logger;
  * <p>An internal request is executed to lookup the site attributes.
  */
 public class PSGetSiteBaseUrl implements IPSUdfProcessor {
+  /** Creates a new PSGetSiteBaseUrl. */
+  public PSGetSiteBaseUrl() {}
+
   /**
    * Implementation of the method in the interface. See method description for more details of the
    * implementation.

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSInsertAsRelatedItem.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSInsertAsRelatedItem.java
@@ -41,6 +41,9 @@ import org.w3c.dom.Document;
  * @see PSModifyRelatedContent
  */
 public class PSInsertAsRelatedItem implements IPSResultDocumentProcessor {
+  /** Creates a new PSInsertAsRelatedItem. */
+  public PSInsertAsRelatedItem() {}
+
   // see IPSResultDocumentProcessor#canModifyStyleSheet()
   public boolean canModifyStyleSheet() {
     return false;

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSModifyRelatedContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSModifyRelatedContent.java
@@ -56,6 +56,9 @@ import org.w3c.dom.Document;
  * for all active assembly update functionality.
  */
 public class PSModifyRelatedContent extends PSDefaultExtension implements IPSRequestPreProcessor {
+  /** Creates a new PSModifyRelatedContent. */
+  public PSModifyRelatedContent() {}
+
   /** This exit does not take any parameters. */
   public void preProcessRequest(Object[] params, IPSRequestContext request)
       throws PSExtensionProcessingException {
@@ -167,6 +170,10 @@ public class PSModifyRelatedContent extends PSDefaultExtension implements IPSReq
   /**
    * Convenience method that calls {@link move(int, IPSRequestContext, boolean) move(rid, request,
    * true)}.
+   *
+   * @param rid the id of the relationship to move up.
+   * @param request the request context.
+   * @throws PSException if an error occurs performing the move.
    */
   public static void moveUp(int rid, IPSRequestContext request) throws PSException {
     move(rid, request, true);
@@ -175,6 +182,10 @@ public class PSModifyRelatedContent extends PSDefaultExtension implements IPSReq
   /**
    * Convenience method that calls {@link move(int, IPSRequestContext, boolean) move(rid, request,
    * false)}.
+   *
+   * @param rid the id of the relationship to move down.
+   * @param request the request context.
+   * @throws PSException if an error occurs performing the move.
    */
   public static void moveDown(int rid, IPSRequestContext request) throws PSException {
     move(rid, request, false);
@@ -346,11 +357,14 @@ public class PSModifyRelatedContent extends PSDefaultExtension implements IPSReq
   }
 
   /**
-   * @param rid
-   * @param slotId
-   * @param index
-   * @param request
-   * @throws PSException
+   * Moves the supplied relationship to a new slot position.
+   *
+   * @param rid the id of the relationship to move.
+   * @param slotId the id of the destination slot.
+   * @param index the index within the destination slot.
+   * @param newVariantId the id of the new variant to use.
+   * @param request the request context.
+   * @throws PSException if an error occurs performing the move.
    */
   public static void moveToSlot(
       int rid, int slotId, int index, int newVariantId, IPSRequestContext request)
@@ -387,8 +401,12 @@ public class PSModifyRelatedContent extends PSDefaultExtension implements IPSReq
   }
 
   /**
-   * @param rid
-   * @param index
+   * Reorders the supplied relationship to a new index in its slot.
+   *
+   * @param rid the id of the relationship to reorder.
+   * @param index the new index within the slot.
+   * @param request the request context.
+   * @throws PSException if an error occurs performing the reorder.
    */
   public static void reorder(int rid, int index, IPSRequestContext request) throws PSException {
     PSRelationship relationship = getRelationship(rid, request);
@@ -446,6 +464,14 @@ public class PSModifyRelatedContent extends PSDefaultExtension implements IPSReq
         PSActiveAssemblyProcessorProxy.PROCTYPE_SERVERLOCAL, request);
   }
 
+  /**
+   * Gets the relationships for the supplied relationship id.
+   *
+   * @param rid the relationship id.
+   * @param request the request context.
+   * @return the set of relationships for the id.
+   * @throws PSCmsException if an error occurs.
+   */
   public static PSRelationshipSet getRelationships(int rid, IPSRequestContext request)
       throws PSCmsException {
     PSRelationshipFilter filter = new PSRelationshipFilter();
@@ -455,6 +481,14 @@ public class PSModifyRelatedContent extends PSDefaultExtension implements IPSReq
     return processor.getRelationships(filter);
   }
 
+  /**
+   * Gets a single relationship by its id.
+   *
+   * @param rid the relationship id.
+   * @param request the request context.
+   * @return the relationship for the id.
+   * @throws PSCmsException if an error occurs.
+   */
   public static PSRelationship getRelationship(int rid, IPSRequestContext request)
       throws PSCmsException {
     PSRelationshipSet relationships = getRelationships(rid, request);
@@ -485,7 +519,15 @@ public class PSModifyRelatedContent extends PSDefaultExtension implements IPSReq
     }
   }
 
-  /** Convenience method that calls {@link getSlotType(int, request)}. */
+  /**
+   * Convenience method that calls {@link getSlotType(int, IPSRequestContext) getSlotType(int,
+   * request)}.
+   *
+   * @param slotid the slot id as a string.
+   * @param request the request context.
+   * @return the slot type for the given slot id.
+   * @throws PSCmsException if an error occurs.
+   */
   public static PSSlotType getSlotType(String slotid, IPSRequestContext request)
       throws PSCmsException {
     try {

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSPublishableContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSPublishableContent.java
@@ -31,12 +31,8 @@ public class PSPublishableContent extends PSSimpleJavaUdfExtension {
    * This UDF tests whether or not the addressed content is publishable or not. Makes a call to
    * isPublishable method to determine the item's publishable status.
    *
-   * @param params a comma separated list of tokens that represent publishable content, may be
-   *     <code>null</code> or empty, in which case the defaults <code>y,i</code> are used. params[1]
-   *     is the content id of the item to test, may be <code>null</code>, in which case the content
-   *     id of the supplied request is used. If no valid content id is supplied, an exception is
-   *     thrown. params[2] is the revision of the item to test, may be <code>null</code>, in which
-   *     case the current revision is used.
+   * @param params extension args: [0] publishable tokens (comma-separated; default y,i), [1]
+   *     content id (optional), [2] revision (optional)
    * @param request the request to operate on, not <code>null</code>.
    * @return a <code>Boolean</code> with a value of <code>true</code> if the supplied content item
    *     is publishable, <code>false</code> otherwise.

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSPublishableContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSPublishableContent.java
@@ -24,17 +24,19 @@ import com.percussion.system.utils.PSCms;
 
 /** Tests if the addressed content is publishable or not. */
 public class PSPublishableContent extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSPublishableContent. */
+  public PSPublishableContent() {}
+
   /**
    * This UDF tests whether or not the addressed content is publishable or not. Makes a call to
    * isPublishable method to determine the item's publishable status.
    *
-   * @param params[0] a comma separated list of tokens that represent publishable content, may be
-   *     <code>null</code> or empty, in which case the defaults <code>y,i</code> are used.
-   * @param params[1] the content id of the item to test, may be <code>null</code>, in which case
-   *     the content id of the supplied request is used. If no valid content id is supplied, an
-   *     exception is thrown.
-   * @param params[2] the revision of the item to test, may be <code>null</code>, in which case the
-   *     current revision is used.
+   * @param params a comma separated list of tokens that represent publishable content, may be
+   *     <code>null</code> or empty, in which case the defaults <code>y,i</code> are used. params[1]
+   *     is the content id of the item to test, may be <code>null</code>, in which case the content
+   *     id of the supplied request is used. If no valid content id is supplied, an exception is
+   *     thrown. params[2] is the revision of the item to test, may be <code>null</code>, in which
+   *     case the current revision is used.
    * @param request the request to operate on, not <code>null</code>.
    * @return a <code>Boolean</code> with a value of <code>true</code> if the supplied content item
    *     is publishable, <code>false</code> otherwise.

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSSiteFolderAuthTypeFilter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSSiteFolderAuthTypeFilter.java
@@ -76,6 +76,9 @@ import org.w3c.dom.NodeList;
  * it is a publishable variant or not. If not removes the link.
  */
 public class PSSiteFolderAuthTypeFilter implements IPSResultDocumentProcessor {
+  /** Creates a new PSSiteFolderAuthTypeFilter. */
+  public PSSiteFolderAuthTypeFilter() {}
+
   /* (non-Javadoc)
    * @see com.percussion.extension.IPSResultDocumentProcessor#canModifyStyleSheet()
    */

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSSysTemplateToSysVariantid.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSSysTemplateToSysVariantid.java
@@ -44,6 +44,8 @@ import org.w3c.dom.NodeList;
  * <p>This exit requires the existance of App resource sys_ceSupport/variantlist.xml.
  */
 public class PSSysTemplateToSysVariantid implements IPSRequestPreProcessor {
+  /** Creates a new PSSysTemplateToSysVariantid. */
+  public PSSysTemplateToSysVariantid() {}
 
   /*
    * @see com.percussion.extension.IPSRequestPreProcessor#preProcessRequest(

--- a/modules/extensions-main/src/main/java/com/percussion/ce/PSDependencyTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/ce/PSDependencyTree.java
@@ -51,6 +51,8 @@ import org.xml.sax.InputSource;
  * content item as a tree.
  */
 public class PSDependencyTree implements IPSResultDocumentProcessor {
+  /** Creates a new PSDependencyTree. */
+  public PSDependencyTree() {}
 
   private static final Logger log = LogManager.getLogger(PSDependencyTree.class);
 
@@ -268,7 +270,11 @@ public class PSDependencyTree implements IPSResultDocumentProcessor {
   /** Indent string for rendering the tree for the style sheet */
   public static final String INDENT = "..";
 
-  /** Main routine for testing */
+  /**
+   * Main routine for testing.
+   *
+   * @param args the command line arguments.
+   */
   public static void main(String[] args) {
 
     PSDependencyTree pSDependencyTree = new PSDependencyTree();

--- a/modules/extensions-main/src/main/java/com/percussion/ce/PSInlineImageSizeExtractor.java
+++ b/modules/extensions-main/src/main/java/com/percussion/ce/PSInlineImageSizeExtractor.java
@@ -37,6 +37,9 @@ import org.w3c.dom.Element;
  * modification takes place.
  */
 public class PSInlineImageSizeExtractor implements IPSResultDocumentProcessor {
+  /** Creates a new PSInlineImageSizeExtractor. */
+  public PSInlineImageSizeExtractor() {}
+
   /*
    * Implementation of the method required by the interface IPSExtension.
    */

--- a/modules/extensions-main/src/main/java/com/percussion/ce/PSRemoveControlChars.java
+++ b/modules/extensions-main/src/main/java/com/percussion/ce/PSRemoveControlChars.java
@@ -35,6 +35,8 @@ import java.util.Set;
  * to the modify command handler in the ContentEditorSystemDef as an input data exit.
  */
 public class PSRemoveControlChars implements IPSRequestPreProcessor {
+  /** Creates a new PSRemoveControlChars. */
+  public PSRemoveControlChars() {}
 
   /*
    * @see com.percussion.extension.IPSRequestPreProcessor#preProcessRequest(java.lang.Object[], com.percussion.server.IPSRequestContext)

--- a/modules/extensions-main/src/main/java/com/percussion/ce/PSWepFixImages.java
+++ b/modules/extensions-main/src/main/java/com/percussion/ce/PSWepFixImages.java
@@ -43,6 +43,8 @@ import org.w3c.dom.NodeList;
  * img tag.
  */
 public class PSWepFixImages extends PSFileInfo implements IPSRequestPreProcessor {
+  /** Creates a new PSWepFixImages. */
+  public PSWepFixImages() {}
 
   /** Pre processes the request. */
   public void preProcessRequest(Object[] params, IPSRequestContext request)

--- a/modules/extensions-main/src/main/java/com/percussion/cms/PSCalculateCompareRevision.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cms/PSCalculateCompareRevision.java
@@ -34,6 +34,9 @@ import org.apache.logging.log4j.Logger;
  * @author dougrand
  */
 public class PSCalculateCompareRevision implements IPSRequestPreProcessor {
+  /** Creates a new PSCalculateCompareRevision. */
+  public PSCalculateCompareRevision() {}
+
   private static final String SYS_REVISION2 = "sys_revision2";
   private static final Logger log = LogManager.getLogger(PSCalculateCompareRevision.class);
 

--- a/modules/extensions-main/src/main/java/com/percussion/cms/PSCleanupCrossSiteLiniks.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cms/PSCleanupCrossSiteLiniks.java
@@ -80,6 +80,9 @@ import org.w3c.dom.Document;
  */
 public class PSCleanupCrossSiteLiniks extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
+  /** Creates a new PSCleanupCrossSiteLiniks. */
+  public PSCleanupCrossSiteLiniks() {}
+
   /*
    * (non-Javadoc)
    *

--- a/modules/extensions-main/src/main/java/com/percussion/cms/PSGetInlineVariantBody.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cms/PSGetInlineVariantBody.java
@@ -34,6 +34,8 @@ import org.w3c.dom.Element;
  */
 public class PSGetInlineVariantBody extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
+  /** Creates a new PSGetInlineVariantBody. */
+  public PSGetInlineVariantBody() {}
 
   public boolean canModifyStyleSheet() {
     return false;

--- a/modules/extensions-main/src/main/java/com/percussion/cms/PSGetModifiedInlineLinkData.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cms/PSGetModifiedInlineLinkData.java
@@ -47,6 +47,9 @@ import org.w3c.dom.NodeList;
  */
 public class PSGetModifiedInlineLinkData extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
+  /** Creates a new PSGetModifiedInlineLinkData. */
+  public PSGetModifiedInlineLinkData() {}
+
   /* (non-Javadoc)
    * @see com.percussion.extension.IPSResultDocumentProcessor#canModifyStyleSheet()
    */

--- a/modules/extensions-main/src/main/java/com/percussion/community/PSAddCommunityEnabledFlag.java
+++ b/modules/extensions-main/src/main/java/com/percussion/community/PSAddCommunityEnabledFlag.java
@@ -34,6 +34,9 @@ import org.w3c.dom.Element;
  * this attribute is yes if communities are enabled or no if communities are disabled.
  */
 public class PSAddCommunityEnabledFlag implements IPSResultDocumentProcessor {
+  /** Creates a new PSAddCommunityEnabledFlag. */
+  public PSAddCommunityEnabledFlag() {}
+
   /*
    * Implementation of the method required by the interface IPSExtension.
    */

--- a/modules/extensions-main/src/main/java/com/percussion/community/PSAddDefaultCommunity.java
+++ b/modules/extensions-main/src/main/java/com/percussion/community/PSAddDefaultCommunity.java
@@ -36,6 +36,9 @@ import org.w3c.dom.Element;
  * attributes will get empty values.
  */
 public class PSAddDefaultCommunity implements IPSResultDocumentProcessor {
+  /** Creates a new PSAddDefaultCommunity. */
+  public PSAddDefaultCommunity() {}
+
   /*
    * Implementation of the method required by the interface IPSExtension.
    */

--- a/modules/extensions-main/src/main/java/com/percussion/community/PSAuthenticateUser.java
+++ b/modules/extensions-main/src/main/java/com/percussion/community/PSAuthenticateUser.java
@@ -38,8 +38,6 @@ import org.w3c.dom.NodeList;
  * This exit authenticates the current user by means of his role-community membership. The following
  * is the list of things that happen:
  *
- * <p>
- *
  * <UL>
  *   <LI>If the communities feature is disabled (by setting communities_enabled=no in
  *       Server.properties file, the passes the authentication and the user's communityid is set to
@@ -56,6 +54,9 @@ import org.w3c.dom.NodeList;
  * </UL>
  */
 public class PSAuthenticateUser implements IPSRequestPreProcessor {
+  /** Creates a new PSAuthenticateUser. */
+  public PSAuthenticateUser() {}
+
   /*
    * Implementation of the interface method
    */
@@ -84,7 +85,7 @@ public class PSAuthenticateUser implements IPSRequestPreProcessor {
    *     process request method, assumed never <code>null</code>.
    * @param name Community name, can not be null
    * @return Community id.
-   * @throws Exception
+   * @throws Exception if an error occurs.
    */
   public static String getCommunityId(IPSRequestContext request, String name) throws Exception {
     // Backup parameters

--- a/modules/extensions-main/src/main/java/com/percussion/community/PSModifyCommunity.java
+++ b/modules/extensions-main/src/main/java/com/percussion/community/PSModifyCommunity.java
@@ -27,6 +27,8 @@ import com.percussion.system.utils.IPSHtmlParameters;
 import java.io.File;
 
 /**
+ * Modifies the user's community based on the parameters passed into the pre-exit.
+ *
  * @author dougrand
  *     <p>This exit modifies the user's community based on the parameters passed into the pre-exit.
  *     The user's community is modified if:
@@ -38,6 +40,9 @@ import java.io.File;
  *     </ul>
  */
 public class PSModifyCommunity implements IPSRequestPreProcessor {
+  /** Creates a new PSModifyCommunity. */
+  public PSModifyCommunity() {}
+
   /**
    * The name of this extension, defined in the {@link #init(IPSExtensionDef, File) init} method and
    * never modified after.

--- a/modules/extensions-main/src/main/java/com/percussion/cx/PSAddNewItemToFolder.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cx/PSAddNewItemToFolder.java
@@ -38,6 +38,9 @@ import org.w3c.dom.Document;
  * to the folder.
  */
 public class PSAddNewItemToFolder implements IPSResultDocumentProcessor {
+  /** Creates a new PSAddNewItemToFolder. */
+  public PSAddNewItemToFolder() {}
+
   // see IPSResultDocumentProcessor#canModifyStyleSheet()
   public boolean canModifyStyleSheet() {
     return false;

--- a/modules/extensions-main/src/main/java/com/percussion/cx/PSGetAadItemTypeIconPaths.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cx/PSGetAadItemTypeIconPaths.java
@@ -47,6 +47,9 @@ import org.w3c.dom.NodeList;
  * resultDoc does not contain expected input.
  */
 public class PSGetAadItemTypeIconPaths implements IPSResultDocumentProcessor {
+  /** Creates a new PSGetAadItemTypeIconPaths. */
+  public PSGetAadItemTypeIconPaths() {}
+
   /*
    * (non-Javadoc)
    *

--- a/modules/extensions-main/src/main/java/com/percussion/cx/PSGetItemTypeIconPaths.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cx/PSGetItemTypeIconPaths.java
@@ -63,6 +63,9 @@ import org.xml.sax.SAXException;
  * this exit.
  */
 public class PSGetItemTypeIconPaths implements IPSResultDocumentProcessor {
+  /** Creates a new PSGetItemTypeIconPaths. */
+  public PSGetItemTypeIconPaths() {}
+
   /*
    * (non-Javadoc)
    * @see com.percussion.extension.IPSResultDocumentProcessor#processResultDocument(java.lang.Object[], com.percussion.server.IPSRequestContext, org.w3c.dom.Document)

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/PSSortXmlExtension.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/PSSortXmlExtension.java
@@ -50,6 +50,8 @@ import org.w3c.dom.Document;
  * @author adamgent
  */
 public class PSSortXmlExtension implements IPSResultDocumentProcessor {
+  /** Creates a new PSSortXmlExtension. */
+  public PSSortXmlExtension() {}
 
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {}
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/ca/PSDeleteContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/ca/PSDeleteContent.java
@@ -49,6 +49,9 @@ import org.w3c.dom.Element;
  * The XML element pkey must be mapped to the primary key in the backed table(s).
  */
 public class PSDeleteContent implements IPSRequestPreProcessor {
+  /** Creates a new PSDeleteContent. */
+  public PSDeleteContent() {}
+
   /*
    * implementation of the method in the interface IPSRequestPreProcessor
    */
@@ -236,7 +239,11 @@ public class PSDeleteContent implements IPSRequestPreProcessor {
     return result;
   }
 
-  /** main method for testing purpose. */
+  /**
+   * main method for testing purpose.
+   *
+   * @param args the command line arguments.
+   */
   public static void main(String[] args) {
     PSDeleteContent.getPurgeAppResource(
         "http://10.10.10.17:9992/Rhythmyx/xr_ceImage/image.html?sys_command=preview&sys_contentid=78&sys_revision=1");

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSAddUserControlsToTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSAddUserControlsToTree.java
@@ -39,6 +39,9 @@ import org.w3c.dom.Node;
  */
 public class PSAddUserControlsToTree extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
+  /** Creates a new PSAddUserControlsToTree. */
+  public PSAddUserControlsToTree() {}
+
   /**
    * This method handles the post-exit request by loading the specified file, parsing it into a
    * Document, and appending it to the parentNode in the result document.

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCheckIfVariantIsInUse.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCheckIfVariantIsInUse.java
@@ -46,6 +46,8 @@ import java.util.Iterator;
  * @author dougrand
  */
 public class PSCheckIfVariantIsInUse implements IPSRequestPreProcessor {
+  /** Creates a new PSCheckIfVariantIsInUse. */
+  public PSCheckIfVariantIsInUse() {}
 
   public void preProcessRequest(Object[] params, IPSRequestContext request)
       throws PSAuthorizationException,

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCloneOverrideField.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCloneOverrideField.java
@@ -33,8 +33,6 @@ import org.w3c.dom.Text;
  * Then the value is located based on the name of the element supplied. The parameter description is
  * as follows:
  *
- * <p>
- *
  * <ul>
  *   <li>First parameter is the name of the Rhythmyx resource that generates the field value to be
  *       overridden. This has a syntax of ../<code>rxApp</code>/ <code>resource</code>.cml
@@ -48,6 +46,9 @@ import org.w3c.dom.Text;
  * @author RammohanVangapalli
  */
 public class PSCloneOverrideField extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSCloneOverrideField. */
+  public PSCloneOverrideField() {}
+
   /* (non-Javadoc)
    * @see com.percussion.extension.IPSUdfProcessor#processUdf(java.lang.Object[], com.percussion.server.IPSRequestContext)
    */

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCmsObjectNameLookup.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCmsObjectNameLookup.java
@@ -41,6 +41,9 @@ import org.w3c.dom.NodeList;
  * feature.
  */
 public class PSCmsObjectNameLookup extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
+  /** Creates a new PSCmsObjectNameLookup. */
+  public PSCmsObjectNameLookup() {}
+
   // Implementation of the Interface
   public Object processUdf(Object[] params, IPSRequestContext request)
       throws PSConversionException {

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCopySiteDef.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCopySiteDef.java
@@ -56,6 +56,9 @@ import org.w3c.dom.Element;
  * @author paulhoward
  */
 public class PSCopySiteDef extends PSDefaultExtension implements IPSResultDocumentProcessor {
+  /** Creates a new PSCopySiteDef. */
+  public PSCopySiteDef() {}
+
   // see base class method for details
   public boolean canModifyStyleSheet() {
     return false;

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSGetRelationshipProps.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSGetRelationshipProps.java
@@ -48,6 +48,9 @@ import org.w3c.dom.Element;
  */
 public class PSGetRelationshipProps extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
+  /** Creates a new PSGetRelationshipProps. */
+  public PSGetRelationshipProps() {}
+
   // see IPSResultDocumentProcessor#canModifyStyleSheet()
   public boolean canModifyStyleSheet() {
     return false;

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSModifySiteDefs.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSModifySiteDefs.java
@@ -49,6 +49,9 @@ import org.w3c.dom.Element;
  * @author paulhoward
  */
 public class PSModifySiteDefs extends PSDefaultExtension implements IPSResultDocumentProcessor {
+  /** Creates a new PSModifySiteDefs. */
+  public PSModifySiteDefs() {}
+
   // see base class method for details
   public boolean canModifyStyleSheet() {
     return false;

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSSearchCommunityHandler.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSSearchCommunityHandler.java
@@ -68,8 +68,18 @@ import org.w3c.dom.NodeList;
  * @author dougrand
  */
 public class PSSearchCommunityHandler implements IPSRequestPreProcessor {
+  /** Creates a new PSSearchCommunityHandler. */
+  public PSSearchCommunityHandler() {}
+
+  /** The logger for this class. */
   protected static Logger ms_log = LogManager.getLogger(PSSearchCommunityHandler.class);
 
+  /**
+   * Pre processes the search community request.
+   *
+   * @param params the extension parameters.
+   * @param request the request context.
+   */
   @SuppressWarnings("unused")
   public void preProcessRequest(Object[] params, IPSRequestContext request) {
     IPSBackEndRoleMgr rmgr = PSRoleMgrLocator.getBackEndRoleManager();

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSSelectAASlots.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSSelectAASlots.java
@@ -45,6 +45,9 @@ import org.w3c.dom.NodeList;
  * @author dougrand
  */
 public class PSSelectAASlots implements IPSResultDocumentProcessor {
+  /** Creates a new PSSelectAASlots. */
+  public PSSelectAASlots() {}
+
   private static final Logger log = LogManager.getLogger(PSSelectAASlots.class);
 
   public boolean canModifyStyleSheet() {

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/components/PSDeleteChildComponentRelations.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/components/PSDeleteChildComponentRelations.java
@@ -33,6 +33,9 @@ import org.w3c.dom.Document;
  * request to another resource which deletes the other relation(CHILDRELATION).
  */
 public class PSDeleteChildComponentRelations implements IPSResultDocumentProcessor {
+  /** Creates a new PSDeleteChildComponentRelations. */
+  public PSDeleteChildComponentRelations() {}
+
   /*
    * Implementation of the method required by the interface IPSExtension.
    */

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/components/PSMenuTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/components/PSMenuTree.java
@@ -53,6 +53,9 @@ import org.w3c.dom.Text;
  * <p>Multiple requests are made to expand each child item to menu item.
  */
 public class PSMenuTree implements IPSResultDocumentProcessor {
+  /** Creates a new PSMenuTree. */
+  public PSMenuTree() {}
+
   /*
    * Implementation of the method required by the interface IPSExtension.
    */

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSAddAllowableWorkflowsForContentType.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSAddAllowableWorkflowsForContentType.java
@@ -66,6 +66,9 @@ import org.w3c.dom.Text;
 public class PSAddAllowableWorkflowsForContentType extends PSDefaultExtension
     implements IPSResultDocumentProcessor, IPSRequestPreProcessor {
 
+  /** Creates a new PSAddAllowableWorkflowsForContentType. */
+  public PSAddAllowableWorkflowsForContentType() {}
+
   private static final Logger log =
       LogManager.getLogger(PSAddAllowableWorkflowsForContentType.class);
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSCheckOutSlotItem.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSCheckOutSlotItem.java
@@ -37,6 +37,9 @@ import org.w3c.dom.Element;
  * then does not show the slots for that item.
  */
 public class PSCheckOutSlotItem extends PSDefaultExtension implements IPSResultDocumentProcessor {
+  /** Creates a new PSCheckOutSlotItem. */
+  public PSCheckOutSlotItem() {}
+
   // see IPSResultDocumentProcessor#canModifyStyleSheet()
   public boolean canModifyStyleSheet() {
     return false;

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSConvertCustomSearchOperator.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSConvertCustomSearchOperator.java
@@ -38,6 +38,8 @@ import org.w3c.dom.Element;
  */
 public class PSConvertCustomSearchOperator extends PSDefaultExtension
     implements IPSRequestPreProcessor {
+  /** Creates a new PSConvertCustomSearchOperator. */
+  public PSConvertCustomSearchOperator() {}
 
   /**
    * Converts an operator value sent by a custom search to the appropriate SQL operator.

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSCreateTranslations.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSCreateTranslations.java
@@ -41,6 +41,8 @@ import org.w3c.dom.Element;
  * with the status of translations for each content item.
  */
 public class PSCreateTranslations extends PSDefaultExtension implements IPSResultDocumentProcessor {
+  /** Creates a new PSCreateTranslations. */
+  public PSCreateTranslations() {}
 
   private static final Logger log = LogManager.getLogger(PSCreateTranslations.class);
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSDeleteContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSDeleteContent.java
@@ -63,6 +63,9 @@ import org.w3c.dom.Element;
  * primary key in the backed table(s).
  */
 public class PSDeleteContent implements IPSRequestPreProcessor {
+  /** Creates a new PSDeleteContent. */
+  public PSDeleteContent() {}
+
   /*
    * implementation of the method in the interface IPSRequestPreProcessor
    */

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/encoding/PSCSSEncode.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/encoding/PSCSSEncode.java
@@ -26,6 +26,7 @@ import com.percussion.server.IPSRequestContext;
 import java.io.File;
 import org.owasp.encoder.Encode;
 
+/** Field input transformer that CSS-encodes the supplied string parameter. */
 public class PSCSSEncode implements IPSFieldInputTransformer {
 
   /***

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/encoding/PSHTMLEncode.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/encoding/PSHTMLEncode.java
@@ -26,6 +26,7 @@ import com.percussion.server.IPSRequestContext;
 import java.io.File;
 import org.owasp.encoder.Encode;
 
+/** Field input transformer that HTML-encodes the supplied string parameter. */
 public class PSHTMLEncode implements IPSFieldInputTransformer {
 
   /***

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/encoding/PSJavaScriptEncode.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/encoding/PSJavaScriptEncode.java
@@ -26,6 +26,7 @@ import com.percussion.server.IPSRequestContext;
 import java.io.File;
 import org.owasp.encoder.Encode;
 
+/** Field input transformer that JavaScript-encodes the supplied string parameter. */
 public class PSJavaScriptEncode implements IPSFieldInputTransformer {
 
   /***

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/encoding/PSURIComponentEncode.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/encoding/PSURIComponentEncode.java
@@ -26,6 +26,7 @@ import com.percussion.server.IPSRequestContext;
 import java.io.File;
 import org.owasp.encoder.Encode;
 
+/** Field input transformer that URI-component-encodes the supplied string parameter. */
 public class PSURIComponentEncode implements IPSFieldInputTransformer {
 
   /***

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/encoding/PSXMLEncode.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/encoding/PSXMLEncode.java
@@ -26,6 +26,7 @@ import com.percussion.server.IPSRequestContext;
 import java.io.File;
 import org.owasp.encoder.Encode;
 
+/** Field input transformer that XML-encodes the supplied string parameter. */
 public class PSXMLEncode implements IPSFieldInputTransformer {
 
   /***

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/Base64Decoder.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/Base64Decoder.java
@@ -27,6 +27,9 @@ import com.percussion.util.PSBase64Decoder;
  * {@link Base64Decoder#processUdf processUdf} for a description.
  */
 public class Base64Decoder extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
+  /** Creates a new Base64Decoder. */
+  public Base64Decoder() {}
+
   /**
    * The Base64Decoder class is used to decode data from the base64 format.
    *

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/Base64Encoder.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/Base64Encoder.java
@@ -28,6 +28,9 @@ import com.percussion.util.PSBase64Encoder;
  * {@link Base64Encoder#processUdf processUdf} for a description.
  */
 public class Base64Encoder extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
+  /** Creates a new Base64Encoder. */
+  public Base64Encoder() {}
+
   /**
    * The Base64Encoder class is used to encode data from the normal format.
    *

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSAddAllParamsToUrl.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSAddAllParamsToUrl.java
@@ -49,6 +49,9 @@ import org.w3c.dom.*;
  * attributes of an element.
  */
 public class PSAddAllParamsToUrl implements IPSResultDocumentProcessor {
+  /** Creates a new PSAddAllParamsToUrl. */
+  public PSAddAllParamsToUrl() {}
+
   /*
    * Implementation of the method defined by the interface
    */

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSAddCurrentDateTime.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSAddCurrentDateTime.java
@@ -37,6 +37,9 @@ import org.apache.commons.lang3.time.FastDateFormat;
  * string, date time offset, and truncate.
  */
 public class PSAddCurrentDateTime extends PSDefaultExtension implements IPSRequestPreProcessor {
+  /** Creates a new PSAddCurrentDateTime. */
+  public PSAddCurrentDateTime() {}
+
   /**
    * Adds a the current date and time to the provided request.
    *
@@ -102,6 +105,7 @@ public class PSAddCurrentDateTime extends PSDefaultExtension implements IPSReque
    * @param offset the number of hours to offset the date passed in. Can be negative, positive or
    *     zero.
    * @param truncate flag to indicate if we want to truncate this date/time
+   * @return the offset date.
    */
   public static Date getDateOffset(Date date, int offset, boolean truncate) {
     long oneDay = 86400000L;

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSAddIsManagedNavUsed.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSAddIsManagedNavUsed.java
@@ -36,6 +36,9 @@ import org.w3c.dom.Element;
  * <p>The supplied parameters will be ignored.
  */
 public class PSAddIsManagedNavUsed implements IPSResultDocumentProcessor {
+  /** Creates a new PSAddIsManagedNavUsed. */
+  public PSAddIsManagedNavUsed() {}
+
   // Implementation of the method required by the interface IPSExtension.
   public void init(IPSExtensionDef extensionDef, File file) throws PSExtensionException {
     ms_fullExtensionName = extensionDef.getRef().toString();

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSAddPluginProperties.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSAddPluginProperties.java
@@ -44,6 +44,9 @@ import org.w3c.dom.Element;
  * </ol>
  */
 public class PSAddPluginProperties implements IPSResultDocumentProcessor {
+  /** Creates a new PSAddPluginProperties. */
+  public PSAddPluginProperties() {}
+
   /*
    * Implementation of the method required by the interface IPSExtension.
    */

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSAddServerProperties.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSAddServerProperties.java
@@ -40,6 +40,9 @@ import org.w3c.dom.Element;
  * resulting value is empty. Parameters with empty names will be ignored.
  */
 public class PSAddServerProperties implements IPSResultDocumentProcessor {
+  /** Creates a new PSAddServerProperties. */
+  public PSAddServerProperties() {}
+
   /*
    * Implementation of the method required by the interface IPSExtension.
    */

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSAppendUserRoles.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSAppendUserRoles.java
@@ -38,6 +38,9 @@ import org.w3c.dom.Element;
  * is always "Role'.
  */
 public class PSAppendUserRoles implements IPSResultDocumentProcessor {
+  /** Creates a new PSAppendUserRoles. */
+  public PSAppendUserRoles() {}
+
   /*
    * Implementation of the method defined by the interface
    */

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSBinaryChooser.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSBinaryChooser.java
@@ -21,7 +21,15 @@ import com.percussion.extension.IPSUdfProcessor;
 import com.percussion.extension.PSDefaultExtension;
 import com.percussion.server.IPSRequestContext;
 
+/**
+ * Compares two string values and returns one of two alternatives based on the result.
+ *
+ * @author dougrand
+ */
 public class PSBinaryChooser extends PSDefaultExtension implements IPSUdfProcessor {
+  /** Creates a new PSBinaryChooser. */
+  public PSBinaryChooser() {}
+
   /**
    * Compares the first param to the 2nd param as Strings. If they are equal, the 3rd param is
    * returned, otherwise the 4th param is returned. The comparison is performed case insensitive. If

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSCascadeDelete.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSCascadeDelete.java
@@ -54,6 +54,9 @@ import org.w3c.dom.NodeList;
  * which is processed by the update resource).
  */
 public class PSCascadeDelete extends PSDefaultExtension implements IPSRequestPreProcessor {
+  /** Creates a new PSCascadeDelete. */
+  public PSCascadeDelete() {}
+
   /*
    * Implementation of the method in the interface
    * <code>com.percussion.extension.IPSRequestPreProcessor</code>

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSCollapseHtmlParameter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSCollapseHtmlParameter.java
@@ -32,6 +32,9 @@ import org.w3c.dom.Document;
  */
 public class PSCollapseHtmlParameter extends PSDefaultExtension
     implements IPSRequestPreProcessor, IPSResultDocumentProcessor {
+  /** Creates a new PSCollapseHtmlParameter. */
+  public PSCollapseHtmlParameter() {}
+
   /*
    * Implementation of the method required by
    * <code>IPSRequestPreProcessor</code> interface

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSCopyParameter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSCopyParameter.java
@@ -31,10 +31,22 @@ import java.io.File;
  * the key specified by the destination exit parameter
  */
 public class PSCopyParameter implements IPSItemInputTransformer {
+  /** Creates a new PSCopyParameter. */
   public PSCopyParameter() {
     // nothing to do
   }
 
+  /**
+   * Copies a request parameter from the source key to the destination key.
+   *
+   * @param params the extension parameters; index 0 is the source name and index 1 is the
+   *     destination name.
+   * @param request the request context.
+   * @throws PSAuthorizationException if authorization fails.
+   * @throws PSRequestValidationException if the request is invalid.
+   * @throws PSParameterMismatchException if the parameters are mismatched.
+   * @throws PSExtensionProcessingException if processing fails.
+   */
   // see IPSRequestPreProcessor
   public void preProcessRequest(Object[] params, IPSRequestContext request)
       throws PSAuthorizationException,

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSDateDifference.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSDateDifference.java
@@ -31,6 +31,9 @@ import java.util.GregorianCalendar;
  * difference.
  */
 public class PSDateDifference extends PSDefaultExtension implements IPSUdfProcessor {
+  /** Creates a new PSDateDifference. */
+  public PSDateDifference() {}
+
   /**
    * @see com.percussion.extension.IPSUdfProcessor#processUdf(java.lang.Object[],
    *     com.percussion.server.IPSRequestContext)

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSDirectoryIndexTouchWorkflowAction.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSDirectoryIndexTouchWorkflowAction.java
@@ -56,6 +56,8 @@ import org.apache.logging.log4j.Logger;
  */
 public class PSDirectoryIndexTouchWorkflowAction extends PSDefaultExtension
     implements IPSWorkflowAction {
+  /** Creates a new PSDirectoryIndexTouchWorkflowAction. */
+  public PSDirectoryIndexTouchWorkflowAction() {}
 
   /** The logger for this class. */
   private static final Logger ms_logger =

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFileInfo.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFileInfo.java
@@ -85,6 +85,8 @@ import java.util.StringTokenizer;
  * length is 0), the corresponding parameter will not be added to the server's parameter map.
  */
 public class PSFileInfo extends PSDefaultExtension implements IPSRequestPreProcessor {
+  /** Creates a new PSFileInfo. */
+  public PSFileInfo() {}
 
   /**
    * This method handles the pre-exit request.

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFormatFileTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFormatFileTree.java
@@ -46,6 +46,8 @@ import org.w3c.dom.Text;
  * @author David Benua
  */
 public class PSFormatFileTree extends PSDefaultExtension implements IPSResultDocumentProcessor {
+  /** Creates a new PSFormatFileTree. */
+  public PSFormatFileTree() {}
 
   private static final Logger log = LogManager.getLogger(PSFormatFileTree.class);
 
@@ -290,7 +292,7 @@ public class PSFormatFileTree extends PSDefaultExtension implements IPSResultDoc
   /**
    * This is a dummy main() for use in debugging only
    *
-   * @param args
+   * @param args the command line arguments.
    */
   public static void main(String[] args) {
     PSFormatFileTree pSFT = new PSFormatFileTree();

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSGetBase64Encoded.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSGetBase64Encoded.java
@@ -34,6 +34,9 @@ import java.net.URL;
  * {@link #processUdf(Object[], IPSRequestContext) processUdf} for a description.
  */
 public class PSGetBase64Encoded extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSGetBase64Encoded. */
+  public PSGetBase64Encoded() {}
+
   /**
    * Firts this creates a URL from the supplied parameters and attaches the pssessionid as one of
    * the html parameters. It then makes an internal request using the created URL, base64 encodes

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSGetBase64EncodedBody.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSGetBase64EncodedBody.java
@@ -27,6 +27,9 @@ import java.io.InputStream;
  * it only returns Base64 encoded <code>BODY</code> portion of the fetched HTML document.
  */
 public class PSGetBase64EncodedBody extends PSGetBase64Encoded {
+  /** Creates a new PSGetBase64EncodedBody. */
+  public PSGetBase64EncodedBody() {}
+
   /**
    * Overridden method of the base class. Returns an InputStream that only returns the data found in
    * the <code>BODY</code> portion of the HTTP response.

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSGetFileSize.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSGetFileSize.java
@@ -29,6 +29,9 @@ import java.net.URL;
  * {@link #processUdf(Object[], IPSRequestContext) processUdf} for a description.
  */
 public class PSGetFileSize extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSGetFileSize. */
+  public PSGetFileSize() {}
+
   /**
    * First this creates a URL from the supplied parameters and attaches the pssessionid as one of
    * the html parameters. It then makes an internal request using the created URL, base64 encodes

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSGetSessionVariable.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSGetSessionVariable.java
@@ -26,6 +26,9 @@ import com.percussion.server.IPSRequestContext;
  * <p>See {@link PSGetSessionVariable#preProcessRequest preProcessRequest} for a description.
  */
 public class PSGetSessionVariable extends PSDefaultExtension implements IPSRequestPreProcessor {
+  /** Creates a new PSGetSessionVariable. */
+  public PSGetSessionVariable() {}
+
   /**
    * Gets a session object and adds it to the request parameters as a String.
    *

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSImageInfoExtractor.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSImageInfoExtractor.java
@@ -40,6 +40,8 @@ import org.apache.logging.log4j.Logger;
  * be added to the request as image size attributes. Requires the SUN JAI library.
  */
 public class PSImageInfoExtractor extends PSFileInfo implements IPSItemInputTransformer {
+  /** Creates a new PSImageInfoExtractor. */
+  public PSImageInfoExtractor() {}
 
   private static final Logger log = LogManager.getLogger(PSImageInfoExtractor.class);
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSIncrementalContentFilter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSIncrementalContentFilter.java
@@ -96,6 +96,8 @@ import org.w3c.dom.Node;
  */
 public class PSIncrementalContentFilter extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
+  /** Creates a new PSIncrementalContentFilter. */
+  public PSIncrementalContentFilter() {}
 
   private static final Logger log = LogManager.getLogger(PSIncrementalContentFilter.class);
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSInlineLinkCleanup.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSInlineLinkCleanup.java
@@ -75,6 +75,9 @@ import org.w3c.dom.Element;
  * the database for the processed result.
  */
 public class PSInlineLinkCleanup extends PSDefaultExtension implements IPSResultDocumentProcessor {
+  /** Creates a new PSInlineLinkCleanup. */
+  public PSInlineLinkCleanup() {}
+
   private static final Logger log = LogManager.getLogger(PSInlineLinkCleanup.class);
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLink.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLink.java
@@ -30,18 +30,17 @@ import java.util.HashMap;
  * {@link #processUdf(Object[], IPSRequestContext) processUdf} for a description.
  */
 public class PSMakeAbsLink extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
+  /** Creates a new PSMakeAbsLink. */
+  public PSMakeAbsLink() {}
+
   /**
    * Creates a URL from the supplied parameters and returns it.
    *
    * <p>A URI has the following pieces for purposes of this description (see RFC 2396 for more
    * details):
    *
-   * <p>
-   *
    * <p>&lt;scheme&gt;://&lt;host&gt;&lt;path-segments&gt;
    * &lt;resource&gt;?&lt;query&gt;#&lt;fragment&gt;
-   *
-   * <p>
    *
    * <p>All parts except resource are optional.
    *

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLinkSecure.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLinkSecure.java
@@ -30,18 +30,17 @@ import java.util.HashMap;
  * {@link #processUdf(Object[], IPSRequestContext) processUdf} for a description.
  */
 public class PSMakeAbsLinkSecure extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
+  /** Creates a new PSMakeAbsLinkSecure. */
+  public PSMakeAbsLinkSecure() {}
+
   /**
    * Creates a URL from the supplied parameters and returns it.
    *
    * <p>A URI has the following pieces for purposes of this description (see RFC 2396 for more
    * details):
    *
-   * <p>
-   *
    * <p>&lt;scheme&gt;://&lt;host&gt;&lt;path-segments&gt;
    * &lt;resource&gt;?&lt;query&gt;#&lt;fragment&gt;
-   *
-   * <p>
    *
    * <p>All parts except resource are optional.
    *
@@ -67,8 +66,6 @@ public class PSMakeAbsLinkSecure extends PSSimpleJavaUdfExtension implements IPS
    * port, and Rhythmyx root will be added, assuming it is relative from the originating requests
    * app root. For an empty string, all parts of the originating request will be used, substituting
    * the supplied parameters.If the port is 80, no port number will be added to the generated url.
-   *
-   * <p>
    *
    * <p>Multiple name/value pairs may be specified for the parameters. For example, if the following
    * were supplied as parameters:
@@ -133,7 +130,6 @@ public class PSMakeAbsLinkSecure extends PSSimpleJavaUdfExtension implements IPS
    * </table>
    *     <p>The table below shows the possible combinations of input parameter values and the
    *     resulting protocol and port used:
-   *     <p>
    *     <table border="1">
    * <caption style="display:none">Protocol and port combinations</caption>
    * <tr>
@@ -190,7 +186,7 @@ public class PSMakeAbsLinkSecure extends PSSimpleJavaUdfExtension implements IPS
    *    supplied URL</td>
    * </tr>
    * </table>
-   *     <p>
+   *
    * @param request The current request context. May not be <code>null</code>.
    * @return The absolute URL created from the supplied foundation, user session information, and
    *     supplied parameters and values. If the resource is <code>null</code>, an empty string will

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLinkSecureEx.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLinkSecureEx.java
@@ -29,18 +29,17 @@ import java.util.HashMap;
  * {@link #processUdf(Object[], IPSRequestContext) processUdf} for a description.
  */
 public class PSMakeAbsLinkSecureEx extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
+  /** Creates a new PSMakeAbsLinkSecureEx. */
+  public PSMakeAbsLinkSecureEx() {}
+
   /**
    * Creates a URL from the supplied parameters and returns it.
    *
    * <p>A URI has the following pieces for purposes of this description (see RFC 2396 for more
    * details):
    *
-   * <p>
-   *
    * <p>&lt;scheme&gt;://&lt;host&gt;&lt;path-segments&gt;
    * &lt;resource&gt;?&lt;query&gt;#&lt;fragment&gt;
-   *
-   * <p>
    *
    * <p>All parts except resource are optional.
    *
@@ -66,8 +65,6 @@ public class PSMakeAbsLinkSecureEx extends PSSimpleJavaUdfExtension implements I
    * port, and Rhythmyx root will be added, assuming it is relative from the originating requests
    * app root. For an empty string, all parts of the originating request will be used, substituting
    * the supplied parameters.If the port is 80, no port number will be added to the generated url.
-   *
-   * <p>
    *
    * <p>Multiple name/value pairs may be specified for the parameters. For example, if the following
    * were supplied as parameters:
@@ -146,7 +143,6 @@ public class PSMakeAbsLinkSecureEx extends PSSimpleJavaUdfExtension implements I
    * </table>
    *     <p>The table below shows the possible combinations of input parameter values and the
    *     resulting protocol and port used:
-   *     <p>
    *     <table border="1">
    *       <caption style="display:none">Protocol and port combinations</caption>
    * <tr>
@@ -203,7 +199,7 @@ public class PSMakeAbsLinkSecureEx extends PSSimpleJavaUdfExtension implements I
    *    supplied URL</td>
    * </tr>
    * </table>
-   *     <p>
+   *
    * @param request The current request context. May not be <code>null</code>.
    * @return The absolute URL created from the supplied foundation, user session information, and
    *     supplied parameters and values. If the resource is <code>null</code>, an empty string will

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeDeleteRowsXmlDoc.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeDeleteRowsXmlDoc.java
@@ -50,6 +50,9 @@ import org.w3c.dom.Element;
  * in this case.
  */
 public class PSMakeDeleteRowsXmlDoc implements IPSRequestPreProcessor {
+  /** Creates a new PSMakeDeleteRowsXmlDoc. */
+  public PSMakeDeleteRowsXmlDoc() {}
+
   /*
    * implementation of the method in the interface IPSRequestPreProcessor
    */

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeIntLink.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeIntLink.java
@@ -30,6 +30,9 @@ import java.util.HashMap;
  * {@link #processUdf(Object[], IPSRequestContext) processUdf} for a description.
  */
 public class PSMakeIntLink extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
+  /** Creates a new PSMakeIntLink. */
+  public PSMakeIntLink() {}
+
   /**
    * Creates a URL from the supplied parameters and returns it with the sessionid attached as one of
    * the html parameters. The server and port are set to the Rhythmyx server's address and port.
@@ -37,12 +40,8 @@ public class PSMakeIntLink extends PSSimpleJavaUdfExtension implements IPSUdfPro
    * <p>A URI has the following pieces for purposes of this description (see RFC 2396 for more
    * details):
    *
-   * <p>
-   *
    * <p>&lt;scheme&gt;://&lt;host&gt;&lt;path-segments&gt;
    * &lt;resource&gt;?&lt;query&gt;#&lt;fragment&gt;
-   *
-   * <p>
    *
    * <p>All parts except resource are optional.
    *

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeInternalRequest.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeInternalRequest.java
@@ -44,6 +44,9 @@ import org.xml.sax.SAXException;
  * A UDF that makes an internal request to the specified resource and returns the result document.
  */
 public class PSMakeInternalRequest extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSMakeInternalRequest. */
+  public PSMakeInternalRequest() {}
+
   /**
    * Makes an internal request to the specified Rhythmyx resource and returns the result document.
    *

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeLink.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeLink.java
@@ -29,6 +29,9 @@ import java.util.HashMap;
  * {@link #processUdf(Object[], IPSRequestContext) processUdf} for a description.
  */
 public class PSMakeLink extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
+  /** Creates a new PSMakeLink. */
+  public PSMakeLink() {}
+
   /**
    * Creates a URL from the supplied parameters and returns it. Upto 6 name/ value pairs may be
    * specified for the arguments. For example, if the following were supplied as arguments:

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSNullIf.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSNullIf.java
@@ -31,6 +31,8 @@ import com.percussion.server.PSRequestValidationException;
  * &lt;select> tags.
  */
 public class PSNullIf extends PSDefaultExtension implements IPSRequestPreProcessor {
+  /** Creates a new PSNullIf. */
+  public PSNullIf() {}
 
   /**
    * Compares the request parameters' values whose names are supplied to the supplied value, and if

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSPageLinkText.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSPageLinkText.java
@@ -33,7 +33,10 @@ import javax.jcr.RepositoryException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/** UDF that returns the page link text for a page id found in the request. */
 public class PSPageLinkText extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
+  /** Creates a new PSPageLinkText. */
+  public PSPageLinkText() {}
 
   private static final Logger log = LogManager.getLogger(PSPageLinkText.class);
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParamExtractor.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParamExtractor.java
@@ -49,6 +49,9 @@ import org.w3c.dom.Document;
  * it is specified as 8 now (which means 10 total parameters for the exit).
  */
 public class PSParamExtractor extends PSDefaultExtension implements IPSRequestPreProcessor {
+  /** Creates a new PSParamExtractor. */
+  public PSParamExtractor() {}
+
   /*
    * Required by the interface. Actual processing happens in this method.
    * @see IPSRequestPreProcessor#preProcessRequestt()

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParamStringListToMultiParams.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParamStringListToMultiParams.java
@@ -36,6 +36,9 @@ import org.w3c.dom.Document;
  */
 public class PSParamStringListToMultiParams extends PSDefaultExtension
     implements IPSRequestPreProcessor, IPSResultDocumentProcessor {
+  /** Creates a new PSParamStringListToMultiParams. */
+  public PSParamStringListToMultiParams() {}
+
   /** See {@link #process(Object[], IPSRequestContext)} for the description. */
   public void preProcessRequest(Object[] params, IPSRequestContext request)
       throws PSParameterMismatchException {

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParameterTokenizer.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParameterTokenizer.java
@@ -53,6 +53,8 @@ import org.apache.logging.log4j.Logger;
  * <p>This exit supports 3 delimiters: semicolon, period, and comma.
  */
 public class PSParameterTokenizer extends PSDefaultExtension implements IPSRequestPreProcessor {
+  /** Creates a new PSParameterTokenizer. */
+  public PSParameterTokenizer() {}
 
   private static final Logger log = LogManager.getLogger(IPSConstants.ASSEMBLY_LOG);
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParamsToXml.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParamsToXml.java
@@ -54,6 +54,8 @@ import org.w3c.dom.Element;
  * now.
  */
 public class PSParamsToXml extends PSDefaultExtension implements IPSResultDocumentProcessor {
+  /** Creates a new PSParamsToXml. */
+  public PSParamsToXml() {}
 
   /*
    * Required by the interface. This exit never modifies the stylesheet.

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSPrepareInClause.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSPrepareInClause.java
@@ -39,6 +39,8 @@ import java.util.Iterator;
  * quotes.
  */
 public class PSPrepareInClause implements IPSRequestPreProcessor {
+  /** Creates a new PSPrepareInClause. */
+  public PSPrepareInClause() {}
 
   // see IPSExtension interface
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSProxyQueryResource.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSProxyQueryResource.java
@@ -67,6 +67,8 @@ import org.xml.sax.SAXException;
  * @author adamgent
  */
 public class PSProxyQueryResource extends PSDefaultExtension implements IPSResultDocumentProcessor {
+  /** Creates a new PSProxyQueryResource. */
+  public PSProxyQueryResource() {}
 
   private static final String PARAM_PASSWORD = "password";
   private static final String PARAM_USER = "user";

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSQueryExtensions.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSQueryExtensions.java
@@ -30,10 +30,14 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 /**
+ * Queries the extension manager to provide a list of matching extensions.
+ *
  * @author dougrand
  *     <p>Query the extension manager to provide a list of matching extensions.
  */
 public class PSQueryExtensions extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSQueryExtensions. */
+  public PSQueryExtensions() {}
 
   /*
    * (non-Javadoc)

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSReplaceResultDocument.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSReplaceResultDocument.java
@@ -35,8 +35,6 @@ import org.w3c.dom.Node;
  * internal request names today. To overcome this restriction one can use this exit. To use this
  * exit one needs to do the following:
  *
- * <p>
- *
  * <OL>
  *   <LI>Create other resource that need to be executed conditionally by probably cloning the
  *       original and modifying suitably and give proper internal names (pipe names)
@@ -56,6 +54,9 @@ import org.w3c.dom.Node;
  * of the execution of the internal request.
  */
 public class PSReplaceResultDocument implements IPSResultDocumentProcessor {
+  /** Creates a new PSReplaceResultDocument. */
+  public PSReplaceResultDocument() {}
+
   // see IPSResultDocumentProcessor#canModifyStyleSheet()
   public boolean canModifyStyleSheet() {
     return false;

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSRhythmyxRoot.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSRhythmyxRoot.java
@@ -26,6 +26,9 @@ import com.percussion.server.PSServer;
  * calls to rhythmyx resources.
  */
 public class PSRhythmyxRoot extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSRhythmyxRoot. */
+  public PSRhythmyxRoot() {}
+
   /**
    * This UDF constructs the rhythmyx root url out of the supplied request and returns it as <code>
    * String</code>.

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSetArrayHtmlParameter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSetArrayHtmlParameter.java
@@ -55,6 +55,9 @@ import org.w3c.dom.NodeList;
  * </ol>
  */
 public class PSSetArrayHtmlParameter implements IPSRequestPreProcessor {
+  /** Creates a new PSSetArrayHtmlParameter. */
+  public PSSetArrayHtmlParameter() {}
+
   /*
    * (non-Javadoc)
    *
@@ -174,6 +177,11 @@ public class PSSetArrayHtmlParameter implements IPSRequestPreProcessor {
    */
   public void init(IPSExtensionDef def, File codeRoot) throws PSExtensionException {}
 
+  /**
+   * Main for manual testing.
+   *
+   * @param args the command line arguments.
+   */
   public static void main(String[] args) {}
 
   /** Logger for this exit. */

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSetHtmlParameter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSetHtmlParameter.java
@@ -28,6 +28,9 @@ import java.io.File;
 
 /** This pre-exit sets / creates or removes a single request parameter */
 public class PSSetHtmlParameter implements IPSRequestPreProcessor {
+  /** Creates a new PSSetHtmlParameter. */
+  public PSSetHtmlParameter() {}
+
   /**
    * This is the implementation of the IPSRequestPreProcessor interface This exit expects two
    * parameters to be passed in: params[0] - parameter name (required), params[1] - parameter value

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSetSessionVariable.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSetSessionVariable.java
@@ -27,6 +27,9 @@ import com.percussion.server.IPSRequestContext;
  * <p>See {@link PSSetSessionVariable#preProcessRequest preProcessRequest} for a description.
  */
 public class PSSetSessionVariable extends PSDefaultExtension implements IPSRequestPreProcessor {
+  /** Creates a new PSSetSessionVariable. */
+  public PSSetSessionVariable() {}
+
   /**
    * Sets a session variable with the value of a request parameter.
    *

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdfBaseTest.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdfBaseTest.java
@@ -21,22 +21,54 @@ import com.percussion.extension.PSSimpleJavaUdfExtension;
 import com.percussion.server.IPSRequestContext;
 
 /**
+ * Base test class for simple Java UDF extensions.
+ *
  * @author DougRand
  *     <p>To change the template for this generated type comment go to
  *     Window&gt;Preferences&gt;Java&gt;Code Generation&gt;Code and Comments
  */
 public abstract class PSSimpleJavaUdfBaseTest {
+  /** Creates a new PSSimpleJavaUdfBaseTest. */
+  public PSSimpleJavaUdfBaseTest() {}
+
+  /**
+   * Calls the UDF with no parameters.
+   *
+   * @param ext the UDF extension to invoke.
+   * @param request the request context.
+   * @return the UDF result.
+   * @throws Exception if processing fails.
+   */
   public Object callUDF(PSSimpleJavaUdfExtension ext, IPSRequestContext request) throws Exception {
     Object params[] = new Object[0];
     return ext.processUdf(params, request);
   }
 
+  /**
+   * Calls the UDF with one parameter.
+   *
+   * @param ext the UDF extension to invoke.
+   * @param request the request context.
+   * @param p the single parameter value.
+   * @return the UDF result.
+   * @throws Exception if processing fails.
+   */
   public Object callUDF(PSSimpleJavaUdfExtension ext, IPSRequestContext request, Object p)
       throws Exception {
     Object params[] = new Object[] {p};
     return ext.processUdf(params, request);
   }
 
+  /**
+   * Calls the UDF with two parameters.
+   *
+   * @param ext the UDF extension to invoke.
+   * @param request the request context.
+   * @param p1 the first parameter value.
+   * @param p2 the second parameter value.
+   * @return the UDF result.
+   * @throws Exception if processing fails.
+   */
   public Object callUDF(
       PSSimpleJavaUdfExtension ext, IPSRequestContext request, Object p1, Object p2)
       throws Exception {
@@ -44,6 +76,17 @@ public abstract class PSSimpleJavaUdfBaseTest {
     return ext.processUdf(params, request);
   }
 
+  /**
+   * Calls the UDF with three parameters.
+   *
+   * @param ext the UDF extension to invoke.
+   * @param request the request context.
+   * @param p1 the first parameter value.
+   * @param p2 the second parameter value.
+   * @param p3 the third parameter value.
+   * @return the UDF result.
+   * @throws Exception if processing fails.
+   */
   public Object callUDF(
       PSSimpleJavaUdfExtension ext, IPSRequestContext request, Object p1, Object p2, Object p3)
       throws Exception {
@@ -51,6 +94,18 @@ public abstract class PSSimpleJavaUdfBaseTest {
     return ext.processUdf(params, request);
   }
 
+  /**
+   * Calls the UDF with four parameters.
+   *
+   * @param ext the UDF extension to invoke.
+   * @param request the request context.
+   * @param p1 the first parameter value.
+   * @param p2 the second parameter value.
+   * @param p3 the third parameter value.
+   * @param p4 the fourth parameter value.
+   * @return the UDF result.
+   * @throws Exception if processing fails.
+   */
   public Object callUDF(
       PSSimpleJavaUdfExtension ext,
       IPSRequestContext request,
@@ -63,6 +118,19 @@ public abstract class PSSimpleJavaUdfBaseTest {
     return ext.processUdf(params, request);
   }
 
+  /**
+   * Calls the UDF with five parameters.
+   *
+   * @param ext the UDF extension to invoke.
+   * @param request the request context.
+   * @param p1 the first parameter value.
+   * @param p2 the second parameter value.
+   * @param p3 the third parameter value.
+   * @param p4 the fourth parameter value.
+   * @param p5 the fifth parameter value.
+   * @return the UDF result.
+   * @throws Exception if processing fails.
+   */
   public Object callUDF(
       PSSimpleJavaUdfExtension ext,
       IPSRequestContext request,

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_add.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_add.java
@@ -30,6 +30,9 @@ import com.percussion.system.utils.PSCalculation;
  * @since 1.1
  */
 public class PSSimpleJavaUdf_add extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSSimpleJavaUdf_add. */
+  public PSSimpleJavaUdf_add() {}
+
   /* ************ IPSUdfProcessor Interface Implementation ************ */
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_cloneTitle.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_cloneTitle.java
@@ -58,6 +58,8 @@ import java.util.Iterator;
  * @author Vitaly.
  */
 public class PSSimpleJavaUdf_cloneTitle extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSSimpleJavaUdf_cloneTitle. */
+  public PSSimpleJavaUdf_cloneTitle() {}
 
   /* (non-Javadoc)
    * @see com.percussion.extension.IPSUdfProcessor#processUdf(java.lang.Object[], com.percussion.server.IPSRequestContext)

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_concat.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_concat.java
@@ -28,6 +28,9 @@ import com.percussion.server.IPSRequestContext;
  * @since 1.1
  */
 public class PSSimpleJavaUdf_concat extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSSimpleJavaUdf_concat. */
+  public PSSimpleJavaUdf_concat() {}
+
   /* ************ IPSUdfProcessor Interface Implementation ************ */
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_dateAdjust.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_dateAdjust.java
@@ -43,6 +43,9 @@ import java.util.Date;
  * @since 1.1
  */
 public class PSSimpleJavaUdf_dateAdjust extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSSimpleJavaUdf_dateAdjust. */
+  public PSSimpleJavaUdf_dateAdjust() {}
+
   /* ************ IPSUdfProcessor Interface Implementation ************ */
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_dateFormat.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_dateFormat.java
@@ -103,6 +103,9 @@ import org.apache.commons.lang3.StringUtils;
  * @since 1.1
  */
 public class PSSimpleJavaUdf_dateFormat extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSSimpleJavaUdf_dateFormat. */
+  public PSSimpleJavaUdf_dateFormat() {}
+
   /* ************ IPSUdfProcessor Interface Implementation ************ */
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_dateFormatEx.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_dateFormatEx.java
@@ -100,6 +100,9 @@ import org.apache.commons.lang3.StringUtils;
  * @since 2.0
  */
 public class PSSimpleJavaUdf_dateFormatEx extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSSimpleJavaUdf_dateFormatEx. */
+  public PSSimpleJavaUdf_dateFormatEx() {}
+
   /* ************ IPSUdfProcessor Interface Implementation ************ */
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_decodeURL.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_decodeURL.java
@@ -23,6 +23,9 @@ import java.net.URLDecoder;
 
 /** The PSSimpleJavaUdf_decodeURL class Decodes a "x-www-form-urlencoded" to a String. */
 public class PSSimpleJavaUdf_decodeURL extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSSimpleJavaUdf_decodeURL. */
+  public PSSimpleJavaUdf_decodeURL() {}
+
   /* ************ IPSUdfProcessor Interface Implementation ************ */
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_divide.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_divide.java
@@ -31,6 +31,9 @@ import com.percussion.system.utils.PSCalculation;
  * @since 1.1
  */
 public class PSSimpleJavaUdf_divide extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSSimpleJavaUdf_divide. */
+  public PSSimpleJavaUdf_divide() {}
+
   /* ************ IPSUdfProcessor Interface Implementation ************ */
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_encodeForUrl.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_encodeForUrl.java
@@ -28,6 +28,9 @@ import org.apache.commons.lang3.StringUtils;
  * @author paulhoward
  */
 public class PSSimpleJavaUdf_encodeForUrl extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSSimpleJavaUdf_encodeForUrl. */
+  public PSSimpleJavaUdf_encodeForUrl() {}
+
   /**
    * See class description.
    *

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_literal.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_literal.java
@@ -30,6 +30,9 @@ import com.percussion.server.IPSRequestContext;
  * @since 1.1
  */
 public class PSSimpleJavaUdf_literal extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSSimpleJavaUdf_literal. */
+  public PSSimpleJavaUdf_literal() {}
+
   /* ************ IPSUdfProcessor Interface Implementation ************ */
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_multiply.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_multiply.java
@@ -29,6 +29,9 @@ import com.percussion.system.utils.PSCalculation;
  * @since 1.1
  */
 public class PSSimpleJavaUdf_multiply extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSSimpleJavaUdf_multiply. */
+  public PSSimpleJavaUdf_multiply() {}
+
   /* ************ IPSUdfProcessor Interface Implementation ************ */
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_overrideLiteral.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_overrideLiteral.java
@@ -28,6 +28,9 @@ import com.percussion.server.IPSRequestContext;
  */
 public class PSSimpleJavaUdf_overrideLiteral extends PSSimpleJavaUdfExtension
     implements IPSFieldInputTransformer {
+  /** Creates a new PSSimpleJavaUdf_overrideLiteral. */
+  public PSSimpleJavaUdf_overrideLiteral() {}
+
   /**
    * Returns the supplied literal (params[0]) as String or the override value if an override
    * parameter (params[1]) is specified and was found on the supplied request. If found, the

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_replace.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_replace.java
@@ -31,6 +31,9 @@ import com.percussion.util.PSStringOperation;
  */
 public class PSSimpleJavaUdf_replace extends PSSimpleJavaUdfExtension
     implements IPSFieldInputTransformer {
+  /** Creates a new PSSimpleJavaUdf_replace. */
+  public PSSimpleJavaUdf_replace() {}
+
   /* ************ IPSUdfProcessor Interface Implementation ************ */
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_subtract.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_subtract.java
@@ -30,6 +30,9 @@ import com.percussion.system.utils.PSCalculation;
  * @since 1.1
  */
 public class PSSimpleJavaUdf_subtract extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSSimpleJavaUdf_subtract. */
+  public PSSimpleJavaUdf_subtract() {}
+
   /* ************ IPSUdfProcessor Interface Implementation ************ */
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_toHash.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_toHash.java
@@ -24,6 +24,9 @@ import com.percussion.server.IPSRequestContext;
 /** The PSSimpleJavaUdf_toHash class returns a hashcode for the object passed into the UDF. */
 public class PSSimpleJavaUdf_toHash extends PSSimpleJavaUdfExtension
     implements IPSFieldInputTransformer {
+  /** Creates a new PSSimpleJavaUdf_toHash. */
+  public PSSimpleJavaUdf_toHash() {}
+
   /* ************ IPSUdfProcessor Interface Implementation ************ */
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_toLowerCase.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_toLowerCase.java
@@ -31,6 +31,9 @@ import com.percussion.server.IPSRequestContext;
  */
 public class PSSimpleJavaUdf_toLowerCase extends PSSimpleJavaUdfExtension
     implements IPSFieldInputTransformer {
+  /** Creates a new PSSimpleJavaUdf_toLowerCase. */
+  public PSSimpleJavaUdf_toLowerCase() {}
+
   /* ************ IPSUdfProcessor Interface Implementation ************ */
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_toProperCase.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_toProperCase.java
@@ -32,6 +32,9 @@ import com.percussion.util.PSStringOperation;
  */
 public class PSSimpleJavaUdf_toProperCase extends PSSimpleJavaUdfExtension
     implements IPSFieldInputTransformer {
+  /** Creates a new PSSimpleJavaUdf_toProperCase. */
+  public PSSimpleJavaUdf_toProperCase() {}
+
   /* ************ IPSUdfProcessor Interface Implementation ************ */
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_toUpperCase.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_toUpperCase.java
@@ -31,6 +31,9 @@ import com.percussion.server.IPSRequestContext;
  */
 public class PSSimpleJavaUdf_toUpperCase extends PSSimpleJavaUdfExtension
     implements IPSFieldInputTransformer {
+  /** Creates a new PSSimpleJavaUdf_toUpperCase. */
+  public PSSimpleJavaUdf_toUpperCase() {}
+
   /* ************ IPSUdfProcessor Interface Implementation ************ */
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSplitDateParam.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSplitDateParam.java
@@ -49,6 +49,9 @@ import java.util.Date;
  * etc. If not specified, date will not be set into the request parameters.
  */
 public class PSSplitDateParam implements IPSRequestPreProcessor {
+  /** Creates a new PSSplitDateParam. */
+  public PSSplitDateParam() {}
+
   /**
    * See the class description above for parameter details.
    *

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSStringTrimmerUdf.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSStringTrimmerUdf.java
@@ -22,6 +22,9 @@ import com.percussion.server.IPSRequestContext;
 
 /** Strips leading and trailing white space from the supplied string. */
 public class PSStringTrimmerUdf extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSStringTrimmerUdf. */
+  public PSStringTrimmerUdf() {}
+
   /* ************ IPSUdfProcessor Interface Implementation ************ */
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSuperConcat.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSuperConcat.java
@@ -35,6 +35,8 @@ import com.percussion.server.IPSRequestContext;
  * @see PSSimpleJavaUdfExtension
  */
 public class PSSuperConcat extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSSuperConcat. */
+  public PSSuperConcat() {}
 
   /**
    * Processes the provided parameters and concatenates all non-empty values.

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSTextToXml.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSTextToXml.java
@@ -34,6 +34,9 @@ import org.w3c.dom.Element;
  * match.
  */
 public class PSTextToXml extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSTextToXml. */
+  public PSTextToXml() {}
+
   /**
    * Parses the text and returns the document.
    *

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSTouchContentAndParentItems.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSTouchContentAndParentItems.java
@@ -43,6 +43,8 @@ import org.apache.logging.log4j.Logger;
  */
 public class PSTouchContentAndParentItems extends PSDefaultExtension
     implements IPSRequestPreProcessor {
+  /** Creates a new PSTouchContentAndParentItems. */
+  public PSTouchContentAndParentItems() {}
 
   private static final Logger log = LogManager.getLogger(PSTouchContentAndParentItems.class);
 
@@ -55,8 +57,8 @@ public class PSTouchContentAndParentItems extends PSDefaultExtension
    *     limit a number of parents a user would like to be touched (the default value is set as
    *     'unlimited') In case if index[1] receives a negative number the exit assumes 'unlimited'.
    * @param request server contructed request object
-   * @throws PSParameterMismatchException
-   * @throws PSExtensionProcessingException
+   * @throws PSParameterMismatchException if the parameters do not match what is expected.
+   * @throws PSExtensionProcessingException if processing fails.
    */
   public void preProcessRequest(Object[] params, IPSRequestContext request)
       throws PSParameterMismatchException, PSExtensionProcessingException {

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSTouchItemsWorkflowAction.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSTouchItemsWorkflowAction.java
@@ -41,6 +41,8 @@ import org.apache.logging.log4j.Logger;
  * @author yubingchen
  */
 public class PSTouchItemsWorkflowAction extends PSDefaultExtension implements IPSWorkflowAction {
+  /** Creates a new PSTouchItemsWorkflowAction. */
+  public PSTouchItemsWorkflowAction() {}
 
   private static final Logger ms_logger = LogManager.getLogger(PSTouchItemsWorkflowAction.class);
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSTouchParentItems.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSTouchParentItems.java
@@ -28,11 +28,6 @@ import com.percussion.extension.IPSWorkflowAction;
  *
  * @see PSTouchItemsWorkflowAction
  */
-/**
- * Workflow action that touches parent items.
- *
- * @see PSTouchItemsWorkflowAction
- */
 public class PSTouchParentItems extends PSTouchItemsWorkflowAction implements IPSWorkflowAction {
   /** Creates a new PSTouchParentItems. */
   public PSTouchParentItems() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSTouchParentItems.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSTouchParentItems.java
@@ -28,4 +28,12 @@ import com.percussion.extension.IPSWorkflowAction;
  *
  * @see PSTouchItemsWorkflowAction
  */
-public class PSTouchParentItems extends PSTouchItemsWorkflowAction implements IPSWorkflowAction {}
+/**
+ * Workflow action that touches parent items.
+ *
+ * @see PSTouchItemsWorkflowAction
+ */
+public class PSTouchParentItems extends PSTouchItemsWorkflowAction implements IPSWorkflowAction {
+  /** Creates a new PSTouchParentItems. */
+  public PSTouchParentItems() {}
+}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSUploadFileAttrs.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSUploadFileAttrs.java
@@ -32,6 +32,8 @@ import org.apache.commons.lang3.time.FastDateFormat;
  * date value in a given date format.
  */
 public class PSUploadFileAttrs extends PSDefaultExtension implements IPSRequestPreProcessor {
+  /** Creates a new PSUploadFileAttrs. */
+  public PSUploadFileAttrs() {}
 
   /**
    * Does the all the work for the class. See the class description.

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSValidateFile.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSValidateFile.java
@@ -27,6 +27,9 @@ import org.apache.commons.lang3.StringUtils;
  * content of the supplied file is not empty.
  */
 public class PSValidateFile extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSValidateFile. */
+  public PSValidateFile() {}
+
   /**
    * See {@link #processUdf(Object[], IPSRequestContext)}.
    *

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSValidateString.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSValidateString.java
@@ -23,6 +23,9 @@ import org.apache.commons.lang3.StringUtils;
 
 /** Checks if a string is empty, null, or whitespace. */
 public class PSValidateString extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSValidateString. */
+  public PSValidateString() {}
+
   /* ************ IPSUdfProcessor Interface Implementation ************ */
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSConvertDate.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSConvertDate.java
@@ -47,6 +47,9 @@ import java.util.Date;
  * @see java.util.Date
  */
 public class PSConvertDate extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSConvertDate. */
+  public PSConvertDate() {}
+
   /* ************ IPSUdfProcessor Interface Implementation ************ */
   public Object processUdf(Object[] params, IPSRequestContext request)
       throws com.percussion.data.PSConversionException {

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizeDate.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizeDate.java
@@ -40,6 +40,9 @@ import java.util.Date;
  * @see java.util.Date
  */
 public class PSLocalizeDate extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSLocalizeDate. */
+  public PSLocalizeDate() {}
+
   public Object processUdf(Object[] params, IPSRequestContext request)
       throws com.percussion.data.PSConversionException {
     Object date = params[0];

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizeDateToUser.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizeDateToUser.java
@@ -38,6 +38,9 @@ import java.util.Date;
  * @see java.util.Date
  */
 public class PSLocalizeDateToUser extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSLocalizeDateToUser. */
+  public PSLocalizeDateToUser() {}
+
   public Object processUdf(Object[] params, IPSRequestContext request)
       throws com.percussion.data.PSConversionException {
     Object date = params[0];

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizedTextLookup.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizedTextLookup.java
@@ -41,6 +41,8 @@ import org.apache.logging.log4j.Logger;
  * @see PSI18nUtils#getString
  */
 public class PSLocalizedTextLookup extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSLocalizedTextLookup. */
+  public PSLocalizedTextLookup() {}
 
   private static final Logger log = LogManager.getLogger(PSLocalizedTextLookup.class);
 
@@ -77,9 +79,10 @@ public class PSLocalizedTextLookup extends PSSimpleJavaUdfExtension {
     return PSI18nUtils.getString(PSI18nUtils.makeLookupKey(list), lang);
   }
 
-  /*
-   * main method for test purpose
-   * @param args  not used
+  /**
+   * main method for test purpose.
+   *
+   * @param args not used
    */
   public static void main(String[] args) {
     PSLocalizedTextLookup o = new PSLocalizedTextLookup();

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizedTextLookupUser.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizedTextLookupUser.java
@@ -39,6 +39,8 @@ import org.apache.logging.log4j.Logger;
  * @see PSI18nUtils#getString
  */
 public class PSLocalizedTextLookupUser extends PSSimpleJavaUdfExtension {
+  /** Creates a new PSLocalizedTextLookupUser. */
+  public PSLocalizedTextLookupUser() {}
 
   private static final Logger log = LogManager.getLogger(PSLocalizedTextLookupUser.class);
 
@@ -68,9 +70,10 @@ public class PSLocalizedTextLookupUser extends PSSimpleJavaUdfExtension {
     return result;
   }
 
-  /*
-   * main method for test purpose
-   * @param args  not used
+  /**
+   * main method for test purpose.
+   *
+   * @param args not used
    */
   public static void main(String[] args) {
     PSLocalizedTextLookup o = new PSLocalizedTextLookup();

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishContent.java
@@ -79,6 +79,8 @@ import org.xml.sax.SAXException;
  * requests.
  */
 public class PSPublishContent extends PSDefaultExtension implements IPSWorkflowAction {
+  /** Creates a new PSPublishContent. */
+  public PSPublishContent() {}
 
   private static final Logger log = LogManager.getLogger(PSPublishContent.class);
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishEditionForPreview.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishEditionForPreview.java
@@ -46,6 +46,8 @@ import org.w3c.dom.NodeList;
  */
 public class PSPublishEditionForPreview extends PSDefaultExtension
     implements IPSRequestPreProcessor, IPSResultDocumentProcessor {
+  /** Creates a new PSPublishEditionForPreview. */
+  public PSPublishEditionForPreview() {}
 
   private static final Logger log = LogManager.getLogger(PSPublishEditionForPreview.class);
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/security/PSAllowOnlyBooleanValues.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/security/PSAllowOnlyBooleanValues.java
@@ -51,12 +51,27 @@ import org.w3c.dom.Element;
 public class PSAllowOnlyBooleanValues
     implements IPSResultDocumentProcessor, IPSAllowOnlyItemInputValidator {
 
+  /** Creates a new PSAllowOnlyBooleanValues. */
+  public PSAllowOnlyBooleanValues() {}
+
+  /** The TRUE boolean string. */
   public static String TRUE = "true";
+
+  /** The YES boolean string. */
   public static String YES = "yes";
+
+  /** The FALSE boolean string. */
   public static String FALSE = "false";
+
+  /** The NO boolean string. */
   public static String NO = "no";
+
+  /** The ONE boolean string. */
   public static String ONE = "1";
+
+  /** The ZERO boolean string. */
   public static String ZERO = "0";
+
   private String ms_fullExtensionName;
 
   @Override
@@ -80,6 +95,16 @@ public class PSAllowOnlyBooleanValues
     return ret;
   }
 
+  /**
+   * Validates and normalizes boolean parameters from the request.
+   *
+   * @param params the extension parameters.
+   * @param request the request context.
+   * @throws PSAuthorizationException if authorization fails.
+   * @throws PSRequestValidationException if the request is invalid.
+   * @throws PSParameterMismatchException if the parameters are mismatched.
+   * @throws PSExtensionProcessingException if processing fails.
+   */
   public void preProcessRequest(Object[] params, IPSRequestContext request)
       throws PSAuthorizationException,
           PSRequestValidationException,

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/security/PSAllowOnlyGuidValues.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/security/PSAllowOnlyGuidValues.java
@@ -33,8 +33,16 @@ import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+/**
+ * Validates that the supplied input is a GUID value.
+ *
+ * @author natechadwick
+ */
 public class PSAllowOnlyGuidValues
     implements IPSResultDocumentProcessor, IPSAllowOnlyItemInputValidator {
+
+  /** Creates a new PSAllowOnlyGuidValues. */
+  public PSAllowOnlyGuidValues() {}
 
   private String ms_fullExtensionName;
 
@@ -57,6 +65,16 @@ public class PSAllowOnlyGuidValues
     return ret;
   }
 
+  /**
+   * Validates GUID parameters from the request.
+   *
+   * @param params the extension parameters.
+   * @param request the request context.
+   * @throws PSAuthorizationException if authorization fails.
+   * @throws PSRequestValidationException if the request is invalid.
+   * @throws PSParameterMismatchException if the parameters are mismatched.
+   * @throws PSExtensionProcessingException if processing fails.
+   */
   public void preProcessRequest(Object[] params, IPSRequestContext request)
       throws PSAuthorizationException,
           PSRequestValidationException,

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/security/PSAllowOnlyIntegerValues.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/security/PSAllowOnlyIntegerValues.java
@@ -33,8 +33,16 @@ import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+/**
+ * Validates that the supplied input is an integer value.
+ *
+ * @author natechadwick
+ */
 public class PSAllowOnlyIntegerValues
     implements IPSResultDocumentProcessor, IPSAllowOnlyItemInputValidator {
+
+  /** Creates a new PSAllowOnlyIntegerValues. */
+  public PSAllowOnlyIntegerValues() {}
 
   private String ms_fullExtensionName;
 
@@ -55,6 +63,16 @@ public class PSAllowOnlyIntegerValues
     return ret;
   }
 
+  /**
+   * Validates integer parameters from the request.
+   *
+   * @param params the extension parameters.
+   * @param request the request context.
+   * @throws PSAuthorizationException if authorization fails.
+   * @throws PSRequestValidationException if the request is invalid.
+   * @throws PSParameterMismatchException if the parameters are mismatched.
+   * @throws PSExtensionProcessingException if processing fails.
+   */
   public void preProcessRequest(Object[] params, IPSRequestContext request)
       throws PSAuthorizationException,
           PSRequestValidationException,

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/security/PSAllowOnlyNumericValues.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/security/PSAllowOnlyNumericValues.java
@@ -33,8 +33,16 @@ import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+/**
+ * Validates that the supplied input is a numeric value.
+ *
+ * @author natechadwick
+ */
 public class PSAllowOnlyNumericValues
     implements IPSResultDocumentProcessor, IPSAllowOnlyItemInputValidator {
+  /** Creates a new PSAllowOnlyNumericValues. */
+  public PSAllowOnlyNumericValues() {}
+
   private String ms_fullExtensionName;
 
   @Override
@@ -54,6 +62,16 @@ public class PSAllowOnlyNumericValues
     return ret;
   }
 
+  /**
+   * Validates numeric parameters from the request.
+   *
+   * @param params the extension parameters.
+   * @param request the request context.
+   * @throws PSAuthorizationException if authorization fails.
+   * @throws PSRequestValidationException if the request is invalid.
+   * @throws PSParameterMismatchException if the parameters are mismatched.
+   * @throws PSExtensionProcessingException if processing fails.
+   */
   public void preProcessRequest(Object[] params, IPSRequestContext request)
       throws PSAuthorizationException,
           PSRequestValidationException,

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/security/PSAllowOnlyPathValues.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/security/PSAllowOnlyPathValues.java
@@ -35,8 +35,16 @@ import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+/**
+ * Validates that the supplied input is a valid path value.
+ *
+ * @author natechadwick
+ */
 public class PSAllowOnlyPathValues
     implements IPSResultDocumentProcessor, IPSAllowOnlyItemInputValidator {
+  /** Creates a new PSAllowOnlyPathValues. */
+  public PSAllowOnlyPathValues() {}
+
   private String ms_fullExtensionName;
 
   @Override
@@ -64,6 +72,16 @@ public class PSAllowOnlyPathValues
     return ret;
   }
 
+  /**
+   * Validates path parameters from the request.
+   *
+   * @param params the extension parameters.
+   * @param request the request context.
+   * @throws PSAuthorizationException if authorization fails.
+   * @throws PSRequestValidationException if the request is invalid.
+   * @throws PSParameterMismatchException if the parameters are mismatched.
+   * @throws PSExtensionProcessingException if processing fails.
+   */
   public void preProcessRequest(Object[] params, IPSRequestContext request)
       throws PSAuthorizationException,
           PSRequestValidationException,

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/security/PSAllowOnlyTheseCharacters.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/security/PSAllowOnlyTheseCharacters.java
@@ -33,8 +33,16 @@ import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+/**
+ * Validates that the supplied input matches a configured set of allowed characters.
+ *
+ * @author natechadwick
+ */
 public class PSAllowOnlyTheseCharacters
     implements IPSResultDocumentProcessor, IPSAllowOnlyItemInputValidator {
+
+  /** Creates a new PSAllowOnlyTheseCharacters. */
+  public PSAllowOnlyTheseCharacters() {}
 
   private String ms_fullExtensionName;
 
@@ -53,6 +61,16 @@ public class PSAllowOnlyTheseCharacters
     return ret;
   }
 
+  /**
+   * Validates character parameters from the request.
+   *
+   * @param params the extension parameters.
+   * @param request the request context.
+   * @throws PSAuthorizationException if authorization fails.
+   * @throws PSRequestValidationException if the request is invalid.
+   * @throws PSParameterMismatchException if the parameters are mismatched.
+   * @throws PSExtensionProcessingException if processing fails.
+   */
   public void preProcessRequest(Object[] params, IPSRequestContext request)
       throws PSAuthorizationException,
           PSRequestValidationException,

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSFormDecode.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSFormDecode.java
@@ -33,6 +33,9 @@ import java.io.File;
  * @author erikserating
  */
 public class PSFormDecode implements IPSFieldInputTransformer {
+  /** Creates a new PSFormDecode. */
+  public PSFormDecode() {}
+
   /* (non-Javadoc)
    * @see com.percussion.extension.IPSUdfProcessor#
    * processUdf(java.lang.Object[], com.percussion.server.IPSRequestContext)

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSFormEncode.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSFormEncode.java
@@ -38,6 +38,8 @@ import org.apache.commons.lang3.StringUtils;
  * @author erikserating
  */
 public class PSFormEncode implements IPSFieldInputTransformer {
+  /** Creates a new PSFormEncode. */
+  public PSFormEncode() {}
 
   /* (non-Javadoc)
    * @see com.percussion.extension.IPSUdfProcessor#

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSFormEncodeDecodeHelper.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSFormEncodeDecodeHelper.java
@@ -39,6 +39,8 @@ import org.apache.logging.log4j.Logger;
  * @author erikserating
  */
 public class PSFormEncodeDecodeHelper {
+  /** Creates a new PSFormEncodeDecodeHelper. */
+  public PSFormEncodeDecodeHelper() {}
 
   private static final Logger log = LogManager.getLogger(PSFormEncodeDecodeHelper.class);
 
@@ -193,7 +195,11 @@ public class PSFormEncodeDecodeHelper {
     return buff.toString();
   }
 
-  // Main for testing
+  /**
+   * Main for testing.
+   *
+   * @param args the command line arguments.
+   */
   public static void main(String[] args) {
     String encoded = encode(ms_test_string);
     String decoded = decode(encoded);
@@ -228,7 +234,7 @@ public class PSFormEncodeDecodeHelper {
    */
   private static final int MAX_COMMENT_INPUT_LENGTH = 64 * 1024;
 
-  // Test string
+  /** Test string used by main for manual testing. */
   public static final String ms_test_string =
       "<body>\n"
           + "<form action=\"test.jsp\" method=\"post\">\n"

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSFormatDate.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSFormatDate.java
@@ -52,6 +52,9 @@ import java.text.ParseException;
  * @author dougrand
  */
 public class PSFormatDate implements IPSFieldOutputTransformer {
+  /** Creates a new PSFormatDate. */
+  public PSFormatDate() {}
+
   public Object processUdf(Object[] params, @SuppressWarnings("unused") IPSRequestContext request)
       throws PSConversionException {
     PSExtensionParams ep = new PSExtensionParams(params);

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSJexlInputTranslation.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSJexlInputTranslation.java
@@ -51,6 +51,8 @@ import java.io.File;
  * @author dougrand
  */
 public class PSJexlInputTranslation implements IPSFieldInputTransformer {
+  /** Creates a new PSJexlInputTranslation. */
+  public PSJexlInputTranslation() {}
 
   public Object processUdf(Object[] params, IPSRequestContext request)
       throws PSConversionException {

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSMapInputValue.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSMapInputValue.java
@@ -53,6 +53,8 @@ import java.net.URLDecoder;
  * @author dougrand
  */
 public class PSMapInputValue implements IPSFieldInputTransformer {
+  /** Creates a new PSMapInputValue. */
+  public PSMapInputValue() {}
 
   public Object processUdf(Object[] params, IPSRequestContext request)
       throws PSConversionException {

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSMapOutputValue.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSMapOutputValue.java
@@ -53,6 +53,8 @@ import java.net.URLDecoder;
  * @author dougrand
  */
 public class PSMapOutputValue implements IPSFieldOutputTransformer {
+  /** Creates a new PSMapOutputValue. */
+  public PSMapOutputValue() {}
 
   public Object processUdf(Object[] params, IPSRequestContext request)
       throws PSConversionException {

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSNormalizeDate.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSNormalizeDate.java
@@ -54,6 +54,9 @@ import java.text.ParseException;
  * @author dougrand
  */
 public class PSNormalizeDate implements IPSFieldInputTransformer {
+  /** Creates a new PSNormalizeDate. */
+  public PSNormalizeDate() {}
+
   public Object processUdf(Object[] params, @SuppressWarnings("unused") IPSRequestContext request)
       throws PSConversionException {
     PSExtensionParams ep = new PSExtensionParams(params);

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSTrimStringValue.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSTrimStringValue.java
@@ -50,6 +50,8 @@ import org.apache.commons.lang3.StringUtils;
  * @author dougrand
  */
 public class PSTrimStringValue implements IPSFieldInputTransformer {
+  /** Creates a new PSTrimStringValue. */
+  public PSTrimStringValue() {}
 
   public Object processUdf(Object[] params, @SuppressWarnings("unused") IPSRequestContext request)
       throws PSConversionException {

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/usersearch/PSServerUserSearch.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/usersearch/PSServerUserSearch.java
@@ -62,6 +62,9 @@ import org.w3c.dom.NodeList;
  * <p>The element root indicates any Document Element of the result document.
  */
 public class PSServerUserSearch implements IPSResultDocumentProcessor {
+  /** Creates a new PSServerUserSearch. */
+  public PSServerUserSearch() {}
+
   /*
    * Implementation of the method defined by the interface
    */

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/utils/PSExtensionParamsHelper.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/utils/PSExtensionParamsHelper.java
@@ -95,7 +95,7 @@ public class PSExtensionParamsHelper {
    *
    * @param args slot finders args from slotfinder.getFinderArguments()
    * @param selectors The selectors that are passed with the find method.
-   * @param log
+   * @param log the logger to use.
    */
   public PSExtensionParamsHelper(
       Map<String, ? extends Object> args, Map<String, Object> selectors, Logger log) {
@@ -118,7 +118,7 @@ public class PSExtensionParamsHelper {
    * Gets a parameter by first trying to get it from the request then followed by the parameters
    * passed to the extension.
    *
-   * @param paramName
+   * @param paramName the name of the parameter to look up.
    * @return The value of the parameter, or null if the parameter is not found.
    */
   public String getParameter(String paramName) {
@@ -181,10 +181,22 @@ public class PSExtensionParamsHelper {
     return null;
   }
 
+  /**
+   * Gets the required parameter as a Number.
+   *
+   * @param paramName the name of the parameter to look up.
+   * @return the parameter value as a Number.
+   */
   public Number getRequiredParameterAsNumber(String paramName) {
     return paramToNumber(paramName, getRequiredParameter(paramName));
   }
 
+  /**
+   * Gets the required parameter as a Boolean.
+   *
+   * @param paramName the name of the parameter to look up.
+   * @return the parameter value as a Boolean.
+   */
   public Boolean getRequiredParameterAsBoolean(String paramName) {
     return paramToBoolean(paramName, getRequiredParameter(paramName));
   }
@@ -194,7 +206,7 @@ public class PSExtensionParamsHelper {
    *
    * @param paramName Name of the parameter.
    * @return value of the parameter never null or empty.
-   * @throws IllegalArgumentException
+   * @throws IllegalArgumentException if the parameter is missing or empty.
    */
   public String getRequiredParameter(String paramName) {
     String value = getParameter(paramName);
@@ -206,10 +218,24 @@ public class PSExtensionParamsHelper {
     return value;
   }
 
+  /**
+   * Gets the optional parameter as a Number.
+   *
+   * @param paramName the name of the parameter to look up.
+   * @param defaultValue the default value if the parameter is not found.
+   * @return the parameter value as a Number, or the default if not found.
+   */
   public Number getOptionalParameterAsNumber(String paramName, String defaultValue) {
     return paramToNumber(paramName, getOptionalParameter(paramName, defaultValue));
   }
 
+  /**
+   * Gets the optional parameter as a Boolean.
+   *
+   * @param paramName the name of the parameter to look up.
+   * @param defaultValue the default value if the parameter is not found.
+   * @return the parameter value as a Boolean, or the default if not found.
+   */
   public Boolean getOptionalParameterAsBoolean(String paramName, Boolean defaultValue) {
     String b = (defaultValue.booleanValue()) ? "true" : "false";
     return paramToBoolean(paramName, getOptionalParameter(paramName, b));
@@ -231,12 +257,25 @@ public class PSExtensionParamsHelper {
     return value;
   }
 
+  /**
+   * Throws an IllegalArgumentException for the given parameter.
+   *
+   * @param paramName the name of the parameter that is invalid.
+   * @param reason the reason the parameter is invalid.
+   */
   public void errorOnParameter(String paramName, String reason) {
     String error = "Parameter: " + paramName + " is invalid." + " Reason: " + reason;
     log.error(error);
     throw new IllegalArgumentException(error);
   }
 
+  /**
+   * Converts a parameter value to a Number.
+   *
+   * @param paramName the name of the parameter being converted.
+   * @param param the parameter value to convert.
+   * @return the converted Number value.
+   */
   public Number paramToNumber(String paramName, String param) {
     try {
       return NumberUtils.createNumber(param);
@@ -247,6 +286,13 @@ public class PSExtensionParamsHelper {
     }
   }
 
+  /**
+   * Converts a parameter value to a Boolean.
+   *
+   * @param paramName the name of the parameter being converted.
+   * @param param the parameter value to convert.
+   * @return the converted Boolean value.
+   */
   public Boolean paramToBoolean(String paramName, String param) {
     Converter cvt = new BooleanConverter();
     try {
@@ -270,10 +316,16 @@ public class PSExtensionParamsHelper {
     return this.extensionParameters;
   }
 
+  /**
+   * Sets the logger for this helper.
+   *
+   * @param log the logger to use.
+   */
   protected void doLog(Logger log) {
     this.log = log;
   }
 
+  /** Populates the extension parameters map from the extension definition. */
   protected void doParameters() {
     extensionParameters = new HashMap<>();
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/utils/PSTidyUtils.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/utils/PSTidyUtils.java
@@ -37,6 +37,9 @@ import org.w3c.dom.Document;
  * @author yubingchen
  */
 public class PSTidyUtils {
+  /** Creates a new PSTidyUtils. */
+  public PSTidyUtils() {}
+
   /** The logger for this class. */
   private static final Logger ms_logger = LogManager.getLogger("PSHtmlUtils");
 
@@ -57,6 +60,11 @@ public class PSTidyUtils {
     return PSXmlDocumentBuilder.toString(doc);
   }
 
+  /**
+   * Sets the tidy properties used by this utility.
+   *
+   * @param props the tidy properties to set, must not be null.
+   */
   public static void setTidyProperties(Properties props) {
     notNull(props);
     m_tidyProperties = props;

--- a/modules/extensions-main/src/main/java/com/percussion/filter/DefaultPasswordFilter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/filter/DefaultPasswordFilter.java
@@ -30,9 +30,17 @@ import org.apache.logging.log4j.Logger;
  * security providers.
  */
 public class DefaultPasswordFilter implements IPSPasswordFilter {
+  /** Creates a new DefaultPasswordFilter. */
+  public DefaultPasswordFilter() {}
+
+  /** The logger for this class. */
   public static final Logger log = LogManager.getLogger(DefaultPasswordFilter.class);
 
-  /* Main method used to test or encrypt from command line */
+  /**
+   * Main method used to test or encrypt from command line.
+   *
+   * @param args the command line arguments.
+   */
   public static void main(String[] args) {
     DefaultPasswordFilter filter = new DefaultPasswordFilter();
 

--- a/modules/extensions-main/src/main/java/com/percussion/relationship/PSTranslationConstraint.java
+++ b/modules/extensions-main/src/main/java/com/percussion/relationship/PSTranslationConstraint.java
@@ -40,6 +40,8 @@ import org.apache.logging.log4j.Logger;
  * created.
  */
 public class PSTranslationConstraint extends PSDefaultExtension implements IPSRequestPreProcessor {
+  /** Creates a new PSTranslationConstraint. */
+  public PSTranslationConstraint() {}
 
   private static final Logger log = LogManager.getLogger(PSTranslationConstraint.class);
 

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSContextMenu.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSContextMenu.java
@@ -56,6 +56,9 @@ import org.w3c.dom.NodeList;
  * (Param*)&gt;
  */
 public class PSContextMenu implements IPSResultDocumentProcessor {
+  /** Creates a new PSContextMenu. */
+  public PSContextMenu() {}
+
   /*
    * Implementation of the method required by the interface IPSExtension.
    */

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGenerateContentTypeList.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGenerateContentTypeList.java
@@ -53,8 +53,12 @@ import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+/** Generates the content type list for the Content Manager UI. */
 public class PSGenerateContentTypeList extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
+  /** Creates a new PSGenerateContentTypeList. */
+  public PSGenerateContentTypeList() {}
+
   // see IPSResultDocumentProcessor#canModifyStyleSheet()
   public boolean canModifyStyleSheet() {
     return false;
@@ -312,10 +316,9 @@ public class PSGenerateContentTypeList extends PSDefaultExtension
     return retList;
   }
 
-  /*
-   * Alphabetically Sorts PSMenuAction object based on its type PSMenuAction
-   * object of type MENU are sorted first and are followed by MENUITEM type
-   * object
+  /**
+   * Alphabetically sorts PSMenuAction objects based on their type. PSMenuAction objects of type
+   * MENU are sorted first and are followed by MENUITEM type objects.
    */
   public static Comparator<PSMenuAction> actionComparator =
       new Comparator<PSMenuAction>() {
@@ -337,8 +340,10 @@ public class PSGenerateContentTypeList extends PSDefaultExtension
 
   private static final Logger log = LogManager.getLogger(PSGenerateContentTypeList.class);
 
+  /** Server property name for content type grouping in CX. */
   public static final String SERVER_PROP_GROUP_CONTENTTYPES = "contentTypeGroupingInCX";
 
+  /** Server property name to skip folders when there is only a single submenu in CX. */
   public static final String SERVER_PROP_SKIP_FOLDERS = "skipFoldersIfOnlySingleSubMenuInCX";
 
   private static String CONTENTTYPES_PATH_PREFIX = "/contentTypes/";

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGenerateVariantList.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGenerateVariantList.java
@@ -68,8 +68,12 @@ import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+/** Generates the variant list for the Content Manager UI. */
 public class PSGenerateVariantList extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
+  /** Creates a new PSGenerateVariantList. */
+  public PSGenerateVariantList() {}
+
   // see IPSResultDocumentProcessor#canModifyStyleSheet()
   public boolean canModifyStyleSheet() {
     return false;
@@ -358,8 +362,10 @@ public class PSGenerateVariantList extends PSDefaultExtension
         }
       };
 
+  /** Server property name for templates grouping in CX. */
   public static final String SERVER_PROP_GROUP_TEMPLATES = "templatesGroupingInCX";
 
+  /** Server property name to skip folders when there is only a single submenu in CX. */
   public static final String SERVER_PROP_SKIP_FOLDERS = "skipFoldersIfOnlySingleSubMenuInCX";
 
   private static String TEMPLATES_PATH_PREFIX = "/templates/";

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGetAndSetCxOptions.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGetAndSetCxOptions.java
@@ -51,6 +51,9 @@ import org.xml.sax.SAXException;
  * any problems and we won't be storing bad data.
  */
 public class PSGetAndSetCxOptions implements IPSResultDocumentProcessor, IPSRequestPreProcessor {
+  /** Creates a new PSGetAndSetCxOptions. */
+  public PSGetAndSetCxOptions() {}
+
   /**
    * @see IPSResultDocumentProcessor *
    */

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSManageActionInfo.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSManageActionInfo.java
@@ -34,7 +34,14 @@ import org.w3c.dom.Element;
  * Load and manage action information in the user session. Used by the filtering exit {@link
  * com.percussion.uicontext.PSFilterContextMenu}to obtain information about each action.
  */
+/**
+ * Load and manage action information in the user session. Used by the filtering exit {@link
+ * com.percussion.uicontext.PSFilterContextMenu}to obtain information about each action.
+ */
 public class PSManageActionInfo {
+  /** Creates a new PSManageActionInfo. */
+  public PSManageActionInfo() {}
+
   /** The component processor proxy. Initialized on demand. */
   private PSComponentProcessorProxy m_componentProcessor = null;
 

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSManageActionInfo.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSManageActionInfo.java
@@ -34,10 +34,6 @@ import org.w3c.dom.Element;
  * Load and manage action information in the user session. Used by the filtering exit {@link
  * com.percussion.uicontext.PSFilterContextMenu}to obtain information about each action.
  */
-/**
- * Load and manage action information in the user session. Used by the filtering exit {@link
- * com.percussion.uicontext.PSFilterContextMenu}to obtain information about each action.
- */
 public class PSManageActionInfo {
   /** Creates a new PSManageActionInfo. */
   public PSManageActionInfo() {}

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSTranslationKeyValueAccessor.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSTranslationKeyValueAccessor.java
@@ -45,6 +45,9 @@ import org.w3c.dom.Document;
  * processResultDocument(Object[], IPSRequestContext, Document)}
  */
 public class PSTranslationKeyValueAccessor implements IPSResultDocumentProcessor {
+  /** Creates a new PSTranslationKeyValueAccessor. */
+  public PSTranslationKeyValueAccessor() {}
+
   /**
    * @see IPSResultDocumentProcessor *
    */

--- a/modules/extensions-main/src/main/java/com/percussion/validate/PSRangeValidator.java
+++ b/modules/extensions-main/src/main/java/com/percussion/validate/PSRangeValidator.java
@@ -23,7 +23,14 @@ import com.percussion.extension.IPSFieldValidator;
  *
  * @author dougrand
  */
+/**
+ * Abstract base class used to write range validators.
+ *
+ * @author dougrand
+ */
 public abstract class PSRangeValidator implements IPSFieldValidator {
+  /** Creates a new PSRangeValidator. */
+  public PSRangeValidator() {}
 
   /**
    * Check the value against the range.

--- a/modules/extensions-main/src/main/java/com/percussion/validate/PSRangeValidator.java
+++ b/modules/extensions-main/src/main/java/com/percussion/validate/PSRangeValidator.java
@@ -23,11 +23,6 @@ import com.percussion.extension.IPSFieldValidator;
  *
  * @author dougrand
  */
-/**
- * Abstract base class used to write range validators.
- *
- * @author dougrand
- */
 public abstract class PSRangeValidator implements IPSFieldValidator {
   /** Creates a new PSRangeValidator. */
   public PSRangeValidator() {}

--- a/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateDate.java
+++ b/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateDate.java
@@ -69,6 +69,8 @@ import java.util.Date;
  * @author dougrand
  */
 public class PSValidateDate extends PSRangeValidator {
+  /** Creates a new PSValidateDate. */
+  public PSValidateDate() {}
 
   public Object processUdf(Object[] params, IPSRequestContext request)
       throws PSConversionException {

--- a/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateJexlExpression.java
+++ b/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateJexlExpression.java
@@ -51,6 +51,8 @@ import java.io.File;
  * @author dougrand
  */
 public class PSValidateJexlExpression implements IPSFieldValidator {
+  /** Creates a new PSValidateJexlExpression. */
+  public PSValidateJexlExpression() {}
 
   /**
    * (non-Javadoc)

--- a/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateNumber.java
+++ b/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateNumber.java
@@ -68,6 +68,8 @@ import java.io.File;
  * @author dougrand
  */
 public class PSValidateNumber extends PSRangeValidator {
+  /** Creates a new PSValidateNumber. */
+  public PSValidateNumber() {}
 
   public Object processUdf(Object[] params, IPSRequestContext request)
       throws PSConversionException {

--- a/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateRequired.java
+++ b/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateRequired.java
@@ -44,6 +44,9 @@ import org.apache.commons.lang3.StringUtils;
  * @author dougrand
  */
 public class PSValidateRequired implements IPSFieldValidator {
+  /** Creates a new PSValidateRequired. */
+  public PSValidateRequired() {}
+
   public Object processUdf(Object[] params, @SuppressWarnings("unused") IPSRequestContext request) {
     Object value;
 

--- a/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateSlotName.java
+++ b/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateSlotName.java
@@ -43,6 +43,9 @@ import org.w3c.dom.NodeList;
  * the database and has the same slotid passed in by this request.
  */
 public class PSValidateSlotName implements IPSRequestPreProcessor {
+  /** Creates a new PSValidateSlotName. */
+  public PSValidateSlotName() {}
+
   /*
    * Implementation of the method in the interface IPSRequestPreProcessor
    * Empty in this case as it is not needed

--- a/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateStringLength.java
+++ b/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateStringLength.java
@@ -54,6 +54,8 @@ import java.io.File;
  * @author dougrand
  */
 public class PSValidateStringLength extends PSRangeValidator {
+  /** Creates a new PSValidateStringLength. */
+  public PSValidateStringLength() {}
 
   public Object processUdf(Object[] params, IPSRequestContext request)
       throws PSConversionException {

--- a/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateStringPattern.java
+++ b/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateStringPattern.java
@@ -25,7 +25,10 @@ import com.percussion.server.IPSRequestContext;
 import java.io.File;
 import java.util.regex.Pattern;
 
+/** Validates a string value against a regular expression pattern. */
 public class PSValidateStringPattern implements IPSFieldValidator {
+  /** Creates a new PSValidateStringPattern. */
+  public PSValidateStringPattern() {}
 
   public Object processUdf(Object[] params, IPSRequestContext request)
       throws PSConversionException {

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSNodePrinter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSNodePrinter.java
@@ -35,7 +35,7 @@ public class PSNodePrinter extends com.percussion.xml.PSNodePrinter {
    * Only constructor. Takes the print writer as the argument.
    *
    * @param out must not be <code>null</code>.
-   * @throws IllegalArgumentException
+   * @throws IllegalArgumentException if the writer is null.
    */
   public PSNodePrinter(Writer out) {
     super(out);

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSSaxErrorHandler.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSSaxErrorHandler.java
@@ -51,20 +51,40 @@ public class PSSaxErrorHandler implements ErrorHandler {
     m_printWriter = pw;
   }
 
+  /**
+   * Sets whether fatal errors should be thrown.
+   *
+   * @param shouldThrow whether fatal errors should be thrown.
+   */
   public void throwOnFatalErrors(boolean shouldThrow) {
 
     m_throwFatalErrors = shouldThrow;
   }
 
+  /**
+   * Sets whether errors should be thrown.
+   *
+   * @param shouldThrow whether errors should be thrown.
+   */
   public void throwOnErrors(boolean shouldThrow) {
     m_throwErrors = shouldThrow;
   }
 
+  /**
+   * Sets whether warnings should be thrown.
+   *
+   * @param shouldThrow whether warnings should be thrown.
+   */
   public void throwOnWarnings(boolean shouldThrow) {
     m_throwWarnings = shouldThrow;
   }
 
-  // report an error
+  /**
+   * Reports a SAX parse error.
+   *
+   * @param exception the parse exception.
+   * @throws SAXException if configured to throw.
+   */
   public void error(SAXParseException exception) throws SAXException {
     if (m_printWriter != null) {
       m_printWriter.println("Parser Error: " + exception.toString());
@@ -75,7 +95,12 @@ public class PSSaxErrorHandler implements ErrorHandler {
     if (m_throwErrors) throw exception;
   }
 
-  // report a fatal error
+  /**
+   * Reports a SAX parse fatal error.
+   *
+   * @param exception the parse exception.
+   * @throws SAXException if configured to throw.
+   */
   public void fatalError(SAXParseException exception) throws SAXException {
     if (m_printWriter != null) {
       m_printWriter.println("Parser Fatal Error: " + exception.toString());
@@ -85,7 +110,12 @@ public class PSSaxErrorHandler implements ErrorHandler {
     if (m_throwFatalErrors) throw exception;
   }
 
-  // report a warning
+  /**
+   * Reports a SAX parse warning.
+   *
+   * @param exception the parse exception.
+   * @throws SAXException if configured to throw.
+   */
   public void warning(SAXParseException exception) throws SAXException {
     if (m_printWriter != null) {
       m_printWriter.println("Parser Warning: " + exception.toString());
@@ -95,26 +125,56 @@ public class PSSaxErrorHandler implements ErrorHandler {
     if (m_throwWarnings) throw exception;
   }
 
+  /**
+   * Gets the number of errors recorded.
+   *
+   * @return the number of errors.
+   */
   public int numErrors() {
     return m_errors.size();
   }
 
+  /**
+   * Gets the number of fatal errors recorded.
+   *
+   * @return the number of fatal errors.
+   */
   public int numFatalErrors() {
     return m_fatalErrors.size();
   }
 
+  /**
+   * Gets the number of warnings recorded.
+   *
+   * @return the number of warnings.
+   */
   public int numWarnings() {
     return m_warnings.size();
   }
 
+  /**
+   * Gets an iterator over the recorded errors.
+   *
+   * @return the errors iterator.
+   */
   public Iterator errors() {
     return m_errors.iterator();
   }
 
+  /**
+   * Gets an iterator over the recorded fatal errors.
+   *
+   * @return the fatal errors iterator.
+   */
   public Iterator fatalErrors() {
     return m_fatalErrors.iterator();
   }
 
+  /**
+   * Gets an iterator over the recorded warnings.
+   *
+   * @return the warnings iterator.
+   */
   public Iterator warnings() {
     return m_warnings.iterator();
   }

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdCopyDom.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdCopyDom.java
@@ -64,6 +64,9 @@ import org.w3c.dom.Node;
  * document element (sometimes called root element) of the XML result document.
  */
 public class PSXdCopyDom extends PSDefaultExtension implements IPSResultDocumentProcessor {
+  /** Creates a new PSXdCopyDom. */
+  public PSXdCopyDom() {}
+
   /**
    * Copy a subtree of the source XML document into the result document.
    *

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdDomToFile.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdDomToFile.java
@@ -76,6 +76,8 @@ import org.w3c.dom.Document;
  * <p>The output for a pre-exit is always stored in an HTML parameter as a File.
  */
 public class PSXdDomToFile extends PSDefaultExtension implements IPSRequestPreProcessor {
+  /** Creates a new PSXdDomToFile. */
+  public PSXdDomToFile() {}
 
   /**
    * This method handles the pre-exit request.

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdDomToParams.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdDomToParams.java
@@ -46,8 +46,6 @@ import org.w3c.dom.Node;
  * parameters that are already there if appendParameter flag is not set or is "no". If flag is set
  * to "yes" then the new values will be appended to the existing parameters.
  *
- * <p>
- *
  * <p>The parameters for this exit are:
  *
  * <table border="1">
@@ -73,6 +71,9 @@ import org.w3c.dom.Node;
  * </table>
  */
 public class PSXdDomToParams extends PSDefaultExtension implements IPSRequestPreProcessor {
+  /** Creates a new PSXdDomToParams. */
+  public PSXdDomToParams() {}
+
   /**
    * This method handles the pre-exit request.
    *

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdDomToText.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdDomToText.java
@@ -71,11 +71,11 @@ import org.w3c.dom.Document;
  * <p>When called as a post-exit, the output is a node in the XML result document The special node
  * name "." (period) will cause the new document fragment to be copied directly underneath the
  * <code>&lt;root&gt;</code> element.
- *
- * <p>
  */
 public class PSXdDomToText extends PSDefaultExtension
     implements IPSRequestPreProcessor, IPSResultDocumentProcessor {
+  /** Creates a new PSXdDomToText. */
+  public PSXdDomToText() {}
 
   /**
    * This method handles the pre-exit request.

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdFileToTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdFileToTree.java
@@ -33,8 +33,6 @@ import org.w3c.dom.Node;
  * A Rhythmyx post-exit to load an XML document from the file system and add it to the result
  * document
  *
- * <p>
- *
  * <table border="1">
  *   <caption style="display:none">Parameters</caption>
  *   <tr><th>Param #</th><th>Name</th><th>Description</th><th>Default</th><tr>
@@ -55,6 +53,9 @@ import org.w3c.dom.Node;
  * </table>
  */
 public class PSXdFileToTree extends PSDefaultExtension implements IPSResultDocumentProcessor {
+  /** Creates a new PSXdFileToTree. */
+  public PSXdFileToTree() {}
+
   /**
    * This method handles the post-exit request by loading the specified file, parsing it into a
    * Document, and appending it to the parentNode in the result document.

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdMoveInputDocument.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdMoveInputDocument.java
@@ -39,6 +39,8 @@ import org.w3c.dom.Document;
  * <p>This exit has one one parameter: the Name of the HTML parameter to create.
  */
 public class PSXdMoveInputDocument extends PSDefaultExtension implements IPSRequestPreProcessor {
+  /** Creates a new PSXdMoveInputDocument. */
+  public PSXdMoveInputDocument() {}
 
   /**
    * This method handles the pre-exit request.

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdMultiTextToTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdMultiTextToTree.java
@@ -31,6 +31,9 @@ import org.w3c.dom.NodeList;
  * multiple fields with the same name.
  */
 public class PSXdMultiTextToTree extends PSXdTextToTree implements IPSResultDocumentProcessor {
+  /** Creates a new PSXdMultiTextToTree. */
+  public PSXdMultiTextToTree() {}
+
   /**
    * Returns a list which contains all the elements from the specified document <code>resultDoc
    * </code> with the specified tag name <code>textSourceName</code>

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdProcessRelatedLinks.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdProcessRelatedLinks.java
@@ -46,6 +46,8 @@ import org.w3c.dom.NodeList;
  * <p>There is only one parameter: the name of the XMLDOM private object to be scanned.
  */
 public class PSXdProcessRelatedLinks extends PSDefaultExtension implements IPSRequestPreProcessor {
+  /** Creates a new PSXdProcessRelatedLinks. */
+  public PSXdProcessRelatedLinks() {}
 
   public void preProcessRequest(Object[] params, IPSRequestContext request)
       throws PSAuthorizationException,

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdRemoveElements.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdRemoveElements.java
@@ -39,6 +39,8 @@ import org.w3c.dom.Node;
  * </code>. The root element name is never included in the path name.
  */
 public class PSXdRemoveElements extends PSDefaultExtension implements IPSResultDocumentProcessor {
+  /** Creates a new PSXdRemoveElements. */
+  public PSXdRemoveElements() {}
 
   /**
    * This method handles the post-exit request.

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdTextCleanup.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdTextCleanup.java
@@ -132,10 +132,11 @@ import org.jsoup.select.Elements;
  *
  * <p>Rhythmyx provides default files for JSoup (html-cleaner.properties) and ServerPageTags
  * (rxW2KServerPageTags.xml).
- *
- * <p>
  */
 public class PSXdTextCleanup extends PSDefaultExtension implements IPSRequestPreProcessor {
+  /** Creates a new PSXdTextCleanup. */
+  public PSXdTextCleanup() {}
+
   private static final Logger log = LogManager.getLogger(IPSConstants.EXTENSIONS_LOG);
 
   /**

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdTextToDom.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdTextToDom.java
@@ -109,6 +109,8 @@ import org.w3c.dom.Document;
  */
 public class PSXdTextToDom extends PSDefaultExtension
     implements IPSRequestPreProcessor, IPSResultDocumentProcessor {
+  /** Creates a new PSXdTextToDom. */
+  public PSXdTextToDom() {}
 
   /**
    * This method handles the pre-exit request.

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdTextToTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdTextToTree.java
@@ -36,6 +36,9 @@ import org.xml.sax.SAXParseException;
  * Document.
  */
 public class PSXdTextToTree extends PSDefaultExtension implements IPSResultDocumentProcessor {
+  /** Creates a new PSXdTextToTree. */
+  public PSXdTextToTree() {}
+
   /**
    * This method handles the post-exit request.
    *

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdTransformDom.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdTransformDom.java
@@ -109,6 +109,8 @@ import org.xml.sax.SAXException;
  */
 public class PSXdTransformDom extends PSDefaultExtension
     implements IPSRequestPreProcessor, IPSResultDocumentProcessor {
+  /** Creates a new PSXdTransformDom. */
+  public PSXdTransformDom() {}
 
   /**
    * This method handles the pre-exit request.

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdTransformDomToText.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdTransformDomToText.java
@@ -109,6 +109,8 @@ import org.xml.sax.SAXException;
  */
 public class PSXdTransformDomToText extends PSDefaultExtension
     implements IPSRequestPreProcessor, IPSResultDocumentProcessor {
+  /** Creates a new PSXdTransformDomToText. */
+  public PSXdTransformDomToText() {}
 
   /**
    * This method handles the pre-exit request.

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXmlDocumentBuilder.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXmlDocumentBuilder.java
@@ -20,4 +20,7 @@ package com.percussion.xmldom;
 /**
  * @deprecated Use com.percussion.xml.PSXmlDocumentBuilder instead
  */
-public class PSXmlDocumentBuilder extends com.percussion.xml.PSXmlDocumentBuilder {}
+public class PSXmlDocumentBuilder extends com.percussion.xml.PSXmlDocumentBuilder {
+  /** Creates a new PSXmlDocumentBuilder. */
+  public PSXmlDocumentBuilder() {}
+}

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXmlDomContext.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXmlDomContext.java
@@ -67,6 +67,8 @@ public class PSXmlDomContext {
   /**
    * create a context where an IPSRequestContext is not available. This is primarily used when
    * debugging.
+   *
+   * @param functionName the name of the function being processed.
    */
   public PSXmlDomContext(String functionName) {
     m_function = functionName;
@@ -76,6 +78,9 @@ public class PSXmlDomContext {
   /**
    * create a context for the extension. The context should be a be a member variable of the Process
    * method in each extension.
+   *
+   * @param functionName the name of the function being processed.
+   * @param req the request context.
    */
   public PSXmlDomContext(String functionName, IPSRequestContext req) {
     m_req = req;
@@ -103,7 +108,11 @@ public class PSXmlDomContext {
     m_rxCommentHandling = value;
   }
 
-  /** Allows support routines to print trace messages without knowing about the IPSRequestContext */
+  /**
+   * Allows support routines to print trace messages without knowing about the IPSRequestContext.
+   *
+   * @param msg the trace message to print.
+   */
   public void printTraceMessage(String msg) {
     if (!m_logging) return;
 
@@ -121,17 +130,30 @@ public class PSXmlDomContext {
     else return "127.0.0.1:" + m_req.getServerListenerPort() + PSServer.getRequestRoot();
   }
 
-  /** get the tidy properties for this operation context */
+  /**
+   * Gets the tidy properties for this operation context.
+   *
+   * @return the tidy properties.
+   */
   public Properties getTidyProperties() {
     return m_tidyProperties;
   }
 
-  /** set the tidy properties for this operation context */
+  /**
+   * Sets the tidy properties for this operation context.
+   *
+   * @param props the tidy properties to set.
+   */
   public void setTidyProperties(Properties props) {
     m_tidyProperties = props;
   }
 
-  /** set the tidy properties from a file */
+  /**
+   * Sets the tidy properties from a file.
+   *
+   * @param FileName the name of the file to load the tidy properties from.
+   * @throws IOException if the file cannot be read.
+   */
   public void setTidyProperties(String FileName) throws IOException {
     IPSRhythmyxInfo rxInfo = PSRhythmyxInfoLocator.getRhythmyxInfo();
     String rxRootDir = (String) rxInfo.getProperty(IPSRhythmyxInfo.Key.ROOT_DIRECTORY);
@@ -140,7 +162,11 @@ public class PSXmlDomContext {
     }
   }
 
-  /** determine if Tidy processing is enabled for this context */
+  /**
+   * Determine if Tidy processing is enabled for this context.
+   *
+   * @return <code>true</code> if tidy processing is enabled, <code>false</code> otherwise.
+   */
   public boolean isTidyEnabled() {
     return (null != m_tidyProperties && !m_tidyProperties.isEmpty());
   }
@@ -193,12 +219,18 @@ public class PSXmlDomContext {
     return m_logging;
   }
 
-  /** Sets the Validate flag. If this flag is <code>true</code>, use the validating parser. */
+  /**
+   * Sets the Validate flag. If this flag is <code>true</code>, use the validating parser.
+   *
+   * @param validate whether to use the validating parser.
+   */
   public void setValidate(boolean validate) {
     m_validate = validate;
   }
 
   /**
+   * Determines whether the validating parser should be used.
+   *
    * @return <code>true</code> when the validating parser should be used; <code>false</code> when
    *     the non-validating parser should be used.
    */
@@ -208,12 +240,16 @@ public class PSXmlDomContext {
 
   /**
    * Sets the use tidy pprint flag. If this flag is <code>true</code>, use the tidy pretty print.
+   *
+   * @param pprint the pretty-print flag to set.
    */
   public void setUsePrettyPrint(boolean pprint) {
     m_pprint = pprint;
   }
 
   /**
+   * Returns the tidy pretty print flag.
+   *
    * @return tidy pretty print flag.
    */
   public boolean getUsePrettyPrint() {

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXmlDomUtils.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXmlDomUtils.java
@@ -66,7 +66,9 @@ public class PSXmlDomUtils {
    * @param cx the PSXmlDomContext for this request.
    * @param incomingFile The file which contains the XML/HTML document.
    * @return the parsed Document as an XML tree; may be <code>null</code> or empty.
-   * @throws IOException
+   * @throws IOException if an I/O error occurs.
+   * @throws PSExtensionProcessingException if an extension processing error occurs.
+   * @throws SAXException if a parse error occurs.
    */
   public static Document loadXmlDocument(PSXmlDomContext cx, File incomingFile)
       throws IOException, PSExtensionProcessingException, SAXException {
@@ -84,6 +86,9 @@ public class PSXmlDomUtils {
    * @param incomingFile The file which contains the XML/HTML document.
    * @param encoding the character encoding to use
    * @return the parsed Document as an XML tree.
+   * @throws IOException if an I/O error occurs.
+   * @throws PSExtensionProcessingException if an extension processing error occurs.
+   * @throws SAXException if a parse error occurs.
    */
   public static Document loadXmlDocument(PSXmlDomContext cx, File incomingFile, String encoding)
       throws IOException, PSExtensionProcessingException, SAXException {
@@ -339,9 +344,9 @@ public class PSXmlDomUtils {
    *
    * @param inFile The incoming file
    * @param encoding The standard Java name for the file's encoding method
-   * @throws FileNotFoundException
-   * @throws UnsupportedEncodingException
-   * @throws java.io.IOException
+   * @throws FileNotFoundException if the file does not exist.
+   * @throws UnsupportedEncodingException if the encoding is not supported.
+   * @throws java.io.IOException if an I/O error occurs.
    * @return The file as a <code>String</code>, never <code>null</code>
    */
   protected static String readInFile(File inFile, String encoding) throws IOException {
@@ -366,9 +371,9 @@ public class PSXmlDomUtils {
    * Read a file into a <code>String</code>, in chunks, using the default encoding.
    *
    * @param inFile the incoming file
-   * @throws FileNotFoundException
-   * @throws UnsupportedEncodingException
-   * @throws java.io.IOException
+   * @throws FileNotFoundException if the file does not exist.
+   * @throws UnsupportedEncodingException if the encoding is not supported.
+   * @throws java.io.IOException if an I/O error occurs.
    * @return The file as a <code>String</code>, never <code>null</code>
    */
   protected static String readInFile(File inFile) throws IOException {

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXmlTreeWalker.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXmlTreeWalker.java
@@ -29,11 +29,6 @@ import org.w3c.dom.Node;
  *
  * @deprecated Use com.percussion.xml.PSXmlTreeWalker instead
  */
-/**
- * Deprecated wrapper around {@link com.percussion.xml.PSXmlTreeWalker}.
- *
- * @deprecated Use com.percussion.xml.PSXmlTreeWalker instead
- */
 public class PSXmlTreeWalker extends com.percussion.xml.PSXmlTreeWalker implements Serializable {
   /**
    * Constructs a new tree walker for the supplied document.

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXmlTreeWalker.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXmlTreeWalker.java
@@ -29,8 +29,16 @@ import org.w3c.dom.Node;
  *
  * @deprecated Use com.percussion.xml.PSXmlTreeWalker instead
  */
+/**
+ * Deprecated wrapper around {@link com.percussion.xml.PSXmlTreeWalker}.
+ *
+ * @deprecated Use com.percussion.xml.PSXmlTreeWalker instead
+ */
 public class PSXmlTreeWalker extends com.percussion.xml.PSXmlTreeWalker implements Serializable {
   /**
+   * Constructs a new tree walker for the supplied document.
+   *
+   * @param doc the document to walk.
    * @see com.percussion.xml.PSXmlTreeWalker#PSXmlTreeWalker(Document)
    */
   public PSXmlTreeWalker(Document doc) {
@@ -38,6 +46,9 @@ public class PSXmlTreeWalker extends com.percussion.xml.PSXmlTreeWalker implemen
   }
 
   /**
+   * Constructs a new tree walker for the supplied root element.
+   *
+   * @param root the root element to walk.
    * @see com.percussion.xml.PSXmlTreeWalker#PSXmlTreeWalker(Element)
    */
   public PSXmlTreeWalker(Element root) {
@@ -45,6 +56,9 @@ public class PSXmlTreeWalker extends com.percussion.xml.PSXmlTreeWalker implemen
   }
 
   /**
+   * Constructs a new tree walker for the supplied root node.
+   *
+   * @param root the root node to walk.
    * @see com.percussion.xml.PSXmlTreeWalker#PSXmlTreeWalker(Node)
    */
   public PSXmlTreeWalker(Node root) {
@@ -52,6 +66,9 @@ public class PSXmlTreeWalker extends com.percussion.xml.PSXmlTreeWalker implemen
   }
 
   /**
+   * Writes the walked tree to the supplied writer.
+   *
+   * @param out the writer to write to.
    * @see com.percussion.xml.PSXmlTreeWalker#write(Writer)
    */
   public void write(Writer out) {
@@ -59,6 +76,10 @@ public class PSXmlTreeWalker extends com.percussion.xml.PSXmlTreeWalker implemen
   }
 
   /**
+   * Writes the walked tree to the supplied writer with optional indentation.
+   *
+   * @param out the writer to write to.
+   * @param indentFlag whether to indent the output.
    * @see com.percussion.xml.PSXmlTreeWalker#write(Writer, boolean)
    */
   public void write(Writer out, boolean indentFlag) {


### PR DESCRIPTION
Fixes #1712

## Summary

The \extensions-main\ module built successfully, but \mvn clean install\ produced 100 Javadoc source warnings and 1 Javadoc error block. This PR documents every previously undocumented public/protected type, constructor, method, field, and constant in the module so the Javadoc generation phase now reports **0 warnings and 0 errors**.

## Validation

\\\ash
cd modules/extensions-main
../mvnw clean install
\\\

- **BUILD SUCCESS**
- Tests run: **46**, Failures: **0**, Errors: **0**, Skipped: **0**
- Javadoc source warnings: **0** (down from 100)
- Javadoc error blocks: **0** (down from 1)
- No new compile warnings versus baseline

## Fixes applied (categorized by kind)

- **52** \use of default constructor\ — added explicit Javadoc-commented no-arg constructors (\/** Creates a new X. */ public X() {}\) as the first member of each affected class.
- **30** \
o comment\ — added 1-line \/** The <Name>. */\ Javadoc blocks to undocumented public methods, fields, and inner enums.
- **8** \empty <p> tag\ — removed empty \<p></p>\ / \<p/>\ lines from class-level Javadoc.
- **3** \
o main description\ — added a one-line description to class-level Javadoc blocks that had only \/** ... */\ tags.
- **2** \
o description for @param\ — appended \	he X.\ to bare \@param\ lines.
- **2** \
o description for @throws\ — appended \if an error occurs.\ to bare \@throws\ lines.
- **2** \
o @param for args\ — added missing \@param args\ tag.
- **1** \
o @return\ — added missing \@return\ tag.

After the first round of fixes cleared the original 100 warnings, the Maven javadoc plugin's 100-warning cap revealed additional warnings in the same module; the same kinds of fixes were applied iteratively until the module produced zero Javadoc warnings.

## Files

- **193 files modified**, all under \modules/extensions-main/src/main/java/\.
- 1009 insertions, 103 deletions.

## Pre-PR Spotless

\mvn spotless:apply\ then \mvn spotless:check\ both exited 0. Spotless also rewrote a number of files **outside the scope of this issue** (DTS services, WebUI tests, perc-toolkit, sitemanage, etc.). Those changes are intentionally left **uncommitted on this branch** so the feature PR contains only in-scope Javadoc fixes; they belong on a separate \chore: Spotless cleanup\ PR.

## Out of scope

Out-of-scope Spotless hits are intentionally left as uncommitted working-tree changes on this branch.

> Co-Authored by Kilo MiniMax-M3 using minimax-coding-plan/MiniMax-M3 with agent implementer.