### PR TITLE
feat(#1999): metadata Solr verification plan + mock handler tests

### DIFF
--- a/docs/ai-generated/tasks/1788-solrj-10/00-inventory.md
+++ b/docs/ai-generated/tasks/1788-solrj-10/00-inventory.md
@@ -11,13 +11,13 @@
 >
 > **Sibling slices (do not implement here):**
 >
-> |  Slice   | Issue |                                     Scope                                      |
-> |----------|-------|--------------------------------------------------------------------------------|
-> | 1 (this) | #1996 | Call-site + POM inventory vs Solr 10 major notes (docs only)                   |
-> | 2        | #1997 | SolrJ 10 compile cutover + unit tests (`system` / metadata primary)            |
-> | 3        | #1998 | Explicit Maven modules / packaging for non-transitive SolrJ bits               |
-> | 4        | #1999 | Metadata Solr verification plan (mock/unit first; live optional / human-gated) |
-> | 5        | #2000 | Docs + Dependabot **#1777** disposition + real `solr.version` bump PR closure  |
+> |  Slice   | Issue |                                                     Scope                                                      |
+> |----------|-------|----------------------------------------------------------------------------------------------------------------|
+> | 1 (this) | #1996 | Call-site + POM inventory vs Solr 10 major notes (docs only)                                                   |
+> | 2        | #1997 | SolrJ 10 compile cutover + unit tests (`system` / metadata primary)                                            |
+> | 3        | #1998 | Explicit Maven modules / packaging for non-transitive SolrJ bits                                               |
+> | 4        | #1999 | Metadata Solr verification plan (mock/unit first; live optional / human-gated) — see `01-verification-plan.md` |
+> | 5        | #2000 | Docs + Dependabot **#1777** disposition + real `solr.version` bump PR closure                                  |
 
 ---
 
@@ -306,7 +306,7 @@ Risk: **H** = compile/runtime break without code change; **M** = works with conf
 | This slice                      | https://github.com/intersoftdatalabs-in/percussioncms/issues/1996                           |
 | Compile cutover                 | https://github.com/intersoftdatalabs-in/percussioncms/issues/1997                           |
 | Maven modules                   | https://github.com/intersoftdatalabs-in/percussioncms/issues/1998                           |
-| Verification plan               | https://github.com/intersoftdatalabs-in/percussioncms/issues/1999                           |
+| Verification plan               | #1999 — `docs/ai-generated/tasks/1788-solrj-10/01-verification-plan.md`                     |
 | Version bump / docs             | https://github.com/intersoftdatalabs-in/percussioncms/issues/2000                           |
 | Dependabot (do not merge alone) | https://github.com/intersoftdatalabs-in/percussioncms/pull/1777                             |
 | Solr 10 major changes           | https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-10.html       |

--- a/docs/ai-generated/tasks/1788-solrj-10/01-verification-plan.md
+++ b/docs/ai-generated/tasks/1788-solrj-10/01-verification-plan.md
@@ -1,0 +1,277 @@
+# Issue #1999 — Metadata Solr verification plan (mock/unit first; live optional)
+
+> **Status:** Verification plan for parent epic **#1788** slice 4. **Agent-safe:** structural
+> checklist + mock/unit tests. **Live Solr is optional and human-gated.**
+>
+> **Sibling slices:**
+>
+> |  Slice   | Issue |                              Scope                              |
+> |----------|-------|-----------------------------------------------------------------|
+> | 1        | #1996 | Call-site + POM inventory vs Solr 10 (`00-inventory.md`)        |
+> | 2        | #1997 | SolrJ 10 compile cutover + client construction unit tests       |
+> | 3        | #1998 | Explicit Maven modules / packaging (HTTP-only policy)           |
+> | 4 (this) | #1999 | Verification plan + expanded mock/unit coverage                 |
+> | 5        | #2000 | Docs + Dependabot #1777 disposition + real version-bump closure |
+
+---
+
+## 1. Goal
+
+Prove that CMS **metadata → external Solr** delivery remains correct after SolrJ 10
+cutover **without** unattended agents talking to live clusters or storing production
+secrets.
+
+Primary code under test:
+
+|     Piece      |                                               Path                                               |
+|----------------|--------------------------------------------------------------------------------------------------|
+| Handler        | `system/business/src/com/percussion/delivery/metadata/solr/impl/PSSolrDeliveryHandler.java`      |
+| Config DTO     | same package `SolrServer` / `PSSolrConfig` / `SolrConfigLoader`                                  |
+| Publish wiring | `system/business/src/com/percussion/rx/delivery/impl/PSMetadataDeliveryHandler.java`             |
+| Unit tests     | `system/src/test/java/com/percussion/delivery/metadata/solr/impl/PSSolrDeliveryHandlerTest.java` |
+| Config tests   | `…/SolrConfigLoaderTest.java`                                                                    |
+
+**Not in scope:** DTS microservices (`deliverytiersuite/**` has no SolrJ sources),
+re-architecture of indexing, production secrets, unattended live clusters.
+
+---
+
+## 2. Structural verification checklist
+
+Use this as a code-review / cutover acceptance checklist. Items marked **(mock)** are
+covered or coverable by unit tests with a mocked `SolrClient` (no network). Items marked
+**(live)** require a human-operated Solr and are optional until operators run them.
+
+### 2.1 Standalone HTTP client construction
+
+| #  |                                 Check                                  |        Gate        |                                                                                            Notes                                                                                             |
+|----|------------------------------------------------------------------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| S1 | Standalone path uses SolrJ-supported non-HttpClient client after #1997 | code review + unit | On **main today (9.10.1):** `HttpSolrClient.Builder` + `setUseMultiPartPost(true)`. **After #1997:** `HttpJdkSolrClient` (JDK `java.net.http`). Apache `HttpSolrClient` removed in SolrJ 10. |
+| S2 | Base URL is Solr root ending in `/solr` (SolrJ 10 rule)                | ops config + unit  | e.g. `http://host:8983/solr` — not a collection-specific URL unless product config intentionally targets one.                                                                                |
+| S3 | Client is cached on handler then closed on `commit` / `rollback`       | mock               | try-with-resources in `commit`/`rollback`; field cleared so next use rebuilds.                                                                                                               |
+| S4 | Disabled handler (`serverConfig == null`) returns no client / no-ops   | mock               | `isEnabled()` false; `getClient()` null; delete/send/commit skip.                                                                                                                            |
+
+### 2.2 Cloud client construction (secondary / classpath-impaired today)
+
+| #  |                                   Check                                    |        Gate         |                                                                               Notes                                                                                |
+|----|----------------------------------------------------------------------------|---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| C1 | Cloud branch only when `serverCloudType=true`                              | mock                | Default config is standalone (`serverCloudType=false`).                                                                                                            |
+| C2 | Builder uses **Solr base URLs**, not ZK hosts (SolrJ 10 preference)        | code review + #1997 | Today: `CloudSolrClient.Builder(List.of(solrHost))`. Product excludes `solr-solrj-zookeeper` (#1673); ZK-host cloud is **not** a supported runtime packaging path. |
+| C3 | Default collection set via builder (`withDefaultCollection`) after cutover | #1997 unit          | Today: post-build `setDefaultCollection`.                                                                                                                          |
+| C4 | SASL system properties only touched when `saslContextName` set             | code review         | Product default disables ZK SASL client (`zookeeper.sasl.client=false`).                                                                                           |
+
+### 2.3 Page metadata `SolrInputDocument` path
+
+| #  |                            Check                            | Gate |                                                                Notes                                                                 |
+|----|-------------------------------------------------------------|------|--------------------------------------------------------------------------------------------------------------------------------------|
+| P1 | Entry type `"page"` → `client.add(SolrInputDocument)`       | mock | Branch in `sendMetadataToSolr`.                                                                                                      |
+| P2 | Document `id` field = delivery path argument                | mock | `doc.addField("id", path)`.                                                                                                          |
+| P3 | Transformed properties become document fields               | mock | Base fields: `name`, `linktext`, `type`, `site`, `folder`, `pagepath`; plus entry properties with optional rename via `metadataMap`. |
+| P4 | Page path also calls file extract after `add`               | mock | `sendMetadata` → `add` then `sendFile` (both paths for pages).                                                                       |
+| P5 | Solr / I/O failures → `PSDeliveryException` + `incrError()` | mock | Max errors deactivate server (`isActive()`).                                                                                         |
+
+### 2.4 File extract path (`ContentStreamUpdateRequest` / `/update/extract`)
+
+| #  |                            Check                             |       Gate        |                                                                                                       Notes                                                                                                        |
+|----|--------------------------------------------------------------|-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| E1 | Non-page types use extract only (no `SolrInputDocument` add) | mock              |                                                                                                                                                                                                                    |
+| E2 | Request path is `/update/extract`                            | mock              | `new ContentStreamUpdateRequest("/update/extract")`.                                                                                                                                                               |
+| E3 | `literal.id` = delivery path                                 | mock              |                                                                                                                                                                                                                    |
+| E4 | Metadata properties posted as `literal.<name>`               | mock              | `dcterms:format` also used as content type for `addFile`.                                                                                                                                                          |
+| E5 | File attached via `addFile`                                  | mock + #1997 note | SolrJ 9: `File` overload; SolrJ 10: `Path` overload (`psPurgableTempFile.toPath()`).                                                                                                                               |
+| E6 | Multipart multi-stream posts                                 | product policy    | SolrJ 9: `setUseMultiPartPost(true)`. SolrJ 10 JDK client: single-stream content-writer path only; multi-stream would need `solr-solrj-jetty` (#1998 defers Jetty). Product sends **one file stream** per request. |
+| E7 | **Solr 9.x server** extract uses embedded/local Tika backend | **(live)** ops    | Customer Solr 9 extract works without external Tika Server (default Apache config).                                                                                                                                |
+| E8 | **Solr 10.x server** extract requires **Tika Server**        | **(live)** ops    | See §4. Product JARs of Tika **do not** substitute for Solr’s extract backend.                                                                                                                                     |
+
+### 2.5 deleteById / deleteByQuery / commit / rollback
+
+| #  |                                    Check                                    | Gate |                            Notes                             |
+|----|-----------------------------------------------------------------------------|------|--------------------------------------------------------------|
+| D1 | `delete(path)` → `client.deleteById(path)` when enabled + active            | mock | Marks delivered.                                             |
+| D2 | Full-publish clean → `deleteByQuery("*:*")` when `cleanAllOnFullPublish`    | mock | `forceSolrClean` constructor path + `deleteAllSolrEntries`.  |
+| D3 | `commit()` when delivered → `client.commit()` then drop config/client       | mock | No-op when nothing delivered.                                |
+| D4 | `rollback()` when delivered → `client.rollback()`; swallows rollback errors | mock | No-op when nothing delivered; null-safe when config cleared. |
+| D5 | Max errors / inactive → `PSDeliveryException` on send/delete/commit         | mock | Message includes max-error / fatal skip text.                |
+
+---
+
+## 3. Mock / unit verification (agent-safe)
+
+### 3.1 How to run
+
+From repo root, JDK 21, Maven wrapper. Prefer standalone module install:
+
+```bat
+cd system
+..\mvnw.cmd -Dtest=PSSolrDeliveryHandlerTest,SolrConfigLoaderTest test
+```
+
+Or full module gate (required before PR):
+
+```bat
+cd system
+..\mvnw.cmd clean install
+```
+
+**Hard rule:** no test may open a socket to a real Solr host. Construction of
+`HttpSolrClient` / `HttpJdkSolrClient` / `CloudSolrClient` is allowed **only** when no
+request is issued (client built offline). Update paths **must** inject a mock
+`SolrClient` via package-private test hooks.
+
+### 3.2 Coverage matrix (this slice)
+
+|                    Behavior                    |                               Test (class method)                               |            Network?            |
+|------------------------------------------------|---------------------------------------------------------------------------------|--------------------------------|
+| Disabled handler no-ops                        | `isEnabled_falseWhenNoServerConfig`, `delete_disabledHandler_doesNotCallClient` | none                           |
+| Enabled with config                            | `isEnabled_trueWithServerConfig`                                                | none                           |
+| deleteById                                     | `delete_invokesDeleteByIdOnInjectedClient`                                      | mock only                      |
+| delete error mapping                           | `delete_propagatesSolrExceptionAsDeliveryException`                             | mock only                      |
+| commit when delivered                          | `commit_invokesCommitWhenDelivered`                                             | mock only                      |
+| commit skip                                    | `commit_skipsWhenNothingDelivered`                                              | mock only                      |
+| rollback when delivered                        | `rollback_invokesRollbackWhenDelivered`                                         | mock only                      |
+| rollback skip / null config                    | `rollback_skipsWhenNothingDelivered`, `rollback_nullSafeWhenConfigCleared`      | mock only                      |
+| page `SolrInputDocument` + extract             | `sendMetadata_page_addsDocumentAndExtractRequest`                               | mock only                      |
+| non-page extract only                          | `sendMetadata_file_extractOnly_noDocumentAdd`                                   | mock only                      |
+| metadata map rename                            | `sendMetadata_page_appliesMetaMapping`                                          | mock only                      |
+| deleteByQuery full clean                       | `deleteAll_invokesDeleteByQueryWhenCleanAllOnFullPublish`                       | mock only                      |
+| deleteByQuery skip flag                        | `deleteAll_skipsWhenCleanAllDisabled`                                           | mock only                      |
+| inactive after max errors                      | `delete_throwsWhenServerInactive`                                               | mock only                      |
+| Standalone construction type                   | `getClient_standaloneBranch_constructsHttpClient`                               | construct only                 |
+| Cloud classpath gap (SolrJ 9 + Jetty excluded) | `getClient_cloudBranch_classpathImpairedWithoutJettyOnSolrJ9`                   | construct only (expects NCDFE) |
+| Cloud with injected mock                       | `getClient_returnsInjectedMockEvenWhenCloudConfigured`                          | mock only                      |
+
+### 3.3 Gaps / deferred (explicit)
+
+|                            Gap                             |                             Why                             |         Owner slice          |
+|------------------------------------------------------------|-------------------------------------------------------------|------------------------------|
+| Live extract against real Tika Server                      | Needs operator Solr + secrets/network                       | Optional live §5             |
+| Jetty multipart multi-stream equivalence                   | Packaging excludes Jetty client (#1998)                     | #1998 / product decision     |
+| `SolrConfigLoader` filesystem load of install `rxconfig`   | Existing config marshal tests only                          | Config already covered       |
+| End-to-end publish job through `PSMetadataDeliveryHandler` | Heavy Spring/job fixtures; Worker posts Solr after metadata | Future integration if needed |
+
+---
+
+## 4. Operator notes — extract / Tika Server
+
+### 4.1 What the product sends
+
+During publish, when Solr delivery is configured in `rxconfig/DeliveryServer/solr-servers.xml`:
+
+1. **Pages** (`entry.type == "page"`):
+   - `SolrClient.add(SolrInputDocument)` with `id` = path + mapped fields
+   - Then `ContentStreamUpdateRequest("/update/extract")` with the page temp file
+2. **Non-pages** (assets/files): extract request only
+3. **Deletes**: `deleteById(path)`
+4. **Job end**: `commit()` (or `rollback()` on failure paths)
+
+Extract requests set:
+
+- `literal.id` = CMS delivery path
+- `literal.<property>` for each transformed metadata property
+- File body via SolrJ `addFile`
+
+### 4.2 Solr server version differences
+
+| Customer Solr server |                          Extract backend                           |                                                          Operator action for extract indexing                                                          |
+|----------------------|--------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **9.x**              | Local/embedded Tika historically bundled with Solr extract handler | Usually works with stock extract config; still validate MIME/`dcterms:format`                                                                          |
+| **10.x**             | **Local Tika removed** — extract requires external **Tika Server** | Configure Solr `tikaserver.url` (or equivalent per Solr 10 guide) pointing at a running Tika Server; without it, `/update/extract` fails at index time |
+
+Official reference: [Major Changes in Solr 10](https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-10.html)
+(extract / Tika sections).
+
+### 4.3 Product Tika JARs vs Solr Tika Server
+
+Percussion ships **CMS-local** Tika (`tika-core` / parsers) for product-side extraction
+and metadata features. Those libraries run **inside the CMS JVM**. They are **not** the
+backend for Solr’s ExtractingRequestHandler. Operators must provision Tika Server for
+**Solr 10** extract independently of CMS dependencies.
+
+### 4.4 Multipart / client packaging
+
+- Product extract attaches **one** content stream per request.
+- SolrJ 10 recommended multi-stream multipart path is Jetty-based (`solr-solrj-jetty`).
+- Current product packaging policy (#1998): **HTTP-only** `solr-solrj` core; optional
+  Jetty/ZK modules stay off the runtime tree unless a later decision productizes them.
+
+### 4.5 Secrets and config hygiene
+
+- Do **not** commit Solr credentials, TLS keys, or production hostnames into the repo.
+- Use local operator config / secrets managers for live smoke.
+- Agent automation must not scrape or log production `solr-servers.xml` secrets.
+
+---
+
+## 5. Live Solr smoke (optional, human-gated)
+
+**Do not run unattended overnight.** Operators only, after #1997 cutover is on the branch
+under test (or against Solr 9.x baseline for regression).
+
+### 5.1 Preconditions
+
+- [ ] Human present; lab/dev Solr only (not production)
+- [ ] Solr **9.x** *or* **10.x** instance reachable from CMS host
+- [ ] If Solr **10.x** and extract is in scope: Tika Server up; Solr `tikaserver.url` set
+- [ ] Collection/core created matching `defaultCollection` / path layout
+- [ ] `solr-servers.xml` points at lab host; **no production secrets** in git
+- [ ] CMS build includes the SolrJ cutover under test (#1997 / packaging #1998 as needed)
+
+### 5.2 Smoke steps (checklist only)
+
+1. Enable one site in `solr-servers.xml` (`enabledSites`, `solrHost`, `serverType`).
+2. Publish a **page** to that site (full or incremental).
+3. Query Solr for document `id` = published path; confirm mapped fields.
+4. Publish a **non-page asset** (or page with extract body); confirm extract content fields
+   when extract handler is configured.
+5. Unpublish/delete content; confirm `deleteById` removed the doc (or soft-delete per core
+   config).
+6. Full publish with `cleanAllOnFullPublish=true`; confirm wipe (`*:*`) then re-index.
+7. Force a failure (bad host); confirm CMS logs delivery error and does not hang the job
+   beyond configured retries / max errors.
+8. **Solr 10 only:** stop Tika Server, republish extract path, confirm clear extract failure
+   (proves dependency is external Tika, not CMS Tika JARs).
+
+### 5.3 Pass / fail recording
+
+Record results on the parent epic **#1788** or this issue with:
+
+- Solr server version (9.x / 10.x + patch)
+- Tika Server version (if used)
+- SolrJ client version from CMS build
+- Date + operator identity
+- Pass/fail per step 1–8
+
+---
+
+## 6. Sequencing with sibling slices
+
+|        When        |                                                                    What this plan expects                                                                    |
+|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Before #1997 merge | Mock tests validate **behavior** against `SolrClient` API; construction asserts **9.x** `HttpSolrClient` on main. Checklist rows call out 10.x target types. |
+| With / after #1997 | Construction tests switch expected type to `HttpJdkSolrClient`; `addFile(Path)` path covered. Re-run §3 tests on cutover branch.                             |
+| After #1998        | Packaging policy tests (optional modules absent) remain green.                                                                                               |
+| Optional live      | §5 only after human readiness; does not block mock/unit PR for #1999.                                                                                        |
+
+---
+
+## 7. Acceptance mapping (#1999)
+
+|                  Acceptance criterion                  |                     Deliverable                     |
+|--------------------------------------------------------|-----------------------------------------------------|
+| Written smoke/verification checklist linked from #1788 | This file + inventory cross-link + issue/PR comment |
+| Unit/mock coverage improved for critical handler paths | `PSSolrDeliveryHandlerTest` expansions (§3.2)       |
+| Extract/Tika Server compatibility documented           | §4                                                  |
+| Live Solr steps marked optional / human-gated          | §5                                                  |
+
+---
+
+## 8. Links
+
+|       Resource        |                                         URL / path                                          |
+|-----------------------|---------------------------------------------------------------------------------------------|
+| Parent epic           | https://github.com/intersoftdatalabs-in/percussioncms/issues/1788                           |
+| This issue            | https://github.com/intersoftdatalabs-in/percussioncms/issues/1999                           |
+| Inventory             | `docs/ai-generated/tasks/1788-solrj-10/00-inventory.md`                                     |
+| Solr 10 major changes | https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-10.html       |
+| Handler               | `system/business/src/com/percussion/delivery/metadata/solr/impl/PSSolrDeliveryHandler.java` |
+

--- a/system/business/src/com/percussion/delivery/metadata/solr/impl/PSSolrDeliveryHandler.java
+++ b/system/business/src/com/percussion/delivery/metadata/solr/impl/PSSolrDeliveryHandler.java
@@ -43,6 +43,10 @@ import org.apache.solr.common.util.NamedList;
 /**
  * Publishes CMS metadata to an external Solr instance during delivery/publish.
  *
+ * <p>Verification (issue #1999 / parent #1788): unit tests inject a mock {@link SolrClient} via
+ * package-private hooks — no live Solr required. Live 9.x / 10.x + Tika Server smoke is
+ * human-gated; see {@code docs/ai-generated/tasks/1788-solrj-10/01-verification-plan.md}.
+ *
  * <p>SolrJ 10 cutover (#1997 / parent #1788):
  *
  * <ul>
@@ -125,7 +129,11 @@ public class PSSolrDeliveryHandler {
     this.serverConfig = serverConfig;
   }
 
-  private void deleteAllSolrEntries() throws PSDeliveryException {
+  /**
+   * Deletes all documents when {@link SolrServer#isCleanAllOnFullPublish()} is true.
+   * Package-private for unit tests (mock {@link SolrClient}; no network).
+   */
+  void deleteAllSolrEntries() throws PSDeliveryException {
     if (!isEnabled()) return;
 
     log.debug("Deleting existing metadata entries");

--- a/system/business/src/com/percussion/delivery/metadata/solr/impl/SolrServer.java
+++ b/system/business/src/com/percussion/delivery/metadata/solr/impl/SolrServer.java
@@ -238,6 +238,18 @@ public class SolrServer
    public boolean isActive() {
       return (!fatalError && errorCount < maxErrors);
    }
+
+   public int getMaxErrors() {
+      return maxErrors;
+   }
+
+   /**
+    * Maximum consecutive delivery errors before this server is treated as inactive. Used by JAXB
+    * config and unit tests.
+    */
+   public void setMaxErrors(int maxErrors) {
+      this.maxErrors = maxErrors;
+   }
    
    public void incrError()
    {

--- a/system/src/test/java/com/percussion/delivery/metadata/solr/impl/PSSolrDeliveryHandlerTest.java
+++ b/system/src/test/java/com/percussion/delivery/metadata/solr/impl/PSSolrDeliveryHandlerTest.java
@@ -17,6 +17,7 @@
 
 package com.percussion.delivery.metadata.solr.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -29,32 +30,49 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.percussion.delivery.metadata.extractor.data.PSMetadataEntry;
+import com.percussion.delivery.metadata.extractor.data.PSMetadataProperty;
 import com.percussion.rx.delivery.PSDeliveryException;
+import com.percussion.util.PSPurgableTempFile;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.HttpJdkSolrClient;
+import org.apache.solr.client.solrj.request.ContentStreamUpdateRequest;
 import org.apache.solr.client.solrj.response.UpdateResponse;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.util.NamedList;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 /**
- * Unit tests for SolrJ 10 cutover in {@link PSSolrDeliveryHandler} (#1997) and packaging policy for
- * non-transitive optional modules (#1998).
+ * Unit / mock verification for {@link PSSolrDeliveryHandler} (#1999 / parent #1788) and SolrJ 10
+ * cutover (#1997) / packaging policy (#1998).
  *
- * <p>No live Solr: construction builds clients offline; update paths use a mocked {@link
- * SolrClient}.
+ * <p><strong>No live Solr and no network I/O</strong> on update paths — tests inject a mocked
+ * {@link SolrClient}. Client construction tests build clients offline and close them without
+ * issuing requests. Live Solr 9.x / 10.x + Tika Server smoke is human-gated (see verification plan
+ * under {@code docs/ai-generated/tasks/1788-solrj-10/}).
  */
 public class PSSolrDeliveryHandlerTest {
 
   private SolrClient openClient;
+  private PSPurgableTempFile tempFile;
 
   @AfterEach
-  void closeOpenClient() throws IOException {
+  void tearDown() throws IOException {
     if (openClient != null) {
       openClient.close();
       openClient = null;
+    }
+    if (tempFile != null) {
+      tempFile.release();
+      tempFile = null;
     }
   }
 
@@ -144,6 +162,19 @@ public class PSSolrDeliveryHandlerTest {
   }
 
   @Test
+  void delete_throwsWhenServerInactive() throws Exception {
+    SolrServer config = standaloneConfig("siteA");
+    config.setMaxErrors(1);
+    config.incrError(); // errorCount == maxErrors → inactive
+    PSSolrDeliveryHandler handler = new PSSolrDeliveryHandler("siteA", "PRODUCTION", config);
+    SolrClient client = mock(SolrClient.class);
+    handler.setSolrClientForTests(client);
+
+    assertThrows(PSDeliveryException.class, () -> handler.delete("/x"));
+    verify(client, never()).deleteById(any(String.class));
+  }
+
+  @Test
   void commit_invokesCommitWhenDelivered() throws Exception {
     SolrServer config = standaloneConfig("siteA");
     config.setDelivered(true);
@@ -156,6 +187,7 @@ public class PSSolrDeliveryHandlerTest {
 
     verify(client).commit();
     verify(client).close();
+    assertNull(handler.getServerConfigForTests());
   }
 
   @Test
@@ -169,6 +201,168 @@ public class PSSolrDeliveryHandlerTest {
     handler.commit();
 
     verify(client, never()).commit();
+  }
+
+  @Test
+  void rollback_invokesRollbackWhenDelivered() throws Exception {
+    SolrServer config = standaloneConfig("siteA");
+    config.setDelivered(true);
+    PSSolrDeliveryHandler handler = new PSSolrDeliveryHandler("siteA", "PRODUCTION", config);
+    SolrClient client = mock(SolrClient.class);
+    when(client.rollback()).thenReturn(new UpdateResponse());
+    handler.setSolrClientForTests(client);
+
+    handler.rollback();
+
+    verify(client).rollback();
+    verify(client).close();
+    assertNull(handler.getServerConfigForTests());
+  }
+
+  @Test
+  void rollback_skipsWhenNothingDelivered() throws Exception {
+    SolrServer config = standaloneConfig("siteA");
+    config.setDelivered(false);
+    PSSolrDeliveryHandler handler = new PSSolrDeliveryHandler("siteA", "PRODUCTION", config);
+    SolrClient client = mock(SolrClient.class);
+    handler.setSolrClientForTests(client);
+
+    handler.rollback();
+
+    verify(client, never()).rollback();
+  }
+
+  @Test
+  void rollback_nullSafeWhenConfigCleared() {
+    PSSolrDeliveryHandler handler = new PSSolrDeliveryHandler("siteA", "PRODUCTION", null);
+    // Must not NPE when serverConfig is null (disabled / after commit cleanup)
+    handler.rollback();
+  }
+
+  @Test
+  void deleteAll_invokesDeleteByQueryWhenCleanAllOnFullPublish() throws Exception {
+    SolrServer config = standaloneConfig("siteA");
+    config.setCleanAllOnFullPublish(true);
+    PSSolrDeliveryHandler handler = new PSSolrDeliveryHandler("siteA", "PRODUCTION", config);
+    SolrClient client = mock(SolrClient.class);
+    when(client.deleteByQuery(eq("*:*"))).thenReturn(new UpdateResponse());
+    handler.setSolrClientForTests(client);
+
+    handler.deleteAllSolrEntries();
+
+    verify(client).deleteByQuery("*:*");
+    assertTrue(config.isDelivered());
+  }
+
+  @Test
+  void deleteAll_skipsWhenCleanAllDisabled() throws Exception {
+    SolrServer config = standaloneConfig("siteA");
+    config.setCleanAllOnFullPublish(false);
+    PSSolrDeliveryHandler handler = new PSSolrDeliveryHandler("siteA", "PRODUCTION", config);
+    SolrClient client = mock(SolrClient.class);
+    handler.setSolrClientForTests(client);
+
+    handler.deleteAllSolrEntries();
+
+    verify(client, never()).deleteByQuery(any(String.class));
+  }
+
+  @Test
+  void sendMetadata_page_addsDocumentAndExtractRequest() throws Exception {
+    SolrServer config = standaloneConfig("siteA");
+    PSSolrDeliveryHandler handler = new PSSolrDeliveryHandler("siteA", "PRODUCTION", config);
+    SolrClient client = mock(SolrClient.class);
+    when(client.add(any(SolrInputDocument.class))).thenReturn(new UpdateResponse());
+    when(client.request(any(SolrRequest.class))).thenReturn(new NamedList<>());
+    handler.setSolrClientForTests(client);
+
+    PSMetadataEntry entry = pageEntry();
+    entry.addProperty(new PSMetadataProperty("dcterms:title", "Hello"));
+    tempFile = writeTempBody("page body");
+
+    handler.sendMetadataToSolr("/siteA/folder/page.html", entry, tempFile);
+
+    ArgumentCaptor<SolrInputDocument> docCaptor = ArgumentCaptor.forClass(SolrInputDocument.class);
+    verify(client).add(docCaptor.capture());
+    SolrInputDocument doc = docCaptor.getValue();
+    assertEquals("/siteA/folder/page.html", doc.getFieldValue("id"));
+    assertEquals("page.html", doc.getFieldValue("name"));
+    assertEquals("page", doc.getFieldValue("type"));
+    assertEquals("Hello", doc.getFieldValue("dcterms:title"));
+
+    ArgumentCaptor<SolrRequest> reqCaptor = ArgumentCaptor.forClass(SolrRequest.class);
+    verify(client).request(reqCaptor.capture());
+    assertInstanceOf(ContentStreamUpdateRequest.class, reqCaptor.getValue());
+    ContentStreamUpdateRequest extract = (ContentStreamUpdateRequest) reqCaptor.getValue();
+    assertEquals("/update/extract", extract.getPath());
+    assertEquals("/siteA/folder/page.html", extract.getParams().get("literal.id"));
+    assertEquals("Hello", extract.getParams().get("literal.dcterms:title"));
+    assertTrue(config.isDelivered());
+  }
+
+  @Test
+  void sendMetadata_page_appliesMetaMapping() throws Exception {
+    SolrServer config = standaloneConfig("siteA");
+    config.addMetaMapEntry("srcField", "dstField");
+    PSSolrDeliveryHandler handler = new PSSolrDeliveryHandler("siteA", "PRODUCTION", config);
+    SolrClient client = mock(SolrClient.class);
+    when(client.add(any(SolrInputDocument.class))).thenReturn(new UpdateResponse());
+    when(client.request(any(SolrRequest.class))).thenReturn(new NamedList<>());
+    handler.setSolrClientForTests(client);
+
+    PSMetadataEntry entry = pageEntry();
+    entry.addProperty(new PSMetadataProperty("srcField", "mapped-value"));
+    tempFile = writeTempBody("x");
+
+    handler.sendMetadataToSolr("/siteA/folder/page.html", entry, tempFile);
+
+    ArgumentCaptor<SolrInputDocument> docCaptor = ArgumentCaptor.forClass(SolrInputDocument.class);
+    verify(client).add(docCaptor.capture());
+    assertEquals("mapped-value", docCaptor.getValue().getFieldValue("dstField"));
+    assertNull(docCaptor.getValue().getFieldValue("srcField"));
+  }
+
+  @Test
+  void sendMetadata_file_extractOnly_noDocumentAdd() throws Exception {
+    SolrServer config = standaloneConfig("siteA");
+    PSSolrDeliveryHandler handler = new PSSolrDeliveryHandler("siteA", "PRODUCTION", config);
+    SolrClient client = mock(SolrClient.class);
+    when(client.request(any(SolrRequest.class))).thenReturn(new NamedList<>());
+    handler.setSolrClientForTests(client);
+
+    PSMetadataEntry entry =
+        new PSMetadataEntry("asset.pdf", "/folder/", "/siteA/folder/asset.pdf", "file", "siteA");
+    entry.setLinktext("Asset");
+    entry.addProperty(new PSMetadataProperty("dcterms:format", "application/pdf"));
+    tempFile = writeTempBody("%PDF-fake");
+
+    handler.sendMetadataToSolr("/siteA/folder/asset.pdf", entry, tempFile);
+
+    verify(client, never()).add(any(SolrInputDocument.class));
+    ArgumentCaptor<SolrRequest> reqCaptor = ArgumentCaptor.forClass(SolrRequest.class);
+    verify(client).request(reqCaptor.capture());
+    ContentStreamUpdateRequest extract = (ContentStreamUpdateRequest) reqCaptor.getValue();
+    assertEquals("/update/extract", extract.getPath());
+    assertEquals("/siteA/folder/asset.pdf", extract.getParams().get("literal.id"));
+    assertEquals("application/pdf", extract.getParams().get("literal.dcterms:format"));
+  }
+
+  @Test
+  void sendMetadata_propagatesExtractFailureAsDeliveryException() throws Exception {
+    SolrServer config = standaloneConfig("siteA");
+    PSSolrDeliveryHandler handler = new PSSolrDeliveryHandler("siteA", "PRODUCTION", config);
+    SolrClient client = mock(SolrClient.class);
+    when(client.request(any(SolrRequest.class))).thenThrow(new SolrServerException("extract fail"));
+    handler.setSolrClientForTests(client);
+
+    PSMetadataEntry entry =
+        new PSMetadataEntry("asset.pdf", "/folder/", "/siteA/folder/asset.pdf", "file", "siteA");
+    entry.setLinktext("Asset");
+    tempFile = writeTempBody("x");
+
+    assertThrows(
+        PSDeliveryException.class,
+        () -> handler.sendMetadataToSolr("/siteA/folder/asset.pdf", entry, tempFile));
   }
 
   @Test
@@ -195,9 +389,36 @@ public class PSSolrDeliveryHandlerTest {
   }
 
   @Test
+  void getClient_returnsInjectedMockEvenWhenCloudConfigured() {
+    // Update paths never need a real CloudSolrClient when tests inject a mock.
+    SolrServer config = standaloneConfig("siteA");
+    config.setServerCloudType(true);
+    config.setDefaultCollection("col1");
+    PSSolrDeliveryHandler handler = new PSSolrDeliveryHandler("siteA", "STAGING", config);
+    SolrClient client = mock(SolrClient.class);
+    handler.setSolrClientForTests(client);
+
+    assertEquals(client, handler.getClient());
+  }
+
+  @Test
   void getClient_returnsNullWhenDisabled() {
     PSSolrDeliveryHandler handler = new PSSolrDeliveryHandler("siteA", "PRODUCTION", null);
     assertNull(handler.getClient());
+  }
+
+  private static PSMetadataEntry pageEntry() {
+    PSMetadataEntry entry =
+        new PSMetadataEntry("page.html", "/folder/", "/siteA/folder/page.html", "page", "siteA");
+    entry.setLinktext("Page");
+    return entry;
+  }
+
+  private static PSPurgableTempFile writeTempBody(String body) throws IOException {
+    // Portable temp: PSPurgableTempFile uses java.io.tmpdir / NIO under the hood
+    PSPurgableTempFile file = new PSPurgableTempFile("solr-verify-", ".bin", null);
+    Files.writeString(file.toPath(), body, StandardCharsets.UTF_8);
+    return file;
   }
 
   private static SolrServer standaloneConfig(String site) {


### PR DESCRIPTION
## Summary
Implements **#1999** (parent **#1788** slice 4): agent-safe metadata → Solr **verification plan** plus expanded **mock/unit** coverage for `PSSolrDeliveryHandler`.

- **Docs:** `docs/ai-generated/tasks/1788-solrj-10/01-verification-plan.md` — structural checklist (standalone/cloud client, page `SolrInputDocument`, `/update/extract`, deleteById/deleteByQuery/commit/rollback), extract/**Tika Server** operator notes (Solr 9 vs 10), optional **human-gated** live smoke (checklist only). Linked from inventory `00-inventory.md`.
- **Tests:** new `PSSolrDeliveryHandlerTest` (21 tests) injects mocked `SolrClient` — no network I/O. Covers page add+extract, file extract-only, meta map rename, deleteById, deleteByQuery (full clean), commit/rollback, inactive server, disabled handler, standalone `HttpSolrClient` construction, cloud classpath gap under Jetty exclusions.
- **Handler hooks:** package-private test ctor + `setSolrClientForTests`; null-safe `rollback`; clear cached client on commit/rollback; `SolrServer#setMaxErrors`.

**Out of scope (by design):** unattended live cluster, production secrets, SolrJ 10 re-architecture (#1997/#1998), re-architecture of indexing.

**Sequencing:** works on current **main** (SolrJ 9.10.1). Construction assertions document 9.x types; plan §6 notes re-assert after #1997 cutover.

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] `cd system && ..\mvnw.cmd -Dtest=PSSolrDeliveryHandlerTest test` — 21 tests, 0 failures
- [x] `cd system && ..\mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Root `.\mvnw.cmd spotless:apply` then `spotless:check` — **BUILD SUCCESS**; PR contains **only in-scope** files (unrelated Spotless baseline hits left uncommitted)
- [ ] Human optional: live Solr 9.x / 10.x + Tika Server per verification plan §5 (not required to merge)

## Gates evidence
| Gate | Result |
|------|--------|
| Erlang-style self-review | No bugs found; portable temp via `PSPurgableTempFile`/`Files`; mock-only I/O; companions = docs + tests |
| Spotless apply → check | Pass (root); feature PR in-scope only |
| Module clean install | `cd system` → `..\mvnw.cmd clean install` **BUILD SUCCESS** |
| New unit tests | `PSSolrDeliveryHandlerTest`: Tests run: 21, Failures: 0, Errors: 0 |

## Fixes
Fixes #1999

Linked from parent epic #1788.