### PR TITLE
fix(WebUI): dashboard proxyScheme falls back to request scheme (#1160)

### DIFF
--- a/WebUI/src/main/java/com/percussion/webui/util/PSProxyHostScheme.java
+++ b/WebUI/src/main/java/com/percussion/webui/util/PSProxyHostScheme.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.webui.util;
+
+import java.util.Locale;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Resolves the public-facing URL scheme when the CMS is behind a reverse proxy.
+ *
+ * <p>Dashboard gadget specs are built as absolute URLs using this scheme. A hardcoded {@code http}
+ * fallback produces mixed-content URLs on HTTPS front-ends; browsers block them before the request
+ * reaches the app server (symptom: "Unable to retrieve specs" with no server log). Prefer the
+ * inbound request scheme when {@code proxyScheme} is unset.
+ *
+ * <p>Used from dashboard JSPs so the rule is unit-testable outside the JSP container.
+ */
+public final class PSProxyHostScheme {
+
+  private static final Logger log = LogManager.getLogger(PSProxyHostScheme.class);
+
+  private PSProxyHostScheme() {}
+
+  /**
+   * Resolve the public scheme for absolute URLs while {@code requestBehindProxy} is active.
+   *
+   * <p>When {@code configuredProxyScheme} is null/blank, returns the request scheme (HTTPS
+   * preserved). When configured and it differs from the request scheme, logs WARN; logs ERROR when
+   * request is HTTPS but configured scheme is HTTP (mixed-content risk for gadget specs).
+   *
+   * @param requestScheme scheme from {@code request.getScheme()}, may be null/blank
+   * @param configuredProxyScheme value of {@code server.properties} {@code proxyScheme}, may be
+   *     null/blank when unset
+   * @return scheme to emit in absolute public URLs; never null (falls back to {@code "http"} only
+   *     when both inputs are missing)
+   */
+  public static String resolveBehindProxy(String requestScheme, String configuredProxyScheme) {
+    String request = normalizeScheme(requestScheme);
+    String configured = normalizeScheme(configuredProxyScheme);
+
+    if (configured != null && request != null && !configured.equalsIgnoreCase(request)) {
+      log.warn(
+          "requestBehindProxy is true but proxyScheme '{}' differs from request scheme '{}'. "
+              + "Absolute gadget/public URLs will use proxyScheme; mismatches can cause "
+              + "mixed-content failures (e.g. dashboard 'Unable to retrieve specs').",
+          configured,
+          request);
+      if ("https".equals(request) && "http".equals(configured)) {
+        log.error(
+            "proxyScheme is 'http' while the inbound request scheme is 'https'. "
+                + "Browsers will block mixed-content gadget specs. "
+                + "Set proxyScheme=https in server.properties, or leave proxyScheme unset to "
+                + "inherit the request scheme.");
+      }
+    }
+
+    if (configured != null) {
+      return configured;
+    }
+    if (request != null) {
+      return request;
+    }
+    return "http";
+  }
+
+  /**
+   * Normalize a scheme token: trim, lower-case (Locale.ROOT), empty → null.
+   *
+   * @param scheme raw scheme, may be null
+   * @return normalized scheme or null
+   */
+  static String normalizeScheme(String scheme) {
+    if (scheme == null) {
+      return null;
+    }
+    String trimmed = scheme.trim();
+    if (trimmed.isEmpty()) {
+      return null;
+    }
+    return trimmed.toLowerCase(Locale.ROOT);
+  }
+}

--- a/WebUI/src/main/webapp/cm/app/dashboard.jsp
+++ b/WebUI/src/main/webapp/cm/app/dashboard.jsp
@@ -3,6 +3,7 @@
 <%@ page import="com.percussion.services.utils.jspel.PSRoleUtilities" %>
 <%@ page import="com.percussion.utils.container.IPSConnector" %>
 <%@ page import="com.percussion.server.PSServer" %>
+<%@ page import="com.percussion.webui.util.PSProxyHostScheme" %>
 <%@ taglib uri="/WEB-INF/tmxtags.tld" prefix="i18n" %>
 <%@ taglib uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" prefix="csrf" %>
 
@@ -26,12 +27,15 @@
 
     int nonSslPort = request.getServerPort();//connector.getPort();
     String hostAddress = request.getServerName();//connector.getCallbackHost();
+    // Default to the inbound request scheme so HTTPS front-ends stay HTTPS when proxyScheme is unset.
     String hostScheme = request.getScheme();
     String debug = request.getParameter("debug");
 
     if(PSServer.isRequestBehindProxy(request)) {
         nonSslPort  = Integer.valueOf(PSServer.getProperty("proxyPort",""+nonSslPort));
-        hostScheme  = PSServer.getProperty("proxyScheme", "http");
+        // Prefer configured proxyScheme; fall back to request scheme (not hardcoded "http").
+        // Logs WARN/ERROR when configured scheme mismatches the request (mixed-content risk).
+        hostScheme  = PSProxyHostScheme.resolveBehindProxy(hostScheme, PSServer.getProperty("proxyScheme"));
         hostAddress = PSServer.getProperty("publicCmsHostname", "localhost");
         if(nonSslPort == 80 || nonSslPort == 443){
             nonSslPort = -1;

--- a/WebUI/src/main/webapp/cm/pages/app/dashboard.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/dashboard.jsp
@@ -3,6 +3,7 @@
 <%@ page import="com.percussion.services.utils.jspel.PSRoleUtilities" %>
 <%@ page import="com.percussion.utils.container.IPSConnector" %>
 <%@ page import="com.percussion.server.PSServer" %>
+<%@ page import="com.percussion.webui.util.PSProxyHostScheme" %>
 <%@ taglib uri="/WEB-INF/tmxtags.tld" prefix="i18n" %>
 <%@ taglib uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" prefix="csrf" %>
 
@@ -26,12 +27,15 @@
 
     int nonSslPort = request.getServerPort();//connector.getPort();
     String hostAddress = request.getServerName();//connector.getCallbackHost();
+    // Default to the inbound request scheme so HTTPS front-ends stay HTTPS when proxyScheme is unset.
     String hostScheme = request.getScheme();
     String debug = request.getParameter("debug");
 
     if(PSServer.isRequestBehindProxy(request)) {
         nonSslPort  = Integer.valueOf(PSServer.getProperty("proxyPort",""+nonSslPort));
-        hostScheme  = PSServer.getProperty("proxyScheme", "http");
+        // Prefer configured proxyScheme; fall back to request scheme (not hardcoded "http").
+        // Logs WARN/ERROR when configured scheme mismatches the request (mixed-content risk).
+        hostScheme  = PSProxyHostScheme.resolveBehindProxy(hostScheme, PSServer.getProperty("proxyScheme"));
         hostAddress = PSServer.getProperty("publicCmsHostname", "localhost");
         if(nonSslPort == 80 || nonSslPort == 443){
             nonSslPort = -1;

--- a/WebUI/src/test/java/com/percussion/webui/util/PSProxyHostSchemeTest.java
+++ b/WebUI/src/test/java/com/percussion/webui/util/PSProxyHostSchemeTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.webui.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+/**
+ * Behavioral tests for proxy public-scheme resolution used by dashboard JSPs (issue #1160).
+ *
+ * <p>Primary regression: when {@code proxyScheme} is unset, inherit {@code request.getScheme()}
+ * instead of hardcoding {@code "http"} (mixed content on HTTPS).
+ */
+public class PSProxyHostSchemeTest {
+
+  @Test
+  public void inheritsHttpsRequestSchemeWhenProxySchemeUnset() {
+    assertEquals("https", PSProxyHostScheme.resolveBehindProxy("https", null));
+    assertEquals("https", PSProxyHostScheme.resolveBehindProxy("https", ""));
+    assertEquals("https", PSProxyHostScheme.resolveBehindProxy("https", "   "));
+  }
+
+  @Test
+  public void inheritsHttpRequestSchemeWhenProxySchemeUnset() {
+    assertEquals("http", PSProxyHostScheme.resolveBehindProxy("http", null));
+  }
+
+  @Test
+  public void prefersConfiguredProxySchemeWhenSet() {
+    assertEquals("https", PSProxyHostScheme.resolveBehindProxy("http", "https"));
+    assertEquals("http", PSProxyHostScheme.resolveBehindProxy("https", "http"));
+  }
+
+  @Test
+  public void normalizesConfiguredSchemeCaseAndWhitespace() {
+    assertEquals("https", PSProxyHostScheme.resolveBehindProxy("http", " HTTPS "));
+    assertEquals("http", PSProxyHostScheme.resolveBehindProxy("https", "HTTP"));
+  }
+
+  @Test
+  public void fallsBackToHttpOnlyWhenBothMissing() {
+    assertEquals("http", PSProxyHostScheme.resolveBehindProxy(null, null));
+    assertEquals("http", PSProxyHostScheme.resolveBehindProxy("", null));
+  }
+
+  @Test
+  public void normalizesRequestSchemeWhenConfiguredMissing() {
+    assertEquals("https", PSProxyHostScheme.resolveBehindProxy(" HTTPS ", null));
+  }
+
+  @Test
+  public void normalizeSchemeTrimsAndLowerCases() {
+    assertEquals("https", PSProxyHostScheme.normalizeScheme(" HTTPS "));
+    assertNull(PSProxyHostScheme.normalizeScheme(null));
+    assertNull(PSProxyHostScheme.normalizeScheme(""));
+    assertNull(PSProxyHostScheme.normalizeScheme("  "));
+  }
+}

--- a/WebUI/war/app/dashboard.jsp
+++ b/WebUI/war/app/dashboard.jsp
@@ -3,6 +3,7 @@
 <%@ page import="com.percussion.services.utils.jspel.PSRoleUtilities" %>
 <%@ page import="com.percussion.utils.container.IPSConnector" %>
 <%@ page import="com.percussion.server.PSServer" %>
+<%@ page import="com.percussion.webui.util.PSProxyHostScheme" %>
 <%@ taglib uri="/WEB-INF/tmxtags.tld" prefix="i18n" %>
 <%@ taglib uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" prefix="csrf" %>
 
@@ -26,12 +27,15 @@
 
     int nonSslPort = request.getServerPort();//connector.getPort();
     String hostAddress = request.getServerName();//connector.getCallbackHost();
+    // Default to the inbound request scheme so HTTPS front-ends stay HTTPS when proxyScheme is unset.
     String hostScheme = request.getScheme();
     String debug = request.getParameter("debug");
 
     if(PSServer.isRequestBehindProxy(request)) {
         nonSslPort  = Integer.valueOf(PSServer.getProperty("proxyPort",""+nonSslPort));
-        hostScheme  = PSServer.getProperty("proxyScheme", "http");
+        // Prefer configured proxyScheme; fall back to request scheme (not hardcoded "http").
+        // Logs WARN/ERROR when configured scheme mismatches the request (mixed-content risk).
+        hostScheme  = PSProxyHostScheme.resolveBehindProxy(hostScheme, PSServer.getProperty("proxyScheme"));
         hostAddress = PSServer.getProperty("publicCmsHostname", "localhost");
         if(nonSslPort == 80 || nonSslPort == 443){
             nonSslPort = -1;


### PR DESCRIPTION
## Summary

Fixes dashboard **\"Unable to retrieve specs\"** when CMS is behind a reverse proxy and `proxyScheme` is unset or misconfigured as `http` on an HTTPS front-end.

**Root cause:** All three `dashboard.jsp` copies used:
```java
hostScheme = PSServer.getProperty(\"proxyScheme\", \"http\");
```
Unset `proxyScheme` therefore forced absolute gadget URLs to `http://…`. Browsers block those as mixed content **before** the request reaches the app server, so operators see a 500-style UI message with **no server log**.

**Fix:**
1. Extract unit-testable `PSProxyHostScheme.resolveBehindProxy(requestScheme, configuredProxyScheme)`:
   - Prefer configured `proxyScheme` when set
   - Otherwise inherit `request.getScheme()` (HTTPS preserved)
   - **WARN** when configured scheme differs from request scheme
   - **ERROR** when request is `https` but `proxyScheme` is `http` (mixed-content path)
2. Wire helper into all three dashboard JSP copies:
   - `WebUI/src/main/webapp/cm/app/dashboard.jsp` (WAR source)
   - `WebUI/src/main/webapp/cm/pages/app/dashboard.jsp`
   - `WebUI/war/app/dashboard.jsp` (legacy twin kept in lockstep)

No OS path / file I/O changes. Portable (scheme strings only).

**Out of scope (not residual for #1160):** other call sites still default `proxyScheme` to hardcoded `\"http\"` (`PSServer.getProxyURL`, `PSEditCommandHandler`). Dashboard-only symptom addressed here; those can be cleaned up separately if desired.

Fixes #1160

## Test plan

- [x] Unit tests: `PSProxyHostSchemeTest` — inherits HTTPS when unset; prefers configured; case/whitespace normalize; mismatch paths exercise logging
- [x] Standalone module: `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**
  - Surefire: `PSProxyHostSchemeTest` Tests run: **7**, Failures: **0**
  - Full WebUI Java suite + Vitest: green (1129 frontend tests, existing Java tests)
- [ ] Manual (optional / QA): HTTPS CMS with `requestBehindProxy=true` and `proxyScheme` **unset** → dashboard gadget specs load over `https`
- [ ] Manual (optional / QA): set `proxyScheme=http` under HTTPS → server log shows WARN + ERROR mixed-content guidance

## Gates evidence

| Gate | Result |
|------|--------|
| Erlang-style self-review | No bugs found; pure scheme resolution; no path I/O; companions: helper + tests + 3 JSPs |
| Spotless | `mvnw.cmd spotless:apply` then `mvnw.cmd spotless:check` (repo root) — SUCCESS; only in-scope files committed (out-of-scope Spotless doc rewrite discarded) |
| Pre-PR Maven | `cd WebUI` → `..\mvnw.cmd clean install` — BUILD SUCCESS, no new test failures |
| Commit | `2a6a43d848` |

## Residual work

None for #1160. Optional follow-up (not blocking): align remaining `proxyScheme` hardcoded `\"http\"` defaults in system module with request-scheme inheritance — not opened as residual issues (orthogonal call sites).