### PR TITLE
chore(deps): Artemis 2.55.0 and drop unused netty-all

### DIFF
--- a/WebUI/pom.xml
+++ b/WebUI/pom.xml
@@ -274,13 +274,14 @@
         </dependency>
         <!-- Embedded JMS: Apache Artemis (not ActiveMQ Classic). Restores
              88ca5716b0 after merge 3755de7510 reintroduced Classic 5.7.0
-             (Dependabot #79 CVE-2012-6092, #80 CVE-2013-1880). -->
+             (Dependabot #79 CVE-2012-6092, #80 CVE-2013-1880).
+             Coordinates: org.apache.artemis (TLP); Netty is transitive only. -->
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-jakarta-client</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <ant.contrib.version>1.0b3</ant.contrib.version>
         <ant.version>1.10.14</ant.version>
         <aopalliance.version>1.0</aopalliance.version>
-        <artemis.version>2.52.0</artemis.version>
+        <artemis.version>2.55.0</artemis.version>
         <avalon.version>4.1.5</avalon.version>
         <awssdk.version>1.12.797</awssdk.version>
         <batik.version>1.19</batik.version>
@@ -215,7 +215,6 @@
         <mockito.version>5.21.0</mockito.version>
         <mssql.version>13.3.1.jre11-preview</mssql.version>
         <mysql.connector.version>8.4.0</mysql.connector.version>
-        <nettyall.version>4.2.16.Final</nettyall.version>
         <ojdbc17.version>23.26.0.0.0</ojdbc17.version>
         <opencsv.version>5.12.0</opencsv.version>
         <oracle.version>12.1.0.1</oracle.version>
@@ -487,11 +486,6 @@
                 <scope>test</scope>
             </dependency>
             <!-- End Junit 5-->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-all</artifactId>
-                <version>${nettyall.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.mortbay.jasper</groupId>
                 <artifactId>apache-jsp</artifactId>
@@ -1043,13 +1037,15 @@
                 <artifactId>commons-compress</artifactId>
                 <version>${commons.compress.version}</version>
             </dependency>
+            <!-- Apache Artemis TLP coordinates (org.apache.artemis); packages remain
+                 org.apache.activemq.artemis.* for API compatibility. -->
             <dependency>
-                <groupId>org.apache.activemq</groupId>
+                <groupId>org.apache.artemis</groupId>
                 <artifactId>artemis-server</artifactId>
                 <version>${artemis.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.activemq</groupId>
+                <groupId>org.apache.artemis</groupId>
                 <artifactId>artemis-jakarta-client</artifactId>
                 <version>${artemis.version}</version>
             </dependency>


### PR DESCRIPTION
## Summary

- Bump **`artemis.version` 2.52.0 → 2.55.0** (current Maven Central release).
- Switch managed/WebUI deps to **`org.apache.artemis`** (TLP coordinates; Java packages stay `org.apache.activemq.artemis.*`).
- **Remove unused** `io.netty:netty-all` + `nettyall.version` from root `dependencyManagement` (no product `import io.netty`; nothing depended on `netty-all`).

## Why

Artemis 2.52 left modular Netty at **4.1.130.Final**, which kept Dependabot transitive Netty alerts open. Artemis **2.55.0** pins Netty to **4.1.135.Final**. The direct `netty-all` 4.2.x pin never replaced those modular jars.

## Verification

```text
WebUI dependency:tree → artemis-server:2.55.0 + io.netty:*:4.1.135.Final
cd WebUI && ../mvnw clean package -DskipTests -Dspotless.check.skip=true -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true
→ BUILD SUCCESS
```

Note: some Netty GHSAs still list first patched as **4.1.136.Final**; this PR does not force a modular Netty override beyond what Artemis 2.55 ships.

Co-Authored by Grok Build 0.2.117 using grok-4.5 with agent Grok.