### PR TITLE
fix(system): Jackson-migrate PSKeyword domain + IPSGuid string serde (#1888)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-1888-pskeyword-jackson-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-1888-pskeyword-jackson-erlang.md
@@ -1,0 +1,39 @@
+# Erlang review — issue #1888 PSKeyword Jackson migrate
+
+**Branch:** `fix/issue-1888-pskeyword-jackson`  
+**Date:** 2026-08-04  
+**Scope:** `PSKeyword` / `PSKeywordChoice` domain Jackson wire + utils `IPSGuid` string serde  
+**Recommendation:** **approve**  
+**Gate:** May commit/push: **yes**
+
+## Summary
+
+Migrates content keyword design objects to the Jackson-backed `PSXmlSerializationHelper` (default since #1887) with package-shaped nested element `choice`, golden/round-trip tests, offline `Adhoc_Type.keyword` package smoke, and a shared `IPSGuid` string converter required for `<guid>` package XML (also unblocks pre-existing `PSTemplateSlotXmlRestoreTest` failures on main after #1887).
+
+## Issues
+
+None blocking.
+
+### Observations (non-blocking)
+
+- `PSKeyword.betwixt` retained for dual-engine rollback until #1824.
+- Catalog interface default methods suppressed via `@JsonAutoDetect(getterVisibility=NONE)` + explicit `@JsonProperty` opt-in — correct companion pattern for other catalog domain types later.
+- `setChoice` / `addChoice` `@JsonIgnore` avoids Jackson conflicting with collection item name `choice`.
+
+## Cross-platform path checklist
+
+- Tests load classpath resources via `ClassLoader.getResourceAsStream` (portable).
+- Package fixture is a resource copy, not filesystem path string assertions.
+- **Outcome:** clean.
+
+## Memory patterns hit
+
+- Prefer annotations/mix-ins on domain types; keep public `fromXML`/`toXML` call sites.
+- Document approved XML deviations vs Betwixt.
+- Shared converter in utils when domain batch proves IPSGuid binding needed.
+
+## Verification
+
+- `cd modules/utils && ../../mvnw clean install` — BUILD SUCCESS (`PSJacksonXmlSerializationHelperTest` 13 tests)
+- `cd system && ../mvnw clean install` — BUILD SUCCESS (`PSKeywordXmlSerializationTest` 6 tests; suite green)
+- Module Spotless apply then check on system; utils Spotless before commit

--- a/docs/ai-generated/tasks/505-betwixt-jackson/1888-pskeyword-deviations.md
+++ b/docs/ai-generated/tasks/505-betwixt-jackson/1888-pskeyword-deviations.md
@@ -1,0 +1,49 @@
+# Issue #1888 — PSKeyword / PSKeywordChoice Jackson wire deviations
+
+Parent: #1823 · Epic: #505 · Facade: #1887 · Pilot: #1822
+
+## Scope delivered
+
+- Production `PSKeyword` / `PSKeywordChoice` annotated for Jackson-backed
+  `PSXmlSerializationHelper` (default engine).
+- Nested package element name pinned to **`choice`** (not `keyword-choice`).
+- Golden fixture + round-trip tests + offline package smoke (`Adhoc_Type.keyword`).
+- `PSKeyword.betwixt` **retained** for dual-engine rollback
+  (`-Dcom.percussion.xml.serialization.engine=betwixt`) until #1824.
+
+## Approved XML deviations (Jackson write vs historical Betwixt packages)
+
+|                         Historical Betwixt / package dump                          |                              Jackson default write                              |                                               Notes                                               |
+|------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| Graph-identity `id="…"` attributes on complex elements                             | Not emitted                                                                     | Property values live in child elements; documented in #1887                                       |
+| Root `<null>` on package archives                                                  | Root `<keyword>` on modern write                                                | Read path still rewrites legacy `<null>` → mapped root                                            |
+| Nested item `<choice>`                                                             | Nested item `<choice>`                                                          | **Parity** via `@JacksonXmlProperty(localName="choice")`                                          |
+| Mapped type name `keyword-choice` (if type-mapped write)                           | Not used for nested items                                                       | Standalone `PSKeywordChoice.toXML()` root is still `keyword-choice`                               |
+| `<guid>0-14-…</guid>`                                                              | Emitted/read as string                                                          | Shared `IPSGuid` converter in `PSJacksonXmlSerializationHelper` (Betwixt parity)                  |
+| `<name>` (alias of label)                                                          | Omitted                                                                         | Package read tolerates extra `name`                                                               |
+| `<type>KEYWORD_DEF</type>`                                                         | Omitted                                                                         | Catalog summary; not needed for install                                                           |
+| Catalog default methods (`description-optional`, `display-string`, `type-enum`, …) | Omitted via `@JsonAutoDetect(getterVisibility=NONE)` + explicit `@JsonProperty` | Interface defaults otherwise leak into Jackson XML                                                |
+| `<version>`                                                                        | Suppressed (`@IPSXmlSerialization`)                                             | Same as Betwixt annotation path                                                                   |
+| Optional wrapper getters (`*Optional` on choice)                                   | Suppressed                                                                      | Avoid spurious elements                                                                           |
+| Property order                                                                     | `choices` first then scalars + guid (`@JsonPropertyOrder`)                      | Packages interleave name/type; golden captures Jackson order                                      |
+
+## Package install smoke (offline)
+
+Fixture: `system/src/test/resources/.../Adhoc_Type.keyword` (copy of
+`modules/perc-packages/.../perc.widget.blogIndexPage/Adhoc_Type.keyword`).
+
+`PSKeyword.fromXML` restores id, label, value, keyword-type, sequence, description,
+and all three choices with element name `choice` under legacy `<null>` root.
+
+## Utils companion (shared)
+
+`PSJacksonXmlSerializationHelper` registers `IPSGuid`/`PSGuid` string serde (Betwixt
+`PSBetwixtObjectConverter` parity). Unblocks package XML with `<guid>` for keywords and
+pre-existing assembly slot restore tests after the #1887 Jackson facade default.
+
+## Not in this PR
+
+- Full assembly/security/workflow domain annotation batches
+- Betwixt POM removal (#1824)
+- Live CMS package install
+

--- a/modules/utils/src/main/java/com/percussion/services/utils/xml/PSJacksonXmlSerializationHelper.java
+++ b/modules/utils/src/main/java/com/percussion/services/utils/xml/PSJacksonXmlSerializationHelper.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.services.utils.xml;
 
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.xml.IPSXmlSerialization;
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -24,16 +26,20 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.lang3.StringUtils;
+import tools.jackson.core.JacksonException;
 import tools.jackson.databind.BeanDescription;
+import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.PropertyNamingStrategies;
 import tools.jackson.databind.SerializationConfig;
 import tools.jackson.databind.SerializationFeature;
 import tools.jackson.databind.cfg.MapperConfig;
+import tools.jackson.databind.deser.std.FromStringDeserializer;
 import tools.jackson.databind.introspect.AnnotatedMember;
 import tools.jackson.databind.module.SimpleModule;
 import tools.jackson.databind.ser.BeanPropertyWriter;
 import tools.jackson.databind.ser.ValueSerializerModifier;
+import tools.jackson.databind.ser.std.ToStringSerializer;
 import tools.jackson.dataformat.xml.JacksonXmlAnnotationIntrospector;
 import tools.jackson.dataformat.xml.XmlMapper;
 import tools.jackson.dataformat.xml.XmlWriteFeature;
@@ -63,6 +69,9 @@ import tools.jackson.dataformat.xml.XmlWriteFeature;
  * <p><strong>Approved XML deviations vs historical Betwixt writes:</strong> Jackson does not emit
  * Betwixt graph-identity {@code id="…"} attributes on complex elements (values live in child
  * elements).
+ *
+ * <p>{@link IPSGuid} / {@link PSGuid} use string form (same as historical Betwixt {@code
+ * PSBetwixtObjectConverter}) via a registered module (issue #1888).
  */
 public final class PSJacksonXmlSerializationHelper {
 
@@ -186,17 +195,76 @@ public final class PSJacksonXmlSerializationHelper {
     SimpleModule suppressModule = new SimpleModule("ps-ips-xml-serialization-suppress");
     suppressModule.setSerializerModifier(new IpsXmlSuppressionModifier());
 
+    SimpleModule guidModule = new SimpleModule("ps-ips-guid-string");
+    // Match Betwixt PSBetwixtObjectConverter: IPSGuid ↔ toString / new PSGuid(String)
+    guidModule.addSerializer(IPSGuid.class, new ToStringSerializer(IPSGuid.class));
+    guidModule.addSerializer(PSGuid.class, new ToStringSerializer(PSGuid.class));
+    guidModule.addDeserializer(IPSGuid.class, new IpsGuidFromStringDeserializer());
+    guidModule.addDeserializer(PSGuid.class, new PsGuidFromStringDeserializer());
+
     return XmlMapper.builder()
         .defaultUseWrapper(true)
         .propertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE)
         .annotationIntrospector(new PsJacksonXmlAnnotationIntrospector())
         .addModule(suppressModule)
+        .addModule(guidModule)
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
         // Betwixt pretty-prints; keep Jackson pretty for readable golden comparison
         .enable(SerializationFeature.INDENT_OUTPUT)
         // Avoid empty XML declaration quirks when comparing to Betwixt body fragments
         .disable(XmlWriteFeature.WRITE_XML_DECLARATION)
         .build();
+  }
+
+  /**
+   * Deserializes package/design {@code <guid>} string values into {@link IPSGuid}, matching {@link
+   * PSBetwixtObjectConverter#stringToObject}.
+   */
+  static final class IpsGuidFromStringDeserializer extends FromStringDeserializer<IPSGuid> {
+    private static final long serialVersionUID = 1L;
+
+    IpsGuidFromStringDeserializer() {
+      super(IPSGuid.class);
+    }
+
+    @Override
+    protected IPSGuid _deserialize(String value, DeserializationContext ctxt)
+        throws JacksonException {
+      if (StringUtils.isBlank(value)) {
+        return null;
+      }
+      try {
+        return new PSGuid(value.trim());
+      } catch (RuntimeException ex) {
+        return (IPSGuid)
+            ctxt.handleWeirdStringValue(
+                IPSGuid.class, value, "not a valid PSGuid string: %s", ex.getMessage());
+      }
+    }
+  }
+
+  /** Concrete {@link PSGuid} string deserializer (same wire form as {@link IPSGuid}). */
+  static final class PsGuidFromStringDeserializer extends FromStringDeserializer<PSGuid> {
+    private static final long serialVersionUID = 1L;
+
+    PsGuidFromStringDeserializer() {
+      super(PSGuid.class);
+    }
+
+    @Override
+    protected PSGuid _deserialize(String value, DeserializationContext ctxt)
+        throws JacksonException {
+      if (StringUtils.isBlank(value)) {
+        return null;
+      }
+      try {
+        return new PSGuid(value.trim());
+      } catch (RuntimeException ex) {
+        return (PSGuid)
+            ctxt.handleWeirdStringValue(
+                PSGuid.class, value, "not a valid PSGuid string: %s", ex.getMessage());
+      }
+    }
   }
 
   /**

--- a/modules/utils/src/test/java/com/percussion/services/utils/xml/PSJacksonXmlSerializationHelperTest.java
+++ b/modules/utils/src/test/java/com/percussion/services/utils/xml/PSJacksonXmlSerializationHelperTest.java
@@ -231,6 +231,23 @@ class PSJacksonXmlSerializationHelperTest {
   }
 
   @Test
+  void ipsGuidSerializesAndDeserializesAsBetwixtStringForm() throws Exception {
+    // Parity with PSBetwixtObjectConverter — required for package <guid> elements (#1888).
+    SampleWithGuid original = new SampleWithGuid();
+    original.setId(513L);
+    original.setGuid(new com.percussion.services.guidmgr.data.PSGuid("0-5-513"));
+
+    String xml = PSJacksonXmlSerializationHelper.writeToXml(original);
+    assertTrue(xml.contains("<guid>0-5-513</guid>") || xml.contains(">0-5-513<"), xml);
+
+    SampleWithGuid restored =
+        PSJacksonXmlSerializationHelper.readFromXml(xml, SampleWithGuid.class);
+    assertNotNull(restored.getGuid());
+    assertEquals("0-5-513", restored.getGuid().toString());
+    assertEquals(513L, restored.getId());
+  }
+
+  @Test
   void ipsXmlSerializationSuppressIsHonoredByJackson() throws Exception {
     SampleKeyword original = pilotKeyword();
     original.setInternalOnly("secret-must-not-appear");
@@ -363,6 +380,28 @@ class PSJacksonXmlSerializationHelperTest {
 
     public void setInternalOnly(String internalOnly) {
       this.internalOnly = internalOnly;
+    }
+  }
+
+  @JacksonXmlRootElement(localName = "sample-with-guid")
+  public static class SampleWithGuid {
+    private long id;
+    private com.percussion.utils.guid.IPSGuid guid;
+
+    public long getId() {
+      return id;
+    }
+
+    public void setId(long id) {
+      this.id = id;
+    }
+
+    public com.percussion.utils.guid.IPSGuid getGuid() {
+      return guid;
+    }
+
+    public void setGuid(com.percussion.utils.guid.IPSGuid guid) {
+      this.guid = guid;
     }
   }
 

--- a/system/pom.xml
+++ b/system/pom.xml
@@ -535,6 +535,11 @@
 			<groupId>tools.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
+		<!-- Design-object Jackson XML annotations (PSKeyword etc.; #1888 / epic #505) -->
+		<dependency>
+			<groupId>tools.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-xml</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>com.percussion</groupId>
 			<artifactId>perc-shared-test-resources</artifactId>

--- a/system/services/src/com/percussion/services/content/data/PSKeyword.java
+++ b/system/services/src/com/percussion/services/content/data/PSKeyword.java
@@ -17,6 +17,10 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.services.content.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.catalog.IPSCatalogItem;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
@@ -25,14 +29,6 @@ import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.xml.IPSXmlSerialization;
-
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -40,7 +36,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.persistence.Version;
-
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -48,6 +49,9 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * This object represents a single keyword with enhanced Java 11 support.
@@ -66,9 +70,33 @@ import org.xml.sax.SAXException;
  *
  * @since Java 11 Modernization
  */
+/**
+ * Design-object XML root is {@code keyword} (PS/IPS strip + hyphenation). Nested package archives
+ * use item element {@code choice} (not the mapped type name {@code keyword-choice}) — pinned via
+ * Jackson annotations and {@link PSXmlSerializationHelper#addType(String, Class)} (issue #1888 /
+ * epic #505).
+ */
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSKeyword")
 @Table(name = "RXLOOKUP")
+@JacksonXmlRootElement(localName = "keyword")
+// Opt-in XML surface: catalog interface default methods must not leak into design XML.
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({
+  "choices",
+  "description",
+  "guid",
+  "id",
+  "keywordType",
+  "label",
+  "sequence",
+  "value"
+})
 public class PSKeyword implements Serializable, IPSCatalogSummary,
    IPSCatalogItem, IPSCloneTuner {
 
@@ -115,7 +143,7 @@ public class PSKeyword implements Serializable, IPSCatalogSummary,
 
    static {
       // Package XML uses <choice> (collection singular of "choices"), not the mapped type name
-      // "keyword-choice". Register once for Betwixt (not on every fromXML call).
+      // "keyword-choice". Register once for Betwixt + Jackson type maps (not on every fromXML).
       PSXmlSerializationHelper.addType("choice", PSKeywordChoice.class);
    }
 
@@ -180,6 +208,7 @@ public class PSKeyword implements Serializable, IPSCatalogSummary,
     * 
     * @return the keyword type, never <code>null</code> or empty.
     */
+   @JsonProperty
    public String getKeywordType()
    {
       return keywordType;
@@ -209,6 +238,7 @@ public class PSKeyword implements Serializable, IPSCatalogSummary,
     * 
     * @return the keyword value, never <code>null</code>, may be empty.
     */
+   @JsonProperty
    public String getValue()
    {
       return (value != null) ? value : "";
@@ -236,6 +266,7 @@ public class PSKeyword implements Serializable, IPSCatalogSummary,
     * 
     * @return the keyword label, never <code>null</code> or empty.
     */
+   @JsonProperty
    public String getLabel()
    {
       return label;
@@ -269,6 +300,7 @@ public class PSKeyword implements Serializable, IPSCatalogSummary,
     * 
     * @return the keyword description, may be <code>null</code> or empty.
     */
+   @JsonProperty
    public String getDescription()
    {
       return description;
@@ -290,6 +322,7 @@ public class PSKeyword implements Serializable, IPSCatalogSummary,
     * 
     * @return the 0 based display sequence.
     */
+   @JsonProperty
    public Integer getSequence()
    {
       return sequence;
@@ -314,6 +347,8 @@ public class PSKeyword implements Serializable, IPSCatalogSummary,
     *
     * @return Optional containing the list of choices, never null
     */
+   @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public Optional<List<PSKeywordChoice>> getChoicesOptional() {
       return Optional.ofNullable(m_choices);
    }
@@ -321,8 +356,15 @@ public class PSKeyword implements Serializable, IPSCatalogSummary,
    /**
     * Get the keyword choices (legacy method for backward compatibility).
     *
+    * <p>Jackson pins nested items to package element name {@code choice} (matches historical
+    * {@code PSKeyword.betwixt} and {@link PSXmlSerializationHelper#addType} registration). Without
+    * this annotation Jackson would emit the mapped type name {@code keyword-choice}.
+    *
     * @return the list of choices, never {@code null}, may be empty
     */
+   @JsonProperty
+   @JacksonXmlElementWrapper(localName = "choices")
+   @JacksonXmlProperty(localName = "choice")
    public List<PSKeywordChoice> getChoices() {
       return m_choices != null ? m_choices : List.of();
    }
@@ -339,9 +381,13 @@ public class PSKeyword implements Serializable, IPSCatalogSummary,
    /**
     * Set a keyword choice, either inserts a new one or updated an existing one
     * based on the label case insensitive.
+    *
+    * <p>Ignored by Jackson (conflicts with collection item name {@code choice}); use
+    * {@link #setChoices(List)} for XML restore. Still used by service/API callers.
     * 
     * @param choice the keyword choice to set, not <code>null</code>.
     */
+   @JsonIgnore
    public void setChoice(PSKeywordChoice choice)
    {
       if (choice == null)
@@ -363,10 +409,12 @@ public class PSKeyword implements Serializable, IPSCatalogSummary,
    }
 
    /**
-    * Necessary for betwixt serialization
+    * Necessary for Betwixt rollback serialization ({@code PSKeyword.betwixt} updater). Jackson uses
+    * {@link #setChoices(List)} instead.
     * 
-    * @param choice
+    * @param choice the keyword choice to add, not {@code null}
     */
+   @JsonIgnore
    public void addChoice(PSKeywordChoice choice)
    {
       if (choice == null)
@@ -423,6 +471,7 @@ public class PSKeyword implements Serializable, IPSCatalogSummary,
     * 
     * @return The lookup id, <code>null</code> if not initialized yet.
     */
+   @JsonProperty
    public long getId()
    {
       return this.m_id;
@@ -479,6 +528,11 @@ public class PSKeyword implements Serializable, IPSCatalogSummary,
     * 
     * @see IPSCatalogSummary#getGUID()
     */
+   /**
+    * Catalog GUID. Jackson emits/reads string form via shared {@code IPSGuid} converter in {@code
+    * PSJacksonXmlSerializationHelper} (parity with Betwixt {@code PSBetwixtObjectConverter}).
+    */
+   @JsonProperty("guid")
    public IPSGuid getGUID()
    {
       return new PSGuid(PSTypeEnum.KEYWORD_DEF, m_id);
@@ -489,6 +543,12 @@ public class PSKeyword implements Serializable, IPSCatalogSummary,
     * 
     * @see IPSCatalogSummary#getName()
     */
+   /**
+    * Alias of {@link #getLabel()} for {@link IPSCatalogSummary}. Jackson omits {@code <name>}
+    * (duplicate of {@code <label>}); packages historically emitted both with the same value and
+    * read tolerates extra {@code name}. Betwixt rollback still emits name.
+    */
+   @JsonIgnore
    public String getName()
    {
       return getLabel();
@@ -499,7 +559,13 @@ public class PSKeyword implements Serializable, IPSCatalogSummary,
     * 
     * @see IPSCatalogSummary#getType()
     */
+   /**
+    * Catalog type name ({@code KEYWORD_DEF}). Jackson omits {@code <type>}; packages may still
+    * contain a legacy {@code <type>} element which is ignored on Jackson read. Betwixt rollback
+    * still emits type.
+    */
    @Override
+   @JsonIgnore
    public String getType()
    {
       return PSTypeEnum.KEYWORD_DEF.name();

--- a/system/services/src/com/percussion/services/content/data/PSKeywordChoice.java
+++ b/system/services/src/com/percussion/services/content/data/PSKeywordChoice.java
@@ -17,36 +17,40 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.services.content.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
-
+import com.percussion.utils.xml.IPSXmlSerialization;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.Optional;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
- * Represents a single keyword choice with enhanced Java 11 support.
+ * Represents a single keyword choice.
  *
- * <p>Keyword choices are used to define selectable options within a keyword.
- * This class provides comprehensive functionality for managing choice data with
- * modern Java 11 features including validation, serialization, and safe navigation.
- *
- * <p>Key features:
- * <ul>
- *   <li>Enhanced null safety with Objects.requireNonNull()</li>
- *   <li>Optional-based safe value access</li>
- *   <li>Immutable factory methods</li>
- *   <li>Comprehensive validation with clear error messages</li>
- * </ul>
+ * <p>Nested package item element name is {@code choice} (registered from {@link PSKeyword}), not
+ * the default mapped type name {@code keyword-choice}. {@link JacksonXmlRootElement} applies to
+ * standalone {@link #toXML()}/{@link #fromXML(String)} only.
  *
  * @since Java 11 Modernization
  */
+@JacksonXmlRootElement(localName = "keyword-choice")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({"description", "label", "sequence", "value"})
 public class PSKeywordChoice implements Serializable {
 
    /**
@@ -121,6 +125,8 @@ public class PSKeywordChoice implements Serializable {
     *
     * @return Optional containing the value if non-null, empty Optional otherwise
     */
+   @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public Optional<String> getValueOptional() {
       return Optional.ofNullable(value);
    }
@@ -130,6 +136,7 @@ public class PSKeywordChoice implements Serializable {
     *
     * @return the keyword choice value, never {@code null}, may be empty
     */
+   @JsonProperty
    public String getValue() {
       return value != null ? value : "";
    }
@@ -149,6 +156,7 @@ public class PSKeywordChoice implements Serializable {
     * 
     * @return the keyword choice label, never {@code null} or empty
     */
+   @JsonProperty
    public String getLabel() {
       return label;
    }
@@ -171,6 +179,8 @@ public class PSKeywordChoice implements Serializable {
     *
     * @return Optional containing the description if non-null, empty Optional otherwise
     */
+   @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public Optional<String> getDescriptionOptional() {
       return Optional.ofNullable(description);
    }
@@ -180,6 +190,7 @@ public class PSKeywordChoice implements Serializable {
     *
     * @return the keyword choice description, may be {@code null} or empty
     */
+   @JsonProperty
    public String getDescription() {
       return description;
    }
@@ -198,6 +209,7 @@ public class PSKeywordChoice implements Serializable {
     *
     * @return the 0-based display sequence, never {@code null}
     */
+   @JsonProperty
    public Integer getSequence() {
       return sequence != null ? sequence : 0;
    }

--- a/system/src/test/java/com/percussion/services/content/data/PSKeywordXmlSerializationTest.java
+++ b/system/src/test/java/com/percussion/services/content/data/PSKeywordXmlSerializationTest.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.content.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * Golden / round-trip / package-fixture smoke for {@link PSKeyword} and {@link PSKeywordChoice}
+ * under the Jackson-backed {@code PSXmlSerializationHelper} (issue #1888, epic #505).
+ *
+ * <p>Offline only — no live CMS. Package smoke loads shipped {@code .keyword} XML from {@code
+ * perc-packages} (copied under test resources).
+ */
+class PSKeywordXmlSerializationTest {
+
+  @Test
+  void writeEmitsChoiceNotKeywordChoiceAndSuppressesVersion() throws Exception {
+    PSKeyword original = sampleAdhocKeyword();
+    String xml = original.toXML();
+
+    assertNotNull(xml);
+    assertFalse(xml.trim().startsWith("<null"), "modern write must not emit legacy null root");
+    assertTrue(containsTag(xml, "keyword"), "root keyword: " + xml);
+    assertTrue(containsTag(xml, "choice"), "nested package element choice: " + xml);
+    assertFalse(
+        containsTag(xml, "keyword-choice"),
+        "must not emit mapped type name keyword-choice: " + xml);
+    assertFalse(xml.contains("secret-must-not"), xml);
+    assertFalse(containsTag(xml, "version"), "version suppressed: " + xml);
+    assertTrue(containsTag(xml, "guid"), "guid string form on Jackson path: " + xml);
+    assertTrue(xml.contains("0-14-125") || xml.contains(">125<"), xml);
+    assertFalse(containsTag(xml, "guid-optional"), xml);
+    assertFalse(containsTag(xml, "description-optional"), xml);
+    assertFalse(containsTag(xml, "display-string"), xml);
+    assertFalse(containsTag(xml, "name-optional"), xml);
+    assertFalse(containsTag(xml, "type-enum"), xml);
+    assertFalse(containsTag(xml, "type-ordinal"), xml);
+    assertFalse(containsTag(xml, "identifier-string"), xml);
+    // bare <name>/<type> catalog aliases
+    assertFalse(xml.matches("(?s).*<name(\\s|>).*"), "name alias suppressed: " + xml);
+    assertFalse(xml.matches("(?s).*<type(\\s|>).*"), "catalog type suppressed: " + xml);
+    assertTrue(xml.contains("Adhoc_Type"), xml);
+    assertTrue(xml.contains("Anonymous"), xml);
+  }
+
+  @Test
+  void writeMatchesGoldenFixture() throws Exception {
+    PSKeyword original = sampleAdhocKeyword();
+    String xml = original.toXML();
+    String golden = loadResource("com/percussion/services/content/data/ps-keyword-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+  }
+
+  @Test
+  void roundTripWriteReadRestoresChoicesAndScalars() throws Exception {
+    PSKeyword original = sampleAdhocKeyword();
+    String xml = original.toXML();
+
+    PSKeyword restored = new PSKeyword();
+    restored.fromXML(xml);
+
+    assertKeywordGraphEquals(original, restored);
+  }
+
+  @Test
+  void fromXmlAcceptsLegacyNullRootPackageShape() throws Exception {
+    String legacy =
+        """
+        <?xml version="1.0" encoding="utf-8"?>  <null id="1">
+            <choices>
+              <choice id="2">
+                <description>Ad Hoc Assignment Anonymous Access</description>
+                <label>Anonymous</label>
+                <sequence>3</sequence>
+                <value>2</value>
+              </choice>
+              <choice id="3">
+                <description>Ad Hoc Assignment Enabled</description>
+                <label>Enabled</label>
+                <sequence>2</sequence>
+                <value>1</value>
+              </choice>
+            </choices>
+            <guid>0-14-125</guid>
+            <description>Ad Hoc Assignment Lookups</description>
+            <id>125</id>
+            <keyword-type>1</keyword-type>
+            <label>Adhoc_Type</label>
+            <name>Adhoc_Type</name>
+            <sequence>1</sequence>
+            <type>KEYWORD_DEF</type>
+            <value>125</value>
+          </null>
+        """;
+
+    PSKeyword restored = new PSKeyword();
+    restored.fromXML(legacy);
+
+    assertEquals(125L, restored.getId());
+    assertEquals("Adhoc_Type", restored.getLabel());
+    assertEquals("125", restored.getValue());
+    assertEquals("1", restored.getKeywordType());
+    assertEquals(1, restored.getSequence().intValue());
+    assertEquals("Ad Hoc Assignment Lookups", restored.getDescription());
+    assertNotNull(restored.getChoices());
+    assertEquals(2, restored.getChoices().size());
+    assertEquals("Anonymous", restored.getChoices().get(0).getLabel());
+    assertEquals("2", restored.getChoices().get(0).getValue());
+    assertEquals(3, restored.getChoices().get(0).getSequence().intValue());
+    assertEquals("Enabled", restored.getChoices().get(1).getLabel());
+  }
+
+  @Test
+  void packageFixtureAdhocTypeKeywordSmoke() throws Exception {
+    // Offline package smoke: shipped perc.widget.blogIndexPage Adhoc_Type.keyword shape
+    String packaged = loadResource("com/percussion/services/content/data/Adhoc_Type.keyword");
+    assertTrue(packaged.contains("<null"), "fixture should keep legacy null root");
+    assertTrue(packaged.contains("<choice"), packaged);
+
+    PSKeyword restored = new PSKeyword();
+    restored.fromXML(packaged);
+
+    assertEquals(125L, restored.getId());
+    assertEquals("Adhoc_Type", restored.getLabel());
+    assertEquals("125", restored.getValue());
+    assertEquals("1", restored.getKeywordType());
+    assertEquals(3, restored.getChoices().size());
+
+    PSKeywordChoice disabled =
+        restored.getChoices().stream()
+            .filter(c -> "Disabled".equals(c.getLabel()))
+            .findFirst()
+            .orElseThrow();
+    assertEquals("0", disabled.getValue());
+    assertEquals(1, disabled.getSequence().intValue());
+    assertEquals("Ad Hoc Assignment Disabled", disabled.getDescription());
+  }
+
+  @Test
+  void choiceStandaloneRoundTrip() throws Exception {
+    PSKeywordChoice original =
+        PSKeywordChoice.of("2", "Anonymous", "Ad Hoc Assignment Anonymous Access", 3);
+    String xml = original.toXML();
+    assertTrue(containsTag(xml, "keyword-choice"), "standalone root uses mapped type name: " + xml);
+
+    PSKeywordChoice restored = new PSKeywordChoice();
+    restored.fromXML(xml);
+    assertEquals(original, restored);
+  }
+
+  private static PSKeyword sampleAdhocKeyword() {
+    PSKeyword keyword = new PSKeyword("Adhoc_Type", "Ad Hoc Assignment Lookups", "125");
+    keyword.setId(125L);
+    keyword.setSequence(1);
+    keyword.addChoice(
+        PSKeywordChoice.of("2", "Anonymous", "Ad Hoc Assignment Anonymous Access", 3));
+    keyword.addChoice(PSKeywordChoice.of("1", "Enabled", "Ad Hoc Assignment Enabled", 2));
+    keyword.addChoice(PSKeywordChoice.of("0", "Disabled", "Ad Hoc Assignment Disabled", 1));
+    return keyword;
+  }
+
+  private static void assertKeywordGraphEquals(PSKeyword expected, PSKeyword actual) {
+    assertNotNull(actual);
+    assertEquals(expected.getId(), actual.getId());
+    assertEquals(expected.getLabel(), actual.getLabel());
+    assertEquals(expected.getValue(), actual.getValue());
+    assertEquals(expected.getKeywordType(), actual.getKeywordType());
+    assertEquals(expected.getDescription(), actual.getDescription());
+    assertEquals(expected.getSequence(), actual.getSequence());
+    List<PSKeywordChoice> eChoices = expected.getChoices();
+    List<PSKeywordChoice> aChoices = actual.getChoices();
+    assertEquals(eChoices.size(), aChoices.size());
+    for (int i = 0; i < eChoices.size(); i++) {
+      assertEquals(eChoices.get(i), aChoices.get(i), "choice index " + i);
+    }
+  }
+
+  private static boolean containsTag(String xml, String localName) {
+    return xml.contains("<" + localName) || xml.contains("</" + localName + ">");
+  }
+
+  private static String loadResource(String classpath) throws Exception {
+    try (InputStream in =
+        PSKeywordXmlSerializationTest.class.getClassLoader().getResourceAsStream(classpath)) {
+      assertNotNull(in, "missing test resource: " + classpath);
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  /**
+   * Compare logical XML trees: ignore XML declaration, Betwixt graph-identity {@code id}
+   * attributes, insignificant whitespace, and HTML comments.
+   */
+  private static void assertLogicalXmlParity(String expectedXml, String actualXml)
+      throws Exception {
+    Document expected = parseXml(stripXmlDeclaration(expectedXml));
+    Document actual = parseXml(stripXmlDeclaration(actualXml));
+    assertElementTreeEquals(expected.getDocumentElement(), actual.getDocumentElement(), "/");
+  }
+
+  private static String stripXmlDeclaration(String xml) {
+    String s = Objects.requireNonNull(xml).trim();
+    if (s.startsWith("<?xml")) {
+      int end = s.indexOf("?>");
+      if (end >= 0) {
+        s = s.substring(end + 2).trim();
+      }
+    }
+    // Drop leading HTML/XML comments before root
+    while (s.startsWith("<!--")) {
+      int end = s.indexOf("-->");
+      if (end < 0) {
+        break;
+      }
+      s = s.substring(end + 3).trim();
+    }
+    return s;
+  }
+
+  private static Document parseXml(String xml) throws Exception {
+    var factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    var builder = factory.newDocumentBuilder();
+    return builder.parse(new InputSource(new java.io.StringReader(xml)));
+  }
+
+  private static void assertElementTreeEquals(Element expected, Element actual, String path) {
+    assertEquals(expected.getTagName(), actual.getTagName(), "tag at " + path);
+    // Ignore graph-identity id attributes (Betwixt); compare child elements + text only
+    List<Node> eChildren = significantChildren(expected);
+    List<Node> aChildren = significantChildren(actual);
+    assertEquals(
+        eChildren.size(),
+        aChildren.size(),
+        "child count at "
+            + path
+            + " expected="
+            + summarize(eChildren)
+            + " actual="
+            + summarize(aChildren));
+    for (int i = 0; i < eChildren.size(); i++) {
+      Node en = eChildren.get(i);
+      Node an = aChildren.get(i);
+      if (en.getNodeType() == Node.TEXT_NODE) {
+        assertEquals(en.getTextContent().trim(), an.getTextContent().trim(), "text at " + path);
+      } else {
+        assertElementTreeEquals(
+            (Element) en, (Element) an, path + "/" + ((Element) en).getTagName() + "[" + i + "]");
+      }
+    }
+  }
+
+  private static List<Node> significantChildren(Element el) {
+    NodeList nl = el.getChildNodes();
+    java.util.ArrayList<Node> out = new java.util.ArrayList<>();
+    boolean hasElementChild = false;
+    for (int i = 0; i < nl.getLength(); i++) {
+      if (nl.item(i).getNodeType() == Node.ELEMENT_NODE) {
+        hasElementChild = true;
+        break;
+      }
+    }
+    for (int i = 0; i < nl.getLength(); i++) {
+      Node n = nl.item(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE) {
+        out.add(n);
+      } else if (n.getNodeType() == Node.TEXT_NODE && !hasElementChild) {
+        String t = n.getTextContent();
+        if (t != null && !t.trim().isEmpty()) {
+          out.add(n);
+        }
+      }
+    }
+    return out;
+  }
+
+  private static String summarize(List<Node> nodes) {
+    StringBuilder b = new StringBuilder("[");
+    for (int i = 0; i < nodes.size(); i++) {
+      if (i > 0) {
+        b.append(',');
+      }
+      Node n = nodes.get(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE) {
+        b.append(((Element) n).getTagName());
+      } else {
+        b.append("#text");
+      }
+    }
+    return b.append(']').toString();
+  }
+}

--- a/system/src/test/resources/com/percussion/services/content/data/Adhoc_Type.keyword
+++ b/system/src/test/resources/com/percussion/services/content/data/Adhoc_Type.keyword
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>  <null id="1">
+    <choices>
+      <choice id="2">
+        <description>Ad Hoc Assignment Anonymous Access</description>
+        <label>Anonymous</label>
+        <sequence>3</sequence>
+        <value>2</value>
+      </choice>
+      <choice id="3">
+        <description>Ad Hoc Assignment Enabled</description>
+        <label>Enabled</label>
+        <sequence>2</sequence>
+        <value>1</value>
+      </choice>
+      <choice id="4">
+        <description>Ad Hoc Assignment Disabled</description>
+        <label>Disabled</label>
+        <sequence>1</sequence>
+        <value>0</value>
+      </choice>
+    </choices>
+    <guid>0-14-125</guid>
+    <description>Ad Hoc Assignment Lookups</description>
+    <id>125</id>
+    <keyword-type>1</keyword-type>
+    <label>Adhoc_Type</label>
+    <name>Adhoc_Type</name>
+    <sequence>1</sequence>
+    <type>KEYWORD_DEF</type>
+    <value>125</value>
+  </null>

--- a/system/src/test/resources/com/percussion/services/content/data/ps-keyword-golden.xml
+++ b/system/src/test/resources/com/percussion/services/content/data/ps-keyword-golden.xml
@@ -1,0 +1,38 @@
+<!-- Golden snapshot for production PSKeyword / PSKeywordChoice Jackson wire
+	shape (issue #1888 / epic #505). Nested item element is package name "choice"
+	(not mapped type name "keyword-choice"). Approved Jackson deviations vs historical
+	Betwixt package dumps: - no graph-identity id="…" attributes on complex elements
+	- no <name> or <type> (catalog aliases of label / KEYWORD_DEF) - catalog
+	interface default-method properties suppressed (description-optional, etc.)
+	- no XML declaration (PSJacksonXmlSerializationHelper default) - version
+	remains suppressed via @IPSXmlSerialization - <guid> uses shared IPSGuid
+	string converter (Betwixt parity) -->
+<keyword>
+	<choices>
+		<choice>
+			<description>Ad Hoc Assignment Anonymous Access</description>
+			<label>Anonymous</label>
+			<sequence>3</sequence>
+			<value>2</value>
+		</choice>
+		<choice>
+			<description>Ad Hoc Assignment Enabled</description>
+			<label>Enabled</label>
+			<sequence>2</sequence>
+			<value>1</value>
+		</choice>
+		<choice>
+			<description>Ad Hoc Assignment Disabled</description>
+			<label>Disabled</label>
+			<sequence>1</sequence>
+			<value>0</value>
+		</choice>
+	</choices>
+	<description>Ad Hoc Assignment Lookups</description>
+	<guid>0-14-125</guid>
+	<id>125</id>
+	<keyword-type>1</keyword-type>
+	<label>Adhoc_Type</label>
+	<sequence>1</sequence>
+	<value>125</value>
+</keyword>


### PR DESCRIPTION
## Summary

Issue **#1888** (parent #1823 / epic #505): migrate content keyword design objects to the Jackson-backed `PSXmlSerializationHelper` with package-shaped wire parity.

### Changes
- **`PSKeyword` / `PSKeywordChoice`**: Jackson annotations pin nested package element name **`choice`** (not `keyword-choice`); opt-in `@JsonProperty` surface via `@JsonAutoDetect(getterVisibility=NONE)` so catalog interface default methods do not leak; suppress version; keep public `fromXML`/`toXML`.
- **Utils companion**: register shared `IPSGuid`/`PSGuid` string serde in `PSJacksonXmlSerializationHelper` (Betwixt `PSBetwixtObjectConverter` parity) so package `<guid>` binds. Also unblocks pre-existing `PSTemplateSlotXmlRestoreTest` failures on main after #1887 facade default.
- **Tests**: golden fixture, write/read round-trip, legacy `<null>` root, offline package smoke (`Adhoc_Type.keyword` from perc-packages).
- **`PSKeyword.betwixt` retained** for dual-engine rollback until #1824.
- Documented approved XML deviations: `docs/ai-generated/tasks/505-betwixt-jackson/1888-pskeyword-deviations.md`.

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #1888  
Related: #1823 #505 #1887 #1822

## Test plan
- [x] `cd modules/utils && ../../mvnw clean install` — BUILD SUCCESS (`PSJacksonXmlSerializationHelperTest`: 13 tests)
- [x] `cd system && ../mvnw clean install` — BUILD SUCCESS (`PSKeywordXmlSerializationTest`: 6 tests; suite green including `PSTemplateSlotXmlRestoreTest`)
- [x] Spotless: module `spotless:apply` then `spotless:check` (utils + system; in-scope only)
- [x] Erlang self-review: approve — `docs/ai-generated/code-reviews/issue-1888-pskeyword-jackson-erlang.md`

## Gates evidence
| Gate | Result |
|------|--------|
| Standalone clean install `modules/utils` | BUILD SUCCESS |
| Standalone clean install `system` | BUILD SUCCESS |
| Spotless apply → check | pass (in-scope) |
| Erlang | approve |
| Cross-platform paths | classpath resource fixtures only |

## Residual
None for this slice. Later domain batches (security/workflow/assembly annotations) remain under #1823.