### PR TITLE
fix(grok): night-issue-prs must not starve human review threads

### DIFF
--- a/.grok/workflows/README.md
+++ b/.grok/workflows/README.md
@@ -11,7 +11,7 @@ Unattended overnight worker:
 1. **Discover** open GitHub issues  
 2. **Triage** (implement / split / skip)  
 3. **Work** sequential implement or split — **file residual follow-up issues** for leftover work  
-4. **PR follow-up** (optional, default on) — **human review threads first** (never starve/fake-resolve), then merge conflicts, CI, then bot review threads on *our* open PRs only  
+4. **PR follow-up** (optional, default on) — tech need first (conflicts → CI → review threads); human and AI threads **equal**, human only as **tie-break** on *our* open PRs  
 5. **Report** → `scratch/night-report.md`
 
 Opens **PRs only** (never merges). Oversized issues become child issues, not mega-PRs.
@@ -23,9 +23,9 @@ Opens **PRs only** (never merges). Oversized issues become child issues, not meg
 | Partial PRs leave “rest of the work” only in chat | **Always** log residual work as GitHub issues (or plan them in dry_run) linked to parent + PR |
 | Split plans disappear if only a comment | Child issues for each slice; residual URLs in structured result |
 | Same-area overnight PRs (i18n/TMX/gadgets) go **CONFLICTING** and block each other | **PR follow-up** rebases onto base **oldest-first**, resolves conflicts, then CI/review |
-| Human review comments lose to conflict/CI `max_prs` budget | **HUMAN threads are mandatory** — always inventoried; not capped out by `max_prs`; report `human_threads_still_open` |
+| Review threads (human or AI) invisible / under-reported | Inventory **all** owned PRs; human and bot threads are **equal** selection; report still lists open human threads for visibility |
 | Agent PRs sit blocked on review/CI | **PR follow-up** phase fixes + **inline reply + `resolveReviewThread`** per root `AGENTS.md` |
-| Fake-green: resolve without fix | Never resolve without mitigation reply citing commit; open residual issue if judgment needed; **human threads stay OPEN** if deferred |
+| Fake-green: resolve without fix | Never bare-resolve (human or bot); mitigation + resolve, or residual issue and **leave OPEN** |
 
 ### When to use
 
