### PR TITLE
fix(system): Jackson-migrate content leftovers + PSNodeDefinition (#1921)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-1921-content-leftovers-jackson-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-1921-content-leftovers-jackson-erlang.md
@@ -1,0 +1,34 @@
+# Erlang review — issue #1921 content leftovers + PSNodeDefinition Jackson
+
+**Reviewer persona:** Erlang (strict pre-commit)  
+**Change class:** Jackson-migrate design-object XML surface (content + contentmgr)  
+**Verdict:** PASS (no hard-gate bugs)
+
+## Scope reviewed
+
+- `PSAutoTranslation`, `PSContentTypeSummary`/`Child`, `PSFieldDescription`, `PSFolderProperty`, `PSItemStatus`
+- `PSNodeDefinition` (contentmgr)
+- Golden + round-trip tests under `system/src/test/...`
+- Deviations note: `docs/ai-generated/tasks/505-betwixt-jackson/1921-content-leftovers-deviations.md`
+
+## Checklist
+
+|                    Gate                     |                                                        Result                                                         |
+|---------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| Behavioral unit tests for new/changed logic | PASS — 12 offline tests (8 content leftovers + 4 node-def)                                                            |
+| Portable paths                              | PASS — no new filesystem path construction                                                                            |
+| Change-class companions                     | PASS — annotations + goldens + round-trip; type registration for nested fields/children; deviations doc               |
+| `.betwixt` drop only when proven            | N/A — no production betwixt for these types                                                                           |
+| Helper registration conflicts               | LOW — static `addType` for nested names only; coordinates with existing auto-translation / variant-guid registrations |
+
+## Findings
+
+### Non-blocking notes
+
+1. **PSNodeDefinition template restore** still requires live content manager (`addTemplateId` → locator). Offline tests intentionally cover write shape + scalar restore only; live path remains in `PSContentTypeMgrTest`. Documented in deviations.
+2. **setWorkflowIds** is a no-op for non-empty input (historical surface had no workflow adder). Acceptable for this slice; residual only if package install proves workflow-id restore is required offline.
+3. **PSFolderProperty** gained `toXML`/`fromXML` (inventory marked RW; previously missing). Low risk additive API.
+
+## Hard-gate bugs
+
+None.

--- a/docs/ai-generated/tasks/505-betwixt-jackson/1921-content-leftovers-deviations.md
+++ b/docs/ai-generated/tasks/505-betwixt-jackson/1921-content-leftovers-deviations.md
@@ -1,0 +1,28 @@
+# Issue #1921 — content leftovers + PSNodeDefinition Jackson deviations
+
+Parent: #1892 · Grandparent: #1823 · Epic: #505
+
+## Scope delivered
+
+|               Type               |      Package      |                                     Notes                                     |
+|----------------------------------|-------------------|-------------------------------------------------------------------------------|
+| `PSAutoTranslation`              | `content.data`    | Opt-in Jackson; suppress catalog aliases, version, GUID, `Optional` accessors |
+| `PSFieldDescription`             | `content.data`    | Root `field-description`; `exportable` omit-null                              |
+| `PSContentTypeSummary` / `Child` | `content.data`    | Nested `field-description` / `content-type-summary-child`                     |
+| `PSFolderProperty`               | `content.data`    | Added `toXML`/`fromXML`; opt-in surface; suppress `Optional` accessors        |
+| `PSItemStatus`                   | `content.data`    | No-arg ctor + `setId`; content id as wire property `id`                       |
+| `PSNodeDefinition`               | `contentmgr.data` | Opt-in surface; `template-id` / workflow `string` items; TreeSet order        |
+
+## Approved Jackson deviations vs historical Betwixt
+
+- No graph-identity `id="…"` attributes on complex elements
+- No XML declaration (`PSJacksonXmlSerializationHelper` default)
+- Catalog / `Optional` / Hibernate association graph suppressed on modern write
+- `PSNodeDefinition` template association **restore** still needs live content-manager (integration tests); offline suite pins write shape + scalar restore
+- No production `.betwixt` files existed for these types (nothing to drop)
+
+## Tests
+
+- `PSContentLeftoversXmlSerializationTest` — golden + round-trip (8 tests)
+- `PSNodeDefinitionXmlSerializationTest` — golden + scalar/package smoke (4 tests)
+

--- a/docs/ai-generated/tasks/505-betwixt-jackson/1921-content-leftovers-deviations.md
+++ b/docs/ai-generated/tasks/505-betwixt-jackson/1921-content-leftovers-deviations.md
@@ -19,10 +19,13 @@ Parent: #1892 · Grandparent: #1823 · Epic: #505
 - No XML declaration (`PSJacksonXmlSerializationHelper` default)
 - Catalog / `Optional` / Hibernate association graph suppressed on modern write
 - `PSNodeDefinition` template association **restore** still needs live content-manager (integration tests); offline suite pins write shape + scalar restore
+- `PSNodeDefinition` workflow association **restore** is offline-friendly via `setWorkflowIds` / `addWorkflowGuid` (new `PSContentTypeWorkflow` rows; association PK left unset for Hibernate). Live package install may still re-merge existing DB rows via `PSContentTypeHelper`.
+- `PSNodeDefinition#getId` / `getRawContentType` fail-fast (NPE) when unset — no synthetic `0L` (historical Betwixt unboxing).
+- `PSItemStatus#setFromState` / `setToState` allow `null` (no transition / Jackson absent optionals) and reject empty non-null strings. Historical setters used `StringUtils.isEmpty` (also rejected null); null is intentional for Jackson + domain.
 - No production `.betwixt` files existed for these types (nothing to drop)
 
 ## Tests
 
-- `PSContentLeftoversXmlSerializationTest` — golden + round-trip (8 tests)
-- `PSNodeDefinitionXmlSerializationTest` — golden + scalar/package smoke (4 tests)
+- `PSContentLeftoversXmlSerializationTest` — golden + round-trip + null/empty state contract
+- `PSNodeDefinitionXmlSerializationTest` — golden + scalar/package smoke + workflow restore + fail-fast id getters
 

--- a/system/services/src/com/percussion/services/content/data/PSAutoTranslation.java
+++ b/system/services/src/com/percussion/services/content/data/PSAutoTranslation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,10 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.services.content.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.catalog.IPSCatalogItem;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
@@ -24,12 +28,6 @@ import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.xml.IPSXmlSerialization;
-
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.Objects;
-import java.util.Optional;
-
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -38,7 +36,10 @@ import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.persistence.Version;
-
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -46,22 +47,14 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
- * Represents a single auto translation definition with enhanced Java 11 support.
+ * Represents a single auto translation definition.
  *
- * <p>Auto translations define automatic translation settings for content types
- * based on locale, workflow, and community configurations. This class provides
- * comprehensive functionality for managing auto translation data with modern
- * Java 11 features including validation, serialization, and safe navigation.
- *
- * <p>Key features:
- * <ul>
- *   <li>Enhanced null safety with Objects.requireNonNull()</li>
- *   <li>Optional-based safe value access</li>
- *   <li>Immutable factory methods</li>
- *   <li>Comprehensive validation with clear error messages</li>
- * </ul>
+ * <p>Design-object XML root is {@code auto-translation} (PS/IPS strip + hyphenation). Jackson
+ * opt-in surface suppresses catalog aliases, version, composite key, and {@link Optional} accessors
+ * (issue #1921 / epic #505).
  *
  * @since Java 11 Modernization
  */
@@ -69,442 +62,468 @@ import org.xml.sax.SAXException;
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSAutoTranslation")
 @Table(name = "PSX_AUTOTRANSLATION")
 @IdClass(PSAutoTranslationPK.class)
+@JacksonXmlRootElement(localName = "auto-translation")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({
+  "communityId",
+  "communityName",
+  "contentTypeId",
+  "contentTypeName",
+  "locale",
+  "workflowId",
+  "workflowName"
+})
 public class PSAutoTranslation implements IPSCatalogSummary, Serializable, IPSCatalogItem {
 
-   /**
-    * Serial version UID for serialization compatibility.
-    */
-   private static final long serialVersionUID = -7673907948835742673L;
+  /** Serial version UID for serialization compatibility. */
+  private static final long serialVersionUID = -7673907948835742673L;
 
-   @Id
-   @Column(name = "CONTENTTYPEID", nullable = false)
-   private long contentTypeId;
+  @Id
+  @Column(name = "CONTENTTYPEID", nullable = false)
+  private long contentTypeId;
 
-   /**
-    * The content type name for this auto translation, initialized while
-    * constructed, never {@code null} or empty.
-    */
-   @Transient
-   private String contentTypeName;
+  /**
+   * The content type name for this auto translation, initialized while constructed, never {@code
+   * null} or empty.
+   */
+  @Transient private String contentTypeName;
 
-   @Basic
-   @Column(name = "WORKFLOWID", nullable = false)
-   private long workflowId;
+  @Basic
+  @Column(name = "WORKFLOWID", nullable = false)
+  private long workflowId;
 
-   /**
-    * The workflow name for this auto translation, initialized while
-    * constructed, never {@code null} or empty.
-    */
-   @Transient
-   private String workflowName;
+  /**
+   * The workflow name for this auto translation, initialized while constructed, never {@code null}
+   * or empty.
+   */
+  @Transient private String workflowName;
 
-   @Basic
-   @Column(name = "COMMUNITYID", nullable = false)
-   private long communityId;
+  @Basic
+  @Column(name = "COMMUNITYID", nullable = false)
+  private long communityId;
 
-   /**
-    * The community name for this auto translation, initialized while
-    * constructed, never {@code null} or empty.
-    */
-   @Transient
-   private String communityName;
+  /**
+   * The community name for this auto translation, initialized while constructed, never {@code null}
+   * or empty.
+   */
+  @Transient private String communityName;
 
-   /**
-    * The locale code for this auto translation, initialized while
-    * constructed, never {@code null} or empty.
-    */
-   @Id
-   @Column(name = "LOCALE", nullable = false)
-   private String locale;
+  /**
+   * The locale code for this auto translation, initialized while constructed, never {@code null} or
+   * empty.
+   */
+  @Id
+  @Column(name = "LOCALE", nullable = false)
+  private String locale;
 
-   @Version
-   @Column(name = "VERSION")
-   private Integer m_version = null;
+  @Version
+  @Column(name = "VERSION")
+  private Integer m_version = null;
 
-   /**
-    * Default constructor required for JPA/Hibernate.
-    * Use factory methods or parameterized constructors for creating new instances.
-    */
-   public PSAutoTranslation() {
-      // Required by JPA
-   }
+  /**
+   * Default constructor required for JPA/Hibernate.
+   *
+   * <p>Use factory methods or parameterized constructors for creating new instances.
+   */
+  public PSAutoTranslation() {
+    // Required by JPA
+  }
 
-   /**
-    * Create a new auto translation with specified parameters using modern validation.
-    *
-    * @param contentTypeId the content type ID, must be > 0
-    * @param locale the locale code, not {@code null} or empty
-    * @param workflowId the workflow ID, must be > 0
-    * @param communityId the community ID, must be > 0
-    * @throws IllegalArgumentException if validation fails
-    */
-   public PSAutoTranslation(long contentTypeId, String locale, long workflowId, long communityId) {
-      if (contentTypeId <= 0) {
-         throw new IllegalArgumentException("contentTypeId must be > 0");
-      }
-      if (StringUtils.isBlank(locale)) {
-         throw new IllegalArgumentException("locale cannot be null or empty");
-      }
-      if (workflowId <= 0) {
-         throw new IllegalArgumentException("workflowId must be > 0");
-      }
-      if (communityId <= 0) {
-         throw new IllegalArgumentException("communityId must be > 0");
-      }
+  /**
+   * Create a new auto translation with specified parameters using modern validation.
+   *
+   * @param contentTypeId the content type ID, must be &gt; 0
+   * @param locale the locale code, not {@code null} or empty
+   * @param workflowId the workflow ID, must be &gt; 0
+   * @param communityId the community ID, must be &gt; 0
+   * @throws IllegalArgumentException if validation fails
+   */
+  public PSAutoTranslation(long contentTypeId, String locale, long workflowId, long communityId) {
+    if (contentTypeId <= 0) {
+      throw new IllegalArgumentException("contentTypeId must be > 0");
+    }
+    if (StringUtils.isBlank(locale)) {
+      throw new IllegalArgumentException("locale cannot be null or empty");
+    }
+    if (workflowId <= 0) {
+      throw new IllegalArgumentException("workflowId must be > 0");
+    }
+    if (communityId <= 0) {
+      throw new IllegalArgumentException("communityId must be > 0");
+    }
 
-      this.contentTypeId = contentTypeId;
-      this.locale = locale;
-      this.workflowId = workflowId;
-      this.communityId = communityId;
-   }
+    this.contentTypeId = contentTypeId;
+    this.locale = locale;
+    this.workflowId = workflowId;
+    this.communityId = communityId;
+  }
 
-   /**
-    * Create a new auto translation using factory method with enhanced validation.
-    *
-    * @param contentTypeId the content type ID, must be > 0
-    * @param locale the locale code, not {@code null} or empty
-    * @param workflowId the workflow ID, must be > 0
-    * @param communityId the community ID, must be > 0
-    * @return a new PSAutoTranslation instance
-    * @throws IllegalArgumentException if validation fails
-    */
-   public static PSAutoTranslation of(long contentTypeId, String locale, long workflowId, long communityId) {
-      return new PSAutoTranslation(contentTypeId, locale, workflowId, communityId);
-   }
+  /**
+   * Create a new auto translation using factory method with enhanced validation.
+   *
+   * @param contentTypeId the content type ID, must be &gt; 0
+   * @param locale the locale code, not {@code null} or empty
+   * @param workflowId the workflow ID, must be &gt; 0
+   * @param communityId the community ID, must be &gt; 0
+   * @return a new PSAutoTranslation instance
+   * @throws IllegalArgumentException if validation fails
+   */
+  public static PSAutoTranslation of(
+      long contentTypeId, String locale, long workflowId, long communityId) {
+    return new PSAutoTranslation(contentTypeId, locale, workflowId, communityId);
+  }
 
-   /**
-    * All auto translations are represented by a single GUID for locking purposes.
-    *
-    * @return the GUID, never {@code null}
-    */
-   public static IPSGuid getAutoTranslationsGUID() {
-      return new PSGuid(PSTypeEnum.AUTO_TRANSLATIONS, 0);
-   }
+  /**
+   * All auto translations are represented by a single GUID for locking purposes.
+   *
+   * @return the GUID, never {@code null}
+   */
+  public static IPSGuid getAutoTranslationsGUID() {
+    return new PSGuid(PSTypeEnum.AUTO_TRANSLATIONS, 0);
+  }
 
-   /**
-    * Get the key representation of this object.
-    *
-    * @return the key, never {@code null}
-    */
-   @IPSXmlSerialization(suppress = true)
-   public PSAutoTranslationPK getKey() {
-      return new PSAutoTranslationPK(contentTypeId, locale);
-   }
+  /**
+   * Get the key representation of this object.
+   *
+   * @return the key, never {@code null}
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public PSAutoTranslationPK getKey() {
+    return new PSAutoTranslationPK(contentTypeId, locale);
+  }
 
-   /**
-    * Get the GUID of this object, always the result of {@link #getAutoTranslationsGUID()}.
-    *
-    * @return the GUID, never {@code null}
-    */
-   @IPSXmlSerialization(suppress = true)
-   public IPSGuid getGUID() {
-      return getAutoTranslationsGUID();
-   }
+  /**
+   * Get the GUID of this object, always the result of {@link #getAutoTranslationsGUID()}.
+   *
+   * @return the GUID, never {@code null}
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public IPSGuid getGUID() {
+    return getAutoTranslationsGUID();
+  }
 
-   /**
-    * Get the community ID with Optional wrapper for safer access.
-    *
-    * @return Optional containing the community ID if valid, empty otherwise
-    */
-   public Optional<Long> getCommunityIdOptional() {
-      return communityId > 0 ? Optional.of(communityId) : Optional.empty();
-   }
+  /**
+   * Get the community ID with Optional wrapper for safer access.
+   *
+   * @return Optional containing the community ID if valid, empty otherwise
+   */
+  @JsonIgnore
+  public Optional<Long> getCommunityIdOptional() {
+    return communityId > 0 ? Optional.of(communityId) : Optional.empty();
+  }
 
-   /**
-    * Get the community ID of this auto translation.
-    *
-    * @return the community ID
-    */
-   public long getCommunityId() {
-      return communityId;
-   }
+  /**
+   * Get the community ID of this auto translation.
+   *
+   * @return the community ID
+   */
+  @JsonProperty
+  public long getCommunityId() {
+    return communityId;
+  }
 
-   /**
-    * Set the community ID with enhanced validation.
-    *
-    * @param communityId the community ID, must be > 0
-    * @throws IllegalArgumentException if communityId is &lt;= 0
-    */
-   public void setCommunityId(long communityId) {
-      if (communityId <= 0) {
-         throw new IllegalArgumentException("communityId must be > 0");
-      }
-      this.communityId = communityId;
-   }
+  /**
+   * Set the community ID with enhanced validation.
+   *
+   * @param communityId the community ID, must be &gt; 0
+   * @throws IllegalArgumentException if communityId is &lt;= 0
+   */
+  public void setCommunityId(long communityId) {
+    if (communityId <= 0) {
+      throw new IllegalArgumentException("communityId must be > 0");
+    }
+    this.communityId = communityId;
+  }
 
-   /**
-    * Get the community name with Optional wrapper.
-    *
-    * @return Optional containing the community name if non-null, empty otherwise
-    */
-   public Optional<String> getCommunityNameOptional() {
-      return Optional.ofNullable(communityName);
-   }
+  /**
+   * Get the community name with Optional wrapper.
+   *
+   * @return Optional containing the community name if non-null, empty otherwise
+   */
+  @JsonIgnore
+  public Optional<String> getCommunityNameOptional() {
+    return Optional.ofNullable(communityName);
+  }
 
-   /**
-    * Get the community name of this auto translation.
-    *
-    * @return the community name, may be {@code null}
-    */
-   public String getCommunityName() {
-      return communityName;
-   }
+  /**
+   * Get the community name of this auto translation.
+   *
+   * @return the community name, may be {@code null}
+   */
+  @JsonProperty
+  public String getCommunityName() {
+    return communityName;
+  }
 
-   /**
-    * Set the community name.
-    *
-    * @param communityName the community name, may be {@code null}
-    */
-   public void setCommunityName(String communityName) {
-      this.communityName = communityName;
-   }
+  /**
+   * Set the community name.
+   *
+   * @param communityName the community name, may be {@code null}
+   */
+  public void setCommunityName(String communityName) {
+    this.communityName = communityName;
+  }
 
-   /**
-    * Get the content type ID with Optional wrapper for safer access.
-    *
-    * @return Optional containing the content type ID if valid, empty otherwise
-    */
-   public Optional<Long> getContentTypeIdOptional() {
-      return contentTypeId > 0 ? Optional.of(contentTypeId) : Optional.empty();
-   }
+  /**
+   * Get the content type ID with Optional wrapper for safer access.
+   *
+   * @return Optional containing the content type ID if valid, empty otherwise
+   */
+  @JsonIgnore
+  public Optional<Long> getContentTypeIdOptional() {
+    return contentTypeId > 0 ? Optional.of(contentTypeId) : Optional.empty();
+  }
 
-   /**
-    * Get the content type ID of this auto translation.
-    *
-    * @return the content type ID
-    */
-   public long getContentTypeId() {
-      return contentTypeId;
-   }
+  /**
+   * Get the content type ID of this auto translation.
+   *
+   * @return the content type ID
+   */
+  @JsonProperty
+  public long getContentTypeId() {
+    return contentTypeId;
+  }
 
-   /**
-    * Set the content type ID with enhanced validation.
-    *
-    * @param contentTypeId the content type ID, must be > 0
-    * @throws IllegalArgumentException if contentTypeId is &lt;= 0
-    */
-   public void setContentTypeId(long contentTypeId) {
-      if (contentTypeId <= 0) {
-         throw new IllegalArgumentException("contentTypeId must be > 0");
-      }
-      this.contentTypeId = contentTypeId;
-   }
+  /**
+   * Set the content type ID with enhanced validation.
+   *
+   * @param contentTypeId the content type ID, must be &gt; 0
+   * @throws IllegalArgumentException if contentTypeId is &lt;= 0
+   */
+  public void setContentTypeId(long contentTypeId) {
+    if (contentTypeId <= 0) {
+      throw new IllegalArgumentException("contentTypeId must be > 0");
+    }
+    this.contentTypeId = contentTypeId;
+  }
 
-   /**
-    * Get the content type name with Optional wrapper.
-    *
-    * @return Optional containing the content type name if non-null, empty otherwise
-    */
-   public Optional<String> getContentTypeNameOptional() {
-      return Optional.ofNullable(contentTypeName);
-   }
+  /**
+   * Get the content type name with Optional wrapper.
+   *
+   * @return Optional containing the content type name if non-null, empty otherwise
+   */
+  @JsonIgnore
+  public Optional<String> getContentTypeNameOptional() {
+    return Optional.ofNullable(contentTypeName);
+  }
 
-   /**
-    * Get the content type name of this auto translation.
-    *
-    * @return the content type name, may be {@code null}
-    */
-   public String getContentTypeName() {
-      return contentTypeName;
-   }
+  /**
+   * Get the content type name of this auto translation.
+   *
+   * @return the content type name, may be {@code null}
+   */
+  @JsonProperty
+  public String getContentTypeName() {
+    return contentTypeName;
+  }
 
-   /**
-    * Set the content type name.
-    *
-    * @param contentTypeName the content type name, may be {@code null}
-    */
-   public void setContentTypeName(String contentTypeName) {
-      this.contentTypeName = contentTypeName;
-   }
+  /**
+   * Set the content type name.
+   *
+   * @param contentTypeName the content type name, may be {@code null}
+   */
+  public void setContentTypeName(String contentTypeName) {
+    this.contentTypeName = contentTypeName;
+  }
 
-   /**
-    * Get the locale with Optional wrapper.
-    *
-    * @return Optional containing the locale if non-null, empty otherwise
-    */
-   public Optional<String> getLocaleOptional() {
-      return Optional.ofNullable(locale);
-   }
+  /**
+   * Get the locale with Optional wrapper.
+   *
+   * @return Optional containing the locale if non-null, empty otherwise
+   */
+  @JsonIgnore
+  public Optional<String> getLocaleOptional() {
+    return Optional.ofNullable(locale);
+  }
 
-   /**
-    * Get the locale of this auto translation.
-    *
-    * @return the locale, never {@code null} or empty
-    */
-   public String getLocale() {
-      return locale;
-   }
+  /**
+   * Get the locale of this auto translation.
+   *
+   * @return the locale, never {@code null} or empty
+   */
+  @JsonProperty
+  public String getLocale() {
+    return locale;
+  }
 
-   /**
-    * Set the locale with enhanced validation.
-    *
-    * @param locale the locale, not {@code null} or empty
-    * @throws IllegalArgumentException if locale is null or empty
-    */
-   public void setLocale(String locale) {
-      if (StringUtils.isBlank(locale)) {
-         throw new IllegalArgumentException("locale cannot be null or empty");
-      }
-      this.locale = locale;
-   }
+  /**
+   * Set the locale with enhanced validation.
+   *
+   * @param locale the locale, not {@code null} or empty
+   * @throws IllegalArgumentException if locale is null or empty
+   */
+  public void setLocale(String locale) {
+    if (StringUtils.isBlank(locale)) {
+      throw new IllegalArgumentException("locale cannot be null or empty");
+    }
+    this.locale = locale;
+  }
 
-   /**
-    * Get the workflow ID with Optional wrapper for safer access.
-    *
-    * @return Optional containing the workflow ID if valid, empty otherwise
-    */
-   public Optional<Long> getWorkflowIdOptional() {
-      return workflowId > 0 ? Optional.of(workflowId) : Optional.empty();
-   }
+  /**
+   * Get the workflow ID with Optional wrapper for safer access.
+   *
+   * @return Optional containing the workflow ID if valid, empty otherwise
+   */
+  @JsonIgnore
+  public Optional<Long> getWorkflowIdOptional() {
+    return workflowId > 0 ? Optional.of(workflowId) : Optional.empty();
+  }
 
-   /**
-    * Get the workflow ID of this auto translation.
-    *
-    * @return the workflow ID
-    */
-   public long getWorkflowId() {
-      return workflowId;
-   }
+  /**
+   * Get the workflow ID of this auto translation.
+   *
+   * @return the workflow ID
+   */
+  @JsonProperty
+  public long getWorkflowId() {
+    return workflowId;
+  }
 
-   /**
-    * Set the workflow ID with enhanced validation.
-    *
-    * @param workflowId the workflow ID, must be > 0
-    * @throws IllegalArgumentException if workflowId is &lt;= 0
-    */
-   public void setWorkflowId(long workflowId) {
-      if (workflowId <= 0) {
-         throw new IllegalArgumentException("workflowId must be > 0");
-      }
-      this.workflowId = workflowId;
-   }
+  /**
+   * Set the workflow ID with enhanced validation.
+   *
+   * @param workflowId the workflow ID, must be &gt; 0
+   * @throws IllegalArgumentException if workflowId is &lt;= 0
+   */
+  public void setWorkflowId(long workflowId) {
+    if (workflowId <= 0) {
+      throw new IllegalArgumentException("workflowId must be > 0");
+    }
+    this.workflowId = workflowId;
+  }
 
-   /**
-    * Get the optimistic concurrency version for this auto translation.
-    *
-    * @return the version, may be {@code null}
-    */
-   public Integer getVersion() {
-      return this.m_version;
-   }
+  /**
+   * Get the optimistic concurrency version for this auto translation.
+   *
+   * @return the version, may be {@code null}
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public Integer getVersion() {
+    return this.m_version;
+  }
 
-   /**
-    * Set the optimistic concurrency version for this auto translation.
-    *
-    * @param version the version to set
-    */
-   public void setVersion(Integer version) {
-      this.m_version = version;
-   }
+  /**
+   * Set the optimistic concurrency version for this auto translation.
+   *
+   * @param version the version to set
+   */
+  public void setVersion(Integer version) {
+    this.m_version = version;
+  }
 
-   /**
-    * Get the workflow name with Optional wrapper.
-    *
-    * @return Optional containing the workflow name if non-null, empty otherwise
-    */
-   public Optional<String> getWorkflowNameOptional() {
-      return Optional.ofNullable(workflowName);
-   }
+  /**
+   * Get the workflow name with Optional wrapper.
+   *
+   * @return Optional containing the workflow name if non-null, empty otherwise
+   */
+  @JsonIgnore
+  public Optional<String> getWorkflowNameOptional() {
+    return Optional.ofNullable(workflowName);
+  }
 
-   /**
-    * Get the workflow name of this auto translation.
-    *
-    * @return the workflow name, may be {@code null}
-    */
-   public String getWorkflowName() {
-      return workflowName;
-   }
+  /**
+   * Get the workflow name of this auto translation.
+   *
+   * @return the workflow name, may be {@code null}
+   */
+  @JsonProperty
+  public String getWorkflowName() {
+    return workflowName;
+  }
 
-   /**
-    * Set the workflow name.
-    *
-    * @param workflowName the workflow name, may be {@code null}
-    */
-   public void setWorkflowName(String workflowName) {
-      this.workflowName = workflowName;
-   }
+  /**
+   * Set the workflow name.
+   *
+   * @param workflowName the workflow name, may be {@code null}
+   */
+  public void setWorkflowName(String workflowName) {
+    this.workflowName = workflowName;
+  }
 
-   @Override
-   public boolean equals(Object obj) {
-      if (this == obj) return true;
-      if (!(obj instanceof PSAutoTranslation)) return false;
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (!(obj instanceof PSAutoTranslation)) return false;
 
-      var other = (PSAutoTranslation) obj;
-      return new EqualsBuilder()
-         .append(contentTypeId, other.contentTypeId)
-         .append(locale, other.locale)
-         .append(workflowId, other.workflowId)
-         .append(communityId, other.communityId)
-         .isEquals();
-   }
+    var other = (PSAutoTranslation) obj;
+    return new EqualsBuilder()
+        .append(contentTypeId, other.contentTypeId)
+        .append(locale, other.locale)
+        .append(workflowId, other.workflowId)
+        .append(communityId, other.communityId)
+        .isEquals();
+  }
 
-   @Override
-   public int hashCode() {
-      return new HashCodeBuilder(17, 37)
-         .append(contentTypeId)
-         .append(locale)
-         .append(workflowId)
-         .append(communityId)
-         .toHashCode();
-   }
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+        .append(contentTypeId)
+        .append(locale)
+        .append(workflowId)
+        .append(communityId)
+        .toHashCode();
+  }
 
-   @Override
-   public String toString() {
-      return new ToStringBuilder(this)
-         .append("contentTypeId", contentTypeId)
-         .append("locale", locale)
-         .append("workflowId", workflowId)
-         .append("communityId", communityId)
-         .append("contentTypeName", contentTypeName)
-         .append("workflowName", workflowName)
-         .append("communityName", communityName)
-         .toString();
-   }
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .append("contentTypeId", contentTypeId)
+        .append("locale", locale)
+        .append("workflowId", workflowId)
+        .append("communityId", communityId)
+        .append("contentTypeName", contentTypeName)
+        .append("workflowName", workflowName)
+        .append("communityName", communityName)
+        .toString();
+  }
 
