### PR TITLE
fix(webui): add country-flag-icons to Maven frontend package

### DIFF
--- a/WebUI/src/main/frontend/package-lock.json
+++ b/WebUI/src/main/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "backbone": "^1.6.0",
         "bootstrap": "^5.3.8",
         "bowser": "^2.11.0",
+        "country-flag-icons": "^1.6.20",
         "datatables.net": "^2.3.7",
         "date-fns": "^4.1.0",
         "handlebars": "^4.7.9",
@@ -1322,6 +1323,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
       "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
+    },
+    "node_modules/country-flag-icons": {
+      "version": "1.6.20",
+      "resolved": "https://registry.npmjs.org/country-flag-icons/-/country-flag-icons-1.6.20.tgz",
+      "integrity": "sha512-py8JiEKzjhYw6HPJ0L7SxLgCYim36UPRTZX43/kqGueUCZLSvnrqAiwW8HtQibur7mdkFQUkjOgdK+o/9FBtaw==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {

--- a/WebUI/src/main/frontend/package.json
+++ b/WebUI/src/main/frontend/package.json
@@ -20,6 +20,7 @@
     "backbone": "^1.6.0",
     "bootstrap": "^5.3.8",
     "bowser": "^2.11.0",
+    "country-flag-icons": "^1.6.20",
     "datatables.net": "^2.3.7",
     "date-fns": "^4.1.0",
     "handlebars": "^4.7.9",

--- a/WebUI/src/main/ts/country-flag-icons-react-3x2.d.ts
+++ b/WebUI/src/main/ts/country-flag-icons-react-3x2.d.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Ambient types for {@code country-flag-icons/react/3x2}.
+ *
+ * The package ships {@code index.d.ts}, but WebUI tsconfig maps {@code "*"} →
+ * {@code node_modules/*}, which resolves the nested package via package.json
+ * {@code "main"} ({@code index.cjs}). TypeScript then looks for {@code index.d.cts}
+ * and never picks up the adjacent {@code .d.ts} (package {@code "exports".types}
+ * is bypassed by path mapping).
+ *
+ * Keep this declaration until path mapping no longer shadows package exports,
+ * or the package ships {@code index.d.cts}.
+ */
+declare module "country-flag-icons/react/3x2" {
+  import type { FC, SVGProps } from "react";
+
+  type FlagComponent = FC<SVGProps<SVGSVGElement> & { title?: string }>;
+
+  /** ISO 3166-1 alpha-2 (and some subdivision) flag React components. */
+  const flags: { [countryCode: string]: FlagComponent };
+  export = flags;
+}

--- a/docs/ai-generated/code-reviews/webui-country-flag-icons-frontend-erlang.md
+++ b/docs/ai-generated/code-reviews/webui-country-flag-icons-frontend-erlang.md
@@ -12,10 +12,10 @@
 
 ## Changes reviewed
 
-| Path | Role |
-|------|------|
-| `WebUI/src/main/frontend/package.json` | Declare dependency for Maven npm install |
-| `WebUI/src/main/frontend/package-lock.json` | Lockfile for reproducible install |
+|                         Path                          |                                                                      Role                                                                       |
+|-------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `WebUI/src/main/frontend/package.json`                | Declare dependency for Maven npm install                                                                                                        |
+| `WebUI/src/main/frontend/package-lock.json`           | Lockfile for reproducible install                                                                                                               |
 | `WebUI/src/main/ts/country-flag-icons-react-3x2.d.ts` | Ambient types: path map `"*"` → `node_modules/*` resolves nested package `main` (`index.cjs`) and misses package `exports.types` / `index.d.ts` |
 
 ## Issues
@@ -30,3 +30,4 @@ N/A — npm metadata and TypeScript ambient module only.
 
 - `tsc --noEmit` from `WebUI/src/main/frontend` (exit 0 after fix)
 - Vite build previously resolved the package when present under `frontend/node_modules`
+

--- a/docs/ai-generated/code-reviews/webui-country-flag-icons-frontend-erlang.md
+++ b/docs/ai-generated/code-reviews/webui-country-flag-icons-frontend-erlang.md
@@ -1,0 +1,32 @@
+# Erlang review: WebUI country-flag-icons frontend dep
+
+**Scope:** Uncommitted fix — add `country-flag-icons` to Maven frontend npm package + ambient types  
+**Date:** 2026-08-03  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** Incomplete change-class closure (dual package.json); multi-copy lockstep under WebUI
+
+## Summary
+
+`LocaleFlag` imports `country-flag-icons/react/3x2`. The dependency lived only on `WebUI/package.json` (optional root install). Maven `frontend-maven-plugin` installs from `WebUI/src/main/frontend/package.json`, so clean machines fail with “Cannot find module”. Machines with a prior root `npm install` under `WebUI/` still resolve via upward `node_modules` walk — explains machine-specific failure.
+
+## Changes reviewed
+
+| Path | Role |
+|------|------|
+| `WebUI/src/main/frontend/package.json` | Declare dependency for Maven npm install |
+| `WebUI/src/main/frontend/package-lock.json` | Lockfile for reproducible install |
+| `WebUI/src/main/ts/country-flag-icons-react-3x2.d.ts` | Ambient types: path map `"*"` → `node_modules/*` resolves nested package `main` (`index.cjs`) and misses package `exports.types` / `index.d.ts` |
+
+## Issues
+
+None (bugs). No new runtime logic; existing `LocaleFlag` / login tests cover flag UI. No path/file I/O.
+
+## Cross-platform path checklist
+
+N/A — npm metadata and TypeScript ambient module only.
+
+## Verification
+
+- `tsc --noEmit` from `WebUI/src/main/frontend` (exit 0 after fix)
+- Vite build previously resolved the package when present under `frontend/node_modules`


### PR DESCRIPTION
## Summary

- Add `country-flag-icons@^1.6.20` to `WebUI/src/main/frontend/package.json` (and lockfile) so Maven `frontend-maven-plugin` installs the package used by `LocaleFlag`.
- Add ambient TypeScript module types for `country-flag-icons/react/3x2` because WebUI tsconfig path mapping (`*` → `node_modules/*`) resolves the nested package via `main: index.cjs` and misses the package's `index.d.ts` / `exports.types`.

### Why this was machine-specific

| Machine | What happens |
|---------|----------------|
| Clean / Maven-only (VJ) | npm install only under `src/main/frontend` → package missing → **Cannot find module** |
| Prior root `WebUI` npm install (you) | package under `WebUI/node_modules` → Node walks up and resolves → build OK |

## Test plan

- [x] `cd WebUI/src/main/frontend` → `tsc --noEmit -p tsconfig.json` (exit 0)
- [x] `npm run build:modern` (tsc + vite) — success
- [x] `npm test -- --run ../../test/ts/login` — 8 files, 56 tests passed
- [x] `mvnw.cmd -pl WebUI spotless:apply` then `spotless:check` — BUILD SUCCESS
- [x] Pre-push root `spotless:check` reactor — BUILD SUCCESS
- [ ] VJ: checkout this PR branch and rebuild WebUI (clean/Maven-only) should resolve `country-flag-icons/react/3x2`

## Pre-PR gates

- **Erlang:** approve — `docs/ai-generated/code-reviews/webui-country-flag-icons-frontend-erlang.md`
- **Spotless:** apply then check (module + pre-push monorepo); in-scope files only
- **Frontend verification:** `build:modern` + login Vitest (full WebUI WAR `clean install` not run this session)

## Notes for future deps

SPA runtime deps used by `src/main/ts` must be declared in **`WebUI/src/main/frontend/package.json`** (Maven install cwd), not only `WebUI/package.json`.