### PR TITLE
fix(perc-exceptions-spring): resolve all 100 Javadoc warnings (#1780)

### DIFF
--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/IPSValidationException.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/IPSValidationException.java
@@ -18,12 +18,18 @@ package com.percussion.share.service.exception;
 
 import com.percussion.share.validation.PSValidationErrors;
 
+/**
+ * Marks a {@link RuntimeException} that exposes its underlying {@link PSValidationErrors} so the
+ * errors can be serialized (for example, across a REST boundary).
+ *
+ * @author adamgent
+ */
 public interface IPSValidationException {
 
   /**
-   * Serializable Validation errors.
+   * Returns the serializable validation errors carried by this exception.
    *
-   * @return maybe <code>null</code>.
+   * @return the validation errors, may be {@code null} when no errors have been recorded.
    */
   public PSValidationErrors getValidationErrors();
 }

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSBeanValidationException.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSBeanValidationException.java
@@ -28,21 +28,49 @@ public class PSBeanValidationException extends PSSpringValidationException {
 
   private static final long serialVersionUID = 8097878230304938879L;
 
+  /**
+   * Constructs a bean validation exception that wraps the given cause.
+   *
+   * @param cause the underlying cause, may be {@code null}.
+   */
   public PSBeanValidationException(Throwable cause) {
     super(cause);
   }
 
+  /**
+   * Constructs a bean validation exception for the given target and method.
+   *
+   * @param target the bean being validated, may be {@code null}.
+   * @param methodName the canonical name used to identify the bean in the resulting binding result,
+   *     never {@code null}.
+   */
   public PSBeanValidationException(Object target, String methodName) {
     super(methodName);
     init(target, methodName);
   }
 
+  /**
+   * Constructs a bean validation exception with a custom message and cause.
+   *
+   * @param target the bean being validated, may be {@code null}.
+   * @param methodName the canonical name used to identify the bean in the resulting binding result,
+   *     never {@code null}.
+   * @param message the detail message, may be {@code null}.
+   * @param cause the underlying cause, may be {@code null}.
+   */
   public PSBeanValidationException(
       Object target, String methodName, String message, Throwable cause) {
     super(message, cause);
     init(target, methodName);
   }
 
+  /**
+   * Initializes this exception with a Spring {@link BeanPropertyBindingResult} for the supplied
+   * target.
+   *
+   * @param target the bean being validated, may be {@code null}.
+   * @param objectName the name to associate with the binding result, never {@code null}.
+   */
   protected void init(Object target, String objectName) {
     setSpringValidationErrors(new BeanPropertyBindingResult(target, objectName));
   }

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSBeanValidationUtils.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSBeanValidationUtils.java
@@ -19,10 +19,40 @@ package com.percussion.share.service.exception;
 import com.percussion.share.validation.PSAbstractBeanValidator;
 import com.percussion.share.validation.PSValidationErrors;
 
+/**
+ * Utility class providing convenience methods for validating beans using the default {@link
+ * PSAbstractBeanValidator} instance.
+ *
+ * @author adamgent
+ */
 public class PSBeanValidationUtils {
+
+  /**
+   * Default constructor required for proxy-based instantiation frameworks; this is a static utility
+   * class and should not be instantiated.
+   */
+  public PSBeanValidationUtils() {
+    super();
+  }
+
+  /**
+   * The default no-op bean validator. Subclasses or callers may supply a more specific validator
+   * via the {@code validate(...)} overloads; the default validator simply records the call.
+   */
   public static PSAbstractBeanValidator<Object> defaultValidator = new DefaultValidator();
 
+  /**
+   * Default {@link PSAbstractBeanValidator} that performs no additional validation beyond what is
+   * contributed by the underlying Spring/OVal mechanism.
+   *
+   * @author adamgent
+   */
   public static class DefaultValidator extends PSAbstractBeanValidator<Object> {
+
+    /** Default constructor required for proxy-based instantiation frameworks. */
+    public DefaultValidator() {
+      super();
+    }
 
     @Override
     protected void doValidation(Object obj, PSBeanValidationException e) {
@@ -30,6 +60,15 @@ public class PSBeanValidationUtils {
     }
   }
 
+  /**
+   * Validates the given object and returns its validation errors, throwing a {@link
+   * PSBeanValidationException} if any errors are present.
+   *
+   * @param <FULL> the type of the object to validate.
+   * @param obj the object to validate, never {@code null}.
+   * @return the validation errors, never {@code null}.
+   * @throws PSBeanValidationException if validation produces any errors.
+   */
   public static <FULL> PSValidationErrors getValidationErrorsOrFailIfInvalid(FULL obj)
       throws PSBeanValidationException {
     try {
@@ -41,6 +80,14 @@ public class PSBeanValidationUtils {
     }
   }
 
+  /**
+   * Validates the given object and returns the resulting exception container so callers can decide
+   * how to surface the errors.
+   *
+   * @param <FULL> the type of the object to validate.
+   * @param obj the object to validate, never {@code null}.
+   * @return a {@link PSBeanValidationException} carrying any validation errors, never {@code null}.
+   */
   public static <FULL> PSBeanValidationException validate(FULL obj) {
     try {
       PSBeanValidationException e = defaultValidator.validate(obj);
@@ -50,6 +97,14 @@ public class PSBeanValidationUtils {
     }
   }
 
+  /**
+   * Returns the validation errors recorded for the given object, or an empty result when there are
+   * none.
+   *
+   * @param <FULL> the type of the object to validate.
+   * @param obj the object to validate, never {@code null}.
+   * @return the validation errors, never {@code null}.
+   */
   public static <FULL> PSValidationErrors getValidationErrors(FULL obj) {
     try {
       PSBeanValidationException e = defaultValidator.validate(obj);
@@ -59,6 +114,13 @@ public class PSBeanValidationUtils {
     }
   }
 
+  /**
+   * Validates the given object, writing any errors into the supplied exception container.
+   *
+   * @param <FULL> the type of the object to validate.
+   * @param obj the object to validate, never {@code null}.
+   * @param errors the container that receives any validation errors, never {@code null}.
+   */
   public static <FULL> void validate(FULL obj, PSBeanValidationException errors) {
     defaultValidator.validate(obj, errors);
   }

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSErrorUtils.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSErrorUtils.java
@@ -30,6 +30,23 @@ import com.percussion.share.validation.PSErrors.PSObjectError;
  */
 public class PSErrorUtils {
 
+  /**
+   * Default constructor required for proxy-based instantiation frameworks; this is a static utility
+   * class and should not be instantiated.
+   */
+  public PSErrorUtils() {
+    super();
+  }
+
+  /**
+   * Creates a {@link PSErrors} object that represents the given exception. The resulting errors
+   * object contains a single global error whose code is taken from {@link
+   * IPSException#getErrorCode()} when applicable or the exception class's canonical name otherwise.
+   *
+   * @param exception the exception to convert, never {@code null}.
+   * @return the populated errors object, never {@code null}.
+   * @throws NullPointerException if {@code exception} is {@code null}.
+   */
   public static PSErrors createErrorsFromException(Throwable exception) {
     notNull(exception, "exception cannot be null");
     PSErrors errors = new PSErrors();
@@ -57,22 +74,51 @@ public class PSErrorUtils {
     return errors;
   }
 
+  /**
+   * Wraps the given errors in a runtime exception that carries them forward.
+   *
+   * @param errors the errors to wrap, never {@code null}.
+   * @return a {@link PSProxyException} carrying the supplied errors, never {@code null}.
+   * @throws NullPointerException if {@code errors} is {@code null}.
+   */
   public static RuntimeException createExceptionFromErrors(PSErrors errors) {
     notNull(errors, "errors cannot be null");
     return new PSProxyException(errors);
   }
 
+  /**
+   * A runtime exception that carries a {@link PSErrors} payload across boundaries where checked
+   * exceptions cannot be thrown.
+   *
+   * @author adamgent
+   */
   public static class PSProxyException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
+
+    /** The message returned by {@link #getMessage()}; may be {@code null}. */
     private String message;
+
+    /** The wrapped errors; never {@code null} after {@link #convert(PSErrors)} is invoked. */
     protected PSErrors errors;
 
+    /**
+     * Constructs a proxy exception that wraps the supplied errors.
+     *
+     * @param errors the errors to carry, may be {@code null} until {@link #convert(PSErrors)} is
+     *     called.
+     */
     public PSProxyException(PSErrors errors) {
       super();
       this.errors = errors;
     }
 
+    /**
+     * Replaces the carried errors and synchronizes this exception's message with the global error's
+     * default message.
+     *
+     * @param errors the new errors to carry, never {@code null}.
+     */
     protected void convert(PSErrors errors) {
       this.errors = errors;
       notNull(errors, "errors cannot be null");
@@ -85,6 +131,11 @@ public class PSErrorUtils {
       return message;
     }
 
+    /**
+     * Sets the message returned by {@link #getMessage()}.
+     *
+     * @param message the message to expose, may be {@code null}.
+     */
     protected void setMessage(String message) {
       this.message = message;
     }

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSParameterValidationUtils.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSParameterValidationUtils.java
@@ -19,22 +19,68 @@ package com.percussion.share.service.exception;
 import com.percussion.share.validation.PSValidationErrors;
 import com.percussion.share.validation.PSValidationErrorsBuilder;
 
+/**
+ * Utility helpers that build and throw {@link PSParametersValidationException} instances when
+ * method parameters fail validation.
+ *
+ * @author adamgent
+ */
 public class PSParameterValidationUtils {
 
+  /**
+   * Default constructor required for proxy-based instantiation frameworks; this is a static utility
+   * class and should not be instantiated.
+   */
+  public PSParameterValidationUtils() {
+    super();
+  }
+
+  /**
+   * Rejects the given value when it is {@code null}, throwing a {@link PSValidationException}
+   * annotated with the supplied method and field names.
+   *
+   * @param method the name of the method being validated, never {@code null}.
+   * @param field the name of the parameter being validated, never {@code null}.
+   * @param value the value to check, may be {@code null}.
+   * @throws PSValidationException if {@code value} is {@code null}.
+   */
   public static void rejectIfNull(String method, String field, Object value)
       throws PSValidationException {
     throwIfErrors(new PSValidationErrorsBuilder(method).rejectIfNull(field, value).build());
   }
 
+  /**
+   * Rejects the given value when it is {@code null}, empty, or contains only whitespace, throwing a
+   * {@link PSValidationException} annotated with the supplied method and field names.
+   *
+   * @param method the name of the method being validated, never {@code null}.
+   * @param field the name of the parameter being validated, never {@code null}.
+   * @param value the value to check, may be {@code null}.
+   * @throws PSValidationException if {@code value} is {@code null}, empty, or blank.
+   */
   public static void rejectIfBlank(String method, String field, String value)
       throws PSValidationException {
     throwIfErrors(new PSValidationErrorsBuilder(method).rejectIfBlank(field, value).build());
   }
 
+  /**
+   * Creates a new {@link PSValidationErrorsBuilder} associated with the given method name so
+   * callers can chain additional rejection rules.
+   *
+   * @param method the name of the method being validated, never {@code null}.
+   * @return a new builder, never {@code null}.
+   */
   public static PSValidationErrorsBuilder validateParameters(String method) {
     return new PSValidationErrorsBuilder(method);
   }
 
+  /**
+   * Throws a {@link PSParametersValidationException} when the supplied validation errors contain at
+   * least one entry.
+   *
+   * @param pve the validation errors to evaluate, never {@code null}.
+   * @throws PSValidationException if the validation errors contain any entries.
+   */
   public static void throwIfErrors(PSValidationErrors pve) throws PSValidationException {
     new PSParametersValidationException(pve).throwIfInvalid();
   }

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSParametersValidationException.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSParametersValidationException.java
@@ -26,9 +26,14 @@ import com.percussion.share.validation.PSValidationErrors;
  */
 public class PSParametersValidationException extends PSValidationException {
 
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Constructs a parameters validation exception that wraps the given validation errors.
+   *
+   * @param validationErrors the validation errors to wrap, never {@code null}.
+   */
   public PSParametersValidationException(PSValidationErrors validationErrors) {
     super(validationErrors);
   }
-
-  private static final long serialVersionUID = 1L;
 }

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSPropertiesValidationException.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSPropertiesValidationException.java
@@ -30,14 +30,30 @@ import org.springframework.validation.MapBindingResult;
 public class PSPropertiesValidationException extends PSSpringValidationException {
 
   private static final long serialVersionUID = 1L;
+
+  /** The property map that backs the binding result; never {@code null}. */
   private Map<String, Object> properties = new HashMap<>();
 
+  /**
+   * Constructs a properties validation exception for the given target and method.
+   *
+   * @param target the property-like object being validated, may be {@code null}.
+   * @param methodName the name to associate with the resulting binding result, never {@code null}.
+   */
   public PSPropertiesValidationException(Object target, String methodName) {
     super(methodName);
     init(target, methodName);
     setProperties(getProperties());
   }
 
+  /**
+   * Constructs a properties validation exception with a custom message and cause.
+   *
+   * @param target the property-like object being validated, may be {@code null}.
+   * @param methodName the name to associate with the resulting binding result, never {@code null}.
+   * @param message the detail message, may be {@code null}.
+   * @param cause the underlying cause, may be {@code null}.
+   */
   public PSPropertiesValidationException(
       Object target, String methodName, String message, Throwable cause) {
     super(message, cause);
@@ -45,19 +61,41 @@ public class PSPropertiesValidationException extends PSSpringValidationException
     setProperties(getProperties());
   }
 
+  /**
+   * Initializes the binding result for the given target using its runtime type.
+   *
+   * @param target the property-like object being validated, may be {@code null}.
+   * @param objectName the name to associate with the resulting binding result, never {@code null}.
+   */
   protected void init(Object target, String objectName) {
     init(getProperties(), objectName);
   }
 
+  /**
+   * Initializes the binding result with the supplied property map.
+   *
+   * @param properties the property map to validate, never {@code null}.
+   * @param objectName the name to associate with the resulting binding result, never {@code null}.
+   */
   protected void init(Map<String, Object> properties, String objectName) {
     MapBindingResult mbr = new MapBindingResult(properties, objectName);
     setSpringValidationErrors(mbr);
   }
 
+  /**
+   * Returns the underlying property map that backs the binding result.
+   *
+   * @return the property map, never {@code null}.
+   */
   public Map<String, Object> getProperties() {
     return properties;
   }
 
+  /**
+   * Replaces the underlying property map and rebuilds the binding result.
+   *
+   * @param parameters the new property map, never {@code null}.
+   */
   public void setProperties(Map<String, Object> parameters) {
     this.properties = parameters;
     init(parameters, getObjectName());

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSSpringValidationException.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSSpringValidationException.java
@@ -35,27 +35,58 @@ public abstract class PSSpringValidationException extends PSValidationException
     implements Errors, IPSValidationException {
 
   private static final long serialVersionUID = 1L;
+
+  /** The wrapped Spring {@link Errors} container; may be {@code null} when not configured. */
   private Errors springValidationErrors;
 
+  /**
+   * Constructs a Spring validation exception that wraps the given cause.
+   *
+   * @param cause the underlying cause, may be {@code null}.
+   */
   public PSSpringValidationException(Throwable cause) {
     super(cause);
   }
 
+  /**
+   * Constructs a Spring validation exception with the given message.
+   *
+   * @param message the detail message, may be {@code null}.
+   */
   public PSSpringValidationException(String message) {
     super(message);
   }
 
+  /**
+   * Constructs a Spring validation exception with the given message and cause.
+   *
+   * @param message the detail message, may be {@code null}.
+   * @param cause the underlying cause, may be {@code null}.
+   */
   public PSSpringValidationException(String message, Throwable cause) {
     super(message, cause);
     reject(cause, message);
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * @return this exception for fluent chaining, never {@code null}.
+   * @throws PSSpringValidationException always thrown when this exception is currently in an
+   *     invalid state.
+   */
   @Override
   public PSSpringValidationException throwIfInvalid() throws PSSpringValidationException {
     if (hasErrors()) throw this;
     return this;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * @return a fresh {@link PSValidationErrors} view of the wrapped Spring errors, never {@code
+   *     null}.
+   */
   @Override
   public PSValidationErrors getValidationErrors() {
     PSValidationErrors ve = new PSValidationErrors();
@@ -63,18 +94,41 @@ public abstract class PSSpringValidationException extends PSValidationException
     return ve;
   }
 
+  /**
+   * Returns the underlying Spring {@link Errors} container that this exception adapts.
+   *
+   * @return the Spring errors container, may be {@code null} when none has been configured.
+   */
   protected Errors getSpringValidationErrors() {
     return springValidationErrors;
   }
 
+  /**
+   * Replaces the underlying Spring {@link Errors} container.
+   *
+   * @param validationErrors the new Spring errors container, may be {@code null}.
+   */
   protected void setSpringValidationErrors(Errors validationErrors) {
     this.springValidationErrors = validationErrors;
   }
 
+  /**
+   * Rejects the given exception by recording a global error whose code is the exception's canonical
+   * class name.
+   *
+   * @param exception the throwable to reject, never {@code null}.
+   * @param defaultMessage the default message to associate with the rejection, may be {@code null}.
+   */
   public void reject(Throwable exception, String defaultMessage) {
     reject(exception.getClass().getCanonicalName(), defaultMessage);
   }
 
+  /**
+   * Copies Spring {@link Errors} content into the supplied {@link PSValidationErrors} container.
+   *
+   * @param v the destination container, never {@code null}.
+   * @param errors the source Spring errors, never {@code null}.
+   */
   protected void convert(PSValidationErrors v, org.springframework.validation.Errors errors) {
     v.setMethodName(errors.getObjectName());
     List<org.springframework.validation.FieldError> fes = errors.getFieldErrors();
@@ -87,12 +141,25 @@ public abstract class PSSpringValidationException extends PSValidationException
     }
   }
 
+  /**
+   * Converts a Spring {@link ObjectError} into a {@link PSObjectError}.
+   *
+   * @param oe the Spring object error, never {@code null}.
+   * @return the converted {@link PSObjectError}, never {@code null}.
+   */
   protected PSObjectError convert(org.springframework.validation.ObjectError oe) {
     PSObjectError oew = new PSObjectError();
     convert(oe, oew);
     return oew;
   }
 
+  /**
+   * Copies the relevant fields of a Spring {@link ObjectError} into the supplied {@link
+   * PSObjectError}.
+   *
+   * @param oe the source Spring object error, never {@code null}.
+   * @param oew the destination, never {@code null}.
+   */
   protected void convert(org.springframework.validation.ObjectError oe, PSObjectError oew) {
     oew.setCode(oe.getCode());
     oew.setDefaultMessage(oe.getDefaultMessage());
@@ -108,6 +175,12 @@ public abstract class PSSpringValidationException extends PSValidationException
     return rvalue;
   }
 
+  /**
+   * Converts a Spring {@link FieldError} into a {@link PSFieldError}.
+   *
+   * @param oe the Spring field error, never {@code null}.
+   * @return the converted {@link PSFieldError}, never {@code null}.
+   */
   protected PSFieldError convert(org.springframework.validation.FieldError oe) {
     PSFieldError oew = new PSFieldError();
     convert(oe, oew);
@@ -122,119 +195,286 @@ public abstract class PSSpringValidationException extends PSValidationException
     return super.toString() + springValidationErrors.toString();
   }
 
+  /**
+   * Adds all errors from the supplied instance into the wrapped Spring container.
+   *
+   * @param arg0 the source errors, never {@code null}.
+   */
   public void addAllErrors(Errors arg0) {
     springValidationErrors.addAllErrors(arg0);
   }
 
+  /**
+   * Returns all errors (field and global) from the wrapped Spring container.
+   *
+   * @return the list of all errors, never {@code null}.
+   */
   public List<ObjectError> getAllErrors() {
     return springValidationErrors.getAllErrors();
   }
 
+  /**
+   * Returns the total number of errors (field and global) recorded by the wrapped Spring container.
+   *
+   * @return the total error count.
+   */
   public int getErrorCount() {
     return springValidationErrors.getErrorCount();
   }
 
+  /**
+   * Returns the first field error recorded by the wrapped Spring container, or {@code null} when
+   * there are none.
+   *
+   * @return the first field error, may be {@code null}.
+   */
   public FieldError getFieldError() {
     return springValidationErrors.getFieldError();
   }
 
+  /**
+   * Returns the first field error recorded for the supplied field, or {@code null} when there are
+   * none.
+   *
+   * @param arg0 the field name, may be {@code null}.
+   * @return the first field error for the field, may be {@code null}.
+   */
   public FieldError getFieldError(String arg0) {
     return springValidationErrors.getFieldError(arg0);
   }
 
+  /**
+   * Returns the number of field errors recorded by the wrapped Spring container.
+   *
+   * @return the field error count.
+   */
   public int getFieldErrorCount() {
     return springValidationErrors.getFieldErrorCount();
   }
 
+  /**
+   * Returns the number of field errors recorded for the supplied field.
+   *
+   * @param arg0 the field name, may be {@code null}.
+   * @return the field error count for the field.
+   */
   public int getFieldErrorCount(String arg0) {
     return springValidationErrors.getFieldErrorCount(arg0);
   }
 
+  /**
+   * Returns all field errors recorded by the wrapped Spring container.
+   *
+   * @return the list of field errors, never {@code null}.
+   */
   public List<FieldError> getFieldErrors() {
     return springValidationErrors.getFieldErrors();
   }
 
+  /**
+   * Returns all field errors recorded for the supplied field.
+   *
+   * @param arg0 the field name, may be {@code null}.
+   * @return the list of field errors for the field, never {@code null}.
+   */
   public List<FieldError> getFieldErrors(String arg0) {
     return springValidationErrors.getFieldErrors(arg0);
   }
 
+  /**
+   * Returns the type of the supplied field as known to the wrapped Spring container.
+   *
+   * @param arg0 the field name, never {@code null}.
+   * @return the field type, may be {@code null} when the field is unknown.
+   */
   public Class<?> getFieldType(String arg0) {
     return springValidationErrors.getFieldType(arg0);
   }
 
+  /**
+   * Returns the value of the supplied field on the target object as known to the wrapped Spring
+   * container.
+   *
+   * @param arg0 the field name, never {@code null}.
+   * @return the field value, may be {@code null}.
+   */
   public Object getFieldValue(String arg0) {
     return springValidationErrors.getFieldValue(arg0);
   }
 
+  /**
+   * Returns the first global error recorded by the wrapped Spring container, or {@code null} when
+   * there are none.
+   *
+   * @return the first global error, may be {@code null}.
+   */
   public ObjectError getGlobalError() {
     return springValidationErrors.getGlobalError();
   }
 
+  /**
+   * Returns the number of global errors recorded by the wrapped Spring container.
+   *
+   * @return the global error count.
+   */
   public int getGlobalErrorCount() {
     return springValidationErrors.getGlobalErrorCount();
   }
 
+  /**
+   * Returns all global errors recorded by the wrapped Spring container.
+   *
+   * @return the list of global errors, never {@code null}.
+   */
   public List<ObjectError> getGlobalErrors() {
     return springValidationErrors.getGlobalErrors();
   }
 
+  /**
+   * Returns the current nested path used by the wrapped Spring container.
+   *
+   * @return the nested path, never {@code null}.
+   */
   public String getNestedPath() {
     return springValidationErrors.getNestedPath();
   }
 
+  /**
+   * Returns the object name associated with the wrapped Spring container.
+   *
+   * @return the object name, never {@code null}.
+   */
   public String getObjectName() {
     return springValidationErrors.getObjectName();
   }
 
+  /**
+   * Indicates whether the wrapped Spring container has any field or global errors.
+   *
+   * @return {@code true} when at least one error is recorded.
+   */
   public boolean hasErrors() {
     return springValidationErrors.hasErrors();
   }
 
+  /**
+   * Indicates whether the wrapped Spring container has any field errors.
+   *
+   * @return {@code true} when at least one field error is recorded.
+   */
   public boolean hasFieldErrors() {
     return springValidationErrors.hasFieldErrors();
   }
 
+  /**
+   * Indicates whether the wrapped Spring container has any field errors for the supplied field.
+   *
+   * @param arg0 the field name, may be {@code null}.
+   * @return {@code true} when at least one field error is recorded for the field.
+   */
   public boolean hasFieldErrors(String arg0) {
     return springValidationErrors.hasFieldErrors(arg0);
   }
 
+  /**
+   * Indicates whether the wrapped Spring container has any global errors.
+   *
+   * @return {@code true} when at least one global error is recorded.
+   */
   public boolean hasGlobalErrors() {
     return springValidationErrors.hasGlobalErrors();
   }
 
+  /**
+   * Pops the most recently pushed nested path from the wrapped Spring container.
+   *
+   * @throws IllegalStateException if there is no nested path to pop.
+   */
   public void popNestedPath() throws IllegalStateException {
     springValidationErrors.popNestedPath();
   }
 
+  /**
+   * Pushes the supplied sub path onto the nested path of the wrapped Spring container.
+   *
+   * @param arg0 the sub path to push, never {@code null}.
+   */
   public void pushNestedPath(String arg0) {
     springValidationErrors.pushNestedPath(arg0);
   }
 
+  /**
+   * Rejects the supplied error code with the given message-format arguments and default message on
+   * the wrapped Spring container.
+   *
+   * @param errorCode the error code, may be {@code null}.
+   * @param errorArgs the message-format arguments, may be {@code null}.
+   * @param defaultMessage the default message, may be {@code null}.
+   */
   public void reject(String errorCode, Object[] errorArgs, String defaultMessage) {
     springValidationErrors.reject(errorCode, errorArgs, defaultMessage);
   }
 
+  /**
+   * Rejects the supplied error code with the given default message on the wrapped Spring container.
+   *
+   * @param errorCode the error code, may be {@code null}.
+   * @param defaultMessage the default message, may be {@code null}.
+   */
   public void reject(String errorCode, String defaultMessage) {
     springValidationErrors.reject(errorCode, defaultMessage);
   }
 
+  /**
+   * Rejects the supplied error code on the wrapped Spring container.
+   *
+   * @param errorCode the error code, may be {@code null}.
+   */
   public void reject(String errorCode) {
     springValidationErrors.reject(errorCode);
   }
 
+  /**
+   * Rejects the supplied value for the given field with the supplied error code, arguments, and
+   * default message.
+   *
+   * @param field the field name, may be {@code null}.
+   * @param errorCode the error code, may be {@code null}.
+   * @param errorArgs the message-format arguments, may be {@code null}.
+   * @param defaultMessage the default message, may be {@code null}.
+   */
   public void rejectValue(
       String field, String errorCode, Object[] errorArgs, String defaultMessage) {
     springValidationErrors.rejectValue(field, errorCode, errorArgs, defaultMessage);
   }
 
+  /**
+   * Rejects the supplied value for the given field with the supplied error code and default
+   * message.
+   *
+   * @param field the field name, may be {@code null}.
+   * @param errorCode the error code, may be {@code null}.
+   * @param defaultMessage the default message, may be {@code null}.
+   */
   public void rejectValue(String field, String errorCode, String defaultMessage) {
     springValidationErrors.rejectValue(field, errorCode, defaultMessage);
   }
 
+  /**
+   * Rejects the supplied value for the given field with the supplied error code.
+   *
+   * @param field the field name, may be {@code null}.
+   * @param errorCode the error code, may be {@code null}.
+   */
   public void rejectValue(String field, String errorCode) {
     springValidationErrors.rejectValue(field, errorCode);
   }
 
+  /**
+   * Sets the nested path of the wrapped Spring container.
+   *
+   * @param arg0 the nested path, may be {@code null}.
+   */
   public void setNestedPath(String arg0) {
     springValidationErrors.setNestedPath(arg0);
   }

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSValidationException.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSValidationException.java
@@ -33,38 +33,73 @@ import com.percussion.share.validation.PSValidationErrors;
 public abstract class PSValidationException extends PSDataServiceException
     implements IPSValidationException {
 
+  /** The validation errors carried by this exception; may be {@code null}. */
   private PSValidationErrors validationErrors;
 
+  /**
+   * Constructs a validation exception that wraps the given validation errors.
+   *
+   * @param validationErrors the validation errors to wrap, never {@code null}.
+   */
   public PSValidationException(PSValidationErrors validationErrors) {
     super(validationErrors.toString());
     setValidationErrors(validationErrors);
   }
 
+  /**
+   * Constructs a validation exception with the given message.
+   *
+   * @param message the detail message, may be {@code null}.
+   */
   public PSValidationException(String message) {
     super(message);
   }
 
+  /**
+   * Constructs a validation exception with the given message and cause.
+   *
+   * @param message the detail message, may be {@code null}.
+   * @param cause the underlying cause, may be {@code null}.
+   */
   public PSValidationException(String message, Throwable cause) {
     super(message, cause);
   }
 
+  /**
+   * Constructs a validation exception that wraps the given cause.
+   *
+   * @param cause the underlying cause, may be {@code null}.
+   */
   public PSValidationException(Throwable cause) {
     super(cause);
   }
 
-  /** {@inheritDoc} */
+  /**
+   * {@inheritDoc}
+   *
+   * @return the wrapped validation errors, may be {@code null} when the exception was constructed
+   *     without a {@link PSValidationErrors} instance.
+   */
+  @Override
   public PSValidationErrors getValidationErrors() {
     return validationErrors;
   }
 
+  /**
+   * Replaces the validation errors carried by this exception.
+   *
+   * @param validationErrors the new validation errors, may be {@code null}.
+   */
   public void setValidationErrors(PSValidationErrors validationErrors) {
     this.validationErrors = validationErrors;
   }
 
   /**
-   * This exception will be thrown if its invalid.
+   * Throws this exception if any validation errors are present.
    *
-   * @return never <code>null</code>.
+   * @return this exception for fluent chaining, never {@code null}.
+   * @throws PSValidationException always thrown when this exception is currently in an invalid
+   *     state (i.e. it carries validation errors).
    */
   public PSValidationException throwIfInvalid() throws PSValidationException {
     if (validationErrors != null && validationErrors.hasErrors()) {

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSAbstractBeanValidator.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSAbstractBeanValidator.java
@@ -25,18 +25,38 @@ import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
 /**
- * See springs {@link Validator}.
+ * Adapter that wraps the OVal-based Spring {@link SpringValidator} and exposes a {@link
+ * PSBeanValidationException}-aware contract for validating plain Java bean objects. See Spring's
+ * {@link Validator} for the general contract.
  *
  * @author adamgent
  * @param <FULL> the class to be validated.
  */
 public abstract class PSAbstractBeanValidator<FULL> implements Validator {
+  /**
+   * Default constructor required for proxy-based instantiation frameworks; subclasses provide the
+   * bean-specific behavior via {@link #doValidation(Object, PSBeanValidationException)}.
+   */
+  protected PSAbstractBeanValidator() {
+    super();
+  }
+
+  /** The wrapped OVal Spring validator. */
   private SpringValidator ovalValidator = new SpringValidator();
 
   {
     ovalValidator.setValidator(new net.sf.oval.Validator());
   }
 
+  /**
+   * Validates the given object and returns the resulting exception container.
+   *
+   * @param obj the object to validate, never {@code null}.
+   * @return a {@link PSBeanValidationException} that aggregates any validation errors; the
+   *     exception is never {@code null} but is only meant to be thrown via {@link
+   *     PSBeanValidationException#throwIfInvalid()}.
+   * @throws PSValidationException if {@code obj} is {@code null}.
+   */
   public PSBeanValidationException validate(FULL obj) throws PSValidationException {
 
     PSParameterValidationUtils.rejectIfNull("validate", "object", obj);
@@ -46,13 +66,40 @@ public abstract class PSAbstractBeanValidator<FULL> implements Validator {
     return e;
   }
 
+  /**
+   * Template method that subclasses override to perform bean-specific validation in addition to
+   * OVal constraint checks.
+   *
+   * @param obj the object being validated, never {@code null}.
+   * @param e the exception container into which additional errors should be recorded, never {@code
+   *     null}.
+   * @throws PSValidationException if validation cannot proceed; the exception is added as a
+   *     suppressed error on {@code e}.
+   */
   protected abstract void doValidation(FULL obj, PSBeanValidationException e)
       throws PSValidationException;
 
+  /**
+   * Delegates the Spring {@link Validator#supports(Class)} contract to the underlying OVal
+   * validator.
+   *
+   * @param clazz the candidate target class, never {@code null}.
+   * @return {@code true} if the underlying validator supports {@code clazz}.
+   */
   public boolean supports(Class<?> clazz) {
     return ovalValidator.supports(clazz);
   }
 
+  /**
+   * Validates the given object using the wrapped OVal validator and then forwards to {@link
+   * #doValidation(Object, PSBeanValidationException)} when the {@link Errors} container is a {@link
+   * PSBeanValidationException}.
+   *
+   * @param object the object to validate, may be {@code null} only when the wrapped validator
+   *     accepts it.
+   * @param errors the Spring {@link Errors} container to populate; must be a {@link
+   *     PSBeanValidationException} to receive the additional {@link #doValidation} pass.
+   */
   public void validate(Object object, Errors errors) {
     try {
       ovalValidator.validate(object, errors);

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSAbstractPropertiesValidator.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSAbstractPropertiesValidator.java
@@ -23,15 +23,38 @@ import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
 /**
- * An adapter to validate property like objects.
+ * Adapter that validates property-like objects (such as {@link java.util.Map}s or {@link
+ * java.util.Properties}) by exposing a Spring {@link Validator} facade and producing {@link
+ * PSPropertiesValidationException} instances.
  *
  * @author adamgent
  * @param <PROPERTIES> property like object.
  */
 public abstract class PSAbstractPropertiesValidator<PROPERTIES> implements Validator {
 
+  /**
+   * Default constructor required for proxy-based instantiation frameworks; subclasses provide the
+   * type-specific behavior via {@link #getType()}.
+   */
+  protected PSAbstractPropertiesValidator() {
+    super();
+  }
+
+  /**
+   * Returns the concrete class that this validator supports. Subclasses must supply a non-null
+   * value.
+   *
+   * @return the property class supported by this validator, never {@code null}.
+   */
   protected abstract Class<PROPERTIES> getType();
 
+  /**
+   * Validates the given properties object and returns the resulting exception container.
+   *
+   * @param obj the properties object to validate, never {@code null}.
+   * @return a {@link PSPropertiesValidationException} that aggregates any validation errors, never
+   *     {@code null}.
+   */
   public PSPropertiesValidationException validate(PROPERTIES obj) {
     PSPropertiesValidationException e =
         new PSPropertiesValidationException(obj, obj.getClass().getCanonicalName());
@@ -39,14 +62,36 @@ public abstract class PSAbstractPropertiesValidator<PROPERTIES> implements Valid
     return e;
   }
 
+  /**
+   * Indicates whether this validator supports the given class.
+   *
+   * @param klass the candidate class, may be {@code null}.
+   * @return {@code true} only when {@code klass} equals the type returned by {@link #getType()}.
+   */
   public boolean supports(Class<?> klass) {
     notNull(getType(), "getType() cannot return null");
     if (klass == getType()) return true;
     return false;
   }
 
+  /**
+   * Template method that subclasses override to perform property-specific validation.
+   *
+   * @param properties the property-like object being validated, never {@code null}.
+   * @param e the exception container into which validation errors should be recorded, never {@code
+   *     null}.
+   */
   protected abstract void doValidation(PROPERTIES properties, PSPropertiesValidationException e);
 
+  /**
+   * Spring {@link Validator} entry point that forwards to {@link #doValidation} after the supplied
+   * {@code errors} container has been cast to {@link PSPropertiesValidationException}.
+   *
+   * @param properties the property-like object to validate, expected to be of type {@code
+   *     PROPERTIES}.
+   * @param errors the {@link PSPropertiesValidationException} container to populate, never {@code
+   *     null}.
+   */
   public void validate(Object properties, Errors errors) {
     doValidation((PROPERTIES) properties, (PSPropertiesValidationException) errors);
   }

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSErrorCause.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSErrorCause.java
@@ -43,14 +43,27 @@ public class PSErrorCause {
   private String localizedMessage;
   private Throwable cause;
 
+  /** Default no-arg constructor required for JAXB serialization. */
   public PSErrorCause() {
     super();
   }
 
+  /**
+   * Constructs a wrapper for the given cause without sending the stack trace to the client.
+   *
+   * @param cause the cause to wrap, may be {@code null}.
+   */
   public PSErrorCause(Throwable cause) {
     init(cause, false);
   }
 
+  /**
+   * Initializes the wrapper with the given throwable and stack-trace visibility flag.
+   *
+   * @param t the throwable to wrap, may be {@code null}.
+   * @param sendErrorStackToClient when {@code true}, the stack trace is included for delivery to
+   *     the client.
+   */
   protected void init(Throwable t, boolean sendErrorStackToClient) {
     setLocalizedMessage(t.getLocalizedMessage());
     setMessage(t.getMessage());
@@ -62,19 +75,39 @@ public class PSErrorCause {
     setCause(t.getCause());
   }
 
+  /**
+   * Returns the nested cause wrapper, if any.
+   *
+   * @return the nested {@link PSErrorCause}, may be {@code null}.
+   */
   public PSErrorCause getErrorCause() {
     return errorCause;
   }
 
+  /**
+   * Sets the nested cause wrapper.
+   *
+   * @param cause the nested cause wrapper, may be {@code null}.
+   */
   public void setErrorCause(PSErrorCause cause) {
     this.errorCause = cause;
   }
 
+  /**
+   * Returns the underlying throwable that this wrapper was built from. Not serialized by JAXB.
+   *
+   * @return the underlying throwable, may be {@code null}.
+   */
   @XmlTransient
   public Throwable getCause() {
     return cause;
   }
 
+  /**
+   * Sets the underlying throwable and updates the nested cause wrapper accordingly.
+   *
+   * @param cause the underlying throwable, may be {@code null}.
+   */
   public void setCause(Throwable cause) {
     this.cause = cause;
     if (cause != null) {
@@ -82,14 +115,30 @@ public class PSErrorCause {
     }
   }
 
+  /**
+   * Returns the list of {@link PSErrorCauseElement} entries that make up the cause stack trace.
+   *
+   * @return the cause stack trace list, may be {@code null}.
+   */
   public List<PSErrorCauseElement> getErrorCauseStackTrace() {
     return errorCauseStackTrace;
   }
 
+  /**
+   * Replaces the cause stack trace with the supplied list.
+   *
+   * @param errorCauseStackTrace the new cause stack trace list, may be {@code null}.
+   */
   public void setErrorCauseStackTrace(List<PSErrorCauseElement> errorCauseStackTrace) {
     this.errorCauseStackTrace = errorCauseStackTrace;
   }
 
+  /**
+   * Returns the combined stack trace reconstructed from the cause stack and the explicit stack
+   * trace. Not serialized by JAXB.
+   *
+   * @return the combined stack trace, never {@code null} but may be empty.
+   */
   @XmlTransient
   public StackTraceElement[] getStackTrace() {
     List<StackTraceElement> stack = new ArrayList<>();
@@ -104,6 +153,11 @@ public class PSErrorCause {
     return stack.toArray(new StackTraceElement[] {});
   }
 
+  /**
+   * Sets the explicit stack trace and rebuilds the serializable cause stack trace list.
+   *
+   * @param stackTrace the new stack trace, may be {@code null}.
+   */
   public void setStackTrace(StackTraceElement[] stackTrace) {
     this.stackTrace = stackTrace;
     if (stackTrace != null) {
@@ -114,22 +168,47 @@ public class PSErrorCause {
     }
   }
 
+  /**
+   * Returns the message of the underlying throwable.
+   *
+   * @return the message, may be {@code null}.
+   */
   public String getMessage() {
     return message;
   }
 
+  /**
+   * Sets the message after sanitizing it for safe HTML rendering.
+   *
+   * @param message the message to sanitize and store, may be {@code null}.
+   */
   public void setMessage(String message) {
     this.message = SecureStringUtils.sanitizeStringForHTML(message);
   }
 
+  /**
+   * Returns the localized message of the underlying throwable.
+   *
+   * @return the localized message, may be {@code null}.
+   */
   public String getLocalizedMessage() {
     return localizedMessage;
   }
 
+  /**
+   * Sets the localized message after sanitizing it for safe HTML rendering.
+   *
+   * @param localizedMessage the localized message to sanitize and store, may be {@code null}.
+   */
   public void setLocalizedMessage(String localizedMessage) {
     this.localizedMessage = SecureStringUtils.sanitizeStringForHTML(localizedMessage);
   }
 
+  /**
+   * JAXB-serializable representation of a single {@link StackTraceElement}.
+   *
+   * @author adamgent
+   */
   public static class PSErrorCauseElement {
 
     private String className;
@@ -137,14 +216,25 @@ public class PSErrorCause {
     private int lineNumber;
     private String methodName;
 
+    /** Default no-arg constructor required for JAXB serialization. */
     public PSErrorCauseElement() {
       super();
     }
 
+    /**
+     * Reconstructs the underlying {@link StackTraceElement} from the serialized fields.
+     *
+     * @return the reconstructed stack trace element, never {@code null}.
+     */
     public StackTraceElement getStackTraceElement() {
       return new StackTraceElement(getClassName(), getMethodName(), getFileName(), getLineNumber());
     }
 
+    /**
+     * Constructs an element by copying the relevant fields from the supplied stack trace element.
+     *
+     * @param element the stack trace element to copy, never {@code null}.
+     */
     public PSErrorCauseElement(StackTraceElement element) {
       setClassName(element.getClassName());
       setFileName(element.getFileName());
@@ -152,38 +242,78 @@ public class PSErrorCause {
       setMethodName(element.getMethodName());
     }
 
+    /**
+     * Returns the fully qualified class name of the stack frame.
+     *
+     * @return the class name, may be {@code null}.
+     */
     @XmlAttribute
     public String getClassName() {
       return className;
     }
 
+    /**
+     * Sets the fully qualified class name of the stack frame.
+     *
+     * @param className the class name, may be {@code null}.
+     */
     public void setClassName(String className) {
       this.className = className;
     }
 
+    /**
+     * Returns the source file name of the stack frame.
+     *
+     * @return the file name, may be {@code null}.
+     */
     @XmlAttribute
     public String getFileName() {
       return fileName;
     }
 
+    /**
+     * Sets the source file name of the stack frame.
+     *
+     * @param fileName the file name, may be {@code null}.
+     */
     public void setFileName(String fileName) {
       this.fileName = fileName;
     }
 
+    /**
+     * Returns the line number of the stack frame.
+     *
+     * @return the line number; values &lt; 0 indicate an unknown line.
+     */
     @XmlAttribute
     public int getLineNumber() {
       return lineNumber;
     }
 
+    /**
+     * Sets the line number of the stack frame.
+     *
+     * @param lineNumber the line number; pass a negative value when unknown.
+     */
     public void setLineNumber(int lineNumber) {
       this.lineNumber = lineNumber;
     }
 
+    /**
+     * Returns the method name of the stack frame.
+     *
+     * @return the method name, may be {@code null}.
+     */
     @XmlAttribute
     public String getMethodName() {
       return methodName;
     }
 
+    /**
+     * Sets the method name of the stack frame.
+     *
+     * @param methodName the method name, may be {@code null}.
+     */
     public void setMethodName(String methodName) {
       this.methodName = methodName;
     }

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSErrors.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSErrors.java
@@ -38,12 +38,27 @@ import java.util.List;
 @JsonRootName(value = "Errors")
 public class PSErrors {
 
+  /** Default constructor required for JAXB serialization. */
+  public PSErrors() {
+    super();
+  }
+
   private PSObjectError globalError;
 
+  /**
+   * Returns the single global error associated with this object, or {@code null} when none is set.
+   *
+   * @return the global error, may be {@code null}.
+   */
   public PSObjectError getGlobalError() {
     return globalError;
   }
 
+  /**
+   * Sets the single global error associated with this object.
+   *
+   * @param globalError the global error, may be {@code null}.
+   */
   public void setGlobalError(PSObjectError globalError) {
     this.globalError = globalError;
   }
@@ -62,6 +77,7 @@ public class PSErrors {
     private List<String> arguments;
     private PSErrorCause cause;
 
+    /** Default no-arg constructor required for JAXB serialization. */
     public PSObjectError() {
       super();
     }
@@ -76,6 +92,11 @@ public class PSErrors {
       return arguments;
     }
 
+    /**
+     * Sets the message-format arguments that will be substituted into {@link #getDefaultMessage()}.
+     *
+     * @param arguments the message arguments, may be {@code null}.
+     */
     public void setArguments(List<String> arguments) {
       this.arguments = arguments;
     }
@@ -89,22 +110,47 @@ public class PSErrors {
       return defaultMessage;
     }
 
+    /**
+     * Sets the default message after sanitizing it for safe HTML rendering.
+     *
+     * @param defaultMessage the default message to sanitize and store, may be {@code null}.
+     */
     public void setDefaultMessage(String defaultMessage) {
       this.defaultMessage = SecureStringUtils.sanitizeStringForHTML(defaultMessage);
     }
 
+    /**
+     * Returns the error code that identifies the type of error.
+     *
+     * @return the error code, may be {@code null}.
+     */
     public String getCode() {
       return code;
     }
 
+    /**
+     * Sets the error code after sanitizing it for safe HTML rendering.
+     *
+     * @param code the error code to sanitize and store, may be {@code null}.
+     */
     public void setCode(String code) {
       this.code = SecureStringUtils.sanitizeStringForHTML(code);
     }
 
+    /**
+     * Returns the underlying cause wrapper, if any.
+     *
+     * @return the cause wrapper, may be {@code null}.
+     */
     public PSErrorCause getCause() {
       return cause;
     }
 
+    /**
+     * Sets the underlying cause wrapper.
+     *
+     * @param cause the cause wrapper, may be {@code null}.
+     */
     public void setCause(PSErrorCause cause) {
       this.cause = cause;
     }

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSSpringOvalValidator.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSSpringOvalValidator.java
@@ -39,14 +39,33 @@ public class PSSpringOvalValidator implements Validator, InitializingBean {
 
   private net.sf.oval.Validator validator;
 
+  /**
+   * Constructs a validator that delegates to the supplied OVal validator.
+   *
+   * @param validator the OVal validator to delegate to, never {@code null}.
+   */
   public PSSpringOvalValidator(net.sf.oval.Validator validator) {
     this.validator = validator;
   }
 
+  /**
+   * Indicates whether this validator supports the given class. This implementation returns {@code
+   * true} for all classes because OVal itself is consulted at validation time.
+   *
+   * @param clazz the candidate class, never {@code null}.
+   * @return always {@code true}.
+   */
   public boolean supports(Class<?> clazz) {
     return true;
   }
 
+  /**
+   * Validates the given target, writing any constraint violations and nested-property errors into
+   * the supplied {@link Errors} container.
+   *
+   * @param target the object to validate, may be {@code null} only when OVal accepts it.
+   * @param errors the container that receives any validation errors, never {@code null}.
+   */
   public void validate(Object target, Errors errors) {
     doValidate(target, errors, "");
   }
@@ -110,14 +129,30 @@ public class PSSpringOvalValidator implements Validator, InitializingBean {
     return list;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * @throws Exception if the underlying OVal validator has not been configured.
+   */
+  @Override
   public void afterPropertiesSet() throws Exception {
     Assert.notNull(validator, "Property [validator] is not set");
   }
 
+  /**
+   * Returns the OVal validator that backs this Spring adapter.
+   *
+   * @return the OVal validator, may be {@code null} until {@link #setValidator} is called.
+   */
   public net.sf.oval.Validator getValidator() {
     return validator;
   }
 
+  /**
+   * Sets the OVal validator that backs this Spring adapter.
+   *
+   * @param validator the OVal validator to delegate to, never {@code null}.
+   */
   public void setValidator(net.sf.oval.Validator validator) {
     this.validator = validator;
   }

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSValidationErrors.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSValidationErrors.java
@@ -37,74 +37,162 @@ public class PSValidationErrors extends PSErrors {
   private List<PSObjectError> globalErrors = new ArrayList<>();
   private String methodName;
 
+  /** Default no-arg constructor required for JAXB serialization. */
   public PSValidationErrors() {
     super();
   }
 
+  /**
+   * Indicates whether this object carries any field or global errors.
+   *
+   * @return {@code true} when at least one field or global error is recorded.
+   */
   public boolean hasErrors() {
     return (!(globalErrors.isEmpty() && fieldErrors.isEmpty()));
   }
 
+  /**
+   * Returns the name of the method that produced the validation errors.
+   *
+   * @return the method name, may be {@code null}.
+   */
   public String getMethodName() {
     return methodName;
   }
 
+  /**
+   * Sets the name of the method that produced the validation errors.
+   *
+   * @param methodName the method name, may be {@code null}.
+   */
   public void setMethodName(String methodName) {
     this.methodName = methodName;
   }
 
+  /**
+   * Returns the list of field errors recorded for the validated object.
+   *
+   * @return the field errors list, never {@code null}.
+   */
   public List<PSFieldError> getFieldErrors() {
     return fieldErrors;
   }
 
+  /**
+   * Replaces the list of field errors.
+   *
+   * @param fieldErrors the new field errors list, may be {@code null}.
+   */
   public void setFieldErrors(List<PSFieldError> fieldErrors) {
     this.fieldErrors = fieldErrors;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * @return the first global error, or {@code null} when no global errors are recorded.
+   */
   @Override
   public PSObjectError getGlobalError() {
     if (getGlobalErrors() == null || getGlobalErrors().isEmpty()) return null;
     return getGlobalErrors().get(0);
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * @param globalError the global error to insert at the head of the global errors list, may be
+   *     {@code null}.
+   */
   @Override
   public void setGlobalError(PSObjectError globalError) {
     getGlobalErrors().add(0, globalError);
   }
 
+  /**
+   * Returns the list of global errors recorded for the validated object.
+   *
+   * @return the global errors list, never {@code null}.
+   */
   public List<PSObjectError> getGlobalErrors() {
     return globalErrors;
   }
 
+  /**
+   * Replaces the list of global errors.
+   *
+   * @param objectErrors the new global errors list, may be {@code null}.
+   */
   public void setGlobalErrors(List<PSObjectError> objectErrors) {
     this.globalErrors = objectErrors;
   }
 
+  /**
+   * JAXB-serializable representation of a single field error.
+   *
+   * @author adamgent
+   */
   public static class PSFieldError extends PSObjectError {
+    /** Default constructor required for JAXB serialization. */
+    public PSFieldError() {
+      super();
+    }
+
     private String field;
     private Object rejectedValue;
     private boolean bindingFailure;
 
+    /**
+     * Returns the name of the field that failed validation.
+     *
+     * @return the field name, may be {@code null}.
+     */
     public String getField() {
       return field;
     }
 
+    /**
+     * Sets the name of the field that failed validation.
+     *
+     * @param field the field name, may be {@code null}.
+     */
     public void setField(String field) {
       this.field = field;
     }
 
+    /**
+     * Returns the value that was rejected during validation.
+     *
+     * @return the rejected value, may be {@code null}.
+     */
     public Object getRejectedValue() {
       return rejectedValue;
     }
 
+    /**
+     * Sets the value that was rejected during validation.
+     *
+     * @param rejectedValue the rejected value, may be {@code null}.
+     */
     public void setRejectedValue(Object rejectedValue) {
       this.rejectedValue = rejectedValue;
     }
 
+    /**
+     * Indicates whether this error is the result of a binding failure (such as a type conversion
+     * error) rather than a constraint violation.
+     *
+     * @return {@code true} when this is a binding failure.
+     */
     public boolean isBindingFailure() {
       return bindingFailure;
     }
 
+    /**
+     * Marks this error as a binding failure or a regular validation failure.
+     *
+     * @param bindingFailure {@code true} to mark this as a binding failure.
+     */
     public void setBindingFailure(boolean bindingFailure) {
       this.bindingFailure = bindingFailure;
     }

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSValidationErrorsBuilder.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSValidationErrorsBuilder.java
@@ -31,14 +31,27 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class PSValidationErrorsBuilder {
 
+  /** The {@link PSValidationErrors} being built up by this builder. */
   private PSValidationErrors validationErrors;
 
+  /**
+   * Constructs a new builder that records errors against the given object or method name.
+   *
+   * @param objectName the name of the method or object being validated, never {@code null}.
+   */
   public PSValidationErrorsBuilder(String objectName) {
     super();
     this.validationErrors = new PSValidationErrors();
     this.validationErrors.setMethodName(objectName);
   }
 
+  /**
+   * Records a global error with the supplied code and default message.
+   *
+   * @param code the error code, may be {@code null}.
+   * @param defaultMessage the default message, may be {@code null}.
+   * @return this builder for fluent chaining, never {@code null}.
+   */
   public PSValidationErrorsBuilder reject(String code, String defaultMessage) {
     PSObjectError objectError = new PSObjectError();
     objectError.setCode(code);
@@ -47,6 +60,15 @@ public class PSValidationErrorsBuilder {
     return this;
   }
 
+  /**
+   * Records a field error with the supplied code, default message, and rejected value.
+   *
+   * @param field the name of the field that failed validation, never {@code null}.
+   * @param code the error code, never {@code null}.
+   * @param defaultMessage the default message, never {@code null}.
+   * @param value the value that was rejected, may be {@code null}.
+   * @return this builder for fluent chaining, never {@code null}.
+   */
   public PSValidationErrorsBuilder rejectField(
       String field, String code, String defaultMessage, Object value) {
     notNull(field, "field cannot be null");
@@ -60,25 +82,61 @@ public class PSValidationErrorsBuilder {
     return this;
   }
 
+  /**
+   * Convenience rule that records a field error when the supplied value is {@code null}.
+   *
+   * @param field the name of the field being validated, never {@code null}.
+   * @param value the value to check, may be {@code null}.
+   * @return this builder for fluent chaining, never {@code null}.
+   */
   public PSValidationErrorsBuilder rejectIfNull(String field, Object value) {
     if (value == null) return rejectField(field, field + " cannot be null", value);
     return this;
   }
 
+  /**
+   * Convenience rule that records a field error when the supplied value is {@code null}, empty, or
+   * contains only whitespace.
+   *
+   * @param field the name of the field being validated, never {@code null}.
+   * @param value the value to check, may be {@code null}.
+   * @return this builder for fluent chaining, never {@code null}.
+   */
   public PSValidationErrorsBuilder rejectIfBlank(String field, String value) {
     if (StringUtils.isBlank(value)) return rejectField(field, field + " cannot be blank", value);
     return this;
   }
 
+  /**
+   * Records a field error using the current method name (configured on the underlying {@link
+   * PSValidationErrors}) as the error code prefix.
+   *
+   * @param field the name of the field that failed validation, never {@code null}.
+   * @param defaultMessage the default message, may be {@code null}.
+   * @param value the value that was rejected, may be {@code null}.
+   * @return this builder for fluent chaining, never {@code null}.
+   */
   public PSValidationErrorsBuilder rejectField(String field, String defaultMessage, Object value) {
     rejectField(field, validationErrors.getMethodName() + "#" + field, defaultMessage, value);
     return this;
   }
 
+  /**
+   * Returns the current state of the validation errors and resets the builder's view of them.
+   *
+   * @return the validation errors accumulated so far, never {@code null}.
+   */
   public PSValidationErrors build() {
     return validationErrors;
   }
 
+  /**
+   * Convenience method that throws a {@link PSParametersValidationException} if any errors have
+   * been recorded.
+   *
+   * @return this builder for fluent chaining, never {@code null}.
+   * @throws PSValidationException always thrown when this builder is currently in an invalid state.
+   */
   public PSValidationErrorsBuilder throwIfInvalid() throws PSValidationException {
     new PSParametersValidationException(validationErrors).throwIfInvalid();
     return this;


### PR DESCRIPTION
## Summary

Resolves issue [#1780](https://github.com/intersoftdatalabs-in/percussioncms/issues/1780) by adding missing Javadoc to every public type, method, and private field in the \perc-exceptions-spring\ module so that the Javadoc generation phase now completes with **zero warnings and zero error blocks** (down from 100 source warnings and 1 error block).

## Root Cause

The Maven Javadoc plugin (with the parent \doclint=all\ configuration) flagged every public/protected class member and several private fields that lacked Javadoc comments. The single \@throws\ diagnostic came from \PSValidationException#throwIfInvalid\.

## Changes

- Added Javadoc to all 16 classes/interfaces under \com.percussion.share.service.exception\ and \com.percussion.share.validation\:
  - \IPSValidationException\
  - \PSBeanValidationException\, \PSBeanValidationUtils\
  - \PSErrorUtils\ (and inner \PSProxyException\)
  - \PSParameterValidationUtils\, \PSParametersValidationException\
  - \PSPropertiesValidationException\
  - \PSSpringOvalValidator\
  - \PSSpringValidationException\
  - \PSValidationException\ (added \@throws\ for \	hrowIfInvalid\)
  - \PSAbstractBeanValidator\, \PSAbstractPropertiesValidator\
  - \PSErrorCause\ (and inner \PSErrorCauseElement\)
  - \PSErrors\ (and inner \PSObjectError\)
  - \PSValidationErrors\ (and inner \PSFieldError\)
  - \PSValidationErrorsBuilder\
- Added explicit no-arg constructors (with Javadoc) where doclint reported \use of default constructor, which does not provide a comment\.
- Documented private fields that doclint flagged (\properties\, \springValidationErrors\, \alidationErrors\, \message\, etc.).

No public API, signatures, or behavior were changed.

## Pre-PR Verification (per root \AGENTS.md\)

| Command | Result |
| --- | --- |
| \mvn clean javadoc:javadoc\ (in \modules/perc-exceptions-spring\) | **0 warnings** (was 100) |
| \mvn clean install\ (standalone, JDK 21) | **BUILD SUCCESS**, no new warnings |
| \mvn spotless:apply\ then \mvn spotless:check\ | **clean** |
| \mvn javadoc:jar\ | javadoc jar produced, no warnings |
| Tests | 0 (module contains no unit tests) |

Spotless touched **only** the in-scope files of this PR — no out-of-scope formatting debt was folded into the commit.

## Refs

- Issue: #1780
- Branch: \ix/1780-perc-exceptions-spring-javadoc-cleanup\

> Co-Authored by Kilo Kilo using MiniMax-M3 with agent Kilo.