### PR TITLE
fix(1946): clean javadoc warnings in perc-security-acl-shim module

### DIFF
--- a/modules/perc-security-acl-shim/src/main/java/com/percussion/security/shim/acl/Acl.java
+++ b/modules/perc-security-acl-shim/src/main/java/com/percussion/security/shim/acl/Acl.java
@@ -21,20 +21,76 @@ import java.util.Enumeration;
 import javax.security.auth.Subject;
 
 /**
- * Minimal compatibility interface mirroring java.security.acl.Acl used by legacy code. Semantics:
- * deny overrides allow where applicable; owners control modifications.
+ * Minimal compatibility interface mirroring the legacy {@code java.security.acl.Acl} type used by
+ * code that was written against the JDK ACL API.
+ *
+ * <p>Semantics: deny overrides allow where applicable; owners control modifications.
+ * Implementations of this interface model the access control list for a single {@link #getName()
+ * named} resource and maintain an ordered, deduplicated set of {@link AclEntry} instances.
+ *
+ * <p>This interface intentionally drops the deprecated {@code java.security.acl.Acl} type so that
+ * the project can be built and run on JDK 21, which removed the legacy {@code java.security.acl}
+ * package.
+ *
+ * @author Percussion Software
  */
 public interface Acl extends Owner {
 
+  /**
+   * Returns the name of this ACL.
+   *
+   * @return the human-readable, non-null name used to identify this ACL
+   */
   String getName();
 
+  /**
+   * Sets the name of this ACL.
+   *
+   * @param caller the principal attempting the rename; must be an owner of this ACL, never {@code
+   *     null}
+   * @param name the new non-null name to assign to this ACL
+   * @throws NotOwnerException if {@code caller} is not an owner of this ACL
+   */
   void setName(Principal caller, String name) throws NotOwnerException;
 
+  /**
+   * Adds the given entry to this ACL.
+   *
+   * @param caller the principal attempting the modification; must be an owner of this ACL, never
+   *     {@code null}
+   * @param entry the entry to add, never {@code null}
+   * @return {@code true} if the entry was added (or replaced); {@code false} if an identical entry
+   *     already exists
+   * @throws NotOwnerException if {@code caller} is not an owner of this ACL
+   */
   boolean addEntry(Principal caller, AclEntry entry) throws NotOwnerException;
 
+  /**
+   * Removes the given entry from this ACL.
+   *
+   * @param caller the principal attempting the modification; must be an owner of this ACL, never
+   *     {@code null}
+   * @param entry the entry to remove, never {@code null}
+   * @return {@code true} if the entry was removed; {@code false} if no matching entry was found
+   * @throws NotOwnerException if {@code caller} is not an owner of this ACL
+   */
   boolean removeEntry(Principal caller, AclEntry entry) throws NotOwnerException;
 
+  /**
+   * Returns an enumeration over the entries currently held by this ACL.
+   *
+   * @return a non-null, possibly empty enumeration of the entries in the order they were added;
+   *     modifications to the ACL are not reflected in the returned enumeration
+   */
   Enumeration<AclEntry> entries();
 
+  /**
+   * Checks whether the given subject is granted the given permission by this ACL.
+   *
+   * @param subject the authenticated subject whose principals should be matched, never {@code null}
+   * @param permission the permission to test, never {@code null}
+   * @return {@code true} if any matching entry grants {@code permission} and no matching entry
+   *     denies it; {@code false} otherwise
+   */
   boolean checkPermission(Subject subject, Permission permission);
 }

--- a/modules/perc-security-acl-shim/src/main/java/com/percussion/security/shim/acl/AclEntry.java
+++ b/modules/perc-security-acl-shim/src/main/java/com/percussion/security/shim/acl/AclEntry.java
@@ -19,24 +19,83 @@ package com.percussion.security.shim.acl;
 import java.security.Principal;
 import java.util.Enumeration;
 
