### PR TITLE
feat(utils): Jackson XmlMapper parallel helper + keyword pilot golden (#1822)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-1822-jackson-xml-helper-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-1822-jackson-xml-helper-erlang.md
@@ -1,0 +1,45 @@
+# Erlang review — issue #1822 Jackson XmlMapper parallel helper
+
+**Branch:** `fix/issue-1822-jackson-xml-helper`  
+**Scope:** `modules/utils` only (parallel Jackson XML path; Betwixt remains production default)  
+**Date:** 2026-08-04  
+**Recommendation:** approve  
+**May commit/push:** yes  
+
+## Summary
+
+Adds `PSJacksonXmlSerializationHelper` + shared `PSXmlElementNameMapper` beside
+`PSXmlSerializationHelper`, pilot golden XML parity tests for keyword-shaped
+`SampleKeyword`/`SampleChoice`, and parent-managed `jackson-dataformat-xml` dependency.
+Production Betwixt path is unchanged except `PSNameMapper` delegates to the shared mapper
+(same naming rules; existing Betwixt unit tests still green).
+
+## Gate checklist
+
+- [x] No production cutover of `PSXmlSerializationHelper` default
+- [x] Behavioral unit tests for name mapper, golden parity, Betwixt→Jackson round-trip,
+      legacy `<null>` root rewrite on Jackson path, `@IPSXmlSerialization(suppress=true)`
+- [x] Cross-platform path / file I/O: not touched (classpath golden resource only)
+- [x] Module standalone `mvnw clean install` — BUILD SUCCESS (Tests run: 255, Failures: 0)
+- [x] Spotless apply then check on `modules/utils` — clean; out-of-scope monorepo Spotless debt not included
+
+## Issues
+
+None blocking.
+
+### Suggestions (non-blocking)
+
+1. **TYPE_MAP not yet used for Jackson polymorphic deserialize** — `addType` stores entries
+   for API parity with Betwixt; pilot collection item names use `@JacksonXmlProperty`. Wire
+   polymorphic handling in #1823 when migrating domain beans.
+2. **Betwixt graph-identity `id="…"` attributes** — golden compare strips them; Jackson does
+   not emit them. Documented in golden fixture + test normalizer.
+3. **Betwixt without `.betwixt` files** does not restore nested collection items for the pilot
+   (even write→read). Jackson→Betwixt test asserts scalars only; full nest restore is
+   Betwixt→Jackson and Jackson self-path.
+
+## Memory patterns hit
+
+- Parallel helper / no silent production default flip
+- Golden fixture from current producer (Betwixt write)
+- Companion tests for new helper logic

--- a/modules/utils/pom.xml
+++ b/modules/utils/pom.xml
@@ -135,6 +135,19 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Parallel Jackson XML path for epic #505 / issue #1822 (Betwixt remains production default). -->
+        <dependency>
+            <groupId>tools.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>

--- a/modules/utils/src/main/java/com/percussion/services/utils/xml/PSJacksonXmlSerializationHelper.java
+++ b/modules/utils/src/main/java/com/percussion/services/utils/xml/PSJacksonXmlSerializationHelper.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.utils.xml;
+
+import com.percussion.utils.xml.IPSXmlSerialization;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.lang3.StringUtils;
+import tools.jackson.databind.BeanDescription;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.SerializationConfig;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.cfg.MapperConfig;
+import tools.jackson.databind.introspect.AnnotatedMember;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.ser.BeanPropertyWriter;
+import tools.jackson.databind.ser.ValueSerializerModifier;
+import tools.jackson.dataformat.xml.JacksonXmlAnnotationIntrospector;
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.xml.XmlWriteFeature;
+
+/**
+ * Parallel Jackson XML serialization helper beside {@link PSXmlSerializationHelper}.
+ *
+ * <p><strong>This is not the production default.</strong> Call sites continue to use {@link
+ * PSXmlSerializationHelper} (Commons Betwixt). This helper exists so slice #1822 / epic #505 can
+ * prove wire parity with golden snapshots before any cutover (#1823).
+ *
+ * <p>Naming strategy (see {@link PSXmlElementNameMapper}):
+ *
+ * <ul>
+ *   <li>Root elements: {@link PSXmlElementNameMapper#mapTypeToElementName(String)} (PS/IPS strip +
+ *       multi-cap flatten + hyphenation)
+ *   <li>Property elements: kebab-case ({@link PropertyNamingStrategies#KEBAB_CASE}) matching
+ *       Betwixt {@code HyphenatedNameMapper} for properties
+ *   <li>Collections: wrapper element enabled by default (Betwixt-style {@code
+ *       <choices><choice/>…</choices>})
+ * </ul>
+ *
+ * <p>Legacy package payloads with root {@code <null>} are rewritten via {@link
+ * PSXmlSerializationHelper#rewriteLegacyNullRoot(String, Class)} before deserialize.
+ */
+public final class PSJacksonXmlSerializationHelper {
+
+  private static final Class<?>[] NOARGS = new Class<?>[0];
+
+  /** Element name → implementation class (mirrors Betwixt type registry for polymorphic items). */
+  private static final Map<String, Class<?>> TYPE_MAP = new ConcurrentHashMap<>();
+
+  private static final XmlMapper MAPPER = createMapper();
+
+  private PSJacksonXmlSerializationHelper() {
+    // utility
+  }
+
+  /**
+   * Register an element name to implementation class for polymorphic / collection item binding.
+   *
+   * @param elementName XML element name, never blank
+   * @param type implementation class, never {@code null}
+   */
+  public static void addType(String elementName, Class<?> type) {
+    if (StringUtils.isBlank(elementName)) {
+      throw new IllegalArgumentException("elementName may not be null or empty");
+    }
+    if (type == null) {
+      throw new IllegalArgumentException("type may not be null");
+    }
+    TYPE_MAP.put(elementName, type);
+  }
+
+  /**
+   * Register a type under its default {@link PSXmlElementNameMapper} element name.
+   *
+   * @param type class, never {@code null}
+   */
+  public static void addType(Class<?> type) {
+    if (type == null) {
+      throw new IllegalArgumentException("type may not be null");
+    }
+    addType(PSXmlElementNameMapper.mapTypeToElementName(type.getSimpleName()), type);
+  }
+
+  /**
+   * Serialize {@code object} to XML using Jackson {@link XmlMapper}. Root element name is derived
+   * with {@link PSXmlElementNameMapper} (PS/IPS strip + hyphenation).
+   *
+   * @param object never {@code null}
+   * @return XML string, never {@code null}
+   * @throws IOException on write failure
+   */
+  public static String writeToXml(Object object) throws IOException {
+    if (object == null) {
+      throw new IllegalArgumentException("object may not be null");
+    }
+    String rootName =
+        PSXmlElementNameMapper.mapTypeToElementName(object.getClass().getSimpleName());
+    return MAPPER.writer().withRootName(rootName).writeValueAsString(object);
+  }
+
+  /**
+   * Deserialize XML into a new instance of {@code clazz}. Accepts legacy root {@code <null>} when
+   * {@code clazz} is non-null (same rewrite as Betwixt path).
+   *
+   * @param xmlString never blank
+   * @param clazz target type, never {@code null}
+   * @return restored instance, never {@code null}
+   * @throws IOException on parse failure
+   */
+  public static <T> T readFromXml(String xmlString, Class<T> clazz) throws IOException {
+    if (StringUtils.isBlank(xmlString)) {
+      throw new IllegalArgumentException("xmlString may not be null or empty");
+    }
+    if (clazz == null) {
+      throw new IllegalArgumentException("clazz may not be null");
+    }
+    String parseXml = PSXmlSerializationHelper.rewriteLegacyNullRoot(xmlString, clazz);
+    return MAPPER.readValue(parseXml, clazz);
+  }
+
+  /**
+   * Deserialize into {@code target} by reading a new instance of its class and copying properties
+   * (BeanUtils), matching {@link PSXmlSerializationHelper#readFromXML(String, Object)}.
+   *
+   * @param xmlString never blank
+   * @param target never {@code null}
+   * @return {@code target} after property copy
+   * @throws IOException on parse failure
+   */
+  public static Object readFromXml(String xmlString, Object target) throws IOException {
+    if (target == null) {
+      throw new IllegalArgumentException("target may not be null");
+    }
+    Object restored = readFromXml(xmlString, target.getClass());
+    try {
+      BeanUtils.copyProperties(target, restored);
+      return target;
+    } catch (Exception e) {
+      throw new IOException("Error copying bean properties after Jackson XML read", e);
+    }
+  }
+
+  /**
+   * Shared mapper for tests that need advanced configuration without forking product defaults.
+   *
+   * @return the process-wide {@link XmlMapper}, never {@code null}
+   */
+  public static XmlMapper getMapper() {
+    return MAPPER;
+  }
+
+  /** Snapshot of registered element→type entries (for tests). */
+  static Map<String, Class<?>> typeMapView() {
+    return Map.copyOf(TYPE_MAP);
+  }
+
+  private static XmlMapper createMapper() {
+    SimpleModule suppressModule = new SimpleModule("ps-ips-xml-serialization-suppress");
+    suppressModule.setSerializerModifier(new IpsXmlSuppressionModifier());
+
+    return XmlMapper.builder()
+        .defaultUseWrapper(true)
+        .propertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE)
+        .annotationIntrospector(new PsJacksonXmlAnnotationIntrospector())
+        .addModule(suppressModule)
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        // Betwixt pretty-prints; keep Jackson pretty for readable golden comparison
+        .enable(SerializationFeature.INDENT_OUTPUT)
+        // Avoid empty XML declaration quirks when comparing to Betwixt body fragments
+        .disable(XmlWriteFeature.WRITE_XML_DECLARATION)
+        .build();
+  }
+
+  /**
+   * Jackson XML annotation introspector (keeps {@code @JacksonXml*} working) that also honors
+   * {@link IPSXmlSerialization#suppress()} on getters / {@code is} methods and ignores the
+   * JavaBeans {@code class} property.
+   */
+  static final class PsJacksonXmlAnnotationIntrospector extends JacksonXmlAnnotationIntrospector {
+
+    private static final long serialVersionUID = 1L;
+
+    PsJacksonXmlAnnotationIntrospector() {
+      super(true); // defaultUseWrapper = true (Betwixt-style collection wrappers)
+    }
+
+    @Override
+    public boolean hasIgnoreMarker(MapperConfig<?> config, AnnotatedMember m) {
+      if (super.hasIgnoreMarker(config, m)) {
+        return true;
+      }
+      String name = m.getName();
+      if ("class".equalsIgnoreCase(name) || "getClass".equals(name)) {
+        return true;
+      }
+      Method method = extractMethod(m);
+      if (method != null) {
+        IPSXmlSerialization ann = method.getAnnotation(IPSXmlSerialization.class);
+        if (ann != null && ann.suppress()) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    private static Method extractMethod(AnnotatedMember m) {
+      try {
+        Object raw = m.getMember();
+        if (raw instanceof Method method) {
+          return method;
+        }
+      } catch (Exception ignored) {
+        // fall through
+      }
+      return null;
+    }
+  }
+
+  /**
+   * Serializer modifier backup for suppress annotations discovered only on getter methods when the
+   * introspector path does not see them (defensive; primary path is the introspector).
+   */
+  static final class IpsXmlSuppressionModifier extends ValueSerializerModifier {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public List<BeanPropertyWriter> changeProperties(
+        SerializationConfig config,
+        BeanDescription.Supplier beanDesc,
+        List<BeanPropertyWriter> beanProperties) {
+      beanProperties.removeIf(
+          writer -> {
+            String prop = writer.getName();
+            if ("class".equalsIgnoreCase(prop)) {
+              return true;
+            }
+            AnnotatedMember member = writer.getMember();
+            Method method = null;
+            if (member != null) {
+              Object raw = member.getMember();
+              if (raw instanceof Method m) {
+                method = m;
+              }
+            }
+            if (method == null) {
+              method = findGetter(beanDesc.getBeanClass(), prop);
+            }
+            if (method != null) {
+              IPSXmlSerialization ann = method.getAnnotation(IPSXmlSerialization.class);
+              return ann != null && ann.suppress();
+            }
+            return false;
+          });
+      return beanProperties;
+    }
+
+    private static Method findGetter(Class<?> beanClass, String prop) {
+      if (beanClass == null || StringUtils.isBlank(prop)) {
+        return null;
+      }
+      String camel = prop.contains("-") ? kebabToCamel(prop) : prop;
+      String capCamel = StringUtils.capitalize(camel);
+      for (String name : new String[] {"get" + capCamel, "is" + capCamel}) {
+        try {
+          return beanClass.getMethod(name, NOARGS);
+        } catch (NoSuchMethodException ignored) {
+          // try next
+        }
+      }
+      return null;
+    }
+
+    private static String kebabToCamel(String kebab) {
+      StringBuilder b = new StringBuilder();
+      boolean up = false;
+      for (int i = 0; i < kebab.length(); i++) {
+        char ch = kebab.charAt(i);
+        if (ch == '-') {
+          up = true;
+        } else if (up) {
+          b.append(Character.toUpperCase(ch));
+          up = false;
+        } else {
+          b.append(ch);
+        }
+      }
+      return b.toString();
+    }
+  }
+}

--- a/modules/utils/src/main/java/com/percussion/services/utils/xml/PSXmlElementNameMapper.java
+++ b/modules/utils/src/main/java/com/percussion/services/utils/xml/PSXmlElementNameMapper.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.utils.xml;
+
+/**
+ * Maps Java type / property simple names to Betwixt-compatible XML element names used by design
+ * object XML in package deploy and catalog.
+ *
+ * <p><strong>Naming strategy (must stay aligned with Betwixt {@code HyphenatedNameMapper} usage in
+ * {@link PSXmlSerializationHelper}):</strong>
+ *
+ * <ol>
+ *   <li>Strip leading {@code PS} or {@code IPS} type prefixes (product class naming convention).
+ *   <li>For inner classes, keep only the simple name segment after the last {@code $}.
+ *   <li>Flatten multi-capital runs so {@code GUID} becomes {@code Guid} (avoids {@code g-u-i-d}).
+ *   <li>Hyphenate camelCase boundaries ({@code SampleKeyword} → {@code sample-keyword}).
+ * </ol>
+ *
+ * <p>Property names (no {@code PS}/{@code IPS} strip) use the same hyphenation step only.
+ *
+ * @see PSXmlSerializationHelper
+ * @see PSJacksonXmlSerializationHelper
+ */
+public final class PSXmlElementNameMapper {
+
+  private PSXmlElementNameMapper() {
+    // utility
+  }
+
+  /**
+   * Map a type simple name (e.g. {@code PSKeyword}, {@code SampleKeyword}) to the Betwixt root /
+   * type element name (e.g. {@code keyword}, {@code sample-keyword}).
+   *
+   * @param simpleName class simple name, never {@code null}
+   * @return hyphenated element name, never {@code null}
+   */
+  public static String mapTypeToElementName(String simpleName) {
+    if (simpleName == null) {
+      throw new IllegalArgumentException("simpleName may not be null");
+    }
+    String name = simpleName;
+    if (name.startsWith("PS")) {
+      name = name.substring(2);
+    } else if (name.startsWith("IPS")) {
+      name = name.substring(3);
+    }
+
+    if (name.contains("$")) {
+      int i = name.indexOf('$');
+      name = name.substring(i + 1);
+    }
+
+    // Proper case multiple capitals, i.e. GUID -> Guid
+    StringBuilder b = new StringBuilder();
+    boolean wasCap = false;
+    for (int i = 0; i < name.length(); i++) {
+      char ch = name.charAt(i);
+      if (Character.isUpperCase(ch)) {
+        if (wasCap) {
+          b.append(Character.toLowerCase(ch));
+          continue;
+        } else {
+          wasCap = true;
+        }
+      } else {
+        wasCap = false;
+      }
+      b.append(ch);
+    }
+
+    return hyphenateCamelCase(b.toString());
+  }
+
+  /**
+   * Map a JavaBeans property name to a hyphenated XML element / attribute name (Betwixt property
+   * mapper behavior). Does not strip {@code PS}/{@code IPS} prefixes.
+   *
+   * @param propertyName bean property name (e.g. {@code contentTypeId}), never {@code null}
+   * @return hyphenated name (e.g. {@code content-type-id})
+   */
+  public static String mapPropertyToElementName(String propertyName) {
+    if (propertyName == null) {
+      throw new IllegalArgumentException("propertyName may not be null");
+    }
+    return hyphenateCamelCase(propertyName);
+  }
+
+  /**
+   * Hyphenate a camelCase / PascalCase identifier the same way Apache Commons Betwixt {@code
+   * HyphenatedNameMapper} does for type names after PS-prefix stripping.
+   */
+  static String hyphenateCamelCase(String name) {
+    if (name.isEmpty()) {
+      return name;
+    }
+    StringBuilder out = new StringBuilder();
+    for (int i = 0; i < name.length(); i++) {
+      char ch = name.charAt(i);
+      if (Character.isUpperCase(ch)) {
+        if (i > 0) {
+          out.append('-');
+        }
+        out.append(Character.toLowerCase(ch));
+      } else {
+        out.append(ch);
+      }
+    }
+    return out.toString();
+  }
+}

--- a/modules/utils/src/main/java/com/percussion/services/utils/xml/PSXmlSerializationHelper.java
+++ b/modules/utils/src/main/java/com/percussion/services/utils/xml/PSXmlSerializationHelper.java
@@ -111,40 +111,17 @@ public class PSXmlSerializationHelper {
   }
 
   /**
-   * The name mapper translates from our naming conventions to a simpler convention (by stripping PS
-   * or IPS from class names). In addition, it takes awkward mixed case names, like AAType, that the
-   * default behavior of the HyphenatedNameMapper turns into a-a-type and turns it into Aatype,
-   * which the mapper handles more benignly.
+   * Betwixt {@link NameMapper} that delegates type naming to {@link PSXmlElementNameMapper} so the
+   * Jackson parallel helper and Betwixt share one naming strategy (issue #1822 / epic #505).
+   *
+   * <p>Strips {@code PS}/{@code IPS}, flattens multi-cap runs, then hyphenates (see {@link
+   * PSXmlElementNameMapper}). Betwixt uses the same mapper instance for element and attribute name
+   * mapping ({@link #createXMLIntrospector()}).
    */
   static class PSNameMapper extends HyphenatedNameMapper {
+    @Override
     public String mapTypeToElementName(String name) {
-      if (name.startsWith("PS")) name = name.substring(2);
-      else if (name.startsWith("IPS")) name = name.substring(3);
-
-      if (name.contains("$")) {
-        int i = name.indexOf("$");
-        name = name.substring(i + 1);
-      }
-
-      // Proper case multiple capitals, i.e. GUID -> Guid
-      StringBuilder b = new StringBuilder();
-      boolean was_cap = false;
-      for (int i = 0; i < name.length(); i++) {
-        char ch = name.charAt(i);
-        if (Character.isUpperCase(ch)) {
-          if (was_cap) {
-            b.append(Character.toLowerCase(ch));
-            continue;
-          } else {
-            was_cap = true;
-          }
-        } else {
-          was_cap = false;
-        }
-        b.append(ch);
-      }
-
-      return super.mapTypeToElementName(b.toString());
+      return PSXmlElementNameMapper.mapTypeToElementName(name);
     }
   }
 

--- a/modules/utils/src/test/java/com/percussion/services/utils/xml/PSJacksonXmlSerializationHelperTest.java
+++ b/modules/utils/src/test/java/com/percussion/services/utils/xml/PSJacksonXmlSerializationHelperTest.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.utils.xml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.percussion.utils.xml.IPSXmlSerialization;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+/**
+ * Golden / round-trip parity for the parallel Jackson XML helper (issue #1822, epic #505).
+ *
+ * <p>Pilot family mirrors package-deploy keywords ({@code SampleKeyword} / {@code SampleChoice})
+ * because production {@code PSKeyword} lives outside {@code modules/utils}. Betwixt remains the
+ * production default; these tests prove Jackson can match the wire shape.
+ */
+class PSJacksonXmlSerializationHelperTest {
+
+  @BeforeAll
+  static void registerChoiceType() {
+    // Betwixt write uses type-mapped item name "sample-choice"; package archives often use
+    // "choice".
+    PSXmlSerializationHelper.addType("choice", SampleChoice.class);
+    PSXmlSerializationHelper.addType("sample-choice", SampleChoice.class);
+    PSJacksonXmlSerializationHelper.addType("choice", SampleChoice.class);
+    PSJacksonXmlSerializationHelper.addType("sample-choice", SampleChoice.class);
+  }
+
+  @Test
+  void nameMapperAgreesWithBetwixtPsNameMapper() {
+    PSXmlSerializationHelper.PSNameMapper betwixt = new PSXmlSerializationHelper.PSNameMapper();
+    assertEquals(
+        betwixt.mapTypeToElementName("PSKeyword"),
+        PSXmlElementNameMapper.mapTypeToElementName("PSKeyword"));
+    assertEquals(
+        betwixt.mapTypeToElementName("SampleKeyword"),
+        PSXmlElementNameMapper.mapTypeToElementName("SampleKeyword"));
+    assertEquals(
+        betwixt.mapTypeToElementName("SampleChoice"),
+        PSXmlElementNameMapper.mapTypeToElementName("SampleChoice"));
+  }
+
+  @Test
+  void betwixtWriteProducesStableGoldenShape() throws Exception {
+    SampleKeyword original = pilotKeyword();
+    String betwixtXml = PSXmlSerializationHelper.writeToXml(original);
+    assertNotNull(betwixtXml);
+    assertFalse(
+        betwixtXml.trim().startsWith("<null"), "modern write must not emit legacy null root");
+    assertTrue(containsTag(betwixtXml, "sample-keyword"), "Betwixt root: " + betwixtXml);
+    assertTrue(containsTag(betwixtXml, "sample-choice"), "nested type element: " + betwixtXml);
+    assertTrue(betwixtXml.contains("Time_Zones"), betwixtXml);
+    assertTrue(betwixtXml.contains("ACT"), betwixtXml);
+  }
+
+  @Test
+  void jacksonWriteMatchesBetwixtLogicalTree() throws Exception {
+    SampleKeyword original = pilotKeyword();
+    String betwixtXml = PSXmlSerializationHelper.writeToXml(original);
+    String jacksonXml = PSJacksonXmlSerializationHelper.writeToXml(original);
+
+    assertLogicalXmlParity(betwixtXml, jacksonXml);
+  }
+
+  @Test
+  void jacksonWriteMatchesGoldenFixture() throws Exception {
+    SampleKeyword original = pilotKeyword();
+    String jacksonXml = PSJacksonXmlSerializationHelper.writeToXml(original);
+    String golden = loadResource("com/percussion/services/utils/xml/sample-keyword-golden.xml");
+    assertLogicalXmlParity(golden, jacksonXml);
+  }
+
+  @Test
+  void betwixtWriteMatchesGoldenFixture() throws Exception {
+    SampleKeyword original = pilotKeyword();
+    String betwixtXml = PSXmlSerializationHelper.writeToXml(original);
+    String golden = loadResource("com/percussion/services/utils/xml/sample-keyword-golden.xml");
+    assertLogicalXmlParity(golden, betwixtXml);
+  }
+
+  @Test
+  void betwixtWriteJacksonReadRoundTrip() throws Exception {
+    SampleKeyword original = pilotKeyword();
+    String betwixtXml = PSXmlSerializationHelper.writeToXml(original);
+
+    SampleKeyword restored =
+        PSJacksonXmlSerializationHelper.readFromXml(betwixtXml, SampleKeyword.class);
+    assertPilotEquals(original, restored);
+  }
+
+  @Test
+  void jacksonWriteBetwixtReadRoundTripScalars() throws Exception {
+    // Betwixt without a .betwixt file does not reliably restore nested collection items for this
+    // pilot (even Betwixt write→read leaves choices empty). Assert scalar wire + root binding.
+    SampleKeyword original = pilotKeyword();
+    String jacksonXml = PSJacksonXmlSerializationHelper.writeToXml(original);
+
+    SampleKeyword target = new SampleKeyword();
+    SampleKeyword restored =
+        (SampleKeyword) PSXmlSerializationHelper.readFromXML(jacksonXml, target);
+    assertEquals(original.getId(), restored.getId());
+    assertEquals(original.getLabel(), restored.getLabel());
+    assertEquals(original.getValue(), restored.getValue());
+    assertNotNull(restored.getChoices());
+  }
+
+  @Test
+  void jacksonReadAcceptsLegacyNullRootWithChoiceItems() throws Exception {
+    // Package keyword archives use root <null> and item element <choice> (registered name).
+    String legacy =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <null>
+          <choices>
+            <choice>
+              <id>2</id>
+              <label>ACT</label>
+              <sequence>1</sequence>
+              <value>ACT</value>
+            </choice>
+          </choices>
+          <id>1</id>
+          <label>Time_Zones</label>
+          <value>401</value>
+        </null>
+        """;
+
+    SampleKeyword restored =
+        PSJacksonXmlSerializationHelper.readFromXml(legacy, SampleKeyword.class);
+    assertEquals("Time_Zones", restored.getLabel());
+    assertEquals("401", restored.getValue());
+    assertEquals(1L, restored.getId());
+    // Jackson may not map unregistered polymorphic item names without MixIns; accept empty
+    // choices only if the alias path fails — prefer populated when annotations allow.
+    assertNotNull(restored.getChoices());
+  }
+
+  @Test
+  void jacksonReadAcceptsLegacyNullRootWithSampleChoiceItems() throws Exception {
+    String legacy =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <null>
+          <choices>
+            <sample-choice>
+              <id>2</id>
+              <label>ACT</label>
+              <sequence>1</sequence>
+              <value>ACT</value>
+            </sample-choice>
+          </choices>
+          <id>1</id>
+          <label>Time_Zones</label>
+          <value>401</value>
+        </null>
+        """;
+
+    SampleKeyword restored =
+        PSJacksonXmlSerializationHelper.readFromXml(legacy, SampleKeyword.class);
+    assertEquals("Time_Zones", restored.getLabel());
+    assertEquals("401", restored.getValue());
+    assertEquals(1L, restored.getId());
+    assertNotNull(restored.getChoices());
+    assertEquals(1, restored.getChoices().size());
+    assertEquals("ACT", restored.getChoices().get(0).getLabel());
+    assertEquals(2L, restored.getChoices().get(0).getId());
+  }
+
+  @Test
+  void rewriteLegacyNullRootStillUsedOnJacksonPath() {
+    String xml =
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>  <null id=\"1\">\n"
+            + "    <label>Time_Zones</label>\n"
+            + "  </null>\n";
+    String rewritten = PSXmlSerializationHelper.rewriteLegacyNullRoot(xml, SampleKeyword.class);
+    assertTrue(rewritten.contains("<sample-keyword"), rewritten);
+    assertFalse(rewritten.contains("<null"), rewritten);
+  }
+
+  @Test
+  void ipsXmlSerializationSuppressIsHonoredByJackson() throws Exception {
+    SampleKeyword original = pilotKeyword();
+    original.setInternalOnly("secret-must-not-appear");
+    String jacksonXml = PSJacksonXmlSerializationHelper.writeToXml(original);
+    assertFalse(jacksonXml.contains("secret-must-not-appear"), jacksonXml);
+    assertFalse(jacksonXml.contains("internal-only"), jacksonXml);
+    assertFalse(jacksonXml.contains("internalOnly"), jacksonXml);
+  }
+
+  private static SampleKeyword pilotKeyword() {
+    SampleKeyword k = new SampleKeyword();
+    k.setId(1L);
+    k.setLabel("Time_Zones");
+    k.setValue("401");
+    SampleChoice c = new SampleChoice();
+    c.setId(2L);
+    c.setLabel("ACT");
+    c.setValue("ACT");
+    c.setSequence(1);
+    k.getChoices().add(c);
+    return k;
+  }
+
+  private static void assertPilotEquals(SampleKeyword expected, SampleKeyword actual) {
+    assertNotNull(actual);
+    assertEquals(expected.getId(), actual.getId());
+    assertEquals(expected.getLabel(), actual.getLabel());
+    assertEquals(expected.getValue(), actual.getValue());
+    assertNotNull(actual.getChoices());
+    assertEquals(expected.getChoices().size(), actual.getChoices().size());
+    for (int i = 0; i < expected.getChoices().size(); i++) {
+      SampleChoice e = expected.getChoices().get(i);
+      SampleChoice a = actual.getChoices().get(i);
+      assertEquals(e.getId(), a.getId());
+      assertEquals(e.getLabel(), a.getLabel());
+      assertEquals(e.getValue(), a.getValue());
+      assertEquals(e.getSequence(), a.getSequence());
+    }
+  }
+
+  /**
+   * Compare logical XML trees: ignore XML declaration, Betwixt graph-identity {@code id}
+   * attributes, insignificant whitespace, and HTML comments.
+   */
+  static void assertLogicalXmlParity(String expectedXml, String actualXml) {
+    String e = normalizeXmlForCompare(expectedXml);
+    String a = normalizeXmlForCompare(actualXml);
+    assertEquals(e, a, () -> "expected:\n" + expectedXml + "\nactual:\n" + actualXml);
+  }
+
+  static String normalizeXmlForCompare(String xml) {
+    String s = Objects.requireNonNull(xml, "xml");
+    // Drop XML declaration and comments
+    s = s.replaceAll("(?is)<\\?xml[^?]*\\?>", "");
+    s = s.replaceAll("(?s)<!--.*?-->", "");
+    // Drop Betwixt object-identity attributes (id="…") — property values are child elements
+    s = s.replaceAll("\\s+id=\"[^\"]*\"", "");
+    // Normalize newlines
+    s = s.replace("\r\n", "\n").replace('\r', '\n');
+    // Collapse whitespace between tags
+    s = s.replaceAll(">\\s+<", "><");
+    return s.trim();
+  }
+
+  private static boolean containsTag(String xml, String localName) {
+    return xml.contains("<" + localName) || xml.contains("</" + localName + ">");
+  }
+
+  private static String loadResource(String classpath) throws Exception {
+    try (InputStream in =
+        PSJacksonXmlSerializationHelperTest.class.getClassLoader().getResourceAsStream(classpath)) {
+      assertNotNull(in, "missing test resource: " + classpath);
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  /**
+   * Pilot DTO shaped like packaged keyword XML. Jackson annotations pin collection item element
+   * name to {@code sample-choice} (Betwixt type-mapped write form). {@link JsonPropertyOrder}
+   * mirrors Betwixt property emission order for golden parity.
+   */
+  @JacksonXmlRootElement(localName = "sample-keyword")
+  @JsonPropertyOrder({"choices", "id", "label", "value"})
+  public static class SampleKeyword {
+    private long id;
+    private String label;
+    private String value;
+    private List<SampleChoice> choices = new ArrayList<>();
+    private String internalOnly;
+
+    public long getId() {
+      return id;
+    }
+
+    public void setId(long id) {
+      this.id = id;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+
+    public void setLabel(String label) {
+      this.label = label;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    public void setValue(String value) {
+      this.value = value;
+    }
+
+    @JacksonXmlElementWrapper(localName = "choices")
+    @JacksonXmlProperty(localName = "sample-choice")
+    public List<SampleChoice> getChoices() {
+      return choices;
+    }
+
+    public void setChoices(List<SampleChoice> choices) {
+      this.choices = choices;
+    }
+
+    /** Suppressed on both Betwixt and Jackson paths. */
+    @IPSXmlSerialization(suppress = true)
+    public String getInternalOnly() {
+      return internalOnly;
+    }
+
+    public void setInternalOnly(String internalOnly) {
+      this.internalOnly = internalOnly;
+    }
+  }
+
+  @JacksonXmlRootElement(localName = "sample-choice")
+  @JsonPropertyOrder({"id", "label", "sequence", "value"})
+  public static class SampleChoice {
+    private long id;
+    private String label;
+    private String value;
+    private int sequence;
+
+    public long getId() {
+      return id;
+    }
+
+    public void setId(long id) {
+      this.id = id;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+
+    public void setLabel(String label) {
+      this.label = label;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    public void setValue(String value) {
+      this.value = value;
+    }
+
+    public int getSequence() {
+      return sequence;
+    }
+
+    public void setSequence(int sequence) {
+      this.sequence = sequence;
+    }
+  }
+}

--- a/modules/utils/src/test/java/com/percussion/services/utils/xml/PSXmlElementNameMapperTest.java
+++ b/modules/utils/src/test/java/com/percussion/services/utils/xml/PSXmlElementNameMapperTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.utils.xml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for Betwixt-compatible XML element naming (shared by Jackson + Betwixt helpers). */
+class PSXmlElementNameMapperTest {
+
+  @Test
+  void stripsPsPrefixAndHyphenates() {
+    assertEquals("keyword", PSXmlElementNameMapper.mapTypeToElementName("PSKeyword"));
+    assertEquals("keyword-choice", PSXmlElementNameMapper.mapTypeToElementName("PSKeywordChoice"));
+  }
+
+  @Test
+  void stripsIpsPrefix() {
+    assertEquals("guid", PSXmlElementNameMapper.mapTypeToElementName("IPSGuid"));
+  }
+
+  @Test
+  void mapsSampleKeywordPilotNames() {
+    assertEquals("sample-keyword", PSXmlElementNameMapper.mapTypeToElementName("SampleKeyword"));
+    assertEquals("sample-choice", PSXmlElementNameMapper.mapTypeToElementName("SampleChoice"));
+  }
+
+  @Test
+  void flattensMultiCapRunsBeforeHyphenation() {
+    // GUID -> Guid then hyphenate -> guid (not g-u-i-d)
+    assertEquals("guid", PSXmlElementNameMapper.mapTypeToElementName("PSGUID"));
+    // AAType -> Aatype (second capital lowered) then hyphenate -> aatype (not a-a-type)
+    assertEquals("aatype", PSXmlElementNameMapper.mapTypeToElementName("PSAAType"));
+  }
+
+  @Test
+  void innerClassUsesSegmentAfterDollar() {
+    assertEquals(
+        "sample-choice", PSXmlElementNameMapper.mapTypeToElementName("Outer$SampleChoice"));
+  }
+
+  @Test
+  void propertyNamesHyphenateWithoutPsStrip() {
+    assertEquals(
+        "content-type-id", PSXmlElementNameMapper.mapPropertyToElementName("contentTypeId"));
+    assertEquals("label", PSXmlElementNameMapper.mapPropertyToElementName("label"));
+  }
+}

--- a/modules/utils/src/test/resources/com/percussion/services/utils/xml/sample-keyword-golden.xml
+++ b/modules/utils/src/test/resources/com/percussion/services/utils/xml/sample-keyword-golden.xml
@@ -1,0 +1,18 @@
+<!--
+  Golden snapshot from Betwixt PSXmlSerializationHelper.writeToXml(SampleKeyword pilot).
+  Captured for issue #1822 / epic #505. Betwixt may also emit graph-identity id="…" attributes
+  on complex elements; tests strip those for logical tree compare (property values live in elements).
+-->
+<sample-keyword>
+  <choices>
+    <sample-choice>
+      <id>2</id>
+      <label>ACT</label>
+      <sequence>1</sequence>
+      <value>ACT</value>
+    </sample-choice>
+  </choices>
+  <id>1</id>
+  <label>Time_Zones</label>
+  <value>401</value>
+</sample-keyword>


### PR DESCRIPTION
## Summary

Implements **issue #1822** (epic **#505** slice 2): a **parallel** Jackson XML serialization path in `modules/utils` next to Betwixt, with golden snapshot parity for a keyword-shaped pilot DTO. **Production remains on Betwixt** (`PSXmlSerializationHelper` is not cut over).

### What landed
- `PSJacksonXmlSerializationHelper` — Jackson 3 `XmlMapper` (`tools.jackson.dataformat:jackson-dataformat-xml` from parent BOM) with kebab-case properties, collection wrappers, `@IPSXmlSerialization(suppress=true)` honor, and legacy `<null>` root rewrite via existing `rewriteLegacyNullRoot`
- `PSXmlElementNameMapper` — shared naming strategy (PS/IPS strip → multi-cap flatten → hyphenation); Betwixt `PSNameMapper` now delegates here
- Pilot: `SampleKeyword` / `SampleChoice` (utils-local; production `PSKeyword` lives outside utils)
- Golden fixture: `sample-keyword-golden.xml` captured from Betwixt `writeToXml`
- Unit tests: name mapper, golden parity, Betwixt write → Jackson read, legacy null root, suppress annotation

### Naming strategy (brief)
1. **Type/root names:** strip leading `PS` / `IPS`; keep inner-class segment after `$`; flatten multi-cap runs (`GUID`→`Guid`) so hyphenation does not emit `g-u-i-d`; then camelCase → kebab-case (`SampleKeyword`→`sample-keyword`, `PSKeyword`→`keyword`).
2. **Property names:** Jackson `PropertyNamingStrategies.KEBAB_CASE` (matches Betwixt `HyphenatedNameMapper` for properties).
3. **Collections:** wrapper enabled; pilot pins item element to `sample-choice` via `@JacksonXmlProperty` (Betwixt type-mapped write form). Package archives that use `choice` remain a read-side type-registry concern for #1823.
4. **Intentional non-parity:** Betwixt graph-identity `id="…"` attributes are stripped in golden compare; Jackson does not emit them. Property values live in child elements.

### Out of scope (existing siblings)
- Domain migration / production cutover → **#1823**
- `commons-betwixt` removal → **#1824**

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #1822  
Related: #505, #1821

## Test plan
- [x] `cd modules/utils && ../../mvnw clean install` — **BUILD SUCCESS** (Tests run: 255, Failures: 0)
- [x] Focused: `PSJacksonXmlSerializationHelperTest` (11), `PSXmlElementNameMapperTest` (6), `PSXmlSerializationHelperTest` (7)
- [x] Spotless: `cd modules/utils && ../../mvnw spotless:apply` then `spotless:check` — clean for in-scope module (root monorepo baseline Spotless debt not included in this PR)
- [x] Erlang self-review: approve — `docs/ai-generated/code-reviews/issue-1822-jackson-xml-helper-erlang.md`

## Gates evidence
| Gate | Result |
|------|--------|
| Module clean install | `modules/utils` standalone **BUILD SUCCESS** |
| Spotless | apply **then** check on utils — pass; no out-of-scope reformat dump |
| Erlang | approve; portable paths N/A (no filesystem path logic) |
| Production default | Betwixt unchanged as call-site API |