### PR TITLE
fix: expand Betwixt idref permissions on Jackson ACL read (#1899)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-1899-acl-idref-expansion-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-1899-acl-idref-expansion-erlang.md
@@ -1,0 +1,22 @@
+# Erlang self-review — issue #1899 (ACL Betwixt idref expansion)
+
+**Change class:** Jackson XML pre-read helper + package ACL install safety (residual of #1889).
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs / logic errors | None found: two-pass collect definitions then materialize idref stubs; keeps local element name for cross-name refs (`first-owner` → `typed-principal`); unresolved idrefs left as empty stubs |
+| Behavioral tests | `PSBetwixtIdrefExpanderTest` (7): no-op, permission expand, first-owner expand, unresolved stub, baseline package snippet, negative without expansion. `PSSecurityXmlSerializationTest` (11): package smoke asserts idref community entries regain `RUNTIME_VISIBLE`; synthetic equal permission sets for full+idref siblings |
+| Portable paths | DOM parse via `PSXmlDocumentBuilder` / classpath fixtures only; no OS path construction |
+| Companions | Expander in `modules/utils`; wired in `PSJacksonXmlSerializationHelper.readFromXml`; deviations doc product decision **expand on read**; system security tests updated |
+| Spotless | apply → check on `modules/utils` + `system` (+ in-scope deviations md); out-of-scope baseline Spotless rewrites discarded |
+| Module clean install | `cd modules/utils && ../../mvnw clean install` BUILD SUCCESS (272 tests). `cd system && ../mvnw clean install` BUILD SUCCESS (1012 tests, 0 failures) |
+
+## Product decision
+
+Expand Betwixt `idref` graphs on Jackson read rather than mass-rewriting shipped `*.aclDef` package files.
+
+## Residual
+
+None for this slice. Live CMS package install remains out of scope (offline smoke only), same as #1889.

--- a/docs/ai-generated/tasks/505-betwixt-jackson/1889-security-domain-deviations.md
+++ b/docs/ai-generated/tasks/505-betwixt-jackson/1889-security-domain-deviations.md
@@ -1,6 +1,6 @@
 # Issue #1889 — Security domain Jackson wire deviations
 
-Parent: #1823 · Epic: #505 · Facade: #1887 · Keyword slice: #1888 · Pilot: #1822
+Parent: #1823 · Epic: #505 · Facade: #1887 · Keyword slice: #1888 · Pilot: #1822 · Residual: #1899
 
 ## Scope delivered
 
@@ -15,19 +15,19 @@ Parent: #1823 · Epic: #505 · Facade: #1887 · Keyword slice: #1888 · Pilot: #
 
 ## Approved XML deviations (Jackson write vs historical Betwixt packages)
 
-|                 Historical Betwixt / package dump                 |       Jackson default write        |                                                                                                                     Notes                                                                                                                     |
-|-------------------------------------------------------------------|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Graph-identity `id="…"` attributes on complex elements            | Not emitted                        | Property values live in child elements; documented in #1887                                                                                                                                                                                   |
-| Shared permission nodes via Betwixt `idref="…"`                   | Not resolved                       | Jackson does not expand graph idrefs; only fully-inlined `<ps-permission>` blocks restore. Package smoke asserts inline perms (first community entry + Default owner). Residual: #1899.                                                       |
-| Entry derived flags (`community`/`user`/`group`/`role`/`owner`/…) | Omitted                            | Derived from `type` + permissions; package read ignores extras (`FAIL_ON_UNKNOWN_PROPERTIES=false`)                                                                                                                                           |
-| Nested `<typed-principal>…</typed-principal>`                     | Omitted                            | Redundant with entry `name` + `type`                                                                                                                                                                                                          |
-| `<first-owner>`                                                   | Omitted                            | Computed; getter can throw without owners                                                                                                                                                                                                     |
-| `<object-guid>`                                                   | Omitted                            | Derived from `object-id` + `object-type`                                                                                                                                                                                                      |
-| Catalog `<label>` on ACL                                          | Omitted                            | Alias of `name`                                                                                                                                                                                                                               |
-| Community `<role-associations>` / `<site-associations>`           | Omitted                            | Historical betwixt **hide**; wire form uses scalar `<roles><long>…`                                                                                                                                                                           |
-| Community catalog `<type>` / `<label>` / `<version>`              | Omitted                            | Catalog aliases / Hibernate version                                                                                                                                                                                                           |
-| Login nested `PSRole` / `PSLocale` graphs                         | Omitted                            | Legacy objectstore types not Jackson-annotated in this slice; scalars + nested `PSCommunity` covered                                                                                                                                          |
-| Entry/permission set iteration order                              | Sorted (name / permission ordinal) | Deterministic package export + golden parity                                                                                                                                                                                                  |
+|                 Historical Betwixt / package dump                 |       Jackson default write        |                                                                                          Notes                                                                                           |
+|-------------------------------------------------------------------|------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Graph-identity `id="…"` attributes on complex elements            | Not emitted                        | Property values live in child elements; documented in #1887                                                                                                                              |
+| Shared permission nodes via Betwixt `idref="…"`                   | Not emitted on write               | **Read:** expanded by `PSBetwixtIdrefExpander` before Jackson bind (product decision **expand on read**, #1899). Package smoke asserts idref community entries regain `RUNTIME_VISIBLE`. |
+| Entry derived flags (`community`/`user`/`group`/`role`/`owner`/…) | Omitted                            | Derived from `type` + permissions; package read ignores extras (`FAIL_ON_UNKNOWN_PROPERTIES=false`)                                                                                      |
+| Nested `<typed-principal>…</typed-principal>`                     | Omitted                            | Redundant with entry `name` + `type`                                                                                                                                                     |
+| `<first-owner>`                                                   | Omitted                            | Computed; getter can throw without owners. Idref form is still expanded on read for graph completeness.                                                                                  |
+| `<object-guid>`                                                   | Omitted                            | Derived from `object-id` + `object-type`                                                                                                                                                 |
+| Catalog `<label>` on ACL                                          | Omitted                            | Alias of `name`                                                                                                                                                                          |
+| Community `<role-associations>` / `<site-associations>`           | Omitted                            | Historical betwixt **hide**; wire form uses scalar `<roles><long>…`                                                                                                                      |
+| Community catalog `<type>` / `<label>` / `<version>`              | Omitted                            | Catalog aliases / Hibernate version                                                                                                                                                      |
+| Login nested `PSRole` / `PSLocale` graphs                         | Omitted                            | Legacy objectstore types not Jackson-annotated in this slice; scalars + nested `PSCommunity` covered                                                                                     |
+| Entry/permission set iteration order                              | Sorted (name / permission ordinal) | Deterministic package export + golden parity                                                                                                                                             |
 
 ## Package install smoke (offline)
 
@@ -35,18 +35,33 @@ Fixture: `system/src/test/resources/.../percPage.contentType.aclDef` (copy of
 `modules/perc-packages/.../perc.Baseline/percPage.contentType.aclDef`).
 
 `PSAclImpl.fromXML` restores name, object-id/type, guid string form, entry names/types, and
-permissions for fully-inlined permission blocks. Entries that only reference permissions via
-`idref` do not regain those permissions under Jackson (documented above).
+permissions for both fully-inlined permission blocks and Betwixt `idref` siblings (via expand on
+read). Synthetic unit coverage: equal permission sets for one full definition + idref sibling
+entries; expander unit tests in `modules/utils` (`PSBetwixtIdrefExpanderTest`).
+
+## Residual #1899 — closed
+
+|       Field       |                                                                                                   Value                                                                                                    |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Residual          | #1899                                                                                                                                                                                                      |
+| Decision          | **expand on read**                                                                                                                                                                                         |
+| Implementation    | `PSBetwixtIdrefExpander` in `modules/utils`, invoked from `PSJacksonXmlSerializationHelper.readFromXml` after legacy `<null>` root rewrite                                                                 |
+| Scope             | General Betwixt idref stubs (not ACL-only): materializes children onto the idref element, keeps local element name (supports `<ps-permission idref>` and `<first-owner idref>` → typed-principal children) |
+| Not chosen        | Rewrite every shipped `*.aclDef` package file as the only fix                                                                                                                                              |
+| Unresolved idrefs | Left as empty stubs (same as pre-#1899 silent miss); logged at debug                                                                                                                                       |
 
 ## Utils companion (shared)
 
 `PSJacksonXmlSerializationHelper` registers `IPSGuid`/`PSGuid` string serde (Betwixt
 `PSBetwixtObjectConverter` parity). Required for package `<guid>` on ACL/community.
 
+`PSBetwixtIdrefExpander` expands graph idrefs on every Jackson XML read (fast-path no-op when
+payload has no `idref` substring).
+
 ## Not in this PR
 
 - Keywords / workflow / assembly domain batches
 - Betwixt POM removal (#1824)
 - Live CMS package install
-- Betwixt `idref` graph expansion for ACL permissions (follow-up residual if needed)
+- Mass rewrite of package `*.aclDef` files (unnecessary given expand-on-read)
 

--- a/modules/utils/src/main/java/com/percussion/services/utils/xml/PSBetwixtIdrefExpander.java
+++ b/modules/utils/src/main/java/com/percussion/services/utils/xml/PSBetwixtIdrefExpander.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.utils.xml;
+
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * Pre-read expander for Apache Commons Betwixt graph-identity {@code idref} attributes.
+ *
+ * <p>Historical package dumps (ACL {@code *.aclDef}, etc.) share repeated graph nodes by writing a
+ * full element with {@code id="N"} once, then later empty siblings as {@code <ps-permission
+ * idref="N"/>}. Jackson XML does not resolve Betwixt idrefs; without expansion, only fully-inlined
+ * permission blocks restore and package install can silently drop permissions (issue #1899 / epic
+ * #505).
+ *
+ * <p><strong>Product decision:</strong> expand on read (not rewrite every package file). Applied on
+ * the Jackson deserialize path via {@link PSJacksonXmlSerializationHelper#readFromXml(String,
+ * Class)}.
+ *
+ * <p>Algorithm:
+ *
+ * <ol>
+ *   <li>Fast-path: if the payload has no {@code idref} substring, return unchanged.
+ *   <li>Index every element that has an {@code id} attribute and is not itself an idref stub.
+ *   <li>For each element with {@code idref}, remove the attribute and deep-copy attributes/children
+ *       from the referenced definition while keeping the local element name (so {@code <first-owner
+ *       idref="…"/>} can materialize children of a {@code <typed-principal id="…">}).
+ * </ol>
+ *
+ * <p>Unresolved idrefs are left as empty stubs (same as pre-expansion Jackson behavior).
+ */
+public final class PSBetwixtIdrefExpander {
+
+  private static final Logger log = LogManager.getLogger(PSBetwixtIdrefExpander.class);
+
+  /** Substring probe — case-sensitive attribute name as emitted by Betwixt. */
+  private static final String IDREF_PROBE = "idref";
+
+  private PSBetwixtIdrefExpander() {
+    // utility
+  }
+
+  /**
+   * Expand Betwixt {@code idref} graph references into full element copies.
+   *
+   * @param xmlString XML payload, may be blank
+   * @return expanded XML, or the original string when no expansion is needed / possible
+   * @throws IOException if the document cannot be parsed or written after expansion
+   */
+  public static String expandIdrefs(String xmlString) throws IOException {
+    if (StringUtils.isBlank(xmlString) || !xmlString.contains(IDREF_PROBE)) {
+      return xmlString;
+    }
+
+    Document doc;
+    try {
+      doc = PSXmlDocumentBuilder.createXmlDocument(new StringReader(xmlString), false);
+    } catch (SAXException e) {
+      throw new IOException("Failed to parse XML for Betwixt idref expansion", e);
+    }
+    if (doc == null || doc.getDocumentElement() == null) {
+      return xmlString;
+    }
+
+    Map<String, Element> definitions = new HashMap<>();
+    collectDefinitions(doc.getDocumentElement(), definitions);
+
+    List<Element> idrefNodes = new ArrayList<>();
+    collectIdrefNodes(doc.getDocumentElement(), idrefNodes);
+
+    if (idrefNodes.isEmpty()) {
+      return xmlString;
+    }
+
+    int expanded = 0;
+    int unresolved = 0;
+    for (Element ref : idrefNodes) {
+      String refId = ref.getAttribute(IDREF_PROBE);
+      if (StringUtils.isBlank(refId)) {
+        continue;
+      }
+      Element def = definitions.get(refId);
+      if (def == null) {
+        unresolved++;
+        log.debug(
+            "Unresolved Betwixt idref='{}' on element <{}>; leaving empty stub",
+            refId,
+            ref.getTagName());
+        continue;
+      }
+      materializeFromDefinition(ref, def);
+      expanded++;
+    }
+
+    if (expanded == 0) {
+      return xmlString;
+    }
+    if (unresolved > 0) {
+      log.debug(
+          "Betwixt idref expansion: expanded={}, unresolved={} (unresolved left as empty stubs)",
+          expanded,
+          unresolved);
+    }
+
+    return PSXmlDocumentBuilder.toString(doc);
+  }
+
+  /**
+   * Whether {@code element} is an idref stub (has {@code idref} and is not a definition).
+   *
+   * @param element never {@code null}
+   * @return true when the element declares {@code idref}
+   */
+  static boolean isIdrefStub(Element element) {
+    return element != null && element.hasAttribute(IDREF_PROBE);
+  }
+
+  private static void collectDefinitions(Element element, Map<String, Element> definitions) {
+    if (element.hasAttribute("id") && !element.hasAttribute(IDREF_PROBE)) {
+      String id = element.getAttribute("id");
+      if (StringUtils.isNotBlank(id) && !definitions.containsKey(id)) {
+        definitions.put(id, element);
+      }
+    }
+    NodeList children = element.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      Node child = children.item(i);
+      if (child.getNodeType() == Node.ELEMENT_NODE) {
+        collectDefinitions((Element) child, definitions);
+      }
+    }
+  }
+
+  private static void collectIdrefNodes(Element element, List<Element> idrefNodes) {
+    if (element.hasAttribute(IDREF_PROBE)) {
+      idrefNodes.add(element);
+    }
+    NodeList children = element.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      Node child = children.item(i);
+      if (child.getNodeType() == Node.ELEMENT_NODE) {
+        collectIdrefNodes((Element) child, idrefNodes);
+      }
+    }
+  }
+
+  /**
+   * Copy definition attributes (except {@code id}/{@code idref}) and deep-clone children onto the
+   * idref element. Keeps the local tag name of {@code target}.
+   */
+  private static void materializeFromDefinition(Element target, Element definition) {
+    target.removeAttribute(IDREF_PROBE);
+
+    NamedNodeMap attrs = definition.getAttributes();
+    if (attrs != null) {
+      for (int i = 0; i < attrs.getLength(); i++) {
+        Attr attr = (Attr) attrs.item(i);
+        String name = attr.getName();
+        if ("id".equals(name) || IDREF_PROBE.equals(name)) {
+          continue;
+        }
+        if (!target.hasAttribute(name)) {
+          target.setAttribute(name, attr.getValue());
+        }
+      }
+    }
+
+    // Drop any pre-existing children (idref stubs are empty in package dumps)
+    while (target.hasChildNodes()) {
+      target.removeChild(target.getFirstChild());
+    }
+
+    NodeList defChildren = definition.getChildNodes();
+    for (int i = 0; i < defChildren.getLength(); i++) {
+      Node cloned = defChildren.item(i).cloneNode(true);
+      target.appendChild(cloned);
+    }
+  }
+}

--- a/modules/utils/src/main/java/com/percussion/services/utils/xml/PSJacksonXmlSerializationHelper.java
+++ b/modules/utils/src/main/java/com/percussion/services/utils/xml/PSJacksonXmlSerializationHelper.java
@@ -66,9 +66,14 @@ import tools.jackson.dataformat.xml.XmlWriteFeature;
  * <p>Legacy package payloads with root {@code <null>} are rewritten via {@link
  * PSXmlSerializationHelper#rewriteLegacyNullRoot(String, Class)} before deserialize.
  *
+ * <p>Betwixt graph-identity {@code idref} stubs (e.g. shared {@code <ps-permission idref="N"/>} in
+ * package ACL XML) are expanded via {@link PSBetwixtIdrefExpander} before bind so package install
+ * does not silently drop permissions (issue #1899).
+ *
  * <p><strong>Approved XML deviations vs historical Betwixt writes:</strong> Jackson does not emit
  * Betwixt graph-identity {@code id="…"} attributes on complex elements (values live in child
- * elements).
+ * elements). On <em>read</em>, historical idrefs are expanded (product decision: expand on read —
+ * #1899).
  *
  * <p>{@link IPSGuid} / {@link PSGuid} use string form (same as historical Betwixt {@code
  * PSBetwixtObjectConverter}) via a registered module (issue #1888 / #1890 / #1891 / epic #505).
@@ -133,7 +138,8 @@ public final class PSJacksonXmlSerializationHelper {
 
   /**
    * Deserialize XML into a new instance of {@code clazz}. Accepts legacy root {@code <null>} when
-   * {@code clazz} is non-null (same rewrite as Betwixt path).
+   * {@code clazz} is non-null (same rewrite as Betwixt path). Expands Betwixt {@code idref} graph
+   * stubs via {@link PSBetwixtIdrefExpander} before bind (issue #1899).
    *
    * @param xmlString never blank
    * @param clazz target type, never {@code null}
@@ -148,6 +154,7 @@ public final class PSJacksonXmlSerializationHelper {
       throw new IllegalArgumentException("clazz may not be null");
     }
     String parseXml = PSXmlSerializationHelper.rewriteLegacyNullRoot(xmlString, clazz);
+    parseXml = PSBetwixtIdrefExpander.expandIdrefs(parseXml);
     return MAPPER.readValue(parseXml, clazz);
   }
 

--- a/modules/utils/src/main/java/com/percussion/services/utils/xml/PSXmlSerializationHelper.java
+++ b/modules/utils/src/main/java/com/percussion/services/utils/xml/PSXmlSerializationHelper.java
@@ -82,6 +82,9 @@ import org.xml.sax.helpers.DefaultHandler;
  * <ul>
  *   <li>Betwixt graph-identity {@code id="…"} attributes on complex elements are not emitted by
  *       Jackson (property values live in child elements).
+ *   <li>Historical {@code idref} graph stubs are expanded on Jackson <em>read</em> via {@link
+ *       PSBetwixtIdrefExpander} (product decision expand-on-read, #1899) so package ACL permissions
+ *       are not silently dropped.
  *   <li>Property / collection item element names for unannotated domain beans may differ until
  *       domain migration slices add Jackson annotations or shared mix-ins (#1888+).
  * </ul>

--- a/modules/utils/src/test/java/com/percussion/services/utils/xml/PSBetwixtIdrefExpanderTest.java
+++ b/modules/utils/src/test/java/com/percussion/services/utils/xml/PSBetwixtIdrefExpanderTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.utils.xml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * Unit tests for {@link PSBetwixtIdrefExpander} (issue #1899 — expand Betwixt graph idrefs before
+ * Jackson bind so package ACL permissions are not silently dropped).
+ */
+class PSBetwixtIdrefExpanderTest {
+
+  @Test
+  void expandIdrefsNoOpWhenNoIdrefSubstring() throws Exception {
+    String xml = "<root><ps-permission><permission>READ</permission></ps-permission></root>";
+    assertSame(xml, PSBetwixtIdrefExpander.expandIdrefs(xml));
+  }
+
+  @Test
+  void expandIdrefsNoOpWhenBlank() throws Exception {
+    assertSame(null, PSBetwixtIdrefExpander.expandIdrefs(null));
+    assertEquals("", PSBetwixtIdrefExpander.expandIdrefs(""));
+    assertEquals("   ", PSBetwixtIdrefExpander.expandIdrefs("   "));
+  }
+
+  @Test
+  void expandsPermissionIdrefToFullElementCopy() throws Exception {
+    String xml =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <acl-impl>
+          <entries>
+            <entry>
+              <name>Admin</name>
+              <ps-permissions>
+                <ps-permission id="3">
+                  <acl-entry-id>100</acl-entry-id>
+                  <id>200</id>
+                  <permission>RUNTIME_VISIBLE</permission>
+                </ps-permission>
+              </ps-permissions>
+            </entry>
+            <entry>
+              <name>Member</name>
+              <ps-permissions>
+                <ps-permission idref="3"/>
+              </ps-permissions>
+            </entry>
+          </entries>
+        </acl-impl>
+        """;
+
+    String expanded = PSBetwixtIdrefExpander.expandIdrefs(xml);
+    assertFalse(expanded.contains("idref"), "idref should be expanded: " + expanded);
+
+    Document doc = parse(expanded);
+    List<Element> perms = elementsByTag(doc.getDocumentElement(), "ps-permission");
+    assertEquals(2, perms.size());
+    for (Element perm : perms) {
+      assertFalse(perm.hasAttribute("idref"), perm.toString());
+      assertEquals("RUNTIME_VISIBLE", firstChildText(perm, "permission"));
+      assertEquals("200", firstChildText(perm, "id"));
+    }
+  }
+
+  @Test
+  void expandsFirstOwnerIdrefKeepingLocalElementName() throws Exception {
+    // Package dumps reference typed-principal via first-owner idref (different element names).
+    String xml =
+        """
+        <acl-impl>
+          <entry>
+            <typed-principal id="16">
+              <name>Default</name>
+              <principal-type>USER</principal-type>
+              <user>true</user>
+            </typed-principal>
+          </entry>
+          <first-owner idref="16"/>
+        </acl-impl>
+        """;
+
+    String expanded = PSBetwixtIdrefExpander.expandIdrefs(xml);
+    assertFalse(expanded.contains("idref"), expanded);
+
+    Document doc = parse(expanded);
+    List<Element> firstOwners = elementsByTag(doc.getDocumentElement(), "first-owner");
+    assertEquals(1, firstOwners.size());
+    Element fo = firstOwners.get(0);
+    assertEquals("first-owner", fo.getTagName());
+    assertEquals("Default", firstChildText(fo, "name"));
+    assertEquals("USER", firstChildText(fo, "principal-type"));
+  }
+
+  @Test
+  void unresolvedIdrefLeftAsEmptyStub() throws Exception {
+    String xml =
+        """
+        <root>
+          <ps-permission idref="missing"/>
+        </root>
+        """;
+    String expanded = PSBetwixtIdrefExpander.expandIdrefs(xml);
+    // No definition → original string returned when expanded count is 0
+    assertTrue(expanded.contains("idref=\"missing\"") || expanded.contains("idref='missing'"));
+  }
+
+  @Test
+  void baselinePackageSnippetExpandsAllPermissionIdrefs() throws Exception {
+    // Shape from perc.widget.templateDef.aclDef / percPage.contentType.aclDef
+    String snippet =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <acl-impl id="1">
+          <entries>
+            <entry id="2">
+              <name>Corporate_Investments_Admin</name>
+              <ps-permissions>
+                <ps-permission id="3">
+                  <acl-entry-id>-1</acl-entry-id>
+                  <id>-2</id>
+                  <permission>RUNTIME_VISIBLE</permission>
+                </ps-permission>
+              </ps-permissions>
+            </entry>
+            <entry id="5">
+              <name>Enterprise_Investments</name>
+              <ps-permissions>
+                <ps-permission idref="3"/>
+              </ps-permissions>
+            </entry>
+            <entry id="7">
+              <name>Corporate_Investments</name>
+              <ps-permissions>
+                <ps-permission idref="3"/>
+              </ps-permissions>
+            </entry>
+            <entry id="9">
+              <name>Enterprise_Investments_Admin</name>
+              <ps-permissions>
+                <ps-permission idref="3"/>
+              </ps-permissions>
+            </entry>
+            <entry id="11">
+              <name>Default</name>
+              <ps-permissions>
+                <ps-permission id="12">
+                  <permission>READ</permission>
+                </ps-permission>
+                <ps-permission id="13">
+                  <permission>OWNER</permission>
+                </ps-permission>
+              </ps-permissions>
+              <typed-principal id="16">
+                <name>Default</name>
+                <principal-type>USER</principal-type>
+              </typed-principal>
+            </entry>
+          </entries>
+          <first-owner idref="16"/>
+        </acl-impl>
+        """;
+
+    String expanded = PSBetwixtIdrefExpander.expandIdrefs(snippet);
+    assertFalse(expanded.contains("idref"), expanded);
+
+    Document doc = parse(expanded);
+    List<Element> runtimeVisible = new ArrayList<>();
+    for (Element perm : elementsByTag(doc.getDocumentElement(), "ps-permission")) {
+      if ("RUNTIME_VISIBLE".equals(firstChildText(perm, "permission"))) {
+        runtimeVisible.add(perm);
+      }
+    }
+    assertEquals(4, runtimeVisible.size(), "one inline + three expanded idrefs");
+
+    List<Element> firstOwners = elementsByTag(doc.getDocumentElement(), "first-owner");
+    assertEquals(1, firstOwners.size());
+    assertEquals("Default", firstChildText(firstOwners.get(0), "name"));
+  }
+
+  @Test
+  void negativeWithoutExpansionIdrefStubsHaveNoPermissionChild() throws Exception {
+    String xml =
+        """
+        <root>
+          <ps-permission id="3">
+            <permission>RUNTIME_VISIBLE</permission>
+          </ps-permission>
+          <ps-permission idref="3"/>
+        </root>
+        """;
+    Document raw = parse(xml);
+    List<Element> perms = elementsByTag(raw.getDocumentElement(), "ps-permission");
+    assertEquals(2, perms.size());
+    assertEquals("RUNTIME_VISIBLE", firstChildText(perms.get(0), "permission"));
+    assertTrue(
+        firstChildText(perms.get(1), "permission") == null
+            || firstChildText(perms.get(1), "permission").isEmpty(),
+        "idref stub has no permission child until expansion");
+  }
+
+  private static Document parse(String xml) throws Exception {
+    var factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    var builder = factory.newDocumentBuilder();
+    return builder.parse(new InputSource(new StringReader(xml)));
+  }
+
+  private static List<Element> elementsByTag(Element root, String tag) {
+    List<Element> out = new ArrayList<>();
+    collectByTag(root, tag, out);
+    return out;
+  }
+
+  private static void collectByTag(Element el, String tag, List<Element> out) {
+    if (tag.equals(el.getTagName())) {
+      out.add(el);
+    }
+    NodeList children = el.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      Node n = children.item(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE) {
+        collectByTag((Element) n, tag, out);
+      }
+    }
+  }
+
+  private static String firstChildText(Element parent, String childTag) {
+    NodeList children = parent.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      Node n = children.item(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE && childTag.equals(n.getNodeName())) {
+        return n.getTextContent() == null ? null : n.getTextContent().trim();
+      }
+    }
+    return null;
+  }
+}

--- a/system/src/test/java/com/percussion/services/security/data/PSSecurityXmlSerializationTest.java
+++ b/system/src/test/java/com/percussion/services/security/data/PSSecurityXmlSerializationTest.java
@@ -174,12 +174,13 @@ class PSSecurityXmlSerializationTest {
 
   @Test
   void packageFixtureAclDefSmokeRestoresScalarsAndInlinePermissions() throws Exception {
-    // Offline package smoke: shipped percPage.contentType.aclDef (Betwixt idref sharing remains a
-    // documented deviation — only fully-inlined permission blocks restore under Jackson).
+    // Offline package smoke: shipped percPage.contentType.aclDef. Betwixt idref sharing is expanded
+    // on Jackson read (#1899) so sibling community entries regain RUNTIME_VISIBLE.
     String packaged =
         loadResource("com/percussion/services/security/data/percPage.contentType.aclDef");
     assertTrue(packaged.contains("<acl-impl"), packaged);
     assertTrue(packaged.contains("<entry"), packaged);
+    assertTrue(packaged.contains("idref"), "fixture still uses Betwixt idref sharing");
 
     PSAclImpl restored = new PSAclImpl();
     restored.fromXML(packaged);
@@ -198,12 +199,82 @@ class PSSecurityXmlSerializationTest {
         permissionNames(admin.getPsPermissions()).contains("RUNTIME_VISIBLE"),
         "inline perms on first entry: " + permissionNames(admin.getPsPermissions()));
 
+    // idref siblings must expand to the same permission set as the full definition (#1899)
+    for (String communityName :
+        List.of(
+            "Enterprise_Investments", "Corporate_Investments", "Enterprise_Investments_Admin")) {
+      PSAclEntryImpl community = findEntry(restored, communityName);
+      assertNotNull(community, communityName);
+      assertEquals(PrincipalTypes.COMMUNITY, community.getType());
+      assertTrue(
+          permissionNames(community.getPsPermissions()).contains("RUNTIME_VISIBLE"),
+          communityName
+              + " idref perms must expand: "
+              + permissionNames(community.getPsPermissions()));
+    }
+
     PSAclEntryImpl defaultUser = findEntry(restored, "Default");
     assertNotNull(defaultUser);
     assertEquals(PrincipalTypes.USER, defaultUser.getType());
     Collection<String> defaultPerms = permissionNames(defaultUser.getPsPermissions());
     assertTrue(defaultPerms.contains("OWNER"), defaultPerms.toString());
     assertTrue(defaultPerms.contains("READ"), defaultPerms.toString());
+  }
+
+  @Test
+  void syntheticIdrefPermissionSiblingsRestoreEqualPermissionSets() throws Exception {
+    // Minimal synthetic ACL: one full permission definition + idref sibling entries.
+    String xml =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <acl-impl>
+          <guid>0-17-9002</guid>
+          <name>IdrefAcl</name>
+          <description>idref expand smoke</description>
+          <object-id>1</object-id>
+          <object-type>2</object-type>
+          <entries>
+            <entry>
+              <id>11</id>
+              <name>RoleA</name>
+              <type>ROLE</type>
+              <ps-permissions>
+                <ps-permission id="3">
+                  <acl-entry-id>11</acl-entry-id>
+                  <id>21</id>
+                  <permission>RUNTIME_VISIBLE</permission>
+                </ps-permission>
+                <ps-permission id="4">
+                  <acl-entry-id>11</acl-entry-id>
+                  <id>22</id>
+                  <permission>READ</permission>
+                </ps-permission>
+              </ps-permissions>
+            </entry>
+            <entry>
+              <id>12</id>
+              <name>RoleB</name>
+              <type>ROLE</type>
+              <ps-permissions>
+                <ps-permission idref="3"/>
+                <ps-permission idref="4"/>
+              </ps-permissions>
+            </entry>
+          </entries>
+        </acl-impl>
+        """;
+
+    PSAclImpl restored = new PSAclImpl();
+    restored.fromXML(xml);
+
+    PSAclEntryImpl a = findEntry(restored, "RoleA");
+    PSAclEntryImpl b = findEntry(restored, "RoleB");
+    assertNotNull(a);
+    assertNotNull(b);
+    assertEquals(
+        permissionNames(a.getPsPermissions()),
+        permissionNames(b.getPsPermissions()),
+        "idref sibling must restore equal permission set after expand-on-read");
   }
 
   @Test


### PR DESCRIPTION
## Summary

Closes residual **#1899** from security-domain Jackson migration (**#1889** / epic **#505**).

Historical package ACL XML (`*.aclDef`) shares repeated `<ps-permission>` nodes via Betwixt graph-identity `idref`. Jackson XML does not expand those stubs, so package install could silently drop permissions on sibling ACL entries.

**Product decision: expand on read** (not mass-rewrite shipped package files).

- New `PSBetwixtIdrefExpander` in `modules/utils`: materializes idref stubs into full element copies (keeps local element name — supports `ps-permission` and `first-owner` → typed-principal).
- Wired into `PSJacksonXmlSerializationHelper.readFromXml` after legacy `<null>` root rewrite.
- Unit tests for expander + strengthened package ACL smoke (`percPage.contentType.aclDef`) asserting idref community entries regain `RUNTIME_VISIBLE`.
- Updated `1889-security-domain-deviations.md` with residual closed decision.
- Incidental: remove duplicate `ipsGuidSerializesAndDeserializesAsBetwixtStringForm` method that broke `utils` testCompile on main.

## Test plan

- [x] `cd modules/utils && ../../mvnw clean install` — BUILD SUCCESS (`PSBetwixtIdrefExpanderTest` 7/0; suite 272 tests)
- [x] `cd system && ../mvnw clean install` — BUILD SUCCESS (`PSSecurityXmlSerializationTest` 11/0; suite 1012 tests, 0 failures)
- [x] Spotless apply then check on `modules/utils` + `system` (in-scope only; out-of-scope baseline rewrites discarded)
- [x] Erlang self-review: `docs/ai-generated/code-reviews/issue-1899-acl-idref-expansion-erlang.md`

## Gates evidence

| Gate | Evidence |
|------|----------|
| Standalone Maven | utils + system clean install SUCCESS |
| Spotless | apply then check; feature PR in-scope only |
| Erlang | no bugs; portable paths; companions complete |
| Expand on read | deviations doc + tests |

Fixes #1899  
Related #1889 #1823 #505

Operator: Grok: night-issue-prs (model grok-4.5)