### PR TITLE
fix(deps): pin commons-configuration2 to 2.15.1 (#1676)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -337,7 +337,7 @@
                 <artifactId>Java-WebSocket</artifactId>
                 <version>${java.websocket.version}</version>
             </dependency>
-            <!-- WebUI → artemis-server transitive; security floor for Dependabot (#1676) -->
+            <!-- WebUI → artemis-server → commons-configuration2; Dependabot floor ≥2.15.0 (issue #1676) -->
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-configuration2</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,8 @@
         <!-- CodeMirror 6 has a completely different API. -->
         <codemirror.version>5.65.20</codemirror.version>
         <commons-cli.version>1.11.0</commons-cli.version>
+        <!-- WebUI → artemis-server → commons-configuration2; Dependabot floor ≥2.15.0 (issue #1676) -->
+        <commons-configuration2.version>2.15.1</commons-configuration2.version>
         <commons-email.version>1.6.0</commons-email.version>
         <commons.beanutils.version>1.11.0</commons.beanutils.version>
         <commons.codec.version>1.20.0</commons.codec.version>
@@ -334,6 +336,12 @@
                 <groupId>org.java-websocket</groupId>
                 <artifactId>Java-WebSocket</artifactId>
                 <version>${java.websocket.version}</version>
+            </dependency>
+            <!-- WebUI → artemis-server transitive; security floor for Dependabot (#1676) -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>${commons-configuration2.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
## Summary

Pins `org.apache.commons:commons-configuration2` to **2.15.1** via root parent `dependencyManagement` (and matching property), clearing the Dependabot advisory range `[2.2, 2.15.0)`.

### Source-of-pull investigation

Full reactor:
```text
mvnw dependency:tree -Dincludes=org.apache.commons:commons-configuration2
```

Only non-empty hit:

| Module | Chain |
|--------|--------|
| `WebUI` (`com.percussion:perc-web-ui`) | `org.apache.artemis:artemis-server:2.55.0` → `commons-configuration2` |

- Artifact is **not declared** in any module POM (transitive only).
- Artemis 2.55.0 (`artemis-project` property `commons.config.version`) already resolves **2.15.1**.
- Explicit parent pin matches existing transitive CVE floors (`zookeeper`, `Java-WebSocket`, `plexus-utils`) so a future Artemis/other dep regression cannot pull &lt; 2.15.0.

### Change

- Property: `commons-configuration2.version` = `2.15.1`
- `dependencyManagement` entry for `org.apache.commons:commons-configuration2`
- **No** child POM changes
- **Out of scope:** commons-configuration **1.x** removal remains #1675

## Test plan

- [x] Reactor `dependency:tree -Dincludes=org.apache.commons:commons-configuration2` → only WebUI/artemis path
- [x] Post-pin: `mvnw -pl WebUI dependency:tree -Dincludes=org.apache.commons:commons-configuration2` → `2.15.1`
- [x] Property evaluates to `2.15.1`; managed dependency present on WebUI
- [x] Spotless: `mvnw.cmd spotless:apply` then `mvnw.cmd spotless:check` (both SUCCESS)
- [x] Parent-only change — no module standalone clean install required (no child POM edits)
- [x] Erlang self-review: dependencyManagement floor only; no product code/path I/O; no new behavioral logic requiring unit tests
- [x] Out-of-scope Spotless rewrite of unrelated review doc discarded; PR contains only `pom.xml`

## Gates evidence

| Gate | Result |
|------|--------|
| Spotless apply → check | BUILD SUCCESS |
| Source tree investigation | WebUI → artemis-server only |
| Resolved version | 2.15.1 (≥ 2.15.0) |
| Module clean install | N/A (parent-only) |

Fixes #1676