### PR TITLE
fix(webui): Bulk Upload HTTP 405 — exact /uploadAssetFile mapping (GH-1812)

### DIFF
--- a/WebUI/src/main/webapp/WEB-INF/web.xml
+++ b/WebUI/src/main/webapp/WEB-INF/web.xml
@@ -389,6 +389,15 @@
         <url-pattern>/servlet/tdschemaxml</url-pattern>
     </servlet-mapping>
     
+    <!--
+      Exact /uploadAssetFile: modern Bulk Upload POSTs /cm/uploadAssetFile with no pathInfo.
+      /* covers legacy callers that append a trailing path segment.
+      GH-1812: prefix-only mapping caused HTTP 405 on the exact path.
+    -->
+    <servlet-mapping>
+        <servlet-name>assetUploadServlet</servlet-name>
+        <url-pattern>/uploadAssetFile</url-pattern>
+    </servlet-mapping>
     <servlet-mapping>
         <servlet-name>assetUploadServlet</servlet-name>
         <url-pattern>/uploadAssetFile/*</url-pattern>

--- a/WebUI/src/main/webapp/cm/WEB-INF/web.xml
+++ b/WebUI/src/main/webapp/cm/WEB-INF/web.xml
@@ -479,6 +479,15 @@
         <url-pattern>/adf/*</url-pattern>
     </servlet-mapping>
     -->
+    <!--
+      Exact /uploadAssetFile: modern Bulk Upload POSTs /cm/uploadAssetFile with no pathInfo.
+      /* covers legacy callers that append a trailing path segment.
+      GH-1812: prefix-only mapping caused HTTP 405 on the exact path.
+    -->
+    <servlet-mapping>
+        <servlet-name>assetUploadServlet</servlet-name>
+        <url-pattern>/uploadAssetFile</url-pattern>
+    </servlet-mapping>
     <servlet-mapping>
         <servlet-name>assetUploadServlet</servlet-name>
         <url-pattern>/uploadAssetFile/*</url-pattern>

--- a/WebUI/src/test/ts/api/dashboard/shellGadgetsApi.test.ts
+++ b/WebUI/src/test/ts/api/dashboard/shellGadgetsApi.test.ts
@@ -2,13 +2,16 @@
  * Copyright 1999-2026 Percussion Software, Inc.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   normalizeThemeSummary,
   resolveAssetUploadUrl,
   fetchThemeSummaries,
+  uploadAssetFile,
+  uploadAssetFiles,
 } from "@/api/dashboard/shellGadgetsApi";
 import * as client from "@/api/client";
+import * as csrf from "@/api/csrf";
 import { PATHS } from "@/api/paths";
 
 vi.mock("@/api/client", async (importOriginal) => {
@@ -16,14 +19,126 @@ vi.mock("@/api/client", async (importOriginal) => {
   return { ...actual, get: vi.fn() };
 });
 
+vi.mock("@/api/csrf", () => ({
+  getCsrfToken: vi.fn(() => null),
+}));
+
 describe("shellGadgetsApi", () => {
+  const originalPathname = window.location.pathname;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(csrf.getCsrfToken).mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    // restore pathname when tests rewrote it via history
+    window.history.replaceState({}, "", originalPathname || "/");
+  });
+
+  it("resolveAssetUploadUrl defaults to exact /cm/uploadAssetFile", () => {
+    // jsdom default pathname is often /
+    expect(resolveAssetUploadUrl()).toBe("/cm/uploadAssetFile");
   });
 
   it("resolveAssetUploadUrl prefers /cm when on cm path", () => {
-    // jsdom default pathname is often /
-    expect(resolveAssetUploadUrl()).toMatch(/uploadAssetFile/);
+    window.history.replaceState({}, "", "/cm/app/home");
+    expect(resolveAssetUploadUrl()).toBe("/cm/uploadAssetFile");
+  });
+
+  it("resolveAssetUploadUrl uses Rhythmyx context when on that path", () => {
+    window.history.replaceState({}, "", "/Rhythmyx/ui/index.jsp");
+    expect(resolveAssetUploadUrl()).toBe("/Rhythmyx/uploadAssetFile");
+  });
+
+  it("uploadAssetFile POSTs multipart to exact upload URL with folder and type", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ result: "uploaded.txt" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.mocked(csrf.getCsrfToken).mockReturnValue({
+      headerName: "OWASP_CSRFTOKEN",
+      token: "csrf-token-value",
+    });
+
+    const file = new File(["payload"], "uploaded.txt", { type: "text/plain" });
+    const result = await uploadAssetFile({
+      file,
+      folder: "/Assets/uploads/",
+      assetType: "file",
+      approveOnUpload: true,
+    });
+
+    expect(result).toEqual({
+      fileName: "uploaded.txt",
+      ok: true,
+      assetName: "uploaded.txt",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    // Exact path (no trailing slash / pathInfo) — must match web.xml exact mapping (GH-1812)
+    expect(url).toBe("/cm/uploadAssetFile");
+    expect(init.method).toBe("POST");
+    expect(init.credentials).toBe("same-origin");
+    expect(init.body).toBeInstanceOf(FormData);
+    const form = init.body as FormData;
+    expect(form.get("folder")).toBe("/Assets/uploads/");
+    expect(form.get("assetType")).toBe("file");
+    expect(form.get("approveOnUpload")).toBe("true");
+    expect(form.get("file")).toBeInstanceOf(File);
+    const headers = init.headers as Headers;
+    expect(headers.get("OWASP_CSRFTOKEN")).toBe("csrf-token-value");
+    expect(headers.get("Accept")).toMatch(/json/);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("uploadAssetFile surfaces HTTP status when response is not ok", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 405,
+      text: async () => "",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const file = new File(["x"], "x.txt", { type: "text/plain" });
+    const result = await uploadAssetFile({ file });
+    expect(result).toEqual({
+      fileName: "x.txt",
+      ok: false,
+      error: "HTTP 405",
+    });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("uploadAssetFiles uploads each file sequentially", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ result: "a.txt" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ result: "b.txt" }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const files = [
+      new File(["a"], "a.txt", { type: "text/plain" }),
+      new File(["b"], "b.txt", { type: "text/plain" }),
+    ];
+    const out = await uploadAssetFiles(files, { folder: "/Assets/uploads/" });
+    expect(out).toHaveLength(2);
+    expect(out.every((r) => r.ok)).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    vi.unstubAllGlobals();
   });
 
   it("normalizeThemeSummary", () => {

--- a/WebUI/src/test/ts/api/dashboard/shellGadgetsApi.test.ts
+++ b/WebUI/src/test/ts/api/dashboard/shellGadgetsApi.test.ts
@@ -59,7 +59,8 @@ describe("shellGadgetsApi", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
     vi.mocked(csrf.getCsrfToken).mockReturnValue({
-      headerName: "OWASP_CSRFTOKEN",
+      // Match production csrf.ts DEFAULT_HEADER_NAME (hyphen, not underscore).
+      headerName: "OWASP-CSRFTOKEN",
       token: "csrf-token-value",
     });
 
@@ -89,7 +90,7 @@ describe("shellGadgetsApi", () => {
     expect(form.get("approveOnUpload")).toBe("true");
     expect(form.get("file")).toBeInstanceOf(File);
     const headers = init.headers as Headers;
-    expect(headers.get("OWASP_CSRFTOKEN")).toBe("csrf-token-value");
+    expect(headers.get("OWASP-CSRFTOKEN")).toBe("csrf-token-value");
     expect(headers.get("Accept")).toMatch(/json/);
 
     vi.unstubAllGlobals();

--- a/WebUI/src/test/ts/dashboard/BulkUploadWidget.test.tsx
+++ b/WebUI/src/test/ts/dashboard/BulkUploadWidget.test.tsx
@@ -35,4 +35,52 @@ describe("BulkUploadWidget", () => {
     });
     expect(screen.getByText(/1\/1 succeeded/)).toBeDefined();
   });
+
+  it("passes folder, asset type, and approve flag to uploadAssetFiles", async () => {
+    vi.mocked(api.uploadAssetFiles).mockResolvedValue([
+      { fileName: "img.png", ok: true, assetName: "img.png" },
+    ]);
+    render(<BulkUploadWidget />);
+
+    fireEvent.change(screen.getByTestId("bulk-upload-folder"), {
+      target: { value: "/Assets/custom/" },
+    });
+    fireEvent.change(screen.getByTestId("bulk-upload-type"), {
+      target: { value: "image" },
+    });
+    // Approve checkbox is the only checkbox in the widget
+    fireEvent.click(screen.getByRole("checkbox"));
+
+    const file = new File(["png"], "img.png", { type: "image/png" });
+    fireEvent.change(screen.getByTestId("bulk-upload-files"), {
+      target: { files: [file] },
+    });
+
+    await waitFor(() => {
+      expect(api.uploadAssetFiles).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          folder: "/Assets/custom/",
+          assetType: "image",
+          approveOnUpload: true,
+        }),
+      );
+    });
+  });
+
+  it("shows per-file HTTP error from upload result (e.g. 405 mapping miss)", async () => {
+    vi.mocked(api.uploadAssetFiles).mockResolvedValue([
+      { fileName: "bad.bin", ok: false, error: "HTTP 405" },
+    ]);
+    render(<BulkUploadWidget />);
+    const file = new File(["x"], "bad.bin", { type: "application/octet-stream" });
+    fireEvent.change(screen.getByTestId("bulk-upload-files"), {
+      target: { files: [file] },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-upload-results")).toBeDefined();
+    });
+    expect(screen.getByText(/0\/1 succeeded/)).toBeDefined();
+    expect(screen.getByText(/HTTP 405/)).toBeDefined();
+  });
 });

--- a/WebUI/war/WEB-INF/web.xml
+++ b/WebUI/war/WEB-INF/web.xml
@@ -371,6 +371,15 @@
         <url-pattern>/servlet/tdschemaxml</url-pattern>
     </servlet-mapping>
     
+    <!--
+      Exact /uploadAssetFile: modern Bulk Upload POSTs /cm/uploadAssetFile with no pathInfo.
+      /* covers legacy callers that append a trailing path segment.
+      GH-1812: prefix-only mapping caused HTTP 405 on the exact path.
+    -->
+    <servlet-mapping>
+        <servlet-name>assetUploadServlet</servlet-name>
+        <url-pattern>/uploadAssetFile</url-pattern>
+    </servlet-mapping>
     <servlet-mapping>
         <servlet-name>assetUploadServlet</servlet-name>
         <url-pattern>/uploadAssetFile/*</url-pattern>

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-1812-bulk-upload.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-1812-bulk-upload.spec.js
@@ -1,0 +1,131 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regression: Bulk Upload HTTP 405 (GH-1812).
+ *
+ * <p>Client {@code resolveAssetUploadUrl()} POSTs the exact path
+ * {@code /cm/uploadAssetFile} (no pathInfo). WebUI {@code web.xml} must
+ * declare that exact {@code url-pattern} (prefix {@code /*} alone does not
+ * match on servlet containers). Selecting a file in the Bulk Upload gadget
+ * must not yield HTTP 405 Method Not Allowed.</p>
+ *
+ * <p>Requires a live CMS with the modern Home gadgets section. Playwright
+ * could not be executed in the agent session if no install is configured —
+ * the spec is still required companion coverage per WebUI AGENTS.md.</p>
+ */
+
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+
+/**
+ * Ensure the Bulk Upload gadget is on the dashboard (not in default layout).
+ * @param {import('@playwright/test').Page} page
+ */
+async function ensureBulkUploadGadget(page) {
+  const widget = page.getByTestId("bulk-upload-widget");
+  if (await widget.isVisible().catch(() => false)) {
+    return;
+  }
+
+  await page.getByTestId("dashboard-add-gadget").click();
+  // Search filter in Add Gadget modal (no dedicated testid on the input).
+  const search = page.locator('input[placeholder]').first();
+  await search.fill("Bulk Upload");
+  // Click the Add button next to the Bulk Upload catalog entry.
+  const row = page
+    .locator("div")
+    .filter({ hasText: /^Bulk Upload/ })
+    .first();
+  await expect(row).toBeVisible({ timeout: 10_000 });
+  await row.getByRole("button", { name: /add/i }).click();
+  await expect(widget).toBeVisible({ timeout: 15_000 });
+}
+
+test.describe("Bulk Upload exact mapping (GH-1812)", () => {
+  test("file select POSTs exact /uploadAssetFile and is not HTTP 405", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+
+    // Modern Home hosts the gadgets section (PR-7).
+    await page.goto(`${BASE_URL}/Rhythmyx/cm/app/home`);
+    await page.waitForLoadState("networkidle");
+    await expect(page.getByTestId("home-gadgets-section")).toBeVisible({
+      timeout: 30_000,
+    });
+
+    await ensureBulkUploadGadget(page);
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "perc-bulk-upload-"));
+    const samplePath = path.join(tmpDir, "gh-1812-sample.txt");
+    fs.writeFileSync(samplePath, "GH-1812 bulk upload regression sample\n", "utf8");
+
+    const uploadResponsePromise = page.waitForResponse(
+      (res) => {
+        try {
+          const u = new URL(res.url());
+          return (
+            u.pathname.endsWith("/uploadAssetFile") &&
+            res.request().method() === "POST"
+          );
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 45_000 },
+    );
+
+    await page.getByTestId("bulk-upload-files").setInputFiles(samplePath);
+
+    const response = await uploadResponsePromise;
+    // Primary regression assertion: exact-path mapping must not 405.
+    expect(
+      response.status(),
+      `POST ${response.url()} returned ${response.status()} (body excerpt)`,
+    ).not.toBe(405);
+
+    // Success path shows results; failure path must not be "HTTP 405".
+    const results = page.getByTestId("bulk-upload-results");
+    const errorBox = page.getByTestId("bulk-upload-error");
+    await expect
+      .poll(async () => {
+        if (await results.isVisible().catch(() => false)) return "results";
+        if (await errorBox.isVisible().catch(() => false)) return "error";
+        return "pending";
+      }, { timeout: 30_000 })
+      .not.toBe("pending");
+
+    if (await results.isVisible().catch(() => false)) {
+      await expect(results).toContainText(/succeeded|✓|✕/i);
+      await expect(results).not.toContainText("HTTP 405");
+    } else {
+      const errText = await errorBox.innerText();
+      expect(errText).not.toMatch(/HTTP\s*405/i);
+    }
+
+    try {
+      fs.unlinkSync(samplePath);
+      fs.rmdirSync(tmpDir);
+    } catch {
+      /* best-effort temp cleanup */
+    }
+  });
+});

