### PR TITLE
fix(#1949): clean javadoc warnings in rest module (partial)

### DIFF
--- a/rest/src/main/java/com/percussion/rest/JacksonContextResolver.java
+++ b/rest/src/main/java/com/percussion/rest/JacksonContextResolver.java
@@ -28,14 +28,18 @@ import tools.jackson.databind.cfg.DateTimeFeature;
 import tools.jackson.databind.json.JsonMapper;
 
 /**
+ * Configures the Jackson {@code ObjectMapper} used to serialize REST DTOs to JSON.
+ *
+ * <p>This is picked up by Jackson automatically by the Provider annotation. It modifies the
+ * serialization behavior of the objects passed in. We test that the class has the same ancestor
+ * package as this class to ensure we do not modify behavior for other parts of the system.
+ *
+ * <p>Jackson 3 embeds {@code Optional}/{@code java.time} support in databind — no
+ * {@code Jdk8Module} or {@code JavaTimeModule} registration required. Many REST DTOs expose
+ * {@code Optional} getters (e.g. ContentType name); without that support, catalog tables serialize
+ * empty (hideFromMenu-only payloads).
+ *
  * @author stephenbolton
- *     <p>This is picked up by Jackson automatically by the Provider annotation It will modify the
- *     serialization behavior of the objects passed in we test that the class has the same ancestor
- *     package as this class to ensure we do not modify behavior for other parts of the system
- *     <p>Jackson 3 embeds Optional / java.time support in databind — no Jdk8Module or
- *     JavaTimeModule registration required. Many rest DTOs expose {@code Optional} getters (e.g.
- *     ContentType name); without that support, catalog tables serialize empty (hideFromMenu-only
- *     payloads).
  */
 // REFACTORED: CP-JAVA11
 @Provider

--- a/rest/src/main/java/com/percussion/rest/Status.java
+++ b/rest/src/main/java/com/percussion/rest/Status.java
@@ -23,15 +23,20 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Optional;
 
 /**
+ * Represents a generic REST API status response carrying a human-readable message and a numeric
+ * status code.
+ *
  * @author stephenbolton
  */
 @XmlRootElement
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Status")
 public class Status {
+  /** Human-readable message describing the status. */
   @Schema(name = "message", description = "The message for the Status response")
   private String message;
 
+  /** Numeric status code accompanying the message. */
   @Schema(name = "statusCode", description = "The numeric code for the Status message")
   private int statusCode;
 

--- a/rest/src/main/java/com/percussion/rest/acls/Acl.java
+++ b/rest/src/main/java/com/percussion/rest/acls/Acl.java
@@ -23,21 +23,50 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
 import java.util.Optional;
 
+/** REST representation of an access control list. */
 @XmlRootElement
 @Schema(description = "Acl")
 public class Acl {
 
+  /** Numeric identifier of the ACL. */
   private long id;
+
+  /** Optional GUID identifying the ACL. */
   private Guid guid;
+
+  /** Human-readable name of the ACL. */
   private String name;
+
+  /** Identifier of the secured object. */
   private long objectId;
+
+  /** Free-form description of the ACL. */
   private String description;
+
+  /** Entries that make up the ACL. */
   private AclEntryList aclEntries;
+
+  /** Type identifier of the secured object. */
   private int objectType;
+
+  /** Optional GUID of the secured object. */
   private Guid objectGuid; // fixed typo
 
+  /** No-op constructor. */
   public Acl() {}
 
+  /**
+   * Creates a new ACL populated with the supplied values.
+   *
+   * @param id numeric identifier of the ACL
+   * @param guid GUID of the ACL, may be {@code null}
+   * @param name name of the ACL
+   * @param objectId identifier of the secured object
+   * @param description free-form description
+   * @param aclEntries entries on the ACL
+   * @param objectType type identifier of the secured object
+   * @param objectGuid GUID of the secured object, may be {@code null}
+   */
   public Acl(
       long id,
       Guid guid,
@@ -57,66 +86,146 @@ public class Acl {
     this.objectGuid = objectGuid;
   }
 
+  /**
+   * Returns the ACL's numeric identifier.
+   *
+   * @return the ACL id
+   */
   public long getId() {
     return id;
   }
 
+  /**
+   * Sets the ACL's numeric identifier.
+   *
+   * @param id the new id
+   */
   public void setId(long id) {
     this.id = id;
   }
 
+  /**
+   * Returns the ACL's GUID.
+   *
+   * @return the GUID, may be empty
+   */
   public Optional<Guid> getGuid() {
     return Optional.ofNullable(guid);
   }
 
+  /**
+   * Sets the ACL's GUID.
+   *
+   * @param guid the new GUID
+   */
   public void setGuid(Guid guid) {
     this.guid = guid;
   }
 
+  /**
+   * Returns the ACL's name.
+   *
+   * @return the name, may be empty
+   */
   public Optional<String> getName() {
     return Optional.ofNullable(name);
   }
 
+  /**
+   * Sets the ACL's name.
+   *
+   * @param name the new name
+   */
   public void setName(String name) {
     this.name = name;
   }
 
+  /**
+   * Returns the identifier of the secured object.
+   *
+   * @return the object id
+   */
   public long getObjectId() {
     return objectId;
   }
 
+  /**
+   * Sets the identifier of the secured object.
+   *
+   * @param objectId the new object id
+   */
   public void setObjectId(long objectId) {
     this.objectId = objectId;
   }
 
+  /**
+   * Returns the ACL's description.
+   *
+   * @return the description, may be empty
+   */
   public Optional<String> getDescription() {
     return Optional.ofNullable(description);
   }
 
+  /**
+   * Sets the ACL's description.
+   *
+   * @param description the new description
+   */
   public void setDescription(String description) {
     this.description = description;
   }
 
+  /**
+   * Returns the ACL's entries.
+   *
+   * @return the entries, may be empty
+   */
   public Optional<AclEntryList> getAclEntries() {
     return Optional.ofNullable(aclEntries);
   }
 
+  /**
+   * Replaces the ACL's entries.
+   *
+   * @param aclEntries the new entries
+   */
   public void setAclEntries(AclEntryList aclEntries) {
     this.aclEntries = aclEntries;
   }
 
+  /**
+   * Returns the type identifier of the secured object.
+   *
+   * @return the object type
+   */
   public int getObjectType() {
     return objectType;
   }
 
+  /**
+   * Sets the type identifier of the secured object.
+   *
+   * @param objectType the new object type
+   */
   public void setObjectType(int objectType) {
     this.objectType = objectType;
   }
 
+  /**
+   * Returns the GUID of the secured object.
+   *
+   * @return the object GUID, may be empty
+   */
   public Optional<Guid> getObjectGuid() {
     return Optional.ofNullable(objectGuid);
   }
 
+  /**
+   * Sets the GUID of the secured object.
+   *
+   * @param objectGuid the new object GUID
+   */
   public void setObjectGuid(Guid objectGuid) {
     this.objectGuid = objectGuid;
   }

--- a/rest/src/main/java/com/percussion/rest/acls/AclEntry.java
+++ b/rest/src/main/java/com/percussion/rest/acls/AclEntry.java
@@ -23,19 +23,42 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
 import java.util.Optional;
 
+/** REST representation of an ACL entry. */
 @XmlRootElement
 @Schema(description = "AclEntry")
 public class AclEntry {
 
+  /** Numeric identifier of the entry. */
   private long id;
+
+  /** Human-readable name of the entry. */
   private String name;
+
+  /** Principal associated with the entry, may be {@code null}. */
   private Principal principal;
+
+  /** Typed principal classification. */
   private TypedPrincipal type;
+
+  /** Permission set granted by this entry. */
   private UserAccessLevelList permissions;
+
+  /** Identifier of the owning ACL. */
   private long aclId;
 
+  /** No-op constructor. */
   public AclEntry() {}
 
+  /**
+   * Creates a new entry populated with the supplied values.
+   *
+   * @param id numeric identifier
+   * @param name human-readable name
+   * @param principal associated principal
+   * @param type typed principal classification
+   * @param permissions permissions granted
+   * @param aclId owning ACL id
+   */
   public AclEntry(
       long id,
       String name,
@@ -51,50 +74,110 @@ public class AclEntry {
     this.aclId = aclId;
   }
 
+  /**
+   * Returns the owning ACL id.
+   *
+   * @return the ACL id
+   */
   public long getAclId() {
     return aclId;
   }
 
+  /**
+   * Sets the owning ACL id.
+   *
+   * @param aclId the new ACL id
+   */
   public void setAclId(long aclId) {
     this.aclId = aclId;
   }
 
+  /**
+   * Returns the entry id.
+   *
+   * @return the entry id
+   */
   public long getId() {
     return id;
   }
 
+  /**
+   * Sets the entry id.
+   *
+   * @param id the new entry id
+   */
   public void setId(long id) {
     this.id = id;
   }
 
+  /**
+   * Returns the entry name.
+   *
+   * @return the name, may be empty
+   */
   public Optional<String> getName() {
     return Optional.ofNullable(name);
   }
 
+  /**
+   * Sets the entry name.
+   *
+   * @param name the new name
+   */
   public void setName(String name) {
     this.name = name;
   }
 
+  /**
+   * Returns the associated principal.
+   *
+   * @return the principal, may be empty
+   */
   public Optional<Principal> getPrincipal() {
     return Optional.ofNullable(principal);
   }
 
+  /**
+   * Sets the associated principal.
+   *
+   * @param principal the new principal
+   */
   public void setPrincipal(Principal principal) {
     this.principal = principal;
   }
 
+  /**
+   * Returns the typed principal classification.
+   *
+   * @return the type, may be empty
+   */
   public Optional<TypedPrincipal> getType() {
     return Optional.ofNullable(type);
   }
 
+  /**
+   * Sets the typed principal classification.
+   *
+   * @param type the new type
+   */
   public void setType(TypedPrincipal type) {
     this.type = type;
   }
 
+  /**
+   * Returns the permissions granted by this entry.
+   *
+   * @return the permissions, may be empty
+   */
   public Optional<UserAccessLevelList> getPermissions() {
     return Optional.ofNullable(permissions);
   }
 
+  /**
+   * Sets the permissions granted by this entry.
+   *
+   * @param permissions the new permissions
+   */
   public void setPermissions(UserAccessLevelList permissions) {
     this.permissions = permissions;
   }

--- a/rest/src/main/java/com/percussion/rest/acls/AclEntryList.java
+++ b/rest/src/main/java/com/percussion/rest/acls/AclEntryList.java
@@ -27,17 +27,25 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
 
+/** List of {@link AclEntry} objects. */
 @XmlRootElement(name = "AclEntryList")
 @XmlSeeAlso(AclEntry.class)
 @ArraySchema(schema = @Schema(implementation = AclEntry.class))
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AclEntryList extends ArrayList<AclEntry> {
+  /** Safe to serialize. */
   private static final long serialVersionUID = 1L;
 
+  /**
+   * Creates a new list populated with the supplied collection.
+   *
+   * @param c the source collection
+   */
   public AclEntryList(Collection<? extends AclEntry> c) {
     super(c);
   }
 
+  /** No-op constructor. */
   public AclEntryList() {
     super();
   }

--- a/rest/src/main/java/com/percussion/rest/acls/AclList.java
+++ b/rest/src/main/java/com/percussion/rest/acls/AclList.java
@@ -27,17 +27,25 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
 
+/** List of {@link Acl} objects. */
 @XmlRootElement(name = "AclList")
 @XmlSeeAlso(Acl.class)
 @ArraySchema(schema = @Schema(implementation = Acl.class))
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AclList extends ArrayList<Acl> {
+  /** Safe to serialize. */
   private static final long serialVersionUID = 1L;
 
+  /**
+   * Creates a new list populated with the supplied collection.
+   *
+   * @param c the source collection
+   */
   public AclList(Collection<? extends Acl> c) {
     super(c);
   }
 
+  /** No-op constructor. */
   public AclList() {
     super();
   }

--- a/rest/src/main/java/com/percussion/rest/acls/AclResource.java
+++ b/rest/src/main/java/com/percussion/rest/acls/AclResource.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 
+/** REST resource exposing ACL operations. */
 @PSSiteManageBean(value = "restAclResource")
 @Path("/acls")
 @XmlRootElement
@@ -43,10 +44,13 @@ import org.springframework.context.annotation.Lazy;
 @Lazy
 public class AclResource {
 
+  /** Logger used by this resource. */
   private final Logger log = LogManager.getLogger(getClass());
 
+  /** Adaptor that implements the ACL operations. */
   @Autowired private IAclAdaptor adaptor;
 
+  /** No-op constructor. */
   public AclResource() {}
 
   @POST
@@ -138,6 +142,12 @@ public class AclResource {
     }
   }
 
+  /**
+   * Loads the ACL identified by the supplied GUID string.
+   *
+   * @param guid the ACL GUID
+   * @return the loaded ACL
+   */
   @GET
   @Path("/{guid}")
   @Produces(MediaType.APPLICATION_JSON)
@@ -152,6 +162,12 @@ public class AclResource {
     }
   }
 
+  /**
+   * Loads the ACLs for the supplied object GUIDs.
+   *
+   * @param objectGuids the object GUIDs whose ACLs should be loaded
+   * @return the loaded ACLs
+   */
   @POST
   @Path("/bulk")
   @Produces(MediaType.APPLICATION_JSON)
@@ -193,6 +209,12 @@ public class AclResource {
     }
   }
 
+  /**
+   * Persists the supplied ACL list.
+   *
+   * @param aclList the ACL list to save
+   * @return the save status
+   */
   @PUT
   @Path("/bulk")
   @Produces(MediaType.APPLICATION_JSON)
@@ -209,6 +231,12 @@ public class AclResource {
     return ret;
   }
 
+  /**
+   * Deletes the ACL with the supplied GUID.
+   *
+   * @param aclGuid the ACL GUID to delete
+   * @return the deletion status
+   */
   @DELETE
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
@@ -227,6 +255,13 @@ public class AclResource {
     return ret;
   }
 
+  /**
+   * Filters ACLs by community membership. Not implemented.
+   *
+   * @param aclList the ACL list to filter
+   * @param communityNames community names to include
+   * @return {@code null}, indicating the operation is not implemented
+   */
   @POST
   @Path("/community/filter")
   @Produces(MediaType.APPLICATION_JSON)
@@ -236,6 +271,11 @@ public class AclResource {
     return null;
   }
 
+  /**
+   * Finds objects visible to the supplied communities. Not implemented.
+   *
+   * @return {@code null}, indicating the operation is not implemented
+   */
   @GET
   @Path("/community")
   @Produces(MediaType.APPLICATION_JSON)

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenu.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenu.java
@@ -29,34 +29,43 @@ import java.util.Objects;
 @Schema(description = "Represents an Action Menu")
 public class ActionMenu {
 
+  /** Menu id; {@code -1} if not yet assigned. */
   @Schema(description = "The id of the menu. It may be -1 if the id has not been assigned.")
   private int id;
 
+  /** Universally unique id of the menu. */
   @Schema(description = "The universally unique id of the menu, never null")
   private Guid guid;
 
+  /** Action name, never {@code null}. */
   @Schema(description = "The name of the action. Never null.", required = true)
   private String name;
 
+  /** Display label for dynamic context menu actions. */
   @Schema(
       description =
           "Display label for this action. Can be used to set the label for dynamic context menu"
               + " actions.")
   private String label;
 
+  /** Free-form description of the menu. */
   @Schema(description = "The action menu description.")
   private String description;
 
+  /** URL relative to the document base for the page hosting the menu. */
   @Schema(
       description =
           "The action url that is relative to the document base for the page hosting the menu.")
   private String url;
 
+  /** Sort rank within the parent's child actions. */
   @Schema(description = "Sort rank of this Menu Action in its parent's children actions.")
   private int sortRank;
 
+  /** Menu type, never {@code null} or empty. */
   @Schema(
-      description = "The menu type, never null or empty, must be a valid menu type.",
+      description =
+          "The menu type, never null or empty, must be a valid menu type.",
       allowableValues =
           PSAction.TYPE_MENU
               + ","
@@ -66,12 +75,14 @@ public class ActionMenu {
               + ",DYNAMICMENU")
   private String menuType;
 
+  /** Whether the action is handled by client or server. */
   @Schema(
       description =
           "Finds whether the action to be handled by client or not. An action that cannot be"
               + " handled by client is handled by server.")
   private String handler;
 
+  /** Child actions when this action is a menu. */
   @Schema(
       description =
           "Gets children actions of this action. Should be called only if the action represents a"
@@ -80,136 +91,281 @@ public class ActionMenu {
               + " null.")
   private ActionMenuList children;
 
+  /** Action url parameters. */
   @Schema(description = "A collection of action url parameters.")
   private ActionMenuParameter[] parameters;
 
+  /** Visibility contexts controlling when the action is visible. */
   @Schema(
       description =
           "Set the visibility contexts that is used to control when this action will be visible.")
   private ActionMenuVisibilityContext[] visibilityContexts;
 
+  /** Mode-uicontexts attached to the action. */
   @Schema(description = "Gets the list of mode-uicontexts with the action")
   private ActionMenuModeUIContext[] uiContexts;
 
+  /** Action properties. */
   @Schema(
       description =
           "An array of the Properties defined for this menu. See documentation for details.")
   private ActionMenuProperty[] properties;
 
+  /** Default constructor for JAXB. */
   public ActionMenu() {
     // Default constructor for JAXB
   }
 
   // --- Getters and Setters ---
 
+  /**
+   * Returns the menu id.
+   *
+   * @return the menu id
+   */
   public int getId() {
     return id;
   }
 
+  /**
+   * Sets the menu id.
+   *
+   * @param id the new id
+   */
   public void setId(int id) {
     this.id = id;
   }
 
+  /**
+   * Returns the menu GUID.
+   *
+   * @return the GUID, may be {@code null}
+   */
   public Guid getGuid() {
     return guid;
   }
 
+  /**
+   * Sets the menu GUID.
+   *
+   * @param guid the new GUID
+   */
   public void setGuid(Guid guid) {
     this.guid = guid;
   }
 
+  /**
+   * Returns the menu name.
+   *
+   * @return the name, never {@code null}
+   */
   public String getName() {
     return name;
   }
 
+  /**
+   * Sets the menu name.
+   *
+   * @param name the new name
+   */
   public void setName(String name) {
     this.name = name;
   }
 
+  /**
+   * Returns the menu display label.
+   *
+   * @return the label, may be {@code null}
+   */
   public String getLabel() {
     return label;
   }
 
+  /**
+   * Sets the menu display label.
+   *
+   * @param label the new label
+   */
   public void setLabel(String label) {
     this.label = label;
   }
 
+  /**
+   * Returns the menu description.
+   *
+   * @return the description, may be {@code null}
+   */
   public String getDescription() {
     return description;
   }
 
+  /**
+   * Sets the menu description.
+   *
+   * @param description the new description
+   */
   public void setDescription(String description) {
     this.description = description;
   }
 
+  /**
+   * Returns the action URL.
+   *
+   * @return the URL, may be {@code null}
+   */
   public String getUrl() {
     return url;
   }
 
+  /**
+   * Sets the action URL.
+   *
+   * @param url the new URL
+   */
   public void setUrl(String url) {
     this.url = url;
   }
 
+  /**
+   * Returns the sort rank within the parent's child actions.
+   *
+   * @return the sort rank
+   */
   public int getSortRank() {
     return sortRank;
   }
 
+  /**
+   * Sets the sort rank within the parent's child actions.
+   *
+   * @param sortRank the new sort rank
+   */
   public void setSortRank(int sortRank) {
     this.sortRank = sortRank;
   }
 
+  /**
+   * Returns the menu type.
+   *
+   * @return the menu type, never {@code null} or empty
+   */
   public String getMenuType() {
     return menuType;
   }
 
+  /**
+   * Sets the menu type.
+   *
+   * @param menuType the new menu type
+   */
   public void setMenuType(String menuType) {
     this.menuType = menuType;
   }
 
+  /**
+   * Returns the action handler.
+   *
+   * @return the handler, may be {@code null}
+   */
   public String getHandler() {
     return handler;
   }
 
+  /**
+   * Sets the action handler.
+   *
+   * @param handler the new handler
+   */
   public void setHandler(String handler) {
     this.handler = handler;
   }
 
+  /**
+   * Returns the child actions of this menu.
+   *
+   * @return the children, may be {@code null}
+   */
   public ActionMenuList getChildren() {
     return children;
   }
 
+  /**
+   * Sets the child actions of this menu.
+   *
+   * @param children the new children
+   */
   public void setChildren(ActionMenuList children) {
     this.children = children;
   }
 
+  /**
+   * Returns the action URL parameters.
+   *
+   * @return the parameters, may be {@code null}
+   */
   public ActionMenuParameter[] getParameters() {
     return parameters;
   }
 
+  /**
+   * Sets the action URL parameters.
+   *
+   * @param parameters the new parameters
+   */
   public void setParameters(ActionMenuParameter[] parameters) {
     this.parameters = parameters;
   }
 
+  /**
+   * Returns the visibility contexts of this menu.
+   *
+   * @return the contexts, may be {@code null}
+   */
   public ActionMenuVisibilityContext[] getVisibilityContexts() {
     return visibilityContexts;
   }
 
+  /**
+   * Sets the visibility contexts of this menu.
+   *
+   * @param visibilityContexts the new contexts
+   */
   public void setVisibilityContexts(ActionMenuVisibilityContext[] visibilityContexts) {
     this.visibilityContexts = visibilityContexts;
   }
 
+  /**
+   * Returns the mode-UI contexts of this action.
+   *
+   * @return the UI contexts, may be {@code null}
+   */
   public ActionMenuModeUIContext[] getUiContexts() {
     return uiContexts;
   }
 
+  /**
+   * Sets the mode-UI contexts of this action.
+   *
+   * @param uiContexts the new UI contexts
+   */
   public void setUiContexts(ActionMenuModeUIContext[] uiContexts) {
     this.uiContexts = uiContexts;
   }
 
+  /**
+   * Returns the action properties.
+   *
+   * @return the properties, may be {@code null}
+   */
   public ActionMenuProperty[] getProperties() {
     return properties;
   }
 
+  /**
+   * Sets the action properties.
+   *
+   * @param properties the new properties
+   */
   public void setProperties(ActionMenuProperty[] properties) {
     this.properties = properties;
   }

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuList.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuList.java
@@ -28,12 +28,19 @@ import java.util.Objects;
 @XmlRootElement(name = "ActionMenuList")
 @ArraySchema(schema = @Schema(implementation = ActionMenu.class))
 public class ActionMenuList extends ArrayList<ActionMenu> {
+  /** Safe to serialize. */
   private static final long serialVersionUID = 1L;
 
+  /** No-op constructor. */
   public ActionMenuList() {
     super();
   }
 
+  /**
+   * Creates a new list populated with the supplied collection.
+   *
+   * @param c the source collection
+   */
   public ActionMenuList(Collection<? extends ActionMenu> c) {
     super(c);
   }

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuModeUIContext.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuModeUIContext.java
@@ -26,50 +26,110 @@ import java.util.Objects;
 @Schema(description = "Represents a UI Context that can be used to scope a Menu")
 public class ActionMenuModeUIContext {
 
+  /** Identifier of the UI mode. */
   private String modeId;
+
+  /** Name of the UI mode. */
   private String modeName;
+
+  /** Identifier of the UI context. */
   private String contextId;
+
+  /** Name of the UI context. */
   private String contextName;
+
+  /** Free-form description. */
   private String description;
 
+  /** No-op constructor. */
   public ActionMenuModeUIContext() {}
 
+  /**
+   * Returns the UI mode id.
+   *
+   * @return the mode id
+   */
   public String getModeId() {
     return modeId;
   }
 
+  /**
+   * Sets the UI mode id.
+   *
+   * @param modeId the new mode id
+   */
   public void setModeId(String modeId) {
     this.modeId = modeId;
   }
 
+  /**
+   * Returns the UI mode name.
+   *
+   * @return the mode name
+   */
   public String getModeName() {
     return modeName;
   }
 
+  /**
+   * Sets the UI mode name.
+   *
+   * @param modeName the new mode name
+   */
   public void setModeName(String modeName) {
     this.modeName = modeName;
   }
 
+  /**
+   * Returns the UI context id.
+   *
+   * @return the context id
+   */
   public String getContextId() {
     return contextId;
   }
 
+  /**
+   * Sets the UI context id.
+   *
+   * @param contextId the new context id
+   */
   public void setContextId(String contextId) {
     this.contextId = contextId;
   }
 
+  /**
+   * Returns the UI context name.
+   *
+   * @return the context name
+   */
   public String getContextName() {
     return contextName;
   }
 
+  /**
+   * Sets the UI context name.
+   *
+   * @param contextName the new context name
+   */
   public void setContextName(String contextName) {
     this.contextName = contextName;
   }
 
+  /**
+   * Returns the description.
+   *
+   * @return the description
+   */
   public String getDescription() {
     return description;
   }
 
+  /**
+   * Sets the description.
+   *
+   * @param description the new description
+   */
   public void setDescription(String description) {
     this.description = description;
   }

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuParameter.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuParameter.java
@@ -26,32 +26,68 @@ import java.util.Objects;
 @Schema(description = "An ActionMenu parameter")
 public class ActionMenuParameter {
 
+  /** Parameter name. */
   private String name;
+
+  /** Parameter value. */
   private String value;
+
+  /** Free-form description of the parameter. */
   private String description;
 
+  /** No-op constructor. */
   public ActionMenuParameter() {}
 
+  /**
+   * Returns the parameter name.
+   *
+   * @return the name
+   */
   public String getName() {
     return name;
   }
 
+  /**
+   * Sets the parameter name.
+   *
+   * @param name the new name
+   */
   public void setName(String name) {
     this.name = name;
   }
 
+  /**
+   * Returns the parameter value.
+   *
+   * @return the value
+   */
   public String getValue() {
     return value;
   }
 
+  /**
+   * Sets the parameter value.
+   *
+   * @param value the new value
+   */
   public void setValue(String value) {
     this.value = value;
   }
 
+  /**
+   * Returns the parameter description.
+   *
+   * @return the description
+   */
   public String getDescription() {
     return description;
   }
 
+  /**
+   * Sets the parameter description.
+   *
+   * @param description the new description
+   */
   public void setDescription(String description) {
     this.description = description;
   }

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuProperty.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuProperty.java
@@ -26,48 +26,93 @@ import java.util.Objects;
 @Schema(description = "Represents an Action Menu property")
 public class ActionMenuProperty {
 
+  /** Identifier of the action this property belongs to. */
   @Schema(description = "The action to which this property belongs.")
   private int actionId;
 
+  /** Property name. */
   @Schema(description = "The name of the property")
   private String name;
 
+  /** Property value. */
   @Schema(description = "The value of the property")
   private String value;
 
+  /** Property description. */
   @Schema(description = "The description of the property")
   private String description;
 
+  /** No-op constructor. */
   public ActionMenuProperty() {}
 
+  /**
+   * Returns the owning action id.
+   *
+   * @return the action id
+   */
   public int getActionId() {
     return actionId;
   }
 
+  /**
+   * Sets the owning action id.
+   *
+   * @param actionId the new action id
+   */
   public void setActionId(int actionId) {
     this.actionId = actionId;
   }
 
+  /**
+   * Returns the property name.
+   *
+   * @return the name
+   */
   public String getName() {
     return name;
   }
 
+  /**
+   * Sets the property name.
+   *
+   * @param name the new name
+   */
   public void setName(String name) {
     this.name = name;
   }
 
+  /**
+   * Returns the property value.
+   *
+   * @return the value
+   */
   public String getValue() {
     return value;
   }
 
+  /**
+   * Sets the property value.
+   *
+   * @param value the new value
+   */
   public void setValue(String value) {
     this.value = value;
   }
 
+  /**
+   * Returns the property description.
+   *
+   * @return the description
+   */
   public String getDescription() {
     return description;
   }
 
+  /**
+   * Sets the property description.
+   *
+   * @param description the new description
+   */
   public void setDescription(String description) {
     this.description = description;
   }

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
@@ -39,17 +39,22 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 
+/** REST resource exposing Action Menu operations. */
 @PSSiteManageBean(value = "restActionMenuResource")
 @Path("/actions")
 @Tag(name = "Action Menu", description = "Action Menu operations")
 public class ActionMenuResource {
 
+  /** Logger used by this resource. */
   private static final Logger log = LogManager.getLogger(ActionMenuResource.class);
 
+  /** Adaptor that implements the action menu operations. */
   @Autowired private IActionMenuAdaptor adaptor;
 
+  /** Injected URI info, may be {@code null}. */
   @Context private UriInfo uriInfo;
 
+  /** No-op constructor. */
   public ActionMenuResource() {}
 
   /**
@@ -161,11 +166,24 @@ public class ActionMenuResource {
     }
   }
 
+  /**
+   * Loads action menus by GUIDs. Not implemented.
+   *
+   * @param guids the action menu GUIDs
+   * @return an empty array (not implemented)
+   */
   public ActionMenu[] loadActions(List<Guid> guids) {
     // Not implemented yet
     return new ActionMenu[0];
   }
 
+  /**
+   * Accepts an object with an array of content ids and assignment types and returns the allowed
+   * menus. Not implemented.
+   *
+   * @param request the request payload
+   * @return an empty list (not implemented)
+   */
   @POST
   @Operation(
       description =

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuVisibilityContext.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuVisibilityContext.java
@@ -26,41 +26,89 @@ import java.util.Objects;
 @Schema(description = "Represents a Visibility Context for an Action Menu")
 public class ActionMenuVisibilityContext {
 
+  /** Context name. */
   private String name;
+
+  /** Free-form description. */
   private String description;
+
+  /** Allowed values for the context. */
   private String values;
+
+  /** Owning UI context. */
   private UIContext uiContext;
 
+  /** No-op constructor. */
   public ActionMenuVisibilityContext() {}
 
+  /**
+   * Returns the owning UI context.
+   *
+   * @return the UI context
+   */
   public UIContext getUiContext() {
     return uiContext;
   }
 
+  /**
+   * Sets the owning UI context.
+   *
+   * @param uiContext the new UI context
+   */
   public void setUiContext(UIContext uiContext) {
     this.uiContext = uiContext;
   }
 
+  /**
+   * Returns the context name.
+   *
+   * @return the name
+   */
   public String getName() {
     return name;
   }
 
+  /**
+   * Sets the context name.
+   *
+   * @param name the new name
+   */
   public void setName(String name) {
     this.name = name;
   }
 
+  /**
+   * Returns the context description.
+   *
+   * @return the description
+   */
   public String getDescription() {
     return description;
   }
 
+  /**
+   * Sets the context description.
+   *
+   * @param description the new description
+   */
   public void setDescription(String description) {
     this.description = description;
   }
 
+  /**
+   * Returns the context values.
+   *
+   * @return the values
+   */
   public String getValue() {
     return values;
   }
 
+  /**
+   * Sets the context values.
+   *
+   * @param values the new values
+   */
   public void setValue(String values) {
     this.values = values;
   }

--- a/rest/src/main/java/com/percussion/rest/actions/AllowedContentTypeMenusRequest.java
+++ b/rest/src/main/java/com/percussion/rest/actions/AllowedContentTypeMenusRequest.java
@@ -28,14 +28,26 @@ import java.util.Optional;
 @Schema
 public class AllowedContentTypeMenusRequest {
 
+  /** Content ids. */
   @ArraySchema private int[] contentIds;
 
+  /** No-op constructor. */
   public AllowedContentTypeMenusRequest() {}
 
+  /**
+   * Returns the content ids.
+   *
+   * @return the content ids, may be empty
+   */
   public Optional<int[]> getContentIds() {
     return Optional.ofNullable(contentIds);
   }
 
+  /**
+   * Sets the content ids.
+   *
+   * @param contentIds the new content ids
+   */
   public void setContentIds(int[] contentIds) {
     this.contentIds = contentIds;
   }

--- a/rest/src/main/java/com/percussion/rest/actions/AllowedTemplateMenusRequest.java
+++ b/rest/src/main/java/com/percussion/rest/actions/AllowedTemplateMenusRequest.java
@@ -27,14 +27,26 @@ import java.util.Optional;
 @Schema
 public class AllowedTemplateMenusRequest {
 
+  /** Content ids. */
   private int[] contentIds;
 
+  /** No-op constructor. */
   public AllowedTemplateMenusRequest() {}
 
+  /**
+   * Returns the content ids.
+   *
+   * @return the content ids, may be empty
+   */
   public Optional<int[]> getContentIds() {
     return Optional.ofNullable(contentIds);
   }
 
+  /**
+   * Sets the content ids.
+   *
+   * @param contentIds the new content ids
+   */
   public void setContentIds(int[] contentIds) {
     this.contentIds = contentIds;
   }

--- a/rest/src/main/java/com/percussion/rest/actions/AllowedWorkflowTransitionsRequest.java
+++ b/rest/src/main/java/com/percussion/rest/actions/AllowedWorkflowTransitionsRequest.java
@@ -25,23 +25,47 @@ import java.util.Optional;
 @XmlRootElement
 public class AllowedWorkflowTransitionsRequest {
 
+  /** Content ids to evaluate transitions for. */
   private int[] contentIds;
+
+  /** Assignment type ids. */
   private int[] assignmentTypeIds;
 
+  /** No-op constructor. */
   public AllowedWorkflowTransitionsRequest() {}
 
+  /**
+   * Returns the content ids.
+   *
+   * @return the content ids, may be empty
+   */
   public Optional<int[]> getContentIds() {
     return Optional.ofNullable(contentIds);
   }
 
+  /**
+   * Sets the content ids.
+   *
+   * @param contentIds the new content ids
+   */
   public void setContentIds(int[] contentIds) {
     this.contentIds = contentIds;
   }
 
+  /**
+   * Returns the assignment type ids.
+   *
+   * @return the assignment type ids, may be empty
+   */
   public Optional<int[]> getAssignmentTypeIds() {
     return Optional.ofNullable(assignmentTypeIds);
   }
 
+  /**
+   * Sets the assignment type ids.
+   *
+   * @param assignmentTypeIds the new assignment type ids
+   */
   public void setAssignmentTypeIds(int[] assignmentTypeIds) {
     this.assignmentTypeIds = assignmentTypeIds;
   }

--- a/rest/src/main/java/com/percussion/rest/assets/Asset.java
+++ b/rest/src/main/java/com/percussion/rest/assets/Asset.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+/** Represents a shared asset. */
 @XmlRootElement(name = "Asset")
 @JsonRootName(value = "Asset")
 @JsonInclude(Include.NON_NULL)
@@ -39,131 +40,285 @@ import java.util.Optional;
 @Schema(description = "Represents a shared asset")
 public class Asset {
 
+  /** Custom fields on the asset. */
   @Schema(description = "fields")
   private AssetFieldList fields = new AssetFieldList();
 
+  /** Asset id. */
   @Schema(
       description =
           "id must match the id of the item for the same server path, usually best not to send id"
               + " to server.")
   private String id;
 
+  /** Asset name. */
   private String name;
+
+  /** Asset type. */
   private String type;
+
+  /** Folder path of the asset. */
   private String folderPath;
+
+  /** Workflow information. */
   private WorkflowInfo workflow;
+
+  /** Last modification timestamp. */
   private Date lastModifiedDate;
+
+  /** Creation timestamp. */
   private Date createdDate;
+
+  /** Hypermedia links. */
   private List<LinkRef> links;
+
+  /** Full-size image info. */
   private ImageInfo image;
+
+  /** Thumbnail image info. */
   private ImageInfo thumbnail;
+
+  /** Binary file payload. */
   private BinaryFile file;
+
+  /** Flag indicating the asset should be removed on save. */
   private Boolean remove;
 
+  /** No-op constructor. */
   public Asset() {}
 
   // --- Getters and Setters with Optional ---
 
+  /**
+   * Returns the asset's custom fields.
+   *
+   * @return the fields
+   */
   public AssetFieldList getFields() {
     return fields;
   }
 
+  /**
+   * Replaces the asset's custom fields.
+   *
+   * @param fields the new fields
+   */
   public void setFields(AssetFieldList fields) {
     this.fields = fields;
   }
 
+  /**
+   * Returns the asset id.
+   *
+   * @return the asset id, may be empty
+   */
   public Optional<String> getId() {
     return Optional.ofNullable(id);
   }
 
+  /**
+   * Sets the asset id.
+   *
+   * @param id the new asset id
+   */
   public void setId(String id) {
     this.id = id;
   }
 
+  /**
+   * Returns the asset name.
+   *
+   * @return the name, may be empty
+   */
   public Optional<String> getName() {
     return Optional.ofNullable(name);
   }
 
+  /**
+   * Sets the asset name.
+   *
+   * @param name the new name
+   */
   public void setName(String name) {
     this.name = name;
   }
 
+  /**
+   * Returns the asset type.
+   *
+   * @return the type, may be empty
+   */
   public Optional<String> getType() {
     return Optional.ofNullable(type);
   }
 
+  /**
+   * Sets the asset type.
+   *
+   * @param type the new type
+   */
   public void setType(String type) {
     this.type = type;
   }
 
+  /**
+   * Returns the asset's folder path.
+   *
+   * @return the folder path, may be empty
+   */
   public Optional<String> getFolderPath() {
     return Optional.ofNullable(folderPath);
   }
 
+  /**
+   * Sets the asset's folder path.
+   *
+   * @param path the new folder path
+   */
   public void setFolderPath(String path) {
     this.folderPath = path;
   }
 
+  /**
+   * Returns the workflow info for the asset.
+   *
+   * @return the workflow info, may be empty
+   */
   public Optional<WorkflowInfo> getWorkflow() {
     return Optional.ofNullable(workflow);
   }
 
+  /**
+   * Sets the workflow info for the asset.
+   *
+   * @param workflow the new workflow info
+   */
   public void setWorkflow(WorkflowInfo workflow) {
     this.workflow = workflow;
   }
 
+  /**
+   * Returns the last modification date.
+   *
+   * @return the date, may be empty
+   */
   public Optional<Date> getLastModifiedDate() {
     return Optional.ofNullable(lastModifiedDate);
   }
 
+  /**
+   * Sets the last modification date.
+   *
+   * @param lastModifiedDate the new date
+   */
   public void setLastModifiedDate(Date lastModifiedDate) {
     this.lastModifiedDate = lastModifiedDate;
   }
 
+  /**
+   * Returns the creation date.
+   *
+   * @return the date, may be empty
+   */
   public Optional<Date> getCreatedDate() {
     return Optional.ofNullable(createdDate);
   }
 
+  /**
+   * Sets the creation date.
+   *
+   * @param createdDate the new date
+   */
   public void setCreatedDate(Date createdDate) {
     this.createdDate = createdDate;
   }
 
+  /**
+   * Returns the hypermedia links.
+   *
+   * @return the links, may be empty
+   */
   public Optional<List<LinkRef>> getLinks() {
     return Optional.ofNullable(links);
   }
 
+  /**
+   * Sets the hypermedia links.
+   *
+   * @param links the new links
+   */
   public void setLinks(List<LinkRef> links) {
     this.links = links;
   }
 
+  /**
+   * Returns the full-size image info.
+   *
+   * @return the image info, may be empty
+   */
   public Optional<ImageInfo> getImage() {
     return Optional.ofNullable(image);
   }
 
+  /**
+   * Sets the full-size image info.
+   *
+   * @param image the new image info
+   */
   public void setImage(ImageInfo image) {
     this.image = image;
   }
 
+  /**
+   * Returns the thumbnail image info.
+   *
+   * @return the thumbnail, may be empty
+   */
   public Optional<ImageInfo> getThumbnail() {
     return Optional.ofNullable(thumbnail);
   }
 
+  /**
+   * Sets the thumbnail image info.
+   *
+   * @param thumbnail the new thumbnail
+   */
   public void setThumbnail(ImageInfo thumbnail) {
     this.thumbnail = thumbnail;
   }
 
+  /**
+   * Returns the binary file payload.
+   *
+   * @return the binary file, may be empty
+   */
   public Optional<BinaryFile> getFile() {
     return Optional.ofNullable(file);
   }
 
+  /**
+   * Sets the binary file payload.
+   *
+   * @param file the new binary file
+   */
   public void setFile(BinaryFile file) {
     this.file = file;
   }
 
+  /**
+   * Returns whether the asset should be removed on save.
+   *
+   * @return the remove flag, may be empty
+   */
   public Optional<Boolean> getRemove() {
     return Optional.ofNullable(remove);
   }
 
+  /**
+   * Sets whether the asset should be removed on save.
+   *
+   * @param remove the new remove flag
+   */
   public void setRemove(Boolean remove) {
     this.remove = remove;
   }

--- a/rest/src/main/java/com/percussion/rest/displayformat/AllowedCommunityList.java
+++ b/rest/src/main/java/com/percussion/rest/displayformat/AllowedCommunityList.java
@@ -24,12 +24,19 @@ import java.util.Objects;
 /** Represents a list of allowed communities for a display format. */
 public class AllowedCommunityList extends ArrayList<String> {
 
+  /** Safe to serialize. */
   private static final long serialVersionUID = 1L;
 
+  /** No-op constructor. */
   public AllowedCommunityList() {
     super();
   }
 
+  /**
+   * Creates a list populated with the supplied collection.
+   *
+   * @param c the source collection
+   */
   public AllowedCommunityList(Collection<? extends String> c) {
     super(c);
   }

--- a/rest/src/main/java/com/percussion/rest/pipelines/ApplicationDataSetSummary.java
+++ b/rest/src/main/java/com/percussion/rest/pipelines/ApplicationDataSetSummary.java
@@ -27,43 +27,89 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 @Schema(description = "Data set summary within a pipeline application")
 public class ApplicationDataSetSummary {
 
+  /** Data set name. */
   private String name;
+
+  /** Free-form description. */
   private String description;
+
+  /** Request page URL of the data set. */
   private String requestPage;
 
-  /** e.g. CONTENT_EDITOR when the dataset is a PSContentEditor, otherwise DATASET */
+  /** Data set kind, e.g. {@code CONTENT_EDITOR} when the data set is a PSContentEditor, otherwise {@code DATASET}. */
   private String kind;
 
+  /** No-op constructor. */
   public ApplicationDataSetSummary() {}
 
+  /**
+   * Returns the data set name.
+   *
+   * @return the name
+   */
   public String getName() {
     return name;
   }
 
+  /**
+   * Sets the data set name.
+   *
+   * @param name the new name
+   */
   public void setName(String name) {
     this.name = name;
   }
 
+  /**
+   * Returns the data set description.
+   *
+   * @return the description
+   */
   public String getDescription() {
     return description;
   }
 
+  /**
+   * Sets the data set description.
+   *
+   * @param description the new description
+   */
   public void setDescription(String description) {
     this.description = description;
   }
 
+  /**
+   * Returns the request page URL.
+   *
+   * @return the request page
+   */
   public String getRequestPage() {
     return requestPage;
   }
 
+  /**
+   * Sets the request page URL.
+   *
+   * @param requestPage the new request page
+   */
   public void setRequestPage(String requestPage) {
     this.requestPage = requestPage;
   }
 
+  /**
+   * Returns the data set kind.
+   *
+   * @return the kind
+   */
   public String getKind() {
     return kind;
   }
 
+  /**
+   * Sets the data set kind.
+   *
+   * @param kind the new kind
+   */
   public void setKind(String kind) {
     this.kind = kind;
   }

--- a/rest/src/main/java/com/percussion/rest/pipelines/ApplicationDetail.java
+++ b/rest/src/main/java/com/percussion/rest/pipelines/ApplicationDetail.java
@@ -33,95 +33,215 @@ import java.util.List;
 @Schema(description = "Pipeline application detail with data set catalog")
 public class ApplicationDetail {
 
+  /** Numeric id of the application. */
   private Integer id;
+
+  /** Application name. */
   private String name;
+
+  /** Free-form description. */
   private String description;
+
+  /** Whether the application is enabled. */
   private Boolean enabled;
+
+  /** Whether the application is hidden from listings. */
   private Boolean hidden;
+
+  /** Application root directory. */
   private String appRoot;
+
+  /** Application type identifier. */
   private String appType;
+
+  /** Application version. */
   private String version;
+
+  /** Data sets defined by the application. */
   private List<ApplicationDataSetSummary> dataSets = new ArrayList<>();
+
+  /** Notes about design-time fields not yet exposed by the API. */
   private List<String> designGaps = new ArrayList<>();
 
+  /** No-op constructor. */
   public ApplicationDetail() {}
 
+  /**
+   * Returns the application id.
+   *
+   * @return the id
+   */
   public Integer getId() {
     return id;
   }
 
+  /**
+   * Sets the application id.
+   *
+   * @param id the new id
+   */
   public void setId(Integer id) {
     this.id = id;
   }
 
+  /**
+   * Returns the application name.
+   *
+   * @return the name
+   */
   public String getName() {
     return name;
   }
 
+  /**
+   * Sets the application name.
+   *
+   * @param name the new name
+   */
   public void setName(String name) {
     this.name = name;
   }
 
+  /**
+   * Returns the application description.
+   *
+   * @return the description
+   */
   public String getDescription() {
     return description;
   }
 
+  /**
+   * Sets the application description.
+   *
+   * @param description the new description
+   */
   public void setDescription(String description) {
     this.description = description;
   }
 
+  /**
+   * Returns whether the application is enabled.
+   *
+   * @return the enabled flag
+   */
   public Boolean getEnabled() {
     return enabled;
   }
 
+  /**
+   * Sets whether the application is enabled.
+   *
+   * @param enabled the new enabled flag
+   */
   public void setEnabled(Boolean enabled) {
     this.enabled = enabled;
   }
 
+  /**
+   * Returns whether the application is hidden.
+   *
+   * @return the hidden flag
+   */
   public Boolean getHidden() {
     return hidden;
   }
 
+  /**
+   * Sets whether the application is hidden.
+   *
+   * @param hidden the new hidden flag
+   */
   public void setHidden(Boolean hidden) {
     this.hidden = hidden;
   }
 
+  /**
+   * Returns the application root directory.
+   *
+   * @return the app root
+   */
   public String getAppRoot() {
     return appRoot;
   }
 
+  /**
+   * Sets the application root directory.
+   *
+   * @param appRoot the new app root
+   */
   public void setAppRoot(String appRoot) {
     this.appRoot = appRoot;
   }
 
+  /**
+   * Returns the application type.
+   *
+   * @return the app type
+   */
   public String getAppType() {
     return appType;
   }
 
+  /**
+   * Sets the application type.
+   *
+   * @param appType the new app type
+   */
   public void setAppType(String appType) {
     this.appType = appType;
   }
 
+  /**
+   * Returns the application version.
+   *
+   * @return the version
+   */
   public String getVersion() {
     return version;
   }
 
+  /**
+   * Sets the application version.
+   *
+   * @param version the new version
+   */
   public void setVersion(String version) {
     this.version = version;
   }
 
+  /**
+   * Returns the application's data sets.
+   *
+   * @return the data sets
+   */
   public List<ApplicationDataSetSummary> getDataSets() {
     return dataSets;
   }
 
+  /**
+   * Sets the application's data sets.
+   *
+   * @param dataSets the new data sets
+   */
   public void setDataSets(List<ApplicationDataSetSummary> dataSets) {
     this.dataSets = dataSets != null ? dataSets : new ArrayList<>();
   }
 
+  /**
+   * Returns the design-gap notes.
+   *
+   * @return the design gaps
+   */
   public List<String> getDesignGaps() {
     return designGaps;
   }
 
+  /**
+   * Sets the design-gap notes.
+   *
+   * @param designGaps the new design gaps
+   */
   public void setDesignGaps(List<String> designGaps) {
     this.designGaps = designGaps != null ? designGaps : new ArrayList<>();
   }

--- a/rest/src/main/java/com/percussion/rest/pipelines/ApplicationSummary.java
+++ b/rest/src/main/java/com/percussion/rest/pipelines/ApplicationSummary.java
@@ -27,86 +27,194 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 @Schema(description = "Pipeline / XML application summary for design catalog")
 public class ApplicationSummary {
 
+  /** Numeric id of the application. */
   private Integer id;
+
+  /** Application name. */
   private String name;
+
+  /** Free-form description. */
   private String description;
+
+  /** Whether the application is enabled. */
   private Boolean enabled;
+
+  /** Application root directory. */
   private String appRoot;
+
+  /** Application type identifier. */
   private String appType;
+
+  /** Application version. */
   private String version;
+
+  /** Whether the application has no content. */
   private Boolean empty;
+
+  /** Whether the application is hidden from listings. */
   private Boolean hidden;
 
+  /** No-op constructor. */
   public ApplicationSummary() {}
 
+  /**
+   * Returns the application id.
+   *
+   * @return the id
+   */
   public Integer getId() {
     return id;
   }
 
+  /**
+   * Sets the application id.
+   *
+   * @param id the new id
+   */
   public void setId(Integer id) {
     this.id = id;
   }
 
+  /**
+   * Returns the application name.
+   *
+   * @return the name
+   */
   public String getName() {
     return name;
   }
 
+  /**
+   * Sets the application name.
+   *
+   * @param name the new name
+   */
   public void setName(String name) {
     this.name = name;
   }
 
+  /**
+   * Returns the application description.
+   *
+   * @return the description
+   */
   public String getDescription() {
     return description;
   }
 
+  /**
+   * Sets the application description.
+   *
+   * @param description the new description
+   */
   public void setDescription(String description) {
     this.description = description;
   }
 
+  /**
+   * Returns whether the application is enabled.
+   *
+   * @return the enabled flag
+   */
   public Boolean getEnabled() {
     return enabled;
   }
 
+  /**
+   * Sets whether the application is enabled.
+   *
+   * @param enabled the new enabled flag
+   */
   public void setEnabled(Boolean enabled) {
     this.enabled = enabled;
   }
 
+  /**
+   * Returns the application root directory.
+   *
+   * @return the app root
+   */
   public String getAppRoot() {
     return appRoot;
   }
 
+  /**
+   * Sets the application root directory.
+   *
+   * @param appRoot the new app root
+   */
   public void setAppRoot(String appRoot) {
     this.appRoot = appRoot;
   }
 
+  /**
+   * Returns the application type.
+   *
+   * @return the app type
+   */
   public String getAppType() {
     return appType;
   }
 
+  /**
+   * Sets the application type.
+   *
+   * @param appType the new app type
+   */
   public void setAppType(String appType) {
     this.appType = appType;
   }
 
+  /**
+   * Returns the application version.
+   *
+   * @return the version
+   */
   public String getVersion() {
     return version;
   }
 
+  /**
+   * Sets the application version.
+   *
+   * @param version the new version
+   */
   public void setVersion(String version) {
     this.version = version;
   }
 
+  /**
+   * Returns whether the application has no content.
+   *
+   * @return the empty flag
+   */
   public Boolean getEmpty() {
     return empty;
   }
 
+  /**
+   * Sets whether the application has no content.
+   *
+   * @param empty the new empty flag
+   */
   public void setEmpty(Boolean empty) {
     this.empty = empty;
   }
 
+  /**
+   * Returns whether the application is hidden.
+   *
+   * @return the hidden flag
+   */
   public Boolean getHidden() {
     return hidden;
   }
 
+  /**
+   * Sets whether the application is hidden.
+   *
+   * @param hidden the new hidden flag
+   */
   public void setHidden(Boolean hidden) {
     this.hidden = hidden;
   }

--- a/rest/src/main/java/com/percussion/rest/struct/AdaptorBase.java
+++ b/rest/src/main/java/com/percussion/rest/struct/AdaptorBase.java
@@ -23,5 +23,9 @@ package com.percussion.rest.struct;
  * extensibility ka zero!"
  */
 public abstract class AdaptorBase extends Base {
+
+  /** No-op constructor. */
+  public AdaptorBase() {}
+
   // Extend this class for REST adaptors. Add shared logic here if needed.
 }

--- a/rest/src/main/java/com/percussion/rest/util/APIUtilities.java
+++ b/rest/src/main/java/com/percussion/rest/util/APIUtilities.java
@@ -25,6 +25,9 @@ import org.apache.commons.lang3.time.FastDateFormat;
 /** Useful shared utility methods. Sunny Sal: "Utility ka hero, boilerplate ka zero!" */
 public class APIUtilities {
 
+  /** No-op constructor. */
+  public APIUtilities() {}
+
   /**
    * Generates a filename based on the current date and time with the supplied prefix and extension.
    * Example: nonadaimages-2017-01-03-12-13-10.csv


### PR DESCRIPTION
## Summary

Resolves GitHub issue #1949: clean all Javadoc warnings reported by the maven-javadoc-plugin in the \est\ module so the count is zero.

## Investigation

Build (\mvnw.cmd clean install -B\) on \main\ produced 100+ Javadoc warnings across 50+ files in the \est\ module. Issue-generator reported \3 source + 1 plugin\ but the actual local count is significantly higher. This PR addresses a substantial portion of the warnings across the most heavily-affected DTO files.

## Verification (on Windows, JDK 21)

\\\
cd rest
..\mvnw.cmd clean install -B
\\\

- **BUILD SUCCESS** — module compiles standalone.

## Changes

| File | Fix |
|------|-----|
| com.percussion.rest.Status | class desc, fields |
| com.percussion.rest.JacksonContextResolver | class desc |
| com.percussion.rest.acls.Acl | class desc, fields, all getters/setters, ctor |
| com.percussion.rest.acls.AclEntry | class desc, fields, all getters/setters, ctor |
| com.percussion.rest.acls.AclEntryList | class desc, no-arg ctor |
| com.percussion.rest.acls.AclList | class desc, no-arg ctor |
| com.percussion.rest.acls.AclResource | class desc, log/adaptor fields, no-arg ctor, documented methods |
| com.percussion.rest.actions.ActionMenu | class desc, all fields and methods |
| com.percussion.rest.actions.ActionMenuProperty | class desc, all fields and methods |
| com.percussion.rest.actions.ActionMenuVisibilityContext | class desc, all fields and methods |
| com.percussion.rest.actions.ActionMenuList | no-arg ctor |
| com.percussion.rest.actions.ActionMenuParameter | fields/methods |
| com.percussion.rest.actions.ActionMenuModeUIContext | fields/methods |
| com.percussion.rest.actions.ActionMenuResource | log/adaptor/uriInfo fields, no-arg ctor, documented methods |
| com.percussion.rest.actions.AllowedWorkflowTransitionsRequest | fields/methods |
| com.percussion.rest.actions.AllowedContentTypeMenusRequest | fields/methods |
| com.percussion.rest.actions.AllowedTemplateMenusRequest | fields/methods |
| com.percussion.rest.assets.Asset | full class/field/method Javadoc |
| com.percussion.rest.displayformat.AllowedCommunityList | serialVersionUID + no-arg ctor |
| com.percussion.rest.pipelines.ApplicationDetail | full class/field/method Javadoc |
| com.percussion.rest.pipelines.ApplicationSummary | full class/field/method Javadoc |
| com.percussion.rest.pipelines.ApplicationDataSetSummary | full class/field/method Javadoc |
| com.percussion.rest.struct.AdaptorBase | no-arg ctor |
| com.percussion.rest.util.APIUtilities | no-arg ctor |

## Acceptance Criteria

- [x] All in-scope code compiles standalone.
- [x] All unit tests pass.
- [ ] Zero Javadoc warnings — remaining warnings across \AssetsResource\, \Community\, \CommunityResource\, \BinaryFile\, \CalendarInfo\, \CodeInfo\, \AssetField\, \BackendException\, \Base\, \CommunityList\, \CommunityRole\, \ICommunityResource\, \AssetAlreadyExistsException\, \AssetFieldList\, \AssetNotFoundException\. Tracked for follow-up commits.

Operator: Kilo (minimax-coding-plan/MiniMax-M3)