### PR TITLE
fix(system): Jackson-migrate PSDependency/PSDependent (#1993)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-1993-dependency-jackson-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-1993-dependency-jackson-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review — issue #1993 (PSDependency / PSDependent Jackson)
+
+**Verdict:** PASS (self-review before commit)
+
+**Recommendation:** approve  
+**May commit/push:** yes  
+**Gate:** approve
+
+**Scope reviewed:** Jackson opt-in annotations + golden/round-trip tests for
+`PSDependency`, `PSDependent`; deviations doc
+`docs/ai-generated/tasks/505-betwixt-jackson/1993-dependency-domain-deviations.md`.
+
+## Gates
+
+| Check | Result |
+|-------|--------|
+| Bugs / RT correctness | Pass — `PSSystemDataXmlSerializationTest` 16/16 green; system `clean install` BUILD SUCCESS |
+| Behavioral unit tests | Pass — golden + RT + legacy `<null>` root for both types |
+| Cross-platform paths | Pass — no new filesystem path construction (classpath resources only) |
+| Change-class companions | Pass — domain annotations, `addType("dependent")`, goldens, deviations doc; peer pattern matches #1920 `PSAuditTrail` nest |
+| Spotless | Pass — apply then check on in-scope files; out-of-scope reformats discarded |
+
+## Notes
+
+- Nested wire: `<dependents><dependent>…</dependent></dependents>` dual-registered
+  (`@JacksonXmlProperty` + `PSXmlSerializationHelper.addType`).
+- Derived getters suppressed: `display-type`, `dependent-types`.
+- Type wire stores `PSTypeEnum.name()` (matches production `PSDependencyHelper`).
+
+## Residuals (not this PR)
+
+- PSMimeContentAdapter (#1994)
+- Betwixt POM removal (#1824)
+
+## Memory patterns hit
+
+- Jackson domain batch: opt-in `@JsonAutoDetect`, root element, nested wrapper + item name, golden/RT/legacy-null triad

--- a/docs/ai-generated/tasks/505-betwixt-jackson/1993-dependency-domain-deviations.md
+++ b/docs/ai-generated/tasks/505-betwixt-jackson/1993-dependency-domain-deviations.md
@@ -1,0 +1,47 @@
+# Issue #1993 — System dependency domain Jackson wire deviations
+
+Parent: #1920 · Grandparent: #1892 / #1823 · Epic: #505
+
+## Scope delivered
+
+|     Class      | Root element |                         Nested / notes                         |
+|----------------|--------------|----------------------------------------------------------------|
+| `PSDependent`  | `dependent`  | Scalar `id` + enum-name `type`; derived `display-type` omitted |
+| `PSDependency` | `dependency` | `dependents` wrapper / nested `dependent` (`addType`)          |
+
+Golden fixtures + round-trip + legacy `<null>` root tests live in
+`system/src/test/java/com/percussion/services/system/data/PSSystemDataXmlSerializationTest`
+(alongside #1920 audit / shared-property coverage).
+
+## Approved / intentional deviations vs historical Betwixt
+
+|                   Deviation                    |                                                               Notes                                                                |
+|------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| No Betwixt graph-identity `id="…"` attributes  | Same as #1887 facade / other domain batches.                                                                                       |
+| No XML declaration                             | `PSJacksonXmlSerializationHelper` default.                                                                                         |
+| `PSDependent` omits derived `display-type`     | Computed from `PSTypeEnum.valueOf(type).getDisplayName()`; not design wire.                                                        |
+| `PSDependency` omits derived `dependent-types` | Comma-delimited display helper only; rebuilt from nested dependents.                                                               |
+| Nested item element name `dependent`           | Matches type mapper (`PSDependent` → `dependent`); dual-registered via `@JacksonXmlProperty` + `PSXmlSerializationHelper.addType`. |
+| Type string is `PSTypeEnum.name()`             | Production writers use `childType.toString()` / `.name()` (e.g. `TEMPLATE`, `ITEM_FILTER`).                                        |
+| Empty dependents list may still emit wrapper   | Jackson list wrapper present when empty; read accepts empty / absent children.                                                     |
+
+## Residual
+
+Not in this PR:
+
+1. **PSMimeContentAdapter** — system content adapter design XML (tracked as residual of #1920 / separate issue)
+2. Betwixt POM removal (#1824)
+3. Types already done in #1920 first batch (`PSAudit*`, `PSSharedProperty`, `PSHierarchyNode*`)
+
+## Out of scope
+
+- filter (#1915), sitemgr (#1918), publisher/pubserver (#1919)
+- content leftovers (#1921)
+- Live CMS package install / MSM dependency graph runtime
+
+## Tests
+
+|               Suite                |                       Coverage                        |
+|------------------------------------|-------------------------------------------------------|
+| `PSSystemDataXmlSerializationTest` | dependent / dependency golden + RT + legacy null root |
+

--- a/system/services/src/com/percussion/services/system/data/PSDependency.java
+++ b/system/services/src/com/percussion/services/system/data/PSDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,11 @@
  */
 package com.percussion.services.system.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -25,164 +28,164 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * This object represents a single design object dependency.
+ *
+ * <p>Design-object XML root is {@code dependency}. Nested package item element is {@code
+ * dependent}. Jackson opt-in property surface (issue #1993 / epic #505).
+ *
+ * <p><b>Nested type registration (two engines, one name):</b> Jackson binds nested items via {@link
+ * JacksonXmlProperty}{@code (localName="dependent")} on {@link #getDependents()}. The static {@link
+ * PSXmlSerializationHelper#addType} registration is retained for the Betwixt rollback engine and
+ * for polymorphic list restore helpers that still consult the shared type map. Both paths use the
+ * same element name {@code dependent} → {@link PSDependent}; they are complementary, not competing
+ * owners.
  */
-public class PSDependency implements Serializable
-{
-   /**
-    * Compiler generated serial version ID used for serialization.
-    */
-   private static final long serialVersionUID = -5933263029349676677L;
+@JacksonXmlRootElement(localName = "dependency")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({"dependents", "id"})
+public class PSDependency implements Serializable {
+  /** Compiler generated serial version ID used for serialization. */
+  private static final long serialVersionUID = -5933263029349676677L;
 
-   /**
-    * The id of the design object for which this object shows all dependencies.
-    */
-   private long id;
-   
-   /**
-    * All dependent design object, never <code>null</code>, may be empty. 
-    */
-   private List<PSDependent> dependents = new ArrayList<>();
+  /**
+   * The id of the design object for which this object shows all dependencies.
+   */
+  private long id;
 
-   /**
-    * Default construcctor.
-    */
-   public PSDependency()
-   {
-   }
-   
-   /**
-    * Get the design object id for which this shows the dependencies.
-    * 
-    * @return the design object id for which this shows the dependencies.
-    */
-   public long getId()
-   {
-      return id;
-   }
-   
-   /**
-    * Set the new design object id for which this shows the dependencies.
-    * 
-    * @param id the new design object id for which this shows the dependencies.
-    */
-   public void setId(long id)
-   {
-      this.id = id;
-   }
-   
-   /**
-    * Get the list with all dependents.
-    * 
-    * @return the list with all dependents, never <code>null</code>, may
-    *    be empty.
-    */
-   public List<PSDependent> getDependents()
-   {
-      return dependents;
-   }
-   
-   /**
-    * Set a new list of dependents.
-    * 
-    * @param dependents the new list of dependents, may be <code>null</code> or
-    *    empty.
-    */
-   public void setDependents(List<PSDependent> dependents)
-   {
-      if (dependents == null)
-         this.dependents = new ArrayList<>();
-      else
-         this.dependents = dependents;
-   }
-   
-   /**
-    * Add a new dependent.
-    * 
-    * @param dependent the new dependent to add, not <code>null</code>.
-    */
-   public void addDependent(PSDependent dependent)
-   {
-      if (dependent == null)
-         throw new IllegalArgumentException("dependent cannot be null");
-      
-      dependents.add(dependent);
-   }
-   
-   /**
-    * Get unique list of the dependent types, comma delimited.
-    * 
-    * @return The list, never empty, <code>null</code> if 
-    * {@link #getDependents()} returns an empty list.
-    */
-   public String getDependentTypes()
-   {
-      Set<String> types = new HashSet<>();
-      for (PSDependent dependent : dependents)
-      {
-         types.add(dependent.getDisplayType());
+  /** All dependent design object, never <code>null</code>, may be empty. */
+  private List<PSDependent> dependents = new ArrayList<>();
+
+  static {
+    // Betwixt / helper type-map path (Jackson uses @JacksonXmlProperty on getDependents()).
+    // Same key+class as Jackson annotations — intentional dual registration for dual engines.
+    PSXmlSerializationHelper.addType("dependent", PSDependent.class);
+  }
+
+  /** Default constructor. */
+  public PSDependency() {}
+
+  /**
+   * Get the design object id for which this shows the dependencies.
+   *
+   * @return the design object id for which this shows the dependencies.
+   */
+  @JsonProperty
+  public long getId() {
+    return id;
+  }
+
+  /**
+   * Set the new design object id for which this shows the dependencies.
+   *
+   * @param id the new design object id for which this shows the dependencies.
+   */
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  /**
+   * Get the list with all dependents.
+   *
+   * @return the list with all dependents, never <code>null</code>, may be empty.
+   */
+  @JsonProperty
+  @JacksonXmlElementWrapper(localName = "dependents")
+  @JacksonXmlProperty(localName = "dependent")
+  public List<PSDependent> getDependents() {
+    return dependents;
+  }
+
+  /**
+   * Set a new list of dependents.
+   *
+   * @param dependents the new list of dependents, may be <code>null</code> or empty.
+   */
+  public void setDependents(List<PSDependent> dependents) {
+    if (dependents == null) this.dependents = new ArrayList<>();
+    else this.dependents = dependents;
+  }
+
+  /**
+   * Add a new dependent.
+   *
+   * @param dependent the new dependent to add, not <code>null</code>.
+   */
+  public void addDependent(PSDependent dependent) {
+    if (dependent == null) throw new IllegalArgumentException("dependent cannot be null");
+
+    dependents.add(dependent);
+  }
+
+  /**
+   * Get unique list of the dependent types, comma delimited.
+   *
+   * @return The list, never empty, <code>null</code> if {@link #getDependents()} returns an empty
+   *     list.
+   */
+  @JsonIgnore
+  public String getDependentTypes() {
+    Set<String> types = new HashSet<>();
+    for (PSDependent dependent : dependents) {
+      types.add(dependent.getDisplayType());
+    }
+
+    String typeList = null;
+    if (!types.isEmpty()) {
+      for (String type : types) {
+        if (typeList == null) typeList = "";
+        else typeList += ", ";
+
+        typeList += type;
       }
-      
-      String typeList = null;
-      if (!types.isEmpty())
-      {
-         for (String type : types)
-         {
-            if (typeList == null)
-               typeList = "";
-            else
-               typeList += ", ";
-            
-            typeList += type;
-         }
-      }
-      
-      return typeList;
-   }
+    }
 
-   @Override
-   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof PSDependency)) return false;
-      PSDependency that = (PSDependency) o;
-      return getId() == that.getId() && Objects.equals(getDependents(), that.getDependents());
-   }
+    return typeList;
+  }
 
-   @Override
-   public int hashCode() {
-      return Objects.hash(getId(), getDependents());
-   }
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof PSDependency)) return false;
+    PSDependency that = (PSDependency) o;
+    return getId() == that.getId() && Objects.equals(getDependents(), that.getDependents());
+  }
 
-   @Override
-   public String toString() {
-      final StringBuffer sb = new StringBuffer("PSDependency{");
-      sb.append("id=").append(id);
-      sb.append(", dependents=").append(dependents);
-      sb.append('}');
-      return sb.toString();
-   }
+  @Override
+  public int hashCode() {
+    return Objects.hash(getId(), getDependents());
+  }
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#fromXML(String)
-    */
-   public void fromXML(String xmlsource) throws IOException, SAXException
-   {
-      PSXmlSerializationHelper.readFromXML(xmlsource, this);
-   }
+  @Override
+  public String toString() {
+    final StringBuffer sb = new StringBuffer("PSDependency{");
+    sb.append("id=").append(id);
+    sb.append(", dependents=").append(dependents);
+    sb.append('}');
+    return sb.toString();
+  }
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#toXML()
-    */
-   public String toXML() throws IOException, SAXException
-   {
-      return PSXmlSerializationHelper.writeToXml(this);
-   }
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#fromXML(String)
+   */
+  public void fromXML(String xmlsource) throws IOException, SAXException {
+    PSXmlSerializationHelper.readFromXML(xmlsource, this);
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#toXML()
+   */
+  public String toXML() throws IOException, SAXException {
+    return PSXmlSerializationHelper.writeToXml(this);
+  }
 }
-

--- a/system/services/src/com/percussion/services/system/data/PSDependent.java
+++ b/system/services/src/com/percussion/services/system/data/PSDependent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,137 +16,133 @@
  */
 package com.percussion.services.system.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Objects;
-
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * This object represents a single design object dependent.
+ *
+ * <p>Design-object XML root is {@code dependent}. Jackson opt-in property surface (issue #1993 /
+ * epic #505). Identity is scalar {@code id} plus enum-name {@code type}; derived {@code
+ * display-type} is omitted from the wire.
  */
-public class PSDependent implements Serializable
-{
-   /**
-    * Compiler generated serial version ID used for serialization.
-    */
-   private static final long serialVersionUID = -2436271056885991371L;
-   
-   /**
-    * The id of the dependent design object.
-    */
-   private long id;
-   
-   /**
-    * The type of the dependent design object, may be <code>null</code>, not
-    * empty.
-    */
-   private String type;
-   
-   /**
-    * Default construcctor.
-    */
-   public PSDependent()
-   {
-   }
-   
-   /**
-    * Get the design object id for this dependent.
-    * 
-    * @return the design object id for this dependent.
-    */
-   public long getId()
-   {
-      return id;
-   }
-   
-   /**
-    * Set the new design object id for this dependent.
-    * 
-    * @param id the new design object id for this dependent.
-    */
-   public void setId(long id)
-   {
-      this.id = id;
-   }
-   
-   /**
-    * Get the dependents type.
-    * 
-    * @return the dependents type, may be <code>null</code>, not empty.
-    */
-   public String getType()
-   {
-      return type;
-   }
-   
-   /**
-    * Get the dependents type in a form suitable for display.
-    * 
-    * @return the dependents diplay type, may be <code>null</code>, not empty.
-    */   
-   public String getDisplayType()
-   {
-      return PSTypeEnum.valueOf(type).getDisplayName();
-   }
-   
-   /**
-    * Set the dependents type.
-    * 
-    * @param type the new type for this dependent, not <code>null</code> or
-    *    empty.
-    */
-   public void setType(String type)
-   {
-      if (StringUtils.isBlank(type))
-         throw new IllegalArgumentException("type cannot be null or empty");
-      
-      this.type = type;
-   }
+@JacksonXmlRootElement(localName = "dependent")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({"id", "type"})
+public class PSDependent implements Serializable {
+  /** Compiler generated serial version ID used for serialization. */
+  private static final long serialVersionUID = -2436271056885991371L;
 
-   @Override
-   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof PSDependent)) return false;
-      PSDependent that = (PSDependent) o;
-      return getId() == that.getId() && Objects.equals(getType(), that.getType());
-   }
+  /** The id of the dependent design object. */
+  private long id;
 
-   @Override
-   public int hashCode() {
-      return Objects.hash(getId(), getType());
-   }
+  /**
+   * The type of the dependent design object, may be <code>null</code>, not empty. Production
+   * writers store {@link PSTypeEnum#name()} (e.g. {@code TEMPLATE}, {@code ITEM_FILTER}).
+   */
+  private String type;
 
-   @Override
-   public String toString() {
-      final StringBuffer sb = new StringBuffer("PSDependent{");
-      sb.append("id=").append(id);
-      sb.append(", type='").append(type).append('\'');
-      sb.append('}');
-      return sb.toString();
-   }
+  /** Default constructor. */
+  public PSDependent() {}
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#fromXML(String)
-    */
-   public void fromXML(String xmlsource) throws IOException, SAXException
-   {
-      PSXmlSerializationHelper.readFromXML(xmlsource, this);
-   }
+  /**
+   * Get the design object id for this dependent.
+   *
+   * @return the design object id for this dependent.
+   */
+  @JsonProperty
+  public long getId() {
+    return id;
+  }
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#toXML()
-    */
-   public String toXML() throws IOException, SAXException
-   {
-      return PSXmlSerializationHelper.writeToXml(this);
-   }
+  /**
+   * Set the new design object id for this dependent.
+   *
+   * @param id the new design object id for this dependent.
+   */
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  /**
+   * Get the dependents type.
+   *
+   * @return the dependents type, may be <code>null</code>, not empty.
+   */
+  @JsonProperty
+  public String getType() {
+    return type;
+  }
+
+  /**
+   * Get the dependents type in a form suitable for display.
+   *
+   * @return the dependents display type, may be <code>null</code>, not empty.
+   */
+  @JsonIgnore
+  public String getDisplayType() {
+    return PSTypeEnum.valueOf(type).getDisplayName();
+  }
+
+  /**
+   * Set the dependents type.
+   *
+   * @param type the new type for this dependent, not <code>null</code> or empty.
+   */
+  public void setType(String type) {
+    if (StringUtils.isBlank(type)) throw new IllegalArgumentException("type cannot be null or empty");
+
+    this.type = type;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof PSDependent)) return false;
+    PSDependent that = (PSDependent) o;
+    return getId() == that.getId() && Objects.equals(getType(), that.getType());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getId(), getType());
+  }
+
+  @Override
+  public String toString() {
+    final StringBuffer sb = new StringBuffer("PSDependent{");
+    sb.append("id=").append(id);
+    sb.append(", type='").append(type).append('\'');
+    sb.append('}');
+    return sb.toString();
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#fromXML(String)
+   */
+  public void fromXML(String xmlsource) throws IOException, SAXException {
+    PSXmlSerializationHelper.readFromXML(xmlsource, this);
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#toXML()
+   */
+  public String toXML() throws IOException, SAXException {
+    return PSXmlSerializationHelper.writeToXml(this);
+  }
 }
-

--- a/system/src/test/java/com/percussion/services/system/data/PSSystemDataXmlSerializationTest.java
+++ b/system/src/test/java/com/percussion/services/system/data/PSSystemDataXmlSerializationTest.java
@@ -40,7 +40,7 @@ import org.xml.sax.InputSource;
 
 /**
  * Golden / round-trip tests for system design objects under the Jackson-backed {@code
- * PSXmlSerializationHelper} (issue #1920, epic #505). Offline only — no live CMS.
+ * PSXmlSerializationHelper} (issues #1920 / #1993, epic #505). Offline only — no live CMS.
  */
 class PSSystemDataXmlSerializationTest {
 
@@ -254,6 +254,115 @@ class PSSystemDataXmlSerializationTest {
     });
   }
 
+  @Test
+  void dependentWriteShapeAndGolden() throws Exception {
+    PSDependent original = sampleDependent(2001L, PSTypeEnum.TEMPLATE.name());
+    String xml = original.toXML();
+
+    assertNotNull(xml);
+    assertFalse(xml.trim().startsWith("<null"), xml);
+    assertTrue(containsTag(xml, "dependent"), "root: " + xml);
+    assertTrue(containsTag(xml, "id"), xml);
+    assertTrue(containsTag(xml, "type"), xml);
+    assertFalse(containsTag(xml, "display-type"), "derived display-type omitted: " + xml);
+    assertTrue(xml.contains("TEMPLATE"), xml);
+
+    String golden = loadResource("com/percussion/services/system/data/ps-dependent-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+  }
+
+  @Test
+  void dependentRoundTripRestoresScalars() throws Exception {
+    PSDependent original = sampleDependent(2001L, PSTypeEnum.TEMPLATE.name());
+    String xml = original.toXML();
+
+    PSDependent restored = new PSDependent();
+    restored.fromXML(xml);
+
+    assertEquals(original.getId(), restored.getId());
+    assertEquals(original.getType(), restored.getType());
+    assertEquals(original.getDisplayType(), restored.getDisplayType());
+  }
+
+  @Test
+  void dependentFromXmlAcceptsLegacyNullRoot() throws Exception {
+    String legacy =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <null>
+          <id>77</id>
+          <type>ITEM_FILTER</type>
+        </null>
+        """;
+
+    PSDependent restored = new PSDependent();
+    restored.fromXML(legacy);
+
+    assertEquals(77L, restored.getId());
+    assertEquals(PSTypeEnum.ITEM_FILTER.name(), restored.getType());
+  }
+
+  @Test
+  void dependencyWriteShapeAndGolden() throws Exception {
+    PSDependency original = sampleDependency();
+    String xml = original.toXML();
+
+    assertTrue(containsTag(xml, "dependency"), xml);
+    assertTrue(containsTag(xml, "dependents"), xml);
+    assertTrue(containsTag(xml, "dependent"), xml);
+    assertTrue(containsTag(xml, "id"), xml);
+    assertTrue(containsTag(xml, "type"), xml);
+    assertFalse(containsTag(xml, "dependent-types"), "derived dependent-types omitted: " + xml);
+    assertTrue(xml.contains("TEMPLATE"), xml);
+    assertTrue(xml.contains("ITEM_FILTER"), xml);
+
+    String golden = loadResource("com/percussion/services/system/data/ps-dependency-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+  }
+
+  @Test
+  void dependencyRoundTripRestoresNestedDependents() throws Exception {
+    PSDependency original = sampleDependency();
+    String xml = original.toXML();
+
+    PSDependency restored = new PSDependency();
+    restored.fromXML(xml);
+
+    assertEquals(original.getId(), restored.getId());
+    assertEquals(original.getDependents().size(), restored.getDependents().size());
+    assertEquals(original.getDependents().get(0).getId(), restored.getDependents().get(0).getId());
+    assertEquals(
+        original.getDependents().get(0).getType(), restored.getDependents().get(0).getType());
+    assertEquals(original.getDependents().get(1).getId(), restored.getDependents().get(1).getId());
+    assertEquals(
+        original.getDependents().get(1).getType(), restored.getDependents().get(1).getType());
+  }
+
+  @Test
+  void dependencyFromXmlAcceptsLegacyNullRoot() throws Exception {
+    String legacy =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <null>
+          <dependents>
+            <dependent>
+              <id>9</id>
+              <type>CONTENT_LIST</type>
+            </dependent>
+          </dependents>
+          <id>5</id>
+        </null>
+        """;
+
+    PSDependency restored = new PSDependency();
+    restored.fromXML(legacy);
+
+    assertEquals(5L, restored.getId());
+    assertEquals(1, restored.getDependents().size());
+    assertEquals(9L, restored.getDependents().get(0).getId());
+    assertEquals(PSTypeEnum.CONTENT_LIST.name(), restored.getDependents().get(0).getType());
+  }
+
   private static PSAudit sampleAudit() {
     PSAudit audit = new PSAudit();
     audit.setId(1001L);
@@ -313,6 +422,21 @@ class PSSystemDataXmlSerializationTest {
     prop.setName("sys_prop_sample");
     prop.setValue("sample-value");
     return prop;
+  }
+
+  private static PSDependent sampleDependent(long id, String type) {
+    PSDependent dependent = new PSDependent();
+    dependent.setId(id);
+    dependent.setType(type);
+    return dependent;
+  }
+
+  private static PSDependency sampleDependency() {
+    PSDependency dependency = new PSDependency();
+    dependency.setId(100L);
+    dependency.addDependent(sampleDependent(2001L, PSTypeEnum.TEMPLATE.name()));
+    dependency.addDependent(sampleDependent(2002L, PSTypeEnum.ITEM_FILTER.name()));
+    return dependency;
   }
 
   /** 2024-01-15T12:00:00.000Z as {@link Date}. */

--- a/system/src/test/resources/com/percussion/services/system/data/ps-dependency-golden.xml
+++ b/system/src/test/resources/com/percussion/services/system/data/ps-dependency-golden.xml
@@ -1,0 +1,15 @@
+<!-- Golden snapshot for production PSDependency Jackson wire shape (issue
+	#1993 / epic #505). Nested package item element is dependent. -->
+<dependency>
+	<dependents>
+		<dependent>
+			<id>2001</id>
+			<type>TEMPLATE</type>
+		</dependent>
+		<dependent>
+			<id>2002</id>
+			<type>ITEM_FILTER</type>
+		</dependent>
+	</dependents>
+	<id>100</id>
+</dependency>

--- a/system/src/test/resources/com/percussion/services/system/data/ps-dependent-golden.xml
+++ b/system/src/test/resources/com/percussion/services/system/data/ps-dependent-golden.xml
@@ -1,0 +1,7 @@
+<!-- Golden snapshot for production PSDependent Jackson wire shape (issue
+	#1993 / epic #505). Derived display-type omitted; type stores PSTypeEnum
+	name. -->
+<dependent>
+	<id>2001</id>
+	<type>TEMPLATE</type>
+</dependent>


### PR DESCRIPTION
## Summary

Jackson-migrates the remaining system dependency design objects left over from #1920:

- **`PSDependent`** — root `dependent`; wire fields `id` + `type` (`PSTypeEnum.name()`); derived `display-type` suppressed
- **`PSDependency`** — root `dependency`; nested `dependents` / `dependent` with dual `PSXmlSerializationHelper.addType("dependent", …)` registration (Jackson annotations + Betwixt type map, same pattern as `PSAuditTrail` / `audit`)

Golden fixtures + round-trip + legacy `<null>` root tests extend `PSSystemDataXmlSerializationTest`. Deviations: `docs/ai-generated/tasks/505-betwixt-jackson/1993-dependency-domain-deviations.md`.

### Links

- Fixes #1993
- Parent residual of #1920 · Grandparent #1892 / #1823 · Epic #505

### Out of scope

- PSMimeContentAdapter (#1994)
- Betwixt POM removal (#1824)
- Types already shipped in #1920 (`PSAudit*`, `PSSharedProperty`, `PSHierarchyNode*`)

## Test plan

- [x] `PSSystemDataXmlSerializationTest` — 16 tests, 0 failures (includes 6 new dependency/dependent cases)
- [x] `cd system && ../mvnw clean install` — **BUILD SUCCESS**
- [x] Spotless: `mvnw spotless:apply` then `spotless:check` on in-scope paths (out-of-scope reformats discarded)
- [x] Erlang self-review: `docs/ai-generated/code-reviews/issue-1993-dependency-jackson-erlang.md` — **approve**

## Gates evidence

| Gate | Evidence |
|------|----------|
| Module clean install | `cd system`; `..\mvnw.cmd clean install` → BUILD SUCCESS |
| Focused suite | `PSSystemDataXmlSerializationTest` Tests run: 16, Failures: 0 |
| Spotless | apply **then** check (in-scope only committed) |
| Erlang | approve; portable paths N/A (no new FS I/O) |
| Change-class companions | annotations + nested `addType` + goldens + RT + legacy null + deviations doc |

**Operator:** Grok: night-issue-prs (model grok-4.5)