### PR TITLE
fix(rest): ContentType list JSON emits name/label/guid (#1693)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-1693-contenttype-list-dto-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-1693-contenttype-list-dto-erlang.md
@@ -1,0 +1,47 @@
+# Erlang review: issue #1693 ContentType list DTO serialization
+
+**Branch:** `fix/issue-1693-contenttype-list-dto`  
+**Scope:** `rest` module only (ContentType wire DTO + unit/resource tests)  
+**Date:** 2026-08-04  
+**Reviewer persona:** Erlang (independent of implementer)
+
+## Summary
+
+`GET /contenttypes` list items were observed live as hideFromMenu-only. Root cause: `ContentType` used `Optional` getters with `@JsonInclude(NON_NULL)`; without reliable Optional unwrapping on the wire path, name/label/guid were dropped. Production mapping (`ApiUtils.convertContentType`) already sets those fields.
+
+**Fix:** Align `ContentType` getters with `ContentTypeDetail` (plain `String` / `Guid` return types). Extend unit and Mockito resource tests to assert list JSON is not hideFromMenu-only. Spring test stub `TestContentTypeAdaptor` returns populated samples for MainTest context scan.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs | none found |
+| Behavioral unit tests for changed logic | yes (Jackson serialisation + resource list + adaptor stub) |
+| Cross-platform path / file I/O | not touched |
+| Change-class companions | rest resource/DTO/test stubs; sitemanage adaptor mapping already correct — no sitemanage change |
+| New dependencies | none |
+| May commit/push | **yes** |
+
+## Issues
+
+None.
+
+### Nits (non-blocking)
+
+- `TemplateSummary` still uses Optional getters; covered by existing Jackson test and Jackson 3 unwrapping. Out of scope for this slice unless similar live symptoms appear.
+- Nested `Guid` still uses Optional for some string fields; ContentTypeDetail already depends on the same Guid type successfully for detail views.
+
+## Tests run
+
+```text
+cd rest && ../mvnw clean install
+# focused: JacksonContextResolverOptionalTest, ContentTypesTest, ContentTypesResourceDetailTest — pass
+```
+
+## Residual (not this PR)
+
+- Playwright developer-catalog-smoke against live CMS after redeploy remains under parent #1690 / #1695 (and redeploy #1692).

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentType.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,16 @@ import com.percussion.rest.Guid;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
-import java.util.Optional;
 
-/** Represents a Content Type in Percussion CMS. */
+/**
+ * Represents a Content Type summary in Percussion CMS.
+ *
+ * <p>Wire getters return plain types (not {@code Optional}) so Jackson/CXF JSON always emits {@code
+ * name}, {@code label}, and {@code guid} when set. Optional-returning getters historically dropped
+ * those fields under {@code @JsonInclude(NON_NULL)} when the mapper did not unwrap {@code
+ * Optional}, leaving only {@code hideFromMenu} on the list wire shape (issue #1693). Matches {@link
+ * ContentTypeDetail} getter style.
+ */
 @XmlRootElement(name = "ContentType")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Represents a Content Type")
@@ -69,64 +76,64 @@ public class ContentType {
 
   public ContentType() {}
 
-  public Optional<Guid> getGuid() {
-    return Optional.ofNullable(guid);
+  public Guid getGuid() {
+    return guid;
   }
 
   public void setGuid(Guid guid) {
     this.guid = guid;
   }
 
-  public Optional<Guid> getObjectType() {
-    return Optional.ofNullable(objectType);
+  public Guid getObjectType() {
+    return objectType;
   }
 
   public void setObjectType(Guid objectType) {
     this.objectType = objectType;
   }
 
-  public Optional<String> getName() {
-    return Optional.ofNullable(name);
+  public String getName() {
+    return name;
   }
 
   public void setName(String name) {
     this.name = name;
   }
 
-  public Optional<String> getLabel() {
-    return Optional.ofNullable(label);
+  public String getLabel() {
+    return label;
   }
 
   public void setLabel(String label) {
     this.label = label;
   }
 
-  public Optional<String> getDescription() {
-    return Optional.ofNullable(description);
+  public String getDescription() {
+    return description;
   }
 
   public void setDescription(String description) {
     this.description = description;
   }
 
-  public Optional<String> getNewRequest() {
-    return Optional.ofNullable(newRequest);
+  public String getNewRequest() {
+    return newRequest;
   }
 
   public void setNewRequest(String newRequest) {
     this.newRequest = newRequest;
   }
 
-  public Optional<String> getQueryRequest() {
-    return Optional.ofNullable(queryRequest);
+  public String getQueryRequest() {
+    return queryRequest;
   }
 
   public void setQueryRequest(String queryRequest) {
     this.queryRequest = queryRequest;
   }
 
-  public Optional<String> getUpdateRequest() {
-    return Optional.ofNullable(updateRequest);
+  public String getUpdateRequest() {
+    return updateRequest;
   }
 
   public void setUpdateRequest(String updateRequest) {

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -19,14 +19,18 @@ package com.percussion.rest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.contenttypes.ContentType;
+import com.percussion.rest.contenttypes.ContentTypeList;
 import com.percussion.rest.templates.TemplateSummary;
+import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.ObjectMapper;
 
 /**
- * Jackson 3 databind unwraps {@code Optional} DTO getters by default (no Jdk8Module). Content-type
- * and template catalogs must serialize names for the Developer SPA tables.
+ * Catalog DTOs must serialize names (and related fields) for Developer SPA tables. ContentType list
+ * historically collapsed to hideFromMenu-only when Optional getters were not unwrapped (issue
+ * #1693). ContentType now uses plain getters; TemplateSummary still uses Optional and relies on
+ * Jackson 3 databind unwrapping.
  */
 @Tag("UnitTest")
 class JacksonContextResolverOptionalTest {
@@ -34,17 +38,38 @@ class JacksonContextResolverOptionalTest {
   private final ObjectMapper mapper = new JacksonContextResolver().getContext(ContentType.class);
 
   @Test
-  void contentType_serializesNameLabelNotOnlyHideFromMenu() {
+  void contentType_serializesNameLabelGuidNotOnlyHideFromMenu() {
     ContentType ct = new ContentType();
     ct.setName("percPage");
     ct.setLabel("Page");
     ct.setDescription("Page content type");
     ct.setHideFromMenu(false);
+    ct.setGuid(new Guid("0-2-311"));
 
     String json = mapper.writeValueAsString(ct);
     assertTrue(json.contains("percPage"), json);
     assertTrue(json.contains("Page"), json);
     assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("\"label\""), json);
+    assertTrue(json.contains("\"guid\""), json);
+    assertTrue(json.contains("0-2-311") || json.contains("311"), json);
+  }
+
+  @Test
+  void contentTypeList_serializesNamesNotHideFromMenuOnly() {
+    ContentType ct = new ContentType();
+    ct.setName("percPage");
+    ct.setLabel("Page");
+    ct.setGuid(new Guid("0-2-311"));
+    ct.setHideFromMenu(false);
+
+    ContentTypeList list = new ContentTypeList(List.of(ct));
+    String json = mapper.writeValueAsString(list);
+    assertTrue(json.contains("percPage"), json);
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("\"label\""), json);
+    // List root wrap uses ContentType (XmlRootElement on ContentTypeList) or plain array
+    assertTrue(json.contains("ContentType") || json.startsWith("["), json);
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -18,18 +18,25 @@
 package com.percussion.rest.contenttypes;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.percussion.rest.Guid;
+import com.percussion.rest.JacksonContextResolver;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.UriInfo;
 import java.net.URI;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 @Tag("UnitTest")
 public class ContentTypesResourceDetailTest {
@@ -47,11 +54,56 @@ public class ContentTypesResourceDetailTest {
   }
 
   @Test
+  public void listContentTypesReturnsNameLabelGuid() {
+    ContentType ct = sampleContentType();
+    when(adaptor.listContentTypes(any())).thenReturn(List.of(ct));
+
+    List<ContentType> list = resource.listContentTypes();
+    assertEquals(1, list.size());
+    ContentType first = list.get(0);
+    assertEquals("percPage", first.getName());
+    assertEquals("Page", first.getLabel());
+    assertNotNull(first.getGuid());
+    assertFalse(first.isHideFromMenu());
+  }
+
+  @Test
+  public void listContentTypesJsonIsNotHideFromMenuOnly() {
+    ContentType ct = sampleContentType();
+    when(adaptor.listContentTypes(any())).thenReturn(List.of(ct));
+
+    List<ContentType> list = resource.listContentTypes();
+    ObjectMapper mapper = new JacksonContextResolver().getContext(ContentType.class);
+    String json = mapper.writeValueAsString(new ContentTypeList(list));
+
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("percPage"), json);
+    assertTrue(json.contains("\"label\""), json);
+    assertTrue(json.contains("Page"), json);
+    assertTrue(json.contains("\"guid\""), json);
+    // Regression: live install returned only hideFromMenu per item (#1693)
+    assertFalse(
+        json.replaceAll("\\s", "").contains("{\"hideFromMenu\":false}")
+            && !json.contains("\"name\""),
+        json);
+  }
+
+  @Test
   public void getContentTypeReturnsDetail() {
     ContentTypeDetail d = new ContentTypeDetail();
     d.setName("percPage");
     when(adaptor.getContentType(any(), eq("percPage"))).thenReturn(d);
     assertEquals("percPage", resource.getContentType("percPage").getName());
+  }
+
+  private static ContentType sampleContentType() {
+    ContentType ct = new ContentType();
+    ct.setName("percPage");
+    ct.setLabel("Page");
+    ct.setDescription("Page content type");
+    ct.setGuid(new Guid("0-2-311"));
+    ct.setHideFromMenu(false);
+    return ct;
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTest.java
@@ -2,18 +2,68 @@
 
 package com.percussion.rest.contenttypes;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.rest.Guid;
+import com.percussion.rest.JacksonContextResolver;
 import com.percussion.rest.MainTest;
-import java.net.URISyntaxException;
+import java.net.URI;
+import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
+/**
+ * Content type catalog list must expose name/label/guid on the wire (Developer SPA table). See
+ * issue #1693 hideFromMenu-only regression.
+ */
 @Tag("UnitTest")
 public class ContentTypesTest extends MainTest {
 
   private final ContentTypesTestAdaptor adaptor = new ContentTypesTestAdaptor();
 
   @Test
-  public void testListContentTypes() throws URISyntaxException {
-    // TODO: Implement me
+  public void testListContentTypesPopulatesIdentityFields() {
+    List<ContentType> list = adaptor.listContentTypes(URI.create("http://localhost/services/"));
+    assertNotNull(list);
+    assertFalse(list.isEmpty());
+
+    ContentType first = list.get(0);
+    assertEquals("percPage", first.getName());
+    assertEquals("Page", first.getLabel());
+    assertNotNull(first.getGuid());
+  }
+
+  @Test
+  public void testListContentTypesJsonNotHideFromMenuOnly() {
+    List<ContentType> list = adaptor.listContentTypes(URI.create("http://localhost/services/"));
+    ObjectMapper mapper = new JacksonContextResolver().getContext(ContentType.class);
+    String json = mapper.writeValueAsString(new ContentTypeList(list));
+
+    assertTrue(json.contains("\"name\""), json);
+    assertTrue(json.contains("percPage"), json);
+    assertTrue(json.contains("\"label\""), json);
+    assertTrue(json.contains("\"guid\""), json);
+    assertFalse(
+        json.replaceAll("\\s", "").equals("{\"ContentType\":[{\"hideFromMenu\":false}]}")
+            || (json.contains("hideFromMenu") && !json.contains("\"name\"")),
+        "List JSON must not be hideFromMenu-only: " + json);
+  }
+
+  @Test
+  public void testContentTypePlainGettersRoundTrip() {
+    ContentType ct = new ContentType();
+    ct.setName("rffFile");
+    ct.setLabel("File");
+    ct.setGuid(new Guid("0-2-312"));
+    ct.setHideFromMenu(true);
+
+    assertEquals("rffFile", ct.getName());
+    assertEquals("File", ct.getLabel());
+    assertEquals(312, ct.getGuid().getUuid());
+    assertTrue(ct.isHideFromMenu());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,22 @@
 
 package com.percussion.rest.contenttypes;
 
+import com.percussion.rest.Guid;
 import java.net.URI;
 import java.util.List;
 
+/** Standalone test adaptor with populated list items for #1693 serialization coverage. */
 public class ContentTypesTestAdaptor implements IContentTypesAdaptor {
+
+  private static ContentType samplePage() {
+    ContentType ct = new ContentType();
+    ct.setName("percPage");
+    ct.setLabel("Page");
+    ct.setDescription("Page content type");
+    ct.setGuid(new Guid("0-2-311"));
+    ct.setHideFromMenu(false);
+    return ct;
+  }
 
   /**
    * List all content types available to the System.
@@ -30,7 +42,7 @@ public class ContentTypesTestAdaptor implements IContentTypesAdaptor {
    */
   @Override
   public List<ContentType> listContentTypes(URI baseUri) {
-    return null;
+    return List.of(samplePage());
   }
 
   /**
@@ -42,7 +54,7 @@ public class ContentTypesTestAdaptor implements IContentTypesAdaptor {
    */
   @Override
   public List<ContentType> listContentTypes(URI baseUri, int siteId) {
-    return null;
+    return List.of(samplePage());
   }
 
   /**
@@ -54,7 +66,7 @@ public class ContentTypesTestAdaptor implements IContentTypesAdaptor {
    */
   @Override
   public List<ContentType> listContentTypesByFilter(URI baseUri, ContentTypeFilter filter) {
-    return null;
+    return List.of(samplePage());
   }
 
   @Override

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
@@ -19,6 +19,7 @@
 
 package com.percussion.rest.test.apibridge;
 
+import com.percussion.rest.Guid;
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeDetail;
 import com.percussion.rest.contenttypes.ContentTypeFilter;
@@ -27,12 +28,22 @@ import java.net.URI;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
-/** Test adaptor for ContentType API bridge. */
+/** Test adaptor for ContentType API bridge (Spring MainTest companion stub). */
 @Component
 public class TestContentTypeAdaptor implements IContentTypesAdaptor {
 
   public TestContentTypeAdaptor() {
     // Default constructor
+  }
+
+  private static ContentType samplePage() {
+    ContentType ct = new ContentType();
+    ct.setName("percPage");
+    ct.setLabel("Page");
+    ct.setDescription("Page content type");
+    ct.setGuid(new Guid("0-2-311"));
+    ct.setHideFromMenu(false);
+    return ct;
   }
 
   /**
@@ -43,7 +54,7 @@ public class TestContentTypeAdaptor implements IContentTypesAdaptor {
    */
   @Override
   public List<ContentType> listContentTypes(URI baseUri) {
-    return null;
+    return List.of(samplePage());
   }
 
   /**
@@ -55,7 +66,7 @@ public class TestContentTypeAdaptor implements IContentTypesAdaptor {
    */
   @Override
   public List<ContentType> listContentTypes(URI baseUri, int siteId) {
-    return null;
+    return List.of(samplePage());
   }
 
   /**
@@ -67,7 +78,7 @@ public class TestContentTypeAdaptor implements IContentTypesAdaptor {
    */
   @Override
   public List<ContentType> listContentTypesByFilter(URI baseUri, ContentTypeFilter filter) {
-    return null;
+    return List.of(samplePage());
   }
 
   @Override


### PR DESCRIPTION
## Summary

`GET /services/contenttypes` returned list items with only `hideFromMenu` (no `name` / `label` / `guid`), so the Developer content-types table showed empty rows.

**Root cause:** `ContentType` wire DTO used `Optional`-returning getters with `@JsonInclude(NON_NULL)`. When Optional was not unwrapped on the Jackson/CXF path, those properties vanished and only the primitive boolean remained.

**Not the cause:** `ContentTypeAdaptor.listContentTypes` → `ApiUtils.convertContentType` already sets name, label, and guid from design WS summaries.

**Fix:** Change `ContentType` getters to plain types (same style as `ContentTypeDetail`). No new APIs; no sitemanage mapping change.

## Test plan

- [x] `JacksonContextResolverOptionalTest` — name/label/guid present; list serialization
- [x] `ContentTypesResourceDetailTest` — list resource returns identity fields + JSON not hideFromMenu-only
- [x] `ContentTypesTest` + test adaptors populated with sample data
- [x] `cd rest && ../mvnw clean install` — **BUILD SUCCESS**, Tests run: **173**, Failures: **0**
- [x] Spotless: `./mvnw spotless:apply` then `./mvnw spotless:check` (in-scope only; unrelated baseline format left uncommitted)
- [x] Erlang review: approve — `docs/ai-generated/code-reviews/issue-1693-contenttype-list-dto-erlang.md`

## Residual / not in this PR

Live Playwright developer-catalog-smoke (CT section) after redeploy remains under parent **#1690** / **#1695** and redeploy **#1692**. Unit/resource coverage only here.

## Fixes

Fixes #1693  
Refs #1690

> Co-Authored by Grok Build using grok-4.5 with agent main.