### PR TITLE
fix(deps): ban ZooKeeper jars and document empty SolrJ tree (#1673)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,12 @@
         <xmpbox.version>2.0.17</xmpbox.version>
         <xstream.version>1.4.21</xstream.version>
         <!-- Transitive CVE floors (see dependencyManagement BOM / pins below) -->
-        <!-- SolrJ → ZK 3.9.4; Dependabot #210/#211 need ≥3.9.5 -->
+        <!-- SolrJ historically pinned ZK 3.9.4; floor 3.9.5 is Maven Central latest
+             (Apache current 3.9.x as of 2026-08). Product excludes solr-solrj-zookeeper
+             and bans ZK via enforcer (issue #1673) — HTTP SolrJ only. Keep this pin if
+             CloudSolrClient+ZK is re-enabled: remove bans/exclusions and re-add the
+             optional module. Dependabot may still list 3.9.5 in residual advisory ranges
+             with no newer patched artifact; empty tree is the mitigation. -->
         <zookeeper.version>3.9.5</zookeeper.version>
     </properties>
     <dependencyManagement>
@@ -311,7 +316,8 @@
                  Product does not call Netty/ZooKeeper APIs directly. AWS SDK v1 and
                  SolrJ still pull com.fasterxml Jackson 2.x; Artemis pulls modular Netty.
                  Import BOMs so every module version is forced without sprinkling per-artifact
-                 pins. Exclude Solr's optional ZK client module so its 3.9.4 pin cannot win. -->
+                 pins. Solr's optional ZK client is excluded from solr-solrj (issue #1673);
+                 ZK jars are also banned by enforcer while the tree is empty. -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
@@ -326,6 +332,8 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Managed floor only if CloudSolrClient+ZK is re-enabled (see zookeeper.version).
+                 Not on the runtime tree today — solr-solrj exclusions + enforcer ban. -->
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
@@ -1028,10 +1036,11 @@
                 <artifactId>solr-solrj</artifactId>
                 <version>${solr.version}</version>
                 <exclusions>
-                    <!-- Optional SolrCloud client; pins ZK 3.9.4 (Dependabot #210/#211).
-                         HTTP SolrJ does not need this module. If CloudSolrClient+ZK is
-                         required later, re-add solr-solrj-zookeeper and rely on
-                         zookeeper.version (3.9.5+) management above. -->
+                    <!-- Issue #1673: optional SolrCloud ZK client (historically ZK 3.9.4).
+                         Product uses HTTP SolrJ only — no CloudSolrClient. Keep off the
+                         tree; enforcer bans zookeeper/zookeeper-jute. If CloudSolrClient+ZK
+                         is required later: drop these exclusions, remove the enforcer ban,
+                         and rely on zookeeper.version (3.9.5, Central latest) management. -->
                     <exclusion>
                         <groupId>org.apache.solr</groupId>
                         <artifactId>solr-solrj-zookeeper</artifactId>
@@ -2211,20 +2220,28 @@
                                         <!-- Issue #1672: ban unmaintained junrar entirely.
                                              Excluded from tika-parsers-standard-package above;
                                              ban prevents re-introduction via any transitive. -->
-                                        <excludes>
-                                            <exclude>com.github.junrar:junrar</exclude>
                                         <!-- Issue #1674: ban Java-WebSocket advisory range (,1.4.1].
                                              Floor is ${java.websocket.version} (1.6.0) via
                                              dependencyManagement; javafx-webview-debugger
                                              otherwise pulls 1.3.7. -->
-                                        <excludes>
-                                            <exclude>org.java-websocket:Java-WebSocket:*:[,1.4.1]</exclude>
                                         <!-- Issue #1804: com.sun:tools (tools.jar) is not a valid Maven
                                              dependency on JDK 9+ / Maven 3.9+. systemPath ${tools.jar}
                                              fails absolute-path validation and tools.jar is gone from
                                              modern JDKs. Ban so it cannot re-enter dependencyManagement. -->
+                                        <!-- Issue #1673: ban ZooKeeper client jars entirely.
+                                             solr-solrj already excludes solr-solrj-zookeeper +
+                                             zookeeper/zookeeper-jute (HTTP Solr only). Tree is
+                                             empty on system/WebUI/sitemanage/rest/deployer.
+                                             No newer Central pin than 3.9.5; Dependabot residual
+                                             advisory noise on 3.9.x is mitigated by absence from
+                                             the tree. Drop this ban only if CloudSolrClient+ZK
+                                             is intentionally re-enabled. -->
                                         <excludes>
+                                            <exclude>com.github.junrar:junrar</exclude>
+                                            <exclude>org.java-websocket:Java-WebSocket:*:[,1.4.1]</exclude>
                                             <exclude>com.sun:tools</exclude>
+                                            <exclude>org.apache.zookeeper:zookeeper</exclude>
+                                            <exclude>org.apache.zookeeper:zookeeper-jute</exclude>
                                         </excludes>
                                         <searchTransitive>true</searchTransitive>
                                     </bannedDependencies>


### PR DESCRIPTION
## Summary

Closes the remaining work for **#1673** on `org.apache.zookeeper:zookeeper` / `zookeeper-jute` (Dependabot advisory ranges on 3.x; no newer Central pin than 3.9.5).

**Prior mitigation (already on main):**
- Parent `zookeeper.version=3.9.5` + `dependencyManagement` for `zookeeper` and `zookeeper-jute`
- Managed `solr-solrj` excludes `solr-solrj-zookeeper`, `zookeeper`, and `zookeeper-jute` (HTTP Solr only)

**This PR:**
1. **Tree proof** — key SolrJ / reactor consumers resolve **no** `org.apache.zookeeper` artifacts
2. **Enforcer ban** — ban `org.apache.zookeeper:zookeeper` and `zookeeper-jute` (all versions) in parent `maven-enforcer-plugin` `bannedDependencies` (inherited by modules that enable enforcer)
3. **Comments** — document empty-tree mitigation, residual Dependabot noise on 3.9.5 with no patched newer artifact, and how to re-enable CloudSolrClient+ZK if ever required (drop exclusions + ban; keep ``)

No production Java code changes; dependency/POM only. Product still does not call ZooKeeper APIs (SASL keys in `PSSolrDeliveryHandler` remain config strings only).

### Tree proof (empty)

| Module | `dependency:tree -Dincludes=org.apache.zookeeper` |
|--------|------------------------------------------------------|
| `system` (solr-solrj consumer) | **empty** |
| `WebUI` (solr-solrj consumer) | **empty** |
| `projects/sitemanage` | **empty** |
| `rest` | **empty** |
| `deployer` | **empty** |
| `modules/perc-distribution-tree` | **empty** |
| DTS suite | **empty** |

`system` SolrJ path (no ZK):

`
com.percussion:perc-system:jar:8.2.0-SNAPSHOT
\- org.apache.solr:solr-solrj:jar:9.10.1:compile (optional)
   +- org.apache.solr:solr-api:jar:9.10.1:compile (optional)
   \- org.apache.solr:solr-solrj-streaming:jar:9.10.1:runtime (optional)
`

Maven Central latest remains **3.9.5** (Apache current 3.9.x as of 2026-08). Dependabot may still list residual advisory ranges covering 3.9.x; mitigation is **absence from the tree**, not a version bump.

## Test plan

- [x] `cd system && ../mvnw.cmd dependency:tree -Dincludes=org.apache.zookeeper` → empty, BUILD SUCCESS
- [x] `cd WebUI && ../mvnw.cmd dependency:tree -Dincludes=org.apache.zookeeper` → empty, BUILD SUCCESS
- [x] `cd projects/sitemanage && ../../mvnw.cmd dependency:tree -Dincludes=org.apache.zookeeper` → empty, BUILD SUCCESS
- [x] `rest`, `deployer`, `perc-distribution-tree`, DTS suite trees → empty
- [x] `cd modules/utils && ../../mvnw.cmd validate` → `BannedDependencies` **passed** (Rule 6)
- [x] `mvnw.cmd -N install -DskipTests` (parent POM) → **BUILD SUCCESS**
- [x] Root `mvnw.cmd spotless:apply` then `spotless:check` → **SUCCESS**; only `pom.xml` committed (out-of-scope Spotless baseline rewrites discarded)

## Gates

| Gate | Result |
|------|--------|
| Erlang self-review | Pass — POM-only, no path I/O, no new logic; companions = depManagement pin (kept) + solr-solrj exclusions (kept) + enforcer ban + tree proof |
| Spotless apply → check | Pass (in-scope only) |
| Module clean install | Parent `-N` SUCCESS; enforcer validate on `utils` SUCCESS |
| Unit tests | N/A (no Java logic) |

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #1673