### PR TITLE
fix(1910): clean javadoc warnings in perc-simple module

### DIFF
--- a/modules/Simple/src/main/java/com/percussion/tools/simple/PSCETemplateGenerator.java
+++ b/modules/Simple/src/main/java/com/percussion/tools/simple/PSCETemplateGenerator.java
@@ -45,6 +45,14 @@ import org.xml.sax.SAXException;
  */
 public class PSCETemplateGenerator {
 
+  /**
+   * Default constructor; provided so the implicit default constructor has explicit Javadoc and
+   * doclint does not warn about its use.
+   */
+  public PSCETemplateGenerator() {
+    // utility class - no instance state
+  }
+
   private static final Logger log = LogManager.getLogger(PSCETemplateGenerator.class);
 
   /**
@@ -215,6 +223,8 @@ public class PSCETemplateGenerator {
    * </ol>
    *
    * Any errors are written to System.out
+   *
+   * @param args the command-line arguments as documented above
    */
   public static void main(String[] args) {
     File source = null;

--- a/modules/Simple/src/main/java/com/percussion/tools/simple/PSClassGenerator.java
+++ b/modules/Simple/src/main/java/com/percussion/tools/simple/PSClassGenerator.java
@@ -33,6 +33,15 @@ import org.apache.logging.log4j.Logger;
 
 /** This class is used to create dummy classes with stubbed out methods. */
 public class PSClassGenerator {
+
+  /**
+   * Default constructor; provided so the implicit default constructor has explicit Javadoc and
+   * doclint does not warn about its use.
+   */
+  public PSClassGenerator() {
+    // utility class - no instance state
+  }
+
   private static final Logger log = LogManager.getLogger(PSClassGenerator.class);
 
   /**
@@ -434,6 +443,8 @@ public class PSClassGenerator {
    *       existing directory.
    *   <li>package: The package of the generated java classes.
    * </ol>
+   *
+   * @param args the command-line arguments as documented above
    */
   public static void main(String[] args) {
     File srcClassDir = null;

--- a/modules/Simple/src/main/java/com/percussion/tools/simple/PSCopyAntInstallerClasspath.java
+++ b/modules/Simple/src/main/java/com/percussion/tools/simple/PSCopyAntInstallerClasspath.java
@@ -34,6 +34,14 @@ import org.apache.logging.log4j.Logger;
  */
 public class PSCopyAntInstallerClasspath {
 
+  /**
+   * Default constructor; provided so the implicit default constructor has explicit Javadoc and
+   * doclint does not warn about its use.
+   */
+  public PSCopyAntInstallerClasspath() {
+    // utility class - no instance state
+  }
+
   private static final Logger log = LogManager.getLogger(PSCopyAntInstallerClasspath.class);
 
   /**
@@ -133,6 +141,8 @@ public class PSCopyAntInstallerClasspath {
    * </ol>
    *
    * Any errors are written to System.out
+   *
+   * @param args the command-line arguments as documented above
    */
   public static void main(String[] args) {
     try {

--- a/modules/Simple/src/main/java/com/percussion/tools/simple/PSCopyManifest.java
+++ b/modules/Simple/src/main/java/com/percussion/tools/simple/PSCopyManifest.java
@@ -44,6 +44,14 @@ import org.apache.logging.log4j.Logger;
  */
 public class PSCopyManifest {
 
+  /**
+   * Default constructor; provided so the implicit default constructor has explicit Javadoc and
+   * doclint does not warn about its use.
+   */
+  public PSCopyManifest() {
+    // utility class - no instance state
+  }
+
   private static final Logger log = LogManager.getLogger(PSCopyManifest.class);
 
   /**
@@ -173,9 +181,8 @@ public class PSCopyManifest {
    * </ol>
    *
    * Any errors are written to System.out
-   */
-  /**
-   * @param args
+   *
+   * @param args the command-line arguments as documented above
    */
   public static void main(String[] args) {
     try {

--- a/modules/Simple/src/main/java/com/percussion/tools/simple/PSDirectoryAnalyzer.java
+++ b/modules/Simple/src/main/java/com/percussion/tools/simple/PSDirectoryAnalyzer.java
@@ -44,6 +44,14 @@ import org.apache.logging.log4j.Logger;
  */
 public class PSDirectoryAnalyzer {
 
+  /**
+   * Default constructor; provided so the implicit default constructor has explicit Javadoc and
+   * doclint does not warn about its use.
+   */
+  public PSDirectoryAnalyzer() {
+    // utility class - no instance state
+  }
+
   private static final Logger log = LogManager.getLogger(PSDirectoryAnalyzer.class);
 
   /**
@@ -280,6 +288,8 @@ public class PSDirectoryAnalyzer {
    * </ol>
    *
    * Any errors are written to System.out
+   *
+   * @param args the command-line arguments as documented above
    */
   public static void main(String[] args) {
     try {

--- a/modules/Simple/src/main/java/com/percussion/tools/simple/PSPrepForConvert.java
+++ b/modules/Simple/src/main/java/com/percussion/tools/simple/PSPrepForConvert.java
@@ -247,8 +247,12 @@ public class PSPrepForConvert {
     transformer.transform(source, result);
   }
 
-  /*
-   * Main class
+  /**
+   * Main entry point. Usage: <code>java PSPrepForConvert [&lt;ServerBase path&gt;]</code>.
+   *
+   * @param args optional single-element array containing the server base directory path; if missing
+   *     or more than one element is supplied, the usage message is printed and the method returns
+   *     without doing anything
    */
   public static void main(String[] args) {
     if (args.length == 1) {

--- a/modules/Simple/src/main/java/com/percussion/tools/simple/PSRgs2Xml.java
+++ b/modules/Simple/src/main/java/com/percussion/tools/simple/PSRgs2Xml.java
@@ -227,9 +227,11 @@ public class PSRgs2Xml {
   }
 
   /**
-   * Main method Usage: java PSRgs2Xml [rgsfilePath] [xmlOuputFilePath]
+   * Main method. Usage: <code>java PSRgs2Xml [rgsfilePath] [xmlOuputFilePath]</code>.
    *
-   * @param args
+   * @param args the command-line arguments; the first element is the path to the rgs file to
+   *     convert and the second element is the path to the YGuard xml file to produce. If fewer than
+   *     two arguments are supplied, the usage message is printed and the method returns.
    */
   public static void main(String[] args) {
     if (args.length >= 2) {

--- a/modules/Simple/src/main/java/com/percussion/tools/simple/PSXmlExtractor.java
+++ b/modules/Simple/src/main/java/com/percussion/tools/simple/PSXmlExtractor.java
@@ -51,6 +51,14 @@ import org.xml.sax.SAXParseException;
  */
 public class PSXmlExtractor {
 
+  /**
+   * Default constructor; provided so the implicit default constructor has explicit Javadoc and
+   * doclint does not warn about its use. All methods on this class are static.
+   */
+  public PSXmlExtractor() {
+    // utility class - no instance state
+  }
+
   private static final Logger log = LogManager.getLogger(PSXmlExtractor.class);
 
   /**
@@ -211,8 +219,26 @@ public class PSXmlExtractor {
   }
 
   /**
-   * Convenience Version for {@link #extract(File, File, String, URL, List, Map)}. Assumes <code>
-   * null</code> for <code>addList</code> parameter.
+   * Convenience overload of {@link #extract(File, File, String, URL, List, Map, String)} that
+   * assumes <code>null</code> for <code>addList</code> and <code>null</code> for <code>dtdPath
+   * </code>.
+   *
+   * @param source The source Xml file, may not be <code>null</code>. Must point to an existing Xml
+   *     file. File is assumed to be in UTF-8.
+   * @param target The file to write the extracted Xml to. May not be <code>null</code>. File
+   *     pointed to may or may not exist. If it does not, then it is created, including any
+   *     necessary directories. If it exists, it will be overwritten.
+   * @param element The element to extract. Must exist in the source document. May not be <code>null
+   *     </code> or empty. Will extract the first instance of this element that is found.
+   * @param dtd An optional dtd to use to validate the target. May be <code>null</code>.
+   * @param excludeList a list of element names as Strings to exclude from the extracted element.
+   *     May be <code>null</code>. All elements matching this name will be excluded.
+   * @return <code>null</code> if dtd is supplied and extracted xml is successfully validated, or if
+   *     no dtd is supplied. Returns an error message if a dtd is supplied and validation fails.
+   * @throws IllegalArgumentException if any param is invalid.
+   * @throws IOException if any io error occurs
+   * @throws FileNotFoundException if any file cannot be located.
+   * @throws SAXException if the source file cannot be parsed.
    */
   public static String extract(
       File source, File target, String element, URL dtd, List<String> excludeList)
@@ -221,8 +247,27 @@ public class PSXmlExtractor {
   }
 
   /**
-   * Convenience Version for {@link #extract(File, File, String, URL, List, Map, boolean)}. Assumes
-   * <code>false</code> for <code>addDtd</code> parameter.
+   * Convenience overload of {@link #extract(File, File, String, URL, List, Map, boolean)} that
+   * assumes <code>false</code> for <code>addDtd</code>.
+   *
+   * @param source The source Xml file, may not be <code>null</code>. Must point to an existing Xml
+   *     file. File is assumed to be in UTF-8.
+   * @param target The file to write the extracted Xml to. May not be <code>null</code>. File
+   *     pointed to may or may not exist. If it does not, then it is created, including any
+   *     necessary directories. If it exists, it will be overwritten.
+   * @param element The element to extract. Must exist in the source document. May not be <code>null
+   *     </code> or empty. Will extract the first instance of this element that is found.
+   * @param dtd An optional dtd to use to validate the target. May be <code>null</code>.
+   * @param excludeList a list of element names as Strings to exclude from the extracted element.
+   *     May be <code>null</code>. All elements matching this name will be excluded.
+   * @param addList a map of elements to add with parent element tag name as key and the <code>
+   *     Element</code> object as value. May be <code>null</code>.
+   * @return <code>null</code> if dtd is supplied and extracted xml is successfully validated, or if
+   *     no dtd is supplied. Returns an error message if a dtd is supplied and validation fails.
+   * @throws IllegalArgumentException if any param is invalid.
+   * @throws IOException if any io error occurs
+   * @throws FileNotFoundException if any file cannot be located.
+   * @throws SAXException if the source file cannot be parsed.
    */
   public static String extract(
       File source,
@@ -357,6 +402,8 @@ public class PSXmlExtractor {
    * </ol>
    *
    * Any errors are written to System.out
+   *
+   * @param args the command-line arguments as documented above
    */
   public static void main(String[] args) {
     File source = null;


### PR DESCRIPTION
Resolves #1910

## Summary
The \perc-simple\ (modules/Simple) module's javadoc generation phase previously reported warnings (the 13 'src warnings' the issue tracker recorded, plus additional convenience-overload and default-constructor warnings that surface on JDK 21 with the parent \ailOnWarnings=false, doclint=all\ configuration).

All public types and methods in \com.percussion.tools.simple\ now have complete, valid Javadoc.

## Files changed (8)

| File | Changes |
|---|---|
| PSXmlExtractor.java | Default ctor javadoc; full @param/@return/@throws on the two convenience extract overloads; @param args on main |
| PSCopyManifest.java | Default ctor javadoc; collapsed duplicated main javadoc into one complete block with @param |
| PSCopyAntInstallerClasspath.java | Default ctor javadoc; @param args on main |
| PSDirectoryAnalyzer.java | Default ctor javadoc; @param args on main |
| PSRgs2Xml.java | Proper @param description on main |
| PSPrepForConvert.java | Replaced bare block comment above main with full Javadoc + @param |
| PSClassGenerator.java | Default ctor javadoc; @param args on main |
| PSCETemplateGenerator.java | Default ctor javadoc; @param args on main |

## Validation

Run from \modules/Simple\ with JDK 21 + \mvnw.cmd\:

\\\ash
cd modules/Simple
..\\..\\mvnw.cmd clean install
\\\

- **BUILD SUCCESS**
- Javadoc warnings: **0** (was 13+)
- Tests: \PSXmlExtractorTest\ — 4 run, 0 failures, 0 errors, 2 skipped
- \spotless:apply\ then \spotless:check\: pass

## Acceptance criteria

- [x] Resolve all Javadoc source warnings in the perc-simple module.
- [x] Ensure all public APIs have complete and valid Javadoc.
- [x] Verify the module builds successfully with zero Javadoc errors and zero Javadoc warnings.
- [x] No regressions.

---
Operator: Kilo (minimax-coding-plan/MiniMax-M3)