### PR TITLE
fix(utils): switch PSXmlSerializationHelper facade to Jackson (#1887)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-1887-xml-helper-jackson-facade-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-1887-xml-helper-jackson-facade-erlang.md
@@ -1,0 +1,47 @@
+# Erlang review — issue #1887 PSXmlSerializationHelper Jackson facade
+
+**Branch:** `fix/issue-1887-xml-helper-jackson-facade`  
+**Scope:** `modules/utils` only (production facade cutover to Jackson; Betwixt retained for rollback)  
+**Date:** 2026-08-04  
+**Recommendation:** approve  
+**May commit/push:** yes  
+
+## Summary
+
+Switches `PSXmlSerializationHelper` public `writeToXml` / `readFromXML` defaults to Jackson via
+`PSJacksonXmlSerializationHelper` while preserving signatures (`addType`, `readFromXML`,
+`writeToXml`, `getIdFromXml`, `rewriteLegacyNullRoot`). `addType` dual-registers Betwixt + Jackson
+type maps. Betwixt remains on the classpath; emergency rollback via system property
+`com.percussion.xml.serialization.engine=betwixt` (default `jackson`). No domain bean migration
+(out of scope — later #1823 slices / #1888+). No `commons-betwixt` POM removal.
+
+## Gate checklist
+
+- [x] Public API signature parity preserved
+- [x] Behavioral unit tests: golden fixture via facade, Jackson round-trip with nested choices,
+      legacy `<null>` root, suppress annotation, engine property rollback, dual `addType` registry
+- [x] Cross-platform path / file I/O: not touched (classpath golden resource only)
+- [x] Module standalone `mvnw clean install` — BUILD SUCCESS
+- [x] Spotless apply then check on `modules/utils` (in-scope only)
+- [x] `synchronized` retained on public write/read until Betwixt fully removed
+- [x] No Betwixt POM / `.betwixt` file removal
+
+## Issues
+
+None blocking.
+
+### Suggestions (non-blocking)
+
+1. **Jackson TYPE_MAP still not wired for polymorphic item deserialize** — collection item names
+   for domain beans still need Jackson annotations or mix-ins in domain slices (#1888+).
+2. **Rollback flag removal** — drop `ENGINE_PROPERTY` and Betwixt private paths after domain
+   migration and #1824 (`commons-betwixt` removal). Documented on the helper and in the PR body.
+3. **Approved XML deviation** — Jackson does not emit Betwixt graph-identity `id="…"` attributes;
+   golden compare continues to strip them.
+
+## Memory patterns hit
+
+- Facade cutover after parallel pilot proved golden parity
+- Dual-engine rollback property with explicit removal plan
+- Companion golden + round-trip + legacy null-root tests for production path change
+- Keep Betwixt dependency until dedicated removal issue

--- a/modules/utils/src/main/java/com/percussion/services/utils/xml/PSJacksonXmlSerializationHelper.java
+++ b/modules/utils/src/main/java/com/percussion/services/utils/xml/PSJacksonXmlSerializationHelper.java
@@ -39,11 +39,12 @@ import tools.jackson.dataformat.xml.XmlMapper;
 import tools.jackson.dataformat.xml.XmlWriteFeature;
 
 /**
- * Parallel Jackson XML serialization helper beside {@link PSXmlSerializationHelper}.
+ * Jackson XML serialization engine used by {@link PSXmlSerializationHelper} (production default as
+ * of issue #1887 / epic #505 slice 1).
  *
- * <p><strong>This is not the production default.</strong> Call sites continue to use {@link
- * PSXmlSerializationHelper} (Commons Betwixt). This helper exists so slice #1822 / epic #505 can
- * prove wire parity with golden snapshots before any cutover (#1823).
+ * <p>Call sites should continue to use the {@link PSXmlSerializationHelper} facade. This helper may
+ * also be invoked directly by tests and dual-path diagnostics. Betwixt remains on the classpath for
+ * emergency rollback via {@link PSXmlSerializationHelper#ENGINE_PROPERTY}.
  *
  * <p>Naming strategy (see {@link PSXmlElementNameMapper}):
  *
@@ -51,13 +52,17 @@ import tools.jackson.dataformat.xml.XmlWriteFeature;
  *   <li>Root elements: {@link PSXmlElementNameMapper#mapTypeToElementName(String)} (PS/IPS strip +
  *       multi-cap flatten + hyphenation)
  *   <li>Property elements: kebab-case ({@link PropertyNamingStrategies#KEBAB_CASE}) matching
- *       Betwixt {@code HyphenatedNameMapper} for properties
+ *       historical Betwixt {@code HyphenatedNameMapper} for properties
  *   <li>Collections: wrapper element enabled by default (Betwixt-style {@code
  *       <choices><choice/>…</choices>})
  * </ul>
  *
  * <p>Legacy package payloads with root {@code <null>} are rewritten via {@link
  * PSXmlSerializationHelper#rewriteLegacyNullRoot(String, Class)} before deserialize.
+ *
+ * <p><strong>Approved XML deviations vs historical Betwixt writes:</strong> Jackson does not emit
+ * Betwixt graph-identity {@code id="…"} attributes on complex elements (values live in child
+ * elements).
  */
 public final class PSJacksonXmlSerializationHelper {
 
@@ -168,8 +173,12 @@ public final class PSJacksonXmlSerializationHelper {
     return MAPPER;
   }
 
-  /** Snapshot of registered element→type entries (for tests). */
-  static Map<String, Class<?>> typeMapView() {
+  /**
+   * Snapshot of registered element→type entries (for tests and diagnostics).
+   *
+   * @return unmodifiable copy, never {@code null}
+   */
+  public static Map<String, Class<?>> typeMapView() {
     return Map.copyOf(TYPE_MAP);
   }
 

--- a/modules/utils/src/main/java/com/percussion/services/utils/xml/PSXmlSerializationHelper.java
+++ b/modules/utils/src/main/java/com/percussion/services/utils/xml/PSXmlSerializationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,10 +61,30 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
 /**
- * Helper methods for handling serialization to and from XML. This sets up betwixt with default
- * classes that handle the translation of class names to element names and in particular sets up
- * type mapping information to assist in converting back from xml; an area that betwixt is very weak
- * in.
+ * Helper methods for handling serialization to and from XML.
+ *
+ * <p><strong>Production engine (issue #1887 / epic #505):</strong> public {@link #writeToXml},
+ * {@link #readFromXML} entry points default to Jackson XML via {@link
+ * PSJacksonXmlSerializationHelper}. Naming uses {@link PSXmlElementNameMapper}. Commons Betwixt
+ * remains on the classpath and is still available as an emergency rollback only.
+ *
+ * <p><strong>Rollback flag:</strong> set system property {@value #ENGINE_PROPERTY} to {@value
+ * #ENGINE_BETWIXT} to force the legacy Betwixt path. Default is {@value #ENGINE_JACKSON}. Remove
+ * this flag when domain slices and #1824 (Betwixt POM removal) complete — do not leave dual engines
+ * indefinitely.
+ *
+ * <p>Public API preserved: {@link #addType}, {@link #readFromXML}, {@link #writeToXml}, {@link
+ * #getIdFromXml}, {@link #rewriteLegacyNullRoot}. Methods remain {@code synchronized} until Betwixt
+ * is fully removed and concurrency is re-proven.
+ *
+ * <p><strong>Approved XML deviations vs historical Betwixt writes:</strong>
+ *
+ * <ul>
+ *   <li>Betwixt graph-identity {@code id="…"} attributes on complex elements are not emitted by
+ *       Jackson (property values live in child elements).
+ *   <li>Property / collection item element names for unannotated domain beans may differ until
+ *       domain migration slices add Jackson annotations or shared mix-ins (#1888+).
+ * </ul>
  *
  * @author dougrand
  */
@@ -72,6 +92,23 @@ import org.xml.sax.helpers.DefaultHandler;
 public class PSXmlSerializationHelper {
   /** Static for logging */
   private static final Logger log = LogManager.getLogger(PSXmlSerializationHelper.class);
+
+  /**
+   * System property selecting the XML serialization engine for {@link #writeToXml} / {@link
+   * #readFromXML}.
+   *
+   * <p>Values: {@value #ENGINE_JACKSON} (default) or {@value #ENGINE_BETWIXT} (rollback).
+   *
+   * <p><strong>Removal plan:</strong> drop this property and Betwixt code paths after domain
+   * consumer migration (#1823 slices) and {@code commons-betwixt} removal (#1824).
+   */
+  public static final String ENGINE_PROPERTY = "com.percussion.xml.serialization.engine";
+
+  /** Default production engine. */
+  public static final String ENGINE_JACKSON = "jackson";
+
+  /** Emergency rollback engine (Betwixt). */
+  public static final String ENGINE_BETWIXT = "betwixt";
 
   /** Static used for method lookup */
   static final Class[] NOARGS = new Class[0];
@@ -112,7 +149,7 @@ public class PSXmlSerializationHelper {
 
   /**
    * Betwixt {@link NameMapper} that delegates type naming to {@link PSXmlElementNameMapper} so the
-   * Jackson parallel helper and Betwixt share one naming strategy (issue #1822 / epic #505).
+   * Jackson helper and Betwixt share one naming strategy (issue #1822 / epic #505).
    *
    * <p>Strips {@code PS}/{@code IPS}, flattens multi-cap runs, then hyphenates (see {@link
    * PSXmlElementNameMapper}). Betwixt uses the same mapper instance for element and attribute name
@@ -207,6 +244,8 @@ public class PSXmlSerializationHelper {
       throw new IllegalArgumentException("type may not be null");
     }
     ms_typeMap.put(elementName, type);
+    // Keep Jackson type registry in lock-step (polymorphic / collection items).
+    PSJacksonXmlSerializationHelper.addType(elementName, type);
   }
 
   /**
@@ -219,9 +258,18 @@ public class PSXmlSerializationHelper {
     if (type == null) {
       throw new IllegalArgumentException("type may not be null");
     }
-    PSNameMapper mapper = new PSNameMapper();
-    String name = mapper.mapTypeToElementName(type.getSimpleName());
+    String name = PSXmlElementNameMapper.mapTypeToElementName(type.getSimpleName());
     addType(name, type);
+  }
+
+  /**
+   * Whether the public facade uses Jackson (default) or the Betwixt rollback path.
+   *
+   * @return {@code true} when Jackson is selected (including blank/unknown property values)
+   */
+  public static boolean isJacksonEngine() {
+    String value = System.getProperty(ENGINE_PROPERTY, ENGINE_JACKSON);
+    return !ENGINE_BETWIXT.equalsIgnoreCase(StringUtils.trimToEmpty(value));
   }
 
   /** Holds the suppression strategy singleton. */
@@ -352,25 +400,33 @@ public class PSXmlSerializationHelper {
   }
 
   /**
-   * Write the given object to an XML string. This method uses the commons betwixt library to
-   * serialize the object using reflection. Please note that you must have public methods for each
-   * and every property you wish to persist to the XML string.
+   * Write the given object to an XML string. Default engine is Jackson ({@link
+   * PSJacksonXmlSerializationHelper}); set {@value #ENGINE_PROPERTY}={@value #ENGINE_BETWIXT} for
+   * the legacy Betwixt path.
    *
    * <p>Properties that should not be persisted should have the {@link IPSXmlSerialization}
    * annotation added to their <code>get</code> or <code>is</code> methods.
    *
-   * <p>Note: ph - This method needs to be synchronized because the underlying implementation
-   * library is not thread safe. What I found was that when serializing an object to xml, sometimes
-   * an empty document would be created even though the object was valid. This only happened when
-   * several objects were being processed at the same time. The beanutils jars reported a threading
-   * issue fixed in v1.8, but I tried the latest jars, and they didn't resolve the issue.
+   * <p>Note: methods stay synchronized until Betwixt is removed and concurrency is re-proven
+   * (historical Betwixt / BeanUtils threading issues; keep the gate for the dual-engine period).
    *
    * @param object the object to write, never <code>null</code>
    * @return the XML representation of the object
    * @throws IOException if there's a problem writing the object
-   * @throws SAXException if there's a problem writing the object
+   * @throws SAXException if there's a problem writing the object (Betwixt path)
    */
   public static synchronized String writeToXml(Object object) throws IOException, SAXException {
+    if (object == null) {
+      throw new IllegalArgumentException("object may not be null");
+    }
+    if (isJacksonEngine()) {
+      return PSJacksonXmlSerializationHelper.writeToXml(object);
+    }
+    return writeToXmlBetwixt(object);
+  }
+
+  /** Legacy Betwixt write path (rollback only). */
+  private static String writeToXmlBetwixt(Object object) throws IOException, SAXException {
     Writer w = new StringWriter();
     BeanWriter writer = new BeanWriter(w);
     standardBetwixtConfiguration(writer);
@@ -420,9 +476,9 @@ public class PSXmlSerializationHelper {
   }
 
   /**
-   * Read the object's information from the given XML source using the betwixt library. If your
-   * object has one or more properties that are expressed as abstract classes or interfaces, you
-   * must register the needed classes by calling {@link #addType(String, Class)}.
+   * Read the object's information from the given XML source. If your object has one or more
+   * properties that are expressed as abstract classes or interfaces, you must register the needed
+   * classes by calling {@link #addType(String, Class)}.
    *
    * @param xmlsource the xml source, never <code>null</code> or empty
    * @param object the object to read, never <code>null</code>
@@ -435,7 +491,7 @@ public class PSXmlSerializationHelper {
     if (object == null) {
       throw new IllegalArgumentException("object may not be null");
     }
-    Object restored = readFromXML(xmlsource, object != null ? object.getClass() : null);
+    Object restored = readFromXML(xmlsource, object.getClass());
     try {
       BeanUtils.copyProperties(object, restored);
       return object;
@@ -450,20 +506,72 @@ public class PSXmlSerializationHelper {
   }
 
   /**
-   * Read the object's information from the given XML source using the betwixt library. If your
-   * object has one or more properties that are expressed as abstract classes or interfaces, you
-   * must register the needed classes by calling {@link #addType(String, Class)}.
+   * Read the object's information from the given XML source. Default engine is Jackson; set {@value
+   * #ENGINE_PROPERTY}={@value #ENGINE_BETWIXT} for the legacy Betwixt path. If your object has one
+   * or more properties that are expressed as abstract classes or interfaces, you must register the
+   * needed classes by calling {@link #addType(String, Class)}.
    *
    * @param xmlString the xml source, never <code>null</code> or empty
-   * @return clazz the class to read, may be <code>null</code>
+   * @param clazz the class to read, may be <code>null</code> (resolved from root element via type
+   *     map when possible)
+   * @return restored object, never {@code null} on success
    * @throws IOException
    * @throws SAXException
    */
-  public static Object readFromXML(String xmlString, Class clazz) throws IOException, SAXException {
+  public static synchronized Object readFromXML(String xmlString, Class clazz)
+      throws IOException, SAXException {
     if (StringUtils.isBlank(xmlString)) {
       throw new IllegalArgumentException("xmlString may not be null or empty");
     }
 
+    if (isJacksonEngine()) {
+      return readFromXMLJackson(xmlString, clazz);
+    }
+    return readFromXMLBetwixt(xmlString, clazz);
+  }
+
+  /**
+   * Jackson deserialize path for the public facade.
+   *
+   * @param xmlString never blank
+   * @param clazz target type, may be {@code null} (resolved from root via {@link #ms_typeMap})
+   */
+  private static Object readFromXMLJackson(String xmlString, Class clazz)
+      throws IOException, SAXException {
+    Class<?> target = clazz;
+    String parseXml = rewriteLegacyNullRoot(xmlString, target);
+
+    if (target == null) {
+      target = resolveClassFromRootElement(parseXml);
+      if (target == null) {
+        String rootName = peekRootElementName(parseXml);
+        throw new SAXException(
+            "No bean found"
+                + (rootName != null ? ", root element '" + rootName + "'" : "")
+                + ". Register the root type with addType or pass an explicit Class.");
+      }
+      // If root was still legacy <null>, rewrite now that type is known
+      parseXml = rewriteLegacyNullRoot(parseXml, target);
+    }
+
+    try {
+      return PSJacksonXmlSerializationHelper.readFromXml(parseXml, target);
+    } catch (IOException e) {
+      String rootName = peekRootElementName(parseXml);
+      throw new SAXException(
+          "No bean found"
+              + " for "
+              + target.getName()
+              + (rootName != null ? ", root element '" + rootName + "'" : "")
+              + ": "
+              + e.getMessage(),
+          e);
+    }
+  }
+
+  /** Legacy Betwixt read path (rollback only). */
+  private static Object readFromXMLBetwixt(String xmlString, Class clazz)
+      throws IOException, SAXException {
     // Rewrite legacy Betwixt root <null>…</null> to the mapped type element name
     // before parsing. Package payloads (keywords, etc.) were often written with a
     // root of "null"; Betwixt 0.7 only allows one registered name per class, and
@@ -512,18 +620,50 @@ public class PSXmlSerializationHelper {
   }
 
   /**
+   * Resolve a registered implementation class from the document root element name.
+   *
+   * @param xmlString XML to peek, never blank
+   * @return registered class or {@code null}
+   */
+  private static Class<?> resolveClassFromRootElement(String xmlString) {
+    String rootName = peekRootElementName(xmlString);
+    if (StringUtils.isBlank(rootName)) {
+      return null;
+    }
+    return ms_typeMap.get(rootName);
+  }
+
+  /**
+   * Best-effort root element local name (no full schema validation).
+   *
+   * @param xmlString never blank
+   * @return root tag name or {@code null}
+   */
+  private static String peekRootElementName(String xmlString) {
+    try {
+      Document doc = PSXmlDocumentBuilder.createXmlDocument(new StringReader(xmlString), false);
+      if (doc != null && doc.getDocumentElement() != null) {
+        return doc.getDocumentElement().getTagName();
+      }
+    } catch (Exception e) {
+      log.debug("Could not peek root element name: {}", PSExceptionUtils.getMessageForLog(e));
+    }
+    return null;
+  }
+
+  /**
    * When {@code clazz} is provided and the document root is the legacy element name {@code null},
-   * rewrite open/close root tags to the Betwixt-mapped type name (via {@link PSNameMapper}).
+   * rewrite open/close root tags to the mapped type name (via {@link PSXmlElementNameMapper}).
    *
    * <p>Package archives under {@code modules/perc-packages} commonly contain keyword XML whose root
-   * is {@code <null id="…">} rather than {@code <keyword>}. Left unchanged, Betwixt cannot bind the
-   * root and {@link #readFromXML(String, Class)} fails with "No bean found".
+   * is {@code <null id="…">} rather than {@code <keyword>}. Left unchanged, neither Betwixt nor
+   * Jackson can bind the root and {@link #readFromXML(String, Class)} fails with "No bean found".
    *
    * @param xmlString original XML, never blank
    * @param clazz target type, may be {@code null} (no rewrite)
-   * @return XML ready for Betwixt (possibly unchanged)
+   * @return XML ready for deserialize (possibly unchanged)
    */
-  static String rewriteLegacyNullRoot(String xmlString, Class<?> clazz) {
+  public static String rewriteLegacyNullRoot(String xmlString, Class<?> clazz) {
     if (clazz == null || StringUtils.isBlank(xmlString)) {
       return xmlString;
     }
@@ -532,8 +672,7 @@ public class PSXmlSerializationHelper {
       return xmlString;
     }
 
-    PSNameMapper mapper = new PSNameMapper();
-    String mapped = mapper.mapTypeToElementName(clazz.getSimpleName());
+    String mapped = PSXmlElementNameMapper.mapTypeToElementName(clazz.getSimpleName());
     if (StringUtils.isBlank(mapped) || "null".equals(mapped)) {
       return xmlString;
     }

--- a/modules/utils/src/test/java/com/percussion/services/utils/xml/PSJacksonXmlSerializationHelperTest.java
+++ b/modules/utils/src/test/java/com/percussion/services/utils/xml/PSJacksonXmlSerializationHelperTest.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
@@ -35,11 +36,13 @@ import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
- * Golden / round-trip parity for the parallel Jackson XML helper (issue #1822, epic #505).
+ * Golden / round-trip parity for the Jackson XML engine (issue #1822, cutover #1887, epic #505).
  *
  * <p>Pilot family mirrors package-deploy keywords ({@code SampleKeyword} / {@code SampleChoice})
- * because production {@code PSKeyword} lives outside {@code modules/utils}. Betwixt remains the
- * production default; these tests prove Jackson can match the wire shape.
+ * because production {@code PSKeyword} lives outside {@code modules/utils}. The production facade
+ * {@link PSXmlSerializationHelper} now defaults to this engine; tests here still call the helper
+ * directly and force Betwixt via {@link PSXmlSerializationHelper#ENGINE_PROPERTY} when comparing
+ * engines.
  */
 class PSJacksonXmlSerializationHelperTest {
 
@@ -51,6 +54,11 @@ class PSJacksonXmlSerializationHelperTest {
     PSXmlSerializationHelper.addType("sample-choice", SampleChoice.class);
     PSJacksonXmlSerializationHelper.addType("choice", SampleChoice.class);
     PSJacksonXmlSerializationHelper.addType("sample-choice", SampleChoice.class);
+  }
+
+  @AfterEach
+  void clearEngineProperty() {
+    System.clearProperty(PSXmlSerializationHelper.ENGINE_PROPERTY);
   }
 
   @Test
@@ -68,7 +76,9 @@ class PSJacksonXmlSerializationHelperTest {
   }
 
   @Test
-  void betwixtWriteProducesStableGoldenShape() throws Exception {
+  void betwixtRollbackWriteProducesStableGoldenShape() throws Exception {
+    System.setProperty(
+        PSXmlSerializationHelper.ENGINE_PROPERTY, PSXmlSerializationHelper.ENGINE_BETWIXT);
     SampleKeyword original = pilotKeyword();
     String betwixtXml = PSXmlSerializationHelper.writeToXml(original);
     assertNotNull(betwixtXml);
@@ -83,7 +93,10 @@ class PSJacksonXmlSerializationHelperTest {
   @Test
   void jacksonWriteMatchesBetwixtLogicalTree() throws Exception {
     SampleKeyword original = pilotKeyword();
+    System.setProperty(
+        PSXmlSerializationHelper.ENGINE_PROPERTY, PSXmlSerializationHelper.ENGINE_BETWIXT);
     String betwixtXml = PSXmlSerializationHelper.writeToXml(original);
+    System.clearProperty(PSXmlSerializationHelper.ENGINE_PROPERTY);
     String jacksonXml = PSJacksonXmlSerializationHelper.writeToXml(original);
 
     assertLogicalXmlParity(betwixtXml, jacksonXml);
@@ -98,7 +111,9 @@ class PSJacksonXmlSerializationHelperTest {
   }
 
   @Test
-  void betwixtWriteMatchesGoldenFixture() throws Exception {
+  void betwixtRollbackWriteMatchesGoldenFixture() throws Exception {
+    System.setProperty(
+        PSXmlSerializationHelper.ENGINE_PROPERTY, PSXmlSerializationHelper.ENGINE_BETWIXT);
     SampleKeyword original = pilotKeyword();
     String betwixtXml = PSXmlSerializationHelper.writeToXml(original);
     String golden = loadResource("com/percussion/services/utils/xml/sample-keyword-golden.xml");
@@ -106,9 +121,21 @@ class PSJacksonXmlSerializationHelperTest {
   }
 
   @Test
+  void facadeDefaultWriteMatchesGoldenFixture() throws Exception {
+    System.clearProperty(PSXmlSerializationHelper.ENGINE_PROPERTY);
+    SampleKeyword original = pilotKeyword();
+    String facadeXml = PSXmlSerializationHelper.writeToXml(original);
+    String golden = loadResource("com/percussion/services/utils/xml/sample-keyword-golden.xml");
+    assertLogicalXmlParity(golden, facadeXml);
+  }
+
+  @Test
   void betwixtWriteJacksonReadRoundTrip() throws Exception {
     SampleKeyword original = pilotKeyword();
+    System.setProperty(
+        PSXmlSerializationHelper.ENGINE_PROPERTY, PSXmlSerializationHelper.ENGINE_BETWIXT);
     String betwixtXml = PSXmlSerializationHelper.writeToXml(original);
+    System.clearProperty(PSXmlSerializationHelper.ENGINE_PROPERTY);
 
     SampleKeyword restored =
         PSJacksonXmlSerializationHelper.readFromXml(betwixtXml, SampleKeyword.class);
@@ -116,9 +143,8 @@ class PSJacksonXmlSerializationHelperTest {
   }
 
   @Test
-  void jacksonWriteBetwixtReadRoundTripScalars() throws Exception {
-    // Betwixt without a .betwixt file does not reliably restore nested collection items for this
-    // pilot (even Betwixt write→read leaves choices empty). Assert scalar wire + root binding.
+  void jacksonWriteFacadeReadRoundTripScalars() throws Exception {
+    // Nested collection restore on unannotated paths can differ by engine; assert scalar wire.
     SampleKeyword original = pilotKeyword();
     String jacksonXml = PSJacksonXmlSerializationHelper.writeToXml(original);
 

--- a/modules/utils/src/test/java/com/percussion/services/utils/xml/PSXmlSerializationHelperTest.java
+++ b/modules/utils/src/test/java/com/percussion/services/utils/xml/PSXmlSerializationHelperTest.java
@@ -18,20 +18,41 @@
 package com.percussion.services.utils.xml;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /**
- * Regression for package-deploy keyword install: Betwixt payloads often use a root element named
- * {@code null} instead of the mapped type name. Deserialization must still restore the bean.
+ * Facade regression for {@link PSXmlSerializationHelper} after the Jackson cutover (#1887 / epic
+ * #505). Covers legacy {@code <null>} root rewrite, golden pilot shapes, round-trip, suppress
+ * annotation, and Betwixt rollback engine property.
  */
 class PSXmlSerializationHelperTest {
 
-  /** Minimal bean shaped like packaged keyword/choice XML. */
+  @BeforeAll
+  static void registerChoiceTypes() {
+    PSXmlSerializationHelper.addType(
+        "choice", PSJacksonXmlSerializationHelperTest.SampleChoice.class);
+    PSXmlSerializationHelper.addType(
+        "sample-choice", PSJacksonXmlSerializationHelperTest.SampleChoice.class);
+    PSXmlSerializationHelper.addType(PSJacksonXmlSerializationHelperTest.SampleKeyword.class);
+  }
+
+  @AfterEach
+  void clearEngineProperty() {
+    System.clearProperty(PSXmlSerializationHelper.ENGINE_PROPERTY);
+  }
+
+  /** Minimal unannotated bean for rewrite-only cases (no nested collection assert). */
   public static class SampleKeyword {
     private long id;
     private String label;
@@ -108,6 +129,19 @@ class PSXmlSerializationHelperTest {
     public void setSequence(int sequence) {
       this.sequence = sequence;
     }
+  }
+
+  @Test
+  void defaultEngineIsJackson() {
+    System.clearProperty(PSXmlSerializationHelper.ENGINE_PROPERTY);
+    assertTrue(PSXmlSerializationHelper.isJacksonEngine());
+  }
+
+  @Test
+  void betwixtEnginePropertyForcesRollback() {
+    System.setProperty(
+        PSXmlSerializationHelper.ENGINE_PROPERTY, PSXmlSerializationHelper.ENGINE_BETWIXT);
+    assertFalse(PSXmlSerializationHelper.isJacksonEngine());
   }
 
   @Test
@@ -215,5 +249,131 @@ class PSXmlSerializationHelperTest {
     SampleKeyword restored = (SampleKeyword) PSXmlSerializationHelper.readFromXML(xml, target);
     assertEquals("Demo", restored.getLabel());
     assertEquals("7", restored.getValue());
+  }
+
+  @Test
+  void facadeWriteMatchesGoldenFixture() throws Exception {
+    // Use Jackson pilot DTO (simple name SampleKeyword → root sample-keyword).
+    PSJacksonXmlSerializationHelperTest.SampleKeyword original = jacksonPilotKeyword();
+    String facadeXml = PSXmlSerializationHelper.writeToXml(original);
+    String golden = loadResource("com/percussion/services/utils/xml/sample-keyword-golden.xml");
+    PSJacksonXmlSerializationHelperTest.assertLogicalXmlParity(golden, facadeXml);
+  }
+
+  @Test
+  void facadeJacksonRoundTripRestoresNestedChoices() throws Exception {
+    PSJacksonXmlSerializationHelperTest.SampleKeyword original = jacksonPilotKeyword();
+    String xml = PSXmlSerializationHelper.writeToXml(original);
+    assertTrue(xml.contains("sample-keyword"), xml);
+    assertTrue(xml.contains("sample-choice"), xml);
+
+    PSJacksonXmlSerializationHelperTest.SampleKeyword target =
+        new PSJacksonXmlSerializationHelperTest.SampleKeyword();
+    PSJacksonXmlSerializationHelperTest.SampleKeyword restored =
+        (PSJacksonXmlSerializationHelperTest.SampleKeyword)
+            PSXmlSerializationHelper.readFromXML(xml, target);
+    assertSame(target, restored);
+    assertEquals(original.getId(), restored.getId());
+    assertEquals(original.getLabel(), restored.getLabel());
+    assertEquals(original.getValue(), restored.getValue());
+    assertEquals(1, restored.getChoices().size());
+    assertEquals("ACT", restored.getChoices().get(0).getLabel());
+  }
+
+  @Test
+  void facadeReadAcceptsLegacyNullRootWithSampleChoiceItems() throws Exception {
+    String legacy =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <null>
+          <choices>
+            <sample-choice>
+              <id>2</id>
+              <label>ACT</label>
+              <sequence>1</sequence>
+              <value>ACT</value>
+            </sample-choice>
+          </choices>
+          <id>1</id>
+          <label>Time_Zones</label>
+          <value>401</value>
+        </null>
+        """;
+
+    PSJacksonXmlSerializationHelperTest.SampleKeyword restored =
+        (PSJacksonXmlSerializationHelperTest.SampleKeyword)
+            PSXmlSerializationHelper.readFromXML(
+                legacy, new PSJacksonXmlSerializationHelperTest.SampleKeyword());
+    assertEquals("Time_Zones", restored.getLabel());
+    assertEquals("401", restored.getValue());
+    assertEquals(1L, restored.getId());
+    assertNotNull(restored.getChoices());
+    assertEquals(1, restored.getChoices().size());
+    assertEquals("ACT", restored.getChoices().get(0).getLabel());
+  }
+
+  @Test
+  void facadeHonorsIpsXmlSerializationSuppress() throws Exception {
+    PSJacksonXmlSerializationHelperTest.SampleKeyword original = jacksonPilotKeyword();
+    original.setInternalOnly("secret-must-not-appear");
+    String xml = PSXmlSerializationHelper.writeToXml(original);
+    assertFalse(xml.contains("secret-must-not-appear"), xml);
+    assertFalse(xml.contains("internal-only"), xml);
+    assertFalse(xml.contains("internalOnly"), xml);
+  }
+
+  @Test
+  void betwixtRollbackEngineStillWritesAndReadsScalars() throws Exception {
+    System.setProperty(
+        PSXmlSerializationHelper.ENGINE_PROPERTY, PSXmlSerializationHelper.ENGINE_BETWIXT);
+    assertFalse(PSXmlSerializationHelper.isJacksonEngine());
+
+    SampleKeyword original = new SampleKeyword();
+    original.setId(9);
+    original.setLabel("Rollback");
+    original.setValue("9");
+
+    String xml = PSXmlSerializationHelper.writeToXml(original);
+    assertNotNull(xml);
+    assertTrue(xml.contains("sample-keyword") || xml.contains("SampleKeyword"), xml);
+
+    SampleKeyword target = new SampleKeyword();
+    SampleKeyword restored = (SampleKeyword) PSXmlSerializationHelper.readFromXML(xml, target);
+    assertEquals("Rollback", restored.getLabel());
+    assertEquals("9", restored.getValue());
+  }
+
+  @Test
+  void addTypeRegistersOnJacksonHelper() {
+    class LocalMarker {
+      // marker type for registry only
+    }
+    String name = "local-marker-" + System.nanoTime();
+    PSXmlSerializationHelper.addType(name, LocalMarker.class);
+    assertEquals(LocalMarker.class, PSJacksonXmlSerializationHelper.typeMapView().get(name));
+  }
+
+  private static PSJacksonXmlSerializationHelperTest.SampleKeyword jacksonPilotKeyword() {
+    PSJacksonXmlSerializationHelperTest.SampleKeyword k =
+        new PSJacksonXmlSerializationHelperTest.SampleKeyword();
+    k.setId(1L);
+    k.setLabel("Time_Zones");
+    k.setValue("401");
+    PSJacksonXmlSerializationHelperTest.SampleChoice c =
+        new PSJacksonXmlSerializationHelperTest.SampleChoice();
+    c.setId(2L);
+    c.setLabel("ACT");
+    c.setValue("ACT");
+    c.setSequence(1);
+    k.getChoices().add(c);
+    return k;
+  }
+
+  private static String loadResource(String classpath) throws Exception {
+    try (InputStream in =
+        PSXmlSerializationHelperTest.class.getClassLoader().getResourceAsStream(classpath)) {
+      assertNotNull(in, "missing test resource: " + classpath);
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
   }
 }

--- a/modules/utils/src/test/resources/com/percussion/services/utils/xml/sample-keyword-golden.xml
+++ b/modules/utils/src/test/resources/com/percussion/services/utils/xml/sample-keyword-golden.xml
@@ -1,7 +1,9 @@
 <!--
-  Golden snapshot from Betwixt PSXmlSerializationHelper.writeToXml(SampleKeyword pilot).
-  Captured for issue #1822 / epic #505. Betwixt may also emit graph-identity id="…" attributes
-  on complex elements; tests strip those for logical tree compare (property values live in elements).
+  Golden snapshot from Betwixt write of SampleKeyword pilot (issue #1822).
+  Production facade PSXmlSerializationHelper defaults to Jackson (#1887) which matches this
+  logical tree. Betwixt may also emit graph-identity id="…" attributes on complex elements;
+  tests strip those for logical tree compare (property values live in elements). Approved
+  deviation: Jackson does not emit those id attributes.
 -->
 <sample-keyword>
   <choices>


### PR DESCRIPTION
## Summary

Implements **issue #1887** (parent **#1823** slice 1 / epic **#505**): cut over `PSXmlSerializationHelper` production internals to Jackson XML while **preserving the public API**. Builds on pilot **#1822** (PR #1886).

### What landed
- `PSXmlSerializationHelper.writeToXml` / `readFromXML` default to `PSJacksonXmlSerializationHelper`
- Public API unchanged: `addType`, `readFromXML`, `writeToXml`, `getIdFromXml`, `rewriteLegacyNullRoot` (now public)
- `addType` dual-registers Betwixt + Jackson type maps
- Methods remain `synchronized` until Betwixt is fully removed
- **Rollback flag:** `-Dcom.percussion.xml.serialization.engine=betwixt` (default `jackson`)
  - **Removal plan:** drop property + Betwixt private paths after domain consumer slices (#1823 / #1888+) and `commons-betwixt` removal (#1824)
- Expanded golden / round-trip / legacy `<null>` root / suppress / engine-property tests
- `commons-betwixt` **not** removed; domain `.betwixt` files untouched; no domain bean migration

### Approved XML deviations
- Jackson does **not** emit Betwixt graph-identity `id="…"` attributes on complex elements (property values live in child elements). Golden compare continues to strip them.
- Unannotated domain collection item element names may still need annotations/mix-ins in later domain slices.

### Out of scope
- Domain consumer migration → later #1823 slices / #1888+
- `commons-betwixt` POM removal → #1824
- Dropping domain `.betwixt` files

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #1887  
Related: #1823, #505, #1822

## Test plan
- [x] `cd modules/utils && ../../mvnw clean install` — **BUILD SUCCESS** (Tests run: 264, Failures: 0)
- [x] Focused: `PSXmlSerializationHelperTest` (15), `PSJacksonXmlSerializationHelperTest` (12), `PSXmlElementNameMapperTest` (6)
- [x] Spotless: `mvnw spotless:apply -pl modules/utils` **then** `spotless:check -pl modules/utils` — clean; in-scope only
- [x] Erlang self-review: approve — `docs/ai-generated/code-reviews/issue-1887-xml-helper-jackson-facade-erlang.md`

## Gates evidence
| Gate | Result |
|------|--------|
| Module clean install | `modules/utils` standalone **BUILD SUCCESS** |
| Spotless | apply **then** check on utils — pass; no out-of-scope reformat dump |
| Erlang | approve; portable paths N/A (no filesystem path logic) |
| Betwixt retained | yes (rollback path + classpath) |