### PR TITLE
fix(system): enable PSObjectSummary Jackson equality round-trip (#1903)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-1903-psobjectsummary-jackson-rt-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-1903-psobjectsummary-jackson-rt-erlang.md
@@ -1,0 +1,30 @@
+# Erlang review — issue #1903 PSObjectSummary Jackson equality RT
+
+**Reviewer persona:** Erlang (strict pre-commit)  
+**Change class:** catalog/security domain Jackson bean surface for object-summary XML  
+**Modules:** `system` only
+
+## Verdict: **APPROVE**
+
+### Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs / incorrect assertions | Pass — historical suppress of nested `permissions` restored; `permission-value` string path + `setGUID` restore wire form |
+| Behavioral unit tests | Pass — `PSObjectSummaryTest` write-shape + both equality RTs green (3/3) |
+| Cross-platform paths | Pass — no filesystem path construction |
+| Change-class companions | Pass — peer suppress/`@JsonIgnore` + `setGUID` pattern from #1888/#1889/#1915; SOAP orphan-brace compile fix required for module clean install |
+| Spotless / clean install | Pass — in-scope only; `cd system && ../mvnw clean install` BUILD SUCCESS (Tests run: 1035, Failures: 0) |
+
+### Findings
+
+1. **Root cause** — Java 11 modernization dropped Betwixt bean surface (`setGUID`, suppressed `getPermissions`, `permissionValue`, `getId`). Nested empty `PSUserAccessLevel` then failed Jackson deserialize.
+2. **Fix** — Restore suppress on nested permissions + `permission-value` string; restore GUID/label/type setters; add `PSUserAccessLevel` no-arg + `setPermissions` and suppress derived `has*Access`.
+3. **Equals** — Restored fuller historical equality (id/type/name/label/description/locked/permissions) so complete RT is meaningful.
+4. **Drive-by** — Remove orphan class-body braces in `AssemblySOAPImpl` / `AssemblyDesignSOAPImpl` introduced by #1932 (blocked `perc-system` compile).
+
+### Memory patterns hit
+
+- Jackson domain slices: suppress derived getters with `@IPSXmlSerialization` + `@JsonIgnore`
+- GUID as string property via shared `IPSGuid` converter
+- Do not fold monorepo Spotless noise into feature PR

--- a/system/services/src/com/percussion/services/catalog/data/PSObjectSummary.java
+++ b/system/services/src/com/percussion/services/catalog/data/PSObjectSummary.java
@@ -17,9 +17,10 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.services.catalog.data;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
-import com.percussion.services.guidmgr.data.PSDesignGuid;
 import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.locking.data.PSObjectLock;
 import com.percussion.services.locking.data.PSObjectLockSummary;
@@ -28,13 +29,10 @@ import com.percussion.services.security.data.PSUserAccessLevel;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.xml.IPSXmlSerialization;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * Container which holds common information available for all design objects with enhanced Java 11 support.
@@ -224,37 +222,113 @@ public class PSObjectSummary implements IPSCatalogSummary {
       this.description = s.getDescription();
    }
 
+   /**
+    * Catalog GUID. Jackson emits/reads string form via the shared {@code IPSGuid} converter in
+    * {@code PSJacksonXmlSerializationHelper} (parity with Betwixt {@code PSBetwixtObjectConverter}).
+    */
    @Override
+   @JsonProperty("guid")
    public IPSGuid getGUID() {
       return new PSGuid(type, id);
    }
 
-   @Override
-   public String getType() {
-      return type == null ? null : type.name();
+   /**
+    * Set the GUID for XML / bean restore (Jackson + Betwixt). Populates both id and type.
+    *
+    * @param guid the new guid, not {@code null}
+    */
+   public void setGUID(IPSGuid guid) {
+      Objects.requireNonNull(guid, "guid cannot be null");
+      this.id = guid.longValue();
+      this.type = PSTypeEnum.valueOf(guid.getType());
    }
 
+   /**
+    * Raw id used by some call sites. Suppressed from XML (wire form is {@code guid}).
+    *
+    * @return the object id
+    */
+   @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
+   public long getId() {
+      return id;
+   }
+
+   /**
+    * Set the raw object id (not the preferred XML path; prefer {@link #setGUID(IPSGuid)}).
+    *
+    * @param id the new object id
+    */
+   public void setId(long id) {
+      this.id = id;
+   }
+
+   @Override
+   @JsonProperty
+   public String getType() {
+      if (type == null) {
+         type = PSTypeEnum.INVALID;
+      }
+      return type.name();
+   }
+
+   /**
+    * Set the object type from its enum name (XML / bean restore).
+    *
+    * @param typeName the type name, not blank
+    */
+   public void setType(String typeName) {
+      if (StringUtils.isBlank(typeName)) {
+         throw new IllegalArgumentException("type cannot be null or empty");
+      }
+      this.type = PSTypeEnum.valueOf(typeName);
+   }
+
+   /**
+    * Typed enum access. Suppressed from XML (wire form is {@link #getType()} string).
+    *
+    * @return the type enum, may be {@code null} before population
+    */
+   @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public PSTypeEnum getTypeEnum() {
       return type;
    }
 
    @Override
+   @JsonProperty
    public String getName() {
       return name;
    }
 
    @Override
+   @JsonProperty
    public String getLabel() {
       return label != null ? label : name;
    }
 
+   /**
+    * Set the object label. Defaults to the object name if blank.
+    *
+    * @param label the new object label, may be blank
+    */
+   public void setLabel(String label) {
+      if (StringUtils.isBlank(label)) {
+         this.label = name;
+      } else {
+         this.label = label;
+      }
+   }
+
    @Override
+   @JsonProperty
    public String getDescription() {
       return description;
    }
 
    /**
     * Set the object's description.
+    *
     * @param desc the description, may be {@code null} or empty
     */
    public void setDescription(String desc) {
@@ -262,8 +336,9 @@ public class PSObjectSummary implements IPSCatalogSummary {
    }
 
    /**
-    * Set the object's name. Used by callers that construct summaries and then
-    * need to adjust the name.
+    * Set the object's name. Used by callers that construct summaries and then need to adjust the
+    * name.
+    *
     * @param name the name to set, not {@code null} or empty
     */
    public void setName(String name) {
@@ -278,9 +353,10 @@ public class PSObjectSummary implements IPSCatalogSummary {
     *
     * @return Optional containing the description if present and non-empty, empty otherwise
     */
+   @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public Optional<String> getDescriptionOptional() {
-      return Optional.ofNullable(description)
-         .filter(desc -> !desc.trim().isEmpty());
+      return Optional.ofNullable(description).filter(desc -> !desc.trim().isEmpty());
    }
 
    /**
@@ -288,15 +364,20 @@ public class PSObjectSummary implements IPSCatalogSummary {
     *
     * @return Optional containing permissions if valid, empty otherwise
     */
+   @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public Optional<PSUserAccessLevel> getPermissionsOptional() {
       return m_arePermissionsValid ? Optional.ofNullable(permissions) : Optional.empty();
    }
 
    /**
-    * Get the object permissions.
+    * Object permissions for API use. Nested {@link PSUserAccessLevel} is suppressed on XML write
+    * (historical Betwixt design; issue #1903) — wire form is {@link #getPermissionValue()}.
     *
     * @return the permissions, never {@code null}
     */
+   @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public PSUserAccessLevel getPermissions() {
       return permissions;
    }
@@ -305,7 +386,7 @@ public class PSObjectSummary implements IPSCatalogSummary {
     * Set the object permissions with validation.
     *
     * @param permissions the permissions to set, not {@code null}
-    * @throws IllegalArgumentException if permissions is null
+    * @throws NullPointerException if permissions is null
     */
    public void setPermissions(PSUserAccessLevel permissions) {
       Objects.requireNonNull(permissions, "permissions cannot be null");
@@ -314,10 +395,48 @@ public class PSObjectSummary implements IPSCatalogSummary {
    }
 
    /**
+    * Permissions as a comma-separated enum name list for XML serialization (Betwixt / Jackson).
+    * Nested {@link PSUserAccessLevel} is not written; see {@link #getPermissions()}.
+    *
+    * @return permission names joined by {@code ,}, never {@code null} (may be empty)
+    */
+   @JsonProperty
+   public String getPermissionValue() {
+      var rval = new StringBuilder();
+      for (PSPermissions p : permissions.getPermissions()) {
+         if (rval.length() > 0) {
+            rval.append(',');
+         }
+         rval.append(p.name());
+      }
+      return rval.toString();
+   }
+
+   /**
+    * Restore permissions from the XML string form produced by {@link #getPermissionValue()}.
+    *
+    * @param permissionsStr comma-separated {@link PSPermissions} names, may be blank
+    */
+   public void setPermissionValue(String permissionsStr) {
+      if (StringUtils.isBlank(permissionsStr)) {
+         return;
+      }
+      for (String token : permissionsStr.split(",")) {
+         if (StringUtils.isBlank(token)) {
+            continue;
+         }
+         permissions.getPermissions().add(PSPermissions.valueOf(token.trim()));
+      }
+      m_arePermissionsValid = true;
+   }
+
+   /**
     * Check if permissions have been explicitly set on this object.
     *
     * @return true if permissions are valid and have been set
     */
+   @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public boolean arePermissionsValid() {
       return m_arePermissionsValid;
    }
@@ -327,6 +446,8 @@ public class PSObjectSummary implements IPSCatalogSummary {
     *
     * @return Optional containing lock information if object is locked, empty otherwise
     */
+   @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public Optional<PSObjectLockSummary> getLockedOptional() {
       return Optional.ofNullable(locked);
    }
@@ -336,6 +457,7 @@ public class PSObjectSummary implements IPSCatalogSummary {
     *
     * @return the lock information if object is locked, {@code null} otherwise
     */
+   @JsonProperty
    public PSObjectLockSummary getLocked() {
       return locked;
    }
@@ -350,10 +472,13 @@ public class PSObjectSummary implements IPSCatalogSummary {
    }
 
    /**
-    * Check if this object is currently locked.
+    * Check if this object is currently locked. Suppressed so it does not collide with the {@code
+    * locked} property written from {@link #getLocked()}.
     *
     * @return true if the object has lock information
     */
+   @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public boolean isLocked() {
       return locked != null;
    }
@@ -364,39 +489,49 @@ public class PSObjectSummary implements IPSCatalogSummary {
     * @param userName the user name to check, may be {@code null}
     * @return true if the object is locked by the specified user
     */
+   @IPSXmlSerialization(suppress = true)
+   @JsonIgnore
    public boolean isLockedBy(String userName) {
       return getLockedOptional()
-         .map(lockSummary -> Objects.equals(lockSummary.getLocker(), userName))
-         .orElse(false);
+          .map(lockSummary -> Objects.equals(lockSummary.getLocker(), userName))
+          .orElse(false);
    }
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj) return true;
-      if (!(obj instanceof PSObjectSummary)) return false;
+      if (this == obj) {
+         return true;
+      }
+      if (!(obj instanceof PSObjectSummary)) {
+         return false;
+      }
 
       var other = (PSObjectSummary) obj;
-      return Objects.equals(id, other.id) &&
-             Objects.equals(type, other.type) &&
-             Objects.equals(name, other.name);
+      return id == other.id
+          && Objects.equals(type, other.type)
+          && Objects.equals(name, other.name)
+          && Objects.equals(getLabel(), other.getLabel())
+          && Objects.equals(description, other.description)
+          && Objects.equals(locked, other.locked)
+          && Objects.equals(permissions, other.permissions);
    }
 
    @Override
    public int hashCode() {
-      return Objects.hash(id, type, name);
+      return Objects.hash(id, type, name, getLabel(), description, permissions, locked);
    }
 
    @Override
    public String toString() {
       return new ToStringBuilder(this)
-         .append("id", id)
-         .append("type", type)
-         .append("name", name)
-         .append("label", label)
-         .append("description", description)
-         .append("locked", isLocked())
-         .append("permissionsValid", m_arePermissionsValid)
-         .toString();
+          .append("id", id)
+          .append("type", type)
+          .append("name", name)
+          .append("label", label)
+          .append("description", description)
+          .append("locked", isLocked())
+          .append("permissionsValid", m_arePermissionsValid)
+          .toString();
    }
 
    /**

--- a/system/services/src/com/percussion/services/security/data/PSUserAccessLevel.java
+++ b/system/services/src/com/percussion/services/security/data/PSUserAccessLevel.java
@@ -16,108 +16,119 @@
  */
 package com.percussion.services.security.data;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.percussion.services.security.PSPermissions;
-
-import java.util.AbstractSet;
-import java.util.Arrays;
+import com.percussion.utils.xml.IPSXmlSerialization;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
-
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * Provides the sum of a user's permissions for a given resource.
+ *
+ * <p>Jackson bean surface (issue #1903 / epic #505): no-arg constructor plus {@link
+ * #setPermissions(Collection)} so empty nested graphs deserialize when this type appears under XML.
+ * Derived {@code has*Access} predicates are suppressed from serialization.
  */
-public class PSUserAccessLevel
-{
-   /**
-    * Default ctor.
-    * 
-    * @param permissions The collection all permissions the user has for a given
-    * resource, may be <code>null</code> or empty if the user has no 
-    * permissions.
-    */
-   public PSUserAccessLevel(Collection<PSPermissions> permissions)
-   {
-      m_permissions = new HashSet<>();
-      if (permissions != null)
-         m_permissions.addAll(permissions);
-   }
+public class PSUserAccessLevel {
+  /**
+   * No-arg constructor for Jackson / XML frameworks. Permissions start empty until {@link
+   * #setPermissions(Collection)} or the collection constructor is used.
+   */
+  public PSUserAccessLevel() {
+    m_permissions = new HashSet<>();
+  }
 
-   /**
-    * @return <code>true</code> if this access level has read pemission, false
-    * otherwise.
-    */
-   public boolean hasReadAccess()
-   {
-      return m_permissions.contains(PSPermissions.READ);
-   }
+  /**
+   * Construct with the given permission collection.
+   *
+   * @param permissions The collection of all permissions the user has for a given resource, may be
+   *     {@code null} or empty if the user has no permissions.
+   */
+  public PSUserAccessLevel(Collection<PSPermissions> permissions) {
+    m_permissions = new HashSet<>();
+    if (permissions != null) {
+      m_permissions.addAll(permissions);
+    }
+  }
 
-   /**
-    * @return <code>true</code> if this access level has update pemission,
-    * false otherwise.
-    */
-   public boolean hasUpdateAccess()
-   {
-      return m_permissions.contains(PSPermissions.UPDATE);
-   }
+  /**
+   * @return {@code true} if this access level has read permission, false otherwise.
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public boolean hasReadAccess() {
+    return m_permissions.contains(PSPermissions.READ);
+  }
 
-   /**
-    * @return <code>true</code> if this access level has delete pemission,
-    * false otherwise.
-    */
-   public boolean hasDeleteAccess()
-   {
-      return m_permissions.contains(PSPermissions.DELETE);
-   }
+  /**
+   * @return {@code true} if this access level has update permission, false otherwise.
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public boolean hasUpdateAccess() {
+    return m_permissions.contains(PSPermissions.UPDATE);
+  }
 
-   /**
-    * @return <code>true</code> if this access level has runtime permission,
-    * false otherwise.
-    */
-   public boolean hasRuntimeAccess()
-   {
-      return m_permissions.contains(PSPermissions.RUNTIME_VISIBLE);
-   }
-   
+  /**
+   * @return {@code true} if this access level has delete permission, false otherwise.
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public boolean hasDeleteAccess() {
+    return m_permissions.contains(PSPermissions.DELETE);
+  }
 
-   /**
-    * @return <code>true</code> if this access level has owner permission,
-    * false otherwise.
-    */
-   public boolean hasOwnerAccess()
-   {
-      return m_permissions.contains(PSPermissions.OWNER);
-   }
-   
-   /**
-    * Get the set of permissions represented by this object.
-    * 
-    * @return The set, never <code>null</code>.  Modifications to this set will
-    * affect this object.
-    */
-   public Set<PSPermissions> getPermissions()
-   {
-      return m_permissions;
-   }
+  /**
+   * @return {@code true} if this access level has runtime permission, false otherwise.
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public boolean hasRuntimeAccess() {
+    return m_permissions.contains(PSPermissions.RUNTIME_VISIBLE);
+  }
 
-   @Override
-   public String toString() {
-      final StringBuffer sb = new StringBuffer("PSUserAccessLevel{");
-      sb.append("m_permissions=").append(m_permissions);
-      sb.append('}');
-      return sb.toString();
-   }
+  /**
+   * @return {@code true} if this access level has owner permission, false otherwise.
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public boolean hasOwnerAccess() {
+    return m_permissions.contains(PSPermissions.OWNER);
+  }
 
-   /**
-    * Set of all permissions, never <code>null</code> after construction, may
-    * be empty. 
-    */
-   private Set<PSPermissions> m_permissions;
+  /**
+   * Get the set of permissions represented by this object.
+   *
+   * @return The set, never {@code null}. Modifications to this set will affect this object.
+   */
+  @JsonProperty
+  public Set<PSPermissions> getPermissions() {
+    return m_permissions;
+  }
+
+  /**
+   * Replace the permission set (Jackson / bean restore).
+   *
+   * @param permissions may be {@code null} or empty
+   */
+  public void setPermissions(Collection<PSPermissions> permissions) {
+    m_permissions = new HashSet<>();
+    if (permissions != null) {
+      m_permissions.addAll(permissions);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "PSUserAccessLevel{m_permissions=" + m_permissions + '}';
+  }
+
+  /**
+   * Set of all permissions, never {@code null} after construction, may be empty.
+   */
+  private Set<PSPermissions> m_permissions;
 
    @Override
    public boolean equals(Object o) {

--- a/system/src/test/java/com/percussion/services/catalog/data/PSObjectSummaryTest.java
+++ b/system/src/test/java/com/percussion/services/catalog/data/PSObjectSummaryTest.java
@@ -29,16 +29,16 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
  * Object summary serialization coverage under Jackson-backed {@link PSXmlSerializationHelper}
- * (issue #1893 / parent #1823 / epic #505).
+ * (issue #1903 residual of #1893 / parent #1823 / epic #505).
  *
- * <p>Write-side shape tests are enabled. Full equality round-trips remain disabled until catalog /
- * security domain suppress annotations land for {@code permissions} / {@link PSUserAccessLevel} (no
- * default constructor; nested graph fails Jackson deserialize). Tracked as residual of #1893.
+ * <p>Write-side shape and full equality round-trips are enabled. Nested {@link PSUserAccessLevel}
+ * is suppressed on write (historical Betwixt {@code @IPSXmlSerialization}); permissions wire as
+ * {@code permission-value}. {@link PSUserAccessLevel} also has a Jackson no-arg constructor for
+ * empty nested graphs elsewhere.
  *
  * <p><strong>Approved deviations:</strong> no Betwixt graph-identity {@code id="…"} attributes on
  * write.
@@ -61,7 +61,8 @@ public class PSObjectSummaryTest {
   }
 
   /**
-   * Write-side shape for a minimal summary: modern root, name/label/guid present, no graph ids.
+   * Write-side shape for a minimal summary: modern root, name/label/guid present, no nested
+   * permissions graph, no graph ids.
    *
    * @throws Exception on write failure
    */
@@ -80,20 +81,17 @@ public class PSObjectSummaryTest {
     assertTrue(ser.contains("Test object summary"), ser);
     assertTrue(ser.contains("Test object summary label"), ser);
     assertTrue(containsTag(ser, "guid"), ser);
+    assertFalse(containsTag(ser, "permissions"), "nested permissions suppressed: " + ser);
     assertFalse(BETWIXT_GRAPH_ID_ATTR.matcher(ser).find(), "no graph id attrs: " + ser);
     assertFalse(ser.trim().startsWith("<null"), ser);
   }
 
   /**
-   * Full equality round-trip for an incomplete summary. Blocked on Jackson: empty {@code
-   * permissions} / {@link PSUserAccessLevel} has no default constructor.
+   * Full equality round-trip for an incomplete summary (default empty permissions).
    *
-   * @throws Exception
+   * @throws Exception on write/read failure
    */
   @Test
-  @Disabled(
-      "Residual #1893: PSObjectSummary permissions→PSUserAccessLevel lacks default ctor; needs"
-          + " catalog/security suppress or bean fix in a domain slice (not this PR).")
   public void testSerialization() throws Exception {
     PSObjectSummary nsum =
         new PSObjectSummary(
@@ -109,16 +107,11 @@ public class PSObjectSummaryTest {
   }
 
   /**
-   * Fully populated summary including lock + permissions. Same residual blocker as {@link
-   * #testSerialization()} plus historical JRE/OS flakiness notes.
+   * Fully populated summary including lock + permissions (permission-value string path).
    *
-   * @throws Exception
+   * @throws Exception on write/read failure
    */
   @Test
-  @Disabled(
-      "Residual #1893: complete summary RT needs PSUserAccessLevel / permissions Jackson"
-          + " support (catalog domain). Historical note: also flaky on certain JRE/OS with"
-          + " Betwixt.")
   public void testCompleteSerialization() throws Exception {
     PSObjectSummary nsum =
         new PSObjectSummary(
@@ -135,6 +128,12 @@ public class PSObjectSummaryTest {
     nsum.setPermissions(new PSUserAccessLevel(permissions));
 
     String ser = PSXmlSerializationHelper.writeToXml(nsum);
+    assertTrue(containsTag(ser, "permission-value"), ser);
+    assertTrue(ser.contains("RUNTIME_VISIBLE"), ser);
+    assertTrue(ser.contains("OWNER"), ser);
+    assertFalse(containsTag(ser, "permissions"), "nested permissions suppressed: " + ser);
+    assertTrue(containsTag(ser, "locked"), ser);
+
     PSObjectSummary restore = (PSObjectSummary) PSXmlSerializationHelper.readFromXML(ser);
 
     org.junit.jupiter.api.Assertions.assertEquals(nsum, restore, "Expected to be equal");

--- a/system/webservices/src/com/percussion/webservices/assembly/AssemblySOAPImpl.java
+++ b/system/webservices/src/com/percussion/webservices/assembly/AssemblySOAPImpl.java
@@ -44,7 +44,7 @@ public class AssemblySOAPImpl extends PSBaseSOAPImpl implements Assembly {
   public AssemblySOAPImpl() {
     // SOAP implementations are stateless; the superclass handles wiring
   }
-{
+
    /*
     * (non-Javadoc)
     *

--- a/system/webservices/src/com/percussion/webservices/assemblydesign/AssemblyDesignSOAPImpl.java
+++ b/system/webservices/src/com/percussion/webservices/assemblydesign/AssemblyDesignSOAPImpl.java
@@ -48,7 +48,7 @@ public class AssemblyDesignSOAPImpl extends PSBaseSOAPImpl
   public AssemblyDesignSOAPImpl() {
     // SOAP implementations are stateless; the superclass handles wiring
   }
-{
+
    /*
     * (non-Javadoc)
     *


### PR DESCRIPTION
## Summary

Residual of #1893 / epic #505: enable `PSObjectSummary` full equality round-trips under Jackson-backed `PSXmlSerializationHelper`.

**Root cause:** Java 11 modernization dropped the Betwixt bean surface (`setGUID`, suppressed nested `getPermissions()`, `permissionValue` string path). Nested empty `PSUserAccessLevel` (no true no-arg ctor) then failed Jackson deserialize.

**Fix (minimal, peer-aligned with #1888/#1889/#1915):**
- `PSObjectSummary`: restore `@IPSXmlSerialization(suppress)` + `@JsonIgnore` on nested permissions / derived Optional/`is*` getters; restore `getPermissionValue`/`setPermissionValue`, `setGUID`, `getId`/`setId`, `setLabel`, `setType`; fuller historical `equals`/`hashCode`.
- `PSUserAccessLevel`: no-arg ctor + `setPermissions(Collection)`; suppress derived `has*Access`.
- Re-enable `PSObjectSummaryTest#testSerialization` and `#testCompleteSerialization`; strengthen write-shape assertions (`permission-value`, no nested `permissions`).
- Drive-by compile fix: remove orphan class-body braces in `AssemblySOAPImpl` / `AssemblyDesignSOAPImpl` left by #1932 (blocked `perc-system` compile on `main`).

Fixes #1903  
Related: #1893 #1823 #505

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] `cd system && ../mvnw.cmd -Dtest=PSObjectSummaryTest test` — Tests run: 3, Failures: 0
- [x] `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 1035, Failures: 0, Errors: 0, Skipped: 240)
- [x] Root `mvnw.cmd spotless:apply` then `spotless:check` (in-scope only committed; out-of-scope Spotless noise discarded)
- [x] Erlang pre-commit: `docs/ai-generated/code-reviews/issue-1903-psobjectsummary-jackson-rt-erlang.md` — APPROVE

## Gates evidence

| Gate | Evidence |
|------|----------|
| Spotless | apply then check exit 0; only in-scope files on this PR |
| Module clean install | `cd system && ../mvnw.cmd clean install` BUILD SUCCESS |
| PSObjectSummaryTest | 3/3 green (write-shape + 2 equality RTs) |
| Erlang | approve — no bugs / portable paths / companions OK |

## Out of scope

- Person/serializer fixtures (#1893 leftovers)
- commons-betwixt POM removal (#1824)
- Broad catalog leftovers (#1920)