### PR TITLE
fix(WebUI): mock jsdom location navigation in Vitest setup

### DIFF
--- a/WebUI/src/main/frontend/vitest.setup.ts
+++ b/WebUI/src/main/frontend/vitest.setup.ts
@@ -56,3 +56,229 @@ window.getComputedStyle = ((elt: Element, pseudoElt?: string | null) => {
   }
   return originalGetComputedStyle(elt);
 }) as typeof window.getComputedStyle;
+
+/**
+ * jsdom does not implement full document navigation. Assigning
+ * {@code window.location.href} or calling {@code assign}/{@code replace}
+ * with a non-hash URL emits "Not implemented: navigation …" on the
+ * virtual console and can fail Vitest suites when production code
+ * redirects (Dashboard legacy flag, HomeShell open item, safeNavigate,
+ * session 401 redirect, etc.).
+ *
+ * <p>Install a plain Location-like mock that applies navigations via
+ * {@code history.pushState}/{@code replaceState} so pathname/search/hash
+ * stay readable for React Router and tests. Production navigation
+ * semantics are unchanged outside the test runner.</p>
+ *
+ * <p>Vitest's jsdom environment exposes a configurable
+ * {@code window.location}; pure Node JSDOM often does not — in that case
+ * we no-op rather than throw.</p>
+ */
+function installJsdomLocationNavigationMock(): void {
+  if (typeof window === "undefined" || typeof window.location === "undefined") {
+    return;
+  }
+
+  const locationDesc = Object.getOwnPropertyDescriptor(window, "location");
+  if (!locationDesc?.configurable) {
+    return;
+  }
+
+  let current: URL;
+  try {
+    current = new URL(window.location.href);
+  } catch {
+    current = new URL("http://localhost:3000/");
+  }
+
+  const origPushState = window.history.pushState.bind(window.history);
+  const origReplaceState = window.history.replaceState.bind(window.history);
+
+  const syncFromHistoryUrl = (url: string | URL | null | undefined): void => {
+    if (url == null || url === "") {
+      return;
+    }
+    try {
+      current = new URL(String(url), current.href);
+    } catch {
+      // ignore unparseable history URLs
+    }
+  };
+
+  // Keep mock state aligned when tests (or React Router) call history APIs.
+  window.history.pushState = function pushState(data, unused, url) {
+    const result = origPushState(data, unused, url as string | URL | null | undefined);
+    syncFromHistoryUrl(url as string | URL | null | undefined);
+    return result;
+  };
+  window.history.replaceState = function replaceState(data, unused, url) {
+    const result = origReplaceState(
+      data,
+      unused,
+      url as string | URL | null | undefined,
+    );
+    syncFromHistoryUrl(url as string | URL | null | undefined);
+    return result;
+  };
+
+  window.addEventListener("popstate", () => {
+    try {
+      if (typeof document !== "undefined" && document.URL) {
+        current = new URL(document.URL);
+      }
+    } catch {
+      // ignore
+    }
+  });
+
+  const parseRelative = (input: string | URL): URL =>
+    new URL(String(input), current.href);
+
+  const applyUrl = (next: URL, replace: boolean): void => {
+    current = next;
+    const path = `${next.pathname}${next.search}${next.hash}`;
+    try {
+      if (replace) {
+        origReplaceState(window.history.state, "", path);
+      } else {
+        origPushState(window.history.state, "", path);
+      }
+    } catch {
+      // history rejects some cross-origin / invalid URLs — swallow in tests
+    }
+  };
+
+  const mockLocation = {
+    get href() {
+      return current.href;
+    },
+    set href(value: string) {
+      try {
+        applyUrl(parseRelative(value), false);
+      } catch {
+        // ignore invalid assignments
+      }
+    },
+    get protocol() {
+      return current.protocol;
+    },
+    set protocol(value: string) {
+      const next = new URL(current.href);
+      next.protocol = value;
+      current = next;
+    },
+    get host() {
+      return current.host;
+    },
+    set host(value: string) {
+      const next = new URL(current.href);
+      next.host = value;
+      current = next;
+    },
+    get hostname() {
+      return current.hostname;
+    },
+    set hostname(value: string) {
+      const next = new URL(current.href);
+      next.hostname = value;
+      current = next;
+    },
+    get port() {
+      return current.port;
+    },
+    set port(value: string) {
+      const next = new URL(current.href);
+      next.port = value;
+      current = next;
+    },
+    get pathname() {
+      return current.pathname;
+    },
+    set pathname(value: string) {
+      try {
+        const next = new URL(current.href);
+        next.pathname = value;
+        applyUrl(next, true);
+      } catch {
+        // ignore
+      }
+    },
+    get search() {
+      return current.search;
+    },
+    set search(value: string) {
+      try {
+        const next = new URL(current.href);
+        next.search = value;
+        applyUrl(next, true);
+      } catch {
+        // ignore
+      }
+    },
+    get hash() {
+      return current.hash;
+    },
+    set hash(value: string) {
+      try {
+        const next = new URL(current.href);
+        next.hash = value;
+        applyUrl(next, true);
+      } catch {
+        // ignore
+      }
+    },
+    get origin() {
+      return current.origin;
+    },
+    get ancestorOrigins(): DOMStringList {
+      return [] as unknown as DOMStringList;
+    },
+    assign(url: string | URL) {
+      try {
+        applyUrl(parseRelative(url), false);
+      } catch {
+        // ignore
+      }
+    },
+    replace(url: string | URL) {
+      try {
+        applyUrl(parseRelative(url), true);
+      } catch {
+        // ignore
+      }
+    },
+    reload() {
+      // no-op in unit tests
+    },
+    toString() {
+      return current.href;
+    },
+  } as Location;
+
+  // Vitest jsdom: window.location is configurable — replace with mock.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (window as any).location;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).location = mockLocation;
+
+  // Soft-filter residual navigation jsdomErrors if any code path still hits
+  // the real Location (e.g. document.defaultView edge cases).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const virtualConsole = (window as any)._virtualConsole;
+  if (virtualConsole && typeof virtualConsole.on === "function") {
+    virtualConsole.on("jsdomError", (error: Error) => {
+      if (
+        error &&
+        typeof error.message === "string" &&
+        /Not implemented: navigation/i.test(error.message)
+      ) {
+        return;
+      }
+      // Re-surface non-navigation jsdom errors to stderr for visibility.
+      // eslint-disable-next-line no-console
+      console.error(error);
+    });
+  }
+}
+
+installJsdomLocationNavigationMock();

