### PR TITLE
fix(1931): clean javadoc warnings in perc-toolkit module

### DIFF
--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/servlet/DemandPreviewController.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/demandpreview/servlet/DemandPreviewController.java
@@ -43,6 +43,9 @@ import org.springframework.web.servlet.mvc.Controller;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
 
 /**
+ * Spring MVC controller that triggers an on-demand preview publish of a single content item for the
+ * requesting user, returning the published preview URL via the configured view.
+ *
  * @author DavidBenua
  */
 public class DemandPreviewController extends ParameterizableViewController implements Controller {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/ImageData.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/ImageData.java
@@ -19,6 +19,9 @@ package com.percussion.pso.imageedit.data;
 import java.io.Serializable;
 
 /**
+ * Holds the binary image data together with the metadata tracked by {@link ImageMetaData}. Used by
+ * the image editor to load and persist images through the Rhythmyx content repository.
+ *
  * @author DavidBenua
  */
 public class ImageData extends ImageMetaData implements Serializable {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/ImageSizeDefinition.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/data/ImageSizeDefinition.java
@@ -17,6 +17,9 @@
 package com.percussion.pso.imageedit.data;
 
 /**
+ * Represents a single named image-size variant available in the image editor, including the
+ * rendered dimensions and the Rhythmyx snippet / binary templates used to produce it.
+ *
  * @author DavidBenua
  */
 public class ImageSizeDefinition {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/ImageSizeDefinitionManagerLocator.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/ImageSizeDefinitionManagerLocator.java
@@ -19,6 +19,9 @@ package com.percussion.pso.imageedit.services;
 import com.percussion.services.PSBaseServiceLocator;
 
 /**
+ * Spring service locator for the image-size definition manager bean used by the image editor
+ * subsystem.
+ *
  * @author DavidBenua
  */
 public class ImageSizeDefinitionManagerLocator extends PSBaseServiceLocator {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/cache/ImageCacheManagerLocator.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/cache/ImageCacheManagerLocator.java
@@ -19,6 +19,9 @@ package com.percussion.pso.imageedit.services.cache;
 import com.percussion.services.PSBaseServiceLocator;
 
 /**
+ * Spring service locator for the image-meta-data cache manager bean used by the image editor
+ * subsystem.
+ *
  * @author DavidBenua
  */
 public class ImageCacheManagerLocator extends PSBaseServiceLocator {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/jexl/ImageEditorTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/services/jexl/ImageEditorTools.java
@@ -39,6 +39,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
+ * JEXL utility bean exposed to Rhythmyx templates that performs image-related lookups and
+ * operations, such as locating image-size definitions and resolving image metadata for the image
+ * editor UI.
+ *
  * @author DavidBenua
  */
 public class ImageEditorTools extends PSJexlUtilBase implements IPSJexlExpression {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/ImageSizeDefinitionLookupController.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/ImageSizeDefinitionLookupController.java
@@ -32,6 +32,9 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /**
+ * Spring MVC controller that looks up the available image-size definitions for the image editor and
+ * forwards them to the configured view as an XML document.
+ *
  * @author DavidBenua
  */
 @org.springframework.stereotype.Controller

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImageEditorTestPageController.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImageEditorTestPageController.java
@@ -32,6 +32,9 @@ import org.springframework.web.servlet.mvc.Controller;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
 
 /**
+ * Spring MVC controller used by the image-editor test page to load and render sample {@link
+ * com.percussion.pso.imageedit.data.MasterImageMetaData} for the image-editor UI.
+ *
  * @author DavidBenua
  */
 public class ImageEditorTestPageController extends ParameterizableViewController

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImageEditorTestPageController.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImageEditorTestPageController.java
@@ -33,7 +33,7 @@ import org.springframework.web.servlet.mvc.ParameterizableViewController;
 
 /**
  * Spring MVC controller used by the image-editor test page to load and render sample {@link
- * com.percussion.pso.imageedit.data.MasterImageMetaData} for the image-editor UI.
+ * MasterImageMetaData} for the image-editor UI.
  *
  * @author DavidBenua
  */

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImagePersistenceManagerImpl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImagePersistenceManagerImpl.java
@@ -40,6 +40,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
+ * Default {@link ImagePersistenceManager} implementation that loads and saves image items (master
+ * and child rows) through the standard Rhythmyx content APIs.
+ *
  * @author DavidBenua
  */
 public class ImagePersistenceManagerImpl extends ImageItemSupport

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImageResizeManagerImpl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImageResizeManagerImpl.java
@@ -34,6 +34,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
+ * Default {@link ImageResizeManager} implementation that resizes images in memory using the
+ * standard Java ImageIO APIs, applying a configurable compression level and rescale-step size.
+ *
  * @author DavidBenua
  */
 public class ImageResizeManagerImpl implements ImageResizeManager {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImageResizeManagerImpl.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/imageedit/web/impl/ImageResizeManagerImpl.java
@@ -35,7 +35,7 @@ import org.apache.logging.log4j.Logger;
 
 /**
  * Default {@link ImageResizeManager} implementation that resizes images in memory using the
- * standard Java ImageIO APIs, applying a configurable compression level and rescale-step size.
+ * standard Java ImageIO APIs, applying a configurable compression level and rescaling step size.
  *
  * @author DavidBenua
  */


### PR DESCRIPTION
Resolves #1931

## Summary
The \perc-toolkit\ (modules/perc-toolkit) module's javadoc generation phase previously reported 10 source warnings on JDK 21 with the parent \ailOnWarnings=false, doclint=all\ configuration. All public types in the imageedit and demandpreview subpackages of \com.percussion.pso\ now have complete, valid Javadoc.

## Files changed (10)

| File | Changes |
|---|---|
| DemandPreviewController.java | Added class-level Javadoc describing the on-demand preview publishing flow. |
| ImageData.java | Added class-level Javadoc. |
| ImageSizeDefinition.java | Added class-level Javadoc. |
| ImageSizeDefinitionManagerLocator.java | Added class-level Javadoc. |
| ImageCacheManagerLocator.java | Added class-level Javadoc. |
| ImageEditorTools.java | Added class-level Javadoc describing its template-time JEXL usage. |
| ImageSizeDefinitionLookupController.java | Added class-level Javadoc. |
| ImageEditorTestPageController.java | Added class-level Javadoc. |
| ImagePersistenceManagerImpl.java | Added class-level Javadoc. |
| ImageResizeManagerImpl.java | Added class-level Javadoc. |

## Validation

Run from \modules/perc-toolkit\ with JDK 21 + \mvnw.cmd\:

\\\ash
cd modules/perc-toolkit
..\\..\\mvnw.cmd javadoc:javadoc
\\\

- Javadoc warnings: **0** (was 10)
- \mvnw spotless:apply\ then \mvnw spotless:check\: pass

## Acceptance criteria

- [x] Resolve all Javadoc source warnings in the perc-toolkit module.
- [x] Ensure all public APIs have complete and valid Javadoc.
- [x] Verify the module builds successfully with zero Javadoc errors and zero Javadoc warnings.
- [x] No regressions.
- [x] Unrelated build warnings (Other Warnings: 201) are pre-existing baseline, out of scope per the issue.

---
Operator: Kilo (minimax-coding-plan/MiniMax-M3)