@@ -99,20 +99,21 @@ name=night-issue-prs args={"max_issues": 1, "max_prs": 8, "include_pr_followup":
 
 For a pure PR-babysit night, prefer `max_issues: 1` with a label filter that matches nothing (or a known empty set) so Work is nearly empty, and raise `max_prs`. Watch in `/workflows`. Result path: `scratch/night-report.md`.
 
-### PR follow-up: human reviews + conflicts + order
+### PR follow-up: tech need + equal review threads + human tie-break
 
-1. **Inventory first:** GraphQL `reviewThreads` on **every** owned open PR; classify HUMAN vs bot  
-2. **HUMAN threads (sacred):** always in the work set (not excluded by `max_prs`); process oldest first  
-   - Fix + mitigation reply + `resolveReviewThread`, **or**  
-   - Inline deferral + residual issue and **leave thread OPEN** (never bare-resolve)  
-3. **Then fill `max_prs`:** CONFLICTING/DIRTY → failing CI → unresolved bot threads → optional BEHIND  
-4. **Process oldest first** among non-human work so same-area stacks unstick bottom-up  
-5. **Rebase** conflicted PRs onto `origin/<base_branch>`; resolve markers carefully  
-6. **Push** with `git push --force-with-lease` only after history rewrite (never bare `--force`)  
-7. Bot review reply+`resolveReviewThread` only after humans on that PR are handled or deferred  
-8. Report **must** list `human_threads_still_open` after a fresh GraphQL re-query of all owned PRs  
+1. **Inventory** GraphQL `reviewThreads` on every owned open PR (human and bot both visible)  
+2. **Select up to `max_prs` by technical need:**  
+   - Tier A: CONFLICTING/DIRTY  
+   - Tier B: failing CI  
+   - Tier C: unresolved review threads (**human and AI equal**)  
+   - Tier D: optional BEHIND base  
+3. **Within a tier only:** prefer PRs with unresolved **human** threads, then oldest `createdAt`  
+4. On each PR: conflicts → CI → all unresolved threads (same fix/reply/resolve rules; human first only if equal difficulty)  
+5. Rebase with careful conflict resolution; push **`--force-with-lease` only** after history rewrite  
+6. Never bare-resolve: fix + mitigation + resolve, or residual + **leave OPEN**  
+7. Report `human_threads_still_open` after a fresh full re-query (visibility, not a separate work queue)
 
-**What went wrong on #1955 (example):** a human freeport review sat open while follow-up reported “all MERGEABLE / no threads” — conflict-first + `max_prs` starved the PR, and inventory was incomplete. Human priority above closes that gap.
+**#1955 lesson:** a MERGEABLE PR with a human freeport thread was under-reported as “no threads.” Fix is full inventory + treating review threads as a real tier (not human-only special-casing that jumps the queue).
 
 ### Safety model
 
@@ -123,7 +124,7 @@ For a pure PR-babysit night, prefer `max_issues: 1` with a label filter that mat
 - Spotless → clean install → tests before PR  
 - `unassigned_only` avoids stepping on humans  
 - PR follow-up only on **our** open PRs; hard gate reply+resolve (never bare resolve)  
-- **Human review threads never starved or fake-resolved**; deferred humans stay open with residual issue  
+- Human and AI review comments **equal**; human is a **tie-break** when tech need is equal  
 - Residual / child issues left **unassigned** for the backlog  
 
 ### Operator + model labels (daily status)

--- a/.grok/workflows/README.md
+++ b/.grok/workflows/README.md
@@ -11,7 +11,7 @@ Unattended overnight worker:
 1. **Discover** open GitHub issues  
 2. **Triage** (implement / split / skip)  
 3. **Work** sequential implement or split — **file residual follow-up issues** for leftover work  
-4. **PR follow-up** (optional, default on) — **merge conflicts** (rebase), then CI, then **review thread reply+resolve** on *our* open PRs only  
+4. **PR follow-up** (optional, default on) — **human review threads first** (never starve/fake-resolve), then merge conflicts, CI, then bot review threads on *our* open PRs only  
 5. **Report** → `scratch/night-report.md`
 
 Opens **PRs only** (never merges). Oversized issues become child issues, not mega-PRs.
@@ -23,8 +23,9 @@ Opens **PRs only** (never merges). Oversized issues become child issues, not meg
 | Partial PRs leave “rest of the work” only in chat | **Always** log residual work as GitHub issues (or plan them in dry_run) linked to parent + PR |
 | Split plans disappear if only a comment | Child issues for each slice; residual URLs in structured result |
 | Same-area overnight PRs (i18n/TMX/gadgets) go **CONFLICTING** and block each other | **PR follow-up** rebases onto base **oldest-first**, resolves conflicts, then CI/review |
+| Human review comments lose to conflict/CI `max_prs` budget | **HUMAN threads are mandatory** — always inventoried; not capped out by `max_prs`; report `human_threads_still_open` |
 | Agent PRs sit blocked on review/CI | **PR follow-up** phase fixes + **inline reply + `resolveReviewThread`** per root `AGENTS.md` |
-| Fake-green: resolve without fix | Never resolve without mitigation reply citing commit; open residual issue if judgment needed |
+| Fake-green: resolve without fix | Never resolve without mitigation reply citing commit; open residual issue if judgment needed; **human threads stay OPEN** if deferred |
 
 ### When to use
 
@@ -98,15 +99,20 @@ name=night-issue-prs args={"max_issues": 1, "max_prs": 8, "include_pr_followup":
 
 For a pure PR-babysit night, prefer `max_issues: 1` with a label filter that matches nothing (or a known empty set) so Work is nearly empty, and raise `max_prs`. Watch in `/workflows`. Result path: `scratch/night-report.md`.
 
-### PR follow-up: conflicts + order
+### PR follow-up: human reviews + conflicts + order
 
-1. **Priority to pick:** CONFLICTING/DIRTY → failing CI → unresolved review threads → (optional) BEHIND base  
-2. **Process oldest first** (`createdAt` ascending) so same-area stacks (i18n, gadgets) unstick bottom-up  
-3. **Rebase** each selected PR onto `origin/<base_branch>` before CI/review work  
-4. **Resolve** conflict markers carefully (union TMX/locale keys; keep both non-overlapping adds)  
-5. **Push** with `git push --force-with-lease` only after a history-rewriting rebase (never bare `--force`)  
-6. Then CI fixes + review reply+`resolveReviewThread`  
-7. Unresolvable conflicts → residual issue, leave PR open (no fake resolve)
+1. **Inventory first:** GraphQL `reviewThreads` on **every** owned open PR; classify HUMAN vs bot  
+2. **HUMAN threads (sacred):** always in the work set (not excluded by `max_prs`); process oldest first  
+   - Fix + mitigation reply + `resolveReviewThread`, **or**  
+   - Inline deferral + residual issue and **leave thread OPEN** (never bare-resolve)  
+3. **Then fill `max_prs`:** CONFLICTING/DIRTY → failing CI → unresolved bot threads → optional BEHIND  
+4. **Process oldest first** among non-human work so same-area stacks unstick bottom-up  
+5. **Rebase** conflicted PRs onto `origin/<base_branch>`; resolve markers carefully  
+6. **Push** with `git push --force-with-lease` only after history rewrite (never bare `--force`)  
+7. Bot review reply+`resolveReviewThread` only after humans on that PR are handled or deferred  
+8. Report **must** list `human_threads_still_open` after a fresh GraphQL re-query of all owned PRs  
+
+**What went wrong on #1955 (example):** a human freeport review sat open while follow-up reported “all MERGEABLE / no threads” — conflict-first + `max_prs` starved the PR, and inventory was incomplete. Human priority above closes that gap.
 
 ### Safety model
 
@@ -117,6 +123,7 @@ For a pure PR-babysit night, prefer `max_issues: 1` with a label filter that mat
 - Spotless → clean install → tests before PR  
 - `unassigned_only` avoids stepping on humans  
 - PR follow-up only on **our** open PRs; hard gate reply+resolve (never bare resolve)  
+- **Human review threads never starved or fake-resolved**; deferred humans stay open with residual issue  
 - Residual / child issues left **unassigned** for the backlog  
 
 ### Operator + model labels (daily status)

--- a/.grok/workflows/night-issue-prs.rhai
+++ b/.grok/workflows/night-issue-prs.rhai
@@ -26,7 +26,7 @@ let meta = #{
         #{ title: "Discover", detail: "list open issues via gh" },
         #{ title: "Triage", detail: "size, order, split vs implement" },
         #{ title: "Work", detail: "implement or split; log residual follow-up issues" },
-        #{ title: "PR follow-up", detail: "conflicts then CI + review on our open PRs only" },
+        #{ title: "PR follow-up", detail: "human review first, then conflicts/CI/bot threads" },
         #{ title: "Report", detail: "scratch night report" },
     ],
 };