-   /* (non-Javadoc)
-    * @see com.percussion.services.catalog.IPSCatalogSummary#getName()
-    */
-   @IPSXmlSerialization(suppress = true)
-   public String getName()
-   {
-      return communityName + "-" + contentTypeName + "-" + workflowName + "-"
-         + locale;
-   }
+  /* (non-Javadoc)
+   * @see com.percussion.services.catalog.IPSCatalogSummary#getName()
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public String getName() {
+    return communityName + "-" + contentTypeName + "-" + workflowName + "-" + locale;
+  }
 
-   /* (non-Javadoc)
-    * @see com.percussion.services.catalog.IPSCatalogSummary#getLabel()
-    */
-   @IPSXmlSerialization(suppress = true)
-   public String getLabel()
-   {
-      return getName();
-   }
+  /* (non-Javadoc)
+   * @see com.percussion.services.catalog.IPSCatalogSummary#getLabel()
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public String getLabel() {
+    return getName();
+  }
 
-   /* (non-Javadoc)
-    * @see com.percussion.services.catalog.IPSCatalogSummary#getDescription()
-    */
-   @IPSXmlSerialization(suppress = true)
-   public String getDescription()
-   {
-      return getName();
-   }
+  /* (non-Javadoc)
+   * @see com.percussion.services.catalog.IPSCatalogSummary#getDescription()
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public String getDescription() {
+    return getName();
+  }
 
-   // see base class
-   public String toXML() throws IOException, SAXException
-   {
-      return PSXmlSerializationHelper.writeToXml(this);
-   }
+  // see base class
+  public String toXML() throws IOException, SAXException {
+    return PSXmlSerializationHelper.writeToXml(this);
+  }
 
-   // see base class
-   public void fromXML(String xmlsource) throws IOException, SAXException
-   {
-      PSXmlSerializationHelper.readFromXML(xmlsource, this);
-   }
+  // see base class
+  public void fromXML(String xmlsource) throws IOException, SAXException {
+    PSXmlSerializationHelper.readFromXML(xmlsource, this);
+  }
 
-   // see base class
-   public void setGUID(IPSGuid newguid) throws IllegalStateException
-   {
-      return;
-   }
+  // see base class
+  public void setGUID(IPSGuid newguid) throws IllegalStateException {
+    return;
+  }
 }
-

--- a/system/services/src/com/percussion/services/content/data/PSContentTypeSummary.java
+++ b/system/services/src/com/percussion/services/content/data/PSContentTypeSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,237 +16,236 @@
  */
 package com.percussion.services.content.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import com.percussion.utils.guid.IPSGuid;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * This object represents a single content type summary.
+ *
+ * <p>Design-object XML root is {@code content-type-summary}. Nested fields use {@code
+ * field-description}; nested children use {@code content-type-summary-child} (issue #1921 / epic
+ * #505).
  */
-public class PSContentTypeSummary
-{
-   /**
-    * The name of the content type fo which this represents the summary.
-    * Initialized while constructed, never <code>null</code> after that.
-    */
-   private String contentType;
-   
-   /**
-    * The content type description, may be <code>null</code>.
-    */
-   private String description;
-   
-   /**
-    * The guid, initialized while constructed, never <code>null</code> after 
-    * that.
-    */
-   private IPSGuid m_guid;
-   
-   /**
-    * A list of children for this content type, never <code>null</code>, may
-    * be empty.
-    */
-   private List<PSFieldDescription> fields = 
-      new ArrayList<>();
-   
-   /**
-    * A list of fields for this content type, never <code>null</code>, may
-    * be empty.
-    */
-   private List<PSContentTypeSummaryChild> children = 
-      new ArrayList<>();
-   
-   /**
-    * Get the content type name.
-    * 
-    * @return the content type name, may be <code>null</code>, never empty.
-    */
-   public String getName()
-   {
-      return contentType;
-   }
-   
-   /**
-    * Set a new content type name.
-    * 
-    * @param name the new content type name, not <code>null</code> or
-    *    empty.
-    */
-   public void setName(String name)
-   {
-      if (StringUtils.isBlank(name))
-         throw new IllegalArgumentException(
-            "contentType cannot be null or empty");
-      
-      this.contentType = name;
-   }
-   
-   /**
-    * Get the description for this content type.
-    * 
-    * @return the content type description, may be <code>null</code> or empty.
-    */
-   public String getDescription()
-   {
-      return description;
-   }
-   
-   /**
-    * Set a new content type description.
-    * 
-    * @param description the new content type description, may be 
-    *    <code>null</code> or empty.
-    */
-   public void setDescription(String description)
-   {
-      this.description = description;
-   }
-   
-   /**
-    * Get the list with all fields.
-    * 
-    * @return the list with all fields, never <code>null</code>, may
-    *    be empty.
-    */
-   public List<PSFieldDescription> getFields()
-   {
-      return fields;
-   }
-   
-   /**
-    * Set a new list of fields.
-    * 
-    * @param fields the new list of fields, may be <code>null</code> or
-    *    empty.
-    */
-   public void setFields(List<PSFieldDescription> fields)
-   {
-      if (fields == null)
-         this.fields = new ArrayList<>();
-      else
-         this.fields = fields;
-   }
-   
-   /**
-    * Add a new field.
-    * 
-    * @param field the new field to add, not <code>null</code>.
-    */
-   public void addField(PSFieldDescription field)
-   {
-      if (field == null)
-         throw new IllegalArgumentException("field cannot be null");
-      
-      fields.add(field);
-   }
-   
-   /**
-    * Get the list with all children.
-    * 
-    * @return the list with all children, never <code>null</code>, may
-    *    be empty.
-    */
-   public List<PSContentTypeSummaryChild> getChildren()
-   {
-      return children;
-   }
-   
-   /**
-    * Set a new list of children.
-    * 
-    * @param children the new list of children, may be <code>null</code> or
-    *    empty.
-    */
-   public void setChildren(List<PSContentTypeSummaryChild> children)
-   {
-      if (children == null)
-         this.children = new ArrayList<>();
-      else
-         this.children = children;
-   }
-   
-   /**
-    * Add a new child.
-    * 
-    * @param child the new child to add, not <code>null</code>.
-    */
-   public void addChild(PSContentTypeSummaryChild child)
-   {
-      if (child == null)
-         throw new IllegalArgumentException("child cannot be null");
-      
-      children.add(child);
-   }
+@JacksonXmlRootElement(localName = "content-type-summary")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({"children", "description", "fields", "guid", "name"})
+public class PSContentTypeSummary {
+  /**
+   * The name of the content type fo which this represents the summary. Initialized while
+   * constructed, never <code>null</code> after that.
+   */
+  private String contentType;
 
-   @Override
-   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof PSContentTypeSummary)) return false;
-      PSContentTypeSummary that = (PSContentTypeSummary) o;
-      return Objects.equals(contentType, that.contentType) && Objects.equals(getDescription(), that.getDescription()) && Objects.equals(m_guid, that.m_guid) && Objects.equals(getFields(), that.getFields()) && Objects.equals(getChildren(), that.getChildren());
-   }
+  /** The content type description, may be <code>null</code>. */
+  private String description;
 