--- a/projects/sitemanage/src/test/java/com/percussion/assetmanagement/service/impl/BulkUploadEmptyFileTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/assetmanagement/service/impl/BulkUploadEmptyFileTest.java
@@ -71,6 +71,40 @@ class BulkUploadEmptyFileTest {
     assertTrue(text.contains("err.put(\"error\""));
     // Generic Exception path must not surface raw e.getMessage() to the client
     assertTrue(text.contains("Upload failed due to an unexpected server error."));
+    // Multipart POST entry point used by Bulk Upload (GH-1812)
+    assertTrue(text.contains("protected void doPost"));
+    assertTrue(text.contains("@MultipartConfig"));
+  }
+
+  /**
+   * GH-1812: client {@code resolveAssetUploadUrl()} POSTs exact {@code /cm/uploadAssetFile}.
+   * Prefix-only {@code /uploadAssetFile/*} does not match that path on servlet containers, so
+   * web.xml must declare an exact {@code /uploadAssetFile} mapping (and may keep /* for legacy).
+   */
+  @Test
+  void webXmlMapsExactUploadAssetFileForBulkUploadPost() throws Exception {
+    Path root = resolveRepoRoot();
+    Path[] webXmls = {
+      root.resolve("WebUI/src/main/webapp/WEB-INF/web.xml"),
+      root.resolve("WebUI/src/main/webapp/cm/WEB-INF/web.xml"),
+      root.resolve("WebUI/war/WEB-INF/web.xml"),
+    };
+    for (Path webXml : webXmls) {
+      if (!Files.isRegularFile(webXml)) {
+        fail("missing web.xml: " + webXml);
+      }
+      String text = Files.readString(webXml, StandardCharsets.UTF_8);
+      assertTrue(
+          text.contains("<url-pattern>/uploadAssetFile</url-pattern>"),
+          "exact /uploadAssetFile mapping required in " + webXml);
+      assertTrue(
+          text.contains("<url-pattern>/uploadAssetFile/*</url-pattern>"),
+          "prefix /uploadAssetFile/* mapping should remain in " + webXml);
+      // Mapping must bind to the asset upload servlet, not an unrelated name
+      assertTrue(
+          text.contains("<servlet-name>assetUploadServlet</servlet-name>"),
+          "assetUploadServlet must be declared in " + webXml);
+    }
   }
 
   /** Pure-function coverage of empty/whitespace guard + message (GH-728 / #775). */


