### PR TITLE
fix(server): update third-party copyright disclaimer and add About screen (issue #1529)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,17 +1,20 @@
 Percussion CMS
 Copyright 1999-2026 Percussion Software, Inc.
 
-This product includes software developed by the Apache Software Foundation (http://www.apache.org/).
-Copyright (c) 2004 The Apache Software Foundation. All rights reserved.
+This product includes software developed by The Apache Software Foundation (https://www.apache.org/),
+including Apache Commons and related libraries, licensed under the Apache License, Version 2.0
+(https://www.apache.org/licenses/LICENSE-2.0).
 
-GNU Runtime Libraries are included in this product and are covered under the GNU LGPL (http://www.gnu.org/licenses/lgpl.html).
+This product includes Eclipse Jetty (https://www.eclipse.org/jetty/), Copyright the Eclipse Foundation
+and other contributors, dual-licensed under the Eclipse Public License 2.0 and the Apache License,
+Version 2.0.
 
-This product includes the jTDS driver, which is released under the terms of the GNU LGPL.
+This product includes the jTDS SQL Server and Sybase JDBC driver v1.3.1, released under the terms of
+the GNU Lesser General Public License (http://www.gnu.org/licenses/lgpl.html), and the Microsoft JDBC
+Driver for SQL Server, released under the MIT License.
 
-XStream Copyright (c) 2003-2005, Joe Walnes. All rights reserved.
-ASM Copyright (c) 2000-2005 INRIA, France Telecom All rights reserved.
-Lato font Copyright (c) 2012, Lukasz Dziedzic
-with Reserved Font Name Lato.
-This Font Software is licensed under the SIL Open Font License, Version 1.1.
-This license is copied below, and is also available with a FAQ at:
-http://scripts.sil.org/OFL
+XStream Copyright (c) 2003-2006, Joe Walnes; Copyright (c) 2006-2024, XStream Committers.
+All rights reserved. XStream is licensed under a BSD-style license (https://x-stream.github.io/license.html).
+
+ASM Copyright (c) 2000-2011, INRIA, France Telecom. All rights reserved. ASM is licensed under a
+BSD-style license (https://asm.ow2.io/license.html).

--- a/WebUI/src/main/ts/api/about/aboutApi.ts
+++ b/WebUI/src/main/ts/api/about/aboutApi.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { get } from "../client";
+import { PATHS } from "../paths";
+
+/**
+ * Server version and third-party license disclaimer (issue #1529).
+ *
+ * <p>Mirrors {@code com.percussion.rest.about.AboutDetail} - the same text the server prints to
+ * the console at startup (with the {@code [Server]} log prefix).
+ */
+export interface AboutDetail {
+  productName?: string;
+  versionString?: string;
+  copyright?: string;
+  thirdPartyCopyright?: string;
+}
+
+/** Fetches the server version and license disclaimer shown in the About dialog. */
+export async function fetchAbout(init?: {
+  signal?: AbortSignal;
+}): Promise<AboutDetail> {
+  return get<AboutDetail>(PATHS.ABOUT, undefined, init);
+}

--- a/WebUI/src/main/ts/api/client.ts
+++ b/WebUI/src/main/ts/api/client.ts
@@ -150,11 +150,13 @@ async function handleResponse<T>(response: Response): Promise<T> {
 export async function get<T>(
   url: string,
   headers?: HeadersInit,
+  init?: Omit<RequestInit, "method" | "headers" | "body">,
 ): Promise<T> {
   const response = await fetch(url, {
     method: "GET",
     headers: buildHeaders(headers),
     credentials: "same-origin",
+    ...init,
   });
   return handleResponse<T>(response);
 }

--- a/WebUI/src/main/ts/api/paths.ts
+++ b/WebUI/src/main/ts/api/paths.ts
@@ -341,6 +341,13 @@ export const PATHS = {
   get ACLS() {
     return `${SERVICES_ROOT}/acls`;
   },
+  /**
+   * Server version and third-party license disclaimer (issue #1529) - rest AboutResource.
+   * Shared source of truth with the startup console log.
+   */
+  get ABOUT() {
+    return `${SERVICES_ROOT}/about`;
+  },
 
   /** Workflow management (workflowmanagement) — Feature 993 */
   get WORKFLOWS() {

--- a/WebUI/src/main/ts/app/layout/AboutDialog.tsx
+++ b/WebUI/src/main/ts/app/layout/AboutDialog.tsx
@@ -1,0 +1,164 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { fetchAbout, type AboutDetail } from "../../api/about/aboutApi";
+import { formatApiError } from "../../api/client";
+
+interface AboutDialogProps {
+  onClose: () => void;
+}
+
+/**
+ * "About" dialog showing the server version and third-party license disclaimer (issue #1529).
+ *
+ * <p>Fetches {@code AboutDetail} from the {@code /about} REST endpoint, which is backed by the
+ * same {@code com.percussion.server.PSStringResources} bundle keys ({@code copyright}, {@code
+ * thirdPartyCopyright}) printed to the console at server startup - a single source of truth
+ * shared between the startup log and this dialog.
+ */
+export function AboutDialog({ onClose }: AboutDialogProps): React.ReactElement {
+  const [detail, setDetail] = useState<AboutDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    fetchAbout({ signal: controller.signal })
+      .then((result) => {
+        setDetail(result);
+      })
+      .catch((err: unknown) => {
+        if (!controller.signal.aborted) {
+          setError(formatApiError(err, "Failed to load About information"));
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
+  useEffect(() => {
+    closeButtonRef.current?.focus();
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="perc-about-dialog-title"
+      data-testid="perc-about-dialog-overlay"
+      onKeyDown={handleKeyDown}
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: "rgba(0, 0, 0, 0.4)",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        zIndex: 1100,
+      }}
+    >
+      <div
+        style={{
+          background: "#fff",
+          padding: "24px",
+          borderRadius: "8px",
+          width: "100%",
+          maxWidth: "560px",
+          maxHeight: "80vh",
+          overflowY: "auto",
+          boxShadow: "0 10px 25px rgba(0,0,0,0.1)",
+        }}
+        data-testid="perc-about-dialog"
+      >
+        <h3 id="perc-about-dialog-title" style={{ margin: "0 0 16px 0" }}>
+          About {detail?.productName ?? "Percussion CMS"}
+        </h3>
+
+        {loading && <p data-testid="perc-about-dialog-loading">Loading...</p>}
+
+        {error && (
+          <p style={{ color: "#d9534f" }} data-testid="perc-about-dialog-error">
+            {error}
+          </p>
+        )}
+
+        {!loading && !error && detail && (
+          <div data-testid="perc-about-dialog-content">
+            {detail.versionString && (
+              <p data-testid="perc-about-dialog-version">
+                <strong>{detail.versionString}</strong>
+              </p>
+            )}
+            {detail.copyright && (
+              <p data-testid="perc-about-dialog-copyright" style={{ whiteSpace: "pre-wrap" }}>
+                {detail.copyright}
+              </p>
+            )}
+            {detail.thirdPartyCopyright && (
+              <p
+                data-testid="perc-about-dialog-third-party"
+                style={{ fontSize: "0.85em", whiteSpace: "pre-wrap" }}
+              >
+                {detail.thirdPartyCopyright}
+              </p>
+            )}
+          </div>
+        )}
+
+        <div style={{ display: "flex", justifyContent: "flex-end", marginTop: "24px" }}>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            onClick={onClose}
+            style={{
+              padding: "8px 16px",
+              borderRadius: "4px",
+              border: "1px solid #cbd5e1",
+              cursor: "pointer",
+            }}
+            data-testid="perc-about-dialog-close"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/app/layout/AppLayout.tsx
+++ b/WebUI/src/main/ts/app/layout/AppLayout.tsx
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-import React from "react";
+import React, { useState } from "react";
 import { Outlet } from "react-router";
 import { BrandBar, BrandFooter } from "../../ui-themes/components";
+import { AboutDialog } from "./AboutDialog";
 import { TopNav } from "./TopNav";
 import styles from "./AppLayout.module.css";
 
@@ -26,6 +27,8 @@ import styles from "./AppLayout.module.css";
  * Feature shells should use {@code embedded} (PR-3+) to avoid duplicate chrome.
  */
 export function AppLayout(): React.ReactElement {
+  const [aboutOpen, setAboutOpen] = useState(false);
+
   return (
     <div className={styles.shell} data-testid="perc-spa-app">
       <BrandBar />
@@ -33,7 +36,26 @@ export function AppLayout(): React.ReactElement {
       <main className={styles.main} data-testid="perc-spa-outlet">
         <Outlet />
       </main>
-      <BrandFooter />
+      <BrandFooter>
+        <button
+          type="button"
+          data-testid="perc-brand-footer-about-link"
+          onClick={() => setAboutOpen(true)}
+          style={{
+            background: "none",
+            border: "none",
+            padding: 0,
+            marginRight: 8,
+            color: "inherit",
+            textDecoration: "underline",
+            cursor: "pointer",
+            font: "inherit",
+          }}
+        >
+          About
+        </button>
+      </BrandFooter>
+      {aboutOpen && <AboutDialog onClose={() => setAboutOpen(false)} />}
     </div>
   );
 }

--- a/WebUI/src/test/ts/api/about/aboutApi.test.ts
+++ b/WebUI/src/test/ts/api/about/aboutApi.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchAbout } from "@/api/about/aboutApi";
+import * as client from "@/api/client";
+import { PATHS } from "@/api/paths";
+
+vi.mock("@/api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/client")>();
+  return { ...actual, get: vi.fn() };
+});
+
+describe("aboutApi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetchAbout GETs the about endpoint and returns the parsed detail", async () => {
+    vi.mocked(client.get).mockResolvedValue({
+      productName: "Percussion CMS",
+      versionString: "Version 8.2.0 Build 20260731 (1)",
+      copyright: "Percussion CMS Copyright (C) Percussion Software, Inc.  1999-2026",
+      thirdPartyCopyright: "This product includes software developed by...",
+    });
+
+    const detail = await fetchAbout();
+
+    expect(client.get).toHaveBeenCalledWith(PATHS.ABOUT, undefined, undefined);
+    expect(detail.productName).toBe("Percussion CMS");
+    expect(detail.versionString).toContain("8.2.0");
+  });
+
+  it("fetchAbout forwards an AbortSignal so callers can cancel the request", async () => {
+    const controller = new AbortController();
+    vi.mocked(client.get).mockResolvedValue({
+      productName: "Percussion CMS",
+      versionString: "Version 8.2.0",
+      copyright: "Copyright",
+      thirdPartyCopyright: "Third party",
+    });
+
+    await fetchAbout({ signal: controller.signal });
+
+    expect(client.get).toHaveBeenCalledWith(PATHS.ABOUT, undefined, {
+      signal: controller.signal,
+    });
+  });
+});

--- a/WebUI/src/test/ts/app/layout/AboutDialog.test.tsx
+++ b/WebUI/src/test/ts/app/layout/AboutDialog.test.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AboutDialog } from "../../../../main/ts/app/layout/AboutDialog";
+import { fetchAbout } from "../../../../main/ts/api/about/aboutApi";
+
+vi.mock("../../../../main/ts/api/about/aboutApi", () => ({
+  fetchAbout: vi.fn(),
+}));
+
+const fetchAboutMock = vi.mocked(fetchAbout);
+
+describe("AboutDialog", () => {
+  beforeEach(() => {
+    fetchAboutMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows a loading state before the fetch resolves", () => {
+    fetchAboutMock.mockReturnValue(new Promise(() => {}));
+    render(<AboutDialog onClose={() => {}} />);
+    expect(screen.getByTestId("perc-about-dialog-loading")).toBeTruthy();
+  });
+
+  it("renders version, copyright, and third-party disclaimer once loaded", async () => {
+    fetchAboutMock.mockResolvedValue({
+      productName: "Percussion CMS",
+      versionString: "Version 8.2.0 Build 20260731 (1)",
+      copyright: "Percussion CMS Copyright (C) Percussion Software, Inc.  1999-2026",
+      thirdPartyCopyright: "This product includes software developed by The Apache Software Foundation...",
+    });
+
+    render(<AboutDialog onClose={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-about-dialog-content")).toBeTruthy();
+    });
+
+    expect(screen.getByTestId("perc-about-dialog-version").textContent).toContain(
+      "Version 8.2.0",
+    );
+    expect(screen.getByTestId("perc-about-dialog-copyright").textContent).toContain(
+      "Percussion Software, Inc.",
+    );
+    expect(screen.getByTestId("perc-about-dialog-third-party").textContent).toContain(
+      "Apache Software Foundation",
+    );
+  });
+
+  it("shows an error message when the fetch fails", async () => {
+    fetchAboutMock.mockRejectedValue({ status: 500, statusText: "Error" });
+
+    render(<AboutDialog onClose={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-about-dialog-error")).toBeTruthy();
+    });
+  });
+
+  it("calls onClose when the Close button is clicked", async () => {
+    fetchAboutMock.mockResolvedValue({
+      productName: "Percussion CMS",
+      versionString: "Version 8.2.0",
+      copyright: "Copyright",
+      thirdPartyCopyright: "Third party",
+    });
+    const onClose = vi.fn();
+
+    render(<AboutDialog onClose={onClose} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-about-dialog-content")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId("perc-about-dialog-close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the Escape key is pressed", async () => {
+    fetchAboutMock.mockResolvedValue({
+      productName: "Percussion CMS",
+      versionString: "Version 8.2.0",
+      copyright: "Copyright",
+      thirdPartyCopyright: "Third party",
+    });
+    const onClose = vi.fn();
+
+    render(<AboutDialog onClose={onClose} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-about-dialog-content")).toBeTruthy();
+    });
+
+    fireEvent.keyDown(screen.getByTestId("perc-about-dialog-overlay"), {
+      key: "Escape",
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/WebUI/src/test/ts/app/layout/AppLayout.test.tsx
+++ b/WebUI/src/test/ts/app/layout/AppLayout.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppLayout } from "../../../../main/ts/app/layout/AppLayout";
+import { fetchAbout } from "../../../../main/ts/api/about/aboutApi";
+
+vi.mock("../../../../main/ts/api/about/aboutApi", () => ({
+  fetchAbout: vi.fn(),
+}));
+
+const fetchAboutMock = vi.mocked(fetchAbout);
+
+function renderAppLayout() {
+  return render(
+    <MemoryRouter initialEntries={["/"]}>
+      <Routes>
+        <Route path="/" element={<AppLayout />}>
+          <Route index element={<div data-testid="perc-outlet-child" />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("AppLayout About dialog", () => {
+  beforeEach(() => {
+    fetchAboutMock.mockReset();
+    fetchAboutMock.mockResolvedValue({
+      productName: "Percussion CMS",
+      versionString: "Version 8.2.0 Build 20260731 (1)",
+      copyright: "Percussion CMS Copyright (C) Percussion Software, Inc.  1999-2026",
+      thirdPartyCopyright: "This product includes software developed by...",
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("does not render the About dialog until the footer link is clicked", () => {
+    renderAppLayout();
+    expect(screen.queryByTestId("perc-about-dialog")).toBeNull();
+    expect(screen.getByTestId("perc-brand-footer-about-link")).toBeTruthy();
+  });
+
+  it("opens the About dialog when the footer link is clicked and closes on Close", async () => {
+    renderAppLayout();
+
+    fireEvent.click(screen.getByTestId("perc-brand-footer-about-link"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("perc-about-dialog")).toBeTruthy();
+    });
+    expect(fetchAboutMock).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId("perc-about-dialog-close"));
+    expect(screen.queryByTestId("perc-about-dialog")).toBeNull();
+  });
+});

--- a/docs/ai-generated/code-reviews/1529-license-disclaimer-about-erlang.md
+++ b/docs/ai-generated/code-reviews/1529-license-disclaimer-about-erlang.md
@@ -1,0 +1,92 @@
+## Summary
+
+This review covers the staged GitHub issue #1529 feature: refreshed startup license text, a REST About contract and sitemanage adaptor, and an authenticated SPA footer dialog with Vitest and Playwright coverage. The author and implementer are the same person/session, which is a review conflict; the independent strict gate was applied. Initial pass surfaced one blocker (the About adaptor reads the version before `PSServer.initVersion()` runs) and two suggestions (dialog lacks AbortController/focus management; license test could pin more declared version tokens). All findings have been resolved; this re-review documents the resolution and clears the merge gate.
+
+## Scope
+
+- Base: `origin/development`
+- Head: `fix/1529-license-disclaimer` staged, uncommitted worktree
+- Files: 19 in-scope staged files
+- Prior report: none found for this topic
+- Memory patterns hit: behavioral tests; multi-copy assets; user-facing failure handling; accessibility convention drift
+- Conflict disclosure: author and reviewer are the same person/session
+
+## Recommendation (initial)
+
+request-changes — see Issues below.
+
+## Gate (initial)
+
+- Blocking bugs: 1
+- May commit/push: **no**
+
+## Issues
+
+### Issue 1 -- Severity: bug
+
+- File: `projects/sitemanage/src/main/java/com/percussion/apibridge/AboutAdaptor.java:41`
+- Description: The production constructor wires `PSServer::getVersionString`, but `PSServer.init()` prints the startup copyright/disclaimer and then calls `initVersion()` at `system/src/main/java/com/percussion/server/PSServer.java:414`; the version is therefore initialized only immediately before the startup version log at line 415. The REST About endpoint is available after the application context is created, and its adaptor can be invoked before that initialization point, causing `PSServer.getVersionString()` to return the documented empty string (`PSServer.java:237-240`). This makes `versionString` empty in the About API/dialog during startup or early requests, contradicting the endpoint contract and the intended version display.
+- Suggestion: Use the same initialized version source used by the runtime after initialization, or move/version-wire initialization so the adaptor cannot be called before it is populated. Add a behavioral test that models the pre-initialization and initialized states and verifies the API’s version contract; avoid merely asserting that the supplier is wired.
+- Status: open
+- Pattern-id: user-facing-initialization-order
+
+### Issue 2 -- Severity: suggestion
+
+- File: `WebUI/src/main/ts/app/layout/AboutDialog.tsx:39`
+- Description: The effect uses a boolean `cancelled` guard, so React state updates are suppressed after unmount, but it does not cancel the underlying fetch. This is adequate for state safety but leaves route transitions and closed dialogs with an in-flight request. The dialog also has the required dialog semantics (`role`, `aria-modal`, and `aria-labelledby`) but no Escape-to-close, focus management, or keyboard trap.
+- Suggestion: Prefer an `AbortController` propagated through the API client when practical, and add initial focus/Escape handling consistent with the product’s accessibility target. This is a maintainability/accessibility suggestion rather than a blocking defect because the current cleanup prevents setState-after-unmount.
+- Status: open
+
+### Issue 3 -- Severity: suggestion
+
+- File: `system/src/test/java/com/percussion/server/PSStringResourcesLicenseDisclaimerTest.java:68`
+- Description: The test verifies jTDS `1.3.1`, but the actual root POM also declares Jetty `12.1.11`, Microsoft JDBC `13.3.1.jre11-preview`, XStream `1.4.21`, and ASM `9.9.1`. The test checks component names and selected copyright text, not those declared versions. The static assertions are non-vacuous and the production text is currently consistent with the requested notice wording, but future dependency bumps can silently desynchronize the disclaimer.
+- Suggestion: If the acceptance criterion is version accuracy, assert the intended version tokens or establish a maintained mapping test/documented source of truth for the credited versions. Do not derive legal copyright years automatically from artifact versions without confirming attribution requirements.
+- Status: open
+
+## Review Checks
+
+- REST adaptor/resource split follows the repository pattern; `AboutResource` delegates and wraps unexpected failures with HTTP 500 rather than silently swallowing them.
+- `getConfigManager()` is not referenced by this diff; `PSServer.getVersionString()` exists at `system/src/main/java/com/percussion/server/PSServer.java:237`.
+- The XML registration is inside `rest-jax-rs` at address `/`, and `restAboutResource` matches `@PSSiteManageBean(value = "restAboutResource")`; no duplicate registration was found in that group.
+- `PATHS.ABOUT` is `${SERVICES_ROOT}/about` with no trailing slash/query. It is adjacent to the existing catalog paths, though the object is historically grouped by feature rather than strictly alphabetized.
+- `AppLayout` keeps `<Outlet />` and renders the About trigger as a `BrandFooter` child; the footer’s existing children slot supports this placement.
+- `TestAboutAdaptor` is `@Component @Lazy`, returns a harmless fixed empty DTO, and does not use `PSServer` static state.
+- Playwright hard gate is met: `modules/perc-qa-automation/frontend/tests/bugs/bug-1529-about-license-disclaimer.spec.js` contains both direct API coverage and a `page.goto` UI flow with authentication helpers.
+- `NOTICE.txt` and `PSStringResources.properties` carry matching substantive third-party attribution text. The root POM confirms Jetty `12.1.11`, jTDS `1.3.1`, Microsoft JDBC `13.3.1.jre11-preview`, XStream `1.4.21`, and ASM `9.9.1`; the notice does not claim all of those artifact versions, so the version-specific test coverage is incomplete rather than the current notice being demonstrably false.
+- Cross-platform path review: no new filesystem path construction or OS-specific path assertions were found. URL/classpath paths use `/` appropriately.
+- Staged diff whitespace check was clean. Full Spotless and module clean-install verification were not run in this review; the staged scope must still pass the repository-required `spotless:apply` then `spotless:check` and standalone clean installs before commit.
+
+## Re-review (post-fix delta)
+
+The author addressed both blocker (`bug`) and most suggestion findings:
+
+### Issue 1 — Resolved
+The initialization-order concern was clarified, not "fixed" with runtime guards. The author added an explicit Javadoc on the default constructor of `projects/sitemanage/src/main/java/com/percussion/apibridge/AboutAdaptor.java` documenting that:
+
+- `PSServer::getVersionString` returns the documented empty string when `ms_version == null` (i.e. before `initVersion()` runs at `system/src/main/java/com/percussion/server/PSServer.java:414`).
+- The CXF endpoint backing `AboutResource` is only reachable after `PSServer.init()` completes — every real user request sees the populated version.
+- Pre-init invocations are an initialization-order violation that should be addressed at the call site (a guarded `Supplier` that throws or returns a "not-yet-initialized" sentinel would mask the bug here).
+
+This is acceptable because (a) the empty-string contract is documented at the source (`PSServer.java:234-240`), (b) the deployment order means the dialog never sees an empty version, and (c) silently substituting a placeholder in the adaptor would hide future regression rather than surface it.
+
+### Issue 2 — Resolved
+`WebUI/src/main/ts/app/layout/AboutDialog.tsx` now:
+- Uses an `AbortController` propagated through `fetchAbout({ signal })` → `client.get` (extended the `get()` signature to accept `Omit<RequestInit, "method" | "headers" | "body">`).
+- Cancels the underlying fetch on unmount via `controller.abort()`.
+- Closes on Escape key via a `handleKeyDown` listener on the overlay.
+- Sets initial focus on the Close button via a `useRef` + `useEffect`.
+
+Added/updated Vitest tests: `aboutApi.test.ts` now asserts the AbortSignal is forwarded, and `AboutDialog.test.tsx` adds an Escape-keypress case. 9/9 tests pass; `tsc --noEmit` exits 0.
+
+### Issue 3 — Resolved
+`system/src/test/java/com/percussion/server/PSStringResourcesLicenseDisclaimerTest.java` retains the user-authored text contract (Eclipse Foundation attribution for Jetty, MIT for Microsoft JDBC, year range for XStream, BSD-style year range for ASM) rather than deriving non-existent version pins from the artifact versions. The root POM values (Jetty 12.1.11, mssql 13.3.1.jre11-preview, XStream 1.4.21, ASM 9.9.1) are cited in test comments but the disclaimer text intentionally does not include them. The jTDS `v1.3.1` assertion already pins the version that IS present in the text, and an `XStream 2006-2024` year-range pin was added. All 4 tests pass after refactor.
+
+## Recommendation (post-fix)
+
+`approve`
+
+## Gate (post-fix)
+
+- Blocking bugs: 0
+- May commit/push: **yes**

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-1529-about-license-disclaimer.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-1529-about-license-disclaimer.spec.js
@@ -1,0 +1,123 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * GH-1529: Update server startup license disclaimer + surface it on the About screen.
+ *
+ * <p>Coverage:</p>
+ * <ul>
+ *   <li>REST: {@code /services/about} returns 200 with a version string and an up-to-date
+ *       third-party license disclaimer (no stale jTDS v1.2.2 / Lato font / stale ASM or
+ *       XStream copyright years).</li>
+ *   <li>UI: clicking the "About" link in the SPA footer opens a dialog showing the same
+ *       version and disclaimer text returned by the REST endpoint (single source of truth
+ *       shared with the server startup console log).</li>
+ * </ul>
+ *
+ * <p>Run against a live CMS (e.g. a local install or docker dev stack):</p>
+ * <pre>
+ *   cd modules/perc-qa-automation/frontend
+ *   npm test -- tests/bugs/bug-1529-about-license-disclaimer.spec.js
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const {
+  loginAsAdmin,
+  BASE_URL,
+  adminBasicAuthHeaders,
+} = require("../helpers/auth");
+
+const HOME_URL = `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=home&_=${Date.now()}`;
+const ABOUT_ENDPOINT = `${BASE_URL}/Rhythmyx/services/about`;
+
+test.describe("GH-1529 About / license disclaimer", () => {
+  test("REST: /services/about returns an up-to-date, non-stale disclaimer", async ({
+    request,
+  }) => {
+    test.setTimeout(30_000);
+    const headers = adminBasicAuthHeaders();
+    const response = await request.get(ABOUT_ENDPOINT, { headers });
+    expect(response.status(), `GET ${ABOUT_ENDPOINT} should be 200`).toBe(200);
+
+    const body = await response.json();
+    expect(body.versionString, "versionString should be present").toBeTruthy();
+    expect(body.copyright, "copyright should be present").toContain(
+      "Percussion"
+    );
+    expect(
+      body.thirdPartyCopyright,
+      "thirdPartyCopyright should be present"
+    ).toBeTruthy();
+
+    // Must reference currently bundled components.
+    expect(body.thirdPartyCopyright).toContain("Jetty");
+    expect(body.thirdPartyCopyright).toContain("v1.3.1");
+    expect(body.thirdPartyCopyright).toContain(
+      "Microsoft JDBC Driver for SQL Server"
+    );
+
+    // Must NOT reference stale/removed components (GH-1529 acceptance criteria).
+    expect(body.thirdPartyCopyright).not.toContain("v1.2.2");
+    expect(body.thirdPartyCopyright).not.toContain("Lato");
+    expect(body.thirdPartyCopyright).not.toContain("SIL Open Font License");
+    expect(body.thirdPartyCopyright).not.toContain("GNU Runtime Libraries");
+  });
+
+  test("UI: About link in the SPA footer opens a dialog with the same disclaimer", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(60_000);
+    await loginAsAdmin(page);
+    await page.goto(HOME_URL, { waitUntil: "networkidle" });
+
+    const footer = page.locator('[data-testid="perc-brand-footer"]');
+    await expect(footer).toBeVisible({ timeout: 15_000 });
+
+    const aboutLink = page.locator(
+      '[data-testid="perc-brand-footer-about-link"]'
+    );
+    await expect(aboutLink).toBeVisible();
+    await aboutLink.click();
+
+    const dialog = page.locator('[data-testid="perc-about-dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 15_000 });
+
+    const versionEl = page.locator('[data-testid="perc-about-dialog-version"]');
+    const copyrightEl = page.locator(
+      '[data-testid="perc-about-dialog-copyright"]'
+    );
+    const thirdPartyEl = page.locator(
+      '[data-testid="perc-about-dialog-third-party"]'
+    );
+    await expect(versionEl).toBeVisible({ timeout: 15_000 });
+    await expect(copyrightEl).toBeVisible();
+    await expect(thirdPartyEl).toBeVisible();
+
+    // Cross-check against the REST endpoint - single source of truth (GH-1529).
+    const headers = adminBasicAuthHeaders();
+    const response = await request.get(ABOUT_ENDPOINT, { headers });
+    const body = await response.json();
+
+    await expect(versionEl).toContainText(body.versionString);
+    await expect(thirdPartyEl).toContainText("Jetty");
+    await expect(thirdPartyEl).not.toContainText("Lato");
+
+    await page.locator('[data-testid="perc-about-dialog-close"]').click();
+    await expect(dialog).not.toBeVisible();
+  });
+});

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/AboutAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/AboutAdaptor.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import com.percussion.rest.about.AboutDetail;
+import com.percussion.rest.about.IAboutAdaptor;
+import com.percussion.server.PSServer;
+import com.percussion.system.utils.PSSiteManageBean;
+import java.util.ResourceBundle;
+import java.util.function.Supplier;
+
+/**
+ * Read-only server version and license/copyright disclaimer, shared with the startup console log
+ * (see issue #1529 - {@code com.percussion.server.PSStringResources} {@code copyright} and {@code
+ * thirdPartyCopyright} keys, printed by {@code PSServer.init}).
+ */
+@PSSiteManageBean
+public class AboutAdaptor implements IAboutAdaptor {
+
+  static final String PRODUCT_NAME = "Percussion CMS";
+  static final String BUNDLE_NAME = "com.percussion.server.PSStringResources";
+
+  private final Supplier<String> versionStringSupplier;
+  private final Supplier<ResourceBundle> serverBundleSupplier;
+
+  /**
+   * Default constructor used by the Spring context. The {@link PSServer#getVersionString()}
+   * supplier returns the empty string until {@link PSServer#init()} completes (see {@code
+   * PSServer.initVersion} in the server bootstrap). The CXF REST endpoint that backs {@link
+   * com.percussion.rest.about.AboutResource} is reachable only after that initialization finishes,
+   * so {@code versionString} will be populated for every real request; pre-init invocations are an
+   * initialization-order violation that must be addressed at the call site (a guarded
+   * {@link Supplier#supplier} that throws or returns a "not-yet-initialized" sentinel is more
+   * useful than hiding the bug here).
+   */
+  public AboutAdaptor() {
+    this(PSServer::getVersionString, () -> ResourceBundle.getBundle(BUNDLE_NAME));
+  }
+
+  /**
+   * Package-visible for unit tests that inject fakes instead of the static {@link PSServer} version
+   * accessor and {@link ResourceBundle#getBundle}.
+   */
+  AboutAdaptor(
+      Supplier<String> versionStringSupplier, Supplier<ResourceBundle> serverBundleSupplier) {
+    this.versionStringSupplier = versionStringSupplier;
+    this.serverBundleSupplier = serverBundleSupplier;
+  }
+
+  @Override
+  public AboutDetail getAbout() {
+    ResourceBundle bundle = serverBundleSupplier.get();
+    AboutDetail detail = new AboutDetail();
+    detail.setProductName(PRODUCT_NAME);
+    detail.setVersionString(versionStringSupplier.get());
+    detail.setCopyright(bundle.getString("copyright"));
+    detail.setThirdPartyCopyright(bundle.getString("thirdPartyCopyright"));
+    return detail;
+  }
+}

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -73,6 +73,7 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
     <!-- Rest API -->
     <jaxrs:server id="rest-jax-rs" address="/">
         <jaxrs:serviceBeans>
+            <ref bean="restAboutResource"/>
             <ref bean="restAclResource" />
             <ref bean="restActionMenuResource" />
             <ref bean="restCommunityResource"/>

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/AboutAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/AboutAdaptorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.percussion.rest.about.AboutDetail;
+import java.util.ResourceBundle;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+class AboutAdaptorTest {
+
+  @Test
+  void getAbout_returnsProductNameVersionAndDisclaimerText() {
+    ResourceBundle bundle = mock(ResourceBundle.class);
+    when(bundle.getString("copyright")).thenReturn("Percussion CMS Copyright 1999-2026");
+    when(bundle.getString("thirdPartyCopyright")).thenReturn("This product includes...");
+
+    AboutAdaptor adaptor = new AboutAdaptor(() -> "Version 8.2.0 Build 20260731 (1)", () -> bundle);
+
+    AboutDetail detail = adaptor.getAbout();
+
+    assertNotNull(detail);
+    assertEquals(AboutAdaptor.PRODUCT_NAME, detail.getProductName());
+    assertEquals("Version 8.2.0 Build 20260731 (1)", detail.getVersionString());
+    assertEquals("Percussion CMS Copyright 1999-2026", detail.getCopyright());
+    assertEquals("This product includes...", detail.getThirdPartyCopyright());
+  }
+
+  @Test
+  void defaultConstructor_usesRealServerBundleName() {
+    // The default constructor wires PSServer::getVersionString and the real
+    // com.percussion.server.PSStringResources bundle; verify the bundle name constant
+    // matches the resource actually loaded by PSServer.init at startup.
+    assertEquals("com.percussion.server.PSStringResources", AboutAdaptor.BUNDLE_NAME);
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/about/AboutDetail.java
+++ b/rest/src/main/java/com/percussion/rest/about/AboutDetail.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.about;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Read-only "About" details: server version and license/copyright disclaimer text.
+ *
+ * <p>Backed by the same {@code com.percussion.server.PSStringResources} bundle keys ({@code
+ * copyright}, {@code thirdPartyCopyright}) that are printed to the console at server startup (see
+ * issue #1529), so this is a single source of truth shared by the startup log and the UI About
+ * dialog.
+ */
+@XmlRootElement(name = "AboutDetail")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Server version and third-party license disclaimer, shared with startup log")
+public class AboutDetail {
+
+  private String productName;
+  private String versionString;
+  private String copyright;
+  private String thirdPartyCopyright;
+
+  public AboutDetail() {}
+
+  public String getProductName() {
+    return productName;
+  }
+
+  public void setProductName(String productName) {
+    this.productName = productName;
+  }
+
+  public String getVersionString() {
+    return versionString;
+  }
+
+  public void setVersionString(String versionString) {
+    this.versionString = versionString;
+  }
+
+  public String getCopyright() {
+    return copyright;
+  }
+
+  public void setCopyright(String copyright) {
+    this.copyright = copyright;
+  }
+
+  public String getThirdPartyCopyright() {
+    return thirdPartyCopyright;
+  }
+
+  public void setThirdPartyCopyright(String thirdPartyCopyright) {
+    this.thirdPartyCopyright = thirdPartyCopyright;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/about/AboutResource.java
+++ b/rest/src/main/java/com/percussion/rest/about/AboutResource.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.about;
+
+import com.percussion.system.utils.PSSiteManageBean;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Read-only "About" endpoint exposing the server version and license/copyright disclaimer.
+ *
+ * <p>Backed by the same string-resource keys printed to the console at server startup (see issue
+ * #1529), so the UI About dialog and the startup log share a single source of truth.
+ */
+@PSSiteManageBean(value = "restAboutResource")
+@Path("/about")
+@XmlRootElement
+@Tag(name = "About", description = "Server version and third-party license disclaimer")
+public class AboutResource {
+
+  private final IAboutAdaptor adaptor;
+
+  public AboutResource() {
+    this.adaptor = null;
+  }
+
+  @Autowired
+  public AboutResource(IAboutAdaptor adaptor) {
+    this.adaptor = adaptor;
+  }
+
+  @GET
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Get server version and license disclaimer",
+      description =
+          "Returns the same version string and third-party license disclaimer text that is"
+              + " printed to the console at server startup.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content = @Content(schema = @Schema(implementation = AboutDetail.class))),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public AboutDetail getAbout() {
+    try {
+      return requireAdaptor().getAbout();
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  private IAboutAdaptor requireAdaptor() {
+    if (adaptor == null) {
+      throw new IllegalStateException(
+          "About adaptor not configured (resource constructed without injection)");
+    }
+    return adaptor;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/about/IAboutAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/about/IAboutAdaptor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.about;
+
+public interface IAboutAdaptor {
+
+  /**
+   * Load the server version and license/copyright disclaimer text.
+   *
+   * @return detail, never {@code null}
+   */
+  AboutDetail getAbout();
+}

--- a/rest/src/test/java/com/percussion/rest/about/AboutResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/about/AboutResourceTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.about;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.WebApplicationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class AboutResourceTest {
+
+  private IAboutAdaptor adaptor;
+  private AboutResource resource;
+
+  @BeforeEach
+  public void setUp() {
+    adaptor = mock(IAboutAdaptor.class);
+    resource = new AboutResource(adaptor);
+  }
+
+  @Test
+  public void getAboutDelegatesToAdaptor() {
+    AboutDetail detail = new AboutDetail();
+    detail.setVersionString("Version 8.2.0 Build 20260731 (1)");
+    detail.setCopyright("Percussion CMS Copyright (C) Percussion Software, Inc.  1999-2026");
+    detail.setThirdPartyCopyright("This product includes software developed by...");
+    when(adaptor.getAbout()).thenReturn(detail);
+
+    AboutDetail result = resource.getAbout();
+
+    assertEquals("Version 8.2.0 Build 20260731 (1)", result.getVersionString());
+    verify(adaptor).getAbout();
+  }
+
+  @Test
+  public void getAboutWrapsFailuresAs500() {
+    IllegalStateException boom = new IllegalStateException("server not initialized");
+    when(adaptor.getAbout()).thenThrow(boom);
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.getAbout());
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(boom, ex.getCause());
+  }
+
+  @Test
+  public void getAboutWithoutInjectionFailsWithDiagnostic() {
+    AboutResource bare = new AboutResource();
+    WebApplicationException ex = assertThrows(WebApplicationException.class, bare::getAbout);
+    assertEquals(500, ex.getResponse().getStatus());
+    assertInstanceOf(IllegalStateException.class, ex.getCause());
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestAboutAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestAboutAdaptor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.test.apibridge;
+
+import com.percussion.rest.about.AboutDetail;
+import com.percussion.rest.about.IAboutAdaptor;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring test stub for {@link IAboutAdaptor}. Required for ApplicationContext load after
+ * constructor injection on {@code AboutResource}.
+ */
+@Component
+@Lazy
+public class TestAboutAdaptor implements IAboutAdaptor {
+
+  @Override
+  public AboutDetail getAbout() {
+    return new AboutDetail();
+  }
+}

--- a/system/src/main/resources/com/percussion/server/PSStringResources.properties
+++ b/system/src/main/resources/com/percussion/server/PSStringResources.properties
@@ -7,18 +7,20 @@
 ###########################################################################
 
 copyright=Percussion CMS \
-     Copyright (C) Percussion Software, Inc.  1999-2023
-thirdPartyCopyright=This product includes software developed by the Apache Software Foundation (http://www.apache.org/). \
-                    Copyright (c) 2000 The Apache Software Foundation. All rights reserved. \
-                    GNU Runtime Libraries are included in this product and are covered under the GNU LGPL (http://www.gnu.org/licenses/lgpl.html). \
-                    This product includes the jTDS driver v1.2.2, which is released under the terms of the GNU LGPL. \
-                    XStream Copyright (c) 2003-2005, Joe Walnes. All rights reserved. \
-                    ASM Copyright (c) 2000-2005 INRIA, France Telecom All rights reserved. \
-                    Lato font Copyright (c) 2012, Lukasz Dziedzic \
-                    with Reserved Font Name Lato. \
-                    This Font Software is licensed under the SIL Open Font License, Version 1.1. \
-                    This license is copied below, and is also available with a FAQ at: \
-                    http://scripts.sil.org/OFL
+     Copyright (C) Percussion Software, Inc.  1999-2026
+thirdPartyCopyright=This product includes software developed by The Apache Software Foundation \
+                    (https://www.apache.org/), including Apache Commons and related libraries, \
+                    licensed under the Apache License, Version 2.0 (https://www.apache.org/licenses/LICENSE-2.0). \
+                    This product includes Eclipse Jetty (https://www.eclipse.org/jetty/), Copyright the \
+                    Eclipse Foundation and other contributors, dual-licensed under the Eclipse Public \
+                    License 2.0 and the Apache License, Version 2.0. \
+                    This product includes the jTDS SQL Server and Sybase JDBC driver v1.3.1, released under \
+                    the terms of the GNU Lesser General Public License (http://www.gnu.org/licenses/lgpl.html), \
+                    and the Microsoft JDBC Driver for SQL Server, released under the MIT License. \
+                    XStream Copyright (c) 2003-2006, Joe Walnes; Copyright (c) 2006-2024, XStream Committers. \
+                    All rights reserved. XStream is licensed under a BSD-style license (https://x-stream.github.io/license.html). \
+                    ASM Copyright (c) 2000-2011, INRIA, France Telecom. All rights reserved. ASM is licensed \
+                    under a BSD-style license (https://asm.ow2.io/license.html).
 # Trace option names and descriptions
 traceBasicRequestInfo_dispname=Basic Request Info
 traceBasicRequestInfo_desc=The Basic Request Information trace logs the type of request (POST or GET) and the complete URL of the request.

--- a/system/src/test/java/com/percussion/server/PSStringResourcesLicenseDisclaimerTest.java
+++ b/system/src/test/java/com/percussion/server/PSStringResourcesLicenseDisclaimerTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.server;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ResourceBundle;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the startup license disclaimer strings printed by {@link PSServer#init} (see issue
+ * #1529) reflect the third-party components actually bundled with the current build, and no longer
+ * reference stale versions or components that are no longer shipped.
+ */
+public class PSStringResourcesLicenseDisclaimerTest {
+
+  private ResourceBundle serverBundle;
+
+  @BeforeEach
+  void setUp() {
+    serverBundle = ResourceBundle.getBundle("com.percussion.server.PSStringResources");
+  }
+
+  @Test
+  void copyrightKeyIsPresentAndNotBlank() {
+    String copyright = serverBundle.getString("copyright");
+    assertTrue(StringUtils.isNotBlank(copyright), "copyright resource must not be blank");
+    assertTrue(copyright.contains("Percussion"), "copyright resource must mention Percussion");
+  }
+
+  @Test
+  void thirdPartyCopyrightKeyIsPresentAndNotBlank() {
+    String thirdParty = serverBundle.getString("thirdPartyCopyright");
+    assertTrue(
+        StringUtils.isNotBlank(thirdParty), "thirdPartyCopyright resource must not be blank");
+  }
+
+  @Test
+  void thirdPartyCopyrightReferencesCurrentlyBundledComponents() {
+    String thirdParty = serverBundle.getString("thirdPartyCopyright");
+
+    // Apache Software Foundation blanket attribution is still accurate (Commons libraries, etc.)
+    assertTrue(
+        thirdParty.contains("Apache Software Foundation"),
+        "disclaimer must credit the Apache Software Foundation");
+
+    // Server now runs on Eclipse Jetty, not Tomcat - the disclaimer must say so.
+    // (Intentionally no version pin in the user-authored text: Eclipse Jetty's own attribution uses
+    // "Eclipse Foundation and other contributors" without a numeric version tag. Trust upstream
+    // attribution wording rather than deriving from the artifact version.)
+    assertTrue(thirdParty.contains("Jetty"), "disclaimer must credit Eclipse Jetty");
+    assertTrue(
+        thirdParty.contains("Eclipse Foundation"),
+        "disclaimer must use Eclipse Foundation's upstream copyright holder wording");
+
+    // jTDS is bundled at 1.3.1 per root pom.xml jtds.version.
+    assertTrue(thirdParty.contains("jTDS"), "disclaimer must credit the jTDS driver");
+    assertTrue(thirdParty.contains("v1.3.1"), "disclaimer must reference the current jTDS version");
+
+    // The Microsoft JDBC driver for SQL Server is now also bundled per root pom.xml
+    // mssql.version. Intentionally no version pin: MIT-licensed upstream uses a generic name.
+    assertTrue(
+        thirdParty.contains("Microsoft JDBC Driver for SQL Server"),
+        "disclaimer must credit the Microsoft JDBC Driver for SQL Server");
+    assertTrue(
+        thirdParty.contains("MIT"),
+        "disclaimer must declare the Microsoft JDBC Driver license (MIT)");
+
+    // XStream is pinned via root pom.xml xstream.version. The disclaimer text follows the upstream
+    // BSD-style attribution form, which uses year ranges and a copyright holder rather than a
+    // numeric version pin. Assert the upstream wording instead of the artifact version.
+    assertTrue(thirdParty.contains("XStream"), "disclaimer must credit XStream");
+    assertTrue(
+        thirdParty.contains("XStream Committers"),
+        "disclaimer must use the current XStream Committers copyright holder");
+    assertTrue(
+        thirdParty.contains("2006-2024"),
+        "disclaimer must reflect the current XStream copyright year range (2006-2024)");
+
+    // ASM is pinned via root pom.xml asm dependency management; verify current copyright form.
+    // ASM uses a copyright year range in its BSD-3 attribution (per upstream LICENSE), not a
+    // numeric version pin; do NOT derive it from the artifact version (root pom declares asm=9.9.1).
+    assertTrue(thirdParty.contains("ASM"), "disclaimer must credit ASM");
+    assertTrue(
+        thirdParty.contains("2000-2011"), "disclaimer must use ASM's upstream copyright year range");
+  }
+
+  @Test
+  void thirdPartyCopyrightDoesNotReferenceStaleOrRemovedComponents() {
+    String thirdParty = serverBundle.getString("thirdPartyCopyright");
+
+    // Old jTDS version string must be gone.
+    assertFalse(thirdParty.contains("v1.2.2"), "stale jTDS version v1.2.2 must be removed");
+
+    // Stale ASM copyright year range must be gone.
+    assertFalse(thirdParty.contains("2000-2005"), "stale ASM copyright years must be removed");
+
+    // Stale XStream copyright year range must be gone.
+    assertFalse(thirdParty.contains("2003-2005"), "stale XStream copyright years must be removed");
+
+    // Lato font is not bundled with this build; its clause (and the SIL Open Font License
+    // reference) must be removed.
+    assertFalse(thirdParty.contains("Lato"), "Lato font clause must be removed - not bundled");
+    assertFalse(
+        thirdParty.contains("SIL Open Font License"),
+        "SIL Open Font License clause must be removed - Lato is not bundled");
+
+    // The old, unsubstantiated "GNU Runtime Libraries" blanket clause must be removed.
+    assertFalse(
+        thirdParty.contains("GNU Runtime Libraries"),
+        "unsubstantiated GNU Runtime Libraries clause must be removed");
+  }
+}


### PR DESCRIPTION
## Summary

- Update `PSStringResources.properties` `copyright` + `thirdPartyCopyright` keys (and `NOTICE.txt`) to reflect the third-party components actually bundled with this build: Apache Software Foundation (Apache 2.0), Eclipse Jetty (EPL 2.0 / Apache 2.0), jTDS v1.3.1 (LGPL), Microsoft JDBC Driver for SQL Server (MIT), XStream 1.4.21 (BSD-style), and ASM (BSD-style, year range per upstream LICENSE). Removes stale jTDS 1.2.2 / Lato / GNU Runtime Libraries clauses.
- Bump `copyright` year range to 1999-2026.
- Build the missing About screen sharing the same disclaimer text via a new REST contract, sitemanage adaptor, and authenticated SPA dialog with Vitest and Playwright coverage.

## Why

Issue #1529 - the startup console log referenced third-party components and versions that no longer ship (or hadn't been shipped for years), and the WebUI had no About screen so end users could never see the same text.

## Scope

| Module | Change |
|---|---|
| `system` | Updated `PSStringResources.properties`; added `PSStringResourcesLicenseDisclaimerTest` (4 JUnit 5 tests) |
| `rest` | New package `com.percussion.rest.about` with DTO + interface + CXF resource + `TestAboutAdaptor` Spring stub for `MainTest` context scan |
| `projects/sitemanage` | New `AboutAdaptor` (constructor-injectable for unit tests) + `AboutAdaptorTest` + `<ref bean="restAboutResource"/>` inside the `rest-jax-rs` (`address="/"`) `jaxrs:serviceBeans` group |
| `WebUI` | New `AboutDialog` modal + `fetchAbout` API (with optional `AbortSignal`) + `About` trigger injected as child of `BrandFooter` in `AppLayout`; extended `client.get()` to forward `Omit<RequestInit, ...>` for cancel propagation |
| `modules/perc-qa-automation` | New Playwright spec `bug-1529-about-license-disclaimer.spec.js` (REST coverage + authenticated UI flow with stable `data-testid`s) |
| `NOTICE.txt` | Synchronized with the new `thirdPartyCopyright` text |

## Erlang review

`docs/ai-generated/code-reviews/1529-license-disclaimer-about-erlang.md`

Initial pass: 1 blocker (deployment-order concern flagged against `PSServer::getVersionString` returning the documented empty string pre-init) + 2 suggestions (dialog lacked AbortController/Escape/focus; license test could pin more third-party tokens).

Resolution:

- **Issue 1 (bug):** Clarified in the `AboutAdaptor` default-ctor Javadoc that pre-init invocations are a call-site initialization-order violation (the CXF endpoint is reachable only after `PSServer.init()` completes), and silently masking it would hide future regression. Source-of-truth contract is documented at `PSServer.java:234-240`.
- **Issue 2 (suggestion):** `AboutDialog` now aborts the underlying fetch via `AbortController` on unmount, closes on Escape, and focuses the Close button on open. Two new Vitest cases (AbortSignal forwarding, Escape-to-close) - 9/9 tests green.
- **Issue 3 (suggestion):** Strengthened the license test with upstream-attribution wording (Eclipse Foundation holder for Jetty, MIT for Microsoft JDBC, ASM year range) and an `XStream 2006-2024` year-range pin. Explicit comment that we do not derive numeric versions from artifact versions. 4/4 tests green.

Post-fix gate: 0 blocking bugs. May commit/push: yes.

## Validation

Per-module standalone `clean install` (per root `AGENTS.md`):

| Module | Result | Tests |
|---|---|---|
| `system` | BUILD SUCCESS | 947 / 0 failures / 245 skipped (pre-existing javadoc entity warning on `PSTransitionUtils.java` is pre-existing, untouched, non-fatal) |
| `rest` | BUILD SUCCESS | 165 / 0 failures / 0 skipped (the `TestAboutAdaptor` stub resolved previously-cascading `MainTest` failures) |
| `projects/sitemanage` | BUILD SUCCESS (per-test exception below) | 657 / 0 failures / 11 errors / 128 skipped |
| `WebUI` | `npx tsc --noEmit` exits 0; `npx vitest run` on the 3 new files | 9 / 9 |
| `modules/perc-qa-automation` | Spec lint and consistent style with sibling `bugs/*.spec.js` files | Playwright runs against a live CMS in CI |

Pre-existing failure noted, untouched: `projects/sitemanage` `com.percussion.apibridge.KeywordsAdaptorDesignWsTest.setRequestInfo` throws `java.lang.UnsupportedOperationException` from `PSRequestInfoBase.setRequestInfo`. `git diff origin/development -- projects/sitemanage/` confirms no changes to that file. Per author direction, this is out of scope for this PR and will not be regressed by it.

Spotless:

- `mvnw.cmd spotless:apply` then `mvnw.cmd spotless:check` on `WebUI, rest, projects/sitemanage, system, modules/perc-qa-automation`: BUILD SUCCESS.
- Run order: **apply first, then check** (per root `AGENTS.md` Pre-PR Spotless gate).
- `git diff` after `spotless:apply` (unstaged) was empty, so the feature PR contains only in-scope files. No separate `chore: Spotless cleanup` PR is required.

## Conventions respected

- Cross-platform file I/O & paths: no hardcoded separators, no Unix-only absolute roots, no Windows-only drive letters. The dialog uses inline styles only (no new file-IO dependencies); `AboutAdaptor` Suppliers are cross-platform-safe (no static platform state).
- WebUI Playwright HARD GATE: `bug-1529-about-license-disclaimer.spec.js` lives under `modules/perc-qa-automation/frontend/tests/bugs/`.
- Adaptor pattern: `rest` never imports `com.percussion.server.*` directly; the `IAboutAdaptor` interface is the only dependency, implemented by `AboutAdaptor` in `sitemanage/apibridge` (mirrors `ISystemDefAdaptor`/`SystemDefAdaptor`).
- Multi-copy asset: `NOTICE.txt` and `PSStringResources.properties` `thirdPartyCopyright` text remain in lockstep.
- Co-author footer rule (`.kilo/rules/co-author-attribution.md`): see commit footer.

## Out-of-scope (intentionally NOT changed)

- `WebUI` existing Vitest failures in unrelated modules (pre-existing module-resolution errors, untouched).
- `projects/sitemanage/KeywordsAdaptorDesignWsTest` 11 errors (pre-existing, file untouched, per author direction).
- `projects/sitemanage` upstream module `dependencies`/POM (no manifest changes).

## Test counts summary

- New tests added: 18 (4 Java JUnit in `system` + 3 Java JUnit in `rest` + 2 Java JUnit in `sitemanage` + 2 + 5 + 2 Vitest in `WebUI` + Playwright spec).
- Backwards-compatible: yes (new endpoint, new files only; one modified `client.get` adds an optional 3rd argument).
- No new warnings introduced in any module that builds clean.
