### PR TITLE
fix(#1950): clean javadoc warnings in servletutils module

### DIFF
--- a/modules/servletutils/src/main/java/com/percussion/servlet_utils/servlet/PSInputValidatorFilter.java
+++ b/modules/servletutils/src/main/java/com/percussion/servlet_utils/servlet/PSInputValidatorFilter.java
@@ -71,12 +71,16 @@ import org.apache.logging.log4j.Logger;
  */
 public class PSInputValidatorFilter implements Filter {
 
+  /** HTTP status returned when a parameter fails validation. */
   public static final int RESPONSE_ERROR_STATUS = 422;
 
+  /** Default value used when the enable property is absent. */
   protected static final boolean VALIDATOR_ENABLE_DEFAULT_PARAM_VALUE = false;
 
+  /** Name of the system property that turns the filter on or off. */
   public static final String VALIDATOR_ENABLE_PROP_NAME = "PSInputValidatorFilter.enable";
 
+  /** Name of the system property that points at the validator configuration resource. */
   public static final String VALIDATOR_CONFIG_RESOURCE_PROP_NAME =
       "PSInputValidatorFilter.configResource";
 
@@ -100,19 +104,27 @@ public class PSInputValidatorFilter implements Filter {
     // Only allow a numeric, i.e. 10 or 4.5
     NUMERIC(Pattern.compile("\\d+.\\d+"));
 
+    /** Compiled regular expression associated with this restriction type. */
     private Pattern pattern;
 
     RestrictType(Pattern p) {
       this.pattern = p;
     }
 
+    /**
+     * Returns the compiled pattern used to enforce this restriction.
+     *
+     * @return the pattern, never {@code null}
+     */
     public Pattern getPattern() {
       return this.pattern;
     }
   }
 
+  /** Whether this filter instance currently has validation enabled. */
   private boolean isEnabled = false;
 
+  /** No-op constructor. */
   public PSInputValidatorFilter() {
     // ctor
   }

--- a/modules/servletutils/src/main/java/com/percussion/servlet_utils/servlet/PSMockHttpServletRequest.java
+++ b/modules/servletutils/src/main/java/com/percussion/servlet_utils/servlet/PSMockHttpServletRequest.java
@@ -81,85 +81,188 @@ public class PSMockHttpServletRequest implements HttpServletRequest {
   private ServletContext servletContext;
   private Locale locale = Locale.getDefault();
 
+  /** No-op constructor. */
   public PSMockHttpServletRequest() {}
 
+  /**
+   * Convenience constructor that seeds the request method and URI.
+   *
+   * @param method the HTTP method, defaults to {@code GET} when {@code null}
+   * @param requestURI the request URI, defaults to empty when {@code null}
+   */
   public PSMockHttpServletRequest(String method, String requestURI) {
     this.method = method != null ? method : "GET";
     setRequestURI(requestURI != null ? requestURI : "");
   }
 
+  /**
+   * Sets the HTTP method.
+   *
+   * @param method the method
+   */
   public void setMethod(String method) {
     this.method = method;
   }
 
+  /**
+   * Sets the URL scheme.
+   *
+   * @param scheme the scheme
+   */
   public void setScheme(String scheme) {
     this.scheme = scheme;
   }
 
+  /**
+   * Sets the server name.
+   *
+   * @param serverName the server name
+   */
   public void setServerName(String serverName) {
     this.serverName = serverName;
   }
 
+  /**
+   * Sets the server port.
+   *
+   * @param serverPort the server port
+   */
   public void setServerPort(int serverPort) {
     this.serverPort = serverPort;
   }
 
+  /**
+   * Sets the context path.
+   *
+   * @param contextPath the context path, never {@code null}
+   */
   public void setContextPath(String contextPath) {
     this.contextPath = contextPath != null ? contextPath : "";
   }
 
+  /**
+   * Sets the servlet path.
+   *
+   * @param servletPath the servlet path, never {@code null}
+   */
   public void setServletPath(String servletPath) {
     this.servletPath = servletPath != null ? servletPath : "";
   }
 
+  /**
+   * Sets the path info.
+   *
+   * @param pathInfo the path info
+   */
   public void setPathInfo(String pathInfo) {
     this.pathInfo = pathInfo;
   }
 
+  /**
+   * Sets the query string.
+   *
+   * @param queryString the query string
+   */
   public void setQueryString(String queryString) {
     this.queryString = queryString;
   }
 
+  /**
+   * Sets the request URI.
+   *
+   * @param requestURI the request URI, never {@code null}
+   */
   public void setRequestURI(String requestURI) {
     this.requestURI = requestURI != null ? requestURI : "";
   }
 
+  /**
+   * Sets the request protocol.
+   *
+   * @param protocol the protocol
+   */
   public void setProtocol(String protocol) {
     this.protocol = protocol;
   }
 
+  /**
+   * Sets the remote client address.
+   *
+   * @param remoteAddr the remote address
+   */
   public void setRemoteAddr(String remoteAddr) {
     this.remoteAddr = remoteAddr;
   }
 
+  /**
+   * Sets the remote client host.
+   *
+   * @param remoteHost the remote host
+   */
   public void setRemoteHost(String remoteHost) {
     this.remoteHost = remoteHost;
   }
 
+  /**
+   * Sets the remote authenticated user.
+   *
+   * @param remoteUser the remote user
+   */
   public void setRemoteUser(String remoteUser) {
     this.remoteUser = remoteUser;
   }
 
+  /**
+   * Sets the authentication scheme.
+   *
+   * @param authType the auth type
+   */
   public void setAuthType(String authType) {
     this.authType = authType;
   }
 
+  /**
+   * Sets whether the request was made over a secure transport.
+   *
+   * @param secure {@code true} for HTTPS-like requests
+   */
   public void setSecure(boolean secure) {
     this.secure = secure;
   }
 
+  /**
+   * Sets the authenticated user principal.
+   *
+   * @param userPrincipal the principal, may be {@code null}
+   */
   public void setUserPrincipal(Principal userPrincipal) {
     this.userPrincipal = userPrincipal;
   }
 
+  /**
+   * Sets the request content type.
+   *
+   * @param contentType the content type
+   */
   public void setContentType(String contentType) {
     this.contentType = contentType;
   }
 
+  /**
+   * Sets the request body content.
+   *
+   * @param content the body bytes, never {@code null}
+   */
   public void setContent(byte[] content) {
     this.content = content != null ? content : new byte[0];
   }
 
+  /**
+   * Sets a single-valued parameter, removing any existing values if {@code value} is {@code null}.
+   *
+   * @param name the parameter name
+   * @param value the parameter value, or {@code null} to remove
+   */
   public void setParameter(String name, String value) {
     if (name == null) {
       return;
@@ -171,6 +274,12 @@ public class PSMockHttpServletRequest implements HttpServletRequest {
     }
   }
 
+  /**
+   * Sets a multi-valued parameter, removing any existing values if {@code values} is {@code null}.
+   *
+   * @param name the parameter name
+   * @param values the parameter values
+   */
   public void setParameter(String name, String... values) {
     if (name == null) {
       return;
@@ -182,6 +291,11 @@ public class PSMockHttpServletRequest implements HttpServletRequest {
     }
   }
 
+  /**
+   * Replaces all parameters with the supplied map.
+   *
+   * @param params the new parameter map, may be {@code null}
+   */
   public void setParameters(Map<String, String[]> params) {
     parameters.clear();
     if (params != null) {
@@ -189,14 +303,30 @@ public class PSMockHttpServletRequest implements HttpServletRequest {
     }
   }
 
+  /**
+   * Appends a header value to the list of headers for {@code name}.
+   *
+   * @param name the header name
+   * @param value the header value
+   */
   public void addHeader(String name, String value) {
     headers.computeIfAbsent(normalize(name), k -> new ArrayList<>()).add(value);
   }
 
+  /**
+   * Sets the active HTTP session.
+   *
+   * @param session the session, may be {@code null}
+   */
   public void setSession(HttpSession session) {
     this.session = session;
   }
 
+  /**
+   * Sets the active servlet context.
+   *
+   * @param servletContext the servlet context
+   */
   public void setServletContext(ServletContext servletContext) {
     this.servletContext = servletContext;
   }

--- a/modules/servletutils/src/main/java/com/percussion/servlet_utils/servlet/PSMockHttpServletResponse.java
+++ b/modules/servletutils/src/main/java/com/percussion/servlet_utils/servlet/PSMockHttpServletResponse.java
@@ -41,19 +41,44 @@ import java.util.Map;
  */
 public class PSMockHttpServletResponse implements HttpServletResponse {
 
+  /** Accumulated response body. */
   private final ByteArrayOutputStream content = new ByteArrayOutputStream();
+
+  /** Response headers keyed by header name. */
   private final Map<String, List<String>> headers = new LinkedHashMap<>();
+
+  /** Cookies that have been added to the response. */
   private final List<Cookie> cookies = new ArrayList<>();
 
+  /** HTTP status code, defaults to {@link #SC_OK}. */
   private int status = SC_OK;
+
+  /** Character encoding used for the response body, defaults to UTF-8. */
   private String characterEncoding = StandardCharsets.UTF_8.name();
+
+  /** Response content type, may be {@code null}. */
   private String contentType;
+
+  /** Locale associated with the response. */
   private Locale locale = Locale.getDefault();
+
+  /** Whether the response has been committed. */
   private boolean committed;
+
+  /** Lazily created print writer for the response body. */
   private PrintWriter writer;
+
+  /** Lazily created servlet output stream for the response body. */
   private ServletOutputStream outputStream;
 
+  /** No-op constructor. */
+  public PSMockHttpServletResponse() {
+    // no-op
+  }
+
   /**
+   * Returns the accumulated response body decoded using the configured character encoding.
+   *
    * @return response body using the configured character encoding
    */
   public String getContentAsString() {
@@ -67,6 +92,8 @@ public class PSMockHttpServletResponse implements HttpServletResponse {
   }
 
   /**
+   * Returns the accumulated response body as raw bytes.
+   *
    * @return raw response bytes
    */
   public byte[] getContentAsByteArray() {

--- a/modules/servletutils/src/main/java/com/percussion/servlet_utils/servlet/PSServletUtils.java
+++ b/modules/servletutils/src/main/java/com/percussion/servlet_utils/servlet/PSServletUtils.java
@@ -83,10 +83,13 @@ public class PSServletUtils {
   /** The name of the Spring configuration file for the sitemanage module. */
   public static final String SITEMANAGE_FILE_NAME = "sitemanage-beans.xml";
 
+  /** File name of the package beans XML descriptor used during servlet wiring. */
   public static final String PACKAGE_BEANS_FILE_NAME = "package-beans.xml";
 
+  /** File name of the image widget beans XML descriptor. */
   public static final String IMAGEWIDGET_BEANS_FILE_NAME = "imageWidget-beans.xml";
 
+  /** File name of the image widget servlet XML descriptor. */
   public static final String IMAGEWIDGET_SERVLET_FILE_NAME = "imageWidget-servlet.xml";
 
   /**
@@ -360,8 +363,8 @@ public class PSServletUtils {
    *
    * @param req the request, never <code>null</code>, will normally be a mock/internal request
    * @return the mock response, never <code>null</code>
-   * @throws IOException
-   * @throws ServletException
+   * @throws IOException if the underlying request/response handling fails
+   * @throws ServletException if the servlet container signals an error during dispatch
    */
   public static PSMockHttpServletResponse callServlet(HttpServletRequest req)
       throws ServletException, IOException {


### PR DESCRIPTION
## Summary

Resolves GitHub issue #1950: clean all Javadoc warnings reported by the maven-javadoc-plugin in the \servletutils\ module so the count is zero.

## Verification (on Windows, JDK 21)

\\\
cd modules/servletutils
..\..\mvnw.cmd clean install -B
\\\

- **BUILD SUCCESS** — module compiles standalone.
- **Zero Javadoc warnings** — only two non-javadoc JUnit warnings remain (test discovery).

## Changes

| File | Fix |
|------|-----|
| PSInputValidatorFilter | constants, enum field/c-tor, isEnabled, ctor |
| PSMockHttpServletRequest | all setters, ctor |
| PSMockHttpServletResponse | class fields, ctor, getContentAs* |
| PSServletUtils | constants, callServlet @throws |

## Acceptance Criteria

- [x] All in-scope code compiles standalone.
- [x] All unit tests pass.
- [x] Zero Javadoc warnings.
- [x] No new compiler warnings.

Operator: Kilo (minimax-coding-plan/MiniMax-M3)