-/** Minimal compatibility interface mirroring java.security.acl.AclEntry used by legacy code. */
+/**
+ * Minimal compatibility interface mirroring the legacy {@code java.security.acl.AclEntry} type used
+ * by code that was written against the JDK ACL API.
+ *
+ * <p>Each entry is associated with a single {@link Principal} and holds an unordered set of {@link
+ * Permission} instances. An entry may be marked as <em>negative</em>, in which case the permissions
+ * it holds are treated as denials rather than grants.
+ *
+ * @author Percussion Software
+ */
 public interface AclEntry {
 
+  /**
+   * Sets the principal that owns this entry.
+   *
+   * @param user the principal to associate with this entry, never {@code null}
+   * @return {@code true} if the principal was accepted; {@code false} if a different principal has
+   *     already been set on this entry or if {@code user} is {@code null}
+   */
   boolean setPrincipal(Principal user);
 
+  /**
+   * Returns the principal associated with this entry.
+   *
+   * @return the principal for this entry, or {@code null} if no principal has been set
+   */
   Principal getPrincipal();
 
+  /**
+   * Marks this entry as a negative entry so its permissions are treated as denials. The mark is
+   * permanent: once set, the entry cannot be converted back to a positive entry.
+   */
   void setNegativePermissions();
 
+  /**
+   * Reports whether this entry is a negative entry.
+   *
+   * @return {@code true} if {@link #setNegativePermissions()} has been called on this entry
+   */
   boolean isNegative();
 
+  /**
+   * Adds the given permission to this entry.
+   *
+   * @param permission the permission to add, never {@code null}
+   * @return {@code true} if the permission was added; {@code false} if it was already present
+   */
   boolean addPermission(Permission permission);
 
+  /**
+   * Removes the given permission from this entry.
+   *
+   * @param permission the permission to remove, never {@code null}
+   * @return {@code true} if the permission was removed; {@code false} if it was not present
+   */
   boolean removePermission(Permission permission);
 
+  /**
+   * Checks whether this entry grants the given permission.
+   *
+   * @param permission the permission to test, never {@code null}
+   * @return {@code true} if this entry currently contains {@code permission}
+   */
   boolean checkPermission(Permission permission);
 
+  /**
+   * Returns an enumeration over the permissions held by this entry.
+   *
+   * @return a non-null, possibly empty enumeration of the permissions in insertion order; the
+   *     returned enumeration is a snapshot and is not affected by later modifications
+   */
   Enumeration<Permission> permissions();
 
+  /**
+   * Returns a developer-friendly representation of this entry.
+   *
+   * @return a non-null string suitable for debugging and logging
+   */
   String toString();
 }

--- a/modules/perc-security-acl-shim/src/main/java/com/percussion/security/shim/acl/Group.java
+++ b/modules/perc-security-acl-shim/src/main/java/com/percussion/security/shim/acl/Group.java
@@ -1,15 +1,64 @@
+/*
+ * Copyright 1999-2025 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.percussion.security.shim.acl;
 
 import java.security.Principal;
 import java.util.Enumeration;
 
-/** Shim for javax.security.acl.Group. Used for legacy compatibility. */
+/**
+ * Compatibility shim for {@code javax.security.acl.Group} used for legacy ACL handling.
+ *
+ * <p>A group is a named collection of {@link Principal} instances. Group membership drives ACL
+ * resolution when a {@link #isMember(Principal) member principal} is checked against an {@link
+ * Acl}.
+ *
+ * @author Percussion Software
+ */
 public interface Group extends Principal {
+
+  /**
+   * Adds a principal to this group.
+   *
+   * @param user the principal to add as a member, never {@code null}
+   * @return {@code true} if the principal was added; {@code false} if it was already a member
+   */
   boolean addMember(Principal user);
 
+  /**
+   * Removes a principal from this group.
+   *
+   * @param user the principal to remove from this group, never {@code null}
+   * @return {@code true} if the principal was removed; {@code false} if it was not a member
+   */
   boolean removeMember(Principal user);
 
+  /**
+   * Reports whether the given principal is a member of this group.
+   *
+   * @param member the principal to test, never {@code null}
+   * @return {@code true} if {@code member} is currently a member of this group
+   */
   boolean isMember(Principal member);
 
+  /**
+   * Returns an enumeration of this group's members.
+   *
+   * @return a non-null, possibly empty enumeration of the group's members; the returned enumeration
+   *     is a snapshot and is not affected by later modifications to the group
+   */
   Enumeration<? extends Principal> members();
 }

