### PR TITLE
chore(deps): Tika 3.3.1, OpenJFX 17.0.20, Java-WebSocket 1.6.0

### DIFF
--- a/modules/DesktopContentExplorer/pom.xml
+++ b/modules/DesktopContentExplorer/pom.xml
@@ -12,27 +12,23 @@
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>17</version>
+            <!-- version from parent javafx.version (17.0.20+) -->
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-graphics</artifactId>
-            <version>17</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-base</artifactId>
-            <version>17</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-web</artifactId>
-            <version>17</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-swing</artifactId>
-            <version>17</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -147,6 +143,17 @@
             <groupId>com.vladsch.javafx-webview-debugger</groupId>
             <artifactId>javafx-webview-debugger</artifactId>
             <version>0.8.6</version>
+            <exclusions>
+                <!-- Parent manages Java-WebSocket at ${java.websocket.version} (1.6.0) -->
+                <exclusion>
+                    <groupId>org.java-websocket</groupId>
+                    <artifactId>Java-WebSocket</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.java-websocket</groupId>
+            <artifactId>Java-WebSocket</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vladsch.boxed-json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,14 @@
         <surefireArgLine/>
         <swagger.ui.version>5.31.0</swagger.ui.version>
         <swagger.version>2.2.42</swagger.version>
-        <tika.version>3.2.3</tika.version>
+        <!-- 3.3.1 pulls junrar 7.6.0 (clears Dependabot #208/#214; was 7.5.5 on 3.2.3) -->
+        <tika.version>3.3.1</tika.version>
+        <!-- Desktop Content Explorer OpenJFX line (bare "17" was unpatched javafx-media) -->
+        <javafx.version>17.0.20</javafx.version>
+        <!-- javafx-webview-debugger → Java-WebSocket 1.3.7; floor for Dependabot #204 -->
+        <java.websocket.version>1.6.0</java.websocket.version>
+        <!-- minify-maven-plugin and other plugins; Dependabot #213 -->
+        <plexus.utils.version>4.0.3</plexus.utils.version>
         <!-- TinyMCE 6.8.x is the last series under the MIT license. -->
         <!-- TinyMCE 7+ switched to GPL-2.0-or-later, which is incompatible -->
         <!-- with this project's Apache 2.0 license for distribution. -->
@@ -303,6 +310,47 @@
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper-jute</artifactId>
                 <version>${zookeeper.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.java-websocket</groupId>
+                <artifactId>Java-WebSocket</artifactId>
+                <version>${java.websocket.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>${plexus.utils.version}</version>
+            </dependency>
+            <!-- OpenJFX managed versions (DCE uses ${javafx.version}) -->
+            <dependency>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-controls</artifactId>
+                <version>${javafx.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-graphics</artifactId>
+                <version>${javafx.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-base</artifactId>
+                <version>${javafx.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-web</artifactId>
+                <version>${javafx.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-media</artifactId>
+                <version>${javafx.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-swing</artifactId>
+                <version>${javafx.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.xbean</groupId>
@@ -2038,7 +2086,7 @@
                         <dependency>
                             <groupId>org.codehaus.plexus</groupId>
                             <artifactId>plexus-utils</artifactId>
-                            <version>4.0.3</version>
+                            <version>${plexus.utils.version}</version>
                         </dependency>
                         <dependency>
                             <groupId>com.google.javascript</groupId>


### PR DESCRIPTION
## Summary

Clears remaining Dependabot noise except **ESAPI → commons-configuration 1.x** (deferred per product decision).

| Alert | Package | Change |
|-------|---------|--------|
| #208, #214 | `junrar` | **Tika 3.2.3 → 3.3.1** (ships **junrar 7.6.0**, ≥7.5.10) |
| #204 | `Java-WebSocket` | Floor **1.6.0**; re-declare on DCE after excluding old pin from `javafx-webview-debugger` |
| #205 | `javafx-media` | OpenJFX **17 → 17.0.20** (managed + DCE) |
| #213 | `plexus-utils` | Manage **4.0.3** (was already on minify-plugin; now reactor-wide property) |
| #206 | `commons-configuration` 1.x via ESAPI | **Skipped** for now |

## Verification

```text
WebUI: tika-parsers-standard-package:3.3.1 → junrar:7.6.0
DCE:   javafx-*:17.0.20, javafx-media:17.0.20, Java-WebSocket:1.6.0
```

Co-Authored by Grok Build 0.2.117 using grok-4.5 with agent Grok.