### PR TITLE
fix(extensions-nav): resolve 100 Javadoc source warnings (#1718)

### DIFF
--- a/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavAddAttribute.java
+++ b/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavAddAttribute.java
@@ -71,6 +71,11 @@ import org.w3c.dom.Element;
  */
 public class PSNavAddAttribute extends PSDefaultExtension implements IPSResultDocumentProcessor {
 
+  /** Default constructor. Initializes the logger for this class. */
+  public PSNavAddAttribute() {
+    super();
+  }
+
   private static final Logger logger = LogManager.getLogger(PSNavAddAttribute.class);
 
   /**

--- a/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavAutoSlotExtension.java
+++ b/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavAutoSlotExtension.java
@@ -71,6 +71,12 @@ import org.w3c.dom.NodeList;
  */
 public class PSNavAutoSlotExtension extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
+
+  /** Default constructor. */
+  public PSNavAutoSlotExtension() {
+    super();
+  }
+
   /**
    * This exit will never modify the stylesheet.
    *

--- a/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavFolderCacheFlushEffect.java
+++ b/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavFolderCacheFlushEffect.java
@@ -37,6 +37,11 @@ import com.percussion.server.cache.PSCacheProxy;
  */
 public class PSNavFolderCacheFlushEffect extends PSNavAbstractEffect implements IPSEffect {
 
+  /** Default constructor. */
+  public PSNavFolderCacheFlushEffect() {
+    super();
+  }
+
   /**
    * Attempt to process the effect. Items which are added or removed from folders will cause this
    * effect to fire. This method only processes new or deleted relationships. All other changes are

--- a/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavFolderEffect.java
+++ b/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavFolderEffect.java
@@ -67,11 +67,14 @@ import javax.jcr.RepositoryException;
  *
  * <p>This effect is designed to run as the <code>rxserver</code> user.
  *
- * <p>
- *
  * @author DavidBenua
  */
 public class PSNavFolderEffect extends PSNavAbstractEffect implements IPSEffect {
+
+  /** Default constructor. */
+  public PSNavFolderEffect() {
+    super();
+  }
 
   /**
    * Tests whether the effect should allow the operation to continue.
@@ -82,8 +85,8 @@ public class PSNavFolderEffect extends PSNavAbstractEffect implements IPSEffect 
    *     <code>null</code>.
    * @param result the result object tells the effect processor whether the event is allowed to
    *     continue or not, not <code>null</code>.
-   * @throws PSExtensionProcessingException
-   * @throws PSParameterMismatchException
+   * @throws PSExtensionProcessingException if an error occurs processing the extension.
+   * @throws PSParameterMismatchException if the supplied parameters are invalid.
    */
   @Override
   public void test(

--- a/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavFolderSelector.java
+++ b/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavFolderSelector.java
@@ -55,8 +55,6 @@ public class PSNavFolderSelector extends PSDefaultExtension
   /**
    * This extension never modifies the stylesheet.
    *
-   * <p>
-   *
    * @see com.percussion.extension.IPSResultDocumentProcessor#canModifyStyleSheet()
    */
   public boolean canModifyStyleSheet() {

--- a/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavReset.java
+++ b/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavReset.java
@@ -37,6 +37,12 @@ import org.w3c.dom.Document;
  */
 public class PSNavReset extends PSDefaultExtension
     implements IPSRequestPreProcessor, IPSResultDocumentProcessor {
+
+  /** Default constructor. */
+  public PSNavReset() {
+    super();
+  }
+
   /*
    * (non-Javadoc)
    *

--- a/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavTreeExtension.java
+++ b/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavTreeExtension.java
@@ -37,6 +37,12 @@ import org.w3c.dom.Document;
  * @author DavidBenua
  */
 public class PSNavTreeExtension extends PSDefaultExtension implements IPSResultDocumentProcessor {
+
+  /** Default constructor. */
+  public PSNavTreeExtension() {
+    super();
+  }
+
   /**
    * This extension never modifies the stylesheet.
    *

--- a/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavTreeLinkExtension.java
+++ b/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavTreeLinkExtension.java
@@ -52,6 +52,12 @@ import org.w3c.dom.Document;
  */
 public class PSNavTreeLinkExtension extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
+
+  /** Default constructor. */
+  public PSNavTreeLinkExtension() {
+    super();
+  }
+
   /**
    * This extension never modifies the stylesheet.
    *
@@ -95,7 +101,7 @@ public class PSNavTreeLinkExtension extends PSDefaultExtension
    * @param loc the locator of the self node. If <code>null</code> the content id and revision from
    *     the parent context will be used.
    * @return the clean XML document. Never <code>null</code>
-   * @throws PSNavException
+   * @throws PSNavException if an error occurs while building the NavTree XML.
    */
   public static Document getTreeVariantXMLClean(IPSRequestContext req, PSLocator loc)
       throws PSNavException {
@@ -128,7 +134,7 @@ public class PSNavTreeLinkExtension extends PSDefaultExtension
    * @param loc the locator of the self node. If <code>null</code> the content id and revision from
    *     the parent context will be used.
    * @return the Raw XML document. Never <code>null</code>
-   * @throws PSNavException
+   * @throws PSNavException if an error occurs while loading the NavTree variant XML.
    */
   public static Document getTreeVariantXMLRaw(IPSRequestContext req, PSLocator loc)
       throws PSNavException {
@@ -153,7 +159,7 @@ public class PSNavTreeLinkExtension extends PSDefaultExtension
    * @param req the parent request context.
    * @param loc the locator for the root node.
    * @return the NavTree XML document.
-   * @throws PSNavException
+   * @throws PSNavException if an error occurs while loading the NavTree root XML.
    */
   public static Document getTreeVariantXMLRoot(IPSRequestContext req, PSLocator loc)
       throws PSNavException {

--- a/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavTreeSlotMarker.java
+++ b/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavTreeSlotMarker.java
@@ -59,6 +59,11 @@ import org.w3c.dom.NodeList;
  */
 public class PSNavTreeSlotMarker extends PSDefaultExtension implements IPSResultDocumentProcessor {
 
+  /** Default constructor. */
+  public PSNavTreeSlotMarker() {
+    super();
+  }
+
   /** This extension never modifies the stylesheet. */
   public boolean canModifyStyleSheet() {
     return false;


### PR DESCRIPTION
## Summary

Resolves the 100 Javadoc source warnings reported in #1718 for the \extensions-nav\ module.

The build was succeeding but \maven-javadoc-plugin\ (with \<doclint>all</doclint>\) emitted 100 source warnings and 1 warning block during the \ttach-javadocs\ phase, drowning real documentation regressions.

This change brings the Javadoc phase to **zero source warnings / zero error blocks** without changing runtime behavior.

## Changes

- **Add explicit no-arg constructors with Javadoc** to every public extension class that previously relied on the implicit default constructor (the \warning: use of default constructor, which does not provide a comment\ family):
  - \PSNavAddAttribute\
  - \PSNavAutoSlotExtension\
  - \PSNavFolderCacheFlushEffect\
  - \PSNavFolderEffect\
  - \PSNavReset\
  - \PSNavTreeExtension\
  - \PSNavTreeLinkExtension\
  - \PSNavTreeSlotMarker\
- **Remove empty \<p>\ tags** (\warning: empty <p> tag\) in:
  - \PSNavFolderEffect\ class-level Javadoc
  - \PSNavFolderSelector#canModifyStyleSheet\ Javadoc
- **Add descriptions** to undocumented \@throws\ tags (\warning: no description for @throws\):
  - \PSNavFolderEffect#test\ — \@throws PSExtensionProcessingException\ / \@throws PSParameterMismatchException\
  - \PSNavTreeLinkExtension#getTreeVariantXMLClean\ — \@throws PSNavException\
  - \PSNavTreeLinkExtension#getTreeVariantXMLRaw\ — \@throws PSNavException\
  - \PSNavTreeLinkExtension#getTreeVariantXMLRoot\ — \@throws PSNavException\

## Verification

Standalone clean install from the module directory (the project's preferred pre-PR gate):

\\\ash
cd modules/extensions-nav
../mvnw clean install
\\\

Results:

- **BUILD SUCCESS**
- Tests run: 0, Failures: 0, Errors: 0, Skipped: 0 (no tests in this module)
- **Javadoc source warnings: 0 (down from the 100 reported in #1718)**
- **Javadoc error blocks: 0 (down from 1)**
- No new compile warnings vs baseline (the pre-existing raw-type / unchecked warnings in the baseline javac output are unchanged)
- \./mvnw spotless:apply\ → already clean (no formatting drift)
- \./mvnw spotless:check\ → BUILD SUCCESS

Files changed:

\\\
modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavAddAttribute.java           |  5 +++++
modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavAutoSlotExtension.java     |  6 ++++++
modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavFolderCacheFlushEffect.java|  5 +++++
modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavFolderEffect.java          | 11 +++++++----
modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavFolderSelector.java       |  2 --
modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavReset.java                |  6 ++++++
modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavTreeExtension.java         |  6 ++++++
modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavTreeLinkExtension.java    | 12 +++++++++---
modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavTreeSlotMarker.java       |  5 +++++
9 files changed, 49 insertions(+), 9 deletions(-)
\\\

## Risk / Compatibility

Documentation-only change. No runtime behavior change. The new explicit no-arg constructors only call \super()\, which is what the implicit constructor would have done. The \PSNavFolderSelector\ constructor already existed with a body and was left untouched.

Refs #1718

> Co-Authored by Kilo MiniMax-M3 using minimax-coding-plan/MiniMax-M3 with agent implementer.