### PR TITLE
fix(webui): stop force-using already-detected analyze dependencies

### DIFF
--- a/WebUI/pom.xml
+++ b/WebUI/pom.xml
@@ -849,15 +849,19 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
             </plugin>
-            <!-- TwelveMonkeys dependencies loaded via SPI by IIOProviderContextListener in web.xml -->
+            <!--
+              ImageIO codecs are loaded via SPI by IIOProviderContextListener (web.xml), so the
+              dependency analyzer cannot see bytecode refs. Force-mark imageio-* only.
+
+              Do NOT list servlet-utils or twelvemonkeys.servlet:servlet here: they are already
+              detected as used (web.xml / compile classpath). maven-dependency-plugin 3.11+
+              fails analyze-only if usedDependencies overlaps detected used deps.
+            -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <configuration>
                     <usedDependencies>
-                        <!-- Runtime: PSContextLoaderListener / perc-system need servlet-utils on WAR classpath -->
-                        <usedDependency>com.percussion:servlet-utils</usedDependency>
-                        <usedDependency>com.twelvemonkeys.servlet:servlet</usedDependency>
                         <usedDependency>com.twelvemonkeys.imageio:imageio-core</usedDependency>
                         <usedDependency>com.twelvemonkeys.imageio:imageio-bmp</usedDependency>
                         <usedDependency>com.twelvemonkeys.imageio:imageio-jpeg</usedDependency>


### PR DESCRIPTION
## Summary
- `maven-dependency-plugin` 3.11+ fails `analyze-only` when `usedDependencies` lists artifacts already detected as used.
- Remove `com.percussion:servlet-utils` and `com.twelvemonkeys.servlet:servlet` from the force-used list in `WebUI/pom.xml`.
- Keep TwelveMonkeys `imageio-*` SPI force entries (not visible as bytecode refs).
- Real WAR dependency declarations for those artifacts are unchanged.

## Test plan
- [x] `cd WebUI && ../mvnw.cmd dependency:analyze-only -DskipTests` → BUILD SUCCESS
- [ ] CI clean install / analyze on `perc-web-ui`

## Pre-PR gates
- POM-only config change (no Java/JS sources); Spotless not required for this XML config tweak.
- Standalone `dependency:analyze-only` verified on the changed module.
- Unrelated `modules/perc-common-ui-bundle/package-lock.json` left uncommitted.

> Co-Authored by Grok Build using grok-4.5 with agent main.