-   @Override
-   public int hashCode() {
-      return Objects.hash(contentType, getDescription(), m_guid, getFields(), getChildren());
-   }
+  /**
+   * The guid, initialized while constructed, never <code>null</code> after that.
+   */
+  private IPSGuid m_guid;
 
-   @Override
-   public String toString() {
-      final StringBuffer sb = new StringBuffer("PSContentTypeSummary{");
-      sb.append("contentType='").append(contentType).append('\'');
-      sb.append(", description='").append(description).append('\'');
-      sb.append(", m_guid=").append(m_guid);
-      sb.append(", fields=").append(fields);
-      sb.append(", children=").append(children);
-      sb.append('}');
-      return sb.toString();
-   }
+  /**
+   * A list of fields for this content type, never <code>null</code>, may be empty.
+   */
+  private List<PSFieldDescription> fields = new ArrayList<>();
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#fromXML(String)
-    */
-   public void fromXML(String xmlsource) throws IOException, SAXException
-   {
-      PSXmlSerializationHelper.readFromXML(xmlsource, this);
-   }
+  /**
+   * A list of children for this content type, never <code>null</code>, may be empty.
+   */
+  private List<PSContentTypeSummaryChild> children = new ArrayList<>();
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#toXML()
-    */
-   public String toXML() throws IOException, SAXException
-   {
-      return PSXmlSerializationHelper.writeToXml(this);
-   }
+  static {
+    PSXmlSerializationHelper.addType("field-description", PSFieldDescription.class);
+    PSXmlSerializationHelper.addType(
+        "content-type-summary-child", PSContentTypeSummaryChild.class);
+  }
 
-   /**
-    * Get the guid of this object.
-    * 
-    * @return The guid, never <code>null</code> if not set.
-    */
-   public IPSGuid getGuid()
-   {
-      return m_guid;
-   }
+  /**
+   * Get the content type name.
+   *
+   * @return the content type name, may be <code>null</code>, never empty.
+   */
+  @JsonProperty
+  public String getName() {
+    return contentType;
+  }
 
