### PR TITLE
fix(system): rewire PSRunEdition JobPubLog URL to modern Publishing logs (GH-1844)

### DIFF
--- a/docs/ai-generated/tasks/#000-unified-ui-plan/ui-layer-inventory.md
+++ b/docs/ai-generated/tasks/#000-unified-ui-plan/ui-layer-inventory.md
@@ -170,19 +170,19 @@ PSContentExplorerHeader, PSContentExplorerLoginPanel, etc.
 
 **Publishing JSP pages (28)**:
 
-|                       Page                        |                                                                           Feature                                                                            |
-|---------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `SiteList.jsp` / `SiteEditor.jsp`                 | Publishing site management                                                                                                                                   |
-| `EditionList.jsp` / `EditionEditor.jsp`           | Edition management                                                                                                                                           |
-| `ContentlistView.jsp` / `ContentlistEditor.jsp`   | Content list management                                                                                                                                      |
-| `ContextList.jsp` / `ContextEditor.jsp`           | Publishing context management                                                                                                                                |
-| `DeliveryTypeList.jsp` / `DeliveryTypeEditor.jsp` | Delivery type management                                                                                                                                     |
-| `LocationSchemeEditor.jsp`                        | Location scheme configuration                                                                                                                                |
-| `ActiveJobStatus.jsp`                             | Active publishing job status                                                                                                                                 |
-| `RuntimeEdition.jsp` / `RuntimeEditionList.jsp`   | Runtime edition execution                                                                                                                                    |
-| `AllPubLogs.jsp` / `SitePubLogs.jsp`              | Publishing logs                                                                                                                                              |
-| `JobPubLog.jsp` / `ItemPubLog.jsp`                | Job/item level logs                                                                                                                                          |
-| `DemandPublish.jsp`                               | On-demand publishing — server consumer rewired (#1842): `PSDemandPublishServlet` → `/cm/app/?view=publish&section=status`; JSP delete still deferred (#1818) |
+|                       Page                        |                                                                               Feature                                                                                |
+|---------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `SiteList.jsp` / `SiteEditor.jsp`                 | Publishing site management                                                                                                                                           |
+| `EditionList.jsp` / `EditionEditor.jsp`           | Edition management                                                                                                                                                   |
+| `ContentlistView.jsp` / `ContentlistEditor.jsp`   | Content list management                                                                                                                                              |
+| `ContextList.jsp` / `ContextEditor.jsp`           | Publishing context management                                                                                                                                        |
+| `DeliveryTypeList.jsp` / `DeliveryTypeEditor.jsp` | Delivery type management                                                                                                                                             |
+| `LocationSchemeEditor.jsp`                        | Location scheme configuration                                                                                                                                        |
+| `ActiveJobStatus.jsp`                             | Active publishing job status                                                                                                                                         |
+| `RuntimeEdition.jsp` / `RuntimeEditionList.jsp`   | Runtime edition execution                                                                                                                                            |
+| `AllPubLogs.jsp` / `SitePubLogs.jsp`              | Publishing logs                                                                                                                                                      |
+| `JobPubLog.jsp` / `ItemPubLog.jsp`                | Job/item level logs — server consumer rewired (#1844): `PSRunEdition` `$sys.editionLogUrl` → `/cm/app/?view=publish&section=logs`; JSP delete still deferred (#1818) |
+| `DemandPublish.jsp`                               | On-demand publishing — server consumer rewired (#1842): `PSDemandPublishServlet` → `/cm/app/?view=publish&section=status`; JSP delete still deferred (#1818)         |
 
 ---
 

--- a/specs/990-unified-publishing-ui/checklists/removal-inventory.md
+++ b/specs/990-unified-publishing-ui/checklists/removal-inventory.md
@@ -89,6 +89,7 @@ Detailed audit notes (grep tables, historical faces dump pointers):
 | `dce_header.jsp` Runtime link              | Points to modern Runtime          | Done              | No deep faces URL                               |
 | Remaining `ui/pubruntime/*.jsp` deep pages | **Keep packaged** until #1818     | Deferred (RET-06) | Product **nav** callers: **zero** (audit #1817) |
 | `PSDemandPublishServlet` post-queue UI     | Rewired off `DemandPublish.jsp`   | Done (#1842)      | Redirect → modern shell status (see note below) |
+| `PSRunEdition` `$sys.editionLogUrl`        | Rewired off `JobPubLog.faces`     | Done (#1844)      | Modern shell logs deep link (see note below)    |
 
 **Tracked files (2026-08-04)** — `WebUI/src/main/webapp/ui/pubruntime/` (13 JSPs):
 
@@ -102,7 +103,7 @@ Detailed audit notes (grep tables, historical faces dump pointers):
 | `DeleteSiteItemLogsWarning.jsp` | yes                         | none               | —                                      | Delete                        |
 | `ErrorMessage.jsp`              | yes                         | none               | —                                      | Delete                        |
 | `ItemPubLog.jsp`                | yes                         | none               | —                                      | Delete                        |
-| `JobPubLog.jsp`                 | yes                         | none               | **`PSRunEdition` builds `.faces` URL** | Rewire URL then Delete        |
+| `JobPubLog.jsp`                 | yes                         | none               | **`PSRunEdition` rewired (#1844)**     | **Delete** (no live consumer) |
 | `NoSelectionWarning.jsp`        | yes                         | none               | —                                      | Delete                        |
 | `RuntimeEdition.jsp`            | yes                         | none               | —                                      | Delete                        |
 | `RuntimeEditionList.jsp`        | yes                         | none               | —                                      | Delete                        |
@@ -118,6 +119,17 @@ Demand `requestid` is **not** appended: modern shell deep-link contract has no
 request-id filter. **`web.xml` mapping `/publisher/demandpublishing` is kept.**
 **JSP file delete still deferred** under #1818 — this rewire only removes the
 live server-side consumer so DemandPublish.jsp can be deleted safely later.
+
+**RET-06 residual — JobPubLog consumer rewire (issue #1844, 2026-08-04):**
+`system/.../PSRunEdition.getPublishingLogURL()` no longer builds
+`/ui/pubruntime/JobPubLog.faces?sys_publishingJobId=…` (faces stack already gone).
+It now targets the modern Publishing shell peer
+`publishingShellHref({ section: 'logs' })` →
+`{protocol}://{host}:{port}{requestRoot}/cm/app/?view=publish&section=logs`.
+Job-id query is **not** appended: modern shell deep-link contract has no job-id
+filter yet (only `section` / optional `siteId` / `serverId`). **JSP file delete
+still deferred** under #1818 / packaging follow-up — this rewire only removes the
+live server-side consumer so JobPubLog.jsp can be deleted safely later.
 
 **Sign-off**: Entry-path retirement Done; deep-page file deletion **explicitly deferred** to #1818 after UAT + non-nav rewires.  
 **Tracking issue**: [#1372](https://github.com/intersoftdatalabs-in/percussioncms/issues/1372) · audit [#1817](https://github.com/intersoftdatalabs-in/percussioncms/issues/1817)

--- a/system/services/src/com/percussion/services/schedule/impl/PSRunEdition.java
+++ b/system/services/src/com/percussion/services/schedule/impl/PSRunEdition.java
@@ -36,7 +36,6 @@ import com.percussion.services.sitemgr.IPSSite;
 import com.percussion.services.sitemgr.IPSSiteManager;
 import com.percussion.services.sitemgr.PSSiteManagerException;
 import com.percussion.services.sitemgr.PSSiteManagerLocator;
-import com.percussion.system.utils.IPSHtmlParameters;
 import com.percussion.utils.guid.IPSGuid;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -216,18 +215,51 @@ public class PSRunEdition implements IPSTask, IPSPublishingJobStatusCallback
    }
    
    /**
-    * @return the URL for viewing the publishing log.
+    * @return the absolute URL for viewing publishing logs in the modern shell.
     */
    private String getPublishingLogURL()
    {
       String protocol = "http";
       if (PSServer.getListenerPort() == PSServer.getSslListenerPort())
          protocol = "https";
-      String url = protocol + "://" + PSServer.getFullyQualifiedHostName() + ":"
-            + PSServer.getListenerPort() + PSServer.getRequestRoot()
-            + "/ui/pubruntime/JobPubLog.faces?"
-            + IPSHtmlParameters.PUBLISH_JOB_ID + "=" + m_jobId;
-      return url;
+      return buildPublishingLogURL(
+            protocol,
+            PSServer.getFullyQualifiedHostName(),
+            PSServer.getListenerPort(),
+            PSServer.getRequestRoot());
+   }
+
+   /**
+    * Builds the absolute publishing-logs deep link used in task notification templates
+    * ({@code $sys.editionLogUrl}).
+    * <p>
+    * Targets the modern Publishing shell — peer WebUI {@code publishingShellHref({ section:
+    * 'logs' })} → {@code /cm/app/?view=publish&section=logs}. Host/port/protocol/request-root
+    * assembly uses URL path separators only ({@code /}); never OS file separators.
+    * <p>
+    * <b>Job id query:</b> the modern shell deep-link contract supports {@code section}, optional
+    * {@code siteId}/{@code serverId}, but not a job-id filter. The legacy
+    * {@code JobPubLog.faces?sys_publishingJobId=} query is intentionally omitted (faces stack
+    * already removed). Callers land on the Logs section; job-level drill-down remains a future
+    * shell enhancement.
+    *
+    * @param protocol {@code http} or {@code https}, never {@code null} or blank
+    * @param host fully qualified host name, never {@code null} or blank
+    * @param port listener port
+    * @param requestRoot CMS request root (e.g. {@code /Rhythmyx} or empty); may be {@code null}
+    * @return absolute URL, never {@code null}
+    */
+   static String buildPublishingLogURL(
+         String protocol, String host, int port, String requestRoot)
+   {
+      if (StringUtils.isBlank(protocol))
+         throw new IllegalArgumentException("protocol may not be null or blank");
+      if (StringUtils.isBlank(host))
+         throw new IllegalArgumentException("host may not be null or blank");
+      // URL path elements always use '/'; do not use File.separator
+      String root = requestRoot == null ? "" : requestRoot;
+      return protocol + "://" + host + ":" + port + root
+            + "/cm/app/?view=publish&section=logs";
    }
    
    /**

--- a/system/src/test/java/com/percussion/services/schedule/impl/PSRunEditionTest.java
+++ b/system/src/test/java/com/percussion/services/schedule/impl/PSRunEditionTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.schedule.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link PSRunEdition} publishing-log URL assembly (issue #1844).
+ *
+ * <p>Asserts absolute URL shape with pure string components — no filesystem path construction — so
+ * asserts are portable on Windows and Unix.
+ */
+class PSRunEditionTest {
+
+  @Test
+  void buildPublishingLogURL_httpEmptyRoot_matchesModernShellLogs() {
+    String url = PSRunEdition.buildPublishingLogURL("http", "cms.example.com", 9992, "");
+
+    assertEquals("http://cms.example.com:9992/cm/app/?view=publish&section=logs", url);
+  }
+
+  @Test
+  void buildPublishingLogURL_httpsWithRequestRoot_prefixesRoot() {
+    String url = PSRunEdition.buildPublishingLogURL("https", "cms.example.com", 8443, "/Rhythmyx");
+
+    assertEquals("https://cms.example.com:8443/Rhythmyx/cm/app/?view=publish&section=logs", url);
+  }
+
+  @Test
+  void buildPublishingLogURL_nullRequestRoot_treatedAsEmpty() {
+    String url = PSRunEdition.buildPublishingLogURL("http", "localhost", 8080, null);
+
+    assertEquals("http://localhost:8080/cm/app/?view=publish&section=logs", url);
+  }
+
+  @Test
+  void buildPublishingLogURL_dropsLegacyJobPubLogFacesAndJobIdQuery() {
+    String url = PSRunEdition.buildPublishingLogURL("http", "host.local", 80, "/Rhythmyx");
+
+    assertFalse(url.contains("JobPubLog"));
+    assertFalse(url.contains(".faces"));
+    assertFalse(url.contains("sys_publishingJobId"));
+    assertFalse(url.contains("sys_publishjobid"));
+    assertTrue(url.contains("view=publish"));
+    assertTrue(url.contains("section=logs"));
+    // URL path separator is always '/'; never OS file separator
+    assertFalse(url.contains("\\"));
+  }
+
+  @Test
+  void buildPublishingLogURL_rejectsBlankProtocolOrHost() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSRunEdition.buildPublishingLogURL("", "host", 80, ""));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSRunEdition.buildPublishingLogURL("http", "  ", 80, ""));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSRunEdition.buildPublishingLogURL(null, "host", 80, ""));
+  }
+}

--- a/system/src/test/java/com/percussion/services/schedule/impl/PSRunEditionTest.java
+++ b/system/src/test/java/com/percussion/services/schedule/impl/PSRunEditionTest.java
@@ -77,5 +77,9 @@ class PSRunEditionTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> PSRunEdition.buildPublishingLogURL(null, "host", 80, ""));
+    // StringUtils.isBlank(null) is true — host must be non-null and non-blank
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSRunEdition.buildPublishingLogURL("http", null, 80, ""));
   }
 }


