### PR TITLE
fix(1984): co-locate DTS dts-tomcat.service.in with installDts service scripts

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/README.md
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/README.md
@@ -124,9 +124,12 @@ when available:
 | `DTSStagingService.sh`    | `PercussionStagingDTS`    |
 
 Shared unit template: `dts-tomcat.service.in` (`Type=forking`, `TimeoutStartSec=1800`, journal).  
-Ops notes: `README-systemd.md` (dry-run / non-root limitations, migration uninstall→install,
-init.d retained as start helper + fallback). Flags: `--systemd`, `--initd`. Install requires
-root (no product `--dry-run`). Windows `.bat` unchanged.
+`installDts.xml` co-locates the template and `README-systemd.md` under `Deployment/Server/`
+next to `DTSProductionService.sh` / `DTSStagingService.sh` (scripts resolve
+`dirname $0`/dts-tomcat.service.in; GH-1984). Ops notes: `README-systemd.md` (dry-run /
+non-root limitations, migration uninstall→install, init.d retained as start helper +
+fallback). Flags: `--systemd`, `--initd`. Install requires root (no product `--dry-run`).
+Windows `.bat` unchanged.
 
 **Dual-ship policy:** keep init.d until a live Linux soak signs off (do not remove
 init.d / #1976 without ops review). `installDts.xml` places the role-specific

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/README-systemd.md
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/README-systemd.md
@@ -17,8 +17,9 @@ init.d under GH-1976 without human approval). Packaging guards:
 `DtsLinuxServiceDualShipPackagingTest`.
 
 Shared unit template: `dts-tomcat.service.in` (must sit next to the role
-installer under `Deployment/Server/` after install — `installDts.xml` co-locates
-it). Ops README also remains at the DTS install root.
+installer under `Deployment/Server/` after install/upgrade — `installDts.xml`
+co-locates it with `DTS*Service.sh`; GH-1984). Ops README also remains at the
+DTS install root and is co-located under `Deployment/Server/` on Linux.
 
 SysV/init.d remains available as:
 

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/rxconfig/Installer/installDts.xml
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/rxconfig/Installer/installDts.xml
@@ -522,15 +522,18 @@
 					  only Production OR Staging lands here (not both). Windows binaries
 					  go to bin/; Linux systemd unit template MUST sit next to the .sh
 					  (DTS*Service.sh resolves dts-tomcat.service.in via dirname of $0).
