### PR TITLE
fix(webui): add axe-core to Maven frontend package for Vitest a11y

### DIFF
--- a/WebUI/src/main/frontend/package-lock.json
+++ b/WebUI/src/main/frontend/package-lock.json
@@ -39,6 +39,7 @@
         "@types/react": "^19.1.4",
         "@types/react-dom": "^19.1.5",
         "@vitejs/plugin-react": "^6.0.2",
+        "axe-core": "^4.12.1",
         "eslint": "^10.8.0",
         "jsdom": "^26.1.0",
         "prettier": "^3.5.3",
@@ -1234,6 +1235,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/backbone": {

--- a/WebUI/src/main/frontend/package.json
+++ b/WebUI/src/main/frontend/package.json
@@ -45,6 +45,7 @@
     "@types/react": "^19.1.4",
     "@types/react-dom": "^19.1.5",
     "@vitejs/plugin-react": "^6.0.2",
+    "axe-core": "^4.12.1",
     "eslint": "^10.8.0",
     "jsdom": "^26.1.0",
     "prettier": "^3.5.3",


### PR DESCRIPTION
## Summary

- Add `axe-core@^4.12.1` as a **devDependency** on `WebUI/src/main/frontend/package.json` (and lockfile).
- Content Explorer a11y helpers (`src/test/ts/contentExplorer/a11y.ts`) import `axe-core`; Maven `frontend-maven-plugin` installs/runs Vitest from `src/main/frontend`, not `WebUI/` root.

### Same dual-package drift as #1748

| Machine | What happens |
|---------|----------------|
| Clean / Maven-only (Vijay) | npm install only under `src/main/frontend` → **cannot find module axe-core** |
| Prior root `WebUI` npm install | package under `WebUI/node_modules` → Node walks up → tests pass |

Root-only vs frontend scan after #1748: **only `axe-core` was still missing** from frontend.

## Test plan

- [x] `npm install` in `WebUI/src/main/frontend` installs `axe-core`
- [x] `npm test -- --run ../../test/ts/contentExplorer/RelationshipsView.test.tsx` — 4 tests passed (includes axe gate)
- [ ] Vijay: pull PR / `development` after merge and re-run WebUI tests

## Notes

SPA/test packages used by `src/main/ts` or `src/test/ts` must be declared in **`WebUI/src/main/frontend/package.json`** (Maven install cwd).