### PR TITLE
fix(system): Jackson-migrate filter domain PSItemFilter + rule defs (#1915)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-1915-filter-jackson-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-1915-filter-jackson-erlang.md
@@ -1,0 +1,20 @@
+# Erlang review — issue #1915 filter Jackson migration
+
+**Change class:** design-object XML domain batch (Jackson annotations + golden/round-trip tests)
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs / behavioral regressions | Pass — suppress parentFilter/version/rule/GUID/circular filter; live rule set mutation via field in mergeRules |
+| Unit tests for new/changed logic | Pass — `PSItemFilterXmlSerializationTest` (6 tests) |
+| Cross-platform paths | Pass — classpath resources only; no filesystem path joins |
+| Companions from peers (#1888–#1891) | Pass — annotations, addType, golden, package smoke, deviations doc |
+| Spotless in-scope only | Pass — out-of-scope apply hits discarded |
+| Module clean install | Required before PR |
+
+## Notes
+
+- `getGUID()` uses `new PSGuid(...)` (no GuidManager) for offline XML parity with peers.
+- `setParam` constructs `PSItemFilterRuleParam(true)` to avoid GuidManager during XML restore.
+- No `.betwixt` files for filter domain.

--- a/docs/ai-generated/tasks/505-betwixt-jackson/1915-filter-domain-deviations.md
+++ b/docs/ai-generated/tasks/505-betwixt-jackson/1915-filter-domain-deviations.md
@@ -1,0 +1,49 @@
+# Issue #1915 — Filter domain Jackson wire deviations
+
+Parent: #1892 · Grandparent: #1823 · Epic: #505 · Facade: #1887
+
+## Scope delivered
+
+- Production design objects annotated for Jackson-backed `PSXmlSerializationHelper`:
+  - `PSItemFilter` (root `item-filter`)
+  - `PSItemFilterRuleDef` (nested package element `rule-def`)
+  - `PSItemFilterRuleParam` (registered type name `parameters`; package wire usually uses parent string map `params`)
+- Golden fixture + round-trip tests + offline package smoke (`perc_public.filterDef`, `perc_staging.filterDef`)
+- Keep `PSXmlSerializationHelper.addType("rule-def", …)` / `addType("parameters", …)`
+- No `.betwixt` files existed for filter types (nothing to drop)
+
+## Approved XML deviations (Jackson write vs historical Betwixt packages)
+
+|           Historical Betwixt / package dump            |           Jackson default write            |                             Notes                              |
+|--------------------------------------------------------|--------------------------------------------|----------------------------------------------------------------|
+| Graph-identity `id="…"` attributes on complex elements | Not emitted                                | Property values live in child elements; documented in #1887    |
+| Nested `<filter idref="…"/>` on each `rule-def`        | Omitted                                    | Circular parent; restored via `PSItemFilter.setRuleDefs`       |
+| Empty `<parent-filter-id/>`                            | May emit `xsi:nil="true"` when null        | Read accepts empty / nil / absent                              |
+| Nested `parameters` bean elements                      | String map under `params` (key-as-element) | Matches package empty `<params/>`; non-empty uses key children |
+| Mapped type name `item-filter-rule-def` as nested item | Nested uses package name `rule-def`        | Standalone root still `item-filter-rule-def`                   |
+| Version / Hibernate fields                             | Omitted                                    | `@IPSXmlSerialization(suppress=true)` + `@JsonIgnore`          |
+
+## Package install smoke (offline)
+
+Fixtures (copied under test resources from `modules/perc-packages/.../perc.Baseline/`):
+
+- `perc_public.filterDef` — two rules, empty params, Betwixt filter idrefs ignored
+- `perc_staging.filterDef` — one staging rule
+
+`PSItemFilter.fromXML` restores name, description, legacy-authtype-id, guid string form, and rule-name set. Circular filter idrefs are not required on restore.
+
+## Residual (siblings of #1915 under #1892)
+
+Not in this PR — file separate children:
+
+1. sitemgr (`PSSite` / `PSSiteProperty` / `PSPublishingContext` / `PSLocationScheme`)
+2. publisher / pubserver (`PSContentList` / `PSEdition` / `PSDeliveryType` / `PSPubServer`)
+3. catalog / system / ui leftovers (beyond `PSObjectSummary` #1903)
+4. content leftovers beyond keywords + contentmgr `PSNodeDefinition` if needed
+
+## Not in this PR
+
+- Betwixt POM removal (#1824)
+- Live CMS package install
+- Mass rewrite of package `*.filterDef` files
+

--- a/system/services/src/com/percussion/services/filter/data/PSItemFilter.java
+++ b/system/services/src/com/percussion/services/filter/data/PSItemFilter.java
@@ -16,6 +16,11 @@
  */
 package com.percussion.services.filter.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.data.IPSCloneTuner;
@@ -28,21 +33,24 @@ import com.percussion.services.filter.IPSItemFilterRuleDef;
 import com.percussion.services.filter.PSFilterException;
 import com.percussion.services.filter.PSFilterServiceLocator;
 import com.percussion.services.guidmgr.PSGuidHelper;
-import com.percussion.services.guidmgr.PSGuidUtils;
+import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.xml.IPSXmlSerialization;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
-import org.hibernate.annotations.NaturalId;
-import org.hibernate.annotations.NaturalIdCache;
-import org.xml.sax.SAXException;
-
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 import jakarta.persistence.Basic;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -54,28 +62,51 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.NaturalIdCache;
+import org.xml.sax.SAXException;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * Implementation for an item filter, this is a pure mapping object to bring
  * database info into memory.
- * 
+ *
+ * <p>Design-object XML root is {@code item-filter}. Nested package item element is {@code rule-def}
+ * (registered via {@link PSXmlSerializationHelper#addType}). Jackson opt-in property surface (issue
+ * #1915 / #1892 / epic #505).
+ *
  * @author dougrand
  */
 @Entity
 @NaturalIdCache(region = "PSItemFilter_NaturalId")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSItemFilter")
 @Table(name = "PSX_ITEM_FILTER")
+@JacksonXmlRootElement(localName = "item-filter")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({
+  "description",
+  "guid",
+  "label",
+  "legacyAuthtypeId",
+  "name",
+  "parentFilterId",
+  "ruleDefs"
+})
 public class PSItemFilter implements IPSItemFilter, IPSCatalogSummary,
    IPSCloneTuner
 {
@@ -207,6 +238,7 @@ public class PSItemFilter implements IPSItemFilter, IPSCatalogSummary,
     *  (non-Javadoc)
     * @see com.percussion.services.catalog.IPSCatalogSummary#getName()
     */
+   @JsonProperty
    public String getName()
    {
       return name;
@@ -223,6 +255,7 @@ public class PSItemFilter implements IPSItemFilter, IPSCatalogSummary,
    /**
     * Internal implementation for name setting.
     */
+   @JsonIgnore
    public void setNameImpl(String name) throws PSFilterException
    {
       this.name = name;
@@ -231,6 +264,7 @@ public class PSItemFilter implements IPSItemFilter, IPSCatalogSummary,
     * @return Returns the parentFilter.
     */
    @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public IPSItemFilter getParentFilter()
    {
       return parentFilter;
@@ -239,6 +273,7 @@ public class PSItemFilter implements IPSItemFilter, IPSCatalogSummary,
    /**
     * @param parentFilter The parentFilter to set.
     */
+   @JsonIgnore
    public void setParentFilter(IPSItemFilter parentFilter)
    {
       this.parentFilter = parentFilter;
@@ -248,6 +283,7 @@ public class PSItemFilter implements IPSItemFilter, IPSCatalogSummary,
     * Get the parent filter id for xml serialization
     * @return the parent id or <code>null</code>
     */
+   @JsonProperty
    public IPSGuid getParentFilterId()
    {
       if (parentFilter != null)
@@ -282,6 +318,7 @@ public class PSItemFilter implements IPSItemFilter, IPSCatalogSummary,
     *  (non-Javadoc)
     * @see com.percussion.services.catalog.IPSCatalogSummary#getDescription()
     */
+   @JsonProperty
    public String getDescription()
    {
       return description;
@@ -292,6 +329,7 @@ public class PSItemFilter implements IPSItemFilter, IPSCatalogSummary,
     *
     * @return true if description is present and non-empty
     */
+   @JsonIgnore
    public boolean hasDescription() {
       return StringUtils.isNotBlank(description);
    }
@@ -309,6 +347,7 @@ public class PSItemFilter implements IPSItemFilter, IPSCatalogSummary,
     *  (non-Javadoc)
     * @see com.percussion.services.filter.IPSItemFilter#getLegacyAuthtypeId()
     */
+   @JsonProperty
    public Integer getLegacyAuthtypeId()
    {
       return legacy_authtype;
@@ -323,10 +362,26 @@ public class PSItemFilter implements IPSItemFilter, IPSCatalogSummary,
       legacy_authtype = authTypeId;
    }
    /**
-    *  (non-Javadoc)
-    * @see com.percussion.services.filter.IPSItemFilter#setRuleDefs(java.util.Set)
+    * {@inheritDoc}
     */
+   @Override
    public void setRuleDefs(Set<IPSItemFilterRuleDef> ruleDefs)
+   {
+      applyRuleDefs(ruleDefs);
+   }
+
+   /**
+    * Jackson / design-object XML restore for nested {@code rule-def} items.
+    *
+    * @param ruleDefs rule definitions, may be {@code null}
+    */
+   @JsonProperty
+   public void setRuleDefs(List<? extends IPSItemFilterRuleDef> ruleDefs)
+   {
+      applyRuleDefs(ruleDefs);
+   }
+
+   private void applyRuleDefs(Collection<? extends IPSItemFilterRuleDef> ruleDefs)
    {
       rules.clear();
       if (ruleDefs != null)
@@ -336,17 +391,37 @@ public class PSItemFilter implements IPSItemFilter, IPSCatalogSummary,
             k.setFilter(this);
             rules.add(k);
          });
-
       }
    }
 
    /**
-    *  (non-Javadoc)
+    * Nested package item element is {@code rule-def} (matches historical Betwixt {@code addType}
+    * registration). Sorted by rule name for deterministic design-object XML / golden parity.
+    *
+    * <p>Returns a live-backed view is intentionally <em>not</em> used: callers that need to mutate
+    * the set must use {@link #addRuleDef}/{@link #removeRuleDef}/{@link #setRuleDefs}.
+    *
     * @see com.percussion.services.filter.IPSItemFilter#getRuleDefs()
     */
+   @JsonProperty
+   @JacksonXmlElementWrapper(localName = "rule-defs")
+   @JacksonXmlProperty(localName = "rule-def")
+   @JsonDeserialize(contentAs = PSItemFilterRuleDef.class)
    public Set<IPSItemFilterRuleDef> getRuleDefs()
    {
-      return rules;
+      // Stable order for design-object XML / golden parity (backing store is a Set).
+      return rules.stream()
+          .sorted(
+              Comparator.comparing(
+                  def -> {
+                    try {
+                      return def.getRuleName();
+                    } catch (PSFilterException e) {
+                      return "";
+                    }
+                  },
+                  Comparator.nullsLast(String::compareToIgnoreCase)))
+          .collect(Collectors.toCollection(java.util.LinkedHashSet::new));
    }
 
    /**
@@ -373,9 +448,11 @@ public class PSItemFilter implements IPSItemFilter, IPSCatalogSummary,
     * Get the guid for xml serialization
     * @return the guid, never <code>null</code>
     */
+   @JsonProperty("guid")
    public IPSGuid getGUID()
    {
-      return PSGuidUtils.makeGuid(filter_id, PSTypeEnum.ITEM_FILTER);
+      // Construct without GuidManager / Spring (offline design-object XML + unit tests).
+      return new PSGuid(PSTypeEnum.ITEM_FILTER, filter_id);
    }
    
    /**
@@ -389,6 +466,8 @@ public class PSItemFilter implements IPSItemFilter, IPSCatalogSummary,
       {
          throw new IllegalArgumentException("newguid may not be null");
       }
+      // Allow overwrite on design-object XML restore (BeanUtils + Jackson); same pattern as
+      // PSKeyword#setGUID / PSCommunity (issue #1915).
       filter_id = newguid.longValue();
    }
 
@@ -396,12 +475,14 @@ public class PSItemFilter implements IPSItemFilter, IPSCatalogSummary,
     *  (non-Javadoc)
     * @see com.percussion.services.filter.IPSItemFilter#addRuleDef(com.percussion.services.filter.IPSItemFilterRuleDef)
     */
+   @JsonIgnore
    public void addRuleDef(IPSItemFilterRuleDef def)
    {
       def.setFilter(this);
       rules.add(def);
    }
 
+   @JsonIgnore
    public void addRuleDefImpl(IPSItemFilterRuleDef def) {
       addRuleDef(def);
    }
@@ -410,11 +491,13 @@ public class PSItemFilter implements IPSItemFilter, IPSCatalogSummary,
     *  (non-Javadoc)
     * @see com.percussion.services.filter.IPSItemFilter#removeRuleDef(com.percussion.services.filter.IPSItemFilterRuleDef)
     */
+   @JsonIgnore
    public void removeRuleDef(IPSItemFilterRuleDef def)
    {
       rules.remove(def);
    }
 
+   @JsonIgnore
    public void removeRuleDefImpl(IPSItemFilterRuleDef def) {
       removeRuleDef(def);
    }
@@ -423,6 +506,7 @@ public class PSItemFilter implements IPSItemFilter, IPSCatalogSummary,
     * @return Returns the version.
     */
    @IPSXmlSerialization(suppress=true)
+   @JsonIgnore
    public Integer getVersion()
    {
       return version;
@@ -431,6 +515,7 @@ public class PSItemFilter implements IPSItemFilter, IPSCatalogSummary,
    /**
     * @param version The version to set.
     */
+   @JsonIgnore
    public void setVersion(Integer version)
    {
       this.version = version;
@@ -517,14 +602,28 @@ public class PSItemFilter implements IPSItemFilter, IPSCatalogSummary,
    /* (non-Javadoc)
     * @see IPSCatalogSummary#getLabel()
     */
+   @JsonProperty
    public String getLabel()
    {
       return getName();
+   }
+
+   /**
+    * Label is an alias of {@link #getName()} for package/catalog XML parity. Ignore writes that
+    * would duplicate name; name element remains authoritative.
+    *
+    * @param label ignored
+    */
+   @JsonIgnore
+   public void setLabel(String label)
+   {
+      // catalog alias of name — package fixtures emit both; name is authoritative on restore
    }
    
    /* (non-Javadoc)
     * @see com.percussion.services.data.IPSCloneTuner#tuneClone(long)
     */
+   @JsonIgnore
    public Object tuneClone(long newId)
    {
       filter_id = newId;
@@ -563,10 +662,10 @@ public class PSItemFilter implements IPSItemFilter, IPSCatalogSummary,
          sourceRuleNames.add(def.getRuleName());
       }
 
-      // Check old rules, remove if they no longer belong. When this loop 
+      // Check old rules, remove if they no longer belong. When this loop
       // is done, oldRuleNamesMap will contain the old rules that are still
-      // present
-      Iterator<IPSItemFilterRuleDef> iter = getRuleDefs().iterator();
+      // present. Mutate the live field (getRuleDefs returns a sorted copy for XML).
+      Iterator<IPSItemFilterRuleDef> iter = rules.iterator();
       while(iter.hasNext())
       {
          IPSItemFilterRuleDef def = iter.next();

--- a/system/services/src/com/percussion/services/filter/data/PSItemFilterRuleDef.java
+++ b/system/services/src/com/percussion/services/filter/data/PSItemFilterRuleDef.java
@@ -16,6 +16,10 @@
  */
 package com.percussion.services.filter.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.error.PSNotFoundException;
 import com.percussion.extension.IPSExtensionManager;
 import com.percussion.extension.PSExtensionException;
@@ -31,12 +35,12 @@ import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.xml.IPSXmlSerialization;
-import org.apache.commons.lang3.StringUtils;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
-
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
 import jakarta.persistence.Basic;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -51,23 +55,37 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.persistence.Version;
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * This data object represents a single rule instantiation for an item filter.
  * Rules are applied in rule priority order - the order of the actual defs is
  * not relevant (at least at this point).
  *
- * @author dougrand
+ * <p>Nested package item element is {@code rule-def} (registered from {@link PSItemFilter}), not
+ * the default mapped type name {@code item-filter-rule-def}. {@link JacksonXmlRootElement} applies
+ * to standalone serialization only. Package wire uses string map {@code params} (not nested
+ * {@code parameters} bean elements); {@link PSXmlSerializationHelper#addType} still registers
+ * {@code parameters}→{@link PSItemFilterRuleParam} for polymorphic read parity.
  *
+ * @author dougrand
  */
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSItemFilterRuleDef")
 @Table(name = "PSX_ITEM_FILTER_RULE")
+@JacksonXmlRootElement(localName = "item-filter-rule-def")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({"params", "ruleName"})
 public class PSItemFilterRuleDef implements IPSItemFilterRuleDef,
    Serializable
 {
@@ -174,6 +192,7 @@ public class PSItemFilterRuleDef implements IPSItemFilterRuleDef,
 
 
    @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public IPSItemFilterRule getRule() throws PSFilterException
    {
       if (m_rule == null)
@@ -188,6 +207,7 @@ public class PSItemFilterRuleDef implements IPSItemFilterRuleDef,
     * cases that require manipulation of the version.
     * @param v the version, could be <code>null</code>
     */
+   @JsonIgnore
    public void setVersion(Integer v)
    {
       this.version = v;
@@ -200,6 +220,7 @@ public class PSItemFilterRuleDef implements IPSItemFilterRuleDef,
     * database.
     */
    @IPSXmlSerialization(suppress=true)
+   @JsonIgnore
    public Integer getVersion()
    {
       return this.version;
@@ -210,6 +231,7 @@ public class PSItemFilterRuleDef implements IPSItemFilterRuleDef,
     * @return the name of the extension, never <code>null</code> or empty
     * @throws PSFilterException
     */
+   @JsonProperty
    public String getRuleName() throws PSFilterException
    {
       return name;
@@ -267,6 +289,7 @@ public class PSItemFilterRuleDef implements IPSItemFilterRuleDef,
     * @return the guid, never <code>null</code>
     */
    @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public IPSGuid getGUID()
    {
       initializeRuleIdIfNeeded(false);
@@ -277,6 +300,7 @@ public class PSItemFilterRuleDef implements IPSItemFilterRuleDef,
     * Set the guid representation of the rule def.
     * @param newguid the new guid, never <code>null</code>
     */
+   @JsonIgnore
    public void setGUID(IPSGuid newguid)
    {
       if (newguid == null)
@@ -300,6 +324,7 @@ public class PSItemFilterRuleDef implements IPSItemFilterRuleDef,
     * Set the rule name
     * @param rulename the new rule name, never <code>null</code> or empty
     */
+   @JsonIgnore
    public void setRule(String rulename)
    {
       if (StringUtils.isBlank(rulename))
@@ -310,24 +335,26 @@ public class PSItemFilterRuleDef implements IPSItemFilterRuleDef,
    }
 
    /**
-    * Set the parameters for the given rule
-    * @param params the parameter, if <code>null</code> then the current
-    *   parameters will be cleared.
+    * Set the parameters for the given rule (Jackson design-object XML + service callers).
+    *
+    * @param params the parameter, if <code>null</code> then the current parameters will be
+    *     cleared.
     */
+   @JsonProperty("params")
    public void setParams(Map<String, String> params)
    {
-      if (params == null)
+      if (this.params != null)
       {
-         if (this.params != null)
-         {
-            this.params.clear();
-         }
+         this.params.clear();
       }
-      else
+      if (params != null)
       {
          for (Map.Entry<String, String> entry : params.entrySet())
          {
-            setParam(entry.getKey(), entry.getValue());
+            if (entry.getKey() != null && entry.getValue() != null)
+            {
+               setParam(entry.getKey(), entry.getValue());
+            }
          }
       }
    }
@@ -337,11 +364,13 @@ public class PSItemFilterRuleDef implements IPSItemFilterRuleDef,
     * @param parameterName the parameter name, never <code>null</code> or empty
     * @param value the parameter value, never <code>null</code> or empty
     */
+   @JsonIgnore
    public void addParam(String parameterName, String value)
    {
       setParam(parameterName, value);
    }
 
+   @JsonIgnore
    public void setParam(String parameterName, String value)
    {
       if (StringUtils.isBlank(parameterName))
@@ -356,7 +385,9 @@ public class PSItemFilterRuleDef implements IPSItemFilterRuleDef,
       PSItemFilterRuleParam param = this.params.get(parameterName);
       if (param == null)
       {
-         param = new PSItemFilterRuleParam(isClientSide);
+         // Prefer client-side / default construction so design-object XML restore and offline unit
+         // tests do not require GuidManager / Spring (ids assigned on PrePersist when needed).
+         param = new PSItemFilterRuleParam(true);
          param.setRuleDef(this);
          param.setName(parameterName);
          param.setValue(value);
@@ -368,6 +399,7 @@ public class PSItemFilterRuleDef implements IPSItemFilterRuleDef,
       }
    }
 
+   @JsonIgnore
    public void removeParam(String parameterName)
    {
       PSItemFilterRuleParam param = this.params.get(parameterName);
@@ -378,11 +410,18 @@ public class PSItemFilterRuleDef implements IPSItemFilterRuleDef,
       }
    }
 
+   /**
+    * Parent filter association. Package Betwixt dumps used graph {@code idref}; modern Jackson
+    * write omits the circular parent (restored via {@link PSItemFilter#setRuleDefs}).
+    */
+   @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public IPSItemFilter getFilter()
    {
       return filter;
    }
 
+   @JsonIgnore
    public void setFilter(IPSItemFilter f)
    {
       filter = (PSItemFilter) f;
@@ -430,14 +469,38 @@ public class PSItemFilterRuleDef implements IPSItemFilterRuleDef,
       }
    }
 
+   /**
+    * Parameter map for service API callers (unmodifiable). Design-object XML uses {@link
+    * #getParamsForXml()} / {@link #setParams(Map)}.
+    *
+    * @return unmodifiable map, never {@code null}
+    */
+   @JsonIgnore
    public Map<String, String> getParams()
    {
-      Map<String, String> rval = new HashMap<>();
+      Map<String, String> rval = new TreeMap<>();
       for (Map.Entry<String, PSItemFilterRuleParam> e : this.params.entrySet())
       {
          rval.put(e.getKey(), e.getValue().getValue());
       }
       return Collections.unmodifiableMap(rval);
+   }
+
+   /**
+    * Mutable sorted params for Jackson design-object XML. Package fixtures use empty {@code
+    * <params/>}; non-empty maps write key-as-element children.
+    *
+    * @return mutable map, never {@code null}
+    */
+   @JsonProperty("params")
+   public Map<String, String> getParamsForXml()
+   {
+      Map<String, String> rval = new TreeMap<>();
+      for (Map.Entry<String, PSItemFilterRuleParam> e : this.params.entrySet())
+      {
+         rval.put(e.getKey(), e.getValue().getValue());
+      }
+      return rval;
    }
 
    /**

--- a/system/services/src/com/percussion/services/filter/data/PSItemFilterRuleParam.java
+++ b/system/services/src/com/percussion/services/filter/data/PSItemFilterRuleParam.java
@@ -16,11 +16,15 @@
  */
 package com.percussion.services.filter.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.PSGuidHelper;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-
+import com.percussion.utils.xml.IPSXmlSerialization;
+import java.io.Serializable;
+import java.util.Objects;
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -31,11 +35,16 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.persistence.Version;
-import java.io.Serializable;
-import java.util.Objects;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
- * Represents a single parameter for the rule definition
+ * Represents a single parameter for the rule definition.
+ *
+ * <p>Registered under package element name {@code parameters} via {@code
+ * PSXmlSerializationHelper.addType}. Production package {@code *.filterDef} wire typically uses the
+ * parent {@code params} string map instead of nested parameter beans.
  *
  * @author dougrand
  */
@@ -43,6 +52,14 @@ import java.util.Objects;
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE,
       region = "PSItemFilterRuleParam")
 @Table(name = "PSX_ITEM_FILTER_RULE_PARAM")
+@JacksonXmlRootElement(localName = "parameters")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({"id", "name", "value"})
 public class PSItemFilterRuleParam implements Serializable
 {
    /**
@@ -128,6 +145,7 @@ public class PSItemFilterRuleParam implements Serializable
    /**
     * @return Returns the id.
     */
+   @JsonProperty
    public Long getId()
    {
       initializeIdIfNeeded(false);
@@ -135,8 +153,17 @@ public class PSItemFilterRuleParam implements Serializable
    }
 
    /**
+    * @param id primary key, may be {@code null} before persist
+    */
+   public void setId(Long id)
+   {
+      this.id = id;
+   }
+
+   /**
     * @return Returns the name.
     */
+   @JsonProperty
    public String getName()
    {
       return name;
@@ -153,6 +180,7 @@ public class PSItemFilterRuleParam implements Serializable
    /**
     * @return Returns the value.
     */
+   @JsonProperty
    public String getValue()
    {
       return value;
@@ -169,6 +197,8 @@ public class PSItemFilterRuleParam implements Serializable
    /**
     * @return Returns the ruleDef.
     */
+   @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public PSItemFilterRuleDef getRuleDef()
    {
       return ruleDef;
@@ -177,9 +207,28 @@ public class PSItemFilterRuleParam implements Serializable
    /**
     * @param ruleDef The ruleDef to set.
     */
+   @JsonIgnore
    public void setRuleDef(PSItemFilterRuleDef ruleDef)
    {
       this.ruleDef = ruleDef;
+   }
+
+   /**
+    * Hibernate version — not part of design-object XML wire.
+    *
+    * @return version, may be {@code null}
+    */
+   @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
+   public Integer getVersion()
+   {
+      return version;
+   }
+
+   @JsonIgnore
+   public void setVersion(Integer version)
+   {
+      this.version = version;
    }
 
    @Override

--- a/system/src/test/java/com/percussion/services/filter/data/PSItemFilterXmlSerializationTest.java
+++ b/system/src/test/java/com/percussion/services/filter/data/PSItemFilterXmlSerializationTest.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.filter.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.filter.IPSItemFilterRuleDef;
+import com.percussion.services.guidmgr.data.PSGuid;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * Golden / round-trip / package-fixture smoke for filter design objects under the Jackson-backed
+ * {@code PSXmlSerializationHelper} (issue #1915 / #1892, epic #505). Offline only — no live CMS.
+ */
+class PSItemFilterXmlSerializationTest {
+
+  @Test
+  void writeEmitsItemFilterRuleDefParamsAndSuppressesVersionParentFilter() throws Exception {
+    PSItemFilter original = samplePublicFilter();
+    String xml = original.toXML();
+
+    assertNotNull(xml);
+    assertFalse(xml.trim().startsWith("<null"), "modern write must not emit legacy null root");
+    assertTrue(containsTag(xml, "item-filter"), "root item-filter: " + xml);
+    assertTrue(containsTag(xml, "rule-defs"), xml);
+    assertTrue(containsTag(xml, "rule-def"), "nested package element rule-def: " + xml);
+    assertFalse(
+        containsTag(xml, "item-filter-rule-def"),
+        "must not emit mapped type name item-filter-rule-def as nested: " + xml);
+    assertTrue(containsTag(xml, "params"), xml);
+    assertTrue(containsTag(xml, "rule-name"), xml);
+    assertTrue(containsTag(xml, "guid"), xml);
+    assertTrue(containsTag(xml, "legacy-authtype-id"), xml);
+    assertTrue(xml.contains("perc_public"), xml);
+    assertTrue(xml.contains("perc_publicAssetFilter") || xml.contains("TESTRULE"), xml);
+    assertFalse(containsTag(xml, "version"), "version suppressed: " + xml);
+    // parentFilter object suppressed; parent-filter-id may be empty/null omitted
+    assertFalse(xml.matches("(?s).*<parent-filter(\\s|>).*"), "parentFilter object: " + xml);
+    // circular filter on rule-def omitted on modern write (package used idref)
+    assertFalse(xml.matches("(?s).*<filter(\\s|>).*"), "circular filter on rule-def: " + xml);
+  }
+
+  @Test
+  void writeMatchesGoldenFixture() throws Exception {
+    String xml = samplePublicFilter().toXML();
+    String golden = loadResource("com/percussion/services/filter/data/ps-item-filter-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+  }
+
+  @Test
+  void roundTripRestoresScalarsRulesAndParams() throws Exception {
+    PSItemFilter original = samplePublicFilter();
+    String xml = original.toXML();
+
+    PSItemFilter restored = new PSItemFilter();
+    restored.fromXML(xml);
+
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getDescription(), restored.getDescription());
+    assertEquals(original.getLegacyAuthtypeId(), restored.getLegacyAuthtypeId());
+    assertEquals(original.getGUID().toString(), restored.getGUID().toString());
+    assertNull(restored.getParentFilter());
+    assertEquals(original.getRuleDefs().size(), restored.getRuleDefs().size());
+
+    Map<String, String> originalParamsByRule = ruleParamsByName(original);
+    Map<String, String> restoredParamsByRule = ruleParamsByName(restored);
+    assertEquals(originalParamsByRule.keySet(), restoredParamsByRule.keySet());
+    for (String ruleName : originalParamsByRule.keySet()) {
+      assertEquals(
+          originalParamsByRule.get(ruleName),
+          restoredParamsByRule.get(ruleName),
+          "params for " + ruleName);
+    }
+  }
+
+  @Test
+  void fromXmlAcceptsLegacyNullRootPackageShape() throws Exception {
+    String legacy =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <null id="1">
+          <guid>0-7-11</guid>
+          <description>Public Asset Filter.</description>
+          <label>perc_public</label>
+          <legacy-authtype-id>1</legacy-authtype-id>
+          <name>perc_public</name>
+          <parent-filter-id/>
+          <rule-defs>
+            <rule-def id="2">
+              <params>
+                <sys_context>1</sys_context>
+              </params>
+              <rule-name>***TESTRULE***</rule-name>
+            </rule-def>
+          </rule-defs>
+        </null>
+        """;
+
+    PSItemFilter restored = new PSItemFilter();
+    restored.fromXML(legacy);
+
+    assertEquals("perc_public", restored.getName());
+    assertEquals("Public Asset Filter.", restored.getDescription());
+    assertEquals(1, restored.getLegacyAuthtypeId().intValue());
+    assertEquals(11L, restored.getGUID().longValue());
+    assertEquals(1, restored.getRuleDefs().size());
+    IPSItemFilterRuleDef rule = restored.getRuleDefs().iterator().next();
+    assertEquals(PSItemFilterRuleDef.TEST_RULE_NAME, rule.getRuleName());
+    assertEquals("1", rule.getParam("sys_context"));
+  }
+
+  @Test
+  void packageFixturePublicFilterSmokeRestoresScalarsAndRules() throws Exception {
+    String packaged = loadResource("com/percussion/services/filter/data/perc_public.filterDef");
+    assertTrue(packaged.contains("<item-filter"), packaged);
+    assertTrue(packaged.contains("<rule-def"), packaged);
+    assertTrue(packaged.contains("idref"), "fixture still uses Betwixt filter idref");
+
+    PSItemFilter restored = new PSItemFilter();
+    restored.fromXML(packaged);
+
+    assertEquals("perc_public", restored.getName());
+    assertEquals("Public Asset Filter.", restored.getDescription());
+    assertEquals(1, restored.getLegacyAuthtypeId().intValue());
+    assertNotNull(restored.getGUID());
+    // Package guid is host-type-uuid form (750232-7-11); longValue is the UUID bits, not 11.
+    assertEquals("750232-7-11", restored.getGUID().toString());
+    assertEquals(2, restored.getRuleDefs().size());
+
+    Map<String, String> byName = ruleNamesToEmpty(restored);
+    assertTrue(byName.containsKey("Java/global/percussion/itemfilter/perc_publicAssetFilter"));
+    assertTrue(byName.containsKey("Java/global/percussion/itemfilter/perc_unscheduledFilter"));
+  }
+
+  @Test
+  void packageFixtureStagingFilterSmoke() throws Exception {
+    String packaged = loadResource("com/percussion/services/filter/data/perc_staging.filterDef");
+    PSItemFilter restored = new PSItemFilter();
+    restored.fromXML(packaged);
+
+    assertEquals("perc_staging", restored.getName());
+    assertEquals(1, restored.getRuleDefs().size());
+    assertEquals(
+        "Java/global/percussion/itemfilter/perc_stagingFilter",
+        restored.getRuleDefs().iterator().next().getRuleName());
+  }
+
+  private static PSItemFilter samplePublicFilter() throws Exception {
+    PSItemFilter filter = new PSItemFilter();
+    filter.setGUID(new PSGuid(PSTypeEnum.ITEM_FILTER, 11L));
+    filter.setName("perc_public");
+    filter.setDescription("Public Asset Filter.");
+    filter.setLegacyAuthtypeId(1);
+
+    PSItemFilterRuleDef publicRule = new PSItemFilterRuleDef(true);
+    publicRule.setRule(PSItemFilterRuleDef.TEST_RULE_NAME);
+    publicRule.setParam("sys_context", "1");
+    filter.addRuleDef(publicRule);
+
+    PSItemFilterRuleDef unscheduled = new PSItemFilterRuleDef(true);
+    unscheduled.setRule("***TESTRULE-UNSCHEDULED***");
+    filter.addRuleDef(unscheduled);
+
+    return filter;
+  }
+
+  private static Map<String, String> ruleParamsByName(PSItemFilter filter) throws Exception {
+    Map<String, String> out = new LinkedHashMap<>();
+    for (IPSItemFilterRuleDef def : filter.getRuleDefs()) {
+      StringBuilder flat = new StringBuilder();
+      def.getParams().entrySet().stream()
+          .sorted(Map.Entry.comparingByKey())
+          .forEach(e -> flat.append(e.getKey()).append('=').append(e.getValue()).append(';'));
+      out.put(def.getRuleName(), flat.toString());
+    }
+    return out;
+  }
+
+  private static Map<String, String> ruleNamesToEmpty(PSItemFilter filter) throws Exception {
+    Map<String, String> out = new LinkedHashMap<>();
+    for (IPSItemFilterRuleDef def : filter.getRuleDefs()) {
+      out.put(def.getRuleName(), "");
+    }
+    return out;
+  }
+
+  private static boolean containsTag(String xml, String localName) {
+    return xml.contains("<" + localName) || xml.contains("</" + localName + ">");
+  }
+
+  private static String loadResource(String classpath) throws Exception {
+    try (InputStream in =
+        PSItemFilterXmlSerializationTest.class.getClassLoader().getResourceAsStream(classpath)) {
+      assertNotNull(in, "missing test resource: " + classpath);
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static void assertLogicalXmlParity(String expectedXml, String actualXml)
+      throws Exception {
+    Document expected = parseXml(stripXmlDeclaration(expectedXml));
+    Document actual = parseXml(stripXmlDeclaration(actualXml));
+    assertElementTreeEquals(expected.getDocumentElement(), actual.getDocumentElement(), "/");
+  }
+
+  private static String stripXmlDeclaration(String xml) {
+    String s = Objects.requireNonNull(xml).trim();
+    if (s.startsWith("<?xml")) {
+      int end = s.indexOf("?>");
+      if (end >= 0) {
+        s = s.substring(end + 2).trim();
+      }
+    }
+    while (s.startsWith("<!--")) {
+      int end = s.indexOf("-->");
+      if (end < 0) {
+        break;
+      }
+      s = s.substring(end + 3).trim();
+    }
+    return s;
+  }
+
+  private static Document parseXml(String xml) throws Exception {
+    var factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    var builder = factory.newDocumentBuilder();
+    return builder.parse(new InputSource(new java.io.StringReader(xml)));
+  }
+
+  private static void assertElementTreeEquals(Element expected, Element actual, String path) {
+    assertEquals(expected.getTagName(), actual.getTagName(), "tag at " + path);
+    java.util.List<Node> eChildren = significantChildren(expected);
+    java.util.List<Node> aChildren = significantChildren(actual);
+    assertEquals(
+        eChildren.size(),
+        aChildren.size(),
+        "child count at "
+            + path
+            + " expected="
+            + summarize(eChildren)
+            + " actual="
+            + summarize(aChildren));
+    for (int i = 0; i < eChildren.size(); i++) {
+      Node en = eChildren.get(i);
+      Node an = aChildren.get(i);
+      if (en.getNodeType() == Node.TEXT_NODE) {
+        assertEquals(en.getTextContent().trim(), an.getTextContent().trim(), "text at " + path);
+      } else {
+        assertElementTreeEquals(
+            (Element) en, (Element) an, path + "/" + ((Element) en).getTagName() + "[" + i + "]");
+      }
+    }
+  }
+
+  private static java.util.List<Node> significantChildren(Element el) {
+    NodeList nl = el.getChildNodes();
+    java.util.ArrayList<Node> out = new java.util.ArrayList<>();
+    boolean hasElementChild = false;
+    for (int i = 0; i < nl.getLength(); i++) {
+      if (nl.item(i).getNodeType() == Node.ELEMENT_NODE) {
+        hasElementChild = true;
+        break;
+      }
+    }
+    for (int i = 0; i < nl.getLength(); i++) {
+      Node n = nl.item(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE) {
+        out.add(n);
+      } else if (n.getNodeType() == Node.TEXT_NODE && !hasElementChild) {
+        String t = n.getTextContent();
+        if (t != null && !t.trim().isEmpty()) {
+          out.add(n);
+        }
+      }
+    }
+    return out;
+  }
+
+  private static String summarize(java.util.List<Node> nodes) {
+    StringBuilder b = new StringBuilder("[");
+    for (int i = 0; i < nodes.size(); i++) {
+      if (i > 0) {
+        b.append(',');
+      }
+      Node n = nodes.get(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE) {
+        b.append(((Element) n).getTagName());
+      } else {
+        b.append("#text");
+      }
+    }
+    return b.append(']').toString();
+  }
+}

--- a/system/src/test/resources/com/percussion/services/filter/data/perc_public.filterDef
+++ b/system/src/test/resources/com/percussion/services/filter/data/perc_public.filterDef
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>  <item-filter id="1">
+    <guid>750232-7-11</guid>
+    <description>Public Asset Filter.</description>
+    <label>perc_public</label>
+    <legacy-authtype-id>1</legacy-authtype-id>
+    <name>perc_public</name>
+    <parent-filter-id/>
+    <rule-defs>
+      <rule-def id="2">
+        <filter idref="1"/>
+        <params/>
+        <rule-name>Java/global/percussion/itemfilter/perc_publicAssetFilter</rule-name>
+      </rule-def>
+      <rule-def id="3">
+        <filter idref="1"/>
+        <params/>
+        <rule-name>Java/global/percussion/itemfilter/perc_unscheduledFilter</rule-name>
+      </rule-def>
+    </rule-defs>
+  </item-filter>

--- a/system/src/test/resources/com/percussion/services/filter/data/perc_staging.filterDef
+++ b/system/src/test/resources/com/percussion/services/filter/data/perc_staging.filterDef
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>  <item-filter id="1">
+    <guid>12806958-7-13</guid>
+    <description>FIlters out items that are not allowed for staging.</description>
+    <label>perc_staging</label>
+    <legacy-authtype-id>1</legacy-authtype-id>
+    <name>perc_staging</name>
+    <parent-filter-id/>
+    <rule-defs>
+      <rule-def id="2">
+        <filter idref="1"/>
+        <params/>
+        <rule-name>Java/global/percussion/itemfilter/perc_stagingFilter</rule-name>
+      </rule-def>
+    </rule-defs>
+  </item-filter>

--- a/system/src/test/resources/com/percussion/services/filter/data/ps-item-filter-golden.xml
+++ b/system/src/test/resources/com/percussion/services/filter/data/ps-item-filter-golden.xml
@@ -1,0 +1,31 @@
+<!-- Golden snapshot for production PSItemFilter / PSItemFilterRuleDef Jackson
+	wire shape (issue #1915 / #1892 / epic #505). Nested item element is package
+	name "rule-def" (not mapped type name "item-filter-rule-def"). Approved Jackson
+	deviations vs historical Betwixt package dumps: - no graph-identity id="…"
+	attributes on complex elements - no circular <filter idref> on rule-def (restored
+	via parent setRuleDefs) - null parent-filter-id may emit xsi:nil (package
+	used empty element) - no XML declaration (PSJacksonXmlSerializationHelper
+	default) - version / parentFilter remain suppressed via @IPSXmlSerialization
+	- <guid> uses shared IPSGuid string converter (Betwixt parity) - params map
+	uses key-as-element children when non-empty -->
+<item-filter>
+	<description>Public Asset Filter.</description>
+	<guid>0-7-11</guid>
+	<label>perc_public</label>
+	<legacy-authtype-id>1</legacy-authtype-id>
+	<name>perc_public</name>
+	<parent-filter-id
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+	<rule-defs>
+		<rule-def>
+			<params>
+				<sys_context>1</sys_context>
+			</params>
+			<rule-name>***TESTRULE***</rule-name>
+		</rule-def>
+		<rule-def>
+			<params />
+			<rule-name>***TESTRULE-UNSCHEDULED***</rule-name>
+		</rule-def>
+	</rule-defs>
+</item-filter>


### PR DESCRIPTION
## Summary

Jackson-migrates the **filter** design-object package under `system/services/.../filter/data` for the Jackson-backed `PSXmlSerializationHelper` (slice 6a of remaining system domains).

- Annotate `PSItemFilter`, `PSItemFilterRuleDef`, `PSItemFilterRuleParam`
- Nested package element `rule-def`; keep `addType` for `rule-def` / `parameters`
- Honor `@IPSXmlSerialization(suppress=true)` (parentFilter, version, rule, rule GUID)
- Omit circular `filter` idref on modern write (restored via `setRuleDefs`)
- Golden + round-trip + offline package smoke (`perc_public` / `perc_staging` filterDef)
- Deviations: `docs/ai-generated/tasks/505-betwixt-jackson/1915-filter-domain-deviations.md`

## Fixes / links

- **Fixes #1915** (filter-only child)
- Related #1892 #1823 #505 #1887
- Residual children (parent #1892 stays open): #1918 sitemgr · #1919 publisher/pubserver · #1920 catalog/system/ui leftovers · #1921 content leftovers + PSNodeDefinition

## Test plan

- [x] `PSItemFilterXmlSerializationTest` — 6 tests (golden, round-trip, legacy null root, package smoke)
- [x] `cd system && ../mvnw clean install` — BUILD SUCCESS
- [x] Spotless: root `mvnw spotless:apply` then `spotless:check` (in-scope only; out-of-scope apply hits discarded)
- [x] Erlang self-review: `docs/ai-generated/code-reviews/issue-1915-filter-jackson-erlang.md`

## Gates evidence

| Gate | Evidence |
|------|----------|
| Module clean install | `cd system; ..\mvnw.cmd clean install` → BUILD SUCCESS (~1m30s) |
| Unit tests | `PSItemFilterXmlSerializationTest` Tests run: 6, Failures: 0 |
| Spotless | apply then check; only filter domain + docs committed |
| Erlang | no bugs / portable paths / companions from peers |

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.