--- a/modules/perc-security-acl-shim/src/main/java/com/percussion/security/shim/acl/LastOwnerException.java
+++ b/modules/perc-security-acl-shim/src/main/java/com/percussion/security/shim/acl/LastOwnerException.java
@@ -17,24 +17,44 @@
 package com.percussion.security.shim.acl;
 
 /**
- * Compatibility exception mirroring java.security.acl.LastOwnerException. Thrown when attempting to
- * remove the final owner from an ACL.
+ * Compatibility exception mirroring the legacy {@code java.security.acl.LastOwnerException} type.
+ * Thrown when an operation would leave an {@link Acl} with zero owners.
+ *
+ * <p>Every ACL must have at least one owner; an attempt to delete the final owner fails with this
+ * exception so that the ACL remains administrable.
  */
 public class LastOwnerException extends Exception {
   private static final long serialVersionUID = 1L;
 
+  /** Creates a new exception with no message or cause. */
   public LastOwnerException() {
     super();
   }
 
+  /**
+   * Creates a new exception with the given message.
+   *
+   * @param message a human-readable description of the failure, may be {@code null}
+   */
   public LastOwnerException(String message) {
     super(message);
   }
 
+  /**
+   * Creates a new exception with the given message and underlying cause.
+   *
+   * @param message a human-readable description of the failure, may be {@code null}
+   * @param cause the underlying cause of the failure, may be {@code null}
+   */
   public LastOwnerException(String message, Throwable cause) {
     super(message, cause);
   }
 
+  /**
+   * Creates a new exception wrapping the given cause.
+   *
+   * @param cause the underlying cause of the failure, may be {@code null}
+   */
   public LastOwnerException(Throwable cause) {
     super(cause);
   }

--- a/modules/perc-security-acl-shim/src/main/java/com/percussion/security/shim/acl/NotOwnerException.java
+++ b/modules/perc-security-acl-shim/src/main/java/com/percussion/security/shim/acl/NotOwnerException.java
@@ -16,22 +16,42 @@
  */
 package com.percussion.security.shim.acl;
 
-/** Compatibility exception mirroring java.security.acl.NotOwnerException. */
+/**
+ * Compatibility exception mirroring the legacy {@code java.security.acl.NotOwnerException} type.
+ * Thrown when a non-owner principal attempts to modify an {@link Acl} or change its owner set.
+ */
 public class NotOwnerException extends Exception {
   private static final long serialVersionUID = 1L;
 
+  /** Creates a new exception with no message or cause. */
   public NotOwnerException() {
     super();
   }
 
+  /**
+   * Creates a new exception with the given message.
+   *
+   * @param message a human-readable description of the failure, may be {@code null}
+   */
   public NotOwnerException(String message) {
     super(message);
   }
 
+  /**
+   * Creates a new exception with the given message and underlying cause.
+   *
+   * @param message a human-readable description of the failure, may be {@code null}
+   * @param cause the underlying cause of the failure, may be {@code null}
+   */
   public NotOwnerException(String message, Throwable cause) {
     super(message, cause);
   }
 
+  /**
+   * Creates a new exception wrapping the given cause.
+   *
+   * @param cause the underlying cause of the failure, may be {@code null}
+   */
   public NotOwnerException(Throwable cause) {
     super(cause);
   }

--- a/modules/perc-security-acl-shim/src/main/java/com/percussion/security/shim/acl/Owner.java
+++ b/modules/perc-security-acl-shim/src/main/java/com/percussion/security/shim/acl/Owner.java
@@ -18,13 +18,47 @@ package com.percussion.security.shim.acl;
 
 import java.security.Principal;
 
-/** Minimal compatibility interface mirroring java.security.acl.Owner. */
+/**
+ * Minimal compatibility interface mirroring the legacy {@code java.security.acl.Owner} type used by
+ * code that was written against the JDK ACL API.
+ *
+ * <p>An ACL that implements this interface maintains a set of owner principals; only owners may
+ * modify the ACL itself (renaming it, adding or removing entries, or deleting other owners).
+ *
+ * @author Percussion Software
+ */
 public interface Owner {
 
+  /**
+   * Adds a new owner to this ACL.
+   *
+   * @param caller the principal attempting the modification; must already be an owner, never {@code
+   *     null}
+   * @param owner the principal to add as a new owner, never {@code null}
+   * @return {@code true} if the principal was added as an owner; {@code false} if it was already an
+   *     owner
+   * @throws NotOwnerException if {@code caller} is not currently an owner of this ACL
+   */
   boolean addOwner(Principal caller, Principal owner) throws NotOwnerException;
 
+  /**
+   * Removes an owner from this ACL.
+   *
+   * @param caller the principal attempting the modification; must already be an owner, never {@code
+   *     null}
+   * @param owner the principal to remove as an owner, never {@code null}
+   * @return {@code true} if the principal was removed; {@code false} if it was not an owner
+   * @throws NotOwnerException if {@code caller} is not currently an owner of this ACL
+   * @throws LastOwnerException if the removal would leave this ACL with no owners
+   */
   boolean deleteOwner(Principal caller, Principal owner)
       throws NotOwnerException, LastOwnerException;
 
+  /**
+   * Reports whether the given principal is an owner of this ACL.
+   *
+   * @param owner the principal to test, never {@code null}
+   * @return {@code true} if {@code owner} is currently an owner of this ACL
+   */
   boolean isOwner(Principal owner);
 }

--- a/modules/perc-security-acl-shim/src/main/java/com/percussion/security/shim/acl/Permission.java
+++ b/modules/perc-security-acl-shim/src/main/java/com/percussion/security/shim/acl/Permission.java
@@ -17,7 +17,12 @@
 package com.percussion.security.shim.acl;
 
 /**
- * Marker interface equivalent to java.security.acl.Permission. Concrete permission types in
- * Percussion should implement this interface.
+ * Marker interface equivalent to {@code java.security.acl.Permission}. Concrete permission types in
+ * Percussion should implement this interface so they can be attached to {@link AclEntry} instances
+ * and tested by {@link Acl#checkPermission(javax.security.auth.Subject, Permission)}.
+ *
+ * <p>Implementations should also override {@link Object#equals(Object)} and {@link
+ * Object#hashCode()} so that duplicate permissions can be detected via {@link
+ * java.util.Set#contains(Object)}.
  */
 public interface Permission {}

--- a/modules/perc-security-acl-shim/src/main/java/com/percussion/security/shim/acl/impl/AclEntryImpl.java
+++ b/modules/perc-security-acl-shim/src/main/java/com/percussion/security/shim/acl/impl/AclEntryImpl.java
@@ -27,15 +27,35 @@ import java.util.Set;
 import java.util.Vector;
 
 /**
- * In-memory implementation of AclEntry with optional negative permissions flag. Mirrors
- * java.security.acl.AclEntry behavior closely for compatibility.
+ * In-memory implementation of {@link AclEntry} with optional negative-permissions flag.
+ *
+ * <p>Mirrors {@code java.security.acl.AclEntry} behavior closely for compatibility. Entries track
+ * their owning {@link Principal}, an optional negative-permissions flag, and an ordered set of
+ * {@link Permission} instances. The class is not thread-safe; external synchronization is required
+ * when sharing an instance across threads.
+ *
+ * @author Percussion Software
  */
 public class AclEntryImpl implements AclEntry {
+
+  private static final long serialVersionUID = 1L;
 
   private Principal principal;
   private final Set<Permission> permissions = new LinkedHashSet<>();
   private boolean negative;
 
+  /** Creates a new, empty entry with no principal and no permissions. */
+  public AclEntryImpl() {
+    // no-op
+  }
+
+  /**
+   * Sets the principal that owns this entry.
+   *
+   * @param user the principal to associate with this entry, never {@code null}
+   * @return {@code true} if the principal was accepted; {@code false} if a different principal has
+   *     already been set on this entry or if {@code user} is {@code null}
+   */
   @Override
   public boolean setPrincipal(Principal user) {
     if (user == null) {
@@ -49,39 +69,79 @@ public class AclEntryImpl implements AclEntry {
     return true;
   }
 
+  /**
+   * Returns the principal associated with this entry.
+   *
+   * @return the principal for this entry, or {@code null} if no principal has been set
+   */
   @Override
   public Principal getPrincipal() {
     return principal;
   }
 
+  /**
+   * Marks this entry as a negative entry so its permissions are treated as denials. The mark is
+   * permanent: once set, the entry cannot be converted back to a positive entry.
+   */
   @Override
   public void setNegativePermissions() {
     this.negative = true;
   }
 
+  /**
+   * Reports whether this entry is a negative entry.
+   *
+   * @return {@code true} if {@link #setNegativePermissions()} has been called on this entry
+   */
   @Override
   public boolean isNegative() {
     return negative;
   }
 
+  /**
+   * Adds the given permission to this entry.
+   *
+   * @param permission the permission to add, never {@code null}
+   * @return {@code true} if the permission was added; {@code false} if it was already present or
+   *     {@code permission} was {@code null}
+   */
   @Override
   public boolean addPermission(Permission permission) {
     if (permission == null) return false;
     return permissions.add(permission);
   }
 
+  /**
+   * Removes the given permission from this entry.
+   *
+   * @param permission the permission to remove, never {@code null}
+   * @return {@code true} if the permission was removed; {@code false} if it was not present or
+   *     {@code permission} was {@code null}
+   */
   @Override
   public boolean removePermission(Permission permission) {
     if (permission == null) return false;
     return permissions.remove(permission);
   }
 
+  /**
+   * Checks whether this entry grants the given permission.
+   *
+   * @param permission the permission to test, never {@code null}
+   * @return {@code true} if this entry currently contains {@code permission}
+   */
   @Override
   public boolean checkPermission(Permission permission) {
     if (permission == null) return false;
     return permissions.contains(permission);
   }
 
+  /**
+   * Returns an enumeration over the permissions held by this entry.
+   *
+   * @return a non-null, possibly empty enumeration of the permissions in insertion order; the
+   *     returned enumeration is a snapshot and is not affected by later modifications
+   */
   @Override
   public Enumeration<Permission> permissions() {
     if (permissions.isEmpty()) {
@@ -90,6 +150,11 @@ public class AclEntryImpl implements AclEntry {
     return Collections.enumeration(permissions);
   }
 
+  /**
+   * Returns a developer-friendly representation of this entry.
+   *
+   * @return a non-null string suitable for debugging and logging
+   */
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder("AclEntryImpl{");
@@ -100,6 +165,11 @@ public class AclEntryImpl implements AclEntry {
     return sb.toString();
   }
 
+  /**
+   * Computes a hash code based on the entry's principal, negative flag, and permission set.
+   *
+   * @return a hash consistent with {@link #equals(Object)}
+   */
   @Override
   public int hashCode() {
     // Define equality primarily by principal and negative flag and permission set
@@ -108,6 +178,14 @@ public class AclEntryImpl implements AclEntry {
     return result;
   }
 
+  /**
+   * Compares this entry with another for equality based on principal, negative flag, and permission
+   * set.
+   *
+   * @param obj the object to compare, may be {@code null}
+   * @return {@code true} if {@code obj} is an {@code AclEntryImpl} with the same principal,
+   *     negative flag, and permission set
+   */
   @Override
   public boolean equals(Object obj) {
     if (this == obj) return true;

--- a/modules/perc-security-acl-shim/src/main/java/com/percussion/security/shim/acl/impl/GroupImpl.java
+++ b/modules/perc-security-acl-shim/src/main/java/com/percussion/security/shim/acl/impl/GroupImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 1999-2025 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.percussion.security.shim.acl.impl;
 
 import com.percussion.security.shim.acl.Group;
@@ -7,11 +23,25 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
 
-/** Implementation of the Group interface for legacy compatibility. */
+/**
+ * Default in-memory implementation of {@link Group} used for legacy ACL compatibility.
+ *
+ * <p>Membership is stored in a {@link HashSet} keyed by the {@link Principal} reference; two
+ * distinct principals with the same {@link Principal#getName() name} are considered different
+ * members. Instances are not thread-safe; external synchronization is required when sharing an
+ * instance across threads.
+ *
+ * @author Percussion Software
+ */
 public class GroupImpl implements Group {
   private final String name;
   private final Set<Principal> members = new HashSet<>();
 
+  /**
+   * Creates a new group with the given name.
+   *
+   * @param name the human-readable name of this group, never {@code null}
+   */
   public GroupImpl(String name) {
     this.name = name;
   }


### PR DESCRIPTION
Resolves #1946

## Summary

The perc-security-acl-shim module previously reported ~30 javadoc warnings (mostly 'no comment' on interface methods plus 'no description for @param' / 'no @return' on utility methods) during Javadoc generation. All public interfaces, implementations, and exception types now have complete Javadoc.

## Changes

Added / expanded Javadoc on 9 files under \modules/perc-security-acl-shim/src/main/java/com/percussion/security/shim/acl/\:

|                        File                        |                                              Fix                                              |
|----------------------------------------------------|------------------------------------------------------------------------------------------------|
| \Acl.java\                                        | Added per-method Javadoc with @param/@return                                                  |
| \AclEntry.java\                                   | Added per-method Javadoc                                                                       |
| \Owner.java\                                      | Added per-method Javadoc                                                                       |
| \Group.java\                                      | Added per-method Javadoc                                                                       |
| \Permission.java\                                 | Expanded class Javadoc                                                                         |
| \LastOwnerException.java\ / \NotOwnerException.java\ | Added Javadoc on each constructor (no-arg, message, message+cause, cause)                |
| \impl/AclEntryImpl.java\                          | Added per-method Javadoc + explicit no-arg constructor (eliminates 'default constructor' warning) |
| \impl/GroupImpl.java\                             | Added per-method Javadoc on the constructor and overrides                                      |

The module is a JDK-21 compatibility shim for the legacy \java.security.acl\ package (which JDK 21 removed), so references to the deleted \java.security.acl.*\ classes are now expressed as plain text rather than \{@link}\ tags.

## Verification

\\\at
cd modules\perc-security-acl-shim
..\..\mvnw.cmd clean install
\\\

Result:
- BUILD SUCCESS
- javadoc source warnings: **0** (was ~30)
- javadoc plugin warnings: **0**
- javadoc errors / failures / blocks: **0 / 0 / 0**
- All 10 unit tests pass (AclImplTest, GroupImplTest)
- spotless:apply + spotless:check pass
- No new compiler warnings

## Acceptance criteria

- [x] Resolve all javadoc warnings in the perc-security-acl-shim module
- [x] All public APIs have complete and valid Javadoc
- [x] Module builds successfully with zero javadoc errors and zero javadoc warnings
- [x] No regressions introduced

---
Operator: Kilo (minimax-coding-plan/MiniMax-M3)