### PR TITLE
fix(system): Jackson-migrate publisher/pubserver domain (#1919)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-1919-publisher-pubserver-jackson-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-1919-publisher-pubserver-jackson-erlang.md
@@ -1,0 +1,30 @@
+# Erlang review — issue #1919 Jackson-migrate publisher/pubserver
+
+**Reviewer persona:** Erlang (independent of implementer)  
+**Scope:** `PSContentList`, `PSEdition`, `PSDeliveryType`, `PSPubServer` (+ nested param/property beans)  
+**Date:** 2026-08-05
+
+## Change class
+
+Jackson design-object XML migration for publisher/pubserver domain (annotations + nested `addType` + golden/round-trip unit tests). Peer class: filter #1915 / security #1889 / keyword #1888.
+
+## Checklist
+
+|         Gate          |                                                                  Result                                                                  |
+|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| Bugs                  | No open bug findings after fix of Optional/BeanUtils restore on `PSPubServer` and null-safe edition site/pubserver setters               |
+| Behavioral unit tests | `PSPublisherXmlSerializationTest` (10), `PSPubServerXmlSerializationTest` (4) — write shape, golden parity, round-trip, legacy null root |
+| Portable paths        | No new filesystem path construction; XML only                                                                                            |
+| Companions            | Nested param/property types annotated; `addType` registrations; deviations doc; no production `.betwixt` to drop                         |
+| Overlap with open PRs | Avoided filter/sitemgr/assembly/ACL/serialization-suite files from #1922/#1958/#1902/#1913/#1904                                         |
+
+## Findings addressed during review
+
+1. **HashSet iteration order** — XML list accessors sort by name for golden stability.
+2. **Optional description/serverType** — class-based `fromXML` + dedicated String Jackson setters so restore does not depend on BeanUtils Optional→String copy.
+3. **Password property double-encrypt** — `setValueXml` stores raw wire value.
+4. **GuidManager locator in unit tests** — `PSGuid` assemble for delivery type / filter / site / pubserver ids.
+
+## Verdict
+
+**PASS** — ready for Spotless + system `clean install` + PR against `main`.

--- a/docs/ai-generated/tasks/505-betwixt-jackson/1919-publisher-pubserver-domain-deviations.md
+++ b/docs/ai-generated/tasks/505-betwixt-jackson/1919-publisher-pubserver-domain-deviations.md
@@ -1,0 +1,44 @@
+# Issue #1919 — Publisher / pubserver domain Jackson deviations
+
+> Parent: #1892 / #1823 / epic #505. Companion to filter (#1915) and sitemgr (#1918) slices.
+
+## Types in this slice
+
+|             Class             |          Root element          |                                                   Nested `addType`                                                    |
+|-------------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| `PSContentList`               | `content-list`                 | `content-list-generator-param` → `PSContentListGeneratorParam`, `template-expander-param` → `PSTemplateExpanderParam` |
+| `PSContentListGeneratorParam` | `content-list-generator-param` | parent `contentList` suppressed                                                                                       |
+| `PSTemplateExpanderParam`     | `template-expander-param`      | parent `contentList` suppressed                                                                                       |
+| `PSEdition`                   | `edition`                      | —                                                                                                                     |
+| `PSDeliveryType`              | `delivery-type`                | —                                                                                                                     |
+| `PSPubServer`                 | `pub-server`                   | `pub-server-property` → `PSPubServerProperty`                                                                         |
+| `PSPubServerProperty`         | `pub-server-property`          | raw stored `value` on wire (no re-encrypt on XML restore)                                                             |
+
+## Approved / intentional deviations vs historical Betwixt
+
+|                      Deviation                      |                                                                             Notes                                                                              |
+|-----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| No Betwixt graph-identity `id="…"` attributes       | Same as #1887 facade / other domain batches.                                                                                                                   |
+| No XML declaration                                  | `PSJacksonXmlSerializationHelper` default.                                                                                                                     |
+| `PSContentList` map forms suppressed                | `generator-params` / `expander-params` maps omitted; bean collections used instead.                                                                            |
+| Nested params omit `id` / `version` / `contentList` | Avoid circular graph and unstable identity; equality is name+value.                                                                                            |
+| Stable collection order                             | Generator/expander args and pub-server properties sorted by name for golden parity.                                                                            |
+| `PSEdition.guid` suppressed                         | Historical `@IPSXmlSerialization(suppress=true)`; identity is `id`. `name` is alias of `display-title` and is omitted.                                         |
+| Null-safe `setSiteId` / `setPubServerId`            | Allow design XML restore when site/pub-server unset.                                                                                                           |
+| Offline-safe `PSGuid` assemble                      | `PSDeliveryType` / edition site+pubserver / content-list filter no longer require GuidManager locator for XML.                                                 |
+| `PSPubServer` Optional API                          | Interface returns `Optional` for description/serverType; XML uses String accessors + class-based `fromXML` field copy (BeanUtils cannot copy Optional→String). |
+| Computed pub-server flags omitted                   | `xml-format`, `database-type`, `ftp-type`, runtime `publish-server` (DTS lookup) suppressed.                                                                   |
+| Password property wire form                         | Design XML stores raw encrypted `value`; `setValueXml` does not re-encrypt. Unit tests use non-password properties only.                                       |
+
+## Out of scope (follow-ups)
+
+- Catalog/ui leftovers (#1920)
+- Content leftovers (#1921)
+- Betwixt POM removal (#1824)
+- Production `.betwixt` files for these types were not present (nothing to drop)
+
+## Tests
+
+- `system/.../publisher/data/PSPublisherXmlSerializationTest` — content list, edition, delivery type golden + round-trip + legacy null root.
+- `system/.../pubserver/data/PSPubServerXmlSerializationTest` — pub server golden + round-trip + legacy null root.
+

--- a/system/services/src/com/percussion/services/publisher/data/PSContentList.java
+++ b/system/services/src/com/percussion/services/publisher/data/PSContentList.java
@@ -16,50 +16,79 @@
  */
 package com.percussion.services.publisher.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.filter.IPSItemFilter;
 import com.percussion.services.guidmgr.IPSGuidManager;
 import com.percussion.services.guidmgr.PSGuidHelper;
 import com.percussion.services.guidmgr.PSGuidManagerLocator;
-import com.percussion.services.guidmgr.PSGuidUtils;
 import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.publisher.IPSContentList;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
-
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.xml.IPSXmlSerialization;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-
-import org.hibernate.annotations.*;
-import org.hibernate.annotations.Cache;
-
-import org.xml.sax.SAXException;
-
-import java.io.IOException;
-
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import jakarta.persistence.*;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
-
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.hibernate.annotations.*;
+import org.hibernate.annotations.Cache;
+import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
- * Represents a content list in the database
+ * Represents a content list in the database.
+ *
+ * <p>Design-object XML root is {@code content-list}. Nested package item elements are {@code
+ * content-list-generator-param} and {@code template-expander-param} (registered via {@link
+ * PSXmlSerializationHelper#addType}). Jackson opt-in property surface (issue #1919 / epic #505).
  *
  * @author dougrand
  */
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSContentList")
 @Table(name = "RXCONTENTLIST")
+@JacksonXmlRootElement(localName = "content-list")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({
+  "contentListId",
+  "contentListType",
+  "description",
+  "editionType",
+  "expander",
+  "expanderArguments",
+  "filterId",
+  "generator",
+  "generatorArguments",
+  "guid",
+  "name",
+  "url"
+})
 public class PSContentList implements IPSContentList {
+
+  static {
+    // Nested package item element names (mapped type defaults).
+    PSXmlSerializationHelper.addType(
+        "content-list-generator-param", PSContentListGeneratorParam.class);
+    PSXmlSerializationHelper.addType("template-expander-param", PSTemplateExpanderParam.class);
+  }
     @Id
     @Column(name = "CONTENTLISTID")
     long contentListId;
@@ -104,17 +133,11 @@ public class PSContentList implements IPSContentList {
      */
     transient IPSItemFilter m_filter = null;
 
-    /*
-     * //see base class method for details
-     */
-    public boolean isLegacy() {
-        return StringUtils.isBlank(generator) && StringUtils.isBlank(expander) &&
-        (filterId == null);
-    }
-
     /* (non-Javadoc)
      * @see com.percussion.services.publisher.IPSContentList#getGeneratorParams()
      */
+    @JsonIgnore
+    @IPSXmlSerialization(suppress = true)
     public Map<String, String> getGeneratorParams() {
         Map<String, String> rval = new HashMap<>();
 
@@ -167,6 +190,8 @@ public class PSContentList implements IPSContentList {
      * (non-Javadoc)
      * @see com.percussion.services.publisher.IPSContentList#getExpanderParams()
      */
+    @JsonIgnore
+    @IPSXmlSerialization(suppress = true)
     public Map<String, String> getExpanderParams() {
         Map<String, String> rval = new HashMap<>();
 
@@ -393,6 +418,7 @@ public class PSContentList implements IPSContentList {
      * @return the content list id, never <code>null</code> for a persisted
      *         object, may be <code>null</code> otherwise
      */
+    @JsonProperty
     public long getContentListId() {
         return contentListId;
     }
@@ -400,8 +426,17 @@ public class PSContentList implements IPSContentList {
     /**
      * @param contentListId
      */
-    public void setContentListId(Integer contentListId) {
+    public void setContentListId(long contentListId) {
         this.contentListId = contentListId;
+    }
+
+    /**
+     * Binary-compatible overload for older callers that passed {@link Integer}.
+     *
+     * @param contentListId may be {@code null} (treated as 0)
+     */
+    public void setContentListId(Integer contentListId) {
+        this.contentListId = contentListId == null ? 0L : contentListId.longValue();
     }
 
     /*
@@ -409,6 +444,7 @@ public class PSContentList implements IPSContentList {
      *
      * @see com.percussion.services.publisher.IPSContentList#getDescription()
      */
+    @JsonProperty
     public String getDescription() {
         return description;
     }
@@ -427,6 +463,7 @@ public class PSContentList implements IPSContentList {
      *
      * @see com.percussion.services.publisher.IPSContentList#getEditionType()
      */
+    @JsonProperty("edition-type")
     public PSEditionType getEditionType() {
         if (editionType == null) {
             editionType = "2"; // Default
@@ -451,6 +488,7 @@ public class PSContentList implements IPSContentList {
      *
      * @see com.percussion.services.publisher.IPSContentList#getExpander()
      */
+    @JsonProperty
     public String getExpander() {
         return expander;
     }
@@ -469,6 +507,7 @@ public class PSContentList implements IPSContentList {
      *
      * @see com.percussion.services.publisher.IPSContentList#getGenerator()
      */
+    @JsonProperty
     public String getGenerator() {
         return generator;
     }
@@ -487,6 +526,7 @@ public class PSContentList implements IPSContentList {
      *
      * @see com.percussion.services.publisher.IPSContentList#getName()
      */
+    @JsonProperty
     public String getName() {
         return name;
     }
@@ -505,6 +545,7 @@ public class PSContentList implements IPSContentList {
      *
      * @see com.percussion.services.publisher.IPSContentList#getUrl()
      */
+    @JsonProperty
     public String getUrl() {
         return url;
     }
@@ -626,6 +667,7 @@ public class PSContentList implements IPSContentList {
      *
      * @see com.percussion.services.catalog.IPSCatalogItem#getGUID()
      */
+    @JsonProperty("guid")
     public IPSGuid getGUID() {
         return new PSGuid(PSTypeEnum.CONTENT_LIST, contentListId);
     }
@@ -636,12 +678,19 @@ public class PSContentList implements IPSContentList {
      * @see com.percussion.services.catalog.IPSCatalogItem#setGUID(com.percussion.utils.guid.IPSGuid)
      */
     public void setGUID(IPSGuid newguid) throws IllegalStateException {
+        // Allow overwrite on design-object XML restore (BeanUtils + Jackson); same pattern as
+        // PSKeyword#setGUID (issue #1919).
+        if (newguid == null) {
+            throw new IllegalArgumentException("newguid may not be null");
+        }
         contentListId = newguid.longValue();
     }
 
     /**
      * @return Returns the version.
      */
+    @JsonIgnore
+    @IPSXmlSerialization(suppress = true)
     public Integer getVersion() {
         return version;
     }
@@ -658,11 +707,13 @@ public class PSContentList implements IPSContentList {
      *
      * @see com.percussion.services.publisher.IPSContentList#getFilter()
      */
+    @JsonProperty("filter-id")
     public IPSGuid getFilterId() {
         if (filterId == null) {
             return null;
         } else {
-            return PSGuidUtils.makeGuid(filterId, PSTypeEnum.ITEM_FILTER);
+            // Offline-safe assemble (avoid PSGuidUtils/locator in unit tests).
+            return new PSGuid(PSTypeEnum.ITEM_FILTER, filterId);
         }
     }
 
@@ -681,6 +732,7 @@ public class PSContentList implements IPSContentList {
         m_filter = null;
     }
 
+    @JsonIgnore
     @IPSXmlSerialization(suppress = true)
     public IPSItemFilter getFilter() {
         return m_filter;
@@ -706,13 +758,24 @@ public class PSContentList implements IPSContentList {
      * @see com.percussion.services.publisher.IPSContentList#getType()
      */
     @Override
+    @JsonIgnore
     public String getType() {
         return PSTypeEnum.CONTENT_LIST.name();
     }
 
+    @JsonProperty("content-list-type")
     public Type getContentListType() {
         int tordinal = (type == null) ? 0 : type.shortValue();
         return Type.valueOf(tordinal);
+    }
+
+    /**
+     * Jackson / design-object restore for {@link #getContentListType()}.
+     *
+     * @param newtype never {@code null}
+     */
+    public void setContentListType(Type newtype) {
+        setContentListTypeImpl(newtype);
     }
 
     @Override
@@ -731,7 +794,111 @@ public class PSContentList implements IPSContentList {
     /*
      * Backwards-compatible setter that remains for binary compatibility
      */
+    @JsonIgnore
     public void setType(Type newtype) {
         setContentListTypeImpl(newtype);
+    }
+
+    /**
+     * Generator argument beans (unordered set for Hibernate / mutators).
+     *
+     * @return never {@code null}
+     */
+    @JsonIgnore
+    public Set<PSContentListGeneratorParam> getGeneratorArguments() {
+        if (generatorArguments == null) {
+            generatorArguments = new HashSet<>();
+        }
+        return generatorArguments;
+    }
+
+    /**
+     * Stable-order generator arguments for design-object XML (sorted by name).
+     *
+     * @return never {@code null}
+     */
+    @JsonProperty("generator-arguments")
+    @JacksonXmlElementWrapper(localName = "generator-arguments")
+    @JacksonXmlProperty(localName = "content-list-generator-param")
+    public java.util.List<PSContentListGeneratorParam> getGeneratorArgumentsXml() {
+        return getGeneratorArguments().stream()
+            .sorted(
+                java.util.Comparator.comparing(
+                    p -> p.getName() == null ? "" : p.getName(), String.CASE_INSENSITIVE_ORDER))
+            .collect(java.util.stream.Collectors.toList());
+    }
+
+    /**
+     * Restore generator argument beans from design-object XML.
+     *
+     * @param args may be {@code null} (treated as empty)
+     */
+    public void setGeneratorArgumentsXml(java.util.List<PSContentListGeneratorParam> args) {
+        this.generatorArguments = new HashSet<>();
+        if (args != null) {
+            for (PSContentListGeneratorParam p : args) {
+                if (p != null) {
+                    p.setContentList(this);
+                    this.generatorArguments.add(p);
+                }
+            }
+        }
+    }
+
+    /**
+     * Expander argument beans (unordered set for Hibernate / mutators).
+     *
+     * @return never {@code null}
+     */
+    @JsonIgnore
+    public Set<PSTemplateExpanderParam> getExpanderArguments() {
+        if (expanderArguments == null) {
+            expanderArguments = new HashSet<>();
+        }
+        return expanderArguments;
+    }
+
+    /**
+     * Stable-order expander arguments for design-object XML (sorted by name).
+     *
+     * @return never {@code null}
+     */
+    @JsonProperty("expander-arguments")
+    @JacksonXmlElementWrapper(localName = "expander-arguments")
+    @JacksonXmlProperty(localName = "template-expander-param")
+    public java.util.List<PSTemplateExpanderParam> getExpanderArgumentsXml() {
+        return getExpanderArguments().stream()
+            .sorted(
+                java.util.Comparator.comparing(
+                    p -> p.getName() == null ? "" : p.getName(), String.CASE_INSENSITIVE_ORDER))
+            .collect(java.util.stream.Collectors.toList());
+    }
+
+    /**
+     * Restore expander argument beans from design-object XML.
+     *
+     * @param args may be {@code null} (treated as empty)
+     */
+    public void setExpanderArgumentsXml(java.util.List<PSTemplateExpanderParam> args) {
+        this.expanderArguments = new HashSet<>();
+        if (args != null) {
+            for (PSTemplateExpanderParam p : args) {
+                if (p != null) {
+                    p.setContentList(this);
+                    this.expanderArguments.add(p);
+                }
+            }
+        }
+    }
+
+    /**
+     * Legacy computed flag — not part of design-object XML.
+     */
+    @JsonIgnore
+    @Override
+    public boolean isLegacy() {
+        return StringUtils.isBlank(generator)
+            && StringUtils.isBlank(expander)
+            && (filterId == null);
     }
 }

--- a/system/services/src/com/percussion/services/publisher/data/PSContentListGeneratorParam.java
+++ b/system/services/src/com/percussion/services/publisher/data/PSContentListGeneratorParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,169 +16,171 @@
  */
 package com.percussion.services.publisher.data;
 
-
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.percussion.utils.xml.IPSXmlSerialization;
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
-
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * Represents a single parameter to be passed to the generator by default.
- * 
+ *
+ * <p>Nested package item element is {@code content-list-generator-param} (registered from {@link
+ * PSContentList}). Parent {@code contentList} is suppressed to avoid circular graph write (issue
+ * #1919 / epic #505).
+ *
  * @author dougrand
- * 
  */
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, 
-      region = "PSContentListGeneratorParam")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSContentListGeneratorParam")
 @Table(name = "PSX_CONTENTLIST_GEN_PARAM")
-public class PSContentListGeneratorParam
-{
-   @Id
-   @Column(name = "PARAM_ID")
-   private long id;
+@JacksonXmlRootElement(localName = "content-list-generator-param")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({"name", "value"})
+public class PSContentListGeneratorParam {
+  @Id
+  @Column(name = "PARAM_ID")
+  private long id;
 
-   @SuppressWarnings("unused")
-   @Version
-   private int version;
+  @SuppressWarnings("unused")
+  @Version
+  private int version;
 
-   @Basic
-   private String name;
+  @Basic private String name;
 
-   @Basic
-   private String value;
+  @Basic private String value;
 
-   @ManyToOne(targetEntity = PSContentList.class)
-   @JoinColumn(name = "CONTENT_LIST_ID")
-   private PSContentList contentList;
+  @ManyToOne(targetEntity = PSContentList.class)
+  @JoinColumn(name = "CONTENT_LIST_ID")
+  private PSContentList contentList;
 
-   /**
-    * @return Returns the contentList.
-    */
-   public PSContentList getContentList()
-   {
-      return contentList;
-   }
+  /**
+   * @return Returns the contentList.
+   */
+  @JsonIgnore
+  @IPSXmlSerialization(suppress = true)
+  public PSContentList getContentList() {
+    return contentList;
+  }
 
-   /**
-    * @param contentList The contentList to set.
-    */
-   public void setContentList(PSContentList contentList)
-   {
-      this.contentList = contentList;
-   }
+  /**
+   * @param contentList The contentList to set.
+   */
+  public void setContentList(PSContentList contentList) {
+    this.contentList = contentList;
+  }
 
-   /**
-    * @return Returns the id.
-    */
-   public long getId()
-   {
-      return id;
-   }
+  /**
+   * @return Returns the id.
+   */
+  @JsonIgnore
+  @IPSXmlSerialization(suppress = true)
+  public long getId() {
+    return id;
+  }
 
-   /**
-    * @param id The id to set.
-    */
-   public void setId(long id)
-   {
-      this.id = id;
-   }
+  /**
+   * @param id The id to set.
+   */
+  public void setId(long id) {
+    this.id = id;
+  }
 
-   /**
-    * @return Returns the name.
-    */
-   public String getName()
-   {
-      return name;
-   }
+  /**
+   * @return Returns the name.
+   */
+  @JsonProperty
+  public String getName() {
+    return name;
+  }
 
-   /**
-    * @param name The name to set.
-    */
-   public void setName(String name)
-   {
-      this.name = name;
-   }
+  /**
+   * @param name The name to set.
+   */
+  public void setName(String name) {
+    this.name = name;
+  }
 
-   /**
-    * @return Returns the value.
-    */
-   public String getValue()
-   {
-      return value;
-   }
+  /**
+   * @return Returns the value.
+   */
+  @JsonProperty
+  public String getValue() {
+    return value;
+  }
 
-   /**
-    * @param value The value to set.
-    */
-   public void setValue(String value)
-   {
-      this.value = value;
-   }
+  /**
+   * @param value The value to set.
+   */
+  public void setValue(String value) {
+    this.value = value;
+  }
 
-   /**
-    * @return Returns the version.
-    */
-   public int getVersion()
-   {
-      return version;
-   }
+  /**
+   * @return Returns the version.
+   */
+  @JsonIgnore
+  @IPSXmlSerialization(suppress = true)
+  public int getVersion() {
+    return version;
+  }
 
-   /**
-    * @param version The version to set.
-    */
-   public void setVersion(int version)
-   {
-      this.version = version;
-   }
+  /**
+   * @param version The version to set.
+   */
+  public void setVersion(int version) {
+    this.version = version;
+  }
 
-   /** (non-Javadoc)
-    * @see java.lang.Object#equals(java.lang.Object)
-    */
-   @Override
-   public boolean equals(Object arg0)
-   {
-      if (!(arg0 instanceof PSContentListGeneratorParam))
-         return false;
-      PSContentListGeneratorParam parm = (PSContentListGeneratorParam) arg0;
+  /** (non-Javadoc)
+   * @see java.lang.Object#equals(java.lang.Object)
+   */
+  @Override
+  public boolean equals(Object arg0) {
+    if (!(arg0 instanceof PSContentListGeneratorParam)) return false;
+    PSContentListGeneratorParam parm = (PSContentListGeneratorParam) arg0;
 
-      return new EqualsBuilder().append(name, parm.name).append(value,
-            parm.value).isEquals();
-   }
+    return new EqualsBuilder().append(name, parm.name).append(value, parm.value).isEquals();
+  }
 
-   /** (non-Javadoc)
-    * @see java.lang.Object#hashCode()
-    */
-   @Override
-   public int hashCode()
-   {
-      return name.hashCode();
-   }
+  /** (non-Javadoc)
+   * @see java.lang.Object#hashCode()
+   */
+  @Override
+  public int hashCode() {
+    return name != null ? name.hashCode() : 0;
+  }
 
-   /**
-    * (non-Javadoc)
-    *
-    * @see Object#toString()
-    */
-   @Override
-   public String toString() {
-      final StringBuffer sb = new StringBuffer("PSContentListGeneratorParam{");
-      sb.append("id=").append(id);
-      sb.append(", version=").append(version);
-      sb.append(", name='").append(name).append('\'');
-      sb.append(", value='").append(value).append('\'');
-      sb.append(", contentList=").append(contentList);
-      sb.append('}');
-      return sb.toString();
-   }
+  /**
+   * (non-Javadoc)
+   *
+   * @see Object#toString()
+   */
+  @Override
+  public String toString() {
+    final StringBuffer sb = new StringBuffer("PSContentListGeneratorParam{");
+    sb.append("id=").append(id);
+    sb.append(", version=").append(version);
+    sb.append(", name='").append(name).append('\'');
+    sb.append(", value='").append(value).append('\'');
+    sb.append('}');
+    return sb.toString();
+  }
 }

--- a/system/services/src/com/percussion/services/publisher/data/PSDeliveryType.java
+++ b/system/services/src/com/percussion/services/publisher/data/PSDeliveryType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,190 +16,185 @@
  */
 package com.percussion.services.publisher.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.catalog.PSTypeEnum;
-import com.percussion.services.guidmgr.IPSGuidManager;
-import com.percussion.services.guidmgr.PSGuidManagerLocator;
+import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.publisher.IPSDeliveryType;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import com.percussion.utils.guid.IPSGuid;
-
-import java.io.IOException;
-
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-
+import java.io.IOException;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * @see IPSDeliveryType
+ *
+ * <p>Design-object XML root is {@code delivery-type}. Jackson opt-in property surface (issue #1919 /
+ * epic #505).
  */
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSDeliveryType")
 @Table(name = "PSX_DELIVERY_TYPE")
-public class PSDeliveryType implements IPSDeliveryType
-{
-   @Id
-   long id;
-   
-   @Basic
-   String name;
+@JacksonXmlRootElement(localName = "delivery-type")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({"beanName", "description", "guid", "name", "unpublishingRequiresAssembly"})
+public class PSDeliveryType implements IPSDeliveryType {
+  @Id long id;
 
-   @Basic
-   String description;
+  @Basic String name;
 
-   @Basic
-   @Column(name = "BEAN_NAME")
-   String beanName;
+  @Basic String description;
 
-   @Basic
-   @Column(name = "UNPUBLISHING_REQUIRES_ASSEMBLY")
-   int unpublishingRequiresAssembly;
+  @Basic
+  @Column(name = "BEAN_NAME")
+  String beanName;
 
-   /**
-    * The default constructor.
-    */
-   public PSDeliveryType() 
-   {
-   }
+  @Basic
+  @Column(name = "UNPUBLISHING_REQUIRES_ASSEMBLY")
+  int unpublishingRequiresAssembly;
 
-   /**
-    * @return the id
-    */
-   public IPSGuid getGUID()
-   {
-      IPSGuidManager gmgr = PSGuidManagerLocator.getGuidMgr();
-      return gmgr.makeGuid(id, PSTypeEnum.DELIVERY_TYPE);
-   }
+  /** The default constructor. */
+  public PSDeliveryType() {}
 
-   /**
-    * @param guid the guid to set, never <code>null</code>
-    */
-   public void setGUID(IPSGuid guid)
-   {
-      this.id = guid.getUUID();
-   }
+  /**
+   * @return the id
+   */
+  @JsonProperty("guid")
+  public IPSGuid getGUID() {
+    // Offline-safe assemble (avoid GuidManager locator in unit tests).
+    return new PSGuid(PSTypeEnum.DELIVERY_TYPE, id);
+  }
 
-   /*
-    * //see base class method for details
-    */
-   public String toXML() throws IOException, SAXException
-   {
-      return PSXmlSerializationHelper.writeToXml(this);
-   }
-   
-   /*
-    * //see base class method for details
-    */
-   public void fromXML(String xmlsource) throws IOException, SAXException
-   {
-      PSXmlSerializationHelper.readFromXML(xmlsource, this);  
-   }
+  /**
+   * @param guid the guid to set, never <code>null</code>
+   */
+  public void setGUID(IPSGuid guid) {
+    if (guid == null) {
+      throw new IllegalArgumentException("guid may not be null");
+    }
+    this.id = guid.getUUID();
+  }
 
-   /**
-    * Get the name of the bean to be used when publishing. This name is used to
-    * look up a spring bean on the publisher side of the delivery.
-    * 
-    * @return the beanName, never <code>null</code> or empty.
-    */
-   public String getBeanName()
-   {
-      return beanName;
-   }
+  /*
+   * //see base class method for details
+   */
+  public String toXML() throws IOException, SAXException {
+    return PSXmlSerializationHelper.writeToXml(this);
+  }
 
-   /**
-    * Set the bean name.
-    * 
-    * @param beanName the beanName to set, never <code>null</code> or empty.
-    */
-   public void setBeanName(String beanName)
-   {
-      if (StringUtils.isBlank(beanName))
-      {
-         throw new IllegalArgumentException("beanName may not be null or empty");
-      }
-      this.beanName = beanName;
-   }
+  /*
+   * //see base class method for details
+   */
+  public void fromXML(String xmlsource) throws IOException, SAXException {
+    PSXmlSerializationHelper.readFromXML(xmlsource, this);
+  }
 
-   @Override
-   public void setBeanNameImpl(String beanName) {
-      setBeanName(beanName);
-   }
+  /**
+   * Get the name of the bean to be used when publishing. This name is used to look up a spring bean
+   * on the publisher side of the delivery.
+   *
+   * @return the beanName, never <code>null</code> or empty.
+   */
+  @JsonProperty("bean-name")
+  public String getBeanName() {
+    return beanName;
+  }
 
-   @Override
-   public void setNameImpl(String name) {
-      setName(name);
-   }
+  /**
+   * Set the bean name.
+   *
+   * @param beanName the beanName to set, never <code>null</code> or empty.
+   */
+  public void setBeanName(String beanName) {
+    if (StringUtils.isBlank(beanName)) {
+      throw new IllegalArgumentException("beanName may not be null or empty");
+    }
+    this.beanName = beanName;
+  }
 
-   /**
-    * Get the description that describes this location.
-    * 
-    * @return the description, can be <code>null</code> or empty.
-    */
-   public String getDescription()
-   {
-      return description;
-   }
+  @Override
+  public void setBeanNameImpl(String beanName) {
+    setBeanName(beanName);
+  }
 
-   /**
-    * Set the description.
-    * 
-    * @param description the description to set
-    */
-   public void setDescription(String description)
-   {
-      this.description = description;
-   }
+  @Override
+  public void setNameImpl(String name) {
+    setName(name);
+  }
 
-   /**
-    * Get the name of the delivery location.
-    * 
-    * @return the name, never <code>null</code> or empty.
-    */
-   public String getName()
-   {
-      return name;
-   }
+  /**
+   * Get the description that describes this location.
+   *
+   * @return the description, can be <code>null</code> or empty.
+   */
+  @JsonProperty
+  public String getDescription() {
+    return description;
+  }
 
-   /**
-    * Set the name of the delivery location.
-    * 
-    * @param name the name to set, never <code>null</code> or empty.
-    */
-   public void setName(String name)
-   {
-      if (StringUtils.isBlank(name))
-      {
-         throw new IllegalArgumentException("name may not be null or empty");
-      }
-      this.name = name;
-   }
+  /**
+   * Set the description.
+   *
+   * @param description the description to set
+   */
+  public void setDescription(String description) {
+    this.description = description;
+  }
 
-   /**
-    * It determines if the item need to be unpublished.
-    * 
-    * @return <code>true</code> if the item must be assembled for the 
-    * unpublishing case; otherwise return <code>false</code>.
-    */
-   public boolean isUnpublishingRequiresAssembly()
-   {
-      return unpublishingRequiresAssembly == 1;
-   }
+  /**
+   * Get the name of the delivery location.
+   *
+   * @return the name, never <code>null</code> or empty.
+   */
+  @JsonProperty
+  public String getName() {
+    return name;
+  }
 
-   /**
-    * Set the value, see {@link #isUnpublishingRequiresAssembly()}.
-    * 
-    * @param isUnpublishingRequiresAssembly the unpublishingRequiresAssembly to
-    *           set.
-    */
-   public void setUnpublishingRequiresAssembly(
-         boolean isUnpublishingRequiresAssembly)
-   {
-      this.unpublishingRequiresAssembly = isUnpublishingRequiresAssembly ? 1 : 0;
-   }
+  /**
+   * Set the name of the delivery location.
+   *
+   * @param name the name to set, never <code>null</code> or empty.
+   */
+  public void setName(String name) {
+    if (StringUtils.isBlank(name)) {
+      throw new IllegalArgumentException("name may not be null or empty");
+    }
+    this.name = name;
+  }
+
+  /**
+   * It determines if the item need to be unpublished.
+   *
+   * @return <code>true</code> if the item must be assembled for the unpublishing case; otherwise
+   *     return <code>false</code>.
+   */
+  @JsonProperty("unpublishing-requires-assembly")
+  public boolean isUnpublishingRequiresAssembly() {
+    return unpublishingRequiresAssembly == 1;
+  }
+
+  /**
+   * Set the value, see {@link #isUnpublishingRequiresAssembly()}.
+   *
+   * @param isUnpublishingRequiresAssembly the unpublishingRequiresAssembly to set.
+   */
+  public void setUnpublishingRequiresAssembly(boolean isUnpublishingRequiresAssembly) {
+    this.unpublishingRequiresAssembly = isUnpublishingRequiresAssembly ? 1 : 0;
+  }
 }

--- a/system/services/src/com/percussion/services/publisher/data/PSEdition.java
+++ b/system/services/src/com/percussion/services/publisher/data/PSEdition.java
@@ -18,37 +18,55 @@ package com.percussion.services.publisher.data;
 
 // Generated Dec 16, 2005 4:46:50 PM by Hibernate Tools 3.1.0 beta1JBIDERC2
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.catalog.IPSCatalogItem;
 import com.percussion.services.catalog.PSTypeEnum;
-import com.percussion.services.guidmgr.IPSGuidManager;
-import com.percussion.services.guidmgr.PSGuidManagerLocator;
-import com.percussion.services.guidmgr.PSGuidUtils;
+import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.publisher.IPSEdition;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.xml.IPSXmlSerialization;
-
-import java.io.IOException;
-
 import jakarta.persistence.Basic;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import jakarta.persistence.Version;
-
+import java.io.IOException;
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * @see IPSEdition
+ *
+ * <p>Design-object XML root is {@code edition}. Jackson opt-in property surface (issue #1919 / epic
+ * #505). Historical Betwixt suppressed {@code guid}; identity uses {@code id}. {@code name} is an
+ * alias of {@code display-title} and is omitted on write.
  */
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSEdition")
 @Table(name = "RXEDITION")
+@JacksonXmlRootElement(localName = "edition")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({
+  "comment",
+  "displayTitle",
+  "editionType",
+  "id",
+  "priority",
+  "pubServerId",
+  "siteId"
+})
 public class PSEdition implements IPSCatalogItem, IPSEdition, Cloneable
 {
    /**
@@ -100,6 +118,7 @@ public class PSEdition implements IPSCatalogItem, IPSEdition, Cloneable
    /* (non-Javadoc)
     * @see com.percussion.services.publisher.data.IPSEdition#getId()
     */
+   @JsonProperty
    public long getId()
    {
       return this.editionid;
@@ -116,6 +135,7 @@ public class PSEdition implements IPSCatalogItem, IPSEdition, Cloneable
    /* (non-Javadoc)
     * @see com.percussion.services.publisher.data.IPSEdition#getDisplayTitle()
     */
+   @JsonProperty("display-title")
    public String getDisplayTitle()
    {
       return this.displaytitle;
@@ -125,6 +145,7 @@ public class PSEdition implements IPSCatalogItem, IPSEdition, Cloneable
     *  (non-Javadoc)
     * @see com.percussion.services.publisher.IPSEdition#getName()
     */
+   @JsonIgnore
    public String getName()
    {
       return getDisplayTitle();
@@ -174,6 +195,7 @@ public class PSEdition implements IPSCatalogItem, IPSEdition, Cloneable
    /* (non-Javadoc)
     * @see com.percussion.services.publisher.data.IPSEdition#getComment()
     */
+   @JsonProperty
    public String getComment()
    {
       return this.editioncomment;
@@ -190,6 +212,7 @@ public class PSEdition implements IPSCatalogItem, IPSEdition, Cloneable
    /* (non-Javadoc)
     * @see com.percussion.services.publisher.data.IPSEdition#getEditionType()
     */
+   @JsonProperty("edition-type")
    public PSEditionType getEditionType()
    {
       try
@@ -224,12 +247,13 @@ public class PSEdition implements IPSCatalogItem, IPSEdition, Cloneable
    /* (non-Javadoc)
     * @see com.percussion.services.publisher.data.IPSEdition#getDestSite()
     */
+   @JsonProperty("site-id")
    public IPSGuid getSiteId()
    {
       if (this.destsite == null)
          return null;
       
-      return PSGuidUtils.makeGuid(this.destsite, PSTypeEnum.SITE);
+      return new PSGuid(PSTypeEnum.SITE, this.destsite);
    }
 
    /* (non-Javadoc)
@@ -237,21 +261,24 @@ public class PSEdition implements IPSCatalogItem, IPSEdition, Cloneable
     */
    public void setSiteId(IPSGuid siteId)
    {
-      this.destsite = siteId.longValue();
+      // Null-safe for design-object XML restore when site is unset (issue #1919).
+      this.destsite = siteId == null ? null : siteId.longValue();
    }
 
    /*
     * (non-Javadoc)
     * @see com.percussion.services.publisher.IPSEdition#getPubServerId()
     */
+   @JsonProperty("pub-server-id")
    public IPSGuid getPubServerId()
    {
       if (this.pubserver == null)
          return null;
       
-      return PSGuidUtils.makeGuid(this.pubserver, PSTypeEnum.PUBLISHING_SERVER);
+      return new PSGuid(PSTypeEnum.PUBLISHING_SERVER, this.pubserver);
    }
    
+   @JsonIgnore
    public IPSGuid getPubServerOrSiteId()
    {
       return pubserver == null ? getSiteId() : getPubServerId();
@@ -263,12 +290,14 @@ public class PSEdition implements IPSCatalogItem, IPSEdition, Cloneable
     */
    public void setPubServerId(IPSGuid serverId)
    {
-      pubserver = serverId.longValue();
+      // Null-safe for design-object XML restore when pub server is unset (issue #1919).
+      pubserver = serverId == null ? null : serverId.longValue();
    }
    
    /* (non-Javadoc)
     * @see com.percussion.services.publisher.data.IPSEdition#getPriority()
     */
+   @JsonProperty
    public Priority getPriority()
    {
       if (priority == null)
@@ -335,11 +364,12 @@ public class PSEdition implements IPSCatalogItem, IPSEdition, Cloneable
    /* (non-Javadoc)
     * @see com.percussion.services.publisher.IPSEdition#getGUID()
     */
+   @JsonIgnore
    @IPSXmlSerialization(suppress=true)
    public IPSGuid getGUID()
    {
-      IPSGuidManager gmgr = PSGuidManagerLocator.getGuidMgr();
-      return gmgr.makeGuid(editionid, PSTypeEnum.EDITION); 
+      // Offline-safe assemble (historical design XML suppressed guid; uses id).
+      return new PSGuid(PSTypeEnum.EDITION, editionid);
    }
 
    /* (non-Javadoc)
@@ -350,10 +380,8 @@ public class PSEdition implements IPSCatalogItem, IPSEdition, Cloneable
       if (guid == null)
          throw new IllegalArgumentException("guid may not be null");
       
-      if (editionid != -1L)
-         throw new IllegalStateException("guid can only be set once");
-      
-      editionid = guid != null ? guid.getUUID() : null;
+      // Allow overwrite on design-object XML restore (BeanUtils + Jackson).
+      editionid = guid.getUUID();
    }
 
    /**
@@ -361,6 +389,8 @@ public class PSEdition implements IPSCatalogItem, IPSEdition, Cloneable
     * 
     * @return returns the version, may be <code>null</code>.
     */
+   @JsonIgnore
+   @IPSXmlSerialization(suppress = true)
    public Integer getVersion()
    {
       return version;

--- a/system/services/src/com/percussion/services/publisher/data/PSTemplateExpanderParam.java
+++ b/system/services/src/com/percussion/services/publisher/data/PSTemplateExpanderParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,172 +16,175 @@
  */
 package com.percussion.services.publisher.data;
 
-
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.percussion.utils.xml.IPSXmlSerialization;
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
-
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
- * Represents a single parameter to be passsed to the expander by default
- * 
- * @author dougrand
+ * Represents a single parameter to be passed to the expander by default.
  *
+ * <p>Nested package item element is {@code template-expander-param} (registered from {@link
+ * PSContentList}). Parent {@code contentList} is suppressed to avoid circular graph write (issue
+ * #1919 / epic #505).
+ *
+ * @author dougrand
  */
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSTemplateExpanderParam")
 @Table(name = "PSX_CONTENTLIST_EXPANDER_PARAM")
-public class PSTemplateExpanderParam
-{
-   @Id
-   @Column(name = "PARAM_ID")
-   private long id;
-   
-   @SuppressWarnings("unused")
-   @Version
-   private Integer version;
-   
-   @Basic
-   private String name;
-   
-   @Basic
-   private String value;
-   
-   @ManyToOne(targetEntity = PSContentList.class)
-   @JoinColumn(name = "CONTENT_LIST_ID")
-   private PSContentList contentList;
+@JacksonXmlRootElement(localName = "template-expander-param")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({"name", "value"})
+public class PSTemplateExpanderParam {
+  @Id
+  @Column(name = "PARAM_ID")
+  private long id;
 
-   /**
-    * @return Returns the contentList.
-    */
-   public PSContentList getContentList()
-   {
-      return contentList;
-   }
+  @SuppressWarnings("unused")
+  @Version
+  private Integer version;
 
-   /**
-    * @param contentList The contentList to set.
-    */
-   public void setContentList(PSContentList contentList)
-   {
-      this.contentList = contentList;
-   }
+  @Basic private String name;
 
-   /**
-    * @return Returns the id.
-    */
-   public long getId()
-   {
-      return id;
-   }
+  @Basic private String value;
 
-   /**
-    * @param id The id to set.
-    */
-   public void setId(long id)
-   {
-      this.id = id;
-   }
+  @ManyToOne(targetEntity = PSContentList.class)
+  @JoinColumn(name = "CONTENT_LIST_ID")
+  private PSContentList contentList;
 
-   /**
-    * @return Returns the name.
-    */
-   public String getName()
-   {
-      return name;
-   }
+  /**
+   * @return Returns the contentList.
+   */
+  @JsonIgnore
+  @IPSXmlSerialization(suppress = true)
+  public PSContentList getContentList() {
+    return contentList;
+  }
 
-   /**
-    * @param name The name to set.
-    */
-   public void setName(String name)
-   {
-      this.name = name;
-   }
+  /**
+   * @param contentList The contentList to set.
+   */
+  public void setContentList(PSContentList contentList) {
+    this.contentList = contentList;
+  }
 
-   /**
-    * @return Returns the value.
-    */
-   public String getValue()
-   {
-      return value;
-   }
+  /**
+   * @return Returns the id.
+   */
+  @JsonIgnore
+  @IPSXmlSerialization(suppress = true)
+  public long getId() {
+    return id;
+  }
 
-   /**
-    * @param value The value to set.
-    */
-   public void setValue(String value)
-   {
-      this.value = value;
-   }
+  /**
+   * @param id The id to set.
+   */
+  public void setId(long id) {
+    this.id = id;
+  }
 
-   /**
-    * @return Returns the version.
-    */
-   public Integer getVersion()
-   {
-      return version;
-   }
+  /**
+   * @return Returns the name.
+   */
+  @JsonProperty
+  public String getName() {
+    return name;
+  }
 
-   /**
-    * @param version The version to set.
-    */
-   public void setVersion(Integer version)
-   {
-      this.version = version;
-   }
-   
-   /**
-    * (non-Javadoc)
-    * 
-    * @see java.lang.Object#equals(java.lang.Object)
-    */
-   @Override
-   public boolean equals(Object arg0)
-   {
-      if (!(arg0 instanceof PSTemplateExpanderParam))
-         return false;
-      PSTemplateExpanderParam parm = (PSTemplateExpanderParam) arg0;
+  /**
+   * @param name The name to set.
+   */
+  public void setName(String name) {
+    this.name = name;
+  }
 
-      return new EqualsBuilder().append(name, parm.name).append(value,
-            parm.value).isEquals();
-   }
+  /**
+   * @return Returns the value.
+   */
+  @JsonProperty
+  public String getValue() {
+    return value;
+  }
 
-   /**
-    * (non-Javadoc)
-    * 
-    * @see java.lang.Object#hashCode()
-    */
-   @Override
-   public int hashCode()
-   {
-      return name.hashCode();
-   }
+  /**
+   * @param value The value to set.
+   */
+  public void setValue(String value) {
+    this.value = value;
+  }
 
-   /**
-    * (non-Javadoc)
-    *
-    * @see Object#toString()
-    */
-   @Override
-   public String toString() {
-      final StringBuffer sb = new StringBuffer("PSTemplateExpanderParam{");
-      sb.append("id=").append(id);
-      sb.append(", version=").append(version);
-      sb.append(", name='").append(name).append('\'');
-      sb.append(", value='").append(value).append('\'');
-      sb.append(", contentList=").append(contentList);
-      sb.append('}');
-      return sb.toString();
-   }
+  /**
+   * @return Returns the version.
+   */
+  @JsonIgnore
+  @IPSXmlSerialization(suppress = true)
+  public Integer getVersion() {
+    return version;
+  }
+
+  /**
+   * @param version The version to set.
+   */
+  public void setVersion(Integer version) {
+    this.version = version;
+  }
+
+  /**
+   * (non-Javadoc)
+   *
+   * @see java.lang.Object#equals(java.lang.Object)
+   */
+  @Override
+  public boolean equals(Object arg0) {
+    if (!(arg0 instanceof PSTemplateExpanderParam)) return false;
+    PSTemplateExpanderParam parm = (PSTemplateExpanderParam) arg0;
+
+    return new EqualsBuilder().append(name, parm.name).append(value, parm.value).isEquals();
+  }
+
+  /**
+   * (non-Javadoc)
+   *
+   * @see java.lang.Object#hashCode()
+   */
+  @Override
+  public int hashCode() {
+    return name != null ? name.hashCode() : 0;
+  }
+
+  /**
+   * (non-Javadoc)
+   *
+   * @see Object#toString()
+   */
+  @Override
+  public String toString() {
+    final StringBuffer sb = new StringBuffer("PSTemplateExpanderParam{");
+    sb.append("id=").append(id);
+    sb.append(", version=").append(version);
+    sb.append(", name='").append(name).append('\'');
+    sb.append(", value='").append(value).append('\'');
+    sb.append('}');
+    return sb.toString();
+  }
 }

--- a/system/services/src/com/percussion/services/pubserver/data/PSPubServer.java
+++ b/system/services/src/com/percussion/services/pubserver/data/PSPubServer.java
@@ -16,6 +16,14 @@
  */
 package com.percussion.services.pubserver.data;
 
+import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.Validate.notEmpty;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.delivery.service.PSDeliveryInfoServiceLocator;
 import com.percussion.delivery.service.impl.PSDeliveryInfoService;
 import com.percussion.services.catalog.IPSCatalogIdentifier;
@@ -26,16 +34,7 @@ import com.percussion.services.pubserver.IPSPubServerDao;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import com.percussion.share.data.PSAbstractDataObject;
 import com.percussion.utils.guid.IPSGuid;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.Validate;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
-import org.xml.sax.SAXException;
-
+import com.percussion.utils.xml.IPSXmlSerialization;
 import jakarta.persistence.Basic;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -50,22 +49,55 @@ import java.io.Serializable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.Validate.notEmpty;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * Represents a publishing server related to a given site.
- * 
+ *
+ * <p>Design-object XML root is {@code pub-server}. Nested property item element is {@code
+ * pub-server-property} (registered via {@link PSXmlSerializationHelper#addType}). Jackson opt-in
+ * property surface (issue #1919 / epic #505).
+ *
  * @author leonardohildt
- * 
  */
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSPubServer")
 @Table(name = "PSX_PUBSERVER")
+@JacksonXmlRootElement(localName = "pub-server")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({
+  "description",
+  "guid",
+  "hasFullPublished",
+  "name",
+  "properties",
+  "publishType",
+  "serverId",
+  "siteId",
+  "siteRenamed",
+  "serverTypeXml"
+})
 public class PSPubServer extends PSAbstractDataObject implements Serializable, IPSCatalogIdentifier, IPSPubServer
 {
+  static {
+    PSXmlSerializationHelper.addType("pub-server-property", PSPubServerProperty.class);
+  }
 
    /**
     * 
@@ -108,9 +140,32 @@ public class PSPubServer extends PSAbstractDataObject implements Serializable, I
    /**
     * @return the serverType wrapped in an Optional. If unset, defaults to {@link #PRODUCTION}.
     */
+   @JsonIgnore
    public java.util.Optional<String> getServerType()
    {
       return java.util.Optional.of(StringUtils.isBlank(serverType) ? PRODUCTION : serverType);
+   }
+
+   /**
+    * Design-object XML form of server type (defaults to {@link #PRODUCTION} when blank).
+    *
+    * @return never blank
+    */
+   @JsonProperty("server-type")
+   public String getServerTypeXml()
+   {
+      return StringUtils.isBlank(serverType) ? PRODUCTION : serverType;
+   }
+
+   /**
+    * Jackson setter for {@code server-type} (avoids Optional {@link #getServerType()} conflict).
+    *
+    * @param serverType may be blank (defaults to {@link #PRODUCTION})
+    */
+   @JsonProperty("server-type")
+   public void setServerTypeXml(String serverType)
+   {
+      setServerType(serverType);
    }
 
    /**
@@ -118,6 +173,7 @@ public class PSPubServer extends PSAbstractDataObject implements Serializable, I
     *
     * @return {@code true} if fully published, {@code false} otherwise
     */
+   @JsonProperty("has-full-published")
    public boolean hasFullPublished()
    {
       return "yes".equalsIgnoreCase(hasFullPublished) || Boolean.TRUE.toString().equalsIgnoreCase(hasFullPublished);
@@ -180,17 +236,54 @@ public class PSPubServer extends PSAbstractDataObject implements Serializable, I
 
    public void setProperties(Set<PSPubServerProperty> properties)
    {
-      this.properties = properties;
+      this.properties = properties != null ? properties : new HashSet<>();
    }
 
+   /**
+    * Hibernate / mutator view of properties (unordered set).
+    *
+    * @return never {@code null}
+    */
+   @JsonIgnore
    public Set<PSPubServerProperty> getProperties()
    {
+      if (properties == null)
+      {
+         properties = new HashSet<>();
+      }
       return properties;
+   }
+
+   /**
+    * Stable-order property list for design-object XML (sorted by name).
+    *
+    * @return never {@code null}
+    */
+   @JsonProperty("properties")
+   @JacksonXmlElementWrapper(localName = "properties")
+   @JacksonXmlProperty(localName = "pub-server-property")
+   public java.util.List<PSPubServerProperty> getPropertiesXml()
+   {
+      return getProperties().stream()
+          .sorted(java.util.Comparator.comparing(
+              p -> p.getName() == null ? "" : p.getName(), String.CASE_INSENSITIVE_ORDER))
+          .collect(java.util.stream.Collectors.toList());
+   }
+
+   /**
+    * Restore properties from design-object XML.
+    *
+    * @param props may be {@code null}
+    */
+   public void setPropertiesXml(java.util.List<PSPubServerProperty> props)
+   {
+      setProperties(props == null ? new HashSet<>() : new HashSet<>(props));
    }
    
    /**
     * @return the id
     */
+   @JsonProperty("guid")
    public IPSGuid getGUID()
    {
       return new PSGuid(PSTypeEnum.PUBLISHING_SERVER, serverId);
@@ -201,6 +294,10 @@ public class PSPubServer extends PSAbstractDataObject implements Serializable, I
     */
    public void setGUID(IPSGuid guid)
    {
+      if (guid == null)
+      {
+         throw new IllegalArgumentException("guid may not be null");
+      }
       this.serverId = guid.getUUID();
    }
 
@@ -209,6 +306,7 @@ public class PSPubServer extends PSAbstractDataObject implements Serializable, I
     * 
     * @return Returns the site id, never <code>null</code>
     */
+   @JsonProperty("site-id")
    public long getSiteId()
    {
       return siteId;
@@ -235,7 +333,19 @@ public class PSPubServer extends PSAbstractDataObject implements Serializable, I
     */
    public void fromXML(String xmlsource) throws IOException, SAXException
    {
-      PSXmlSerializationHelper.readFromXML(xmlsource, this);
+      // Class-based read (not BeanUtils copy): Optional getters for description / serverType
+      // prevent BeanUtils property-copy of those scalar fields (issue #1919).
+      PSPubServer src =
+          (PSPubServer) PSXmlSerializationHelper.readFromXML(xmlsource, PSPubServer.class);
+      this.serverId = src.serverId;
+      this.siteId = src.siteId;
+      this.name = src.name;
+      this.description = src.description;
+      this.publishType = src.publishType;
+      this.serverType = src.serverType;
+      this.hasFullPublished = src.hasFullPublished;
+      this.siteRenamed = src.siteRenamed;
+      setProperties(src.properties != null ? new HashSet<>(src.properties) : new HashSet<>());
    }
 
    /**
@@ -243,6 +353,7 @@ public class PSPubServer extends PSAbstractDataObject implements Serializable, I
     * 
     * @return the server name, never <code>null</code> or empty.
     */
+   @JsonProperty
    public String getName()
    {
       return name;
@@ -263,9 +374,32 @@ public class PSPubServer extends PSAbstractDataObject implements Serializable, I
     * 
     * @return Optional containing the description if set, otherwise empty.
     */
+   @JsonIgnore
    public java.util.Optional<String> getDescription()
    {
       return java.util.Optional.ofNullable(description);
+   }
+
+   /**
+    * Design-object XML form of description (nullable string).
+    *
+    * @return may be {@code null}
+    */
+   @JsonProperty("description")
+   public String getDescriptionXml()
+   {
+      return description;
+   }
+
+   /**
+    * Jackson setter for {@code description} (avoids Optional {@link #getDescription()} conflict).
+    *
+    * @param description the description to set
+    */
+   @JsonProperty("description")
+   public void setDescriptionXml(String description)
+   {
+      this.description = description;
    }
 
    /**
@@ -283,6 +417,7 @@ public class PSPubServer extends PSAbstractDataObject implements Serializable, I
     * 
     * @return the server id, never <code>null</code> or empty.
     */
+   @JsonProperty("server-id")
    public long getServerId()
    {
       return serverId;
@@ -303,6 +438,7 @@ public class PSPubServer extends PSAbstractDataObject implements Serializable, I
     * 
     * @return the publish type, never <code>null</code> or empty.
     */
+   @JsonProperty("publish-type")
    public String getPublishType()
    {
       return publishType;
@@ -404,6 +540,8 @@ public class PSPubServer extends PSAbstractDataObject implements Serializable, I
     * 
     * @see com.percussion.services.pubserver.IPSPubServer#isXmlFormat()
     */
+   @JsonIgnore
+   @IPSXmlSerialization(suppress = true)
    public boolean isXmlFormat()
    {
       return equalsIgnoreCase(
@@ -416,6 +554,8 @@ public class PSPubServer extends PSAbstractDataObject implements Serializable, I
     * 
     * @see com.percussion.services.pubserver.IPSPubServer#isDatabaseType()
     */
+   @JsonIgnore
+   @IPSXmlSerialization(suppress = true)
    public boolean isDatabaseType()
    {
       return getPublishTypeEnum()
@@ -424,8 +564,10 @@ public class PSPubServer extends PSAbstractDataObject implements Serializable, I
    }
 
    /**
-
+    * Whether publish type is FTP-based (computed; not design XML).
     */
+   @JsonIgnore
+   @IPSXmlSerialization(suppress = true)
    public boolean isFtpType()
    {
       return getPublishTypeEnum()
@@ -438,6 +580,7 @@ public class PSPubServer extends PSAbstractDataObject implements Serializable, I
      * Returns whether or not the site has been renamed since the last full publish.
      * @return <code>true</code> if the site has been renamed since last full publish.
      */
+    @JsonProperty("site-renamed")
     public boolean getSiteRenamed()
     {
         return "y".equals(siteRenamed);
@@ -474,6 +617,8 @@ public class PSPubServer extends PSAbstractDataObject implements Serializable, I
        return true;
    }
 
+   @JsonIgnore
+   @IPSXmlSerialization(suppress = true)
    public java.util.Optional<String> getPublishServer(){
       PSDeliveryInfoService psDeliveryInfoService = (PSDeliveryInfoService) PSDeliveryInfoServiceLocator.getDeliveryInfoService();
       List<String> adminUrls = psDeliveryInfoService.getAdminUrls(this.serverType);

--- a/system/services/src/com/percussion/services/pubserver/data/PSPubServerProperty.java
+++ b/system/services/src/com/percussion/services/pubserver/data/PSPubServerProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,25 @@
  */
 package com.percussion.services.pubserver.data;
 
-import com.percussion.security.error.PSExceptionUtils;
+import static com.percussion.services.pubserver.IPSPubServerDao.PUBLISH_PASSWORD_PROPERTY;
+import static com.percussion.util.PSBase64Decoder.decode;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.security.PSEncryptionException;
 import com.percussion.security.PSEncryptor;
+import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.server.PSServer;
 import com.percussion.share.data.PSAbstractDataObject;
 import com.percussion.utils.io.PathUtils;
+import com.percussion.utils.xml.IPSXmlSerialization;
+import jakarta.persistence.Basic;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -29,181 +42,199 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-
-import jakarta.persistence.Basic;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-
-import static com.percussion.services.pubserver.IPSPubServerDao.PUBLISH_PASSWORD_PROPERTY;
-import static com.percussion.util.PSBase64Decoder.decode;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * Represents a single property for the server.
- * 
+ *
+ * <p>Nested package item element is {@code pub-server-property} (registered from {@link
+ * PSPubServer}). Design XML exposes {@code name} and raw stored {@code value} (encrypted form for
+ * password properties is the stored wire form; issue #1919 / epic #505).
+ *
  * @author leonardohildt
- * 
  */
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSPubServerProperty")
 @Table(name = "PSX_PUBSERVER_PROPERTIES")
-public class PSPubServerProperty extends PSAbstractDataObject
-{
-   private static final Logger log = LogManager.getLogger(PSPubServerProperty.class);
+@JacksonXmlRootElement(localName = "pub-server-property")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({"name", "value"})
+public class PSPubServerProperty extends PSAbstractDataObject {
+  private static final Logger log = LogManager.getLogger(PSPubServerProperty.class);
 
-   /**
-    * 
-    */
-   private static final long serialVersionUID = 1L;
+  /** */
+  private static final long serialVersionUID = 1L;
 
-   @Id
-   @Column(name = "SERVERPROPERTYID")
-   private long propertyId = -1L;
+  @Id
+  @Column(name = "SERVERPROPERTYID")
+  private long propertyId = -1L;
 
-   @Basic
-   @Column(name = "PUBSERVERID")
-   long serverId;
+  @Basic
+  @Column(name = "PUBSERVERID")
+  long serverId;
 
-   @Basic
-   @Column(name = "PROPERTYNAME")
-   private String name;
+  @Basic
+  @Column(name = "PROPERTYNAME")
+  private String name;
 
-   @Basic
-   @Column(name = "PROPERTYVALUE")
-   private String value;
+  @Basic
+  @Column(name = "PROPERTYVALUE")
+  private String value;
 
-   /**
-    * The default constructor.
-    */
-   public PSPubServerProperty()
-   {
-   }
+  /** The default constructor. */
+  public PSPubServerProperty() {}
 
-   @Override
-   public boolean equals(Object obj)
-   {
-      if ( !(obj instanceof PSPubServerProperty) )
-         return false;
-      
-      // use "name" & "value" should be enough to avoid same pair more than once to make sure the property names are unique within a PSPubServer
-      PSPubServerProperty b = (PSPubServerProperty) obj;
-      return new EqualsBuilder().append(name, b.name).append(value, b.value).isEquals();
-   }
-   
-   @Override
-   public int hashCode()
-   {
-      // use "name" should be enough to avoid same pair more than once to make sure the property names are unique within a PSPubServer
-      return new HashCodeBuilder().append(name).toHashCode();
-   }
-   
-   /**
-    * The database id for this object
-    * 
-    * @return Returns the serverPropertyId, never <code>null</code> after
-    *         persistence
-    */
-   public long getPropertyId()
-   {
-      return propertyId;
-   }
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof PSPubServerProperty)) return false;
 
-   /**
-    * @param propertyId The propertyId to set.
-    */
-   public void setPropertyId(long propertyId)
-   {
-      this.propertyId = propertyId;
-   }
+    // use "name" & "value" should be enough to avoid same pair more than once to make sure the
+    // property names are unique within a PSPubServer
+    PSPubServerProperty b = (PSPubServerProperty) obj;
+    return new EqualsBuilder().append(name, b.name).append(value, b.value).isEquals();
+  }
 
-   /**
-    * The server id for this object
-    * 
-    * @return Returns the serverId, never <code>null</code> after persistence
-    */
-   public long getServerId()
-   {
-      return serverId;
-   }
+  @Override
+  public int hashCode() {
+    // use "name" should be enough to avoid same pair more than once to make sure the property names
+    // are unique within a PSPubServer
+    return new HashCodeBuilder().append(name).toHashCode();
+  }
 
-   /**
-    * @param serverId The server id to set.
-    */
-   public void setServerId(long serverId)
-   {
-      this.serverId = serverId;
-   }
+  /**
+   * The database id for this object
+   *
+   * @return Returns the serverPropertyId, never <code>null</code> after persistence
+   */
+  @JsonIgnore
+  @IPSXmlSerialization(suppress = true)
+  public long getPropertyId() {
+    return propertyId;
+  }
 
-   /**
-    * Get the property name
-    * 
-    * @return Returns the property name, never <code>null</code> or empty
-    */
-   public String getName()
-   {
-      return name;
-   }
+  /**
+   * @param propertyId The propertyId to set.
+   */
+  public void setPropertyId(long propertyId) {
+    this.propertyId = propertyId;
+  }
 
-   /**
-    * @param name The name to set, never <code>null</code> or empty
-    */
-   public void setName(String name)
-   {
-      if (StringUtils.isBlank(name))
-      {
-         throw new IllegalArgumentException("name may not be null or empty");
+  /**
+   * The server id for this object
+   *
+   * @return Returns the serverId, never <code>null</code> after persistence
+   */
+  @JsonIgnore
+  @IPSXmlSerialization(suppress = true)
+  public long getServerId() {
+    return serverId;
+  }
+
+  /**
+   * @param serverId The server id to set.
+   */
+  public void setServerId(long serverId) {
+    this.serverId = serverId;
+  }
+
+  /**
+   * Get the property name
+   *
+   * @return Returns the property name, never <code>null</code> or empty
+   */
+  @JsonProperty
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * @param name The name to set, never <code>null</code> or empty
+   */
+  public void setName(String name) {
+    if (StringUtils.isBlank(name)) {
+      throw new IllegalArgumentException("name may not be null or empty");
+    }
+    this.name = name;
+  }
+
+  /**
+   * Get the value (decrypted when this is a password property).
+   *
+   * @return Returns the value, may be <code>null</code> or empty.
+   */
+  @JsonIgnore
+  @IPSXmlSerialization(suppress = true)
+  public String getValue() {
+    if (isEncodedProperty()) {
+      try {
+
+        return StringUtils.isEmpty(value)
+            ? value
+            : PSEncryptor.decryptString(
+                PathUtils.getRxDir().getAbsolutePath().concat(PSEncryptor.SECURE_DIR), value);
+      } catch (PSEncryptionException e) {
+        return StringUtils.isEmpty(value) ? value : decode(value);
       }
-      this.name = name;
-   }
+    } else {
+      return value;
+    }
+  }
 
-   /**
-    * Get the value
-    * 
-    * @return Returns the value, may be <code>null</code> or empty.
-    */
-   public String getValue()
-   {
-      if (isEncodedProperty()) {
-         try {
+  /**
+   * Raw stored value for design-object XML (does not decrypt password properties).
+   *
+   * @return may be {@code null}
+   */
+  @JsonProperty("value")
+  public String getValueXml() {
+    return value;
+  }
 
-            return StringUtils.isEmpty(value) ? value : PSEncryptor.decryptString(PathUtils.getRxDir().getAbsolutePath().concat(PSEncryptor.SECURE_DIR),value);
-         } catch (PSEncryptionException e) {
-            return StringUtils.isEmpty(value) ? value : decode(value);
-         }
+  /**
+   * @param value The value to set (encrypts when this is a password property).
+   */
+  public void setValue(String value) {
+    if (isEncodedProperty()) {
+      try {
+        String enc =
+            PSEncryptor.encryptString(
+                PSServer.getRxDir().getAbsolutePath().concat(PSEncryptor.SECURE_DIR), value);
+        this.value = StringUtils.isEmpty(value) ? value : enc;
+      } catch (PSEncryptionException e) {
+        log.error(
+            "Unable to encrypt encoded property: {} Error: {}",
+            this.name,
+            PSExceptionUtils.getMessageForLog(e));
+        log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+        this.value = value;
       }
-      else {
-         return value;
-      }
-   }
+    } else {
+      this.value = value;
+    }
+  }
 
-   /**
-    * @param value The value to set.
-    */
-   public void setValue(String value)
-   {
-      if (isEncodedProperty()) {
-         try {
-            String enc = PSEncryptor.encryptString(PSServer.getRxDir().getAbsolutePath().concat(PSEncryptor.SECURE_DIR),value);
-            this.value = StringUtils.isEmpty(value) ? value : enc;
-         } catch (PSEncryptionException e) {
-            log.error("Unable to encrypt encoded property: {} Error: {}", this.name,
-                    PSExceptionUtils.getMessageForLog(e));
-            log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-            this.value= value;
-         }
-      }
-      else {
-         this.value = value;
-      }
-   }
+  /**
+   * Jackson setter for design-object XML {@code value} — stores the raw wire form without
+   * re-encrypting (password properties are already encrypted on the wire).
+   *
+   * @param value may be {@code null}
+   */
+  @JsonProperty("value")
+  public void setValueXml(String value) {
+    this.value = value;
+  }
 
-   /**
-    * Determines if the property value is encrypted.
-    * @return <code>true</code> if the value is encrypted; <code>false</code> otherwise.
-    */
-   private boolean isEncodedProperty()
-   {
-      return PUBLISH_PASSWORD_PROPERTY.equals(name);
-   }
+  /**
+   * Determines if the property value is encrypted.
+   *
+   * @return <code>true</code> if the value is encrypted; <code>false</code> otherwise.
+   */
+  private boolean isEncodedProperty() {
+    return PUBLISH_PASSWORD_PROPERTY.equals(name);
+  }
 }

--- a/system/src/test/java/com/percussion/services/publisher/data/PSPublisherXmlSerializationTest.java
+++ b/system/src/test/java/com/percussion/services/publisher/data/PSPublisherXmlSerializationTest.java
@@ -1,0 +1,427 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.publisher.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.services.publisher.IPSContentList;
+import com.percussion.services.publisher.IPSEdition;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * Golden / round-trip tests for publisher design objects under the Jackson-backed {@code
+ * PSXmlSerializationHelper} (issue #1919, epic #505). Offline only — no live CMS.
+ */
+class PSPublisherXmlSerializationTest {
+
+  @Test
+  void contentListWriteEmitsNestedParamsAndSuppressesVersionMaps() throws Exception {
+    PSContentList original = sampleContentList();
+    String xml = original.toXML();
+
+    assertNotNull(xml);
+    assertFalse(xml.trim().startsWith("<null"), xml);
+    assertTrue(containsTag(xml, "content-list"), "root: " + xml);
+    assertTrue(containsTag(xml, "generator-arguments"), xml);
+    assertTrue(containsTag(xml, "content-list-generator-param"), xml);
+    assertTrue(containsTag(xml, "expander-arguments"), xml);
+    assertTrue(containsTag(xml, "template-expander-param"), xml);
+    assertTrue(containsTag(xml, "guid"), xml);
+    assertTrue(containsTag(xml, "filter-id"), xml);
+    assertTrue(containsTag(xml, "content-list-type"), xml);
+    assertTrue(containsTag(xml, "edition-type"), xml);
+    assertTrue(xml.contains("sample_clist"), xml);
+    assertFalse(containsTag(xml, "version"), "version suppressed: " + xml);
+    assertFalse(containsTag(xml, "generator-params"), "map form suppressed: " + xml);
+    assertFalse(containsTag(xml, "expander-params"), "map form suppressed: " + xml);
+    assertFalse(xml.matches("(?s).*<filter(\\s|>).*"), "filter object suppressed: " + xml);
+  }
+
+  @Test
+  void contentListWriteMatchesGoldenFixture() throws Exception {
+    String xml = sampleContentList().toXML();
+    String golden =
+        loadResource("com/percussion/services/publisher/data/ps-content-list-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+  }
+
+  @Test
+  void contentListRoundTripRestoresScalarsParamsAndFilter() throws Exception {
+    PSContentList original = sampleContentList();
+    String xml = original.toXML();
+
+    PSContentList restored = new PSContentList();
+    restored.fromXML(xml);
+
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getDescription(), restored.getDescription());
+    assertEquals(original.getUrl(), restored.getUrl());
+    assertEquals(original.getGenerator(), restored.getGenerator());
+    assertEquals(original.getExpander(), restored.getExpander());
+    assertEquals(original.getEditionType(), restored.getEditionType());
+    assertEquals(original.getContentListType(), restored.getContentListType());
+    assertEquals(original.getGUID().toString(), restored.getGUID().toString());
+    assertEquals(original.getFilterId().toString(), restored.getFilterId().toString());
+    assertEquals(
+        sortedParams(original.getGeneratorParams()), sortedParams(restored.getGeneratorParams()));
+    assertEquals(
+        sortedParams(original.getExpanderParams()), sortedParams(restored.getExpanderParams()));
+  }
+
+  @Test
+  void contentListFromXmlAcceptsLegacyNullRoot() throws Exception {
+    String legacy =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <null>
+          <content-list-id>501</content-list-id>
+          <content-list-type>NORMAL</content-list-type>
+          <description>Legacy list</description>
+          <edition-type>AUTOMATIC</edition-type>
+          <expander>Java/global/percussion/system/sys_TemplateExpand</expander>
+          <expander-arguments>
+            <template-expander-param>
+              <name>template</name>
+              <value>rffSnTitleLink</value>
+            </template-expander-param>
+          </expander-arguments>
+          <filter-id>0-7-11</filter-id>
+          <generator>Java/global/percussion/system/sys_SearchGenerator</generator>
+          <generator-arguments>
+            <content-list-generator-param>
+              <name>query</name>
+              <value>//*</value>
+            </content-list-generator-param>
+          </generator-arguments>
+          <guid>0-21-501</guid>
+          <name>legacy_clist</name>
+          <url>../sys_cxSupport/contentlist.xml</url>
+        </null>
+        """;
+
+    PSContentList restored = new PSContentList();
+    restored.fromXML(legacy);
+
+    assertEquals("legacy_clist", restored.getName());
+    assertEquals("Legacy list", restored.getDescription());
+    assertEquals(501L, restored.getContentListId());
+    assertEquals(IPSContentList.Type.NORMAL, restored.getContentListType());
+    assertEquals(PSEditionType.AUTOMATIC, restored.getEditionType());
+    assertEquals("0-7-11", restored.getFilterId().toString());
+    assertEquals("//*", restored.getGeneratorParams().get("query"));
+    assertEquals("rffSnTitleLink", restored.getExpanderParams().get("template"));
+  }
+
+  @Test
+  void editionWriteSuppressesGuidNameAndVersion() throws Exception {
+    PSEdition original = sampleEdition();
+    String xml = original.toXML();
+
+    assertNotNull(xml);
+    assertTrue(containsTag(xml, "edition"), xml);
+    assertTrue(containsTag(xml, "display-title"), xml);
+    assertTrue(containsTag(xml, "comment"), xml);
+    assertTrue(containsTag(xml, "edition-type"), xml);
+    assertTrue(containsTag(xml, "site-id"), xml);
+    assertTrue(containsTag(xml, "pub-server-id"), xml);
+    assertTrue(containsTag(xml, "priority"), xml);
+    assertTrue(containsTag(xml, "id"), xml);
+    assertFalse(containsTag(xml, "guid"), "historical guid suppressed: " + xml);
+    assertFalse(containsTag(xml, "version"), xml);
+    assertFalse(xml.matches("(?s).*<name(\\s|>).*"), "name alias of display-title: " + xml);
+    assertTrue(xml.contains("Publish Site"), xml);
+  }
+
+  @Test
+  void editionWriteMatchesGoldenFixture() throws Exception {
+    String xml = sampleEdition().toXML();
+    String golden = loadResource("com/percussion/services/publisher/data/ps-edition-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+  }
+
+  @Test
+  void editionRoundTripRestoresScalars() throws Exception {
+    PSEdition original = sampleEdition();
+    String xml = original.toXML();
+
+    PSEdition restored = new PSEdition();
+    restored.fromXML(xml);
+
+    assertEquals(original.getId(), restored.getId());
+    assertEquals(original.getDisplayTitle(), restored.getDisplayTitle());
+    assertEquals(original.getComment(), restored.getComment());
+    assertEquals(original.getEditionType(), restored.getEditionType());
+    assertEquals(original.getPriority(), restored.getPriority());
+    assertEquals(original.getSiteId().toString(), restored.getSiteId().toString());
+    assertEquals(original.getPubServerId().toString(), restored.getPubServerId().toString());
+  }
+
+  @Test
+  void editionFromXmlAcceptsLegacyNullRootAndNullSite() throws Exception {
+    String legacy =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <null>
+          <comment>c</comment>
+          <display-title>E1</display-title>
+          <edition-type>NORMAL</edition-type>
+          <id>9001</id>
+          <priority>HIGH</priority>
+        </null>
+        """;
+
+    PSEdition restored = new PSEdition();
+    restored.fromXML(legacy);
+
+    assertEquals(9001L, restored.getId());
+    assertEquals("E1", restored.getDisplayTitle());
+    assertEquals("c", restored.getComment());
+    assertEquals(PSEditionType.NORMAL, restored.getEditionType());
+    assertEquals(IPSEdition.Priority.HIGH, restored.getPriority());
+    assertNull(restored.getSiteId());
+    assertNull(restored.getPubServerId());
+  }
+
+  @Test
+  void deliveryTypeWriteAndRoundTrip() throws Exception {
+    PSDeliveryType original = sampleDeliveryType();
+    String xml = original.toXML();
+
+    assertTrue(containsTag(xml, "delivery-type"), xml);
+    assertTrue(containsTag(xml, "bean-name"), xml);
+    assertTrue(containsTag(xml, "unpublishing-requires-assembly"), xml);
+    assertTrue(containsTag(xml, "guid"), xml);
+    assertTrue(xml.contains("filesystem"), xml);
+
+    String golden =
+        loadResource("com/percussion/services/publisher/data/ps-delivery-type-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+
+    PSDeliveryType restored = new PSDeliveryType();
+    restored.fromXML(xml);
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getDescription(), restored.getDescription());
+    assertEquals(original.getBeanName(), restored.getBeanName());
+    assertEquals(
+        original.isUnpublishingRequiresAssembly(), restored.isUnpublishingRequiresAssembly());
+    assertEquals(original.getGUID().toString(), restored.getGUID().toString());
+  }
+
+  @Test
+  void deliveryTypeFromXmlAcceptsLegacyNullRoot() throws Exception {
+    String legacy =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <null>
+          <bean-name>sys_fileDeliveryHandler</bean-name>
+          <description>d</description>
+          <guid>0-112-7</guid>
+          <name>filesystem</name>
+          <unpublishing-requires-assembly>false</unpublishing-requires-assembly>
+        </null>
+        """;
+    PSDeliveryType restored = new PSDeliveryType();
+    restored.fromXML(legacy);
+    assertEquals("filesystem", restored.getName());
+    assertEquals("sys_fileDeliveryHandler", restored.getBeanName());
+    assertFalse(restored.isUnpublishingRequiresAssembly());
+    assertEquals(7L, restored.getGUID().getUUID());
+  }
+
+  private static PSContentList sampleContentList() {
+    PSContentList list = new PSContentList();
+    list.setGUID(new PSGuid(PSTypeEnum.CONTENT_LIST, 501L));
+    list.setName("sample_clist");
+    list.setDescription("Sample content list");
+    list.setUrl("../sys_cxSupport/contentlist.xml?sys_deliverytype=filesystem");
+    list.setGenerator("Java/global/percussion/system/sys_SearchGenerator");
+    list.setExpander("Java/global/percussion/system/sys_TemplateExpand");
+    list.setEditionType(PSEditionType.AUTOMATIC);
+    list.setContentListType(IPSContentList.Type.NORMAL);
+    list.setFilterId(new PSGuid(PSTypeEnum.ITEM_FILTER, 11L));
+
+    PSContentListGeneratorParam g = new PSContentListGeneratorParam();
+    g.setId(1L);
+    g.setName("query");
+    g.setValue("//*[jcr:primaryType='percPage']");
+    g.setContentList(list);
+
+    PSTemplateExpanderParam e = new PSTemplateExpanderParam();
+    e.setId(2L);
+    e.setName("template");
+    e.setValue("perc.page");
+    e.setContentList(list);
+
+    list.getGeneratorArguments().add(g);
+    list.getExpanderArguments().add(e);
+    return list;
+  }
+
+  private static PSEdition sampleEdition() {
+    PSEdition edition = new PSEdition();
+    edition.setId(9001L);
+    edition.setDisplayTitle("Publish Site");
+    edition.setComment("Full site publish");
+    edition.setEditionType(PSEditionType.NORMAL);
+    edition.setPriority(IPSEdition.Priority.MEDIUM);
+    edition.setSiteId(new PSGuid(PSTypeEnum.SITE, 301L));
+    edition.setPubServerId(new PSGuid(PSTypeEnum.PUBLISHING_SERVER, 401L));
+    return edition;
+  }
+
+  private static PSDeliveryType sampleDeliveryType() {
+    PSDeliveryType dt = new PSDeliveryType();
+    dt.setGUID(new PSGuid(PSTypeEnum.DELIVERY_TYPE, 7L));
+    dt.setName("filesystem");
+    dt.setDescription("Publish to the filesystem");
+    dt.setBeanName("sys_fileDeliveryHandler");
+    dt.setUnpublishingRequiresAssembly(false);
+    return dt;
+  }
+
+  private static Map<String, String> sortedParams(Map<String, String> in) {
+    return new TreeMap<>(in == null ? new HashMap<>() : in);
+  }
+
+  private static boolean containsTag(String xml, String localName) {
+    return xml.contains("<" + localName) || xml.contains("</" + localName + ">");
+  }
+
+  private static String loadResource(String classpath) throws Exception {
+    try (InputStream in =
+        PSPublisherXmlSerializationTest.class.getClassLoader().getResourceAsStream(classpath)) {
+      assertNotNull(in, "missing test resource: " + classpath);
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static void assertLogicalXmlParity(String expectedXml, String actualXml)
+      throws Exception {
+    Document expected = parseXml(stripXmlDeclaration(expectedXml));
+    Document actual = parseXml(stripXmlDeclaration(actualXml));
+    assertElementTreeEquals(expected.getDocumentElement(), actual.getDocumentElement(), "/");
+  }
+
+  private static String stripXmlDeclaration(String xml) {
+    String s = Objects.requireNonNull(xml).trim();
+    if (s.startsWith("<?xml")) {
+      int end = s.indexOf("?>");
+      if (end >= 0) {
+        s = s.substring(end + 2).trim();
+      }
+    }
+    while (s.startsWith("<!--")) {
+      int end = s.indexOf("-->");
+      if (end < 0) {
+        break;
+      }
+      s = s.substring(end + 3).trim();
+    }
+    return s;
+  }
+
+  private static Document parseXml(String xml) throws Exception {
+    var factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    var builder = factory.newDocumentBuilder();
+    return builder.parse(new InputSource(new java.io.StringReader(xml)));
+  }
+
+  private static void assertElementTreeEquals(Element expected, Element actual, String path) {
+    assertEquals(expected.getTagName(), actual.getTagName(), "tag at " + path);
+    java.util.List<Node> eChildren = significantChildren(expected);
+    java.util.List<Node> aChildren = significantChildren(actual);
+    assertEquals(
+        eChildren.size(),
+        aChildren.size(),
+        "child count at "
+            + path
+            + " expected="
+            + summarize(eChildren)
+            + " actual="
+            + summarize(aChildren));
+    for (int i = 0; i < eChildren.size(); i++) {
+      Node en = eChildren.get(i);
+      Node an = aChildren.get(i);
+      if (en.getNodeType() == Node.TEXT_NODE) {
+        assertEquals(en.getTextContent().trim(), an.getTextContent().trim(), "text at " + path);
+      } else {
+        assertElementTreeEquals(
+            (Element) en, (Element) an, path + "/" + ((Element) en).getTagName() + "[" + i + "]");
+      }
+    }
+  }
+
+  private static java.util.List<Node> significantChildren(Element el) {
+    NodeList nl = el.getChildNodes();
+    java.util.ArrayList<Node> out = new java.util.ArrayList<>();
+    boolean hasElementChild = false;
+    for (int i = 0; i < nl.getLength(); i++) {
+      if (nl.item(i).getNodeType() == Node.ELEMENT_NODE) {
+        hasElementChild = true;
+        break;
+      }
+    }
+    for (int i = 0; i < nl.getLength(); i++) {
+      Node n = nl.item(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE) {
+        out.add(n);
+      } else if (n.getNodeType() == Node.TEXT_NODE && !hasElementChild) {
+        String t = n.getTextContent();
+        if (t != null && !t.trim().isEmpty()) {
+          out.add(n);
+        }
+      }
+    }
+    return out;
+  }
+
+  private static String summarize(java.util.List<Node> nodes) {
+    StringBuilder b = new StringBuilder("[");
+    for (int i = 0; i < nodes.size(); i++) {
+      if (i > 0) {
+        b.append(',');
+      }
+      Node n = nodes.get(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE) {
+        b.append(((Element) n).getTagName());
+      } else {
+        b.append("#text");
+      }
+    }
+    return b.append(']').toString();
+  }
+}

--- a/system/src/test/java/com/percussion/services/pubserver/data/PSPubServerXmlSerializationTest.java
+++ b/system/src/test/java/com/percussion/services/pubserver/data/PSPubServerXmlSerializationTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.pubserver.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * Golden / round-trip tests for {@link PSPubServer} / {@link PSPubServerProperty} under the
+ * Jackson-backed {@code PSXmlSerializationHelper} (issue #1919, epic #505). Offline only.
+ */
+class PSPubServerXmlSerializationTest {
+
+  @Test
+  void writeEmitsPropertiesAndSuppressesComputedFlags() throws Exception {
+    PSPubServer original = samplePubServer();
+    String xml = original.toXML();
+
+    assertNotNull(xml);
+    assertFalse(xml.trim().startsWith("<null"), xml);
+    assertTrue(containsTag(xml, "pub-server"), "root: " + xml);
+    assertTrue(containsTag(xml, "properties"), xml);
+    assertTrue(containsTag(xml, "pub-server-property"), xml);
+    assertTrue(containsTag(xml, "guid"), xml);
+    assertTrue(containsTag(xml, "server-type"), xml);
+    assertTrue(containsTag(xml, "publish-type"), xml);
+    assertTrue(containsTag(xml, "has-full-published"), xml);
+    assertTrue(containsTag(xml, "site-renamed"), xml);
+    assertTrue(xml.contains("Default_Server"), xml);
+    assertTrue(xml.contains("folder"), xml);
+    assertFalse(containsTag(xml, "xml-format"), "computed: " + xml);
+    assertFalse(containsTag(xml, "database-type"), "computed: " + xml);
+    assertFalse(containsTag(xml, "ftp-type"), "computed: " + xml);
+    assertFalse(containsTag(xml, "publish-server"), "runtime DTS lookup: " + xml);
+  }
+
+  @Test
+  void writeMatchesGoldenFixture() throws Exception {
+    String xml = samplePubServer().toXML();
+    String golden = loadResource("com/percussion/services/pubserver/data/ps-pub-server-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+  }
+
+  @Test
+  void roundTripRestoresScalarsAndProperties() throws Exception {
+    PSPubServer original = samplePubServer();
+    String xml = original.toXML();
+
+    PSPubServer restored = new PSPubServer();
+    restored.fromXML(xml);
+
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getDescriptionXml(), restored.getDescriptionXml());
+    assertEquals(original.getPublishType(), restored.getPublishType());
+    assertEquals(original.getServerTypeXml(), restored.getServerTypeXml());
+    assertEquals(original.getServerId(), restored.getServerId());
+    assertEquals(original.getSiteId(), restored.getSiteId());
+    assertEquals(original.getGUID().toString(), restored.getGUID().toString());
+    assertEquals(original.hasFullPublished(), restored.hasFullPublished());
+    assertEquals(original.getSiteRenamed(), restored.getSiteRenamed());
+    assertEquals(propertyMap(original), propertyMap(restored));
+  }
+
+  @Test
+  void fromXmlAcceptsLegacyNullRoot() throws Exception {
+    String legacy =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <null>
+          <description>Legacy pub server</description>
+          <guid>0-152-401</guid>
+          <has-full-published>false</has-full-published>
+          <name>Legacy_Server</name>
+          <properties>
+            <pub-server-property>
+              <name>folder</name>
+              <value>/sites/legacy</value>
+            </pub-server-property>
+          </properties>
+          <publish-type>filesystem</publish-type>
+          <server-id>401</server-id>
+          <server-type>PRODUCTION</server-type>
+          <site-id>301</site-id>
+          <site-renamed>false</site-renamed>
+        </null>
+        """;
+
+    PSPubServer restored = new PSPubServer();
+    restored.fromXML(legacy);
+
+    assertEquals("Legacy_Server", restored.getName());
+    assertEquals("Legacy pub server", restored.getDescriptionXml());
+    assertEquals("filesystem", restored.getPublishType());
+    assertEquals("PRODUCTION", restored.getServerTypeXml());
+    assertEquals(401L, restored.getServerId());
+    assertEquals(301L, restored.getSiteId());
+    assertEquals("/sites/legacy", restored.getPropertyValue("folder").orElse(null));
+    assertFalse(restored.hasFullPublished());
+    assertFalse(restored.getSiteRenamed());
+  }
+
+  private static PSPubServer samplePubServer() {
+    PSPubServer server = new PSPubServer();
+    server.setGUID(new PSGuid(PSTypeEnum.PUBLISHING_SERVER, 401L));
+    server.setServerId(401L);
+    server.setSiteId(301L);
+    server.setName("Default_Server");
+    server.setDescription("Default publishing server");
+    server.setPublishType("filesystem");
+    server.setServerType(PSPubServer.PRODUCTION);
+    server.setHasFullPublished(true);
+    server.setSiteRenamed(false);
+
+    PSPubServerProperty folder = new PSPubServerProperty();
+    folder.setPropertyId(1L);
+    folder.setServerId(401L);
+    folder.setName("folder");
+    folder.setValue("/sites/default");
+
+    PSPubServerProperty format = new PSPubServerProperty();
+    format.setPropertyId(2L);
+    format.setServerId(401L);
+    format.setName("format");
+    format.setValue("HTML");
+
+    server.getProperties().add(folder);
+    server.getProperties().add(format);
+    return server;
+  }
+
+  private static Map<String, String> propertyMap(PSPubServer server) {
+    Map<String, String> out = new TreeMap<>();
+    for (PSPubServerProperty p : server.getProperties()) {
+      out.put(p.getName(), p.getValueXml());
+    }
+    return out;
+  }
+
+  private static boolean containsTag(String xml, String localName) {
+    return xml.contains("<" + localName) || xml.contains("</" + localName + ">");
+  }
+
+  private static String loadResource(String classpath) throws Exception {
+    try (InputStream in =
+        PSPubServerXmlSerializationTest.class.getClassLoader().getResourceAsStream(classpath)) {
+      assertNotNull(in, "missing test resource: " + classpath);
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static void assertLogicalXmlParity(String expectedXml, String actualXml)
+      throws Exception {
+    Document expected = parseXml(stripXmlDeclaration(expectedXml));
+    Document actual = parseXml(stripXmlDeclaration(actualXml));
+    assertElementTreeEquals(expected.getDocumentElement(), actual.getDocumentElement(), "/");
+  }
+
+  private static String stripXmlDeclaration(String xml) {
+    String s = Objects.requireNonNull(xml).trim();
+    if (s.startsWith("<?xml")) {
+      int end = s.indexOf("?>");
+      if (end >= 0) {
+        s = s.substring(end + 2).trim();
+      }
+    }
+    while (s.startsWith("<!--")) {
+      int end = s.indexOf("-->");
+      if (end < 0) {
+        break;
+      }
+      s = s.substring(end + 3).trim();
+    }
+    return s;
+  }
+
+  private static Document parseXml(String xml) throws Exception {
+    var factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    var builder = factory.newDocumentBuilder();
+    return builder.parse(new InputSource(new java.io.StringReader(xml)));
+  }
+
+  private static void assertElementTreeEquals(Element expected, Element actual, String path) {
+    assertEquals(expected.getTagName(), actual.getTagName(), "tag at " + path);
+    java.util.List<Node> eChildren = significantChildren(expected);
+    java.util.List<Node> aChildren = significantChildren(actual);
+    assertEquals(
+        eChildren.size(),
+        aChildren.size(),
+        "child count at "
+            + path
+            + " expected="
+            + summarize(eChildren)
+            + " actual="
+            + summarize(aChildren));
+    for (int i = 0; i < eChildren.size(); i++) {
+      Node en = eChildren.get(i);
+      Node an = aChildren.get(i);
+      if (en.getNodeType() == Node.TEXT_NODE) {
+        assertEquals(en.getTextContent().trim(), an.getTextContent().trim(), "text at " + path);
+      } else {
+        assertElementTreeEquals(
+            (Element) en, (Element) an, path + "/" + ((Element) en).getTagName() + "[" + i + "]");
+      }
+    }
+  }
+
+  private static java.util.List<Node> significantChildren(Element el) {
+    NodeList nl = el.getChildNodes();
+    java.util.ArrayList<Node> out = new java.util.ArrayList<>();
+    boolean hasElementChild = false;
+    for (int i = 0; i < nl.getLength(); i++) {
+      if (nl.item(i).getNodeType() == Node.ELEMENT_NODE) {
+        hasElementChild = true;
+        break;
+      }
+    }
+    for (int i = 0; i < nl.getLength(); i++) {
+      Node n = nl.item(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE) {
+        out.add(n);
+      } else if (n.getNodeType() == Node.TEXT_NODE && !hasElementChild) {
+        String t = n.getTextContent();
+        if (t != null && !t.trim().isEmpty()) {
+          out.add(n);
+        }
+      }
+    }
+    return out;
+  }
+
+  private static String summarize(java.util.List<Node> nodes) {
+    StringBuilder b = new StringBuilder("[");
+    for (int i = 0; i < nodes.size(); i++) {
+      if (i > 0) {
+        b.append(',');
+      }
+      Node n = nodes.get(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE) {
+        b.append(((Element) n).getTagName());
+      } else {
+        b.append("#text");
+      }
+    }
+    return b.append(']').toString();
+  }
+}

--- a/system/src/test/resources/com/percussion/services/publisher/data/ps-content-list-golden.xml
+++ b/system/src/test/resources/com/percussion/services/publisher/data/ps-content-list-golden.xml
@@ -1,0 +1,28 @@
+<!-- Golden snapshot for production PSContentList Jackson wire shape (issue
+	#1919 / epic #505). Nested items content-list-generator-param / template-expander-param.
+	Approved deviations: no Betwixt graph-identity id attrs; version / map param
+	forms / filter object suppressed; no XML declaration. -->
+<content-list>
+	<content-list-id>501</content-list-id>
+	<content-list-type>NORMAL</content-list-type>
+	<description>Sample content list</description>
+	<edition-type>AUTOMATIC</edition-type>
+	<expander>Java/global/percussion/system/sys_TemplateExpand</expander>
+	<filter-id>0-7-11</filter-id>
+	<generator>Java/global/percussion/system/sys_SearchGenerator</generator>
+	<guid>0-21-501</guid>
+	<name>sample_clist</name>
+	<url>../sys_cxSupport/contentlist.xml?sys_deliverytype=filesystem</url>
+	<generator-arguments>
+		<content-list-generator-param>
+			<name>query</name>
+			<value>//*[jcr:primaryType='percPage']</value>
+		</content-list-generator-param>
+	</generator-arguments>
+	<expander-arguments>
+		<template-expander-param>
+			<name>template</name>
+			<value>perc.page</value>
+		</template-expander-param>
+	</expander-arguments>
+</content-list>

--- a/system/src/test/resources/com/percussion/services/publisher/data/ps-delivery-type-golden.xml
+++ b/system/src/test/resources/com/percussion/services/publisher/data/ps-delivery-type-golden.xml
@@ -1,0 +1,9 @@
+<!-- Golden snapshot for production PSDeliveryType Jackson wire shape (issue
+	#1919 / epic #505). Offline-safe PSGuid form for guid. -->
+<delivery-type>
+	<bean-name>sys_fileDeliveryHandler</bean-name>
+	<description>Publish to the filesystem</description>
+	<guid>0-112-7</guid>
+	<name>filesystem</name>
+	<unpublishing-requires-assembly>false</unpublishing-requires-assembly>
+</delivery-type>

--- a/system/src/test/resources/com/percussion/services/publisher/data/ps-edition-golden.xml
+++ b/system/src/test/resources/com/percussion/services/publisher/data/ps-edition-golden.xml
@@ -1,0 +1,12 @@
+<!-- Golden snapshot for production PSEdition Jackson wire shape (issue #1919
+	/ epic #505). Historical guid suppressed (identity via id); name alias of
+	display-title omitted. -->
+<edition>
+	<comment>Full site publish</comment>
+	<display-title>Publish Site</display-title>
+	<edition-type>NORMAL</edition-type>
+	<id>9001</id>
+	<priority>MEDIUM</priority>
+	<pub-server-id>0-152-401</pub-server-id>
+	<site-id>0-9-301</site-id>
+</edition>

--- a/system/src/test/resources/com/percussion/services/pubserver/data/ps-pub-server-golden.xml
+++ b/system/src/test/resources/com/percussion/services/pubserver/data/ps-pub-server-golden.xml
@@ -1,0 +1,24 @@
+<!-- Golden snapshot for production PSPubServer / PSPubServerProperty Jackson
+	wire shape (issue #1919 / epic #505). Nested pub-server-property; properties
+	sorted by name; computed flags and DTS publish-server lookup suppressed. -->
+<pub-server>
+	<description>Default publishing server</description>
+	<guid>0-152-401</guid>
+	<has-full-published>true</has-full-published>
+	<name>Default_Server</name>
+	<publish-type>filesystem</publish-type>
+	<server-id>401</server-id>
+	<site-id>301</site-id>
+	<site-renamed>false</site-renamed>
+	<server-type>PRODUCTION</server-type>
+	<properties>
+		<pub-server-property>
+			<name>folder</name>
+			<value>/sites/default</value>
+		</pub-server-property>
+		<pub-server-property>
+			<name>format</name>
+			<value>HTML</value>
+		</pub-server-property>
+	</properties>
+</pub-server>


### PR DESCRIPTION
## Summary

Jackson-migrates publisher/pubserver design objects for issue **#1919** (slice 6c of #1823 / epic #505):

- `PSContentList` (+ `PSContentListGeneratorParam`, `PSTemplateExpanderParam`)
- `PSEdition`
- `PSDeliveryType`
- `PSPubServer` (+ `PSPubServerProperty`)

Uses Jackson-backed `PSXmlSerializationHelper` with opt-in annotations, nested `addType` names, offline-safe `PSGuid` assemble, stable name-sorted collections, and golden/round-trip unit tests.

**Out of scope:** filter (#1915 / PR #1922), sitemgr (#1918 / PR #1958), catalog/ui leftovers (#1920), content leftovers (#1921), Betwixt POM removal (#1824).

**Parents:** #1892 · #1823 · #505

## Test plan

- [x] `PSPublisherXmlSerializationTest` — Tests run: 10, Failures: 0
- [x] `PSPubServerXmlSerializationTest` — Tests run: 4, Failures: 0
- [x] Standalone `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Spotless: `mvnw.cmd spotless:apply` then `spotless:check` (in-scope only; out-of-scope Spotless hits discarded)
- [x] Erlang self-review: `docs/ai-generated/code-reviews/issue-1919-publisher-pubserver-jackson-erlang.md`
- [x] Deviations: `docs/ai-generated/tasks/505-betwixt-jackson/1919-publisher-pubserver-domain-deviations.md`

## Gates evidence

| Gate | Evidence |
|------|----------|
| Module clean install | `cd system` → `..\mvnw.cmd clean install` → BUILD SUCCESS |
| Unit tests | Publisher 10 + PubServer 4 = 14, Failures: 0 |
| Spotless | apply **then** check from repo root; feature PR contains only in-scope files |
| Erlang | PASS (documented) |
| Cross-platform | XML-only; no new filesystem path construction |

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #1919