### PR TITLE
fix(1924): clean javadoc warnings in perc-thumbnail module

### DIFF
--- a/modules/perc-thumbnail/src/main/java/com/percussion/thumbnail/PSScreenCapture.java
+++ b/modules/perc-thumbnail/src/main/java/com/percussion/thumbnail/PSScreenCapture.java
@@ -30,6 +30,13 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * Utility class for generating thumbnails from screen captures. Provides methods to write a
+ * placeholder thumbnail to disk and to invoke the configured screen-capture command (typically a
+ * headless browser) against a target URL.
+ *
+ * <p>All methods are static; the class is not meant to be instantiated.
+ */
 public class PSScreenCapture {
 
   private PSScreenCapture() {
@@ -48,13 +55,29 @@ public class PSScreenCapture {
 
   private static PSProperties ms_serverProps = null;
 
+  /**
+   * Classpath resource path of the placeholder thumbnail image used when a real screen capture
+   * cannot be produced.
+   */
   public static final String EMPTY_THUMB_RESOURCE =
       "META-INF/resources/sys_resources/images/thumbnail/empty-thumb.jpg";
 
+  /**
+   * Copies the placeholder thumbnail image to the supplied destination path.
+   *
+   * @param imagePathForGeneration the on-disk path to write the placeholder image to, may not be
+   *     <code>null</code>.
+   */
   public static void generateEmptyThumb(String imagePathForGeneration) {
     copyResource(EMPTY_THUMB_RESOURCE, new File(imagePathForGeneration));
   }
 
+  /**
+   * Loads (and caches) the Rhythmyx server properties file used to look up the screen-capture
+   * command.
+   *
+   * @return the loaded properties, or <code>null</code> when the file cannot be read.
+   */
   private static PSProperties getServerProperties() {
     if (ms_serverProps != null) {
       return ms_serverProps;
@@ -70,6 +93,13 @@ public class PSScreenCapture {
     return ms_serverProps;
   }
 
+  /**
+   * Resolves a path under the Rhythmyx configuration directory, asserting that it exists on disk.
+   *
+   * @param path the relative path under the Rhythmyx root, may not be <code>null</code>.
+   * @return the absolute path of the resolved directory.
+   * @throws IllegalArgumentException if the resolved path does not exist.
+   */
   public static String getRxConfigDir(String path) {
 
     File item = new File(PathUtils.getRxDir(null), path);
@@ -79,6 +109,13 @@ public class PSScreenCapture {
     return item.getAbsolutePath();
   }
 
+  /**
+   * Captures a screenshot of the supplied URL using the configured screen-capture command and
+   * writes the resulting image to {@code imagePath}.
+   *
+   * @param urlForCapture the URL to capture, may not be <code>null</code> or empty.
+   * @param imagePath the on-disk path to write the captured image to, may not be <code>null</code>.
+   */
   public static void takeCapture(String urlForCapture, String imagePath) {
     try {
       Properties serverProps = getServerProperties();

--- a/modules/perc-thumbnail/src/main/java/com/percussion/thumbnail/PSThumbnailImageUtils.java
+++ b/modules/perc-thumbnail/src/main/java/com/percussion/thumbnail/PSThumbnailImageUtils.java
@@ -29,9 +29,27 @@ import javax.imageio.plugins.jpeg.JPEGImageWriteParam;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/** Utility class for resizing on-disk thumbnail images using the standard Java ImageIO APIs. */
 public class PSThumbnailImageUtils {
+
+  /**
+   * Default constructor; provided so the implicit default constructor has explicit Javadoc and
+   * doclint does not warn about its use.
+   */
+  public PSThumbnailImageUtils() {
+    // utility class - no instance state
+  }
+
   private static final Logger log = LogManager.getLogger(PSThumbnailImageUtils.class);
 
+  /**
+   * Resizes the on-disk image at the supplied path to the standard thumbnail dimensions and
+   * re-encodes it as a JPEG, waiting for the source file to become available and writable first.
+   *
+   * @param thumbnailFilePath the on-disk path of the thumbnail image, may not be <code>null</code>.
+   * @throws InterruptedException if the wait for the source file to become available is
+   *     interrupted.
+   */
   public static void resizeThumbnail(String thumbnailFilePath) throws InterruptedException {
 
     File inImageFile = new File(thumbnailFilePath);


### PR DESCRIPTION
Resolves #1924

## Summary
The \perc-thumbnail\ (modules/perc-thumbnail) module's javadoc generation phase previously reported 9 source warnings on JDK 21 with the parent \ailOnWarnings=false, doclint=all\ configuration. All public types and methods in \com.percussion.thumbnail\ now have complete, valid Javadoc.

## Files changed (2)

| File | Changes |
|---|---|
| PSScreenCapture.java | Added class-level Javadoc; completed Javadoc on EMPTY_THUMB_RESOURCE constant and all four methods (generateEmptyThumb, getRxConfigDir, takeCapture, plus the private getServerProperties helper). |
| PSThumbnailImageUtils.java | Added class-level Javadoc; added explicit no-arg constructor with Javadoc; completed Javadoc on resizeThumbnail. |

## Validation

Run from \modules/perc-thumbnail\ with JDK 21 + \mvnw.cmd\:

\\\ash
cd modules/perc-thumbnail
..\\..\\mvnw.cmd javadoc:javadoc
\\\

- Javadoc warnings: **0** (was 9)
- \mvnw spotless:apply\ then \mvnw spotless:check\: pass

## Acceptance criteria

- [x] Resolve all Javadoc source warnings in the perc-thumbnail module.
- [x] Ensure all public APIs have complete and valid Javadoc.
- [x] Verify the module builds successfully with zero Javadoc errors and zero Javadoc warnings.
- [x] No regressions.

---
Operator: Kilo (minimax-coding-plan/MiniMax-M3)