### PR TITLE
fix(perc-packages): add Schema.org JSON-LD to Directory widget (#806)

### DIFF
--- a/modules/perc-packages/pom.xml
+++ b/modules/perc-packages/pom.xml
@@ -12,8 +12,15 @@
         <packages.output.dir>${basedir}/target/distribution/Packages</packages.output.dir>
         <packages.source.dir>${basedir}/src/main/resources/Packages</packages.source.dir>
         <packages.temp.dir>${basedir}/target/temp/Packages</packages.temp.dir>
+        <skipTests>false</skipTests>
     </properties>
-    <dependencies/>
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
     <build>
         <resources>
             <resource>

--- a/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/sys__UserDependency--rxconfig/Widgets/percDirectory.xml
+++ b/modules/perc-packages/src/main/resources/Packages/perc.widget.directory/sys__UserDependency--rxconfig/Widgets/percDirectory.xml
@@ -212,6 +212,19 @@
        <div class="$!rootclass">
 #if( ! $perc.widgetContents.isEmpty() )
 ##
+## Schema.org ItemList JSON-LD (built while iterating $directoryResults)
+## Multi-instance de-dupe uses script id, same pattern as percPerson / percOrganization / percDepartment.
+##
+#set( $scriptSchemaId = "perc-directory-schema-" + $assetContentId )##
+#set( $directorySchema = $rx.string.getJSONObject() )##
+#set( $dummy = $directorySchema.put("@context", "http://schema.org") )##
+#set( $dummy = $directorySchema.put("@type", "ItemList") )##
+#if( "$!{directoryTitle}" != "" )##
+#set( $dummy = $directorySchema.put("name", $directoryTitle) )##
+#end##
+#set( $itemListElement = $rx.string.getJSONArray() )##
+#set( $schemaItemPosition = 0 )##
+##
 ## Script to Initialize perc-directory.js
 ##
 #if( $orgSearchId == -1 )##
@@ -475,6 +488,58 @@
 ##
 #set( $personCaption = $person.getProperty('personCaption').String )##
 ##
+## Schema.org Person entry for this directory result (ItemList element)
+##
+#set( $personSchema = $rx.string.getJSONObject() )##
+#set( $dummy = $personSchema.put("@type", "Person") )##
+#set( $personFullName = "" )##
+#if( "$!{personNamePrefix}" != "" && "$!{personNamePrefix}" != "#" )##
+#set( $personFullName = $personFullName + $personNamePrefix + " " )##
+#set( $dummy = $personSchema.put("honorificPrefix", $personNamePrefix) )##
+#end##
+#if( "$!{personFirstName}" != "" && "$!{personFirstName}" != "#" )##
+#set( $personFullName = $personFullName + $personFirstName + " " )##
+#set( $dummy = $personSchema.put("givenName", $personFirstName) )##
+#end##
+#if( "$!{personLastName}" != "" && "$!{personLastName}" != "#" )##
+#set( $personFullName = $personFullName + $personLastName )##
+#set( $dummy = $personSchema.put("familyName", $personLastName) )##
+#end##
+#set( $personFullName = $personFullName.trim() )##
+#if( "$!{personFullName}" != "" )##
+#set( $dummy = $personSchema.put("name", $personFullName) )##
+#end##
+#if( "$!{dptName}" != "" && "$!{dptName}" != "#" )##
+#set( $worksForOrg = $rx.string.getJSONObject() )##
+#set( $dummy = $worksForOrg.put("@type", "Organization") )##
+#if( "$!{orgName}" != "" && "$!{orgName}" != "#" )##
+#set( $dummy = $worksForOrg.put("name", $orgName) )##
+#end##
+#set( $deptOrg = $rx.string.getJSONObject() )##
+#set( $dummy = $deptOrg.put("@type", "Organization") )##
+#set( $dummy = $deptOrg.put("name", $dptName) )##
+#set( $dummy = $worksForOrg.put("department", $deptOrg) )##
+#set( $dummy = $personSchema.put("worksFor", $worksForOrg) )##
+#elseif( "$!{orgName}" != "" && "$!{orgName}" != "#" )##
+#set( $dummy = $personSchema.put("worksFor", $orgName) )##
+#end##
+#if( "$!{personTitle}" != "" && "$!{personTitle}" != "#" )##
+#set( $dummy = $personSchema.put("jobTitle", $personTitle) )##
+#end##
+#if( "$!{personPhone}" != "" && "$!{personPhone}" != "#" )##
+#set( $dummy = $personSchema.put("telephone", $personPhone) )##
+#end##
+#if( "$!{personEmail}" != "" && "$!{personEmail}" != "#" )##
+#set( $personMailTo = "mailto:" + $personEmail )##
+#set( $dummy = $personSchema.put("email", $personMailTo) )##
+#end##
+#set( $schemaItemPosition = $schemaItemPosition + 1 )##
+#set( $listItem = $rx.string.getJSONObject() )##
+#set( $dummy = $listItem.put("@type", "ListItem") )##
+#set( $dummy = $listItem.put("position", $schemaItemPosition) )##
+#set( $dummy = $listItem.put("item", $personSchema) )##
+#set( $dummy = $itemListElement.put($listItem) )##
+##
 ##
 ## HTML for disply
 ##
@@ -673,6 +738,17 @@
 #end## --( $person in $directoryResults )--
 ##
 #end## --( $directoryResults.size() > 0 )--
+##
+## Emit Schema.org ItemList JSON-LD into page head (once per widget instance)
+##
+#if( $itemListElement.length() > 0 )##
+#set( $dummy = $directorySchema.put("numberOfItems", $itemListElement.length()) )##
+#set( $dummy = $directorySchema.put("itemListElement", $itemListElement) )##
+#set( $addlHead = $perc.page.getAdditionalHeadContent() )##
+#if( !($addlHead.contains($scriptSchemaId)) )##
+$perc.page.setAdditionalHeadContent("$!{addlHead}<script async id='$!{scriptSchemaId}' type='application/ld+json'>$!{directorySchema}</script>")##
+#end##
+#end## --( $itemListElement.length() > 0 )--
 ##
 #if( $directoryLayoutFormat == "table" )##
                     </tbody>

--- a/modules/perc-packages/src/test/java/com/percussion/packages/PSDirectoryWidgetSchemaOrgTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/PSDirectoryWidgetSchemaOrgTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for issue #806: Directory widget package Velocity must emit Schema.org JSON-LD
+ * (ItemList of Person entries) via additional head content, matching peer directory package widgets
+ * (percPerson / percOrganization / percDepartment).
+ */
+class PSDirectoryWidgetSchemaOrgTest {
+
+  private static final String DIRECTORY_WIDGET_RESOURCE =
+      "/Packages/perc.widget.directory/sys__UserDependency--rxconfig/Widgets/percDirectory.xml";
+
+  private static final String PERSON_WIDGET_RESOURCE =
+      "/Packages/perc.widget.directory/sys__UserDependency--rxconfig/Widgets/percPerson.xml";
+
+  @Test
+  void percDirectoryXml_containsSchemaOrgJsonLdMarkers() throws IOException {
+    String xml = readClasspathResource(DIRECTORY_WIDGET_RESOURCE);
+
+    assertTrue(
+        xml.contains("http://schema.org"),
+        "percDirectory.xml must set JSON-LD @context to schema.org");
+    assertTrue(
+        xml.contains("application/ld+json"),
+        "percDirectory.xml must emit application/ld+json script type");
+    assertTrue(
+        xml.contains("ItemList"), "percDirectory.xml must use Schema.org ItemList for directory");
+    assertTrue(
+        xml.contains("perc-directory-schema-"),
+        "percDirectory.xml must use multi-instance script id prefix perc-directory-schema-");
+    assertTrue(
+        xml.contains("setAdditionalHeadContent"),
+        "percDirectory.xml must inject JSON-LD via setAdditionalHeadContent");
+    assertTrue(
+        xml.contains("getJSONObject()"),
+        "percDirectory.xml must build JSON-LD with $rx.string.getJSONObject");
+    assertTrue(
+        xml.contains("getJSONArray()"),
+        "percDirectory.xml must build itemListElement with $rx.string.getJSONArray");
+    assertTrue(
+        xml.contains("\"Person\"") || xml.contains("\"@type\", \"Person\""),
+        "percDirectory.xml must type directory entries as Person");
+    assertTrue(
+        xml.contains("itemListElement"),
+        "percDirectory.xml must populate Schema.org itemListElement");
+  }
+
+  @Test
+  void percPersonXml_stillContainsPeerSchemaOrgMarkers() throws IOException {
+    // Guard against accidental package resource packaging breakage while asserting peer parity.
+    String xml = readClasspathResource(PERSON_WIDGET_RESOURCE);
+    assertTrue(xml.contains("http://schema.org"));
+    assertTrue(xml.contains("application/ld+json"));
+    assertTrue(xml.contains("setAdditionalHeadContent"));
+  }
+
+  private static String readClasspathResource(String resourcePath) throws IOException {
+    try (InputStream in = PSDirectoryWidgetSchemaOrgTest.class.getResourceAsStream(resourcePath)) {
+      assertNotNull(in, "Classpath resource missing: " + resourcePath);
+      String content = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+      assertFalse(content.isBlank(), "Classpath resource empty: " + resourcePath);
+      return content;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Schema.org markup was present on Person, Organization, and Department widgets but missing from the Directory widget (`percDirectory.xml`), so published directory pages had no JSON-LD in page source.

This PR adds Schema.org **ItemList** JSON-LD for directory results assembled in `$directoryResults`:
- Each person entry: `Person` with `name` / givenName / familyName, `worksFor` (org string or nested Organization + department), `jobTitle`, `telephone`, `email` (when available)
- Injected via `$perc.page.setAdditionalHeadContent` as `application/ld+json`
- Multi-instance de-dupe via script id `perc-directory-schema-` + asset content id (same pattern as peer widgets)
- Velocity only — no OS path I/O

Fixes #806

## Test plan
- [x] Resource regression: `PSDirectoryWidgetSchemaOrgTest` asserts `schema.org`, `application/ld+json`, `ItemList`, `setAdditionalHeadContent`, `perc-directory-schema-` markers in packaged `percDirectory.xml`
- [x] Peer guard: `percPerson.xml` still contains Schema.org markers
- [ ] Manual: place Directory widget, publish, view page source — expect `<script type="application/ld+json">` ItemList with Person items

## Gates evidence
### Erlang-style self-review
- Peer pattern mirrored (Person/Org/Department head-content + script id de-dupe)
- Null/empty/`#` guards for optional person fields
- No filesystem path construction (package Velocity only)
- Change class: package widget Velocity + resource assertion test + junit test dep on `perc-packages`

### Spotless
```
./mvnw spotless:apply
./mvnw spotless:check
```
Both **SUCCESS**. Out-of-scope Spotless hit on unrelated code-review markdown was **not** included in this PR.

### Maven (standalone module)
```
cd modules/perc-packages
../../mvnw clean install
```
**BUILD SUCCESS** — `Tests run: 2, Failures: 0, Errors: 0, Skipped: 0`  
No new dependency-analyze warnings. Pre-existing Javadoc warning on `PSPackageBuilder.main` unchanged.

### Commit
`84bfb8dafa` — in-scope only:
- `percDirectory.xml`
- `PSDirectoryWidgetSchemaOrgTest.java`
- `modules/perc-packages/pom.xml` (JUnit 5 test scope)