### PR DESCRIPTION
## Summary
Fixes **#1812**: Bulk Upload gadget returned **HTTP 405 Method Not Allowed** on `POST /cm/uploadAssetFile` immediately after selecting a file.

**Root cause:** Modern client `resolveAssetUploadUrl()` POSTs the **exact** path `/cm/uploadAssetFile` (no pathInfo). WebUI `web.xml` only declared `/uploadAssetFile/*`, which does not match the exact path on servlet containers. `PSAssetUploadServlet` already implements `doPost` + multipart correctly.

**Change:** Add exact `<url-pattern>/uploadAssetFile</url-pattern>` alongside the existing `/*` mapping in all WebUI `web.xml` variants (canonical `src/main/webapp`, `cm`, and tracked `war` copy).

**Out of scope (residual):** Home gadget HTTP 500s for `deliveryConsent` / `contenttraffic` → **#1815**.

## Test plan
- [x] Vitest: `shellGadgetsApi` exact URL, multipart POST + CSRF, sequential multi-file, HTTP 405 error surface
- [x] Vitest: `BulkUploadWidget` options pass-through and HTTP 405 result display
- [x] `BulkUploadEmptyFileTest`: web.xml exact + prefix mapping assertions; servlet `doPost` / `@MultipartConfig`
- [x] Manual code review of client URL vs mapping alignment (no live CMS required for this slice)
- [ ] Optional live smoke: Home → Bulk Upload → choose file → expect JSON upload response (not 405)

## Gates evidence
### Spotless
```
cd projects/sitemanage && ../../mvnw.cmd spotless:apply && ../../mvnw.cmd spotless:check  # BUILD SUCCESS
cd WebUI && ../mvnw.cmd spotless:apply && ../mvnw.cmd spotless:check                      # BUILD SUCCESS
```
In-scope only (no monorepo reformat dump).

### Pre-PR Maven (standalone)
```
cd projects/sitemanage && ../../mvnw.cmd clean install  # BUILD SUCCESS
# BulkUploadEmptyFileTest: Tests run: 4, Failures: 0
cd WebUI && ../mvnw.cmd clean install                   # BUILD SUCCESS
# Vitest: Test Files 179 passed; Tests 1136 passed
```

### Erlang-style self-review
- No production path I/O changes; URL patterns are servlet path strings (always `/`).
- Change class: servlet URL mapping alignment + regression tests (web.xml + client Vitest).
- Playwright not required (mapping-only; BulkUploadWidget UX unchanged).
- Companions: all three web.xml variants updated; sitemanage regression test + WebUI Vitest.

## Residual
- #1815 — deliveryConsent / contenttraffic HTTP 500 follow-up from parent issue description.

Closes #1812