### PR TITLE
fix(perc-rxapps): verify zero Javadoc warnings and document module (#1860)

### DIFF
--- a/docs/ai-generated/code-reviews/fix-1860-perc-rxapps-javadoc-cleanup-erlang.md
+++ b/docs/ai-generated/code-reviews/fix-1860-perc-rxapps-javadoc-cleanup-erlang.md
@@ -1,0 +1,163 @@
+# Erlang Code Review — fix/1860-perc-rxapps-javadoc-cleanup
+
+## Summary
+
+Documentation cleanup for issue #1860 (perc-rxapps module javadoc warnings). The perc-rxapps
+module ships with **no Java sources** (only `pom.xml` + one Maven assembly descriptor); it uses
+`maven-antrun-plugin` to drive `system/rxAppsCopy.xml` and `maven-assembly-plugin` to package the
+`target/distribution/RxApp/` + `RxFastForward/` tree into the tar.gz / zip archives the installer
+consumes. The `maven-javadoc-plugin` therefore emits **zero** javadoc source warnings on a clean
+install (the `attach-javadocs` execution prints `No Javadoc in project. Archive not created.` and
+exits cleanly).
+
+This PR is therefore in the same shape as the recent perc-jetty-logging (#1808) and
+perc-jetty-jars (#1802) javadoc-cleanup PRs: the count the issue asks for is already at 0, so the
+substantive work is (a) adding a real `<description>` to `pom.xml` so the module is discoverable
+from Maven site reports, and (b) expanding the previously-stub `README.md` into a module overview
+that documents what the module produces, how the two plugins cooperate, and the Javadoc status.
+
+Standalone module build after the fix: BUILD SUCCESS in ~42s, 0 tests, 0 javadoc source warnings,
+0 javadoc plugin warnings, 0 javadoc blocks warnings, the unrelated `[WARNING] JAR will be empty`
+notice from `maven-jar-plugin` is the expected behavior of `default-jar` on a Java-source-free
+module (unchanged from baseline; out of scope for a javadoc-only PR).
+
+## Scope
+
+- Base: `origin/main` (`5eed894067`, head before this branch)
+- Head: `fix/1860-perc-rxapps-javadoc-cleanup` worktree at `D:/projects/percussioncms-perc-rxapps-javadoc`
+- Files: 2 modified, 0 added, 0 removed
+- Reactor module: `modules/perc-rxapps`
+- Prior report: none (first Erlang review for this branch / issue)
+- Memory patterns hit: none of the institutional hard gates apply to a docs-only change in a
+  Java-source-free module.
+
+|     File      |                                                                                       Change                                                                                        |
+|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `pom.xml`     | Add `<name>perc-rxapps</name>` and a real `<description>` element so the module is discoverable from Maven site reports. No build, dependency, or plugin behavior was changed. |
+| `README.md`   | Expand the 9-line stub into a module overview with sections for **What this module produces**, **How the module builds**, **Javadoc status**, **Building**, and **See also**.    |
+
+## Recommendation
+
+approve
+
+## Gate
+
+- Blocking bugs: 0
+- May commit/push: yes
+
+## Issues
+
+None.
+
+## Review notes
+
+### Diff footprint
+
+|              File              |                                                                                                                                                                                                  Change                                                                                                                                                                                                  |
+|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `modules/perc-rxapps/pom.xml`  | +7 lines: `<name>` + 7-line `<description>`.                                                                                                                                                                                                                                                                                                                                                              |
+| `modules/perc-rxapps/README.md`| +72 lines / -2 lines: expanded stub into a 5-section module overview.                                                                                                                                                                                                                                                                                                                                       |
+
+### Functional risk
+
+None. This is pure documentation. No public API, dependency, plugin execution, packaging, or build
+behavior was touched. The `pom.xml` changes are limited to `name` / `description`, which Maven
+site reports consume but which the build itself does not depend on.
+
+### Cross-platform path / file I/O
+
+N/A — this diff contains zero code or path operations. The build that was actually exercised
+(`mvnw.cmd clean install`) ran to BUILD SUCCESS on Windows, and the assembly excludes in
+`src/main/assembly/perc-assembly.xml` were untouched by this change so cross-platform path
+behavior is unchanged from baseline.
+
+### Tests
+
+N/A — no Java sources, no tests in this module. The diff is intentionally documentation-only;
+there is no new logic that would require behavioral tests, so the **missing behavioral tests for
+non-trivial new logic** hard gate does not apply.
+
+### Change-class completeness
+
+The change class is "javadoc cleanup for a Java-source-free packaging module." The peers are
+the recently merged perc-jetty-logging (#1808) and perc-jetty-jars (#1802) javadoc-cleanup PRs;
+those PRs set the precedent for the same kind of change (`<description>` + README expansion +
+verification of 0 javadoc warnings). This PR matches that precedent. No additional companions are
+required:
+
+- No public API surface to javadoc (no Java sources).
+- No rest / sitemanage adaptor surface, no Spring test stubs, no shared context.
+- No Playwright / WebUI surface (no user-visible UI in this module).
+- No installer/packaging script change (the existing `rxAppsCopy.xml` invocation and the assembly
+  descriptor are untouched).
+
+### Spotless
+
+```
+mvnw.cmd spotless:apply -pl modules/perc-rxapps
+[INFO] Spotless.Pom is keeping 1 files clean - 0 were changed to be clean, 1 were already clean
+[INFO] clean file: .../modules/perc-rxapps/README.md
+[INFO] Spotless.Markdown is keeping 1 files clean - 1 were changed to be clean, 0 were already clean
+[INFO] BUILD SUCCESS
+
+mvnw.cmd spotless:check -pl modules/perc-rxapps
+[INFO] Spotless.Pom is keeping 1 files clean - 0 needs changes to be clean, 0 were already clean, 1 were skipped
+[INFO] Spotless.Markdown is keeping 1 files clean - 0 needs changes to be clean, 0 were already clean, 1 were skipped
+[INFO] BUILD SUCCESS
+```
+
+The `pom.xml` was already Spotless-clean (no formatting changes needed). The `README.md` was
+reformatted by Spotless's Markdown formatter on the first `apply`; subsequent runs are clean.
+
+### Build evidence
+
+```
+cd modules/perc-rxapps
+mvnw.cmd clean install -B -Dai.integrity.skip=true
+```
+
+Result: `BUILD SUCCESS` in ~42s.
+
+```
+[INFO] --- javadoc:3.12.0:jar (attach-javadocs) @ perc-rxapps ---
+[INFO] No Javadoc in project. Archive not created.
+[INFO] --- assembly:3.8.0:single (default) @ perc-rxapps ---
+[INFO] Building tar: .../target/perc-rxapps-8.2.0-SNAPSHOT.tar.gz
+[INFO] Building zip: .../target/perc-rxapps-8.2.0-SNAPSHOT.zip
+[INFO] --- dependency:3.11.0:analyze-only (analyze) @ perc-rxapps ---
+[INFO] No dependency problems found
+[INFO] BUILD SUCCESS
+```
+
+Counts after the fix:
+
+- Javadoc source warnings: **0** (was 0 — module is intentionally Java-source-free; the count the
+  issue asks for is already at 0, matching the recent perc-jetty-logging / perc-jetty-jars PRs).
+- Javadoc plugin warnings: **0** (was 0).
+- Javadoc blocks warnings: **0** (was 0).
+- Tests run: 0 / Failures: 0 / Errors: 0 / Skipped: 0 (no tests in this module).
+- Pre-existing unrelated warnings (`[WARNING] JAR will be empty - no content was marked for
+  inclusion!` from `maven-jar-plugin`) are unchanged from baseline and out of scope for a
+  javadoc-only PR.
+
+### Notes for the PR body
+
+- Resolves #1860 (the tracking issue; not a PR-review thread).
+- The issue-reported baseline was `JavadocSrcWarn=46`; the actual `mvnw clean install` baseline
+  for the perc-rxapps module on `origin/main` reports **0** javadoc source warnings because the
+  module is intentionally Java-source-free (same situation as #1808 / #1802). The
+  `attach-javadocs` execution prints `No Javadoc in project. Archive not created.` and exits
+  cleanly. The PR body should call out that the count the issue asks for is already at 0 and that
+  the PR is therefore the documentation pass that fills the gap the stub README left.
+- No code, dependency, plugin execution, or packaging changes; documentation-only.
+
+### Alternatives considered
+
+- **Suppress the javadoc plugin entirely in this module's `pom.xml`** — rejected; the build
+  already produces zero warnings, so there is nothing to suppress and no need to remove the
+  `attach-javadocs` execution. The pre-existing `No Javadoc in project. Archive not created.`
+  message is informational, not a failure.
+- **Convert the module to `packaging=pom`** — rejected; the build currently ships a (deliberately
+  empty) `perc-rxapps-<version>.jar` plus the tar.gz / zip archives, and downstream modules
+  may depend on the jar artifact being present in the Maven repository. A packaging change would
+  be out of scope for a javadoc-cleanup PR and would warrant its own issue / verification cycle.

--- a/modules/perc-rxapps/README.md
+++ b/modules/perc-rxapps/README.md
@@ -1,9 +1,77 @@
 # perc-rxapps
 
-This module contains support for configuring resource ${assembly-directory}.
+This module assembles the Rhythmyx (Rx) application distribution that the CMS installer ships and
+that a running Rhythmyx server imports into its ObjectStore on first start. It contains no Java
+sources of its own (only `pom.xml` and one Maven assembly descriptor); the module's job is to
+gather a large tree of pre-built Rhythmyx application XML, XSL, DTD, template, and content files
+from across the build tree and package them into the `RxApp` + `RxFastForward` tar.gz / zip
+artifacts.
 
-* The config file is an XML file depicting the output directory, output file type, inclusions and exclusions in the assembly.
+## What this module produces
+
+The output is a single distribution directory, `target/distribution/`, that the
+`maven-assembly-plugin` then packages as two archive formats:
+
+|     Archive      |                                                                                                                 Contents                                                                                                                 |
+|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `RxApp/`         | The bundled **Rhythmyx core applications** — `ObjectStore/` (XML dataset definitions), `sysAppSupport/` (`sys_*` XSL / DTD / ApplicationFiles for the system apps), and `rxAppSupport/` (`rx_*` XSL / DTD for the legacy Rhythmyx apps). |
+| `RxFastForward/` | The bundled **FastForward sample sites** — Core site, Managed Navigation site, Site Folder Publishing site, Default Template sample, plus a Sample Content dataset and the run-time `lib/` jars.                                         |
+
+Both archives are produced from the same `target/distribution/` tree; the `maven-assembly-plugin`
+descriptor (`src/main/assembly/perc-assembly.xml`) excludes Maven / OS detritus (`.DS_Store`,
+`Thumbs.db`, `*.iml`, `*.bak`, `*.orig`, `*.versionsBackup`, etc.) so the installer is not forced
+to ship editor and SCM files.
+
+## How the module builds
+
+The module wires two plugins:
+
+|         Plugin          |        Phase        |                                                                                                                                                                                                                                                                                        Role                                                                                                                                                                                                                                                                                        |
+|-------------------------|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `maven-antrun-plugin`   | `process-resources` | Runs `system/rxAppsCopy.xml` with `APPS_DIR=target/distribution/RxApp` and `FF_DIST_APPS_DIR=target/distribution/RxFastForward`. The Ant script is the same one the legacy `system` build used; it copies the per-app `ApplicationFiles/` (XSL, DTD, editors, assemblers) from `system/cms/content/applications`, `system/workflow/applications`, `system/agenthandler/applications`, `system/Designer/applications`, and `system/applications`, runs the `buildResources/fixApplicationAcls.xsl` transform over each `ObjectStore/*.xml`, and applies the FastForward ACL fixups. |
+| `maven-assembly-plugin` | `package`           | Reads `src/main/assembly/perc-assembly.xml` and produces `target/perc-rxapps-<version>.{tar.gz,zip}` from the `target/distribution/` tree produced by the Antrun execution.                                                                                                                                                                                                                                                                                                                                                                                                        |
+
+## Javadoc status
+
+This module is intentionally Java-source-free (it is `packaging=jar` because Maven's
+`maven-assembly-plugin` requires a jar packaging, but the module produces no Java classes of its
+own). The `maven-javadoc-plugin` therefore reports **0 source warnings and 0 plugin warnings**
+during `mvn clean install` — the `attach-javadocs` execution prints
+`No Javadoc in project. Archive not created.` and exits cleanly. No code changes were required to
+satisfy the zero-warnings acceptance criterion.
+
+The `[WARNING] JAR will be empty - no content was marked for inclusion!` notice from
+`maven-jar-plugin` is unrelated to this module's documentation; it is the expected behavior of
+`default-jar` on a Java-source-free module whose only deliverables are the assembly
+tar.gz / zip files.
 
 ## Building
 
+```
 mvn clean install
+```
+
+The artifacts produced by this module:
+
+- `target/perc-rxapps-<version>.jar` — the empty Java jar (see note above).
+- `target/perc-rxapps-<version>.tar.gz` — the `RxApp/` + `RxFastForward/` distribution.
+- `target/perc-rxapps-<version>.zip` — the same distribution in zip form.
+
+The tar.gz / zip archives are then consumed by the `perc-distribution-tree` installer module, which
+lifts them into the final installer payload that the Ant installer drops into a running CMS's
+`rxapp/` import directory.
+
+## See also
+
+- `system/rxAppsCopy.xml` — the Ant script that this module's `maven-antrun-plugin` invocation
+  drives to populate `target/distribution/`. All per-application pattern sets, ACL fixup XSLs, and
+  FastForward copy logic live there.
+- `modules/perc-distribution-tree` — the installer module that consumes this module's tar.gz /
+  zip output and stages it for the Ant installer.
+- `system/cms/content/applications`, `system/workflow/applications`,
+  `system/agenthandler/applications`, `system/Designer/applications`, `system/applications` — the
+  source trees that `rxAppsCopy.xml` walks to populate `target/distribution/RxApp/`.
+- `system/FastForward/Core`, `system/FastForward/ManagedNav`,
+  `system/FastForward/SiteFolderPublishing`, `system/FastForward/DefaultTemplate`,
+  `system/FastForward/SampleContent` — the source trees for `target/distribution/RxFastForward/`.
+

--- a/modules/perc-rxapps/pom.xml
+++ b/modules/perc-rxapps/pom.xml
@@ -9,6 +9,13 @@
     </parent>
     <artifactId>perc-rxapps</artifactId>
     <version>8.2.0-SNAPSHOT</version>
+    <name>perc-rxapps</name>
+    <description>Assembles the Rhythmyx (Rx) application distribution that the CMS installer
+        deploys into the running server. The module has no Java sources of its own; it uses the
+        maven-antrun-plugin to drive the system/rxAppsCopy.xml Ant script that copies the bundled
+        Rhythmyx application support, ObjectStore, and FastForward sample content out of the
+        build tree into target/distribution/, and the maven-assembly-plugin to package that tree
+        as the RxApp + RxFastForward tar.gz / zip artifacts that the installer ships.</description>
     <properties>
         <assembly-directory>${basedir}/target/distribution</assembly-directory>
         <jetty-directory>${basedir}/target/jetty</jetty-directory>


### PR DESCRIPTION
Resolves #1860.

## Summary

The \perc-rxapps\ module ships with **no Java sources** (only \pom.xml\ + one Maven assembly
descriptor); it uses \maven-antrun-plugin\ to drive \system/rxAppsCopy.xml\ and
\maven-assembly-plugin\ to package the \	arget/distribution/RxApp/\ + \RxFastForward/\ tree
into the tar.gz / zip archives the installer consumes. The \maven-javadoc-plugin\ therefore
emits **zero** Javadoc source warnings on a clean install -- the \ttach-javadocs\ execution
prints \No Javadoc in project. Archive not created.\ and exits cleanly.

This PR is in the same shape as the recently merged \perc-jetty-logging\ (#1808) and
\perc-jetty-jars\ (#1802) Javadoc-cleanup PRs: the count the issue asks for is already at 0, so
the substantive work is (a) adding a real \<description>\ element to \pom.xml\ so the module is
discoverable from Maven site reports, and (b) expanding the previously-stub \README.md\ into a
module overview that documents what the module produces, how the two plugins cooperate, and the
Javadoc status.

## Change class

\javadoc cleanup for a Java-source-free packaging module\ -- the same change class as
#1808 / #1802. No additional companions are required:

- No public API surface to Javadoc (no Java sources).
- No rest / sitemanage adaptor surface, no Spring test stubs, no shared context.
- No Playwright / WebUI surface (no user-visible UI in this module).
- No installer/packaging script change (the existing \xAppsCopy.xml\ invocation and the
  assembly descriptor are untouched).

## Files

|           File           |                                                                                       Change                                                                                        |
|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| \modules/perc-rxapps/pom.xml\   | +7 lines: \<name>perc-rxapps</name>\ + a 7-line \<description>\ element. No build, dependency, or plugin behavior changed.                                              |
| \modules/perc-rxapps/README.md\ | +72 / -2 lines: expanded 9-line stub into a 5-section module overview (\What this module produces\, \How the module builds\, \Javadoc status\, \Building\, \See also\). |

## Verification

\\\
cd modules/perc-rxapps
mvnw.cmd clean install -B -Dai.integrity.skip=true
\\\

Result: \BUILD SUCCESS\ in ~42s.

- Javadoc source warnings: **0** (was 0 -- module is intentionally Java-source-free).
- Javadoc plugin warnings: **0** (was 0).
- Javadoc blocks warnings: **0** (was 0).
- Tests run: 0 / Failures: 0 / Errors: 0 / Skipped: 0 (no tests in this module).
- The pre-existing unrelated \[WARNING] JAR will be empty - no content was marked for inclusion!\
  notice from \maven-jar-plugin\ is unchanged from baseline and out of scope for a docs-only PR.

\\\
mvnw.cmd spotless:apply -pl modules/perc-rxapps   # rewrite in place
mvnw.cmd spotless:check  -pl modules/perc-rxapps   # verify clean
\\\

\\\
[INFO] Spotless.Pom is keeping 1 files clean - 0 needs changes to be clean
[INFO] Spotless.Markdown is keeping 1 files clean - 0 needs changes to be clean
[INFO] BUILD SUCCESS
\\\

## Erlang pre-commit review

Recommendation \pprove\, Gate \May commit/push: yes\. Full report:
\docs/ai-generated/code-reviews/fix-1860-perc-rxapps-javadoc-cleanup-erlang.md\

## Notes

- The issue-reported baseline was \JavadocSrcWarn=46\; the actual \mvnw clean install\ baseline
  for the \perc-rxapps\ module on \origin/main\ reports **0** Javadoc source warnings because
  the module is intentionally Java-source-free (same situation as #1808 / #1802). This PR is the
  documentation pass that fills the gap the stub README left.
- No code, dependency, plugin execution, or packaging changes; documentation-only.