### PR TITLE
fix(system): rewire PSDemandPublishServlet to modern Publishing status (GH-1842)

### DIFF
--- a/docs/ai-generated/tasks/#000-unified-ui-plan/ui-layer-inventory.md
+++ b/docs/ai-generated/tasks/#000-unified-ui-plan/ui-layer-inventory.md
@@ -170,19 +170,19 @@ PSContentExplorerHeader, PSContentExplorerLoginPanel, etc.
 
 **Publishing JSP pages (28)**:
 
-|                       Page                        |            Feature            |
-|---------------------------------------------------|-------------------------------|
-| `SiteList.jsp` / `SiteEditor.jsp`                 | Publishing site management    |
-| `EditionList.jsp` / `EditionEditor.jsp`           | Edition management            |
-| `ContentlistView.jsp` / `ContentlistEditor.jsp`   | Content list management       |
-| `ContextList.jsp` / `ContextEditor.jsp`           | Publishing context management |
-| `DeliveryTypeList.jsp` / `DeliveryTypeEditor.jsp` | Delivery type management      |
-| `LocationSchemeEditor.jsp`                        | Location scheme configuration |
-| `ActiveJobStatus.jsp`                             | Active publishing job status  |
-| `RuntimeEdition.jsp` / `RuntimeEditionList.jsp`   | Runtime edition execution     |
-| `AllPubLogs.jsp` / `SitePubLogs.jsp`              | Publishing logs               |
-| `JobPubLog.jsp` / `ItemPubLog.jsp`                | Job/item level logs           |
-| `DemandPublish.jsp`                               | On-demand publishing          |
+|                       Page                        |                                                                           Feature                                                                            |
+|---------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `SiteList.jsp` / `SiteEditor.jsp`                 | Publishing site management                                                                                                                                   |
+| `EditionList.jsp` / `EditionEditor.jsp`           | Edition management                                                                                                                                           |
+| `ContentlistView.jsp` / `ContentlistEditor.jsp`   | Content list management                                                                                                                                      |
+| `ContextList.jsp` / `ContextEditor.jsp`           | Publishing context management                                                                                                                                |
+| `DeliveryTypeList.jsp` / `DeliveryTypeEditor.jsp` | Delivery type management                                                                                                                                     |
+| `LocationSchemeEditor.jsp`                        | Location scheme configuration                                                                                                                                |
+| `ActiveJobStatus.jsp`                             | Active publishing job status                                                                                                                                 |
+| `RuntimeEdition.jsp` / `RuntimeEditionList.jsp`   | Runtime edition execution                                                                                                                                    |
+| `AllPubLogs.jsp` / `SitePubLogs.jsp`              | Publishing logs                                                                                                                                              |
+| `JobPubLog.jsp` / `ItemPubLog.jsp`                | Job/item level logs                                                                                                                                          |
+| `DemandPublish.jsp`                               | On-demand publishing — server consumer rewired (#1842): `PSDemandPublishServlet` → `/cm/app/?view=publish&section=status`; JSP delete still deferred (#1818) |
 
 ---
 

--- a/specs/990-unified-publishing-ui/checklists/removal-inventory.md
+++ b/specs/990-unified-publishing-ui/checklists/removal-inventory.md
@@ -88,6 +88,7 @@ Detailed audit notes (grep tables, historical faces dump pointers):
 | `ui/pubruntime/index.jsp`                  | Redirect → modern Runtime section | Done              | 301 → `/cm/app/?view=publish&section=runtime`   |
 | `dce_header.jsp` Runtime link              | Points to modern Runtime          | Done              | No deep faces URL                               |
 | Remaining `ui/pubruntime/*.jsp` deep pages | **Keep packaged** until #1818     | Deferred (RET-06) | Product **nav** callers: **zero** (audit #1817) |
+| `PSDemandPublishServlet` post-queue UI     | Rewired off `DemandPublish.jsp`   | Done (#1842)      | Redirect → modern shell status (see note below) |
 
 **Tracked files (2026-08-04)** — `WebUI/src/main/webapp/ui/pubruntime/` (13 JSPs):
 
@@ -95,7 +96,7 @@ Detailed audit notes (grep tables, historical faces dump pointers):
 |---------------------------------|-----------------------------|--------------------|----------------------------------------|-------------------------------|
 | `index.jsp`                     | entry                       | n/a (redirect)     | —                                      | **KEEP** redirect             |
 | `PubRuntimeAuthentication.jsp`  | include                     | none               | included by Runtime pages              | Delete with Runtime faces set |
-| `DemandPublish.jsp`             | **no** (plain JSP progress) | none               | **`PSDemandPublishServlet` forward**   | **KEEP / rewire first**       |
+| `DemandPublish.jsp`             | **no** (plain JSP progress) | none               | **Servlet rewired (#1842)**            | **Delete** (no live consumer) |
 | `ActiveJobStatus.jsp`           | yes                         | none               | —                                      | Delete                        |
 | `AllPubLogs.jsp`                | yes                         | none               | —                                      | Delete                        |
 | `DeleteSiteItemLogsWarning.jsp` | yes                         | none               | —                                      | Delete                        |
@@ -106,6 +107,17 @@ Detailed audit notes (grep tables, historical faces dump pointers):
 | `RuntimeEdition.jsp`            | yes                         | none               | —                                      | Delete                        |
 | `RuntimeEditionList.jsp`        | yes                         | none               | —                                      | Delete                        |
 | `SitePubLogs.jsp`               | yes                         | none               | —                                      | Delete                        |
+
+**RET-06 residual — DemandPublish servlet rewire (issue #1842, 2026-08-04):**
+`system/.../PSDemandPublishServlet` no longer forwards to
+`/ui/pubruntime/DemandPublish.jsp` after `queueDemandWork` succeeds.
+It now `sendRedirect`s to the modern Publishing shell peer
+`publishingShellHref({ section: 'status' })` →
+`{contextPath}/cm/app/?view=publish&section=status` (URL path separators only).
+Demand `requestid` is **not** appended: modern shell deep-link contract has no
+request-id filter. **`web.xml` mapping `/publisher/demandpublishing` is kept.**
+**JSP file delete still deferred** under #1818 — this rewire only removes the
+live server-side consumer so DemandPublish.jsp can be deleted safely later.
 
 **Sign-off**: Entry-path retirement Done; deep-page file deletion **explicitly deferred** to #1818 after UAT + non-nav rewires.  
 **Tracking issue**: [#1372](https://github.com/intersoftdatalabs-in/percussioncms/issues/1372) · audit [#1817](https://github.com/intersoftdatalabs-in/percussioncms/issues/1817)
@@ -194,13 +206,13 @@ Recoverable at: `git show aa46aa5f86^:WebUI/src/main/webapp/WEB-INF/publishing-f
 
 These are **not** product-nav, but are **product/engine** callers. Deleting the target pages without rewiring breaks demand publish / scheduled-edition log links / seed menus.
 
-|           Owner           |                                                     Code / data                                                     |                   Target                   |                                                        Recommended rewire                                                        |
-|---------------------------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| Demand publish servlet    | `system/business/.../PSDemandPublishServlet.java`                                                                   | Forward `/ui/pubruntime/DemandPublish.jsp` | Modern Runtime status (or thin non-JSF progress page kept under a non-faces path)                                                |
-| Demand servlet mapping    | `web.xml` url-pattern `/publisher/demandpublishing` (WebUI + cm + war)                                              | Same servlet                               | Keep mapping; change forward target only                                                                                         |
-| Publish Now action seed   | `modules/perc-distribution-tree/.../cmsTableData.xml` ACTIONID 217 `Publish_Now` URL `../ui/publishing/publish.jsp` | Demand publish JSP                         | Point at modern item publish-now / REST-backed UI (US6) or servlet path                                                          |
-| Publish Now FF seed       | `.../RxffTableData.xml`, `system/FastForward/Core/Config/Data/RxffTableData.xml`                                    | Same URL                                   | Same                                                                                                                             |
-| Scheduled edition log URL | `system/services/.../PSRunEdition.getPublishingLogURL()`                                                            | `/ui/pubruntime/JobPubLog.faces?…`         | Modern `view=publish&section=logs` (+ job id query if supported); **current `.faces` URL is already non-functional** without JSF |
+|           Owner           |                                                     Code / data                                                     |                                 Target                                  |                                                        Recommended rewire                                                        |
+|---------------------------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| Demand publish servlet    | `system/business/.../PSDemandPublishServlet.java`                                                                   | ~~Forward `/ui/pubruntime/DemandPublish.jsp`~~ → redirect modern status | **Done (#1842):** `sendRedirect` → `{contextPath}/cm/app/?view=publish&section=status`                                           |
+| Demand servlet mapping    | `web.xml` url-pattern `/publisher/demandpublishing` (WebUI + cm + war)                                              | Same servlet                                                            | **Kept** (#1842); only post-queue UI target changed                                                                              |
+| Publish Now action seed   | `modules/perc-distribution-tree/.../cmsTableData.xml` ACTIONID 217 `Publish_Now` URL `../ui/publishing/publish.jsp` | Demand publish JSP                                                      | Point at modern item publish-now / REST-backed UI (US6) or servlet path                                                          |
+| Publish Now FF seed       | `.../RxffTableData.xml`, `system/FastForward/Core/Config/Data/RxffTableData.xml`                                    | Same URL                                                                | Same                                                                                                                             |
+| Scheduled edition log URL | `system/services/.../PSRunEdition.getPublishingLogURL()`                                                            | `/ui/pubruntime/JobPubLog.faces?…`                                      | Modern `view=publish&section=logs` (+ job id query if supported); **current `.faces` URL is already non-functional** without JSF |
 
 ### Installer / distribution peers (no delete in #1817)
 
@@ -277,7 +289,7 @@ These are **not** product-nav, but are **product/engine** callers. Deleting the 
 
 ## Deletion checklist — Child C Runtime (#1818)
 
-**Prereqs**: #1817 (Done) · prefer after or with #1819 · #1371 UAT or human ack · rewire `DemandPublish.jsp` servlet forward and `PSRunEdition` JobPubLog URL.
+**Prereqs**: #1817 (Done) · prefer after or with #1819 · #1371 UAT or human ack · **DemandPublish servlet rewire Done (#1842)** · `PSRunEdition` JobPubLog URL rewire (see #1844).
 
 ### Delete (Runtime-exclusive deep faces / chrome)
 
@@ -287,6 +299,7 @@ These are **not** product-nav, but are **product/engine** callers. Deleting the 
 - [ ] `ErrorMessage.jsp`
 - [ ] `ItemPubLog.jsp`
 - [ ] `JobPubLog.jsp` (after `PSRunEdition` rewire)
+- [ ] `DemandPublish.jsp` (**servlet rewired #1842** — safe to delete with Runtime set)
 - [ ] `NoSelectionWarning.jsp`
 - [ ] `RuntimeEdition.jsp`
 - [ ] `RuntimeEditionList.jsp`
@@ -296,7 +309,7 @@ These are **not** product-nav, but are **product/engine** callers. Deleting the 
 ### Keep
 
 - [ ] `index.jsp` (modern Runtime redirect)
-- [ ] `DemandPublish.jsp` until `PSDemandPublishServlet` rewired (or rewire + replace progress UI in same PR)
+- [x] `PSDemandPublishServlet` post-queue UI rewired (#1842) — keep `/publisher/demandpublishing` mapping
 
 ### Faces-config / packaging
 
@@ -308,7 +321,7 @@ These are **not** product-nav, but are **product/engine** callers. Deleting the 
 
 - [ ] Modern Runtime / Status / Logs sections load
 - [ ] `ui/pubruntime/index.jsp` still redirects
-- [ ] `/publisher/demandpublishing` still returns a usable progress/result UI
+- [ ] `/publisher/demandpublishing` still queues demand work and redirects to modern Status (#1842)
 - [ ] Scheduled edition completion links open modern logs (after rewire)
 
 ---

--- a/system/business/src/com/percussion/rx/publisher/servlet/PSDemandPublishServlet.java
+++ b/system/business/src/com/percussion/rx/publisher/servlet/PSDemandPublishServlet.java
@@ -39,26 +39,32 @@ import java.text.MessageFormat;
 import java.util.List;
 
 /**
- * Invokes demand publishing and presents a user interface to allow the user to
- * see the current status of the publishing job associated with the demand
- * request.
+ * Invokes demand publishing and redirects the browser to the modern Publishing
+ * shell status section so the user can monitor related publish jobs.
  * <p>
- * After queuing the request, this servlet invokes a JSP to present the progress
- * data.
- * 
- * @author dougrand 
+ * After queuing the request, this servlet no longer forwards to the legacy
+ * {@code /ui/pubruntime/DemandPublish.jsp} progress page (rewired for RET-06 /
+ * issue #1842). The {@code /publisher/demandpublishing} mapping is retained.
+ *
+ * @author dougrand
  */
 public class PSDemandPublishServlet extends HttpServlet
 {
    /**
-    * 
+    *
     */
    private static final long serialVersionUID = 1L;
    private static final Logger log = LogManager.getLogger("publish-jsp");
 
+   /**
+    * Modern Publishing shell status deep link — peer WebUI {@code
+    * publishingShellHref({ section: 'status' })}.
+    */
+   static final String PUBLISHING_STATUS_PATH = "/cm/app/?view=publish&section=status";
+
    /*
     * (non-Javadoc)
-    * 
+    *
     * @see jakarta.servlet.http.HttpServlet#service(jakarta.servlet.http.HttpServletRequest,
     *      jakarta.servlet.http.HttpServletResponse)
     */
@@ -127,9 +133,34 @@ public class PSDemandPublishServlet extends HttpServlet
          throw new ServletException(e);
       }
 
-      request.setAttribute("requestid", requestId);
-      var dispatcher = request.getRequestDispatcher("/ui/pubruntime/DemandPublish.jsp");
-      dispatcher.forward(request, resp);
+      log.info("Demand publishing queued requestId={}; redirecting to modern Publishing status", requestId);
+      // Context-relative redirect — URL path separators only (not File.separator)
+      var redirectUrl = buildPublishingStatusRedirectURL(request.getContextPath());
+      resp.sendRedirect(resp.encodeRedirectURL(redirectUrl));
+   }
+
+   /**
+    * Builds the context-relative redirect target used after a successful demand-publish
+    * queue.
+    * <p>
+    * Targets the modern Publishing shell — peer WebUI {@code publishingShellHref({ section:
+    * 'status' })} → {@code /cm/app/?view=publish&section=status}. Path assembly uses URL
+    * separators only ({@code /}); never OS file separators.
+    * <p>
+    * <b>Request id:</b> the modern shell deep-link contract supports {@code section} and
+    * optional {@code siteId}/{@code serverId}, but not a demand {@code requestid} filter.
+    * The legacy JSP progress page attribute is intentionally not carried on the query
+    * string; callers land on the Status section.
+    *
+    * @param contextPath servlet context path (e.g. {@code /Rhythmyx} or empty); may be
+    *     {@code null}
+    * @return context-relative redirect URL, never {@code null}
+    */
+   static String buildPublishingStatusRedirectURL(String contextPath)
+   {
+      // URL path elements always use '/'; do not use File.separator
+      String root = contextPath == null ? "" : contextPath;
+      return root + PUBLISHING_STATUS_PATH;
    }
 
    /**

--- a/system/src/test/java/com/percussion/rx/publisher/servlet/PSDemandPublishServletTest.java
+++ b/system/src/test/java/com/percussion/rx/publisher/servlet/PSDemandPublishServletTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rx.publisher.servlet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link PSDemandPublishServlet} publishing-status redirect URL assembly (issue
+ * #1842).
+ *
+ * <p>Asserts context-relative URL shape with pure string components — no filesystem path
+ * construction — so asserts are portable on Windows and Unix. Peer: {@code PSRunEditionTest}
+ * JobPubLog rewire (#1844).
+ */
+class PSDemandPublishServletTest {
+
+  @Test
+  void buildPublishingStatusRedirectURL_emptyContext_matchesModernShellStatus() {
+    String url = PSDemandPublishServlet.buildPublishingStatusRedirectURL("");
+
+    assertEquals("/cm/app/?view=publish&section=status", url);
+  }
+
+  @Test
+  void buildPublishingStatusRedirectURL_withRequestRoot_prefixesRoot() {
+    String url = PSDemandPublishServlet.buildPublishingStatusRedirectURL("/Rhythmyx");
+
+    assertEquals("/Rhythmyx/cm/app/?view=publish&section=status", url);
+  }
+
+  @Test
+  void buildPublishingStatusRedirectURL_nullContext_treatedAsEmpty() {
+    String url = PSDemandPublishServlet.buildPublishingStatusRedirectURL(null);
+
+    assertEquals("/cm/app/?view=publish&section=status", url);
+  }
+
+  @Test
+  void buildPublishingStatusRedirectURL_dropsLegacyDemandPublishJsp() {
+    String url = PSDemandPublishServlet.buildPublishingStatusRedirectURL("/Rhythmyx");
+
+    assertFalse(url.contains("DemandPublish"));
+    assertFalse(url.contains("pubruntime"));
+    assertFalse(url.contains(".jsp"));
+    assertFalse(url.contains("requestid"));
+    assertTrue(url.contains("view=publish"));
+    assertTrue(url.contains("section=status"));
+    // URL path separator is always '/'; never OS file separator
+    assertFalse(url.contains("\\"));
+  }
+
+  @Test
+  void publishingStatusPath_constant_matchesItemPublishPathsPeer() {
+    assertEquals(
+        "/cm/app/?view=publish&section=status", PSDemandPublishServlet.PUBLISHING_STATUS_PATH);
+  }
+}


### PR DESCRIPTION
## Summary

Rewires the post-queue UI for demand publishing so /publisher/demandpublishing no longer depends on the legacy Runtime JSP progress page.

- **Before:** after `queueDemandWork` succeeds, `RequestDispatcher.forward` to `/ui/pubruntime/DemandPublish.jsp`
- **After:** `sendRedirect` to modern Publishing shell status — peer WebUI `publishingShellHref({ section: 'status' })` → `{contextPath}/cm/app/?view=publish&section=status`
- **Kept:** `web.xml` mapping `/publisher/demandpublishing` (WebUI + cm + war trees unchanged)
- **Not deleted:** `DemandPublish.jsp` remains packaged until #1818 (this PR only removes the live servlet consumer)
- **Request id:** not appended — modern shell deep-link contract supports `section` / optional `siteId` / `serverId` only (same pattern as #1844 JobPubLog job-id omission)

## Changes

| Path | Change |
|------|--------|
| `system/.../PSDemandPublishServlet.java` | Post-queue redirect + package-visible `buildPublishingStatusRedirectURL` |
| `system/.../PSDemandPublishServletTest.java` | URL shape unit tests (context root / null / no OS separators / no legacy JSP) |
| `specs/990-unified-publishing-ui/checklists/removal-inventory.md` | DemandPublish row → rewired; #1818 checklist can delete JSP |
| `docs/ai-generated/tasks/#000-unified-ui-plan/ui-layer-inventory.md` | DemandPublish consumer rewired note |

## Test plan

- [x] `cd system && ..\mvnw.cmd -Dtest=PSDemandPublishServletTest test` — Tests run: 5, Failures: 0
- [x] `cd system && ..\mvnw.cmd clean install` — BUILD SUCCESS (includes PSDemandPublishServletTest)
- [x] Root `mvnw.cmd spotless:apply` **then** `spotless:check` — BUILD SUCCESS; only in-scope files committed (out-of-scope Spotless baseline rewrites restored, not included)
- [x] Erlang-style self-review: no bugs; URL uses `/` only (not `File.separator`); pure builder unit-tested; companions (inventory docs) closed

## Gates evidence

- **Spotless:** root `spotless:apply` first, then `spotless:check`; feature PR contains only intentional task files
- **Maven:** standalone `system` `clean install` BUILD SUCCESS
- **Erlang self-review:** portable URL assembly; behavioral unit tests; change-class companions closed
- **Operator:** Grok: night-issue-prs (model grok-4.5)

Fixes #1842