### PR TITLE
chore(deps): floor ZooKeeper, Jackson 2.x, and Netty for CVE overrides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,13 @@
         <artemis.version>2.55.0</artemis.version>
         <avalon.version>4.1.5</avalon.version>
         <awssdk.version>1.12.797</awssdk.version>
+        <!-- Transitive CVE floors (see dependencyManagement BOM / pins below) -->
+        <!-- SolrJ → ZK 3.9.4; Dependabot #210/#211 need ≥3.9.5 -->
+        <zookeeper.version>3.9.5</zookeeper.version>
+        <!-- AWS SDK v1 / SolrJ still use com.fasterxml Jackson 2.x; product runtime is tools.jackson 3.x -->
+        <jackson.fasterxml.version>2.22.1</jackson.fasterxml.version>
+        <!-- Artemis modular Netty (not netty-all); Dependabot needs ≥4.1.136.Final -->
+        <netty.version>4.1.136.Final</netty.version>
         <batik.version>1.19</batik.version>
         <bc.version>1.84</bc.version>
         <build.helper.maven.plugin.version>3.6.1</build.helper.maven.plugin.version>
@@ -132,8 +139,9 @@
         <httpcomponents.core.version>4.4.16</httpcomponents.core.version>
         <httpcomponents.version>4.5.14</httpcomponents.version>
         <install.jre.version>8.222.10.1</install.jre.version>
-        <!-- Jackson 3.x runtime (tools.jackson); annotations stay on 2.x com.fasterxml by design -->
-        <jackson.annotation.api.version>2.21</jackson.annotation.api.version>
+        <!-- Jackson 3.x runtime (tools.jackson); annotations stay on 2.x com.fasterxml by design.
+             Annotations use major.minor only (2.22), not patch (jackson-bom jackson.version.annotations). -->
+        <jackson.annotation.api.version>2.22</jackson.annotation.api.version>
         <jackson.version>3.1.5</jackson.version>
         <jakarta.activation.version>2.1.4</jakarta.activation.version>
         <jakarta.annotation.api.version>3.0.0</jakarta.annotation.api.version>
@@ -267,6 +275,35 @@
     </properties>
     <dependencyManagement>
         <dependencies>
+            <!-- ===== Transitive security floors (BOM imports first) =====
+                 Product does not call Netty/ZooKeeper APIs directly. AWS SDK v1 and
+                 SolrJ still pull com.fasterxml Jackson 2.x; Artemis pulls modular Netty.
+                 Import BOMs so every module version is forced without sprinkling per-artifact
+                 pins. Exclude Solr's optional ZK client module so its 3.9.4 pin cannot win. -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.fasterxml.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>${zookeeper.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper-jute</artifactId>
+                <version>${zookeeper.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.xbean</groupId>
                 <artifactId>xbean-spring</artifactId>
@@ -910,6 +947,24 @@
                 <artifactId>solr-solrj</artifactId>
                 <version>${solr.version}</version>
                 <exclusions>
+                    <!-- Optional SolrCloud client; pins ZK 3.9.4 (Dependabot #210/#211).
+                         HTTP SolrJ does not need this module. If CloudSolrClient+ZK is
+                         required later, re-add solr-solrj-zookeeper and rely on
+                         zookeeper.version (3.9.5+) management above. -->
+                    <exclusion>
+                        <groupId>org.apache.solr</groupId>
+                        <artifactId>solr-solrj-zookeeper</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.zookeeper</groupId>
+                        <artifactId>zookeeper</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.zookeeper</groupId>
+                        <artifactId>zookeeper-jute</artifactId>
+                    </exclusion>
+                    <!-- com.fasterxml Jackson 2.x for SolrJ is version-forced via jackson-bom
+                         (do not exclude — SolrJ needs it at runtime). Netty via netty-bom. -->
                     <exclusion>
                         <groupId>io.netty</groupId>
                         <artifactId>netty-buffer</artifactId>
@@ -980,6 +1035,9 @@
                 <artifactId>aws-java-sdk-sts</artifactId>
                 <version>${awssdk.version}</version>
             </dependency>
+            <!-- AWS v1 still pulls com.fasterxml Jackson 2.x (pins 2.17.2 in its POM).
+                 Versions are forced by jackson-bom import above (${jackson.fasterxml.version}).
+                 Do not exclude without re-adding — S3/STS need Jackson on the classpath. -->
             <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
@@ -1038,7 +1096,9 @@
                 <version>${commons.compress.version}</version>
             </dependency>
             <!-- Apache Artemis TLP coordinates (org.apache.artemis); packages remain
-                 org.apache.activemq.artemis.* for API compatibility. -->
+                 org.apache.activemq.artemis.* for API compatibility.
+                 Modular Netty versions forced by netty-bom import (${netty.version});
+                 do not exclude Netty from Artemis — broker/client require it at runtime. -->
             <dependency>
                 <groupId>org.apache.artemis</groupId>
                 <artifactId>artemis-server</artifactId>


### PR DESCRIPTION
## Summary

Force patched **transitive** floors without rewriting product APIs:

| Concern | Source | Before | After |
|---------|--------|--------|--------|
| **ZooKeeper** | SolrJ `solr-solrj-zookeeper` | 3.9.4 | **Excluded** (optional SolrCloud client); managed floor **3.9.5** if reintroduced |
| **Jackson 2.x** (`com.fasterxml…`) | AWS SDK v1 (and SolrJ) | 2.17.2 | **`jackson-bom` 2.22.1** |
| **Netty modular** | Artemis 2.55 | 4.1.135 | **`netty-bom` 4.1.136.Final** |
| **Jackson 3** (`tools.jackson…`) | Product | 3.1.5 | **unchanged** |

### Why not “exclude Jackson from AWS / Netty from Artemis”?

Excluding those jars removes them from the classpath unless re-declared. S3/STS and the embedded Artemis broker **need** them. Maven **BOM import** is the correct way to force versions on remaining transitive edges.

### Solr ZK

HTTP SolrJ does not need `solr-solrj-zookeeper`. That module is excluded (plus direct ZK artifacts). If we ever need CloudSolrClient+ZK, re-add the module and keep `zookeeper.version=3.9.5`.

## Verification

```text
WebUI tree:
  solr-solrj:9.10.1  (no solr-solrj-zookeeper / no zookeeper)
  artemis-server → netty-codec-http/handler 4.1.136.Final
  tools.jackson-databind 3.1.5
  com.fasterxml jackson-databind/core 2.22.1 (via rest/system)
system tree:
  aws-java-sdk-core → jackson-databind/core/cbor 2.22.1
```

Addresses Dependabot families for ZK #210/#211, Jackson #243–#249, and Netty modular residuals after Artemis 2.55.

Co-Authored by Grok Build 0.2.117 using grok-4.5 with agent Grok.