### PR TITLE
fix(perc-jetty): restore defaults/bin/rxjetty.sh start-helper (#1983)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,10 @@ system/.settings/*
 .idea/sonarlint/issuestore/index.pb
 spotless-index-file
 bin/
+# GH-1983: ship Jetty start-helper under defaults/bin/ (install-jetty-service.sh contract).
+# Root bin/ ignore must not hide this packaged template.
+!modules/perc-jetty/src/main/jetty/defaults/bin/
+!modules/perc-jetty/src/main/jetty/defaults/bin/**
 target/
 .codeql-db/
 .codeql-results/

--- a/docs/ai-generated/code-reviews/issue-1983-restore-rxjetty-sh-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-1983-restore-rxjetty-sh-erlang.md
@@ -1,0 +1,50 @@
+# Erlang review: issue #1983 restore `defaults/bin/rxjetty.sh`
+
+**Date:** 2026-08-05  
+**Branch:** `fix/issue-1983-restore-rxjetty-sh`  
+**Scope:** GH-1983 — restore Jetty start-helper template for Linux service install  
+**Recommendation:** **approve**  
+**May commit/push:** yes  
+**Gate:** pass
+
+## Summary
+
+Restores the pre-Jetty-12 `rxjetty.sh` start-helper under
+`modules/perc-jetty/src/main/jetty/defaults/bin/rxjetty.sh` so
+`install-jetty-service.sh` can sed-substitute `${rxjetty_service}` into
+`/etc/init.d/<ServiceName>` for both systemd and `--initd` paths. Assembly
+copies `src/main/jetty/**` into the distribution; zip verified to include
+`defaults/bin/rxjetty.sh`. Structural tests cover template markers and install
+script contract. README-systemd documents the template path. Root `.gitignore`
+`bin/` exception is required so the packaged path is versioned.
+
+## Cross-platform path checklist
+
+- [x] No new hard-coded OS separators for local filesystem joins in Java
+- [x] Tests use `Path.of(...)` components
+- [x] Shell template is Unix-only by product design (Linux service install); LF endings
+- [x] Packaging path `defaults/bin/rxjetty.sh` matches install script contract
+
+## Issues
+
+None (bugs / missing behavioral tests / non-portable I/O).
+
+### Nits (non-blocking)
+
+- Historical template retains shell-quoting caveats (`su -c` with expanded
+  `RUN_CMD`); same as pre-a82b983bce contract — out of scope for restore.
+- `UID -eq 0` alignment for start-stop-daemon when root (was historical `UID -eq 2`)
+  matches Jetty 12 upstream and unit docs; nohup path remains fallback.
+
+## Tests / build evidence
+
+- `cd modules/perc-jetty && ../../mvnw clean install` → BUILD SUCCESS  
+  Tests run: 58, Failures: 0, Errors: 0, Skipped: 7  
+  New: `RxJettyStartHelperTemplateTest` (4), extended `InstallJettyServiceScriptTest` (7)
+- Root `./mvnw spotless:apply` then `./mvnw spotless:check` → SUCCESS  
+  (out-of-scope Spotless hits left uncommitted)
+
+## Memory patterns hit
+
+- Packaging companions: assert both source template and assembly output when possible
+- Installer contract structural tests (string markers) over live root systemctl

--- a/modules/perc-jetty/src/main/jetty/defaults/bin/rxjetty.sh
+++ b/modules/perc-jetty/src/main/jetty/defaults/bin/rxjetty.sh
@@ -1,0 +1,630 @@
+#!/usr/bin/env bash
+# Percussion CMS Jetty start-helper template (GH-1983 / specs/988-linux-systemd-services).
+# Packaged at jetty/defaults/bin/rxjetty.sh. install-jetty-service.sh substitutes
+# ${rxjetty_service} via sed into /etc/init.d/<ServiceName>.
+# Type=forking systemd units rely on start (start-stop-daemon -b or nohup) writing JETTY_PID
+# before the parent exits. Do not change fork+PID behavior without verifying the unit template.
+#
+# chkconfig: 2345 20 80
+# description: Description comes here....
+# LSB Tags
+### BEGIN INIT INFO
+# Provides:          ${rxjetty_service}
+# Required-Start:    $local_fs $network
+# Required-Stop:     $local_fs $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Jetty start script.
+# Description:       Start Jetty web server.
+### END INIT INFO
+
+# Startup script for jetty under *nix systems (it works under NT/cygwin too).
+
+##################################################
+# Set the name which is used by other variables.
+# Defaults to the file name without extension.
+##################################################
+NAME=$(echo $(basename $0) | sed -e 's/^[SK][0-9]*//' -e 's/\.sh$//')
+
+# To get the service to restart correctly on reboot, uncomment below (3 lines):
+# ========================
+#chkconfig: 3 99 99
+# description: Percussion CMS Jetty webserver
+# processname: ${rxjetty_service}
+# ========================
+
+# Configuration files
+#
+# /etc/default/$NAME
+#   If it exists, this is read at the start of script. It may perform any 
+#   sequence of shell commands, like setting relevant environment variables.
+#
+# $HOME/.$NAMErc (e.g. $HOME/.jettyrc)
+#   If it exists, this is read at the start of script. It may perform any 
+#   sequence of shell commands, like setting relevant environment variables.
+#
+# /etc/$NAME.conf
+#   If found, and no configurations were given on the command line,
+#   the file will be used as this script's configuration. 
+#   Each line in the file may contain:
+#     - A comment denoted by the pound (#) sign as first non-blank character.
+#     - The path to a regular file, which will be passed to jetty as a 
+#       config.xml file.
+#     - The path to a directory. Each *.xml file in the directory will be
+#       passed to jetty as a config.xml file.
+#     - All other lines will be passed, as-is to the start.jar
+#
+#   The files will be checked for existence before being passed to jetty.
+#
+# Configuration variables
+#
+# JAVA
+#   Command to invoke Java. If not set, java (from the PATH) will be used.
+#
+# JAVA_OPTIONS
+#   Extra options to pass to the JVM
+#
+# JETTY_HOME
+#   Where Jetty is installed. If not set, the script will try go
+#   guess it by looking at the invocation path for the script
+#   The java system property "jetty.home" will be
+#   set to this value for use by configure.xml files, f.e.:
+#
+#    <Arg><Property name="jetty.home" default="."/>/webapps/jetty.war</Arg>
+#
+# JETTY_BASE
+#   Where your Jetty base directory is.  If not set, the value from
+#   $JETTY_HOME will be used.
+#
+# JETTY_RUN
+#   Where the $NAME.pid file should be stored. It defaults to the
+#   first available of /var/run, /usr/var/run, JETTY_BASE and /tmp
+#   if not set.
+#  
+# JETTY_PID
+#   The Jetty PID file, defaults to $JETTY_RUN/$NAME.pid
+#   
+# JETTY_ARGS
+#   The default arguments to pass to jetty.
+#   For example
+#      JETTY_ARGS=jetty.http.port=8080 jetty.ssl.port=8443
+#
+# JETTY_USER
+#   if set, then used as a username to run the server as
+#
+# JETTY_SHELL
+#   If set, then used as the shell by su when starting the server.  Will have
+#   no effect if start-stop-daemon exists.  Useful when JETTY_USER does not
+#   have shell access, e.g. /bin/false
+#
+
+usage()
+{
+    echo "Usage: ${0##*/} [-d] {start|stop|run|restart|check|supervise} [ CONFIGS ... ] "
+    exit 1
+}
+
+[ $# -gt 0 ] || usage
+
+
+##################################################
+# Some utility functions
+##################################################
+findDirectory()
+{
+  local L OP=$1
+  shift
+  for L in "$@"; do
+    [ "$OP" "$L" ] || continue 
+    printf %s "$L"
+    break
+  done 
+}
+
+running()
+{
+  if [ -f "$1" ]
+  then
+    local PID=$(cat "$1" 2>/dev/null) || return 1
+    kill -0 "$PID" 2>/dev/null
+    return
+  fi
+  rm -f "$1"
+  return 1
+}
+
+started()
+{
+     rm -f $JETTY_RUN/${NAME}.pid
+     rm -f $JETTY_BASE/${NAME}.state
+
+  # wait for 500*8s to see "STARTED" in PID file, needs jetty-started.xml as argument
+  for T in {1..500}
+  do
+    sleep 8 
+    [ -z "$(grep STARTED $1 2>/dev/null)" ] || return 0
+    [ -z "$(grep STOPPED $1 2>/dev/null)" ] || return 1
+    [ -z "$(grep FAILED $1 2>/dev/null)" ] || return 1
+    local PID=$(cat "$2" 2>/dev/null) || return 1
+    kill -0 "$PID" 2>/dev/null || return 1
+    echo -n ". "
+  done
+
+  return 1;
+}
+
+
+readConfig()
+{
+  (( DEBUG )) && echo "Reading $1.."
+  source "$1"
+}
+
+dumpEnv()
+{
+    echo "JAVA           =  $JAVA"
+    echo "JAVA_OPTIONS   =  ${JAVA_OPTIONS[*]}"
+    echo "JETTY_HOME     =  $JETTY_HOME"
+    echo "JETTY_BASE     =  $JETTY_BASE"
+    echo "START_D        =  $START_D"
+    echo "START_INI      =  $START_INI"
+    echo "JETTY_START    =  $JETTY_START"
+    echo "JETTY_CONF     =  $JETTY_CONF"
+    echo "JETTY_ARGS     =  ${JETTY_ARGS[*]}"
+    echo "JETTY_RUN      =  $JETTY_RUN"
+    echo "JETTY_PID      =  $JETTY_PID"
+    echo "JETTY_START_LOG=  $JETTY_START_LOG"
+    echo "JETTY_STATE    =  $JETTY_STATE"
+    echo "RUN_CMD        =  ${RUN_CMD[*]}"
+}
+
+
+
+##################################################
+# Get the action & configs
+##################################################
+CONFIGS=()
+NO_START=0
+DEBUG=0
+
+while [[ $1 = -* ]]; do
+  case $1 in
+    -d) DEBUG=1 ;;
+  esac
+  shift
+done
+ACTION=$1
+shift
+
+##################################################
+# Read any configuration files
+##################################################
+ETC=/etc
+if [ $UID != 0 ]
+then 
+  ETC=$HOME/etc
+fi
+
+for CONFIG in {/etc,~/etc}/default/${NAME}{,9} $HOME/.${NAME}rc; do
+  if [ -f "$CONFIG" ] ; then 
+    readConfig "$CONFIG"
+  fi
+done
+
+
+##################################################
+# Set tmp if not already set.
+##################################################
+TMPDIR=${TMPDIR:-/tmp}
+
+##################################################
+# Jetty's hallmark
+##################################################
+JETTY_INSTALL_TRACE_FILE="start.jar"
+
+
+##################################################
+# Try to determine JETTY_HOME if not set
+##################################################
+if [ -z "$JETTY_HOME" ] 
+then
+  JETTY_SH=$0
+  case "$JETTY_SH" in
+    /*)     JETTY_HOME=${JETTY_SH%/*/*} ;;
+    ./*/*)  JETTY_HOME=${JETTY_SH%/*/*} ;;
+    ./*)    JETTY_HOME=.. ;;
+    */*/*)  JETTY_HOME=./${JETTY_SH%/*/*} ;;
+    */*)    JETTY_HOME=. ;;
+    *)      JETTY_HOME=.. ;;
+  esac
+
+  if [ ! -f "$JETTY_HOME/$JETTY_INSTALL_TRACE_FILE" ]
+  then 
+    JETTY_HOME=
+  fi
+fi
+
+
+##################################################
+# No JETTY_HOME yet? We're out of luck!
+##################################################
+if [ -z "$JETTY_HOME" ]; then
+  echo "** ERROR: JETTY_HOME not set, you need to set it or install in a standard location" 
+  exit 1
+fi
+
+cd "$JETTY_HOME"
+JETTY_HOME=$PWD
+
+
+##################################################
+# Set JETTY_BASE 
+##################################################
+if [ -z "$JETTY_BASE" ]; then
+  JETTY_BASE=$JETTY_HOME
+fi
+
+cd "$JETTY_BASE"
+JETTY_BASE=$PWD
+
+
+#####################################################
+# Check that jetty is where we think it is
+#####################################################
+if [ ! -r "$JETTY_HOME/$JETTY_INSTALL_TRACE_FILE" ] 
+then
+  echo "** ERROR: Oops! Jetty doesn't appear to be installed in $JETTY_HOME"
+  echo "** ERROR:  $JETTY_HOME/$JETTY_INSTALL_TRACE_FILE is not readable!"
+  exit 1
+fi
+
+##################################################
+# Try to find this script's configuration file,
+# but only if no configurations were given on the
+# command line.
+##################################################
+if [ -z "$JETTY_CONF" ] 
+then
+  if [ -f $ETC/${NAME}.conf ]
+  then
+    JETTY_CONF=$ETC/${NAME}.conf
+  elif [ -f "$JETTY_BASE/etc/jetty.conf" ]
+  then
+    JETTY_CONF=$JETTY_BASE/etc/jetty.conf
+  elif [ -f "$JETTY_HOME/etc/jetty.conf" ]
+  then
+    JETTY_CONF=$JETTY_HOME/etc/jetty.conf
+  fi
+fi
+
+#####################################################
+# Find a location for the pid file
+#####################################################
+if [ -z "$JETTY_RUN" ] 
+then
+  JETTY_RUN=$(findDirectory -w /var/run /usr/var/run $JETTY_BASE /tmp)
+fi
+
+#####################################################
+# Find a pid and state file
+#####################################################
+if [ -z "$JETTY_PID" ] 
+then
+  JETTY_PID="$JETTY_RUN/${NAME}.pid"
+fi
+
+if [ -z "$JETTY_STATE" ] 
+then
+  JETTY_STATE=$JETTY_BASE/${NAME}.state
+fi
+
+case "`uname`" in
+CYGWIN*) JETTY_STATE="`cygpath -w $JETTY_STATE`";;
+esac
+
+
+JETTY_ARGS=(${JETTY_ARGS[*]} "jetty.state=$JETTY_STATE")
+
+##################################################
+# Get the list of config.xml files from jetty.conf
+##################################################
+if [ -f "$JETTY_CONF" ] && [ -r "$JETTY_CONF" ] 
+then
+  while read -r CONF
+  do
+    if expr "$CONF" : '#' >/dev/null ; then
+      continue
+    fi
+
+    if [ -d "$CONF" ] 
+    then
+      # assume it's a directory with configure.xml files
+      # for example: /etc/jetty.d/
+      # sort the files before adding them to the list of JETTY_ARGS
+      for XMLFILE in "$CONF/"*.xml
+      do
+        if [ -r "$XMLFILE" ] && [ -f "$XMLFILE" ] 
+        then
+          JETTY_ARGS=(${JETTY_ARGS[*]} "$XMLFILE")
+        else
+          echo "** WARNING: Cannot read '$XMLFILE' specified in '$JETTY_CONF'" 
+        fi
+      done
+    else
+      # assume it's a command line parameter (let start.jar deal with its validity)
+      JETTY_ARGS=(${JETTY_ARGS[*]} "$CONF")
+    fi
+  done < "$JETTY_CONF"
+fi
+
+##################################################
+# Setup JAVA if unset
+##################################################
+if [ -z "$JAVA" ]
+then
+  JAVA=$(which java)
+fi
+
+if [ -z "$JAVA" ]
+then
+  echo "Cannot find a Java JDK. Please set either set JAVA or put java (>=1.5) in your PATH." >&2
+  exit 1
+fi
+
+#####################################################
+# See if JETTY_LOGS is defined
+#####################################################
+if [ -z "$JETTY_LOGS" ] && [ -d $JETTY_BASE/logs ] 
+then
+  JETTY_LOGS=$JETTY_BASE/logs
+fi
+if [ -z "$JETTY_LOGS" ] && [ -d $JETTY_HOME/logs ] 
+then
+  JETTY_LOGS=$JETTY_HOME/logs
+fi
+if [ "$JETTY_LOGS" ]
+then
+
+  case "`uname`" in
+  CYGWIN*) JETTY_LOGS="`cygpath -w $JETTY_LOGS`";;
+  esac
+
+  JAVA_OPTIONS=(${JAVA_OPTIONS[*]} "-Djetty.logging.dir=$JETTY_LOGS")
+fi
+
+#####################################################
+# Are we running on Windows? Could be, with Cygwin/NT.
+#####################################################
+case "`uname`" in
+CYGWIN*) PATH_SEPARATOR=";";;
+*) PATH_SEPARATOR=":";;
+esac
+
+
+#####################################################
+# Add jetty properties to Java VM options.
+#####################################################
+
+case "`uname`" in
+CYGWIN*) 
+JETTY_HOME="`cygpath -w $JETTY_HOME`"
+JETTY_BASE="`cygpath -w $JETTY_BASE`"
+TMPDIR="`cygpath -w $TMPDIR`"
+;;
+esac
+
+JAVA_OPTIONS=(${JAVA_OPTIONS[*]} "-XX:+DisableAttachMechanism" "-Djetty.home=$JETTY_HOME" "-Djetty.base=$JETTY_BASE" "-Djava.io.tmpdir=$TMPDIR")
+
+#####################################################
+# This is how the Jetty server will be started
+#####################################################
+
+JETTY_START=$JETTY_HOME/start.jar
+START_INI=$JETTY_BASE/start.ini
+START_D=$JETTY_BASE/start.d
+if [ ! -f "$START_INI" -a ! -d "$START_D" ]
+then
+  echo "Cannot find a start.ini file or a start.d directory in your JETTY_BASE directory: $JETTY_BASE" >&2
+  exit 1
+fi
+
+case "`uname`" in
+CYGWIN*) JETTY_START="`cygpath -w $JETTY_START`";;
+esac
+
+RUN_ARGS=(${JAVA_OPTIONS[@]} -jar "$JETTY_START" ${JETTY_ARGS[*]})
+RUN_CMD=("$JAVA" ${RUN_ARGS[@]})
+
+#####################################################
+# Comment these out after you're happy with what 
+# the script is doing.
+#####################################################
+if (( DEBUG ))
+then
+  dumpEnv
+fi
+
+##################################################
+# Do the action
+##################################################
+case "$ACTION" in
+  start)
+    echo -n "Starting Jetty: "
+
+    if (( NO_START )); then 
+      echo "Not starting ${NAME} - NO_START=1";
+      exit
+    fi
+
+	dtest=$(start-stop-daemon --test --oknodo -S -p"$JETTY_PID"  -d"$JETTY_BASE" -b -m -a "$JAVA" -- "${RUN_ARGS[@]}" start-log-file="$JETTY_LOGS/start.log" 2>&1 )
+
+
+if [ $UID -eq 0 ] && [[ "$dtest" !=  *"not found"* &&  "$dtest" !=  *"invalid argument"* ]]; then
+
+      unset CH_USER
+      if [ -n "$JETTY_USER" ]
+      then
+        CH_USER="-c$JETTY_USER"
+      fi
+
+      start-stop-daemon -S -p"$JETTY_PID" $CH_USER -d"$JETTY_BASE" -b -m -a "$JAVA" -- "${RUN_ARGS[@]}" start-log-file="$JETTY_START_LOG"
+
+    else
+
+      if running $JETTY_PID
+      then
+        echo "Already Running $(cat $JETTY_PID)!"
+        exit 1
+      fi
+
+      if [ -n "$JETTY_USER" ] && [ `whoami` != "$JETTY_USER" ]
+      then
+        unset SU_SHELL
+        if [ "$JETTY_SHELL" ]
+        then
+          SU_SHELL="-s $JETTY_SHELL"
+        fi
+
+        chown -R "$JETTY_USER:$JETTY_USER" "$JETTY_RUN"
+        touch "$JETTY_PID"
+
+        chown "$JETTY_USER:$JETTY_USER" "$JETTY_PID"
+        # FIXME: Broken solution: wordsplitting, pathname expansion, arbitrary command execution, etc.
+        su - "$JETTY_USER" $SU_SHELL -c "
+          cd ${JETTY_BASE}
+          0<&- &>/dev/null
+          nohup ${RUN_CMD[*]} start-log-file="$JETTY_START_LOG" 0<&- &>/dev/null &
+          echo \$! > '$JETTY_PID'"
+      else
+        "${RUN_CMD[@]}" > /dev/null &
+        disown $!
+        echo $! > "$JETTY_PID"
+      fi
+
+    fi
+
+    if expr "${JETTY_ARGS[*]}" : '.*jetty-started.xml.*' >/dev/null
+    then
+      if started "$JETTY_STATE" "$JETTY_PID"
+      then
+        echo "OK `date`"
+      else
+        echo "FAILED `date`"
+        exit 1
+      fi
+    else
+      echo "ok `date`"
+    fi
+
+    ;;
+
+  stop)
+    echo -n "Stopping Jetty: "
+   dtest=$(start-stop-daemon --test --oknodo -K -p"$JETTY_PID" -d"$JETTY_BASE" -a "$JAVA" -s HUP 2>&1 )
+
+
+if [ $UID -eq 0 ] && [[ "$dtest" !=  *"not found"* &&  "$dtest" !=  *"invalid argument"* ]]; then
+
+      start-stop-daemon -K -p"$JETTY_PID" -d"$JETTY_HOME" -a "$JAVA" -s HUP
+      
+      TIMEOUT=60
+      while running "$JETTY_PID"; do
+        if (( TIMEOUT-- == 0 )); then
+          start-stop-daemon -K -p"$JETTY_PID" -d"$JETTY_HOME" -a "$JAVA" -s KILL
+        fi
+
+        sleep 1
+      done
+    else
+      if [ ! -f "$JETTY_PID" ] ; then
+        echo "ERROR: no pid found at $JETTY_PID"
+        exit 1
+      fi
+
+      PID=$(cat "$JETTY_PID" 2>/dev/null)
+      if [ -z "$PID" ] ; then
+        echo "ERROR: no pid id found in $JETTY_PID"
+        exit 1
+      fi
+      kill "$PID" 2>/dev/null
+      
+      TIMEOUT=60
+      while running $JETTY_PID; do
+        if (( TIMEOUT-- == 0 )); then
+          kill -KILL "$PID" 2>/dev/null
+        fi
+
+        sleep 1
+      done
+    fi
+
+     rm -f $JETTY_RUN/${NAME}.pid
+     rm -f $JETTY_BASE/${NAME}.state
+
+    echo OK
+
+    ;;
+
+  restart)
+    JETTY_SH=$0
+    > "$JETTY_STATE"
+    if [ ! -f $JETTY_SH ]; then
+      if [ ! -f $JETTY_HOME/bin/jetty.sh ]; then
+        echo "$JETTY_HOME/bin/jetty.sh does not exist."
+        exit 1
+      fi
+      JETTY_SH=$JETTY_HOME/bin/jetty.sh
+    fi
+
+    "$JETTY_SH" stop "$@"
+    "$JETTY_SH" start "$@"
+
+    ;;
+
+  supervise)
+    #
+    # Under control of daemontools supervise monitor which
+    # handles restarts and shutdowns via the svc program.
+    #
+    exec "${RUN_CMD[@]}"
+
+    ;;
+
+  run|demo)
+    echo "Running Jetty: "
+
+    if running "$JETTY_PID"
+    then
+      echo Already Running $(cat "$JETTY_PID")!
+      exit 1
+    fi
+
+    exec "${RUN_CMD[@]}"
+    ;;
+
+  check|status)
+    if running "$JETTY_PID"
+    then
+      echo "Jetty running pid=$(< "$JETTY_PID")"
+    else
+      echo "Jetty NOT running"
+    fi
+    echo
+    dumpEnv
+    echo
+    
+    if running "$JETTY_PID"
+    then
+      exit 0
+    fi
+    exit 1
+
+    ;;
+
+  *)
+    usage
+
+    ;;
+esac
+
+exit 0

--- a/modules/perc-jetty/src/main/jetty/service/README-systemd.md
+++ b/modules/perc-jetty/src/main/jetty/service/README-systemd.md
@@ -40,11 +40,15 @@ sudo ./install-jetty-service.sh [ServiceName] install
 
 Prompts for the run-as user (same as before), writes:
 
-|   Artifact   |                                              Path                                               |
-|--------------|-------------------------------------------------------------------------------------------------|
-| Environment  | `/etc/default/<ServiceName>`                                                                    |
-| Start helper | `/etc/init.d/<ServiceName>` (used by ExecStart; **not** enabled via chkconfig on systemd hosts) |
-| Unit         | `/etc/systemd/system/<ServiceName>.service`                                                     |
+|   Artifact   |                                                                 Path                                                                  |
+|--------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| Environment  | `/etc/default/<ServiceName>`                                                                                                          |
+| Start helper | `/etc/init.d/<ServiceName>` (from `jetty/defaults/bin/rxjetty.sh`; used by ExecStart; **not** enabled via chkconfig on systemd hosts) |
+| Unit         | `/etc/systemd/system/<ServiceName>.service`                                                                                           |
+
+The start-helper template ships at `<rxDir>/jetty/defaults/bin/rxjetty.sh` (GH-1983). Install
+substitutes `${rxjetty_service}` into `/etc/init.d/<ServiceName>` for **both** systemd and
+`--initd` paths. Service install hard-fails if that template is missing.
 
 Then:
 
@@ -85,10 +89,10 @@ for packaging verification on a non-root workstation.
 
 Use this on a packaging machine, CI agent, or non-root workstation:
 
-1. **Confirm artifacts ship** under `<rxDir>/jetty/service/`:
-   - `percussion-cms.service.in`
-   - `install-jetty-service.sh`
-   - this `README-systemd.md`
+1. **Confirm artifacts ship**:
+   - under `<rxDir>/jetty/service/`: `percussion-cms.service.in`, `install-jetty-service.sh`,
+     this `README-systemd.md`
+   - under `<rxDir>/jetty/defaults/bin/`: `rxjetty.sh` (start-helper template; required by install)
 2. **Contract keys** in the unit template (see
    `specs/988-linux-systemd-services/contracts/systemd-unit-contract.md`):
    - `Type=forking`, `PIDFile=`, `EnvironmentFile=`, `ExecStart`/`ExecStop`
@@ -103,7 +107,7 @@ Use this on a packaging machine, CI agent, or non-root workstation:
    ```bash
    # from repo, module standalone
    cd modules/perc-jetty
-   ../../mvnw test -Dtest=SystemdUnitTemplateTest,InstallJettyServiceScriptTest
+   ../../mvnw test -Dtest=SystemdUnitTemplateTest,InstallJettyServiceScriptTest,RxJettyStartHelperTemplateTest
    ```
 6. **Migration rehearsal (document only)**: uninstall → install order below; do not
    run against production without change control.

--- a/modules/perc-jetty/src/test/java/com/percussion/jetty/service/InstallJettyServiceScriptTest.java
+++ b/modules/perc-jetty/src/test/java/com/percussion/jetty/service/InstallJettyServiceScriptTest.java
@@ -112,4 +112,22 @@ class InstallJettyServiceScriptTest {
             || script.contains("cat > \"/etc/default/"),
         "writes defaults file");
   }
+
+  @Test
+  void script_requiresRxJettyTemplateFromDefaultsBin() {
+    // GH-1983: both systemd and --initd paths call installInitScriptAndDefaults, which hard-fails
+    // without jetty/defaults/bin/rxjetty.sh (sed ${rxjetty_service} into /etc/init.d/<name>).
+    assertTrue(script.contains("installInitScriptAndDefaults"), "shared init helper install");
+    assertTrue(
+        script.contains("${JETTY_DEFAULTS}/bin/rxjetty.sh")
+            || script.contains("JETTY_DEFAULTS}/bin/rxjetty.sh"),
+        "template path under defaults/bin/rxjetty.sh");
+    assertTrue(
+        script.contains("s/\\${rxjetty_service}/") || script.contains("${rxjetty_service}"),
+        "sed service-name placeholder");
+    assertTrue(
+        script.contains("Missing Jetty service template")
+            || script.contains("Missing Jetty service template:"),
+        "hard-fail when template absent");
+  }
 }

--- a/modules/perc-jetty/src/test/java/com/percussion/jetty/service/RxJettyStartHelperTemplateTest.java
+++ b/modules/perc-jetty/src/test/java/com/percussion/jetty/service/RxJettyStartHelperTemplateTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.jetty.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * GH-1983: structural contract for the shipped {@code defaults/bin/rxjetty.sh} start-helper
+ * template used by {@code install-jetty-service.sh} (systemd and {@code --initd}).
+ *
+ * <p>The template is sed-substituted ({@code ${rxjetty_service}}) into {@code
+ * /etc/init.d/<ServiceName>} and must fork + write {@code JETTY_PID} for {@code Type=forking}
+ * units. Tests are read-only on source (and assembled distribution when present).
+ */
+class RxJettyStartHelperTemplateTest {
+
+  private static final Path MODULE_TEMPLATE =
+      Path.of("src", "main", "jetty", "defaults", "bin", "rxjetty.sh");
+  private static final Path REPO_TEMPLATE =
+      Path.of("modules", "perc-jetty").resolve(MODULE_TEMPLATE);
+
+  private static final Path MODULE_DIST =
+      Path.of("target", "distribution", "defaults", "bin", "rxjetty.sh");
+  private static final Path REPO_DIST = Path.of("modules", "perc-jetty").resolve(MODULE_DIST);
+
+  private static Path templatePath;
+  private static String template;
+
+  @BeforeAll
+  static void load() throws Exception {
+    templatePath = resolveExisting(MODULE_TEMPLATE, REPO_TEMPLATE);
+    if (templatePath == null) {
+      fail(
+          "missing defaults/bin/rxjetty.sh under module or repo-relative paths from CWD "
+              + Path.of("").toAbsolutePath().normalize());
+    }
+    template = Files.readString(templatePath, StandardCharsets.UTF_8);
+  }
+
+  private static Path resolveExisting(Path moduleRelative, Path repoRelative) {
+    Path cwd = Path.of("").toAbsolutePath().normalize();
+    Path[] candidates =
+        new Path[] {
+          cwd.resolve(moduleRelative),
+          cwd.resolve(repoRelative),
+          cwd.getParent() != null ? cwd.getParent().resolve(repoRelative) : null,
+        };
+    for (Path c : candidates) {
+      if (c != null && Files.isRegularFile(c)) {
+        return c.normalize();
+      }
+    }
+    return null;
+  }
+
+  @Test
+  void template_existsWithServiceSedPlaceholder() {
+    assertTrue(Files.isRegularFile(templatePath), () -> "missing " + templatePath);
+    assertTrue(
+        template.contains("${rxjetty_service}"),
+        "must keep ${rxjetty_service} for install-jetty-service.sh sed substitution");
+    assertTrue(
+        template.contains("Provides:") || template.contains("### BEGIN INIT INFO"),
+        "LSB init headers for SysV / systemd helper");
+  }
+
+  @Test
+  void template_forksAndWritesPid_forTypeForking() {
+    assertTrue(template.contains("JETTY_PID"), "JETTY_PID contract for PIDFile=");
+    assertTrue(
+        template.contains("start-stop-daemon") || template.contains("nohup"),
+        "must background via start-stop-daemon and/or nohup for Type=forking");
+    assertTrue(template.contains("start-stop-daemon"), "start-stop-daemon path documented");
+    assertTrue(template.contains("nohup"), "nohup fallback path");
+    assertTrue(
+        template.contains("echo $! >")
+            || template.contains("echo $! > ")
+            || template.contains("echo \\$! >")
+            || template.contains("-m -a")
+            || template.contains("-m "),
+        "PID must be written on start (start-stop-daemon -m and/or echo $!)");
+  }
+
+  @Test
+  void template_exposesStartStopRestartForUnitExec() {
+    // percussion-cms.service.in: ExecStart=... start / ExecStop=... stop
+    assertTrue(template.contains("start)"), "start action");
+    assertTrue(template.contains("stop)"), "stop action");
+    assertTrue(template.contains("restart)"), "restart action (no ExecReload)");
+  }
+
+  @Test
+  void template_assembledIntoDistributionDefaultsBin_whenPresent() {
+    Path dist = resolveExisting(MODULE_DIST, REPO_DIST);
+    // process-resources populates target/distribution before surefire on clean install;
+    // skip soft if a focused test-only invocation did not run resource copy.
+    if (dist == null) {
+      Path expected = Path.of("").toAbsolutePath().normalize().resolve(MODULE_DIST);
+      assertTrue(
+          !Files.isDirectory(expected.getParent().getParent().getParent()),
+          () ->
+              "assembly-directory exists but defaults/bin/rxjetty.sh missing: "
+                  + expected
+                  + " (antrun copies src/main/jetty/**)");
+      return;
+    }
+    assertTrue(Files.isRegularFile(dist), () -> "assembled template missing: " + dist);
+  }
+}


