### PR TITLE
fix(dts): stage UserConfiguration in installer fat jar (GH-1825)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/README.md
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/README.md
@@ -162,18 +162,25 @@ java -jar delivery-tier-distribution.jar <install-or-upgrade-folder>
 `MainDTSPreInstall` validates Zip entry paths with
 `com.percussion.security.validation.PathValidation` (CWE-22 / ZipSlip). That class
 lives in `perc-security-utils` and is **not** on a thin jar classpath when using
-`java -jar`.
+`java -jar`. Likewise, `InstallerUserSettings` needs
+`com.intsof.common.utilities.UserConfiguration` from `com.intsof.common:utilities`
+(compile dependency only unless staged into the jar).
 
-**GH-1180:** package runs a **minimal** `maven-shade-plugin` step that merges only:
+**GH-1180 / GH-1825:** `maven-dependency-plugin` unpacks required classes into
+`${project.build.outputDirectory}` so `maven-jar-plugin` ships them in the fat
+installer jar:
 
-|               Artifact               |           What is included            |
-|--------------------------------------|---------------------------------------|
-| `com.percussion:perc-security-utils` | `PathValidation` + nested types only  |
-| `org.apache.logging.log4j:log4j-api` | Required by `PathValidation`'s logger |
+|               Artifact               |           What is included            |             Execution id             |
+|--------------------------------------|---------------------------------------|--------------------------------------|
+| `com.percussion:perc-security-utils` | `PathValidation` + nested types only  | `unpack-pathvalidation`              |
+| `org.apache.logging.log4j:log4j-api` | Required by `PathValidation`'s logger | `unpack-pathvalidation`              |
+| `com.intsof.common:utilities`        | Full jar (~27 KB; no 3rd-party deps)  | `unpack-userconfiguration` (GH-1825) |
 
 This is intentionally **not** a full `jar-with-dependencies` (unlike
 `perc-distribution-tree`), so wars/Tomcat/Spring stay out of the installer jar.
 
-Verify phase fails the build if `PathValidation.class` or `LogManager.class` is
-missing from the packaged jar (`verify-pathvalidation-shaded` antrun).
+Verify phase fails the build if `PathValidation.class`, `LogManager.class`,
+`UserConfiguration.class`, or `AppConfigurationFolder.class` is missing from the
+packaged jar (`verify-pathvalidation-shaded` antrun). Unit tests under
+`DtsInstallerJarContains*` assert the same jar listing invariants.
 

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml
@@ -918,6 +918,40 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>unpack-userconfiguration</id>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.intsof.common</groupId>
+                                    <artifactId>utilities</artifactId>
+                                    <version>${intsof.common.utilities.version}</version>
+                                    <type>jar</type>
+                                    <!--
+                                      GH-1825: InstallerUserSettings opens
+                                      com.intsof.common.utilities.UserConfiguration
+                                      (and AppConfigurationFolder) at wizard start.
+                                      java -jar has no external classpath, so the
+                                      compile-only utilities dependency never reaches
+                                      the fat installer jar unless we stage classes
+                                      into project.build.outputDirectory — same
+                                      pattern as unpack-pathvalidation (GH-1180).
+
+                                      Full jar is ~27 KB with no third-party runtime
+                                      deps; prefer full unpack over brittle class
+                                      lists so nested/transitive types cannot be
+                                      missed later.
+                                    -->
+                                    <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                                    <excludes>META-INF/MANIFEST.MF,META-INF/maven/**</excludes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>copy-deployment-server-common-lib</id>
                         <goals>
                             <goal>copy</goal>
@@ -1097,9 +1131,10 @@
                         </configuration>
                     </execution>
                     <!--
-                      GH-1180 regression gate: the packaged installer jar must contain
-                      PathValidation after the minimal shade. Runs on every verify so a
-                      future pom change cannot drop the shade without failing the build.
+                      GH-1180 / GH-1825 regression gate: the packaged installer jar must
+                      contain PathValidation (minimal shade) and UserConfiguration
+                      (utilities unpack). Runs on every verify so a future pom change
+                      cannot drop the shade/unpack without failing the build.
                     -->
                     <execution>
                         <id>verify-pathvalidation-shaded</id>
@@ -1125,6 +1160,14 @@
                                     <contains string="${dts.installer.listing}" substring="org/apache/logging/log4j/LogManager.class"/>
                                 </condition>
                                 <fail message="GH-1180: ${dts.installer.jar} is missing log4j-api (LogManager) required by PathValidation." unless="dts.has.log4j.api"/>
+                                <condition property="dts.has.userconfiguration">
+                                    <contains string="${dts.installer.listing}" substring="com/intsof/common/utilities/UserConfiguration.class"/>
+                                </condition>
+                                <fail message="GH-1825: ${dts.installer.jar} is missing UserConfiguration.class — unpack-userconfiguration of com.intsof.common:utilities failed or was removed." unless="dts.has.userconfiguration"/>
+                                <condition property="dts.has.appconfigurationfolder">
+                                    <contains string="${dts.installer.listing}" substring="com/intsof/common/utilities/AppConfigurationFolder.class"/>
+                                </condition>
+                                <fail message="GH-1825: ${dts.installer.jar} is missing AppConfigurationFolder.class — unpack-userconfiguration of com.intsof.common:utilities failed or was removed." unless="dts.has.appconfigurationfolder"/>
                                 <condition property="dts.has.server.xml">
                                     <contains string="${dts.installer.listing}" substring="distribution/Deployment/Server/conf/server.xml"/>
                                 </condition>
@@ -1133,7 +1176,7 @@
                                     <contains string="${dts.installer.listing}" substring="distribution/Deployment/Server/webapps/perc-metadata-services.war"/>
                                 </condition>
                                 <fail message="DTS installer jar missing perc-metadata-services.war (Cargo package not staged)." unless="dts.has.metadata.war"/>
-                                <echo message="GH-1180: PathValidation + log4j-api + Tomcat/server.xml + metadata war present in ${dts.installer.jar}"/>
+                                <echo message="GH-1180/GH-1825: PathValidation + log4j-api + UserConfiguration + Tomcat/server.xml + metadata war present in ${dts.installer.jar}"/>
                             </target>
                         </configuration>
                     </execution>

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsInstallerJarContainsUserConfigurationTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsInstallerJarContainsUserConfigurationTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.delivery.distribution;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.zip.ZipFile;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression guard for issue #1825.
+ *
+ * <p>{@code InstallerUserSettings} opens {@code com.intsof.common.utilities.UserConfiguration} (and
+ * {@code AppConfigurationFolder}) when the DTS interactive wizard starts. Those classes live in
+ * {@code com.intsof.common:utilities}, which is a compile dependency but is not on a thin {@code
+ * java -jar} classpath unless unpack-staged into {@code project.build.outputDirectory} (see {@code
+ * unpack-userconfiguration} in this module's pom).
+ *
+ * <p>Without the unpack, the installer dies immediately with {@code NoClassDefFoundError:
+ * com/intsof/common/utilities/UserConfiguration}. This test asserts the shipping jar contains the
+ * required classes. No-op when run outside Maven (no build artifact on disk). The antrun {@code
+ * verify-pathvalidation-shaded} gate also asserts the same entries at verify-time.
+ */
+class DtsInstallerJarContainsUserConfigurationTest {
+
+  private static final String USER_CONFIGURATION_CLASS =
+      "com/intsof/common/utilities/UserConfiguration.class";
+  private static final String APP_CONFIGURATION_FOLDER_CLASS =
+      "com/intsof/common/utilities/AppConfigurationFolder.class";
+
+  @Test
+  void shippingJarBundlesUserConfigurationClasses() {
+    Path jar = Path.of("target", "delivery-tier-distribution.jar");
+    if (!Files.isRegularFile(jar)) {
+      return;
+    }
+
+    Set<String> entries = new HashSet<>();
+    try (ZipFile zip = new ZipFile(jar.toFile())) {
+      zip.stream().map(java.util.zip.ZipEntry::getName).forEach(entries::add);
+    } catch (IOException io) {
+      fail("Could not read " + jar + ": " + io.getMessage());
+    }
+
+    assertTrue(
+        entries.contains(USER_CONFIGURATION_CLASS),
+        () ->
+            "Expected "
+                + USER_CONFIGURATION_CLASS
+                + " in "
+                + jar
+                + ". InstallerUserSettings requires it at wizard start (GH-1825). Check"
+                + " maven-dependency-plugin execution unpack-userconfiguration stages"
+                + " com.intsof.common:utilities into project.build.outputDirectory.");
+    assertTrue(
+        entries.contains(APP_CONFIGURATION_FOLDER_CLASS),
+        () ->
+            "Expected "
+                + APP_CONFIGURATION_FOLDER_CLASS
+                + " in "
+                + jar
+                + ". InstallerUserSettings uses AppConfigurationFolder with"
+                + " UserConfiguration (GH-1825). Check unpack-userconfiguration.");
+  }
+}


