### PR TITLE
fix: one-time i18n locale code DB migration (GH-1547)

### DIFF
--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSMigrateI18nLocaleCodes.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSMigrateI18nLocaleCodes.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.ant.install;
+
+import com.percussion.i18n.PSLocaleCodeMigrator;
+import com.percussion.install.InstallUtil;
+import com.percussion.install.PSLogger;
+import com.percussion.tablefactory.PSJdbcDbmsDef;
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.util.Properties;
+import org.apache.tools.ant.BuildException;
+
+/**
+ * ANT task that rewrites persisted locale codes during CMS upgrade (GH-1547).
+ *
+ * <p>Delegates to {@link PSLocaleCodeMigrator}. Idempotent; never deletes rows. Prefer running
+ * after repository setup (server stopped) so {@code rxrepository.properties} is readable.
+ *
+ * <pre>{@code
+ * <PSMigrateI18nLocaleCodes rootDir="${install.dir}" dryRun="false"/>
+ * }</pre>
+ *
+ * <p>Set {@code dryRun="true"} (or {@code -Di18n.locale.migration.dryRun=true}) for staging
+ * rehearsal that counts rewrites without committing.
+ */
+public class PSMigrateI18nLocaleCodes extends PSAction {
+
+  /** Creates the migration task. */
+  public PSMigrateI18nLocaleCodes() {
+    super();
+  }
+
+  private boolean dryRun = false;
+  private boolean failOnError = true;
+
+  /**
+   * @param dryRun when true, count and log only (rollback / no updates)
+   */
+  public void setDryRun(boolean dryRun) {
+    this.dryRun = dryRun;
+  }
+
+  /**
+   * @return whether dry-run mode is enabled
+   */
+  public boolean isDryRun() {
+    return dryRun;
+  }
+
+  /**
+   * @param failOnError when true (default), SQL/config failures throw {@link BuildException}
+   */
+  public void setFailOnError(boolean failOnError) {
+    this.failOnError = failOnError;
+  }
+
+  /**
+   * @return whether failures abort the install
+   */
+  public boolean isFailOnError() {
+    return failOnError;
+  }
+
+  @Override
+  public void execute() throws BuildException {
+    super.execute();
+    String root = getRootDir();
+    if (root == null || root.isBlank()) {
+      throw new BuildException("PSMigrateI18nLocaleCodes: rootDir is required");
+    }
+
+    // System property wins for staging rehearsals without editing ANT XML.
+    String sysDry = System.getProperty("i18n.locale.migration.dryRun");
+    if (sysDry != null && !sysDry.isBlank()) {
+      dryRun =
+          "true".equalsIgnoreCase(sysDry.trim())
+              || "yes".equalsIgnoreCase(sysDry.trim())
+              || "1".equals(sysDry.trim());
+    }
+
+    // Portable path join (no hardcoded separators).
+    Path propPath = Path.of(root, "rxconfig", "Installer", "rxrepository.properties");
+    File propFile = propPath.toFile();
+    if (!propFile.isFile()) {
+      PSLogger.logInfo(
+          "PSMigrateI18nLocaleCodes: repository properties not found at "
+              + propPath
+              + " — skipping locale migration (new extract without DB config).");
+      return;
+    }
+
+    if (InstallUtil.checkServerRunning(root)) {
+      String msg =
+          "PSMigrateI18nLocaleCodes: CMS appears to be running. Stop the server before"
+              + " upgrade (offline migration only).";
+      if (failOnError) {
+        throw new BuildException(msg);
+      }
+      PSLogger.logInfo(msg);
+      return;
+    }
+
+    try (FileInputStream in = new FileInputStream(propFile)) {
+      Properties props = new Properties();
+      props.load(in);
+      PSJdbcDbmsDef dbmsDef = new PSJdbcDbmsDef(props);
+      if (getRootDir() != null && !getRootDir().isEmpty()) {
+        InstallUtil.setRootDir(getRootDir());
+      }
+
+      String driver = dbmsDef.getDriver();
+      String server = dbmsDef.getServer();
+      String database = dbmsDef.getDataBase();
+      String uid = dbmsDef.getUserId();
+      String pw = dbmsDef.getPassword();
+
+      PSLogger.logInfo(
+          "PSMigrateI18nLocaleCodes: starting"
+              + (dryRun ? " (dry-run)" : "")
+              + " driver="
+              + driver
+              + " server="
+              + server);
+
+      try (Connection conn = InstallUtil.createConnection(driver, server, database, uid, pw)) {
+        PSLocaleCodeMigrator migrator = new PSLocaleCodeMigrator(PSLogger::logInfo);
+        PSLocaleCodeMigrator.Result result = migrator.migrate(conn, dbmsDef, dryRun);
+        PSLogger.logInfo(
+            "PSMigrateI18nLocaleCodes: done"
+                + " sys_lang="
+                + result.sysLangRewritten()
+                + "/"
+                + result.sysLangScanned()
+                + " contentLocale="
+                + result.contentLocaleRewritten()
+                + "/"
+                + result.contentLocaleScanned());
+      }
+    } catch (BuildException be) {
+      throw be;
+    } catch (Exception e) {
+      String msg = "PSMigrateI18nLocaleCodes failed: " + e.getMessage();
+      PSLogger.logError(msg);
+      if (failOnError) {
+        throw new BuildException(msg, e);
+      }
+    }
+  }
+}

--- a/modules/perc-ant/src/main/resources/com/percussion/ant/antlib.xml
+++ b/modules/perc-ant/src/main/resources/com/percussion/ant/antlib.xml
@@ -163,6 +163,9 @@
 	<!-- #548 DTS per-service Derby→H2 migration -->
 	<taskdef name="PSMigrateDtsEmbeddedRepository"
 		classname="com.percussion.ant.install.PSMigrateDtsEmbeddedRepository" />
