### PR TITLE
fix(dts): align spring-ldap-core 4.1.0 with spring-security 7.1.0

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/pom.xml
@@ -45,6 +45,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Jakarta EE 11 / Tomcat 11 — align with parent jakarta.servlet.api.version (#667) -->
         <servlet.api.version>6.1.0</servlet.api.version>
+        <!-- Align with spring-security-ldap 7.1.x (declares spring-ldap-core 4.1.0) -->
+        <spring.ldap.version>4.1.0</spring.ldap.version>
         <spring.security.version>7.1.0</spring.security.version>
         <sqlserver.version>13.3.1.jre11-preview</sqlserver.version>
         <supercsv.version>2.4.0</supercsv.version>
@@ -234,7 +236,27 @@
             <dependency>
                 <groupId>org.springframework.ldap</groupId>
                 <artifactId>spring-ldap-core</artifactId>
-                <version>4.0.4</version>
+                <version>${spring.ldap.version}</version>
+                <!--
+                  spring-ldap-core 4.1.x pulls micrometer-core 1.17.0; Spring Framework 7.0.x
+                  still manages observation/commons at 1.16.6. DTS does not use LDAP observation
+                  metrics — exclude so RequireUpperBoundDeps / DependencyConvergence pass
+                  (same approach as spring-security-* micrometer exclusions above).
+                -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.micrometer</groupId>
+                        <artifactId>micrometer-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.micrometer</groupId>
+                        <artifactId>micrometer-observation</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.micrometer</groupId>
+                        <artifactId>micrometer-commons</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
## Summary

- Bump managed `spring-ldap-core` from **4.0.4** to **4.1.0** (`spring.ldap.version`) so it matches what `spring-security-ldap` **7.1.0** declares.
- Exclude Micrometer (`micrometer-core` / `observation` / `commons`) from managed `spring-ldap-core` so enforcer does not fail on Micrometer **1.17.0** (from LDAP) vs **1.16.6** (from Spring Framework 7.0.x). Same pattern already used for `spring-security-*` in this POM.
- Fixes `RequireUpperBoundDeps` / `DependencyConvergence` failure on `perc-secure-membership` after #1764.

## Test plan

- [x] `cd deliverytiersuite/delivery-tier-suite/secure-membership && ../../../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Enforcer `RequireUpperBoundDeps` and `DependencyConvergence` pass
- [x] `dependency:tree` shows `spring-ldap-core:4.1.0` aligned under both direct and `spring-security-ldap` paths
- [x] Root `mvnw spotless:apply` then `spotless:check` (only in-scope POM changed)
- [ ] CI green on this PR

## Pre-PR gates

| Gate | Result |
|------|--------|
| Spotless apply → check | pass (in-scope only) |
| Module clean install | `perc-secure-membership` BUILD SUCCESS |
| Erlang review | approve (POM-only dep alignment; no app logic) |