### PR TITLE
fix(distribution): disable mkd-gcm native staging until Central

### DIFF
--- a/modules/perc-distribution-tree/README.md
+++ b/modules/perc-distribution-tree/README.md
@@ -77,6 +77,15 @@ cd modules/perc-distribution-tree
 
 ## Bundled GCM natives (`bin/`)
 
+**Temporarily disabled** until `dev.monkeyking:mkd-gcm-natives` is published to Maven Central. The following are commented out so distribution builds do not require a local `.m2` install of the artifact:
+
+- `pom.xml` — `mkd-gcm-natives` dependency and `stage-gcm-natives` unpack execution
+- `installDistributionFiles.xml` — fail/copy of `mkd_gcm_ffi` into `bin/`
+- `BundledGcmNativesLockstepTest` — `@Disabled` until staging is re-enabled
+- `sitemanage` — `mkd-gcm-sdk` dependency (already commented)
+
+When re-enabling, restore all of the above in one change. Intended behavior:
+
 The i18n crowdsource path (mkd-gcm) needs the native shared library `mkd_gcm_ffi` on the Jetty process library path. `StartJetty.sh` / `StartJetty.bat` set `-Djna.library.path=<installdir>/bin` (and `LD_LIBRARY_PATH` / `PATH`).
 
 Every production build of this module unpacks `dev.monkeyking:mkd-gcm-natives` (version `${mkd.gcm.version}`) and flattens the **platforms shipped by that artifact**:
