### PR TITLE
fix(1925): clean javadoc warnings in perc-tinymce module

### DIFF
--- a/modules/perc-tinymce/README.md
+++ b/modules/perc-tinymce/README.md
@@ -2,6 +2,14 @@
 
 This module contains the support for tinymce editor plugin.
 
+## Javadoc status
+
+This module contains **no Java sources** — it is a packaging-only module that bundles the
+TinyMCE and CodeMirror WebJARs and produces a resource-only JAR under
+`META-INF/resources/sys_resources/tinymce/`. As a result, the Maven Javadoc plugin skips
+the `javadoc:javadoc` goal for this module and the module's `JavadocSrcWarnings` count is
+**structurally zero** by design.
+
 * Configuration files (json files : default, customer overridden etc.) for configuring the tinymce editor.
 * Javascript files to initialize and default editor functionality.
 * Javascript files for customising the functionality.


### PR DESCRIPTION
Resolves #1925

## Summary
The `perc-tinymce` (modules/perc-tinymce) module is a packaging-only module that bundles the TinyMCE and CodeMirror WebJARs and produces a resource-only JAR under `META-INF/resources/sys_resources/tinymce/`. It contains **no Java sources**, so the Maven Javadoc plugin skips the `javadoc:javadoc` goal for this module and the module's `JavadocSrcWarnings` count is structurally zero by design.

This change documents the invariant explicitly in the module README so future readers do not interpret the skipped Javadoc phase as a documentation gap.

## Files changed (1)

| File | Changes |
|---|---|
| README.md | Added a "Javadoc status" section that explains why the module is structurally zero-warning. |

## Validation

Run from `modules/perc-tinymce` with JDK 21 + `mvnw.cmd`:

```
cd modules/perc-tinymce
..\..\mvnw.cmd javadoc:javadoc
```

- BUILD SUCCESS; the `javadoc:3.12.0:javadoc` goal is skipped because the module has no Java sources.
- Javadoc warnings: **0** (structurally).

## Acceptance criteria

- [x] Resolve all Javadoc source warnings in the perc-tinymce module. (Module is structurally zero — no Java sources.)
- [x] Ensure all public APIs have complete and valid Javadoc. (No public APIs exist in this packaging module.)
- [x] Verify the module builds successfully with zero Javadoc errors and zero Javadoc warnings.
- [x] No regressions.
- [x] Unrelated build warnings (Other Warnings: 7) are pre-existing baseline, out of scope per the issue.

---
Operator: Kilo (minimax-coding-plan/MiniMax-M3)