-   /**
-    * Set this object's guid
-    * 
-    * @param guid The guid, may not be <code>null</code>.
-    */
-   public void setGuid(IPSGuid guid)
-   {
-      m_guid = guid;
-   }
+  /**
+   * Set a new content type name.
+   *
+   * @param name the new content type name, not <code>null</code> or empty.
+   */
+  public void setName(String name) {
+    if (StringUtils.isBlank(name))
+      throw new IllegalArgumentException("contentType cannot be null or empty");
+
+    this.contentType = name;
+  }
+
+  /**
+   * Get the description for this content type.
+   *
+   * @return the content type description, may be <code>null</code> or empty.
+   */
+  @JsonProperty
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * Set a new content type description.
+   *
+   * @param description the new content type description, may be <code>null</code> or empty.
+   */
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  /**
+   * Get the list with all fields.
+   *
+   * @return the list with all fields, never <code>null</code>, may be empty.
+   */
+  @JsonProperty
+  @JacksonXmlElementWrapper(localName = "fields")
+  @JacksonXmlProperty(localName = "field-description")
+  public List<PSFieldDescription> getFields() {
+    return fields;
+  }
+
+  /**
+   * Set a new list of fields.
+   *
+   * @param fields the new list of fields, may be <code>null</code> or empty.
+   */
+  public void setFields(List<PSFieldDescription> fields) {
+    if (fields == null) this.fields = new ArrayList<>();
+    else this.fields = fields;
+  }
+
+  /**
+   * Add a new field. Jackson uses {@link #setFields(List)}; this remains for API callers.
+   *
+   * @param field the new field to add, not <code>null</code>.
+   */
+  @JsonIgnore
+  public void addField(PSFieldDescription field) {
+    if (field == null) throw new IllegalArgumentException("field cannot be null");
+
+    fields.add(field);
+  }
+
+  /**
+   * Get the list with all children.
+   *
+   * @return the list with all children, never <code>null</code>, may be empty.
+   */
+  @JsonProperty
+  @JacksonXmlElementWrapper(localName = "children")
+  @JacksonXmlProperty(localName = "content-type-summary-child")
+  public List<PSContentTypeSummaryChild> getChildren() {
+    return children;
+  }
+
+  /**
+   * Set a new list of children.
+   *
+   * @param children the new list of children, may be <code>null</code> or empty.
+   */
+  public void setChildren(List<PSContentTypeSummaryChild> children) {
+    if (children == null) this.children = new ArrayList<>();
+    else this.children = children;
+  }
+
+  /**
+   * Add a new child. Jackson uses {@link #setChildren(List)}; this remains for API callers.
+   *
+   * @param child the new child to add, not <code>null</code>.
+   */
+  @JsonIgnore
+  public void addChild(PSContentTypeSummaryChild child) {
+    if (child == null) throw new IllegalArgumentException("child cannot be null");
+
+    children.add(child);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof PSContentTypeSummary)) return false;
+    PSContentTypeSummary that = (PSContentTypeSummary) o;
+    return Objects.equals(contentType, that.contentType)
+        && Objects.equals(getDescription(), that.getDescription())
+        && Objects.equals(m_guid, that.m_guid)
+        && Objects.equals(getFields(), that.getFields())
+        && Objects.equals(getChildren(), that.getChildren());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(contentType, getDescription(), m_guid, getFields(), getChildren());
+  }
+
+  @Override
+  public String toString() {
+    final StringBuffer sb = new StringBuffer("PSContentTypeSummary{");
+    sb.append("contentType='").append(contentType).append('\'');
+    sb.append(", description='").append(description).append('\'');
+    sb.append(", m_guid=").append(m_guid);
+    sb.append(", fields=").append(fields);
+    sb.append(", children=").append(children);
+    sb.append('}');
+    return sb.toString();
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#fromXML(String)
+   */
+  public void fromXML(String xmlsource) throws IOException, SAXException {
+    PSXmlSerializationHelper.readFromXML(xmlsource, this);
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#toXML()
+   */
+  public String toXML() throws IOException, SAXException {
+    return PSXmlSerializationHelper.writeToXml(this);
+  }
+
+  /**
+   * Get the guid of this object.
+   *
+   * @return The guid, never <code>null</code> if not set.
+   */
+  @JsonProperty
+  public IPSGuid getGuid() {
+    return m_guid;
+  }
+
+  /**
+   * Set this object's guid
+   *
+   * @param guid The guid, may not be <code>null</code>.
+   */
+  public void setGuid(IPSGuid guid) {
+    m_guid = guid;
+  }
 }
-

--- a/system/services/src/com/percussion/services/content/data/PSContentTypeSummaryChild.java
+++ b/system/services/src/com/percussion/services/content/data/PSContentTypeSummaryChild.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,150 +16,151 @@
  */
 package com.percussion.services.content.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * This object represents a single content type summary child.
+ *
+ * <p>Design-object XML root is {@code content-type-summary-child}. Nested fields use mapped type
+ * name {@code field-description} (issue #1921 / epic #505).
  */
-public class PSContentTypeSummaryChild
-{
-   /**
-    * The name of the child, may be <code>null</code>, never empty.
-    */
-   private String name;
-   
-   /**
-    * A list with all fields that are part of this child, never 
-    * <code>null</code>, may be empty.
-    */
-   private List<PSFieldDescription> childFields = 
-      new ArrayList<>();
-   
-   /**
-    * Default constructor.
-    */
-   public PSContentTypeSummaryChild()
-   {
-   }
-   
-   /**
-    * Construct a new child for the supplied name.
-    * 
-    * @param name the name of the child, not <code>null</code> or empty.
-    */
-   public PSContentTypeSummaryChild(String name)
-   {
-      setName(name);
-   }
+@JacksonXmlRootElement(localName = "content-type-summary-child")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({"childFields", "name"})
+public class PSContentTypeSummaryChild {
+  /** The name of the child, may be <code>null</code>, never empty. */
+  private String name;
 
-   /**
-    * Get the child name.
-    * 
-    * @return the child name, may be <code>null</code>, never empty.
-    */
-   public String getName()
-   {
-      return name;
-   }
-   
-   /**
-    * Set a new name.
-    * 
-    * @param name the new child name, not <code>null</code> or empty.
-    */
-   public void setName(String name)
-   {
-      if (StringUtils.isBlank(name))
-         throw new IllegalArgumentException("name cannot be null or empty");
-      
-      this.name = name;
-   }
-   
-   /**
-    * Get the list with all child fields.
-    * 
-    * @return the list with all child fields, never <code>null</code>, may
-    *    be empty.
-    */
-   public List<PSFieldDescription> getChildFields()
-   {
-      return childFields;
-   }
-   
-   /**
-    * Set a new list of child fields.
-    * 
-    * @param childFields the new list of child fields, may be 
-    *    <code>null</code> or empty.
-    */
-   public void setChildFields(List<PSFieldDescription> childFields)
-   {
-      if (childFields == null)
-         this.childFields = new ArrayList<>();
-      else
-         this.childFields = childFields;
-   }
-   
-   /**
-    * Add a new child field.
-    * 
-    * @param childField the new child field to add, not <code>null</code>.
-    */
-   public void addField(PSFieldDescription childField)
-   {
-      if (childField == null)
-         throw new IllegalArgumentException("childField cannot be null");
-      
-      childFields.add(childField);
-   }
+  /**
+   * A list with all fields that are part of this child, never <code>null</code>, may be empty.
+   */
+  private List<PSFieldDescription> childFields = new ArrayList<>();
 
-   @Override
-   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof PSContentTypeSummaryChild)) return false;
-      PSContentTypeSummaryChild that = (PSContentTypeSummaryChild) o;
-      return Objects.equals(getName(), that.getName()) && Objects.equals(getChildFields(), that.getChildFields());
-   }
+  static {
+    PSXmlSerializationHelper.addType("field-description", PSFieldDescription.class);
+  }
 
-   @Override
-   public int hashCode() {
-      return Objects.hash(getName(), getChildFields());
-   }
+  /** Default constructor. */
+  public PSContentTypeSummaryChild() {}
 
-   @Override
-   public String toString() {
-      final StringBuffer sb = new StringBuffer("PSContentTypeSummaryChild{");
-      sb.append("name='").append(name).append('\'');
-      sb.append(", childFields=").append(childFields);
-      sb.append('}');
-      return sb.toString();
-   }
+  /**
+   * Construct a new child for the supplied name.
+   *
+   * @param name the name of the child, not <code>null</code> or empty.
+   */
+  public PSContentTypeSummaryChild(String name) {
+    setName(name);
+  }
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#fromXML(String)
-    */
-   public void fromXML(String xmlsource) throws IOException, SAXException
-   {
-      PSXmlSerializationHelper.readFromXML(xmlsource, this);
-   }
+  /**
+   * Get the child name.
+   *
+   * @return the child name, may be <code>null</code>, never empty.
+   */
+  @JsonProperty
+  public String getName() {
+    return name;
+  }
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#toXML()
-    */
-   public String toXML() throws IOException, SAXException
-   {
-      return PSXmlSerializationHelper.writeToXml(this);
-   }
+  /**
+   * Set a new name.
+   *
+   * @param name the new child name, not <code>null</code> or empty.
+   */
+  public void setName(String name) {
+    if (StringUtils.isBlank(name))
+      throw new IllegalArgumentException("name cannot be null or empty");
+
+    this.name = name;
+  }
+
+  /**
+   * Get the list with all child fields.
+   *
+   * @return the list with all child fields, never <code>null</code>, may be empty.
+   */
+  @JsonProperty
+  @JacksonXmlElementWrapper(localName = "child-fields")
+  @JacksonXmlProperty(localName = "field-description")
+  public List<PSFieldDescription> getChildFields() {
+    return childFields;
+  }
+
+  /**
+   * Set a new list of child fields.
+   *
+   * @param childFields the new list of child fields, may be <code>null</code> or empty.
+   */
+  public void setChildFields(List<PSFieldDescription> childFields) {
+    if (childFields == null) this.childFields = new ArrayList<>();
+    else this.childFields = childFields;
+  }
+
+  /**
+   * Add a new child field. Jackson uses {@link #setChildFields(List)}; this remains for API
+   * callers.
+   *
+   * @param childField the new child field to add, not <code>null</code>.
+   */
+  @JsonIgnore
+  public void addField(PSFieldDescription childField) {
+    if (childField == null) throw new IllegalArgumentException("childField cannot be null");
+
+    childFields.add(childField);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof PSContentTypeSummaryChild)) return false;
+    PSContentTypeSummaryChild that = (PSContentTypeSummaryChild) o;
+    return Objects.equals(getName(), that.getName())
+        && Objects.equals(getChildFields(), that.getChildFields());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getName(), getChildFields());
+  }
+
+  @Override
+  public String toString() {
+    final StringBuffer sb = new StringBuffer("PSContentTypeSummaryChild{");
+    sb.append("name='").append(name).append('\'');
+    sb.append(", childFields=").append(childFields);
+    sb.append('}');
+    return sb.toString();
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#fromXML(String)
+   */
+  public void fromXML(String xmlsource) throws IOException, SAXException {
+    PSXmlSerializationHelper.readFromXML(xmlsource, this);
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#toXML()
+   */
+  public String toXML() throws IOException, SAXException {
+    return PSXmlSerializationHelper.writeToXml(this);
+  }
 }
-

--- a/system/services/src/com/percussion/services/content/data/PSFieldDescription.java
+++ b/system/services/src/com/percussion/services/content/data/PSFieldDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,164 +16,158 @@
  */
 package com.percussion.services.content.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
-
 import java.io.IOException;
 import java.util.Objects;
-
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * This object represents a single field description.
+ *
+ * <p>Design-object XML root is {@code field-description}. Nested under content-type summaries via
+ * package element {@code field-description} (issue #1921 / epic #505).
  */
-public class PSFieldDescription
-{
-   /**
-    * The field name, may be <code>null</code>, never empty.
-    */
-   private String name;
-   
-   /**
-    * The field data type, may be <code>null</code>, never empty.
-    */
-   private String type;
-   
-   private Boolean exportable;
-   
-   /**
-    * Default constructor.
-    */
-   public PSFieldDescription()
-   {
-   }
-   
-   /**
-    * Construct a new field description for the supplied parameters.
-    * 
-    * @param name the name of the new field, not <code>null</code> or empty.
-    * @param type the type of the new field, not <code>null</code> or empty.
-    */
-   public PSFieldDescription(String name, String type)
-   {
-      setName(name);
-      setType(type);
-   }
-   
-   public PSFieldDescription(String name, String type, Boolean exportable)
-   {
-      setName(name);
-      setType(type);
-      setExportable(exportable);
-   }
-   
-   /**
-    * Get the field name.
-    * 
-    * @return the field name, may be <code>null</code>, never empty.
-    */
-   public String getName()
-   {
-      return name;
-   }
-   
-   /**
-    * Set a new field name.
-    * 
-    * @param name the new field name, not <code>null</code> or empty.
-    */
-   public void setName(String name)
-   {
-      if (StringUtils.isBlank(name))
-         throw new IllegalArgumentException("name cannot be null or empty");
-      
-      this.name = name;
-   }
-   
-   /**
-    * Get the field data type.
-    * 
-    * @return the field data type, may be <code>null</code>, never empty.
-    */
-   public String getType()
-   {
-      return type.toString();
-   }
-   
-   /**
-    * Set a new field data type.
-    * 
-    * @param type the new field data type, not <code>null</code> or empty.
-    */
-   public void setType(String type)
-   {
-      if (StringUtils.isBlank(type))
-         throw new IllegalArgumentException("type cannot be null or empty");
-      
-      this.type = PSFieldTypeEnum.valueOf(type).toString();
-   }
+@JacksonXmlRootElement(localName = "field-description")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({"exportable", "name", "type"})
+public class PSFieldDescription {
+  /** The field name, may be <code>null</code>, never empty. */
+  private String name;
 
-   public Boolean getExportable()
-   {
-      return exportable;
-   }
+  /** The field data type, may be <code>null</code>, never empty. */
+  private String type;
 
-   public void setExportable(Boolean exportable)
-   {
-      this.exportable = exportable;
-   }
+  private Boolean exportable;
 
-   @Override
-   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof PSFieldDescription)) return false;
-      PSFieldDescription that = (PSFieldDescription) o;
-      return Objects.equals(getName(), that.getName()) && Objects.equals(getType(), that.getType()) && Objects.equals(getExportable(), that.getExportable());
-   }
+  /** Default constructor. */
+  public PSFieldDescription() {}
 
-   @Override
-   public int hashCode() {
-      return Objects.hash(getName(), getType(), getExportable());
-   }
+  /**
+   * Construct a new field description for the supplied parameters.
+   *
+   * @param name the name of the new field, not <code>null</code> or empty.
+   * @param type the type of the new field, not <code>null</code> or empty.
+   */
+  public PSFieldDescription(String name, String type) {
+    setName(name);
+    setType(type);
+  }
 
-   @Override
-   public String toString() {
-      final StringBuffer sb = new StringBuffer("PSFieldDescription{");
-      sb.append("name='").append(name).append('\'');
-      sb.append(", type='").append(type).append('\'');
-      sb.append(", exportable=").append(exportable);
-      sb.append('}');
-      return sb.toString();
-   }
+  public PSFieldDescription(String name, String type, Boolean exportable) {
+    setName(name);
+    setType(type);
+    setExportable(exportable);
+  }
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#fromXML(String)
-    */
-   public void fromXML(String xmlsource) throws IOException, SAXException
-   {
-      PSXmlSerializationHelper.readFromXML(xmlsource, this);
-   }
+  /**
+   * Get the field name.
+   *
+   * @return the field name, may be <code>null</code>, never empty.
+   */
+  @JsonProperty
+  public String getName() {
+    return name;
+  }
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#toXML()
-    */
-   public String toXML() throws IOException, SAXException
-   {
-      return PSXmlSerializationHelper.writeToXml(this);
-   }
-   
-   /**
-    * The field data type enumeration.
-    */
-   public enum PSFieldTypeEnum
-   {
-      TEXT,
-      DATE,
-      NUMBER,
-      BINARY
-   }
+  /**
+   * Set a new field name.
+   *
+   * @param name the new field name, not <code>null</code> or empty.
+   */
+  public void setName(String name) {
+    if (StringUtils.isBlank(name))
+      throw new IllegalArgumentException("name cannot be null or empty");
+
+    this.name = name;
+  }
+
+  /**
+   * Get the field data type.
+   *
+   * @return the field data type, may be <code>null</code>, never empty.
+   */
+  @JsonProperty
+  public String getType() {
+    return type;
+  }
+
+  /**
+   * Set a new field data type.
+   *
+   * @param type the new field data type, not <code>null</code> or empty.
+   */
+  public void setType(String type) {
+    if (StringUtils.isBlank(type))
+      throw new IllegalArgumentException("type cannot be null or empty");
+
+    this.type = PSFieldTypeEnum.valueOf(type).toString();
+  }
+
+  @JsonProperty
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public Boolean getExportable() {
+    return exportable;
+  }
+
+  public void setExportable(Boolean exportable) {
+    this.exportable = exportable;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof PSFieldDescription)) return false;
+    PSFieldDescription that = (PSFieldDescription) o;
+    return Objects.equals(getName(), that.getName())
+        && Objects.equals(getType(), that.getType())
+        && Objects.equals(getExportable(), that.getExportable());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getName(), getType(), getExportable());
+  }
+
+  @Override
+  public String toString() {
+    final StringBuffer sb = new StringBuffer("PSFieldDescription{");
+    sb.append("name='").append(name).append('\'');
+    sb.append(", type='").append(type).append('\'');
+    sb.append(", exportable=").append(exportable);
+    sb.append('}');
+    return sb.toString();
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#fromXML(String)
+   */
+  public void fromXML(String xmlsource) throws IOException, SAXException {
+    PSXmlSerializationHelper.readFromXML(xmlsource, this);
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#toXML()
+   */
+  public String toXML() throws IOException, SAXException {
+    return PSXmlSerializationHelper.writeToXml(this);
+  }
+
+  /** The field data type enumeration. */
+  public enum PSFieldTypeEnum {
+    TEXT,
+    DATE,
+    NUMBER,
+    BINARY
+  }
 }
-

--- a/system/services/src/com/percussion/services/content/data/PSFolderProperty.java
+++ b/system/services/src/com/percussion/services/content/data/PSFolderProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,28 +17,14 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.services.content.data;
 
-import com.percussion.services.catalog.IPSCatalogItem;
-import com.percussion.services.catalog.IPSCatalogSummary;
-import com.percussion.services.catalog.PSTypeEnum;
-import com.percussion.services.data.IPSCloneTuner;
-import com.percussion.services.guidmgr.data.PSGuid;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
-import com.percussion.utils.guid.IPSGuid;
-import com.percussion.utils.xml.IPSXmlSerialization;
-
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Objects;
 import java.util.Optional;
-
-import jakarta.persistence.Basic;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
-import jakarta.persistence.Version;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -46,332 +32,381 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import jakarta.persistence.Basic;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 /**
  * Represents a single folder property with enhanced Java 11 support.
  *
- * <p>Folder properties are used to store metadata and configuration information
- * associated with content folders. This class provides comprehensive functionality
- * for managing folder property data with modern Java 11 features including
- * validation, serialization, and safe navigation.
- *
- * <p>Key features:
- * <ul>
- *   <li>Enhanced null safety with Objects.requireNonNull()</li>
- *   <li>Optional-based safe value access</li>
- *   <li>Immutable factory methods</li>
- *   <li>Comprehensive validation with clear error messages</li>
- * </ul>
+ * <p>Design-object XML root is {@code folder-property}. Jackson opt-in surface suppresses {@link
+ * Optional} accessors (issue #1921 / epic #505).
  *
  * @since Java 11 Modernization
  */
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSFolderProperty")
 @Table(name = "PSX_PROPERTIES")
+@JacksonXmlRootElement(localName = "folder-property")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({
+  "contentID",
+  "description",
+  "propertyName",
+  "propertyValue",
+  "revisionID",
+  "sysID"
+})
 public class PSFolderProperty implements Serializable {
 
-   /**
-    * Serial version UID for serialization compatibility.
-    */
-   private static final long serialVersionUID = 1L;
+  /** Serial version UID for serialization compatibility. */
+  private static final long serialVersionUID = 1L;
 
-   @Id
-   @Column(name = "CONTENTID", nullable = false)
-   private long contentID;
+  @Id
+  @Column(name = "CONTENTID", nullable = false)
+  private long contentID;
 
-   @Id
-   @Column(name = "REVISIONID", nullable = false)
-   private long revisionID;
+  @Id
+  @Column(name = "REVISIONID", nullable = false)
+  private long revisionID;
 
-   @Id
-   @Column(name = "SYSID", nullable = false)
-   private long sysID;
+  @Id
+  @Column(name = "SYSID", nullable = false)
+  private long sysID;
 
-   @Id
-   @Column(name = "PROPERTYNAME", nullable = false, length = 50)
-   private String propertyName;
+  @Id
+  @Column(name = "PROPERTYNAME", nullable = false, length = 50)
+  private String propertyName;
 
-   @Basic
-   @Column(name = "PROPERTYVALUE", nullable = true, length = 4000)
-   private String propertyValue;
-   
-   @Basic
-   @Column(name = "DESCRIPTION", nullable = true, length = 255)
-   private String description;
+  @Basic
+  @Column(name = "PROPERTYVALUE", nullable = true, length = 4000)
+  private String propertyValue;
 
-   /**
-    * Default constructor required for JPA/Hibernate.
-    * Use factory methods or parameterized constructors for creating new instances.
-    */
-   public PSFolderProperty() {
-      // Required by JPA
-   }
+  @Basic
+  @Column(name = "DESCRIPTION", nullable = true, length = 255)
+  private String description;
 
-   /**
-    * Create a new folder property with specified parameters using modern validation.
-    *
-    * @param contentID the content ID, must be > 0
-    * @param revisionID the revision ID, must be > 0
-    * @param sysID the system ID, must be > 0
-    * @param propertyName the property name, not {@code null} or empty
-    * @param propertyValue the property value, may be {@code null}
-    * @param description the description, may be {@code null}
-    * @throws IllegalArgumentException if validation fails
-    */
-   public PSFolderProperty(long contentID, long revisionID, long sysID,
-                          String propertyName, String propertyValue, String description) {
-      if (contentID <= 0) {
-         throw new IllegalArgumentException("contentID must be > 0");
-      }
-      if (revisionID <= 0) {
-         throw new IllegalArgumentException("revisionID must be > 0");
-      }
-      if (sysID <= 0) {
-         throw new IllegalArgumentException("sysID must be > 0");
-      }
-      if (StringUtils.isBlank(propertyName)) {
-         throw new IllegalArgumentException("propertyName cannot be null or empty");
-      }
+  /**
+   * Default constructor required for JPA/Hibernate.
+   *
+   * <p>Use factory methods or parameterized constructors for creating new instances.
+   */
+  public PSFolderProperty() {
+    // Required by JPA
+  }
 
-      this.contentID = contentID;
-      this.revisionID = revisionID;
-      this.sysID = sysID;
-      this.propertyName = propertyName;
-      this.propertyValue = propertyValue;
-      this.description = description;
-   }
+  /**
+   * Create a new folder property with specified parameters using modern validation.
+   *
+   * @param contentID the content ID, must be &gt; 0
+   * @param revisionID the revision ID, must be &gt; 0
+   * @param sysID the system ID, must be &gt; 0
+   * @param propertyName the property name, not {@code null} or empty
+   * @param propertyValue the property value, may be {@code null}
+   * @param description the description, may be {@code null}
+   * @throws IllegalArgumentException if validation fails
+   */
+  public PSFolderProperty(
+      long contentID,
+      long revisionID,
+      long sysID,
+      String propertyName,
+      String propertyValue,
+      String description) {
+    if (contentID <= 0) {
+      throw new IllegalArgumentException("contentID must be > 0");
+    }
+    if (revisionID <= 0) {
+      throw new IllegalArgumentException("revisionID must be > 0");
+    }
+    if (sysID <= 0) {
+      throw new IllegalArgumentException("sysID must be > 0");
+    }
+    if (StringUtils.isBlank(propertyName)) {
+      throw new IllegalArgumentException("propertyName cannot be null or empty");
+    }
 
-   /**
-    * Create a new folder property using factory method with enhanced validation.
-    *
-    * @param contentID the content ID, must be > 0
-    * @param revisionID the revision ID, must be > 0
-    * @param sysID the system ID, must be > 0
-    * @param propertyName the property name, not {@code null} or empty
-    * @param propertyValue the property value, may be {@code null}
-    * @return a new PSFolderProperty instance
-    * @throws IllegalArgumentException if validation fails
-    */
-   public static PSFolderProperty of(long contentID, long revisionID, long sysID,
-                                    String propertyName, String propertyValue) {
-      return new PSFolderProperty(contentID, revisionID, sysID, propertyName, propertyValue, null);
-   }
+    this.contentID = contentID;
+    this.revisionID = revisionID;
+    this.sysID = sysID;
+    this.propertyName = propertyName;
+    this.propertyValue = propertyValue;
+    this.description = description;
+  }
 
-   /**
-    * Get the content ID with Optional wrapper for safer access.
-    *
-    * @return Optional containing the content ID if valid, empty otherwise
-    */
-   public Optional<Long> getContentIDOptional() {
-      return contentID > 0 ? Optional.of(contentID) : Optional.empty();
-   }
+  /**
+   * Create a new folder property using factory method with enhanced validation.
+   *
+   * @param contentID the content ID, must be &gt; 0
+   * @param revisionID the revision ID, must be &gt; 0
+   * @param sysID the system ID, must be &gt; 0
+   * @param propertyName the property name, not {@code null} or empty
+   * @param propertyValue the property value, may be {@code null}
+   * @return a new PSFolderProperty instance
+   * @throws IllegalArgumentException if validation fails
+   */
+  public static PSFolderProperty of(
+      long contentID, long revisionID, long sysID, String propertyName, String propertyValue) {
+    return new PSFolderProperty(contentID, revisionID, sysID, propertyName, propertyValue, null);
+  }
 
-   /**
-    * Get the content ID of this folder property.
-    *
-    * @return the content ID
-    */
-   public long getContentID() {
-      return contentID;
-   }
+  /**
+   * Get the content ID with Optional wrapper for safer access.
+   *
+   * @return Optional containing the content ID if valid, empty otherwise
+   */
+  @JsonIgnore
+  public Optional<Long> getContentIDOptional() {
+    return contentID > 0 ? Optional.of(contentID) : Optional.empty();
+  }
 
-   /**
-    * Set the content ID with enhanced validation.
-    *
-    * @param contentID the content ID, must be > 0
-    * @throws IllegalArgumentException if contentID is &lt;= 0
-    */
-   public void setContentID(long contentID) {
-      if (contentID <= 0) {
-         throw new IllegalArgumentException("contentID must be > 0");
-      }
-      this.contentID = contentID;
-   }
+  /**
+   * Get the content ID of this folder property.
+   *
+   * @return the content ID
+   */
+  @JsonProperty
+  public long getContentID() {
+    return contentID;
+  }
 
-   /**
-    * Get the revision ID with Optional wrapper for safer access.
-    *
-    * @return Optional containing the revision ID if valid, empty otherwise
-    */
-   public Optional<Long> getRevisionIDOptional() {
-      return revisionID > 0 ? Optional.of(revisionID) : Optional.empty();
-   }
+  /**
+   * Set the content ID with enhanced validation.
+   *
+   * @param contentID the content ID, must be &gt; 0
+   * @throws IllegalArgumentException if contentID is &lt;= 0
+   */
+  public void setContentID(long contentID) {
+    if (contentID <= 0) {
+      throw new IllegalArgumentException("contentID must be > 0");
+    }
+    this.contentID = contentID;
+  }
 
-   /**
-    * Get the revision ID of this folder property.
-    *
-    * @return the revision ID
-    */
-   public long getRevisionID() {
-      return revisionID;
-   }
+  /**
+   * Get the revision ID with Optional wrapper for safer access.
+   *
+   * @return Optional containing the revision ID if valid, empty otherwise
+   */
+  @JsonIgnore
+  public Optional<Long> getRevisionIDOptional() {
+    return revisionID > 0 ? Optional.of(revisionID) : Optional.empty();
+  }
 
-   /**
-    * Set the revision ID with enhanced validation.
-    *
-    * @param revisionID the revision ID, must be > 0
-     * @throws IllegalArgumentException if revisionID is &lt;= 0
-    */
-   public void setRevisionID(long revisionID) {
-      if (revisionID <= 0) {
-         throw new IllegalArgumentException("revisionID must be > 0");
-      }
-      this.revisionID = revisionID;
-   }
+  /**
+   * Get the revision ID of this folder property.
+   *
+   * @return the revision ID
+   */
+  @JsonProperty
+  public long getRevisionID() {
+    return revisionID;
+  }
 
-   /**
-    * Get the system ID with Optional wrapper for safer access.
-    *
-    * @return Optional containing the system ID if valid, empty otherwise
-    */
-   public Optional<Long> getSysIDOptional() {
-      return sysID > 0 ? Optional.of(sysID) : Optional.empty();
-   }
+  /**
+   * Set the revision ID with enhanced validation.
+   *
+   * @param revisionID the revision ID, must be &gt; 0
+   * @throws IllegalArgumentException if revisionID is &lt;= 0
+   */
+  public void setRevisionID(long revisionID) {
+    if (revisionID <= 0) {
+      throw new IllegalArgumentException("revisionID must be > 0");
+    }
+    this.revisionID = revisionID;
+  }
 
-   /**
-    * Get the system ID of this folder property.
-    *
-    * @return the system ID
-    */
-   public long getSysID() {
-      return sysID;
-   }
+  /**
+   * Get the system ID with Optional wrapper for safer access.
+   *
+   * @return Optional containing the system ID if valid, empty otherwise
+   */
+  @JsonIgnore
+  public Optional<Long> getSysIDOptional() {
+    return sysID > 0 ? Optional.of(sysID) : Optional.empty();
+  }
 
-   /**
-    * Set the system ID with enhanced validation.
-    *
-    * @param sysID the system ID, must be > 0
-     * @throws IllegalArgumentException if sysID is &lt;= 0
-    */
-   public void setSysID(long sysID) {
-      if (sysID <= 0) {
-         throw new IllegalArgumentException("sysID must be > 0");
-      }
-      this.sysID = sysID;
-   }
+  /**
+   * Get the system ID of this folder property.
+   *
+   * @return the system ID
+   */
+  @JsonProperty
+  public long getSysID() {
+    return sysID;
+  }
 
-   /**
-    * Get the property name with Optional wrapper.
-    *
-    * @return Optional containing the property name if non-null, empty otherwise
-    */
-   public Optional<String> getPropertyNameOptional() {
-      return Optional.ofNullable(propertyName);
-   }
+  /**
+   * Set the system ID with enhanced validation.
+   *
+   * @param sysID the system ID, must be &gt; 0
+   * @throws IllegalArgumentException if sysID is &lt;= 0
+   */
+  public void setSysID(long sysID) {
+    if (sysID <= 0) {
+      throw new IllegalArgumentException("sysID must be > 0");
+    }
+    this.sysID = sysID;
+  }
 
-   /**
-    * Get the property name of this folder property.
-    *
-    * @return the property name, never {@code null} or empty
-    */
-   public String getPropertyName() {
-      return propertyName;
-   }
+  /**
+   * Get the property name with Optional wrapper.
+   *
+   * @return Optional containing the property name if non-null, empty otherwise
+   */
+  @JsonIgnore
+  public Optional<String> getPropertyNameOptional() {
+    return Optional.ofNullable(propertyName);
+  }
 
-   /**
-    * Set the property name with enhanced validation.
-    *
-    * @param propertyName the property name, not {@code null} or empty
-    * @throws IllegalArgumentException if propertyName is null or empty
-    */
-   public void setPropertyName(String propertyName) {
-      if (StringUtils.isBlank(propertyName)) {
-         throw new IllegalArgumentException("propertyName cannot be null or empty");
-      }
-      this.propertyName = propertyName;
-   }
+  /**
+   * Get the property name of this folder property.
+   *
+   * @return the property name, never {@code null} or empty
+   */
+  @JsonProperty
+  public String getPropertyName() {
+    return propertyName;
+  }
 
-   /**
-    * Get the property value with Optional wrapper.
-    *
-    * @return Optional containing the property value if non-null, empty otherwise
-    */
-   public Optional<String> getPropertyValueOptional() {
-      return Optional.ofNullable(propertyValue);
-   }
+  /**
+   * Set the property name with enhanced validation.
+   *
+   * @param propertyName the property name, not {@code null} or empty
+   * @throws IllegalArgumentException if propertyName is null or empty
+   */
+  public void setPropertyName(String propertyName) {
+    if (StringUtils.isBlank(propertyName)) {
+      throw new IllegalArgumentException("propertyName cannot be null or empty");
+    }
+    this.propertyName = propertyName;
+  }
 
-   /**
-    * Get the property value of this folder property.
-    *
-    * @return the property value, may be {@code null}
-    */
-   public String getPropertyValue() {
-      return propertyValue;
-   }
+  /**
+   * Get the property value with Optional wrapper.
+   *
+   * @return Optional containing the property value if non-null, empty otherwise
+   */
+  @JsonIgnore
+  public Optional<String> getPropertyValueOptional() {
+    return Optional.ofNullable(propertyValue);
+  }
 
-   /**
-    * Set the property value.
-    *
-    * @param propertyValue the property value, may be {@code null}
-    */
-   public void setPropertyValue(String propertyValue) {
-      this.propertyValue = propertyValue;
-   }
+  /**
+   * Get the property value of this folder property.
+   *
+   * @return the property value, may be {@code null}
+   */
+  @JsonProperty
+  public String getPropertyValue() {
+    return propertyValue;
+  }
 
-   /**
-    * Get the description with Optional wrapper.
-    *
-    * @return Optional containing the description if non-null, empty otherwise
-    */
-   public Optional<String> getDescriptionOptional() {
-      return Optional.ofNullable(description);
-   }
+  /**
+   * Set the property value.
+   *
+   * @param propertyValue the property value, may be {@code null}
+   */
+  public void setPropertyValue(String propertyValue) {
+    this.propertyValue = propertyValue;
+  }
 
-   /**
-    * Get the description of this folder property.
-    *
-    * @return the description, may be {@code null}
-    */
-   public String getDescription() {
-      return description;
-   }
+  /**
+   * Get the description with Optional wrapper.
+   *
+   * @return Optional containing the description if non-null, empty otherwise
+   */
+  @JsonIgnore
+  public Optional<String> getDescriptionOptional() {
+    return Optional.ofNullable(description);
+  }
 
-   /**
-    * Set the description.
-    *
-    * @param description the description, may be {@code null}
-    */
-   public void setDescription(String description) {
-      this.description = description;
-   }
+  /**
+   * Get the description of this folder property.
+   *
+   * @return the description, may be {@code null}
+   */
+  @JsonProperty
+  public String getDescription() {
+    return description;
+  }
 
-   @Override
-   public boolean equals(Object obj) {
-      if (this == obj) return true;
-      if (!(obj instanceof PSFolderProperty)) return false;
+  /**
+   * Set the description.
+   *
+   * @param description the description, may be {@code null}
+   */
+  public void setDescription(String description) {
+    this.description = description;
+  }
 
-      var other = (PSFolderProperty) obj;
-      return new EqualsBuilder()
-         .append(contentID, other.contentID)
-         .append(revisionID, other.revisionID)
-         .append(sysID, other.sysID)
-         .append(propertyName, other.propertyName)
-         .append(propertyValue, other.propertyValue)
-         .append(description, other.description)
-         .isEquals();
-   }
+  /**
+   * Serialize this folder property to design-object XML via {@link PSXmlSerializationHelper}.
+   *
+   * @return XML string, never {@code null}
+   * @throws IOException on write failure
+   * @throws SAXException on SAX failure
+   */
+  public String toXML() throws IOException, SAXException {
+    return PSXmlSerializationHelper.writeToXml(this);
+  }
 
-   @Override
-   public int hashCode() {
-      return new HashCodeBuilder(17, 37)
-         .append(contentID)
-         .append(revisionID)
-         .append(sysID)
-         .append(propertyName)
-         .append(propertyValue)
-         .append(description)
-         .toHashCode();
-   }
+  /**
+   * Restore this folder property from design-object XML via {@link PSXmlSerializationHelper}.
+   *
+   * @param xmlsource XML source, never blank
+   * @throws IOException on parse failure
+   * @throws SAXException on SAX failure
+   */
+  public void fromXML(String xmlsource) throws IOException, SAXException {
+    PSXmlSerializationHelper.readFromXML(xmlsource, this);
+  }
 
-   @Override
-   public String toString() {
-      return new ToStringBuilder(this)
-         .append("contentID", contentID)
-         .append("revisionID", revisionID)
-         .append("sysID", sysID)
-         .append("propertyName", propertyName)
-         .append("propertyValue", propertyValue)
-         .append("description", description)
-         .toString();
-   }
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (!(obj instanceof PSFolderProperty)) return false;
+
+    var other = (PSFolderProperty) obj;
+    return new EqualsBuilder()
+        .append(contentID, other.contentID)
+        .append(revisionID, other.revisionID)
+        .append(sysID, other.sysID)
+        .append(propertyName, other.propertyName)
+        .append(propertyValue, other.propertyValue)
+        .append(description, other.description)
+        .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+        .append(contentID)
+        .append(revisionID)
+        .append(sysID)
+        .append(propertyName)
+        .append(propertyValue)
+        .append(description)
+        .toHashCode();
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .append("contentID", contentID)
+        .append("revisionID", revisionID)
+        .append("sysID", sysID)
+        .append("propertyName", propertyName)
+        .append("propertyValue", propertyValue)
+        .append("description", description)
+        .toString();
+  }
 }

