### PR TITLE
fix(988): systemd unit contract docs + dry-run parity (CMS/DTS) (#1977)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/README.md
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/README.md
@@ -124,29 +124,13 @@ when available:
 | `DTSStagingService.sh`    | `PercussionStagingDTS`    |
 
 Shared unit template: `dts-tomcat.service.in` (`Type=forking`, `TimeoutStartSec=1800`, journal).  
-Ops notes: `README-systemd.md`. Flags: `--systemd`, `--initd`. Windows `.bat` unchanged.
+Ops notes: `README-systemd.md` (dry-run / non-root limitations, migration uninstall→install,
+init.d retained as start helper + fallback). Flags: `--systemd`, `--initd`. Install requires
+root (no product `--dry-run`). Windows `.bat` unchanged.
 
 ```bash
 sudo ./DTSProductionService.sh install
-sudo systemctl start PercussionProductionDTS
-journalctl -u PercussionProductionDTS -n 50 --no-pager
-```
-
-## Linux services (systemd) — GH-962
-
-Production and Staging installers under `src/main/rootFiles/` prefer **native systemd**
-when available:
-
-|          Script           |       Default unit        |
-|---------------------------|---------------------------|
-| `DTSProductionService.sh` | `PercussionProductionDTS` |
-| `DTSStagingService.sh`    | `PercussionStagingDTS`    |
-
-Shared unit template: `dts-tomcat.service.in` (`Type=forking`, `TimeoutStartSec=1800`, journal).  
-Ops notes: `README-systemd.md`. Flags: `--systemd`, `--initd`. Windows `.bat` unchanged.
-
-```bash
-sudo ./DTSProductionService.sh install
+# flags: --systemd (require) | --initd (force SysV)
 sudo systemctl start PercussionProductionDTS
 journalctl -u PercussionProductionDTS -n 50 --no-pager
 ```

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/README-systemd.md
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/README-systemd.md
@@ -1,16 +1,40 @@
 # Percussion DTS Linux services (systemd)
 
 Production and Staging DTS installers prefer a **native systemd unit** when
-systemd is available (same approach as CMS Jetty / GH-962).
+systemd is available (same approach as CMS Jetty / GH-962; docs parity for slice
+[#1977](https://github.com/intersoftdatalabs-in/percussioncms/issues/1977)).
 
 |         Installer         |   Default service name    |
 |---------------------------|---------------------------|
 | `DTSProductionService.sh` | `PercussionProductionDTS` |
 | `DTSStagingService.sh`    | `PercussionStagingDTS`    |
 
+Shared unit template: `dts-tomcat.service.in` (next to these scripts after install).
+
+SysV/init.d remains available as:
+
+1. **Start helper** — `ExecStart` / `ExecStop` invoke `/etc/init.d/<ServiceName>`
+   even when a native unit is registered (no dual chkconfig / update-rc.d on the
+   systemd path).
+2. **Fallback** — when systemd is absent, or when forced with `--initd`.
+
+**init.d is not removed** by this feature. Do not delete SysV scripts or the
+`--initd` path when operating dual-ship hosts. Windows `.bat` installers are
+unchanged (Tomcat Windows service).
+
+## Install flags
+
+|    Flag     |                                       Behavior                                       |
+|-------------|--------------------------------------------------------------------------------------|
+| (default)   | Prefer native systemd when `/run/systemd/system` exists and `systemctl` is available |
+| `--systemd` | **Require** systemd; fail install if not available                                   |
+| `--initd`   | Force classic SysV/init.d registration only; **no** native unit file                 |
+| both flags  | Rejected (`Cannot combine --systemd and --initd`)                                    |
+
 ## Install
 
 ```bash
+# Must run as root (or via sudo). There is no --dry-run flag.
 # From the DTS install root (directory containing this script and bin/catalina.sh)
 sudo ./DTSProductionService.sh [ServiceName] install
 sudo ./DTSStagingService.sh [ServiceName] install
@@ -20,7 +44,15 @@ sudo ./DTSStagingService.sh [ServiceName] install
 #   --initd     force classic SysV/init.d registration only
 ```
 
-On systemd hosts:
+On systemd hosts the installer writes:
+
+|   Artifact   |                                              Path                                               |
+|--------------|-------------------------------------------------------------------------------------------------|
+| Environment  | `/etc/default/<ServiceName>`                                                                    |
+| Start helper | `/etc/init.d/<ServiceName>` (used by ExecStart; **not** enabled via chkconfig on systemd hosts) |
+| Unit         | `/etc/systemd/system/<ServiceName>.service`                                                     |
+
+Then:
 
 ```bash
 sudo systemctl start PercussionProductionDTS
@@ -32,6 +64,53 @@ journalctl -u PercussionProductionDTS -n 100 --no-pager
 
 Application logs: `$CATALINA_BASE/logs/` (and Log4j2 configs under `conf/perc/`).
 
+### Privilege model
+
+- The **unit does not set `User=`**; systemd starts the unit as root.
+- Install scripts chown the Tomcat deployment tree to the install-directory owner
+  and install the catalina-based init helper used by `ExecStart` (same as the
+  historic init.d-only path).
+- See comments in `dts-tomcat.service.in` (contract: `User=` present or documented).
+
+## Root requirement and non-root / dry-run limitations
+
+`DTSProductionService.sh` and `DTSStagingService.sh` **require root** (`id -u` must
+be `0`). They write under `/etc/systemd/system`, `/etc/init.d`, `/etc/default`, and
+run directories, then run `systemctl daemon-reload` / `enable`.
+
+|               What you need               |                                  Non-root / dry-run                                  |
+|-------------------------------------------|--------------------------------------------------------------------------------------|
+| Live install, enable, start, uninstall    | **Not supported** without root                                                       |
+| Inspect unit template keys before install | **Yes** — read `dts-tomcat.service.in` next to this README                           |
+| Verify flags and selection logic          | **Yes** — read `DTSProductionService.sh` / `DTSStagingService.sh` (no host writes)   |
+| Structural contract tests (CI / dev)      | **Yes** — Maven tests; no root, no live systemd                                      |
+| Preview generated unit without installing | **Manual** — copy template, substitute placeholders offline (no product `--dry-run`) |
+
+There is **no** `--dry-run` installer flag. Offline review of the template + scripts is
+the supported dry-run path (see checklist below).
+
+## Dry-run install checklist (no live root)
+
+1. **Confirm artifacts ship** at the DTS product surface / `Deployment/Server/` layout
+   after packaging: `dts-tomcat.service.in`, `DTSProductionService.sh`,
+   `DTSStagingService.sh`, this `README-systemd.md`.
+2. **Contract keys** in `dts-tomcat.service.in` (same table as CMS; see
+   `specs/988-linux-systemd-services/contracts/systemd-unit-contract.md`):
+   - `Type=forking`, `PIDFile=`, `EnvironmentFile=`, `ExecStart`/`ExecStop`
+   - `TimeoutStartSec` ≥ 900 (default **1800**), journal stdout/stderr
+   - `WantedBy=multi-user.target`, `After=network.target`
+   - Privilege model documented
+3. **Flags**: both installers document `--systemd` and `--initd`; both together fail.
+4. **Init.d retained**: systemd path keeps the init.d helper for ExecStart and skips
+   SysV boot registration; `--initd` still registers classic boot.
+5. **Run structural tests** (no root):
+
+   ```bash
+   cd deliverytiersuite/delivery-tier-suite/delivery-tier-distribution
+   ../../../mvnw test -Dtest=DtsSystemdUnitTemplateTest,DtsServiceInstallScriptTest
+   ```
+6. **Migration rehearsal (document only)**: uninstall → install order below.
+
 ## Uninstall
 
 ```bash
@@ -39,11 +118,31 @@ sudo ./DTSProductionService.sh [ServiceName] uninstall
 sudo ./DTSStagingService.sh [ServiceName] uninstall
 ```
 
+Disables and removes the systemd unit (when present), removes init.d/default files,
+and clears the run directory for that service name.
+
 ## Migration from init.d-only
 
-1. Uninstall the old service
-2. Re-run install (picks systemd when available)
-3. `systemctl start <ServiceName>`
+Always **uninstall then install** (do not layer a second registration on the same name):
+
+1. `sudo ./DTSProductionService.sh PercussionProductionDTS uninstall`
+2. `sudo ./DTSProductionService.sh PercussionProductionDTS install` (picks systemd when available)
+3. `sudo systemctl start PercussionProductionDTS`
+4. `sudo systemctl status PercussionProductionDTS` and
+   `journalctl -u PercussionProductionDTS -n 50 --no-pager`
+
+Same pattern for Staging (`DTSStagingService.sh` / `PercussionStagingDTS`).
+
+## Force init.d (no systemd unit)
+
+```bash
+sudo ./DTSProductionService.sh PercussionProductionDTS install --initd
+sudo ./DTSStagingService.sh PercussionStagingDTS install --initd
+```
+
+Use when the host has no systemd, or when operators intentionally keep SysV-only
+boot registration. The init.d script remains the start helper on the systemd path
+as well — forcing `--initd` only changes **boot registration**.
 
 ## Windows
 

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/dts-tomcat.service.in
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/dts-tomcat.service.in
@@ -3,10 +3,18 @@
 #   @SERVICE_NAME@  @DESCRIPTION@  @PID_FILE@  @ENV_FILE@  @INIT_SCRIPT@
 #
 # Type=forking: catalina.sh start backgrounds Tomcat and writes CATALINA_PID.
-# Do not change Type without verifying fork+PIDFile behavior.
+# If start ever ran in the foreground without writing PIDFile, systemd would hang
+# until TimeoutStartSec. Do not change Type without verifying fork+PIDFile behavior.
+#
 # TimeoutStartSec=1800 allows slow starts without false systemd timeout.
-# Journal captures stdout/stderr; app logs remain under CATALINA_BASE/logs.
+# Stdout/stderr go to the journal; detailed app logs remain under CATALINA_BASE/logs.
 # No ExecReload: Tomcat init helper uses start/stop (full restart is systemctl restart).
+#
+# User=/privilege model: no User= in this unit. The unit runs as root so the init.d
+# start helper (ExecStart) can manage pid dirs and drop/set ownership consistently
+# with the historic SysV path. Install scripts chown the Tomcat tree to the install
+# directory owner; process identity follows the helper (same as init.d-only installs).
+# See README-systemd.md next to this template after packaging.
 
 [Unit]
 Description=@DESCRIPTION@
@@ -22,6 +30,7 @@ TimeoutStartSec=1800
 TimeoutStopSec=120
 StandardOutput=journal
 StandardError=journal
+# No User= here — privilege model is documented above (contract: present or documented).
 KillMode=control-group
 Restart=on-failure
 RestartSec=10

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsServiceInstallScriptTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsServiceInstallScriptTest.java
@@ -71,6 +71,19 @@ class DtsServiceInstallScriptTest {
   }
 
   @Test
+  void bothScripts_requireRoot_noDryRunFlag() {
+    // GH-1977: install is root-only; no product --dry-run (docs cover offline review)
+    for (String script : List.of(production, staging)) {
+      assertTrue(script.contains("id -u"), "root check via id -u");
+      assertTrue(
+          script.contains("must be run with sudo or as root")
+              || script.contains("must be run as root"),
+          "root error message");
+      assertFalse(script.contains("--dry-run"), "no --dry-run installer flag");
+    }
+  }
+
+  @Test
   void bothScripts_defaultsFile_isEnvironmentFileSafe() {
     // Must not embed mkdir/chown into /etc/default (breaks EnvironmentFile)
     for (String script : List.of(production, staging)) {

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsSystemdUnitTemplateTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsSystemdUnitTemplateTest.java
@@ -25,30 +25,48 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-/** GH-962: DTS Tomcat systemd unit template contract (Production + Staging share one template). */
+/**
+ * GH-962 / GH-1977: DTS Tomcat systemd unit template contract (Production + Staging share one
+ * template). Aligns with {@code
+ * specs/988-linux-systemd-services/contracts/systemd-unit-contract.md} and CMS {@code
+ * SystemdUnitTemplateTest} parity.
+ */
 class DtsSystemdUnitTemplateTest {
 
   private static final Path UNIT_TEMPLATE =
       Path.of("src", "main", "rootFiles", "dts-tomcat.service.in");
 
+  private static final Path README = Path.of("src", "main", "rootFiles", "README-systemd.md");
+
   private static String unitText;
+  private static String readmeText;
 
   @BeforeAll
   static void load() throws Exception {
     assertTrue(
         Files.isRegularFile(UNIT_TEMPLATE), () -> "missing " + UNIT_TEMPLATE.toAbsolutePath());
+    assertTrue(Files.isRegularFile(README), () -> "missing " + README.toAbsolutePath());
     unitText = Files.readString(UNIT_TEMPLATE, StandardCharsets.UTF_8);
+    readmeText = Files.readString(README, StandardCharsets.UTF_8);
   }
 
   @Test
   void unit_isTypeForking_withPidEnvAndExec() {
     assertTrue(unitText.contains("Type=forking"));
+    assertTrue(
+        unitText.contains("fork+PID")
+            || unitText.contains("CATALINA_PID")
+            || unitText.contains("fork"),
+        "documents forking / PID behavior");
     assertTrue(unitText.contains("PIDFile=@PID_FILE@"));
     assertTrue(
         unitText.contains("EnvironmentFile=-@ENV_FILE@")
             || unitText.contains("EnvironmentFile=@ENV_FILE@"));
     assertTrue(unitText.contains("ExecStart=@INIT_SCRIPT@ start"));
     assertTrue(unitText.contains("ExecStop=@INIT_SCRIPT@ stop"));
+    assertTrue(
+        !unitText.contains("ExecReload="),
+        "no ExecReload (restart is systemctl restart, not reload)");
   }
 
   @Test
@@ -65,5 +83,46 @@ class DtsSystemdUnitTemplateTest {
     assertTrue(unitText.contains("StandardOutput=journal"));
     assertTrue(unitText.contains("StandardError=journal"));
     assertTrue(unitText.contains("WantedBy=multi-user.target"));
+    assertTrue(unitText.contains("After=network.target"), "After=network");
+  }
+
+  @Test
+  void unit_hasDescriptionAndPrivilegeModelDocumented() {
+    assertTrue(unitText.contains("Description=@DESCRIPTION@"), "Description placeholder");
+    boolean hasUserDirective = unitText.lines().anyMatch(l -> l.trim().startsWith("User="));
+    boolean documentsPrivilege =
+        unitText.contains("User=")
+            || unitText.toLowerCase().contains("privilege")
+            || unitText.contains("init.d");
+    assertTrue(
+        hasUserDirective || documentsPrivilege,
+        "User= key or privilege model documentation required by contract");
+  }
+
+  @Test
+  void readme_documentsFlagsDryRunAndMigration() {
+    assertTrue(readmeText.contains("--systemd"), "documents --systemd");
+    assertTrue(readmeText.contains("--initd"), "documents --initd");
+    assertTrue(
+        readmeText.toLowerCase().contains("dry-run") || readmeText.contains("non-root"),
+        "documents dry-run / non-root limitations");
+    assertTrue(
+        readmeText.contains("must be run")
+            || readmeText.toLowerCase().contains("requires root")
+            || readmeText.toLowerCase().contains("require root"),
+        "documents root requirement");
+    assertTrue(readmeText.contains("uninstall"), "documents uninstall");
+    assertTrue(
+        readmeText.toLowerCase().contains("migration")
+            || readmeText.contains("uninstall then install"),
+        "documents migration uninstall→install");
+    assertTrue(
+        readmeText.contains("init.d") || readmeText.contains("SysV"),
+        "documents init.d helper/fallback retained");
+    assertTrue(
+        readmeText.contains("not removed")
+            || readmeText.contains("Start helper")
+            || readmeText.contains("start helper"),
+        "documents init.d remains start helper + fallback");
   }
 }

--- a/docs/ai-generated/code-reviews/issue-1977-systemd-unit-templates-docs-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-1977-systemd-unit-templates-docs-erlang.md
@@ -1,0 +1,59 @@
+# Erlang review: issue #1977 systemd unit templates + dry-run docs
+
+**Branch**: `fix/issue-1977-systemd-unit-templates-docs`  
+**Date**: 2026-08-05  
+**Reviewer**: Erlang (pre-commit, implementer session)  
+**Recommendation**: **approve**  
+**May commit/push**: **yes**  
+**Gate**: clean
+
+## Summary
+
+Slice 2 residual for GH-962 / #1977: contract alignment of CMS + DTS systemd unit
+templates (privilege-model documentation), operator dry-run / non-root docs parity
+in both `README-systemd.md` files, quickstart dry-run checklist, extended structural
+tests for contract keys and README flags. **init.d path retained** (helper +
+fallback). No live root install; no SysV removal.
+
+## Scope
+
+- `modules/perc-jetty` unit template, README-systemd, module README, tests
+- `delivery-tier-distribution` unit template, README-systemd, module README, tests
+- `specs/988-linux-systemd-services/quickstart.md`
+
+## Change class
+
+Operator packaging / docs + structural tests for shipped unit templates (not a new
+REST surface or WebUI screen). Companions: dual CMS/DTS docs + dual template tests
++ install-script root/flag assertions.
+
+## Cross-platform path checklist
+
+- [x] Tests use `Path.of(...)` for template/README paths
+- [x] No new filesystem path concatenation with hardcoded separators in product code
+- [x] Operator docs intentionally document Linux systemd/init.d bash paths
+- [x] No Unix-only absolute path assertions in unit tests
+
+## Issues
+
+None (bugs / missing behavioral tests / non-portable I/O).
+
+## Nits (non-blocking)
+
+- DTS unit still omits `Documentation=` (CMS has it); would need a new
+  `@CATALINA_HOME@` (or similar) placeholder in both DTS install scripts — deferred
+  as optional polish; privilege docs close the User= contract item.
+
+## Verification
+
+- `cd modules/perc-jetty && ../../mvnw clean install` → BUILD SUCCESS
+  (`SystemdUnitTemplateTest` 5 tests; `InstallJettyServiceScriptTest` 6 tests)
+- `cd deliverytiersuite/.../delivery-tier-distribution && ../../../mvnw clean install`
+  → BUILD SUCCESS (`DtsSystemdUnitTemplateTest` 4; `DtsServiceInstallScriptTest` 6)
+- Root `mvnw spotless:apply` then `spotless:check`; out-of-scope Spotless hits
+  discarded; only in-scope files staged
+
+## Memory patterns hit
+
+- Partition Spotless out-of-scope rewrites from feature commit
+- Structural packaging tests over live root systemd

--- a/modules/perc-jetty/README.md
+++ b/modules/perc-jetty/README.md
@@ -27,10 +27,12 @@ Native systemd install is provided under `src/main/jetty/service/`:
 
 - `install-jetty-service.sh` — prefers systemd when available; `--initd` forces SysV
 - `percussion-cms.service.in` — unit template (`Type=forking`, `TimeoutStartSec=1800`, journal)
-- `README-systemd.md` — operator install / migrate / journal notes
+- `README-systemd.md` — operator install / migrate / journal notes, **dry-run / non-root**
+  limitations (no `--dry-run` flag; install requires root), and migration uninstall→install
 
 ```bash
 sudo ./install-jetty-service.sh PercussionCMS install
+# flags: --systemd (require) | --initd (force SysV; init.d also remains ExecStart helper)
 sudo systemctl start PercussionCMS
 journalctl -u PercussionCMS -n 50 --no-pager
 ```

--- a/modules/perc-jetty/src/main/jetty/service/README-systemd.md
+++ b/modules/perc-jetty/src/main/jetty/service/README-systemd.md
@@ -4,15 +4,34 @@
 
 On modern Linux hosts, `install-jetty-service.sh` installs a **native systemd unit**
 for the CMS Jetty process (default name `PercussionCMS`). SysV/init.d remains
-available as a fallback when systemd is not present or when forced with `--initd`.
+available as:
 
-This addresses [GitHub issue #962](https://github.com/intersoftdatalabs-in/percussioncms/issues/962):
+1. **Start helper** — `ExecStart` / `ExecStop` always invoke `/etc/init.d/<ServiceName>`
+   even when a native unit is registered (the unit does **not** dual-register that
+   helper via chkconfig / update-rc.d on the systemd path).
+2. **Fallback** — when systemd is absent, or when forced with `--initd`.
+
+This addresses [GitHub issue #962](https://github.com/intersoftdatalabs-in/percussioncms/issues/962)
+(parent of slice [#1977](https://github.com/intersoftdatalabs-in/percussioncms/issues/1977)):
 short start timeouts and empty journals when systemd wraps LSB init scripts during
 long post-upgrade startups.
+
+**init.d is not removed** by this feature. Do not delete SysV scripts or the
+`--initd` path when operating dual-ship hosts.
+
+## Install flags
+
+|    Flag     |                                        Behavior                                         |
+|-------------|-----------------------------------------------------------------------------------------|
+| (default)   | Prefer native systemd when `/run/systemd/system` exists and `systemctl` is available    |
+| `--systemd` | **Require** systemd; fail install if not available                                      |
+| `--initd`   | Force classic init.d / chkconfig (or update-rc.d) registration; **no** native unit file |
+| both flags  | Rejected (`Cannot combine --systemd and --initd`)                                       |
 
 ## Install (systemd — default when available)
 
 ```bash
+# Must run as root (or via sudo). There is no --dry-run flag.
 sudo ./install-jetty-service.sh [ServiceName] install
 # optional flags:
 #   --systemd   require systemd (fail if missing)
@@ -36,6 +55,58 @@ sudo systemctl start <ServiceName>
 sudo systemctl status <ServiceName>
 journalctl -u <ServiceName> -n 100 --no-pager
 ```
+
+### Privilege model
+
+- The **unit does not set `User=`**; systemd starts the unit as root.
+- The Jetty init helper drops / applies the process user from `JETTY_USER` in
+  `/etc/default/<ServiceName>` (set from the install-time run-as prompt).
+- This matches the historic init.d-only path.
+
+## Root requirement and non-root / dry-run limitations
+
+`install-jetty-service.sh` **requires root** (`id -u` must be `0`). It writes under
+`/etc/systemd/system`, `/etc/init.d`, `/etc/default`, and run directories, then runs
+`systemctl daemon-reload` / `enable`.
+
+|               What you need               |                                  Non-root / dry-run                                  |
+|-------------------------------------------|--------------------------------------------------------------------------------------|
+| Live install, enable, start, uninstall    | **Not supported** without root                                                       |
+| Inspect unit template keys before install | **Yes** — read `percussion-cms.service.in` next to this README                       |
+| Verify flags and selection logic          | **Yes** — read `install-jetty-service.sh` (no host writes)                           |
+| Structural contract tests (CI / dev)      | **Yes** — Maven tests; no root, no live systemd                                      |
+| Preview generated unit without installing | **Manual** — copy template, substitute placeholders offline (no product `--dry-run`) |
+
+There is **no** `--dry-run` installer flag. Offline review of the template + scripts is
+the supported dry-run path (see checklist below). Live dual-ship soak is out of scope
+for packaging verification on a non-root workstation.
+
+## Dry-run install checklist (no live root)
+
+Use this on a packaging machine, CI agent, or non-root workstation:
+
+1. **Confirm artifacts ship** under `<rxDir>/jetty/service/`:
+   - `percussion-cms.service.in`
+   - `install-jetty-service.sh`
+   - this `README-systemd.md`
+2. **Contract keys** in the unit template (see
+   `specs/988-linux-systemd-services/contracts/systemd-unit-contract.md`):
+   - `Type=forking`, `PIDFile=`, `EnvironmentFile=`, `ExecStart`/`ExecStop`
+   - `TimeoutStartSec` ≥ 900 (default **1800**), `StandardOutput`/`StandardError=journal`
+   - `WantedBy=multi-user.target`, `After=network.target`
+   - Privilege model documented (no bare `User=` without docs)
+3. **Flags**: script documents `--systemd` and `--initd`; both together must fail.
+4. **Init.d retained**: systemd path keeps `/etc/init.d/<name>` as ExecStart helper and
+   skips SysV boot registration; `--initd` still registers classic boot.
+5. **Run structural tests** (no root):
+
+   ```bash
+   # from repo, module standalone
+   cd modules/perc-jetty
+   ../../mvnw test -Dtest=SystemdUnitTemplateTest,InstallJettyServiceScriptTest
+   ```
+6. **Migration rehearsal (document only)**: uninstall → install order below; do not
+   run against production without change control.
 
 ## Long startup / upgrades
 
@@ -61,9 +132,12 @@ and clears the run directory for that service name.
 
 ## Migration from init.d-only installs
 
+Always **uninstall then install** (do not layer a second registration on the same name):
+
 1. `sudo ./install-jetty-service.sh PercussionCMS uninstall` (stops service if running)
 2. `sudo ./install-jetty-service.sh PercussionCMS install` (picks systemd when available)
 3. `sudo systemctl start PercussionCMS`
+4. `sudo systemctl status PercussionCMS` and `journalctl -u PercussionCMS -n 50 --no-pager`
 
 ## Force init.d (no systemd unit)
 
@@ -71,3 +145,7 @@ and clears the run directory for that service name.
 sudo ./install-jetty-service.sh PercussionCMS install --initd
 ```
 
+Use when the host has no systemd, or when operators intentionally keep SysV-only
+boot registration. The init.d script remains the start helper on the systemd path
+as well — forcing `--initd` only changes **boot registration**, not the existence
+of the helper script on a later native-unit reinstall.

--- a/modules/perc-jetty/src/main/jetty/service/percussion-cms.service.in
+++ b/modules/perc-jetty/src/main/jetty/service/percussion-cms.service.in
@@ -26,9 +26,10 @@ TimeoutStartSec=1800
 TimeoutStopSec=120
 StandardOutput=journal
 StandardError=journal
-# Process user is applied by the Jetty start script via JETTY_USER in EnvironmentFile.
-# Running the unit as root allows the init helper to drop privileges consistently with
-# the historic init.d install path.
+# User=/privilege model: no User= in this unit. Process user is applied by the Jetty
+# start helper via JETTY_USER in EnvironmentFile (/etc/default). Running the unit as
+# root lets the init helper drop privileges consistently with the historic init.d path.
+# See README-systemd.md (contract: User= present or documented).
 KillMode=control-group
 Restart=on-failure
 RestartSec=10

--- a/modules/perc-jetty/src/test/java/com/percussion/jetty/service/InstallJettyServiceScriptTest.java
+++ b/modules/perc-jetty/src/test/java/com/percussion/jetty/service/InstallJettyServiceScriptTest.java
@@ -90,6 +90,17 @@ class InstallJettyServiceScriptTest {
   }
 
   @Test
+  void script_requiresRoot_noDryRunFlag() {
+    // GH-1977: install is root-only; no product --dry-run (docs cover offline review)
+    assertTrue(script.contains("id -u"), "root check via id -u");
+    assertTrue(
+        script.contains("must be run with sudo or as root")
+            || script.contains("must be run as root"),
+        "root error message");
+    assertFalse(script.contains("--dry-run"), "no --dry-run installer flag");
+  }
+
+  @Test
   void defaultsFile_doesNotEmbedShellCommands() {
     // Historical bug: mkdir/chown were written into /etc/default and broke EnvironmentFile
     assertFalse(

--- a/modules/perc-jetty/src/test/java/com/percussion/jetty/service/SystemdUnitTemplateTest.java
+++ b/modules/perc-jetty/src/test/java/com/percussion/jetty/service/SystemdUnitTemplateTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /**
- * GH-962 / specs/988: structural contract for the shipped systemd unit template.
+ * GH-962 / specs/988 / GH-1977: structural contract for the shipped systemd unit template.
  *
  * @see specs/988-linux-systemd-services/contracts/systemd-unit-contract.md
  */
@@ -35,13 +35,19 @@ class SystemdUnitTemplateTest {
   private static final Path UNIT_TEMPLATE =
       Path.of("src", "main", "jetty", "service", "percussion-cms.service.in");
 
+  private static final Path README =
+      Path.of("src", "main", "jetty", "service", "README-systemd.md");
+
   private static String unitText;
+  private static String readmeText;
 
   @BeforeAll
   static void load() throws Exception {
     assertTrue(
         Files.isRegularFile(UNIT_TEMPLATE), () -> "missing " + UNIT_TEMPLATE.toAbsolutePath());
+    assertTrue(Files.isRegularFile(README), () -> "missing " + README.toAbsolutePath());
     unitText = Files.readString(UNIT_TEMPLATE, StandardCharsets.UTF_8);
+    readmeText = Files.readString(README, StandardCharsets.UTF_8);
   }
 
   @Test
@@ -65,7 +71,6 @@ class SystemdUnitTemplateTest {
   @Test
   void unit_hasLongStartTimeoutAndJournal() {
     assertTrue(unitText.contains("TimeoutStartSec=1800"), "TimeoutStartSec default 30m (FR-005)");
-    // Parse numeric value for contract min 900
     int timeout = extractTimeoutStartSec(unitText);
     assertTrue(timeout >= 900, "TimeoutStartSec must be >= 900, was " + timeout);
     assertTrue(unitText.contains("StandardOutput=journal"), "journal stdout");
@@ -77,6 +82,48 @@ class SystemdUnitTemplateTest {
     assertTrue(unitText.contains("[Install]"), "[Install]");
     assertTrue(unitText.contains("WantedBy=multi-user.target"), "WantedBy");
     assertTrue(unitText.contains("After=network.target"), "After=network");
+  }
+
+  @Test
+  void unit_hasDescriptionAndPrivilegeModelDocumented() {
+    // Contract: Description= non-empty (placeholder at ship time)
+    assertTrue(unitText.contains("Description=@DESCRIPTION@"), "Description placeholder");
+    // Contract: User= present OR documented — unit uses init helper privilege drop
+    boolean hasUserDirective = unitText.lines().anyMatch(l -> l.trim().startsWith("User="));
+    boolean documentsPrivilege =
+        unitText.contains("User=")
+            || unitText.contains("privilege")
+            || unitText.contains("JETTY_USER");
+    assertTrue(
+        hasUserDirective || documentsPrivilege,
+        "User= key or privilege model documentation required by contract");
+  }
+
+  @Test
+  void readme_documentsFlagsDryRunAndMigration() {
+    assertTrue(readmeText.contains("--systemd"), "documents --systemd");
+    assertTrue(readmeText.contains("--initd"), "documents --initd");
+    assertTrue(
+        readmeText.toLowerCase().contains("dry-run") || readmeText.contains("non-root"),
+        "documents dry-run / non-root limitations");
+    assertTrue(
+        readmeText.contains("must be run")
+            || readmeText.toLowerCase().contains("requires root")
+            || readmeText.toLowerCase().contains("require root"),
+        "documents root requirement");
+    assertTrue(readmeText.contains("uninstall"), "documents uninstall");
+    assertTrue(
+        readmeText.toLowerCase().contains("migration")
+            || readmeText.contains("uninstall then install"),
+        "documents migration uninstall→install");
+    assertTrue(
+        readmeText.contains("init.d") || readmeText.contains("SysV"),
+        "documents init.d helper/fallback retained");
+    assertTrue(
+        readmeText.contains("not removed")
+            || readmeText.contains("Start helper")
+            || readmeText.contains("start helper"),
+        "documents init.d remains start helper + fallback");
   }
 
   private static int extractTimeoutStartSec(String text) {

--- a/specs/988-linux-systemd-services/quickstart.md
+++ b/specs/988-linux-systemd-services/quickstart.md
@@ -5,14 +5,37 @@
 - Linux host with systemd (or a packaging-only machine for structural tests)
 - Built/installed CMS tree including `jetty/service/`
 - Root for live install tests; **no root** needed for Maven structural tests
+- Installers have **no `--dry-run` flag** — offline template/README review is the dry-run path
+
+## Dry-run checklist (no live root)
+
+Operator-facing detail lives in:
+
+- CMS: `modules/perc-jetty/src/main/jetty/service/README-systemd.md`
+- DTS: `deliverytiersuite/.../delivery-tier-distribution/src/main/rootFiles/README-systemd.md`
+
+Without root, verify:
+
+1. Unit templates present (`percussion-cms.service.in`, `dts-tomcat.service.in`)
+2. Contract keys vs `contracts/systemd-unit-contract.md` (`Type=forking`, PID/env/exec,
+   `TimeoutStartSec` ≥ 900 / default 1800, journal, `WantedBy=multi-user.target`,
+   privilege model documented)
+3. Install flags documented: `--systemd`, `--initd` (not combined)
+4. init.d remains start helper + fallback (not deleted on systemd path)
+5. Migration order documented: **uninstall → install**
+6. Structural Maven tests green (below)
 
 ## Structural (CI / dev workstation)
 
 ```bash
-./mvnw -pl modules/perc-jetty test -Dai.integrity.skip=true
+# Preferred: standalone per module (see AGENTS.md)
+cd modules/perc-jetty && ../../mvnw test -Dtest=SystemdUnitTemplateTest,InstallJettyServiceScriptTest
+cd deliverytiersuite/delivery-tier-suite/delivery-tier-distribution \
+  && ../../../mvnw test -Dtest=DtsSystemdUnitTemplateTest,DtsServiceInstallScriptTest
 ```
 
-Expect tests covering unit template contract keys (see `contracts/systemd-unit-contract.md`).
+Expect tests covering unit template contract keys **and** README dry-run / flag docs
+(see `contracts/systemd-unit-contract.md`; GH-1977).
 
 ## Live install smoke (manual)
 


### PR DESCRIPTION
## Summary

Closes residual **slice 2** of parent [#962](https://github.com/intersoftdatalabs-in/percussioncms/issues/962) / issue [#1977](https://github.com/intersoftdatalabs-in/percussioncms/issues/1977):

- Re-checked CMS `percussion-cms.service.in` and DTS `dts-tomcat.service.in` against `specs/988-linux-systemd-services/contracts/systemd-unit-contract.md`
- Documented **User/privilege model** on both unit templates (no bare `User=`; unit runs as root; helper applies process identity — matches historic init.d path)
- Brought **CMS + DTS `README-systemd.md`** to parity: flags (`--systemd`, `--initd`), root requirement, **no product `--dry-run`**, offline dry-run checklist, migration **uninstall → install**, init.d retained as **start helper + fallback**
- Extended structural tests for contract keys + README docs + root/no-dry-run on install scripts
- Quickstart dry-run checklist; light module README pointers
- **Did not** remove SysV/init.d path

**Operator:** Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] Contract checklist green against both unit templates (tests + review)
- [x] Dry-run install docs accurate (paths, flags, migration uninstall→install)
- [x] No product removal of init.d
- [x] Structural tests:
  - `SystemdUnitTemplateTest` (5), `InstallJettyServiceScriptTest` (6)
  - `DtsSystemdUnitTemplateTest` (4), `DtsServiceInstallScriptTest` (6)

## Gates evidence

| Gate | Result |
|------|--------|
| Erlang pre-commit | **approve** — `docs/ai-generated/code-reviews/issue-1977-systemd-unit-templates-docs-erlang.md` |
| Spotless | `mvnw spotless:apply` then `spotless:check` (root); out-of-scope Spotless rewrites discarded |
| Maven (standalone) | `cd modules/perc-jetty && ../../mvnw clean install` → **BUILD SUCCESS** (Tests run: 53, Failures: 0, Skipped: 7 baseline) |
| Maven (standalone) | `cd deliverytiersuite/.../delivery-tier-distribution && ../../../mvnw clean install` → **BUILD SUCCESS** |
| New warnings | None attributable to this change |

## Out of scope (not residual issues — already child slices of #962)

- Live Linux dual-ship soak (Child C)
- init.d deprecation (Child D)

## Fixes

Fixes #1977  
Related to #962