### PR TITLE
fix(sitemanage): Home gadget empty responses for consent totals + contenttraffic (#1815)

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/activity/service/impl/PSTrafficService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/activity/service/impl/PSTrafficService.java
@@ -60,9 +60,6 @@ import org.apache.logging.log4j.Logger;
 public class PSTrafficService implements IPSTrafficService {
 
   private static final Logger log = LogManager.getLogger(PSTrafficService.class);
-  private static final String NOT_FOUND_ERROR =
-      "Unable to retrieve analytics data. Please use the Google Setup gadget to select a profile"
-          + " for the desired site(s).";
 
   private final IPSActivityService activityService;
   private final IPSAnalyticsProviderQueryService analyticsService;
@@ -112,13 +109,21 @@ public class PSTrafficService implements IPSTrafficService {
     try {
       siteInfo = siteDataService.findByPath(path);
     } catch (Exception e) {
-      throw new PSTrafficServiceException(NOT_FOUND_ERROR);
+      // Empty install / unknown path: Home gadgets should get empty series (HTTP 200), not 500.
+      log.warn(
+          "Content traffic path not found or site unavailable (path={}); returning empty traffic"
+              + " series. Cause: {}",
+          path,
+          PSExceptionUtils.getMessageForLog(e));
+      log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+      return emptyContentTraffic(request);
     }
 
     PSDateRange range;
     try {
       range = createPSDateRange(startDate, endDate, granularity);
     } catch (ParseException e) {
+      // Malformed date / granularity remain real validation errors.
       throw new PSTrafficServiceException(e.getMessage());
     }
 
@@ -243,6 +248,30 @@ public class PSTrafficService implements IPSTrafficService {
     }
 
     return itemPropList;
+  }
+
+  /**
+   * Empty traffic payload for gadget-friendly empty installs / unknown paths. Series lists are
+   * non-null empty so clients can chart without null checks.
+   */
+  private PSContentTraffic emptyContentTraffic(PSContentTrafficRequest request) {
+    PSContentTraffic results = new PSContentTraffic();
+    results.setDates(new ArrayList<>());
+    results.setPageUpdates(new ArrayList<>());
+    results.setNewPages(new ArrayList<>());
+    results.setLivePages(new ArrayList<>());
+    results.setTakeDowns(new ArrayList<>());
+    results.setVisits(new ArrayList<>());
+    results.setUpdateTotals(new ArrayList<>());
+    if (request != null) {
+      if (request.getStartDate() != null) {
+        results.setStartDate(request.getStartDate());
+      }
+      if (request.getEndDate() != null) {
+        results.setEndDate(request.getEndDate());
+      }
+    }
+    return results;
   }
 
   /**

--- a/projects/sitemanage/src/main/java/com/percussion/cookieconsent/service/impl/PSCookieConsentService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/cookieconsent/service/impl/PSCookieConsentService.java
@@ -59,6 +59,12 @@ public class PSCookieConsentService implements IPSCookieConsentService {
   private static final String DTS_URL = "/perc-metadata-services/metadata/consent/log";
   private static final String TOTAL_ENTRIES_URL = DTS_URL + "/totals";
 
+  /**
+   * Empty JSON object returned when DTS indexer is missing or unreachable so Home gadgets receive
+   * HTTP 200 with empty totals instead of HTTP 500.
+   */
+  static final String EMPTY_TOTALS_JSON = "{}";
+
   @Autowired @Lazy private IPSPubServerService pubServerService;
 
   /** The delivery service initialized by constructor, never {@code null}. */
@@ -127,21 +133,33 @@ public class PSCookieConsentService implements IPSCookieConsentService {
       var deliveryServer = findServer(siteName);
 
       if (deliveryServer == null) {
-        throw new WebApplicationException(
-            "Cannot find service of: " + PSDeliveryInfo.SERVICE_INDEXER);
+        log.warn(
+            "Cannot find delivery indexer for cookie consent totals (site={}); returning empty"
+                + " totals",
+            siteName);
+        return EMPTY_TOTALS_JSON;
       }
 
-      var deliveryClient = new PSDeliveryClient();
-      var response =
-          deliveryClient.getString(
-              new PSDeliveryActionOptions(
-                  deliveryServer, TOTAL_ENTRIES_URL + "/" + siteName, HttpMethodType.GET, true));
+      try {
+        var deliveryClient = new PSDeliveryClient();
+        var response =
+            deliveryClient.getString(
+                new PSDeliveryActionOptions(
+                    deliveryServer, TOTAL_ENTRIES_URL + "/" + siteName, HttpMethodType.GET, true));
 
-      if (response != null) {
-        log.debug(SecureStringUtils.stripAllLineBreaks(response));
+        if (response != null) {
+          log.debug(SecureStringUtils.stripAllLineBreaks(response));
+          return response;
+        }
+        return EMPTY_TOTALS_JSON;
+      } catch (RuntimeException e) {
+        log.warn(
+            "DTS cookie consent totals unreachable for site {}: {}; returning empty totals",
+            siteName,
+            PSExceptionUtils.getMessageForLog(e));
+        log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+        return EMPTY_TOTALS_JSON;
       }
-
-      return response;
     } catch (PSValidationException
         | IPSPubServerService.PSPubServerServiceException
         | PSNotFoundException e) {
@@ -159,21 +177,29 @@ public class PSCookieConsentService implements IPSCookieConsentService {
     var deliveryServer = findServer();
 
     if (deliveryServer == null) {
-      throw new WebApplicationException(
-          "Cannot find service of: " + PSDeliveryInfo.SERVICE_INDEXER);
+      log.warn("Cannot find delivery indexer for cookie consent totals; returning empty totals");
+      return EMPTY_TOTALS_JSON;
     }
 
-    var deliveryClient = new PSDeliveryClient();
-    var response =
-        deliveryClient.getString(
-            new PSDeliveryActionOptions(
-                deliveryServer, TOTAL_ENTRIES_URL, HttpMethodType.GET, true));
+    try {
+      var deliveryClient = new PSDeliveryClient();
+      var response =
+          deliveryClient.getString(
+              new PSDeliveryActionOptions(
+                  deliveryServer, TOTAL_ENTRIES_URL, HttpMethodType.GET, true));
 
-    if (response != null) {
-      log.debug(SecureStringUtils.stripAllLineBreaks(response));
+      if (response != null) {
+        log.debug(SecureStringUtils.stripAllLineBreaks(response));
+        return response;
+      }
+      return EMPTY_TOTALS_JSON;
+    } catch (RuntimeException e) {
+      log.warn(
+          "DTS cookie consent totals unreachable: {}; returning empty totals",
+          PSExceptionUtils.getMessageForLog(e));
+      log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+      return EMPTY_TOTALS_JSON;
     }
-
-    return response;
   }
 
   @Override

--- a/projects/sitemanage/src/test/java/com/percussion/activity/service/impl/PSTrafficServiceTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/activity/service/impl/PSTrafficServiceTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.activity.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.percussion.activity.data.PSContentTraffic;
+import com.percussion.activity.data.PSContentTrafficRequest;
+import com.percussion.activity.service.IPSActivityService;
+import com.percussion.activity.service.IPSTrafficService.PSTrafficServiceException;
+import com.percussion.analytics.service.IPSAnalyticsProviderQueryService;
+import com.percussion.analytics.service.IPSAnalyticsProviderService;
+import com.percussion.pagemanagement.service.IPSPageService;
+import com.percussion.pathmanagement.service.IPSPathService;
+import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.service.IPSDataService.DataServiceNotFoundException;
+import com.percussion.sitemanage.data.PSSiteSummary;
+import com.percussion.sitemanage.service.IPSSiteDataService;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for content traffic empty-state behavior used by Home gadgets (unknown path / empty
+ * install must not become HTTP 500).
+ */
+@ExtendWith(MockitoExtension.class)
+class PSTrafficServiceTest {
+
+  @Mock private IPSActivityService activityService;
+  @Mock private IPSAnalyticsProviderQueryService analyticsService;
+  @Mock private IPSAnalyticsProviderService providerService;
+  @Mock private IPSSiteDataService siteDataService;
+  @Mock private IPSPathService pathService;
+  @Mock private IPSFolderHelper folderHelper;
+  @Mock private IPSPageService pageService;
+
+  private PSTrafficService trafficService;
+
+  @BeforeEach
+  void setUp() {
+    trafficService =
+        new PSTrafficService(
+            activityService,
+            analyticsService,
+            providerService,
+            siteDataService,
+            pathService,
+            folderHelper,
+            pageService);
+  }
+
+  @Test
+  void getContentTraffic_unknownPath_returnsEmptySeries() throws Exception {
+    when(siteDataService.findByPath(anyString()))
+        .thenThrow(new DataServiceNotFoundException("Site cannot be found for path: /Sites/Nope"));
+
+    PSContentTrafficRequest request = sampleRequest("/Sites/Nope");
+    PSContentTraffic traffic = trafficService.getContentTraffic(request);
+
+    assertNotNull(traffic);
+    assertTrue(traffic.getDates().isPresent());
+    assertTrue(traffic.getDates().get().isEmpty());
+    assertTrue(traffic.getVisits().isPresent());
+    assertTrue(traffic.getVisits().get().isEmpty());
+    assertTrue(traffic.getNewPages().isPresent());
+    assertTrue(traffic.getNewPages().get().isEmpty());
+    assertTrue(traffic.getPageUpdates().isPresent());
+    assertTrue(traffic.getPageUpdates().get().isEmpty());
+    assertTrue(traffic.getTakeDowns().isPresent());
+    assertTrue(traffic.getTakeDowns().get().isEmpty());
+    assertTrue(traffic.getLivePages().isPresent());
+    assertTrue(traffic.getLivePages().get().isEmpty());
+    assertTrue(traffic.getUpdateTotals().isPresent());
+    assertTrue(traffic.getUpdateTotals().get().isEmpty());
+    assertEquals("01/01/2024", traffic.getStartDate().orElse(null));
+    assertEquals("01/07/2024", traffic.getEndDate().orElse(null));
+  }
+
+  @Test
+  void getContentTraffic_malformedDate_throwsTrafficServiceException() throws Exception {
+    PSSiteSummary site = new PSSiteSummary();
+    site.setName("Demo");
+    site.setId("//Sites/Demo");
+    when(siteDataService.findByPath(anyString())).thenReturn(site);
+
+    PSContentTrafficRequest request = sampleRequest("/Sites/Demo");
+    request.setStartDate("not-a-date");
+    request.setEndDate("also-bad");
+
+    assertThrows(PSTrafficServiceException.class, () -> trafficService.getContentTraffic(request));
+  }
+
+  @Test
+  void getContentTraffic_knownPath_returnsSeriesForRequestedTraffic() throws Exception {
+    PSSiteSummary site = new PSSiteSummary();
+    site.setName("Demo");
+    site.setId("//Sites/Demo");
+    when(siteDataService.findByPath("/Sites/Demo")).thenReturn(site);
+    when(activityService.findPageIdsByPath("/Sites/Demo")).thenReturn(Collections.emptyList());
+    // dateList is breakdown + end day; 7 calendar days -> 8 buckets before removeLast
+    List<Integer> zeros = List.of(0, 0, 0, 0, 0, 0, 0, 0);
+    when(activityService.findPublishedItems(ArgumentMatchers.any(), ArgumentMatchers.any()))
+        .thenReturn(zeros);
+    when(activityService.findNewContentActivities(ArgumentMatchers.any(), ArgumentMatchers.any()))
+        .thenReturn(zeros);
+    when(activityService.findNumberContentActivities(
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.any()))
+        .thenReturn(zeros);
+
+    PSContentTrafficRequest request = sampleRequest("/Sites/Demo");
+    request.setTrafficRequested(List.of("LIVE_PAGES", "NEW_PAGES", "UPDATED_PAGES", "TAKE_DOWNS"));
+
+    PSContentTraffic traffic = trafficService.getContentTraffic(request);
+
+    assertNotNull(traffic);
+    assertTrue(traffic.getSite().isPresent());
+    assertTrue(traffic.getDates().isPresent());
+    assertEquals(7, traffic.getDates().get().size());
+    assertTrue(traffic.getNewPages().isPresent());
+    assertEquals(7, traffic.getNewPages().get().size());
+    assertTrue(traffic.getLivePages().isPresent());
+    assertEquals(7, traffic.getLivePages().get().size());
+  }
+
+  private static PSContentTrafficRequest sampleRequest(String path) {
+    PSContentTrafficRequest request = new PSContentTrafficRequest();
+    request.setPath(path);
+    request.setStartDate("01/01/2024");
+    request.setEndDate("01/07/2024");
+    request.setGranularity("DAY");
+    request.setTrafficRequested(List.of("NEW_PAGES"));
+    return request;
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/cookieconsent/service/impl/PSCookieConsentServiceTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/cookieconsent/service/impl/PSCookieConsentServiceTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cookieconsent.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+import com.percussion.delivery.data.PSDeliveryInfo;
+import com.percussion.delivery.service.IPSDeliveryInfoService;
+import com.percussion.pubserver.IPSPubServerService;
+import jakarta.ws.rs.WebApplicationException;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for Home-gadget cookie consent totals: missing DTS indexer must return empty JSON, not
+ * HTTP 500.
+ */
+@ExtendWith(MockitoExtension.class)
+class PSCookieConsentServiceTest {
+
+  @Mock private IPSDeliveryInfoService deliveryService;
+  @Mock private IPSPubServerService pubServerService;
+
+  private PSCookieConsentService service;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    service = new PSCookieConsentService(deliveryService);
+    Field pubField = PSCookieConsentService.class.getDeclaredField("pubServerService");
+    pubField.setAccessible(true);
+    pubField.set(service, pubServerService);
+  }
+
+  @Test
+  void getAllCookieConsentTotals_nullDeliveryServer_returnsEmptyJson() {
+    when(deliveryService.findByService(PSDeliveryInfo.SERVICE_INDEXER)).thenReturn(null);
+
+    String json = service.getAllCookieConsentTotals();
+
+    assertEquals(PSCookieConsentService.EMPTY_TOTALS_JSON, json);
+  }
+
+  @Test
+  void getCookieConsentForSite_nullDeliveryServer_returnsEmptyJson() throws Exception {
+    when(pubServerService.getDefaultAdminURL("Demo")).thenReturn("https://dts.example/admin");
+    when(deliveryService.findByService(eq(PSDeliveryInfo.SERVICE_INDEXER), isNull(), anyString()))
+        .thenReturn(null);
+
+    String json = service.getCookieConsentForSite("Demo");
+
+    assertEquals(PSCookieConsentService.EMPTY_TOTALS_JSON, json);
+  }
+
+  @Test
+  void getCookieConsentForSite_blankSiteName_throwsWebApplicationException() {
+    assertThrows(WebApplicationException.class, () -> service.getCookieConsentForSite(" "));
+  }
+
+  @Test
+  void getCookieConsentForSite_nullSiteName_throwsWebApplicationException() {
+    assertThrows(WebApplicationException.class, () -> service.getCookieConsentForSite(null));
+  }
+
+  @Test
+  void getCookieConsentForSite_pubServerLookupFailure_throwsWebApplicationException()
+      throws Exception {
+    when(pubServerService.getDefaultAdminURL(any()))
+        .thenThrow(new IPSPubServerService.PSPubServerServiceException("no site"));
+
+    assertThrows(WebApplicationException.class, () -> service.getCookieConsentForSite("Missing"));
+  }
+}


### PR DESCRIPTION
## Summary
Home gadgets call cookie consent totals and content traffic endpoints on empty/no-DTS installs and receive HTTP 500. This PR returns graceful empty payloads (HTTP 200) for those gadget-friendly paths.

### Changes
1. **Cookie consent totals** (PSCookieConsentService)
   - `getAllCookieConsentTotals` / `getCookieConsentForSite`: when delivery indexer is missing or DTS call fails, return `{}` and log warn/debug instead of `WebApplicationException` 500.
   - Blank/invalid siteName still fails validation (unchanged).

2. **Content traffic** (PSTrafficService)
   - `getContentTraffic`: when site path is not found / empty install, return empty `PSContentTraffic` with empty series lists instead of 500.
   - Malformed dates still throw `PSTrafficServiceException` (intentional validation).

### Out of scope
- Full DTS install / live integration
- Playwright E2E
- Export/delete consent endpoints (not Home gadget hot paths)

## Test plan
- [x] Unit: `PSCookieConsentServiceTest` — null delivery server returns `{}`; blank siteName still errors
- [x] Unit: `PSTrafficServiceTest` — unknown path empty series; malformed date still errors; known path series populated
- [x] Module: `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Spotless: `mvnw spotless:apply` then `spotless:check` on sitemanage (in-scope only)

## Gates evidence
| Gate | Result |
|------|--------|
| Behavioral unit tests | PSCookieConsentServiceTest 5/5, PSTrafficServiceTest 3/3 |
| Erlang-style self-review | No bugs found; portable paths N/A (no path I/O); companions = unit tests only (domain service change class) |
| Spotless apply → check | BUILD SUCCESS (module-scoped; no out-of-scope dump) |
| Standalone clean install | `cd projects/sitemanage` → `../../mvnw.cmd clean install` **BUILD SUCCESS** |
| No new warnings from change | Baseline warnings only |

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #1815