### PR TITLE
chore(deps): bump commons-io to 2.22.0 for RequireUpperBoundDeps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <commons.compress.version>1.28.0</commons.compress.version>
         <commons.digester.version>2.1</commons.digester.version>
         <commons.file.upload.version>1.6.0</commons.file.upload.version>
-        <commons.io.version>2.21.0</commons.io.version>
+        <commons.io.version>2.22.0</commons.io.version>
         <commons.lang3.version>3.20.0</commons.lang3.version>
         <commons.logging.version>1.3.5</commons.logging.version>
         <commons.math.version>3.6.1</commons.math.version>


### PR DESCRIPTION
## Summary

- Bumps parent property `commons.io.version` from **2.21.0** → **2.22.0**.
- Fixes `maven-enforcer-plugin` **RequireUpperBoundDeps** failures on `delivery-tier-distribution` (and the same dependency tree elsewhere).

### Root cause

After Tika **3.3.1** (#1733), the tree includes:

```
tika-core:3.3.1 → commons-io:2.22.0
```

while the BOM still managed **2.21.0**, which is below the highest requested version. Other transitive pins (commons-net 2.20.0, csrfguard 2.18.0, etc.) were already below the managed floor and were not the failure.

### Change

| Property | Before | After |
|----------|--------|-------|
| `commons.io.version` | 2.21.0 | 2.22.0 |

Single-line change in root `pom.xml`. `delivery-tier-suite` already consumes `${commons.io.version}` from the parent.

## Test plan

- [x] `cd deliverytiersuite/delivery-tier-suite/delivery-tier-distribution && ../../../mvnw validate` — enforcer (including RequireUpperBoundDeps) **exit 0**
- [ ] CI green on this PR (enforcer + module builds)
- [ ] No Spotless-covered sources changed (property-only POM edit); Spotless apply/check not required for this file set
- [ ] No module Java sources/tests changed; no per-module `clean install` beyond enforcer validation of the failing module

## Risk

Low: patch-level commons-io bump to the version already required by managed Tika. No API/source changes.

---

Co-Authored by Grok Build using grok-4.5 with agent Grok.