### PR TITLE
fix(perc-packages): resolve all Javadoc warnings (#1854)

### DIFF
--- a/modules/perc-packages/src/main/java/com/percussion/packages/PSPackageBuilder.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/PSPackageBuilder.java
@@ -58,6 +58,19 @@ public final class PSPackageBuilder {
     this.tempDir = tempDir;
   }
 
+  /**
+   * Program entry point invoked by the {@code exec-maven-plugin} during the {@code prepare-package}
+   * phase. Expects exactly three arguments: the packages source directory, the output directory for
+   * the generated {@code .ppkg} files, and a scratch directory used while reorganizing the package
+   * contents.
+   *
+   * <p>Usage: {@code PSPackageBuilder <packagesDir> <outputDir> <tempDir>}. Exits with a non-zero
+   * status if the arguments are missing or the packages directory does not exist.
+   *
+   * @param args command-line arguments; must contain at least three entries ordered {@code
+   *     <packagesDir> <outputDir> <tempDir>}.
+   * @throws IOException if an I/O error occurs while preparing, walking or zipping package files.
+   */
   public static void main(String[] args) throws IOException {
     if (args.length < 3) {
       System.err.println("Usage: PSPackageBuilder <packagesDir> <outputDir> <tempDir>");

--- a/modules/perc-packages/src/main/java/com/percussion/packages/PSPackageBuilder.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/PSPackageBuilder.java
@@ -60,12 +60,12 @@ public final class PSPackageBuilder {
 
   /**
    * Program entry point invoked by the {@code exec-maven-plugin} during the {@code prepare-package}
-   * phase. Expects exactly three arguments: the packages source directory, the output directory for
-   * the generated {@code .ppkg} files, and a scratch directory used while reorganizing the package
-   * contents.
+   * phase. Expects at least three arguments: the packages source directory, the output directory
+   * for the generated {@code .ppkg} files, and a scratch directory used while reorganizing the
+   * package contents. Any additional positional arguments beyond the first three are ignored.
    *
    * <p>Usage: {@code PSPackageBuilder <packagesDir> <outputDir> <tempDir>}. Exits with a non-zero
-   * status if the arguments are missing or the packages directory does not exist.
+   * status if fewer than three arguments are supplied or the packages directory does not exist.
    *
    * @param args command-line arguments; must contain at least three entries ordered {@code
    *     <packagesDir> <outputDir> <tempDir>}.


### PR DESCRIPTION
## Summary

Resolves the Javadoc source warning reported by the
`maven-javadoc-plugin` for the `perc-packages` module (`modules/perc-packages`,
the Java package builder for `.ppkg` files). After the change,
`mvn clean install -B` reports **0 Javadoc warnings / 0 Javadoc errors**.

Fixes #1854.

## Change class

Documentation cleanup, single Maven module (`com.percussion:perc-packages`).

## What changed (1 file, +13/-0)

|                                File                                 |                              What was missing                              |
|---------------------------------------------------------------------|--------------------------------------------------------------------------|
| `PSPackageBuilder.java` (only main class in the module)             | `main(String[])` had no Javadoc. Added a full block: main description, `@param args`, `@throws IOException`. |

## Verification (pre-PR local gate)

Run from the module directory:

```bat
cd modules\perc-packages
..\..\mvnw.cmd clean install -B
..\..\mvnw.cmd spotless:apply -B
..\..\mvnw.cmd spotless:check -B
```

- `clean install -B` -> **BUILD SUCCESS**, 0 Javadoc warnings (was 1).
- Tests: **2 run, 0 failures, 0 errors, 0 skipped**.
- `attach-javadocs` execution built `perc-packages-8.2.0-SNAPSHOT-javadoc.jar`.
- `spotless:apply` -> BUILD SUCCESS (1 file reformatted for line-length).
- `spotless:check` -> BUILD SUCCESS.

## Compatibility

- Public API surface unchanged. Javadoc-only addition; no code/behavior
  changes.

Refs GH-1854.

Co-Authored by Kilo Kilo using MiniMax-M3 with agent Kilo.