--- a/WebUI/src/test/ts/dashboard/Dashboard.test.tsx
+++ b/WebUI/src/test/ts/dashboard/Dashboard.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { Dashboard } from "@/dashboard";
 
 describe("Dashboard Component", () => {
@@ -51,15 +51,17 @@ describe("Dashboard Component", () => {
     expect(gridContainer).toBeDefined();
   });
 
-  it("should detect legacy dashboard flag", () => {
-    // Set legacy flag in URL
+  it("should detect legacy dashboard flag and navigate via location.href", async () => {
+    // Set legacy flag in URL — Dashboard useEffect redirects to legacyDashboardUrl.
+    // Shared vitest.setup mock applies href assignment via history so this is
+    // observable under jsdom (raw jsdom emits "Not implemented: navigation").
     window.history.pushState({}, "", "/?legacyDashboard=true");
 
-    const originalLocation = window.location.href;
     try {
       render(<Dashboard legacyDashboardUrl="/legacy.jsp" />);
-      // Navigation would happen - we can't test it directly in jsdom
-      // but we can verify the component handles the param
+      await waitFor(() => {
+        expect(window.location.pathname).toBe("/legacy.jsp");
+      });
     } finally {
       window.history.pushState({}, "", "/");
     }

--- a/WebUI/src/test/ts/login/tmxJspEscapingContract.test.ts
+++ b/WebUI/src/test/ts/login/tmxJspEscapingContract.test.ts
@@ -23,6 +23,11 @@ import { describe, expect, it } from "vitest";
  * login I18N map. Naive replaceAll of quotes left FR/IT strings like
  * Sélectionnez "Remplacer" as invalid JS, so dropdown locale changes for those
  * languages never reassigned window.I18N.message.
+ *
+ * Escaping lives in {@code PSTmxJsCatalog.toJsObjectEntries} (GH-1611), which
+ * uses {@code XSSValidation.escapeJavaScript} offline-tested in perc-i18n.
+ * The JSP must call that helper rather than inlining XSSValidation or a
+ * broken one-liner replaceAll.
  */
 describe("tmx.jsp JS escaping contract", () => {
   const jspPath = resolve(
@@ -31,12 +36,15 @@ describe("tmx.jsp JS escaping contract", () => {
   );
   const text = readFileSync(jspPath, "utf8");
 
-  it("uses XSSValidation.escapeJavaScript for mode=js emission", () => {
-    expect(text).toContain("com.percussion.security.validation.XSSValidation");
-    expect(text).toContain("XSSValidation.escapeJavaScript");
-    // Must not regress to the broken one-liner escape.
+  it("emits mode=js entries via PSTmxJsCatalog (not naive replaceAll)", () => {
+    expect(text).toContain("com.percussion.i18n.PSTmxJsCatalog");
+    expect(text).toContain("PSTmxJsCatalog.toJsObjectEntries");
+    // Must not regress to the broken one-liner escape in the JSP.
     expect(text).not.toMatch(
       /getString\([^)]+\)\.replaceAll\(\s*"\\""\s*,\s*"\\\\\\""\s*\)/,
     );
+    // Must not re-introduce inline XSSValidation calls that bypass the catalog
+    // helper (locale fallback + regression tests live on PSTmxJsCatalog).
+    expect(text).not.toContain("XSSValidation.escapeJavaScript");
   });
 });

--- a/WebUI/src/test/ts/setup/jsdomLocationNavigation.test.ts
+++ b/WebUI/src/test/ts/setup/jsdomLocationNavigation.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Behavioral contract for the shared jsdom location navigation mock
+ * installed in {@code WebUI/src/main/frontend/vitest.setup.ts}.
+ *
+ * Production code (Dashboard legacy redirect, safeNavigate, HomeShell
+ * open item, etc.) assigns {@code window.location.href} or calls
+ * {@code assign}/{@code replace}. Under raw jsdom those operations emit
+ * "Not implemented: navigation" and do not update pathname/search.
+ * The setup mock applies navigations via history so tests can observe
+ * the resulting URL without changing browser semantics in production.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+describe("jsdom location navigation mock (vitest.setup)", () => {
+  afterEach(() => {
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("accepts window.location.href assignment and updates pathname/search", () => {
+    window.history.replaceState({}, "", "/cm/app/home");
+    expect(window.location.pathname).toBe("/cm/app/home");
+
+    window.location.href = "/cm/app/dashboard.jsp?legacy=true";
+
+    expect(window.location.pathname).toBe("/cm/app/dashboard.jsp");
+    expect(window.location.search).toBe("?legacy=true");
+    expect(window.location.href).toContain("/cm/app/dashboard.jsp?legacy=true");
+  });
+
+  it("location.assign and location.replace update the observable URL", () => {
+    window.history.replaceState({}, "", "/cm/app/home");
+
+    window.location.assign("/cm/app/publish");
+    expect(window.location.pathname).toBe("/cm/app/publish");
+
+    window.location.replace("/cm/app/admin/tools");
+    expect(window.location.pathname).toBe("/cm/app/admin/tools");
+  });
+
+  it("stays in sync when tests use history.replaceState (React Router)", () => {
+    window.history.replaceState({}, "", "/cm/app/spa.jsp?entry=home");
+    expect(window.location.pathname).toBe("/cm/app/spa.jsp");
+    expect(window.location.search).toBe("?entry=home");
+
+    window.history.pushState({}, "", "/cm/app/home/library");
+    expect(window.location.pathname).toBe("/cm/app/home/library");
+  });
+
+  it("location.reload is a no-op (does not throw)", () => {
+    expect(() => window.location.reload()).not.toThrow();
+  });
+});

--- a/WebUI/vite.config.ts
+++ b/WebUI/vite.config.ts
@@ -34,6 +34,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "jsdom",
+    // Same setup as src/main/frontend/vite.config.ts so `npm test` from
+    // WebUI root also gets the jsdom location navigation mock, canvas
+    // stubs, and jest-dom matchers.
+    setupFiles: [resolve(__dirname, "src/main/frontend/vitest.setup.ts")],
     include: [
       "src/test/ts/**/*.{test,spec}.{ts,tsx}",
       "src/test/js/**/*.{test,spec}.js",

--- a/docs/ai-generated/code-reviews/issue-1867-jsdom-navigation-mock-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-1867-jsdom-navigation-mock-erlang.md
@@ -1,0 +1,32 @@
+# Erlang review — issue #1867 (jsdom location navigation mock)
+
+**Change class:** Vitest / jsdom test-infrastructure (shared setup mock)  
+**Scope:** `WebUI` only  
+**Production code:** unchanged
+
+## Summary
+
+Install a shared Vitest setup mock so `window.location.href` / `assign` /
+`replace` do not emit jsdom “Not implemented: navigation” when components
+redirect under tests. Navigations are applied via `history.pushState` /
+`replaceState` so pathname/search remain observable for React Router.
+
+Also updates the outdated `tmx.jsp` escaping contract test (pre-existing suite
+blocker on `main`) to assert `PSTmxJsCatalog.toJsObjectEntries` instead of
+inline `XSSValidation` (GH-1611 architecture).
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs in new logic | Pass — mock no-ops when `location` non-configurable; invalid URLs swallowed |
+| Behavioral tests | Pass — `jsdomLocationNavigation.test.ts` + Dashboard legacy redirect assertion |
+| Cross-platform paths | N/A — no filesystem path I/O in mock |
+| Production navigation semantics | Unchanged — setup file only runs under Vitest |
+| Companions | setupFiles wired in both `WebUI/vite.config.ts` and frontend vite config |
+| Spotless apply then check | Pass (WebUI module) |
+| `cd WebUI && ../mvnw clean install` | BUILD SUCCESS |
+
+## Residual
+
+None for #1867. Pre-existing suite green after tmx contract alignment.


### PR DESCRIPTION
## Summary

Fixes Vitest failures under jsdom when components perform programmatic navigation via `window.location.href` / `assign` / `replace` (e.g. Dashboard legacy dashboard redirect). jsdom does not implement full document navigation and emits `Not implemented: navigation`.

**Approach:** shared Vitest setup mock (not happy-dom switch) that applies navigations via `history.pushState` / `replaceState` so pathname/search stay readable for React Router and tests. Production navigation semantics are unchanged.

Also aligns the outdated `tmx.jsp` escaping contract test with `PSTmxJsCatalog.toJsObjectEntries` (pre-existing WebUI suite blocker on `main` after GH-1611).

### Changes
- `WebUI/src/main/frontend/vitest.setup.ts` — install jsdom location navigation mock
- `WebUI/vite.config.ts` — wire same `setupFiles` when running Vitest from WebUI root
- `WebUI/src/test/ts/setup/jsdomLocationNavigation.test.ts` — behavioral contract for the mock
- `WebUI/src/test/ts/dashboard/Dashboard.test.tsx` — assert legacy redirect updates pathname
- `WebUI/src/test/ts/login/tmxJspEscapingContract.test.ts` — expect `PSTmxJsCatalog` helper

Fixes #1867

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] `cd WebUI/src/main/frontend && npm test` — suite green (1140 tests; includes new mock tests)
- [x] Focused: App.test.tsx, percCssGalleryView.test.js, Dashboard.test.tsx, jsdomLocationNavigation.test.ts, safeNavigate, clientSessionRedirect
- [x] `cd WebUI && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Spotless: `cd WebUI && ../mvnw.cmd spotless:apply` then `spotless:check` — BUILD SUCCESS; feature PR contains only in-scope files
- [x] Erlang self-review: `docs/ai-generated/code-reviews/issue-1867-jsdom-navigation-mock-erlang.md`

## Gates evidence
| Gate | Evidence |
|------|----------|
| Erlang | No bugs; portable N/A; production nav unchanged; companions + tests |
| Spotless | apply then check on WebUI; no out-of-scope reformat in PR |
| Maven | standalone `cd WebUI; ..\mvnw.cmd clean install` → BUILD SUCCESS |
| Labels | operator:grok, operator:night-issue-prs, model:grok-4.5 |