@@ -88,9 +97,9 @@ Every production build of this module unpacks `dev.monkeyking:mkd-gcm-natives` (
 
 **macOS (arm64 / x86_64):** `mkd-gcm-natives` **0.2.0 does not ship** Darwin shared libraries. The product still installs and runs on macOS; GCM correction submit is an **opt-in** feature. On hosts without a loadable `mkd_gcm_ffi`, `MkdGcmCorrectionService` catches `UnsatisfiedLinkError` and surfaces a clear configuration error (place the library under `<installdir>/bin` and set `jna.library.path` / `PATH` / `LD_LIBRARY_PATH` when/if a Darwin native is published). Do not invent macOS includes until upstream ships them — otherwise the ANT `<fail>` / empty stage would either block the whole CMS build or silently omit files.
 
-Lockstep: `pom.xml` property `${mkd.gcm.version}` + dependency version, `stage-gcm-natives` unpack includes, and `installDistributionFiles.xml` `<available>` / `<include>` names are asserted by `BundledGcmNativesLockstepTest`.
+Lockstep: `pom.xml` property `${mkd.gcm.version}` + dependency version, `stage-gcm-natives` unpack includes, and `installDistributionFiles.xml` `<available>` / `<include>` names are asserted by `BundledGcmNativesLockstepTest` (when re-enabled).
 
-Staging: `maven-dependency-plugin` execution `stage-gcm-natives` → `_gcm-native-stage/`, then ANT in `installDistributionFiles.xml` copies into `bin/` and deletes the stage dir. Missing **Windows/Linux** natives fail the build (install `mkd-gcm-natives` to local `.m2` until published).
+Staging: `maven-dependency-plugin` execution `stage-gcm-natives` → `_gcm-native-stage/`, then ANT in `installDistributionFiles.xml` copies into `bin/` and deletes the stage dir.
 
 ## Bundled JDBC Drivers
 

--- a/modules/perc-distribution-tree/pom.xml
+++ b/modules/perc-distribution-tree/pom.xml
@@ -36,7 +36,9 @@
         <extensions-directory>${basedir}/target/extensions</extensions-directory>
         <exts.store>${assembly-directory}/Extensions</exts.store>
         <jetty-directory>${basedir}/target/jetty</jetty-directory>
-        <!-- GCM FFI natives (mkd_gcm_ffi) staged into distribution/bin for StartJetty jna.library.path -->
+        <!-- GCM FFI natives (mkd_gcm_ffi) staged into distribution/bin for StartJetty jna.library.path.
+             Staging currently DISABLED (dependency + stage-gcm-natives + ANT block commented) until
+             mkd-gcm-natives is on Maven Central. Keep version property for lockstep re-enable. -->
         <mkd.gcm.version>0.2.0</mkd.gcm.version>
         <packages-directory>${basedir}/target/packages</packages-directory>
         <rxapps-directory>${basedir}/target/rxapps</rxapps-directory>
@@ -144,8 +146,9 @@
             <version>${project.parent.version}</version>
             <scope>provided</scope>
         </dependency>
-        <!-- Build-time only: GCM native shared libs extracted into distribution/bin/
-             (StartJetty sets -Djna.library.path=<installdir>/bin). Local .m2 until published.
+        <!-- TEMP DISABLED until mkd-gcm-natives is on Maven Central (re-enable with ANT + stage-gcm-natives).
+             Build-time only: GCM native shared libs extracted into distribution/bin/
+             (StartJetty sets -Djna.library.path=<installdir>/bin).
         <dependency>
             <groupId>dev.monkeyking</groupId>
             <artifactId>mkd-gcm-natives</artifactId>
@@ -610,10 +613,11 @@
                             <includeTypes>jar</includeTypes>
                         </configuration>
                     </execution>
-                    <!-- Unpack mkd-gcm-natives platform shared libraries so ANT can flatten them
+                    <!-- TEMP DISABLED until mkd-gcm-natives is on Maven Central (re-enable with ANT + dependency).
+                         Unpack mkd-gcm-natives platform shared libraries so ANT can flatten them
                          into distribution/bin/ (consumed via StartJetty -Djna.library.path).
                          Main artifact ships windows-x86_64 + linux-x86_64 under
-                         dev/monkeyking/gcm/native/<platform>/. 
+                         dev/monkeyking/gcm/native/<platform>/.
                     <execution>
                         <id>stage-gcm-natives</id>
                         <goals>

--- a/modules/perc-distribution-tree/src/main/resources/installDistributionFiles.xml
+++ b/modules/perc-distribution-tree/src/main/resources/installDistributionFiles.xml
@@ -701,41 +701,18 @@
 		<echo>Creating jetty work directory..</echo>
 		<mkdir dir="${assembly-directory}/jetty/base/work" />
 
-		<!-- GCM FFI natives for i18n corrections (mkd-gcm). StartJetty sets -Djna.library.path=${installdir}/bin
-			(and LD_LIBRARY_PATH / PATH). Unpack is done by maven-dependency-plugin execution
-			id=stage-gcm-natives into ${assembly-directory}/_gcm-native-stage (platform
-			paths under dev/monkeyking/gcm/native/<platform>/). Flatten both Win64 +
-			Linux64 shared libs into bin/ so one distribution works on either host. Fail
-			loud if the expected files are missing (empty fileset would be a silent no-op). -->
-		<echo>Staging mkd_gcm_ffi natives into bin/..</echo>
-		<mkdir dir="${assembly-directory}/bin" />
-		<fail
-			message="Missing staged Windows mkd_gcm_ffi.dll (mkd-gcm-natives ${mkd.gcm.version} not installed to local .m2?)">
-			<condition>
-				<not>
-					<available
-						file="${assembly-directory}/_gcm-native-stage/dev/monkeyking/gcm/native/windows-x86_64/mkd_gcm_ffi.dll" />
-				</not>
-			</condition>
-		</fail>
-		<fail
-			message="Missing staged Linux libmkd_gcm_ffi.so (mkd-gcm-natives ${mkd.gcm.version} not installed to local .m2?)">
-			<condition>
-				<not>
-					<available
-						file="${assembly-directory}/_gcm-native-stage/dev/monkeyking/gcm/native/linux-x86_64/libmkd_gcm_ffi.so" />
-				</not>
-			</condition>
-		</fail>
-		<copy todir="${assembly-directory}/bin" flatten="true"
-			overwrite="true">
-			<fileset dir="${assembly-directory}/_gcm-native-stage">
-				<include name="**/mkd_gcm_ffi.dll" />
-				<include name="**/libmkd_gcm_ffi.so" />
-			</fileset>
-		</copy>
-		<delete dir="${assembly-directory}/_gcm-native-stage"
-			failonerror="false" verbose="true" />
+		<!-- TEMP DISABLED until dev.monkeyking:mkd-gcm-natives is published to
+			Central (and local .m2 installs are no longer required). Matching pom.xml
+			pieces are already commented: mkd-gcm-natives dependency + stage-gcm-natives
+			unpack. Re-enable this block with those when Central is ready. GCM FFI natives
+			for i18n corrections (mkd-gcm). StartJetty sets -Djna.library.path=${installdir}/bin
+			(and LD_LIBRARY_PATH / PATH). Unpack via maven-dependency-plugin id=stage-gcm-natives
+			into ${assembly-directory}/_gcm-native-stage (paths under dev/monkeyking/gcm/native/<platform>/).
+			Flatten Win64 + Linux64 shared libs into bin/. Fail loud if expected files
+			are missing (empty fileset is silent). echo Staging mkd_gcm_ffi natives into
+			bin/.. mkdir ${assembly-directory}/bin fail if missing windows-x86_64/mkd_gcm_ffi.dll
+			fail if missing linux-x86_64/libmkd_gcm_ffi.so copy flatten **/mkd_gcm_ffi.dll
+			and **/libmkd_gcm_ffi.so into bin/ delete ${assembly-directory}/_gcm-native-stage -->
 
 		<!-- Populate jetty/base/lib/jdbc/ with the curated JDBC driver set. The
 			staged JARs are placed in ${assembly-directory}/_jdbc-stage/ by maven-dependency-plugin

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/gcm/BundledGcmNativesLockstepTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/gcm/BundledGcmNativesLockstepTest.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +38,14 @@ import org.junit.jupiter.api.Test;
  *
  * <p>Analogous to JDBC {@code BundledJdbcDrivers} / {@code InstallXmlDeleteSetTest}: a version or
  * platform-path rename must update every contract site in the same commit.
+ *
+ * <p>Disabled while mkd-gcm-natives staging is commented out (not yet on Maven Central). Re-enable
+ * with the pom dependency, {@code stage-gcm-natives} unpack, and ANT block in {@code
+ * installDistributionFiles.xml}.
  */
+@Disabled(
+    "mkd-gcm-natives staging temporarily disabled until artifact is on Central; see pom.xml +"
+        + " installDistributionFiles.xml")
 class BundledGcmNativesLockstepTest {
 
   private static final Pattern POM_PROPERTY =

--- a/projects/sitemanage/pom.xml
+++ b/projects/sitemanage/pom.xml
@@ -49,9 +49,10 @@
             <artifactId>rest</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
-        <!-- GCM language corrections: thin JNA SDK (local .m2 until published to MonkeyKing Central).
-             Native mkd_gcm_ffi is packaged into <installdir>/bin by perc-distribution-tree
-             (StartJetty -Djna.library.path); do not rely on classpath extraction alone. 
+        <!-- TEMP DISABLED until mkd-gcm-sdk / mkd-gcm-natives are on Maven Central.
+             GCM language corrections: thin JNA SDK. Native mkd_gcm_ffi is packaged into
+             <installdir>/bin by perc-distribution-tree (StartJetty -Djna.library.path);
+             do not rely on classpath extraction alone.
         <dependency>
             <groupId>dev.monkeyking</groupId>
             <artifactId>mkd-gcm-sdk</artifactId>


### PR DESCRIPTION
## Summary

Temporarily disable mkd-gcm native packaging until `dev.monkeyking:mkd-gcm-natives` / `mkd-gcm-sdk` are on Maven Central.

**Root cause:** `pom.xml` already had the `mkd-gcm-natives` dependency and `stage-gcm-natives` unpack commented out, but `installDistributionFiles.xml` still `<fail>`-ed when `mkd_gcm_ffi.dll` / `libmkd_gcm_ffi.so` were missing from the stage dir — breaking `perc-distribution-tree` antrun.

### Changes
- Comment out ANT GCM fail/copy/delete block in `installDistributionFiles.xml`
- Clarify TEMP DISABLED on already-commented pom dependency + `stage-gcm-natives`
- `@Disabled` `BundledGcmNativesLockstepTest` until re-enable
- Document re-enable checklist in module README
- Clarify TEMP DISABLED on already-commented sitemanage `mkd-gcm-sdk` dependency

## Test plan

- [x] `mvnw -Dtest=BundledGcmNativesLockstepTest test` in `perc-distribution-tree` → BUILD SUCCESS (2 skipped)
- [x] Module resource/antrun path no longer fails on missing `mkd_gcm_ffi` (same `test` lifecycle ran process-resources / jetty assembly without GCM fail)
- [x] Spotless apply → check
- [ ] CI green

## Re-enable later

When natives/SDK are on Central: restore pom dependency + `stage-gcm-natives`, restore ANT block, remove `@Disabled` on lockstep test, restore sitemanage `mkd-gcm-sdk` — one coordinated change.