### PR TITLE
feat(qa): #1927 H2 Docker QA entrypoint + health wait + tear-down

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -52,9 +52,17 @@ perc-devctl.py verify-fix --jar <path> [--target ...] [--restart|--no-restart] [
 perc-devctl.py logs-path
 perc-devctl.py inspect-install
 perc-devctl.py show-generated-passwords
+# QA mode — H2-in-Docker CMS for Playwright (no host install) — #1827 / #1927
+perc-devctl.py qa-up [--timeout-seconds N] [--skip-image-build]
+perc-devctl.py qa-health [--timeout-seconds N] [--interval-seconds N] [--url URL]
+perc-devctl.py qa-down [--container NAME]
 ```
 
 Each subcommand writes full output to a timestamped file under `docker/logs/<label>-<ts>.log` and emits a single `RESULT:OK STEP:<label> LOG:<path>` (or `RESULT:FAIL`) line on stdout so agent workflows can parse the result without parsing free-form output.
+
+#### QA mode (`qa-up` / `qa-health` / `qa-down`)
+
+Starts an ephemeral **CMS + H2** matrix cell (same stack as `matrix-install-smoke.py --product cms --db h2 --keep`), waits for `http://127.0.0.1:9993/Rhythmyx/login`, prints `TEST_CMS_URL` / admin username (password from generated install file when available), and tears down with `docker rm -f perc-matrix-cms-h2` so ports and disk are freed (no multi-GB named volume by default). Full operator flow: [workbench-rest-and-qa-modes.md](../docs/developer-module/workbench-rest-and-qa-modes.md) → **QA mode** section.
 
 ### `docker/scripts/hot-deploy-jar.py`
 

--- a/docker/scripts/perc-devctl.py
+++ b/docker/scripts/perc-devctl.py
@@ -9,6 +9,12 @@ docker compose stack and exposes every subcommand the original
 ``it-verify``, ``deploy-jar``, ``verify-fix``, ``logs-path``,
 ``inspect-install``, ``show-generated-passwords``.
 
+QA mode (H2-in-Docker, no host install — issue #1827 / #1927) adds:
+
+* ``qa-up`` — one-shot CMS on H2 via matrix cell (``--keep``), health wait
+* ``qa-health`` — poll published CMS URL until ready (clear timeout)
+* ``qa-down`` — destroy the QA cell (frees ports; no multi-GB orphans)
+
 Each subcommand logs its full output to a timestamped file under
 ``docker/logs/`` and emits a single ``RESULT:OK STEP:<step> LOG:<path>``
 or ``RESULT:FAIL STEP:<step> LOG:<path>`` line on stdout so agent
@@ -75,9 +81,28 @@ VERIFY_TIMEOUT_SECONDS_DEFAULT = 300
 VERIFY_INTERVAL_SECONDS_DEFAULT = 5
 VERIFY_FIX_TIMEOUT_SECONDS_DEFAULT = 240
 
-# HTTP endpoints used by `verify`.
+# HTTP endpoints used by `verify` (dev stack on 9992 / 9980).
 VERIFY_CMS_URL = "http://localhost:9992/Rhythmyx/rest/folders/by-path/Assets"
 VERIFY_DTS_URL = "http://localhost:9980/"
+
+# ---------------------------------------------------------------------------
+# QA mode — H2 matrix cell for Playwright (no host install). Ports match
+# matrix-install-smoke.py defaults so TEST_CMS_URL stays consistent.
+# ---------------------------------------------------------------------------
+QA_CMS_PRODUCT = "cms"
+QA_CMS_DB = "h2"
+QA_CMS_CELL_ID = f"{QA_CMS_PRODUCT}-{QA_CMS_DB}"
+QA_CMS_CONTAINER = f"perc-matrix-{QA_CMS_CELL_ID}"
+QA_CMS_HOST_PORT = 9993
+QA_CMS_BASE_URL = f"http://127.0.0.1:{QA_CMS_HOST_PORT}"
+QA_CMS_PROBE_PATH = "/Rhythmyx/login"
+QA_CMS_PROBE_URL = f"{QA_CMS_BASE_URL}{QA_CMS_PROBE_PATH}"
+QA_ADMIN_USERNAME = "Admin"
+QA_INSTALL_ROOT = "/opt/Percussion"
+QA_PASSWORDS_REL = "var/config/generated/passwords"
+# Matrix silent install can take several minutes on first run.
+QA_PROBE_TIMEOUT_SECONDS_DEFAULT = 900
+QA_PROBE_INTERVAL_SECONDS_DEFAULT = 5
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
@@ -192,6 +217,70 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "show-generated-passwords",
         help="Capture generated passwords file from running container.",
     )
+
+    # --- QA mode (H2 Docker, no host install) — #1827 slice 1 / #1927 ---
+    pqu = sub.add_parser(
+        "qa-up",
+        help=(
+            "Start CMS on H2 in Docker for QA/Playwright (no host install). "
+            "Waits for health; prints TEST_CMS_URL and admin creds hint."
+        ),
+    )
+    pqu.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=QA_PROBE_TIMEOUT_SECONDS_DEFAULT,
+        help=(
+            f"Seconds to wait for CMS ready during install/start "
+            f"(default: {QA_PROBE_TIMEOUT_SECONDS_DEFAULT})."
+        ),
+    )
+    pqu.add_argument(
+        "--skip-image-build",
+        action="store_true",
+        help="Pass --skip-image-build to matrix-install-smoke (reuse local image).",
+    )
+    pqu.add_argument("--dry-run", action="store_true")
+
+    pqh = sub.add_parser(
+        "qa-health",
+        help=(
+            "Poll QA CMS health URL until ready or timeout "
+            f"(default probe: {QA_CMS_PROBE_URL})."
+        ),
+    )
+    pqh.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=QA_PROBE_TIMEOUT_SECONDS_DEFAULT,
+        help=f"Seconds to wait (default: {QA_PROBE_TIMEOUT_SECONDS_DEFAULT}).",
+    )
+    pqh.add_argument(
+        "--interval-seconds",
+        type=int,
+        default=QA_PROBE_INTERVAL_SECONDS_DEFAULT,
+        help=f"Poll interval seconds (default: {QA_PROBE_INTERVAL_SECONDS_DEFAULT}).",
+    )
+    pqh.add_argument(
+        "--url",
+        default=QA_CMS_PROBE_URL,
+        help=f"Probe URL (default: {QA_CMS_PROBE_URL}).",
+    )
+    pqh.add_argument("--dry-run", action="store_true")
+
+    pqd = sub.add_parser(
+        "qa-down",
+        help=(
+            "Tear down the H2 QA CMS cell (docker rm -f). "
+            "Frees published ports; does not leave multi-GB orphans."
+        ),
+    )
+    pqd.add_argument(
+        "--container",
+        default=QA_CMS_CONTAINER,
+        help=f"Container name to remove (default: {QA_CMS_CONTAINER}).",
+    )
+    pqd.add_argument("--dry-run", action="store_true")
 
     return p
 
