### PR TITLE
fix(i18n): harden tmx.jsp hi-in JS catalog path (GH-1611)

### DIFF
--- a/WebUI/src/main/webapp/tmx/tmx.jsp
+++ b/WebUI/src/main/webapp/tmx/tmx.jsp
@@ -1,6 +1,6 @@
 <%@ page import="java.util.*,com.percussion.i18n.PSTmxResourceBundle"%>
+    <%@ page import="com.percussion.i18n.PSTmxJsCatalog" %>
     <%@ page import="com.percussion.services.utils.jspel.PSRoleUtilities" %>
-    <%@ page import="com.percussion.security.validation.XSSValidation" %>
     <%@ page pageEncoding="UTF-8" contentType="text/javascript; charset=UTF-8" %>
 
 
@@ -40,18 +40,12 @@
                  <!ELEMENT tmxmessages (message+)>
 
 
+    Catalog collection and JS/JSON escaping live in {@link com.percussion.i18n.PSTmxJsCatalog}
+    so sparse regional locales (e.g. hi-in → hi → en-us) and Devanagari / quoted segments
+    are regression-tested offline (GH-1611). Do not re-introduce naive replaceAll("\"","\\\"")
+    escaping here.
+
     --%>
-    <%!
-        public boolean accept(String[] prefixes, String key)
-        {
-            for(int i = 0; i < prefixes.length; i++)
-            {
-                if(key.startsWith(prefixes[i]))
-                    return true;
-            }
-            return false;
-        }
-    %>
     <%
         String jspstart = "<" + "%";
         String jspend = "%" + ">";
@@ -74,29 +68,10 @@
             prefix = "javascript.";
         if(mode == null || mode.length() == 0)
             mode = "js";
