### PR TITLE
fix(perc-qa-automation): suppress empty-build warnings and zero Javadoc noise (#1858)

### DIFF
--- a/modules/perc-qa-automation/pom.xml
+++ b/modules/perc-qa-automation/pom.xml
@@ -17,23 +17,56 @@
         <!-- Layer-1 install matrix defaults (opt-in profile matrix-smoke) -->
         <matrix.product>cms</matrix.product>
         <matrix.skip.image.build>true</matrix.skip.image.build>
+        <!--
+            Skip the default Java compilation; this module contains no Java sources.
+            Only the Playwright / Node.js test bundle matters here.
+        -->
+        <maven.compiler.skip>true</maven.compiler.skip>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    <dependencies>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>6.9.6</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.percussion</groupId>
-            <artifactId>perc-shared-test-resources</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
     <build>
+        <resources>
+            <resource>
+                <filtering>false</filtering>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
         <plugins>
+            <!--
+                Disable the default-compile and default-testCompile executions; this
+                module has no Java sources. Keeps the build quiet without changing
+                semantics for the JS/Playwright test flow.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--
+                Disable the attach-javadocs execution; this module has no Java
+                sources, so the Javadoc jar would always be empty. Skipping it
+                also removes the "No Javadoc in project" notice and keeps the
+                install step focused on the test bundle.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>

--- a/modules/perc-qa-automation/src/main/resources/perc-qa-automation-placeholder.txt
+++ b/modules/perc-qa-automation/src/main/resources/perc-qa-automation-placeholder.txt
@@ -1,0 +1,1 @@
+﻿This module intentionally ships no Java sources. The deliverable is the Playwright/Node.js test bundle under rontend/. See README.md and AGENTS.md for usage.


### PR DESCRIPTION
## Summary

Resolves the Javadoc / build-noise issue on the `perc-qa-automation`
module (`modules/perc-qa-automation`, a Playwright/Node.js test
bundle). After this change, `mvn clean install -B` reports **0
`[WARNING]` lines** and produces a populated JAR with no Javadoc
plugin invocation.

Fixes #1858.

## Change class

Build-cleanup + dependency cleanup, single Maven module
(`com.percussion:perc-qa-automation`, packaging `jar`).

## Why this looks different from the other Javadoc PRs

The module has **no Java sources** — it is a JS/Playwright test bundle
under `frontend/`. The `maven-javadoc-plugin` execution on `origin/main`
prints `No Javadoc in project. Archive not created.` and emits **zero
warnings** under the configured JDK 21 + parent `maven-javadoc-plugin
3.12.0` + `<doclint>all</doclint>` combo. The `JavadocSrcWarnings=47`
in the issue report does not reproduce on origin/main from this
worktree; it appears to be a build-report counter artifact rather
than a real Javadoc-tool emission.

The 4 pre-existing build warnings attributable to **this** module on
`origin/main` are unrelated to doclint but are the actual noise the
issue's "warning-free build" acceptance criterion targets:

|                       Origin/main warning                       |                       Fix                       |
|----------------------------------------------------------------|-------------------------------------------------|
| `JAR will be empty - no content was marked for inclusion!`     | Add a placeholder resource so the JAR is non-empty. |
| `No Javadoc in project. Archive not created.`                  | Disable the `attach-javadocs` execution (no Java sources). |
| `Unused declared dependencies: org.testng:testng:6.9.6:test`   | Remove the dependency.                           |
| `Unused declared dependencies: perc-shared-test-resources:8.2.0-SNAPSHOT:test` | Remove the dependency.             |

## What changed (2 files)

|                                      File                                      |                                  Change                                  |
|-------------------------------------------------------------------------------|-----------------------------------------------------------------------|
| `modules/perc-qa-automation/pom.xml`                                           | `<maven.compiler.skip>true</maven.compiler.skip>`; disable `default-compile` / `default-testCompile` (mirrors `perc-common-ui-bundle/pom.xml`); disable `attach-javadocs`; declare `<resources>` block; drop unused TestNG and `perc-shared-test-resources` dependencies. |
| `modules/perc-qa-automation/src/main/resources/perc-qa-automation-placeholder.txt` (new) | One-line pointer explaining that the module ships no Java sources and the deliverable is the Playwright/Node.js test bundle. |

## Verification (pre-PR local gate)

Run from the module directory:

```bat
cd modules\perc-qa-automation
..\..\mvnw.cmd clean install -B
..\..\mvnw.cmd spotless:apply -B
..\..\mvnw.cmd spotless:check -B
```

- `clean install -B` -> **BUILD SUCCESS**, **0 `[WARNING]` lines**
  (was 4 on origin/main).
- JAR produced: `perc-qa-automation-8.2.0-SNAPSHOT.jar` (contains the
  placeholder + auto-generated manifest).
- `dependency:analyze-only` -> "No dependency problems found".
- `attach-javadocs` execution: skipped (no-op for this module).
- `spotless:apply` reformatted the changed pom file (single-file
  in-scope change). `spotless:check` reports the pom.xml clean.

## Out-of-scope (NOT touched by this PR)

- `frontend/tests/bugs/bug-1812-bulk-upload.spec.js` is formatted
  differently from what Spotless' current prettier config produces
  on `origin/main`. `mvn spotless:check -B` fails on this single
  file on `origin/main` already; this PR does not introduce or fix
  the violation. Fixing it belongs in a separate `chore: Spotless
  cleanup` PR (per root `AGENTS.md` → "Out-of-scope Spotless hits").

## Compatibility

- The Maven artifact is still a `jar` (the install/dependency graph
  references it as `com.percussion:perc-qa-automation:jar:8.2.0-SNAPSHOT`).
- The `frontend/` Playwright/Node.js test bundle is untouched.
- The `matrix-smoke` opt-in profile (Docker install matrix) is
  unchanged and still functions.
- No code/behavior changes — only build- and packaging-time cleanup.

Refs GH-1858.

Co-Authored by Kilo Kilo using MiniMax-M3 with agent Kilo.
