### PR TITLE
fix(system): Jackson-migrate sitemgr domain PSSite/context/scheme (#1918)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-1918-sitemgr-jackson-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-1918-sitemgr-jackson-erlang.md
@@ -1,0 +1,26 @@
+# Erlang pre-commit review — issue #1918 (sitemgr Jackson domain)
+
+**Change class:** Jackson design-object domain batch (sitemgr)  
+**Scope:** `PSSite`, `PSSiteProperty`, `PSPublishingContext`, `PSLocationScheme`,
+`PSLocationSchemeParameter` + golden/round-trip tests + deviations doc  
+**Reviewer persona:** independent Erlang (pre-commit)
+
+## Verdict
+
+**PASS** for commit / PR of in-scope files.
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs in new/changed logic | No critical bugs found after BeanUtils null-restore fixes (`setDefaultScheme(null)`, `setContext(null)` must not wipe scalar ids) |
+| Behavioral unit tests | `PSSitemgrXmlSerializationTest` (11) + updated `PSPublishingContextTest` (2) |
+| Cross-platform paths | No filesystem path construction; classpath resources only |
+| Companions (peer filter #1915 / keyword / security) | Jackson opt-in + `addType` + `@IPSXmlSerialization` suppress + golden + round-trip + deviations doc |
+| Out of scope | filter / publisher / catalog leftovers / Betwixt POM (#1824) not touched |
+
+## Notes
+
+- `template-ids` restore still requires assembly service (same as historical helper path); offline tests leave `template-ids` empty.
+- Historical attribute roots (`PSXSite`, `PSXPublishingContext`, `PSXLocationScheme`) documented as deviations.
+- No production `.betwixt` to drop under sitemgr.

--- a/docs/ai-generated/tasks/505-betwixt-jackson/1918-sitemgr-domain-deviations.md
+++ b/docs/ai-generated/tasks/505-betwixt-jackson/1918-sitemgr-domain-deviations.md
@@ -1,0 +1,44 @@
+# Issue #1918 — Sitemgr domain Jackson wire deviations
+
+Parent: #1892 · Grandparent: #1823 · Epic: #505 · Filter sibling: #1915 / PR #1922
+
+## Scope delivered
+
+- Production design objects annotated for Jackson-backed `PSXmlSerializationHelper`:
+  - `PSSite` / `PSSiteProperty`
+  - `PSPublishingContext`
+  - `PSLocationScheme` / `PSLocationSchemeParameter`
+- Nested element names via `addType`: `site-property`, `template-id`, `context` (type map),
+  `default-scheme` (type map), `location-scheme-parameter`
+- Golden + round-trip tests (`PSSitemgrXmlSerializationTest`) + legacy null-root smoke for site
+- No production `.betwixt` files for these types (none present under sitemgr)
+
+## Approved XML deviations (Jackson write vs historical shapes)
+
+|                                 Historical shape                                 |                        Jackson default write                        |                                        Notes                                        |
+|----------------------------------------------------------------------------------|---------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| Graph-identity `id="…"` attributes                                               | Not emitted                                                         | Same as #1887 / peers                                                               |
+| `PSSite` attribute root `PSXSite` (Java-11-era DOM helper)                       | Element root `site` with children                                   | Restored helper path used pre-DOM simplification; modern design-object element tree |
+| `PSPublishingContext` attribute root `PSXPublishingContext`                      | Element root `publishing-context`                                   | Scalar `default-scheme-id` GUID string; nested `default-scheme` object suppressed   |
+| `PSLocationScheme` attribute root `PSXLocationScheme` + `PSXLocationSchemeParam` | Element root `location-scheme` + nested `location-scheme-parameter` | Parameters under `parameter-set`, ordered by sequence                               |
+| Full `associatedTemplates` / `IPSAssemblyTemplate` graphs                        | Omitted                                                             | Wire form is `template-ids` / `template-id` strings; restore needs assembly service |
+| Circular `site` on `PSSiteProperty`                                              | Omitted                                                             | Restored via `PSSite#setProperties`                                                 |
+| Circular `scheme` on parameter                                                   | Omitted                                                             | Restored via `PSLocationScheme#setParameterSet`                                     |
+| Hibernate `version`                                                              | Omitted                                                             | `@IPSXmlSerialization(suppress=true)` + `@JsonIgnore`                               |
+| Catalog `label` on site                                                          | Omitted                                                             | Alias of `name`                                                                     |
+| Null scalars                                                                     | May emit `xsi:nil`                                                  | Documented Jackson default; package read ignores unknown extras                     |
+| No XML declaration                                                               | Default                                                             | `PSJacksonXmlSerializationHelper`                                                   |
+
+## Offline test notes
+
+- **No live CMS.** Template association restore is not exercised offline (assembly service load).
+- Site property parent is re-linked after restore by `setProperties`.
+- `PSPublishingContext#setDefaultScheme(null)` and `PSLocationScheme#setContext(null)` tolerate
+  BeanUtils null property-copy so scalar id restore is not wiped.
+
+## Not in this PR
+
+- filter (#1915), publisher/pubserver (#1919), catalog/ui leftovers (#1920), content leftovers (#1921)
+- Betwixt POM removal (#1824)
+- Live CMS package install
+

--- a/system/services/src/com/percussion/services/sitemgr/data/PSLocationScheme.java
+++ b/system/services/src/com/percussion/services/sitemgr/data/PSLocationScheme.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,33 +17,20 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.services.sitemgr.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.catalog.IPSCatalogIdentifier;
 import com.percussion.services.catalog.IPSCatalogItem;
 import com.percussion.services.catalog.PSTypeEnum;
-import com.percussion.services.guidmgr.PSGuidHelper;
-import com.percussion.services.guidmgr.PSGuidUtils;
 import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.sitemgr.IPSLocationScheme;
 import com.percussion.services.sitemgr.IPSPublishingContext;
+import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import com.percussion.utils.guid.IPSGuid;
-import com.percussion.utils.string.PSStringUtils;
-import com.percussion.utils.xml.IPSXmlErrors;
+import com.percussion.utils.xml.IPSXmlSerialization;
 import com.percussion.utils.xml.PSInvalidXmlException;
-import com.percussion.utils.xml.PSXmlUtils;
-import com.percussion.xml.PSXmlDocumentBuilder;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
-
 import jakarta.persistence.Basic;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -54,24 +41,28 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
-import java.io.IOException;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
- * Modern location scheme data entity representing location generation rules
- * for content publishing using Java 11 features.
+ * Location scheme data entity representing location generation rules for content publishing.
  *
- * <h2>Java 11 Enhancements</h2>
- * <ul>
- * <li>Enhanced validation with Objects.requireNonNull</li>
- * <li>Optional-based safe access for nullable properties</li>
- * <li>Stream API for efficient parameter processing</li>
- * <li>Improved error handling and validation patterns</li>
- * </ul>
+ * <p>Design-object XML root is {@code location-scheme}. Nested parameters use element {@code
+ * location-scheme-parameter} (registered via {@link PSXmlSerializationHelper#addType}). Jackson
+ * opt-in surface (issue #1918 / #1892 / epic #505).
  *
  * @author dougrand (original)
  * @author Sunny Sal (Java 11 refactoring)
@@ -79,407 +70,480 @@ import java.util.Set;
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSLocationScheme")
 @Table(name = "RXLOCATIONSCHEME")
+@JacksonXmlRootElement(localName = "location-scheme")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({
+  "contentTypeId",
+  "contextId",
+  "description",
+  "generator",
+  "guid",
+  "id",
+  "name",
+  "parameterSet",
+  "templateId"
+})
 public class PSLocationScheme implements IPSLocationScheme, IPSCatalogItem, IPSCatalogIdentifier {
 
-    private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
-    @Id
-    @Column(name = "SCHEMEID")
-    private long schemeId = -1;
+  static {
+    PSXmlSerializationHelper.addType(
+        "location-scheme-parameter", PSLocationSchemeParameter.class);
+  }
 
-    @Basic
-    @Column(name = "SCHEMENAME")
-    private String name;
+  @Id
+  @Column(name = "SCHEMEID")
+  private long schemeId = -1;
 
-    @Basic
-    @Column(name = "DESCRIPTION")
-    private String description;
+  @Basic
+  @Column(name = "SCHEMENAME")
+  private String name;
 
-    @Basic
-    @Column(name = "GENERATOR")
-    private String generator;
+  @Basic
+  @Column(name = "DESCRIPTION")
+  private String description;
 
-    @Basic
-    @Column(name = "VARIANTID")
-    private Long templateId;
+  @Basic
+  @Column(name = "GENERATOR")
+  private String generator;
 
-    @Basic
-    @Column(name = "CONTENTTYPEID")
-    private Long contentTypeId;
+  @Basic
+  @Column(name = "VARIANTID")
+  private Long templateId;
 
-    @Basic
-    @Column(name = "CONTEXTID")
-    private Long contextId;
+  @Basic
+  @Column(name = "CONTENTTYPEID")
+  private Long contentTypeId;
 
-    @Version
-    @Column(name = "VERSION")
-    private Integer version;
+  @Basic
+  @Column(name = "CONTEXTID")
+  private Long contextId;
 
-    @OneToMany(targetEntity = PSLocationSchemeParameter.class,
-               cascade = {CascadeType.ALL},
-               fetch = FetchType.EAGER,
-               orphanRemoval = true)
-    @JoinColumn(name = "SCHEMEID", nullable = false)
-    @Fetch(FetchMode.SUBSELECT)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-    private Set<PSLocationSchemeParameter> parameters = new HashSet<>();
+  @Version
+  @Column(name = "VERSION")
+  private Integer version;
 
-    /**
-     * Cloning flag to track cloned instances
-     */
-    private transient boolean isCloned = false;
+  @OneToMany(
+      targetEntity = PSLocationSchemeParameter.class,
+      cascade = {CascadeType.ALL},
+      fetch = FetchType.EAGER,
+      orphanRemoval = true)
+  @JoinColumn(name = "SCHEMEID", nullable = false)
+  @Fetch(FetchMode.SUBSELECT)
+  @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+  private Set<PSLocationSchemeParameter> parameters = new HashSet<>();
 
-    /**
-     * Default constructor.
-     */
-    public PSLocationScheme() {
-        // Default constructor
-    }
+  /** Cloning flag to track cloned instances */
+  private transient boolean isCloned = false;
 
-    /**
-     * Enhanced copy constructor using Java 11 patterns
-     */
-    public PSLocationScheme(PSLocationScheme source) {
-        Objects.requireNonNull(source, "source cannot be null");
+  /** Default constructor. */
+  public PSLocationScheme() {
+    // Default constructor
+  }
 
-        this.name = source.name;
-        this.description = source.description;
-        this.generator = source.generator;
-        this.templateId = source.templateId;
-        this.contentTypeId = source.contentTypeId;
-        this.contextId = source.contextId;
-        this.version = source.version;
-        this.isCloned = true;
+  /**
+   * Enhanced copy constructor using Java 11 patterns
+   */
+  public PSLocationScheme(PSLocationScheme source) {
+    Objects.requireNonNull(source, "source cannot be null");
 
-        // Deep copy parameters using streams
-        this.parameters = new HashSet<>();
-        source.parameters.stream()
-            .map(p -> {
-                PSLocationSchemeParameter copy = new PSLocationSchemeParameter();
-                copy.setName(p.getName());
-                copy.setType(p.getType());
-                copy.setValue(p.getValue());
-                copy.setSequence(p.getSequence());
-                copy.setScheme(this);
-                return copy;
+    this.name = source.name;
+    this.description = source.description;
+    this.generator = source.generator;
+    this.templateId = source.templateId;
+    this.contentTypeId = source.contentTypeId;
+    this.contextId = source.contextId;
+    this.version = source.version;
+    this.isCloned = true;
+
+    // Deep copy parameters using streams
+    this.parameters = new HashSet<>();
+    source.parameters.stream()
+        .map(
+            p -> {
+              PSLocationSchemeParameter copy = new PSLocationSchemeParameter();
+              copy.setName(p.getName());
+              copy.setType(p.getType());
+              copy.setValue(p.getValue());
+              copy.setSequence(p.getSequence());
+              if (p.getParameterId() != null) {
+                copy.setParameterId(p.getParameterId());
+              }
+              copy.setScheme(this);
+              return copy;
             })
-            .forEach(this.parameters::add);
+        .forEach(this.parameters::add);
+  }
+
+  @Override
+  @JsonProperty("guid")
+  public IPSGuid getGUID() {
+    return schemeId == -1 ? null : new PSGuid(PSTypeEnum.LOCATION_SCHEME, schemeId);
+  }
+
+  @Override
+  public void setGUID(IPSGuid guid) throws IllegalStateException {
+    Objects.requireNonNull(guid, "guid cannot be null");
+    if (guid.getType() != PSTypeEnum.LOCATION_SCHEME.getOrdinal()) {
+      throw new IllegalArgumentException("guid must be a location scheme guid");
+    }
+    // Allow overwrite on design-object XML restore (BeanUtils + Jackson)
+    this.schemeId = guid.longValue();
+  }
+
+  @JsonProperty
+  public long getId() {
+    return schemeId;
+  }
+
+  public void setId(long id) {
+    this.schemeId = id;
+  }
+
+  @Override
+  @JsonProperty
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  @JsonProperty
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  @Override
+  @JsonProperty
+  public String getGenerator() {
+    return generator;
+  }
+
+  @Override
+  public void setGenerator(String generator) {
+    this.generator = generator;
+  }
+
+  @Override
+  @JsonProperty
+  public Long getTemplateId() {
+    return templateId;
+  }
+
+  @Override
+  public void setTemplateId(Long templateId) {
+    this.templateId = templateId;
+  }
+
+  @Override
+  @JsonProperty
+  public Long getContentTypeId() {
+    return contentTypeId;
+  }
+
+  @Override
+  public void setContentTypeId(Long contentTypeId) {
+    this.contentTypeId = contentTypeId;
+  }
+
+  @Override
+  @JsonProperty
+  public IPSGuid getContextId() {
+    return Optional.ofNullable(contextId)
+        .map(id -> new PSGuid(PSTypeEnum.CONTEXT, id))
+        .orElse(null);
+  }
+
+  @Override
+  public void setContextId(IPSGuid contextId) {
+    this.contextId = Optional.ofNullable(contextId).map(IPSGuid::longValue).orElse(null);
+  }
+
+  /**
+   * Parameter set for design-object XML and persistence access.
+   *
+   * @return a mutable copy of parameters, never null
+   */
+  @JsonProperty
+  @JacksonXmlElementWrapper(localName = "parameter-set")
+  @JacksonXmlProperty(localName = "location-scheme-parameter")
+  public Set<PSLocationSchemeParameter> getParameterSet() {
+    // LinkedHashSet preserves sequence order for deterministic design-object XML / goldens
+    return parameters.stream()
+        .sorted(
+            (a, b) ->
+                Integer.compare(
+                    a.getSequence() != null ? a.getSequence() : 0,
+                    b.getSequence() != null ? b.getSequence() : 0))
+        .collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new));
+  }
+
+  public void setParameterSet(Set<PSLocationSchemeParameter> parameters) {
+    this.parameters = Optional.ofNullable(parameters).map(HashSet::new).orElse(new HashSet<>());
+    // Re-link parent after XML restore (circular scheme suppressed on write)
+    for (PSLocationSchemeParameter p : this.parameters) {
+      if (p != null) {
+        p.setScheme(this);
+      }
+    }
+  }
+
+  /**
+   * Enhanced parameter management using Java 11 patterns
+   */
+  @JsonIgnore
+  public String getParameter(String name) {
+    Objects.requireNonNull(name, "name cannot be null");
+
+    return parameters.stream()
+        .filter(param -> Objects.equals(param.getName(), name))
+        .map(PSLocationSchemeParameter::getValue)
+        .findFirst()
+        .orElse(null);
+  }
+
+  @JsonIgnore
+  public void setParameter(String name, String value) {
+    Objects.requireNonNull(name, "name cannot be null");
+
+    // Remove existing parameter with same name
+    parameters.removeIf(param -> Objects.equals(param.getName(), name));
+
+    // Add new parameter if value is not blank
+    if (StringUtils.isNotBlank(value)) {
+      var parameter = new PSLocationSchemeParameter();
+      parameter.setName(name);
+      parameter.setValue(value);
+      parameter.setScheme(this);
+      parameters.add(parameter);
+    }
+  }
+
+  @Override
+  @JsonIgnore
+  public java.util.List<String> getParameterNames() {
+    return parameters.stream()
+        .sorted((a, b) -> Integer.compare(a.getSequence(), b.getSequence()))
+        .map(PSLocationSchemeParameter::getName)
+        .collect(java.util.stream.Collectors.toList());
+  }
+
+  @Override
+  @JsonIgnore
+  public String getParameterValue(String name) {
+    Objects.requireNonNull(name, "name cannot be null");
+    return parameters.stream()
+        .filter(p -> Objects.equals(p.getName(), name))
+        .map(PSLocationSchemeParameter::getValue)
+        .findFirst()
+        .orElse(null);
+  }
+
+  @Override
+  @JsonIgnore
+  public String getParameterType(String name) {
+    Objects.requireNonNull(name, "name cannot be null");
+    return parameters.stream()
+        .filter(p -> Objects.equals(p.getName(), name))
+        .map(PSLocationSchemeParameter::getType)
+        .findFirst()
+        .orElse(null);
+  }
+
+  @Override
+  @JsonIgnore
+  public Integer getParameterSequence(String name) {
+    Objects.requireNonNull(name, "name cannot be null");
+    return parameters.stream()
+        .filter(p -> Objects.equals(p.getName(), name))
+        .map(PSLocationSchemeParameter::getSequence)
+        .findFirst()
+        .orElse(null);
+  }
+
+  @Override
+  @JsonIgnore
+  public void setParameter(String name, String type, String value) {
+    addParameter(name, 0, type, value);
+  }
+
+  @Override
+  public void addParameter(String name, int sequence, String type, String value) {
+    Objects.requireNonNull(name, "name cannot be null");
+    Objects.requireNonNull(type, "type cannot be null");
+    Objects.requireNonNull(value, "value cannot be null");
+
+    // If exists, update
+    for (PSLocationSchemeParameter p : parameters) {
+      if (Objects.equals(p.getName(), name)) {
+        p.setType(type);
+        p.setValue(value);
+        p.setSequence(sequence);
+        return;
+      }
     }
 
-    @Override
-    public IPSGuid getGUID() {
-        return schemeId == -1 ? null : new PSGuid(PSTypeEnum.LOCATION_SCHEME, schemeId);
-    }
+    PSLocationSchemeParameter param = new PSLocationSchemeParameter();
+    param.setName(name);
+    param.setType(type);
+    param.setValue(value);
+    param.setSequence(sequence);
+    param.setScheme(this);
+    parameters.add(param);
+  }
 
-    @Override
-    public void setGUID(IPSGuid guid) throws IllegalStateException {
-        Objects.requireNonNull(guid, "guid cannot be null");
-        if (guid.getType() != PSTypeEnum.LOCATION_SCHEME.getOrdinal()) {
-            throw new IllegalArgumentException("guid must be a location scheme guid");
-        }
-        if (schemeId != -1) {
-            throw new IllegalStateException("schemeId is already set");
-        }
-        this.schemeId = guid.longValue();
-    }
+  @Override
+  public void removeParameter(String name) {
+    Objects.requireNonNull(name, "name cannot be null");
+    parameters.removeIf(p -> Objects.equals(p.getName(), name));
+  }
 
-    public long getId() {
-        return schemeId;
-    }
+  /**
+   * Check if this is a cloned instance
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public boolean isCloned() {
+    return isCloned;
+  }
 
-    public void setId(long id) {
-        this.schemeId = id;
-    }
+  /**
+   * Mark this instance as cloned
+   */
+  public void setCloned(boolean cloned) {
+    this.isCloned = cloned;
+  }
 
-    @Override
-    public String getName() {
-        return name;
-    }
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public Integer getVersion() {
+    return version;
+  }
 
-    @Override
-    public void setName(String name) {
-        this.name = name;
-    }
+  public void setVersion(Integer version) {
+    this.version = version;
+  }
 
-    @Override
-    public String getDescription() {
-        return description;
-    }
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null || getClass() != obj.getClass()) return false;
 
-    @Override
-    public void setDescription(String description) {
-        this.description = description;
-    }
+    var scheme = (PSLocationScheme) obj;
+    return new EqualsBuilder()
+        .append(schemeId, scheme.schemeId)
+        .append(name, scheme.name)
+        .append(generator, scheme.generator)
+        .append(templateId, scheme.templateId)
+        .append(contentTypeId, scheme.contentTypeId)
+        .append(contextId, scheme.contextId)
+        .isEquals();
+  }
 
-    @Override
-    public String getGenerator() {
-        return generator;
-    }
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder()
+        .append(schemeId)
+        .append(name)
+        .append(generator)
+        .append(templateId)
+        .append(contentTypeId)
+        .append(contextId)
+        .toHashCode();
+  }
 
-    @Override
-    public void setGenerator(String generator) {
-        this.generator = generator;
+  @Override
+  public void copy(IPSLocationScheme other) {
+    if (other == null) {
+      throw new IllegalArgumentException("other cannot be null");
     }
-
-    @Override
-    public Long getTemplateId() {
-        return templateId;
-    }
-
-    @Override
-    public void setTemplateId(Long templateId) {
-        this.templateId = templateId;
-    }
-
-    @Override
-    public Long getContentTypeId() {
-        return contentTypeId;
-    }
-
-    @Override
-    public void setContentTypeId(Long contentTypeId) {
-        this.contentTypeId = contentTypeId;
-    }
-
-    @Override
-    public IPSGuid getContextId() {
-        return Optional.ofNullable(contextId)
-            .map(id -> new PSGuid(PSTypeEnum.CONTEXT, id))
+    this.name = other.getName();
+    this.description = other.getDescription();
+    this.generator = other.getGenerator();
+    this.templateId = other.getTemplateId();
+    this.contentTypeId = other.getContentTypeId();
+    this.contextId =
+        java.util.Optional.ofNullable(other.getContextId())
+            .map(com.percussion.utils.guid.IPSGuid::longValue)
             .orElse(null);
+    // Copy parameters
+    this.parameters.clear();
+    for (String paramName : other.getParameterNames()) {
+      this.addParameter(
+          paramName,
+          other.getParameterSequence(paramName),
+          other.getParameterType(paramName),
+          other.getParameterValue(paramName));
     }
+  }
 
-    @Override
-    public void setContextId(IPSGuid contextId) {
-        this.contextId = Optional.ofNullable(contextId)
-            .map(IPSGuid::longValue)
-            .orElse(null);
+  @Override
+  @Deprecated
+  @JsonIgnore
+  public void setContext(IPSPublishingContext context) {
+    // Only apply non-null context objects. BeanUtils property-copy after Jackson deserialize
+    // may invoke setContext(null) for the suppressed property and must not wipe contextId
+    // already restored via setContextId (issue #1918).
+    if (context != null) {
+      this.setContextId(context.getGUID());
     }
+  }
 
-    public Set<PSLocationSchemeParameter> getParameterSet() {
-        return new HashSet<>(parameters);
-    }
+  @Override
+  @Deprecated
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public IPSPublishingContext getContext() {
+    // Deprecated API; prefer using getContextId(). Returning null as a
+    // minimal implementation to preserve backward compatibility.
+    return null;
+  }
 
-    public void setParameterSet(Set<PSLocationSchemeParameter> parameters) {
-        this.parameters = Optional.ofNullable(parameters)
-            .map(HashSet::new)
-            .orElse(new HashSet<>());
-    }
+  @Override
+  public void fromXML(String xmlsource)
+      throws java.io.IOException, org.xml.sax.SAXException, PSInvalidXmlException {
+    // Reset identifier and version to avoid restore issues
+    this.schemeId = -1;
+    this.version = null;
+    this.parameters = new HashSet<>();
+    PSXmlSerializationHelper.readFromXML(xmlsource, this);
+  }
 
-    /**
-     * Enhanced parameter management using Java 11 patterns
-     */
-    public String getParameter(String name) {
-        Objects.requireNonNull(name, "name cannot be null");
+  @Override
+  public String toXML() throws java.io.IOException, org.xml.sax.SAXException {
+    return PSXmlSerializationHelper.writeToXml(this);
+  }
 
-        return parameters.stream()
-            .filter(param -> Objects.equals(param.getName(), name))
-            .map(PSLocationSchemeParameter::getValue)
-            .findFirst()
-            .orElse(null);
-    }
+  @Override
+  public Object clone() throws CloneNotSupportedException {
+    // Create a deep copy using copy constructor
+    return new PSLocationScheme(this);
+  }
 
-    public void setParameter(String name, String value) {
-        Objects.requireNonNull(name, "name cannot be null");
-
-        // Remove existing parameter with same name
-        parameters.removeIf(param -> Objects.equals(param.getName(), name));
-
-        // Add new parameter if value is not blank
-        if (StringUtils.isNotBlank(value)) {
-            var parameter = new PSLocationSchemeParameter();
-            parameter.setName(name);
-            parameter.setValue(value);
-            parameter.setScheme(this);
-            parameters.add(parameter);
-        }
-    }
-
-    @Override
-    public java.util.List<String> getParameterNames() {
-        return parameters.stream()
-                .sorted((a, b) -> Integer.compare(a.getSequence(), b.getSequence()))
-                .map(PSLocationSchemeParameter::getName)
-                .collect(java.util.stream.Collectors.toList());
-    }
-
-    @Override
-    public String getParameterValue(String name) {
-        Objects.requireNonNull(name, "name cannot be null");
-        return parameters.stream()
-                .filter(p -> Objects.equals(p.getName(), name))
-                .map(PSLocationSchemeParameter::getValue)
-                .findFirst()
-                .orElse(null);
-    }
-
-    @Override
-    public String getParameterType(String name) {
-        Objects.requireNonNull(name, "name cannot be null");
-        return parameters.stream()
-                .filter(p -> Objects.equals(p.getName(), name))
-                .map(PSLocationSchemeParameter::getType)
-                .findFirst()
-                .orElse(null);
-    }
-
-    @Override
-    public Integer getParameterSequence(String name) {
-        Objects.requireNonNull(name, "name cannot be null");
-        return parameters.stream()
-                .filter(p -> Objects.equals(p.getName(), name))
-                .map(PSLocationSchemeParameter::getSequence)
-                .findFirst()
-                .orElse(null);
-    }
-
-    @Override
-    public void setParameter(String name, String type, String value) {
-        addParameter(name, 0, type, value);
-    }
-
-    @Override
-    public void addParameter(String name, int sequence, String type, String value) {
-        Objects.requireNonNull(name, "name cannot be null");
-        Objects.requireNonNull(type, "type cannot be null");
-        Objects.requireNonNull(value, "value cannot be null");
-
-        // If exists, update
-        for (PSLocationSchemeParameter p : parameters) {
-            if (Objects.equals(p.getName(), name)) {
-                p.setType(type);
-                p.setValue(value);
-                p.setSequence(sequence);
-                return;
-            }
-        }
-
-        PSLocationSchemeParameter param = new PSLocationSchemeParameter();
-        param.setName(name);
-        param.setType(type);
-        param.setValue(value);
-        param.setSequence(sequence);
-        param.setScheme(this);
-        parameters.add(param);
-    }
-
-    @Override
-    public void removeParameter(String name) {
-        Objects.requireNonNull(name, "name cannot be null");
-        parameters.removeIf(p -> Objects.equals(p.getName(), name));
-    }
-
-    /**
-     * Check if this is a cloned instance
-     */
-    public boolean isCloned() {
-        return isCloned;
-    }
-
-    /**
-     * Mark this instance as cloned
-     */
-    public void setCloned(boolean cloned) {
-        this.isCloned = cloned;
-    }
-
-    public Integer getVersion() {
-        return version;
-    }
-
-    public void setVersion(Integer version) {
-        this.version = version;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (obj == null || getClass() != obj.getClass()) return false;
-
-        var scheme = (PSLocationScheme) obj;
-        return new EqualsBuilder()
-            .append(schemeId, scheme.schemeId)
-            .append(name, scheme.name)
-            .append(generator, scheme.generator)
-            .append(templateId, scheme.templateId)
-            .append(contentTypeId, scheme.contentTypeId)
-            .append(contextId, scheme.contextId)
-            .isEquals();
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder()
-            .append(schemeId)
-            .append(name)
-            .append(generator)
-            .append(templateId)
-            .append(contentTypeId)
-            .append(contextId)
-            .toHashCode();
-    }
-
-    @Override
-    public void copy(IPSLocationScheme other) {
-        if (other == null) {
-            throw new IllegalArgumentException("other cannot be null");
-        }
-        this.name = other.getName();
-        this.description = other.getDescription();
-        this.generator = other.getGenerator();
-        this.templateId = other.getTemplateId();
-        this.contentTypeId = other.getContentTypeId();
-        this.contextId = java.util.Optional.ofNullable(other.getContextId()).map(com.percussion.utils.guid.IPSGuid::longValue).orElse(null);
-        // Copy parameters
-        this.parameters.clear();
-        for (String paramName : other.getParameterNames()) {
-            this.addParameter(paramName, other.getParameterSequence(paramName),
-                            other.getParameterType(paramName), other.getParameterValue(paramName));
-        }
-    }
-
-    @Override
-    @Deprecated
-    public void setContext(IPSPublishingContext context) {
-        this.setContextId(context == null ? null : context.getGUID());
-    }
-
-    @Override
-    @Deprecated
-    public IPSPublishingContext getContext() {
-        // Deprecated API; prefer using getContextId(). Returning null as a
-        // minimal implementation to preserve backward compatibility.
-        return null;
-    }
-
-    @Override
-    public void fromXML(String xmlsource) throws java.io.IOException, org.xml.sax.SAXException, PSInvalidXmlException {
-        // Reset identifier and version to avoid restore issues
-        this.schemeId = -1;
-        this.version = null;
-        this.parameters = new HashSet<>();
-        com.percussion.services.utils.xml.PSXmlSerializationHelper.readFromXML(xmlsource, this);
-    }
-
-    @Override
-    public String toXML() throws java.io.IOException, org.xml.sax.SAXException {
-        return com.percussion.services.utils.xml.PSXmlSerializationHelper.writeToXml(this);
-    }
-
-    @Override
-    public Object clone() throws CloneNotSupportedException {
-        // Create a deep copy using copy constructor
-        return new PSLocationScheme(this);
-    }
-
-    @Override
-    public String toString() {
-        return new ToStringBuilder(this)
-            .append("schemeId", schemeId)
-            .append("name", name)
-            .append("generator", generator)
-            .append("templateId", templateId)
-            .append("contentTypeId", contentTypeId)
-            .append("contextId", contextId)
-            .toString();
-    }
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .append("schemeId", schemeId)
+        .append("name", name)
+        .append("generator", generator)
+        .append("templateId", templateId)
+        .append("contentTypeId", contentTypeId)
+        .append("contextId", contextId)
+        .toString();
+  }
 }

--- a/system/services/src/com/percussion/services/sitemgr/data/PSLocationSchemeParameter.java
+++ b/system/services/src/com/percussion/services/sitemgr/data/PSLocationSchemeParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,12 @@
  */
 package com.percussion.services.sitemgr.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.sitemgr.IPSLocationScheme;
-
-import java.io.Serializable;
-
+import com.percussion.utils.xml.IPSXmlSerialization;
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -27,217 +29,214 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-
+import java.io.Serializable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
- * Represents a location scheme parameter
- * 
+ * Represents a location scheme parameter.
+ *
+ * <p>Design-object nested element is {@code location-scheme-parameter}. Parent {@link #getScheme()}
+ * is suppressed (circular); restore is via {@link PSLocationScheme#setParameterSet(java.util.Set)}.
+ * Jackson opt-in surface (issue #1918 / #1892 / epic #505).
+ *
  * @author dougrand
  */
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, 
-      region = "PSLocationScheme_Parameters")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSLocationScheme_Parameters")
 @Table(name = "RXLOCATIONSCHEMEPARAMS")
-public class PSLocationSchemeParameter implements Serializable
-{
-   /**
-    * Serial id identifies versions of serialized data
-    */
-   private static final long serialVersionUID = 1L;
-   
-   @Id
-   @Column(name = "SCHEMEPARAMID")
-   Integer  parameterId;
-   
-   @ManyToOne(targetEntity = PSLocationScheme.class)
-   @JoinColumn(name = "SCHEMEID", nullable = false, insertable = false, updatable = false)
-   IPSLocationScheme scheme;
-   
-   @Basic
-   Integer  sequence;
-   
-   @Basic
-   String   type;
-   
-   @Basic
-   String   name;
-   
-   @Basic
-   String   value;
-   
-   /**
-    * @param parameterId The parameterId to set.
-    */
-   public void setParameterId(Integer parameterId)
-   {
-      this.parameterId = parameterId;
-   }
+@JacksonXmlRootElement(localName = "location-scheme-parameter")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({"name", "parameterId", "sequence", "type", "value"})
+public class PSLocationSchemeParameter implements Serializable {
+  /** Serial id identifies versions of serialized data */
+  private static final long serialVersionUID = 1L;
 
-   /**
-    * Get the name of the parameter
-    * @return Returns the name, never <code>null</code> or empty
-    */
-   public String getName()
-   {
-      return name;
-   }
+  @Id
+  @Column(name = "SCHEMEPARAMID")
+  Integer parameterId;
 
-   /**
-    * @param name The name to set, never <code>null</code> or empty
-    */
-   public void setName(String name)
-   {
-      if (StringUtils.isBlank(name))
-      {
-         throw new IllegalArgumentException("name may not be null or empty");
-      }
-      this.name = name;
-   }
+  @ManyToOne(targetEntity = PSLocationScheme.class)
+  @JoinColumn(name = "SCHEMEID", nullable = false, insertable = false, updatable = false)
+  IPSLocationScheme scheme;
 
-   /**
-    * Get the primary key used to store this parameter
-    * @return Returns the parameterId.
-    */
-   public Integer getParameterId()
-   {
-      return parameterId;
-   }
+  @Basic Integer sequence;
 
-   /**
-    * Get the parent location scheme for this parameter
-    * @return Returns the scheme, never <code>null</code>
-    */
-   public IPSLocationScheme getScheme()
-   {
-      return scheme;
-   }
+  @Basic String type;
 
-   /**
-    * Set a new location scheme, should only be used on a newly constructed
-    * object.
-    * @param scheme The scheme to set, never <code>null</code>
-    */
-   public void setScheme(IPSLocationScheme scheme)
-   {
-      if (scheme == null)
-      {
-         throw new IllegalArgumentException("scheme may not be null");
-      }
-      this.scheme = scheme;
-   }
+  @Basic String name;
 
-   /**
-    * The sequence is really only used in the user interface to order the
-    * parameters. 
-    * @return Returns the sequence.
-    */
-   public Integer getSequence()
-   {
-      return sequence;
-   }
+  @Basic String value;
 
-   /**
-    * Set a new sequence
-    * @param sequence The sequence to set, never <code>null</code>
-    */
-   public void setSequence(Integer sequence)
-   {
-      if (sequence == null)
-      {
-         throw new IllegalArgumentException("sequence may not be null");
-      }
-      this.sequence = sequence;
-   }
+  /**
+   * @param parameterId The parameterId to set.
+   */
+  public void setParameterId(Integer parameterId) {
+    this.parameterId = parameterId;
+  }
 
-   /**
-    * Get the type of the value.
-    * @return Returns the type.
-    */
-   public String getType()
-   {
-      return type;
-   }
+  /**
+   * Get the name of the parameter
+   *
+   * @return Returns the name, never <code>null</code> or empty
+   */
+  @JsonProperty
+  public String getName() {
+    return name;
+  }
 
-   /**
-    * Set a new type
-    * @param type The type to set, never <code>null</code> or empty
-    */
-   public void setType(String type)
-   {
-      if (StringUtils.isBlank(type))
-      {
-         throw new IllegalArgumentException("type may not be null or empty");
-      }
-      this.type = type;
-   }
+  /**
+   * @param name The name to set, never <code>null</code> or empty
+   */
+  public void setName(String name) {
+    if (StringUtils.isBlank(name)) {
+      throw new IllegalArgumentException("name may not be null or empty");
+    }
+    this.name = name;
+  }
 
-   /**
-    * Get the value of the particular parameter
-    * @return Returns the value, never <code>null</code> or empty
-    */
-   public String getValue()
-   {
-      return value;
-   }
+  /**
+   * Get the primary key used to store this parameter
+   *
+   * @return Returns the parameterId.
+   */
+  @JsonProperty
+  public Integer getParameterId() {
+    return parameterId;
+  }
 
-   /**
-    * Set a new value
-    * @param value The value to set, never <code>null</code> or empty
-    */
-   public void setValue(String value)
-   {
-      if (StringUtils.isBlank(value))
-      {
-         throw new IllegalArgumentException("value may not be null or empty");
-      }
-      this.value = value;
-   }
-   
-   /** (non-Javadoc)
-    * @see java.lang.Object#equals(java.lang.Object)
-    */
-   @Override
-   public boolean equals(Object obj)
-   {
-      PSLocationSchemeParameter pb = (PSLocationSchemeParameter) obj;
-      
-      return new EqualsBuilder()
-         .append(parameterId, pb.parameterId)
-         .append(sequence, pb.sequence)
-         .append(type, pb.type)
-         .append(name, pb.name)
-         .append(value, pb.value)
-         .isEquals();
-   }
-   
-   /** (non-Javadoc)
-    * @see java.lang.Object#hashCode()
-    */
-   @Override
-   public int hashCode()
-   {
-      return name.hashCode();
-   }
+  /**
+   * Get the parent location scheme for this parameter
+   *
+   * @return Returns the scheme, never <code>null</code>
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public IPSLocationScheme getScheme() {
+    return scheme;
+  }
 
-   /**
-    * (non-Javadoc)
-    *
-    * @see Object#toString()
-    */
-   @Override
-   public String toString() {
-      final StringBuffer sb = new StringBuffer("PSLocationSchemeParameter{");
-      sb.append("parameterId=").append(parameterId);
-      sb.append(", scheme=").append(scheme);
-      sb.append(", sequence=").append(sequence);
-      sb.append(", type='").append(type).append('\'');
-      sb.append(", name='").append(name).append('\'');
-      sb.append(", value='").append(value).append('\'');
-      sb.append('}');
-      return sb.toString();
-   }
+  /**
+   * Set a new location scheme, should only be used on a newly constructed object.
+   *
+   * @param scheme The scheme to set, never <code>null</code>
+   */
+  /**
+   * Set parent scheme. {@code null} is allowed for BeanUtils property-copy after XML restore
+   * (parent is re-linked via {@link PSLocationScheme#setParameterSet}).
+   */
+  @JsonIgnore
+  public void setScheme(IPSLocationScheme scheme) {
+    this.scheme = scheme;
+  }
+
+  /**
+   * The sequence is really only used in the user interface to order the parameters.
+   *
+   * @return Returns the sequence.
+   */
+  @JsonProperty
+  public Integer getSequence() {
+    return sequence;
+  }
+
+  /**
+   * Set a new sequence
+   *
+   * @param sequence The sequence to set, never <code>null</code>
+   */
+  public void setSequence(Integer sequence) {
+    if (sequence == null) {
+      throw new IllegalArgumentException("sequence may not be null");
+    }
+    this.sequence = sequence;
+  }
+
+  /**
+   * Get the type of the value.
+   *
+   * @return Returns the type.
+   */
+  @JsonProperty
+  public String getType() {
+    return type;
+  }
+
+  /**
+   * Set a new type
+   *
+   * @param type The type to set, never <code>null</code> or empty
+   */
+  public void setType(String type) {
+    if (StringUtils.isBlank(type)) {
+      throw new IllegalArgumentException("type may not be null or empty");
+    }
+    this.type = type;
+  }
+
+  /**
+   * Get the value of the particular parameter
+   *
+   * @return Returns the value, never <code>null</code> or empty
+   */
+  @JsonProperty
+  public String getValue() {
+    return value;
+  }
+
+  /**
+   * Set a new value
+   *
+   * @param value The value to set, never <code>null</code> or empty
+   */
+  public void setValue(String value) {
+    if (StringUtils.isBlank(value)) {
+      throw new IllegalArgumentException("value may not be null or empty");
+    }
+    this.value = value;
+  }
+
+  /** (non-Javadoc) */
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof PSLocationSchemeParameter)) {
+      return false;
+    }
+    PSLocationSchemeParameter pb = (PSLocationSchemeParameter) obj;
+
+    return new EqualsBuilder()
+        .append(parameterId, pb.parameterId)
+        .append(sequence, pb.sequence)
+        .append(type, pb.type)
+        .append(name, pb.name)
+        .append(value, pb.value)
+        .isEquals();
+  }
+
+  /** (non-Javadoc) */
+  @Override
+  public int hashCode() {
+    return name != null ? name.hashCode() : 0;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuffer sb = new StringBuffer("PSLocationSchemeParameter{");
+    sb.append("parameterId=").append(parameterId);
+    sb.append(", scheme=").append(scheme);
+    sb.append(", sequence=").append(sequence);
+    sb.append(", type='").append(type).append('\'');
+    sb.append(", name='").append(name).append('\'');
+    sb.append(", value='").append(value).append('\'');
+    sb.append('}');
+    return sb.toString();
+  }
 }

--- a/system/services/src/com/percussion/services/sitemgr/data/PSPublishingContext.java
+++ b/system/services/src/com/percussion/services/sitemgr/data/PSPublishingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,10 @@
  */
 package com.percussion.services.sitemgr.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.catalog.IPSCatalogIdentifier;
 import com.percussion.services.catalog.IPSCatalogItem;
 import com.percussion.services.catalog.PSTypeEnum;
@@ -24,390 +28,303 @@ import com.percussion.services.sitemgr.IPSLocationScheme;
 import com.percussion.services.sitemgr.IPSPublishingContext;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import com.percussion.utils.guid.IPSGuid;
-import com.percussion.utils.string.PSStringUtils;
-import com.percussion.utils.xml.IPSXmlErrors;
 import com.percussion.utils.xml.IPSXmlSerialization;
 import com.percussion.utils.xml.PSInvalidXmlException;
-import com.percussion.utils.xml.PSXmlUtils;
-import com.percussion.xml.PSXmlDocumentBuilder;
-
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Serializable;
-import java.io.StringReader;
-
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
-
+import java.io.IOException;
+import java.io.Serializable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
- * The publishing context controls how links are generated in the HTML documents
- * during assembly.
- * 
+ * The publishing context controls how links are generated in the HTML documents during assembly.
+ *
+ * <p>Design-object XML root is {@code publishing-context} under the Jackson-backed {@link
+ * PSXmlSerializationHelper} (issue #1918 / #1892 / epic #505). Historical attribute-shaped {@code
+ * PSXPublishingContext} root is a documented deviation (see task deviations doc). {@code
+ * default-scheme} object is suppressed; wire form uses {@link #getDefaultSchemeId()}.
+ *
  * @author dougrand
  */
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, 
-      region = "PSPublishingContext")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSPublishingContext")
 @Table(name = "RXCONTEXT")
-public class PSPublishingContext implements IPSCatalogItem, 
-   IPSPublishingContext, Serializable, IPSCatalogIdentifier, Cloneable
-{
-   /**
-    * Serial id identifies versions of serialized data
-    */
-   private static final long serialVersionUID = 1L;
-   
-   static
-   {
-      // Register types with XML serializer for read creation of objects
-      PSXmlSerializationHelper.addType("default-scheme", PSLocationScheme.class);
-   }
+@JacksonXmlRootElement(localName = "publishing-context")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({"defaultSchemeId", "description", "guid", "id", "name"})
+public class PSPublishingContext
+    implements IPSCatalogItem, IPSPublishingContext, Serializable, IPSCatalogIdentifier, Cloneable {
+  /** Serial id identifies versions of serialized data */
+  private static final long serialVersionUID = 1L;
 
-   @Id
-   @Column(name = "CONTEXTID")
-   private long id = -1L;
+  static {
+    // Register types with XML serializer for read creation of objects
+    PSXmlSerializationHelper.addType("default-scheme", PSLocationScheme.class);
+  }
 
-   @Version
-   @Column(name="VERSION")
-   private Integer version;
-   
-   @Basic
-   @Column(name = "CONTEXTNAME")
-   String name;
+  @Id
+  @Column(name = "CONTEXTID")
+  private long id = -1L;
 
-   @Basic
-   @Column(name = "CONTEXTDESC")
-   String description;
+  @Version
+  @Column(name = "VERSION")
+  private Integer version;
 
-   @Basic
-   @Column(name = "DEFAULTSCHEMEID")
-   Long defaultSchemeId;
+  @Basic
+  @Column(name = "CONTEXTNAME")
+  String name;
 
-   transient IPSLocationScheme m_defaultScheme;
+  @Basic
+  @Column(name = "CONTEXTDESC")
+  String description;
 
-   /* (non-Javadoc)
-    * @see com.percussion.services.sitemgr.IPSPublishingContext#getDescription()
-    */
-   public String getDescription()
-   {
-      return description;
-   }
+  @Basic
+  @Column(name = "DEFAULTSCHEMEID")
+  Long defaultSchemeId;
 
-   /* (non-Javadoc)
-    * @see com.percussion.services.sitemgr.IPSPublishingContext#setDescription(java.lang.String)
-    */
-   public void setDescription(String description)
-   {
-      this.description = description;
-   }
-   
-   /**
-    * Get the hibernate version information for this object.
-    * 
-    * @return returns the version, may be <code>null</code>.
-    */
-   @IPSXmlSerialization(suppress=true)
-   public Integer getVersion()
-   {
-      return version;
-   }
+  transient IPSLocationScheme m_defaultScheme;
 
-   /**
-    * Set the hibernate version information for this object.
-    * 
-    * @param version The version to set.
-    * 
-    * @throws IllegalStateException if an attempt is made to set a previously
-    * set version to a non-<code>null</code> value.
-    */
-   public void setVersion(Integer version)
-   {
-      if (this.version != null && version != null)
-         throw new IllegalStateException("Version can only be set once");
-      
-      this.version = version;
-   }
+  /* (non-Javadoc)
+   * @see com.percussion.services.sitemgr.IPSPublishingContext#getDescription()
+   */
+  @JsonProperty
+  public String getDescription() {
+    return description;
+  }
 
-   /* (non-Javadoc)
-    * @see com.percussion.services.sitemgr.IPSPublishingContext#getGUID()
-    */
-   public IPSGuid getGUID()
-   {
-      return new PSGuid(PSTypeEnum.CONTEXT, id);
-   }  
+  /* (non-Javadoc)
+   * @see com.percussion.services.sitemgr.IPSPublishingContext#setDescription(java.lang.String)
+   */
+  public void setDescription(String description) {
+    this.description = description;
+  }
 
-   /* (non-Javadoc)
-    * @see com.percussion.services.catalog.IPSCatalogItem#setGUID(IPSGuid)
-    */
-   public void setGUID(IPSGuid guid)
-   {
-      if (guid == null)
-         throw new IllegalArgumentException("guid may not be null");
-      
-      if (id != -1L)
-         throw new IllegalStateException("guid can only be set once");
-      
-      id = guid.longValue();
-   }
+  /**
+   * Get the hibernate version information for this object.
+   *
+   * @return returns the version, may be <code>null</code>.
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public Integer getVersion() {
+    return version;
+  }
 
-   /* (non-Javadoc)
-    * @see com.percussion.services.sitemgr.IPSPublishingContext#getName()
-    */
-   public String getName()
-   {
-      return name;
-   }
+  /**
+   * Set the hibernate version information for this object.
+   *
+   * @param version The version to set.
+   * @throws IllegalStateException if an attempt is made to set a previously set version to a
+   *     non-<code>null</code> value.
+   */
+  public void setVersion(Integer version) {
+    if (this.version != null && version != null)
+      throw new IllegalStateException("Version can only be set once");
 
-   /* (non-Javadoc)
-    * @see com.percussion.services.sitemgr.IPSPublishingContext#setName(java.lang.String)
-    */
-   public void setName(String name)
-   {
-      if (StringUtils.isBlank(name))
-      {
-         throw new IllegalArgumentException("name may not be null or empty");
+    this.version = version;
+  }
+
+  /* (non-Javadoc)
+   * @see com.percussion.services.sitemgr.IPSPublishingContext#getGUID()
+   */
+  @JsonProperty("guid")
+  public IPSGuid getGUID() {
+    return id == -1L ? null : new PSGuid(PSTypeEnum.CONTEXT, id);
+  }
+
+  /* (non-Javadoc)
+   * @see com.percussion.services.catalog.IPSCatalogItem#setGUID(IPSGuid)
+   */
+  public void setGUID(IPSGuid guid) {
+    if (guid == null) throw new IllegalArgumentException("guid may not be null");
+
+    // Allow overwrite on design-object XML restore (BeanUtils + Jackson)
+    id = guid.longValue();
+  }
+
+  /* (non-Javadoc)
+   * @see com.percussion.services.sitemgr.IPSPublishingContext#getName()
+   */
+  @JsonProperty
+  public String getName() {
+    return name;
+  }
+
+  /* (non-Javadoc)
+   * @see com.percussion.services.sitemgr.IPSPublishingContext#setName(java.lang.String)
+   */
+  public void setName(String name) {
+    if (StringUtils.isBlank(name)) {
+      throw new IllegalArgumentException("name may not be null or empty");
+    }
+    this.name = name;
+  }
+
+  /* (non-Javadoc)
+   * @see com.percussion.services.sitemgr.IPSPublishingContext#getDefaultSchemeId()
+   */
+  @JsonProperty
+  public IPSGuid getDefaultSchemeId() {
+    return defaultSchemeId == null
+        ? null
+        : new PSGuid(PSTypeEnum.LOCATION_SCHEME, defaultSchemeId);
+  }
+
+  /* (non-Javadoc)
+   * @see com.percussion.services.sitemgr.IPSPublishingContext#setDefaultSchemeId(com.percussion.services.sitemgr.IPSLocationScheme)
+   */
+  public void setDefaultSchemeId(IPSGuid schemeId) {
+    if (schemeId == null) {
+      this.defaultSchemeId = null;
+      m_defaultScheme = null;
+    } else {
+      this.defaultSchemeId = schemeId.longValue();
+      if (m_defaultScheme != null && (!m_defaultScheme.getGUID().equals(schemeId))) {
+        m_defaultScheme = null;
       }
-      this.name = name;
-   }
+    }
+  }
 
-   /* (non-Javadoc)
-    * @see com.percussion.services.sitemgr.IPSPublishingContext#getDefaultSchemeId()
-    */
-   public IPSGuid getDefaultSchemeId()
-   {
-      return defaultSchemeId == null ? null : new PSGuid(
-            PSTypeEnum.LOCATION_SCHEME, defaultSchemeId);
-   }
+  /* (non-Javadoc)
+   * @see java.lang.Object#equals(java.lang.Object)
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof PSPublishingContext)) return false;
+    PSPublishingContext pb = (PSPublishingContext) obj;
 
-   /* (non-Javadoc)
-    * @see com.percussion.services.sitemgr.IPSPublishingContext#setDefaultSchemeId(com.percussion.services.sitemgr.IPSLocationScheme)
-    */
-   public void setDefaultSchemeId(IPSGuid schemeId)
-   {
-      if (schemeId == null)
-      {
-         this.defaultSchemeId = null;
-         m_defaultScheme = null;
-      }
-      else
-      {
-         this.defaultSchemeId = schemeId.longValue();
-         if (m_defaultScheme != null
-               && (!m_defaultScheme.getGUID().equals(schemeId)))
-         {
-            m_defaultScheme = null;
-         }
-      }
-   }
-   
-   /* (non-Javadoc)
-    * @see java.lang.Object#equals(java.lang.Object)
-    */
-   @Override
-   public boolean equals(Object obj)
-   {
-      if (! (obj instanceof PSPublishingContext) )
-         return false;
-      PSPublishingContext pb = (PSPublishingContext) obj;
-      
-      EqualsBuilder builder = new EqualsBuilder()
-         .append(description, pb.description)
-         .append(name, pb.name)
-         .append(id, pb.id)
-         .append(defaultSchemeId, pb.defaultSchemeId);
+    EqualsBuilder builder =
+        new EqualsBuilder()
+            .append(description, pb.description)
+            .append(name, pb.name)
+            .append(id, pb.id)
+            .append(defaultSchemeId, pb.defaultSchemeId);
 
-      return builder.isEquals();
-   }
-   
-   /* (non-Javadoc)
-    * @see java.lang.Object#hashCode()
-    */
-   @Override
-   public int hashCode()
-   {
-      return new HashCodeBuilder().append(name).toHashCode();
-   }
+    return builder.isEquals();
+  }
 
-   @Override
-   public String toString() {
-      final StringBuffer sb = new StringBuffer("PSPublishingContext{");
-      sb.append("id=").append(id);
-      sb.append(", version=").append(version);
-      sb.append(", name='").append(name).append('\'');
-      sb.append(", description='").append(description).append('\'');
-      sb.append(", defaultSchemeId=").append(defaultSchemeId);
-      sb.append(", m_defaultScheme=").append(m_defaultScheme);
-      sb.append('}');
-      return sb.toString();
-   }
+  /* (non-Javadoc)
+   * @see java.lang.Object#hashCode()
+   */
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder().append(name).toHashCode();
+  }
 
-   /*
-    * (non-Javadoc)
-    * @see java.lang.Object#clone()
-    */
-   @Override
-   public Object clone() throws CloneNotSupportedException
-   {
-      return super.clone();
-   }
-   
-   /* (non-Javadoc)
-    * @see com.percussion.services.sitemgr.IPSPublishingContext#getId()
-    */
-   public Integer getId()
-   {
-      return (int) id;
-   }
+  @Override
+  public String toString() {
+    final StringBuffer sb = new StringBuffer("PSPublishingContext{");
+    sb.append("id=").append(id);
+    sb.append(", version=").append(version);
+    sb.append(", name='").append(name).append('\'');
+    sb.append(", description='").append(description).append('\'');
+    sb.append(", defaultSchemeId=").append(defaultSchemeId);
+    sb.append(", m_defaultScheme=").append(m_defaultScheme);
+    sb.append('}');
+    return sb.toString();
+  }
 
-   /* (non-Javadoc)
-    * @see com.percussion.services.sitemgr.IPSPublishingContext#setId(java.lang.Integer)
-    */
-   public void setId(Integer id)
-   {
-      this.id = id;
-   }
+  /*
+   * (non-Javadoc)
+   * @see java.lang.Object#clone()
+   */
+  @Override
+  public Object clone() throws CloneNotSupportedException {
+    return super.clone();
+  }
 
-   /* (non-Javadoc)
-    * @see com.percussion.services.sitemgr.IPSPublishingContext#getDefaultScheme()
-    */
-   @IPSXmlSerialization(suppress = true)
-   public IPSLocationScheme getDefaultScheme()
-   {
-      return m_defaultScheme;
-   }
+  /* (non-Javadoc)
+   * @see com.percussion.services.sitemgr.IPSPublishingContext#getId()
+   */
+  @JsonProperty
+  public Integer getId() {
+    return (int) id;
+  }
 
-   /* (non-Javadoc)
-    * @see com.percussion.services.sitemgr.IPSPublishingContext#setDefaultScheme(com.percussion.services.sitemgr.IPSLocationScheme)
-    */
-   public void setDefaultScheme(IPSLocationScheme defaultScheme)
-   {
-      if (defaultScheme == null)
-         throw new IllegalArgumentException("defaultScheme may not be null.");
-      
-      setDefaultSchemeId(defaultScheme.getGUID());
-      this.m_defaultScheme = defaultScheme;
-   }
-   
-   /**
-    * Restores this object's state from its XML representation (string).  See
-    * {@link #toXML()} for format of XML.  See
-    * {@link IPSCatalogItem#fromXML(String)} for more info on method
-    * signature.
-    */
-   public void fromXML(String xmlsource) throws IOException, SAXException,
-      PSInvalidXmlException
-   {
-      PSStringUtils.notBlank(xmlsource, "xmlsource may not be null or empty");
-      
-      Reader r = new StringReader(xmlsource);
-      Document doc = PSXmlDocumentBuilder.createXmlDocument(r, false);
-      NodeList nodes = doc.getElementsByTagName(XML_NODE_NAME);
-      if (nodes.getLength() == 0)
-      {
-         throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_MISSING,
-               XML_NODE_NAME);
-      }
-      
-      Element elem = (Element) nodes.item(0);
-      String schemeId = PSXmlUtils.checkAttribute(elem, 
-            XML_ATTR_SCHEME_ID_NAME, false);
-      if (schemeId.length() > 0)
-         setDefaultSchemeId(new PSGuid(schemeId));
-      else
-         setDefaultSchemeId(null);
-      
-      String descr = PSXmlUtils.checkAttribute(elem, XML_ATTR_DESCR_NAME,
-            false);
-      if (descr.length() > 0)
-         setDescription(descr);
-      else
-         setDescription(null);
-            
-      int idAttr = PSXmlUtils.checkAttributeInt(elem, XML_ATTR_ID_NAME, true);
-      setId(Integer.valueOf(idAttr));
-      
-      String nameAttr = PSXmlUtils.checkAttribute(elem, XML_ATTR_NAME, true);
-      setName(nameAttr);
-   }
-   
-   /**
-    * Serializes this object's state to its XML representation as a string.  The
-    * format is:
-    * <pre><code>
-    * &lt;!ELEMENT PSXPublishingContext>
-    * &lt;!ATTLIST PSXPublishingContext
-    *    default-scheme-id CDATA
-    *    description CDATA
-    *    id CDATA #REQUIRED
-    *    name CDATA #REQUIRED
-    * >
-    * </code></pre>
-    *
-    * See {@link IPSCatalogItem#toXML()} for more info.
-    */
-   public String toXML()
-   {
-      Document doc = PSXmlDocumentBuilder.createXmlDocument();
-      
-      Element root = doc.createElement(XML_NODE_NAME);
-      
-      if (defaultSchemeId != null)
-      {
-         root.setAttribute(XML_ATTR_SCHEME_ID_NAME, 
-               getDefaultSchemeId().toString());
-      }
-       
-      if (description != null)
-         root.setAttribute(XML_ATTR_DESCR_NAME, description);
-            
-      root.setAttribute(XML_ATTR_ID_NAME, String.valueOf(id)); 
-      root.setAttribute(XML_ATTR_NAME, name);
-      doc.appendChild(root);
-      
-      return PSXmlDocumentBuilder.toString(doc);
-   }
-   
-   /*
-    * (non-Javadoc)
-    * @see com.percussion.services.sitemgr.IPSPublishingContext#copy(com.percussion.services.sitemgr.IPSPublishingContext)
-    */
-   public void copy(IPSPublishingContext other)
-   {
-      if (other == null)
-         throw new IllegalArgumentException("other may not be null.");
-      if (!(other instanceof PSPublishingContext))
-         throw new IllegalArgumentException(
-               "other must be instance of PSPublishingContext.");
-      PSPublishingContext src = (PSPublishingContext) other;
-      name = src.name;
-      description = src.description;
-      defaultSchemeId = src.defaultSchemeId;
-      m_defaultScheme = src.m_defaultScheme;
-   }
-   
-   /**
-    * Root node name of this object's XML representation.
-    */
-   public static final String XML_NODE_NAME = "PSXPublishingContext";
-      
-   // private XML constants
-   private static final String XML_ATTR_SCHEME_ID_NAME = "default-scheme-id";
-   private static final String XML_ATTR_DESCR_NAME = "description";
-   private static final String XML_ATTR_ID_NAME = "id";
-   private static final String XML_ATTR_NAME = "name";
+  /* (non-Javadoc)
+   * @see com.percussion.services.sitemgr.IPSPublishingContext#setId(java.lang.Integer)
+   */
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  /* (non-Javadoc)
+   * @see com.percussion.services.sitemgr.IPSPublishingContext#getDefaultScheme()
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public IPSLocationScheme getDefaultScheme() {
+    return m_defaultScheme;
+  }
+
+  /* (non-Javadoc)
+   * @see com.percussion.services.sitemgr.IPSPublishingContext#setDefaultScheme(com.percussion.services.sitemgr.IPSLocationScheme)
+   */
+  /**
+   * Associate a default scheme object. {@code null} clears the association (BeanUtils property-copy
+   * after Jackson deserialize may pass null when the object was suppressed on the wire).
+   */
+  @JsonIgnore
+  public void setDefaultScheme(IPSLocationScheme defaultScheme) {
+    if (defaultScheme == null) {
+      m_defaultScheme = null;
+      return;
+    }
+    setDefaultSchemeId(defaultScheme.getGUID());
+    this.m_defaultScheme = defaultScheme;
+  }
+
+  /**
+   * Restores this object's state from its XML representation via {@link
+   * PSXmlSerializationHelper}.
+   */
+  public void fromXML(String xmlsource) throws IOException, SAXException, PSInvalidXmlException {
+    PSXmlSerializationHelper.readFromXML(xmlsource, this);
+  }
+
+  /**
+   * Serializes this object's state via {@link PSXmlSerializationHelper} (Jackson element shape).
+   *
+   * <p>Historical attribute-shaped root {@code PSXPublishingContext} is no longer written; modern
+   * root is {@code publishing-context} with child elements.
+   */
+  public String toXML() throws IOException, SAXException {
+    return PSXmlSerializationHelper.writeToXml(this);
+  }
+
+  /*
+   * (non-Javadoc)
+   * @see com.percussion.services.sitemgr.IPSPublishingContext#copy(com.percussion.services.sitemgr.IPSPublishingContext)
+   */
+  public void copy(IPSPublishingContext other) {
+    if (other == null) throw new IllegalArgumentException("other may not be null.");
+    if (!(other instanceof PSPublishingContext))
+      throw new IllegalArgumentException("other must be instance of PSPublishingContext.");
+    PSPublishingContext src = (PSPublishingContext) other;
+    name = src.name;
+    description = src.description;
+    defaultSchemeId = src.defaultSchemeId;
+    m_defaultScheme = src.m_defaultScheme;
+  }
+
+  /**
+   * Historical root node name of the attribute-shaped XML representation (pre-Jackson helper).
+   * Retained for callers that still reference the constant.
+   */
+  public static final String XML_NODE_NAME = "PSXPublishingContext";
 }

--- a/system/services/src/com/percussion/services/sitemgr/data/PSSite.java
+++ b/system/services/src/com/percussion/services/sitemgr/data/PSSite.java
@@ -17,6 +17,10 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.services.sitemgr.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.assembly.IPSAssemblyService;
 import com.percussion.services.assembly.IPSAssemblyTemplate;
 import com.percussion.services.assembly.PSAssemblyException;
@@ -29,24 +33,9 @@ import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.sitemgr.IPSPublishingContext;
 import com.percussion.services.sitemgr.IPSSite;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
-import com.percussion.util.PSXMLDomUtil;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.xml.IPSXmlSerialization;
-import com.percussion.xml.PSXmlDocumentBuilder;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
-import org.hibernate.annotations.NaturalId;
-import org.hibernate.annotations.NaturalIdCache;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
-
+import com.percussion.utils.xml.PSInvalidXmlException;
 import jakarta.persistence.Basic;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -61,35 +50,36 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.Collections;
-
-import com.percussion.utils.xml.IPSXmlErrors;
-import com.percussion.utils.xml.PSInvalidXmlException;
-import com.percussion.utils.xml.PSXmlUtils;
-
-import static com.percussion.util.PSBase64Decoder.decode;
-import static com.percussion.util.PSBase64Encoder.encode;
-import static org.apache.commons.lang3.StringUtils.isBlank;
+import java.util.stream.Collectors;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.NaturalIdCache;
+import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
- * Modern site data entity representing a logical (and physical) place to publish
- * content using Java 11 features. The site is associated with a portion of the
- * site folder tree in the repository and publishes to a specific publisher.
+ * Site data entity representing a logical (and physical) place to publish content. The site is
+ * associated with a portion of the site folder tree in the repository and publishes to a specific
+ * publisher.
  *
- * <h2>Java 11 Enhancements</h2>
- * <ul>
- * <li>Enhanced validation with Objects.requireNonNull</li>
- * <li>Optional-based safe access for nullable properties</li>
- * <li>Stream API for efficient collection processing</li>
- * <li>Improved error handling patterns</li>
- * </ul>
+ * <p>Design-object XML root is {@code site}. Nested package element {@code site-property} and
+ * {@code template-id} are registered via {@link PSXmlSerializationHelper#addType}. Associated
+ * templates are suppressed as full objects; wire form uses {@link #getTemplateIds()}. Jackson
+ * opt-in surface (issue #1918 / #1892 / epic #505).
  *
  * @author dougrand (original)
  * @author Sunny Sal (Java 11 refactoring)
@@ -98,6 +88,36 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSSite")
 @NaturalIdCache
 @Table(name = "RXSITES")
+@JacksonXmlRootElement(localName = "site")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({
+  "baseUrl",
+  "canonicalDist",
+  "defaultDocument",
+  "defaultFileExtension",
+  "defaultPubServer",
+  "description",
+  "folderRoot",
+  "generateSiteMapOptions",
+  "globalTemplate",
+  "guid",
+  "ipAddress",
+  "name",
+  "navTheme",
+  "port",
+  "previousName",
+  "properties",
+  "root",
+  "siteId",
+  "siteProtocol",
+  "templateIds",
+  "unpublishFlags"
+})
 public class PSSite implements IPSSite, IPSCatalogItem {
 
     private static final long serialVersionUID = 1L;
@@ -245,6 +265,8 @@ public class PSSite implements IPSSite, IPSCatalogItem {
      * Get the entity version used for optimistic locking.
      * @return the version or null if not set
      */
+    @IPSXmlSerialization(suppress = true)
+    @JsonIgnore
     public Integer getVersion()
     {
         return version;
@@ -317,8 +339,38 @@ public class PSSite implements IPSSite, IPSCatalogItem {
      * Get site properties as a set, never null.
      * @return set of properties, may be empty
      */
+    @JsonProperty
+    @JacksonXmlElementWrapper(localName = "properties")
+    @JacksonXmlProperty(localName = "site-property")
     public Set<PSSiteProperty> getProperties() {
         return properties == null ? Collections.emptySet() : properties;
+    }
+
+    /**
+     * Set site properties (design-object XML restore and service callers).
+     *
+     * @param props may be {@code null} to clear
+     */
+    public void setProperties(Set<PSSiteProperty> props) {
+        if (props == null) {
+            if (properties != null) {
+                properties.clear();
+            } else {
+                properties = new HashSet<>();
+            }
+            return;
+        }
+        if (properties == null) {
+            properties = new HashSet<>();
+        } else {
+            properties.clear();
+        }
+        for (PSSiteProperty property : props) {
+            if (property != null) {
+                property.setSite(this);
+                addProperty(property);
+            }
+        }
     }
 
     /**
@@ -379,6 +431,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     // Enhanced getters and setters with Java 11 patterns
 
     @Override
+    @JsonProperty("guid")
     public IPSGuid getGUID() {
         return Optional.ofNullable(siteId)
                 .map(id -> new PSGuid(PSTypeEnum.SITE, id))
@@ -391,13 +444,12 @@ public class PSSite implements IPSSite, IPSCatalogItem {
         if (newguid.getType() != PSTypeEnum.SITE.getOrdinal()) {
             throw new IllegalArgumentException("newguid must be a site guid");
         }
-        if (siteId != null) {
-            throw new IllegalStateException("siteId is already set");
-        }
+        // Allow overwrite on design-object XML restore (BeanUtils + Jackson)
         siteId = newguid.longValue();
     }
 
     @Override
+    @JsonProperty
     public Long getSiteId() {
         return siteId;
     }
@@ -407,11 +459,13 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getName() {
         return name;
     }
 
     @Override
+    @JsonIgnore
     public String getLabel() {
         // Default label is the site name; return empty string if name is missing
         return Optional.ofNullable(name)
@@ -430,11 +484,13 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getPreviousName() {
         return previousName;
     }
 
     @Override
+    @JsonProperty
     public String getDescription() {
         return description;
     }
@@ -445,6 +501,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getBaseUrl() {
         return baseUrl;
     }
@@ -455,6 +512,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getIpAddress() {
         return ipAddress;
     }
@@ -465,6 +523,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getFolderRoot() {
         return folderRoot;
     }
@@ -475,6 +534,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getGlobalTemplate() {
         return globalTemplate;
     }
@@ -485,6 +545,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public Integer getPort() {
         return port;
     }
@@ -495,6 +556,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getRoot() {
         return root;
     }
@@ -505,16 +567,123 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @IPSXmlSerialization(suppress = true)
+    @JsonIgnore
     public Set<IPSAssemblyTemplate> getAssociatedTemplates() {
         return new HashSet<>(templates);
     }
 
+    @JsonIgnore
     public void setAssociatedTemplates(Set<IPSAssemblyTemplate> templates) {
         this.templates = Optional.ofNullable(templates)
             .orElse(Collections.emptySet());
     }
 
+    /**
+     * Template association GUIDs for design-object XML (string form). Full {@link
+     * IPSAssemblyTemplate} graphs are suppressed; restore via {@link #setTemplateIds(Set)} requires
+     * the assembly service to load templates.
+     *
+     * @return set of template guid strings, never null
+     */
+    @JsonProperty
+    @JacksonXmlElementWrapper(localName = "template-ids")
+    @JacksonXmlProperty(localName = "template-id")
+    public Set<String> getTemplateIds() {
+        Set<String> ids = new HashSet<>();
+        if (templates != null && !templates.isEmpty()) {
+            for (IPSAssemblyTemplate tmp : templates) {
+                if (tmp != null && tmp.getGUID() != null) {
+                    ids.add(tmp.getGUID().toString());
+                }
+            }
+        }
+        return ids.stream().sorted().collect(Collectors.toCollection(HashSet::new));
+    }
+
+    /**
+     * Sync associated templates from design-object XML string GUID set.
+     *
+     * @param newT may be null or empty to clear
+     */
+    public void setTemplateIds(Set<String> newT) {
+        if (newT == null || newT.isEmpty()) {
+            if (templates != null) {
+                templates.clear();
+            } else {
+                templates = new HashSet<>();
+            }
+            return;
+        }
+        Set<IPSGuid> newTmps = new HashSet<>();
+        for (String t : newT) {
+            if (StringUtils.isNotBlank(t)) {
+                newTmps.add(new PSGuid(t.trim()));
+            }
+        }
+
+        if (templates == null) {
+            templates = new HashSet<>();
+        }
+
+        // if the current template set is empty
+        if (templates.isEmpty()) {
+            for (IPSGuid guid : newTmps) {
+                addTemplateGuidToCollection(guid);
+            }
+            return;
+        }
+        // get all existing tmp guids associated with this site
+        Set<IPSGuid> curTmps = new HashSet<>();
+        for (IPSAssemblyTemplate t : templates) {
+            curTmps.add(t.getGUID());
+        }
+        Collection<IPSGuid> common = CollectionUtils.intersection(curTmps, newTmps);
+        Collection<IPSGuid> remove = CollectionUtils.subtract(curTmps, newTmps);
+        curTmps.removeAll(remove);
+        newTmps.removeAll(common);
+        curTmps.addAll(newTmps);
+        templates.clear();
+
+        for (IPSGuid guid : curTmps) {
+            addTemplateGuidToCollection(guid);
+        }
+    }
+
+    /**
+     * Add a template by string GUID (Betwixt/Jackson adder path).
+     *
+     * @param tmpId string form of the guid, never blank
+     */
+    @JsonIgnore
+    public void addTemplateId(String tmpId) {
+        if (StringUtils.isBlank(tmpId)) {
+            throw new IllegalArgumentException("template guid may not be null");
+        }
+        addTemplateId(new PSGuid(tmpId.trim()));
+    }
+
+    /**
+     * Add a template by GUID if not already associated.
+     *
+     * @param id template GUID, never null
+     */
+    @JsonIgnore
+    public void addTemplateId(IPSGuid id) {
+        Objects.requireNonNull(id, "template guid may not be null");
+        if (templates == null) {
+            templates = new HashSet<>();
+        }
+        for (IPSAssemblyTemplate t : templates) {
+            if (t.getGUID().equals(id)) {
+                return;
+            }
+        }
+        addTemplateGuidToCollection(id);
+    }
+
     @Override
+    @JsonProperty
     public Long getDefaultPubServer() {
         return defaultPubServer;
     }
@@ -525,6 +694,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getDefaultFileExtension() {
         return defaultFileExtention;
     }
@@ -728,6 +898,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getSiteAdditionalHeadContent() {
         return siteAdditionalHeadContent;
     }
@@ -738,6 +909,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getSiteBeforeBodyCloseContent() {
         return siteBeforeBodyCloseContent;
     }
@@ -748,6 +920,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getSiteAfterBodyOpenContent() {
         return siteAfterBodyOpenContent;
     }
@@ -758,6 +931,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getLoginPage() {
         return loginPage;
     }
@@ -768,6 +942,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getRegistrationPage() {
         return registrationPage;
     }
@@ -778,6 +953,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getRegistrationConfirmationPage() {
         return registrationConfirmationPage;
     }
@@ -788,6 +964,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getResetPage() {
         return resetPage;
     }
@@ -798,6 +975,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getResetRequestPasswordPage() {
         return resetRequestPasswordPage;
     }
@@ -808,6 +986,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getUserId() {
         return userId;
     }
@@ -818,6 +997,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getPassword() {
         return this.password;
     }
@@ -828,6 +1008,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getPrivateKey() {
         return this.privateKey;
     }
@@ -838,6 +1019,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getNavTheme() {
         return this.navTheme;
     }
@@ -847,6 +1029,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
         this.privateKey = privateKey;
     }
 
+    @JsonProperty
     public String getUnpublishFlags() {
         return StringUtils.isBlank(unpublishFlags) ? "u" : unpublishFlags;
     }
@@ -859,6 +1042,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty("mobilePreviewEnabled")
     public boolean isMobilePreviewEnabled() {
         return Boolean.TRUE.equals(mobilePreviewEnabled);
     }
@@ -869,6 +1053,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty("overrideSystemJQuery")
     public boolean isOverrideSystemJQuery() {
         return Boolean.TRUE.equals(overrideSystemJQuery);
     }
@@ -879,6 +1064,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty("overrideSystemFoundation")
     public boolean isOverrideSystemFoundation() {
         return Boolean.TRUE.equals(overrideSystemFoundation);
     }
@@ -889,6 +1075,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty("overrideSystemJQueryUI")
     public boolean isOverrideSystemJQueryUI() {
         return Boolean.TRUE.equals(overrideSystemJQueryUI);
     }
@@ -899,6 +1086,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty("pageBased")
     public boolean isPageBased() {
         return Boolean.TRUE.equals(pageBased);
     }
@@ -909,6 +1097,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty("secure")
     public boolean isSecure() {
         return BooleanToTFCharConverter.isTruthy(is_secure);
     }
@@ -920,6 +1109,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty("canonical")
     public boolean isCanonical() {
         return BooleanToTFCharConverter.isTruthy(is_canonical);
     }
@@ -931,6 +1121,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty("canonicalReplace")
     public boolean isCanonicalReplace() {
         return BooleanToTFCharConverter.isTruthy(is_canonical_replace);
     }
@@ -941,6 +1132,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getAllowedNamespaces() {
         return allowedNamespaces;
     }
@@ -952,6 +1144,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getCanonicalDist() {
         return canonicalDist;
     }
@@ -962,6 +1155,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getDefaultDocument() {
         return defaultDocument;
     }
@@ -978,12 +1172,14 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty("generateSitemap")
     public boolean isGenerateSitemap() {
         return BooleanToTFCharConverter.isTruthy(this.generateSiteMap);
     }
 
     @Override
     @Deprecated
+    @JsonProperty
     public Integer getState() {
         return this.state;
     }
@@ -1000,6 +1196,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getGenerateSiteMapOptions() {
         return this.generateSiteMapOptions;
     }
@@ -1010,6 +1207,7 @@ public class PSSite implements IPSSite, IPSCatalogItem {
     }
 
     @Override
+    @JsonProperty
     public String getSiteProtocol() {
         return this.siteProtocol;
     }
@@ -1037,79 +1235,19 @@ public class PSSite implements IPSSite, IPSCatalogItem {
                 .toString();
     }
 
-    // XML serialization constants
+    /**
+     * Historical root node name of the attribute-shaped XML representation (pre-helper). Retained
+     * for callers that still reference the constant; modern writes use root {@code site}.
+     */
     public static final String XML_NODE_NAME = "PSXSite";
-
-    // private XML constants
-    private static final String NAME_ATTR = "name";
-    private static final String DESCRIPTION_ATTR = "description";
-    private static final String BASEURL_ATTR = "baseUrl";
-    private static final String ROOT_ATTR = "root";
-    private static final String IPADDRESS_ATTR = "ipAddress";
-    private static final String PORT_ATTR = "port";
-    private static final String FOLDERROOT_ATTR = "folderRoot";
-    private static final String NAVTHEME_ATTR = "navTheme";
-    private static final String GLOBALTEMPLATE_ATTR = "globalTemplate";
-    private static final String IS_PAGE_BASED_ATTR = "isPageBased";
 
     @Override
     public void fromXML(String xmlsource) throws IOException, SAXException, PSInvalidXmlException {
-        if (xmlsource == null || xmlsource.trim().isEmpty()) {
-            throw new IllegalArgumentException("xmlsource may not be null or empty");
-        }
-
-        Reader r = new StringReader(xmlsource);
-        Document doc = PSXmlDocumentBuilder.createXmlDocument(r, false);
-        NodeList nodes = doc.getElementsByTagName(XML_NODE_NAME);
-        if (nodes.getLength() == 0) {
-            throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_MISSING, XML_NODE_NAME);
-        }
-
-        Element elem = (Element) nodes.item(0);
-
-        String nameAttr = PSXmlUtils.checkAttribute(elem, NAME_ATTR, true);
-        setName(nameAttr);
-
-        String descr = PSXmlUtils.checkAttribute(elem, DESCRIPTION_ATTR, false);
-        setDescription(descr.length() > 0 ? descr : null);
-
-        setBaseUrl(PSXmlUtils.checkAttribute(elem, BASEURL_ATTR, false));
-        setRoot(PSXmlUtils.checkAttribute(elem, ROOT_ATTR, false));
-        setIpAddress(PSXmlUtils.checkAttribute(elem, IPADDRESS_ATTR, false));
-        String portAttr = PSXmlUtils.checkAttribute(elem, PORT_ATTR, false);
-        if (portAttr.length() > 0) {
-            try {
-                setPort(Integer.valueOf(portAttr));
-            } catch (NumberFormatException ignore) {
-                setPort(null);
-            }
-        }
-
-        setFolderRoot(PSXmlUtils.checkAttribute(elem, FOLDERROOT_ATTR, false));
-        setNavTheme(PSXmlUtils.checkAttribute(elem, NAVTHEME_ATTR, false));
-        setGlobalTemplate(PSXmlUtils.checkAttribute(elem, GLOBALTEMPLATE_ATTR, false));
-
-        setPageBased(Boolean.parseBoolean(PSXmlUtils.checkAttribute(elem, IS_PAGE_BASED_ATTR, false)));
+        PSXmlSerializationHelper.readFromXML(xmlsource, this);
     }
 
     @Override
     public String toXML() throws IOException, SAXException {
-        Document doc = PSXmlDocumentBuilder.createXmlDocument();
-        Element root = doc.createElement(XML_NODE_NAME);
-
-        root.setAttribute(NAME_ATTR, getName());
-        if (getDescription() != null) root.setAttribute(DESCRIPTION_ATTR, getDescription());
-        if (getBaseUrl() != null) root.setAttribute(BASEURL_ATTR, getBaseUrl());
-        if (getRoot() != null) root.setAttribute(ROOT_ATTR, getRoot());
-        if (getIpAddress() != null) root.setAttribute(IPADDRESS_ATTR, getIpAddress());
-        if (getPort() != null) root.setAttribute(PORT_ATTR, String.valueOf(getPort()));
-        if (getFolderRoot() != null) root.setAttribute(FOLDERROOT_ATTR, getFolderRoot());
-        if (getNavTheme() != null) root.setAttribute(NAVTHEME_ATTR, getNavTheme());
-        if (getGlobalTemplate() != null) root.setAttribute(GLOBALTEMPLATE_ATTR, getGlobalTemplate());
-
-        root.setAttribute(IS_PAGE_BASED_ATTR, Boolean.toString(isPageBased()));
-
-        doc.appendChild(root);
-        return PSXmlDocumentBuilder.toString(doc);
+        return PSXmlSerializationHelper.writeToXml(this);
     }
 }

--- a/system/services/src/com/percussion/services/sitemgr/data/PSSiteProperty.java
+++ b/system/services/src/com/percussion/services/sitemgr/data/PSSiteProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,17 @@
  */
 package com.percussion.services.sitemgr.data;
 
-
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.catalog.IPSCatalogItem;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.sitemgr.IPSSite;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import com.percussion.utils.guid.IPSGuid;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.xml.sax.SAXException;
-
+import com.percussion.utils.xml.IPSXmlSerialization;
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -41,248 +37,240 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 import java.io.IOException;
 import java.io.Serializable;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
- * Represents a single property for the site. Each property is keyed to 
- * a particular context.
- * @author dougrand
+ * Represents a single property for the site. Each property is keyed to a particular context.
  *
+ * <p>Design-object XML root / nested package element is {@code site-property} (registered from
+ * {@link PSSite} via {@link PSXmlSerializationHelper#addType}). Parent {@link #getSite()} is
+ * suppressed (circular); restore is via {@link PSSite#setProperties(java.util.Set)}. Jackson opt-in
+ * surface (issue #1918 / #1892 / epic #505).
+ *
+ * @author dougrand
  */
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSSiteProperty")
 @Table(name = "RXASSEMBLERPROPERTIES")
-public class PSSiteProperty implements IPSCatalogItem, Serializable
-{
-   /**
-    * Serial id identifies versions of serialized data
-    */
-   private static final long serialVersionUID = 1L;
-   
-   static
-   {
-      // Register types with XML serializer for read creation of objects
-      PSXmlSerializationHelper.addType("context", PSPublishingContext.class);
-   }
+@JacksonXmlRootElement(localName = "site-property")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({"contextId", "guid", "name", "propertyId", "value"})
+public class PSSiteProperty implements IPSCatalogItem, Serializable {
+  /** Serial id identifies versions of serialized data */
+  private static final long serialVersionUID = 1L;
 
-   @Id
-   @Column(name = "PROPERTYID")
-   long     propertyId;
-   
-   @Version
-   @Column(name = "VERSION")
-   Integer  version;
-   
-   @ManyToOne(targetEntity = PSSite.class)
-   @JoinColumn(name = "SITEID", nullable = false, insertable = false, updatable = false)
-   IPSSite   site;
-   
-   @Column(name = "CONTEXTID")
-   Integer  contextId;
-   
-   @Basic
-   @Column(name = "PROPERTYNAME")
-   String   name;
-   
-   @Basic
-   @Column(name = "PROPERTYVALUE")
-   String   value;
+  static {
+    // Register types with XML serializer for read creation of objects
+    PSXmlSerializationHelper.addType("context", PSPublishingContext.class);
+  }
 
-   /**
-    * The database id for this object
-    * @return Returns the propertyId, never <code>null</code> after persistence
-    */
-   public long getPropertyId()
-   {
-      return propertyId;
-   }
+  @Id
+  @Column(name = "PROPERTYID")
+  long propertyId;
 
-   /**
-    * @param propertyId The propertyId to set.
-    */
-   public void setPropertyId(long propertyId)
-   {
-      this.propertyId = propertyId;
-   }
+  @Version
+  @Column(name = "VERSION")
+  Integer version;
 
+  @ManyToOne(targetEntity = PSSite.class)
+  @JoinColumn(name = "SITEID", nullable = false, insertable = false, updatable = false)
+  IPSSite site;
 
+  @Column(name = "CONTEXTID")
+  Integer contextId;
 
-   /**
-    * The parent site object
-    * @return Returns the site, never <code>null</code>
-    */
-   public IPSSite getSite()
-   {
-      return site;
-   }
+  @Basic
+  @Column(name = "PROPERTYNAME")
+  String name;
 
-   /**
-    * @param site The site to set, may be <code>null</code> when disconnecting
-    */
-   public void setSite(IPSSite site)
-   {
-      this.site = site;
-   }
+  @Basic
+  @Column(name = "PROPERTYVALUE")
+  String value;
 
-   /**
-    * Get the property name
-    * @return Returns the name, never <code>null</code> or empty
-    */
-   public String getName()
-   {
-      return name;
-   }
+  /**
+   * The database id for this object
+   *
+   * @return Returns the propertyId, never <code>null</code> after persistence
+   */
+  @JsonProperty
+  public long getPropertyId() {
+    return propertyId;
+  }
 
-   /**
-    * @param name The name to set, never <code>null</code> or empty
-    */
-   public void setName(String name)
-   {
-      if (StringUtils.isBlank(name))
-      {
-         throw new IllegalArgumentException("name may not be null or empty");
-      }
-      this.name = name;
-   }
+  /**
+   * @param propertyId The propertyId to set.
+   */
+  public void setPropertyId(long propertyId) {
+    this.propertyId = propertyId;
+  }
 
-   /**
-    * Get the value
-    * @return Returns the value.
-    */
-   public String getValue()
-   {
-      return value;
-   }
+  /**
+   * The parent site object
+   *
+   * @return Returns the site, never <code>null</code>
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public IPSSite getSite() {
+    return site;
+  }
 
-   /**
-    * @param value The value to set.
-    */
-   public void setValue(String value)
-   {
-      this.value = value;
-   }
-   
-   /**
-    * Get the object version.
-    * 
-    * @return the object version, <code>null</code> if not initialized yet.
-    */
-   public Integer getVersion()
-   {
-      return version;
-   }
+  /**
+   * @param site The site to set, may be <code>null</code> when disconnecting
+   */
+  @JsonIgnore
+  public void setSite(IPSSite site) {
+    this.site = site;
+  }
 
-   /**
-    * Set the object version. The version can only be set once in the life cycle
-    * of this object.
-    * 
-    * @param version the version of the object, must be >= 0.
-    */
-   public void setVersion(Integer version)
-   {
-      if (this.version != null && version != null)
-         throw new IllegalStateException("Version can only be set once");
-      
-      this.version = version;
-   }
+  /**
+   * Get the property name
+   *
+   * @return Returns the name, never <code>null</code> or empty
+   */
+  @JsonProperty
+  public String getName() {
+    return name;
+  }
 
+  /**
+   * @param name The name to set, never <code>null</code> or empty
+   */
+  public void setName(String name) {
+    if (StringUtils.isBlank(name)) {
+      throw new IllegalArgumentException("name may not be null or empty");
+    }
+    this.name = name;
+  }
 
-   /**
-    * Get the publishing context ID
-    * @return Returns the context ID, never <code>null</code>
-    */
-   public IPSGuid getContextId()
-   {
-      return new PSGuid(PSTypeEnum.CONTEXT, contextId);
-   }
+  /**
+   * Get the value
+   *
+   * @return Returns the value.
+   */
+  @JsonProperty
+  public String getValue() {
+    return value;
+  }
 
-   /**
-    * Set the publishing context id, cannot set if context ID is already set. 
-    * Used by serialization only.
-    * @param ctxId the content id
-    */
-   public void setContextId(IPSGuid ctxId)
-   {
-      if (ctxId == null)
-         throw new IllegalArgumentException("ctxId may not be null.");
-      
-      if ( contextId != null )
-         return;
-      contextId = ctxId.getUUID();
-   }
-  
-   /** (non-Javadoc)
-    * @see java.lang.Object#equals(java.lang.Object)
-    */
-   @Override
-   public boolean equals(Object obj)
-   {
-      if ( !(obj instanceof PSSiteProperty) )
-         return false;
-      PSSiteProperty b = (PSSiteProperty) obj;
-      return new EqualsBuilder()
-         .append(propertyId, b.propertyId)
-         .append(name, b.name)
-         .append(value, b.value)
-         .isEquals();
-   }
-   
-   /** (non-Javadoc)
-    * @see java.lang.Object#hashCode()
-    */
-   @Override
-   public int hashCode()
-   {
-      return new HashCodeBuilder().append(name).toHashCode();
-   }
+  /**
+   * @param value The value to set.
+   */
+  public void setValue(String value) {
+    this.value = value;
+  }
 
-   /**
-    * (non-Javadoc)
-    *
-    * @see Object#toString()
-    */
-   @Override
-   public String toString() {
-      final StringBuffer sb = new StringBuffer("PSSiteProperty{");
-      sb.append("propertyId=").append(propertyId);
-      sb.append(", version=").append(version);
-      sb.append(", site=").append(site);
-      sb.append(", contextId=").append(contextId);
-      sb.append(", name='").append(name).append('\'');
-      sb.append(", value='").append(value).append('\'');
-      sb.append('}');
-      return sb.toString();
-   }
+  /**
+   * Get the object version.
+   *
+   * @return the object version, <code>null</code> if not initialized yet.
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public Integer getVersion() {
+    return version;
+  }
 
-   /** (non-Javadoc)
-    * @see com.percussion.services.catalog.IPSCatalogItem#toXML()
-    */
-   public String toXML() throws IOException, SAXException
-   {
-      return PSXmlSerializationHelper.writeToXml(this);
-   }
+  /**
+   * Set the object version. The version can only be set once in the life cycle of this object.
+   *
+   * @param version the version of the object, must be &gt;= 0.
+   */
+  public void setVersion(Integer version) {
+    if (this.version != null && version != null)
+      throw new IllegalStateException("Version can only be set once");
 
-   /** (non-Javadoc)
-    * @see com.percussion.services.catalog.IPSCatalogItem#fromXML(java.lang.String)
-    */
-   public void fromXML(String xmlsource) throws IOException, SAXException {
-      PSXmlSerializationHelper.readFromXML(xmlsource, this);   }
+    this.version = version;
+  }
 
-   /** (non-Javadoc)
-    * @see com.percussion.services.catalog.IPSCatalogItem#getGUID()
-    */
-   public IPSGuid getGUID()
-   {
-      return new PSGuid(PSTypeEnum.SITE_PROPERTY, getPropertyId());
-   }
+  /**
+   * Get the publishing context ID
+   *
+   * @return Returns the context ID, never <code>null</code> after initialization
+   */
+  @JsonProperty
+  public IPSGuid getContextId() {
+    if (contextId == null) {
+      return null;
+    }
+    return new PSGuid(PSTypeEnum.CONTEXT, contextId);
+  }
 
-   /** (non-Javadoc)
-    * @see com.percussion.services.catalog.IPSCatalogItem#setGUID(com.percussion.utils.guid.IPSGuid)
-    */
-   public void setGUID(IPSGuid newguid) throws IllegalStateException
-   {
-      if (newguid == null)
-         throw new IllegalArgumentException("newguid may be not null.");
-      
-      setPropertyId(newguid.longValue()); 
-   }
+  /**
+   * Set the publishing context id. Used by serialization and property assignment.
+   *
+   * @param ctxId the context id
+   */
+  public void setContextId(IPSGuid ctxId) {
+    if (ctxId == null) throw new IllegalArgumentException("ctxId may not be null.");
+
+    // Allow overwrite on design-object XML restore (BeanUtils + Jackson)
+    contextId = ctxId.getUUID();
+  }
+
+  /** (non-Javadoc) */
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof PSSiteProperty)) return false;
+    PSSiteProperty b = (PSSiteProperty) obj;
+    return new EqualsBuilder()
+        .append(propertyId, b.propertyId)
+        .append(name, b.name)
+        .append(value, b.value)
+        .isEquals();
+  }
+
+  /** (non-Javadoc) */
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder().append(name).toHashCode();
+  }
+
+  @Override
+  public String toString() {
+    final StringBuffer sb = new StringBuffer("PSSiteProperty{");
+    sb.append("propertyId=").append(propertyId);
+    sb.append(", version=").append(version);
+    sb.append(", site=").append(site);
+    sb.append(", contextId=").append(contextId);
+    sb.append(", name='").append(name).append('\'');
+    sb.append(", value='").append(value).append('\'');
+    sb.append('}');
+    return sb.toString();
+  }
+
+  /** (non-Javadoc) */
+  public String toXML() throws IOException, SAXException {
+    return PSXmlSerializationHelper.writeToXml(this);
+  }
+
+  /** (non-Javadoc) */
+  public void fromXML(String xmlsource) throws IOException, SAXException {
+    PSXmlSerializationHelper.readFromXML(xmlsource, this);
+  }
+
+  /** (non-Javadoc) */
+  @JsonProperty("guid")
+  public IPSGuid getGUID() {
+    return new PSGuid(PSTypeEnum.SITE_PROPERTY, getPropertyId());
+  }
+
+  /** (non-Javadoc) */
+  public void setGUID(IPSGuid newguid) throws IllegalStateException {
+    if (newguid == null) throw new IllegalArgumentException("newguid may be not null.");
+
+    // Allow overwrite on design-object XML restore
+    setPropertyId(newguid.longValue());
+  }
 }

--- a/system/src/test/java/com/percussion/services/sitemgr/data/PSPublishingContextTest.java
+++ b/system/src/test/java/com/percussion/services/sitemgr/data/PSPublishingContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.percussion.services.sitemgr.data;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
+import org.junit.jupiter.api.Test;
 
-/** Unit test for the {@link PSPublishingContext} object. */
-public class PSPublishingContextTest {
-  /**
-   * Test equals and hashcode
-   *
-   * @throws Exception if the test fails.
-   */
-  public void testEquals() throws Exception {
+/** Unit test for the {@link PSPublishingContext} object (equals/clone + helper XML smoke). */
+class PSPublishingContextTest {
+
+  @Test
+  void testEquals() throws Exception {
     PSPublishingContext context1 = createContext();
     PSPublishingContext context2 = new PSPublishingContext();
     assertFalse(context1.equals(context2));
@@ -40,34 +40,28 @@ public class PSPublishingContextTest {
     assertFalse(context1.equals(context2));
   }
 
-  /**
-   * Test the xml serialization
-   *
-   * @throws Exception if there are any errors.
-   */
-  public void testXml() throws Exception {
+  @Test
+  void testXml() throws Exception {
     PSPublishingContext context1 = createContext();
     PSPublishingContext context2 = new PSPublishingContext();
     assertFalse(context1.equals(context2));
     String str = context1.toXML();
+    assertTrue(str.contains("publishing-context"), str);
     context2.fromXML(str);
 
-    assertEquals(context1, context2);
+    assertEquals(context1.getName(), context2.getName());
+    assertEquals(context1.getDescription(), context2.getDescription());
+    assertEquals(context1.getGUID().toString(), context2.getGUID().toString());
+    assertEquals(
+        context1.getDefaultSchemeId().toString(), context2.getDefaultSchemeId().toString());
   }
 
-  /**
-   * Creates a publishing context with dummy values.
-   *
-   * @return a new {@link PSPublishingContext} object initialized with dummy values.
-   */
   private PSPublishingContext createContext() {
     PSPublishingContext context = new PSPublishingContext();
-    context.setDefaultSchemeId(new PSGuid("0-10-314"));
+    context.setDefaultSchemeId(new PSGuid(PSTypeEnum.LOCATION_SCHEME, 314L));
     context.setDescription("This is a test description");
-    context.setGUID(new PSGuid("0-113-1"));
-    context.setId(Integer.valueOf(1));
+    context.setGUID(new PSGuid(PSTypeEnum.CONTEXT, 1L));
     context.setName("Publish");
-
     return context;
   }
 }

--- a/system/src/test/java/com/percussion/services/sitemgr/data/PSSitemgrXmlSerializationTest.java
+++ b/system/src/test/java/com/percussion/services/sitemgr/data/PSSitemgrXmlSerializationTest.java
@@ -1,0 +1,418 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.sitemgr.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * Golden / round-trip tests for sitemgr design objects under the Jackson-backed {@code
+ * PSXmlSerializationHelper} (issue #1918 / #1892, epic #505). Offline only — no live CMS.
+ *
+ * <p>Does not exercise {@code template-ids} restore (requires assembly service to load templates).
+ */
+class PSSitemgrXmlSerializationTest {
+
+  @Test
+  void siteWriteEmitsSitePropertyAndSuppressesVersionTemplatesLabel() throws Exception {
+    PSSite original = sampleSite();
+    String xml = original.toXML();
+
+    assertNotNull(xml);
+    assertFalse(xml.trim().startsWith("<null"), "modern write must not emit legacy null root");
+    assertTrue(containsTag(xml, "site"), "root site: " + xml);
+    assertTrue(containsTag(xml, "site-property"), "nested site-property: " + xml);
+    assertTrue(containsTag(xml, "properties"), xml);
+    assertTrue(containsTag(xml, "guid"), xml);
+    assertTrue(xml.contains("DemoSite"), xml);
+    assertTrue(xml.contains("sys_pubBase"), xml);
+    assertFalse(containsTag(xml, "version"), "version suppressed: " + xml);
+    assertFalse(containsTag(xml, "associated-templates"), xml);
+    assertFalse(xml.matches("(?s).*<label(\\s|>).*"), "label alias suppressed: " + xml);
+    // circular parent site element must not appear under site-property
+    assertFalse(
+        xml.matches("(?s).*<site-property>[\\s\\S]*?<site[\\s>].*"),
+        "nested site on property: " + xml);
+  }
+
+  @Test
+  void siteWriteMatchesGoldenFixture() throws Exception {
+    String xml = sampleSite().toXML();
+    String golden = loadResource("com/percussion/services/sitemgr/data/ps-site-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+  }
+
+  @Test
+  void siteRoundTripRestoresScalarsAndProperties() throws Exception {
+    PSSite original = sampleSite();
+    String xml = original.toXML();
+
+    PSSite restored = new PSSite();
+    restored.fromXML(xml);
+
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getDescription(), restored.getDescription());
+    assertEquals(original.getBaseUrl(), restored.getBaseUrl());
+    assertEquals(original.getRoot(), restored.getRoot());
+    assertEquals(original.getFolderRoot(), restored.getFolderRoot());
+    assertEquals(original.getNavTheme(), restored.getNavTheme());
+    assertEquals(original.getGlobalTemplate(), restored.getGlobalTemplate());
+    assertEquals(original.getPort(), restored.getPort());
+    assertEquals(original.getIpAddress(), restored.getIpAddress());
+    assertEquals(original.getGUID().toString(), restored.getGUID().toString());
+    assertEquals(original.getSiteId(), restored.getSiteId());
+    assertEquals(original.isSecure(), restored.isSecure());
+    assertEquals(original.isPageBased(), restored.isPageBased());
+    assertEquals(original.isCanonical(), restored.isCanonical());
+    assertEquals(original.getSiteProtocol(), restored.getSiteProtocol());
+    assertEquals(original.getDefaultDocument(), restored.getDefaultDocument());
+    assertEquals(original.getCanonicalDist(), restored.getCanonicalDist());
+    assertEquals(original.getUnpublishFlags(), restored.getUnpublishFlags());
+
+    assertEquals(1, restored.getProperties().size());
+    PSSiteProperty prop = restored.getProperties().iterator().next();
+    assertEquals("sys_pubBase", prop.getName());
+    assertEquals("http://example.com/", prop.getValue());
+    assertEquals("0-113-1", prop.getContextId().toString());
+    assertEquals(501L, prop.getPropertyId());
+    // Parent re-linked by setProperties after wire restore
+    assertNotNull(prop.getSite());
+    assertEquals(restored.getSiteId(), ((PSSite) prop.getSite()).getSiteId());
+  }
+
+  @Test
+  void siteFromXmlAcceptsLegacyNullRoot() throws Exception {
+    // SITE type ordinal is 9 (see PSTypeEnum.SITE); legacy package roots use <null>
+    String legacy =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <null>
+          <base-url>http://localhost:9992/Rhythmyx/</base-url>
+          <description>Legacy null-root site</description>
+          <folder-root>//Sites/Demo</folder-root>
+          <guid>0-9-42</guid>
+          <name>LegacyDemo</name>
+          <root>/</root>
+          <site-id>42</site-id>
+        </null>
+        """;
+
+    PSSite restored = new PSSite();
+    restored.fromXML(legacy);
+
+    assertEquals("LegacyDemo", restored.getName());
+    assertEquals("Legacy null-root site", restored.getDescription());
+    assertEquals(42L, restored.getSiteId().longValue());
+    assertEquals("0-9-42", restored.getGUID().toString());
+    assertEquals("http://localhost:9992/Rhythmyx/", restored.getBaseUrl());
+  }
+
+  @Test
+  void publishingContextWriteEmitsElementShapeAndSuppressesVersionScheme() throws Exception {
+    PSPublishingContext original = sampleContext();
+    String xml = original.toXML();
+
+    assertNotNull(xml);
+    assertTrue(containsTag(xml, "publishing-context"), "root: " + xml);
+    assertTrue(containsTag(xml, "default-scheme-id"), xml);
+    assertTrue(containsTag(xml, "guid"), xml);
+    assertTrue(xml.contains("Publish"), xml);
+    assertFalse(containsTag(xml, "version"), xml);
+    // object element default-scheme (not default-scheme-id scalar)
+    assertFalse(xml.matches("(?s).*<default-scheme[\\s>].*"), "object scheme suppressed: " + xml);
+    assertFalse(xml.contains("PSXPublishingContext"), "historical attr root not used: " + xml);
+  }
+
+  @Test
+  void publishingContextWriteMatchesGoldenFixture() throws Exception {
+    String xml = sampleContext().toXML();
+    String golden =
+        loadResource("com/percussion/services/sitemgr/data/ps-publishing-context-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+  }
+
+  @Test
+  void publishingContextRoundTripRestoresScalars() throws Exception {
+    PSPublishingContext original = sampleContext();
+    String xml = original.toXML();
+
+    PSPublishingContext restored = new PSPublishingContext();
+    restored.fromXML(xml);
+
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getDescription(), restored.getDescription());
+    assertEquals(original.getGUID().toString(), restored.getGUID().toString());
+    assertEquals(
+        original.getDefaultSchemeId().toString(), restored.getDefaultSchemeId().toString());
+    assertNull(restored.getDefaultScheme());
+  }
+
+  @Test
+  void locationSchemeWriteEmitsParametersAndSuppressesVersion() throws Exception {
+    PSLocationScheme original = sampleScheme();
+    String xml = original.toXML();
+
+    assertNotNull(xml);
+    assertTrue(containsTag(xml, "location-scheme"), "root: " + xml);
+    assertTrue(containsTag(xml, "location-scheme-parameter"), xml);
+    assertTrue(containsTag(xml, "parameter-set"), xml);
+    assertTrue(xml.contains("Generic"), xml);
+    assertTrue(xml.contains("sys_pubLocations"), xml);
+    assertFalse(containsTag(xml, "version"), xml);
+    assertFalse(xml.matches("(?s).*<scheme(\\s|>).*"), "circular scheme: " + xml);
+  }
+
+  @Test
+  void locationSchemeWriteMatchesGoldenFixture() throws Exception {
+    String xml = sampleScheme().toXML();
+    String golden =
+        loadResource("com/percussion/services/sitemgr/data/ps-location-scheme-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+  }
+
+  @Test
+  void locationSchemeRoundTripRestoresScalarsAndParameters() throws Exception {
+    PSLocationScheme original = sampleScheme();
+    String xml = original.toXML();
+
+    PSLocationScheme restored = new PSLocationScheme();
+    restored.fromXML(xml);
+
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getDescription(), restored.getDescription());
+    assertEquals(original.getGenerator(), restored.getGenerator());
+    assertEquals(original.getTemplateId(), restored.getTemplateId());
+    assertEquals(original.getContentTypeId(), restored.getContentTypeId());
+    assertEquals(original.getGUID().toString(), restored.getGUID().toString());
+    assertEquals(original.getContextId().toString(), restored.getContextId().toString());
+    assertEquals(original.getParameterNames().size(), restored.getParameterNames().size());
+    assertEquals("java.lang.String", restored.getParameterType("ext"));
+    assertEquals(".html", restored.getParameterValue("ext"));
+    assertEquals(Integer.valueOf(10), restored.getParameterSequence("ext"));
+  }
+
+  @Test
+  void sitePropertyStandaloneRoundTrip() throws Exception {
+    PSSiteProperty original = sampleProperty();
+    String xml = original.toXML();
+    assertTrue(containsTag(xml, "site-property"), xml);
+    assertFalse(containsTag(xml, "version"), xml);
+    assertFalse(xml.matches("(?s).*<site(\\s|>).*"), xml);
+
+    PSSiteProperty restored = new PSSiteProperty();
+    restored.fromXML(xml);
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getValue(), restored.getValue());
+    assertEquals(original.getPropertyId(), restored.getPropertyId());
+    assertEquals(original.getContextId().toString(), restored.getContextId().toString());
+  }
+
+  private static PSSite sampleSite() {
+    PSSite site = new PSSite();
+    site.setSiteId(100L);
+    site.setName("DemoSite");
+    site.setDescription("Sample site for Jackson golden/round-trip");
+    site.setBaseUrl("http://localhost:9992/Rhythmyx/");
+    site.setRoot("/");
+    site.setIpAddress("127.0.0.1");
+    site.setPort(9992);
+    site.setFolderRoot("//Sites/DemoSite");
+    site.setNavTheme("Default");
+    site.setGlobalTemplate("rc.gtt");
+    site.setSecure(false);
+    site.setPageBased(true);
+    site.setCanonical(true);
+    site.setCanonicalReplace(true);
+    site.setSiteProtocol("https");
+    site.setDefaultDocument("index.html");
+    site.setCanonicalDist("sections");
+    site.setUnpublishFlags("u");
+    site.setGenerateSitemap(false);
+    site.setMobilePreviewEnabled(false);
+    site.setOverrideSystemJQuery(false);
+    site.setOverrideSystemFoundation(false);
+    site.setOverrideSystemJQueryUI(false);
+
+    PSSiteProperty prop = sampleProperty();
+    prop.setSite(site);
+    site.addProperty(prop);
+    return site;
+  }
+
+  private static PSSiteProperty sampleProperty() {
+    PSSiteProperty prop = new PSSiteProperty();
+    prop.setPropertyId(501L);
+    prop.setName("sys_pubBase");
+    prop.setValue("http://example.com/");
+    prop.setContextId(new PSGuid(PSTypeEnum.CONTEXT, 1L));
+    return prop;
+  }
+
+  private static PSPublishingContext sampleContext() {
+    PSPublishingContext context = new PSPublishingContext();
+    context.setGUID(new PSGuid(PSTypeEnum.CONTEXT, 1L));
+    context.setName("Publish");
+    context.setDescription("This is a test description");
+    context.setDefaultSchemeId(new PSGuid(PSTypeEnum.LOCATION_SCHEME, 314L));
+    return context;
+  }
+
+  private static PSLocationScheme sampleScheme() {
+    PSLocationScheme scheme = new PSLocationScheme();
+    scheme.setId(314L);
+    scheme.setName("Generic");
+    scheme.setDescription("Generic location scheme");
+    scheme.setGenerator("Java/global/percussion/system/sys_pubLocations");
+    scheme.setTemplateId(501L);
+    scheme.setContentTypeId(301L);
+    scheme.setContextId(new PSGuid(PSTypeEnum.CONTEXT, 1L));
+    scheme.addParameter("ext", 10, "java.lang.String", ".html");
+    scheme.addParameter("path", 20, "java.lang.String", "$sys.site.path");
+    return scheme;
+  }
+
+  private static boolean containsTag(String xml, String localName) {
+    return xml.contains("<" + localName) || xml.contains("</" + localName + ">");
+  }
+
+  private static String loadResource(String classpath) throws Exception {
+    try (InputStream in =
+        PSSitemgrXmlSerializationTest.class.getClassLoader().getResourceAsStream(classpath)) {
+      assertNotNull(in, "missing test resource: " + classpath);
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  /**
+   * Compare logical XML trees: ignore XML declaration, Betwixt graph-identity {@code id}
+   * attributes, insignificant whitespace, and HTML comments.
+   */
+  private static void assertLogicalXmlParity(String expectedXml, String actualXml)
+      throws Exception {
+    Document expected = parseXml(stripXmlDeclaration(expectedXml));
+    Document actual = parseXml(stripXmlDeclaration(actualXml));
+    assertElementTreeEquals(expected.getDocumentElement(), actual.getDocumentElement(), "/");
+  }
+
+  private static String stripXmlDeclaration(String xml) {
+    String s = Objects.requireNonNull(xml).trim();
+    if (s.startsWith("<?xml")) {
+      int end = s.indexOf("?>");
+      if (end >= 0) {
+        s = s.substring(end + 2).trim();
+      }
+    }
+    while (s.startsWith("<!--")) {
+      int end = s.indexOf("-->");
+      if (end < 0) {
+        break;
+      }
+      s = s.substring(end + 3).trim();
+    }
+    return s;
+  }
+
+  private static Document parseXml(String xml) throws Exception {
+    var factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    var builder = factory.newDocumentBuilder();
+    return builder.parse(new InputSource(new java.io.StringReader(xml)));
+  }
+
+  private static void assertElementTreeEquals(Element expected, Element actual, String path) {
+    assertEquals(expected.getTagName(), actual.getTagName(), "tag at " + path);
+    List<Node> eChildren = significantChildren(expected);
+    List<Node> aChildren = significantChildren(actual);
+    assertEquals(
+        eChildren.size(),
+        aChildren.size(),
+        "child count at "
+            + path
+            + " expected="
+            + summarize(eChildren)
+            + " actual="
+            + summarize(aChildren));
+    for (int i = 0; i < eChildren.size(); i++) {
+      Node en = eChildren.get(i);
+      Node an = aChildren.get(i);
+      if (en.getNodeType() == Node.TEXT_NODE) {
+        assertEquals(en.getTextContent().trim(), an.getTextContent().trim(), "text at " + path);
+      } else {
+        assertElementTreeEquals(
+            (Element) en, (Element) an, path + "/" + ((Element) en).getTagName() + "[" + i + "]");
+      }
+    }
+  }
+
+  private static List<Node> significantChildren(Element el) {
+    NodeList nl = el.getChildNodes();
+    java.util.ArrayList<Node> out = new java.util.ArrayList<>();
+    boolean hasElementChild = false;
+    for (int i = 0; i < nl.getLength(); i++) {
+      if (nl.item(i).getNodeType() == Node.ELEMENT_NODE) {
+        hasElementChild = true;
+        break;
+      }
+    }
+    for (int i = 0; i < nl.getLength(); i++) {
+      Node n = nl.item(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE) {
+        out.add(n);
+      } else if (n.getNodeType() == Node.TEXT_NODE && !hasElementChild) {
+        String t = n.getTextContent();
+        if (t != null && !t.trim().isEmpty()) {
+          out.add(n);
+        }
+      }
+    }
+    return out;
+  }
+
+  private static String summarize(List<Node> nodes) {
+    StringBuilder b = new StringBuilder("[");
+    for (int i = 0; i < nodes.size(); i++) {
+      if (i > 0) {
+        b.append(',');
+      }
+      Node n = nodes.get(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE) {
+        b.append(((Element) n).getTagName());
+      } else {
+        b.append("#text");
+      }
+    }
+    return b.append(']').toString();
+  }
+}

--- a/system/src/test/resources/com/percussion/services/sitemgr/data/ps-location-scheme-golden.xml
+++ b/system/src/test/resources/com/percussion/services/sitemgr/data/ps-location-scheme-golden.xml
@@ -1,0 +1,32 @@
+<!-- Golden snapshot for PSLocationScheme / PSLocationSchemeParameter Jackson
+	wire shape (issue #1918 / #1892 / epic #505). Nested location-scheme-parameter
+	under parameter-set; circular scheme suppressed; version suppressed; parameters
+	ordered by sequence. -->
+<location-scheme>
+	<content-type-id>301</content-type-id>
+	<context-id>0-113-1</context-id>
+	<description>Generic location scheme</description>
+	<generator>Java/global/percussion/system/sys_pubLocations</generator>
+	<guid>0-10-314</guid>
+	<id>314</id>
+	<name>Generic</name>
+	<parameter-set>
+		<location-scheme-parameter>
+			<name>ext</name>
+			<parameter-id
+				xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+			<sequence>10</sequence>
+			<type>java.lang.String</type>
+			<value>.html</value>
+		</location-scheme-parameter>
+		<location-scheme-parameter>
+			<name>path</name>
+			<parameter-id
+				xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+			<sequence>20</sequence>
+			<type>java.lang.String</type>
+			<value>$sys.site.path</value>
+		</location-scheme-parameter>
+	</parameter-set>
+	<template-id>501</template-id>
+</location-scheme>

--- a/system/src/test/resources/com/percussion/services/sitemgr/data/ps-publishing-context-golden.xml
+++ b/system/src/test/resources/com/percussion/services/sitemgr/data/ps-publishing-context-golden.xml
@@ -1,0 +1,11 @@
+<!-- Golden snapshot for PSPublishingContext Jackson wire shape (issue #1918
+	/ #1892 / epic #505). Root publishing-context (element children). Historical
+	PSXPublishingContext attribute root is a documented deviation. default-scheme
+	object suppressed; default-scheme-id is scalar GUID. -->
+<publishing-context>
+	<default-scheme-id>0-10-314</default-scheme-id>
+	<description>This is a test description</description>
+	<guid>0-113-1</guid>
+	<id>1</id>
+	<name>Publish</name>
+</publishing-context>

--- a/system/src/test/resources/com/percussion/services/sitemgr/data/ps-site-golden.xml
+++ b/system/src/test/resources/com/percussion/services/sitemgr/data/ps-site-golden.xml
@@ -1,0 +1,75 @@
+<!-- Golden snapshot for PSSite / PSSiteProperty Jackson wire shape (issue
+	#1918 / #1892 / epic #505). Nested element site-property; template-ids empty
+	without assembly service. Approved deviations: no graph id attrs; null scalars
+	may emit xsi:nil; no XML declaration; version / associatedTemplates / label
+	suppressed; circular site on property omitted. -->
+<site>
+	<base-url>http://localhost:9992/Rhythmyx/</base-url>
+	<canonical-dist>sections</canonical-dist>
+	<default-document>index.html</default-document>
+	<default-file-extension
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+	<default-pub-server
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+	<description>Sample site for Jackson golden/round-trip</description>
+	<folder-root>//Sites/DemoSite</folder-root>
+	<generate-site-map-options
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+	<global-template>rc.gtt</global-template>
+	<guid>0-9-100</guid>
+	<ip-address>127.0.0.1</ip-address>
+	<name>DemoSite</name>
+	<nav-theme>Default</nav-theme>
+	<port>9992</port>
+	<previous-name
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+	<properties>
+		<site-property>
+			<context-id>0-113-1</context-id>
+			<guid>0-11-501</guid>
+			<name>sys_pubBase</name>
+			<property-id>501</property-id>
+			<value>http://example.com/</value>
+		</site-property>
+	</properties>
+	<root>/</root>
+	<site-id>100</site-id>
+	<site-protocol>https</site-protocol>
+	<template-ids />
+	<unpublish-flags>u</unpublish-flags>
+	<allowed-namespaces
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+	<canonical>true</canonical>
+	<canonicalReplace>true</canonicalReplace>
+	<generateSitemap>false</generateSitemap>
+	<login-page
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+	<mobilePreviewEnabled>false</mobilePreviewEnabled>
+	<overrideSystemFoundation>false</overrideSystemFoundation>
+	<overrideSystemJQuery>false</overrideSystemJQuery>
+	<overrideSystemJQueryUI>false</overrideSystemJQueryUI>
+	<pageBased>true</pageBased>
+	<password
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+	<private-key
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+	<registration-confirmation-page
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+	<registration-page
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+	<reset-page
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+	<reset-request-password-page
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+	<secure>false</secure>
+	<site-additional-head-content
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+	<site-after-body-open-content
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+	<site-before-body-close-content
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" />
+	<state xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:nil="true" />
+	<user-id xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:nil="true" />
+</site>


### PR DESCRIPTION
## Summary

Jackson-migrates the **sitemgr** design-object package under `system/services/.../sitemgr/data` for the Jackson-backed `PSXmlSerializationHelper` (slice 6b of remaining system domains).

- Annotate `PSSite`, `PSSiteProperty`, `PSPublishingContext`, `PSLocationScheme`, `PSLocationSchemeParameter`
- Nested package elements `site-property`, `location-scheme-parameter`; keep `addType` for `site-property` / `template-id` / `context` / `default-scheme` / `location-scheme-parameter`
- Restore helper `toXML`/`fromXML` for `PSSite` and `PSPublishingContext` (element roots `site` / `publishing-context`)
- Restore `template-ids` wire surface; suppress full `associatedTemplates`, version, circular parent graphs
- Golden + round-trip + legacy null-root smoke for site
- Deviations: `docs/ai-generated/tasks/505-betwixt-jackson/1918-sitemgr-domain-deviations.md`

## Fixes / links

- **Fixes #1918** (sitemgr-only child)
- Related #1892 #1823 #505
- Filter sibling: #1915 / PR #1922
- Residual children (parent #1892 stays open): #1919 publisher/pubserver · #1920 catalog/system/ui leftovers · #1921 content leftovers + PSNodeDefinition

## Test plan

- [x] `PSSitemgrXmlSerializationTest` — 11 tests (golden, round-trip, legacy null root)
- [x] `PSPublishingContextTest` — 2 tests (equals/clone + helper XML)
- [x] `cd system && ../mvnw clean install` — BUILD SUCCESS
- [x] Spotless: root `mvnw spotless:apply` then `spotless:check` (in-scope only; out-of-scope apply hits discarded)
- [x] Erlang self-review: `docs/ai-generated/code-reviews/issue-1918-sitemgr-jackson-erlang.md`

## Gates evidence

| Gate | Evidence |
|------|----------|
| Module clean install | `cd system; ..\mvnw.cmd clean install` → BUILD SUCCESS (~1m32s) |
| Unit tests | `PSSitemgrXmlSerializationTest` Tests run: 11, Failures: 0; `PSPublishingContextTest` Tests run: 2, Failures: 0 |
| Spotless | apply then check; only sitemgr domain + docs committed |
| Erlang | no bugs / portable paths / companions from peers |

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.