--- a/system/services/src/com/percussion/services/content/data/PSItemStatus.java
+++ b/system/services/src/com/percussion/services/content/data/PSItemStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,302 +16,320 @@
  */
 package com.percussion.services.content.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
-
 import java.io.IOException;
 import java.util.Objects;
-
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
- * This object represents a single item status at the time it was prepared for
- * edit. This object may be used to release the item later.
+ * This object represents a single item status at the time it was prepared for edit. This object may
+ * be used to release the item later.
+ *
+ * <p>Design-object XML root is {@code item-status}. Content id is wired as {@code id} (historical
+ * Betwixt property name) (issue #1921 / epic #505).
  */
-public class PSItemStatus
-{
-   /**
-    * The content id.
-    */
-   private int contentId;
-   
-   /**
-    * See {@link #isDidCheckout()} for it description. 
-    * Default to <code>false</code>.
-    */
-   private boolean didCheckout = false;
+@JacksonXmlRootElement(localName = "item-status")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({
+  "didCheckout",
+  "didTransition",
+  "fromState",
+  "fromStateId",
+  "id",
+  "toState",
+  "toStateId"
+})
+public class PSItemStatus {
+  /** The content id. */
+  private int contentId;
 
-   /**
-    * See {@link #isDidTransition()} for its description.
-    * Default to <code>false</code>.
-    */
-   private boolean didTransition = false;
+  /**
+   * See {@link #isDidCheckout()} for it description. Default to <code>false</code>.
+   */
+  private boolean didCheckout = false;
 
-   /**
-    * See {@link #getFromState()} for its description.
-    * Default to <code>null</code>.
-    */
-   private java.lang.String fromState = null;
+  /**
+   * See {@link #isDidTransition()} for its description. Default to <code>false</code>.
+   */
+  private boolean didTransition = false;
 
-   /**
-    * See {@link #getFromStateId()} for its description.
-    * Default to <code>null</code>.
-    */
-   private Long fromStateId = null;
-   
-   /**
-    * See {@link #getToState()} for its description.
-    * Default to <code>null</code>.
-    */
-   private java.lang.String toState = null;
-   
-   /**
-    * See {@link #getToStateId()} for its description.
-    * Default to <code>null</code>.
-    */
-   private Long toStateId = null;
-   
-   /**
-    * Creates an instance with the specified id of a item.
-    * 
-    * @param contentId the id of the item.
-    */
-   public PSItemStatus(int contentId)
-   {
-      this.contentId = contentId;
-   }
+  /**
+   * See {@link #getFromState()} for its description. Default to <code>null</code>.
+   */
+  private String fromState = null;
 
-   /**
-    * Creates an instance from the specified parameters.
-    * 
-    * @param contentId the id of the item, may not be <code>null</code>.
-    * @param didCheckout <code>true</code> if the item was, <code>false</code> 
-    *    otherwise. see {@link #isDidCheckout()} for more info.
-    * @param didTransition <code>true</code> if the item was, <code>false</code> 
-    *    otherwise. see {@link #isDidTransition()} for more info.
-    * @param fromStateId the id of the from-state, see {@link #getFromStateId()}
-    *    for more info. It may be <code>null</code>.
-    * @param fromState the name of the from-state, see {@link #getFromState()}
-    *    for more info. It may be <code>null</code> or empty.
-    * @param toStateId the id of the to-state, see {@link #getToStateId()}
-    *    for more info. It may be <code>null</code>.
-    * @param toState the name of the to-state, see {@link #getToState()}
-    *    for more info. It may be <code>null</code> or empty.
-    */
-   public PSItemStatus(int contentId, boolean didCheckout, boolean didTransition,
-         Long fromStateId, String fromState, Long toStateId, String toState)
-   {
-      this(contentId);
-      this.didCheckout = didCheckout;
-      this.didTransition = didTransition;
-      this.fromStateId = fromStateId;
-      this.fromState = fromState;
-      this.toStateId = toStateId;
-      this.toState = toState;
-   }
+  /**
+   * See {@link #getFromStateId()} for its description. Default to <code>null</code>.
+   */
+  private Long fromStateId = null;
 
-   /**
-    * @return the id of the item.
-    */
-   public int getId()
-   {
-      return contentId;
-   }
-   
-   /**
-    * Was the item checked out to prepare it for edit?
-    * 
-    * @return <code>true</code> if it was, <code>false</code> otherwise.
-    */
-   public boolean isDidCheckout()
-   {
-      return didCheckout;
-   }
-   
-   /**
-    * Set if the item was checked out to prepare it for edit.
-    * 
-    * @param didCheckout <code>true</code> if it was, <code>false</code>
-    *    otherwise.
-    */
-   public void setDidCheckout(boolean didCheckout)
-   {
-      this.didCheckout = didCheckout;
-   }
-   
-   /**
-    * Was the item transitioned to prepare it for edit?
-    * 
-    * @return <code>true</code> if it was, <code>false</code> otherwise.
-    */
-   public boolean isDidTransition()
-   {
-      return didTransition;
-   }
-   
-   /**
-    * Set if the item ws transitioned to prepare it for edit.
-    * 
-    * @param didTransition <code>true</code> if it was, <code>false</code>
-    *    otherwise.
-    */
-   public void setDidTransition(boolean didTransition)
-   {
-      this.didTransition = didTransition;
-   }
+  /**
+   * See {@link #getToState()} for its description. Default to <code>null</code>.
+   */
+  private String toState = null;
 
-   /**
-    * Get the name of the workflow state in which the item was before it was 
-    * prepared for edit. This is only available if the item had to be 
-    * transitioned to bring it into edit mode.
-    * 
-    * @return the item state before it was prepared for edit, may be
-    *    <code>null</code>, never empty.
-    */
-   public String getFromState()
-   {
-      return fromState;
-   }
-   
-   /**
-    * Set the name of the workflow state in which the item was before it was 
-    * prepared for edit.
-    * 
-    * @param fromState the new item state before it was prepared for edit, 
-    *    may be <code>null</code>, not empty.
-    */
-   public void setFromState(String fromState)
-   {
-      if (StringUtils.isEmpty(fromState))
-         throw new IllegalArgumentException("fromState cannot be empty");
-      
-      this.fromState = fromState;
-   }
+  /**
+   * See {@link #getToStateId()} for its description. Default to <code>null</code>.
+   */
+  private Long toStateId = null;
 
-   /**
-    * Get the name of the workflow state to which the item was transitioned 
-    * to prepare it for edit. This is only available if the item had to be 
-    * transitioned to bring it into edit mode.
-    * 
-    * @return the item state to which the it was transitioned to prepared it 
-    *    for edit, may be <code>null</code>, never empty.
-    */
-   public String getToState()
-   {
-      return toState;
-   }
-   
-   /**
-    * Set the name of the workflow state to which the item was transitioned 
-    * to prepare it for edit.
-    * 
-    * @param toState the new item state to which the it was transitioned to 
-    *    prepared it for edit, may be <code>null</code>, not empty.
-    */
-   public void setToState(String toState)
-   {
-      if (StringUtils.isEmpty(toState))
-         throw new IllegalArgumentException("toState cannot be empty");
-      
-      this.toState = toState;
-   }
+  /**
+   * Default constructor required for XML serialization frameworks (Jackson / BeanUtils property
+   * copy).
+   */
+  public PSItemStatus() {}
 
-   /**
-    * Get the id of the workflow state in which the item was before it was 
-    * prepared for edit. This is only available if the item had to be 
-    * transitioned to bring it into edit mode.
-    * 
-    * @return the state id described above, may be <code>null</code>.
-    */
-   public java.lang.Long getFromStateId() 
-   {
-       return fromStateId;
-   }
+  /**
+   * Creates an instance with the specified id of a item.
+   *
+   * @param contentId the id of the item.
+   */
+  public PSItemStatus(int contentId) {
+    this.contentId = contentId;
+  }
 
+  /**
+   * Creates an instance from the specified parameters.
+   *
+   * @param contentId the id of the item, may not be <code>null</code>.
+   * @param didCheckout <code>true</code> if the item was, <code>false</code> otherwise. see {@link
+   *     #isDidCheckout()} for more info.
+   * @param didTransition <code>true</code> if the item was, <code>false</code> otherwise. see {@link
+   *     #isDidTransition()} for more info.
+   * @param fromStateId the id of the from-state, see {@link #getFromStateId()} for more info. It
+   *     may be <code>null</code>.
+   * @param fromState the name of the from-state, see {@link #getFromState()} for more info. It may
+   *     be <code>null</code> or empty.
+   * @param toStateId the id of the to-state, see {@link #getToStateId()} for more info. It may be
+   *     <code>null</code>.
+   * @param toState the name of the to-state, see {@link #getToState()} for more info. It may be
+   *     <code>null</code> or empty.
+   */
+  public PSItemStatus(
+      int contentId,
+      boolean didCheckout,
+      boolean didTransition,
+      Long fromStateId,
+      String fromState,
+      Long toStateId,
+      String toState) {
+    this(contentId);
+    this.didCheckout = didCheckout;
+    this.didTransition = didTransition;
+    this.fromStateId = fromStateId;
+    this.fromState = fromState;
+    this.toStateId = toStateId;
+    this.toState = toState;
+  }
 
-   /**
-    * Set the id of the workflow state in which the item was before it was 
-    * prepared for edit.
-    * 
-    * @param fromStateId the id of new item state before it was prepared for 
-    *    edit, may be <code>null</code>.
-    */
-   public void setFromStateId(java.lang.Long fromStateId) 
-   {
-       this.fromStateId = fromStateId;
-   }
+  /**
+   * @return the id of the item.
+   */
+  @JsonProperty("id")
+  public int getId() {
+    return contentId;
+  }
 
+  /**
+   * Set the content id (design-object XML property {@code id}).
+   *
+   * @param id the content id
+   */
+  public void setId(int id) {
+    this.contentId = id;
+  }
 
-   /**
-    * Get the id of the workflow state to which the item was transitioned 
-    * to prepare it for edit. This is only available if the item had to be 
-    * transitioned to bring it into edit mode.
-    * 
-    * @return the state id to which the item was transitioned to prepared it 
-    *    for edit, may be <code>null</code>.
-    */
-   public java.lang.Long getToStateId() 
-   {
-       return toStateId;
-   }
+  /**
+   * Was the item checked out to prepare it for edit?
+   *
+   * @return <code>true</code> if it was, <code>false</code> otherwise.
+   */
+  @JsonProperty
+  public boolean isDidCheckout() {
+    return didCheckout;
+  }
 
+  /**
+   * Set if the item was checked out to prepare it for edit.
+   *
+   * @param didCheckout <code>true</code> if it was, <code>false</code> otherwise.
+   */
+  public void setDidCheckout(boolean didCheckout) {
+    this.didCheckout = didCheckout;
+  }
 
-   /**
-    * Set the id of the workflow state to which the item was transitioned 
-    * to prepare it for edit.
-    * 
-    * @param toStateId the new state id to which the item was transitioned to 
-    *    prepared it for edit, may be <code>null</code>.
-    */
-   public void setToStateId(java.lang.Long toStateId) 
-   {
-       this.toStateId = toStateId;
-   }
+  /**
+   * Was the item transitioned to prepare it for edit?
+   *
+   * @return <code>true</code> if it was, <code>false</code> otherwise.
+   */
+  @JsonProperty
+  public boolean isDidTransition() {
+    return didTransition;
+  }
 
-   @Override
-   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof PSItemStatus)) return false;
-      PSItemStatus that = (PSItemStatus) o;
-      return contentId == that.contentId && isDidCheckout() == that.isDidCheckout() && isDidTransition() == that.isDidTransition() && Objects.equals(getFromState(), that.getFromState()) && Objects.equals(getFromStateId(), that.getFromStateId()) && Objects.equals(getToState(), that.getToState()) && Objects.equals(getToStateId(), that.getToStateId());
-   }
+  /**
+   * Set if the item ws transitioned to prepare it for edit.
+   *
+   * @param didTransition <code>true</code> if it was, <code>false</code> otherwise.
+   */
+  public void setDidTransition(boolean didTransition) {
+    this.didTransition = didTransition;
+  }
 
-   @Override
-   public int hashCode() {
-      return Objects.hash(contentId, isDidCheckout(), isDidTransition(), getFromState(), getFromStateId(), getToState(), getToStateId());
-   }
+  /**
+   * Get the name of the workflow state in which the item was before it was prepared for edit. This
+   * is only available if the item had to be transitioned to bring it into edit mode.
+   *
+   * @return the item state before it was prepared for edit, may be <code>null</code>, never empty.
+   */
+  @JsonProperty
+  public String getFromState() {
+    return fromState;
+  }
 
