### PR TITLE
fix(#2011): self-contained ant.deps in migration_i18n_locales.xml

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2011-ant-deps-migration-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2011-ant-deps-migration-erlang.md
@@ -1,0 +1,38 @@
+# Erlang review — issue #2011 (ant.deps nested migration)
+
+**Branch:** `fix/issue-2011-ant-deps-migration`  
+**Scope:** uncommitted / feature diff vs `origin/main`  
+**Date:** 2026-08-05  
+**Recommendation:** approve  
+**Gate:** May commit/push: **yes**
+
+## Summary
+
+Nested installer script `migration_i18n_locales.xml` failed at project-level
+`taskdef classpathref="ant.deps"` with **Reference ant.deps not found** because
+Ant applies parent `inheritRefs` only *after* the child project is configured.
+Fix redefines a local `<path id="ant.deps">` from inherited `${install.dir}` /
+`${install.src}` properties (available via `inheritAll` during configure).
+
+## Cross-platform path checklist
+
+- [x] No new hardcoded OS filesystem separators in Java
+- [x] Tests use `Path.of(...)` relative segments only
+- [x] ANT path construction uses Ant `${prop}/...` (installer convention; not Java string concat)
+- [x] No Unix-only absolute path assertions
+
+## Issues
+
+None (bug / missing behavioral tests / non-portable I/O).
+
+### Notes (non-blocking)
+
+- Wiring tests are static XML assertions (appropriate; full installer not required per issue triage).
+- `onerror="ignore"` on taskdef remains; if the class fails to load, target fails later with unknown task — same as pre-fix behavior for class-load issues.
+- Out-of-scope Spotless monorepo hits discarded; only in-scope module files ship.
+
+## Tests / gates evidence
+
+- `cd modules/perc-distribution-tree && ../../mvnw clean install` — BUILD SUCCESS
+- `I18nLocaleMigrationWiringTest` — tests=3, failures=0, errors=0
+- Module `spotless:check` — BUILD SUCCESS (in-scope only)

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/migration_i18n_locales.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/migration_i18n_locales.xml
@@ -5,12 +5,46 @@
 	where PROPERTYNAME='sys_lang' - hi → hi-in; underscore/legacy tags → lower-case
 	hyphen; es stays es * CONTENTSTATUS.LOCALE (issue text may say CT_LOCALE)
 	- es → es-es; other tags normalized only; never deletes rows Dry-run: -Di18n.locale.migration.dryRun=true
-	or dryRun="true" on the task. -->
+	or dryRun="true" on the task. GH-2011: Nested <ant inheritRefs="true"> applies
+	parent references only AFTER this build file is configured. A project-level
+	classpathref="ant.deps" that depends solely on the parent path id therefore
+	fails with "Reference ant.deps not found". Rebuild ant.deps locally from
+	inherited install.dir / install.src (inheritAll properties are available
+	during configure). Mirror the install.xml filesets needed for perc-ant JDBC
+	and extension jars; erroronmissingdir so partial layouts still configure. -->
 <project name="migration_i18n_locales"
 	default="migrateI18nLocales">
 
+	<!-- Local path id (self-contained). Do not rely on parent inheritRefs for
+		project-level taskdef classpathref. -->
+	<path id="ant.deps">
+		<fileset dir="${install.dir}/jetty/base/lib/jdbc"
+			erroronmissingdir="false">
+			<include name="**/*.jar" />
+		</fileset>
+		<fileset dir="${install.src}/jetty/base/lib/jdbc"
+			erroronmissingdir="false">
+			<include name="**/*.jar" />
+		</fileset>
+		<fileset dir="${install.src}/jetty/defaults/lib/perc"
+			erroronmissingdir="false">
+			<include name="**/*.jar" />
+		</fileset>
+		<fileset dir="${install.src}/jetty/defaults/lib/perc-logging"
+			erroronmissingdir="false">
+			<include name="**/*.jar" />
+		</fileset>
+		<fileset
+			dir="${install.src}/jetty/base/webapps/Rhythmyx/WEB-INF/lib"
+			erroronmissingdir="false">
+			<include name="perc-toolkit-*.jar" />
+			<include name="extensions-*.jar" />
+		</fileset>
+	</path>
+
 	<!-- Nested <ant> projects do not inherit parent taskdefs; re-register from
-		ant.deps (path id defined in install.xml, inherited via inheritRefs). -->
+		local ant.deps (perc-ant system classloader also has the class when run via
+		java -jar perc-ant). -->
 	<taskdef name="PSMigrateI18nLocaleCodes"
 		classname="com.percussion.ant.install.PSMigrateI18nLocaleCodes"
 		classpathref="ant.deps" onerror="ignore" />

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/I18nLocaleMigrationWiringTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/I18nLocaleMigrationWiringTest.java
@@ -69,14 +69,49 @@ class I18nLocaleMigrationWiringTest {
     assertTrue(
         LOCAL_ANT_DEPS_PATH.matcher(body).find(),
         "migration_i18n_locales.xml must define <path id=\"ant.deps\"> locally (GH-2011)");
+    // taskdef classpathref must point at that local path (no dangling parent-only ref).
+    assertTrue(
+        CLASSPATHREF_ANT_DEPS.matcher(body).find(),
+        "migration must use classpathref=\"ant.deps\" for PSMigrateI18nLocaleCodes taskdef");
 
-    // If the script still uses classpathref="ant.deps", the local path id must exist (no dangling
-    // ref).
-    if (CLASSPATHREF_ANT_DEPS.matcher(body).find()) {
-      assertTrue(
-          LOCAL_ANT_DEPS_PATH.matcher(body).find(),
-          "classpathref=\"ant.deps\" without local <path id=\"ant.deps\">");
+    // Partial installer layouts must configure: every local ant.deps fileset uses
+    // erroronmissingdir="false".
+    assertTrue(
+        body.contains("erroronmissingdir=\"false\"") || body.contains("erroronmissingdir='false'"),
+        "local ant.deps filesets must set erroronmissingdir=\"false\" for partial layouts");
+    // Count fileset opens vs erroronmissingdir so a fileset without the attribute fails.
+    int filesetCount = 0;
+    int missingDirFalseCount = 0;
+    int searchFrom = 0;
+    while ((searchFrom = body.indexOf("<fileset", searchFrom)) >= 0) {
+      filesetCount++;
+      searchFrom += "<fileset".length();
     }
+    searchFrom = 0;
+    while (true) {
+      int dqi = body.indexOf("erroronmissingdir=\"false\"", searchFrom);
+      int sqi = body.indexOf("erroronmissingdir='false'", searchFrom);
+      int next;
+      if (dqi < 0 && sqi < 0) {
+        break;
+      }
+      if (dqi < 0) {
+        next = sqi;
+      } else if (sqi < 0) {
+        next = dqi;
+      } else {
+        next = Math.min(dqi, sqi);
+      }
+      missingDirFalseCount++;
+      searchFrom = next + "erroronmissingdir=".length();
+    }
+    assertTrue(
+        filesetCount > 0 && missingDirFalseCount >= filesetCount,
+        "every ant.deps fileset needs erroronmissingdir=\"false\" (filesets="
+            + filesetCount
+            + ", attrs="
+            + missingDirFalseCount
+            + ")");
 
     // Properties used to build the local path must come from the parent via inheritAll.
     assertTrue(
@@ -102,11 +137,7 @@ class I18nLocaleMigrationWiringTest {
 
     // Parent still passes inheritAll/inheritRefs for properties and any other refs; classpath for
     // taskdef is self-contained in the child (asserted above).
-    assertTrue(
-        body.contains("install.chain") || body.contains("name=\"install.chain\""),
-        "install.chain target must remain");
-    assertTrue(
-        body.contains("upgrade.chain") || body.contains("name=\"upgrade.chain\""),
-        "upgrade.chain target must remain");
+    assertTrue(body.contains("install.chain"), "install.chain target must remain");
+    assertTrue(body.contains("upgrade.chain"), "upgrade.chain target must remain");
   }
 }

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/I18nLocaleMigrationWiringTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/I18nLocaleMigrationWiringTest.java
@@ -22,12 +22,15 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
- * Regression guard for GH-1547: the installer ships {@code migration_i18n_locales.xml} and both
- * install/upgrade chains invoke it. Uses relative {@link Path} only (cross-platform).
+ * Regression guard for GH-1547 / GH-2011: the installer ships {@code migration_i18n_locales.xml}
+ * with a self-contained {@code ant.deps} path (nested {@code <ant>} does not apply {@code
+ * inheritRefs} until after the child project is configured), and both install/upgrade chains invoke
+ * it. Uses relative {@link Path} only (cross-platform).
  */
 @Tag("UnitTest")
 class I18nLocaleMigrationWiringTest {
@@ -38,6 +41,13 @@ class I18nLocaleMigrationWiringTest {
   private static final Path MIGRATION_XML = INSTALLER.resolve("migration_i18n_locales.xml");
   private static final Path INSTALL_XML = INSTALLER.resolve("install.xml");
 
+  /** Local path id in the nested migration project (not a parent-only inheritRefs dependency). */
+  private static final Pattern LOCAL_ANT_DEPS_PATH =
+      Pattern.compile("<path\\s+id\\s*=\\s*[\"']ant\\.deps[\"']", Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern CLASSPATHREF_ANT_DEPS =
+      Pattern.compile("classpathref\\s*=\\s*[\"']ant\\.deps[\"']", Pattern.CASE_INSENSITIVE);
+
   @Test
   void migrationScriptIsShipped() throws IOException {
     assertTrue(Files.isRegularFile(MIGRATION_XML), "missing " + MIGRATION_XML);
@@ -45,6 +55,33 @@ class I18nLocaleMigrationWiringTest {
     assertTrue(body.contains("PSMigrateI18nLocaleCodes"), "migration must use Ant task");
     assertTrue(body.contains("migrateI18nLocales"), "default target name");
     assertTrue(body.contains("i18n.locale.migration.dryRun"), "dry-run property");
+  }
+
+  /**
+   * GH-2011: project-level {@code classpathref="ant.deps"} must resolve against a path id defined
+   * in this same file. Parent {@code inheritRefs} is applied too late for nested project configure.
+   */
+  @Test
+  void migrationScriptDefinesLocalAntDepsPath() throws IOException {
+    assertTrue(Files.isRegularFile(MIGRATION_XML), "missing " + MIGRATION_XML);
+    String body = Files.readString(MIGRATION_XML, StandardCharsets.UTF_8);
+
+    assertTrue(
+        LOCAL_ANT_DEPS_PATH.matcher(body).find(),
+        "migration_i18n_locales.xml must define <path id=\"ant.deps\"> locally (GH-2011)");
+
+    // If the script still uses classpathref="ant.deps", the local path id must exist (no dangling
+    // ref).
+    if (CLASSPATHREF_ANT_DEPS.matcher(body).find()) {
+      assertTrue(
+          LOCAL_ANT_DEPS_PATH.matcher(body).find(),
+          "classpathref=\"ant.deps\" without local <path id=\"ant.deps\">");
+    }
+
+    // Properties used to build the local path must come from the parent via inheritAll.
+    assertTrue(
+        body.contains("${install.dir}") || body.contains("${install.src}"),
+        "local ant.deps should resolve jars under install.dir and/or install.src");
   }
 
   @Test
@@ -62,5 +99,14 @@ class I18nLocaleMigrationWiringTest {
       idx += "migration_i18n_locales.xml".length();
     }
     assertTrue(hits >= 2, "expected install.chain + upgrade.chain wiring, hits=" + hits);
+
+    // Parent still passes inheritAll/inheritRefs for properties and any other refs; classpath for
+    // taskdef is self-contained in the child (asserted above).
+    assertTrue(
+        body.contains("install.chain") || body.contains("name=\"install.chain\""),
+        "install.chain target must remain");
+    assertTrue(
+        body.contains("upgrade.chain") || body.contains("name=\"upgrade.chain\""),
+        "upgrade.chain target must remain");
   }
 }


### PR DESCRIPTION
## Summary

Fixes full CMS installer abort on Windows when nested `migration_i18n_locales.xml` evaluates project-level `taskdef classpathref="ant.deps"` and fails with **Reference ant.deps not found**.

**Root cause:** Apache Ant applies parent `inheritRefs` only *after* the nested project is configured. `install.xml` correctly defines `path id="ant.deps"` and calls the migration with `inheritAll/inheritRefs=true`, but those path refs are not yet visible to project-level `taskdef` in the child.

**Fix:** Self-contained local `<path id="ant.deps">` in `migration_i18n_locales.xml`, built from inherited `${install.dir}` / `${install.src}` (available via `inheritAll` during configure). Mirrors the JDBC / perc / extension filesets from `install.xml` with `erroronmissingdir="false"`.

## Test plan

- [x] `cd modules/perc-distribution-tree && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] `I18nLocaleMigrationWiringTest` — **Tests run: 3, Failures: 0, Errors: 0**
  - ships migration script + task
  - **local** `<path id="ant.deps">` present; no dangling `classpathref` without local path
  - `install.chain` + `upgrade.chain` still invoke `migration_i18n_locales.xml` (≥2 hits)
- [x] Module Spotless: `spotless:apply` then `spotless:check` (in-scope only; monorepo baseline Spotless hits discarded)
- [x] Erlang pre-commit review: **approve** — report `docs/ai-generated/code-reviews/issue-2011-ant-deps-migration-erlang.md`
- [ ] Full Windows installer smoke (optional QA; not required for this static ANT wiring fix)

## Gates evidence

| Gate | Result |
|------|--------|
| Standalone module clean install | SUCCESS |
| Unit tests (wiring) | 3 / 0 fail |
| Spotless apply → check (in-scope) | PASS |
| Erlang | approve |
| Cross-platform paths | Path.of relative; ANT props |

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2011