### PR TITLE
fix(perc-package-manager): resolve all Javadoc warnings (#1849)

### DIFF
--- a/PCM-PkgMgtUI/src/com/percussion/gwt/pkgmgtui/client/PSConstants.java
+++ b/PCM-PkgMgtUI/src/com/percussion/gwt/pkgmgtui/client/PSConstants.java
@@ -18,6 +18,11 @@ package com.percussion.gwt.pkgmgtui.client;
 
 import java.util.Arrays;
 
+/**
+ * Package management UI constants shared by the GWT client side. Houses
+ * non-translatable defaults such as spacing and resize options used across
+ * the package management widgets.
+ */
 public class PSConstants
 {
     private PSConstants(){}
@@ -32,10 +37,23 @@ public class PSConstants
     private static final String[] dialogResizeOptions = { "L", "B", "R", "T",
             "BL", "BR", "TL", "TR" };
 
+    /**
+     * Returns the default members margin used when laying out vertical stacks
+     * of widgets (for example the transfer buttons in a slush bucket panel).
+     *
+     * @return the default members margin in pixels.
+     */
     public static int getMembersMargin() {
         return membersMargin;
     }
 
+    /**
+     * Returns the default dialog resize handle options used by the package
+     * management dialogs (corners and edges the user may drag from).
+     *
+     * @return a defensive copy of the resize options array; never
+     *     <code>null</code>.
+     */
     public static String[] getDialogResizeOptions() {
         /* Return a copy to avoid vulnerability */
         return Arrays.copyOf(dialogResizeOptions,dialogResizeOptions.length);

--- a/PCM-PkgMgtUI/src/com/percussion/gwt/pkgmgtui/client/PSConvertToSourceDialog.java
+++ b/PCM-PkgMgtUI/src/com/percussion/gwt/pkgmgtui/client/PSConvertToSourceDialog.java
@@ -36,6 +36,11 @@ import com.smartgwt.client.widgets.grid.ListGridField;
 import com.smartgwt.client.widgets.grid.ListGridRecord;
 import com.smartgwt.client.widgets.layout.HLayout;
 
+/**
+ * Dialog that prompts the user to convert a deployed package back to a
+ * source package on the server. Created with the panels wired up by the
+ * no-arg package-private constructor.
+ */
 public class PSConvertToSourceDialog extends Dialog
 {
    /**

--- a/PCM-PkgMgtUI/src/com/percussion/gwt/pkgmgtui/client/PSPackagesTab.java
+++ b/PCM-PkgMgtUI/src/com/percussion/gwt/pkgmgtui/client/PSPackagesTab.java
@@ -62,6 +62,16 @@ public class PSPackagesTab
 {
 
    private static final String BR_TAG="<br/>";
+
+   /**
+    * Default constructor. Provided so that Javadoc generation does not warn
+    * about an implicit default constructor; this class is instantiated by
+    * the GWT package management UI entry point.
+    */
+   public PSPackagesTab()
+   {
+      super();
+   }
    /**
     * Creates the packages tab. Gets the packages info through rest and creates
     * a table to hold that data and returns the tab.

--- a/PCM-PkgMgtUI/src/com/percussion/gwt/pkgmgtui/client/PSVisibilityTab.java
+++ b/PCM-PkgMgtUI/src/com/percussion/gwt/pkgmgtui/client/PSVisibilityTab.java
@@ -47,6 +47,16 @@ import java.util.List;
 public class PSVisibilityTab
 {
    /**
+    * Default constructor. Provided so that Javadoc generation does not warn
+    * about an implicit default constructor; this class is instantiated by
+    * the GWT package management UI entry point.
+    */
+   public PSVisibilityTab()
+   {
+      super();
+   }
+
+   /**
     * Creates the tab and places controls in it and returns the tab.
     * 
     * @return Tab, never <code>null</code>.

--- a/PCM-PkgMgtUI/src/com/percussion/gwt/pkgmgtui/client/PkgMgtUI.java
+++ b/PCM-PkgMgtUI/src/com/percussion/gwt/pkgmgtui/client/PkgMgtUI.java
@@ -46,6 +46,16 @@ public class PkgMgtUI implements EntryPoint
 {
 
    /**
+    * Default constructor. Provided so that Javadoc generation does not warn
+    * about an implicit default constructor; GWT requires a no-arg entry
+    * point class.
+    */
+   public PkgMgtUI()
+   {
+      super();
+   }
+
+   /**
     * This is the entry point method.
     */
    public void onModuleLoad()

--- a/PCM-PkgMgtUI/src/com/percussion/gwt/pkgmgtui/client/controls/PSSlushBucketPanel.java
+++ b/PCM-PkgMgtUI/src/com/percussion/gwt/pkgmgtui/client/controls/PSSlushBucketPanel.java
@@ -79,7 +79,9 @@ public class PSSlushBucketPanel extends HLayout
    }
 
    /**
-    * 
+    * Returns the data records currently selected in the right-hand grid of
+    * this slush bucket panel.
+    *
     * @return the string array of selected data from the right grid. Never
     * <code>null</code> may be empty.
     */
@@ -96,8 +98,10 @@ public class PSSlushBucketPanel extends HLayout
    }
 
    /**
-    * 
-    * @return returns the ListGrid object corresponding to the left grid shown
+    * Returns the left-hand list grid that displays the available items for
+    * the slush bucket.
+    *
+    * @return the {@link ListGrid} object corresponding to the left grid shown
     * in this panel. Never <code>null</code>.
     */
    public ListGrid getLeftGrid()
@@ -106,8 +110,10 @@ public class PSSlushBucketPanel extends HLayout
    }
 
    /**
-    * 
-    * @return returns the ListGrid object corresponding to the right grid shown
+    * Returns the right-hand list grid that displays the selected items for
+    * the slush bucket.
+    *
+    * @return the {@link ListGrid} object corresponding to the right grid shown
     * in this panel. Never <code>null</code>.
     */
    public ListGrid getRightGrid()


### PR DESCRIPTION
## Summary

Resolves all 10 Javadoc source warnings reported by the
`maven-javadoc-plugin` for the `perc-package-manager` module
(`PCM-PkgMgtUI`, GWT package management UI). After the change,
`mvn clean install -B` reports **0 Javadoc warnings / 0 Javadoc errors**.

Fixes #1849.

## Change class

Documentation cleanup, single Maven module
(`com.percussion:perc-package-manager`).

## What changed (6 files, +64/-5)

|                File                |                                  What was missing                                  |
|------------------------------------|-------------------------------------------------------------------------------------|
| `PkgMgtUI.java`                    | Implicit default ctor (warned). Added explicit no-arg ctor with Javadoc.            |
| `PSConstants.java`                 | Missing class-level Javadoc. Added.                                                  |
|                                    | `getMembersMargin` / `getDialogResizeOptions` had no comment. Added.                |
| `PSConvertToSourceDialog.java`     | Missing class-level Javadoc. Added.                                                  |
| `PSPackagesTab.java`               | Implicit default ctor (warned). Added explicit no-arg ctor with Javadoc.             |
| `PSVisibilityTab.java`             | Implicit default ctor (warned). Added explicit no-arg ctor with Javadoc.             |
| `controls/PSSlushBucketPanel.java` | `getSelectedData`, `getLeftGrid`, `getRightGrid` all missing main description. Added.|

## Verification (pre-PR local gate)

Run from the module directory:

```bat
cd PCM-PkgMgtUI
..\mvnw.cmd clean install -B
..\mvnw.cmd spotless:apply -B
..\mvnw.cmd spotless:check -B
```

- `clean install -B` -> **BUILD SUCCESS**, 0 Javadoc warnings (was 10).
  Module has no unit tests; the `attach-javadocs` execution produced the
  `perc-package-manager-8.2.0-SNAPSHOT-javadoc.jar`.
- `spotless:apply` -> clean (no file rewrites).
- `spotless:check` -> BUILD SUCCESS.

## Out of scope (NOT touched by this PR)

Three pre-existing baseline warnings remain in this module and were not
addressed because they are out of the Javadoc issue's scope:

- 3 javac `"possible 'this' escape before subclass is fully initialized"`
  warnings (`PSCommPkgSelectionDialog.java:45`,
  `PSSlushBucketPanel.java:73`, `PSStatusDialog.java:49`).
- `Unused declared dependencies found: org.gwtproject:gwt-user:jar:2.10.0
  (provided)`, `com.smartgwt:smartgwt-skins:jar:14.1p (system)`.

Both were already present on `origin/main` before this change.

## Compatibility

- Public API surface unchanged. No code/behavior changes; only Javadoc
  and three explicit no-arg constructors (same bytecode semantics,
  GWT-compatible).

Refs GH-1849.

Co-Authored by Kilo Kilo using MiniMax-M3 with agent Kilo.
