### PR TITLE
fix(1948): clean javadoc warnings in perc-xml-security module

### DIFF
--- a/modules/perc-xml-security/src/main/java/com/percussion/security/xml/IPSInternalRequestURIResolver.java
+++ b/modules/perc-xml-security/src/main/java/com/percussion/security/xml/IPSInternalRequestURIResolver.java
@@ -21,6 +21,18 @@ import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.URIResolver;
 
+/**
+ * Marker extension of {@link URIResolver} used to delegate URI resolution to handlers that can
+ * service requests internal to the Percussion CMS (for example, XSL includes / imports that should
+ * be served from the running application rather than from the filesystem or network).
+ *
+ * <p>Implementations are installed on a {@link PSCatalogResolver} via {@link
+ * PSCatalogResolver#setInternalRequestURIResolver(IPSInternalRequestURIResolver)}; when a lookup is
+ * performed the catalog resolver consults the installed instance before falling back to its
+ * catalog-driven logic.
+ *
+ * @author Percussion Software
+ */
 public interface IPSInternalRequestURIResolver extends URIResolver {
 
   /**

--- a/modules/perc-xml-security/src/main/java/com/percussion/security/xml/PSCatalogResolver.java
+++ b/modules/perc-xml-security/src/main/java/com/percussion/security/xml/PSCatalogResolver.java
@@ -29,6 +29,22 @@ import org.apache.xml.resolver.CatalogManager;
 import org.apache.xml.resolver.tools.CatalogResolver;
 import org.xml.sax.InputSource;
 
+/**
+ * A {@link CatalogResolver} tailored for Percussion CMS XML processing.
+ *
+ * <p>Builds a {@link CatalogManager} that prefers system IDs and uses a <em>private</em> catalog
+ * instance ({@code useStaticCatalog=false}) so one resolver's parse failures cannot corrupt a
+ * process-wide static catalog. Catalog file paths still come from {@code xml.catalog.files} /
+ * {@code CatalogManager.properties} when set by the JVM (see {@code perc-jetty jvm.ini}). This
+ * product does not ship a classpath {@code CatalogManager.properties}; {@code
+ * ignoreMissingProperties=true} avoids a noisy CatalogManager warning on every resolver
+ * construction. Operators still configure catalogs via the JVM system properties above.
+ *
+ * <p>An optional {@link IPSInternalRequestURIResolver} may be installed to short-circuit catalog
+ * lookups for URIs that should be resolved by the running application.
+ *
+ * @author Percussion Software
+ */
 public class PSCatalogResolver extends CatalogResolver {
 
   private static final Logger log = LogManager.getLogger(PSCatalogResolver.class);
@@ -50,8 +66,11 @@ public class PSCatalogResolver extends CatalogResolver {
   }
 
   /**
+   * Creates a {@link CatalogManager} configured for Percussion CMS usage.
+   *
    * @param privateCatalog when {@code true}, use a non-static (per-manager) catalog; when {@code
    *     false}, allow CatalogManager's shared static catalog
+   * @return a non-null, fully configured {@link CatalogManager}
    */
   static CatalogManager createCatalogManager(boolean privateCatalog) {
     CatalogManager manager = new CatalogManager();
@@ -64,10 +83,22 @@ public class PSCatalogResolver extends CatalogResolver {
     return manager;
   }
 
+  /**
+   * Returns the optional internal-request URI resolver installed on this catalog resolver.
+   *
+   * @return the installed resolver, or {@code null} if no resolver has been installed
+   */
   public IPSInternalRequestURIResolver getInternalRequestURIResolver() {
     return internalRequestURIResolver;
   }
 
+  /**
+   * Installs an internal-request URI resolver that will be consulted before this catalog resolver
+   * performs its catalog-driven resolution.
+   *
+   * @param internalRequestURIResolver the resolver to install; may be {@code null} to clear any
+   *     previously installed resolver
+   */
   public void setInternalRequestURIResolver(
       IPSInternalRequestURIResolver internalRequestURIResolver) {
     this.internalRequestURIResolver = internalRequestURIResolver;
@@ -172,10 +203,22 @@ public class PSCatalogResolver extends CatalogResolver {
   }
 
   /**
-   * JAXP URIResolver API
+   * JAXP URIResolver entry point used by XSLT processors when they encounter an {@code
+   * xsl:include}, {@code xsl:import}, or {@code document()} function.
    *
-   * @param href
-   * @param base
+   * <p>If an {@link IPSInternalRequestURIResolver} is installed and returns a non-null source for
+   * the given URI, that source is returned and catalog lookup is skipped. Otherwise, the underlying
+   * {@link CatalogResolver} is consulted. If the catalog does not contain a mapping the caller is
+   * signaled via a {@link TransformerException} so that the XSLT processor does not silently fall
+   * back to network I/O.
+   *
+   * @param href the URI from the {@code href} attribute or {@code document()} call, may be
+   *     relative; a blank or {@code null} value resolves to {@code null}
+   * @param base the base URI used to resolve {@code href} when an absolute URI is required; may be
+   *     {@code null}
+   * @return a non-null {@link Source} for the resolved URI
+   * @throws TransformerException if the URI cannot be resolved through the internal resolver or the
+   *     configured catalogs
    */
   @Override
   public Source resolve(String href, String base) throws TransformerException {

--- a/modules/perc-xml-security/src/main/java/com/percussion/security/xml/PSSecureXMLUtils.java
+++ b/modules/perc-xml-security/src/main/java/com/percussion/security/xml/PSSecureXMLUtils.java
@@ -36,22 +36,40 @@ import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.XMLReader;
 
-/** Utility class for securing XML parses. */
+/**
+ * Utility class for securing XML parses.
+ *
+ * <p>Provides constant feature URIs and helpers that hard-disable external-entity resolution and
+ * document-type declarations on the various XML parser factories used by Percussion CMS. The
+ * defaults defend against XXE (CWE-611) even when callers mistakenly request the legacy {@code
+ * enableExternalEntities} options.
+ *
+ * @author Percussion Software
+ */
 public class PSSecureXMLUtils {
 
   private PSSecureXMLUtils() {
     // hidden ctor
   }
 
-  //  http://xml.org/sax/features/namespaces
-  // Set to true
+  /**
+   * JAXP {@code secure-processing} feature URI. Always set to {@code true} by the helpers in this
+   * class. See <a href="http://xml.org/sax/features/namespaces">namespaces</a> for the related SAX
+   * feature.
+   */
   public static final String SECURE_PROCESSING_FEATURE = XMLConstants.FEATURE_SECURE_PROCESSING;
 
-  // Set to true based on param
+  /**
+   * Apache Xerces feature URI used to disallow {@code <!DOCTYPE>} declarations. Set to {@code true}
+   * when {@link PSXmlSecurityOptions#isEnableDtdDeclarations()} returns {@code false}.
+   */
   public static final String DISALLOW_DOCTYPES_FEATURE =
       "http://apache.org/xml/features/disallow-doctype-decl";
 
-  // Set to false
+  /**
+   * SAX feature URI used to disable resolution of general external entities. Always set to {@code
+   * false} as a defense-in-depth measure.
+   */
   public static final String SAX_GENERAL_EXTERNAL_ENTITIES_FEATURE =
       "http://xml.org/sax/features/external-general-entities";
 
@@ -67,6 +85,10 @@ public class PSSecureXMLUtils {
   public static final String X2_GENERAL_EXTERNAL_ENTITIES_FEATURE =
       X1_GENERAL_EXTERNAL_ENTITIES_FEATURE;
 
+  /**
+   * Xerces feature URI used to disable resolution of external parameter entities. Always set to
+   * {@code false} as a defense-in-depth measure.
+   */
   public static final String X1_EXTERNAL_PARAMETER_ENTITIES_FEATURE =
       "http://apache.org/xml/features/external-parameter-entities";
 
@@ -74,17 +96,35 @@ public class PSSecureXMLUtils {
   public static final String X2_EXTERNAL_PARAMETER_ENTITIES_FEATURE =
       X1_EXTERNAL_PARAMETER_ENTITIES_FEATURE;
 
+  /** SAX feature URI used to disable external parameter entities. Always set to {@code false}. */
   public static final String SAX_EXTERNAL_PARAMETER_ENTITIES_FEATURE =
       "http://xml.org/sax/features/external-parameter-entities";
 
+  /** Xerces feature URI used to disable loading of external DTDs. Always set to {@code false}. */
   public static final String LOAD_EXTERNAL_DTD =
       "http://apache.org/xml/features/nonvalidating/load-external-dtd";
 
+  /**
+   * Default value used for {@link
+   * javax.xml.parsers.DocumentBuilderFactory#setXIncludeAware(boolean)}. Set to {@code false} so
+   * XInclude processing is disabled.
+   */
   public static final boolean XINCLUDE_AWARE = false;
+
+  /**
+   * Default value used for {@link
+   * javax.xml.parsers.DocumentBuilderFactory#setExpandEntityReferences(boolean)}. Set to {@code
+   * false} so entity references are not expanded into text.
+   */
   public static final boolean EXPAND_ENTITY_REFERENCES = false;
 
   private static final Logger log = LogManager.getLogger(PSSecureXMLUtils.class);
 
+  /**
+   * Log message template emitted when an XML parser reports that one of the security features
+   * requested by this utility is not supported. The single {@code {}} placeholder is filled with
+   * the unsupported feature URI.
+   */
   public static final String UNSUPPORTED_FEATURE_WARN =
       "enableSecureFeatures exception thrown, XML Feature: {} is not supported by this XML Parser.";
 
@@ -206,10 +246,11 @@ public class PSSecureXMLUtils {
   }
 
   /**
-   * Secures XMLInputFactory instances. External entities are disabled and DTD's are turned on or
-   * off based on the caller.
+   * Secures {@link XMLInputFactory} instances. External entities are hard-disabled and DTD support
+   * is enabled or disabled based on the caller-supplied options.
    *
-   * @param options Options for secure processing
+   * @param options the security options to apply; assumed not {@code null}
+   * @return a secured {@link XMLInputFactory} instance with external entities disabled
    */
   public static XMLInputFactory getSecuredXMLInputFactory(PSXmlSecurityOptions options) {
 
@@ -229,6 +270,15 @@ public class PSSecureXMLUtils {
     return xif;
   }
 
+  /**
+   * Returns an XStream instance configured to (de)serialize only classes under the {@code
+   * com.percussion.**} package and to use the DOM driver for XML I/O.
+   *
+   * <p>Note: the type whitelist is intentionally broad so that all Percussion CMS payload classes
+   * can be processed; tighten it for any deployment that handles untrusted input.
+   *
+   * @return a non-null, configured {@link XStream} instance
+   */
   public static XStream getSecuredXStream() {
     XStream xs = new XStream(new DomDriver());
     // TODO: 01-04-2022   whitelist specific classes
@@ -292,6 +342,16 @@ public class PSSecureXMLUtils {
     return tf;
   }
 
+  /**
+   * Returns a {@link SAXParserFactory} for the given implementation class name with
+   * OWASP-recommended security attributes. External entities and external parameter entities are
+   * hard-disabled regardless of caller-supplied options to prevent XXE (CWE-611).
+   *
+   * @param className the fully-qualified SAXParserFactory implementation class name
+   * @param classLoader the class loader to use, may be {@code null}
+   * @param options the security options to apply; assumed not {@code null}
+   * @return a secured {@link SAXParserFactory} instance
+   */
   public static SAXParserFactory getSecuredSaxParserFactory(
       String className, ClassLoader classLoader, PSXmlSecurityOptions options) {
 
@@ -299,6 +359,14 @@ public class PSSecureXMLUtils {
     return enableSPFFeatures(spf, options);
   }
 
+  /**
+   * Returns a {@link SAXParserFactory} configured with OWASP-recommended security attributes.
+   * External entities and external parameter entities are hard-disabled regardless of
+   * caller-supplied options to prevent XXE (CWE-611).
+   *
+   * @param options the security options to apply; assumed not {@code null}
+   * @return a secured {@link SAXParserFactory} instance
+   */
   public static SAXParserFactory getSecuredSaxParserFactory(PSXmlSecurityOptions options) {
 
     SAXParserFactory spf = SAXParserFactory.newInstance();

--- a/modules/perc-xml-security/src/main/java/com/percussion/security/xml/PSXMLEntityResolverWrapper.java
+++ b/modules/perc-xml-security/src/main/java/com/percussion/security/xml/PSXMLEntityResolverWrapper.java
@@ -29,10 +29,35 @@ import org.apache.xerces.xni.parser.XMLInputSource;
 import org.apache.xml.resolver.tools.CatalogResolver;
 import org.xml.sax.InputSource;
 
+/**
+ * Wraps a {@link CatalogResolver} as an Xerces {@link XMLEntityResolver} so that XML parsers
+ * created via {@link PSSecureXMLUtils} can resolve external entities through the configured XML
+ * catalog instead of falling back to the network.
+ *
+ * <p>When the catalog cannot resolve an entity, this wrapper returns a no-op input source rather
+ * than throwing, so the parser simply sees an empty stream and proceeds.
+ *
+ * @author Percussion Software
+ */
 public class PSXMLEntityResolverWrapper implements XMLEntityResolver {
   private CatalogResolver resolver = new CatalogResolver();
   private static final Logger log = LogManager.getLogger(PSXMLEntityResolverWrapper.class);
 
+  /**
+   * Creates a new wrapper that delegates external-entity resolution to a freshly-instantiated
+   * {@link CatalogResolver}.
+   */
+  public PSXMLEntityResolverWrapper() {
+    // no-op
+  }
+
+  /**
+   * Converts a SAX {@link InputSource} into an Xerces {@link XMLInputSource}, copying the public
+   * id, system id, byte/character streams, and encoding.
+   *
+   * @param is the SAX input source to convert, assumed not {@code null}
+   * @return a non-null Xerces input source equivalent to {@code is}
+   */
   private XMLInputSource getXmlInput(InputSource is) {
     XMLInputSource source = new XMLInputSource(is.getPublicId(), is.getSystemId(), null);
     source.setByteStream(is.getByteStream());
@@ -42,11 +67,14 @@ public class PSXMLEntityResolverWrapper implements XMLEntityResolver {
   }
 
   /**
-   * Resolves an external parsed entity. If the entity cannot be resolved, this method should return
-   * null.
+   * Resolves an external parsed entity through the wrapped {@link CatalogResolver}. If the entity
+   * cannot be resolved, returns a no-op {@link XMLInputSource} so the parser sees an empty stream
+   * rather than failing outright.
    *
-   * @param resourceIdentifier location of the XML resource to resolve
-   * @throws XNIException Thrown on general error.
+   * @param resourceIdentifier location of the XML resource to resolve, assumed not {@code null}
+   * @return a non-null {@link XMLInputSource} for the resolved entity, or a no-op source when the
+   *     catalog does not contain a mapping for {@code resourceIdentifier}
+   * @throws XNIException if an unrecoverable error occurs while consulting the catalog
    * @see XMLResourceIdentifier
    */
   @Override

--- a/modules/perc-xml-security/src/main/java/com/percussion/security/xml/PSXmlSecurityOptions.java
+++ b/modules/perc-xml-security/src/main/java/com/percussion/security/xml/PSXmlSecurityOptions.java
@@ -24,8 +24,25 @@ package com.percussion.security.xml;
  * Note that {@link PSSecureXMLUtils} will <em>always</em> hard-disable external entities and
  * external parameter entities regardless of the values set here, as a defense-in-depth measure
  * against XXE (CWE-611).
+ *
+ * @author Percussion Software
  */
 public class PSXmlSecurityOptions {
+
+  /**
+   * Creates a new options bundle with the given flags.
+   *
+   * @param enableExternalEntities whether external general entity references should be enabled;
+   *     ignored by {@link PSSecureXMLUtils}, which always hard-disables them
+   * @param enableDtdDeclarations whether {@code <!DOCTYPE>} declarations should be permitted by the
+   *     secured parser
+   * @param enableExternalDtdReferences whether the secured parser should fetch external DTDs
+   * @param enableSecureProcessing whether the JAXP {@code secure-processing} feature should be
+   *     turned on
+   * @param enableExternalParameterEntities whether external parameter entity references should be
+   *     enabled; ignored by {@link PSSecureXMLUtils}, which always hard-disables them
+   * @param enableValidation whether the secured parser should perform DTD-based validation
+   */
   public PSXmlSecurityOptions(
       boolean enableExternalEntities,
       boolean enableDtdDeclarations,
@@ -75,82 +92,194 @@ public class PSXmlSecurityOptions {
   private String[] allowedPathsForImports;
   private String[] allowedPathsForIncludes;
 
+  /**
+   * Reports whether external general entity references should be enabled. Note that {@link
+   * PSSecureXMLUtils} always hard-disables them regardless of this flag.
+   *
+   * @return {@code true} if external general entities are requested by the caller
+   */
   public boolean isEnableExternalEntities() {
     return enableExternalEntities;
   }
 
+  /**
+   * Sets whether external general entity references should be enabled.
+   *
+   * @param enableExternalEntities {@code true} to request external general entity resolution; note
+   *     that {@link PSSecureXMLUtils} overrides this to {@code false}
+   */
   public void setEnableExternalEntities(boolean enableExternalEntities) {
     this.enableExternalEntities = enableExternalEntities;
   }
 
+  /**
+   * Reports whether {@code <!DOCTYPE>} declarations should be permitted by the secured parser.
+   *
+   * @return {@code true} if DTD declarations are enabled
+   */
   public boolean isEnableDtdDeclarations() {
     return enableDtdDeclarations;
   }
 
+  /**
+   * Sets whether {@code <!DOCTYPE>} declarations should be permitted by the secured parser.
+   *
+   * @param enableDtdDeclarations {@code true} to allow DTD declarations
+   */
   public void setEnableDtdDeclarations(boolean enableDtdDeclarations) {
     this.enableDtdDeclarations = enableDtdDeclarations;
   }
 
+  /**
+   * Reports whether the secured parser should fetch external DTDs.
+   *
+   * @return {@code true} if external DTD references are enabled
+   */
   public boolean isEnableExternalDtdReferences() {
     return enableExternalDtdReferences;
   }
 
+  /**
+   * Sets whether the secured parser should fetch external DTDs.
+   *
+   * @param enableExternalDtdReferences {@code true} to enable external DTD references
+   */
   public void setEnableExternalDtdReferences(boolean enableExternalDtdReferences) {
     this.enableExternalDtdReferences = enableExternalDtdReferences;
   }
 
+  /**
+   * Reports whether the JAXP {@code secure-processing} feature should be turned on.
+   *
+   * @return {@code true} if secure processing is enabled
+   */
   public boolean isEnableSecureProcessing() {
     return enableSecureProcessing;
   }
 
+  /**
+   * Sets whether the JAXP {@code secure-processing} feature should be turned on.
+   *
+   * @param enableSecureProcessing {@code true} to enable secure processing
+   */
   public void setEnableSecureProcessing(boolean enableSecureProcessing) {
     this.enableSecureProcessing = enableSecureProcessing;
   }
 
+  /**
+   * Reports whether external parameter entity references should be enabled. Note that {@link
+   * PSSecureXMLUtils} always hard-disables them regardless of this flag.
+   *
+   * @return {@code true} if external parameter entities are requested by the caller
+   */
   public boolean isEnableExternalParameterEntities() {
     return enableExternalParameterEntities;
   }
 
+  /**
+   * Sets whether external parameter entity references should be enabled.
+   *
+   * @param enableExternalParameterEntities {@code true} to request external parameter entity
+   *     resolution; note that {@link PSSecureXMLUtils} overrides this to {@code false}
+   */
   public void setEnableExternalParameterEntities(boolean enableExternalParameterEntities) {
     this.enableExternalParameterEntities = enableExternalParameterEntities;
   }
 
+  /**
+   * Reports whether the secured parser should perform DTD-based validation.
+   *
+   * @return {@code true} if validation is enabled
+   */
   public boolean isEnableValidation() {
     return enableValidation;
   }
 
+  /**
+   * Sets whether the secured parser should perform DTD-based validation.
+   *
+   * @param enableValidation {@code true} to enable validation
+   */
   public void setEnableValidation(boolean enableValidation) {
     this.enableValidation = enableValidation;
   }
 
+  /**
+   * Returns the allow-list of filesystem paths from which {@code <!DOCTYPE>} declarations may load
+   * DTDs.
+   *
+   * @return the configured paths, or {@code null} when no allow-list is configured
+   */
   public String[] getAllowedPathsForDtdDeclarations() {
     return allowedPathsForDtdDeclarations;
   }
 
+  /**
+   * Sets the allow-list of filesystem paths from which {@code <!DOCTYPE>} declarations may load
+   * DTDs.
+   *
+   * @param allowedPathsForDtdDeclarations the paths to allow, or {@code null} to disable path
+   *     filtering
+   */
   public void setAllowedPathsForDtdDeclarations(String[] allowedPathsForDtdDeclarations) {
     this.allowedPathsForDtdDeclarations = allowedPathsForDtdDeclarations;
   }
 
+  /**
+   * Returns the allow-list of filesystem paths from which external entities may be resolved.
+   *
+   * @return the configured paths, or {@code null} when no allow-list is configured
+   */
   public String[] getAllowedPathsForExternalEntities() {
     return allowedPathsForExternalEntities;
   }
 
+  /**
+   * Sets the allow-list of filesystem paths from which external entities may be resolved.
+   *
+   * @param allowedPathsForExternalEntities the paths to allow, or {@code null} to disable path
+   *     filtering
+   */
   public void setAllowedPathsForExternalEntities(String[] allowedPathsForExternalEntities) {
     this.allowedPathsForExternalEntities = allowedPathsForExternalEntities;
   }
 
+  /**
+   * Returns the allow-list of filesystem paths from which XSL {@code <xsl:import>} elements may
+   * resolve.
+   *
+   * @return the configured paths, or {@code null} when no allow-list is configured
+   */
   public String[] getAllowedPathsForImports() {
     return allowedPathsForImports;
   }
 
+  /**
+   * Sets the allow-list of filesystem paths from which XSL {@code <xsl:import>} elements may
+   * resolve.
+   *
+   * @param allowedPathsForImports the paths to allow, or {@code null} to disable path filtering
+   */
   public void setAllowedPathsForImports(String[] allowedPathsForImports) {
     this.allowedPathsForImports = allowedPathsForImports;
   }
 
+  /**
+   * Returns the allow-list of filesystem paths from which XSL {@code <xsl:include>} elements may
+   * resolve.
+   *
+   * @return the configured paths, or {@code null} when no allow-list is configured
+   */
   public String[] getAllowedPathsForIncludes() {
     return allowedPathsForIncludes;
   }
 
+  /**
+   * Sets the allow-list of filesystem paths from which XSL {@code <xsl:include>} elements may
+   * resolve.
+   *
+   * @param allowedPathsForIncludes the paths to allow, or {@code null} to disable path filtering
+   */
   public void setAllowedPathsForIncludes(String[] allowedPathsForIncludes) {
     this.allowedPathsForIncludes = allowedPathsForIncludes;
   }


### PR DESCRIPTION
Resolves #1948

## Summary

The perc-xml-security module previously reported ~40 javadoc warnings (mostly 'no comment' on constants, getters/setters, and factory methods plus 'no @return' / 'no description for @param') during Javadoc generation. All public classes now have complete Javadoc.

## Changes

Added / expanded Javadoc on 5 files under \modules/perc-xml-security/src/main/java/com\:

|                       File                       |                                            Fix                                            |
|--------------------------------------------------|-------------------------------------------------------------------------------------------|
| \IPSInternalRequestURIResolver.java\            | Added class-level Javadoc explaining its role as a JAXP URIResolver extension              |
| \PSCatalogResolver.java\                        | Added class Javadoc; documented every public method and the internal-URI-resolver accessors |
| \PSSecureXMLUtils.java\                         | Added Javadoc on every public constant and on \getSecuredXStream\ / \getSecuredXMLInputFactory\ / \getSecuredSaxParserFactory\ overloads |
| \PSXMLEntityResolverWrapper.java\               | Added class Javadoc; added explicit no-arg constructor with Javadoc to fix the 'use of default constructor' warning |
| \PSXmlSecurityOptions.java\                     | Added Javadoc on the constructor and every getter/setter                                  |

## Verification

\\\at
cd modules\perc-xml-security
..\..\mvnw.cmd clean install
\\\

Result:
- BUILD SUCCESS
- javadoc source warnings: **0** (was ~40)
- javadoc plugin warnings: **0**
- javadoc errors / failures / blocks: **0 / 0 / 0**
- All 9 unit tests pass (PSCatalogResolverTest, PSSecureXMLUtilsCallSiteOptionsTest)
- spotless:apply + spotless:check pass
- No new compiler warnings

## Acceptance criteria

- [x] Resolve all javadoc warnings in the perc-xml-security module
- [x] All public APIs have complete and valid Javadoc
- [x] Module builds successfully with zero javadoc errors and zero javadoc warnings
- [x] No regressions introduced

---
Operator: Kilo (minimax-coding-plan/MiniMax-M3)