### PR TITLE
fix(distribution): upgrade-safe Publish_Now ACTION replace (GH-1884)

### DIFF
--- a/docs/ai-generated/tasks/1817-publishing-faces-inventory/audit.md
+++ b/docs/ai-generated/tasks/1817-publishing-faces-inventory/audit.md
@@ -63,15 +63,15 @@ Outcome → JSP table: see removal inventory section **Historical faces outcomes
 
 ## Grep consumer audit (non-nav residuals)
 
-|                        Location                        |                           Match                            |                    Classification                     |
-|--------------------------------------------------------|------------------------------------------------------------|-------------------------------------------------------|
-| `PSDemandPublishServlet.java`                          | `getRequestDispatcher("/ui/pubruntime/DemandPublish.jsp")` | **Required rewire** before deleting DemandPublish.jsp |
-| web.xml (×3 trees)                                     | `/publisher/demandpublishing` → DemandPublishingServlet    | Keep mapping                                          |
-| `PSRunEdition.java`                                    | builds `/ui/pubruntime/JobPubLog.faces?…`                  | **Required rewire** (already dead without JSF)        |
-| `cmsTableData.xml` / `RxffTableData.xml` / FastForward | `../ui/publishing/publish.jsp` Publish_Now                 | **Required rewire** or KEEP publish.jsp               |
-| `dce_header.jsp`                                       | modern section links only                                  | Nav OK                                                |
-| Deep JSPs themselves                                   | mutual includes of auth / Trinidad tags                    | Dead without JSF runtime; packaged residual only      |
-| Modern TS under `src/main/ts/publishing`               | design/runtime React sections                              | Replacement product UI — retain                       |
+|                        Location                        |                           Match                            |                                                          Classification                                                          |
+|--------------------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| `PSDemandPublishServlet.java`                          | `getRequestDispatcher("/ui/pubruntime/DemandPublish.jsp")` | **Required rewire** before deleting DemandPublish.jsp                                                                            |
+| web.xml (×3 trees)                                     | `/publisher/demandpublishing` → DemandPublishingServlet    | Keep mapping                                                                                                                     |
+| `PSRunEdition.java`                                    | builds `/ui/pubruntime/JobPubLog.faces?…`                  | **Required rewire** (already dead without JSF)                                                                                   |
+| `cmsTableData.xml` / `RxffTableData.xml` / FastForward | Publish_Now / EI_Publish_Now seed URL                      | **Done (#1843 + #1884):** `../publisher/demandpublishing`; ACTION 217 `action=r` / `onTableCreateOnly=no` upgrades existing rows |
+| `dce_header.jsp`                                       | modern section links only                                  | Nav OK                                                                                                                           |
+| Deep JSPs themselves                                   | mutual includes of auth / Trinidad tags                    | Dead without JSF runtime; packaged residual only                                                                                 |
+| Modern TS under `src/main/ts/publishing`               | design/runtime React sections                              | Replacement product UI — retain                                                                                                  |
 
 ## File counts (tracked)
 

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/RxffTableData.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/RxffTableData.xml
@@ -7334,12 +7334,15 @@ $rx.location.getFirstDefined($sys.item,'rx:inactiveimg_ext,rx:sys_suffix', '.gif
 			<column name="HANDLER">SERVER</column>
 			<column name="VERSION">0</column>
 		</row>
+		<!-- URL rewired from legacy ui/publishing/publish.jsp to PSDemandPublishServlet
+		     mapping (RET-06 / issue #1843). Params (sys_editionid, sys_contentid, sys_folderid)
+		     unchanged. -->
 		<row action="r" onTableCreateOnly="no">
 			<column name="ACTIONID">1012</column>
 			<column name="NAME">EI_Publish_Now</column>
 			<column name="DISPLAYNAME">EI Publish Now</column>
 			<column name="DESCRIPTION">Publish the selected folders or items immediately</column>
-			<column name="URL">../ui/publishing/publish.jsp</column>
+			<column name="URL">../publisher/demandpublishing</column>
 			<column name="SORTORDER">350</column>
 			<column name="TYPE">MENUITEM</column>
 			<column name="HANDLER">SERVER</column>

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableData.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/data/cmsTableData.xml
@@ -6460,14 +6460,17 @@
             <column name="HANDLER">SERVER</column>
             <column name="VERSION">0</column>
         </row>
-        <!-- This action was moved from FF because it is now generic. For
-         backwards compatibility, only add on a clean install. -->
-        <row action="i" onTableCreateOnly="yes">
+        <!-- Moved from FF as a generic SERVER MENUITEM. URL rewired from legacy
+         ui/publishing/publish.jsp to PSDemandPublishServlet mapping (RET-06 / #1843).
+         Upgrade-safe replace (#1884): action=r / onTableCreateOnly=no so existing DB
+         ACTION 217 rows that still point at publish.jsp are rewritten on tabledata load
+         (peer of FF EI_Publish_Now). Params (sys_contentid, sys_folderid, sys_siteid) unchanged. -->
+        <row action="r" onTableCreateOnly="no">
             <column name="ACTIONID">217</column>
             <column name="NAME">Publish_Now</column>
             <column name="DISPLAYNAME">Publish Now</column>
             <column name="DESCRIPTION">Publish the selected folders or items immediately.</column>
-            <column name="URL">../ui/publishing/publish.jsp</column>
+            <column name="URL">../publisher/demandpublishing</column>
             <column name="SORTORDER">350</column>
             <column name="TYPE">MENUITEM</column>
             <column name="HANDLER">SERVER</column>

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/PublishNowActionSeedUrlTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/PublishNowActionSeedUrlTest.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.distribution.install;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * Regression guard for RET-06 / issues #1843 and #1884: Publish Now SERVER MENUITEM seed URLs must
+ * target the stable demand-publish servlet path, not the legacy Design-tree demand JSP, and ACTION
+ * 217 must use upgrade-safe tabledata replace flags so existing DBs are rewritten.
+ *
+ * <p>Peer seed-data guards: {@link SampleSiteLocaleStripTest}. Target path matches {@code web.xml}
+ * mapping {@code /publisher/demandpublishing} ({@code PSDemandPublishServlet}) and the same query
+ * params historically used by {@code ui/publishing/publish.jsp} ({@code sys_contentid}, {@code
+ * sys_folderid}, {@code sys_siteid} / edition id for FF).
+ *
+ * <p>Paths use {@link Path#of(String, String...)} / {@link Path#resolve(String)} only (portable
+ * across Windows and Unix). Assertions are URL-string shape, never OS file separators.
+ */
+@Tag("UnitTest")
+class PublishNowActionSeedUrlTest {
+
+  /** Relative to module CWD when Surefire runs standalone {@code clean install}. */
+  private static final Path CMS_TABLE_DATA =
+      Path.of("src/main/resources/distribution/rxconfig/Installer/data/cmsTableData.xml");
+
+  private static final Path RXFF_TABLE_DATA =
+      Path.of("src/main/resources/distribution/rxconfig/Installer/data/RxffTableData.xml");
+
+  /**
+   * FastForward MSM/source peer kept in lockstep with the distribution Rxff seed (repo-relative
+   * from this module).
+   */
+  private static final Path FF_RXFF_TABLE_DATA =
+      Path.of("..", "..", "system", "FastForward", "Core", "Config", "Data", "RxffTableData.xml");
+
+  /** Context-relative SERVER MENUITEM URL peer of other action seeds ({@code ../…}). */
+  static final String EXPECTED_PUBLISH_NOW_URL = "../publisher/demandpublishing";
+
+  private static final String LEGACY_PUBLISH_JSP = "ui/publishing/publish.jsp";
+
+  /** TableFactory replace — peer of FF {@code EI_Publish_Now} and other upgrade rows. */
+  private static final String UPGRADE_SAFE_ACTION = "r";
+
+  private static final String UPGRADE_SAFE_ON_CREATE_ONLY = "no";
+
+  @Test
+  void cmsPublishNowAction_pointsAtDemandPublishServlet() throws Exception {
+    assertTrue(
+        Files.isRegularFile(CMS_TABLE_DATA), "missing seed: " + CMS_TABLE_DATA.toAbsolutePath());
+
+    Document doc = parse(CMS_TABLE_DATA);
+    Map<String, String> urlByName = menuActionUrlsByName(doc);
+
+    assertTrue(
+        urlByName.containsKey("Publish_Now"), "ACTION Publish_Now missing from cmsTableData");
+    assertEquals(
+        EXPECTED_PUBLISH_NOW_URL,
+        urlByName.get("Publish_Now"),
+        "Publish_Now must use PSDemandPublishServlet path (issue #1843)");
+    assertFalse(
+        urlByName.get("Publish_Now").contains(LEGACY_PUBLISH_JSP),
+        "Publish_Now must not target legacy publish.jsp");
+    assertFalse(urlByName.get("Publish_Now").contains("\\"), "URL path separators must be '/'");
+  }
+
+  /**
+   * Issue #1884: ACTION 217 must not stay clean-install-only insert. Existing upgraded DBs keep
+   * rows with {@code ../ui/publishing/publish.jsp} until tabledata runs a replace.
+   */
+  @Test
+  void cmsPublishNowAction_isUpgradeSafeReplace() throws Exception {
+    Document doc = parse(CMS_TABLE_DATA);
+    Element row = menuActionRowByName(doc, "Publish_Now");
+    assertNotNull(row, "ACTION Publish_Now row missing from cmsTableData RXMENUACTION");
+
+    assertEquals(
+        "217",
+        columnValue(row, "ACTIONID"),
+        "Publish_Now must remain ACTIONID 217 (menu relations / params keyed by id)");
+    assertEquals(
+        UPGRADE_SAFE_ACTION,
+        row.getAttribute("action"),
+        "Publish_Now must use action=r replace (issue #1884; peer EI_Publish_Now)");
+    assertEquals(
+        UPGRADE_SAFE_ON_CREATE_ONLY,
+        row.getAttribute("onTableCreateOnly"),
+        "Publish_Now must use onTableCreateOnly=no so upgrades rewrite existing URL");
+    assertEquals(EXPECTED_PUBLISH_NOW_URL, columnValue(row, "URL"));
+  }
+
+  @Test
+  void cmsPublishNowAction_retainsDemandParamNames() throws Exception {
+    Document doc = parse(CMS_TABLE_DATA);
+    Set<String> params = menuActionParamNames(doc, "217");
+
+    assertTrue(params.contains("sys_contentid"), "Publish_Now must pass sys_contentid: " + params);
+    assertTrue(params.contains("sys_folderid"), "Publish_Now must pass sys_folderid: " + params);
+    assertTrue(params.contains("sys_siteid"), "Publish_Now must pass sys_siteid: " + params);
+  }
+
+  @Test
+  void rxffEiPublishNowAction_pointsAtDemandPublishServlet() throws Exception {
+    assertTrue(
+        Files.isRegularFile(RXFF_TABLE_DATA), "missing seed: " + RXFF_TABLE_DATA.toAbsolutePath());
+
+    Document doc = parse(RXFF_TABLE_DATA);
+    Map<String, String> urlByName = menuActionUrlsByName(doc);
+
+    assertTrue(
+        urlByName.containsKey("EI_Publish_Now"),
+        "ACTION EI_Publish_Now missing from RxffTableData");
+    assertEquals(EXPECTED_PUBLISH_NOW_URL, urlByName.get("EI_Publish_Now"));
+    assertFalse(urlByName.get("EI_Publish_Now").contains(LEGACY_PUBLISH_JSP));
+  }
+
+  @Test
+  void rxffEiPublishNowAction_isUpgradeSafeReplace() throws Exception {
+    Document doc = parse(RXFF_TABLE_DATA);
+    Element row = menuActionRowByName(doc, "EI_Publish_Now");
+    assertNotNull(row, "ACTION EI_Publish_Now row missing from RxffTableData RXMENUACTION");
+
+    assertEquals("1012", columnValue(row, "ACTIONID"));
+    assertEquals(
+        UPGRADE_SAFE_ACTION,
+        row.getAttribute("action"),
+        "EI_Publish_Now peer already uses action=r; keep lockstep with Publish_Now (#1884)");
+    assertEquals(UPGRADE_SAFE_ON_CREATE_ONLY, row.getAttribute("onTableCreateOnly"));
+    assertEquals(EXPECTED_PUBLISH_NOW_URL, columnValue(row, "URL"));
+  }
+
+  @Test
+  void rxffEiPublishNowAction_retainsEditionAndItemParams() throws Exception {
+    Document doc = parse(RXFF_TABLE_DATA);
+    Set<String> params = menuActionParamNames(doc, "1012");
+
+    assertTrue(
+        params.contains("sys_editionid"), "EI_Publish_Now must pass sys_editionid: " + params);
+    assertTrue(
+        params.contains("sys_contentid"), "EI_Publish_Now must pass sys_contentid: " + params);
+    assertTrue(params.contains("sys_folderid"), "EI_Publish_Now must pass sys_folderid: " + params);
+  }
+
+  @Test
+  void fastForwardRxffPeer_matchesDistributionSeedUrl() throws Exception {
+    if (!Files.isRegularFile(FF_RXFF_TABLE_DATA)) {
+      // Standalone checkout may omit FastForward in some agent trees; skip only if absent.
+      return;
+    }
+    Document doc = parse(FF_RXFF_TABLE_DATA);
+    Map<String, String> urlByName = menuActionUrlsByName(doc);
+    assertTrue(urlByName.containsKey("EI_Publish_Now"), "FF peer missing EI_Publish_Now");
+    assertEquals(
+        EXPECTED_PUBLISH_NOW_URL,
+        urlByName.get("EI_Publish_Now"),
+        "system/FastForward RxffTableData must stay lockstep with dist Rxff seed (#1843)");
+    Element row = menuActionRowByName(doc, "EI_Publish_Now");
+    assertNotNull(row);
+    assertEquals(UPGRADE_SAFE_ACTION, row.getAttribute("action"));
+    assertEquals(UPGRADE_SAFE_ON_CREATE_ONLY, row.getAttribute("onTableCreateOnly"));
+  }
+
+  @Test
+  void noInstallerSeedStillReferencesLegacyPublishJspAsActionUrl() throws Exception {
+    for (Path seed : new Path[] {CMS_TABLE_DATA, RXFF_TABLE_DATA}) {
+      String text = Files.readString(seed);
+      // Column values only: allow HTML comments that mention the legacy path historically.
+      Document doc = parse(seed);
+      for (Map.Entry<String, String> e : menuActionUrlsByName(doc).entrySet()) {
+        assertFalse(
+            e.getValue().contains(LEGACY_PUBLISH_JSP),
+            seed + " action " + e.getKey() + " still uses legacy publish.jsp URL: " + e.getValue());
+      }
+      // Silence unused if we only use DOM — keep text load to prove readable encoding
+      assertFalse(text.isBlank());
+    }
+  }
+
+  private static Document parse(Path path)
+      throws IOException, ParserConfigurationException, SAXException {
+    // Peer: SampleSiteLocaleStripTest — local seed files, no external entities.
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setValidating(false);
+    DocumentBuilder builder = factory.newDocumentBuilder();
+    try (var in = Files.newInputStream(path)) {
+      return builder.parse(in);
+    }
+  }
+
+  /** Maps RXMENUACTION NAME → URL for every action row under tables named RXMENUACTION. */
+  private static Map<String, String> menuActionUrlsByName(Document doc) {
+    Map<String, String> out = new HashMap<>();
+    for (Element row : menuActionRows(doc)) {
+      String name = columnValue(row, "NAME");
+      String url = columnValue(row, "URL");
+      if (name != null && url != null) {
+        out.put(name, url);
+      }
+    }
+    return out;
+  }
+
+  /** First RXMENUACTION row whose NAME column matches, or {@code null}. */
+  private static Element menuActionRowByName(Document doc, String actionName) {
+    for (Element row : menuActionRows(doc)) {
+      if (actionName.equals(columnValue(row, "NAME"))) {
+        return row;
+      }
+    }
+    return null;
+  }
+
+  private static Iterable<Element> menuActionRows(Document doc) {
+    java.util.List<Element> rows = new java.util.ArrayList<>();
+    NodeList tables = doc.getElementsByTagName("table");
+    for (int t = 0; t < tables.getLength(); t++) {
+      Element table = (Element) tables.item(t);
+      if (!"RXMENUACTION".equals(table.getAttribute("name"))) {
+        continue;
+      }
+      NodeList rowNodes = table.getElementsByTagName("row");
+      for (int r = 0; r < rowNodes.getLength(); r++) {
+        rows.add((Element) rowNodes.item(r));
+      }
+    }
+    return rows;
+  }
+
+  /** PARAMNAME values for the given ACTIONID under RXMENUACTIONPARAM. */
+  private static Set<String> menuActionParamNames(Document doc, String actionId) {
+    Set<String> out = new HashSet<>();
+    NodeList tables = doc.getElementsByTagName("table");
+    for (int t = 0; t < tables.getLength(); t++) {
+      Element table = (Element) tables.item(t);
+      if (!"RXMENUACTIONPARAM".equals(table.getAttribute("name"))) {
+        continue;
+      }
+      NodeList rows = table.getElementsByTagName("row");
+      for (int r = 0; r < rows.getLength(); r++) {
+        Element row = (Element) rows.item(r);
+        if (actionId.equals(columnValue(row, "ACTIONID"))) {
+          String param = columnValue(row, "PARAMNAME");
+          if (param != null) {
+            out.add(param);
+          }
+        }
+      }
+    }
+    return out;
+  }
+
+  private static String columnValue(Element row, String columnName) {
+    NodeList columns = row.getChildNodes();
+    for (int i = 0; i < columns.getLength(); i++) {
+      Node n = columns.item(i);
+      if (n.getNodeType() != Node.ELEMENT_NODE) {
+        continue;
+      }
+      Element col = (Element) n;
+      if (!"column".equals(col.getTagName())) {
+        continue;
+      }
+      if (columnName.equals(col.getAttribute("name"))) {
+        return col.getTextContent() == null ? null : col.getTextContent().trim();
+      }
+    }
+    return null;
+  }
+}

--- a/specs/990-unified-publishing-ui/checklists/removal-inventory.md
+++ b/specs/990-unified-publishing-ui/checklists/removal-inventory.md
@@ -47,36 +47,36 @@ Detailed audit notes (grep tables, historical faces dump pointers):
 
 **Tracked files (2026-08-04)** — `WebUI/src/main/webapp/ui/publishing/` (28 JSPs):
 
-|                  File                   |         Faces historical?         | Product-nav caller |        Non-nav residual         |      #1819 disposition       |
-|-----------------------------------------|-----------------------------------|--------------------|---------------------------------|------------------------------|
-| `index.jsp`                             | entry                             | n/a (redirect)     | —                               | **KEEP** redirect            |
-| `error.jsp`                             | error page                        | none               | self-includes                   | Delete with Design faces set |
-| `menu.jsp`                              | nav chrome                        | none               | faces tree only                 | Delete                       |
-| `PubDesignAuthentication.jsp`           | include                           | none               | included by Design pages        | Delete with Design pages     |
-| `publish.jsp`                           | demand publish UI (not faces nav) | none               | **Publish_Now** seed action URL | **KEEP / rewire first**      |
-| `AddContextVariable.jsp`                | yes                               | none               | —                               | Delete                       |
-| `AssociateContentlist.jsp`              | yes                               | none               | —                               | Delete                       |
-| `ContentlistEditor.jsp`                 | yes                               | none               | —                               | Delete                       |
-| `ContentlistView.jsp`                   | yes                               | none               | —                               | Delete                       |
-| `ContextEditor.jsp`                     | yes                               | none               | —                               | Delete                       |
-| `ContextList.jsp`                       | yes                               | none               | —                               | Delete                       |
-| `DeliveryTypeEditor.jsp`                | yes                               | none               | —                               | Delete                       |
-| `DeliveryTypeList.jsp`                  | yes                               | none               | —                               | Delete                       |
-| `EditionEditor.jsp`                     | yes                               | none               | —                               | Delete                       |
-| `EditionList.jsp`                       | yes                               | none               | —                               | Delete                       |
-| `ItemBrowser.jsp`                       | yes                               | none               | —                               | Delete                       |
-| `LocationSchemeEditor.jsp`              | yes                               | none               | —                               | Delete                       |
-| `LocationSchemeLegacyEditor.jsp`        | yes                               | none               | —                               | Delete                       |
-| `LocationSchemeParamEditor.jsp`         | yes                               | none               | —                               | Delete                       |
-| `NoSchemeParameterSelectionWarning.jsp` | yes                               | none               | —                               | Delete                       |
-| `NoSelectionWarning.jsp`                | yes                               | none               | —                               | Delete                       |
-| `RemoveConfirmation.jsp`                | yes                               | none               | —                               | Delete                       |
-| `RemoveLocationScheme.jsp`              | yes                               | none               | —                               | Delete                       |
-| `SaveChildSchemeChangesWarning.jsp`     | yes                               | none               | —                               | Delete                       |
-| `SelectEditionFromOtherSite.jsp`        | yes                               | none               | —                               | Delete                       |
-| `SiteEditor.jsp`                        | yes                               | none               | —                               | Delete                       |
-| `SiteList.jsp`                          | yes                               | none               | —                               | Delete                       |
-| `SiteRootBrowser.jsp`                   | yes                               | none               | —                               | Delete                       |
+|                  File                   |         Faces historical?         | Product-nav caller |                    Non-nav residual                    |                        #1819 disposition                         |
+|-----------------------------------------|-----------------------------------|--------------------|--------------------------------------------------------|------------------------------------------------------------------|
+| `index.jsp`                             | entry                             | n/a (redirect)     | —                                                      | **KEEP** redirect                                                |
+| `error.jsp`                             | error page                        | none               | self-includes                                          | Delete with Design faces set                                     |
+| `menu.jsp`                              | nav chrome                        | none               | faces tree only                                        | Delete                                                           |
+| `PubDesignAuthentication.jsp`           | include                           | none               | included by Design pages                               | Delete with Design pages                                         |
+| `publish.jsp`                           | demand publish UI (not faces nav) | none               | Seed rewired (#1843) → `../publisher/demandpublishing` | **KEEP** until #1819 (do not delete here); no seed consumer left |
+| `AddContextVariable.jsp`                | yes                               | none               | —                                                      | Delete                                                           |
+| `AssociateContentlist.jsp`              | yes                               | none               | —                                                      | Delete                                                           |
+| `ContentlistEditor.jsp`                 | yes                               | none               | —                                                      | Delete                                                           |
+| `ContentlistView.jsp`                   | yes                               | none               | —                                                      | Delete                                                           |
+| `ContextEditor.jsp`                     | yes                               | none               | —                                                      | Delete                                                           |
+| `ContextList.jsp`                       | yes                               | none               | —                                                      | Delete                                                           |
+| `DeliveryTypeEditor.jsp`                | yes                               | none               | —                                                      | Delete                                                           |
+| `DeliveryTypeList.jsp`                  | yes                               | none               | —                                                      | Delete                                                           |
+| `EditionEditor.jsp`                     | yes                               | none               | —                                                      | Delete                                                           |
+| `EditionList.jsp`                       | yes                               | none               | —                                                      | Delete                                                           |
+| `ItemBrowser.jsp`                       | yes                               | none               | —                                                      | Delete                                                           |
+| `LocationSchemeEditor.jsp`              | yes                               | none               | —                                                      | Delete                                                           |
+| `LocationSchemeLegacyEditor.jsp`        | yes                               | none               | —                                                      | Delete                                                           |
+| `LocationSchemeParamEditor.jsp`         | yes                               | none               | —                                                      | Delete                                                           |
+| `NoSchemeParameterSelectionWarning.jsp` | yes                               | none               | —                                                      | Delete                                                           |
+| `NoSelectionWarning.jsp`                | yes                               | none               | —                                                      | Delete                                                           |
+| `RemoveConfirmation.jsp`                | yes                               | none               | —                                                      | Delete                                                           |
+| `RemoveLocationScheme.jsp`              | yes                               | none               | —                                                      | Delete                                                           |
+| `SaveChildSchemeChangesWarning.jsp`     | yes                               | none               | —                                                      | Delete                                                           |
+| `SelectEditionFromOtherSite.jsp`        | yes                               | none               | —                                                      | Delete                                                           |
+| `SiteEditor.jsp`                        | yes                               | none               | —                                                      | Delete                                                           |
+| `SiteList.jsp`                          | yes                               | none               | —                                                      | Delete                                                           |
+| `SiteRootBrowser.jsp`                   | yes                               | none               | —                                                      | Delete                                                           |
 
 **Sign-off**: Entry-path retirement Done; deep-page file deletion **explicitly deferred** to #1819 after UAT + non-nav rewires.  
 **Tracking issue**: [#1372](https://github.com/intersoftdatalabs-in/percussioncms/issues/1372) · audit [#1817](https://github.com/intersoftdatalabs-in/percussioncms/issues/1817)
@@ -93,21 +93,21 @@ Detailed audit notes (grep tables, historical faces dump pointers):
 
 **Tracked files (2026-08-04)** — `WebUI/src/main/webapp/ui/pubruntime/` (13 JSPs):
 
-|              File               |      Faces historical?      | Product-nav caller |            Non-nav residual            |       #1818 disposition       |
-|---------------------------------|-----------------------------|--------------------|----------------------------------------|-------------------------------|
-| `index.jsp`                     | entry                       | n/a (redirect)     | —                                      | **KEEP** redirect             |
-| `PubRuntimeAuthentication.jsp`  | include                     | none               | included by Runtime pages              | Delete with Runtime faces set |
-| `DemandPublish.jsp`             | **no** (plain JSP progress) | none               | **Servlet rewired (#1842)**            | **Delete** (no live consumer) |
-| `ActiveJobStatus.jsp`           | yes                         | none               | —                                      | Delete                        |
-| `AllPubLogs.jsp`                | yes                         | none               | —                                      | Delete                        |
-| `DeleteSiteItemLogsWarning.jsp` | yes                         | none               | —                                      | Delete                        |
-| `ErrorMessage.jsp`              | yes                         | none               | —                                      | Delete                        |
-| `ItemPubLog.jsp`                | yes                         | none               | —                                      | Delete                        |
-| `JobPubLog.jsp`                 | yes                         | none               | **`PSRunEdition` rewired (#1844)**     | **Delete** (no live consumer) |
-| `NoSelectionWarning.jsp`        | yes                         | none               | —                                      | Delete                        |
-| `RuntimeEdition.jsp`            | yes                         | none               | —                                      | Delete                        |
-| `RuntimeEditionList.jsp`        | yes                         | none               | —                                      | Delete                        |
-| `SitePubLogs.jsp`               | yes                         | none               | —                                      | Delete                        |
+|              File               |      Faces historical?      | Product-nav caller |          Non-nav residual          |       #1818 disposition       |
+|---------------------------------|-----------------------------|--------------------|------------------------------------|-------------------------------|
+| `index.jsp`                     | entry                       | n/a (redirect)     | —                                  | **KEEP** redirect             |
+| `PubRuntimeAuthentication.jsp`  | include                     | none               | included by Runtime pages          | Delete with Runtime faces set |
+| `DemandPublish.jsp`             | **no** (plain JSP progress) | none               | **Servlet rewired (#1842)**        | **Delete** (no live consumer) |
+| `ActiveJobStatus.jsp`           | yes                         | none               | —                                  | Delete                        |
+| `AllPubLogs.jsp`                | yes                         | none               | —                                  | Delete                        |
+| `DeleteSiteItemLogsWarning.jsp` | yes                         | none               | —                                  | Delete                        |
+| `ErrorMessage.jsp`              | yes                         | none               | —                                  | Delete                        |
+| `ItemPubLog.jsp`                | yes                         | none               | —                                  | Delete                        |
+| `JobPubLog.jsp`                 | yes                         | none               | **`PSRunEdition` rewired (#1844)** | **Delete** (no live consumer) |
+| `NoSelectionWarning.jsp`        | yes                         | none               | —                                  | Delete                        |
+| `RuntimeEdition.jsp`            | yes                         | none               | —                                  | Delete                        |
+| `RuntimeEditionList.jsp`        | yes                         | none               | —                                  | Delete                        |
+| `SitePubLogs.jsp`               | yes                         | none               | —                                  | Delete                        |
 
 **RET-06 residual — DemandPublish servlet rewire (issue #1842, 2026-08-04):**
 `system/.../PSDemandPublishServlet` no longer forwards to
@@ -218,13 +218,13 @@ Recoverable at: `git show aa46aa5f86^:WebUI/src/main/webapp/WEB-INF/publishing-f
 
 These are **not** product-nav, but are **product/engine** callers. Deleting the target pages without rewiring breaks demand publish / scheduled-edition log links / seed menus.
 
-|           Owner           |                                                     Code / data                                                     |                                 Target                                  |                                                        Recommended rewire                                                        |
-|---------------------------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| Demand publish servlet    | `system/business/.../PSDemandPublishServlet.java`                                                                   | ~~Forward `/ui/pubruntime/DemandPublish.jsp`~~ → redirect modern status | **Done (#1842):** `sendRedirect` → `{contextPath}/cm/app/?view=publish&section=status`                                           |
-| Demand servlet mapping    | `web.xml` url-pattern `/publisher/demandpublishing` (WebUI + cm + war)                                              | Same servlet                                                            | **Kept** (#1842); only post-queue UI target changed                                                                              |
-| Publish Now action seed   | `modules/perc-distribution-tree/.../cmsTableData.xml` ACTIONID 217 `Publish_Now` URL `../ui/publishing/publish.jsp` | Demand publish JSP                                                      | Point at modern item publish-now / REST-backed UI (US6) or servlet path                                                          |
-| Publish Now FF seed       | `.../RxffTableData.xml`, `system/FastForward/Core/Config/Data/RxffTableData.xml`                                    | Same URL                                                                | Same                                                                                                                             |
-| Scheduled edition log URL | `system/services/.../PSRunEdition.getPublishingLogURL()`                                                            | `/ui/pubruntime/JobPubLog.faces?…`                                      | Modern `view=publish&section=logs` (+ job id query if supported); **current `.faces` URL is already non-functional** without JSF |
+|           Owner           |                                                   Code / data                                                   |                                 Target                                  |                                                                                                               Recommended rewire                                                                                                                |
+|---------------------------|-----------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Demand publish servlet    | `system/business/.../PSDemandPublishServlet.java`                                                               | ~~Forward `/ui/pubruntime/DemandPublish.jsp`~~ → redirect modern status | **Done (#1842):** `sendRedirect` → `{contextPath}/cm/app/?view=publish&section=status`                                                                                                                                                          |
+| Demand servlet mapping    | `web.xml` url-pattern `/publisher/demandpublishing` (WebUI + cm + war)                                          | Same servlet                                                            | **Kept** (#1842); only post-queue UI target changed                                                                                                                                                                                             |
+| Publish Now action seed   | `modules/perc-distribution-tree/.../cmsTableData.xml` ACTIONID 217 `Publish_Now`                                | ~~`../ui/publishing/publish.jsp`~~ → `../publisher/demandpublishing`    | **Done (#1843 + #1884):** URL → `PSDemandPublishServlet`; `action="r"` / `onTableCreateOnly="no"` so upgrades replace existing ACTION 217 rows (peer of FF `EI_Publish_Now`). Params unchanged (`sys_contentid`, `sys_folderid`, `sys_siteid`). |
+| Publish Now FF seed       | `.../RxffTableData.xml`, `system/FastForward/Core/Config/Data/RxffTableData.xml` ACTIONID 1012 `EI_Publish_Now` | Same servlet path                                                       | **Done (#1843):** same URL rewire; already `action="r"` / `onTableCreateOnly="no"`; FF params keep `sys_editionid` + content/folder ids.                                                                                                        |
+| Scheduled edition log URL | `system/services/.../PSRunEdition.getPublishingLogURL()`                                                        | `/ui/pubruntime/JobPubLog.faces?…`                                      | **Done (#1844):** modern `view=publish&section=logs`                                                                                                                                                                                            |
 
 ### Installer / distribution peers (no delete in #1817)
 
@@ -232,7 +232,7 @@ These are **not** product-nav, but are **product/engine** callers. Deleting the 
 |------------------------|-------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
 | Upgrade cleanup target | `modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/install.xml` | Already deletes residual `publishing-faces-config.xml` on upgrade |
 | Cleanup unit test      | `.../ObsoleteWebInfArtifactsCleanupTest.java`                                                   | Guards the install.xml contract                                   |
-| Seed menu URL          | `cmsTableData.xml` / `RxffTableData.xml`                                                        | Residual `publish.jsp` URL (rewire, not packaging-only)           |
+| Seed menu URL          | `cmsTableData.xml` / `RxffTableData.xml`                                                        | **Rewired (#1843)** + **upgrade replace (#1884)** for ACTION 217  |
 | WAR packaging          | WebUI war packages `ui/publishing/**` and `ui/pubruntime/**` as static webapp files             | #1820 asserts only redirects remain after B+C                     |
 
 ### Docs / bookmark / external refs (preserve or redirect)
@@ -248,7 +248,7 @@ These are **not** product-nav, but are **product/engine** callers. Deleting the 
 
 ## Deletion checklist — Child B Design (#1819)
 
-**Prereqs**: #1817 (Done) · #1371 UAT or human ack · rewire `ui/publishing/publish.jsp` consumers **or** explicitly KEEP that file out of the delete set.
+**Prereqs**: #1817 (Done) · #1371 UAT or human ack · **Publish_Now seed rewired (#1843)** — `publish.jsp` may be deleted in #1819 or kept only if another consumer appears.
 
 ### Delete (Design-exclusive deep faces / chrome)
 
@@ -282,7 +282,7 @@ These are **not** product-nav, but are **product/engine** callers. Deleting the 
 ### Keep
 
 - [ ] `index.jsp` (modern Design redirect)
-- [ ] `publish.jsp` until Publish_Now seed / demand path rewired (or rewire in same PR as #1819)
+- [ ] `publish.jsp` — seed rewired (#1843); optional KEEP for #1819 delete pass (no seed consumer); do not delete in packaging-only PRs
 
 ### Faces-config / packaging
 
@@ -295,7 +295,7 @@ These are **not** product-nav, but are **product/engine** callers. Deleting the 
 
 - [ ] Modern Design section loads
 - [ ] `ui/publishing/index.jsp` still redirects
-- [ ] Item publish-now / Publish_Now still works (if publish.jsp kept or rewired)
+- [ ] Item publish-now / Publish_Now still works via `/publisher/demandpublishing` (seed #1843; upgrade replace #1884 rewrites existing ACTION 217 rows on tabledata load)
 
 ---
 

--- a/system/FastForward/Core/Config/Data/RxffTableData.xml
+++ b/system/FastForward/Core/Config/Data/RxffTableData.xml
@@ -7292,12 +7292,15 @@ $rx.location.getFirstDefined($sys.item,'rx:inactiveimg_ext,rx:sys_suffix', '.gif
 			<column name="HANDLER">SERVER</column>
 			<column name="VERSION">0</column>
 		</row>
+		<!-- URL rewired from legacy ui/publishing/publish.jsp to PSDemandPublishServlet
+		     mapping (RET-06 / issue #1843). Params (sys_editionid, sys_contentid, sys_folderid)
+		     unchanged. -->
 		<row action="r" onTableCreateOnly="no">
 			<column name="ACTIONID">1012</column>
 			<column name="NAME">EI_Publish_Now</column>
 			<column name="DISPLAYNAME">EI Publish Now</column>
 			<column name="DESCRIPTION">Publish the selected folders or items immediately</column>
-			<column name="URL">../ui/publishing/publish.jsp</column>
+			<column name="URL">../publisher/demandpublishing</column>
 			<column name="SORTORDER">350</column>
 			<column name="TYPE">MENUITEM</column>
 			<column name="HANDLER">SERVER</column>


### PR DESCRIPTION
## Summary

Upgrade-safe tabledata replace for **Publish_Now** ACTIONID **217** so existing databases that still point at `../ui/publishing/publish.jsp` get rewritten to `../publisher/demandpublishing` on installer tabledata load.

**Operator:** Grok: night-issue-prs (model grok-4.5)

### What changed

| Path | Change |
|------|--------|
| `modules/perc-distribution-tree/.../cmsTableData.xml` | ACTION 217: URL → demand servlet; `action=\"r\"` / `onTableCreateOnly=\"no\"` (#1884) |
| `.../RxffTableData.xml` + `system/FastForward/.../RxffTableData.xml` | EI_Publish_Now (1012) URL → demand servlet (seed rewire; already upgrade-safe) |
| `PublishNowActionSeedUrlTest.java` | URL + upgrade row-flag regression guards |
| `removal-inventory.md` / `audit.md` | RET-06 residual note for #1843 + #1884 |

### Coordination with #1885 / #1843

Open PR **#1885** rewired seed URLs but left ACTION 217 as clean-install-only (`onTableCreateOnly=yes`) and is **CONFLICTING** with `main`. This PR rebases that seed rewire onto current `main` and completes the **upgrade replace** residual tracked as **#1884**. Prefer merging **this** PR and closing #1885 as superseded (same seed URL outcome + upgrade safety).

### Not in this PR

- Multi-engine SQL migrators (explicitly out of scope)
- Delete `ui/publishing/publish.jsp` (deferred #1819)
- Live CE / AA Publish Now smoke (optional; no install available in this session)

Fixes #1884
Fixes #1843

## Test plan

- [x] `PublishNowActionSeedUrlTest` — URL, params, FF lockstep, **upgrade flags** (`action=r`, `onTableCreateOnly=no`)
- [x] `cd modules/perc-distribution-tree && ../../mvnw.cmd clean install` — **BUILD SUCCESS**, Tests run: **208**, Failures: 0, Errors: 0, Skipped: 3
- [x] Spotless: root `mvnw.cmd -N spotless:apply` then `spotless:check`; module `perc-distribution-tree` apply then check — **in-scope only** (OOS baseline Spotless debt not committed)
- [ ] Manual upgrade: existing DB with ACTION 217 URL `../ui/publishing/publish.jsp` → after tabledata load, URL is `../publisher/demandpublishing`
- [ ] Live CE / AA Publish Now hits `/publisher/demandpublishing` (deferred if no install)

## Gates evidence

| Gate | Result |
|------|--------|
| Erlang-style self-review | Pass — established tabledata `action=r` peer of FF `EI_Publish_Now`; no invented migrators; portable Path APIs in tests; URL uses `/` only |
| Spotless apply → check | Pass (module + root `-N`); feature PR contains only in-scope files |
| Standalone clean install | `perc-distribution-tree` BUILD SUCCESS |
| Unit tests | `PublishNowActionSeedUrlTest` (8 tests) + full module suite green (208 / 0 fail) |
| Residual issues | None for this slice; live CE smoke optional only |