@@ -674,6 +763,242 @@ def cmd_show_generated_passwords(args: argparse.Namespace, paths: tuple[Path, Pa
 
 
 # ---------------------------------------------------------------------------
+# QA mode — H2-in-Docker one-shot (issue #1827 slice 1 / #1927)
+# ---------------------------------------------------------------------------
+
+
+def _qa_matrix_up_argv(
+    repo_root: Path,
+    *,
+    probe_timeout: int,
+    skip_image_build: bool,
+    dry_run: bool,
+) -> List[str]:
+    """Build argv for matrix-install-smoke CMS+H2 with ``--keep`` (pure).
+
+    Uses ``sys.executable`` so Windows/Linux/macOS all invoke the same
+    interpreter that is running perc-devctl (no hardcoded ``python3``).
+    """
+    script = repo_root / "docker" / "scripts" / "matrix-install-smoke.py"
+    argv: List[str] = [
+        sys.executable,
+        str(script),
+        "--repo-root",
+        str(repo_root),
+        "--product",
+        QA_CMS_PRODUCT,
+        "--db",
+        QA_CMS_DB,
+        "--keep",
+        "--probe-timeout",
+        str(probe_timeout),
+    ]
+    if skip_image_build:
+        argv.append("--skip-image-build")
+    if dry_run:
+        argv.append("--dry-run")
+    return argv
+
+
+def _qa_destroy_argv(container_name: str) -> List[str]:
+    """``docker rm -f`` argv for the QA cell (pure; unit-tested)."""
+    return ["docker", "rm", "-f", container_name]
+
+
+def _qa_print_endpoint_banner(
+    *,
+    admin_password_line: Optional[str] = None,
+) -> None:
+    """Emit agent-parseable endpoint + credential guidance after qa-up.
+
+    Does not emit RESULT: lines — callers use ``_run_logged`` for that
+    contract so agent parsers see a single OK/FAIL per step.
+    """
+    print(f"QA_CMS_URL:{QA_CMS_BASE_URL}")
+    print(f"TEST_CMS_URL={QA_CMS_BASE_URL}")
+    print(f"TEST_DB_TYPE={QA_CMS_DB}")
+    print(f"TEST_PRODUCT={QA_CMS_PRODUCT}")
+    print(f"QA_CONTAINER:{QA_CMS_CONTAINER}")
+    print(f"ADMIN_USERNAME={QA_ADMIN_USERNAME}")
+    if admin_password_line:
+        print(admin_password_line)
+    else:
+        # URL path inside container always uses '/'; not a host filesystem path.
+        pwd_path = f"{QA_INSTALL_ROOT}/{QA_PASSWORDS_REL}"
+        print(
+            "ADMIN_PASSWORD: fetch with "
+            f"docker exec {QA_CMS_CONTAINER} cat {pwd_path} "
+            f"(look for {QA_ADMIN_USERNAME}=…)"
+        )
+
+
+def _qa_fetch_admin_password(container_name: str) -> Optional[str]:
+    """Best-effort read of Admin=… from generated passwords in the QA cell.
+
+    Returns a line ``ADMIN_PASSWORD=<value>`` or None if unavailable.
+    Never raises; callers treat missing passwords as non-fatal (URL is enough
+    for health; Playwright login may need env set separately).
+    """
+    pwd_path = f"{QA_INSTALL_ROOT}/{QA_PASSWORDS_REL}"
+    try:
+        completed = subprocess.run(
+            ["docker", "exec", container_name, "cat", pwd_path],
+            shell=False,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    text = completed.stdout or ""
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith(f"{QA_ADMIN_USERNAME}="):
+            value = line.split("=", 1)[1].strip()
+            if value:
+                return f"ADMIN_PASSWORD={value}"
+    return None
+
+
+def cmd_qa_up(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
+    """Bring up CMS on H2 in Docker and wait until the probe URL is ready.
+
+    Delegates install/start/health-wait to ``matrix-install-smoke.py`` with
+    ``--product cms --db h2 --keep``. On success prints ``TEST_CMS_URL`` and
+    admin credential guidance for Playwright / agents.
+    """
+    repo_root, _env_file, _compose_file = paths
+    log_dir = _log_dir(repo_root)
+    dry_run = bool(args.dry_run)
+    probe_timeout = int(args.timeout_seconds)
+    skip_image_build = bool(args.skip_image_build)
+
+    matrix_argv = _qa_matrix_up_argv(
+        repo_root,
+        probe_timeout=probe_timeout,
+        skip_image_build=skip_image_build,
+        dry_run=dry_run,
+    )
+    # Use a dedicated label so logs are easy to find for QA mode.
+    # _run_logged emits RESULT:OK/FAIL STEP:qa-up LOG:<path>.
+    rc, log_file = _run_logged(
+        "qa-up",
+        matrix_argv,
+        log_dir=log_dir,
+        cwd=repo_root,
+        dry_run=dry_run,
+    )
+    if rc != EXIT_OK:
+        # Extra detail line for agent timeout diagnosis (RESULT already printed).
+        print(
+            f"QA_DETAIL:matrix-install-smoke failed "
+            f"timeout_seconds={probe_timeout} LOG:{log_file}"
+        )
+        return rc
+
+    if dry_run:
+        _qa_print_endpoint_banner()
+        return EXIT_OK
+
+    admin_line = _qa_fetch_admin_password(QA_CMS_CONTAINER)
+    _qa_print_endpoint_banner(admin_password_line=admin_line)
+    return EXIT_OK
+
+
+def cmd_qa_health(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
+    """Poll the QA CMS probe URL until ready or a clear timeout error."""
+    repo_root, _env_file, _compose_file = paths
+    log_dir = _log_dir(repo_root)
+    timeout = int(args.timeout_seconds)
+    interval = int(args.interval_seconds)
+    url = args.url or QA_CMS_PROBE_URL
+    max_checks = max(1, timeout // interval) if interval > 0 else 1
+    log_file = _new_log_file(log_dir, "qa-health")
+
+    if args.dry_run:
+        LOG.info(
+            "DRY-RUN: qa-health plan: %d checks x %ds interval against %s",
+            max_checks,
+            interval,
+            url,
+        )
+        with log_file.open("w", encoding="utf-8") as f:
+            f.write(
+                f"DRY-RUN: qa-health max_checks={max_checks} interval={interval}\n"
+                f"url={url}\n"
+                f"container={QA_CMS_CONTAINER}\n"
+            )
+        print(
+            f"RESULT:OK STEP:qa-health HTTP:200 URL:{url} "
+            f"CONTAINER:{QA_CMS_CONTAINER} LOG:{log_file}"
+        )
+        return EXIT_OK
+
+    last_code = 0
+    for check in range(1, max_checks + 1):
+        last_code = _curl_status(url, timeout=5.0)
+        if last_code in (200, 302, 401, 403):
+            with log_file.open("w", encoding="utf-8") as f:
+                f.write("qa-health success\n")
+                f.write(f"url={url}\n")
+                f.write(f"http={last_code}\n")
+                f.write(f"check={check}\n")
+                f.write(f"container={QA_CMS_CONTAINER}\n")
+            print(
+                f"RESULT:OK STEP:qa-health HTTP:{last_code} URL:{url} "
+                f"CONTAINER:{QA_CMS_CONTAINER} LOG:{log_file}"
+            )
+            return EXIT_OK
+        time.sleep(interval)
+
+    with log_file.open("w", encoding="utf-8") as f:
+        f.write("qa-health failed\n")
+        f.write(f"url={url}\n")
+        f.write(f"last_http={last_code}\n")
+        f.write(f"timeout_seconds={timeout}\n")
+        f.write(f"interval_seconds={interval}\n")
+        f.write(f"container={QA_CMS_CONTAINER}\n")
+        f.write(
+            "hint: run qa-up first; ensure installer jar is built "
+            "(modules/perc-distribution-tree package)\n"
+        )
+    print(
+        f"RESULT:FAIL STEP:qa-health DETAIL:timeout after {timeout}s "
+        f"(last_http={last_code}) URL:{url} CONTAINER:{QA_CMS_CONTAINER} "
+        f"LOG:{log_file}"
+    )
+    return EXIT_SUBPROCESS_FAILED
+
+
+def cmd_qa_down(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
+    """Destroy the H2 QA CMS cell so ports/disk are freed by default.
+
+    Uses ``docker rm -f`` on the matrix cell. Install lives inside the
+    container filesystem (no named multi-GB volume by default), so removing
+    the container frees the port and disk used by the cell.
+    """
+    repo_root, _env_file, _compose_file = paths
+    log_dir = _log_dir(repo_root)
+    container = args.container or QA_CMS_CONTAINER
+    dry_run = bool(args.dry_run)
+    rc, log_file = _run_logged(
+        "qa-down",
+        _qa_destroy_argv(container),
+        log_dir=log_dir,
+        cwd=repo_root,
+        dry_run=dry_run,
+    )
+    # RESULT:OK/FAIL already emitted by _run_logged; add agent-parseable detail.
+    print(f"QA_CONTAINER:{container}")
+    if rc == EXIT_OK:
+        print("QA_DETAIL:removed (ports/disk freed)")
+    return rc
+
+
+# ---------------------------------------------------------------------------
 # Dispatch
 # ---------------------------------------------------------------------------
 
@@ -690,6 +1015,9 @@ _DISPATCH = {
     "logs-path": cmd_logs_path,
     "inspect-install": cmd_inspect_install,
     "show-generated-passwords": cmd_show_generated_passwords,
+    "qa-up": cmd_qa_up,
+    "qa-health": cmd_qa_health,
+    "qa-down": cmd_qa_down,
 }
 
 

--- a/docker/scripts/test_perc_devctl.py
+++ b/docker/scripts/test_perc_devctl.py
@@ -179,6 +179,27 @@ class TestSubcommandDryRun(unittest.TestCase):
         self.assertIn("RESULT:OK STEP:verify", out)
         self.assertIn("CMS_HTTP:200", out)
 
+    def test_qa_up_dry_run(self):
+        rc, out = self.runner.run(["qa-up", "--timeout-seconds", "60"])
+        self.assertEqual(rc, pdc.EXIT_OK)
+        self.assertIn("RESULT:OK STEP:qa-up", out)
+        self.assertIn("TEST_CMS_URL=", out)
+        self.assertIn(pdc.QA_CMS_BASE_URL, out)
+        self.assertIn(f"ADMIN_USERNAME={pdc.QA_ADMIN_USERNAME}", out)
+
+    def test_qa_health_dry_run(self):
+        rc, out = self.runner.run(["qa-health", "--timeout-seconds", "30"])
+        self.assertEqual(rc, pdc.EXIT_OK)
+        self.assertIn("RESULT:OK STEP:qa-health", out)
+        self.assertIn("HTTP:200", out)
+        self.assertIn(pdc.QA_CMS_CONTAINER, out)
+
+    def test_qa_down_dry_run(self):
+        rc, out = self.runner.run(["qa-down"])
+        self.assertEqual(rc, pdc.EXIT_OK)
+        self.assertIn("RESULT:OK STEP:qa-down", out)
+        self.assertIn(f"QA_CONTAINER:{pdc.QA_CMS_CONTAINER}", out)
+
     def test_it_verify_dry_run(self):
         rc, out = self.runner.run(["it-verify"])
         self.assertEqual(rc, pdc.EXIT_OK)
@@ -390,6 +411,146 @@ class TestDispatch(unittest.TestCase):
         """
         with self.assertRaises(SystemExit):
             pdc.main(["not-a-command"])
+
+
+class TestQaHelpers(unittest.TestCase):
+    """Pure helpers for QA mode (H2 Docker entrypoint) — no docker."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.addCleanup(self.td.cleanup)
+        self.repo_root = _stub_repo_root(Path(self.td.name))
+        matrix = self.repo_root / "docker" / "scripts" / "matrix-install-smoke.py"
+        matrix.write_text("# stub\n", encoding="utf-8")
+
+    def test_qa_matrix_up_argv_includes_keep_and_h2(self):
+        argv = pdc._qa_matrix_up_argv(
+            self.repo_root,
+            probe_timeout=120,
+            skip_image_build=True,
+            dry_run=True,
+        )
+        self.assertEqual(argv[0], sys.executable)
+        self.assertTrue(any(str(a).endswith("matrix-install-smoke.py") for a in argv))
+        self.assertIn("--product", argv)
+        self.assertIn("cms", argv)
+        self.assertIn("--db", argv)
+        self.assertIn("h2", argv)
+        self.assertIn("--keep", argv)
+        self.assertIn("--probe-timeout", argv)
+        self.assertIn("120", argv)
+        self.assertIn("--skip-image-build", argv)
+        self.assertIn("--dry-run", argv)
+        script_idx = next(
+            i for i, a in enumerate(argv) if str(a).endswith("matrix-install-smoke.py")
+        )
+        expected = (
+            self.repo_root / "docker" / "scripts" / "matrix-install-smoke.py"
+        ).resolve()
+        self.assertEqual(Path(argv[script_idx]), expected)
+
+    def test_qa_matrix_up_argv_no_dry_run_flag_when_live(self):
+        argv = pdc._qa_matrix_up_argv(
+            self.repo_root,
+            probe_timeout=900,
+            skip_image_build=False,
+            dry_run=False,
+        )
+        self.assertNotIn("--dry-run", argv)
+        self.assertNotIn("--skip-image-build", argv)
+        self.assertIn("--keep", argv)
+
+    def test_qa_destroy_argv(self):
+        argv = pdc._qa_destroy_argv("perc-matrix-cms-h2")
+        self.assertEqual(argv, ["docker", "rm", "-f", "perc-matrix-cms-h2"])
+
+    def test_qa_constants_align_with_matrix_ports(self):
+        """Published URL must match matrix-install-smoke CMS host port."""
+        self.assertEqual(pdc.QA_CMS_HOST_PORT, 9993)
+        self.assertEqual(pdc.QA_CMS_CONTAINER, "perc-matrix-cms-h2")
+        self.assertTrue(pdc.QA_CMS_PROBE_URL.endswith("/Rhythmyx/login"))
+        self.assertIn("9993", pdc.QA_CMS_BASE_URL)
+
+
+class TestQaHealthRealMode(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.addCleanup(self.td.cleanup)
+        self.repo_root = _stub_repo_root(Path(self.td.name))
+
+    def test_qa_health_success_on_first_check(self):
+        with unittest.mock.patch.object(pdc, "_curl_status") as mock_curl, \
+             unittest.mock.patch.object(pdc.time, "sleep"):
+            mock_curl.return_value = 200
+            import io
+            from contextlib import redirect_stdout
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = pdc.main([
+                    "--repo-root", str(self.repo_root),
+                    "qa-health", "--timeout-seconds", "10",
+                ])
+            out = buf.getvalue()
+        self.assertEqual(rc, pdc.EXIT_OK)
+        self.assertIn("RESULT:OK STEP:qa-health", out)
+        self.assertIn("HTTP:200", out)
+
+    def test_qa_health_timeout_emits_clear_error(self):
+        with unittest.mock.patch.object(pdc, "_curl_status") as mock_curl, \
+             unittest.mock.patch.object(pdc.time, "sleep"):
+            mock_curl.return_value = 0
+            import io
+            from contextlib import redirect_stdout
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = pdc.main([
+                    "--repo-root", str(self.repo_root),
+                    "qa-health",
+                    "--timeout-seconds", "5",
+                    "--interval-seconds", "5",
+                ])
+            out = buf.getvalue()
+        self.assertEqual(rc, pdc.EXIT_SUBPROCESS_FAILED)
+        self.assertIn("RESULT:FAIL STEP:qa-health", out)
+        self.assertIn("timeout", out)
+        self.assertIn("LOG:", out)
+        self.assertNotIn("LOG:\n", out)
+
+
+class TestQaDownRealMode(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.addCleanup(self.td.cleanup)
+        self.repo_root = _stub_repo_root(Path(self.td.name))
+
+    def test_qa_down_invokes_docker_rm(self):
+        captured = []
+
+        def fake_run(argv, *args, **kwargs):
+            captured.append(list(argv))
+            return subprocess.CompletedProcess(
+                args=argv, returncode=0, stdout="", stderr=""
+            )
+
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with unittest.mock.patch.object(pdc.subprocess, "run", side_effect=fake_run):
+            with redirect_stdout(buf):
+                rc = pdc.main([
+                    "--repo-root", str(self.repo_root),
+                    "qa-down",
+                ])
+        out = buf.getvalue()
+        self.assertEqual(rc, pdc.EXIT_OK)
+        self.assertIn("RESULT:OK STEP:qa-down", out)
+        self.assertTrue(
+            any(
+                a[:3] == ["docker", "rm", "-f"] and pdc.QA_CMS_CONTAINER in a
+                for a in captured
+            ),
+            msg=f"expected docker rm -f {pdc.QA_CMS_CONTAINER} in {captured!r}",
+        )
 
 
 class TestMain(unittest.TestCase):

--- a/docker/scripts/test_perc_devctl.py
+++ b/docker/scripts/test_perc_devctl.py
@@ -444,9 +444,10 @@ class TestQaHelpers(unittest.TestCase):
         script_idx = next(
             i for i, a in enumerate(argv) if str(a).endswith("matrix-install-smoke.py")
         )
-        expected = (
-            self.repo_root / "docker" / "scripts" / "matrix-install-smoke.py"
-        ).resolve()
+        # Match production: str(repo_root / ...) without resolve(). Comparing a
+        # resolved expected path fails on Windows when tempfile uses 8.3 short
+        # names (e.g. RUNNER~1 vs runneradmin on GHA windows-latest).
+        expected = self.repo_root / "docker" / "scripts" / "matrix-install-smoke.py"
         self.assertEqual(Path(argv[script_idx]), expected)
 
     def test_qa_matrix_up_argv_no_dry_run_flag_when_live(self):

--- a/docs/developer-module/workbench-rest-and-qa-modes.md
+++ b/docs/developer-module/workbench-rest-and-qa-modes.md
@@ -102,6 +102,52 @@ Two supported modes. Agents must know which they are in. **Developers/agents do 
 2. Do not ask the developer to copy jars into a personal install to “make QA green.”
 3. Failures are **product or pipeline** defects; file issues, don’t invent local-only workarounds as the fix.
 
+#### H2 Docker one-shot (agents / operators) — up → health → down
+
+Productized entrypoint on `docker/scripts/perc-devctl.py` (cross-platform Python; no shell required). Implements **#1827** slice 1 / **#1927**: CMS on **H2 in Docker**, published URL, no host install.
+
+**Prereq (once per machine / after installer changes):** package the customer CMS installer assembly:
+
+```bash
+cd modules/perc-distribution-tree && ../../mvnw package -DskipTests
+# Windows: cd modules\perc-distribution-tree && ..\..\mvnw.cmd package -DskipTests
+```
+
+**Lifecycle (always use this order for unattended QA):**
+
+```bash
+# 1) UP — silent install + start CMS on H2; waits until /Rhythmyx/login is ready
+python docker/scripts/perc-devctl.py qa-up
+# optional: --timeout-seconds 900  --skip-image-build
+
+# 2) HEALTH — re-check readiness (clear RESULT:FAIL + timeout if not ready)
+python docker/scripts/perc-devctl.py qa-health
+# optional: --timeout-seconds 120  --interval-seconds 5
+
+# 3) (later slices) Playwright against the stack only — no DEV_PERCUSSION_INSTALL
+#    TEST_CMS_URL=http://127.0.0.1:9993  TEST_DB_TYPE=h2  TEST_PRODUCT=cms
+#    ADMIN_USERNAME=Admin  (password printed by qa-up or via docker exec)
+
+# 4) DOWN — destroy the cell; frees host port 9993; no multi-GB orphans by default
+python docker/scripts/perc-devctl.py qa-down
+```
+
+|  Output / constant   |                         Value                          |
+|----------------------|--------------------------------------------------------|
+| Published base URL   | `http://127.0.0.1:9993` (`TEST_CMS_URL`)               |
+| Probe path           | `/Rhythmyx/login`                                      |
+| Container name       | `perc-matrix-cms-h2`                                   |
+| Admin user           | `Admin` (password from install generated passwords)    |
+| RESULT line contract | `RESULT:OK\|FAIL STEP:qa-up\|qa-health\|qa-down LOG:…` |
+
+**Tear-down policy:** `qa-down` runs `docker rm -f` on the QA cell. The install lives **inside** the container (no named multi-GB volume by default), so removing the container frees ports and disk. Prefer `qa-down` after every agent session; do not leave `perc-matrix-cms-h2` running overnight unless debugging.
+
+**Dry-run (no docker):** `python docker/scripts/perc-devctl.py qa-up --dry-run` (and `qa-health` / `qa-down` likewise). Unit tests: `python -m pytest docker/scripts/test_perc_devctl.py -q`.
+
+Equivalent low-level harness (same cell): `python docker/scripts/matrix-install-smoke.py --product cms --db h2 --keep` then destroy with `docker rm -f perc-matrix-cms-h2`. Prefer `perc-devctl.py qa-*` for agents.
+
+Playwright env defaults, surface filters, and CI jobs are **later slices** of #1827 (#1928–#1930).
+
 ### What is *not* a supported long-term process
 
 - “Merged to `development` so the shared QA box should magically update” without **automation**.


### PR DESCRIPTION
## Summary

Implements **#1927** (slice 1 of parent **#1827**): productized **H2-in-Docker** one-shot for unattended QA — up → health wait → tear-down. No host install; no Playwright wiring in this PR (later slices #1928–#1930).

### What landed

| Command | Behavior |
|---------|----------|
| `perc-devctl.py qa-up` | CMS + H2 via `matrix-install-smoke --keep`; waits for ready; prints `TEST_CMS_URL=http://127.0.0.1:9993`, container, Admin user (+ password when available) |
| `perc-devctl.py qa-health` | Polls probe URL; clear `RESULT:FAIL … timeout after Ns` on failure |
| `perc-devctl.py qa-down` | `docker rm -f perc-matrix-cms-h2` — frees port 9993; no multi-GB named volume orphans by default |

Cross-platform: Python-only entrypoint (`sys.executable` + `pathlib.Path`); no new shell scripts.

Docs: `docs/developer-module/workbench-rest-and-qa-modes.md` QA mode section (up → health → down) + `docker/README.md`.

## Test plan

- [x] `python -m pytest docker/scripts/test_perc_devctl.py -q` → **30 passed** (dry-run + pure argv helpers + health success/timeout + docker rm mock)
- [x] Spotless: `mvnw.cmd spotless:apply` then `spotless:check` (in-scope only; OOS baseline formatting not included)
- [x] No Maven module sources changed → standalone `clean install` N/A (docs + docker Python scripts only)
- [ ] Optional live smoke (operator machine with Docker + packaged installer jar): `qa-up` → `qa-health` → `qa-down`

## Gates evidence

| Gate | Result |
|------|--------|
| Behavioral unit tests | 30 passed in `test_perc_devctl.py` |
| Spotless apply → check | exit 0; only 4 in-scope files committed |
| Maven clean install | N/A (no module `pom`/Java/resources change) |
| Erlang-style self-review | Portable paths (`Path`, `sys.executable`); clear timeouts; tear-down frees ports; no secrets |
| Secrets | None committed |

## Scope / non-goals

- **In:** entrypoint + health + tear-down + docs + unit tests
- **Out:** Playwright env golden smoke (#1928), surface filters/AGENTS rules (#1929), CI job (#1930)

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #1927  
Partial for #1827