### PR TITLE
enh(docker): wire freeport into matrix-install-smoke (#2005)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -60,24 +60,32 @@ perc-devctl.py qa-down [--container NAME]
 
 Each subcommand writes full output to a timestamped file under `docker/logs/<label>-<ts>.log` and emits a single `RESULT:OK STEP:<label> LOG:<path>` (or `RESULT:FAIL`) line on stdout so agent workflows can parse the result without parsing free-form output.
 
-#### Host ports / freeport (multi-worktree) — #2001
+#### Host ports / freeport (multi-worktree) — #2001 / #2005
 
-`perc-devctl.py` no longer hardcodes published host ports for the **dev verify** probes or **QA CMS** cell. Resolution order (cross-platform stdlib `socket` bind to port `0` — no Unix-only tooling):
+`perc-devctl.py` and `matrix-install-smoke.py` resolve published host ports via shared helpers in `docker/scripts/perc_host_ports.py` (cross-platform stdlib `socket` bind to port `0` — no Unix-only tooling):
 
 1. **Env override** (wins):
    - Dev stack: `CMS_PORT`, `DTS_PORT` (compose already maps these), or full `VERIFY_CMS_URL` / `VERIFY_DTS_URL`
-   - QA cell: `QA_CMS_HOST_PORT` or `CMS_HOST_PORT`
-2. **Preferred baseline when free** on loopback: CMS `9992`, DTS `9980`, QA CMS `9993`
+   - QA / matrix CMS cell: `QA_CMS_HOST_PORT` or `CMS_HOST_PORT`
+   - Matrix DTS cell: `DTS_HOST_PORT`
+2. **Preferred baseline when free** on loopback: compose CMS `9992`, compose DTS `9980`, matrix/QA CMS `9993`, matrix DTS `9983`
 3. Else **ephemeral freeport** so a second worktree does not hit `address already in use`
 
 **Discover allocated ports:**
 
 - `perc-devctl.py up` prints `CMS_PORT=…`, `DTS_PORT=…`, and the resolved `VERIFY_*_URL` lines
 - `perc-devctl.py qa-up` prints `QA_CMS_HOST_PORT=…` and `TEST_CMS_URL=http://127.0.0.1:<port>`
+- `matrix-install-smoke.py` pins `CMS_HOST_PORT` / `QA_CMS_HOST_PORT` / `DTS_HOST_PORT` for the cell it starts; probe URL and docker `-p` always use that same port
 
-Pin ports across sessions by exporting those env vars before `up` / `qa-up` / `verify`. Tear-down (`down` / `qa-down`) frees the docker publish mapping; the host port itself is not reserved after the container exits.
+**Playwright / `TEST_CMS_URL` contract:**
 
-**Scope note:** matrix-install-smoke still defaults its own `CMS_HOST_PORT=9993` until a follow-up wires freeport into matrix docker `-p` (see #2001 residual). `qa-up` exports `QA_CMS_HOST_PORT` / `CMS_HOST_PORT` for that consumer.
+|       Consumer        |                                                        Source of base URL                                                        |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| After `qa-up`         | Use the printed `TEST_CMS_URL` (or `http://127.0.0.1:$QA_CMS_HOST_PORT`)                                                         |
+| After matrix `--keep` | `http://127.0.0.1:$CMS_HOST_PORT` (export pinned by the harness)                                                                 |
+| CI / local override   | Export `TEST_CMS_URL` **and** matching `QA_CMS_HOST_PORT` / `CMS_HOST_PORT` before `qa-up` so publish + probe + Playwright agree |
+
+Do **not** hardcode `http://127.0.0.1:9993` in agent scripts — 9993 is only the preferred baseline when free. Pin ports across sessions by exporting those env vars before `up` / `qa-up` / `matrix-install-smoke` / `verify`. Tear-down (`down` / `qa-down` / cell destroy) frees the docker publish mapping; the host port itself is not reserved after the container exits.
 
 #### QA mode (`qa-up` / `qa-health` / `qa-down`)
 
@@ -111,10 +119,10 @@ ENTRYPOINT ["/usr/local/bin/python3", "/usr/local/bin/install-update.py"]
 
 Ephemeral cells mount the real installer jars (not a fictional `perc-preinstall.jar`):
 
-| Product |            Installer jar (customer-shipped assembly only)            |        Start after install        |           Default host probe           |
-|---------|----------------------------------------------------------------------|-----------------------------------|----------------------------------------|
-| CMS     | `modules/perc-distribution-tree/target/perc-distribution-tree.jar`   | `jetty/StartJetty.sh`             | `http://127.0.0.1:9993/Rhythmyx/login` |
-| DTS     | `…/delivery-tier-distribution/target/delivery-tier-distribution.jar` | `TomcatStartup.sh` / `startup.sh` | `http://127.0.0.1:9983/`               |
+| Product |            Installer jar (customer-shipped assembly only)            |        Start after install        |        Preferred host probe (when free / no env)        |
+|---------|----------------------------------------------------------------------|-----------------------------------|---------------------------------------------------------|
+| CMS     | `modules/perc-distribution-tree/target/perc-distribution-tree.jar`   | `jetty/StartJetty.sh`             | `http://127.0.0.1:<CMS_HOST_PORT\|9993>/Rhythmyx/login` |
+| DTS     | `…/delivery-tier-distribution/target/delivery-tier-distribution.jar` | `TomcatStartup.sh` / `startup.sh` | `http://127.0.0.1:<DTS_HOST_PORT\|9983>/`               |
 
 Do **not** use `*-SNAPSHOT.jar` — those are plain module jars without the runnable installer main class. Package with `mvn package` so the assembly `finalName` jars exist and are non-empty.
 
@@ -137,7 +145,9 @@ python3 docker/scripts/matrix-install-smoke.py --product dts --db h2,postgresql,
 
 # Leave cell up for Playwright Layer 2 (perc-qa-automation)
 python3 docker/scripts/matrix-install-smoke.py --product cms --db postgresql --keep
-TEST_CMS_URL=http://localhost:9993 TEST_DB_TYPE=postgresql \
+# Prefer printed/pinned CMS_HOST_PORT (or set CMS_HOST_PORT before matrix).
+# Example when preferred 9993 was free:
+TEST_CMS_URL=http://127.0.0.1:${CMS_HOST_PORT:-9993} TEST_DB_TYPE=postgresql \
   npm test --prefix modules/perc-qa-automation/frontend -- tests/install.spec.js
 
 # Destroy cells but keep external DBs for a follow-up matrix run

--- a/docker/scripts/matrix-install-smoke.py
+++ b/docker/scripts/matrix-install-smoke.py
@@ -75,6 +75,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
 
+# Sibling freeport helpers (stdlib only). Ensure scripts dir is importable
+# when this file is loaded via importlib (unit tests) or as a script.
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+from perc_host_ports import find_free_port, is_port_free, resolve_host_port  # noqa: E402
+
 LOG = logging.getLogger("matrix-install-smoke")
 
 EXIT_OK = 0
@@ -87,9 +94,14 @@ ENV_FILE_FALLBACK = ".env.compose.example"
 MATRIX_IMAGE_TAG = "percussion-matrix-cell:local"
 MATRIX_NETWORK = "perc-matrix-net"
 
-# Host ports published for single-cell sequential runs (one CMS, one DTS at a time).
-CMS_HOST_PORT = 9993
-DTS_HOST_PORT = 9983
+# Preferred host ports when free and no env override (single-worktree baseline).
+# Multi-worktree: set CMS_HOST_PORT / QA_CMS_HOST_PORT / DTS_HOST_PORT (or leave
+# unset so freeport allocates) — see resolve_matrix_host_port / docker/README.md.
+# Historical constants kept as aliases for callers/tests that still reference them.
+PREFERRED_CMS_HOST_PORT = 9993
+PREFERRED_DTS_HOST_PORT = 9983
+CMS_HOST_PORT = PREFERRED_CMS_HOST_PORT  # preferred baseline (not a pinned bind)
+DTS_HOST_PORT = PREFERRED_DTS_HOST_PORT
 CMS_PROBE_PATH = "/Rhythmyx/login"
 DTS_PROBE_PATH = "/"
 
@@ -393,6 +405,56 @@ def resolve_installer_jar(repo_root: Path, product: str) -> Path:
 def build_probe_url(product: str, host_port: int) -> str:
     path = CMS_PROBE_PATH if product == "cms" else DTS_PROBE_PATH
     return f"http://127.0.0.1:{host_port}{path}"
+
+
+def resolve_matrix_host_port(product: str) -> int:
+    """Resolve published host port for a matrix cell (env or freeport).
+
+    CMS (aligned with ``perc-devctl`` QA cell / ``TEST_CMS_URL``):
+
+      1. ``QA_CMS_HOST_PORT`` or ``CMS_HOST_PORT`` env (integer)
+      2. Preferred :data:`PREFERRED_CMS_HOST_PORT` (9993) when free
+      3. Ephemeral freeport
+
+    DTS:
+
+      1. ``DTS_HOST_PORT`` env
+      2. Preferred :data:`PREFERRED_DTS_HOST_PORT` (9983) when free
+      3. Ephemeral freeport
+
+    Does not pin env by itself — use :func:`ensure_matrix_host_port` when
+    the chosen port should be visible to child processes / operators.
+    """
+    product = product.lower().strip()
+    if product == "cms":
+        return resolve_host_port(
+            "QA_CMS_HOST_PORT",
+            "CMS_HOST_PORT",
+            preferred=PREFERRED_CMS_HOST_PORT,
+        )
+    if product == "dts":
+        return resolve_host_port(
+            "DTS_HOST_PORT",
+            preferred=PREFERRED_DTS_HOST_PORT,
+        )
+    raise ValueError(f"Unknown product for host port: {product}")
+
+
+def ensure_matrix_host_port(product: str) -> int:
+    """Resolve matrix host port and pin discovery env for operators / Playwright.
+
+    CMS pins ``CMS_HOST_PORT`` and ``QA_CMS_HOST_PORT`` (setdefault for the
+    second key when already set by ``perc-devctl qa-up``). DTS pins
+    ``DTS_HOST_PORT``.
+    """
+    port = resolve_matrix_host_port(product)
+    product = product.lower().strip()
+    if product == "cms":
+        os.environ["CMS_HOST_PORT"] = str(port)
+        os.environ.setdefault("QA_CMS_HOST_PORT", str(port))
+    elif product == "dts":
+        os.environ["DTS_HOST_PORT"] = str(port)
+    return port
 
 
 def build_docker_run_argv(
@@ -706,8 +768,16 @@ def run_cell(
 ) -> CellResult:
     started = time.time()
     name = cell_container_name(cell)
-    host_port = CMS_HOST_PORT if cell.product == "cms" else DTS_HOST_PORT
+    # Env override (QA_CMS_HOST_PORT / CMS_HOST_PORT / DTS_HOST_PORT) or freeport
+    # so multi-worktree agents do not collide on preferred 9993/9983 (#2005).
+    host_port = ensure_matrix_host_port(cell.product)
     probe_url = build_probe_url(cell.product, host_port)
+    LOG.info(
+        "Cell %s host publish %s → probe %s",
+        cell.cell_id,
+        host_port,
+        probe_url,
+    )
     cell_log = log_dir / f"matrix-{cell.cell_id}-{_ts()}.log"
     db_meta = dict(db_services[cell.db_type])
 

--- a/docker/scripts/perc-devctl.py
+++ b/docker/scripts/perc-devctl.py
@@ -58,7 +58,6 @@ import argparse
 import logging
 import os
 import shlex
-import socket
 import subprocess
 import sys
 import time
@@ -67,6 +66,13 @@ import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable, List, Optional, Sequence
+
+# Sibling freeport helpers (stdlib only). Ensure scripts dir is importable
+# when this file is loaded via importlib (unit tests) or as a script.
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+from perc_host_ports import find_free_port, is_port_free, resolve_host_port  # noqa: E402
 
 LOG = logging.getLogger("perc-devctl")
 
@@ -111,62 +117,7 @@ QA_PROBE_TIMEOUT_SECONDS_DEFAULT = 900
 QA_PROBE_INTERVAL_SECONDS_DEFAULT = 5
 
 
-# ---------------------------------------------------------------------------
-# Freeport / host-port resolution (cross-platform; stdlib only) — #2001
-# ---------------------------------------------------------------------------
-
-
-def find_free_port(host: str = "127.0.0.1") -> int:
-    """Allocate an ephemeral free TCP port via bind(port=0).
-
-    Cross-platform (Windows / Linux / macOS). Uses stdlib ``socket`` only —
-    no Unix-only tooling. The port is free at return time; a short TOCTOU
-    race remains until the consumer binds (docker / compose).
-    """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind((host, 0))
-        return int(sock.getsockname()[1])
-
-
-def is_port_free(port: int, host: str = "127.0.0.1") -> bool:
-    """Return True if ``port`` can be bound on ``host`` right now."""
-    try:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            sock.bind((host, port))
-            return True
-    except OSError:
-        return False
-
-
-def resolve_host_port(
-    *env_keys: str,
-    preferred: Optional[int] = None,
-) -> int:
-    """Resolve a host TCP port for published docker services.
-
-    Order:
-      1. First non-empty environment variable among ``env_keys`` (integer).
-      2. ``preferred`` when that port is free on the loopback interface.
-      3. :func:`find_free_port` ephemeral allocation.
-
-    Env override lets operators pin ports across worktrees or match an
-    already-running stack. Leaving env unset prefers the historical single-
-    worktree defaults when free, otherwise allocates a free port so a second
-    worktree does not fail with ``address already in use``.
-    """
-    for key in env_keys:
-        raw = os.environ.get(key, "").strip()
-        if not raw:
-            continue
-        try:
-            return int(raw)
-        except ValueError as exc:
-            raise ValueError(
-                f"env {key}={raw!r} is not an integer host port"
-            ) from exc
-    if preferred is not None and is_port_free(preferred):
-        return preferred
-    return find_free_port()
+# Freeport primitives live in perc_host_ports.py (shared with matrix) — #2001/#2005.
 
 
 def resolve_verify_cms_url() -> str:
@@ -243,7 +194,7 @@ def ensure_qa_cms_host_port() -> int:
     """Resolve QA CMS host port and pin it for child processes / discovery."""
     port = resolve_qa_cms_host_port()
     os.environ["QA_CMS_HOST_PORT"] = str(port)
-    # Shared name matrix-install-smoke residual (#2001 follow-up) will read.
+    # matrix-install-smoke reads CMS_HOST_PORT / QA_CMS_HOST_PORT for docker -p (#2005).
     os.environ.setdefault("CMS_HOST_PORT", str(port))
     return port
 
@@ -1036,7 +987,7 @@ def cmd_qa_up(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
 
     Host port is resolved via :func:`ensure_qa_cms_host_port` (env override
     or freeport) and exported as ``QA_CMS_HOST_PORT`` / ``CMS_HOST_PORT`` so
-    operators and residual matrix freeport wiring can discover it.
+    matrix-install-smoke docker ``-p`` and operators / Playwright agree (#2005).
     """
     repo_root, _env_file, _compose_file = paths
     log_dir = _log_dir(repo_root)

--- a/docker/scripts/perc_host_ports.py
+++ b/docker/scripts/perc_host_ports.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Shared host-port / freeport helpers for docker scripts (#2001 / #2005).
+
+Cross-platform (Windows / Linux / macOS). Uses stdlib ``socket`` only —
+no Unix-only tooling. Callers: ``perc-devctl.py``, ``matrix-install-smoke.py``.
+
+Resolution order for :func:`resolve_host_port`:
+
+  1. First non-empty environment variable among the given keys (integer).
+  2. ``preferred`` when that port is free on the loopback interface.
+  3. :func:`find_free_port` ephemeral allocation.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from typing import Optional
+
+
+def find_free_port(host: str = "127.0.0.1") -> int:
+    """Allocate an ephemeral free TCP port via bind(port=0).
+
+    The port is free at return time; a short TOCTOU race remains until
+    the consumer binds (docker / compose).
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        return int(sock.getsockname()[1])
+
+
+def is_port_free(port: int, host: str = "127.0.0.1") -> bool:
+    """Return True if ``port`` can be bound on ``host`` right now."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind((host, port))
+            return True
+    except OSError:
+        return False
+
+
+def resolve_host_port(
+    *env_keys: str,
+    preferred: Optional[int] = None,
+) -> int:
+    """Resolve a host TCP port for published docker services.
+
+    Env override lets operators pin ports across worktrees or match an
+    already-running stack. Leaving env unset prefers the historical
+    single-worktree defaults when free, otherwise allocates a free port
+    so a second worktree does not fail with ``address already in use``.
+    """
+    for key in env_keys:
+        raw = os.environ.get(key, "").strip()
+        if not raw:
+            continue
+        try:
+            return int(raw)
+        except ValueError as exc:
+            raise ValueError(
+                f"env {key}={raw!r} is not an integer host port"
+            ) from exc
+    if preferred is not None and is_port_free(preferred):
+        return preferred
+    return find_free_port()

--- a/docker/scripts/test_matrix_install_smoke.py
+++ b/docker/scripts/test_matrix_install_smoke.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import importlib.util
+import os
+import socket
 import sys
 import tempfile
 import unittest
@@ -12,6 +14,18 @@ from pathlib import Path
 
 SCRIPTS = Path(__file__).resolve().parent
 MATRIX = SCRIPTS.parent / "matrix"
+
+# Env keys freeport / matrix host-port resolution may set or read.
+_PORT_ENV_KEYS = (
+    "QA_CMS_HOST_PORT",
+    "CMS_HOST_PORT",
+    "DTS_HOST_PORT",
+)
+
+
+def _clear_port_env() -> None:
+    for key in _PORT_ENV_KEYS:
+        os.environ.pop(key, None)
 
 
 def _load(path: Path, name: str):
@@ -244,6 +258,99 @@ class ProbeUrlTests(unittest.TestCase):
             smoke.build_probe_url("dts", 9983),
             "http://127.0.0.1:9983/",
         )
+
+
+class MatrixHostPortFreeportTests(unittest.TestCase):
+    """#2005 — matrix docker -p / probe host port from env or freeport."""
+
+    def setUp(self):
+        _clear_port_env()
+        self.addCleanup(_clear_port_env)
+
+    def test_preferred_baselines(self):
+        self.assertEqual(smoke.PREFERRED_CMS_HOST_PORT, 9993)
+        self.assertEqual(smoke.PREFERRED_DTS_HOST_PORT, 9983)
+        # Historical aliases remain for callers/docs.
+        self.assertEqual(smoke.CMS_HOST_PORT, 9993)
+        self.assertEqual(smoke.DTS_HOST_PORT, 9983)
+
+    def test_cms_env_override_qa_cms_host_port(self):
+        os.environ["QA_CMS_HOST_PORT"] = "18001"
+        self.assertEqual(smoke.resolve_matrix_host_port("cms"), 18001)
+
+    def test_cms_env_override_cms_host_port(self):
+        os.environ["CMS_HOST_PORT"] = "18002"
+        self.assertEqual(smoke.resolve_matrix_host_port("cms"), 18002)
+
+    def test_cms_qa_env_wins_over_cms_host_port(self):
+        os.environ["QA_CMS_HOST_PORT"] = "18003"
+        os.environ["CMS_HOST_PORT"] = "18004"
+        self.assertEqual(smoke.resolve_matrix_host_port("cms"), 18003)
+
+    def test_dts_env_override(self):
+        os.environ["DTS_HOST_PORT"] = "18005"
+        self.assertEqual(smoke.resolve_matrix_host_port("dts"), 18005)
+
+    def test_invalid_env_raises(self):
+        os.environ["CMS_HOST_PORT"] = "not-a-port"
+        with self.assertRaises(ValueError):
+            smoke.resolve_matrix_host_port("cms")
+
+    def test_preferred_when_free(self):
+        preferred = smoke.find_free_port()
+        # Temporarily treat preferred as free preferred baseline via direct resolve.
+        self.assertEqual(
+            smoke.resolve_host_port(preferred=preferred),
+            preferred,
+        )
+
+    def test_falls_back_when_preferred_taken(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            taken = int(sock.getsockname()[1])
+            resolved = smoke.resolve_host_port(preferred=taken)
+            self.assertNotEqual(resolved, taken)
+            self.assertGreater(resolved, 0)
+
+    def test_ensure_cms_pins_env(self):
+        os.environ["QA_CMS_HOST_PORT"] = "17777"
+        port = smoke.ensure_matrix_host_port("cms")
+        self.assertEqual(port, 17777)
+        self.assertEqual(os.environ["CMS_HOST_PORT"], "17777")
+        self.assertEqual(os.environ["QA_CMS_HOST_PORT"], "17777")
+
+    def test_ensure_dts_pins_env(self):
+        os.environ["DTS_HOST_PORT"] = "17778"
+        port = smoke.ensure_matrix_host_port("dts")
+        self.assertEqual(port, 17778)
+        self.assertEqual(os.environ["DTS_HOST_PORT"], "17778")
+
+    def test_docker_run_argv_uses_resolved_host_port(self):
+        """Probe URL and -p mapping must share the same host port (e2e contract)."""
+        os.environ["CMS_HOST_PORT"] = "16661"
+        host_port = smoke.ensure_matrix_host_port("cms")
+        self.assertEqual(host_port, 16661)
+        argv = smoke.build_docker_run_argv(
+            image=smoke.MATRIX_IMAGE_TAG,
+            container_name="perc-matrix-cms-h2",
+            product="cms",
+            db_type="h2",
+            installer_jar_host=Path("/tmp/j.jar"),
+            host_port=host_port,
+            network=smoke.MATRIX_NETWORK,
+            db_meta=smoke.DB_SERVICES["h2"],
+            keep=False,
+        )
+        joined = " ".join(argv)
+        self.assertIn("16661:9992", joined)
+        self.assertEqual(
+            smoke.build_probe_url("cms", host_port),
+            "http://127.0.0.1:16661/Rhythmyx/login",
+        )
+
+    def test_unknown_product_raises(self):
+        with self.assertRaises(ValueError):
+            smoke.resolve_matrix_host_port("oracle")
 
 
 class DbOwnershipAndTeardownTests(unittest.TestCase):

--- a/docker/scripts/test_perc_devctl.py
+++ b/docker/scripts/test_perc_devctl.py
@@ -26,6 +26,7 @@ SCRIPTS = Path(__file__).resolve().parent
 _PORT_ENV_KEYS = (
     "QA_CMS_HOST_PORT",
     "CMS_HOST_PORT",
+    "DTS_HOST_PORT",
     "CMS_PORT",
     "DTS_PORT",
     "VERIFY_CMS_URL",

--- a/docs/developer-module/workbench-rest-and-qa-modes.md
+++ b/docs/developer-module/workbench-rest-and-qa-modes.md
@@ -119,26 +119,31 @@ cd modules/perc-distribution-tree && ../../mvnw package -DskipTests
 # 1) UP — silent install + start CMS on H2; waits until /Rhythmyx/login is ready
 python docker/scripts/perc-devctl.py qa-up
 # optional: --timeout-seconds 900  --skip-image-build
+# Host port: QA_CMS_HOST_PORT / CMS_HOST_PORT env, else preferred 9993 when free, else freeport.
+# qa-up prints QA_CMS_HOST_PORT=… and TEST_CMS_URL=http://127.0.0.1:<port>
 
 # 2) HEALTH — re-check readiness (clear RESULT:FAIL + timeout if not ready)
 python docker/scripts/perc-devctl.py qa-health
 # optional: --timeout-seconds 120  --interval-seconds 5
 
-# 3) (later slices) Playwright against the stack only — no DEV_PERCUSSION_INSTALL
-#    TEST_CMS_URL=http://127.0.0.1:9993  TEST_DB_TYPE=h2  TEST_PRODUCT=cms
+# 3) Playwright against the stack only — no DEV_PERCUSSION_INSTALL
+#    Use the TEST_CMS_URL printed by qa-up (do not hardcode :9993 — multi-worktree freeport).
+#    TEST_CMS_URL=http://127.0.0.1:$QA_CMS_HOST_PORT  TEST_DB_TYPE=h2  TEST_PRODUCT=cms
 #    ADMIN_USERNAME=Admin  (password printed by qa-up or via docker exec)
 
-# 4) DOWN — destroy the cell; frees host port 9993; no multi-GB orphans by default
+# 4) DOWN — destroy the cell; frees the published host port; no multi-GB orphans by default
 python docker/scripts/perc-devctl.py qa-down
 ```
 
-|  Output / constant   |                         Value                          |
-|----------------------|--------------------------------------------------------|
-| Published base URL   | `http://127.0.0.1:9993` (`TEST_CMS_URL`)               |
-| Probe path           | `/Rhythmyx/login`                                      |
-| Container name       | `perc-matrix-cms-h2`                                   |
-| Admin user           | `Admin` (password from install generated passwords)    |
-| RESULT line contract | `RESULT:OK\|FAIL STEP:qa-up\|qa-health\|qa-down LOG:…` |
+|  Output / constant   |                                  Value                                   |
+|----------------------|--------------------------------------------------------------------------|
+| Published base URL   | `TEST_CMS_URL` from `qa-up` (`http://127.0.0.1:<port>`)                  |
+| Preferred baseline   | Host port `9993` when free and no env override                           |
+| Env override         | `QA_CMS_HOST_PORT` or `CMS_HOST_PORT` (matrix docker `-p` uses the same) |
+| Probe path           | `/Rhythmyx/login`                                                        |
+| Container name       | `perc-matrix-cms-h2`                                                     |
+| Admin user           | `Admin` (password from install generated passwords)                      |
+| RESULT line contract | `RESULT:OK\|FAIL STEP:qa-up\|qa-health\|qa-down LOG:…`                   |
 
 **Tear-down policy:** `qa-down` runs `docker rm -f` on the QA cell. The install lives **inside** the container (no named multi-GB volume by default), so removing the container frees ports and disk. Prefer `qa-down` after every agent session; do not leave `perc-matrix-cms-h2` running overnight unless debugging.
 

--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -146,7 +146,9 @@ python3 docker/scripts/matrix-install-smoke.py --product cms --db postgresql --p
 
 # Leave cell up for Playwright Layer 2 (install.spec.js)
 python3 docker/scripts/matrix-install-smoke.py --product cms --db postgresql --keep
-TEST_CMS_URL=http://localhost:9993 TEST_DB_TYPE=postgresql \
+# Use the pinned CMS_HOST_PORT (or TEST_CMS_URL from perc-devctl qa-up). Prefer
+# preferred 9993 only when free — multi-worktree freeport may allocate another port.
+TEST_CMS_URL=http://127.0.0.1:${CMS_HOST_PORT:-9993} TEST_DB_TYPE=postgresql \
   npm test --prefix frontend -- tests/install.spec.js
 ```
 

--- a/modules/perc-qa-automation/frontend/tests/install.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/install.spec.js
@@ -9,25 +9,30 @@
  * Playwright suite (and the rest of perc-qa-automation) can run against it.
  *
  * Usage:
- *   # Bring up a cell and leave it running
+ *   # Bring up a cell and leave it running (pins CMS_HOST_PORT / freeport)
  *   python3 docker/scripts/matrix-install-smoke.py --product cms --db postgresql --keep
+ *   # Or: python docker/scripts/perc-devctl.py qa-up  (prints TEST_CMS_URL)
  *
- *   # Probe login (CMS default host port from the harness: 9993)
- *   TEST_CMS_URL=http://localhost:9993 TEST_DB_TYPE=postgresql \
+ *   # Probe login — always use the harness-printed URL / pinned host port
+ *   # (preferred CMS 9993 / DTS 9983 only when free; do not hardcode freeport).
+ *   TEST_CMS_URL=http://127.0.0.1:${CMS_HOST_PORT:-9993} TEST_DB_TYPE=postgresql \
  *     npm test -- tests/install.spec.js
  *
- *   # DTS (harness host port 9983)
- *   TEST_PRODUCT=dts TEST_CMS_URL=http://localhost:9983 TEST_DB_TYPE=h2 \
+ *   # DTS (preferred host port 9983 when free, else freeport via DTS_HOST_PORT)
+ *   TEST_PRODUCT=dts TEST_CMS_URL=http://127.0.0.1:${DTS_HOST_PORT:-9983} TEST_DB_TYPE=h2 \
  *     npm test -- tests/install.spec.js
  *
  * Environment:
- *   TEST_CMS_URL   Base URL (CMS or DTS) — default http://localhost:9993
+ *   TEST_CMS_URL   Base URL (CMS or DTS) — set from qa-up / matrix pin; fallback
+ *                  http://localhost:9993 is preferred baseline only when free
  *   TEST_DB_TYPE   Label for reporting — default h2
  *   TEST_PRODUCT   cms | dts — default cms (chooses probe path)
+ *   CMS_HOST_PORT / QA_CMS_HOST_PORT / DTS_HOST_PORT — set by harness (#2005)
  */
 
 const { test, expect } = require("@playwright/test");
 
+// Preferred single-worktree baseline when free; prefer TEST_CMS_URL from qa-up.
 const BASE_URL = process.env.TEST_CMS_URL || "http://localhost:9993";
 const DB_TYPE = process.env.TEST_DB_TYPE || "h2";
 const PRODUCT = (process.env.TEST_PRODUCT || "cms").toLowerCase();


### PR DESCRIPTION
## Summary

Wires freeport into `matrix-install-smoke.py` so multi-worktree agents no longer collide on hardcoded CMS `9993` / DTS `9983`.

- **Shared helper** `docker/scripts/perc_host_ports.py` (stdlib `socket` only): `find_free_port`, `is_port_free`, `resolve_host_port` — used by both `perc-devctl` and matrix.
- **Matrix host ports**: env override `QA_CMS_HOST_PORT` / `CMS_HOST_PORT` (CMS) or `DTS_HOST_PORT` (DTS) → preferred 9993/9983 when free → ephemeral freeport. Docker `-p` and probe URLs use the same resolved port; env is pinned for discovery.
- **End-to-end with qa-up**: `perc-devctl qa-up` already exports `QA_CMS_HOST_PORT` / `CMS_HOST_PORT`; matrix now honors them for publish + probe (same port as printed `TEST_CMS_URL`).
- **Docs**: `docker/README.md`, workbench QA modes, perc-qa-automation README / `install.spec.js` — Playwright `TEST_CMS_URL` contract (do not hardcode `:9993`).

Out of scope (existing issues): full DTS/MySQL compose freeport matrix (#2004); two-worktree checklist (#2006).

Fixes #2005  
Related #2001 #2003

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] `python -m pytest docker/scripts/test_matrix_install_smoke.py docker/scripts/test_perc_devctl.py -q` → **84 passed**
- [x] New matrix freeport tests: env override (QA/CMS/DTS), preferred-when-free, fall-back when taken, ensure pins env, docker `-p` + probe share host port
- [x] Existing perc-devctl freeport / qa-up dry-run tests still green after extract
- [ ] Manual (optional): with 9993 occupied, `qa-up --dry-run` / matrix dry-run shows freeport; with `CMS_HOST_PORT=18001` publish mapping uses 18001

## Gates evidence

| Gate | Result |
|------|--------|
| Behavioral unit tests | Pass — 84 tests in docker/scripts (matrix freeport + perc-devctl freeport) |
| Portable paths | Pass — stdlib socket bind only; no OS path construction for ports |
| Change-class companions | Shared helper + matrix resolve/ensure + unit tests + docs / Playwright env contract |
| Spotless | `mvnw -N spotless:apply` (root docs) + `cd modules/perc-qa-automation && ../../mvnw spotless:apply`; **in-scope only** committed. Baseline debt outside scope left uncommitted (e.g. `docs/ai-generated/code-reviews/issue-18*`, `bug-1812-bulk-upload.spec.js`) — not folded into this PR |
| Maven clean install | N/A — no Java/Maven module sources changed (Python docker scripts + docs only) |
| Erlang self-review | No bugs found; freeport API matches #2003; CMS env key order matches qa-up |

## Residual

None for #2005 acceptance. Parent #2001 still tracks #2004 / #2006 separately.