+	<!-- #1547 one-time i18n locale code rewrite (sys_lang + CONTENTSTATUS.LOCALE) -->
+	<taskdef name="PSMigrateI18nLocaleCodes"
+		classname="com.percussion.ant.install.PSMigrateI18nLocaleCodes" />
 	<taskdef name="PSUpgradeEncryption"
 		classname="com.percussion.ant.install.PSUpgradeEncryption" />
 	<taskdef name="PSUpgradeSiteConfig"

--- a/modules/perc-distribution-tree/AGENTS.md
+++ b/modules/perc-distribution-tree/AGENTS.md
@@ -107,6 +107,29 @@ cd modules/perc-distribution-tree
 ../../mvnw clean install
 ```
 
+### Installer DB migrations (locale codes — GH-1547)
+
+One-time upgrade migration rewrites persisted locale tags after the BCP-47 matrix:
+
+|       Piece        |                                               Location                                                |
+|--------------------|-------------------------------------------------------------------------------------------------------|
+| Rewrite map (pure) | `modules/perc-i18n` → `PSLocaleCodeRewrite`                                                           |
+| JDBC migrator      | `modules/perc-i18n` → `PSLocaleCodeMigrator` (tablefactory-qualified UPDATEs, transactional, dry-run) |
+| ANT task           | `modules/perc-ant` → `PSMigrateI18nLocaleCodes` (registered in `antlib.xml`)                          |
+| ANT script         | `rxconfig/Installer/migration_i18n_locales.xml`                                                       |
+| Wire-in            | `install.xml` `install.chain` + `upgrade.chain` after `updateConfiguration`                           |
+
+**Tables:**
+
+* `PSX_PERSISTEDPROPERTYVALUES.PROPERTYVALUE` where `PROPERTYNAME='sys_lang'`: `hi` → `hi-in`; `es` stays `es`; other tags `toLowerCase` + `_`→`-`.
+* `CONTENTSTATUS.LOCALE` (issue text may say `CT_LOCALE`): `es` → `es-es`; never deletes rows; every rewrite is logged.
+
+**Dry-run (staging rehearsal):** `-Di18n.locale.migration.dryRun=true` (counts only; no commit).
+
+**Out of scope:** custom widget configs with `locale=hi` (user re-picks enum).
+
+Tests: `PSLocaleCodeRewriteTest` / `PSLocaleCodeMigratorTest` (perc-i18n); `I18nLocaleMigrationWiringTest` (this module).
+
 ### Verifying the JDBC driver set
 
 After `mvn verify`, the `scripts/verify-jdbc-drivers.py` script (cross-platform Python port of the original `.sh`/`.bat`) runs against the built distribution artifact and asserts that `jetty/base/lib/jdbc/` is populated with the expected JDBC drivers (sourced from parent-POM-managed Maven coordinates; see `pom.xml` execution `stage-jdbc-drivers`). See `scripts/README.md` for invocation details and exit-code table.

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/install.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/install.xml
@@ -675,6 +675,9 @@
 			inheritrefs="true" />
 		<ant antfile="updateConfiguration.xml"
 			target="updateConfiguration" inheritAll="true" inheritRefs="true" />
+		<!-- GH-1547: rewrite persisted locale codes after DB setup (idempotent). -->
+		<ant antfile="migration_i18n_locales.xml"
+			target="migrateI18nLocales" inheritAll="true" inheritRefs="true" />
 		<antcall target="updateAuditLog" inheritall="true"
 			inheritrefs="true" />
 	</target>
@@ -745,6 +748,9 @@
 			failonerror="false" force="true" />
 		<ant antfile="updateConfiguration.xml"
 			target="updateConfiguration" inheritAll="true" inheritRefs="true" />
+		<!-- GH-1547: rewrite persisted locale codes after DB setup (idempotent). -->
+		<ant antfile="migration_i18n_locales.xml"
+			target="migrateI18nLocales" inheritAll="true" inheritRefs="true" />
 	</target>
 	<target name="deleteOldLog4jJars">
 		<delete failonerror="false" includeemptydirs="true"

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/migration_i18n_locales.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/migration_i18n_locales.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- GH-1547: one-time upgrade migration of persisted locale codes after
+	the 17-locale BCP-47 matrix. Invoked from install.xml install.chain and upgrade.chain
+	after updateConfiguration (post-setupDB). Targets: * PSX_PERSISTEDPROPERTYVALUES.PROPERTYVALUE
+	where PROPERTYNAME='sys_lang' - hi → hi-in; underscore/legacy tags → lower-case
+	hyphen; es stays es * CONTENTSTATUS.LOCALE (issue text may say CT_LOCALE)
+	- es → es-es; other tags normalized only; never deletes rows Dry-run: -Di18n.locale.migration.dryRun=true
+	or dryRun="true" on the task. -->
+<project name="migration_i18n_locales"
+	default="migrateI18nLocales">
+
+	<!-- Nested <ant> projects do not inherit parent taskdefs; re-register from
+		ant.deps (path id defined in install.xml, inherited via inheritRefs). -->
+	<taskdef name="PSMigrateI18nLocaleCodes"
+		classname="com.percussion.ant.install.PSMigrateI18nLocaleCodes"
+		classpathref="ant.deps" onerror="ignore" />
+
+	<target name="migrateI18nLocales"
+		description="Rewrite persisted sys_lang and CONTENTSTATUS.LOCALE codes to canonical BCP-47 forms (GH-1547)">
+		<echo>Running i18n locale code migration (GH-1547)...</echo>
+		<!-- dryRun defaults false; override via -Di18n.locale.migration.dryRun=true -->
+		<property name="i18n.locale.migration.dryRun" value="false" />
+		<PSMigrateI18nLocaleCodes
+			rootDir="${install.dir}" dryRun="${i18n.locale.migration.dryRun}"
+			failOnError="true" />
+	</target>
+
+</project>

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/I18nLocaleMigrationWiringTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/I18nLocaleMigrationWiringTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.distribution.install;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression guard for GH-1547: the installer ships {@code migration_i18n_locales.xml} and both
+ * install/upgrade chains invoke it. Uses relative {@link Path} only (cross-platform).
+ */
+@Tag("UnitTest")
+class I18nLocaleMigrationWiringTest {
+
+  private static final Path INSTALLER =
+      Path.of("src", "main", "resources", "distribution", "rxconfig", "Installer");
+
+  private static final Path MIGRATION_XML = INSTALLER.resolve("migration_i18n_locales.xml");
+  private static final Path INSTALL_XML = INSTALLER.resolve("install.xml");
+
+  @Test
+  void migrationScriptIsShipped() throws IOException {
+    assertTrue(Files.isRegularFile(MIGRATION_XML), "missing " + MIGRATION_XML);
+    String body = Files.readString(MIGRATION_XML, StandardCharsets.UTF_8);
+    assertTrue(body.contains("PSMigrateI18nLocaleCodes"), "migration must use Ant task");
+    assertTrue(body.contains("migrateI18nLocales"), "default target name");
+    assertTrue(body.contains("i18n.locale.migration.dryRun"), "dry-run property");
+  }
+
+  @Test
+  void installAndUpgradeChainsInvokeMigration() throws IOException {
+    assertTrue(Files.isRegularFile(INSTALL_XML), "missing " + INSTALL_XML);
+    String body = Files.readString(INSTALL_XML, StandardCharsets.UTF_8);
+    assertTrue(
+        body.contains("migration_i18n_locales.xml"),
+        "install.xml must reference migration_i18n_locales.xml");
+    // Both chains should mention the antfile (count >= 2).
+    int idx = 0;
+    int hits = 0;
+    while ((idx = body.indexOf("migration_i18n_locales.xml", idx)) >= 0) {
+      hits++;
+      idx += "migration_i18n_locales.xml".length();
+    }
+    assertTrue(hits >= 2, "expected install.chain + upgrade.chain wiring, hits=" + hits);
+  }
+}

--- a/modules/perc-i18n/README.md
+++ b/modules/perc-i18n/README.md
@@ -231,11 +231,13 @@ Run tests with:
 
 ## Future Enhancements
 
-- One-time DB migration that rewrites persisted `sys_lang` and
+- ~~One-time DB migration that rewrites persisted `sys_lang` and
   `LOCALE` values from the legacy `hi` / `es` / `en` codes to the
-  canonical regional forms (`hi-in`, `es-es`, `en-us`). Not in scope
-  for the current revision because the runtime loader already handles
-  both forms via normalization.
+  canonical regional forms (`hi-in`, `es-es`, `en-us`).~~ **Done (GH-1547):**
+  `PSLocaleCodeRewrite` + `PSLocaleCodeMigrator` (this module), ANT task
+  `PSMigrateI18nLocaleCodes`, installer script
+  `migration_i18n_locales.xml` (see `modules/perc-distribution-tree/AGENTS.md`).
+  Custom widget `locale=hi` configs remain out of scope (user re-picks).
 - Migrate additional application-specific TMX files to perc-i18n
 - Enhance language tool integration for new language support
 - Implement more sophisticated resource merging strategies

--- a/modules/perc-i18n/pom.xml
+++ b/modules/perc-i18n/pom.xml
@@ -30,6 +30,12 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- In-memory DB for PSLocaleCodeMigrator integration tests (GH-1547) -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- Log4j 2 -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/PSLocaleCodeMigrator.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/PSLocaleCodeMigrator.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.i18n;
+
+import com.percussion.tablefactory.PSJdbcDbmsDef;
+import com.percussion.util.PSSqlHelper;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * One-time upgrade migrator that rewrites persisted locale codes (GH-1547).
+ *
+ * <p>Targets:
+ *
+ * <ul>
+ *   <li>{@code PSX_PERSISTEDPROPERTYVALUES.PROPERTYVALUE} where {@code PROPERTYNAME='sys_lang'}
+ *   <li>{@code CONTENTSTATUS.LOCALE} (issue text may call this CT_LOCALE) bare {@code es} → {@code
+ *       es-es}
+ * </ul>
+ *
+ * <p>Uses portable prepared statements against table names qualified via {@link PSSqlHelper} (same
+ * idiom as {@code PSLocaleHandler} / tablefactory-style updates). Never deletes rows. Logs every
+ * rewrite. Runs inside a single transaction; dry-run counts only and rolls back.
+ */
+public final class PSLocaleCodeMigrator {
+
+  public static final String TABLE_PERSISTED_VALUES = "PSX_PERSISTEDPROPERTYVALUES";
+  public static final String TABLE_CONTENT_STATUS = "CONTENTSTATUS";
+  public static final String PROP_SYS_LANG = "sys_lang";
+
+  private final Consumer<String> log;
+
+  /**
+   * @param log sink for operator-visible messages; must not be {@code null}
+   */
+  public PSLocaleCodeMigrator(Consumer<String> log) {
+    this.log = Objects.requireNonNull(log, "log");
+  }
+
+  /**
+   * Runs the migration on an open connection.
+   *
+   * @param conn open JDBC connection (caller owns lifecycle)
+   * @param dbmsDef repository DBMS definition used for table qualification
+   * @param dryRun when {@code true}, counts and logs would-be rewrites but does not commit
+   * @return scan/rewrite counts
+   * @throws SQLException on JDBC failure (connection left rolled back when possible)
+   */
+  public Result migrate(Connection conn, PSJdbcDbmsDef dbmsDef, boolean dryRun)
+      throws SQLException {
+    Objects.requireNonNull(conn, "conn");
+    Objects.requireNonNull(dbmsDef, "dbmsDef");
+
+    boolean previousAutoCommit = conn.getAutoCommit();
+    conn.setAutoCommit(false);
+    try {
+      Result result = new Result();
+      rewriteSysLangRows(conn, dbmsDef, dryRun, result);
+      rewriteContentLocaleRows(conn, dbmsDef, dryRun, result);
+
+      if (dryRun) {
+        conn.rollback();
+        log.accept(
+            "i18n locale migration dry-run complete (rolled back): "
+                + "sys_lang rewritten="
+                + result.sysLangRewritten()
+                + "/"
+                + result.sysLangScanned()
+                + ", CONTENTSTATUS.LOCALE rewritten="
+                + result.contentLocaleRewritten()
+                + "/"
+                + result.contentLocaleScanned());
+      } else {
+        conn.commit();
+        log.accept(
+            "i18n locale migration committed: "
+                + "sys_lang rewritten="
+                + result.sysLangRewritten()
+                + "/"
+                + result.sysLangScanned()
+                + ", CONTENTSTATUS.LOCALE rewritten="
+                + result.contentLocaleRewritten()
+                + "/"
+                + result.contentLocaleScanned());
+      }
+      return result;
+    } catch (SQLException | RuntimeException e) {
+      try {
+        conn.rollback();
+      } catch (SQLException rollbackEx) {
+        e.addSuppressed(rollbackEx);
+      }
+      log.accept("i18n locale migration failed and rolled back: " + e.getMessage());
+      throw e;
+    } finally {
+      try {
+        conn.setAutoCommit(previousAutoCommit);
+      } catch (SQLException ignore) {
+        // leave connection state as-is if restore fails
+      }
+    }
+  }
+
+  private void rewriteSysLangRows(
+      Connection conn, PSJdbcDbmsDef dbmsDef, boolean dryRun, Result result) throws SQLException {
+    String table =
+        PSSqlHelper.qualifyTableName(
+            TABLE_PERSISTED_VALUES,
+            dbmsDef.getDataBase(),
+            dbmsDef.getSchema(),
+            dbmsDef.getDriver());
+
+    String selectSql =
+        "SELECT USERNAME, PROPERTYNAME, CATEGORY, CONTEXT, PROPERTYVALUE FROM "
+            + table
+            + " WHERE PROPERTYNAME = ?";
+    String updateSql =
+        "UPDATE "
+            + table
+            + " SET PROPERTYVALUE = ? WHERE USERNAME = ? AND PROPERTYNAME = ? AND CATEGORY = ?"
+            + " AND CONTEXT = ?";
+
+    List<SysLangRow> pending = new ArrayList<>();
+    try (PreparedStatement select = conn.prepareStatement(selectSql)) {
+      select.setString(1, PROP_SYS_LANG);
+      try (ResultSet rs = select.executeQuery()) {
+        while (rs.next()) {
+          result.sysLangScanned++;
+          String user = rs.getString(1);
+          String propName = rs.getString(2);
+          String category = rs.getString(3);
+          String context = rs.getString(4);
+          String value = rs.getString(5);
+          if (!PSLocaleCodeRewrite.sysLangNeedsRewrite(value)) {
+            continue;
+          }
+          String rewritten = PSLocaleCodeRewrite.rewriteSysLang(value);
+          pending.add(new SysLangRow(user, propName, category, context, value, rewritten));
+        }
+      }
+    }
+
+    if (pending.isEmpty()) {
+      log.accept("sys_lang: no rows require rewrite (scanned=" + result.sysLangScanned + ")");
+      return;
+    }
+
+    try (PreparedStatement update = conn.prepareStatement(updateSql)) {
+      for (SysLangRow row : pending) {
+        log.accept(
+            "sys_lang rewrite user="
+                + row.user
+                + " context="
+                + row.context
+                + " "
+                + row.from
+                + " -> "
+                + row.to
+                + (dryRun ? " [dry-run]" : ""));
+        if (!dryRun) {
+          update.setString(1, row.to);
+          update.setString(2, row.user);
+          update.setString(3, row.propName);
+          update.setString(4, row.category);
+          update.setString(5, row.context);
+          update.executeUpdate();
+        }
+        result.sysLangRewritten++;
+      }
+    }
+  }
+
+  private void rewriteContentLocaleRows(
+      Connection conn, PSJdbcDbmsDef dbmsDef, boolean dryRun, Result result) throws SQLException {
+    String table =
+        PSSqlHelper.qualifyTableName(
+            TABLE_CONTENT_STATUS, dbmsDef.getDataBase(), dbmsDef.getSchema(), dbmsDef.getDriver());
+
+    // Scan all non-null locales so underscore/case forms are normalized; promote es → es-es.
+    String selectSql = "SELECT CONTENTID, LOCALE FROM " + table + " WHERE LOCALE IS NOT NULL";
+    String updateSql = "UPDATE " + table + " SET LOCALE = ? WHERE CONTENTID = ?";
+
+    List<ContentLocaleRow> pending = new ArrayList<>();
+    try (PreparedStatement select = conn.prepareStatement(selectSql);
+        ResultSet rs = select.executeQuery()) {
+      while (rs.next()) {
+        result.contentLocaleScanned++;
+        int contentId = rs.getInt(1);
+        String locale = rs.getString(2);
+        if (!PSLocaleCodeRewrite.contentLocaleNeedsRewrite(locale)) {
+          continue;
+        }
+        String rewritten = PSLocaleCodeRewrite.rewriteContentLocale(locale);
+        pending.add(new ContentLocaleRow(contentId, locale, rewritten));
+      }
+    }
+
+    if (pending.isEmpty()) {
+      log.accept(
+          "CONTENTSTATUS.LOCALE: no rows require rewrite (scanned="
+              + result.contentLocaleScanned
+              + ")");
+      return;
+    }
+
+    try (PreparedStatement update = conn.prepareStatement(updateSql)) {
+      for (ContentLocaleRow row : pending) {
+        log.accept(
+            "CONTENTSTATUS.LOCALE rewrite contentId="
+                + row.contentId
+                + " "
+                + row.from
+                + " -> "
+                + row.to
+                + (dryRun ? " [dry-run]" : ""));
+        if (!dryRun) {
+          update.setString(1, row.to);
+          update.setInt(2, row.contentId);
+          update.executeUpdate();
+        }
+        result.contentLocaleRewritten++;
+      }
+    }
+  }
+
+  /** Mutable counters returned to callers (also exposed as immutable accessors). */
+  public static final class Result {
+    private int sysLangScanned;
+    private int sysLangRewritten;
+    private int contentLocaleScanned;
+    private int contentLocaleRewritten;
+
+    public int sysLangScanned() {
+      return sysLangScanned;
+    }
+
+    public int sysLangRewritten() {
+      return sysLangRewritten;
+    }
+
+    public int contentLocaleScanned() {
+      return contentLocaleScanned;
+    }
+
+    public int contentLocaleRewritten() {
+      return contentLocaleRewritten;
+    }
+  }
+
+  private record SysLangRow(
+      String user, String propName, String category, String context, String from, String to) {}
+
+  private record ContentLocaleRow(int contentId, String from, String to) {}
+}

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/PSLocaleCodeRewrite.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/PSLocaleCodeRewrite.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.i18n;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Pure rewrite map for one-time upgrade migration of persisted locale codes to the canonical BCP-47
+ * lowercase-hyphen matrix (GH-1547 / i18n recovery plan D1/D6).
+ *
+ * <p>Two surfaces share the same normalizer but differ in regional promotion:
+ *
+ * <ul>
+ *   <li><strong>sys_lang</strong> (user session preference in {@code PSX_PERSISTEDPROPERTYVALUES}):
+ *       {@code hi} → {@code hi-in}; {@code es} stays {@code es} (base locale is still valid for
+ *       login); other legacy tags collapse via {@link #normalize(String)}.
+ *   <li><strong>content locale</strong> ({@code CONTENTSTATUS.LOCALE}; issue text may say {@code
+ *       CT_LOCALE.LOCALE}): seeded {@code es} → {@code es-es} per recovery plan D1; other tags only
+ *       normalize.
+ * </ul>
+ *
+ * <p>Never invents codes outside the normalize + explicit promotion map. Idempotent: applying the
+ * rewrite to an already-canonical value returns the same string.
+ */
+public final class PSLocaleCodeRewrite {
+
+  /** Canonical Hindi regional promoted from bare {@code hi} for {@code sys_lang}. */
+  public static final String HI_IN = "hi-in";
+
+  /** Canonical Spanish (Spain) regional promoted from bare {@code es} for content locale. */
+  public static final String ES_ES = "es-es";
+
+  /** Language-only Spanish base (valid for sys_lang; not rewritten). */
+  public static final String ES = "es";
+
+  /** Language-only Hindi base (promoted for sys_lang). */
+  public static final String HI = "hi";
+
+  private PSLocaleCodeRewrite() {}
+
+  /**
+   * Normalizes a locale tag to BCP-47 lowercase hyphen form. Null-safe: {@code null} stays {@code
+   * null}; blank becomes empty after trim.
+   *
+   * @param raw raw locale tag (may use underscore or mixed case)
+   * @return normalized tag, or {@code null} when {@code raw} is {@code null}
+   */
+  public static String normalize(String raw) {
+    if (raw == null) {
+      return null;
+    }
+    return raw.trim().toLowerCase(Locale.ROOT).replace('_', '-');
+  }
+
+  /**
+   * Rewrites a persisted {@code sys_lang} property value for upgrade.
+   *
+   * <ul>
+   *   <li>{@code hi} → {@code hi-in}
+   *   <li>{@code es} stays {@code es}
+   *   <li>other codes → {@link #normalize(String)}
+   * </ul>
+   *
+   * @param raw stored value, may be {@code null}
+   * @return rewritten value; {@code null} when input is {@code null}
+   */
+  public static String rewriteSysLang(String raw) {
+    if (raw == null) {
+      return null;
+    }
+    String normalized = normalize(raw);
+    if (HI.equals(normalized)) {
+      return HI_IN;
+    }
+    return normalized;
+  }
+
+  /**
+   * Rewrites a content-item locale ({@code CONTENTSTATUS.LOCALE}) for upgrade.
+   *
+   * <ul>
+   *   <li>{@code es} → {@code es-es}
+   *   <li>other codes → {@link #normalize(String)}
+   * </ul>
+   *
+   * @param raw stored value, may be {@code null}
+   * @return rewritten value; {@code null} when input is {@code null}
+   */
+  public static String rewriteContentLocale(String raw) {
+    if (raw == null) {
+      return null;
+    }
+    String normalized = normalize(raw);
+    if (ES.equals(normalized)) {
+      return ES_ES;
+    }
+    return normalized;
+  }
+
+  /**
+   * @param raw stored value
+   * @return {@code true} when {@link #rewriteSysLang(String)} would change the stored form
+   */
+  public static boolean sysLangNeedsRewrite(String raw) {
+    if (raw == null) {
+      return false;
+    }
+    return !Objects.equals(raw, rewriteSysLang(raw));
+  }
+
+  /**
+   * @param raw stored value
+   * @return {@code true} when {@link #rewriteContentLocale(String)} would change the stored form
+   */
+  public static boolean contentLocaleNeedsRewrite(String raw) {
+    if (raw == null) {
+      return false;
+    }
+    return !Objects.equals(raw, rewriteContentLocale(raw));
+  }
+
+  /**
+   * Optional wrapper for callers that prefer empty over null.
+   *
+   * @param raw stored value
+   * @return optional rewritten sys_lang, empty when raw is null/blank after normalize
+   */
+  public static Optional<String> rewriteSysLangOptional(String raw) {
+    String rewritten = rewriteSysLang(raw);
+    if (rewritten == null || rewritten.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(rewritten);
+  }
+}

--- a/modules/perc-i18n/src/test/java/com/percussion/i18n/PSLocaleCodeMigratorTest.java
+++ b/modules/perc-i18n/src/test/java/com/percussion/i18n/PSLocaleCodeMigratorTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.tablefactory.PSJdbcDbmsDef;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * In-memory H2 integration tests for {@link PSLocaleCodeMigrator}. Uses only relative/mem JDBC URLs
+ * — no filesystem path assertions (cross-platform).
+ */
+@Tag("UnitTest")
+class PSLocaleCodeMigratorTest {
+
+  @Test
+  void migrate_rewritesSysLangAndContentLocale_idempotentSecondPass() throws Exception {
+    Properties props = memDbmsProps();
+    PSJdbcDbmsDef dbmsDef = new PSJdbcDbmsDef(props);
+    List<String> logs = new ArrayList<>();
+
+    try (Connection conn =
+        DriverManager.getConnection(props.getProperty(PSJdbcDbmsDef.DB_SERVER_PROPERTY))) {
+      createSchema(conn);
+      seedData(conn);
+
+      PSLocaleCodeMigrator migrator = new PSLocaleCodeMigrator(logs::add);
+      PSLocaleCodeMigrator.Result first = migrator.migrate(conn, dbmsDef, false);
+
+      assertEquals(3, first.sysLangScanned());
+      assertEquals(2, first.sysLangRewritten()); // hi + en_US; es stays
+      assertEquals(3, first.contentLocaleScanned());
+      assertEquals(2, first.contentLocaleRewritten()); // es + en_US; en-us stays
+
+      assertEquals("hi-in", querySysLang(conn, "alice"));
+      assertEquals("es", querySysLang(conn, "bob"));
+      assertEquals("en-us", querySysLang(conn, "carol"));
+      assertEquals("es-es", queryContentLocale(conn, 1));
+      assertEquals("en-us", queryContentLocale(conn, 2));
+      assertEquals("en-us", queryContentLocale(conn, 3));
+
+      assertTrue(logs.stream().anyMatch(l -> l.contains("hi -> hi-in")));
+      assertTrue(logs.stream().anyMatch(l -> l.contains("es -> es-es")));
+      assertTrue(logs.stream().noneMatch(l -> l.contains("delete")), "must never log deletes");
+
+      logs.clear();
+      PSLocaleCodeMigrator.Result second = migrator.migrate(conn, dbmsDef, false);
+      assertEquals(0, second.sysLangRewritten());
+      assertEquals(0, second.contentLocaleRewritten());
+    }
+  }
+
+  @Test
+  void dryRun_countsWithoutCommitting() throws Exception {
+    Properties props = memDbmsProps();
+    PSJdbcDbmsDef dbmsDef = new PSJdbcDbmsDef(props);
+    List<String> logs = new ArrayList<>();
+
+    try (Connection conn =
+        DriverManager.getConnection(props.getProperty(PSJdbcDbmsDef.DB_SERVER_PROPERTY))) {
+      createSchema(conn);
+      seedData(conn);
+
+      PSLocaleCodeMigrator migrator = new PSLocaleCodeMigrator(logs::add);
+      PSLocaleCodeMigrator.Result dry = migrator.migrate(conn, dbmsDef, true);
+
+      assertEquals(2, dry.sysLangRewritten());
+      assertEquals(2, dry.contentLocaleRewritten());
+      // dry-run rolls back — original values remain
+      assertEquals("hi", querySysLang(conn, "alice"));
+      assertEquals("es", queryContentLocale(conn, 1));
+      assertTrue(logs.stream().anyMatch(l -> l.contains("[dry-run]")));
+      assertTrue(logs.stream().anyMatch(l -> l.contains("dry-run complete")));
+    }
+  }
+
+  private static Properties memDbmsProps() {
+    // Unique DB name per test method invocation to avoid H2 static cross-talk.
+    String url = "jdbc:h2:mem:i18n_locale_mig_" + System.nanoTime() + ";DB_CLOSE_DELAY=-1";
+    Properties props = new Properties();
+    props.setProperty(PSJdbcDbmsDef.DB_DRIVER_NAME_PROPERTY, "h2");
+    props.setProperty(PSJdbcDbmsDef.DB_DRIVER_CLASS_NAME_PROPERTY, "org.h2.Driver");
+    props.setProperty(PSJdbcDbmsDef.DB_SERVER_PROPERTY, url);
+    props.setProperty(PSJdbcDbmsDef.UID_PROPERTY, "sa");
+    props.setProperty(PSJdbcDbmsDef.PWD_PROPERTY, "");
+    props.setProperty(PSJdbcDbmsDef.DB_NAME_PROPERTY, "");
+    props.setProperty(PSJdbcDbmsDef.DB_SCHEMA_PROPERTY, "PUBLIC");
+    return props;
+  }
+
+  private static void createSchema(Connection conn) throws Exception {
+    try (Statement st = conn.createStatement()) {
+      st.execute(
+          "CREATE TABLE PSX_PERSISTEDPROPERTYVALUES ("
+              + "CONTEXT VARCHAR(25) NOT NULL,"
+              + "USERNAME VARCHAR(100) NOT NULL,"
+              + "CATEGORY VARCHAR(25) NOT NULL,"
+              + "PROPERTYNAME VARCHAR(50) NOT NULL,"
+              + "PROPERTYVALUE CLOB NOT NULL,"
+              + "PRIMARY KEY (USERNAME, PROPERTYNAME, CATEGORY, CONTEXT))");
+      st.execute(
+          "CREATE TABLE CONTENTSTATUS ("
+              + "CONTENTID INT NOT NULL PRIMARY KEY,"
+              + "LOCALE VARCHAR(50))");
+    }
+  }
+
+  private static void seedData(Connection conn) throws Exception {
+    try (Statement st = conn.createStatement()) {
+      st.execute(
+          "INSERT INTO PSX_PERSISTEDPROPERTYVALUES"
+              + " (CONTEXT, USERNAME, CATEGORY, PROPERTYNAME, PROPERTYVALUE)"
+              + " VALUES ('sess', 'alice', 'sys', 'sys_lang', 'hi')");
+      st.execute(
+          "INSERT INTO PSX_PERSISTEDPROPERTYVALUES"
+              + " (CONTEXT, USERNAME, CATEGORY, PROPERTYNAME, PROPERTYVALUE)"
+              + " VALUES ('sess', 'bob', 'sys', 'sys_lang', 'es')");
+      st.execute(
+          "INSERT INTO PSX_PERSISTEDPROPERTYVALUES"
+              + " (CONTEXT, USERNAME, CATEGORY, PROPERTYNAME, PROPERTYVALUE)"
+              + " VALUES ('sess', 'carol', 'sys', 'sys_lang', 'en_US')");
+      st.execute("INSERT INTO CONTENTSTATUS (CONTENTID, LOCALE) VALUES (1, 'es')");
+      st.execute("INSERT INTO CONTENTSTATUS (CONTENTID, LOCALE) VALUES (2, 'en-us')");
+      st.execute("INSERT INTO CONTENTSTATUS (CONTENTID, LOCALE) VALUES (3, 'en_US')");
+    }
+  }
+
+  private static String querySysLang(Connection conn, String user) throws Exception {
+    try (var ps =
+        conn.prepareStatement(
+            "SELECT PROPERTYVALUE FROM PSX_PERSISTEDPROPERTYVALUES WHERE USERNAME=?")) {
+      ps.setString(1, user);
+      try (var rs = ps.executeQuery()) {
+        assertTrue(rs.next());
+        return rs.getString(1);
+      }
+    }
+  }
+
+  private static String queryContentLocale(Connection conn, int contentId) throws Exception {
+    try (var ps = conn.prepareStatement("SELECT LOCALE FROM CONTENTSTATUS WHERE CONTENTID=?")) {
+      ps.setInt(1, contentId);
+      try (var rs = ps.executeQuery()) {
+        assertTrue(rs.next());
+        return rs.getString(1);
+      }
+    }
+  }
+}

--- a/modules/perc-i18n/src/test/java/com/percussion/i18n/PSLocaleCodeRewriteTest.java
+++ b/modules/perc-i18n/src/test/java/com/percussion/i18n/PSLocaleCodeRewriteTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure rewrite-map tests for GH-1547 locale migration. Cross-platform: no path I/O or OS-specific
+ * asserts.
+ */
+@Tag("UnitTest")
+class PSLocaleCodeRewriteTest {
+
+  @Test
+  void normalize_collapsesCaseAndUnderscore() {
+    assertEquals("en-us", PSLocaleCodeRewrite.normalize("en_US"));
+    assertEquals("en-us", PSLocaleCodeRewrite.normalize("EN-US"));
+    assertEquals("es-es", PSLocaleCodeRewrite.normalize("es_ES"));
+    assertEquals("ja-jp", PSLocaleCodeRewrite.normalize("ja-JP"));
+    assertEquals("hi", PSLocaleCodeRewrite.normalize("HI"));
+    assertNull(PSLocaleCodeRewrite.normalize(null));
+    assertEquals("", PSLocaleCodeRewrite.normalize("  "));
+  }
+
+  @Test
+  void rewriteSysLang_promotesHiOnly() {
+    assertEquals("hi-in", PSLocaleCodeRewrite.rewriteSysLang("hi"));
+    assertEquals("hi-in", PSLocaleCodeRewrite.rewriteSysLang("HI"));
+    assertEquals("hi-in", PSLocaleCodeRewrite.rewriteSysLang("Hi"));
+    // es is already a valid base locale for login — leave alone after normalize
+    assertEquals("es", PSLocaleCodeRewrite.rewriteSysLang("es"));
+    assertEquals("es", PSLocaleCodeRewrite.rewriteSysLang("ES"));
+    assertEquals("en-us", PSLocaleCodeRewrite.rewriteSysLang("en_US"));
+    assertEquals("es-es", PSLocaleCodeRewrite.rewriteSysLang("es_ES"));
+    assertEquals("ja-jp", PSLocaleCodeRewrite.rewriteSysLang("ja-JP"));
+  }
+
+  @Test
+  void rewriteSysLang_idempotentOnCanonical() {
+    assertEquals("hi-in", PSLocaleCodeRewrite.rewriteSysLang("hi-in"));
+    assertEquals("es", PSLocaleCodeRewrite.rewriteSysLang("es"));
+    assertEquals("en-us", PSLocaleCodeRewrite.rewriteSysLang("en-us"));
+    assertFalse(PSLocaleCodeRewrite.sysLangNeedsRewrite("hi-in"));
+    assertFalse(PSLocaleCodeRewrite.sysLangNeedsRewrite("es"));
+    assertFalse(PSLocaleCodeRewrite.sysLangNeedsRewrite("en-us"));
+    assertTrue(PSLocaleCodeRewrite.sysLangNeedsRewrite("hi"));
+    assertTrue(PSLocaleCodeRewrite.sysLangNeedsRewrite("en_US"));
+  }
+
+  @Test
+  void rewriteContentLocale_promotesEsToEsEs() {
+    assertEquals("es-es", PSLocaleCodeRewrite.rewriteContentLocale("es"));
+    assertEquals("es-es", PSLocaleCodeRewrite.rewriteContentLocale("ES"));
+    assertEquals("es-es", PSLocaleCodeRewrite.rewriteContentLocale("es_ES"));
+    assertEquals("es-es", PSLocaleCodeRewrite.rewriteContentLocale("es-es"));
+    // content path does not promote hi → hi-in (sys_lang only)
+    assertEquals("hi", PSLocaleCodeRewrite.rewriteContentLocale("hi"));
+    assertEquals("en-us", PSLocaleCodeRewrite.rewriteContentLocale("en_US"));
+  }
+
+  @Test
+  void rewriteContentLocale_idempotentOnCanonical() {
+    assertFalse(PSLocaleCodeRewrite.contentLocaleNeedsRewrite("es-es"));
+    assertFalse(PSLocaleCodeRewrite.contentLocaleNeedsRewrite("en-us"));
+    assertTrue(PSLocaleCodeRewrite.contentLocaleNeedsRewrite("es"));
+    assertTrue(PSLocaleCodeRewrite.contentLocaleNeedsRewrite("en_US"));
+    // second pass must be a no-op
+    String once = PSLocaleCodeRewrite.rewriteContentLocale("es");
+    assertEquals(once, PSLocaleCodeRewrite.rewriteContentLocale(once));
+  }
+
+  @Test
+  void nullAndBlankInputsAreSafe() {
+    assertNull(PSLocaleCodeRewrite.rewriteSysLang(null));
+    assertNull(PSLocaleCodeRewrite.rewriteContentLocale(null));
+    assertFalse(PSLocaleCodeRewrite.sysLangNeedsRewrite(null));
+    assertFalse(PSLocaleCodeRewrite.contentLocaleNeedsRewrite(null));
+    assertEquals("", PSLocaleCodeRewrite.rewriteSysLang(""));
+    assertEquals("", PSLocaleCodeRewrite.rewriteContentLocale(""));
+  }
+}


### PR DESCRIPTION
## Summary

Implements **#1547**: one-time upgrade migration of persisted locale codes after the 17-locale BCP-47 matrix (follow-up to PR #1545 / i18n recovery).

### What changed

| Layer | Artifact |
| --- | --- |
| Pure rewrite map | `PSLocaleCodeRewrite` (perc-i18n) — `hi` → `hi-in` for sys_lang; `es` stays `es`; content locale `es` → `es-es`; normalize lower-case + `_`→`-` |
| JDBC migrator | `PSLocaleCodeMigrator` — tablefactory-qualified UPDATEs, transactional, dry-run counts only, logs every rewrite, never deletes |
| ANT task | `PSMigrateI18nLocaleCodes` (perc-ant, antlib) |
| Installer script | `migration_i18n_locales.xml` |
| Wire-in | `install.xml` `install.chain` + `upgrade.chain` after `updateConfiguration` |
| Docs | `modules/perc-distribution-tree/AGENTS.md` migration section; perc-i18n README |

**Note:** Issue text says `CT_LOCALE.LOCALE`; the schema table/column is `CONTENTSTATUS.LOCALE` (content-item locale). Documented in AGENTS.md.

**Out of scope (unchanged):** custom widget configs with `locale=hi` — operators re-pick via the widget enum.

### Dry-run

`-Di18n.locale.migration.dryRun=true` (or task attribute) counts would-be rewrites without committing.

## Test plan

- [x] `PSLocaleCodeRewriteTest` — rewrite map + idempotency (8 cases)
- [x] `PSLocaleCodeMigratorTest` — H2 in-mem migrate + dry-run (no FS path asserts)
- [x] `I18nLocaleMigrationWiringTest` — installer script shipped + both chains invoke it
- [x] Module standalone clean installs:
  - `cd modules/perc-i18n && ../../mvnw clean install` → BUILD SUCCESS (Tests run: 8 for new tests)
  - `cd modules/perc-ant && ../../mvnw clean install` / `test` → BUILD SUCCESS
  - `cd modules/perc-distribution-tree && ../../mvnw clean install` → BUILD SUCCESS
- [x] Spotless: apply then check on perc-ant + perc-distribution-tree; Java formatting clean on perc-i18n (prettier JSON step hangs in this environment; Java files already g-j-f clean)
- [x] Erlang-style self-review: portable `Path.of` in Ant task; no Unix-only asserts; no deletes; transactional rollback

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

## Fixes

Fixes #1547

Related: i18n recovery / PR #1545 notes.