### PR TITLE
docs(1940): document zero-javadoc state of ai-shared-develop module

### DIFF
--- a/modules/ai-shared-develop/README.md
+++ b/modules/ai-shared-develop/README.md
@@ -78,3 +78,9 @@ Paste `prompts/erlang-review-uncommitted.md` or attach `agents/erlang-code-revie
 ### Not for production
 
 Do not copy Erlang into `ai-shared-release` or ship it with the CMS product. It is for **developers and AI coding agents** only.
+
+## Javadoc status
+
+This module declares `<packaging>jar</packaging>` but contains **no Java sources** — only agentic resources (`agents/`, `chatmodes/`, `instructions/`, `prompts/`, `skills/`) under `src/main/resources/`. The `maven-javadoc-plugin` reports `No Javadoc in project. Archive not created.` during the build, which is the expected outcome: **zero source warnings, zero plugin warnings, zero errors, zero failures**.
+
+The zero-warning Javadoc baseline for this module is recorded against issue **#1940** and the broader cleanup sweep tracked by **#1909**.


### PR DESCRIPTION
Resolves #1940

## Investigation

The ai-shared-develop module declares \<packaging>jar</packaging>\ but contains **no Java sources** — only agentic resources (\gents/\, \chatmodes/\, \instructions/\, \prompts/\, \skills/\) under \src/main/resources/\. These are loaded by AI coding agents at development time and never shipped to the runtime product.

Because the module has zero Java sources, the \maven-javadoc-plugin\ reports \No Javadoc in project. Archive not created.\ during the build, which is the expected outcome: **zero source warnings, zero plugin warnings, zero errors, zero failures**.

## Verification

Run from \modules/ai-shared-develop\ with JDK 21 + \mvnw.cmd\:

\\\at
cd modules\ai-shared-develop
..\..\mvnw.cmd clean install
\\\

Result:
- BUILD SUCCESS
- javadoc source warnings: **0**
- javadoc plugin warnings: **0**
- javadoc errors / failures / blocks: **0 / 0 / 0**
- spotless:check: pass

The only warnings emitted are \Unused declared dependencies\ from the enforcer plugin (junit-jupiter, mockito-core, mockito-junit-jupiter). These are not javadoc warnings and are out of scope for this issue.

## Changes

Added 'Javadoc status' section to the existing README to:
1. Explicitly document the zero-javadoc invariant for this module.
2. Reference the broader cleanup sweep tracked by #1909.

## Acceptance criteria

- [x] Verify the module builds successfully with zero Javadoc errors and zero Javadoc warnings
- [x] Confirm no regressions are introduced

---
Operator: Kilo (minimax-coding-plan/MiniMax-M3)