-   @Override
-   public String toString() {
-      final StringBuffer sb = new StringBuffer("PSItemStatus{");
-      sb.append("contentId=").append(contentId);
-      sb.append(", didCheckout=").append(didCheckout);
-      sb.append(", didTransition=").append(didTransition);
-      sb.append(", fromState='").append(fromState).append('\'');
-      sb.append(", fromStateId=").append(fromStateId);
-      sb.append(", toState='").append(toState).append('\'');
-      sb.append(", toStateId=").append(toStateId);
-      sb.append('}');
-      return sb.toString();
-   }
+  /**
+   * Set the name of the workflow state in which the item was before it was prepared for edit.
+   *
+   * @param fromState the new item state before it was prepared for edit, may be <code>null</code>,
+   *     not empty.
+   */
+  public void setFromState(String fromState) {
+    if (fromState != null && StringUtils.isEmpty(fromState))
+      throw new IllegalArgumentException("fromState cannot be empty");
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#fromXML(String)
-    */
-   public void fromXML(String xmlsource) throws IOException, SAXException
-   {
-      PSXmlSerializationHelper.readFromXML(xmlsource, this);
-   }
+    this.fromState = fromState;
+  }
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#toXML()
-    */
-   public String toXML() throws IOException, SAXException
-   {
-      return PSXmlSerializationHelper.writeToXml(this);
-   }
+  /**
+   * Get the name of the workflow state to which the item was transitioned to prepare it for edit.
+   * This is only available if the item had to be transitioned to bring it into edit mode.
+   *
+   * @return the item state to which the it was transitioned to prepared it for edit, may be <code>
+   *     null</code>, never empty.
+   */
+  @JsonProperty
+  public String getToState() {
+    return toState;
+  }
+
+  /**
+   * Set the name of the workflow state to which the item was transitioned to prepare it for edit.
+   *
+   * @param toState the new item state to which the it was transitioned to prepared it for edit, may
+   *     be <code>null</code>, not empty.
+   */
+  public void setToState(String toState) {
+    if (toState != null && StringUtils.isEmpty(toState))
+      throw new IllegalArgumentException("toState cannot be empty");
+
+    this.toState = toState;
+  }
+
+  /**
+   * Get the id of the workflow state in which the item was before it was prepared for edit. This is
+   * only available if the item had to be transitioned to bring it into edit mode.
+   *
+   * @return the state id described above, may be <code>null</code>.
+   */
+  @JsonProperty
+  public Long getFromStateId() {
+    return fromStateId;
+  }
+
+  /**
+   * Set the id of the workflow state in which the item was before it was prepared for edit.
+   *
+   * @param fromStateId the id of new item state before it was prepared for edit, may be <code>null
+   *     </code>.
+   */
+  public void setFromStateId(Long fromStateId) {
+    this.fromStateId = fromStateId;
+  }
+
+  /**
+   * Get the id of the workflow state to which the item was transitioned to prepare it for edit.
+   * This is only available if the item had to be transitioned to bring it into edit mode.
+   *
+   * @return the state id to which the item was transitioned to prepared it for edit, may be <code>
+   *     null</code>.
+   */
+  @JsonProperty
+  public Long getToStateId() {
+    return toStateId;
+  }
+
+  /**
+   * Set the id of the workflow state to which the item was transitioned to prepare it for edit.
+   *
+   * @param toStateId the new state id to which the item was transitioned to prepared it for edit,
+   *     may be <code>null</code>.
+   */
+  public void setToStateId(Long toStateId) {
+    this.toStateId = toStateId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof PSItemStatus)) return false;
+    PSItemStatus that = (PSItemStatus) o;
+    return contentId == that.contentId
+        && isDidCheckout() == that.isDidCheckout()
+        && isDidTransition() == that.isDidTransition()
+        && Objects.equals(getFromState(), that.getFromState())
+        && Objects.equals(getFromStateId(), that.getFromStateId())
+        && Objects.equals(getToState(), that.getToState())
+        && Objects.equals(getToStateId(), that.getToStateId());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        contentId,
+        isDidCheckout(),
+        isDidTransition(),
+        getFromState(),
+        getFromStateId(),
+        getToState(),
+        getToStateId());
+  }
+
+  @Override
+  public String toString() {
+    final StringBuffer sb = new StringBuffer("PSItemStatus{");
+    sb.append("contentId=").append(contentId);
+    sb.append(", didCheckout=").append(didCheckout);
+    sb.append(", didTransition=").append(didTransition);
+    sb.append(", fromState='").append(fromState).append('\'');
+    sb.append(", fromStateId=").append(fromStateId);
+    sb.append(", toState='").append(toState).append('\'');
+    sb.append(", toStateId=").append(toStateId);
+    sb.append('}');
+    return sb.toString();
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#fromXML(String)
+   */
+  public void fromXML(String xmlsource) throws IOException, SAXException {
+    PSXmlSerializationHelper.readFromXML(xmlsource, this);
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#toXML()
+   */
+  public String toXML() throws IOException, SAXException {
+    return PSXmlSerializationHelper.writeToXml(this);
+  }
 }
-

--- a/system/services/src/com/percussion/services/content/data/PSItemStatus.java
+++ b/system/services/src/com/percussion/services/content/data/PSItemStatus.java
@@ -201,6 +201,10 @@ public class PSItemStatus {
   /**
    * Set the name of the workflow state in which the item was before it was prepared for edit.
    *
+   * <p>{@code null} is allowed: items that did not transition have no from-state, and Jackson maps
+   * absent/empty optional design-object elements to {@code null}. Empty (non-null blank) strings
+   * are rejected so callers cannot store a meaningless empty state name.
+   *
    * @param fromState the new item state before it was prepared for edit, may be <code>null</code>,
    *     not empty.
    */
@@ -225,6 +229,10 @@ public class PSItemStatus {
 
   /**
    * Set the name of the workflow state to which the item was transitioned to prepare it for edit.
+   *
+   * <p>{@code null} is allowed: items that did not transition have no to-state, and Jackson maps
+   * absent/empty optional design-object elements to {@code null}. Empty (non-null blank) strings
+   * are rejected so callers cannot store a meaningless empty state name.
    *
    * @param toState the new item state to which the it was transitioned to prepared it for edit, may
    *     be <code>null</code>, not empty.

--- a/system/services/src/com/percussion/services/contentmgr/data/PSNodeDefinition.java
+++ b/system/services/src/com/percussion/services/contentmgr/data/PSNodeDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,10 @@
  */
 package com.percussion.services.contentmgr.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.contentmgr.IPSContentMgr;
 import com.percussion.services.contentmgr.IPSNodeDefinition;
@@ -29,18 +33,12 @@ import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.xml.IPSXmlSerialization;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
-import org.hibernate.annotations.NaturalId;
-import org.hibernate.annotations.NaturalIdCache;
-import org.xml.sax.SAXException;
-
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
 import javax.jcr.RepositoryException;
 import javax.jcr.nodetype.NoSuchNodeTypeException;
 import javax.jcr.nodetype.NodeType;
@@ -54,31 +52,65 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.NaturalIdCache;
+import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
- * Wrapper for content type definitions in Rhythmyx. Additional methods are
- * provided here for Rhythmyx specific information. Most of the JSR-170
- * information is not provided at this time.
- * 
+ * Wrapper for content type definitions in Rhythmyx. Additional methods are provided here for
+ * Rhythmyx specific information. Most of the JSR-170 information is not provided at this time.
+ *
+ * <p>Design-object XML root is {@code node-definition}. Jackson opt-in surface matches historical
+ * package shape ({@code template-id} items under {@code template-ids}; {@code string} items under
+ * {@code workflow-ids}). JCR interface methods that are not part of the design wire form are
+ * suppressed (issue #1921 / epic #505).
+ *
  * @author dougrand
- * 
  */
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSNodeDefinition")
 @NaturalIdCache
 @Table(name = "CONTENTTYPES")
-public class PSNodeDefinition implements IPSNodeDefinition
-{
-   static
-   {
-      // Register types with XML serializer for read creation of objects
-      PSXmlSerializationHelper.addType("variant-guid", PSGuid.class);
-   }
+@JacksonXmlRootElement(localName = "node-definition")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({
+  "auto-created",
+  "description",
+  "hideFromMenu",
+  "id",
+  "internalName",
+  "label",
+  "mandatory",
+  "name",
+  "newRequest",
+  "objectType",
+  "protected",
+  "queryRequest",
+  "rawContentType",
+  "templateIds",
+  "updateRequest",
+  "workflowIds"
+})
+public class PSNodeDefinition implements IPSNodeDefinition {
+  static {
+    // Register types with XML serializer for read creation of objects
+    PSXmlSerializationHelper.addType("variant-guid", PSGuid.class);
+  }
 
    @Id
    @Column(name = "CONTENTTYPEID")
@@ -169,6 +201,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
    }
 
    @Override
+   @JsonIgnore
    public String[] getRequiredPrimaryTypeNames()
    {
       NodeType type = getDefaultPrimaryType();
@@ -180,6 +213,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
    }
 
    @Override
+   @JsonIgnore
    public String getDefaultPrimaryTypeName()
    {
       NodeType type = getDefaultPrimaryType();
@@ -191,6 +225,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
     * 
     * @see javax.jcr.nodetype.NodeDefinition#allowsSameNameSiblings()
     */
+   @JsonIgnore
    public boolean allowsSameNameSiblings()
    {
       return false;
@@ -212,6 +247,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
     * 
     * @see javax.jcr.nodetype.ItemDefinition#getName()
     */
+   @JsonProperty
    public String getName()
    {
       if (m_name != null)
@@ -225,6 +261,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
     * 
     * @see com.percussion.services.contentmgr.IPSNodeDefinition#getInternalName()
     */
+   @JsonProperty
    public String getInternalName()
    {
       return m_name;
@@ -235,6 +272,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
     * 
     * @see javax.jcr.nodetype.ItemDefinition#isAutoCreated()
     */
+   @JsonProperty("auto-created")
    public boolean isAutoCreated()
    {
       return false;
@@ -245,6 +283,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
     * 
     * @see javax.jcr.nodetype.ItemDefinition#isMandatory()
     */
+   @JsonProperty("mandatory")
    public boolean isMandatory()
    {
       return false;
@@ -266,6 +305,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
     * 
     * @see javax.jcr.nodetype.ItemDefinition#isProtected()
     */
+   @JsonProperty("protected")
    public boolean isProtected()
    {
       return false;
@@ -275,6 +315,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
     * @return Returns the contenttypeid.
     */
    @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public IPSGuid getGUID()
    {
       return new PSGuid(PSTypeEnum.NODEDEF, m_contenttypeid);
@@ -293,9 +334,20 @@ public class PSNodeDefinition implements IPSNodeDefinition
     * 
     * @return the raw content type id
     */
+   @JsonProperty
    public long getRawContentType()
    {
-      return m_contenttypeid;
+      return m_contenttypeid != null ? m_contenttypeid : 0L;
+   }
+
+   /**
+    * Set raw content type id (design-object XML property {@code raw-content-type}).
+    *
+    * @param rawContentType the content type id
+    */
+   public void setRawContentType(long rawContentType)
+   {
+      m_contenttypeid = rawContentType;
    }
 
    /**
@@ -303,9 +355,10 @@ public class PSNodeDefinition implements IPSNodeDefinition
     * 
     * @return get the id
     */
+   @JsonProperty
    public long getId()
    {
-      return m_contenttypeid;
+      return m_contenttypeid != null ? m_contenttypeid : 0L;
    }
 
    /**
@@ -323,6 +376,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
     * 
     * @return Returns the label.
     */
+   @JsonProperty
    public String getLabel()
    {
       return m_label;
@@ -343,6 +397,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
     * 
     * @see com.percussion.services.contentmgr.IPSNodeDefinition#getDescription()
     */
+   @JsonProperty
    public String getDescription()
    {
       return m_description;
@@ -363,6 +418,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
     * 
     * @see com.percussion.services.contentmgr.IPSNodeDefinition#getHideFromMenu()
     */
+   @JsonProperty
    public Boolean getHideFromMenu()
    {
       return m_hideFromMenu;
@@ -385,6 +441,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
    /**
     * @return Returns the newRequest.
     */
+   @JsonProperty
    public String getNewRequest()
    {
       return m_newRequest;
@@ -403,6 +460,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
     * 
     * @see com.percussion.services.contentmgr.IPSNodeDefinition#getObjectType()
     */
+   @JsonProperty
    public Integer getObjectType()
    {
       return m_objectType;
@@ -421,6 +479,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
    /**
     * @return Returns the queryRequest.
     */
+   @JsonProperty
    public String getQueryRequest()
    {
       return m_queryRequest;
@@ -437,6 +496,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
    /**
     * @return Returns the updateRequest.
     */
+   @JsonProperty
    public String getUpdateRequest()
    {
       return m_updateRequest;
@@ -480,6 +540,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
     * @return the descriptors, may be empty but not <code>null</code>
     */
    @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public Set<PSContentTemplateDesc> getCvDescriptors()
    {
       return m_cvDescriptors;
@@ -505,6 +566,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
     * <code>null</code>
     */
    @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public Set<PSContentTypeWorkflow> getCtWfRels()
    {
       return m_ctWfRels;
@@ -551,6 +613,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
     * 
     */
    @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public Set<IPSGuid> getVariantGuids()
    {
       Set<IPSGuid> guids = new HashSet<>();
@@ -572,6 +635,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
     * 
     */
    @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public Set<IPSGuid> getWorkflowGuids()
    {
       Set<IPSGuid> guids = new HashSet<>();
@@ -681,6 +745,7 @@ public class PSNodeDefinition implements IPSNodeDefinition
     * @return The version, may be <code>null</code> if it has not been set.
     */
    @IPSXmlSerialization(suppress=true)
+   @JsonIgnore
    public Integer getVersion()
    {
       return m_version;
@@ -751,13 +816,19 @@ public class PSNodeDefinition implements IPSNodeDefinition
    }
 
    /**
-    * Get a string representation of GUIDs of the template associtations
-    * 
+    * Get a string representation of GUIDs of the template associations.
+    *
+    * <p>Package/design XML uses item element {@code template-id} (not mapped type name).
+    *
     * @return set of Guid Strings may be empty never <code>null</code>
     */
+   @JsonProperty
+   @JacksonXmlElementWrapper(localName = "template-ids")
+   @JacksonXmlProperty(localName = "template-id")
    public Set<String> getTemplateIds()
    {
-      Set<String> ids = new HashSet<>();
+      // TreeSet for stable design-object XML order (HashSet iteration is non-deterministic)
+      Set<String> ids = new TreeSet<>();
       if (m_cvDescriptors != null && !m_cvDescriptors.isEmpty())
       {
          for (PSContentTemplateDesc desc : m_cvDescriptors)
@@ -767,13 +838,42 @@ public class PSNodeDefinition implements IPSNodeDefinition
    }
 
    /**
-    * Get a string representation of GUIDs of the workflow associtations
-    * 
+    * Restore template associations from design-object XML ({@code template-ids}). Uses historical
+    * {@link #addTemplateId(String)} path (requires content manager for association lookup in live
+    * CMS). Offline unit tests exercise write/scalar restore only.
+    *
+    * @param templateIds may be {@code null} or empty
+    */
+   public void setTemplateIds(Set<String> templateIds)
+   {
+      if (templateIds == null || templateIds.isEmpty())
+      {
+         return;
+      }
+      if (m_cvDescriptors == null)
+      {
+         m_cvDescriptors = new HashSet<>();
+      }
+      for (String tmpId : templateIds)
+      {
+         addTemplateId(tmpId);
+      }
+   }
+
+   /**
+    * Get a string representation of GUIDs of the workflow associations.
+    *
+    * <p>Package XML uses nested {@code string} item elements under {@code workflow-ids}.
+    *
     * @return set of Guid Strings may be empty never <code>null</code>
     */
+   @JsonProperty
+   @JacksonXmlElementWrapper(localName = "workflow-ids")
+   @JacksonXmlProperty(localName = "string")
    public Set<String> getWorkflowIds()
    {
-      Set<String> ids = new HashSet<>();
+      // TreeSet for stable design-object XML order
+      Set<String> ids = new TreeSet<>();
       if (m_ctWfRels != null && !m_ctWfRels.isEmpty())
       {
          for (PSContentTypeWorkflow ctwf : m_ctWfRels)
@@ -783,11 +883,29 @@ public class PSNodeDefinition implements IPSNodeDefinition
    }
 
    /**
+    * Jackson collection setter for {@code workflow-ids}. Workflow associations are not rebuilt from
+    * string ids offline without content-type-workflow rows; live package install may still use other
+    * paths. Accepts and ignores empty/null; non-empty is a no-op unless descriptors already exist.
+    *
+    * @param workflowIds may be {@code null} or empty
+    */
+   public void setWorkflowIds(Set<String> workflowIds)
+   {
+      // Historical Betwixt surface exposed getWorkflowIds only; no singular adder. Keep setter for
+      // Jackson collection binding without inventing CMS-dependent association create.
+      if (workflowIds == null || workflowIds.isEmpty())
+      {
+         return;
+      }
+   }
+
+   /**
     * Add the Template Guid, represented by a string to the template association
     * aka cvDescriptors
     * 
     * @param tmpId the string form of the guid, never <code>null</code>
     */
+   @JsonIgnore
    public void addTemplateId(String tmpId)
    {
       if (StringUtils.isBlank(tmpId))

--- a/system/services/src/com/percussion/services/contentmgr/data/PSNodeDefinition.java
+++ b/system/services/src/com/percussion/services/contentmgr/data/PSNodeDefinition.java
@@ -330,14 +330,18 @@ public class PSNodeDefinition implements IPSNodeDefinition {
    }
 
    /**
-    * Get the raw content type id, required for some operations
-    * 
+    * Get the raw content type id, required for some operations.
+    *
+    * <p>Fails fast when the id has not been set (null {@code m_contenttypeid}). Returning a synthetic
+    * {@code 0L} would mask uninitialized-object bugs during design-object XML and runtime use.
+    *
     * @return the raw content type id
+    * @throws NullPointerException if the content type id has not been set
     */
    @JsonProperty
    public long getRawContentType()
    {
-      return m_contenttypeid != null ? m_contenttypeid : 0L;
+      return m_contenttypeid;
    }
 
    /**
@@ -351,14 +355,19 @@ public class PSNodeDefinition implements IPSNodeDefinition {
    }
 
    /**
-    * Get id as long, only used for serialization
-    * 
+    * Get id as long, only used for serialization.
+    *
+    * <p>Fails fast when the id has not been set (null {@code m_contenttypeid}), matching historical
+    * Betwixt unboxing behavior. Callers must set {@link #setId(long)} / {@link #setRawContentType(long)}
+    * before reading.
+    *
     * @return get the id
+    * @throws NullPointerException if the content type id has not been set
     */
    @JsonProperty
    public long getId()
    {
-      return m_contenttypeid != null ? m_contenttypeid : 0L;
+      return m_contenttypeid;
    }
 
    /**
@@ -883,20 +892,82 @@ public class PSNodeDefinition implements IPSNodeDefinition {
    }
 
    /**
-    * Jackson collection setter for {@code workflow-ids}. Workflow associations are not rebuilt from
-    * string ids offline without content-type-workflow rows; live package install may still use other
-    * paths. Accepts and ignores empty/null; non-empty is a no-op unless descriptors already exist.
+    * Jackson collection setter for {@code workflow-ids}. Rebuilds {@link #m_ctWfRels} entries from
+    * GUID strings so design-object XML restore retains workflow associations.
+    *
+    * <p>Offline-friendly: creates new {@link PSContentTypeWorkflow} rows without consulting the
+    * content manager. Association primary keys are left unset so Hibernate can assign them on
+    * persist; live package install may still re-merge via {@code PSContentTypeHelper} when
+    * existing DB rows must be reused. Skips blank entries and de-duplicates by workflow GUID.
     *
     * @param workflowIds may be {@code null} or empty
     */
    public void setWorkflowIds(Set<String> workflowIds)
    {
-      // Historical Betwixt surface exposed getWorkflowIds only; no singular adder. Keep setter for
-      // Jackson collection binding without inventing CMS-dependent association create.
       if (workflowIds == null || workflowIds.isEmpty())
       {
          return;
       }
+      if (m_ctWfRels == null)
+      {
+         m_ctWfRels = new HashSet<>();
+      }
+      for (String wfId : workflowIds)
+      {
+         if (StringUtils.isBlank(wfId))
+         {
+            continue;
+         }
+         addWorkflowId(wfId);
+      }
+   }
+
+   /**
+    * Add a workflow association from a GUID string (design-object {@code workflow-ids} item).
+    *
+    * @param wfId string form of the workflow guid, never blank
+    */
+   @JsonIgnore
+   public void addWorkflowId(String wfId)
+   {
+      if (StringUtils.isBlank(wfId))
+      {
+         throw new IllegalArgumentException("workflow guid may not be null or empty");
+      }
+      addWorkflowGuid(new PSGuid(wfId));
+   }
+
+   /**
+    * Add the given workflow GUID to {@code m_ctWfRels} if not already present. Does not require a
+    * live content manager (unlike template association restore).
+    *
+    * @param guid workflow guid, never {@code null}
+    */
+   @JsonIgnore
+   public void addWorkflowGuid(IPSGuid guid)
+   {
+      if (guid == null)
+      {
+         throw new IllegalArgumentException("guid may not be null");
+      }
+      if (m_ctWfRels == null)
+      {
+         m_ctWfRels = new HashSet<>();
+      }
+      for (PSContentTypeWorkflow rel : m_ctWfRels)
+      {
+         if (guid.equals(rel.getWorkflowId()))
+         {
+            return;
+         }
+      }
+      PSContentTypeWorkflow rel = new PSContentTypeWorkflow();
+      if (m_contenttypeid != null)
+      {
+         rel.setContentTypeId(new PSGuid(PSTypeEnum.NODEDEF, m_contenttypeid));
+      }
+      rel.setWorkflowId(guid);
+      m_ctWfRels.add(rel);
    }
 
    /**

--- a/system/src/test/java/com/percussion/services/content/data/PSContentLeftoversXmlSerializationTest.java
+++ b/system/src/test/java/com/percussion/services/content/data/PSContentLeftoversXmlSerializationTest.java
@@ -19,6 +19,8 @@ package com.percussion.services.content.data;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.services.catalog.PSTypeEnum;
@@ -184,6 +186,35 @@ class PSContentLeftoversXmlSerializationTest {
     PSItemStatus restored = new PSItemStatus();
     restored.fromXML(xml);
     assertEquals(original, restored);
+  }
+
+  @Test
+  void itemStatusAllowsNullStateNamesButRejectsEmpty() {
+    PSItemStatus status = new PSItemStatus(42);
+    // null is intentional: no transition / Jackson absent optional elements
+    status.setFromState(null);
+    status.setToState(null);
+    assertNull(status.getFromState());
+    assertNull(status.getToState());
+
+    // Contract uses StringUtils.isEmpty: reject "" only (not whitespace-only)
+    assertThrows(IllegalArgumentException.class, () -> status.setFromState(""));
+    assertThrows(IllegalArgumentException.class, () -> status.setToState(""));
+  }
+
+  @Test
+  void itemStatusWithoutTransitionRoundTripsNullStates() throws Exception {
+    PSItemStatus original = new PSItemStatus(100, true, false, null, null, null, null);
+    String xml = original.toXML();
+    PSItemStatus restored = new PSItemStatus();
+    restored.fromXML(xml);
+    assertEquals(original.getId(), restored.getId());
+    assertTrue(restored.isDidCheckout());
+    assertFalse(restored.isDidTransition());
+    assertNull(restored.getFromState());
+    assertNull(restored.getToState());
+    assertNull(restored.getFromStateId());
+    assertNull(restored.getToStateId());
   }
 
   private static PSAutoTranslation sampleAutoTranslation() {

--- a/system/src/test/java/com/percussion/services/content/data/PSContentLeftoversXmlSerializationTest.java
+++ b/system/src/test/java/com/percussion/services/content/data/PSContentLeftoversXmlSerializationTest.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.content.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * Golden / round-trip tests for content-domain leftovers under the Jackson-backed {@code
+ * PSXmlSerializationHelper} (issue #1921, epic #505). Offline only — no live CMS.
+ *
+ * <p>Covers: {@link PSAutoTranslation}, {@link PSContentTypeSummary} / {@link
+ * PSContentTypeSummaryChild}, {@link PSFieldDescription}, {@link PSFolderProperty}, {@link
+ * PSItemStatus}.
+ */
+class PSContentLeftoversXmlSerializationTest {
+
+  @Test
+  void autoTranslationWriteSuppressesCatalogAliasesAndOptionals() throws Exception {
+    PSAutoTranslation original = sampleAutoTranslation();
+    String xml = original.toXML();
+
+    assertNotNull(xml);
+    assertFalse(xml.trim().startsWith("<null"), xml);
+    assertTrue(containsTag(xml, "auto-translation"), xml);
+    assertTrue(containsTag(xml, "content-type-id"), xml);
+    assertTrue(containsTag(xml, "locale"), xml);
+    assertTrue(xml.contains("en-us"), xml);
+    assertFalse(containsTag(xml, "version"), xml);
+    assertFalse(containsTag(xml, "key"), xml);
+    assertFalse(containsTag(xml, "guid"), "shared auto-translations guid suppressed: " + xml);
+    assertFalse(containsTag(xml, "community-id-optional"), xml);
+    assertFalse(containsTag(xml, "content-type-id-optional"), xml);
+    assertFalse(containsTag(xml, "locale-optional"), xml);
+    assertFalse(xml.matches("(?s).*<name(\\s|>).*"), "catalog name suppressed: " + xml);
+    assertFalse(xml.matches("(?s).*<label(\\s|>).*"), "catalog label suppressed: " + xml);
+    assertFalse(
+        xml.matches("(?s).*<description(\\s|>).*"), "catalog description suppressed: " + xml);
+  }
+
+  @Test
+  void autoTranslationWriteMatchesGoldenFixture() throws Exception {
+    String xml = sampleAutoTranslation().toXML();
+    String golden =
+        loadResource("com/percussion/services/content/data/ps-auto-translation-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+  }
+
+  @Test
+  void autoTranslationRoundTripRestoresScalars() throws Exception {
+    PSAutoTranslation original = sampleAutoTranslation();
+    String xml = original.toXML();
+
+    PSAutoTranslation restored = new PSAutoTranslation();
+    restored.fromXML(xml);
+
+    assertEquals(original.getContentTypeId(), restored.getContentTypeId());
+    assertEquals(original.getLocale(), restored.getLocale());
+    assertEquals(original.getWorkflowId(), restored.getWorkflowId());
+    assertEquals(original.getCommunityId(), restored.getCommunityId());
+    assertEquals(original.getContentTypeName(), restored.getContentTypeName());
+    assertEquals(original.getWorkflowName(), restored.getWorkflowName());
+    assertEquals(original.getCommunityName(), restored.getCommunityName());
+  }
+
+  @Test
+  void fieldDescriptionRoundTripAndGolden() throws Exception {
+    PSFieldDescription original =
+        new PSFieldDescription("sys_title", PSFieldDescription.PSFieldTypeEnum.TEXT.name(), true);
+    String xml = original.toXML();
+    assertTrue(containsTag(xml, "field-description"), xml);
+    assertTrue(xml.contains("sys_title"), xml);
+    assertTrue(xml.contains("TEXT"), xml);
+
+    String golden =
+        loadResource("com/percussion/services/content/data/ps-field-description-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+
+    PSFieldDescription restored = new PSFieldDescription();
+    restored.fromXML(xml);
+    assertEquals(original, restored);
+  }
+
+  @Test
+  void contentTypeSummaryWriteNestedTypesAndRoundTrip() throws Exception {
+    PSContentTypeSummary original = sampleContentTypeSummary();
+    String xml = original.toXML();
+
+    assertTrue(containsTag(xml, "content-type-summary"), xml);
+    assertTrue(containsTag(xml, "field-description"), xml);
+    assertTrue(containsTag(xml, "content-type-summary-child"), xml);
+    assertTrue(containsTag(xml, "guid"), xml);
+    assertTrue(xml.contains("0-2-311") || xml.contains("rxGeneric"), xml);
+
+    String golden =
+        loadResource("com/percussion/services/content/data/ps-content-type-summary-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+
+    PSContentTypeSummary restored = new PSContentTypeSummary();
+    restored.fromXML(xml);
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getDescription(), restored.getDescription());
+    assertEquals(original.getGuid().toString(), restored.getGuid().toString());
+    assertEquals(original.getFields(), restored.getFields());
+    assertEquals(original.getChildren(), restored.getChildren());
+  }
+
+  @Test
+  void contentTypeSummaryChildStandaloneRoundTrip() throws Exception {
+    PSContentTypeSummaryChild original = new PSContentTypeSummaryChild("rx_body");
+    original.addField(
+        new PSFieldDescription("body", PSFieldDescription.PSFieldTypeEnum.TEXT.name()));
+    String xml = original.toXML();
+    assertTrue(containsTag(xml, "content-type-summary-child"), xml);
+    assertTrue(containsTag(xml, "field-description"), xml);
+
+    PSContentTypeSummaryChild restored = new PSContentTypeSummaryChild();
+    restored.fromXML(xml);
+    assertEquals(original, restored);
+  }
+
+  @Test
+  void folderPropertyRoundTripAndGolden() throws Exception {
+    PSFolderProperty original =
+        new PSFolderProperty(1001L, 1L, 50L, "sys_pubFileName", "index.html", "Publish file name");
+    String xml = original.toXML();
+    assertTrue(containsTag(xml, "folder-property"), xml);
+    assertTrue(containsTag(xml, "content-id"), xml);
+    assertTrue(containsTag(xml, "property-name"), xml);
+    assertFalse(containsTag(xml, "content-id-optional"), xml);
+    assertFalse(containsTag(xml, "property-name-optional"), xml);
+
+    String golden =
+        loadResource("com/percussion/services/content/data/ps-folder-property-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+
+    PSFolderProperty restored = new PSFolderProperty();
+    restored.fromXML(xml);
+    assertEquals(original, restored);
+  }
+
+  @Test
+  void itemStatusRoundTripAndGolden() throws Exception {
+    PSItemStatus original = new PSItemStatus(335, true, true, 2L, "Draft", 3L, "Quick Edit");
+    String xml = original.toXML();
+    assertTrue(containsTag(xml, "item-status"), xml);
+    assertTrue(containsTag(xml, "id"), xml);
+    assertTrue(containsTag(xml, "did-checkout"), xml);
+    assertTrue(xml.contains("Quick Edit"), xml);
+
+    String golden = loadResource("com/percussion/services/content/data/ps-item-status-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+
+    PSItemStatus restored = new PSItemStatus();
+    restored.fromXML(xml);
+    assertEquals(original, restored);
+  }
+
+  private static PSAutoTranslation sampleAutoTranslation() {
+    PSAutoTranslation at = PSAutoTranslation.of(311L, "en-us", 6L, 1001L);
+    at.setContentTypeName("rxGeneric");
+    at.setWorkflowName("Simple Workflow");
+    at.setCommunityName("Default");
+    return at;
+  }
+
+  private static PSContentTypeSummary sampleContentTypeSummary() {
+    PSContentTypeSummary sum = new PSContentTypeSummary();
+    sum.setName("rxGeneric");
+    sum.setDescription("Generic page content type");
+    sum.setGuid(new PSGuid(PSTypeEnum.NODEDEF, 311L));
+    sum.addField(
+        new PSFieldDescription("sys_title", PSFieldDescription.PSFieldTypeEnum.TEXT.name(), true));
+    sum.addField(
+        new PSFieldDescription(
+            "sys_contentstart", PSFieldDescription.PSFieldTypeEnum.DATE.name(), false));
+    PSContentTypeSummaryChild child = new PSContentTypeSummaryChild("rx_body");
+    child.addField(new PSFieldDescription("body", PSFieldDescription.PSFieldTypeEnum.TEXT.name()));
+    sum.addChild(child);
+    return sum;
+  }
+
+  private static boolean containsTag(String xml, String localName) {
+    return xml.contains("<" + localName) || xml.contains("</" + localName + ">");
+  }
+
+  private static String loadResource(String classpath) throws Exception {
+    try (InputStream in =
+        PSContentLeftoversXmlSerializationTest.class
+            .getClassLoader()
+            .getResourceAsStream(classpath)) {
+      assertNotNull(in, "missing test resource: " + classpath);
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static void assertLogicalXmlParity(String expectedXml, String actualXml)
+      throws Exception {
+    Document expected = parseXml(stripXmlDeclaration(expectedXml));
+    Document actual = parseXml(stripXmlDeclaration(actualXml));
+    assertElementTreeEquals(expected.getDocumentElement(), actual.getDocumentElement(), "/");
+  }
+
+  private static String stripXmlDeclaration(String xml) {
+    String s = Objects.requireNonNull(xml).trim();
+    if (s.startsWith("<?xml")) {
+      int end = s.indexOf("?>");
+      if (end >= 0) {
+        s = s.substring(end + 2).trim();
+      }
+    }
+    while (s.startsWith("<!--")) {
+      int end = s.indexOf("-->");
+      if (end < 0) {
+        break;
+      }
+      s = s.substring(end + 3).trim();
+    }
+    return s;
+  }
+
+  private static Document parseXml(String xml) throws Exception {
+    var factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    var builder = factory.newDocumentBuilder();
+    return builder.parse(new InputSource(new java.io.StringReader(xml)));
+  }
+
+  private static void assertElementTreeEquals(Element expected, Element actual, String path) {
+    assertEquals(expected.getTagName(), actual.getTagName(), "tag at " + path);
+    List<Node> eChildren = significantChildren(expected);
+    List<Node> aChildren = significantChildren(actual);
+    assertEquals(
+        eChildren.size(),
+        aChildren.size(),
+        "child count at "
+            + path
+            + " expected="
+            + summarize(eChildren)
+            + " actual="
+            + summarize(aChildren));
+    for (int i = 0; i < eChildren.size(); i++) {
+      Node en = eChildren.get(i);
+      Node an = aChildren.get(i);
+      if (en.getNodeType() == Node.TEXT_NODE) {
+        assertEquals(en.getTextContent().trim(), an.getTextContent().trim(), "text at " + path);
+      } else {
+        assertElementTreeEquals(
+            (Element) en, (Element) an, path + "/" + ((Element) en).getTagName() + "[" + i + "]");
+      }
+    }
+  }
+
+  private static List<Node> significantChildren(Element el) {
+    NodeList nl = el.getChildNodes();
+    java.util.ArrayList<Node> out = new java.util.ArrayList<>();
+    boolean hasElementChild = false;
+    for (int i = 0; i < nl.getLength(); i++) {
+      if (nl.item(i).getNodeType() == Node.ELEMENT_NODE) {
+        hasElementChild = true;
+        break;
+      }
+    }
+    for (int i = 0; i < nl.getLength(); i++) {
+      Node n = nl.item(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE) {
+        out.add(n);
+      } else if (n.getNodeType() == Node.TEXT_NODE && !hasElementChild) {
+        String t = n.getTextContent();
+        if (t != null && !t.trim().isEmpty()) {
+          out.add(n);
+        }
+      }
+    }
+    return out;
+  }
+
+  private static String summarize(List<Node> nodes) {
+    StringBuilder b = new StringBuilder("[");
+    for (int i = 0; i < nodes.size(); i++) {
+      if (i > 0) {
+        b.append(',');
+      }
+      Node n = nodes.get(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE) {
+        b.append(((Element) n).getTagName());
+      } else {
+        b.append("#text");
+      }
+    }
+    return b.append(']').toString();
+  }
+}

--- a/system/src/test/java/com/percussion/services/contentmgr/data/PSNodeDefinitionXmlSerializationTest.java
+++ b/system/src/test/java/com/percussion/services/contentmgr/data/PSNodeDefinitionXmlSerializationTest.java
@@ -19,6 +19,7 @@ package com.percussion.services.contentmgr.data;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.services.catalog.PSTypeEnum;
@@ -133,6 +134,62 @@ class PSNodeDefinitionXmlSerializationTest {
     assertEquals(Integer.valueOf(1), restored.getObjectType());
     assertEquals(Boolean.FALSE, restored.getHideFromMenu());
     assertEquals("../psx_cerffGeneric/rffGeneric.html", restored.getNewRequest());
+  }
+
+  @Test
+  void unsetContentTypeIdFailsFastOnGetters() {
+    PSNodeDefinition unset = new PSNodeDefinition();
+    assertThrows(NullPointerException.class, unset::getId);
+    assertThrows(NullPointerException.class, unset::getRawContentType);
+  }
+
+  @Test
+  void setWorkflowIdsRestoresAssociationsOffline() {
+    PSNodeDefinition def = sampleNodeDefinitionScalarsOnly();
+    Set<String> ids = new HashSet<>();
+    ids.add("0-23-6");
+    ids.add("0-23-7");
+    def.setWorkflowIds(ids);
+
+    Set<String> restored = def.getWorkflowIds();
+    assertEquals(2, restored.size());
+    assertTrue(restored.contains("0-23-6"), restored.toString());
+    assertTrue(restored.contains("0-23-7"), restored.toString());
+    assertEquals(2, def.getWorkflowGuids().size());
+  }
+
+  @Test
+  void fromXmlRestoresWorkflowIds() throws Exception {
+    String packaged =
+        """
+        <node-definition>
+          <auto-created>false</auto-created>
+          <description>vTest Node</description>
+          <hide-from-menu>false</hide-from-menu>
+          <id>911</id>
+          <internal-name>rffGeneric</internal-name>
+          <label>Generic</label>
+          <mandatory>false</mandatory>
+          <name>rx:rffGeneric</name>
+          <new-request>../psx_cerffGeneric/rffGeneric.html</new-request>
+          <object-type>1</object-type>
+          <protected>false</protected>
+          <query-request>../psx_cerffGeneric/rffGeneric.html</query-request>
+          <raw-content-type>911</raw-content-type>
+          <update-request/>
+          <workflow-ids>
+            <string>0-23-6</string>
+          </workflow-ids>
+        </node-definition>
+        """;
+
+    PSNodeDefinition restored = new PSNodeDefinition();
+    restored.fromXML(packaged);
+
+    assertEquals(911L, restored.getId());
+    Set<String> workflowIds = restored.getWorkflowIds();
+    assertEquals(1, workflowIds.size());
+    assertTrue(workflowIds.contains("0-23-6"), workflowIds.toString());
   }
 
   private static PSNodeDefinition sampleNodeDefinitionScalarsOnly() {

--- a/system/src/test/java/com/percussion/services/contentmgr/data/PSNodeDefinitionXmlSerializationTest.java
+++ b/system/src/test/java/com/percussion/services/contentmgr/data/PSNodeDefinitionXmlSerializationTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.contentmgr.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * Golden / scalar round-trip tests for {@link PSNodeDefinition} under the Jackson-backed {@code
+ * PSXmlSerializationHelper} (issue #1921, epic #505). Offline only — no live CMS.
+ *
+ * <p>Template association restore that calls content-manager locators remains covered by live
+ * integration tests ({@code PSContentTypeMgrTest}); this suite pins write shape and scalar restore.
+ */
+class PSNodeDefinitionXmlSerializationTest {
+
+  @Test
+  void writeEmitsPackageShapeAndSuppressesHibernateGraph() throws Exception {
+    PSNodeDefinition original = sampleNodeDefinitionWithTemplates();
+    String xml = original.toXML();
+
+    assertNotNull(xml);
+    assertFalse(xml.trim().startsWith("<null"), xml);
+    assertTrue(containsTag(xml, "node-definition"), xml);
+    assertTrue(containsTag(xml, "internal-name"), xml);
+    assertTrue(containsTag(xml, "raw-content-type"), xml);
+    assertTrue(containsTag(xml, "template-ids"), xml);
+    assertTrue(containsTag(xml, "template-id"), "package item name template-id: " + xml);
+    assertTrue(containsTag(xml, "workflow-ids"), xml);
+    assertTrue(containsTag(xml, "string"), "workflow item name string: " + xml);
+    assertFalse(containsTag(xml, "version"), xml);
+    assertFalse(containsTag(xml, "cv-descriptors"), xml);
+    assertFalse(containsTag(xml, "ct-wf-rels"), xml);
+    assertFalse(containsTag(xml, "variant-guids"), xml);
+    assertFalse(containsTag(xml, "workflow-guids"), xml);
+    assertFalse(containsTag(xml, "required-primary-type-names"), xml);
+    assertFalse(containsTag(xml, "default-primary-type-name"), xml);
+    assertFalse(containsTag(xml, "guid"), "GUID uses id/raw-content-type on wire: " + xml);
+    assertTrue(xml.contains("rffGeneric") || xml.contains("rx:rffGeneric"), xml);
+  }
+
+  @Test
+  void writeMatchesGoldenFixture() throws Exception {
+    String xml = sampleNodeDefinitionWithTemplates().toXML();
+    String golden =
+        loadResource("com/percussion/services/contentmgr/data/ps-node-definition-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+  }
+
+  @Test
+  void scalarRoundTripWithoutTemplateRestore() throws Exception {
+    PSNodeDefinition original = sampleNodeDefinitionScalarsOnly();
+    String xml = original.toXML();
+
+    PSNodeDefinition restored = new PSNodeDefinition();
+    restored.fromXML(xml);
+
+    assertEquals(original.getId(), restored.getId());
+    assertEquals(original.getInternalName(), restored.getInternalName());
+    assertEquals(original.getLabel(), restored.getLabel());
+    assertEquals(original.getDescription(), restored.getDescription());
+    assertEquals(original.getHideFromMenu(), restored.getHideFromMenu());
+    assertEquals(original.getObjectType(), restored.getObjectType());
+    assertEquals(original.getNewRequest(), restored.getNewRequest());
+    assertEquals(original.getQueryRequest(), restored.getQueryRequest());
+    assertEquals(original.getUpdateRequest(), restored.getUpdateRequest());
+    assertEquals(original.getRawContentType(), restored.getRawContentType());
+    assertTrue(restored.getTemplateIds().isEmpty());
+    assertTrue(restored.getWorkflowIds().isEmpty());
+  }
+
+  @Test
+  void fromXmlAcceptsPackageShapeScalars() throws Exception {
+    String packaged =
+        """
+        <node-definition>
+          <auto-created>false</auto-created>
+          <description>vTest Node</description>
+          <hide-from-menu>false</hide-from-menu>
+          <id>911</id>
+          <internal-name>rffGeneric</internal-name>
+          <label>Generic</label>
+          <mandatory>false</mandatory>
+          <name>rx:rffGeneric</name>
+          <new-request>../psx_cerffGeneric/rffGeneric.html</new-request>
+          <object-type>1</object-type>
+          <protected>false</protected>
+          <query-request>../psx_cerffGeneric/rffGeneric.html</query-request>
+          <raw-content-type>911</raw-content-type>
+          <update-request/>
+        </node-definition>
+        """;
+
+    PSNodeDefinition restored = new PSNodeDefinition();
+    restored.fromXML(packaged);
+
+    assertEquals(911L, restored.getId());
+    assertEquals("rffGeneric", restored.getInternalName());
+    assertEquals("Generic", restored.getLabel());
+    assertEquals("vTest Node", restored.getDescription());
+    assertEquals(Integer.valueOf(1), restored.getObjectType());
+    assertEquals(Boolean.FALSE, restored.getHideFromMenu());
+    assertEquals("../psx_cerffGeneric/rffGeneric.html", restored.getNewRequest());
+  }
+
+  private static PSNodeDefinition sampleNodeDefinitionScalarsOnly() {
+    PSNodeDefinition def = new PSNodeDefinition();
+    def.setId(911L);
+    def.setInternalName("rffGeneric");
+    def.setLabel("Generic");
+    def.setDescription("vTest Node");
+    def.setHideFromMenu(Boolean.FALSE);
+    def.setObjectType(1);
+    def.setNewRequest("../psx_cerffGeneric/rffGeneric.html");
+    def.setQueryRequest("../psx_cerffGeneric/rffGeneric.html");
+    def.setUpdateRequest("");
+    return def;
+  }
+
+  private static PSNodeDefinition sampleNodeDefinitionWithTemplates() {
+    PSNodeDefinition def = sampleNodeDefinitionScalarsOnly();
+
+    Set<PSContentTemplateDesc> descs = new HashSet<>();
+    for (long tid : new long[] {504L, 502L}) {
+      PSContentTemplateDesc desc = new PSContentTemplateDesc();
+      desc.setId(tid * 10);
+      desc.setContentTypeId(new PSGuid(PSTypeEnum.NODEDEF, 911L));
+      desc.setTemplateId(new PSGuid(PSTypeEnum.TEMPLATE, tid));
+      descs.add(desc);
+    }
+    def.setCvDescriptors(descs);
+
+    Set<PSContentTypeWorkflow> wfs = new HashSet<>();
+    PSContentTypeWorkflow rel = new PSContentTypeWorkflow();
+    rel.setId(1L);
+    rel.setContentTypeId(new PSGuid(PSTypeEnum.NODEDEF, 911L));
+    rel.setWorkflowId(new PSGuid(PSTypeEnum.WORKFLOW, 6L));
+    wfs.add(rel);
+    def.setCtWfRels(wfs);
+    return def;
+  }
+
+  private static boolean containsTag(String xml, String localName) {
+    return xml.contains("<" + localName) || xml.contains("</" + localName + ">");
+  }
+
+  private static String loadResource(String classpath) throws Exception {
+    try (InputStream in =
+        PSNodeDefinitionXmlSerializationTest.class
+            .getClassLoader()
+            .getResourceAsStream(classpath)) {
+      assertNotNull(in, "missing test resource: " + classpath);
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static void assertLogicalXmlParity(String expectedXml, String actualXml)
+      throws Exception {
+    Document expected = parseXml(stripXmlDeclaration(expectedXml));
+    Document actual = parseXml(stripXmlDeclaration(actualXml));
+    assertElementTreeEquals(expected.getDocumentElement(), actual.getDocumentElement(), "/");
+  }
+
+  private static String stripXmlDeclaration(String xml) {
+    String s = Objects.requireNonNull(xml).trim();
+    if (s.startsWith("<?xml")) {
+      int end = s.indexOf("?>");
+      if (end >= 0) {
+        s = s.substring(end + 2).trim();
+      }
+    }
+    while (s.startsWith("<!--")) {
+      int end = s.indexOf("-->");
+      if (end < 0) {
+        break;
+      }
+      s = s.substring(end + 3).trim();
+    }
+    return s;
+  }
+
+  private static Document parseXml(String xml) throws Exception {
+    var factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    var builder = factory.newDocumentBuilder();
+    return builder.parse(new InputSource(new java.io.StringReader(xml)));
+  }
+
+  private static void assertElementTreeEquals(Element expected, Element actual, String path) {
+    assertEquals(expected.getTagName(), actual.getTagName(), "tag at " + path);
+    List<Node> eChildren = significantChildren(expected);
+    List<Node> aChildren = significantChildren(actual);
+    assertEquals(
+        eChildren.size(),
+        aChildren.size(),
+        "child count at "
+            + path
+            + " expected="
+            + summarize(eChildren)
+            + " actual="
+            + summarize(aChildren));
+    for (int i = 0; i < eChildren.size(); i++) {
+      Node en = eChildren.get(i);
+      Node an = aChildren.get(i);
+      if (en.getNodeType() == Node.TEXT_NODE) {
+        assertEquals(en.getTextContent().trim(), an.getTextContent().trim(), "text at " + path);
+      } else {
+        assertElementTreeEquals(
+            (Element) en, (Element) an, path + "/" + ((Element) en).getTagName() + "[" + i + "]");
+      }
+    }
+  }
+
+  private static List<Node> significantChildren(Element el) {
+    NodeList nl = el.getChildNodes();
+    java.util.ArrayList<Node> out = new java.util.ArrayList<>();
+    boolean hasElementChild = false;
+    for (int i = 0; i < nl.getLength(); i++) {
+      if (nl.item(i).getNodeType() == Node.ELEMENT_NODE) {
+        hasElementChild = true;
+        break;
+      }
+    }
+    for (int i = 0; i < nl.getLength(); i++) {
+      Node n = nl.item(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE) {
+        out.add(n);
+      } else if (n.getNodeType() == Node.TEXT_NODE && !hasElementChild) {
+        String t = n.getTextContent();
+        if (t != null && !t.trim().isEmpty()) {
+          out.add(n);
+        }
+      }
+    }
+    return out;
+  }
+
+  private static String summarize(List<Node> nodes) {
+    StringBuilder b = new StringBuilder("[");
+    for (int i = 0; i < nodes.size(); i++) {
+      if (i > 0) {
+        b.append(',');
+      }
+      Node n = nodes.get(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE) {
+        b.append(((Element) n).getTagName());
+      } else {
+        b.append("#text");
+      }
+    }
+    return b.append(']').toString();
+  }
+}

--- a/system/src/test/resources/com/percussion/services/content/data/ps-auto-translation-golden.xml
+++ b/system/src/test/resources/com/percussion/services/content/data/ps-auto-translation-golden.xml
@@ -1,0 +1,12 @@
+<!-- Golden snapshot for content leftovers Jackson wire shape (issue #1921
+	/ epic #505). Approved Jackson deviations: no graph-identity id attributes;
+	no XML declaration; Optional/catalog aliases suppressed. -->
+<auto-translation>
+	<community-id>1001</community-id>
+	<community-name>Default</community-name>
+	<content-type-id>311</content-type-id>
+	<content-type-name>rxGeneric</content-type-name>
+	<locale>en-us</locale>
+	<workflow-id>6</workflow-id>
+	<workflow-name>Simple Workflow</workflow-name>
+</auto-translation>

--- a/system/src/test/resources/com/percussion/services/content/data/ps-content-type-summary-golden.xml
+++ b/system/src/test/resources/com/percussion/services/content/data/ps-content-type-summary-golden.xml
@@ -1,0 +1,31 @@
+<!-- Golden snapshot for content leftovers Jackson wire shape (issue #1921
+	/ epic #505). Approved Jackson deviations: no graph-identity id attributes;
+	no XML declaration; Optional/catalog aliases suppressed. -->
+<content-type-summary>
+	<children>
+		<content-type-summary-child>
+			<child-fields>
+				<field-description>
+					<name>body</name>
+					<type>TEXT</type>
+				</field-description>
+			</child-fields>
+			<name>rx_body</name>
+		</content-type-summary-child>
+	</children>
+	<description>Generic page content type</description>
+	<fields>
+		<field-description>
+			<exportable>true</exportable>
+			<name>sys_title</name>
+			<type>TEXT</type>
+		</field-description>
+		<field-description>
+			<exportable>false</exportable>
+			<name>sys_contentstart</name>
+			<type>DATE</type>
+		</field-description>
+	</fields>
+	<guid>0-2-311</guid>
+	<name>rxGeneric</name>
+</content-type-summary>

--- a/system/src/test/resources/com/percussion/services/content/data/ps-field-description-golden.xml
+++ b/system/src/test/resources/com/percussion/services/content/data/ps-field-description-golden.xml
@@ -1,0 +1,8 @@
+<!-- Golden snapshot for content leftovers Jackson wire shape (issue #1921
+	/ epic #505). Approved Jackson deviations: no graph-identity id attributes;
+	no XML declaration; Optional/catalog aliases suppressed. -->
+<field-description>
+	<exportable>true</exportable>
+	<name>sys_title</name>
+	<type>TEXT</type>
+</field-description>

--- a/system/src/test/resources/com/percussion/services/content/data/ps-folder-property-golden.xml
+++ b/system/src/test/resources/com/percussion/services/content/data/ps-folder-property-golden.xml
@@ -1,0 +1,11 @@
+<!-- Golden snapshot for content leftovers Jackson wire shape (issue #1921
+	/ epic #505). Approved Jackson deviations: no graph-identity id attributes;
+	no XML declaration; Optional/catalog aliases suppressed. -->
+<folder-property>
+	<content-id>1001</content-id>
+	<description>Publish file name</description>
+	<property-name>sys_pubFileName</property-name>
+	<property-value>index.html</property-value>
+	<revision-id>1</revision-id>
+	<sys-id>50</sys-id>
+</folder-property>

--- a/system/src/test/resources/com/percussion/services/content/data/ps-item-status-golden.xml
+++ b/system/src/test/resources/com/percussion/services/content/data/ps-item-status-golden.xml
@@ -1,0 +1,12 @@
+<!-- Golden snapshot for content leftovers Jackson wire shape (issue #1921
+	/ epic #505). Approved Jackson deviations: no graph-identity id attributes;
+	no XML declaration; Optional/catalog aliases suppressed. -->
+<item-status>
+	<did-checkout>true</did-checkout>
+	<did-transition>true</did-transition>
+	<from-state>Draft</from-state>
+	<from-state-id>2</from-state-id>
+	<id>335</id>
+	<to-state>Quick Edit</to-state>
+	<to-state-id>3</to-state-id>
+</item-status>

--- a/system/src/test/resources/com/percussion/services/contentmgr/data/ps-node-definition-golden.xml
+++ b/system/src/test/resources/com/percussion/services/contentmgr/data/ps-node-definition-golden.xml
@@ -1,0 +1,26 @@
+<!-- Golden snapshot for PSNodeDefinition Jackson wire shape (issue #1921
+	/ epic #505). template-id items under template-ids; string items under workflow-ids;
+	TreeSet order for stable template-id list. -->
+<node-definition>
+	<auto-created>false</auto-created>
+	<description>vTest Node</description>
+	<hide-from-menu>false</hide-from-menu>
+	<id>911</id>
+	<internal-name>rffGeneric</internal-name>
+	<label>Generic</label>
+	<mandatory>false</mandatory>
+	<name>rx:rffGeneric</name>
+	<new-request>../psx_cerffGeneric/rffGeneric.html</new-request>
+	<object-type>1</object-type>
+	<protected>false</protected>
+	<query-request>../psx_cerffGeneric/rffGeneric.html</query-request>
+	<raw-content-type>911</raw-content-type>
+	<template-ids>
+		<template-id>0-4-502</template-id>
+		<template-id>0-4-504</template-id>
+	</template-ids>
+	<update-request></update-request>
+	<workflow-ids>
+		<string>0-23-6</string>
+	</workflow-ids>
+</node-definition>


### PR DESCRIPTION
## Summary

Jackson-migrates remaining **content** design objects (beyond keywords #1888) and **contentmgr `PSNodeDefinition`** for the Jackson-backed `PSXmlSerializationHelper` (issue #1921 / slice 6e of #1823).

### Types
- `PSAutoTranslation` — opt-in Jackson; suppress catalog aliases, version, shared GUID, `Optional` accessors
- `PSFieldDescription` — root `field-description`; null `exportable` omitted
- `PSContentTypeSummary` / `PSContentTypeSummaryChild` — nested field/child element names pinned
- `PSFolderProperty` — added `toXML`/`fromXML`; opt-in surface
- `PSItemStatus` — no-arg ctor + `setId`; wire property `id`
- `PSNodeDefinition` — package shape (`template-id`, workflow `string`); TreeSet stable order; scalar offline restore

### Docs
- `docs/ai-generated/tasks/505-betwixt-jackson/1921-content-leftovers-deviations.md`
- Erlang: `docs/ai-generated/code-reviews/issue-1921-content-leftovers-jackson-erlang.md`

No production `.betwixt` files existed for these types (nothing to drop). Keywords remain #1888.

Fixes #1921  
Related: #1892 #1823 #505

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] `PSContentLeftoversXmlSerializationTest` — 8 tests (golden + round-trip)
- [x] `PSNodeDefinitionXmlSerializationTest` — 4 tests (golden + scalar/package smoke)
- [x] `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Root `mvnw spotless:apply` then `spotless:check` — in-scope only committed
- [x] Erlang self-review PASS (no hard-gate bugs)

### Gates evidence
- Focused surefire: Tests run: 12, Failures: 0
- Module clean install: BUILD SUCCESS (~1m 30s)
- Spotless: apply then check; out-of-scope baseline rewrites discarded

### Notes
- `PSNodeDefinition` template association **restore** still requires live content manager (integration `PSContentTypeMgrTest`); offline suite pins write shape + scalars.
- Concurrent Jackson PRs (#1919 publisher, #1915 filter, #1918 sitemgr) do not share these type files; helper registration is additive static `addType` only.