### PR TITLE
fix(build): ban com.sun:tools and drop Jetty tools.jar classpath (#1804)

### DIFF
--- a/modules/perc-jetty/src/main/jetty/service/install-jetty-service.bat
+++ b/modules/perc-jetty/src/main/jetty/service/install-jetty-service.bat
@@ -59,7 +59,8 @@ if not defined JAVA_HOME (
 )
 
 set PR_JVM="%JAVA_HOME%\bin\server\jvm.dll"
-set PR_CLASSPATH="%JETTY_HOME%\start.jar;%JAVA_HOME%\lib\tools.jar"
+REM Issue #1804: do not append %JAVA_HOME%\lib\tools.jar — absent on JDK 9+ (product is JDK 21).
+set PR_CLASSPATH="%JETTY_HOME%\start.jar"
 
 @REM JVM Configuration
 set PR_JVMMS=128

--- a/modules/perc-jetty/src/test/java/com/percussion/jetty/service/InstallJettyServiceJavaHomeTest.java
+++ b/modules/perc-jetty/src/test/java/com/percussion/jetty/service/InstallJettyServiceJavaHomeTest.java
@@ -67,6 +67,35 @@ class InstallJettyServiceJavaHomeTest {
   }
 
   /**
+   * Issue #1804: Procrun classpath must not reference JDK {@code lib/tools.jar}. That JAR was
+   * removed in JDK 9+; Maven 3.9+ also rejects the legacy {@code com.sun:tools} systemPath
+   * dependency. Product runtime is JDK 21.
+   */
+  @Test
+  void installBat_procrunClasspathDoesNotReferenceToolsJar() throws Exception {
+    String s = Files.readString(INSTALL_BAT, StandardCharsets.UTF_8);
+    assertTrue(s.contains("PR_CLASSPATH="), "Procrun classpath must be set");
+    // Ignore REM comments that may mention tools.jar historically; only classpath lines matter.
+    boolean classpathHasToolsJar =
+        s.lines()
+            .map(String::trim)
+            .filter(
+                line ->
+                    line.regionMatches(
+                        true, 0, "set PR_CLASSPATH=", 0, "set PR_CLASSPATH=".length()))
+            .anyMatch(line -> line.toLowerCase().contains("tools.jar"));
+    assertFalse(
+        classpathHasToolsJar,
+        "install-jetty-service.bat must not put tools.jar on PR_CLASSPATH (JDK 9+)");
+    assertTrue(
+        s.lines()
+            .map(String::trim)
+            .anyMatch(
+                line -> line.equalsIgnoreCase("set PR_CLASSPATH=\"%JETTY_HOME%\\start.jar\"")),
+        "Procrun classpath should be Jetty start.jar only");
+  }
+
+  /**
    * Regression for kilo-code-bot PR review thread 3631027608: the resolver must be sourced INTO the
    * install shell, not in a subshell. A subshell isolates the assignments of JAVA_HOME / JAVA /
    * RESOLVE_SOURCE from the resolver and silently discards them, bypassing the documented

--- a/pom.xml
+++ b/pom.xml
@@ -2192,7 +2192,13 @@
                                     <dependencyConvergence/>
                                     <banDuplicatePomDependencyVersions/>
                                     <bannedDependencies>
-                                        <excludes/>
+                                        <!-- Issue #1804: com.sun:tools (tools.jar) is not a valid Maven
+                                             dependency on JDK 9+ / Maven 3.9+. systemPath ${tools.jar}
+                                             fails absolute-path validation and tools.jar is gone from
+                                             modern JDKs. Ban so it cannot re-enter dependencyManagement. -->
+                                        <excludes>
+                                            <exclude>com.sun:tools</exclude>
+                                        </excludes>
                                         <searchTransitive>true</searchTransitive>
                                     </bannedDependencies>
                                 </rules>


### PR DESCRIPTION
## Summary
Closes the Maven 3.9+ / JDK 21 gap for legacy `com.sun:tools` (`tools.jar`):

1. **Evidence:** No `com.sun:tools`, `${tools.jar}`, or tools systemPath remains in any `pom.xml` (already removed on `main`).
2. **Hardening:** Parent `maven-enforcer-plugin` `bannedDependencies` now excludes `com.sun:tools` so it cannot re-enter project dependency graphs that inherit the pluginManagement rules.
3. **Runtime residual:** `install-jetty-service.bat` Procrun classpath no longer appends `%JAVA_HOME%\lib\tools.jar` (missing on JDK 9+; product is JDK 21).
4. **Test:** Structural regression in `InstallJettyServiceJavaHomeTest`.

**Operator:** Grok: night-issue-prs (model grok-4.5)

Fixes #1804

## Residual (filed separately)
Legacy non-Maven leftovers (RxFix `build.bat`, historical LAX fixtures, commented install.sh line, optional remote jaxb 2.2.x model noise) tracked as a follow-up issue linked from the PR/issue comments after create.

## Test plan / gates evidence
- [x] `rg`/scan: no `com.sun:tools` / `${tools.jar}` systemPath in POMs
- [x] JDK 21: `mvnw.cmd -N validate` → SUCCESS
- [x] JDK 21: `cd modules/utils && ..\..\mvnw.cmd enforcer:enforce@enforce` → SUCCESS (ban active)
- [x] JDK 21: `cd modules/perc-jetty && ..\..\mvnw.cmd clean install` → BUILD SUCCESS  
  - Tests run: 50, Failures: 0, Errors: 0, Skipped: 7
- [x] Spotless: root `mvnw.cmd spotless:apply` then `spotless:check` (exit 0); **in-scope only** committed (`pom.xml`, jetty bat + test). Out-of-scope Spotless rewrites discarded, not dumped into this PR.
- [x] Erlang-style self-review: no new path I/O bugs; no production Java logic beyond test assertion; change-class companions = enforcer ban + jetty install script + structural test.
- Parent packaging install: `mvnw.cmd -N install -DskipTests` SUCCESS

## Notes
Maven still may log **model validation warnings** when resolving ancient remote `org.glassfish.jaxb:jaxb-runtime:2.2.x` POMs that embed `com.sun:tools` systemPath in *their* dependencyManagement (antrun/plugin classpath). Those are not project POMs; not fixed in this PR.