### PR TITLE
fix(installer): prompt for install dir with last-install as default

### DIFF
--- a/docs/ai-generated/code-reviews/fix-installer-editable-install-path-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-installer-editable-install-path-erlang.md
@@ -1,0 +1,50 @@
+# Erlang review: fix/installer-editable-install-path
+
+**Date:** 2026-08-04  
+**Reviewer:** Erlang (pre-commit / pre-PR)  
+**Scope:** Uncommitted changes on `fix/installer-editable-install-path` vs `origin/main`  
+**Intent:** Interactive CMS installer must show last-install directory as an editable default, not force it and skip the path prompt.
+
+## Summary
+
+`InstallerUserSettings.applyDefaults` correctly fills `cms.install.directory` for silent reuse. `InteractiveInstallWizard.runPhase1` previously treated a non-null path after defaults as “already supplied,” so interactive runs never prompted when last-install settings existed. The fix tracks CLI vs saved path (`pathFromCli`) and always prompts in interactive mode when the CLI path is absent, using the saved path only as `promptForInstallPath` default. Silent/non-TTY behavior is preserved.
+
+## Scope
+
+|            Item            |                                                   Detail                                                    |
+|----------------------------|-------------------------------------------------------------------------------------------------------------|
+| Files                      | `InteractiveInstallWizard.java`, `InstallerUserSettings.java` (Javadoc), two unit test classes              |
+| Prior report               | none for this topic                                                                                         |
+| Memory patterns hit        | Installer interactive vs silent gates; missing behavioral tests for non-trivial wizard logic                |
+| Cross-platform path review | Clean — uses `Path` / `toAbsolutePath().normalize()`; no hardcoded separators; tests use `TempDir` / `Path` |
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+|               Check                |                                 Result                                  |
+|------------------------------------|-------------------------------------------------------------------------|
+| Bugs                               | none                                                                    |
+| Behavioral tests for changed logic | present (accept default, change path, silent still applies saved path)  |
+| Change-class closure               | adequate for installer wizard path resolution (unit tests mirror peers) |
+| Non-portable I/O                   | none                                                                    |
+| **May commit/push**                | **yes**                                                                 |
+
+## Issues
+
+_None blocking._
+
+### suggestion (non-blocking)
+
+None material. Optional future: if other last-install keys are mis-treated as CLI overrides in interactive DB collection, audit separately (out of scope; upgrade path intentionally skips DB prompts).
+
+## Test evidence (session)
+
+```text
+mvnw -Dtest=InteractiveInstallWizardTest,InstallerUserSettingsTest test
+Tests run: 34, Failures: 0, Errors: 0
+BUILD SUCCESS
+```
+

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InstallerUserSettings.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InstallerUserSettings.java
@@ -119,6 +119,10 @@ public final class InstallerUserSettings {
    * Apply saved defaults to a parsed CLI result: fill install path and missing option keys only.
    * Explicit CLI values always win.
    *
+   * <p>When the install path is filled from last-install settings, interactive callers must still
+   * treat it as a <em>default</em> for a path prompt (see {@link InteractiveInstallWizard}), not as
+   * a CLI-supplied path that skips operator confirmation of the directory.
+   *
    * @param parsedArgs CLI parse result
    * @return new parse result with defaults merged
    */

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InteractiveInstallWizard.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/InteractiveInstallWizard.java
@@ -30,7 +30,8 @@ import java.util.Objects;
 /**
  * Console wizard for CMS preinstall (issue #1513).
  *
- * <p><strong>Phase 1:</strong> installation directory (when missing) and summary + confirm.
+ * <p><strong>Phase 1:</strong> installation directory (prompted when not supplied on the CLI;
+ * last-install path is the editable default only) and summary + confirm.
  *
  * <p><strong>Phase 2:</strong> Java home selection ({@link JavaInstallSelection}) after path.
  *
@@ -93,6 +94,16 @@ public final class InteractiveInstallWizard {
    * Phase 1–2: ensure install path, select/persist Java home, resolve DB config from existing
    * CLI/env defaults, show summary, and confirm when interactive.
    *
+   * <p>Install path rules:
+   *
+   * <ul>
+   *   <li>CLI path always wins (no path re-prompt in interactive mode).
+   *   <li>Interactive with no CLI path always prompts; last-install path is only the default the
+   *       operator may accept or change.
+   *   <li>Silent / non-TTY with no CLI path uses the last-install path when present, otherwise
+   *       usage abort.
+   * </ul>
+   *
    * @param parsedArgs CLI parse result (path may be null)
    * @param interactive whether to prompt
    * @param prompt operator I/O; required when interactive
@@ -141,6 +152,10 @@ public final class InteractiveInstallWizard {
 
     InstallerUserSettings userSettings =
         new InstallerUserSettings(userSettingsHome, InstallerUserSettings.PREFIX_CMS);
+    // Track CLI path before defaults: applyDefaults fills install.directory from
+    // ~/.intsof/percussion/last-install.properties for silent reuse, but interactive mode must
+    // still prompt so the operator can change the directory (saved value is the default only).
+    boolean pathFromCli = parsedArgs.installPath() != null;
     DbInstallConfigResolver.ParsedArgs withDefaults = userSettings.applyDefaults(parsedArgs);
 
     Path installPath = withDefaults.installPath();
@@ -149,15 +164,23 @@ public final class InteractiveInstallWizard {
             ? new LinkedHashMap<>(withDefaults.options())
             : new LinkedHashMap<>();
 
-    if (installPath == null) {
-      if (!interactive) {
-        return Phase1Result.abort(EXIT_USAGE, usageMessage());
-      }
-      installPath = promptForInstallPath(prompt, userSettings.loadInstallDirectory().orElse(null));
+    if (pathFromCli) {
+      installPath = installPath.toAbsolutePath().normalize();
+    } else if (interactive) {
+      // Always prompt when the operator did not pass a path on the CLI. Saved last-install path
+      // (if any) is offered as the editable default, not a forced destination.
+      Path defaultPath =
+          installPath != null
+              ? installPath.toAbsolutePath().normalize()
+              : userSettings.loadInstallDirectory().orElse(null);
+      installPath = promptForInstallPath(prompt, defaultPath);
       if (installPath == null) {
         return Phase1Result.abort(EXIT_ABORTED, "Installation cancelled: no install directory.");
       }
+    } else if (installPath == null) {
+      return Phase1Result.abort(EXIT_USAGE, usageMessage());
     } else {
+      // Silent / non-TTY: honor last-install path from applyDefaults
       installPath = installPath.toAbsolutePath().normalize();
     }
 

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/InstallerUserSettingsTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/InstallerUserSettingsTest.java
@@ -163,7 +163,8 @@ class InstallerUserSettingsTest {
     new InstallerUserSettings(tempHome, InstallerUserSettings.PREFIX_CMS)
         .save(prior, "8.2.0", Map.of("db.type", "h2"), null);
 
-    // Empty path answer accepts default; then H2 password prompts + demo-sites + confirm
+    // Empty path answer accepts default; then H2 menu default + password prompts + demo-sites +
+    // confirm. Saved path must appear as the editable default, not skip the path prompt.
     ScriptedPrompt prompt = new ScriptedPrompt("", "", "operator-pwd", "operator-pwd", "", "");
     Path javaHome = Path.of(System.getProperty("java.home")).toAbsolutePath().normalize();
     DbInstallConfigResolver.ParsedArgs parsed =
@@ -172,11 +173,16 @@ class InstallerUserSettingsTest {
         InteractiveInstallWizard.runPhase1(parsed, true, prompt, javaHome, tempHome);
     assertTrue(result.proceed());
     assertEquals(prior.toAbsolutePath().normalize(), result.installPath());
+    assertTrue(
+        prompt.sawInstallDirectoryPrompt,
+        "interactive mode must prompt for install directory when path comes only from"
+            + " last-install.properties");
   }
 
   /** Minimal scripted console for wizard tests. */
   private static final class ScriptedPrompt implements InstallPrompt {
     private final java.util.ArrayDeque<String> answers = new java.util.ArrayDeque<>();
+    private boolean sawInstallDirectoryPrompt;
 
     ScriptedPrompt(String... answers) {
       for (String a : answers) {
@@ -192,6 +198,9 @@ class InstallerUserSettingsTest {
 
     @Override
     public String readLine(String prompt) {
+      if (prompt != null && prompt.contains("Installation directory")) {
+        sawInstallDirectoryPrompt = true;
+      }
       return answers.isEmpty() ? "" : answers.removeFirst();
     }
 

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/InteractiveInstallWizardTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/InteractiveInstallWizardTest.java
@@ -280,6 +280,65 @@ class InteractiveInstallWizardTest {
     assertEquals(savedInstall.toAbsolutePath().normalize(), result.installPath());
   }
 
+  /**
+   * Regression: last-install path must be an editable default in interactive mode, not a forced
+   * destination that skips the directory prompt (operator cannot change install root).
+   */
+  @Test
+  void interactivePromptsWithSavedPathAsDefaultAndAcceptsEmpty() throws Exception {
+    Path savedInstall = tempDir.resolve("prior-install");
+    Files.createDirectories(savedInstall);
+    InstallerUserSettings settings =
+        new InstallerUserSettings(isolatedUserHome(), InstallerUserSettings.PREFIX_CMS);
+    settings.save(savedInstall, "8.2.0", Map.of(), runningJavaHome().toString());
+
+    // empty path → accept default; H2 menu; CMS DB password + confirm; demo-sites; confirm Y
+    ScriptedPrompt prompt = new ScriptedPrompt("", "1", "secret", "secret", "", "y");
+    DbInstallConfigResolver.ParsedArgs parsed =
+        new DbInstallConfigResolver.ParsedArgs(null, Map.of());
+    InteractiveInstallWizard.Phase1Result result =
+        runPhase1Isolated(parsed, true, prompt, runningJavaHome());
+    assertTrue(result.proceed());
+    assertEquals(savedInstall.toAbsolutePath().normalize(), result.installPath());
+    String out = prompt.outputsAsString();
+    assertTrue(
+        out.contains("Installation directory"),
+        "interactive mode must prompt for install directory even when last-install has a path;"
+            + " was:\n"
+            + out);
+    assertTrue(
+        out.contains(savedInstall.toAbsolutePath().normalize().toString())
+            || out.contains(savedInstall.toString()),
+        "path prompt must show saved install path as default; was:\n" + out);
+  }
+
+  /**
+   * Regression: operator can override last-install directory by typing a different path at the
+   * prompt.
+   */
+  @Test
+  void interactiveAllowsChangingSavedInstallDirectory() throws Exception {
+    Path savedInstall = tempDir.resolve("old-install");
+    Path newInstall = tempDir.resolve("new-install");
+    Files.createDirectories(savedInstall);
+    InstallerUserSettings settings =
+        new InstallerUserSettings(isolatedUserHome(), InstallerUserSettings.PREFIX_CMS);
+    settings.save(savedInstall, "8.2.0", Map.of(), runningJavaHome().toString());
+
+    // different path → H2; password + confirm; demo-sites; confirm Y
+    ScriptedPrompt prompt =
+        new ScriptedPrompt(newInstall.toString(), "1", "secret", "secret", "", "y");
+    DbInstallConfigResolver.ParsedArgs parsed =
+        new DbInstallConfigResolver.ParsedArgs(null, Map.of());
+    InteractiveInstallWizard.Phase1Result result =
+        runPhase1Isolated(parsed, true, prompt, runningJavaHome());
+    assertTrue(result.proceed());
+    assertEquals(newInstall.toAbsolutePath().normalize(), result.installPath());
+    assertTrue(
+        prompt.outputsAsString().contains("Installation directory"),
+        "must still show the install-directory prompt when last-install path exists");
+  }
+
   @Test
   void summaryDetectsUpgradeWhenVersionPropertiesPresent() throws Exception {
     Path install = tempDir.resolve("upgrade-root");


### PR DESCRIPTION
## Summary

Interactive CMS preinstall loaded `cms.install.directory` from `~/.intsof/percussion/last-install.properties` via `InstallerUserSettings.applyDefaults` and then treated that path as already resolved, **skipping** the installation-directory prompt. Operators could not change the install root; the summary simply showed the previous path.

### Fix

- Track whether the install path was supplied on the **CLI** (`pathFromCli`).
- **Interactive + no CLI path:** always prompt; last-install path is only the editable default (Enter accepts; typing overrides).
- **CLI path:** unchanged (no re-prompt).
- **Silent / non-TTY:** still reuses last-install path when present.

## Test plan

- [x] Unit tests: accept saved default, override with a different path, silent still applies saved path
- [x] `InteractiveInstallWizardTest` + `InstallerUserSettingsTest` (34 tests)
- [x] Standalone module `clean install` for `perc-distribution-tree`: **BUILD SUCCESS** (Tests run: 197, Failures: 0)
- [x] Spotless: `spotless:apply` then `spotless:check` (in-scope only)
- [x] Erlang pre-commit review: **approve** (`docs/ai-generated/code-reviews/fix-installer-editable-install-path-erlang.md`)
- [ ] Manual: `java -jar modules/perc-distribution-tree/target/perc-distribution-tree.jar` with last-install set → should show `Installation directory [prior]:` and allow change

## Pre-PR gates

| Gate | Result |
|------|--------|
| Erlang | approve |
| Spotless apply → check | pass; no out-of-scope rewrites in commit |
| Module clean install | `cd modules/perc-distribution-tree && ../../mvnw clean install` → BUILD SUCCESS |

> Co-Authored by Grok Build using grok-4.5 with agent main.