-					  GH-1978 dual-ship: also keep template + README at install root via
-					  the * copy (not excluded). Do not drop init.d until soak (#1976).
+					  GH-1984: co-locate unit template + README-systemd.md under
+					  Deployment/Server on Linux. GH-1978 dual-ship: also keep template +
+					  README at install root via the * copy (not excluded). Do not drop
+					  init.d until soak (#1976).
 					-->
 					<copy todir="${install.dir}${staging.dir}/Deployment/Server">
 						<fileset dir="${install.src}">
 							<include name="${serviceFileName}" if="${isWindows}" />
 							<include name="${serviceFileNameLinux}" if="${isLinux}" />
-							<!-- Co-locate unit template with Linux service installer -->
+							<!-- Co-locate unit template + ops README with Linux service installer -->
 							<include name="dts-tomcat.service.in" if="${isLinux}" />
+							<include name="README-systemd.md" if="${isLinux}" />
 						</fileset>
 					</copy>
 
@@ -676,11 +679,15 @@
 						</then>
 					</if>
 
+					<!-- Service scripts + systemd unit template co-located under
+					     Deployment/Server (same as fresh path; GH-1984). -->
 					<copy todir="${install.dir}${staging.dir}/Deployment/Server"
 						overwrite="true" verbose="true">
 						<fileset dir="${install.src}">
 							<include name="${serviceFileName}" if="${isWindows}" />
 							<include name="${serviceFileNameLinux}" if="${isLinux}" />
+							<include name="dts-tomcat.service.in" if="${isLinux}" />
+							<include name="README-systemd.md" if="${isLinux}" />
 						</fileset>
 					</copy>
 
@@ -839,10 +846,11 @@
 					</copy>
 
 					<!--
-					  GH-1978: on upgrade, refresh the role-specific service installer and
-					  co-located systemd unit template under Deployment/Server so systemd
-					  dual-ship assets match the shipping payload. Same intentional excludes
-					  as fresh install: only one role script, not both Production+Staging.
+					  GH-1978 / GH-1984: on upgrade, refresh the role-specific service
+					  installer and co-located systemd unit template + README under
+					  Deployment/Server so dual-ship assets match the shipping payload.
+					  Same intentional excludes as fresh install: only one role script,
+					  not both Production+Staging.
 					-->
 					<copy todir="${install.dir}${staging.dir}/Deployment/Server"
 						overwrite="true" force="true" verbose="true">
@@ -850,6 +858,7 @@
 							<include name="${serviceFileName}" if="${isWindows}" />
 							<include name="${serviceFileNameLinux}" if="${isLinux}" />
 							<include name="dts-tomcat.service.in" if="${isLinux}" />
+							<include name="README-systemd.md" if="${isLinux}" />
 						</fileset>
 					</copy>
 

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsServiceInstallScriptTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsServiceInstallScriptTest.java
@@ -108,4 +108,95 @@ class DtsServiceInstallScriptTest {
   void staging_defaultServiceName() {
     assertTrue(staging.contains("SERVICE_NAME=PercussionStagingDTS"));
   }
+
+  /**
+   * GH-1984: systemd install resolves the unit template beside the service script ({@code dirname
+   * $0}/dts-tomcat.service.in). Scripts are installed under {@code Deployment/Server/}, so the
+   * template must not be assumed only at product surface root.
+   */
+  @Test
+  void bothScripts_resolveUnitTemplateBesideScript() {
+    for (String script : List.of(production, staging)) {
+      assertTrue(
+          script.contains(
+                  "unit_template=\"$(dirname \"$(abspath \"$0\")\")/dts-tomcat.service.in\"")
+              || script.contains(
+                  "unit_template=$(dirname \"$(abspath \"$0\")\")/dts-tomcat.service.in"),
+          "installSystemdUnit must resolve dts-tomcat.service.in next to the service script");
+      assertTrue(
+          script.contains("Missing systemd unit template"),
+          "must fail closed when unit template is missing");
+    }
+  }
+
+  /**
+   * GH-1984 / inventory Gap B: {@code installDts.xml} must copy {@code dts-tomcat.service.in} (and
+   * {@code README-systemd.md}) into {@code Deployment/Server/} on both fresh and upgrade Linux
+   * paths, co-located with {@code DTSProductionService.sh} / {@code DTSStagingService.sh}.
+   */
+  @Test
+  void installDts_colocatesSystemdTemplateWithServiceScripts() throws Exception {
+    Path installDts =
+        Path.of("src", "main", "rootFiles", "rxconfig", "Installer", "installDts.xml");
+    assertTrue(Files.isRegularFile(installDts), () -> "missing " + installDts.toAbsolutePath());
+    String xml = Files.readString(installDts, StandardCharsets.UTF_8);
+
+    // At least two Linux co-location copies (fresh + upgrade).
+    int serviceInIncludes = countOccurrences(xml, "dts-tomcat.service.in");
+    assertTrue(
+        serviceInIncludes >= 2,
+        "installDts.xml must reference dts-tomcat.service.in at least twice (fresh + upgrade); was "
+            + serviceInIncludes);
+
+    int readmeIncludes = countOccurrences(xml, "README-systemd.md");
+    assertTrue(
+        readmeIncludes >= 2,
+        "installDts.xml must reference README-systemd.md at least twice (fresh + upgrade); was "
+            + readmeIncludes);
+
+    // Each Deployment/Server service-script copy block must also include the unit template.
+    int searchFrom = 0;
+    int serverCopyBlocks = 0;
+    while (true) {
+      int copyIdx =
+          xml.indexOf("todir=\"${install.dir}${staging.dir}/Deployment/Server\"", searchFrom);
+      if (copyIdx < 0) {
+        // also match without quotes variation used on upgrade (same attribute form)
+        break;
+      }
+      int filesetEnd = xml.indexOf("</fileset>", copyIdx);
+      assertTrue(filesetEnd > copyIdx, "unclosed fileset after Deployment/Server copy");
+      String block = xml.substring(copyIdx, filesetEnd);
+      if (block.contains("serviceFileNameLinux") || block.contains("${serviceFileNameLinux}")) {
+        serverCopyBlocks++;
+        assertTrue(
+            block.contains("dts-tomcat.service.in"),
+            "Deployment/Server service-script copy must include dts-tomcat.service.in (GH-1984)");
+        assertTrue(
+            block.contains("README-systemd.md"),
+            "Deployment/Server service-script copy must include README-systemd.md (GH-1984)");
+        assertTrue(
+            block.contains("if=\"${isLinux}\""),
+            "systemd template co-location must be gated on isLinux");
+      }
+      searchFrom = filesetEnd + 1;
+    }
+    assertTrue(
+        serverCopyBlocks >= 2,
+        "expected >=2 Deployment/Server service-script copy blocks (fresh+upgrade); was "
+            + serverCopyBlocks);
+  }
+
+  private static int countOccurrences(String haystack, String needle) {
+    int count = 0;
+    int from = 0;
+    while (true) {
+      int idx = haystack.indexOf(needle, from);
+      if (idx < 0) {
+        return count;
+      }
+      count++;
+      from = idx + needle.length();
+    }
+  }
 }

--- a/docs/ai-generated/code-reviews/issue-1984-dts-service-in-colocate-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-1984-dts-service-in-colocate-erlang.md
@@ -1,0 +1,65 @@
+# Erlang review: issue #1984 — DTS systemd unit template co-location
+
+**Branch:** `fix/issue-1984-dts-service-in-colocate`  
+**Reviewer persona:** Erlang (independent pre-commit)  
+**Date:** 2026-08-05  
+**Recommendation:** approve  
+**Gate:** pass  
+**May commit/push:** yes
+
+## Summary
+
+`installDts.xml` installed Linux service scripts under `Deployment/Server/` but left
+`dts-tomcat.service.in` (and `README-systemd.md`) only at product surface root via
+the root `*` fileset. `DTSProductionService.sh` / `DTSStagingService.sh` resolve the
+unit template as `dirname $0`/dts-tomcat.service.in, so systemd install failed unless
+operators copied the template manually.
+
+This change co-locates the template (and README) on **fresh and upgrade** Linux paths
+in the same `Deployment/Server` copy that places the service scripts. Structural tests
+assert both script resolution and installer path wiring. Windows `.bat` behavior is
+unchanged (`if="${isLinux}"` gates). Parent `pom.xml` nested unclosed `<excludes>`
+tags on `main` were fixed so Maven can parse (build blocker unrelated to packaging
+logic but required for verification).
+
+## Scope
+
+- `deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/rxconfig/Installer/installDts.xml`
+- `.../DtsServiceInstallScriptTest.java` (new co-location + resolution tests)
+- Docs: module `README.md`, `README-systemd.md`
+- `pom.xml` (bannedDependencies excludes well-formedness)
+- Cross-platform path review: no new filesystem path joins; tests use `Path.of(...)`
+  segments; Ant destination paths retain product layout conventions (`Deployment/Server`
+  is a product-relative install tree, not OS-specific). Scripts under review still use
+  Unix shell path forms (Linux-only service installers). **Cross-platform path review:
+  clean for this slice.**
+
+Prior report / memory: GH-962 / #1977 systemd dual-ship patterns; Gap B residual of
+#1975 inventory.
+
+## Issues
+
+None at `bug` severity.
+
+### suggestion (non-blocking)
+
+1. **Surface root still retains a copy** of `dts-tomcat.service.in` via the root `*`
+   fileset. Harmless dual ship; operators may still find the template at surface root.
+   No change required for acceptance (co-location beside scripts is the fix).
+
+### nit
+
+1. Parent POM parse fix is slightly outside the packaging residual; documented in PR
+   body so reviewers know why `pom.xml` is in the diff.
+
+## Test evidence
+
+- `cd deliverytiersuite/delivery-tier-suite/delivery-tier-distribution && ../../../mvnw clean install` → **BUILD SUCCESS**
+- `DtsServiceInstallScriptTest` 8 tests, `DtsSystemdUnitTemplateTest` 4 tests — all pass
+- Spotless: `mvnw spotless:apply` then `mvnw spotless:check` → SUCCESS; feature PR commits
+  only in-scope paths (out-of-scope Spotless rewrites left uncommitted)
+
+## Recommendation
+
+Approve for PR against `main`. Does not close #1975 (inventory PR #1985 owns that).
+Links: #1984, #1975, #962.


### PR DESCRIPTION
## Summary

Fixes **#1984** (residual of #1975 Gap B / parent #962): after install or upgrade, `dts-tomcat.service.in` (and `README-systemd.md`) are available next to the Linux DTS service scripts under `Deployment/Server/`.

**Problem:** `DTSProductionService.sh` / `DTSStagingService.sh` resolve the unit template as `dirname $0/dts-tomcat.service.in`. `installDts.xml` already installed those scripts under `Deployment/Server/` but left the template only at product surface root via the root `*` fileset, so systemd install failed unless operators copied the file manually.

**Change:**
- `installDts.xml` fresh **and** upgrade Linux paths: co-locate `dts-tomcat.service.in` + `README-systemd.md` in the same `Deployment/Server` copy that places the service scripts (`if="${isLinux}"` only).
- Extended `DtsServiceInstallScriptTest` for script-side resolution + installer path co-location (no root install required).
- Docs: module README + `README-systemd.md`.
- **Companion:** parent `pom.xml` nested unclosed `<excludes>` under `bannedDependencies` made Maven non-parseable on `main`; fixed to a single well-formed excludes list so builds can run (build blocker, not packaging logic).

**Out of scope (unchanged):** Windows `.bat` behavior, live `systemctl`, closing **#1975** (owned by inventory PR #1985).

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] `cd deliverytiersuite/delivery-tier-suite/delivery-tier-distribution && ../../../mvnw clean install` → **BUILD SUCCESS**
- [x] `DtsServiceInstallScriptTest` (8) + `DtsSystemdUnitTemplateTest` (4) green
- [x] Spotless: `mvnw spotless:apply` **then** `mvnw spotless:check` (feature PR contains only in-scope files; unrelated Spotless hits left uncommitted)
- [x] Erlang pre-commit: approve — `docs/ai-generated/code-reviews/issue-1984-dts-service-in-colocate-erlang.md`
- [ ] CI green on PR

## Gates evidence

| Gate | Result |
|------|--------|
| Module clean install | BUILD SUCCESS (standalone) |
| Behavioral/structural tests | co-location + unit template resolution |
| Spotless apply → check | pass; no out-of-scope dump in this PR |
| Erlang | approve / May commit: yes |
| Cross-platform | Linux service installers only; Ant gates `isLinux`; tests use `Path.of` |

## Links

- Fixes #1984
- Related #1975 (do **not** close — inventory PR #1985)
- Related #962