### PR TITLE
test(system): align serialization suite with Jackson-default helper (#1893)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-1893-system-serialization-tests-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-1893-system-serialization-tests-erlang.md
@@ -1,0 +1,29 @@
+# Erlang review — issue #1893 system serialization tests
+
+**Reviewer persona:** Erlang (strict pre-commit)  
+**Change class:** residual system test suite alignment after Jackson facade (#1887)  
+**Modules:** `system` (test sources + docs only)
+
+## Verdict: **APPROVE** (with residual documented)
+
+### Checklist
+
+|            Gate             |                                 Result                                  |
+|-----------------------------|-------------------------------------------------------------------------|
+| Bugs / incorrect assertions | Pass — RTs re-verified under Jackson default                            |
+| Behavioral unit tests       | Pass — collections re-enabled; RoundTrip offline; Serialization JUnit 5 |
+| Cross-platform paths        | Pass — no filesystem path construction; classpath resources only        |
+| Change-class companions     | Pass — peer suite docs + deviations note; no production domain beans    |
+| Spotless / clean install    | Required on PR gate after this review                                   |
+
+### Findings
+
+1. **PersonList `setPersons`** — required for Jackson list binding; Betwixt used adder-only. Documented on the setter.
+2. **RoundTrip offline** — removes live `PSAssemblyServiceLocator` dependency; keeps equality coverage.
+3. **PSObjectSummary RT** — correctly left `@Disabled` with residual reason (not green-washed).
+4. **No production domain migration** — matches issue out-of-scope; domain goldens remain #1888–#1891.
+
+### Residual follow-up
+
+- Enable `PSObjectSummary` equality RT after catalog/security suppress for `permissions` / `PSUserAccessLevel`.
+

--- a/docs/ai-generated/tasks/505-betwixt-jackson/1893-system-serialization-tests.md
+++ b/docs/ai-generated/tasks/505-betwixt-jackson/1893-system-serialization-tests.md
@@ -1,0 +1,28 @@
+# Issue #1893 — System serialization tests (Jackson default)
+
+Parent: #1823 slice 7 / epic #505. Depends on facade #1887 (merged). Domain slices #1888–#1891 may still refine wire goldens.
+
+## Scope landed
+
+|               Suite               |                                                                   Change                                                                    |
+|-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| `PSObjectSerializerTest`          | Jackson engine assert; wire-shape (no Betwixt graph `id`); enable PersonList collection RT (`setPersons` + `person-list` root registration) |
+| `PSObjectSerializerRoundTripTest` | Re-enabled offline assembly template RT (no live CMS / no slot service)                                                                     |
+| `PSSerializationTest`             | JUnit 5; Guid / Community / Locale behavioral RTs + no-graph-id shape                                                                       |
+| `PSObjectSummaryTest`             | Enabled write-shape; full equality RT still `@Disabled` (residual)                                                                          |
+
+## Approved XML deviations (asserted)
+
+- No Betwixt graph-identity `id="…"` attributes on complex elements under Jackson write.
+- Unannotated collection items use property name as item tag (e.g. nested `<books>`), not type-mapped `<book>`, until domain annotations (#1888+).
+- Unannotated catalog-style beans may still emit derived `*-optional` / `display-string` fields until domain suppress slices land.
+
+## Residual
+
+- `PSObjectSummary` full round-trip fails because nested empty `permissions` / `PSUserAccessLevel` has no default constructor. Needs catalog/security domain suppress or bean support — not production domain migration in this PR.
+
+## Out of scope
+
+- New domain migrations / `.betwixt` removal (#1824)
+- Guid string serde module polish (#1888) — Guid scalar RT already works on main facade for these tests
+

--- a/system/src/test/java/com/percussion/services/catalog/data/PSObjectSummaryTest.java
+++ b/system/src/test/java/com/percussion/services/catalog/data/PSObjectSummaryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
  */
 package com.percussion.services.catalog.data;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
@@ -26,26 +27,73 @@ import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test the object summary object, primarily test the serialization using the helper
+ * Object summary serialization coverage under Jackson-backed {@link PSXmlSerializationHelper}
+ * (issue #1893 / parent #1823 / epic #505).
+ *
+ * <p>Write-side shape tests are enabled. Full equality round-trips remain disabled until catalog /
+ * security domain suppress annotations land for {@code permissions} / {@link PSUserAccessLevel} (no
+ * default constructor; nested graph fails Jackson deserialize). Tracked as residual of #1893.
+ *
+ * <p><strong>Approved deviations:</strong> no Betwixt graph-identity {@code id="…"} attributes on
+ * write.
  *
  * @author dougrand
  */
-@Disabled("Temporarily disabled — failing in perc-system test run")
 public class PSObjectSummaryTest {
-  private static SecureRandom ms_rand = new SecureRandom();
+  private static final SecureRandom ms_rand = new SecureRandom();
+
+  private static final Pattern BETWIXT_GRAPH_ID_ATTR =
+      Pattern.compile("\\sid\\s*=\\s*\"\\d+\"", Pattern.CASE_INSENSITIVE);
 
   public PSObjectSummaryTest() {}
 
+  @BeforeAll
+  static void ensureJacksonDefault() {
+    System.clearProperty(PSXmlSerializationHelper.ENGINE_PROPERTY);
+    assertTrue(PSXmlSerializationHelper.isJacksonEngine());
+    PSXmlSerializationHelper.addType(PSObjectSummary.class);
+  }
+
   /**
-   * Round trip an incomplete summary as the first test
+   * Write-side shape for a minimal summary: modern root, name/label/guid present, no graph ids.
+   *
+   * @throws Exception on write failure
+   */
+  @Test
+  public void testWriteShapeMinimalSummary() throws Exception {
+    PSObjectSummary nsum =
+        new PSObjectSummary(
+            new PSGuid(PSTypeEnum.ACL, ms_rand.nextInt(1000)),
+            "Test object summary",
+            "Test object summary label",
+            null);
+    String ser = PSXmlSerializationHelper.writeToXml(nsum);
+
+    assertTrue(containsTag(ser, "object-summary"), ser);
+    assertTrue(containsTag(ser, "name"), ser);
+    assertTrue(ser.contains("Test object summary"), ser);
+    assertTrue(ser.contains("Test object summary label"), ser);
+    assertTrue(containsTag(ser, "guid"), ser);
+    assertFalse(BETWIXT_GRAPH_ID_ATTR.matcher(ser).find(), "no graph id attrs: " + ser);
+    assertFalse(ser.trim().startsWith("<null"), ser);
+  }
+
+  /**
+   * Full equality round-trip for an incomplete summary. Blocked on Jackson: empty {@code
+   * permissions} / {@link PSUserAccessLevel} has no default constructor.
    *
    * @throws Exception
    */
   @Test
+  @Disabled(
+      "Residual #1893: PSObjectSummary permissions→PSUserAccessLevel lacks default ctor; needs"
+          + " catalog/security suppress or bean fix in a domain slice (not this PR).")
   public void testSerialization() throws Exception {
     PSObjectSummary nsum =
         new PSObjectSummary(
@@ -57,16 +105,20 @@ public class PSObjectSummaryTest {
 
     PSObjectSummary restore = (PSObjectSummary) PSXmlSerializationHelper.readFromXML(ser);
 
-    assertEquals(nsum, restore);
+    org.junit.jupiter.api.Assertions.assertEquals(nsum, restore);
   }
 
   /**
-   * Test fully populated object summary object
+   * Fully populated summary including lock + permissions. Same residual blocker as {@link
+   * #testSerialization()} plus historical JRE/OS flakiness notes.
    *
    * @throws Exception
    */
   @Test
-  @Disabled("TODO: Fix me.  Test fails on certain JRE versions / OS")
+  @Disabled(
+      "Residual #1893: complete summary RT needs PSUserAccessLevel / permissions Jackson"
+          + " support (catalog domain). Historical note: also flaky on certain JRE/OS with"
+          + " Betwixt.")
   public void testCompleteSerialization() throws Exception {
     PSObjectSummary nsum =
         new PSObjectSummary(
@@ -75,7 +127,7 @@ public class PSObjectSummaryTest {
             "Test object summary label",
             null);
     nsum.setLockedInfo("session_1", "orange_julius", 123456789);
-    Collection<PSPermissions> permissions = new ArrayList<PSPermissions>();
+    Collection<PSPermissions> permissions = new ArrayList<>();
 
     permissions.add(PSPermissions.RUNTIME_VISIBLE);
     permissions.add(PSPermissions.OWNER);
@@ -83,11 +135,12 @@ public class PSObjectSummaryTest {
     nsum.setPermissions(new PSUserAccessLevel(permissions));
 
     String ser = PSXmlSerializationHelper.writeToXml(nsum);
-    System.out.println(ser);
-    System.out.println();
     PSObjectSummary restore = (PSObjectSummary) PSXmlSerializationHelper.readFromXML(ser);
-    System.out.println(restore);
 
-    assertEquals(nsum, restore, "Expected to be equal");
+    org.junit.jupiter.api.Assertions.assertEquals(nsum, restore, "Expected to be equal");
+  }
+
+  private static boolean containsTag(String xml, String localName) {
+    return xml.contains("<" + localName) || xml.contains("</" + localName + ">");
   }
 }

--- a/system/src/test/java/com/percussion/services/security/data/PSSerializationTest.java
+++ b/system/src/test/java/com/percussion/services/security/data/PSSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,35 +16,62 @@
  */
 package com.percussion.services.security.data;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.i18n.PSLocale;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
+import java.util.Collection;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
- * Test xml helper serialization of selected objects
+ * Behavioral XML helper serialization for selected security / locale objects under the
+ * Jackson-backed {@link PSXmlSerializationHelper} (issue #1893 / parent #1823 / epic #505).
+ *
+ * <p>Converted from a JUnit 3-style class (methods were not discovered by JUnit Platform) to JUnit
+ * 5. Domain-specific goldens and package fixtures for {@link PSCommunity} / ACL / login live in
+ * issue #1889; this suite keeps lightweight round-trip coverage only.
+ *
+ * <p><strong>Approved deviations:</strong> no Betwixt graph-identity {@code id="…"} attributes;
+ * unannotated beans may emit derived catalog alias fields ({@code *-optional}, {@code
+ * display-string}, …) until domain annotation slices suppress them.
  *
  * @author dougrand
  */
 public class PSSerializationTest {
-  static {
+
+  private static final Pattern BETWIXT_GRAPH_ID_ATTR =
+      Pattern.compile("\\sid\\s*=\\s*\"\\d+\"", Pattern.CASE_INSENSITIVE);
+
+  @BeforeAll
+  static void registerTypesAndEngine() {
+    System.clearProperty(PSXmlSerializationHelper.ENGINE_PROPERTY);
+    assertTrue(PSXmlSerializationHelper.isJacksonEngine());
     PSXmlSerializationHelper.addType(PSCommunity.class);
     PSXmlSerializationHelper.addType(PSLocale.class);
     PSXmlSerializationHelper.addType(PSGuid.class);
   }
 
+  @Test
   public void testGuidSer() throws Exception {
     PSGuid g = new PSGuid(PSTypeEnum.ACL, 101101);
 
     String ser = PSXmlSerializationHelper.writeToXml(g);
+    assertTrue(containsTag(ser, "guid"), ser);
+    assertFalse(BETWIXT_GRAPH_ID_ATTR.matcher(ser).find(), ser);
 
     PSGuid res = (PSGuid) PSXmlSerializationHelper.readFromXML(ser);
 
     assertEquals(g, res);
+    assertEquals(g.toString(), res.toString());
   }
 
+  @Test
   public void testCommunitySerialization() throws Exception {
     PSCommunity community = new PSCommunity();
 
@@ -55,12 +82,26 @@ public class PSSerializationTest {
     community.addRoleAssociation(new PSGuid(PSTypeEnum.ROLE, 11));
 
     String ser = PSXmlSerializationHelper.writeToXml(community);
+    assertTrue(containsTag(ser, "community"), ser);
+    assertTrue(containsTag(ser, "name"), ser);
+    assertTrue(ser.contains("Test_1"), ser);
+    assertFalse(BETWIXT_GRAPH_ID_ATTR.matcher(ser).find(), "no graph id attrs: " + ser);
+    assertFalse(ser.trim().startsWith("<null"), ser);
 
     PSCommunity restore = (PSCommunity) PSXmlSerializationHelper.readFromXML(ser);
     assertEquals(community, restore);
+    assertEquals("Test_1", restore.getName());
+    assertEquals("Test community", restore.getDescription());
+    assertEquals(community.getGUID().toString(), restore.getGUID().toString());
+
+    Collection<Long> roles = restore.getRoles();
+    assertEquals(2, roles.size(), "role associations restored: " + ser);
+    assertTrue(roles.contains(10L), roles.toString());
+    assertTrue(roles.contains(11L), roles.toString());
   }
 
-  public void FIXME_testLocaleSerialization() throws Exception {
+  @Test
+  public void testLocaleSerialization() throws Exception {
     PSLocale locale = new PSLocale();
 
     locale.setLocaleId(111);
@@ -70,9 +111,20 @@ public class PSSerializationTest {
     locale.setStatus(5);
 
     String ser = PSXmlSerializationHelper.writeToXml(locale);
+    assertTrue(containsTag(ser, "locale"), ser);
+    assertFalse(BETWIXT_GRAPH_ID_ATTR.matcher(ser).find(), ser);
 
     PSLocale restore = (PSLocale) PSXmlSerializationHelper.readFromXML(ser);
 
     assertEquals(locale, restore);
+    assertEquals(111, restore.getLocaleId());
+    assertEquals("A locale", restore.getDescription());
+    assertEquals("en_GB", restore.getDisplayName());
+    assertEquals("en_UK_1", restore.getLanguageString());
+    assertEquals(5, restore.getStatus());
+  }
+
+  private static boolean containsTag(String xml, String localName) {
+    return xml.contains("<" + localName) || xml.contains("</" + localName + ">");
   }
 }

--- a/system/src/test/java/com/percussion/xml/serialization/junit/PSObjectSerializerRoundTripTest.java
+++ b/system/src/test/java/com/percussion/xml/serialization/junit/PSObjectSerializerRoundTripTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,49 +17,89 @@
 package com.percussion.xml.serialization.junit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.percussion.services.assembly.IPSAssemblyService;
 import com.percussion.services.assembly.IPSAssemblyTemplate.AAType;
 import com.percussion.services.assembly.IPSAssemblyTemplate.GlobalTemplateUsage;
 import com.percussion.services.assembly.IPSAssemblyTemplate.OutputFormat;
 import com.percussion.services.assembly.IPSAssemblyTemplate.PublishWhen;
-import com.percussion.services.assembly.PSAssemblyServiceLocator;
 import com.percussion.services.assembly.data.PSAssemblyTemplate;
 import com.percussion.services.assembly.data.PSTemplateBinding;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import com.percussion.xml.serialization.PSObjectSerializer;
-import org.junit.jupiter.api.Disabled;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test round tripping of specific objects with the serializer to test conversion code.
+ * Offline round-trip coverage for design objects through {@link PSObjectSerializer} under the
+ * Jackson-backed helper (issue #1893 / parent #1823 / epic #505).
+ *
+ * <p><strong>No live CMS</strong> — earlier versions loaded real slots via {@code
+ * PSAssemblyServiceLocator}; that required a running server and was disabled. This suite builds
+ * in-memory templates only.
+ *
+ * <p>Domain-specific golden / package-fixture coverage for assembly lives in #1891 (and peers).
+ * This class only asserts behavioral equality and the approved no-graph-id wire deviation.
+ *
+ * <p><strong>Approved deviations:</strong> no Betwixt {@code id="…"} graph-identity attributes;
+ * unannotated property dumps may include derived {@code *-optional} / catalog alias fields until
+ * domain annotation slices land.
  *
  * @author dougrand
  */
-@Disabled("Temporarily disabled — failing in perc-system test run")
 public class PSObjectSerializerRoundTripTest {
+
+  private static final Pattern BETWIXT_GRAPH_ID_ATTR =
+      Pattern.compile("\\sid\\s*=\\s*\"\\d+\"", Pattern.CASE_INSENSITIVE);
+
+  @BeforeAll
+  static void ensureJacksonDefault() {
+    System.clearProperty(PSXmlSerializationHelper.ENGINE_PROPERTY);
+    assertTrue(PSXmlSerializationHelper.isJacksonEngine());
+    PSXmlSerializationHelper.addType("assembly-template", PSAssemblyTemplate.class);
+  }
+
   /**
-   * Round trip an assembly template. Use a template that has every field set to a value to make
-   * sure the entire object is correctly serialized.
+   * Round trip an assembly template with every scalar field and bindings set. Does not attach live
+   * slots (offline).
    *
-   * @throws Exception
+   * @throws Exception on serialize/deserialize failure
    */
   @Test
   public void testRoundTripTemplate() throws Exception {
     PSAssemblyTemplate template = setupTemplate();
 
     PSObjectSerializer ser = PSObjectSerializer.getInstance();
-    PSXmlSerializationHelper.addType("assembly-template", PSAssemblyTemplate.class);
     String str = ser.toXmlString(template);
+
+    assertTrue(str.contains("<assembly-template") || str.contains("<assembly-template>"), str);
+    assertFalse(
+        BETWIXT_GRAPH_ID_ATTR.matcher(str).find(),
+        "Jackson must not emit Betwixt graph-identity id attributes: " + str);
+    assertFalse(str.trim().startsWith("<null"), str);
+
     PSAssemblyTemplate restore = (PSAssemblyTemplate) ser.fromXmlString(str);
 
     assertEquals(template, restore);
+    assertEquals(template.getName(), restore.getName());
+    assertEquals(template.getLabel(), restore.getLabel());
+    assertEquals(template.getAssembler(), restore.getAssembler());
+    assertEquals(template.getActiveAssemblyType(), restore.getActiveAssemblyType());
+    assertEquals(template.getOutputFormat(), restore.getOutputFormat());
+    assertEquals(template.getPublishWhen(), restore.getPublishWhen());
+    assertEquals(template.getGlobalTemplateUsage(), restore.getGlobalTemplateUsage());
+    assertEquals(template.getGUID().toString(), restore.getGUID().toString());
+    assertEquals(2, restore.getBindings().size());
+    assertEquals("a", restore.getBindings().get(0).getVariable());
+    assertEquals("1+2", restore.getBindings().get(0).getExpression());
   }
 
-  /** Create a template for the test */
-  private PSAssemblyTemplate setupTemplate() throws Exception {
+  /** Create a fully populated in-memory template for the test (no assembly service). */
+  private PSAssemblyTemplate setupTemplate() {
     PSAssemblyTemplate template = new PSAssemblyTemplate();
     template.setName("test_template_0");
     template.setLabel("test template 0");
@@ -78,11 +118,6 @@ public class PSObjectSerializerRoundTripTest {
     template.setStyleSheetPath("some invalid stylesheet path");
     template.addBinding(new PSTemplateBinding(1, "a", "1+2"));
     template.addBinding(new PSTemplateBinding(2, "b", "2*2"));
-
-    IPSAssemblyService asm = PSAssemblyServiceLocator.getAssemblyService();
-    template.addSlot(asm.loadSlot("501"));
-    template.addSlot(asm.loadSlot("502"));
-
     return template;
   }
 }

--- a/system/src/test/java/com/percussion/xml/serialization/junit/PSObjectSerializerTest.java
+++ b/system/src/test/java/com/percussion/xml/serialization/junit/PSObjectSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package com.percussion.xml.serialization.junit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
@@ -25,23 +27,48 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 /**
+ * System-module coverage for {@link PSObjectSerializer} / {@link PSXmlSerializationHelper} after
+ * the Jackson default cutover (issue #1893 / parent #1823 / epic #505).
+ *
+ * <p>Uses the Person fixture family in {@code modules/utils} ({@link Person}, {@link Address},
+ * {@link Book}, {@link Name}). Behavioral round-trips are the gate; wire shape asserts document
+ * approved Jackson deviations vs historical Betwixt.
+ *
+ * <p><strong>Approved XML deviations (no Betwixt graph identity):</strong>
+ *
+ * <ul>
+ *   <li>Jackson does <em>not</em> emit Betwixt graph-identity {@code id="…"} attributes on complex
+ *       elements (values live in child elements).
+ *   <li>Unannotated collection items use the bean property name as the item element (e.g. nested
+ *       {@code <books>} under a {@code <books>} wrapper) rather than Betwixt type-mapped names such
+ *       as {@code <book>}. Domain slices (#1888+) add annotations where package wire must match
+ *       legacy item tags.
+ * </ul>
+ *
  * @author RammohanVangapalli
  */
 @TestMethodOrder(MethodName.class)
 public class PSObjectSerializerTest {
 
+  /**
+   * Betwixt graph-identity attributes look like {@code id="0"} / {@code id="12"} on complex
+   * elements. Jackson must not emit them (approved deviation #1887 / #1893).
+   */
+  private static final Pattern BETWIXT_GRAPH_ID_ATTR =
+      Pattern.compile("\\sid\\s*=\\s*\"\\d+\"", Pattern.CASE_INSENSITIVE);
+
   public static class PersonList {
-    private final List<Person> mi_people = new ArrayList<>();
+    private List<Person> mi_people = new ArrayList<>();
 
     public PersonList() {
-      //
+      // required for serialization frameworks
     }
 
     public void addPerson(Person x) {
@@ -50,6 +77,16 @@ public class PSObjectSerializerTest {
 
     public List<Person> getPersons() {
       return mi_people;
+    }
+
+    /**
+     * Required for Jackson XML list binding (Betwixt historically used addPerson only). Without a
+     * setter, write/read round-trips leave the list empty under the Jackson engine.
+     *
+     * @param people people to replace, may be {@code null} (treated as empty)
+     */
+    public void setPersons(List<Person> people) {
+      this.mi_people = people == null ? new ArrayList<>() : new ArrayList<>(people);
     }
 
     @Override
@@ -91,9 +128,20 @@ public class PSObjectSerializerTest {
    */
   @BeforeAll
   public static void setUp() throws Exception {
+    // Ensure default production engine (Jackson); residual Betwixt rollback is out of scope here.
+    System.clearProperty(PSXmlSerializationHelper.ENGINE_PROPERTY);
+    assertTrue(
+        PSXmlSerializationHelper.isJacksonEngine(),
+        "suite expects Jackson default after #1887 cutover");
+
     PSXmlSerializationHelper.addType("person", Person.class);
     PSXmlSerializationHelper.addType("address", Address.class);
     PSXmlSerializationHelper.addType("book", Book.class);
+    PSXmlSerializationHelper.addType("name", Name.class);
+    // Jackson root for PersonList uses mapped type name person-list (not legacy alias p-list).
+    PSXmlSerializationHelper.addType("person-list", PersonList.class);
+    PSXmlSerializationHelper.addType("p-list", PersonList.class);
+
     person = new Person("Rammohan", "Vangapalli");
     person.setAddress(new Address("10 Germano Way", "Andover", "MA", "01810"));
     person.addBook(new Book("Life without God1", "09052010"));
@@ -108,6 +156,7 @@ public class PSObjectSerializerTest {
   public void test01Serialization() throws Exception {
     String xml = serializer.toXmlString(person);
     assertTrue(xml.length() > 0);
+    serializedString = xml;
   }
 
   /**
@@ -121,14 +170,36 @@ public class PSObjectSerializerTest {
   }
 
   /**
-   * Test case serializes a collection and restores it, then compares for equality
+   * Jackson wire shape for the Person fixture: modern root, nested beans, books collection, and no
+   * Betwixt graph-identity {@code id} attributes.
+   */
+  @Test
+  public void test01bJacksonWireShapeWithoutGraphIds() throws Exception {
+    String xml = serializer.toXmlString(person);
+    assertNotNull(xml);
+    assertTrue(containsTag(xml, "person"), "root person: " + xml);
+    assertTrue(containsTag(xml, "name"), xml);
+    assertTrue(containsTag(xml, "address"), xml);
+    assertTrue(containsTag(xml, "street"), xml);
+    assertTrue(containsTag(xml, "books"), xml);
+    assertTrue(xml.contains("Rammohan"), xml);
+    assertTrue(xml.contains("Andover"), xml);
+    assertTrue(xml.contains("Life without God1"), xml);
+    assertFalse(
+        BETWIXT_GRAPH_ID_ATTR.matcher(xml).find(),
+        "Jackson must not emit Betwixt graph-identity id attributes: " + xml);
+    assertFalse(xml.trim().startsWith("<null"), "modern write must not use legacy null root");
+  }
+
+  /**
+   * Round-trip a collection root. Registers both the Jackson-mapped root {@code person-list} and
+   * the historical Betwixt alias {@code p-list} for polymorphic lookup; write uses the mapped type
+   * name.
    *
    * @throws Exception error
    */
   @Test
-  @Disabled
   public void test03Collections1() throws Exception {
-    PSXmlSerializationHelper.addType("p-list", PersonList.class);
     PersonList plist = new PersonList();
 
     Person a = new Person();
@@ -144,9 +215,20 @@ public class PSObjectSerializerTest {
     plist.addPerson(c);
 
     String ser = serializer.toXmlString(plist);
+    assertTrue(containsTag(ser, "person-list"), "Jackson root person-list: " + ser);
+    assertFalse(
+        BETWIXT_GRAPH_ID_ATTR.matcher(ser).find(),
+        "no Betwixt graph id attrs on collection write: " + ser);
 
     PersonList deser = (PersonList) serializer.fromXmlString(ser);
 
-    assertTrue(Arrays.equals(plist.getPersons().toArray(), deser.getPersons().toArray()));
+    assertEquals(3, deser.getPersons().size(), "restored people: " + ser);
+    assertTrue(
+        Arrays.equals(plist.getPersons().toArray(), deser.getPersons().toArray()),
+        "person list round-trip under Jackson");
+  }
+
+  private static boolean containsTag(String xml, String localName) {
+    return xml.contains("<" + localName) || xml.contains("</" + localName + ">");
   }
 }


### PR DESCRIPTION
## Summary

Implements **issue #1893** (#1823 slice 7 / epic **#505**): update system-module serialization tests for the Jackson-backed `PSXmlSerializationHelper` after facade cutover #1887 (PR #1897).

### What landed
- `PSObjectSerializerTest` — assert Jackson default; wire shape without Betwixt graph-identity `id` attrs; re-enable PersonList collection RT (`setPersons` + `person-list` root registration)
- `PSObjectSerializerRoundTripTest` — re-enabled **offline** assembly template equality RT (no live CMS / slot service)
- `PSSerializationTest` — converted to **JUnit 5** (was undiscovered); Guid / Community / Locale behavioral RTs + no-graph-id shape
- `PSObjectSummaryTest` — enabled write-shape; full equality RT remains disabled (residual **#1903**)
- Deviations + Erlang notes under `docs/ai-generated/`

### Approved XML deviations
- Jackson does **not** emit Betwixt graph-identity `id="…"` attributes
- Unannotated collection items use property name as item element until domain annotation slices (#1888+)
- Unannotated beans may still emit derived `*-optional` / catalog alias fields until domain suppress slices

### Out of scope
- Domain bean migrations (#1888–#1891)
- commons-betwixt POM removal (#1824)
- `PSObjectSummary` permissions RT → residual #1903

### Residual
- #1903 — enable `PSObjectSummary` equality RT after catalog/security suppress or `PSUserAccessLevel` bean support

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #1893  
Related: #1823, #505, #1887, #1903

## Test plan
- [x] Focused: `PSObjectSerializerTest` (4), `PSObjectSerializerRoundTripTest` (1), `PSSerializationTest` (3), `PSObjectSummaryTest` (1 run + 2 skipped)
- [x] `cd system && ../mvnw clean install` — **BUILD SUCCESS** (Tests run: 995, Failures: 0, Errors: 0, Skipped: 242)
- [x] Spotless: `system` `spotless:apply` **then** `spotless:check` — clean; in-scope only (out-of-scope root markdown rewrites restored)
- [x] Erlang self-review: approve — `docs/ai-generated/code-reviews/issue-1893-system-serialization-tests-erlang.md`