### PR TITLE
fix(membership): Generic Key Spring test ApplicationContext (#2007)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/membership/src/test/resources/hibernate.cfg.xml
+++ b/deliverytiersuite/delivery-tier-suite/membership/src/test/resources/hibernate.cfg.xml
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE hibernate-configuration PUBLIC
 		"-//Hibernate/Hibernate Configuration DTD 3.0//EN"
-		"file:hibernate-configuration-3.0.dtd">
+		"classpath:/hibernate-configuration-3.0.dtd">
 <hibernate-configuration>
 
+	<!-- Prefer packagesToScan on LocalSessionFactoryBean in Spring test beans.
+	     If configLocation still points here, DTD must resolve from the classpath
+	     (not a CWD-relative file: URL, which breaks under Maven Surefire). -->
 	<session-factory>
 		<mapping
 			class="com.percussion.membership.data.rdbms.impl.PSMembership" />

--- a/deliverytiersuite/delivery-tier-suite/membership/src/test/resources/test-beans-generic-key.xml
+++ b/deliverytiersuite/delivery-tier-suite/membership/src/test/resources/test-beans-generic-key.xml
@@ -50,7 +50,11 @@
 	<!-- Only import the minimal test DataSource/Hibernate props -->
 	<import resource="perc-datasources.xml" />
 
-   <!-- Hibernate SessionFactory -->
+   <!-- Hibernate SessionFactory.
+        Use packagesToScan (same as test-beans.xml) instead of configLocation +
+        hibernate.cfg.xml. The test hibernate.cfg.xml DOCTYPE used a relative
+        file: DTD that resolves against the process CWD and fails under Maven
+        Surefire with FileNotFoundException / StAX parse errors. -->
    <bean id="membershipSessionFactory"
          class="org.springframework.orm.jpa.hibernate.LocalSessionFactoryBean">
       <property name="dataSource">
@@ -59,8 +63,10 @@
       <property name="hibernateProperties">
          <ref bean="${hibernateProperties}" />
       </property>
-      <property name="configLocation">
-         <value>hibernate.cfg.xml</value>
+      <property name="packagesToScan">
+         <list>
+            <value>com.percussion.generickey.utils.data.rdbms.impl</value>
+         </list>
       </property>
    </bean>
 

--- a/docs/ai-generated/code-reviews/2007-generic-key-spring-tests-erlang.md
+++ b/docs/ai-generated/code-reviews/2007-generic-key-spring-tests-erlang.md
@@ -1,0 +1,48 @@
+# Erlang review — issue #2007 membership Generic Key Spring tests
+
+**Branch:** `fix/issue-2007-generic-key-spring-tests`  
+**Scope:** test resources only under `deliverytiersuite/delivery-tier-suite/membership`  
+**Date:** 2026-08-05  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Cross-platform path checklist:** N/A (no production file I/O; DTD fix is classpath URI, portable)
+
+## Summary
+
+Root cause of `Failed to load ApplicationContext` for `PSGenericKeyServiceTest` /
+`PSGenericKeyDaoTest` was `test-beans-generic-key.xml` loading Hibernate via
+`configLocation` → test `hibernate.cfg.xml`, whose DOCTYPE system id was
+`file:hibernate-configuration-3.0.dtd` (CWD-relative). Under Maven Surefire the
+CWD is the module directory, so Woodstox/Hibernate failed with
+`FileNotFoundException` → `Error accessing StAX stream`. Cascading
+`ApplicationContext failure threshold` errors followed.
+
+## Change class
+
+**Spring/Hibernate test context wiring for Generic Key slice** — companion is
+alignment with peer `test-beans.xml` (`packagesToScan` + H2 / JpaTransactionManager
+pattern already proven green for membership DAO/service tests).
+
+## Issues
+
+None (bugs / missing behavioral tests / non-portable path I/O).
+
+### Notes (non-blocking)
+
+- Production `WEB-INF/beans.xml` still uses `configLocation` with
+  `/WEB-INF/hibernate.cfg.xml` and classpath DTD — not changed; production
+  security/config untouched as required by issue scope.
+- Existing behavioral tests now exercise the fixed context (create/validate/delete
+  keys). No new production logic; no new unit-test class required.
+- Dependency-analyze warnings on clean install are pre-existing baseline.
+
+## Evidence
+
+- `cd deliverytiersuite/delivery-tier-suite/membership && ../../../mvnw clean install`
+- Tests run: 20, Failures: 0, Errors: 0 — BUILD SUCCESS
+
+## Memory patterns hit
+
+- Prefer peer test wiring (`packagesToScan`) over fragile CWD-relative config
+- Diagnose first `Failed to load ApplicationContext` cause, not threshold cascade
+


### PR DESCRIPTION
## Summary

Fixes perc-membership-services Surefire failures for Generic Key Spring tests (PSGenericKeyServiceTest, PSGenericKeyDaoTest).

**Root cause:** 	est-beans-generic-key.xml configured LocalSessionFactoryBean with configLocation → test hibernate.cfg.xml, whose DOCTYPE system id was ile:hibernate-configuration-3.0.dtd. Woodstox resolved that against the process CWD (module dir under Maven), not the classpath, producing FileNotFoundException → Hibernate Error accessing StAX stream → first Failed to load ApplicationContext, then cascading ApplicationContext failure threshold (1) exceeded.

**Fix (test-only, production untouched):**
- Switch generic-key test membershipSessionFactory to packagesToScan for com.percussion.generickey.utils.data.rdbms.impl (same pattern as working peer 	est-beans.xml).
- Change test hibernate.cfg.xml DTD to classpath:/hibernate-configuration-3.0.dtd for residual configLocation use.

Does not weaken production security or change production WEB-INF/beans.xml.

Fixes #2007

## Test plan

- [x] Reproduced: cd deliverytiersuite/delivery-tier-suite/membership && ../../../mvnw.cmd clean test "-Dtest=PSGenericKeyServiceTest,PSGenericKeyDaoTest" — 4 errors before fix
- [x] After fix: same command — Tests run: 4, Failures: 0, Errors: 0
- [x] Standalone module: cd deliverytiersuite/delivery-tier-suite/membership && ../../../mvnw.cmd clean install — **BUILD SUCCESS**, Tests run: 20, Failures: 0, Errors: 0
- [x] Spotless: root mvnw.cmd spotless:apply then spotless:check (BUILD SUCCESS); PR contains **only in-scope** membership test resources + Erlang report (out-of-scope Spotless rewrites not committed)
- [x] Erlang-style review: approve — report docs/ai-generated/code-reviews/2007-generic-key-spring-tests-erlang.md

## Gates evidence

| Gate | Result |
|------|--------|
| Root cause from first ApplicationContext failure | StAX / CWD-relative DTD |
| Production security / beans | Unchanged |
| Membership clean install | BUILD SUCCESS (20 tests green) |
| Spotless apply → check | Pass; in-scope only on PR |
| Erlang | approve |

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)