-        String[] prefixes = prefix.split(",");
-        PSTmxResourceBundle tmxBundle = PSTmxResourceBundle.getInstance();
-        Iterator keys = tmxBundle.getKeys(locale);
-        // LinkedHashMap preserves stable key order for easier diffs / tests.
-        Map accepted = new LinkedHashMap();
-        if (keys != null)
-        {
-            while(keys.hasNext())
-            {
-                String key = (String)keys.next();
-                if(!prefix.equals("*") && !accept(prefixes, key))
-                    continue;
-                // Keep raw strings here; escape per output mode below.
-                // Do NOT use naive replaceAll("\"","\\\"") — FR/IT (and other)
-                // catalog values embed literal " and newlines. That produced
-                // invalid JS object literals so the login locale dropdown could
-                // load the script without updating I18N.message (chrome stuck
-                // on the previous locale). Escape with XSSValidation /
-                // escapeEcmaScript at emit time.
-                String val = tmxBundle.getString(key, locale);
-                accepted.put(key, val == null ? "" : val);
-            }
-        }
+        // Same accepted map as unit-tested for sys_lang=hi-in / prefix=perc.ui. (GH-1611).
+        // Null getKeys, null keys, and empty values are handled inside collectAccepted.
+        Map accepted = PSTmxJsCatalog.collectAccepted(
+            PSTmxResourceBundle.getInstance(), locale, prefix);
 
         if(mode.equals("js"))
         {
@@ -107,20 +82,7 @@
         this.I18N = {};
     }
     var __tmxMessageMap = {
-        <%
-
-            Iterator keyset = accepted.keySet().iterator();
-            while(keyset.hasNext())
-            {
-                String key = (String)keyset.next();
-                String rawVal = (String)accepted.get(key);
-                String safeKey = XSSValidation.escapeJavaScript(key);
-                String safeVal = XSSValidation.escapeJavaScript(rawVal);
-                if (safeKey == null) safeKey = "";
-                if (safeVal == null) safeVal = "";
-
-        %>"<%= safeKey %>": "<%= safeVal %>"<%if(keyset.hasNext()) out.print(",");%>
-        <%}%>
+        <%= PSTmxJsCatalog.toJsObjectEntries(accepted) %>
     };
 
     function psxGetLocalMessage(key, args) {
@@ -176,25 +138,7 @@
         else if(mode.equals("json"))
         {
             response.setContentType("application/json");
-            Iterator keyset = accepted.keySet().iterator();
-            out.print("{\"tmxmessages\": {");
-            while(keyset.hasNext())
-            {
-                String key = (String)keyset.next();
-                String rawVal = (String)accepted.get(key);
-                String safeKey = XSSValidation.escapeJavaScript(key);
-                String safeVal = XSSValidation.escapeJavaScript(rawVal);
-                if (safeKey == null) safeKey = "";
-                if (safeVal == null) safeVal = "";
-                out.print("\"");
-                out.print(safeKey);
-                out.print("\": \"");
-                out.print(safeVal);
-                out.print("\"");
-                if(keyset.hasNext())
-                    out.print(",");
-            }
-            out.print("}}");
+            out.print(PSTmxJsCatalog.toJsonDocument(accepted));
         }
         else if(mode.equals("xml"))
         {
@@ -204,6 +148,7 @@
             while(keyset.hasNext())
             {
                 String key = (String)keyset.next();
+                if (key == null) continue;
                 String rawVal = (String)accepted.get(key);
                 if (rawVal == null) rawVal = "";
                 out.print("<message key=\"");

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/PSTmxJsCatalog.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/PSTmxJsCatalog.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.i18n;
+
+import com.percussion.security.validation.XSSValidation;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Builds the accepted TMX key/value catalog and JS/JSON payloads that {@code tmx.jsp} emits for the
+ * WebUI (and other clients). Extracted from the JSP so the {@code sys_lang=hi-in} / {@code
+ * prefix=perc.ui.} path can be regression-tested without a servlet container (GH-1611).
+ *
+ * <p>Escape failures must never surface as HTTP 500 on the catalog endpoint: a single bad segment
+ * is replaced with a safe fallback escape rather than aborting the whole map.
+ */
+public final class PSTmxJsCatalog {
+
+  private PSTmxJsCatalog() {
+    // utility
+  }
+
+  /**
+   * Whether {@code key} matches any of the configured prefixes (same rules as {@code tmx.jsp}).
+   *
+   * @param prefixes non-null array of prefix strings; null elements are ignored
+   * @param key message key; {@code null} is never accepted
+   * @return {@code true} if the key should be included in the catalog
+   */
+  public static boolean accept(String[] prefixes, String key) {
+    if (key == null || prefixes == null) {
+      return false;
+    }
+    for (String prefix : prefixes) {
+      if (prefix != null && key.startsWith(prefix)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Collects accepted raw (unescaped) messages for the given locale and prefix filter — the same
+   * map {@code tmx.jsp} builds before mode-specific emit.
+   *
+   * @param bundle resource bundle, never {@code null}
+   * @param language BCP-47 locale (e.g. {@code hi-in}); null/empty uses the bundle default chain
+   * @param prefixParam comma-delimited prefixes, or {@code *} for all keys; null/empty defaults to
+   *     {@code javascript.} (legacy JSP default)
+   * @return ordered map of raw key → raw value; never {@code null} (empty when no keys / null
+   *     iterator)
+   */
+  public static Map<String, String> collectAccepted(
+      PSTmxResourceBundle bundle, String language, String prefixParam) {
+    Objects.requireNonNull(bundle, "bundle");
+    String prefix = prefixParam;
+    if (prefix == null || prefix.isEmpty()) {
+      prefix = "javascript.";
+    }
+    String[] prefixes = prefix.split(",");
+    boolean acceptAll = "*".equals(prefix);
+
+    Map<String, String> accepted = new LinkedHashMap<>();
+    Iterator<String> keys = bundle.getKeys(language);
+    if (keys == null) {
+      return accepted;
+    }
+    while (keys.hasNext()) {
+      String key = keys.next();
+      if (key == null) {
+        continue;
+      }
+      if (!acceptAll && !accept(prefixes, key)) {
+        continue;
+      }
+      String val = bundle.getString(key, language);
+      accepted.put(key, val == null ? "" : val);
+    }
+    return accepted;
+  }
+
+  /**
+   * Escapes a string for embedding inside a double-quoted JavaScript / JSON string literal. Never
+   * returns {@code null}; never throws for ordinary catalog text (including Devanagari, quotes,
+   * newlines, and backslashes).
+   *
+   * @param input may be {@code null}
+   * @return escaped string, never {@code null}
+   */
+  public static String escapeJs(String input) {
+    if (input == null || input.isEmpty()) {
+      return input == null ? "" : input;
+    }
+    try {
+      String escaped = XSSValidation.escapeJavaScript(input);
+      return escaped == null ? "" : escaped;
+    } catch (RuntimeException ex) {
+      // Defensive: catalog endpoint must stay HTTP 200 even if an edge value upsets the escaper.
+      return fallbackEscape(input);
+    }
+  }
+
+  /**
+   * Emits comma-separated {@code "key": "value"} entries suitable for a JS object literal body
+   * (without surrounding braces). Stable iteration order of {@code accepted} is preserved.
+   *
+   * @param accepted raw key/value map; never {@code null}
+   * @return object-entry source; never {@code null}
+   */
+  public static String toJsObjectEntries(Map<String, String> accepted) {
+    Objects.requireNonNull(accepted, "accepted");
+    StringBuilder sb = new StringBuilder(Math.max(64, accepted.size() * 32));
+    boolean first = true;
+    for (Map.Entry<String, String> e : accepted.entrySet()) {
+      if (e.getKey() == null) {
+        continue;
+      }
+      if (!first) {
+        sb.append(',');
+      }
+      first = false;
+      sb.append('"')
+          .append(escapeJs(e.getKey()))
+          .append("\": \"")
+          .append(escapeJs(e.getValue()))
+          .append('"');
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Emits {@code {"tmxmessages": {"k":"v",...}}} JSON used by {@code tmx.jsp} {@code mode=json}.
+   *
+   * @param accepted raw key/value map; never {@code null}
+   * @return JSON document; never {@code null}
+   */
+  public static String toJsonDocument(Map<String, String> accepted) {
+    Objects.requireNonNull(accepted, "accepted");
+    StringBuilder sb = new StringBuilder(Math.max(64, accepted.size() * 32));
+    sb.append("{\"tmxmessages\": {");
+    boolean first = true;
+    for (Map.Entry<String, String> e : accepted.entrySet()) {
+      if (e.getKey() == null) {
+        continue;
+      }
+      if (!first) {
+        sb.append(',');
+      }
+      first = false;
+      sb.append('"')
+          .append(escapeJs(e.getKey()))
+          .append("\": \"")
+          .append(escapeJs(e.getValue()))
+          .append('"');
+    }
+    sb.append("}}");
+    return sb.toString();
+  }
+
+  /**
+   * Minimal fallback when {@link XSSValidation#escapeJavaScript(String)} fails. Escapes backslash,
+   * quotes, and common control characters only.
+   */
+  static String fallbackEscape(String input) {
+    StringBuilder sb = new StringBuilder(input.length() + 16);
+    for (int i = 0; i < input.length(); i++) {
+      char c = input.charAt(i);
+      switch (c) {
+        case '\\':
+          sb.append("\\\\");
+          break;
+        case '"':
+          sb.append("\\\"");
+          break;
+        case '\'':
+          sb.append("\\'");
+          break;
+        case '\n':
+          sb.append("\\n");
+          break;
+        case '\r':
+          sb.append("\\r");
+          break;
+        case '\t':
+          sb.append("\\t");
+          break;
+        case '\u2028':
+          sb.append("\\u2028");
+          break;
+        case '\u2029':
+          sb.append("\\u2029");
+          break;
+        default:
+          sb.append(c);
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/PSTmxJsCatalog.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/PSTmxJsCatalog.java
@@ -174,7 +174,9 @@ public final class PSTmxJsCatalog {
 
   /**
    * Minimal fallback when {@link XSSValidation#escapeJavaScript(String)} fails. Escapes backslash,
-   * quotes, and common control characters only.
+   * quotes, line/paragraph separators, and the full C0 control range ({@code U+0000}–{@code
+   * U+001F}) so the result remains valid JSON / JS string content even if the primary escaper
+   * throws.
    */
   static String fallbackEscape(String input) {
     StringBuilder sb = new StringBuilder(input.length() + 16);
@@ -200,13 +202,18 @@ public final class PSTmxJsCatalog {
           sb.append("\\t");
           break;
         case '\u2028':
-          sb.append("\\u2028");
+          sb.append('\\').append("u2028");
           break;
         case '\u2029':
-          sb.append("\\u2029");
+          sb.append('\\').append("u2029");
           break;
         default:
-          sb.append(c);
+          // Full C0 range (NUL..US) as JSON unicode escapes so catalog stays valid if fallback runs.
+          if (c < 0x20) {
+            sb.append('\\').append(String.format("u%04x", (int) c));
+          } else {
+            sb.append(c);
+          }
       }
     }
     return sb.toString();

--- a/modules/perc-i18n/src/test/java/com/percussion/i18n/PSTmxJsCatalogTest.java
+++ b/modules/perc-i18n/src/test/java/com/percussion/i18n/PSTmxJsCatalogTest.java
@@ -154,6 +154,13 @@ public class PSTmxJsCatalogTest {
     assertEquals("a\\\"b", PSTmxJsCatalog.fallbackEscape("a\"b"));
     assertEquals("a\\nb", PSTmxJsCatalog.fallbackEscape("a\nb"));
     assertEquals("a\\\\b", PSTmxJsCatalog.fallbackEscape("a\\b"));
+    // Full C0 range (not only n/r/t) must be escaped as JSON unicode escapes for validity.
+    // Expected form is backslash + "u" + four hex digits (split so the source stays legal).
+    assertEquals("a\\" + "u0000b", PSTmxJsCatalog.fallbackEscape("a" + (char) 0 + "b"));
+    assertEquals("a\\" + "u0008b", PSTmxJsCatalog.fallbackEscape("a" + '\b' + "b"));
+    assertEquals("a\\" + "u000cb", PSTmxJsCatalog.fallbackEscape("a" + '\f' + "b"));
+    assertEquals("a\\" + "u001fb", PSTmxJsCatalog.fallbackEscape("a" + (char) 0x1f + "b"));
+    assertEquals("a\\" + "u2028b", PSTmxJsCatalog.fallbackEscape("a" + '\u2028' + "b"));
   }
 
   /**
@@ -185,12 +192,9 @@ public class PSTmxJsCatalogTest {
     for (String lang : new String[] {"hi-in", "hi", "en-us"}) {
       Map<String, String> accepted = PSTmxJsCatalog.collectAccepted(bundle, lang, PERC_UI_PREFIX);
       assertNotNull(accepted, "accepted map for " + lang);
-      // hi-in must resolve keys via language-only/default chain (sparse regional).
-      if ("hi-in".equals(lang) || "hi".equals(lang) || "en-us".equals(lang)) {
-        assertFalse(
-            accepted.isEmpty(),
-            "expected perc.ui. keys for " + lang + " after loading product TMX");
-      }
+      // hi-in / hi resolve via language-only/default chain (sparse regional); en-us has full pack.
+      assertFalse(
+          accepted.isEmpty(), "expected perc.ui. keys for " + lang + " after loading product TMX");
 
       for (Map.Entry<String, String> e : accepted.entrySet()) {
         assertNotNull(e.getKey(), "null key in accepted for " + lang);

--- a/modules/perc-i18n/src/test/java/com/percussion/i18n/PSTmxJsCatalogTest.java
+++ b/modules/perc-i18n/src/test/java/com/percussion/i18n/PSTmxJsCatalogTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.percussion.security.validation.XSSValidation;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+
+/**
+ * Regression for GH-1611: {@code tmx.jsp?mode=js&prefix=perc.ui.&sys_lang=hi-in} must build a
+ * complete accepted-key map and escape every key/value without throwing (HTTP 500). Mirrors the JSP
+ * catalog path via {@link PSTmxJsCatalog} and exercises product TMX from the source tree.
+ */
+public class PSTmxJsCatalogTest {
+
+  private static final String PERC_UI_PREFIX = "perc.ui.";
+
+  @BeforeEach
+  void reset() {
+    PSTmxResourceBundle.getInstance().flushCacheForTest();
+  }
+
+  @AfterEach
+  void teardown() {
+    PSTmxResourceBundle.getInstance().flushCacheForTest();
+  }
+
+  @Test
+  public void accept_nullSafe() {
+    assertFalse(PSTmxJsCatalog.accept(null, "perc.ui.x"));
+    assertFalse(PSTmxJsCatalog.accept(new String[] {"perc.ui."}, null));
+    assertFalse(PSTmxJsCatalog.accept(new String[] {null, "perc.ui."}, null));
+    assertTrue(PSTmxJsCatalog.accept(new String[] {"perc.ui."}, "perc.ui.home@Title"));
+    assertFalse(PSTmxJsCatalog.accept(new String[] {"perc.ui."}, "psx.ce.label@X"));
+    assertTrue(PSTmxJsCatalog.accept(new String[] {"a.", "b."}, "b.z"));
+  }
+
+  @Test
+  public void collectAccepted_nullGetKeysYieldsEmptyMap() {
+    // Fresh cache with no language buckets → getKeys returns null.
+    PSTmxResourceBundle bundle = PSTmxResourceBundle.getInstance();
+    assertTrue(bundle.getResourceBundlesForTest().isEmpty());
+    Iterator<String> keys = bundle.getKeys("hi-in");
+    // May be null when no maps exist at all.
+    Map<String, String> accepted = PSTmxJsCatalog.collectAccepted(bundle, "hi-in", PERC_UI_PREFIX);
+    assertNotNull(accepted);
+    assertTrue(accepted.isEmpty());
+    // keys was null or empty — either way, no throw and empty catalog.
+    if (keys != null) {
+      assertFalse(keys.hasNext());
+    }
+  }
+
+  @Test
+  public void collectAccepted_emptyValuesAndSyntheticSparseHiIn() throws Exception {
+    Document doc =
+        parse(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<tmx version=\"1.4\"><header>"
+                + "<prop type=\"supportedlanguage\">en-us</prop>"
+                + "<prop type=\"supportedlanguage\">hi</prop>"
+                + "<prop type=\"supportedlanguage\">hi-in</prop>"
+                + "</header><body>"
+                + "<tu tuid=\"perc.ui.login.modern@Sign in\">"
+                + "<tuv xml:lang=\"en-us\"><seg>Sign in</seg></tuv>"
+                + "<tuv xml:lang=\"hi\"><seg>प्रवेश</seg></tuv>"
+                + "</tu>"
+                + "<tu tuid=\"perc.ui.empty@Blank\">"
+                + "<tuv xml:lang=\"en-us\"><seg></seg></tuv>"
+                + "</tu>"
+                + "<tu tuid=\"perc.ui.quote@Q\">"
+                + "<tuv xml:lang=\"en-us\"><seg>Say \"hi\"</seg></tuv>"
+                + "<tuv xml:lang=\"hi\"><seg>कहो \"नमस्ते\"</seg></tuv>"
+                + "</tu>"
+                + "<tu tuid=\"other.ns@Skip\">"
+                + "<tuv xml:lang=\"en-us\"><seg>nope</seg></tuv>"
+                + "</tu>"
+                + "</body></tmx>");
+    PSTmxResourceBundle.getInstance().addResourcesToCacheForTest(doc);
+
+    Map<String, String> hiIn =
+        PSTmxJsCatalog.collectAccepted(PSTmxResourceBundle.getInstance(), "hi-in", PERC_UI_PREFIX);
+    assertTrue(hiIn.containsKey("perc.ui.login.modern@Sign in"));
+    assertEquals("प्रवेश", hiIn.get("perc.ui.login.modern@Sign in"));
+    // Empty <seg> is invalid → getString returns last sub-key ("Blank"), not null.
+    // Catalog still includes the key with a non-null value (never aborts emit).
+    assertTrue(hiIn.containsKey("perc.ui.empty@Blank"));
+    assertNotNull(hiIn.get("perc.ui.empty@Blank"));
+    assertEquals("Blank", hiIn.get("perc.ui.empty@Blank"));
+    assertEquals("कहो \"नमस्ते\"", hiIn.get("perc.ui.quote@Q"));
+    assertFalse(hiIn.containsKey("other.ns@Skip"));
+
+    Map<String, String> hi =
+        PSTmxJsCatalog.collectAccepted(PSTmxResourceBundle.getInstance(), "hi", PERC_UI_PREFIX);
+    assertEquals("प्रवेश", hi.get("perc.ui.login.modern@Sign in"));
+
+    // Escape every entry — must not throw; shape is "k": "v" pairs.
+    String entries = PSTmxJsCatalog.toJsObjectEntries(hiIn);
+    assertTrue(entries.contains("\"perc.ui.login.modern@Sign in\""));
+    assertTrue(entries.contains("प्रवेश") || entries.contains("\\u"));
+    assertTrue(entries.contains("\\\""), "literal quotes in values must be escaped");
+    String json = PSTmxJsCatalog.toJsonDocument(hiIn);
+    assertTrue(json.startsWith("{\"tmxmessages\": {"));
+    assertTrue(json.endsWith("}}"));
+  }
+
+  @Test
+  public void escapeJs_nullEmptyAndSpecials() {
+    assertEquals("", PSTmxJsCatalog.escapeJs(null));
+    assertEquals("", PSTmxJsCatalog.escapeJs(""));
+    assertEquals("ok", PSTmxJsCatalog.escapeJs("ok"));
+    String quoted = PSTmxJsCatalog.escapeJs("a\"b");
+    assertTrue(quoted.contains("\\\"") || quoted.contains("\\u0022"));
+    String newline = PSTmxJsCatalog.escapeJs("a\nb");
+    assertTrue(newline.contains("\\n") || newline.contains("\\u000a"));
+    // Devanagari passes through as Unicode (or escaped) without throw.
+    assertNotNull(PSTmxJsCatalog.escapeJs("नमस्ते"));
+    assertEquals(XSSValidation.escapeJavaScript("x"), PSTmxJsCatalog.escapeJs("x"));
+  }
+
+  @Test
+  public void fallbackEscape_handlesControlsAndQuotes() {
+    assertEquals("a\\\"b", PSTmxJsCatalog.fallbackEscape("a\"b"));
+    assertEquals("a\\nb", PSTmxJsCatalog.fallbackEscape("a\nb"));
+    assertEquals("a\\\\b", PSTmxJsCatalog.fallbackEscape("a\\b"));
+  }
+
+  /**
+   * Product TMX regression: load every source-tree {@code *.tmx}, then for {@code hi-in} and {@code
+   * hi} build the same accepted map as {@code tmx.jsp} ({@code prefix=perc.ui.}), escape every
+   * key/value, and assert stable JS/JSON object shape without throw (GH-1611).
+   */
+  @Test
+  public void productTmx_hiInAndHi_percUiCatalogEscapesWithoutThrow() throws Exception {
+    Path dir = Paths.get("src", "main", "resources", "i18n").toAbsolutePath().normalize();
+    if (!Files.isDirectory(dir)) {
+      // Source tree not present (e.g. jar-only test run) — skip without failing CI packaging.
+      return;
+    }
+    PSTmxResourceBundle bundle = PSTmxResourceBundle.getInstance();
+    try (Stream<Path> stream = Files.list(dir)) {
+      var files = stream.filter(p -> p.toString().endsWith(".tmx")).sorted().toList();
+      assertFalse(files.isEmpty(), "expected product TMX under " + dir);
+      for (Path f : files) {
+        Document doc = parseFile(f);
+        bundle.addResourcesToCacheForTest(doc);
+      }
+    }
+
+    Map<String, Map<String, PSTmxUnit>> buckets = bundle.getResourceBundlesForTest();
+    assertTrue(
+        buckets.containsKey("hi") || buckets.containsKey("hi-in") || buckets.containsKey("en-us"));
+
+    for (String lang : new String[] {"hi-in", "hi", "en-us"}) {
+      Map<String, String> accepted = PSTmxJsCatalog.collectAccepted(bundle, lang, PERC_UI_PREFIX);
+      assertNotNull(accepted, "accepted map for " + lang);
+      // hi-in must resolve keys via language-only/default chain (sparse regional).
+      if ("hi-in".equals(lang) || "hi".equals(lang) || "en-us".equals(lang)) {
+        assertFalse(
+            accepted.isEmpty(),
+            "expected perc.ui. keys for " + lang + " after loading product TMX");
+      }
+
+      for (Map.Entry<String, String> e : accepted.entrySet()) {
+        assertNotNull(e.getKey(), "null key in accepted for " + lang);
+        assertNotNull(e.getValue(), "null value for key " + e.getKey());
+        try {
+          String safeKey = PSTmxJsCatalog.escapeJs(e.getKey());
+          String safeVal = PSTmxJsCatalog.escapeJs(e.getValue());
+          assertNotNull(safeKey);
+          assertNotNull(safeVal);
+          // Direct XSSValidation path used by older JSP (must also not throw).
+          XSSValidation.escapeJavaScript(e.getKey());
+          XSSValidation.escapeJavaScript(e.getValue());
+        } catch (Throwable t) {
+          fail(
+              "escape threw for lang="
+                  + lang
+                  + " key="
+                  + e.getKey()
+                  + " valueSnippet="
+                  + snippet(e.getValue())
+                  + ": "
+                  + t);
+        }
+      }
+
+      String jsEntries = PSTmxJsCatalog.toJsObjectEntries(accepted);
+      assertNotNull(jsEntries);
+      // Every entry uses quoted keys; first key starts with quote.
+      if (!accepted.isEmpty()) {
+        assertTrue(jsEntries.startsWith("\""), "JS entries must start with quoted key");
+        assertTrue(jsEntries.contains("\": \""), "JS entries must use \": \" separators");
+      }
+
+      String json = PSTmxJsCatalog.toJsonDocument(accepted);
+      assertTrue(json.startsWith("{\"tmxmessages\": {"));
+      assertTrue(json.endsWith("}}"));
+      // escapeJs must neutralize raw newlines inside values (catalog stays one logical emit).
+      assertFalse(json.contains("\r"), "JSON catalog must not embed raw CR for " + lang);
+      // Unescaped LF would break JS string literals when this JSON is inlined; escaper uses \n.
+      if (json.contains("\n")) {
+        // Pretty-print is not used; any newline would be from a failed escape of a value.
+        fail("JSON catalog must not embed raw LF for " + lang);
+      }
+    }
+  }
+
+  @Test
+  public void toJsObjectEntries_skipsNullKeysAndOrdersStable() {
+    Map<String, String> map = new LinkedHashMap<>();
+    map.put("perc.ui.a@A", "1");
+    map.put(null, "x");
+    map.put("perc.ui.b@B", "2");
+    String entries = PSTmxJsCatalog.toJsObjectEntries(map);
+    assertEquals("\"perc.ui.a@A\": \"1\",\"perc.ui.b@B\": \"2\"", entries);
+  }
+
+  private static String snippet(String v) {
+    if (v == null) {
+      return "null";
+    }
+    return v.length() <= 80 ? v : v.substring(0, 80) + "...";
+  }
+
+  private static Document parse(String xml) throws Exception {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(true);
+    factory.setValidating(false);
+    return factory.newDocumentBuilder().parse(new InputSource(new StringReader(xml)));
+  }
+
+  private static Document parseFile(Path f) throws Exception {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setIgnoringComments(true);
+    factory.setIgnoringElementContentWhitespace(true);
+    factory.setValidating(false);
+    factory.setNamespaceAware(true);
+    return factory.newDocumentBuilder().parse(f.toFile());
+  }
+}


### PR DESCRIPTION
## Summary

Home page JS console errors after selecting Hindi (India) (hi-in) because 	mx.jsp?mode=js&prefix=perc.ui.&sys_lang=hi-in returned HTTP 500 (response as 	ext/html, MIME refusal).

This PR extracts catalog collection and JS/JSON escaping from 	mx.jsp into `PSTmxJsCatalog` so the sparse-regional path (hi-in → hi → n-us) is offline-testable and null-safe:

- `collectAccepted`: null `getKeys`, skip null keys, never store null values
- `escapeJs`: `XSSValidation.escapeJavaScript` with non-throwing fallback for edge values
- `toJsObjectEntries` / `toJsonDocument`: stable quoted object shape for JSP emit
- `tmx.jsp`: thin wrapper over the helper (js/json/xml); removes in-JSP escape loop risk

No product TMX content change was required: product `hi`/`en-us` segs all escape cleanly under the new path.

## Test plan

- [x] Unit: `PSTmxJsCatalogTest` — null getKeys, synthetic sparse hi-in, empty/quote values, product TMX `hi-in`/`hi`/`en-us` + `prefix=perc.ui.` full escape
- [x] Unit: existing `PSTmxResourceBundleTest` / `PSTmxResourceBundleScanTest` still green
- [ ] Manual (optional residual): live CMS login as `hi-in`, open Home, confirm `tmx.jsp?...sys_lang=hi-in` is HTTP 200 `text/javascript` with no console MIME error

## Gates evidence

| Gate | Result |
|------|--------|
| Erlang-style self-review | Pass — no NPE on null keys/getKeys; portable `Path` for test TMX load; escape never throws to 500 |
| Spotless | `mvnw spotless:apply` then `spotless:check -pl modules/perc-i18n,WebUI` (in-scope only; out-of-scope doc touch discarded) |
| Maven | `cd modules/perc-i18n && ../../mvnw clean install` → **BUILD SUCCESS**, Tests run: **20**, Failures: **0** |
| WebUI clean install | Not required (JSP-only change; no Java/TS test changes in WebUI) |

## Residual

Live CMS Playwright confirmation of Home + `hi-in` tmx 200 is optional QA follow-up if reviewers want browser proof beyond offline product-TMX regression. No residual issue filed unless requested after review.

Fixes #1611