### PR TITLE
docs(1941): document zero-javadoc state of perc-ai-shared-release module

### DIFF
--- a/modules/ai-shared-release/README.md
+++ b/modules/ai-shared-release/README.md
@@ -77,6 +77,17 @@ The three non-`skills` directories ship as placeholders with a `.gitkeeep` so th
 - **Document end-user-facing skills** in `src/site/markdown/` and the project's end-user help site so operators can find them.
 - **Cross-platform paths only** in any scripts or references. Use `Path` / `pathlib`, never hardcoded `/` or `\` separators.
 
+## Javadoc status
+
+This module declares `<packaging>pom</packaging>` and ships no Java sources.
+The `maven-javadoc-plugin` reports `Not executing Javadoc as the project
+is not a Java classpath-capable package.` during the build, which is the
+expected outcome: **zero source warnings, zero plugin warnings, zero
+errors, zero failures**.
+
+The zero-warning Javadoc baseline for this module is recorded against
+issue **#1941** and the broader cleanup sweep tracked by **#1909**.
+
 ## Related modules
 
 - `modules/ai-shared-develop/` — developer-only AI resources (skills, prompts, agents) used by AI coding agents while working on the Percussion CMS source tree. Built into a JAR; not shipped to end users.


### PR DESCRIPTION
Resolves #1941

## Investigation

The perc-ai-shared-release module declares \<packaging>pom</packaging>\ and ships only resources (skills, agents, prompts, instructions) to the CMS distribution tree (\sys_resources/ai-tools/\). It contains **no Java sources** — only XML/Markdown/text resources under \src/main/resources/\.

Because the module has zero source files and no Java compilation, the \maven-javadoc-plugin\ reports \Not executing Javadoc as the project is not a Java classpath-capable package.\ during the build, which is the expected outcome: **zero source warnings, zero plugin warnings, zero errors, zero failures**.

## Verification

Run from \modules/ai-shared-release\ with JDK 21 + \mvnw.cmd\:

\\\at
cd modules\ai-shared-release
..\..\mvnw.cmd clean install
\\\

Result:
- BUILD SUCCESS
- javadoc source warnings: **0**
- javadoc plugin warnings: **0**
- javadoc errors / failures / blocks: **0 / 0 / 0**
- spotless:check: pass

## Changes

Added 'Javadoc status' section to the existing README to:
1. Explicitly document the zero-javadoc invariant for this module.
2. Reference the broader cleanup sweep tracked by #1909.

## Acceptance criteria

- [x] Verify the module builds successfully with zero Javadoc errors and zero Javadoc warnings
- [x] Confirm no regressions are introduced

---
Operator: Kilo (minimax-coding-plan/MiniMax-M3)