### PR DESCRIPTION
## Summary

Rewires the dead JSF faces publishing-log URL used by scheduled edition notifications so ` $sys.editionLogUrl` points at the modern Publishing shell logs section.

- **Before:** ` {protocol}://{host}:{port}{requestRoot}/ui/pubruntime/JobPubLog.faces?sys_publishingJobId={jobId}` (faces stack already removed; non-functional)
- **After:** ` {protocol}://{host}:{port}{requestRoot}/cm/app/?view=publish&section=logs` — peer WebUI ` publishingShellHref({ section: 'logs' })`
- **Job id:** not appended — modern shell deep-link contract supports ` section` / optional ` siteId` / ` serverId` only. Documented in method Javadoc and RET-06 removal-inventory.
- **Out of scope:** JobPubLog.jsp file delete remains under #1818.

## Changes

| Path | Change |
|------|--------|
| ` system/.../PSRunEdition.java` | ` getPublishingLogURL()` + package-visible ` uildPublishingLogURL(...)` |
| ` system/.../PSRunEditionTest.java` | URL shape unit tests (protocol/host/root/path; no OS separators) |
| ` specs/990-unified-publishing-ui/checklists/removal-inventory.md` | RET-06 JobPubLog consumer rewire note |
| ` docs/ai-generated/tasks/#000-unified-ui-plan/ui-layer-inventory.md` | JobPubLog consumer rewired note |

## Test plan

- [x] ` cd system && ..\mvnw.cmd -Dtest=PSRunEditionTest test` — Tests run: 5, Failures: 0
- [x] ` cd system && ..\mvnw.cmd clean install -Dtest=PSRunEditionTest` — BUILD SUCCESS
- [x] ` cd system && ..\mvnw.cmd spotless:apply` then ` spotless:check` — BUILD SUCCESS
- [x] Root ` spotless:apply` for in-scope markdown; no out-of-scope monorepo reformat committed
- [x] Erlang-style self-review: no bugs; URL uses ` /` only (not file separators); pure builder unit-tested

## Gates evidence

- **Spotless:** module ` spotless:apply` then ` spotless:check` on ` system`; in-scope only on PR
- **Maven:** standalone ` system` ` clean install` (focused new test class) BUILD SUCCESS
- **Erlang self-review:** portable URL assembly; behavioral unit tests; companions (docs/inventory) closed for this change class
- **Operator:** Grok: night-issue-prs (model grok-4.5)

Fixes #1844