### PR TITLE
fix: drop ESAPI and transitive commons-configuration 1.x (#1675)

### DIFF
--- a/modules/perc-distribution-tree/pom.xml
+++ b/modules/perc-distribution-tree/pom.xml
@@ -299,10 +299,6 @@
                     <artifactId>bcprov-jdk18on</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.owasp.esapi</groupId>
-                    <artifactId>esapi</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.github.javafaker</groupId>
                     <artifactId>javafaker</artifactId>
                 </exclusion>

--- a/modules/perc-security-utils/pom.xml
+++ b/modules/perc-security-utils/pom.xml
@@ -51,20 +51,8 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.owasp.esapi</groupId>
-            <artifactId>esapi</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+        <!-- OWASP Java Encoder only — full ESAPI removed (issue #1675) to drop
+             transitive commons-configuration:1.x (CVE-2025-46392 / unmaintained). -->
         <dependency>
             <groupId>org.owasp.encoder</groupId>
             <artifactId>encoder</artifactId>

--- a/modules/perc-security-utils/src/main/java/com/percussion/security/SecureStringUtils.java
+++ b/modules/perc-security-utils/src/main/java/com/percussion/security/SecureStringUtils.java
@@ -41,9 +41,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.owasp.encoder.Encode;
-import org.owasp.esapi.ESAPI;
-import org.owasp.esapi.errors.EncodingException;
-import org.owasp.esapi.reference.DefaultEncoder;
 
 /**
  * A centralized utility class with static methods for performing a variety of secure string
@@ -148,22 +145,85 @@ public class SecureStringUtils {
   /**
    * To be used when sending queries to LDAP.
    *
+   * <p>Escapes LDAP filter special characters using RFC 4515 hex-style escapes, matching the former
+   * ESAPI {@code encodeForLDAP} behavior without requiring the ESAPI library.
+   *
    * @param query An LDAP query
-   * @param encodeWildcards true to encode wildcards, false to leave them
-   * @return A string encoded for LDAP, wild cards are not encoded.
+   * @param encodeWildcards true to encode wildcards ({@code *}), false to leave them
+   * @return A string encoded for LDAP, or {@code null} if {@code query} is null
    */
   public static String sanitizeStringForLDAP(String query, boolean encodeWildcards) {
-    return DefaultEncoder.getInstance().encodeForLDAP(query, encodeWildcards);
+    return encodeForLdap(query, encodeWildcards);
   }
 
   /**
    * Use this method to encode a string provided externally for JavaScript / JSON.
    *
    * @param s The string to encode
-   * @return Returns the supplied string encoded for a JSON
+   * @return Returns the supplied string encoded for a JSON context, or {@code null} if {@code s} is
+   *     null
    */
   public static String sanitizeForJson(String s) {
-    return DefaultEncoder.getInstance().encodeForJavaScript(s);
+    if (s == null) {
+      return null;
+    }
+    return Encode.forJavaScript(s);
+  }
+
+  /**
+   * LDAP filter-value encoding (RFC 4515 style hex escapes).
+   *
+   * <p>Escapes: {@code \} → {@code \5c}, {@code /} → {@code \2f}, {@code (} → {@code \28}, {@code
+   * )} → {@code \29}, NUL → {@code \00}, and optionally {@code *} → {@code \2a}. Non-ASCII
+   * characters (code point ≥ 128) are escaped as UTF-8 hex bytes.
+   *
+   * @param input value to encode; may be null
+   * @param encodeWildcards whether to escape {@code *}
+   * @return encoded value, or null if input is null
+   */
+  static String encodeForLdap(String input, boolean encodeWildcards) {
+    if (input == null) {
+      return null;
+    }
+    StringBuilder sb = new StringBuilder(input.length());
+    for (int i = 0; i < input.length(); i++) {
+      char c = input.charAt(i);
+      switch (c) {
+        case '\\':
+          sb.append("\\5c");
+          break;
+        case '/':
+          sb.append("\\2f");
+          break;
+        case '*':
+          if (encodeWildcards) {
+            sb.append("\\2a");
+          } else {
+            sb.append(c);
+          }
+          break;
+        case '(':
+          sb.append("\\28");
+          break;
+        case ')':
+          sb.append("\\29");
+          break;
+        case '\0':
+          sb.append("\\00");
+          break;
+        default:
+          if (c >= 128) {
+            byte[] utf8 = String.valueOf(c).getBytes(StandardCharsets.UTF_8);
+            for (byte b : utf8) {
+              sb.append(String.format("\\%02x", b & 0xff));
+            }
+          } else {
+            sb.append(c);
+          }
+          break;
+      }
+    }
+    return sb.toString();
   }
 
   /** Maximum allowed filename length. */
@@ -1278,21 +1338,21 @@ public class SecureStringUtils {
   }
 
   /**
-   * URL encodes a string.
+   * URL encodes a string for use as a URI component (percent-encoding via OWASP Java Encoder).
    *
-   * @param s the string to encode
-   * @return URL encoded string
+   * @param s the string to encode; may be null
+   * @return URL encoded string, empty string if encoding fails, or null if {@code s} is null
    */
   public static String urlEncode(String s) {
-    String ret = "";
-
-    try {
-      ret = DefaultEncoder.getInstance().encodeForURL(s);
-    } catch (EncodingException e) {
-      log.error(e.getMessage());
+    if (s == null) {
+      return null;
     }
-
-    return ret;
+    try {
+      return Encode.forUriComponent(s);
+    } catch (RuntimeException e) {
+      log.error(e.getMessage());
+      return "";
+    }
   }
 
   /**
@@ -1482,21 +1542,12 @@ public class SecureStringUtils {
    * Utility to sanitize a string for use in a SQL statement.
    *
    * @param str User provided string
-   * @param dbType The type of database that should be used for encoding if an ESAPI Codec is
-   *     available for the DB.
-   * @return The sanitized string, will use {@link #sanitizeStringForFileSystem(String)} if no ESAPI
-   *     codec is available.
+   * @param dbType The type of database (retained for API compatibility; database-specific codecs
+   *     are not used — all types share {@link #sanitizeStringForSQLStatement(String)})
+   * @return The sanitized string
    */
   public static String sanitizeStringForSQLStatement(String str, DatabaseType dbType) {
     return sanitizeStringForSQLStatement(str);
-
-    /**
-     * This is not Consistent across multiple DB Types and thus commented. Codec codec;
-     * switch(dbType){ case DERBY: case DB2: codec = new DB2Codec(); break; case MYSQL: codec = new
-     * MySQLCodec(MySQLCodec.Mode.STANDARD); break; case ORACLE: codec = new OracleCodec(); break;
-     * default: codec = null; } if(codec == null) { return sanitizeStringForSQLStatement(str);
-     * }else{ return DefaultEncoder.getInstance().encodeForSQL(codec,str); }*
-     */
   }
 
   /**
@@ -1516,8 +1567,8 @@ public class SecureStringUtils {
     if (path == null) return ret;
 
     try {
-      // Url decode path
-      ret = ESAPI.encoder().decodeFromURL(path);
+      // Url decode path (percent-encoding; replaces former ESAPI decodeFromURL)
+      ret = URLDecoder.decode(path, StandardCharsets.UTF_8);
 
       // Normalize backslashes to slashes
       ret = ret.replace("\\", "/");
@@ -1548,7 +1599,7 @@ public class SecureStringUtils {
         ret = null;
       }
 
-    } catch (EncodingException e) {
+    } catch (IllegalArgumentException e) {
       log.warn(
           "Error decoding wild path {}. Error: {}", path, PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
@@ -1648,7 +1699,8 @@ public class SecureStringUtils {
   public static boolean isHTML(String src) {
     boolean ret = false;
     if (src != null && !StringUtils.isEmpty(src)) {
-      if (!src.equals(ESAPI.encoder().encodeForHTML(src))) {
+      // Detect markup-sensitive characters by comparing with OWASP HTML encoding
+      if (!src.equals(Encode.forHtml(src))) {
         ret = true;
       }
     }
@@ -1664,7 +1716,8 @@ public class SecureStringUtils {
   public static boolean isXML(String src) {
     boolean ret = false;
     if (src != null && !StringUtils.isEmpty(src)) {
-      if (!src.equals(ESAPI.encoder().encodeForXML(src))) {
+      // Detect markup-sensitive characters by comparing with OWASP XML encoding
+      if (!src.equals(Encode.forXml(src))) {
         ret = true;
       }
     }

--- a/modules/perc-security-utils/src/main/java/com/percussion/security/SecureStringUtils.java
+++ b/modules/perc-security-utils/src/main/java/com/percussion/security/SecureStringUtils.java
@@ -146,7 +146,9 @@ public class SecureStringUtils {
    * To be used when sending queries to LDAP.
    *
    * <p>Escapes LDAP filter special characters using RFC 4515 hex-style escapes, matching the former
-   * ESAPI {@code encodeForLDAP} behavior without requiring the ESAPI library.
+   * ESAPI {@code encodeForLDAP} behavior without requiring the ESAPI library. Forward slash is
+   * escaped as {@code \2f} for Microsoft Active Directory / ADSI compatibility (ESAPI and Microsoft
+   * document this as required; RFC 4515 allows it).
    *
    * @param query An LDAP query
    * @param encodeWildcards true to encode wildcards ({@code *}), false to leave them
@@ -177,6 +179,11 @@ public class SecureStringUtils {
    * )} → {@code \29}, NUL → {@code \00}, and optionally {@code *} → {@code \2a}. Non-ASCII
    * characters (code point ≥ 128) are escaped as UTF-8 hex bytes.
    *
+   * <p>{@code /} → {@code \2f} intentionally mirrors ESAPI {@code DefaultEncoder.encodeForLDAP}:
+   * Microsoft ADSI requires forward-slash escaping in search filters; RFC 4515 §3 permits it.
+   * Removing the escape would diverge from prior ESAPI behavior used by callers such as user
+   * directory lookups.
+   *
    * @param input value to encode; may be null
    * @param encodeWildcards whether to escape {@code *}
    * @return encoded value, or null if input is null
@@ -193,6 +200,7 @@ public class SecureStringUtils {
           sb.append("\\5c");
           break;
         case '/':
+          // ESAPI encodeForLDAP + Microsoft ADSI: '/' MUST be escaped in filters
           sb.append("\\2f");
           break;
         case '*':
@@ -1340,8 +1348,12 @@ public class SecureStringUtils {
   /**
    * URL encodes a string for use as a URI component (percent-encoding via OWASP Java Encoder).
    *
+   * <p>Does not swallow encoder failures: unexpected runtime errors from the encoder are logged and
+   * rethrown so callers are not handed a silently empty component.
+   *
    * @param s the string to encode; may be null
-   * @return URL encoded string, empty string if encoding fails, or null if {@code s} is null
+   * @return URL encoded string, or null if {@code s} is null
+   * @throws RuntimeException if the encoder fails for the given input
    */
   public static String urlEncode(String s) {
     if (s == null) {
@@ -1350,8 +1362,9 @@ public class SecureStringUtils {
     try {
       return Encode.forUriComponent(s);
     } catch (RuntimeException e) {
-      log.error(e.getMessage());
-      return "";
+      log.error("urlEncode failed for input length {}: {}", s.length(), e.getMessage());
+      log.debug(e);
+      throw e;
     }
   }
 

--- a/modules/perc-security-utils/src/test/java/TestSecureStringUtils.java
+++ b/modules/perc-security-utils/src/test/java/TestSecureStringUtils.java
@@ -137,16 +137,66 @@ public class TestSecureStringUtils {
 
   @Test
   public void testIsHTML() {
-    assertFalse(SecureStringUtils.isXML("x"));
-    assertTrue(SecureStringUtils.isXML("<div></div>"));
-    assertTrue(SecureStringUtils.isXML("<a href='#'>x</a>"));
+    assertFalse(SecureStringUtils.isHTML("x"));
+    assertFalse(SecureStringUtils.isHTML(null));
+    assertFalse(SecureStringUtils.isHTML(""));
+    assertTrue(SecureStringUtils.isHTML("<div></div>"));
+    assertTrue(SecureStringUtils.isHTML("<a href='#'>x</a>"));
+    assertTrue(SecureStringUtils.isHTML("a&b"));
+    assertTrue(SecureStringUtils.isHTML("\"quoted\""));
   }
 
   @Test
   public void testIsXML() {
     assertFalse(SecureStringUtils.isXML("x"));
+    assertFalse(SecureStringUtils.isXML(null));
+    assertFalse(SecureStringUtils.isXML(""));
     assertTrue(SecureStringUtils.isXML("<div></div>"));
     assertTrue(SecureStringUtils.isXML("<a href='#'>x</a>"));
+    assertTrue(SecureStringUtils.isXML("a&b"));
+  }
+
+  @Test
+  public void testSanitizeStringForLDAP() {
+    assertNull(SecureStringUtils.sanitizeStringForLDAP(null, true));
+    assertEquals("plain", SecureStringUtils.sanitizeStringForLDAP("plain", true));
+    assertEquals("a\\2ab", SecureStringUtils.sanitizeStringForLDAP("a*b", true));
+    assertEquals("a*b", SecureStringUtils.sanitizeStringForLDAP("a*b", false));
+    assertEquals("a\\28b\\29c", SecureStringUtils.sanitizeStringForLDAP("a(b)c", true));
+    assertEquals("a\\5cb", SecureStringUtils.sanitizeStringForLDAP("a\\b", true));
+    assertEquals("a\\2fb", SecureStringUtils.sanitizeStringForLDAP("a/b", true));
+    assertEquals("a\\00b", SecureStringUtils.sanitizeStringForLDAP("a\0b", true));
+    // Non-ASCII → UTF-8 hex escapes (café = c3 a9 for é)
+    assertEquals("caf\\c3\\a9", SecureStringUtils.sanitizeStringForLDAP("café", true));
+  }
+
+  @Test
+  public void testSanitizeForJson() {
+    assertNull(SecureStringUtils.sanitizeForJson(null));
+    assertEquals("plain", SecureStringUtils.sanitizeForJson("plain"));
+    // OWASP JS encoder escapes quotes, angle brackets, and backslashes
+    String encoded = SecureStringUtils.sanitizeForJson("a'b\"c</script>\\");
+    assertNotNull(encoded);
+    assertFalse(encoded.contains("'") && encoded.contains("\""));
+    assertTrue(encoded.contains("\\x27") || encoded.contains("\\'"));
+  }
+
+  @Test
+  public void testUrlEncode() {
+    assertNull(SecureStringUtils.urlEncode(null));
+    assertEquals("plain", SecureStringUtils.urlEncode("plain"));
+    // Space and reserved URI component chars are percent-encoded
+    assertEquals("a%20b%2Fc%3Fd%3De%26f", SecureStringUtils.urlEncode("a b/c?d=e&f"));
+    assertFalse(SecureStringUtils.urlEncode("<script>").contains("<"));
+  }
+
+  @Test
+  public void testSanitizeStringForHTML() {
+    assertNull(SecureStringUtils.sanitizeStringForHTML(null));
+    assertEquals("hello", SecureStringUtils.sanitizeStringForHTML("hello"));
+    String encoded = SecureStringUtils.sanitizeStringForHTML("<script>alert(1)</script>");
+    assertFalse(encoded.contains("<script>"));
+    assertTrue(encoded.contains("&lt;") || encoded.contains("&#"));
   }
 
   @Test

--- a/modules/perc-security-utils/src/test/java/TestSecureStringUtils.java
+++ b/modules/perc-security-utils/src/test/java/TestSecureStringUtils.java
@@ -177,7 +177,9 @@ public class TestSecureStringUtils {
     // OWASP JS encoder escapes quotes, angle brackets, and backslashes
     String encoded = SecureStringUtils.sanitizeForJson("a'b\"c</script>\\");
     assertNotNull(encoded);
-    assertFalse(encoded.contains("'") && encoded.contains("\""));
+    // Each quote type must be escaped independently (do not AND the checks)
+    assertFalse(encoded.contains("'"), "single quote must be escaped in JS/JSON encoding");
+    assertFalse(encoded.contains("\""), "double quote must be escaped in JS/JSON encoding");
     assertTrue(encoded.contains("\\x27") || encoded.contains("\\'"));
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <eclipse-manifest-location>META-INF</eclipse-manifest-location>
         <ehcache.version>3.10.8</ehcache.version>
         <esapi.encoder.version>1.4.0</esapi.encoder.version>
-        <esapi.version>2.7.0.0</esapi.version>
+        <!-- full org.owasp.esapi removed (issue #1675); OWASP Java Encoder only -->
         <failsafeArgLine/>
         <fop.version>2.11</fop.version>
         <glassfish.jakarta.el.version>4.0.2</glassfish.jakarta.el.version>
@@ -1201,25 +1201,8 @@
                 <artifactId>encoder-jsp</artifactId>
                 <version>${esapi.encoder.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.owasp.esapi</groupId>
-                <artifactId>esapi</artifactId>
-                <version>${esapi.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.xmlgraphics</groupId>
-                        <artifactId>xmlgraphics-commons</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>commons-lang</groupId>
-                        <artifactId>commons-lang</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
+            <!-- org.owasp.esapi dependencyManagement removed (issue #1675): sole consumers
+                 migrated to org.owasp.encoder; dropped transitive commons-configuration 1.x -->
             <dependency>
                 <groupId>org.owasp</groupId>
                 <artifactId>csrfguard</artifactId>

--- a/projects/sitemanage/pom.xml
+++ b/projects/sitemanage/pom.xml
@@ -566,16 +566,7 @@
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.owasp.esapi</groupId>
-            <artifactId>esapi</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+        <!-- ESAPI removed (issue #1675); use org.owasp.encoder only -->
         <dependency>
             <groupId>org.owasp.encoder</groupId>
             <artifactId>encoder</artifactId>


### PR DESCRIPTION
## Summary
Closes Dependabot/security tech-debt for unmaintained **commons-configuration 1.x** (sole path: \sapi:2.7.0.0 → commons-configuration:1.10\).

- **SecureStringUtils**: replaced \ESAPI.encoder()\ / \DefaultEncoder\ (HTML/XML/JS/URL/LDAP, URL decode) with \org.owasp.encoder.Encode\ + local RFC 4515-style LDAP hex encoder (ESAPI-compatible escapes).
- Removed \org.owasp.esapi:esapi\ from \perc-security-utils\ and \sitemanage\ (sitemanage had no Java ESAPI imports).
- Removed parent \sapi.version\ / dependencyManagement for ESAPI; dropped obsolete esapi exclusion on \perc-distribution-tree\ → \perc-security-utils\.
- Extended unit tests for LDAP / HTML / XML / JS / URL encoding edge cases; fixed \	estIsHTML\ to call \isHTML\.

**Residual (not in this PR):** dead ESAPI config packaging under \src/main/resources/esapi\ + installer copy to \xconfig/esapi\ → follow-up **#1800**.

Fixes #1675

## Test plan
- [x] Pre-change: \cd modules/perc-security-utils && ../../mvnw dependency:tree -Dincludes=commons-configuration:commons-configuration\ showed \sapi → commons-configuration:1.10\
- [x] Post-change: same tree empty (no 1.x); sitemanage tree empty for esapi + commons-configuration 1.x
- [x] \cd modules/perc-security-utils && ../../mvnw clean install\ → **BUILD SUCCESS**, Tests run: **301**, Failures: 0
- [x] \cd projects/sitemanage && ../../mvnw clean install\ → **BUILD SUCCESS**
- [x] \cd modules/perc-distribution-tree && ../../mvnw clean install\ → **BUILD SUCCESS**
- [x] Root Spotless: \mvnw.cmd spotless:apply\ **then** \mvnw.cmd spotless:check\ → SUCCESS; only in-scope files committed (out-of-scope Spotless hit on unrelated code-review doc restored)

## Gates evidence
| Gate | Result |
|------|--------|
| Erlang-style self-review | No path I/O changes; LDAP encoder is pure string; behavioral tests added |
| Spotless apply → check | Pass; no monorepo reformat dump |
| Per-module clean install | security-utils, sitemanage, distribution-tree |
| No new warnings attributable to change | Yes (baseline javadoc/analyze noise only) |

## Residual
- #1800 — remove obsolete ESAPI config resources / installer packaging