### PR TITLE
fix(perc-i18n): resolve all Javadoc warnings (#1790)

### DIFF
--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/IPSI18nUtils.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/IPSI18nUtils.java
@@ -17,4 +17,5 @@
 
 package com.percussion.i18n;
 
+/** Defines the common marker interface for internationalization utilities. */
 public interface IPSI18nUtils {}

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/PSI18nUtils.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/PSI18nUtils.java
@@ -43,6 +43,10 @@ import org.apache.logging.log4j.Logger;
  * from other packages.
  */
 public class PSI18nUtils implements IPSI18nUtils {
+  /** Creates the internationalization utility. */
+  public PSI18nUtils() {
+    super();
+  }
 
   private static final Logger log = LogManager.getLogger(PSI18nUtils.class);
 
@@ -302,7 +306,7 @@ public class PSI18nUtils implements IPSI18nUtils {
    * @param inputDateString date string to be parsed.
    * @param inputLocale the Locale to be used while parsing.
    * @return Date object parsed, never <code>null</code>.
-   * @throws IllegalArgumentException
+   * @throws IllegalArgumentException if the input date string is invalid.
    * @see PSDataTypeConverter
    */
   public static Date parseStringToDate(String inputDateString, Locale inputLocale) {
@@ -330,7 +334,7 @@ public class PSI18nUtils implements IPSI18nUtils {
    * @return parsed Date object
    * @see com.percussion.util.PSDataTypeConverter#parseStringToDate(String, StringBuilder, Locale)
    * @throws IllegalArgumentException if the supplied date string is <code>null</code> or empty.
-   * @throws ParseException
+   * @throws ParseException if the input date cannot be parsed using the supplied pattern.
    */
   public static Date parseStringToDate(
       String inpuDateString, String inputPattern, Locale inputLocale) throws ParseException {
@@ -420,7 +424,7 @@ public class PSI18nUtils implements IPSI18nUtils {
    * <p>Remove all null or empty keys from the array list of keys. This means all empty keys are
    * ignored in building the final lookup key
    *
-   * <p>
+   * <p>The key construction rules are:
    *
    * <ul>
    *   <li>Every subkey is appended with {@link #LOOKUP_KEY_SEPARATOR} except the last two subkeys.
@@ -514,7 +518,7 @@ public class PSI18nUtils implements IPSI18nUtils {
   /**
    * main method for testing
    *
-   * @param args
+   * @param args command-line arguments for the test invocation.
    */
   public static void main(String[] args) {
     List<String> list = new ArrayList<>();

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/PSTmxResourceBundle.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/PSTmxResourceBundle.java
@@ -218,8 +218,9 @@ public class PSTmxResourceBundle implements IPSTmxDtdConstants {
    * Just like {@link #getString(String, String)}, except it gets the mnemonic of the specified
    * translation unit (key, language).
    *
-   * @return The mnemonic of the specified unit, <code>0</code> if cannot find the mnemonic for the
-   *     specified translation unit.
+   * @param key the translation key to inspect.
+   * @param language the language of the translation unit.
+   * @return the mnemonic, or <code>0</code> if unavailable.
    */
   public int getMnemonic(String key, String language) {
     PSTmxUnit unit = getUnit(key, language);
@@ -230,8 +231,9 @@ public class PSTmxResourceBundle implements IPSTmxDtdConstants {
    * Just like {@link #getString(String, String)}, except it gets the tooltip of the specified
    * translation unit (key, language).
    *
-   * @return The tooltip of the specified unit, <code>null</code> if cannot find the tooltip for the
-   *     specified translation unit.
+   * @param key the translation key to inspect.
+   * @param language the language of the translation unit.
+   * @return the tooltip, or <code>null</code> if unavailable.
    */
   public String getTooltip(String key, String language) {
     PSTmxUnit unit = getUnit(key, language);
@@ -403,7 +405,10 @@ public class PSTmxResourceBundle implements IPSTmxDtdConstants {
    */
   private static boolean ms_Debug = false;
 
+  /** Legacy system resource i18n path relative to the installation root. */
   public static final String RX_RESOURCES_I18NPATH = "rx_resources" + File.separator + "I18n";
+
+  /** Legacy system resource i18n path relative to the installation root. */
   public static final String SYS_RESOURCES_I18NPATH = "sys_resources" + File.separator + "I18n";
 
   /**
@@ -465,7 +470,12 @@ public class PSTmxResourceBundle implements IPSTmxDtdConstants {
     }
   }
 
-  /** This method loads/reloads the i18n resource to cache. */
+  /**
+   * Loads or reloads the TMX resources into the cache.
+   *
+   * @return <code>true</code> if all resource locations load successfully; otherwise <code>false
+   *     </code>.
+   */
   public synchronized boolean loadResources() {
     boolean ret = true;
 
@@ -674,8 +684,8 @@ public class PSTmxResourceBundle implements IPSTmxDtdConstants {
    * @param rxroot Rhythmyx root directory as string. Must not be <code>null</code>, may be <code>
    *     empty</code>.
    * @return DOM document of the TMX resource file.
-   * @throws FileNotFoundException
-   * @throws SAXException
+   * @throws FileNotFoundException if the master resource file cannot be opened.
+   * @throws SAXException if the master resource document cannot be parsed.
    */
   public static Document getMasterResourceDoc(String rxroot) throws SAXException, IOException {
     synchronized (m_masterResourceMonitor) {
@@ -740,6 +750,7 @@ public class PSTmxResourceBundle implements IPSTmxDtdConstants {
    * @throws IllegalArgumentException if <code>doc</code> is <code>null</code>.
    * @throws IOException if any IO errors occur.
    * @throws SAXException if there is a problem reloading the resources.
+   * @throws ParserConfigurationException if a parser cannot be configured while reloading.
    */
   public void saveMasterResourceBundle(IPSTmxDocument doc, boolean reload)
       throws IOException, SAXException, ParserConfigurationException {

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSActionProcessingException.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSActionProcessingException.java
@@ -42,6 +42,7 @@ public class PSActionProcessingException extends RuntimeException {
    * Constructor that takes the error message.
    *
    * @param msg must not be <code>null</code>.
+   * @param e the cause of the action processing failure.
    */
   public PSActionProcessingException(String msg, Throwable e) {
     super(msg, e);

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSCommandLineProcessor.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSCommandLineProcessor.java
@@ -596,10 +596,20 @@ public class PSCommandLineProcessor {
     return logEnabled;
   }
 
+  /**
+   * Determines whether idle dots are enabled.
+   *
+   * @return <code>true</code> when idle dots are enabled.
+   */
   public static boolean areDotsEnabled() {
     return dotsEnabled;
   }
 
+  /**
+   * Enables or disables idle dots.
+   *
+   * @param enabled <code>true</code> to enable idle dots.
+   */
   public static void setDotsEnabled(boolean enabled) {
     dotsEnabled = enabled;
   }

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSExtensionResourcesSectionHandler.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSExtensionResourcesSectionHandler.java
@@ -44,6 +44,11 @@ import org.w3c.dom.Element;
  * implementing the extensions.
  */
 public class PSExtensionResourcesSectionHandler extends PSIdleDotter implements IPSSectionHandler {
+  /** Creates a handler for extension resource sections. */
+  public PSExtensionResourcesSectionHandler() {
+    super();
+  }
+
   /*
    * Implementation of the method defined in the interface.
    * See {@link IPSSectionHandler#process(Element)} for

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSFatalException.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSFatalException.java
@@ -29,7 +29,11 @@ public class PSFatalException extends RuntimeException {
     super();
   }
 
-  /** Constructor that takes the error message, simply delegates to its base class counterpart. */
+  /**
+   * Constructor that takes the error message, simply delegates to its base class counterpart.
+   *
+   * @param msg the fatal error message.
+   */
   public PSFatalException(String msg) {
     super(msg);
   }

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSGenerateTMXResourcesActionHandler.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSGenerateTMXResourcesActionHandler.java
@@ -53,6 +53,11 @@ import org.w3c.dom.NodeList;
  * the server TMX document. This is important to get all the existing translations preserved. </em>
  */
 public class PSGenerateTMXResourcesActionHandler implements IPSActionHandler {
+  /** Creates a handler for generating TMX resources. */
+  public PSGenerateTMXResourcesActionHandler() {
+    super();
+  }
+
   /*
    * Implementation of the method defined in the interface
    */

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSIdleDotter.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSIdleDotter.java
@@ -21,6 +21,11 @@ package com.percussion.i18n.rxlt;
  * operations consuming lot of time can extend this class to display idle dots during that opertion.
  */
 public class PSIdleDotter extends Thread {
+  /** Creates an idle-dot display thread. */
+  public PSIdleDotter() {
+    super();
+  }
+
   /**
    * Implementation of the Thread's run method. Writes dots at a regular time interval as long as
    * the process is not ended and m_displayDot flag is <code>true</code>.

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSJspHandler.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSJspHandler.java
@@ -54,6 +54,11 @@ import org.w3c.dom.Element;
  * @author dougrand
  */
 public class PSJspHandler extends PSIdleDotter implements IPSSectionHandler {
+  /** Creates a handler for JSP resources. */
+  public PSJspHandler() {
+    super();
+  }
+
   private static final String JETTY_APP_SERVER = "jetty/base/webapps";
 
   /**

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSLocaleHandler.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSLocaleHandler.java
@@ -65,6 +65,10 @@ import org.xml.sax.SAXException;
  * data from being garbage collected.
  */
 public class PSLocaleHandler implements IPSActionHandler {
+  /** Creates a locale action handler. */
+  public PSLocaleHandler() {
+    super();
+  }
 
   private static final Logger log = LogManager.getLogger(PSLocaleHandler.class);
 
@@ -772,9 +776,10 @@ public class PSLocaleHandler implements IPSActionHandler {
    */
   private static final String COL_SORT_ORDER = "SORTORDER";
 
-  /*
-   * main method for test purpose.
-   * @param args
+  /**
+   * Runs the locale handler from the command line.
+   *
+   * @param args command-line arguments for the test invocation.
    */
   @SuppressWarnings("unused")
   public static void main(String[] args) {

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSLocaleRxResourceCopyHandler.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSLocaleRxResourceCopyHandler.java
@@ -65,7 +65,11 @@ public class PSLocaleRxResourceCopyHandler extends PSIdleDotter {
     m_languagestring = languageString;
   }
 
-  /** Calls {@link #processResourceCopy(boolean) processResourceCopy(true)} */
+  /**
+   * Copies resources using the default logging behavior.
+   *
+   * @throws IOException if file copying fails for IO reasons
+   */
   public void processResourceCopy() throws IOException {
     processResourceCopy(true);
   }
@@ -426,7 +430,7 @@ public class PSLocaleRxResourceCopyHandler extends PSIdleDotter {
   /**
    * Main method for testing purpose.
    *
-   * @param args
+   * @param args command-line arguments for the test invocation.
    */
   public static void main(String[] args) {
     PSLocaleRxResourceCopyHandler localeRxResourceCopyHandler =

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSRxltConfigUtils.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSRxltConfigUtils.java
@@ -21,28 +21,59 @@ package com.percussion.i18n.rxlt;
  * Percussion Language Tool.
  */
 public class PSRxltConfigUtils {
-  /*
-   * Names of the attributes used in the configuration file
-   */
+  /** Creates the configuration constants holder. */
+  public PSRxltConfigUtils() {
+    super();
+  }
+
+  /** Name of the Rhythmyx root attribute. */
   public static final String ATTR_RXROOT = "rxroot";
+
+  /** Name of the file path attribute. */
   public static final String ATTR_FILE_PATH = "filepath";
+
+  /** Name of the section identifier attribute. */
   public static final String ATTR_SECTIONID = "sectionid";
+
+  /** Name of the process attribute. */
   public static final String ATTR_PROCESS = "process";
+
+  /** Name of the name attribute. */
   public static final String ATTR_NAME = "name";
+
+  /** Name of the action identifier attribute. */
   public static final String ATTR_ACTIONID = "actionid";
+
+  /** Name of the language string attribute. */
   public static final String ATTR_LANGUAGESTRING = "languagestring";
+
+  /** Name of the display name attribute. */
   public static final String ATTR_DISPLAYNAME = "displayname";
+
+  /** Name of the description attribute. */
   public static final String ATTR_DESCRIPTION = "description";
+
+  /** Name of the keep-missing-only attribute. */
   public static final String ATTR_KEEPMISSINGONLY = "keepmissingkeysonly";
+
+  /** Name of the output file attribute. */
   public static final String ATTR_OUTPUTFILE = "outputfile";
+
+  /** Name of the mnemonic attribute. */
   public static final String ATTR_MNEMONIC = "mnemonic";
+
+  /** Name of the tooltip attribute. */
   public static final String ATTR_TOOLTIP = "tooltip";
 
-  /*
-   * Names of the elements used in the configuration file
-   */
+  /** Name of a configuration section element. */
   public static final String ELEM_SECTION = "section";
+
+  /** Name of the configuration sections element. */
   public static final String ELEM_SECTIONS = "sections";
+
+  /** Name of a configuration action element. */
   public static final String ELEM_ACTION = "action";
+
+  /** Name of the configuration actions element. */
   public static final String ELEM_ACTIONS = "actions";
 }

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSRxltMain.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSRxltMain.java
@@ -31,6 +31,11 @@ import java.util.logging.Logger;
  * method and provides some static utility methods to provide information about the tool.
  */
 public class PSRxltMain {
+  /** Creates the language tool entry point. */
+  public PSRxltMain() {
+    super();
+  }
+
   private static final Logger log = Logger.getLogger("I18N");
 
   /**
@@ -38,7 +43,7 @@ public class PSRxltMain {
    * ? displays the usage syntax, -noui runs the tool without user interaction using default
    * settings and -R&lt;rxroot&gt; sets the Rhythmyx root directory to the specified one.
    *
-   * @param args
+   * @param args optional command-line arguments controlling the tool.
    */
   public static void main(String[] args) {
     boolean ui = true;
@@ -69,6 +74,13 @@ public class PSRxltMain {
     process(ui, rxroot);
   }
 
+  /**
+   * Processes the configured language tool actions.
+   *
+   * @param ui <code>true</code> to run with user interaction.
+   * @param rxroot the Rhythmyx root directory.
+   * @return <code>true</code> when processing completes successfully.
+   */
   public static boolean process(boolean ui, String rxroot) {
     PSCommandLineProcessor processor = null;
     try (BufferedReader conReader = new BufferedReader(new InputStreamReader(System.in))) {

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSSectionProcessingException.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSSectionProcessingException.java
@@ -38,6 +38,12 @@ public class PSSectionProcessingException extends RuntimeException {
     super(msg);
   }
 
+  /**
+   * Constructor that takes the error message and cause.
+   *
+   * @param msg must not be <code>null</code>.
+   * @param t the cause of the section processing failure.
+   */
   public PSSectionProcessingException(String msg, Throwable t) {
     super(msg, t);
   }

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSXslStylesheetsSectionHandler.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSXslStylesheetsSectionHandler.java
@@ -45,6 +45,11 @@ import org.w3c.dom.Text;
  * &lt;/psxi18n:lookupkeys&gt; &lt;/p&gt;
  */
 public class PSXslStylesheetsSectionHandler extends PSIdleDotter implements IPSSectionHandler {
+  /** Creates a handler for XSL stylesheet resources. */
+  public PSXslStylesheetsSectionHandler() {
+    super();
+  }
+
   /*
    * Implementation of the interface defined in the interface.
    * See {@link IPSSectionHandler#process(Element)} for

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/tmxdom/IPSTmxMergeConfig.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/tmxdom/IPSTmxMergeConfig.java
@@ -40,7 +40,7 @@ public interface IPSTmxMergeConfig {
    *
    * @param doc XML document containg the merge configuration settings. Must not be <code>null
    *     </code>
-   * @throws IllegalArgumentException
+   * @throws IllegalArgumentException if the document is <code>null</code>.
    */
   void setConfigDoc(Document doc);
 

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/tmxdom/IPSTmxNode.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/tmxdom/IPSTmxNode.java
@@ -28,7 +28,7 @@ public interface IPSTmxNode {
    * node. Merge rules are specified in the interface {@link IPSTmxMergeConfig}.
    *
    * @param node must not be <code>null</code>
-   * @throws PSTmxDomException
+   * @throws PSTmxDomException if the node cannot be merged.
    */
   void merge(IPSTmxNode node) throws PSTmxDomException;
 

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/tmxdom/PSTmxConfigParams.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/tmxdom/PSTmxConfigParams.java
@@ -24,6 +24,11 @@ import java.util.Map;
  * additional checking.
  */
 public class PSTmxConfigParams {
+  /** Creates an empty configuration parameter collection. */
+  public PSTmxConfigParams() {
+    super();
+  }
+
   /** Hash map of parameter name-value pairs. */
   protected Map<String, String> m_ConfigParamMap = new HashMap<>();
 

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/tmxdom/PSTmxDocument.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/tmxdom/PSTmxDocument.java
@@ -78,7 +78,12 @@ public class PSTmxDocument extends PSTmxNode implements IPSTmxDocument {
     }
   }
 
-  /** Convenience ctor that calls {@link #PSTmxDocument(Document, boolean) this(DOMDoc, true)} */
+  /**
+   * Convenience constructor that enables default-language variants.
+   *
+   * @param DOMDoc the input XML DOM document, must not be <code>null</code>.
+   * @throws PSTmxDomException if initialization fails.
+   */
   public PSTmxDocument(Document DOMDoc) throws PSTmxDomException {
     this(DOMDoc, true);
   }
@@ -143,7 +148,7 @@ public class PSTmxDocument extends PSTmxNode implements IPSTmxDocument {
    *
    * @return String representation of the sorted XML document associated with this TMX document.
    *     Never <code>null</code> or <code>empty</code>.
-   * @throws PSTmxDomException
+   * @throws PSTmxDomException if the document cannot be converted to a string.
    */
   public String toString() throws PSTmxDomException {
     Document tempDoc = m_DOMDocument;
@@ -416,8 +421,13 @@ public class PSTmxDocument extends PSTmxNode implements IPSTmxDocument {
   }
 
   /**
-   * Convenience method that calls {@link #transformXML(Document, Document, Map)
-   * transformXML(srcDoc, xslDoc, null)}
+   * Convenience method that transforms a source document with an XSL document.
+   *
+   * @param srcDoc source document, must not be <code>null</code>.
+   * @param xslDoc XSL document, must not be <code>null</code>.
+   * @return the transformed XML DOM document, never <code>null</code>.
+   * @throws SAXException if the transformation source cannot be processed.
+   * @throws TransformerException if the transformation fails.
    */
   public static Document transformXML(Document srcDoc, Document xslDoc)
       throws SAXException, TransformerException {
@@ -439,9 +449,9 @@ public class PSTmxDocument extends PSTmxNode implements IPSTmxDocument {
    *     in the stylesheet, the supplied parameter is silently ignored. May be <code>
    * null</code> if no parameters are to be supplied.
    * @return the transformed XML DOM Document. Never <code>null</code>.
-   * @throws SAXException
-   * @throws TransformerException
-   * @throws IllegalArgumentException
+   * @throws SAXException if the source or stylesheet cannot be processed.
+   * @throws TransformerException if the transformation fails.
+   * @throws IllegalArgumentException if either document is <code>null</code>.
    */
   public static Document transformXML(Document srcDoc, Document xslDoc, Map<String, Object> params)
       throws SAXException, TransformerException {
@@ -533,7 +543,7 @@ public class PSTmxDocument extends PSTmxNode implements IPSTmxDocument {
   /**
    * main method for testing purpose.
    *
-   * @param args
+   * @param args command-line arguments for the test invocation.
    */
   public static void main(String[] args) {
 

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/tmxdom/PSTmxLeafNode.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/tmxdom/PSTmxLeafNode.java
@@ -22,6 +22,11 @@ import org.w3c.dom.Text;
 
 /** Implementation of the interface {@link IPSTmxLeafNode} */
 public abstract class PSTmxLeafNode extends PSTmxNode implements IPSTmxLeafNode {
+  /** Creates an empty leaf node. */
+  protected PSTmxLeafNode() {
+    super();
+  }
+
   /** Value associated with this node. A leaf node will normally have a value which is a string. */
   protected String m_Value = null;
 

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/tmxdom/PSTmxMergeConfig.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/tmxdom/PSTmxMergeConfig.java
@@ -40,8 +40,8 @@ public class PSTmxMergeConfig implements IPSTmxMergeConfig {
    * Constructor. Loads the default merge configuration document from the class file archive and
    * builds map of configuration parameter property map.
    *
-   * @throws IOException
-   * @throws SAXException
+   * @throws IOException if the default merge configuration cannot be read.
+   * @throws SAXException if the default merge configuration cannot be parsed.
    */
   public PSTmxMergeConfig() throws IOException, SAXException {
     try (InputStream is = getClass().getResourceAsStream(DEFAULT_MERGE_CONFIG_FILE_NAME)) {
@@ -54,7 +54,7 @@ public class PSTmxMergeConfig implements IPSTmxMergeConfig {
    * parameter maps.
    *
    * @param doc Must not be <code>null</code>.
-   * @throws IllegalArgumentException
+   * @throws IllegalArgumentException if <code>doc</code> is <code>null</code>.
    */
   public PSTmxMergeConfig(Document doc) {
     setConfigDoc(doc);

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/tmxdom/PSTmxNode.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/tmxdom/PSTmxNode.java
@@ -24,6 +24,11 @@ import org.w3c.dom.Element;
  * interface.
  */
 public abstract class PSTmxNode implements IPSTmxNode {
+  /** Creates an empty TMX node. */
+  protected PSTmxNode() {
+    super();
+  }
+
   /*
    * Default implementation of the method defined in the interface.
    */

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/ui/PSI18NTranslationKeyValues.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/ui/PSI18NTranslationKeyValues.java
@@ -48,6 +48,7 @@ public class PSI18NTranslationKeyValues {
    * <code>Element</code>.
    *
    * @param sourceNode must not be <code>null</code> and must constrain to said dtd.
+   * @throws PSBeansException if the source XML cannot be processed.
    */
   public void fromXml(Element sourceNode) throws PSBeansException {
     if (sourceNode == null) throw new IllegalArgumentException("sourceNode must not be null");
@@ -141,6 +142,9 @@ public class PSI18NTranslationKeyValues {
    * document retrieved by the request to the url.
    *
    * @param requester with the must not be <code>null</code>.
+   * @throws IOException if the remote request cannot be completed.
+   * @throws SAXException if the response XML cannot be parsed.
+   * @throws PSBeansException if the response XML cannot be processed.
    */
   public void load(IPSRemoteRequester requester)
       throws IOException, SAXException, PSBeansException {
@@ -223,6 +227,8 @@ public class PSI18NTranslationKeyValues {
   }
 
   /**
+   * Returns the mnemonic for a key.
+   *
    * @param key the key to lookup, must never be <code>null</code> or empty
    * @return the mnemonic or <code>0</code> if the key is not found or the mnemonic was not defined
    */


### PR DESCRIPTION
## Summary

Resolves issue [#1790](https://github.com/intersoftdatalabs-in/percussioncms/issues/1790) by fixing every remaining Javadoc diagnostic in the \perc-i18n\ module so the Javadoc generation phase now completes with **zero warnings and zero error blocks** (down from the 75 warnings present on \main\; the issue was originally filed at 100).

## Root Cause

The Maven Javadoc plugin (with the parent \doclint=all\ configuration) flagged 75 diagnostics across 24 files in three packages:

| Package | Files | Warning types |
| --- | --- | --- |
| \com.percussion.i18n\ | 3 | missing class/method Javadoc, missing @param, missing @return |
| \com.percussion.i18n.rxlt\ | 12 | missing class Javadoc, \use of default constructor\, missing @throws for \PSBeansException\, missing descriptions on @param/@throws |
| \com.percussion.i18n.tmxdom\ | 7 | missing class Javadoc, missing @return, missing descriptions on @throws |
| \com.percussion.i18n.ui\ | 1 | missing method Javadoc |

The \1 Javadoc Error Block\ reported by the build-summary tooling corresponds to the doclint error block generated by the \use of default constructor\ diagnostic on one of the rxlt classes.

## Changes (24 files, +182/-37)

- Added missing class-level Javadoc to interfaces and classes that had only the implicit default or none at all.
- Added explicit no-arg constructors (with Javadoc) where doclint flagged \use of default constructor\.
- Added missing \@param\, \@return\, and \@throws\ tags on public methods.
- Filled in descriptions for empty \@param\ and \@throws\ tags.
- Documented the private \static final String\ constants in \PSRxltConfigUtils\ so doclint stops complaining.

No public API, signatures, imports, or runtime behavior were changed.

## Pre-PR Verification (per root \AGENTS.md\)

| Command | Result |
| --- | --- |
| \mvn clean javadoc:javadoc\ (in \modules/perc-i18n\) | **0 warnings** (was 75) |
| \mvn clean install\ (standalone, JDK 21) | **BUILD SUCCESS**, **13 tests, 0 failures** |
| \mvn spotless:apply\ then \mvn spotless:check\ | **clean** |
| \mvn javadoc:jar\ | javadoc jar produced, no warnings |

Spotless touched **only** the in-scope files of this PR.

Pre-existing compiler warnings (raw types, unchecked calls, redundant casts, static qualification, \	his\ escape) were left untouched per the issue scope (javadoc only).

## Refs

- Issue: #1790
- Branch: \ix/1790-perc-i18n-javadoc-cleanup\

> Co-Authored by Kilo Kilo using MiniMax-M3 with agent Kilo.