### PR DESCRIPTION
## Summary

Restores the CMS Jetty **start-helper template** required by `install-jetty-service.sh` for both **systemd** and **`--initd`** install paths.

After the Jetty 12 / packaging move (`system/Tools/jetty` → `modules/perc-jetty`, #662), `defaults/bin/rxjetty.sh` was missing. Install hard-fails with `Missing Jetty service template` because both registration paths call `installInitScriptAndDefaults` first.

### Changes
- Ship Jetty-12-aligned `modules/perc-jetty/src/main/jetty/defaults/bin/rxjetty.sh` (recovered from pre-`a82b983bce` contract)
  - Keeps `${rxjetty_service}` sed placeholder
  - Fork + `JETTY_PID` write via `start-stop-daemon -b` (root) or `nohup` (fallback) for `Type=forking`
  - Align start-stop-daemon gate to `UID -eq 0` (was historical `UID -eq 2`)
- Root `.gitignore`: exception so repo-wide `bin/` does not hide this packaged path
- Docs: `service/README-systemd.md` notes template location and dry-run checklist
- Tests: `RxJettyStartHelperTemplateTest` + install-script contract assertion

Fixes #1983  
Related: #1975 #962

**Operator:** Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] `cd modules/perc-jetty && ../../mvnw clean install` → **BUILD SUCCESS**
  - Tests run: **58**, Failures: **0**, Errors: **0**, Skipped: 7
  - `RxJettyStartHelperTemplateTest` (4), `InstallJettyServiceScriptTest` (7)
- [x] Assembly/zip contains `defaults/bin/rxjetty.sh`
- [x] Spotless from repo root: `mvnw spotless:apply` **then** `mvnw spotless:check` (order required)
  - Feature PR contains **only in-scope** files; unrelated Spotless rewrites were **not** committed
- [x] Erlang pre-commit review: approve (`docs/ai-generated/code-reviews/issue-1983-restore-rxjetty-sh-erlang.md`)
- [ ] Live root systemctl soak — **out of scope** (#1989 / inventory soak)

## Gates evidence

| Gate | Result |
|------|--------|
| Module clean install (perc-jetty standalone) | BUILD SUCCESS |
| Behavioral/structural unit tests | Pass |
| Spotless apply → check | Pass; out-of-scope split |
| Erlang | approve |
| No live root install | intentional |

## Out of scope

- Live dual-ship systemd soak
- Removing SysV / init.d deprecation path