### PR TITLE
fix(perc-help): resolve all Javadoc warnings (#1781)

### DIFF
--- a/modules/Help/src/main/java/com/percussion/tools/help/PSHelpApplet.java
+++ b/modules/Help/src/main/java/com/percussion/tools/help/PSHelpApplet.java
@@ -29,6 +29,14 @@ public class PSHelpApplet extends JApplet {
 
   private static final long serialVersionUID = 1L;
 
+  /**
+   * Default no-arg constructor required for applet instantiation by the browser/JVM. The applet is
+   * initialized via {@link #init()} rather than through this constructor.
+   */
+  public PSHelpApplet() {
+    super();
+  }
+
   /** Init function for applet. Gets helpset file url and help topic id from applet parameters. */
   public void init() {
     // Get the JavaHelp helpset file and attach the protocol based on its

--- a/modules/Help/src/main/java/com/percussion/tools/help/PSJavaHelp.java
+++ b/modules/Help/src/main/java/com/percussion/tools/help/PSJavaHelp.java
@@ -101,6 +101,8 @@ public class PSJavaHelp {
 
   /**
    * Convenience method to call {@link #setHelpSet(String, String) setHelpSet(helpSetURL, null)}.
+   *
+   * @param helpSetURL the url of the helpset file, may not be {@code null} or empty.
    */
   public void setHelpSet(String helpSetURL) {
     setHelpSet(helpSetURL, null);
@@ -157,6 +159,10 @@ public class PSJavaHelp {
   /**
    * Convenience method for {@link #getHelpSetURL(String, boolean, String) getHelpSetURL(hsFilePath,
    * false, null)}. Please see the link for description of the method and its parameter.
+   *
+   * @param hsFilePath the helpset file for which to get url, may be {@code null} or empty.
+   * @return the url string, may be {@code null} or empty if supplied helpset file path is {@code
+   *     null} or empty.
    */
   public static String getHelpSetURL(String hsFilePath) {
     return getHelpSetURL(hsFilePath, false, null);
@@ -165,6 +171,8 @@ public class PSJavaHelp {
   /**
    * Convenience method for {@link #launchHelp(String, boolean, Window)} launchHelp(helpID, false,
    * null) }. Assumes the help frame is not parented by any dialog.
+   *
+   * @param helpID a key that is used to retrieve the HTML help file, may be {@code null} or empty.
    */
   public static void launchHelp(String helpID) {
     launchHelp(helpID, false, null);


### PR DESCRIPTION
## Summary

Resolves issue [#1781](https://github.com/intersoftdatalabs-in/percussioncms/issues/1781) by fixing the remaining Javadoc diagnostics in the \perc-help\ module so the Javadoc generation phase now completes with **zero warnings and zero error blocks** (down from the 5 warnings still present on \main\; the original issue was filed when the count was higher).

## Root Cause

The Maven Javadoc plugin (with the parent \doclint=all\ configuration) flagged:
- 1 \use of default constructor\ diagnostic on \PSHelpApplet\ (the implicit no-arg constructor was undocumented).
- 3 missing \@param\ tags on \PSJavaHelp\ convenience overloads (\setHelpSet(String)\, \getHelpSetURL(String)\, \launchHelp(String)\).
- 1 missing \@return\ tag on the \getHelpSetURL(String)\ convenience overload.

The \1 Javadoc Error Block\ reported by the build-summary tooling corresponds to the doclint error block generated by the \use of default constructor\ diagnostic on \PSHelpApplet\.

## Changes (2 files, +16 lines)

- \PSHelpApplet.java\: added an explicit no-arg constructor with Javadoc to replace the implicit one.
- \PSJavaHelp.java\: added the missing \@param\ and \@return\ tags on three convenience overloads.

No public API, signatures, or runtime behavior were changed.

## Pre-PR Verification (per root \AGENTS.md\)

| Command | Result |
| --- | --- |
| \mvn clean javadoc:javadoc\ (in \modules/Help\) | **0 warnings** (was 5) |
| \mvn clean install\ (standalone, JDK 21) | **BUILD SUCCESS**, no new warnings |
| \mvn spotless:apply\ then \mvn spotless:check\ | **clean** |
| \mvn javadoc:jar\ | javadoc jar produced, no warnings |
| Tests | 0 (module ships no unit tests; \uild-helper\ adds \	est/src\ if present) |

Spotless touched **only** the in-scope files of this PR.

## Refs

- Issue: #1781
- Branch: \ix/1781-perc-help-javadoc-cleanup\

> Co-Authored by Kilo Kilo using MiniMax-M3 with agent Kilo.