### PR TITLE
fix(system): Jackson-migrate PSAudit/PSSharedProperty/PSHierarchyNode (#1920)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-1920-catalog-system-ui-jackson-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-1920-catalog-system-ui-jackson-erlang.md
@@ -1,0 +1,30 @@
+# Erlang review — issue #1920 (catalog/system/ui first sub-batch)
+
+**Verdict:** PASS (self-review before commit)
+
+**Scope reviewed:** Jackson opt-in annotations + golden/round-trip tests for
+`PSAudit`, `PSAuditTrail`, `PSSharedProperty`, `PSHierarchyNode`,
+`PSHierarchyNodeProperty`; drop obsolete `PSHierarchyNodeProperty.betwixt`;
+deviations doc.
+
+## Gates
+
+| Check | Result |
+|-------|--------|
+| Bugs / RT correctness | Pass — 15 focused tests green; system `clean install` green (1078 tests, 2 prior failures were stale utils SNAPSHOT) |
+| Behavioral unit tests | Pass — golden + RT + legacy `<null>` root per type |
+| Cross-platform paths | Pass — no new filesystem path construction |
+| Change-class companions | Pass — domain annotations, `addType("audit")`, goldens, deviations doc, betwixt drop with rationale |
+| Spotless | Pass — `mvnw -pl system spotless:apply` then `check`; root `-N` for docs |
+
+## Notes
+
+- `event-time` uses UTC + Betwixt ISO8601 pattern for golden stability (documented deviation).
+- `setVersion(null)` ignored so BeanUtils copy after Jackson restore does not NPE.
+- `setNodeType` added so BeanUtils property `nodeType` restores enum form.
+- Historical betwixt mapped non-existent `parentGuid`; production wire is `node-id`.
+
+## Residuals (child issues)
+
+- PSDependency / PSDependent
+- PSMimeContentAdapter

--- a/docs/ai-generated/tasks/505-betwixt-jackson/1920-catalog-system-ui-domain-deviations.md
+++ b/docs/ai-generated/tasks/505-betwixt-jackson/1920-catalog-system-ui-domain-deviations.md
@@ -1,0 +1,60 @@
+# Issue #1920 — Catalog / system / ui leftovers (first sub-batch)
+
+Parent: #1892 · Grandparent: #1823 · Epic: #505 · Inventory: #1821
+
+## Scope delivered (this PR)
+
+|           Class           |       Root element        |                              Nested / notes                              |
+|---------------------------|---------------------------|--------------------------------------------------------------------------|
+| `PSAudit`                 | `audit`                   | Scalar `id` identity; derived `guid` omitted                             |
+| `PSAuditTrail`            | `audit-trail`             | `audits` wrapper / nested `audit` (`addType`)                            |
+| `PSSharedProperty`        | `shared-property`         | `guid` + name + value; Hibernate `version` suppressed                    |
+| `PSHierarchyNode`         | `hierarchy-node`          | `properties` key-as-element map; type enum name; catalog aliases omitted |
+| `PSHierarchyNodeProperty` | `hierarchy-node-property` | Scalar `node-id` (not historical betwixt `parentGuid`)                   |
+
+Golden fixtures + round-trip + legacy `<null>` root tests:
+
+- `system/.../system/data/PSSystemDataXmlSerializationTest`
+- `system/.../ui/data/PSHierarchyNodeXmlSerializationTest`
+
+## Approved / intentional deviations vs historical Betwixt
+
+|                          Deviation                           |                                                          Notes                                                           |
+|--------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| No Betwixt graph-identity `id="…"` attributes                | Same as #1887 facade / other domain batches.                                                                             |
+| No XML declaration                                           | `PSJacksonXmlSerializationHelper` default.                                                                               |
+| `PSAudit` omits derived `guid`                               | Identity is scalar `id`; avoids dual-write / `setGUID` one-shot races.                                                   |
+| `event-time` UTC ISO8601 `yyyyMMdd'T'HHmmssSSS`              | Matches Betwixt `PSDateFormatISO8601` pattern; timezone fixed to UTC for goldens (Betwixt used JVM default zone).        |
+| Hibernate `version` suppressed                               | `@IPSXmlSerialization(suppress=true)` + `@JsonIgnore` on hierarchy + shared property.                                    |
+| `PSHierarchyNode` catalog `label` / `description` suppressed | Aliases of name / always null — not design wire.                                                                         |
+| `PSHierarchyNode` type as enum name                          | `FOLDER` / `PLACEHOLDER` (not ordinal `type-int`).                                                                       |
+| `PSHierarchyNode.properties` key-as-element map              | Sorted `TreeMap` for stable goldens (same pattern as filter params).                                                     |
+| Null root `parent-id` omitted / nil                          | Root nodes may omit parent; read accepts absent parent.                                                                  |
+| `PSHierarchyNodeProperty` uses `node-id`                     | Historical `.betwixt` mapped non-existent `parentGuid`→`parentId` (typo-ridden file); production bean field is `nodeId`. |
+| Dropped `PSHierarchyNodeProperty.betwixt`                    | Unused under Jackson-default facade; golden proves modern wire.                                                          |
+| Null-safe `setVersion`                                       | BeanUtils copy after Jackson restore may pass null.                                                                      |
+| `setNodeType` + idempotent `setType`                         | BeanUtils property `nodeType` must round-trip enum form.                                                                 |
+
+## Residual (file as children of #1920)
+
+Not in this PR:
+
+1. **PSDependency / PSDependent** — system dependency graph leftovers
+2. **PSMimeContentAdapter** — system content adapter design XML
+3. Any other catalog/system/ui holdouts discovered after re-inventory (e.g. `PSLegacyGuid` A-only, `PSLocale` A-only are suppress-only and may not need a slice)
+
+## Out of scope
+
+- filter (#1915), sitemgr (#1918), publisher/pubserver (#1919)
+- content leftovers (#1921)
+- `PSObjectSummary` (#1903 closed)
+- Betwixt POM removal (#1824)
+- Facade engine deletion
+
+## Tests
+
+|                 Suite                 |                                Coverage                                 |
+|---------------------------------------|-------------------------------------------------------------------------|
+| `PSSystemDataXmlSerializationTest`    | audit / audit-trail / shared-property golden + RT + legacy null root    |
+| `PSHierarchyNodeXmlSerializationTest` | hierarchy-node / hierarchy-node-property golden + RT + legacy null root |
+

--- a/system/services/src/com/percussion/services/system/data/PSAudit.java
+++ b/system/services/src/com/percussion/services/system/data/PSAudit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,237 +16,266 @@
  */
 package com.percussion.services.system.data;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.Date;
-import java.util.Objects;
-
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.xml.sax.SAXException;
-
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import com.percussion.utils.guid.IPSGuid;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Objects;
+import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * This object represents a single audit.
+ *
+ * <p>Design-object XML root is {@code audit}. Jackson opt-in property surface (issue #1920 / epic
+ * #505). Identity uses scalar {@code id}; derived {@code guid} is omitted to avoid dual-write /
+ * setGUID one-shot conflicts on restore.
  */
-public class PSAudit implements Serializable
-{
-   /**
-    * Compiler generated serial version ID used for serialization.
-    */
-   private static final long serialVersionUID = 2299868760195078824L;
+@JacksonXmlRootElement(localName = "audit")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({
+  "actor",
+  "currentRevision",
+  "editRevision",
+  "eventTime",
+  "id",
+  "publishable",
+  "stateId",
+  "stateName",
+  "transitionComment",
+  "transitionId",
+  "transitionName"
+})
+public class PSAudit implements Serializable {
+  /** Compiler generated serial version ID used for serialization. */
+  private static final long serialVersionUID = 2299868760195078824L;
 
-   private long id;
-   
-   private boolean publishable;
-   
-   private Date eventTime;
-   
-   private String actor;
-   
-   private long stateId;
-   
-   private String stateName;
-   
-   private long transitionId;
-   
-   private String transitionName;
-   
-   private String transitionComment;
-   
-   private boolean currentRevision;
-   
-   private boolean editRevision;
+  private long id;
 
-   /**
-    * Default constructor.
-    */
-   public PSAudit()
-   {
-   }
-   
-   public long getId()
-   {
-      return id;
-   }
-   
-   public void setId(long id)
-   {
-      this.id = id;
-   }
-   
-   public String getActor()
-   {
-      return actor;
-   }
-   
-   public void setActor(String actor)
-   {
-      this.actor = actor;
-   }
-   
-   public boolean isCurrentRevision()
-   {
-      return currentRevision;
-   }
-   
-   public void setCurrentRevision(boolean currentRevision)
-   {
-      this.currentRevision = currentRevision;
-   }
-   
-   public boolean isEditRevision()
-   {
-      return editRevision;
-   }
-   
-   public void setEditRevision(boolean editRevision)
-   {
-      this.editRevision = editRevision;
-   }
-   
-   public Date getEventTime()
-   {
-      return eventTime;
-   }
-   
-   public void setEventTime(Date eventTime)
-   {
-      this.eventTime = eventTime;
-   }
-   
-   public boolean isPublishable()
-   {
-      return publishable;
-   }
-   
-   public void setPublishable(boolean publishable)
-   {
-      this.publishable = publishable;
-   }
-   
-   public long getStateId()
-   {
-      return stateId;
-   }
-   
-   public void setStateId(long stateId)
-   {
-      this.stateId = stateId;
-   }
-   
-   public String getStateName()
-   {
-      return stateName;
-   }
-   
-   public void setStateName(String stateName)
-   {
-      this.stateName = stateName;
-   }
-   
-   public long getTransitionId()
-   {
-      return transitionId;
-   }
-   
-   public void setTransitionId(long transitionId)
-   {
-      this.transitionId = transitionId;
-   }
-   
-   public String getTransitionName()
-   {
-      return transitionName;
-   }
-   
-   public void setTransitionName(String transitionName)
-   {
-      this.transitionName = transitionName;
-   }
-   
-   public String getTransitionComment()
-   {
-      return transitionComment;
-   }
-   
-   public void setTransitionComment(String transitionComment)
-   {
-      this.transitionComment = transitionComment;
-   }
+  private boolean publishable;
 
-   /* (non-Javadoc)
-    * @see IPSCatalogSummary#getGUID()
-    */
-   public IPSGuid getGUID()
-   {
-      return new PSGuid(PSTypeEnum.ITEM_HISTORY, id);
-   }
+  private Date eventTime;
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#setGUID(IPSGuid)
-    */
-   public void setGUID(IPSGuid newguid) throws IllegalStateException
-   {
-      if (newguid == null)
-         throw new IllegalArgumentException("newguid may not be null");
+  private String actor;
 
-      if (id != 0)
-         throw new IllegalStateException("cannot change existing guid");
+  private long stateId;
 
-      id = newguid.longValue();
-   }
+  private String stateName;
 
-   @Override
-   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof PSAudit)) return false;
-      PSAudit psAudit = (PSAudit) o;
-      return getId() == psAudit.getId() && isPublishable() == psAudit.isPublishable() && getStateId() == psAudit.getStateId() && getTransitionId() == psAudit.getTransitionId() && isCurrentRevision() == psAudit.isCurrentRevision() && isEditRevision() == psAudit.isEditRevision() && Objects.equals(getEventTime(), psAudit.getEventTime()) && Objects.equals(getActor(), psAudit.getActor()) && Objects.equals(getStateName(), psAudit.getStateName()) && Objects.equals(getTransitionName(), psAudit.getTransitionName()) && Objects.equals(getTransitionComment(), psAudit.getTransitionComment());
-   }
+  private long transitionId;
 
-   @Override
-   public int hashCode() {
-      return Objects.hash(getId(), isPublishable(), getEventTime(), getActor(), getStateId(), getStateName(), getTransitionId(), getTransitionName(), getTransitionComment(), isCurrentRevision(), isEditRevision());
-   }
+  private String transitionName;
 
-   @Override
-   public String toString() {
-      final StringBuffer sb = new StringBuffer("PSAudit{");
-      sb.append("id=").append(id);
-      sb.append(", publishable=").append(publishable);
-      sb.append(", eventTime=").append(eventTime);
-      sb.append(", actor='").append(actor).append('\'');
-      sb.append(", stateId=").append(stateId);
-      sb.append(", stateName='").append(stateName).append('\'');
-      sb.append(", transitionId=").append(transitionId);
-      sb.append(", transitionName='").append(transitionName).append('\'');
-      sb.append(", transitionComment='").append(transitionComment).append('\'');
-      sb.append(", currentRevision=").append(currentRevision);
-      sb.append(", editRevision=").append(editRevision);
-      sb.append('}');
-      return sb.toString();
-   }
+  private String transitionComment;
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#fromXML(String)
-    */
-   public void fromXML(String xmlsource) throws IOException, SAXException
-   {
-      PSXmlSerializationHelper.readFromXML(xmlsource, this);
-   }
+  private boolean currentRevision;
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#toXML()
-    */
-   public String toXML() throws IOException, SAXException
-   {
-      return PSXmlSerializationHelper.writeToXml(this);
-   }
+  private boolean editRevision;
+
+  /** Default constructor. */
+  public PSAudit() {}
+
+  @JsonProperty
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  @JsonProperty
+  public String getActor() {
+    return actor;
+  }
+
+  public void setActor(String actor) {
+    this.actor = actor;
+  }
+
+  @JsonProperty("current-revision")
+  public boolean isCurrentRevision() {
+    return currentRevision;
+  }
+
+  public void setCurrentRevision(boolean currentRevision) {
+    this.currentRevision = currentRevision;
+  }
+
+  @JsonProperty("edit-revision")
+  public boolean isEditRevision() {
+    return editRevision;
+  }
+
+  public void setEditRevision(boolean editRevision) {
+    this.editRevision = editRevision;
+  }
+
+  /**
+   * Event time on the design-object wire. Pattern matches historical Betwixt {@code
+   * PSDateFormatISO8601} ({@code yyyyMMdd'T'HHmmssSSS}); timezone fixed to UTC for golden
+   * stability.
+   */
+  @JsonProperty("event-time")
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyyMMdd'T'HHmmssSSS", timezone = "UTC")
+  public Date getEventTime() {
+    return eventTime;
+  }
+
+  public void setEventTime(Date eventTime) {
+    this.eventTime = eventTime;
+  }
+
+  @JsonProperty
+  public boolean isPublishable() {
+    return publishable;
+  }
+
+  public void setPublishable(boolean publishable) {
+    this.publishable = publishable;
+  }
+
+  @JsonProperty("state-id")
+  public long getStateId() {
+    return stateId;
+  }
+
+  public void setStateId(long stateId) {
+    this.stateId = stateId;
+  }
+
+  @JsonProperty("state-name")
+  public String getStateName() {
+    return stateName;
+  }
+
+  public void setStateName(String stateName) {
+    this.stateName = stateName;
+  }
+
+  @JsonProperty("transition-id")
+  public long getTransitionId() {
+    return transitionId;
+  }
+
+  public void setTransitionId(long transitionId) {
+    this.transitionId = transitionId;
+  }
+
+  @JsonProperty("transition-name")
+  public String getTransitionName() {
+    return transitionName;
+  }
+
+  public void setTransitionName(String transitionName) {
+    this.transitionName = transitionName;
+  }
+
+  @JsonProperty("transition-comment")
+  public String getTransitionComment() {
+    return transitionComment;
+  }
+
+  public void setTransitionComment(String transitionComment) {
+    this.transitionComment = transitionComment;
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogSummary#getGUID()
+   */
+  @JsonIgnore
+  public IPSGuid getGUID() {
+    return new PSGuid(PSTypeEnum.ITEM_HISTORY, id);
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#setGUID(IPSGuid)
+   */
+  @JsonIgnore
+  public void setGUID(IPSGuid newguid) throws IllegalStateException {
+    if (newguid == null) throw new IllegalArgumentException("newguid may not be null");
+
+    if (id != 0) throw new IllegalStateException("cannot change existing guid");
+
+    id = newguid.longValue();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof PSAudit)) return false;
+    PSAudit psAudit = (PSAudit) o;
+    return getId() == psAudit.getId()
+        && isPublishable() == psAudit.isPublishable()
+        && getStateId() == psAudit.getStateId()
+        && getTransitionId() == psAudit.getTransitionId()
+        && isCurrentRevision() == psAudit.isCurrentRevision()
+        && isEditRevision() == psAudit.isEditRevision()
+        && Objects.equals(getEventTime(), psAudit.getEventTime())
+        && Objects.equals(getActor(), psAudit.getActor())
+        && Objects.equals(getStateName(), psAudit.getStateName())
+        && Objects.equals(getTransitionName(), psAudit.getTransitionName())
+        && Objects.equals(getTransitionComment(), psAudit.getTransitionComment());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        getId(),
+        isPublishable(),
+        getEventTime(),
+        getActor(),
+        getStateId(),
+        getStateName(),
+        getTransitionId(),
+        getTransitionName(),
+        getTransitionComment(),
+        isCurrentRevision(),
+        isEditRevision());
+  }
+
+  @Override
+  public String toString() {
+    final StringBuffer sb = new StringBuffer("PSAudit{");
+    sb.append("id=").append(id);
+    sb.append(", publishable=").append(publishable);
+    sb.append(", eventTime=").append(eventTime);
+    sb.append(", actor='").append(actor).append('\'');
+    sb.append(", stateId=").append(stateId);
+    sb.append(", stateName='").append(stateName).append('\'');
+    sb.append(", transitionId=").append(transitionId);
+    sb.append(", transitionName='").append(transitionName).append('\'');
+    sb.append(", transitionComment='").append(transitionComment).append('\'');
+    sb.append(", currentRevision=").append(currentRevision);
+    sb.append(", editRevision=").append(editRevision);
+    sb.append('}');
+    return sb.toString();
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#fromXML(String)
+   */
+  public void fromXML(String xmlsource) throws IOException, SAXException {
+    PSXmlSerializationHelper.readFromXML(xmlsource, this);
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#toXML()
+   */
+  public String toXML() throws IOException, SAXException {
+    return PSXmlSerializationHelper.writeToXml(this);
+  }
 }
-

--- a/system/services/src/com/percussion/services/system/data/PSAuditTrail.java
+++ b/system/services/src/com/percussion/services/system/data/PSAuditTrail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,165 +16,161 @@
  */
 package com.percussion.services.system.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * This object represents a single audit trail.
+ *
+ * <p>Design-object XML root is {@code audit-trail}. Nested package item element is {@code audit}
+ * (registered via {@link PSXmlSerializationHelper#addType}). Jackson opt-in property surface (issue
+ * #1920 / epic #505).
  */
-public class PSAuditTrail implements Serializable
-{
-   /**
-    * Compiler generated serial version ID used for serialization.
-    */
-   private static final long serialVersionUID = -8037995317473435726L;
-   
-   private int currentRevision;
-   
-   private int editRevision;
-   
-   private List<PSAudit> audits = new ArrayList<>();
+@JacksonXmlRootElement(localName = "audit-trail")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({"audits", "currentRevision", "editRevision"})
+public class PSAuditTrail implements Serializable {
+  /** Compiler generated serial version ID used for serialization. */
+  private static final long serialVersionUID = -8037995317473435726L;
 
-   /**
-    * Default constructor.
-    */
-   public PSAuditTrail()
-   {
-   }
-   
-   /**
-    * Get the current revision of the item for which this defines the audit
-    * trail.
-    * 
-    * @return the current revision of the item for which this defines the 
-    *    audit trail.
-    */
-   public int getCurrentRevision()
-   {
-      return currentRevision;
-   }
-   
-   /**
-    * Set the current revision of the item for which this defines the audit
-    * trail.
-    * 
-    * @param currentRevision the new current revision of the item for which
-    *    this defines the audit trail.
-    */
-   public void setCurrentRevision(int currentRevision)
-   {
-      this.currentRevision = currentRevision;
-   }
-   
-   /**
-    * Get the edit revision of the item for which this defines the audit
-    * trail.
-    * 
-    * @return the edit revision of the item for which this defines the 
-    *    audit trail.
-    */
-   public int getEditRevision()
-   {
-      return editRevision;
-   }
-   
-   /**
-    * Set the edit revision of the item for which this defines the audit
-    * trail.
-    * 
-    * @param editRevision the new edit revision of the item for which
-    *    this defines the audit trail.
-    */
-   public void setEditRevision(int editRevision)
-   {
-      this.editRevision = editRevision;
-   }
-   
-   /**
-    * Get the list with all audits.
-    * 
-    * @return the list with all audits, never <code>null</code>, may
-    *    be empty.
-    */
-   public List<PSAudit> getAudits()
-   {
-      return audits;
-   }
-   
-   /**
-    * Set a new list of audits.
-    * 
-    * @param audits the new list of audits, may be <code>null</code> or
-    *    empty.
-    */
-   public void setAudits(List<PSAudit> audits)
-   {
-      if (audits == null)
-         this.audits = new ArrayList<>();
-      else
-         this.audits = audits;
-   }
-   
-   /**
-    * Add a new audit.
-    * 
-    * @param audit the new audit to add, not <code>null</code>.
-    */
-   public void addAudit(PSAudit audit)
-   {
-      if (audit == null)
-         throw new IllegalArgumentException("audit cannot be null");
-      
-      audits.add(audit);
-   }
+  private int currentRevision;
 
-   @Override
-   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof PSAuditTrail)) return false;
-      PSAuditTrail that = (PSAuditTrail) o;
-      return getCurrentRevision() == that.getCurrentRevision() && getEditRevision() == that.getEditRevision() && Objects.equals(getAudits(), that.getAudits());
-   }
+  private int editRevision;
 
-   @Override
-   public int hashCode() {
-      return Objects.hash(getCurrentRevision(), getEditRevision(), getAudits());
-   }
+  private List<PSAudit> audits = new ArrayList<>();
 
-   @Override
-   public String toString() {
-      final StringBuffer sb = new StringBuffer("PSAuditTrail{");
-      sb.append("currentRevision=").append(currentRevision);
-      sb.append(", editRevision=").append(editRevision);
-      sb.append(", audits=").append(audits);
-      sb.append('}');
-      return sb.toString();
-   }
+  static {
+    // Nested package item element name for polymorphic list restore.
+    PSXmlSerializationHelper.addType("audit", PSAudit.class);
+  }
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#fromXML(String)
-    */
-   public void fromXML(String xmlsource) throws IOException, SAXException
-   {
-      PSXmlSerializationHelper.readFromXML(xmlsource, this);
-   }
+  /** Default constructor. */
+  public PSAuditTrail() {}
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#toXML()
-    */
-   public String toXML() throws IOException, SAXException
-   {
-      return PSXmlSerializationHelper.writeToXml(this);
-   }
+  /**
+   * Get the current revision of the item for which this defines the audit trail.
+   *
+   * @return the current revision of the item for which this defines the audit trail.
+   */
+  @JsonProperty("current-revision")
+  public int getCurrentRevision() {
+    return currentRevision;
+  }
+
+  /**
+   * Set the current revision of the item for which this defines the audit trail.
+   *
+   * @param currentRevision the new current revision of the item for which this defines the audit
+   *     trail.
+   */
+  public void setCurrentRevision(int currentRevision) {
+    this.currentRevision = currentRevision;
+  }
+
+  /**
+   * Get the edit revision of the item for which this defines the audit trail.
+   *
+   * @return the edit revision of the item for which this defines the audit trail.
+   */
+  @JsonProperty("edit-revision")
+  public int getEditRevision() {
+    return editRevision;
+  }
+
+  /**
+   * Set the edit revision of the item for which this defines the audit trail.
+   *
+   * @param editRevision the new edit revision of the item for which this defines the audit trail.
+   */
+  public void setEditRevision(int editRevision) {
+    this.editRevision = editRevision;
+  }
+
+  /**
+   * Get the list with all audits.
+   *
+   * @return the list with all audits, never <code>null</code>, may be empty.
+   */
+  @JsonProperty
+  @JacksonXmlElementWrapper(localName = "audits")
+  @JacksonXmlProperty(localName = "audit")
+  public List<PSAudit> getAudits() {
+    return audits;
+  }
+
+  /**
+   * Set a new list of audits.
+   *
+   * @param audits the new list of audits, may be <code>null</code> or empty.
+   */
+  public void setAudits(List<PSAudit> audits) {
+    if (audits == null) this.audits = new ArrayList<>();
+    else this.audits = audits;
+  }
+
+  /**
+   * Add a new audit.
+   *
+   * @param audit the new audit to add, not <code>null</code>.
+   */
+  public void addAudit(PSAudit audit) {
+    if (audit == null) throw new IllegalArgumentException("audit cannot be null");
+
+    audits.add(audit);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof PSAuditTrail)) return false;
+    PSAuditTrail that = (PSAuditTrail) o;
+    return getCurrentRevision() == that.getCurrentRevision()
+        && getEditRevision() == that.getEditRevision()
+        && Objects.equals(getAudits(), that.getAudits());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getCurrentRevision(), getEditRevision(), getAudits());
+  }
+
+  @Override
+  public String toString() {
+    final StringBuffer sb = new StringBuffer("PSAuditTrail{");
+    sb.append("currentRevision=").append(currentRevision);
+    sb.append(", editRevision=").append(editRevision);
+    sb.append(", audits=").append(audits);
+    sb.append('}');
+    return sb.toString();
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#fromXML(String)
+   */
+  public void fromXML(String xmlsource) throws IOException, SAXException {
+    PSXmlSerializationHelper.readFromXML(xmlsource, this);
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#toXML()
+   */
+  public String toXML() throws IOException, SAXException {
+    return PSXmlSerializationHelper.writeToXml(this);
+  }
 }
-

--- a/system/services/src/com/percussion/services/system/data/PSAuditTrail.java
+++ b/system/services/src/com/percussion/services/system/data/PSAuditTrail.java
@@ -33,9 +33,14 @@ import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 /**
  * This object represents a single audit trail.
  *
- * <p>Design-object XML root is {@code audit-trail}. Nested package item element is {@code audit}
- * (registered via {@link PSXmlSerializationHelper#addType}). Jackson opt-in property surface (issue
- * #1920 / epic #505).
+ * <p>Design-object XML root is {@code audit-trail}. Nested package item element is {@code audit}.
+ * Jackson opt-in property surface (issue #1920 / epic #505).
+ *
+ * <p><b>Nested type registration (two engines, one name):</b> Jackson binds nested items via {@link
+ * JacksonXmlProperty}{@code (localName="audit")} on {@link #getAudits()}. The static {@link
+ * PSXmlSerializationHelper#addType} registration is retained for the Betwixt rollback engine and
+ * for polymorphic list restore helpers that still consult the shared type map. Both paths use the
+ * same element name {@code audit} → {@link PSAudit}; they are complementary, not competing owners.
  */
 @JacksonXmlRootElement(localName = "audit-trail")
 @JsonAutoDetect(
@@ -56,7 +61,8 @@ public class PSAuditTrail implements Serializable {
   private List<PSAudit> audits = new ArrayList<>();
 
   static {
-    // Nested package item element name for polymorphic list restore.
+    // Betwixt / helper type-map path (Jackson uses @JacksonXmlProperty on getAudits()).
+    // Same key+class as Jackson annotations — intentional dual registration for dual engines.
     PSXmlSerializationHelper.addType("audit", PSAudit.class);
   }
 

--- a/system/services/src/com/percussion/services/system/data/PSSharedProperty.java
+++ b/system/services/src/com/percussion/services/system/data/PSSharedProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,219 +16,219 @@
  */
 package com.percussion.services.system.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.catalog.IPSCatalogItem;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import com.percussion.utils.guid.IPSGuid;
-
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.Objects;
-
+import com.percussion.utils.xml.IPSXmlSerialization;
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
-
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * This object represents a single shared property.
+ *
+ * <p>Design-object XML root is {@code shared-property}. Jackson opt-in property surface (issue
+ * #1920 / epic #505). Hibernate {@code version} is suppressed on the design-object wire.
  */
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, 
-      region = "PSSharedProperty")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSSharedProperty")
 @Table(name = "PSX_SHARED_PROPERTIES")
-public class PSSharedProperty implements Serializable, IPSCatalogItem, Comparable
-{
-   /**
-    * Compiler generated serial version ID used for serialization.
-    */
-   private static final long serialVersionUID = -79604122602978810L;
+@JacksonXmlRootElement(localName = "shared-property")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({"guid", "name", "value"})
+public class PSSharedProperty implements Serializable, IPSCatalogItem, Comparable {
+  /** Compiler generated serial version ID used for serialization. */
+  private static final long serialVersionUID = -79604122602978810L;
 
-   @Id
-   @Column(name = "ID", nullable = false)
-   private long id;
+  @Id
+  @Column(name = "ID", nullable = false)
+  private long id;
 
-   @Version
-   @Column(name = "VERSION")
-   private Integer version;
-   
-   @Basic
-   @Column(name = "NAME", nullable = false, length = 50)
-   private String name;
-   
-   @Basic
-   @Column(name = "VALUE", nullable = true, length = 250)
-   private String value;
+  @Version
+  @Column(name = "VERSION")
+  private Integer version;
 
-   /**
-    * Default constructor.
-    */
-   public PSSharedProperty()
-   {
-   }
-   
-   /**
-    * Construct a new shared property for the supplied parameters.
-    * 
-    * @param name the property name, not <code>null</code> or empty.
-    * @param value the property value, may be <code>null</code> or empty.
-    */
-   public PSSharedProperty(String name, String value)
-   {
-      setName(name);
-      setValue(value);
-   }
+  @Basic
+  @Column(name = "NAME", nullable = false, length = 50)
+  private String name;
 
-   /* (non-Javadoc)
-    * @see IPSCatalogSummary#getGUID()
-    */
-   public IPSGuid getGUID()
-   {
-      return new PSGuid(PSTypeEnum.SHARED_PROPERTY, id);
-   }
+  @Basic
+  @Column(name = "VALUE", nullable = true, length = 250)
+  private String value;
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#setGUID(IPSGuid)
-    */
-   public void setGUID(IPSGuid newguid) throws IllegalStateException
-   {
-      if (newguid == null)
-         throw new IllegalArgumentException("newguid may not be null");
+  /** Default constructor. */
+  public PSSharedProperty() {}
 
-      if (id != 0)
-         throw new IllegalStateException("cannot change existing guid");
+  /**
+   * Construct a new shared property for the supplied parameters.
+   *
+   * @param name the property name, not <code>null</code> or empty.
+   * @param value the property value, may be <code>null</code> or empty.
+   */
+  public PSSharedProperty(String name, String value) {
+    setName(name);
+    setValue(value);
+  }
 
-      id = newguid.longValue();
-   }
-   
-   /**
-    * Get the object version.
-    * 
-    * @return the object version, <code>null</code> if not initialized yet.
-    */
-   public Integer getVersion()
-   {
-      return version;
-   }
-   
-   /**
-    * Set the object version.
-    * 
-    * @param version the version of the object, must be >= 0.
-    */
-   public void setVersion(Integer version)
-   {
-      if (version < 0)
-         throw new IllegalArgumentException("version must be >= 0");
-      
-      this.version = version;
-   }
-   
-   /**
-    * Get the property name.
-    * 
-    * @return the property name, may be <code>null</code>, not empty.
-    */
-   public String getName()
-   {
-      return name;
-   }
-   
-   /**
-    * Set a new property name.
-    * 
-    * @param name the new property name, not <code>null</code> or empty.
-    */
-   public void setName(String name)
-   {
-      if (StringUtils.isBlank(name))
-         throw new IllegalArgumentException("name cannot be null or empty");
-      
-      this.name = name;
-   }
-   
-   /**
-    * Get the property value.
-    * 
-    * @return the property valud, may be <code>null</code> or empty.
-    */
-   public String getValue()
-   {
-      return value;
-   }
-   
-   /**
-    * Set a new property value.
-    * 
-    * @param value the new property value, may be <code>null</code> or empty.
-    */
-   public void setValue(String value)
-   {
-      this.value = value;
-   }
+  /* (non-Javadoc)
+   * @see IPSCatalogSummary#getGUID()
+   */
+  @JsonProperty("guid")
+  public IPSGuid getGUID() {
+    // Offline-safe assemble (avoid GuidManager locator in unit tests).
+    return new PSGuid(PSTypeEnum.SHARED_PROPERTY, id);
+  }
 
-   @Override
-   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof PSSharedProperty)) return false;
-      PSSharedProperty that = (PSSharedProperty) o;
-      return id == that.id && Objects.equals(getVersion(), that.getVersion()) && Objects.equals(getName(), that.getName()) && Objects.equals(getValue(), that.getValue());
-   }
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#setGUID(IPSGuid)
+   */
+  public void setGUID(IPSGuid newguid) throws IllegalStateException {
+    if (newguid == null) throw new IllegalArgumentException("newguid may not be null");
 
-   @Override
-   public int hashCode() {
-      return Objects.hash(id, getVersion(), getName(), getValue());
-   }
+    if (id != 0) throw new IllegalStateException("cannot change existing guid");
 
-   @Override
-   public String toString() {
-      final StringBuffer sb = new StringBuffer("PSSharedProperty{");
-      sb.append("id=").append(id);
-      sb.append(", version=").append(version);
-      sb.append(", name='").append(name).append('\'');
-      sb.append(", value='").append(value).append('\'');
-      sb.append('}');
-      return sb.toString();
-   }
+    id = newguid.longValue();
+  }
 
-   /* (non-Javadoc)
-    * @see java.lang.Comparable#compareTo(T)
-    */
-   public int compareTo(Object o)
-   {
-      if (!(o instanceof PSSharedProperty))
-         throw new IllegalArgumentException(
-            "o must be of type PSSharedproperty");
-      
-      PSSharedProperty property = (PSSharedProperty) o;
-      return getName().compareToIgnoreCase(property.getName());
-   }
+  /**
+   * Get the object version.
+   *
+   * @return the object version, <code>null</code> if not initialized yet.
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public Integer getVersion() {
+    return version;
+  }
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#fromXML(String)
-    */
-   public void fromXML(String xmlsource) throws IOException, SAXException
-   {
-      PSXmlSerializationHelper.readFromXML(xmlsource, this);
-   }
+  /**
+   * Set the object version.
+   *
+   * @param version the version of the object, must be >= 0.
+   */
+  @JsonIgnore
+  public void setVersion(Integer version) {
+    // Null-safe for BeanUtils copy after Jackson design-object XML restore (issue #1920).
+    if (version == null) {
+      return;
+    }
+    if (version < 0) throw new IllegalArgumentException("version must be >= 0");
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#toXML()
-    */
-   public String toXML() throws IOException, SAXException
-   {
-      return PSXmlSerializationHelper.writeToXml(this);
-   }
+    this.version = version;
+  }
+
+  /**
+   * Get the property name.
+   *
+   * @return the property name, may be <code>null</code>, not empty.
+   */
+  @JsonProperty
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Set a new property name.
+   *
+   * @param name the new property name, not <code>null</code> or empty.
+   */
+  public void setName(String name) {
+    if (StringUtils.isBlank(name))
+      throw new IllegalArgumentException("name cannot be null or empty");
+
+    this.name = name;
+  }
+
+  /**
+   * Get the property value.
+   *
+   * @return the property valud, may be <code>null</code> or empty.
+   */
+  @JsonProperty
+  public String getValue() {
+    return value;
+  }
+
+  /**
+   * Set a new property value.
+   *
+   * @param value the new property value, may be <code>null</code> or empty.
+   */
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof PSSharedProperty)) return false;
+    PSSharedProperty that = (PSSharedProperty) o;
+    return id == that.id
+        && Objects.equals(getVersion(), that.getVersion())
+        && Objects.equals(getName(), that.getName())
+        && Objects.equals(getValue(), that.getValue());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, getVersion(), getName(), getValue());
+  }
+
+  @Override
+  public String toString() {
+    final StringBuffer sb = new StringBuffer("PSSharedProperty{");
+    sb.append("id=").append(id);
+    sb.append(", version=").append(version);
+    sb.append(", name='").append(name).append('\'');
+    sb.append(", value='").append(value).append('\'');
+    sb.append('}');
+    return sb.toString();
+  }
+
+  /* (non-Javadoc)
+   * @see java.lang.Comparable#compareTo(T)
+   */
+  public int compareTo(Object o) {
+    if (!(o instanceof PSSharedProperty))
+      throw new IllegalArgumentException("o must be of type PSSharedproperty");
+
+    PSSharedProperty property = (PSSharedProperty) o;
+    return getName().compareToIgnoreCase(property.getName());
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#fromXML(String)
+   */
+  public void fromXML(String xmlsource) throws IOException, SAXException {
+    PSXmlSerializationHelper.readFromXML(xmlsource, this);
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#toXML()
+   */
+  public String toXML() throws IOException, SAXException {
+    return PSXmlSerializationHelper.writeToXml(this);
+  }
 }
-

--- a/system/services/src/com/percussion/services/system/data/PSSharedProperty.java
+++ b/system/services/src/com/percussion/services/system/data/PSSharedProperty.java
@@ -124,17 +124,22 @@ public class PSSharedProperty implements Serializable, IPSCatalogItem, Comparabl
   }
 
   /**
-   * Set the object version.
+   * Set the object version. The version can only be set once in the life cycle of this object.
+   * Pass {@code null} to clear the version (same pattern as {@code PSKeyword}/{@code
+   * PSTemplateSlot}) so design webservice callers can re-init via {@code setVersion(null)} then
+   * {@code setVersion(n)}.
    *
-   * @param version the version of the object, must be >= 0.
+   * @param version the version of the object, must be >= 0, or {@code null} to clear
    */
   @JsonIgnore
   public void setVersion(Integer version) {
-    // Null-safe for BeanUtils copy after Jackson design-object XML restore (issue #1920).
-    if (version == null) {
-      return;
+    if (this.version != null && version != null) {
+      throw new IllegalStateException("version can only be initialized once");
     }
-    if (version < 0) throw new IllegalArgumentException("version must be >= 0");
+
+    if (version != null && version < 0) {
+      throw new IllegalArgumentException("version must be >= 0");
+    }
 
     this.version = version;
   }

--- a/system/services/src/com/percussion/services/ui/data/PSHierarchyNode.java
+++ b/system/services/src/com/percussion/services/ui/data/PSHierarchyNode.java
@@ -199,19 +199,21 @@ public class PSHierarchyNode implements Serializable, IPSCatalogSummary, IPSCata
 
   /**
    * Set the object version. The version can only be set once in the life cycle of this object.
+   * Pass {@code null} to clear the version (same pattern as {@code PSKeyword}/{@code
+   * PSTemplateSlot}) so design webservice callers can re-init via {@code setVersion(null)} then
+   * {@code setVersion(n)}.
    *
-   * @param version the version of the object, must be >= 0.
+   * @param version the version of the object, must be >= 0, or {@code null} to clear
    */
   @JsonIgnore
   public void setVersion(Integer version) {
-    // Null-safe for BeanUtils copy after Jackson design-object XML restore (issue #1920).
-    if (version == null) {
-      return;
-    }
-    if (this.version != null)
+    if (this.version != null && version != null) {
       throw new IllegalStateException("version can only be initialized once");
+    }
 
-    if (version < 0) throw new IllegalArgumentException("version must be >= 0");
+    if (version != null && version < 0) {
+      throw new IllegalArgumentException("version must be >= 0");
+    }
 
     this.version = version;
   }
@@ -298,14 +300,15 @@ public class PSHierarchyNode implements Serializable, IPSCatalogSummary, IPSCata
   }
 
   /**
-   * BeanUtils / Jackson setter for {@link #getNodeType()}. Allows design-object XML restore into a
-   * fresh instance (issue #1920).
+   * Jackson design-object XML setter for {@link #getNodeType()}. Restores into a fresh instance
+   * (issue #1920). Unlike {@link #setType(NodeType)}, this is not one-shot — restore may run after
+   * default construction with {@code type == 0}.
    *
-   * @param nt the node type, may be {@code null} (ignored)
+   * @param nt the node type, not {@code null}
    */
   public void setNodeType(NodeType nt) {
     if (nt == null) {
-      return;
+      throw new IllegalArgumentException("nt cannot be null");
     }
     type = nt.getOrdinal();
   }
@@ -315,13 +318,13 @@ public class PSHierarchyNode implements Serializable, IPSCatalogSummary, IPSCata
    * {@link #setNodeType(NodeType)} / {@link #setTypeInt(int)}.
    *
    * @param nt The new hierarchy node type, not <code>null</code>.
-   * @throws IllegalStateException If called more than once with a different type already set.
+   * @throws IllegalStateException If called more than once (any second call when type is already
+   *     non-zero).
    */
   public void setType(NodeType nt) {
     if (nt == null) throw new IllegalArgumentException("nt cannot be null");
 
-    // Allow idempotent re-set of the same value for BeanUtils copy after Jackson restore.
-    if (type != 0 && type != nt.getOrdinal()) {
+    if (type != 0) {
       throw new IllegalStateException("Can only set the type once.");
     }
 
@@ -350,21 +353,22 @@ public class PSHierarchyNode implements Serializable, IPSCatalogSummary, IPSCata
   }
 
   /**
-   * Get all hierarchy node properties. Sorted {@link TreeMap} for deterministic design-object XML /
-   * goldens.
+   * Get all hierarchy node properties. Never {@code null}; sorting is applied on write via {@link
+   * #setProperties(Map)} so getters do not reassign the field (Kilo review on #1920).
    *
    * @return the hierarchy node properties, never <code>null</code>, may be empty.
    */
   @JsonProperty
   public Map<String, String> getProperties() {
-    if (!(properties instanceof TreeMap)) {
-      properties = new TreeMap<>(properties == null ? Map.of() : properties);
+    if (properties == null) {
+      properties = new TreeMap<>();
     }
     return properties;
   }
 
   /**
-   * Set new hierarchy node properties.
+   * Set new hierarchy node properties. Always stored as a sorted {@link TreeMap} for deterministic
+   * design-object XML / goldens.
    *
    * @param properties the new hierarchy node properties, may be <code>null</code> or empty. All
    *     supplied properties must have a valid id. All properties will be attached to this node.

--- a/system/services/src/com/percussion/services/ui/data/PSHierarchyNode.java
+++ b/system/services/src/com/percussion/services/ui/data/PSHierarchyNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,482 +16,447 @@
  */
 package com.percussion.services.ui.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.catalog.IPSCatalogItem;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.guidmgr.data.PSDesignGuid;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.xml.IPSXmlSerialization;
-
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Map;
-
-
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.persistence.Version;
-
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Map;
+import java.util.TreeMap;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * This object represents a single workbench hierarchy node.
+ *
+ * <p>Design-object XML root is {@code hierarchy-node}. Jackson opt-in property surface (issue #1920
+ * / epic #505). Nested {@code properties} is a string map (key-as-element children). Catalog
+ * summary aliases {@code label}/{@code description}, Hibernate {@code version}, and ordinal-only
+ * {@code type-int} are suppressed. Node type is written as the enum name ({@code FOLDER} /
+ * {@code PLACEHOLDER}).
  */
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE,
-      region = "PSHierarchyNode")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSHierarchyNode")
 @Table(name = "PSX_WB_HIERARCHY_NODE")
-public class PSHierarchyNode implements Serializable, IPSCatalogSummary,
-   IPSCatalogItem
-{
-   /**
-    * Compiler generated serial version ID used for serialization.
-    */
-   private static final long serialVersionUID = -5425086083061018906L;
+@JacksonXmlRootElement(localName = "hierarchy-node")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({"guid", "name", "parentId", "properties", "type"})
+public class PSHierarchyNode implements Serializable, IPSCatalogSummary, IPSCatalogItem {
+  /** Compiler generated serial version ID used for serialization. */
+  private static final long serialVersionUID = -5425086083061018906L;
 
-   /**
-    * Full guid value.
-    */
-   @Id
-   @Column(name = "NODE_ID", nullable = false)
-   private long id;
+  /** Full guid value. */
+  @Id
+  @Column(name = "NODE_ID", nullable = false)
+  private long id;
 
-   @Version
-   @Column(name = "VERSION")
-   private Integer version;
+  @Version
+  @Column(name = "VERSION")
+  private Integer version;
 
-   /**
-    * Full guid value.
-    */
-   @Basic
-   @Column(name = "PARENT_ID", nullable = true)
-   private long parentId;
+  /** Full guid value. */
+  @Basic
+  @Column(name = "PARENT_ID", nullable = true)
+  private long parentId;
 
-   @Basic
-   @Column(name = "NAME", nullable = false, length = 250)
-   private String name;
+  @Basic
+  @Column(name = "NAME", nullable = false, length = 250)
+  private String name;
 
-   @Basic
-   @Column(name = "TYPE", nullable = false)
-   private int type;
+  @Basic
+  @Column(name = "TYPE", nullable = false)
+  private int type;
 
-   @Transient
-   private Map<String, String> properties = new HashMap<>();
+  @Transient private Map<String, String> properties = new TreeMap<>();
 
-   /**
-    * This ctor is meant for serialization only. It should not be used by
-    * clients.
-    */
-   public PSHierarchyNode()
-   {
-   }
+  /**
+   * This ctor is meant for serialization only. It should not be used by clients.
+   */
+  public PSHierarchyNode() {}
 
-   /**
-    * This enum identifies how the node is used.
-    *
-    * @author paulhoward
-    */
-   public enum NodeType
-   {
-      /**
-       * This node is a folder, meaning it can contain other nodes.
-       */
-      FOLDER(1),
+  /**
+   * This enum identifies how the node is used.
+   *
+   * @author paulhoward
+   */
+  public enum NodeType {
+    /**
+     * This node is a folder, meaning it can contain other nodes.
+     */
+    FOLDER(1),
 
-      /**
-       * This node is used to indicate where some other object should be placed
-       * in the hierarchy. It is not a container.
-       */
-      PLACEHOLDER(2);
+    /**
+     * This node is used to indicate where some other object should be placed in the hierarchy. It is
+     * not a container.
+     */
+    PLACEHOLDER(2);
 
-      /**
-       * Lookup enum value by ordinal. Ordinals should be unique. If they are
-       * not unique, then the first enum value with a matching ordinal is
-       * returned.
-       *
-       * @param s ordinal value
-       * @return an enumerated value or <code>null</code> if the ordinal does
-       * not match
-       */
-      public static NodeType valueOf(int s)
-      {
-         NodeType types[] = values();
-         for (int i = 0; i < types.length; i++)
-         {
-            if (types[i].getOrdinal() == s)
-               return types[i];
-         }
-         return null;
+    /**
+     * Lookup enum value by ordinal. Ordinals should be unique. If they are not unique, then the
+     * first enum value with a matching ordinal is returned.
+     *
+     * @param s ordinal value
+     * @return an enumerated value or <code>null</code> if the ordinal does not match
+     */
+    public static NodeType valueOf(int s) {
+      NodeType types[] = values();
+      for (int i = 0; i < types.length; i++) {
+        if (types[i].getOrdinal() == s) return types[i];
       }
-
-      /**
-       * We want to have our own assigned numbers, so we pass that in to the
-       * ctor for each enum.
-       *
-       * @param ordinal Any value is OK.
-       */
-      private NodeType(int ordinal)
-      {
-         m_value = ordinal;
-      }
-
-      /**
-       * Returns the value supplied in the ctor.
-       * @return See description.
-       */
-      public int getOrdinal()
-      {
-         return m_value;
-      }
-
-      /**
-       * See ctor.
-       */
-      private final int m_value;
-   }
-
-   /**
-    * This is not for client use. It should only be used by the betwixt
-    * serialization mechanism. When betwixt supports enums, this could be
-    * removed.
-    *
-    * @return Equivalent to {@link #getType()}.ordinal().
-    */
-   @IPSXmlSerialization(suppress=true)
-   public int getTypeInt()
-   {
-      return type;
-   }
-
-   /**
-    * This is not for client use. It should only be used by the betwixt
-    * serialization mechanism. When betwixt supports enums, this could be
-    * removed.
-    *
-    * @param nodeType Like {@link #setType(NodeType)}, but takes the ordinal of
-    * the enum.
-    */
-   public void setTypeInt(int nodeType)
-   {
-      type = nodeType;
-   }
-
-   /**
-    * Create a valid node.
-    *
-    * @param nodeName See {@link #setName(String)}.
-    * @param nodeGuid See {@link #setGUID(IPSGuid)}.
-    * @param nodeType See {@link #setType(NodeType)}.
-    */
-   public PSHierarchyNode(String nodeName, IPSGuid nodeGuid, NodeType nodeType)
-   {
-      // depend on setters for validation
-      setName(nodeName);
-      setGUID(nodeGuid);
-      setType(nodeType);
-   }
-
-   /**
-    * Get the object version.
-    *
-    * @return the object version, <code>null</code> if not initialized yet.
-    */
-   public Integer getVersion()
-   {
-      return version;
-   }
-
-   /**
-    * Set the object version. The version can only be set once in the life
-    * cycle of this object.
-    *
-    * @param version the version of the object, must be >= 0.
-    */
-   public void setVersion(Integer version)
-   {
-      if (this.version != null)
-         throw new IllegalStateException(
-            "version can only be initialized once");
-
-      if (version < 0)
-         throw new IllegalArgumentException("version must be >= 0");
-
-      this.version = version;
-   }
-
-   /* (non-Javadoc)
-    * @see IPSCatalogSummary#getName()
-    */
-   public String getName()
-   {
-      return name;
-   }
-
-   /**
-    * Set a new name for this hierarchy node. A node cannot have the same name
-    * as a sibling, case-insensitive. This check is performed by the service,
-    * not this class.
-    *
-    * @param nodeName the new name, not <code>null</code> or empty.
-    */
-   public void setName(String nodeName)
-   {
-      if (StringUtils.isBlank(nodeName))
-         throw new IllegalArgumentException("name cannot be null or empty");
-
-      this.name = nodeName;
-   }
-
-   /* (non-Javadoc)
-    * @see IPSCatalogSummary#getLabel()
-    */
-   public String getLabel()
-   {
-      return getName();
-   }
-
-   /* (non-Javadoc)
-    * @see IPSCatalogSummary#getDescription()
-    */
-   public String getDescription()
-   {
       return null;
-   }
+    }
 
-   /* (non-Javadoc)
-    * @see IPSCatalogSummary#getGUID()
-    */
-   public IPSGuid getGUID()
-   {
-      return new PSDesignGuid(id);
-   }
+    /**
+     * We want to have our own assigned numbers, so we pass that in to the ctor for each enum.
+     *
+     * @param ordinal Any value is OK.
+     */
+    private NodeType(int ordinal) {
+      m_value = ordinal;
+    }
 
-   /**
-    * The id of the parent of this hierarchy node, <code>null</code> if this
-    * hierarchy node does not have a parent.
-    *
-    * @return the id of the parent hierarchy node, <code>null</code> if this
-    *    is a root node.
-    */
-   public IPSGuid getParentId()
-   {
-      return parentId == 0 ? null : new PSDesignGuid(parentId);
-   }
+    /**
+     * Returns the value supplied in the ctor.
+     *
+     * @return See description.
+     */
+    public int getOrdinal() {
+      return m_value;
+    }
 
-   /**
-    * Get the type of this hierarchy node (textual form for compatibility with
-    * the catalog identifier API).
-    *
-    * @return the hierarchy node type name as a String, or {@code null} if unknown.
-    */
-   public String getType()
-   {
-      NodeType nt = NodeType.valueOf(type);
-      return nt == null ? null : nt.name();
-   }
+    /** See ctor. */
+    private final int m_value;
+  }
 
-   /**
-    * Convenience accessor returning the enum form of the node type.
-    *
-    * @return the {@link NodeType} or {@code null} if unknown.
-    */
-   public NodeType getNodeType()
-   {
-      return NodeType.valueOf(type);
-   }
+  /**
+   * Ordinal form for persistence / legacy clients. Suppressed on design-object XML; wire uses enum
+   * name via {@link #getNodeType()}.
+   *
+   * @return Equivalent to {@link #getNodeType()}.ordinal when known.
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public int getTypeInt() {
+    return type;
+  }
 
-   /**
-    * Set a new hierarchy node type. This is meant for use w/ the default ctor.
-    * If called otherwise, an exception is thrown.
-    *
-    * @param nt The new hierarchy node type, not <code>null</code>.
-    * @throws IllegalStateException If called more than once.
-    */
-   public void setType(NodeType nt)
-   {
-      if (type != 0)
-         throw new IllegalStateException("Can only set the type once.");
+  /**
+   * Ordinal form for persistence / legacy clients.
+   *
+   * @param nodeType Like {@link #setType(NodeType)}, but takes the ordinal of the enum.
+   */
+  @JsonIgnore
+  public void setTypeInt(int nodeType) {
+    type = nodeType;
+  }
 
-      if (nt == null)
-         throw new IllegalArgumentException("nt cannot be null");
+  /**
+   * Create a valid node.
+   *
+   * @param nodeName See {@link #setName(String)}.
+   * @param nodeGuid See {@link #setGUID(IPSGuid)}.
+   * @param nodeType See {@link #setType(NodeType)}.
+   */
+  public PSHierarchyNode(String nodeName, IPSGuid nodeGuid, NodeType nodeType) {
+    // depend on setters for validation
+    setName(nodeName);
+    setGUID(nodeGuid);
+    setType(nodeType);
+  }
 
-      type = nt.getOrdinal();
-   }
+  /**
+   * Get the object version.
+   *
+   * @return the object version, <code>null</code> if not initialized yet.
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public Integer getVersion() {
+    return version;
+  }
 
-   /**
-    * Set the id of the new parent hierarchy node.
-    *
-    * @param parent the id of the new hierarchy parent, <code>null</code> to
-    *    make this a root node.
-    */
-   public void setParentId(IPSGuid parent)
-   {
-      if (null == parent)
-         parentId = 0;
-      else
-         parentId = new PSDesignGuid(parent).getValue();
-   }
+  /**
+   * Set the object version. The version can only be set once in the life cycle of this object.
+   *
+   * @param version the version of the object, must be >= 0.
+   */
+  @JsonIgnore
+  public void setVersion(Integer version) {
+    // Null-safe for BeanUtils copy after Jackson design-object XML restore (issue #1920).
+    if (version == null) {
+      return;
+    }
+    if (this.version != null)
+      throw new IllegalStateException("version can only be initialized once");
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#setGUID(IPSGuid)
-    */
-   public void setGUID(IPSGuid newguid) throws IllegalStateException
-   {
-      if (newguid == null)
-         throw new IllegalArgumentException("newguid may not be null");
+    if (version < 0) throw new IllegalArgumentException("version must be >= 0");
 
-      if (id != 0)
-         throw new IllegalStateException("cannot change existing guid");
+    this.version = version;
+  }
 
-      id = new PSDesignGuid(newguid).getValue();
-   }
+  /* (non-Javadoc)
+   * @see IPSCatalogSummary#getName()
+   */
+  @JsonProperty
+  public String getName() {
+    return name;
+  }
 
-   /**
-    * Get all hierarchy node properties.
-    *
-    * @return the hierarchy node properties, never <code>null</code>, may
-    *    be empty.
-    */
-   public Map<String, String> getProperties()
-   {
-      return properties;
-   }
+  /**
+   * Set a new name for this hierarchy node. A node cannot have the same name as a sibling,
+   * case-insensitive. This check is performed by the service, not this class.
+   *
+   * @param nodeName the new name, not <code>null</code> or empty.
+   */
+  public void setName(String nodeName) {
+    if (StringUtils.isBlank(nodeName))
+      throw new IllegalArgumentException("name cannot be null or empty");
 
-   /**
-    * Set new hierarchy node properties.
-    *
-    * @param properties the new hierarchy node properties, may be
-    *    <code>null</code> or empty. All supplied properties must have a valid
-    *    id. All properties will be attached to this node.
-    */
-   public void setProperties(Map<String, String> properties)
-   {
-      if (properties == null)
-         this.properties.clear();
-      else
-         this.properties = properties;
-   }
+    this.name = nodeName;
+  }
 
-   /**
-    * Adds a new hierarchy node property or replaces an existing one.
-    *
-    * @param propertyName never <code>null</code> or empty.
-    * @param value may be <code>null</code> or empty.
-    */
-   public void addProperty(String propertyName, String value)
-   {
-      if (StringUtils.isBlank(propertyName))
-         throw new IllegalArgumentException("name cannot be null or empty");
+  /* (non-Javadoc)
+   * @see IPSCatalogSummary#getLabel()
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public String getLabel() {
+    return getName();
+  }
 
-      properties.put(propertyName, value);
-   }
+  /* (non-Javadoc)
+   * @see IPSCatalogSummary#getDescription()
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public String getDescription() {
+    return null;
+  }
 
-   /**
-    * Remove the property for the specified name.
-    *
-    * @param propertyName the name or the property to be removed, may be
-    *    <code>null</code> or empty. Nothing is done if the referenced property
-    *    does not exist.
-    */
-   public void removeProperty(String propertyName)
-   {
-      if (!StringUtils.isBlank(propertyName))
-         properties.remove(propertyName);
-   }
+  /* (non-Javadoc)
+   * @see IPSCatalogSummary#getGUID()
+   */
+  @JsonProperty("guid")
+  public IPSGuid getGUID() {
+    return new PSDesignGuid(id);
+  }
 
-   /**
-    * Get the property for the specified name.
-    *
-    * @param propertyName the name of the property to get, may be <code>null</code> or
-    *    empty.
-    * @return the property for the specified name, <code>null</code> if not
-    *    found.
-    */
-   public String getProperty(String propertyName)
-   {
-      if (StringUtils.isBlank(propertyName))
-         return null;
+  /**
+   * The id of the parent of this hierarchy node, <code>null</code> if this hierarchy node does not
+   * have a parent.
+   *
+   * @return the id of the parent hierarchy node, <code>null</code> if this is a root node.
+   */
+  @JsonProperty("parent-id")
+  public IPSGuid getParentId() {
+    return parentId == 0 ? null : new PSDesignGuid(parentId);
+  }
 
-      return properties.get(propertyName);
-   }
+  /**
+   * Get the type of this hierarchy node (textual form for compatibility with the catalog identifier
+   * API).
+   *
+   * @return the hierarchy node type name as a String, or {@code null} if unknown.
+   */
+  @JsonIgnore
+  public String getType() {
+    NodeType nt = NodeType.valueOf(type);
+    return nt == null ? null : nt.name();
+  }
 
+  /**
+   * Convenience accessor returning the enum form of the node type. Design-object XML uses this
+   * enum name as {@code <type>}.
+   *
+   * @return the {@link NodeType} or {@code null} if unknown.
+   */
+  @JsonProperty("type")
+  public NodeType getNodeType() {
+    return NodeType.valueOf(type);
+  }
 
+  /**
+   * BeanUtils / Jackson setter for {@link #getNodeType()}. Allows design-object XML restore into a
+   * fresh instance (issue #1920).
+   *
+   * @param nt the node type, may be {@code null} (ignored)
+   */
+  public void setNodeType(NodeType nt) {
+    if (nt == null) {
+      return;
+    }
+    type = nt.getOrdinal();
+  }
 
+  /**
+   * Set a new hierarchy node type. One-shot for client construction; design-object XML restore uses
+   * {@link #setNodeType(NodeType)} / {@link #setTypeInt(int)}.
+   *
+   * @param nt The new hierarchy node type, not <code>null</code>.
+   * @throws IllegalStateException If called more than once with a different type already set.
+   */
+  public void setType(NodeType nt) {
+    if (nt == null) throw new IllegalArgumentException("nt cannot be null");
 
-   @Override
-   public int hashCode()
-   {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + ((name == null) ? 0 : name.hashCode());
-      result = prime * result + (int) (parentId ^ (parentId >>> 32));
-      result = prime * result + type;
-      return result;
-   }
+    // Allow idempotent re-set of the same value for BeanUtils copy after Jackson restore.
+    if (type != 0 && type != nt.getOrdinal()) {
+      throw new IllegalStateException("Can only set the type once.");
+    }
 
-   @Override
-   public boolean equals(Object obj)
-   {
-      if (this == obj)
-         return true;
-      if (obj == null)
-         return false;
-      if (getClass() != obj.getClass())
-         return false;
-      PSHierarchyNode other = (PSHierarchyNode) obj;
-      if (name == null)
-      {
-         if (other.name != null)
-            return false;
-      }
-      else if (!name.equals(other.name))
-         return false;
-      if (parentId != other.parentId)
-         return false;
-      if (type != other.type)
-         return false;
-      return true;
-   }
+    type = nt.getOrdinal();
+  }
 
-   @Override
-   public String toString() {
-      final StringBuffer sb = new StringBuffer("PSHierarchyNode{");
-      sb.append("id=").append(id);
-      sb.append(", version=").append(version);
-      sb.append(", parentId=").append(parentId);
-      sb.append(", name='").append(name).append('\'');
-      sb.append(", type=").append(type);
-      sb.append(", properties=").append(properties);
-      sb.append('}');
-      return sb.toString();
-   }
+  /**
+   * Set the id of the new parent hierarchy node.
+   *
+   * @param parent the id of the new hierarchy parent, <code>null</code> to make this a root node.
+   */
+  public void setParentId(IPSGuid parent) {
+    if (null == parent) parentId = 0;
+    else parentId = new PSDesignGuid(parent).getValue();
+  }
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#fromXML(String)
-    */
-   public void fromXML(String xmlsource) throws IOException, SAXException
-   {
-      PSXmlSerializationHelper.readFromXML(xmlsource, this);
-   }
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#setGUID(IPSGuid)
+   */
+  public void setGUID(IPSGuid newguid) throws IllegalStateException {
+    if (newguid == null) throw new IllegalArgumentException("newguid may not be null");
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#toXML()
-    */
-   public String toXML() throws IOException, SAXException
-   {
-      return PSXmlSerializationHelper.writeToXml(this);
-   }
+    if (id != 0) throw new IllegalStateException("cannot change existing guid");
+
+    id = new PSDesignGuid(newguid).getValue();
+  }
+
+  /**
+   * Get all hierarchy node properties. Sorted {@link TreeMap} for deterministic design-object XML /
+   * goldens.
+   *
+   * @return the hierarchy node properties, never <code>null</code>, may be empty.
+   */
+  @JsonProperty
+  public Map<String, String> getProperties() {
+    if (!(properties instanceof TreeMap)) {
+      properties = new TreeMap<>(properties == null ? Map.of() : properties);
+    }
+    return properties;
+  }
+
+  /**
+   * Set new hierarchy node properties.
+   *
+   * @param properties the new hierarchy node properties, may be <code>null</code> or empty. All
+   *     supplied properties must have a valid id. All properties will be attached to this node.
+   */
+  public void setProperties(Map<String, String> properties) {
+    if (properties == null) this.properties = new TreeMap<>();
+    else this.properties = new TreeMap<>(properties);
+  }
+
+  /**
+   * Adds a new hierarchy node property or replaces an existing one.
+   *
+   * @param propertyName never <code>null</code> or empty.
+   * @param value may be <code>null</code> or empty.
+   */
+  public void addProperty(String propertyName, String value) {
+    if (StringUtils.isBlank(propertyName))
+      throw new IllegalArgumentException("name cannot be null or empty");
+
+    getProperties().put(propertyName, value);
+  }
+
+  /**
+   * Remove the property for the specified name.
+   *
+   * @param propertyName the name or the property to be removed, may be <code>null</code> or empty.
+   *     Nothing is done if the referenced property does not exist.
+   */
+  public void removeProperty(String propertyName) {
+    if (!StringUtils.isBlank(propertyName)) getProperties().remove(propertyName);
+  }
+
+  /**
+   * Get the property for the specified name.
+   *
+   * @param propertyName the name of the property to get, may be <code>null</code> or empty.
+   * @return the property for the specified name, <code>null</code> if not found.
+   */
+  public String getProperty(String propertyName) {
+    if (StringUtils.isBlank(propertyName)) return null;
+
+    return getProperties().get(propertyName);
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((name == null) ? 0 : name.hashCode());
+    result = prime * result + (int) (parentId ^ (parentId >>> 32));
+    result = prime * result + type;
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null) return false;
+    if (getClass() != obj.getClass()) return false;
+    PSHierarchyNode other = (PSHierarchyNode) obj;
+    if (name == null) {
+      if (other.name != null) return false;
+    } else if (!name.equals(other.name)) return false;
+    if (parentId != other.parentId) return false;
+    if (type != other.type) return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuffer sb = new StringBuffer("PSHierarchyNode{");
+    sb.append("id=").append(id);
+    sb.append(", version=").append(version);
+    sb.append(", parentId=").append(parentId);
+    sb.append(", name='").append(name).append('\'');
+    sb.append(", type=").append(type);
+    sb.append(", properties=").append(properties);
+    sb.append('}');
+    return sb.toString();
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#fromXML(String)
+   */
+  public void fromXML(String xmlsource) throws IOException, SAXException {
+    PSXmlSerializationHelper.readFromXML(xmlsource, this);
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#toXML()
+   */
+  public String toXML() throws IOException, SAXException {
+    return PSXmlSerializationHelper.writeToXml(this);
+  }
 }
-

--- a/system/services/src/com/percussion/services/ui/data/PSHierarchyNodeProperty.java
+++ b/system/services/src/com/percussion/services/ui/data/PSHierarchyNodeProperty.java
@@ -120,19 +120,21 @@ public class PSHierarchyNodeProperty implements Serializable {
 
   /**
    * Set the object version. The version can only be set once in the life cycle of this object.
+   * Pass {@code null} to clear the version (same pattern as {@code PSKeyword}/{@code
+   * PSTemplateSlot}) so design webservice callers can re-init via {@code setVersion(null)} then
+   * {@code setVersion(n)}.
    *
-   * @param version the version of the object, must be >= 0.
+   * @param version the version of the object, must be >= 0, or {@code null} to clear
    */
   @JsonIgnore
   public void setVersion(Integer version) {
-    // Null-safe for BeanUtils copy after Jackson design-object XML restore (issue #1920).
-    if (version == null) {
-      return;
-    }
-    if (this.version != null)
+    if (this.version != null && version != null) {
       throw new IllegalStateException("version can only be initialized once");
+    }
 
-    if (version < 0) throw new IllegalArgumentException("version must be >= 0");
+    if (version != null && version < 0) {
+      throw new IllegalArgumentException("version must be >= 0");
+    }
 
     this.version = version;
   }

--- a/system/services/src/com/percussion/services/ui/data/PSHierarchyNodeProperty.java
+++ b/system/services/src/com/percussion/services/ui/data/PSHierarchyNodeProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
  */
 package com.percussion.services.ui.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
 import com.percussion.utils.guid.IPSGuid;
-
-import java.io.IOException;
-import java.io.Serializable;
-
-
+import com.percussion.utils.xml.IPSXmlSerialization;
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -30,216 +30,198 @@ import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
-
+import java.io.IOException;
+import java.io.Serializable;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
- * Persist an association between a hierarchy node and a hierarchy node 
- * property.
+ * Persist an association between a hierarchy node and a hierarchy node property.
+ *
+ * <p>Design-object XML root is {@code hierarchy-node-property}. Jackson opt-in property surface
+ * (issue #1920 / epic #505). Historical {@code PSHierarchyNodeProperty.betwixt} mapped a
+ * non-existent {@code parentGuid}/{@code parentId} property; production bean identity is scalar
+ * {@code node-id}. Hibernate {@code version} is suppressed on the design-object wire.
  */
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, 
-      region = "PSHierarchyNodeProperty")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSHierarchyNodeProperty")
 @IdClass(PSHierarchyNodePropertyPK.class)
 @Table(name = "PSX_WB_HIERARCHY_NODE_PROP")
-public class PSHierarchyNodeProperty implements Serializable
-{
-   /**
-    * Compiler generated serial version ID used for serialization.
-    */
-   private static final long serialVersionUID = -982738490837214578L;
+@JacksonXmlRootElement(localName = "hierarchy-node-property")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({"name", "nodeId", "value"})
+public class PSHierarchyNodeProperty implements Serializable {
+  /** Compiler generated serial version ID used for serialization. */
+  private static final long serialVersionUID = -982738490837214578L;
 
-   @Id
-   @Column(name = "NODE_ID")
-   private long nodeId;
+  @Id
+  @Column(name = "NODE_ID")
+  private long nodeId;
 
-   @Id
-   @Column(name = "NAME")
-   private String name;
+  @Id
+  @Column(name = "NAME")
+  private String name;
 
-   @Version
-   @Column(name = "VERSION")
-   private Integer version;
+  @Version
+  @Column(name = "VERSION")
+  private Integer version;
 
-   @Basic
-   @Column(name = "VALUE")
-   private String value;
+  @Basic
+  @Column(name = "VALUE")
+  private String value;
 
-   /**
-    * Default constructor.
-    */
-   public PSHierarchyNodeProperty()
-   {
-   }
-   
-   /**
-    * Construct a new hierarchy node property for the supplied name and
-    * value.
-    * 
-    * @param propName the name of the property, not <code>null</code> or empty.
-    * @param propValue the value of the property, may be <code>null</code> or
-    *    empty.
-    */
-   public PSHierarchyNodeProperty(String propName, String propValue, 
-      IPSGuid parent) 
-   {
-      if (StringUtils.isBlank(propName))
-         throw new IllegalArgumentException("name must not be null/blank");
-      
-      if (parent == null)
-         throw new IllegalArgumentException("parent cannot be null");
+  /** Default constructor. */
+  public PSHierarchyNodeProperty() {}
 
-      nodeId = parent.longValue();
-      setName(propName);
-      setValue(propValue);
-   }
-   
-   public long getNodeId()
-   {
-      return nodeId;
-   }
-   
-   public void setNodeId(long nodeId)
-   {
-      this.nodeId = nodeId;
-   }
-   
-   /**
-    * Get the object version.
-    * 
-    * @return the object version, <code>null</code> if not initialized yet.
-    */
-   public Integer getVersion()
-   {
-      return version;
-   }
-   
-   /**
-    * Set the object version. The version can only be set once in the life 
-    * cycle of this object. 
-    * 
-    * @param version the version of the object, must be >= 0.
-    */
-   public void setVersion(Integer version)
-   {
-      if (this.version != null)
-         throw new IllegalStateException(
-            "version can only be initialized once");
-      
-      if (version < 0)
-         throw new IllegalArgumentException("version must be >= 0");
-      
-      this.version = version;
-   }
-   
-   /**
-    * Get the property name.
-    * 
-    * @return the property name, may be <code>null</code>, never empty.
-    */
-   public String getName()
-   {
-      return name;
-   }
-   
-   /**
-    * Set a new property name.
-    * 
-    * @param name the new property name, not <code>null</code> or empty.
-    */
-   public void setName(String name)
-   {
-      if (StringUtils.isBlank(name))
-         throw new IllegalArgumentException("name cannot be null or empty");
-      
-      this.name = name;
-   }
-   
-   /**
-    * Get the property value.
-    * 
-    * @return the property value, may be <code>null</code> or empty.
-    */
-   public String getValue()
-   {
-      return value;
-   }
-   
-   /**
-    * Set a new property value.
-    * 
-    * @param value the new property value, may be <code>null</code> or empty.
-    */
-   public void setValue(String value)
-   {
-      this.value = value;
-   }
+  /**
+   * Construct a new hierarchy node property for the supplied name and value.
+   *
+   * @param propName the name of the property, not <code>null</code> or empty.
+   * @param propValue the value of the property, may be <code>null</code> or empty.
+   */
+  public PSHierarchyNodeProperty(String propName, String propValue, IPSGuid parent) {
+    if (StringUtils.isBlank(propName))
+      throw new IllegalArgumentException("name must not be null/blank");
 
-  
+    if (parent == null) throw new IllegalArgumentException("parent cannot be null");
 
-   @Override
-   public int hashCode()
-   {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + ((name == null) ? 0 : name.hashCode());
-      result = prime * result + (int) (nodeId ^ (nodeId >>> 32));
-      return result;
-   }
+    nodeId = parent.longValue();
+    setName(propName);
+    setValue(propValue);
+  }
 
-   @Override
-   public boolean equals(Object obj)
-   {
-      if (this == obj)
-         return true;
-      if (obj == null)
-         return false;
-      if (getClass() != obj.getClass())
-         return false;
-      PSHierarchyNodeProperty other = (PSHierarchyNodeProperty) obj;
-      if (name == null)
-      {
-         if (other.name != null)
-            return false;
-      }
-      else if (!name.equals(other.name))
-         return false;
-      if (nodeId != other.nodeId)
-         return false;
-      return true;
-   }
+  @JsonProperty("node-id")
+  public long getNodeId() {
+    return nodeId;
+  }
 
-   @Override
-   public String toString() {
-      final StringBuffer sb = new StringBuffer("PSHierarchyNodeProperty{");
-      sb.append("nodeId=").append(nodeId);
-      sb.append(", name='").append(name).append('\'');
-      sb.append(", version=").append(version);
-      sb.append(", value='").append(value).append('\'');
-      sb.append('}');
-      return sb.toString();
-   }
+  public void setNodeId(long nodeId) {
+    this.nodeId = nodeId;
+  }
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#fromXML(String)
-    */
-   public void fromXML(String xmlsource) throws IOException, SAXException
-   {
-      PSXmlSerializationHelper.readFromXML(xmlsource, this);
-   }
+  /**
+   * Get the object version.
+   *
+   * @return the object version, <code>null</code> if not initialized yet.
+   */
+  @IPSXmlSerialization(suppress = true)
+  @JsonIgnore
+  public Integer getVersion() {
+    return version;
+  }
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#toXML()
-    */
-   public String toXML() throws IOException, SAXException
-   {
-      return PSXmlSerializationHelper.writeToXml(this);
-   }
+  /**
+   * Set the object version. The version can only be set once in the life cycle of this object.
+   *
+   * @param version the version of the object, must be >= 0.
+   */
+  @JsonIgnore
+  public void setVersion(Integer version) {
+    // Null-safe for BeanUtils copy after Jackson design-object XML restore (issue #1920).
+    if (version == null) {
+      return;
+    }
+    if (this.version != null)
+      throw new IllegalStateException("version can only be initialized once");
+
+    if (version < 0) throw new IllegalArgumentException("version must be >= 0");
+
+    this.version = version;
+  }
+
+  /**
+   * Get the property name.
+   *
+   * @return the property name, may be <code>null</code>, never empty.
+   */
+  @JsonProperty
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Set a new property name.
+   *
+   * @param name the new property name, not <code>null</code> or empty.
+   */
+  public void setName(String name) {
+    if (StringUtils.isBlank(name))
+      throw new IllegalArgumentException("name cannot be null or empty");
+
+    this.name = name;
+  }
+
+  /**
+   * Get the property value.
+   *
+   * @return the property value, may be <code>null</code> or empty.
+   */
+  @JsonProperty
+  public String getValue() {
+    return value;
+  }
+
+  /**
+   * Set a new property value.
+   *
+   * @param value the new property value, may be <code>null</code> or empty.
+   */
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((name == null) ? 0 : name.hashCode());
+    result = prime * result + (int) (nodeId ^ (nodeId >>> 32));
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null) return false;
+    if (getClass() != obj.getClass()) return false;
+    PSHierarchyNodeProperty other = (PSHierarchyNodeProperty) obj;
+    if (name == null) {
+      if (other.name != null) return false;
+    } else if (!name.equals(other.name)) return false;
+    if (nodeId != other.nodeId) return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuffer sb = new StringBuffer("PSHierarchyNodeProperty{");
+    sb.append("nodeId=").append(nodeId);
+    sb.append(", name='").append(name).append('\'');
+    sb.append(", version=").append(version);
+    sb.append(", value='").append(value).append('\'');
+    sb.append('}');
+    return sb.toString();
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#fromXML(String)
+   */
+  public void fromXML(String xmlsource) throws IOException, SAXException {
+    PSXmlSerializationHelper.readFromXML(xmlsource, this);
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#toXML()
+   */
+  public String toXML() throws IOException, SAXException {
+    return PSXmlSerializationHelper.writeToXml(this);
+  }
 }
-

--- a/system/src/main/resources/com/percussion/services/ui/data/PSHierarchyNodeProperty.betwixt
+++ b/system/src/main/resources/com/percussion/services/ui/data/PSHierarchyNodeProperty.betwixt
@@ -1,7 +1,0 @@
-<?xml version="1.0"?>
-<info primitiveTypes="element">
-   <element">
-       <element name="parentGuid" property="parentId" class="com.percussion.services.guidmgr.data.PSGuid"/>
-       <addDefaults/>
-   </element>
-</info>

--- a/system/src/test/java/com/percussion/services/system/data/PSSystemDataXmlSerializationTest.java
+++ b/system/src/test/java/com/percussion/services/system/data/PSSystemDataXmlSerializationTest.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.system.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Objects;
+import java.util.TimeZone;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * Golden / round-trip tests for system design objects under the Jackson-backed {@code
+ * PSXmlSerializationHelper} (issue #1920, epic #505). Offline only — no live CMS.
+ */
+class PSSystemDataXmlSerializationTest {
+
+  @Test
+  void auditWriteShapeAndGolden() throws Exception {
+    PSAudit original = sampleAudit();
+    String xml = original.toXML();
+
+    assertNotNull(xml);
+    assertFalse(xml.trim().startsWith("<null"), xml);
+    assertTrue(containsTag(xml, "audit"), "root: " + xml);
+    assertTrue(containsTag(xml, "actor"), xml);
+    assertTrue(containsTag(xml, "event-time"), xml);
+    assertTrue(containsTag(xml, "state-id"), xml);
+    assertTrue(containsTag(xml, "transition-name"), xml);
+    assertTrue(containsTag(xml, "current-revision"), xml);
+    assertTrue(containsTag(xml, "id"), xml);
+    assertFalse(containsTag(xml, "guid"), "derived guid omitted: " + xml);
+    assertTrue(xml.contains("editor"), xml);
+
+    String golden = loadResource("com/percussion/services/system/data/ps-audit-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+  }
+
+  @Test
+  void auditRoundTripRestoresScalars() throws Exception {
+    PSAudit original = sampleAudit();
+    String xml = original.toXML();
+
+    PSAudit restored = new PSAudit();
+    restored.fromXML(xml);
+
+    assertEquals(original.getId(), restored.getId());
+    assertEquals(original.getActor(), restored.getActor());
+    assertEquals(original.isPublishable(), restored.isPublishable());
+    assertEquals(original.isCurrentRevision(), restored.isCurrentRevision());
+    assertEquals(original.isEditRevision(), restored.isEditRevision());
+    assertEquals(original.getStateId(), restored.getStateId());
+    assertEquals(original.getStateName(), restored.getStateName());
+    assertEquals(original.getTransitionId(), restored.getTransitionId());
+    assertEquals(original.getTransitionName(), restored.getTransitionName());
+    assertEquals(original.getTransitionComment(), restored.getTransitionComment());
+    assertEquals(original.getEventTime().getTime(), restored.getEventTime().getTime());
+  }
+
+  @Test
+  void auditFromXmlAcceptsLegacyNullRoot() throws Exception {
+    String legacy =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <null>
+          <actor>legacy-user</actor>
+          <current-revision>true</current-revision>
+          <edit-revision>false</edit-revision>
+          <event-time>20240115T120000000</event-time>
+          <id>42</id>
+          <publishable>true</publishable>
+          <state-id>3</state-id>
+          <state-name>Approved</state-name>
+          <transition-comment>ok</transition-comment>
+          <transition-id>7</transition-id>
+          <transition-name>Approve</transition-name>
+        </null>
+        """;
+
+    PSAudit restored = new PSAudit();
+    restored.fromXML(legacy);
+
+    assertEquals(42L, restored.getId());
+    assertEquals("legacy-user", restored.getActor());
+    assertEquals("Approved", restored.getStateName());
+    assertEquals("Approve", restored.getTransitionName());
+    assertTrue(restored.isPublishable());
+    assertTrue(restored.isCurrentRevision());
+    assertFalse(restored.isEditRevision());
+  }
+
+  @Test
+  void auditTrailWriteShapeAndGolden() throws Exception {
+    PSAuditTrail original = sampleAuditTrail();
+    String xml = original.toXML();
+
+    assertTrue(containsTag(xml, "audit-trail"), xml);
+    assertTrue(containsTag(xml, "audits"), xml);
+    assertTrue(containsTag(xml, "audit"), xml);
+    assertTrue(containsTag(xml, "current-revision"), xml);
+    assertTrue(containsTag(xml, "edit-revision"), xml);
+    assertTrue(xml.contains("editor"), xml);
+
+    String golden = loadResource("com/percussion/services/system/data/ps-audit-trail-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+  }
+
+  @Test
+  void auditTrailRoundTripRestoresNestedAudits() throws Exception {
+    PSAuditTrail original = sampleAuditTrail();
+    String xml = original.toXML();
+
+    PSAuditTrail restored = new PSAuditTrail();
+    restored.fromXML(xml);
+
+    assertEquals(original.getCurrentRevision(), restored.getCurrentRevision());
+    assertEquals(original.getEditRevision(), restored.getEditRevision());
+    assertEquals(original.getAudits().size(), restored.getAudits().size());
+    assertEquals(original.getAudits().get(0).getActor(), restored.getAudits().get(0).getActor());
+    assertEquals(original.getAudits().get(0).getId(), restored.getAudits().get(0).getId());
+    assertEquals(
+        original.getAudits().get(1).getTransitionName(),
+        restored.getAudits().get(1).getTransitionName());
+  }
+
+  @Test
+  void auditTrailFromXmlAcceptsLegacyNullRoot() throws Exception {
+    String legacy =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <null>
+          <audits>
+            <audit>
+              <actor>a1</actor>
+              <current-revision>false</current-revision>
+              <edit-revision>true</edit-revision>
+              <event-time>20240115T120000000</event-time>
+              <id>1</id>
+              <publishable>false</publishable>
+              <state-id>1</state-id>
+              <state-name>Draft</state-name>
+              <transition-comment/>
+              <transition-id>0</transition-id>
+              <transition-name/>
+            </audit>
+          </audits>
+          <current-revision>2</current-revision>
+          <edit-revision>3</edit-revision>
+        </null>
+        """;
+
+    PSAuditTrail restored = new PSAuditTrail();
+    restored.fromXML(legacy);
+
+    assertEquals(2, restored.getCurrentRevision());
+    assertEquals(3, restored.getEditRevision());
+    assertEquals(1, restored.getAudits().size());
+    assertEquals("a1", restored.getAudits().get(0).getActor());
+    assertEquals(1L, restored.getAudits().get(0).getId());
+  }
+
+  @Test
+  void sharedPropertyWriteShapeAndGolden() throws Exception {
+    PSSharedProperty original = sampleSharedProperty();
+    String xml = original.toXML();
+
+    assertTrue(containsTag(xml, "shared-property"), xml);
+    assertTrue(containsTag(xml, "guid"), xml);
+    assertTrue(containsTag(xml, "name"), xml);
+    assertTrue(containsTag(xml, "value"), xml);
+    assertFalse(containsTag(xml, "version"), "version suppressed: " + xml);
+    assertTrue(xml.contains("sys_prop_sample"), xml);
+
+    String golden =
+        loadResource("com/percussion/services/system/data/ps-shared-property-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+  }
+
+  @Test
+  void sharedPropertyRoundTripRestoresScalars() throws Exception {
+    PSSharedProperty original = sampleSharedProperty();
+    String xml = original.toXML();
+
+    PSSharedProperty restored = new PSSharedProperty();
+    restored.fromXML(xml);
+
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getValue(), restored.getValue());
+    assertEquals(original.getGUID().toString(), restored.getGUID().toString());
+  }
+
+  @Test
+  void sharedPropertyFromXmlAcceptsLegacyNullRoot() throws Exception {
+    String legacy =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <null>
+          <guid>0-29-55</guid>
+          <name>legacy_prop</name>
+          <value>legacy_value</value>
+        </null>
+        """;
+
+    PSSharedProperty restored = new PSSharedProperty();
+    restored.fromXML(legacy);
+
+    assertEquals("legacy_prop", restored.getName());
+    assertEquals("legacy_value", restored.getValue());
+    assertEquals(55L, restored.getGUID().getUUID());
+  }
+
+  private static PSAudit sampleAudit() {
+    PSAudit audit = new PSAudit();
+    audit.setId(1001L);
+    audit.setActor("editor");
+    audit.setPublishable(true);
+    audit.setCurrentRevision(true);
+    audit.setEditRevision(false);
+    audit.setStateId(5L);
+    audit.setStateName("Public");
+    audit.setTransitionId(12L);
+    audit.setTransitionName("Publish");
+    audit.setTransitionComment("ship it");
+    // Fixed UTC instant for golden stability (matches @JsonFormat timezone=UTC).
+    audit.setEventTime(fixedEventTime());
+    return audit;
+  }
+
+  private static PSAuditTrail sampleAuditTrail() {
+    PSAuditTrail trail = new PSAuditTrail();
+    trail.setCurrentRevision(2);
+    trail.setEditRevision(3);
+
+    PSAudit a1 = new PSAudit();
+    a1.setId(1001L);
+    a1.setActor("editor");
+    a1.setPublishable(true);
+    a1.setCurrentRevision(false);
+    a1.setEditRevision(true);
+    a1.setStateId(5L);
+    a1.setStateName("Public");
+    a1.setTransitionId(12L);
+    a1.setTransitionName("Publish");
+    a1.setTransitionComment("ship it");
+    a1.setEventTime(fixedEventTime());
+
+    PSAudit a2 = new PSAudit();
+    a2.setId(1002L);
+    a2.setActor("reviewer");
+    a2.setPublishable(false);
+    a2.setCurrentRevision(true);
+    a2.setEditRevision(false);
+    a2.setStateId(3L);
+    a2.setStateName("Review");
+    a2.setTransitionId(9L);
+    a2.setTransitionName("Submit");
+    a2.setTransitionComment("ready");
+    a2.setEventTime(fixedEventTime());
+
+    trail.addAudit(a1);
+    trail.addAudit(a2);
+    return trail;
+  }
+
+  private static PSSharedProperty sampleSharedProperty() {
+    PSSharedProperty prop = new PSSharedProperty();
+    prop.setGUID(new PSGuid(PSTypeEnum.SHARED_PROPERTY, 55L));
+    prop.setName("sys_prop_sample");
+    prop.setValue("sample-value");
+    return prop;
+  }
+
+  /** 2024-01-15T12:00:00.000Z as {@link Date}. */
+  private static Date fixedEventTime() {
+    TimeZone utc = TimeZone.getTimeZone("UTC");
+    java.util.Calendar cal = java.util.Calendar.getInstance(utc);
+    cal.clear();
+    cal.set(2024, java.util.Calendar.JANUARY, 15, 12, 0, 0);
+    cal.set(java.util.Calendar.MILLISECOND, 0);
+    return cal.getTime();
+  }
+
+  private static boolean containsTag(String xml, String localName) {
+    return xml.contains("<" + localName) || xml.contains("</" + localName + ">");
+  }
+
+  private static String loadResource(String classpath) throws Exception {
+    try (InputStream in =
+        PSSystemDataXmlSerializationTest.class.getClassLoader().getResourceAsStream(classpath)) {
+      assertNotNull(in, "missing test resource: " + classpath);
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static void assertLogicalXmlParity(String expectedXml, String actualXml)
+      throws Exception {
+    Document expected = parseXml(stripXmlDeclaration(expectedXml));
+    Document actual = parseXml(stripXmlDeclaration(actualXml));
+    assertElementTreeEquals(expected.getDocumentElement(), actual.getDocumentElement(), "/");
+  }
+
+  private static String stripXmlDeclaration(String xml) {
+    String s = Objects.requireNonNull(xml).trim();
+    if (s.startsWith("<?xml")) {
+      int end = s.indexOf("?>");
+      if (end >= 0) {
+        s = s.substring(end + 2).trim();
+      }
+    }
+    while (s.startsWith("<!--")) {
+      int end = s.indexOf("-->");
+      if (end < 0) {
+        break;
+      }
+      s = s.substring(end + 3).trim();
+    }
+    return s;
+  }
+
+  private static Document parseXml(String xml) throws Exception {
+    var factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    var builder = factory.newDocumentBuilder();
+    return builder.parse(new InputSource(new java.io.StringReader(xml)));
+  }
+
+  private static void assertElementTreeEquals(Element expected, Element actual, String path) {
+    assertEquals(expected.getTagName(), actual.getTagName(), "tag at " + path);
+    java.util.List<Node> eChildren = significantChildren(expected);
+    java.util.List<Node> aChildren = significantChildren(actual);
+    assertEquals(
+        eChildren.size(),
+        aChildren.size(),
+        "child count at "
+            + path
+            + " expected="
+            + summarize(eChildren)
+            + " actual="
+            + summarize(aChildren));
+    for (int i = 0; i < eChildren.size(); i++) {
+      Node en = eChildren.get(i);
+      Node an = aChildren.get(i);
+      if (en.getNodeType() == Node.TEXT_NODE) {
+        assertEquals(en.getTextContent().trim(), an.getTextContent().trim(), "text at " + path);
+      } else {
+        assertElementTreeEquals(
+            (Element) en, (Element) an, path + "/" + ((Element) en).getTagName() + "[" + i + "]");
+      }
+    }
+  }
+
+  private static java.util.List<Node> significantChildren(Element el) {
+    NodeList nl = el.getChildNodes();
+    java.util.ArrayList<Node> out = new java.util.ArrayList<>();
+    boolean hasElementChild = false;
+    for (int i = 0; i < nl.getLength(); i++) {
+      if (nl.item(i).getNodeType() == Node.ELEMENT_NODE) {
+        hasElementChild = true;
+        break;
+      }
+    }
+    for (int i = 0; i < nl.getLength(); i++) {
+      Node n = nl.item(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE) {
+        out.add(n);
+      } else if (n.getNodeType() == Node.TEXT_NODE && !hasElementChild) {
+        String t = n.getTextContent();
+        if (t != null && !t.trim().isEmpty()) {
+          out.add(n);
+        }
+      }
+    }
+    return out;
+  }
+
+  private static String summarize(java.util.List<Node> nodes) {
+    StringBuilder b = new StringBuilder("[");
+    for (int i = 0; i < nodes.size(); i++) {
+      if (i > 0) {
+        b.append(',');
+      }
+      Node n = nodes.get(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE) {
+        b.append(((Element) n).getTagName());
+      } else {
+        b.append("#text");
+      }
+    }
+    return b.append(']').toString();
+  }
+}

--- a/system/src/test/java/com/percussion/services/system/data/PSSystemDataXmlSerializationTest.java
+++ b/system/src/test/java/com/percussion/services/system/data/PSSystemDataXmlSerializationTest.java
@@ -19,6 +19,8 @@ package com.percussion.services.system.data;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.services.catalog.PSTypeEnum;
@@ -234,6 +236,22 @@ class PSSystemDataXmlSerializationTest {
     assertEquals("legacy_prop", restored.getName());
     assertEquals("legacy_value", restored.getValue());
     assertEquals(55L, restored.getGUID().getUUID());
+  }
+
+  @Test
+  void sharedPropertySetVersionOneShotWithNullClear() {
+    PSSharedProperty property = new PSSharedProperty("name", "value");
+    property.setVersion(0);
+    assertEquals(0, property.getVersion());
+    assertThrows(IllegalStateException.class, () -> property.setVersion(1));
+    property.setVersion(null);
+    assertNull(property.getVersion());
+    property.setVersion(2);
+    assertEquals(2, property.getVersion());
+    assertThrows(IllegalArgumentException.class, () -> {
+      property.setVersion(null);
+      property.setVersion(-1);
+    });
   }
 
   private static PSAudit sampleAudit() {

--- a/system/src/test/java/com/percussion/services/ui/data/PSHierarchyNodeXmlSerializationTest.java
+++ b/system/src/test/java/com/percussion/services/ui/data/PSHierarchyNodeXmlSerializationTest.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.services.catalog.PSTypeEnum;
@@ -27,7 +29,10 @@ import com.percussion.services.guidmgr.data.PSDesignGuid;
 import com.percussion.services.guidmgr.data.PSGuid;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
@@ -156,6 +161,74 @@ class PSHierarchyNodeXmlSerializationTest {
     assertEquals(99L, restored.getNodeId());
     assertEquals("legacyKey", restored.getName());
     assertEquals("legacyVal", restored.getValue());
+  }
+
+  @Test
+  void hierarchyNodeSetTypeIsOneShotStrict() {
+    PSDesignGuid guid = new PSDesignGuid(new PSGuid(PSTypeEnum.HIERARCHY_NODE, 1L));
+    PSHierarchyNode node =
+        new PSHierarchyNode("n", guid, PSHierarchyNode.NodeType.FOLDER);
+    assertThrows(
+        IllegalStateException.class, () -> node.setType(PSHierarchyNode.NodeType.FOLDER));
+    assertThrows(
+        IllegalStateException.class, () -> node.setType(PSHierarchyNode.NodeType.PLACEHOLDER));
+    assertThrows(IllegalArgumentException.class, () -> node.setType(null));
+  }
+
+  @Test
+  void hierarchyNodeSetNodeTypeRejectsNullButAllowsOverwrite() {
+    PSHierarchyNode node = new PSHierarchyNode();
+    assertThrows(IllegalArgumentException.class, () -> node.setNodeType(null));
+    node.setNodeType(PSHierarchyNode.NodeType.FOLDER);
+    assertEquals(PSHierarchyNode.NodeType.FOLDER, node.getNodeType());
+    // Jackson restore path may re-assign on a fresh instance; not one-shot.
+    node.setNodeType(PSHierarchyNode.NodeType.PLACEHOLDER);
+    assertEquals(PSHierarchyNode.NodeType.PLACEHOLDER, node.getNodeType());
+  }
+
+  @Test
+  void hierarchyNodeSetVersionOneShotWithNullClear() {
+    PSHierarchyNode node = new PSHierarchyNode();
+    node.setVersion(0);
+    assertEquals(0, node.getVersion());
+    assertThrows(IllegalStateException.class, () -> node.setVersion(1));
+    // Null clears so design WS can re-init (peer: PSKeyword / PSTemplateSlot).
+    node.setVersion(null);
+    assertNull(node.getVersion());
+    node.setVersion(2);
+    assertEquals(2, node.getVersion());
+    assertThrows(IllegalArgumentException.class, () -> {
+      node.setVersion(null);
+      node.setVersion(-1);
+    });
+  }
+
+  @Test
+  void hierarchyNodeGetPropertiesDoesNotReassignField() {
+    PSHierarchyNode node = new PSHierarchyNode();
+    Map<String, String> first = node.getProperties();
+    assertTrue(first instanceof TreeMap);
+    assertSame(first, node.getProperties());
+    Map<String, String> incoming = new HashMap<>();
+    incoming.put("b", "2");
+    incoming.put("a", "1");
+    node.setProperties(incoming);
+    Map<String, String> after = node.getProperties();
+    assertTrue(after instanceof TreeMap);
+    assertEquals("1", after.get("a"));
+    assertSame(after, node.getProperties());
+  }
+
+  @Test
+  void hierarchyNodePropertySetVersionOneShotWithNullClear() {
+    PSHierarchyNodeProperty prop =
+        new PSHierarchyNodeProperty("k", "v", new PSGuid(PSTypeEnum.HIERARCHY_NODE, 1L));
+    prop.setVersion(0);
+    assertThrows(IllegalStateException.class, () -> prop.setVersion(1));
+    prop.setVersion(null);
+    assertNull(prop.getVersion());
+    prop.setVersion(3);
+    assertEquals(3, prop.getVersion());
   }
 
   private static PSHierarchyNode sampleNode() {

--- a/system/src/test/java/com/percussion/services/ui/data/PSHierarchyNodeXmlSerializationTest.java
+++ b/system/src/test/java/com/percussion/services/ui/data/PSHierarchyNodeXmlSerializationTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.ui.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSDesignGuid;
+import com.percussion.services.guidmgr.data.PSGuid;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * Golden / round-trip tests for workbench hierarchy design objects under the Jackson-backed {@code
+ * PSXmlSerializationHelper} (issue #1920, epic #505). Offline only — no live CMS.
+ */
+class PSHierarchyNodeXmlSerializationTest {
+
+  @Test
+  void hierarchyNodeWriteShapeAndGolden() throws Exception {
+    PSHierarchyNode original = sampleNode();
+    String xml = original.toXML();
+
+    assertNotNull(xml);
+    assertFalse(xml.trim().startsWith("<null"), xml);
+    assertTrue(containsTag(xml, "hierarchy-node"), "root: " + xml);
+    assertTrue(containsTag(xml, "guid"), xml);
+    assertTrue(containsTag(xml, "name"), xml);
+    assertTrue(containsTag(xml, "type"), xml);
+    assertTrue(containsTag(xml, "parent-id"), xml);
+    assertTrue(containsTag(xml, "properties"), xml);
+    assertTrue(xml.contains("FOLDER"), xml);
+    assertTrue(xml.contains("Sites"), xml);
+    assertFalse(containsTag(xml, "version"), "version suppressed: " + xml);
+    assertFalse(containsTag(xml, "type-int"), "ordinal form suppressed: " + xml);
+    assertFalse(containsTag(xml, "label"), "catalog label alias suppressed: " + xml);
+    assertFalse(containsTag(xml, "description"), "catalog description suppressed: " + xml);
+
+    String golden = loadResource("com/percussion/services/ui/data/ps-hierarchy-node-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+  }
+
+  @Test
+  void hierarchyNodeRoundTripRestoresScalarsAndProperties() throws Exception {
+    PSHierarchyNode original = sampleNode();
+    String xml = original.toXML();
+
+    PSHierarchyNode restored = new PSHierarchyNode();
+    restored.fromXML(xml);
+
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getNodeType(), restored.getNodeType());
+    assertEquals(original.getGUID().toString(), restored.getGUID().toString());
+    assertEquals(original.getParentId().toString(), restored.getParentId().toString());
+    assertEquals(original.getProperties(), restored.getProperties());
+  }
+
+  @Test
+  void hierarchyNodeFromXmlAcceptsLegacyNullRootAndRootParent() throws Exception {
+    String legacy =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <null>
+          <guid>0-32-200</guid>
+          <name>RootFolder</name>
+          <properties>
+            <icon>folder</icon>
+          </properties>
+          <type>FOLDER</type>
+        </null>
+        """;
+
+    PSHierarchyNode restored = new PSHierarchyNode();
+    restored.fromXML(legacy);
+
+    assertEquals("RootFolder", restored.getName());
+    assertEquals(PSHierarchyNode.NodeType.FOLDER, restored.getNodeType());
+    assertEquals(200L, restored.getGUID().getUUID());
+    assertNull(restored.getParentId());
+    assertEquals("folder", restored.getProperty("icon"));
+  }
+
+  @Test
+  void hierarchyNodePropertyWriteShapeAndGolden() throws Exception {
+    PSHierarchyNodeProperty original = sampleProperty();
+    String xml = original.toXML();
+
+    assertTrue(containsTag(xml, "hierarchy-node-property"), xml);
+    assertTrue(containsTag(xml, "node-id"), xml);
+    assertTrue(containsTag(xml, "name"), xml);
+    assertTrue(containsTag(xml, "value"), xml);
+    assertFalse(containsTag(xml, "version"), "version suppressed: " + xml);
+    assertFalse(containsTag(xml, "parent-id"), "historical betwixt parent-id not used: " + xml);
+    assertFalse(containsTag(xml, "parent-guid"), "historical betwixt parentGuid not used: " + xml);
+    assertTrue(xml.contains("displayOrder"), xml);
+
+    String golden =
+        loadResource("com/percussion/services/ui/data/ps-hierarchy-node-property-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+  }
+
+  @Test
+  void hierarchyNodePropertyRoundTrip() throws Exception {
+    PSHierarchyNodeProperty original = sampleProperty();
+    String xml = original.toXML();
+
+    PSHierarchyNodeProperty restored = new PSHierarchyNodeProperty();
+    restored.fromXML(xml);
+
+    assertEquals(original.getNodeId(), restored.getNodeId());
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getValue(), restored.getValue());
+  }
+
+  @Test
+  void hierarchyNodePropertyFromXmlAcceptsLegacyNullRoot() throws Exception {
+    String legacy =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <null>
+          <name>legacyKey</name>
+          <node-id>99</node-id>
+          <value>legacyVal</value>
+        </null>
+        """;
+
+    PSHierarchyNodeProperty restored = new PSHierarchyNodeProperty();
+    restored.fromXML(legacy);
+
+    assertEquals(99L, restored.getNodeId());
+    assertEquals("legacyKey", restored.getName());
+    assertEquals("legacyVal", restored.getValue());
+  }
+
+  private static PSHierarchyNode sampleNode() {
+    // Use design guid so host/type/uuid form matches production workbench nodes.
+    PSDesignGuid nodeGuid = new PSDesignGuid(new PSGuid(PSTypeEnum.HIERARCHY_NODE, 200L));
+    PSDesignGuid parentGuid = new PSDesignGuid(new PSGuid(PSTypeEnum.HIERARCHY_NODE, 100L));
+
+    PSHierarchyNode node = new PSHierarchyNode("Sites", nodeGuid, PSHierarchyNode.NodeType.FOLDER);
+    node.setParentId(parentGuid);
+    node.addProperty("displayOrder", "10");
+    node.addProperty("icon", "sites");
+    return node;
+  }
+
+  private static PSHierarchyNodeProperty sampleProperty() {
+    PSGuid parent = new PSGuid(PSTypeEnum.HIERARCHY_NODE, 200L);
+    return new PSHierarchyNodeProperty("displayOrder", "10", parent);
+  }
+
+  private static boolean containsTag(String xml, String localName) {
+    return xml.contains("<" + localName) || xml.contains("</" + localName + ">");
+  }
+
+  private static String loadResource(String classpath) throws Exception {
+    try (InputStream in =
+        PSHierarchyNodeXmlSerializationTest.class.getClassLoader().getResourceAsStream(classpath)) {
+      assertNotNull(in, "missing test resource: " + classpath);
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static void assertLogicalXmlParity(String expectedXml, String actualXml)
+      throws Exception {
+    Document expected = parseXml(stripXmlDeclaration(expectedXml));
+    Document actual = parseXml(stripXmlDeclaration(actualXml));
+    assertElementTreeEquals(expected.getDocumentElement(), actual.getDocumentElement(), "/");
+  }
+
+  private static String stripXmlDeclaration(String xml) {
+    String s = Objects.requireNonNull(xml).trim();
+    if (s.startsWith("<?xml")) {
+      int end = s.indexOf("?>");
+      if (end >= 0) {
+        s = s.substring(end + 2).trim();
+      }
+    }
+    while (s.startsWith("<!--")) {
+      int end = s.indexOf("-->");
+      if (end < 0) {
+        break;
+      }
+      s = s.substring(end + 3).trim();
+    }
+    return s;
+  }
+
+  private static Document parseXml(String xml) throws Exception {
+    var factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    var builder = factory.newDocumentBuilder();
+    return builder.parse(new InputSource(new java.io.StringReader(xml)));
+  }
+
+  private static void assertElementTreeEquals(Element expected, Element actual, String path) {
+    assertEquals(expected.getTagName(), actual.getTagName(), "tag at " + path);
+    java.util.List<Node> eChildren = significantChildren(expected);
+    java.util.List<Node> aChildren = significantChildren(actual);
+    assertEquals(
+        eChildren.size(),
+        aChildren.size(),
+        "child count at "
+            + path
+            + " expected="
+            + summarize(eChildren)
+            + " actual="
+            + summarize(aChildren));
+    for (int i = 0; i < eChildren.size(); i++) {
+      Node en = eChildren.get(i);
+      Node an = aChildren.get(i);
+      if (en.getNodeType() == Node.TEXT_NODE) {
+        assertEquals(en.getTextContent().trim(), an.getTextContent().trim(), "text at " + path);
+      } else {
+        assertElementTreeEquals(
+            (Element) en, (Element) an, path + "/" + ((Element) en).getTagName() + "[" + i + "]");
+      }
+    }
+  }
+
+  private static java.util.List<Node> significantChildren(Element el) {
+    NodeList nl = el.getChildNodes();
+    java.util.ArrayList<Node> out = new java.util.ArrayList<>();
+    boolean hasElementChild = false;
+    for (int i = 0; i < nl.getLength(); i++) {
+      if (nl.item(i).getNodeType() == Node.ELEMENT_NODE) {
+        hasElementChild = true;
+        break;
+      }
+    }
+    for (int i = 0; i < nl.getLength(); i++) {
+      Node n = nl.item(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE) {
+        out.add(n);
+      } else if (n.getNodeType() == Node.TEXT_NODE && !hasElementChild) {
+        String t = n.getTextContent();
+        if (t != null && !t.trim().isEmpty()) {
+          out.add(n);
+        }
+      }
+    }
+    return out;
+  }
+
+  private static String summarize(java.util.List<Node> nodes) {
+    StringBuilder b = new StringBuilder("[");
+    for (int i = 0; i < nodes.size(); i++) {
+      if (i > 0) {
+        b.append(',');
+      }
+      Node n = nodes.get(i);
+      if (n.getNodeType() == Node.ELEMENT_NODE) {
+        b.append(((Element) n).getTagName());
+      } else {
+        b.append("#text");
+      }
+    }
+    return b.append(']').toString();
+  }
+}

--- a/system/src/test/resources/com/percussion/services/system/data/ps-audit-golden.xml
+++ b/system/src/test/resources/com/percussion/services/system/data/ps-audit-golden.xml
@@ -1,0 +1,16 @@
+<!-- Golden snapshot for production PSAudit Jackson wire shape (issue #1920
+	/ epic #505). Derived guid omitted; event-time uses Betwixt-compatible ISO8601
+	pattern in UTC. -->
+<audit>
+	<actor>editor</actor>
+	<current-revision>true</current-revision>
+	<edit-revision>false</edit-revision>
+	<event-time>20240115T120000000</event-time>
+	<id>1001</id>
+	<publishable>true</publishable>
+	<state-id>5</state-id>
+	<state-name>Public</state-name>
+	<transition-comment>ship it</transition-comment>
+	<transition-id>12</transition-id>
+	<transition-name>Publish</transition-name>
+</audit>

--- a/system/src/test/resources/com/percussion/services/system/data/ps-audit-trail-golden.xml
+++ b/system/src/test/resources/com/percussion/services/system/data/ps-audit-trail-golden.xml
@@ -1,0 +1,34 @@
+<!-- Golden snapshot for production PSAuditTrail Jackson wire shape (issue
+	#1920 / epic #505). Nested package item element is audit. -->
+<audit-trail>
+	<audits>
+		<audit>
+			<actor>editor</actor>
+			<current-revision>false</current-revision>
+			<edit-revision>true</edit-revision>
+			<event-time>20240115T120000000</event-time>
+			<id>1001</id>
+			<publishable>true</publishable>
+			<state-id>5</state-id>
+			<state-name>Public</state-name>
+			<transition-comment>ship it</transition-comment>
+			<transition-id>12</transition-id>
+			<transition-name>Publish</transition-name>
+		</audit>
+		<audit>
+			<actor>reviewer</actor>
+			<current-revision>true</current-revision>
+			<edit-revision>false</edit-revision>
+			<event-time>20240115T120000000</event-time>
+			<id>1002</id>
+			<publishable>false</publishable>
+			<state-id>3</state-id>
+			<state-name>Review</state-name>
+			<transition-comment>ready</transition-comment>
+			<transition-id>9</transition-id>
+			<transition-name>Submit</transition-name>
+		</audit>
+	</audits>
+	<current-revision>2</current-revision>
+	<edit-revision>3</edit-revision>
+</audit-trail>

--- a/system/src/test/resources/com/percussion/services/system/data/ps-shared-property-golden.xml
+++ b/system/src/test/resources/com/percussion/services/system/data/ps-shared-property-golden.xml
@@ -1,0 +1,7 @@
+<!-- Golden snapshot for production PSSharedProperty Jackson wire shape (issue
+	#1920 / epic #505). Hibernate version suppressed. -->
+<shared-property>
+	<guid>0-29-55</guid>
+	<name>sys_prop_sample</name>
+	<value>sample-value</value>
+</shared-property>

--- a/system/src/test/resources/com/percussion/services/ui/data/ps-hierarchy-node-golden.xml
+++ b/system/src/test/resources/com/percussion/services/ui/data/ps-hierarchy-node-golden.xml
@@ -1,0 +1,13 @@
+<!-- Golden snapshot for production PSHierarchyNode Jackson wire shape (issue
+	#1920 / epic #505). Properties as key-as-element map; type enum name; version/label/description/type-int
+	suppressed. -->
+<hierarchy-node>
+	<guid>0-32-200</guid>
+	<name>Sites</name>
+	<parent-id>0-32-100</parent-id>
+	<properties>
+		<displayOrder>10</displayOrder>
+		<icon>sites</icon>
+	</properties>
+	<type>FOLDER</type>
+</hierarchy-node>

--- a/system/src/test/resources/com/percussion/services/ui/data/ps-hierarchy-node-property-golden.xml
+++ b/system/src/test/resources/com/percussion/services/ui/data/ps-hierarchy-node-property-golden.xml
@@ -1,0 +1,8 @@
+<!-- Golden snapshot for production PSHierarchyNodeProperty Jackson wire
+	shape (issue #1920 / epic #505). Scalar node-id (not historical betwixt parentGuid).
+	Version suppressed. -->
+<hierarchy-node-property>
+	<name>displayOrder</name>
+	<node-id>200</node-id>
+	<value>10</value>
+</hierarchy-node-property>


### PR DESCRIPTION
## Summary

**Partial** for #1920 — first sub-batch of catalog/system/ui Jackson leftovers under epic #505 / #1823 / #1892.

### Migrated types

| Class | Root element | Notes |
|-------|--------------|-------|
| `PSAudit` | `audit` | Scalar `id`; derived `guid` omitted; UTC ISO8601 `event-time` |
| `PSAuditTrail` | `audit-trail` | Nested `audit` via `addType` |
| `PSSharedProperty` | `shared-property` | `guid` + name/value; version suppressed |
| `PSHierarchyNode` | `hierarchy-node` | Properties map; type enum name; catalog aliases suppressed |
| `PSHierarchyNodeProperty` | `hierarchy-node-property` | Scalar `node-id`; dropped obsolete `.betwixt` |

### Companions

- Golden + round-trip + legacy `<null>` root tests
- Deviations: `docs/ai-generated/tasks/505-betwixt-jackson/1920-catalog-system-ui-domain-deviations.md`
- Erlang self-review: `docs/ai-generated/code-reviews/issue-1920-catalog-system-ui-jackson-erlang.md`

### Residual children (not in this PR)

- #1993 — PSDependency / PSDependent
- #1994 — PSMimeContentAdapter

## Test plan

- [x] `PSSystemDataXmlSerializationTest` (9 tests)
- [x] `PSHierarchyNodeXmlSerializationTest` (6 tests)
- [x] `cd system && ../mvnw clean install` — **BUILD SUCCESS** (Tests run: 1078, Failures: 0, Errors: 0, Skipped: 240)
- [x] Spotless: `mvnw -pl system spotless:apply` then `spotless:check`; root `mvnw -N spotless:apply/check` for docs
- [x] Erlang self-review PASS (no bugs, portable paths, companions complete)
- [ ] CI green on PR

## Gates evidence

- Module: `system` only (production + tests + resources + docs)
- No out-of-scope Spotless dump in this PR
- Operator: Grok: night-issue-prs (model grok-4.5)

## Links

Fixes partial #1920 · Related #1892 #1823 #505 · Residuals #1993 #1994