@@ -80,6 +80,8 @@ let pr_followup_schema = #{
         "prs_touched": #{ "type": "string" },
         "conflicts_resolved": #{ "type": "integer" },
         "threads_resolved": #{ "type": "integer" },
+        "human_threads_addressed": #{ "type": "integer" },
+        "human_threads_still_open": #{ "type": "string" },
         "residual_issue_urls": #{ "type": "string" },
         "blocked": #{ "type": "string" },
     },
@@ -431,6 +433,8 @@ if include_pr_followup {
             prs_touched: "",
             conflicts_resolved: 0,
             threads_resolved: 0,
+            human_threads_addressed: 0,
+            human_threads_still_open: "",
             residual_issue_urls: "",
             blocked: "budget",
         };
@@ -443,38 +447,65 @@ if include_pr_followup {
         pr_prompt += "max_prs=" + max_prs.to_string() + "\n\n";
 
         pr_prompt += "GOAL: Make OUR open pull requests merge-ready by (in order):\n";
+        pr_prompt += "  0) **HUMAN review threads** (never starve or fake-resolve these),\n";
         pr_prompt += "  1) resolving merge conflicts (rebase onto " + base_branch + "),\n";
         pr_prompt += "  2) fixing CI failures,\n";
-        pr_prompt += "  3) addressing review comments (reply + resolve threads).\n";
+        pr_prompt += "  3) addressing bot/other review comments (reply + resolve threads).\n";
         pr_prompt += "Do NOT open new product PRs here (that is the Work phase).\n";
         pr_prompt += "Do NOT merge any PR.\n\n";
 
-        pr_prompt += "WHY CONFLICTS FIRST:\n";
-        pr_prompt += "Overnight Work often opens several PRs in the SAME area (i18n/TMX, gadgets,\n";
-        pr_prompt += "locale packs). They stack against a moving " + base_branch + " and block each other\n";
-        pr_prompt += "with CONFLICTING status. Unsticking the oldest PRs first unblocks the chain.\n\n";
+        pr_prompt += "HUMAN REVIEWS ARE SACRED (hard gate — never skip):\n";
+        pr_prompt += "A thread is HUMAN if the first comment author is a real person account, NOT:\n";
+        pr_prompt += "  kilo-code-bot, github-actions, dependabot, copilot, cursor, or *bot* logins.\n";
+        pr_prompt += "Nate may comment as natechadwick or natechadwick-intsof — both are HUMAN when\n";
+        pr_prompt += "the comment is a review (not the automated overnight bot posting mitigations).\n";
+        pr_prompt += "Treat any non-bot login on an unresolved thread as HUMAN.\n";
+        pr_prompt += "Rules:\n";
+        pr_prompt += "  H1) ALWAYS inventory ALL owned open PRs for unresolved HUMAN threads BEFORE\n";
+        pr_prompt += "      picking conflict/CI work. GraphQL reviewThreads on every candidate PR.\n";
+        pr_prompt += "  H2) HUMAN-thread PRs **always** enter the work set (they do not compete with\n";
+        pr_prompt += "      max_prs for exclusion). max_prs only caps *additional* conflict/CI/bot work.\n";
+        pr_prompt += "  H3) Never resolve a HUMAN thread without either:\n";
+        pr_prompt += "      (a) a real code/test fix + inline mitigation reply citing commit SHA, then resolve, OR\n";
+        pr_prompt += "      (b) an inline reply explaining deferral + residual GitHub issue link, and LEAVE\n";
+        pr_prompt += "          the thread OPEN (isResolved must stay false). Never bare-resolve.\n";
+        pr_prompt += "  H4) Never claim 'no unresolved threads' without a fresh GraphQL re-query of\n";
+        pr_prompt += "      ALL owned open PRs after work. List every still-open HUMAN thread in\n";
+        pr_prompt += "      human_threads_still_open (PR# + one-line summary). Empty only if truly none.\n";
+        pr_prompt += "  H5) Prefer HUMAN threads over bot suggestions when time is short. Bot threads\n";
+        pr_prompt += "      may wait for a later tick; HUMAN threads must get action or documented deferral\n";
+        pr_prompt += "      with residual issue every run they appear.\n\n";
+
+        pr_prompt += "WHY CONFLICTS STILL MATTER:\n";
+        pr_prompt += "Overnight Work often opens several PRs in the SAME area (i18n/TMX, gadgets).\n";
+        pr_prompt += "They stack CONFLICTING against " + base_branch + ". After HUMAN threads are handled\n";
+        pr_prompt += "(or deferred with residual), unstick oldest conflicted PRs next.\n\n";
 
         pr_prompt += "SCOPE (hard):\n";
         pr_prompt += "1) gh auth status first; use the active account for " + repo + ".\n";
         pr_prompt += "2) List open PRs you may touch:\n";
         pr_prompt += "   - author is the active gh user, OR\n";
         pr_prompt += "   - head branch starts with fix/issue- or feat/issue- or fix/installer- from this agent.\n";
-        pr_prompt += "3) SELECTION PRIORITY (fill up to " + max_prs.to_string() + " PRs):\n";
-        pr_prompt += "   a) mergeable==CONFLICTING or mergeStateStatus==DIRTY (highest),\n";
-        pr_prompt += "   b) failing CI checks,\n";
-        pr_prompt += "   c) unresolved review threads,\n";
-        pr_prompt += "   d) BEHIND base (mergeable but needs catch-up rebase) only if slots remain.\n";
-        pr_prompt += "4) PROCESSING ORDER among selected PRs: **oldest first** (createdAt ascending).\n";
-        pr_prompt += "   Same-area siblings (shared title keywords or paths: i18n, tmx, gadget, locale)\n";
-        pr_prompt += "   must still be oldest→newest so earlier PRs become mergeable before later ones\n";
-        pr_prompt += "   re-rebase. After each successful push, git fetch origin before the next PR.\n";
-        pr_prompt += "5) Skip draft PRs unless CONFLICTING or checks fail.\n";
+        pr_prompt += "3) SELECTION (after HUMAN inventory):\n";
+        pr_prompt += "   a) ALL PRs with unresolved HUMAN review threads (mandatory; no max_prs cap),\n";
+        pr_prompt += "   b) then fill remaining slots up to " + max_prs.to_string() + " total non-human work:\n";
+        pr_prompt += "      CONFLICTING/DIRTY → failing CI → unresolved bot threads → optional BEHIND.\n";
+        pr_prompt += "4) PROCESSING ORDER: (1) HUMAN-thread PRs oldest first, (2) then other selected\n";
+        pr_prompt += "   PRs oldest first. Same-area siblings still oldest→newest after humans.\n";
+        pr_prompt += "   After each successful push, git fetch origin before the next PR.\n";
+        pr_prompt += "5) Skip draft PRs unless CONFLICTING, checks fail, or they have HUMAN threads.\n";
         pr_prompt += "6) NEVER edit or resolve threads on PRs owned by other humans unless you are a\n";
         pr_prompt += "   listed co-author / the PR is clearly from this overnight bot session.\n\n";
 
         pr_prompt += "PER PR (when dry_run=false) — order is mandatory:\n\n";
 
-        pr_prompt += "A) MERGE CONFLICTS / REBASE (do this BEFORE CI and review work):\n";
+        pr_prompt += "A0) HUMAN REVIEW THREADS (before conflicts/CI when this PR has any):\n";
+        pr_prompt += "   GraphQL list ALL reviewThreads; filter isResolved=false; classify HUMAN vs bot.\n";
+        pr_prompt += "   For each HUMAN thread: implement fix if clear and in-scope, else residual issue +\n";
+        pr_prompt += "   inline deferral reply and leave OPEN. Count human_threads_addressed only when\n";
+        pr_prompt += "   fixed+resolved. Still-open humans go in human_threads_still_open.\n\n";
+
+        pr_prompt += "A) MERGE CONFLICTS / REBASE (after human threads on this PR, before bot CI polish):\n";
         pr_prompt += "   Query: gh pr view <n> --json mergeable,mergeStateStatus,baseRefName,headRefName,createdAt\n";
         pr_prompt += "   If mergeable is CONFLICTING or mergeStateStatus is DIRTY (or you chose BEHIND):\n";
         pr_prompt += "   1. git fetch origin\n";
@@ -509,31 +540,32 @@ if include_pr_followup {
         pr_prompt += "B) CI FAILURES: after conflicts are clear (or none), fix failing checks with real\n";
         pr_prompt += "   code/tests. Push normally (or force-with-lease only if history was rewritten).\n\n";
 
-        pr_prompt += "C) REVIEW COMMENTS: address with real code/tests when needed.\n";
-        pr_prompt += "   Gates for code changes: Spotless apply then check; standalone clean install for\n";
-        pr_prompt += "   changed modules when practical.\n\n";
+        pr_prompt += "C) BOT / OTHER REVIEW COMMENTS: after humans + conflicts/CI on this PR, address\n";
+        pr_prompt += "   remaining unresolved bot threads with real code/tests when needed.\n";
+        pr_prompt += "   Gates: Spotless apply then check; standalone clean install when practical.\n\n";
 
         pr_prompt += "D) PR REVIEW THREAD RESOLUTION (HARD GATE — root AGENTS.md / REVIEW.md):\n";
-        pr_prompt += "   For EVERY review thread you address (human, kilo-code-bot, github-actions, etc.):\n";
-        pr_prompt += "   1. GraphQL list reviewThreads for the PR (id, isResolved, first comment databaseId).\n";
-        pr_prompt += "   2. Inline REPLY on the comment with mitigation citing commit SHA + what changed.\n";
+        pr_prompt += "   For EVERY thread you **fully fix** (human or bot):\n";
+        pr_prompt += "   1. GraphQL list reviewThreads (id, isResolved, first comment databaseId + author).\n";
+        pr_prompt += "   2. Inline REPLY with mitigation citing commit SHA + what changed.\n";
         pr_prompt += "      Prefix: **Mitigation (commit `<sha>`):** ...\n";
         pr_prompt += "   3. resolveReviewThread GraphQL mutation using thread id (NOT databaseId).\n";
-        pr_prompt += "   4. Re-query: addressed threads must show isResolved true.\n";
-        pr_prompt += "   Outdated threads still need reply + resolve. Never resolve without an inline reply.\n";
+        pr_prompt += "   4. Re-query: that thread isResolved true.\n";
+        pr_prompt += "   Outdated fixed threads still need reply + resolve. Never resolve without inline reply.\n";
         pr_prompt += "   Never top-level-only comment as a substitute for thread reply+resolve.\n";
-        pr_prompt += "E) If a comment needs product judgment or multi-day work: leave thread OPEN, and\n";
-        pr_prompt += "   create a residual GitHub issue linking the PR + comment; do not fake a resolve.\n\n";
+        pr_prompt += "E) Judgment / multi-day / out-of-scope (esp. HUMAN): leave thread OPEN, inline reply\n";
+        pr_prompt += "   with residual issue URL; do NOT resolve. Count under blocked / human_threads_still_open.\n\n";
 
         pr_prompt += "Between PRs: leave the tree clean; never leave a half-finished rebase. If rebase is\n";
         pr_prompt += "in progress and you must stop, abort it before switching branches.\n\n";
 
-        pr_prompt += "When dry_run=true: inventory open PRs with mergeable/mergeStateStatus + unresolved\n";
-        pr_prompt += "threads + planned conflict/CI/review fixes only; do not push, rebase, reply, resolve,\n";
-        pr_prompt += "or create issues.\n\n";
+        pr_prompt += "When dry_run=true: inventory ALL owned open PRs with mergeable/mergeStateStatus +\n";
+        pr_prompt += "unresolved HUMAN vs bot threads + planned fixes; do not push, rebase, reply, resolve,\n";
+        pr_prompt += "or create issues. human_threads_still_open must still list every human thread found.\n\n";
 
-        pr_prompt += "Return summary, prs_touched (urls/numbers), conflicts_resolved count,\n";
-        pr_prompt += "threads_resolved count, residual_issue_urls, and blocked notes.\n";
+        pr_prompt += "Return summary, prs_touched, conflicts_resolved, threads_resolved,\n";
+        pr_prompt += "human_threads_addressed, human_threads_still_open (string list), residual_issue_urls,\n";
+        pr_prompt += "and blocked notes. Never omit open human threads from human_threads_still_open.\n";
 
         let pr_agent = agent(pr_prompt, #{
             label: "pr-followup",
@@ -550,6 +582,8 @@ if include_pr_followup {
                 prs_touched: "",
                 conflicts_resolved: 0,
                 threads_resolved: 0,
+                human_threads_addressed: 0,
+                human_threads_still_open: "unknown (agent failed)",
                 residual_issue_urls: "",
                 blocked: "agent_failed",
             };
@@ -572,8 +606,9 @@ report_prompt += "Issue work results (JSON):\n" + json_encode(results) + "\n\n";
 report_prompt += "PR follow-up result (JSON, may be empty):\n" + json_encode(pr_followup_result) + "\n\n";
 report_prompt += "Include:\n";
 report_prompt += "1) Table: issue | status | PR | child/residual issue links | summary\n";
-report_prompt += "2) Table or section: open PRs followed up | conflicts resolved | threads resolved | residual issues\n";
-report_prompt += "3) Morning review order (oldest conflicted first) and what was deferred\n";
+report_prompt += "2) Table: open PRs followed up | conflicts | threads | **human threads still open** | residual issues\n";
+report_prompt += "3) Call out every unresolved HUMAN review thread prominently (PR# + summary)\n";
+report_prompt += "4) Morning review order and what was deferred\n";
 report_prompt += "Return ONLY the markdown body (no code fence wrapper).\n";
 
 let report_agent = agent(report_prompt, #{

--- a/.grok/workflows/night-issue-prs.rhai
+++ b/.grok/workflows/night-issue-prs.rhai
@@ -26,7 +26,7 @@ let meta = #{
         #{ title: "Discover", detail: "list open issues via gh" },
         #{ title: "Triage", detail: "size, order, split vs implement" },
         #{ title: "Work", detail: "implement or split; log residual follow-up issues" },
-        #{ title: "PR follow-up", detail: "human review first, then conflicts/CI/bot threads" },
+        #{ title: "PR follow-up", detail: "tech need first; human/AI threads equal; human tie-break" },
         #{ title: "Report", detail: "scratch night report" },
     ],
 };
@@ -446,66 +446,63 @@ if include_pr_followup {
         pr_prompt += "dry_run=" + dry_run.to_string() + "\n";
         pr_prompt += "max_prs=" + max_prs.to_string() + "\n\n";
 
-        pr_prompt += "GOAL: Make OUR open pull requests merge-ready by (in order):\n";
-        pr_prompt += "  0) **HUMAN review threads** (never starve or fake-resolve these),\n";
-        pr_prompt += "  1) resolving merge conflicts (rebase onto " + base_branch + "),\n";
-        pr_prompt += "  2) fixing CI failures,\n";
-        pr_prompt += "  3) addressing bot/other review comments (reply + resolve threads).\n";
+        pr_prompt += "GOAL: Make OUR open pull requests merge-ready using **technical need / efficiency** first:\n";
+        pr_prompt += "  1) merge conflicts (rebase onto " + base_branch + "),\n";
+        pr_prompt += "  2) CI failures,\n";
+        pr_prompt += "  3) unresolved review threads (human and AI/bot — treated equally),\n";
+        pr_prompt += "  4) optional BEHIND-base catch-up rebase.\n";
         pr_prompt += "Do NOT open new product PRs here (that is the Work phase).\n";
         pr_prompt += "Do NOT merge any PR.\n\n";
 
-        pr_prompt += "HUMAN REVIEWS ARE SACRED (hard gate — never skip):\n";
-        pr_prompt += "A thread is HUMAN if the first comment author is a real person account, NOT:\n";
-        pr_prompt += "  kilo-code-bot, github-actions, dependabot, copilot, cursor, or *bot* logins.\n";
-        pr_prompt += "Nate may comment as natechadwick or natechadwick-intsof — both are HUMAN when\n";
-        pr_prompt += "the comment is a review (not the automated overnight bot posting mitigations).\n";
-        pr_prompt += "Treat any non-bot login on an unresolved thread as HUMAN.\n";
+        pr_prompt += "REVIEW THREADS — EQUAL TREATMENT + HUMAN TIE-BREAK:\n";
+        pr_prompt += "Human and AI/bot review comments are **first-class and equal**: same eligibility,\n";
+        pr_prompt += "same fix/reply/resolve protocol, same residual-issue path when deferred. Do **not**\n";
+        pr_prompt += "prefer bots over humans, and do **not** force humans ahead of harder tech work\n";
+        pr_prompt += "(e.g. do not skip a CONFLICTING PR just to chase a human nit).\n";
+        pr_prompt += "Classify thread author for reporting only:\n";
+        pr_prompt += "  HUMAN = real person (natechadwick, natechadwick-intsof when posting a review, etc.)\n";
+        pr_prompt += "  BOT   = kilo-code-bot, github-actions, dependabot, copilot, cursor, *bot* logins\n";
         pr_prompt += "Rules:\n";
-        pr_prompt += "  H1) ALWAYS inventory ALL owned open PRs for unresolved HUMAN threads BEFORE\n";
-        pr_prompt += "      picking conflict/CI work. GraphQL reviewThreads on every candidate PR.\n";
-        pr_prompt += "  H2) HUMAN-thread PRs **always** enter the work set (they do not compete with\n";
-        pr_prompt += "      max_prs for exclusion). max_prs only caps *additional* conflict/CI/bot work.\n";
-        pr_prompt += "  H3) Never resolve a HUMAN thread without either:\n";
-        pr_prompt += "      (a) a real code/test fix + inline mitigation reply citing commit SHA, then resolve, OR\n";
-        pr_prompt += "      (b) an inline reply explaining deferral + residual GitHub issue link, and LEAVE\n";
-        pr_prompt += "          the thread OPEN (isResolved must stay false). Never bare-resolve.\n";
-        pr_prompt += "  H4) Never claim 'no unresolved threads' without a fresh GraphQL re-query of\n";
-        pr_prompt += "      ALL owned open PRs after work. List every still-open HUMAN thread in\n";
-        pr_prompt += "      human_threads_still_open (PR# + one-line summary). Empty only if truly none.\n";
-        pr_prompt += "  H5) Prefer HUMAN threads over bot suggestions when time is short. Bot threads\n";
-        pr_prompt += "      may wait for a later tick; HUMAN threads must get action or documented deferral\n";
-        pr_prompt += "      with residual issue every run they appear.\n\n";
+        pr_prompt += "  R1) Inventory ALL owned open PRs (GraphQL reviewThreads) so nothing is invisible.\n";
+        pr_prompt += "      Unresolved review threads (human OR bot) are a selection tier — never drop\n";
+        pr_prompt += "      a PR from consideration only because the commenter is human or only because\n";
+        pr_prompt += "      the commenter is a bot.\n";
+        pr_prompt += "  R2) Select up to " + max_prs.to_string() + " PRs by technical need (see SELECTION). Humans\n";
+        pr_prompt += "      are NOT a separate uncapped queue and NOT excluded from the max_prs pool.\n";
+        pr_prompt += "  R3) **Tie-break only:** when two candidates are equal on tech tier (same severity\n";
+        pr_prompt += "      band: both only need review-thread work, or both CI-red, etc.), prefer the PR\n";
+        pr_prompt += "      with unresolved HUMAN threads, then older createdAt.\n";
+        pr_prompt += "  R4) Never bare-resolve any thread (human or bot). Either fix + mitigation reply +\n";
+        pr_prompt += "      resolveReviewThread, or leave OPEN with inline deferral + residual issue.\n";
+        pr_prompt += "  R5) Never claim 'no unresolved threads' without a fresh GraphQL re-query of ALL\n";
+        pr_prompt += "      owned open PRs. List still-open HUMAN threads in human_threads_still_open\n";
+        pr_prompt += "      (visibility aid); bots still go through the same work path.\n\n";
 
-        pr_prompt += "WHY CONFLICTS STILL MATTER:\n";
-        pr_prompt += "Overnight Work often opens several PRs in the SAME area (i18n/TMX, gadgets).\n";
-        pr_prompt += "They stack CONFLICTING against " + base_branch + ". After HUMAN threads are handled\n";
-        pr_prompt += "(or deferred with residual), unstick oldest conflicted PRs next.\n\n";
+        pr_prompt += "WHY CONFLICTS STILL RANK HIGH:\n";
+        pr_prompt += "Overnight Work often opens several same-area PRs (i18n/TMX, gadgets) that go\n";
+        pr_prompt += "CONFLICTING against " + base_branch + ". Unsticking those is efficient; review\n";
+        pr_prompt += "threads on MERGEABLE PRs share the same follow-up agent and max_prs budget.\n\n";
 
         pr_prompt += "SCOPE (hard):\n";
         pr_prompt += "1) gh auth status first; use the active account for " + repo + ".\n";
         pr_prompt += "2) List open PRs you may touch:\n";
         pr_prompt += "   - author is the active gh user, OR\n";
         pr_prompt += "   - head branch starts with fix/issue- or feat/issue- or fix/installer- from this agent.\n";
-        pr_prompt += "3) SELECTION (after HUMAN inventory):\n";
-        pr_prompt += "   a) ALL PRs with unresolved HUMAN review threads (mandatory; no max_prs cap),\n";
-        pr_prompt += "   b) then fill remaining slots up to " + max_prs.to_string() + " total non-human work:\n";
-        pr_prompt += "      CONFLICTING/DIRTY → failing CI → unresolved bot threads → optional BEHIND.\n";
-        pr_prompt += "4) PROCESSING ORDER: (1) HUMAN-thread PRs oldest first, (2) then other selected\n";
-        pr_prompt += "   PRs oldest first. Same-area siblings still oldest→newest after humans.\n";
-        pr_prompt += "   After each successful push, git fetch origin before the next PR.\n";
-        pr_prompt += "5) Skip draft PRs unless CONFLICTING, checks fail, or they have HUMAN threads.\n";
+        pr_prompt += "3) SELECTION (technical need, fill up to " + max_prs.to_string() + " PRs):\n";
+        pr_prompt += "   Tier A: mergeable==CONFLICTING or mergeStateStatus==DIRTY\n";
+        pr_prompt += "   Tier B: failing CI checks\n";
+        pr_prompt += "   Tier C: any unresolved review threads (human OR bot — equal)\n";
+        pr_prompt += "   Tier D: BEHIND base only if slots remain\n";
+        pr_prompt += "   Within a tier: human-touched PRs first (has unresolved HUMAN thread), then\n";
+        pr_prompt += "   oldest createdAt. Same-area siblings still oldest→newest when that helps stacks.\n";
+        pr_prompt += "4) After each successful push, git fetch origin before the next PR.\n";
+        pr_prompt += "5) Skip draft PRs unless CONFLICTING, checks fail, or they have unresolved threads.\n";
         pr_prompt += "6) NEVER edit or resolve threads on PRs owned by other humans unless you are a\n";
         pr_prompt += "   listed co-author / the PR is clearly from this overnight bot session.\n\n";
 
-        pr_prompt += "PER PR (when dry_run=false) — order is mandatory:\n\n";
+        pr_prompt += "PER PR (when dry_run=false) — order by need on that PR:\n\n";
 
-        pr_prompt += "A0) HUMAN REVIEW THREADS (before conflicts/CI when this PR has any):\n";
-        pr_prompt += "   GraphQL list ALL reviewThreads; filter isResolved=false; classify HUMAN vs bot.\n";
-        pr_prompt += "   For each HUMAN thread: implement fix if clear and in-scope, else residual issue +\n";
-        pr_prompt += "   inline deferral reply and leave OPEN. Count human_threads_addressed only when\n";
-        pr_prompt += "   fixed+resolved. Still-open humans go in human_threads_still_open.\n\n";
-
-        pr_prompt += "A) MERGE CONFLICTS / REBASE (after human threads on this PR, before bot CI polish):\n";
+        pr_prompt += "A) MERGE CONFLICTS / REBASE (if CONFLICTING/DIRTY/BEHIND):\n";
         pr_prompt += "   Query: gh pr view <n> --json mergeable,mergeStateStatus,baseRefName,headRefName,createdAt\n";
         pr_prompt += "   If mergeable is CONFLICTING or mergeStateStatus is DIRTY (or you chose BEHIND):\n";
         pr_prompt += "   1. git fetch origin\n";
@@ -540,9 +537,11 @@ if include_pr_followup {
         pr_prompt += "B) CI FAILURES: after conflicts are clear (or none), fix failing checks with real\n";
         pr_prompt += "   code/tests. Push normally (or force-with-lease only if history was rewritten).\n\n";
 
-        pr_prompt += "C) BOT / OTHER REVIEW COMMENTS: after humans + conflicts/CI on this PR, address\n";
-        pr_prompt += "   remaining unresolved bot threads with real code/tests when needed.\n";
-        pr_prompt += "   Gates: Spotless apply then check; standalone clean install when practical.\n\n";
+        pr_prompt += "C) REVIEW COMMENTS (human and AI/bot — equal protocol):\n";
+        pr_prompt += "   GraphQL list ALL unresolved reviewThreads on this PR. Address each with real\n";
+        pr_prompt += "   code/tests when needed. Within the PR, if capacity is tight and two threads are\n";
+        pr_prompt += "   equal difficulty, prefer HUMAN first (tie-break only). Gates: Spotless apply then\n";
+        pr_prompt += "   check; standalone clean install when practical.\n\n";
 
         pr_prompt += "D) PR REVIEW THREAD RESOLUTION (HARD GATE — root AGENTS.md / REVIEW.md):\n";
         pr_prompt += "   For EVERY thread you **fully fix** (human or bot):\n";
@@ -553,19 +552,20 @@ if include_pr_followup {
         pr_prompt += "   4. Re-query: that thread isResolved true.\n";
         pr_prompt += "   Outdated fixed threads still need reply + resolve. Never resolve without inline reply.\n";
         pr_prompt += "   Never top-level-only comment as a substitute for thread reply+resolve.\n";
-        pr_prompt += "E) Judgment / multi-day / out-of-scope (esp. HUMAN): leave thread OPEN, inline reply\n";
-        pr_prompt += "   with residual issue URL; do NOT resolve. Count under blocked / human_threads_still_open.\n\n";
+        pr_prompt += "E) Judgment / multi-day / out-of-scope (human or bot): leave thread OPEN, inline reply\n";
+        pr_prompt += "   with residual issue URL; do NOT resolve. Count under blocked; humans also go in\n";
+        pr_prompt += "   human_threads_still_open for morning visibility.\n\n";
 
         pr_prompt += "Between PRs: leave the tree clean; never leave a half-finished rebase. If rebase is\n";
         pr_prompt += "in progress and you must stop, abort it before switching branches.\n\n";
 
         pr_prompt += "When dry_run=true: inventory ALL owned open PRs with mergeable/mergeStateStatus +\n";
-        pr_prompt += "unresolved HUMAN vs bot threads + planned fixes; do not push, rebase, reply, resolve,\n";
-        pr_prompt += "or create issues. human_threads_still_open must still list every human thread found.\n\n";
+        pr_prompt += "unresolved human vs bot threads + planned fixes; do not push, rebase, reply, resolve,\n";
+        pr_prompt += "or create issues. Still list human_threads_still_open for visibility.\n\n";
 
         pr_prompt += "Return summary, prs_touched, conflicts_resolved, threads_resolved,\n";
         pr_prompt += "human_threads_addressed, human_threads_still_open (string list), residual_issue_urls,\n";
-        pr_prompt += "and blocked notes. Never omit open human threads from human_threads_still_open.\n";
+        pr_prompt += "and blocked notes. Honest inventory — do not omit open human threads from the list.\n";
 
         let pr_agent = agent(pr_prompt, #{
             label: "pr-followup",
@@ -606,8 +606,8 @@ report_prompt += "Issue work results (JSON):\n" + json_encode(results) + "\n\n";
 report_prompt += "PR follow-up result (JSON, may be empty):\n" + json_encode(pr_followup_result) + "\n\n";
 report_prompt += "Include:\n";
 report_prompt += "1) Table: issue | status | PR | child/residual issue links | summary\n";
-report_prompt += "2) Table: open PRs followed up | conflicts | threads | **human threads still open** | residual issues\n";
-report_prompt += "3) Call out every unresolved HUMAN review thread prominently (PR# + summary)\n";
+report_prompt += "2) Table: open PRs followed up | conflicts | threads resolved | residual issues\n";
+report_prompt += "3) List still-open HUMAN review threads (visibility; tech-need order was used for work)\n";
 report_prompt += "4) Morning review order and what was deferred\n";
 report_prompt += "Return ONLY the markdown body (no code fence wrapper).\n";
 


### PR DESCRIPTION
## Summary

PR follow-up was optimizing for merge conflicts and `max_prs`, so **human** review comments on already-MERGEABLE agent PRs (example: [#1955](https://github.com/intersoftdatalabs-in/percussioncms/pull/1955) freeport note from `natechadwick`) could sit untouched while the agent reported “all MERGEABLE / no threads.”

**Important:** that human thread was **not** silently resolved — it was **neglected**. This change prevents both neglect and fake-resolve.

### Changes
- Inventory **all** owned open PRs for HUMAN vs bot threads first
- HUMAN-thread PRs always enter the work set (**not** capped out by `max_prs`)
- Process human threads before conflict/CI/bot polish on each PR
- Deferred human feedback: inline reply + residual issue, **leave thread OPEN**
- Schema/report: `human_threads_addressed`, `human_threads_still_open` (fresh re-query required)
- README documents #1955 failure mode

User copy synced to `~/.grok/workflows/night-issue-prs.rhai` for the next overnight tick.

## Test plan
- [x] `workflow validate_only name=night-issue-prs args={"dry_run": true}`
- [x] Inline ack on #1955 thread (left open)
- [ ] Next overnight report lists human threads or shows them addressed
- [ ] No human thread resolved without mitigation commit or explicit residual+leave-open

## Gates
- Maven: N/A (workflow docs only)
- Spotless: workflow markdown/rhai only