### PR TITLE
fix(#1954): clean javadoc warnings in tlsutils module

### DIFF
--- a/modules/tlsutils/src/main/java/com/percussion/tls/TLSTester.java
+++ b/modules/tlsutils/src/main/java/com/percussion/tls/TLSTester.java
@@ -58,12 +58,25 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/** Utility for verifying TLS connections to a target host. */
 public class TLSTester {
 
+  /** No-op constructor. */
+  public TLSTester() {
+    // no-op
+  }
+
+  /** Logger used by this class. */
   private static final Logger log = LogManager.getLogger(TLSTester.class);
 
+  /** Cached value of the {@code os.name} system property. */
   private static String OS = null;
 
+  /**
+   * Returns the cached value of the {@code os.name} system property, computing it on first access.
+   *
+   * @return the operating system name
+   */
   public static String getOsName() {
     if (OS == null) {
       OS = System.getProperty("os.name");
@@ -71,13 +84,30 @@ public class TLSTester {
     return OS;
   }
 
+  /**
+   * Tests whether the current operating system is Windows.
+   *
+   * @return {@code true} if {@code os.name} starts with "windows"
+   */
   public static boolean isWindows() {
     // perform case-insensitive check, cache handles case already
     return getOsName().toLowerCase().startsWith("windows");
   }
 
+  /** Default password used when reading the bundled keystore. */
   public static final String KEYSTORE_PASS = "changeit";
 
+  /**
+   * Command-line entry point that exercises the TLS utilities against the hosts/ports supplied on
+   * the command line.
+   *
+   * @param args command-line arguments; expected to be {@code host port} pairs
+   * @throws IOException if a network or keystore I/O error occurs
+   * @throws NoSuchAlgorithmException if a required algorithm is not available
+   * @throws CertificateException if a certificate cannot be parsed or validated
+   * @throws KeyManagementException if the key management subsystem fails
+   * @throws KeyStoreException if the keystore cannot be loaded
+   */
   public static void main(String[] args)
       throws IOException,
           NoSuchAlgorithmException,
@@ -343,7 +373,13 @@ public class TLSTester {
     }
   }
 
-  static boolean isUnlimitedCryptoLength() {
+  /**
+ * Tests whether the JCE jurisdiction policy allows unlimited-strength cryptography.
+ *
+ * @return {@code true} if {@link Cipher#getMaxAllowedKeyLength(String)} returns
+ *     {@link Integer#MAX_VALUE} for AES, {@code false} otherwise
+ */
+static boolean isUnlimitedCryptoLength() {
 
     try {
       int length = Cipher.getMaxAllowedKeyLength("AES");
@@ -357,7 +393,10 @@ public class TLSTester {
     return false;
   }
 
-  public static void getEnabledCiphers() {
+  /**
+ * Logs the cipher suites enabled for each installed security provider. Used for diagnostics.
+ */
+public static void getEnabledCiphers() {
     for (Provider provider : Security.getProviders()) {
       log.info("Security Provider: {}", provider.getName());
       for (String key : provider.stringPropertyNames())
@@ -365,6 +404,13 @@ public class TLSTester {
     }
   }
 
+  /**
+   * Converts an X.509 certificate to its PEM-encoded string representation.
+   *
+   * @param cert the certificate to encode, never {@code null}
+   * @return the PEM-encoded certificate, including begin/end markers
+   * @throws CertificateEncodingException if the certificate cannot be DER-encoded
+   */
   protected static String convertToPem(X509Certificate cert) throws CertificateEncodingException {
 
     String cert_begin = "-----BEGIN CERTIFICATE-----\n";

--- a/modules/tlsutils/src/main/java/com/percussion/tls/TLSUtils.java
+++ b/modules/tlsutils/src/main/java/com/percussion/tls/TLSUtils.java
@@ -21,7 +21,21 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import org.apache.commons.codec.binary.Base64;
 
+/** Utility methods for working with TLS certificates. */
 public class TLSUtils {
+
+  /** No-op constructor. */
+  public TLSUtils() {
+    // no-op
+  }
+
+  /**
+   * Converts an X.509 certificate to its PEM-encoded string representation.
+   *
+   * @param cert the certificate to encode, never {@code null}
+   * @return the PEM-encoded certificate, including begin/end markers
+   * @throws CertificateEncodingException if the certificate cannot be DER-encoded
+   */
   protected static String convertToPem(X509Certificate cert) throws CertificateEncodingException {
 
     String cert_begin = "-----BEGIN CERTIFICATE-----\n";

--- a/modules/tlsutils/src/main/java/com/percussion/tls/WrappedTrustManager.java
+++ b/modules/tlsutils/src/main/java/com/percussion/tls/WrappedTrustManager.java
@@ -32,16 +32,28 @@ import javax.net.ssl.X509TrustManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * Aggregates multiple {@link X509TrustManager} instances and delegates certificate checks to each in
+ * order. Used by the TLS testing utilities to evaluate trust against several trust stores.
+ */
 public class WrappedTrustManager implements X509TrustManager {
 
+  /** Logger used by this class. */
   private static final Logger log = LogManager.getLogger(WrappedTrustManager.class);
 
+  /** Wrapped trust managers keyed by their identifying alias. */
   private LinkedHashMap<String, X509TrustManager> wrappedManagers = new LinkedHashMap<>();
 
   WrappedTrustManager() {
     addKeyStore("Default Java", null);
   }
 
+  /**
+   * Registers a named keystore whose trust manager should be wrapped.
+   *
+   * @param name the alias used to identify this trust store
+   * @param keyStore the keystore to wrap, or {@code null} to use the JVM default trust store
+   */
   public void addKeyStore(String name, KeyStore keyStore) {
     try {
       wrappedManagers.put(name, getTrustManager(keyStore));


### PR DESCRIPTION
## Summary

Resolves GitHub issue #1954: clean all Javadoc warnings reported by the maven-javadoc-plugin in the \	lsutils\ module so the count is zero.

## Investigation

Build (\mvnw.cmd clean install -B\) on \main\ produced 13 Javadoc warnings across 3 files in \modules/tlsutils\. Issue-generator reported \8 source + 1 plugin\. This PR addresses every warning produced by the build.

## Verification (on Windows, JDK 21)

\\\
cd modules/tlsutils
..\..\mvnw.cmd clean install -B
\\\

- **BUILD SUCCESS** — module compiles standalone.
- **Zero Javadoc warnings** — \maven-javadoc-plugin\ reports no remaining warnings.

## Changes

| File | Fix |
|------|-----|
| \TLSTester.java\ | class description, no-arg ctor, log/OS/KEYSTORE_PASS fields, all methods documented |
| \TLSUtils.java\ | class description, no-arg ctor, convertToPem documented |
| \WrappedTrustManager.java\ | class description, log/wrappedManagers fields, addKeyStore documented |

## Acceptance Criteria

- [x] All in-scope code compiles standalone.
- [x] All unit tests pass.
- [x] Zero Javadoc warnings.
- [x] No new compiler warnings.

## Notes

- Operator: Kilo (minimax-coding-plan/MiniMax-M3)
- Co-Authored by Kilo using minimax-coding-plan/MiniMax-M3 with agent Kilo.