### PR TITLE
fix(#1944): clean javadoc warnings in perc-openapi-generator-plugin module

### DIFF
--- a/modules/perc-openapi-generator-plugin/src/main/java/com/percussion/maven/OpenAPIGeneratorMojo.java
+++ b/modules/perc-openapi-generator-plugin/src/main/java/com/percussion/maven/OpenAPIGeneratorMojo.java
@@ -48,11 +48,9 @@ import org.reflections.scanners.Scanners;
 public class OpenAPIGeneratorMojo extends AbstractMojo {
 
   /** No-op constructor. */
-  public OpenAPIGeneratorMojo() {
-    // no-op
-  }
+  public OpenAPIGeneratorMojo() {}
 
-  /** Maven project being built; injected by the plugin framework. */
+  /** Maven project being built, injected by the plugin framework. */
   @Parameter(defaultValue = "${project}", readonly = true, required = true)
   MavenProject project;
 

--- a/modules/perc-openapi-generator-plugin/src/main/java/com/percussion/maven/OpenAPIGeneratorMojo.java
+++ b/modules/perc-openapi-generator-plugin/src/main/java/com/percussion/maven/OpenAPIGeneratorMojo.java
@@ -47,6 +47,12 @@ import org.reflections.scanners.Scanners;
 @Mojo(name = "generate-spec", defaultPhase = LifecyclePhase.PROCESS_CLASSES)
 public class OpenAPIGeneratorMojo extends AbstractMojo {
 
+  /** No-op constructor. */
+  public OpenAPIGeneratorMojo() {
+    // no-op
+  }
+
+  /** Maven project being built; injected by the plugin framework. */
   @Parameter(defaultValue = "${project}", readonly = true, required = true)
   MavenProject project;
 


### PR DESCRIPTION
## Summary

Resolves GitHub issue #1944: clean all Javadoc warnings reported by the maven-javadoc-plugin in the \perc-openapi-generator-plugin\ module so the count is zero.

## Verification (on Windows, JDK 21)

\\\
cd modules/perc-openapi-generator-plugin
..\..\mvnw.cmd clean install -B
\\\

- **BUILD SUCCESS** — module compiles standalone.
- **Zero Javadoc warnings**.

## Changes

| File | Fix |
|------|-----|
| OpenAPIGeneratorMojo | no-arg ctor, project field documented |

## Acceptance Criteria

- [x] All in-scope code compiles standalone.
- [x] All unit tests pass.
- [x] Zero Javadoc warnings.
- [x] No new compiler warnings.

Operator: Kilo (minimax-coding-plan/MiniMax-M3)