### PR TITLE
test(webui): residual Vitest title i18n for Home gadgets (#1832+)

### DIFF
--- a/WebUI/src/test/ts/dashboard/CommentsWidget.test.tsx
+++ b/WebUI/src/test/ts/dashboard/CommentsWidget.test.tsx
@@ -2,10 +2,11 @@
  * Copyright 1999-2026 Percussion Software, Inc.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { CommentsWidget } from "@/dashboard/CommentsWidget";
 import * as api from "@/api/dashboard/deliveryGadgetsApi";
+import { MSG } from "@/i18n/message";
 
 vi.mock("@/api/dashboard/deliveryGadgetsApi", async (importOriginal) => {
   const actual =
@@ -16,6 +17,29 @@ vi.mock("@/api/dashboard/deliveryGadgetsApi", async (importOriginal) => {
 describe("CommentsWidget", () => {
   beforeEach(() => {
     vi.mocked(api.fetchDefaultPagesWithComments).mockReset();
+    delete (window as { I18N?: unknown }).I18N;
+  });
+
+  afterEach(() => {
+    delete (window as { I18N?: unknown }).I18N;
+  });
+
+  it("localizes default title via I18N when key resolves (GH-1835)", async () => {
+    (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
+      message: (k: string) =>
+        k === MSG.GADGET_COMMENTS ? "टिप्पणियाँ" : k,
+    };
+    vi.mocked(api.fetchDefaultPagesWithComments).mockResolvedValue({
+      site: "Demo",
+      pages: [],
+    });
+    render(<CommentsWidget refreshInterval={0} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("comments-widget")).toBeDefined();
+    });
+    const titleEl = screen.getByTestId("comments-widget").querySelector("div");
+    expect(titleEl?.textContent).toBe("टिप्पणियाँ");
+    expect(titleEl?.textContent).not.toBe("COMMENTS");
   });
 
   it("lists pages with comments", async () => {

--- a/WebUI/src/test/ts/dashboard/CookieConsentWidget.test.tsx
+++ b/WebUI/src/test/ts/dashboard/CookieConsentWidget.test.tsx
@@ -2,10 +2,11 @@
  * Copyright 1999-2026 Percussion Software, Inc.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { CookieConsentWidget } from "@/dashboard/CookieConsentWidget";
 import * as api from "@/api/dashboard/deliveryGadgetsApi";
+import { MSG } from "@/i18n/message";
 
 vi.mock("@/api/dashboard/deliveryGadgetsApi", async (importOriginal) => {
   const actual =
@@ -16,6 +17,32 @@ vi.mock("@/api/dashboard/deliveryGadgetsApi", async (importOriginal) => {
 describe("CookieConsentWidget", () => {
   beforeEach(() => {
     vi.mocked(api.fetchCookieConsentTotals).mockReset();
+    delete (window as { I18N?: unknown }).I18N;
+  });
+
+  afterEach(() => {
+    delete (window as { I18N?: unknown }).I18N;
+  });
+
+  it("localizes default title via I18N when key resolves (GH-1836)", async () => {
+    (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
+      message: (k: string) =>
+        k === MSG.GADGET_COOKIE_CONSENT ? "कुकी सहमति" : k,
+    };
+    vi.mocked(api.fetchCookieConsentTotals).mockResolvedValue({
+      raw: {},
+      bySite: [],
+      grandTotal: 0,
+    });
+    render(<CookieConsentWidget refreshInterval={0} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("cookie-consent-widget")).toBeDefined();
+    });
+    const titleEl = screen
+      .getByTestId("cookie-consent-widget")
+      .querySelector("div");
+    expect(titleEl?.textContent).toBe("कुकी सहमति");
+    expect(titleEl?.textContent).not.toBe("COOKIE CONSENT");
   });
 
   it("lists totals by site", async () => {

--- a/WebUI/src/test/ts/dashboard/EffectivenessWidget.test.tsx
+++ b/WebUI/src/test/ts/dashboard/EffectivenessWidget.test.tsx
@@ -2,11 +2,12 @@
  * Copyright 1999-2026 Percussion Software, Inc.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { EffectivenessWidget } from "@/dashboard/EffectivenessWidget";
 import * as gadgetApi from "@/api/dashboard/gadgetApi";
 import * as analyticsApi from "@/api/dashboard/analyticsApi";
+import { MSG } from "@/i18n/message";
 
 vi.mock("@/api/dashboard/gadgetApi", async (importOriginal) => {
   const actual =
@@ -32,6 +33,32 @@ describe("EffectivenessWidget", () => {
     vi.mocked(analyticsApi.isAnalyticsProviderConfigured)
       .mockReset()
       .mockResolvedValue(true);
+    delete (window as { I18N?: unknown }).I18N;
+  });
+
+  afterEach(() => {
+    delete (window as { I18N?: unknown }).I18N;
+  });
+
+  it("localizes default title via I18N when key resolves (GH-1834)", async () => {
+    (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
+      message: (k: string) =>
+        k === MSG.GADGET_WHATS_WORKING ? "क्या काम कर रहा है" : k,
+    };
+    vi.mocked(analyticsApi.isAnalyticsProviderConfigured).mockResolvedValue(
+      false,
+    );
+    render(<EffectivenessWidget refreshInterval={0} />);
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("effectiveness-widget-needs-analytics"),
+      ).toBeDefined();
+    });
+    const titleEl = screen
+      .getByTestId("effectiveness-widget")
+      .querySelector("div");
+    expect(titleEl?.textContent).toBe("क्या काम कर रहा है");
+    expect(titleEl?.textContent).not.toBe("What's Working");
   });
 
   it("prompts for Google Setup when analytics missing", async () => {

--- a/WebUI/src/test/ts/dashboard/FormsTrackerWidget.test.tsx
+++ b/WebUI/src/test/ts/dashboard/FormsTrackerWidget.test.tsx
@@ -2,10 +2,11 @@
  * Copyright 1999-2026 Percussion Software, Inc.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { FormsTrackerWidget } from "@/dashboard/FormsTrackerWidget";
 import * as gadgetApi from "@/api/dashboard/gadgetApi";
+import { MSG } from "@/i18n/message";
 
 vi.mock("@/api/dashboard/gadgetApi", async (importOriginal) => {
   const actual =
@@ -21,6 +22,31 @@ describe("FormsTrackerWidget", () => {
   beforeEach(() => {
     vi.mocked(gadgetApi.fetchFormsForDefaultSite).mockReset();
     vi.mocked(gadgetApi.fetchFormsForSite).mockReset();
+    delete (window as { I18N?: unknown }).I18N;
+  });
+
+  afterEach(() => {
+    delete (window as { I18N?: unknown }).I18N;
+  });
+
+  it("localizes default title via I18N when key resolves (GH-1837)", async () => {
+    (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
+      message: (k: string) =>
+        k === MSG.GADGET_FORM_TRACKER ? "फ़ॉर्म ट्रैकर" : k,
+    };
+    vi.mocked(gadgetApi.fetchFormsForDefaultSite).mockResolvedValue({
+      site: "Demo",
+      forms: [],
+    });
+    render(<FormsTrackerWidget refreshInterval={0} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("forms-tracker-empty")).toBeDefined();
+    });
+    const titleEl = screen
+      .getByTestId("forms-tracker-widget")
+      .querySelector("div");
+    expect(titleEl?.textContent).toBe("फ़ॉर्म ट्रैकर");
+    expect(titleEl?.textContent).not.toBe("Form Tracker");
   });
 
   it("lists forms for default site", async () => {

--- a/WebUI/src/test/ts/dashboard/GlobalVariablesWidget.test.tsx
+++ b/WebUI/src/test/ts/dashboard/GlobalVariablesWidget.test.tsx
@@ -2,10 +2,11 @@
  * Copyright 1999-2026 Percussion Software, Inc.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { GlobalVariablesWidget } from "@/dashboard/GlobalVariablesWidget";
 import * as gadgetApi from "@/api/dashboard/gadgetApi";
+import { MSG } from "@/i18n/message";
 
 vi.mock("@/api/dashboard/gadgetApi", async (importOriginal) => {
   const actual =
@@ -19,6 +20,28 @@ vi.mock("@/api/dashboard/gadgetApi", async (importOriginal) => {
 describe("GlobalVariablesWidget", () => {
   beforeEach(() => {
     vi.mocked(gadgetApi.fetchGlobalVariables).mockReset();
+    delete (window as { I18N?: unknown }).I18N;
+  });
+
+  afterEach(() => {
+    delete (window as { I18N?: unknown }).I18N;
+  });
+
+  it("localizes default title via I18N when key resolves (GH-1839)", async () => {
+    (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
+      message: (k: string) =>
+        k === MSG.GADGET_GLOBAL_VARIABLES ? "वैश्विक चर" : k,
+    };
+    vi.mocked(gadgetApi.fetchGlobalVariables).mockResolvedValue([]);
+    render(<GlobalVariablesWidget />);
+    await waitFor(() => {
+      expect(screen.getByTestId("global-variables-empty")).toBeDefined();
+    });
+    const titleEl = screen
+      .getByTestId("global-variables-widget")
+      .querySelector("div");
+    expect(titleEl?.textContent).toBe("वैश्विक चर");
+    expect(titleEl?.textContent).not.toBe("Global Variables");
   });
 
   it("lists variables", async () => {

--- a/WebUI/src/test/ts/dashboard/GoogleSetupWidget.test.tsx
+++ b/WebUI/src/test/ts/dashboard/GoogleSetupWidget.test.tsx
@@ -2,10 +2,11 @@
  * Copyright 1999-2026 Percussion Software, Inc.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { GoogleSetupWidget } from "@/dashboard/GoogleSetupWidget";
 import * as analyticsApi from "@/api/dashboard/analyticsApi";
+import { MSG } from "@/i18n/message";
 
 vi.mock("@/api/dashboard/analyticsApi", async (importOriginal) => {
   const actual =
@@ -26,6 +27,31 @@ describe("GoogleSetupWidget", () => {
     vi.mocked(analyticsApi.fetchAnalyticsProfiles).mockReset();
     vi.mocked(analyticsApi.testAnalyticsConnection).mockReset();
     vi.mocked(analyticsApi.saveAnalyticsSiteMappings).mockReset();
+    delete (window as { I18N?: unknown }).I18N;
+  });
+
+  afterEach(() => {
+    delete (window as { I18N?: unknown }).I18N;
+  });
+
+  it("localizes default title via I18N when key resolves (GH-1833)", async () => {
+    (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
+      message: (k: string) =>
+        k === MSG.GADGET_GOOGLE_SETUP ? "गूगल सेटअप" : k,
+    };
+    vi.mocked(analyticsApi.fetchGoogleSetupSummary).mockResolvedValue({
+      provider: { configured: false, userId: null, siteProfiles: [] },
+      sites: [],
+    });
+    render(<GoogleSetupWidget />);
+    await waitFor(() => {
+      expect(screen.getByTestId("google-setup-content")).toBeDefined();
+    });
+    const titleEl = screen
+      .getByTestId("google-setup-widget")
+      .querySelector("div");
+    expect(titleEl?.textContent).toBe("गूगल सेटअप");
+    expect(titleEl?.textContent).not.toBe("Google Setup");
   });
 
   it("shows not configured and configure form", async () => {

--- a/WebUI/src/test/ts/dashboard/TrafficWidget.test.tsx
+++ b/WebUI/src/test/ts/dashboard/TrafficWidget.test.tsx
@@ -2,11 +2,12 @@
  * Copyright 1999-2026 Percussion Software, Inc.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { TrafficWidget } from "@/dashboard/TrafficWidget";
 import * as gadgetApi from "@/api/dashboard/gadgetApi";
 import * as analyticsApi from "@/api/dashboard/analyticsApi";
+import { MSG } from "@/i18n/message";
 
 vi.mock("@/api/dashboard/gadgetApi", async (importOriginal) => {
   const actual =
@@ -48,6 +49,34 @@ describe("TrafficWidget", () => {
     vi.mocked(analyticsApi.isAnalyticsProviderConfigured)
       .mockReset()
       .mockResolvedValue(true);
+    delete (window as { I18N?: unknown }).I18N;
+  });
+
+  afterEach(() => {
+    delete (window as { I18N?: unknown }).I18N;
+  });
+
+  it("localizes default title via I18N when key resolves (GH-1832)", async () => {
+    (window as unknown as { I18N: { message: (k: string) => string } }).I18N = {
+      message: (k: string) =>
+        k === MSG.GADGET_TRAFFIC ? "ट्रैफ़िक" : k,
+    };
+    vi.mocked(gadgetApi.fetchDefaultContentTraffic).mockResolvedValue({
+      path: "/Sites/Demo",
+      site: "Demo",
+      startDate: "01/01/2026",
+      endDate: "01/31/2026",
+      totalVisits: 0,
+      totalLivePages: 0,
+      points: [],
+    });
+    render(<TrafficWidget refreshInterval={0} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("traffic-widget")).toBeDefined();
+    });
+    const titleEl = screen.getByTestId("traffic-widget").querySelector("div");
+    expect(titleEl?.textContent).toBe("ट्रैफ़िक");
+    expect(titleEl?.textContent).not.toBe("TRAFFIC");
   });
 
   it("renders traffic metrics and chart", async () => {


### PR DESCRIPTION
## Summary

Residual Vitest coverage for Home gadget **default title** localization after product title wiring landed in #1851.

Product widgets already use `title ?? message(MSG.GADGET_*)` (no English re-hardcoding). This PR only adds missing unit tests that:

1. Stub `window.I18N.message` for the widget's `MSG.GADGET_*` key
2. Render with default (omitted) `title`
3. Assert the localized `widgetTitle` text is used (not the English fallback)

### Gadgets covered (new tests)

| Issue | Widget | MSG key |
|-------|--------|---------|
| #1832 | Traffic | `GADGET_TRAFFIC` |
| #1833 | Google Setup | `GADGET_GOOGLE_SETUP` |
| #1834 | What's Working / Effectiveness | `GADGET_WHATS_WORKING` |
| #1835 | Comments | `GADGET_COMMENTS` |
| #1836 | Cookie Consent | `GADGET_COOKIE_CONSENT` |
| #1837 | Form Tracker | `GADGET_FORM_TRACKER` |
| #1839 | Global Variables | `GADGET_GLOBAL_VARIABLES` |

### Re-verified peer title tests (still green)

| Issue | Widget |
|-------|--------|
| #1826 | Activity |
| #1828 | Assets By Status |
| #1829 | Blogs |
| #1830 | Process Monitor |
| (peer) | Workflow Status (#1831 style) |

### Out of scope (separate issues)

- Playwright live-locale regression for Home gadgets (#1876 / #1894 if required later)
- TMX/perc-i18n key additions (keys already present; no MSG/TMX changes)

Fixes #1832
Fixes #1833
Fixes #1834
Fixes #1835
Fixes #1836
Fixes #1837
Fixes #1839
Fixes #1826
Fixes #1828
Fixes #1829
Fixes #1830

## Test plan

- [x] Vitest focused suite: 12 widget test files / 42 tests green (new + peer title tests)
- [x] `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1153, Failures: 0
- [x] Spotless: `mvnw.cmd spotless:apply -pl WebUI` then `spotless:check -pl WebUI` (exit 0; only in-scope test files committed)
- [x] No product TS/Java changes; no perc-i18n/TMX edits
- [x] Erlang-style self-review: tests-only change-class; I18N stubs cleaned in `afterEach`; pattern matches `ActivityWidget.test.tsx` / `AssetsStatusWidget.test.tsx`

### Gates evidence

- **Spotless:** apply then check on WebUI — BUILD SUCCESS; feature PR contains only the 7 test files above
- **Maven:** `cd WebUI; ..\mvnw.cmd clean install` — BUILD SUCCESS; Vitest via frontend plugin: 180 files / 1153 tests passed
- **Operator:** Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.