### PR DESCRIPTION
## Summary

The standalone DTS installer (java -jar delivery-tier-distribution.jar) died immediately with `NoClassDefFoundError: com/intsof/common/utilities/UserConfiguration` because `InstallerUserSettings` depends on `com.intsof.common:utilities` at runtime, but that compile dependency was never staged into the fat installer jar.

**Fix (same packaging pattern as PathValidation / GH-1180):**

- New `maven-dependency-plugin` execution `unpack-userconfiguration` (`process-resources`) unpacks the full `com.intsof.common:utilities` jar (~27 KB, no third-party runtime deps) into `` so `maven-jar-plugin` ships the classes.
- Extended `verify-pathvalidation-shaded` antrun (verify phase) to fail the build if `UserConfiguration.class` or `AppConfigurationFolder.class` is missing from the packaged jar.
- New unit test `DtsInstallerJarContainsUserConfigurationTest`.
- README installer-jar section updated for GH-1825.

No wizard UX changes.

Fixes #1825

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] `cd deliverytiersuite/delivery-tier-suite/delivery-tier-distribution && ../../../mvnw clean install` — **BUILD SUCCESS**
- [x] Surefire: module tests green (including `InstallerUserSettingsTest`, `DtsInstallerJarContainsUserConfigurationTest`)
- [x] Antrun verify: `GH-1180/GH-1825: PathValidation + log4j-api + UserConfiguration + ... present`
- [x] `jar tf target/delivery-tier-distribution.jar` lists `com/intsof/common/utilities/UserConfiguration.class`
- [x] Module `spotless:apply` then `spotless:check` — clean; only in-scope files committed

## Gates evidence

| Gate | Result |
|------|--------|
| Change-class companions (unpack + verify antrun + jar listing test + README) | Done |
| Erlang self-review (no bugs, portable paths, no wizard UX) | Pass |
| Spotless apply → check (module-scoped; in-scope only) | Pass |
| Standalone `mvnw clean install` in `delivery-tier-distribution` | BUILD SUCCESS |
| Residual issues | None |

## Files

- `deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml`
- `.../DtsInstallerJarContainsUserConfigurationTest.java`
- `.../README.md`