### PR TITLE
docs(1945): document zero-javadoc state of perc-openapi-webapp module

### DIFF
--- a/modules/perc-openapi-webapp/README.md
+++ b/modules/perc-openapi-webapp/README.md
@@ -70,3 +70,26 @@ After deployment, access API documentation at:
 3. Verify REST APIs remain functional without Swagger runtime
 4. Confirm Rhythmyx `WEB-INF/lib` has no Swagger artifacts leaked
 
+## Javadoc status
+
+This module is a WAR-only packaging artifact for the Swagger UI web
+resources and contains **no Java sources**. The `maven-javadoc-plugin`
+reports `No Javadoc in project. Archive not created.` during the build,
+which is the expected outcome: **zero source warnings, zero plugin
+warnings, zero errors, zero failures**.
+
+The zero-warning Javadoc baseline for this module is recorded against
+issue **#1945** and the broader cleanup sweep tracked by **#1909**.
+
+## Build
+
+```bat
+cd modules\perc-openapi-webapp
+..\..\mvnw.cmd clean install
+```
+
+Expected: `BUILD SUCCESS`. The non-javadoc warnings about a missing
+`rest-8.2.0-SNAPSHOT.jar` (from the openapi-spec plugin lookup) are
+expected when building this module standalone without first building
+the `rest` module; they are not javadoc warnings.
+

--- a/modules/perc-openapi-webapp/README.md
+++ b/modules/perc-openapi-webapp/README.md
@@ -83,9 +83,18 @@ issue **#1945** and the broader cleanup sweep tracked by **#1909**.
 
 ## Build
 
+Windows:
+
 ```bat
 cd modules\perc-openapi-webapp
 ..\..\mvnw.cmd clean install
+```
+
+Linux / macOS:
+
+```bash
+cd modules/perc-openapi-webapp
+../../mvnw clean install
 ```
 
 Expected: `BUILD SUCCESS`. The non-javadoc warnings about a missing


### PR DESCRIPTION
Resolves #1945

## Investigation

The perc-openapi-webapp module is a WAR packaging artifact for the Swagger UI web resources served at the \/openapi\ context path. It contains **no Java sources** — only static web resources (\index.html\, \openapi.json\, webapp resources) packaged via \maven-war-plugin\.

Because the module has zero Java sources, the \maven-javadoc-plugin\ reports \No Javadoc in project. Archive not created.\ during the build, which is the expected outcome: **zero source warnings, zero plugin warnings, zero errors, zero failures**.

## Verification

Run from \modules/perc-openapi-webapp\ with JDK 21 + \mvnw.cmd\:

\\\at
cd modules\perc-openapi-webapp
..\..\mvnw.cmd clean install
\\\

Result:
- BUILD SUCCESS
- javadoc source warnings: **0**
- javadoc plugin warnings: **0**
- javadoc errors / failures / blocks: **0 / 0 / 0**
- spotless:check: pass

The non-javadoc warnings about a missing \est-8.2.0-SNAPSHOT.jar\ (from the openapi-spec plugin lookup) are expected when building this module standalone without first building the \est\ module; they are not javadoc warnings.

## Changes

Added 'Javadoc status' section and explicit 'Build' section to the existing README to:
1. Document the zero-javadoc invariant for this module.
2. Clarify that the openapi-spec 'REST module not found' warnings are expected when building standalone and are not javadoc warnings.
3. Reference the broader cleanup sweep tracked by #1909.

## Acceptance criteria

- [x] Verify the module builds successfully with zero Javadoc errors and zero Javadoc warnings
- [x] Confirm no regressions are introduced

---
Operator: Kilo (minimax-coding-plan/MiniMax-M3)