### PR TITLE
fix(system): Jackson-migrate PSMimeContentAdapter (#1994)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-1994-mime-content-adapter-jackson-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-1994-mime-content-adapter-jackson-erlang.md
@@ -1,0 +1,40 @@
+# Erlang review — issue #1994 (PSMimeContentAdapter Jackson)
+
+**Verdict:** PASS (self-review before commit)
+
+**Recommendation:** approve  
+**May commit/push:** yes  
+**Gate:** approve
+
+**Scope reviewed:** Jackson opt-in annotations + base64 content wire + golden/round-trip
+tests for `PSMimeContentAdapter`; deviations doc
+`docs/ai-generated/tasks/505-betwixt-jackson/1994-mime-content-adapter-deviations.md`.
+
+## Gates
+
+| Check | Result |
+|-------|--------|
+| Bugs / RT correctness | Pass — `PSSystemDataXmlSerializationTest` 20/20 green (incl. 4 mime tests); `PSMimeContentAdapterTest` 1/1 green |
+| Behavioral unit tests | Pass — golden + inline RT + attachment RT + legacy `<null>` root; interface test JUnit 5 |
+| Cross-platform paths | Pass — no new filesystem path construction (classpath resources + in-memory buffers only) |
+| Change-class companions | Pass — domain annotations, golden fixture, deviations doc; peer pattern matches #1920/#1993 system data batch |
+| Spotless | Pass — module `spotless:apply` then `spotless:check` on system; out-of-scope HierarchyNode reformat discarded |
+
+## Notes
+
+- Wire root `mime-content-adapter`; inline payload is standard Base64 under `content`.
+- API `InputStream` surface is `@JsonIgnore`; `getContentBase64` / `setContentBase64` own the wire.
+- Content buffered as `byte[]` so BeanUtils property-copy order and re-read after `toXML` are safe.
+- `setContent(null)` is null-safe (BeanUtils may clear content before `attachment-id`).
+- Suppressed: `label`, `content-attached`, `description`.
+
+## Residuals (not this PR)
+
+- Betwixt POM removal (#1824)
+- SOAP webservice DTO / converter (already separate)
+
+## Memory patterns hit
+
+- Jackson domain batch: opt-in `@JsonAutoDetect`, root element, golden/RT/legacy-null triad
+- Null-safe setters for BeanUtils XML restore (`setVersion` peer)
+- Binary/content fields: buffer + base64 string property, not raw `InputStream` on the wire

--- a/docs/ai-generated/tasks/505-betwixt-jackson/1994-mime-content-adapter-deviations.md
+++ b/docs/ai-generated/tasks/505-betwixt-jackson/1994-mime-content-adapter-deviations.md
@@ -1,0 +1,51 @@
+# Issue #1994 — PSMimeContentAdapter Jackson wire deviations
+
+Parent: #1920 · Grandparent: #1892 / #1823 · Epic: #505
+
+## Scope delivered
+
+|         Class          |      Root element      |                                  Nested / notes                                  |
+|------------------------|------------------------|----------------------------------------------------------------------------------|
+| `PSMimeContentAdapter` | `mime-content-adapter` | Inline base64 `content`; scalar `attachment-id` / encodings / guid / mime / name |
+
+Golden fixtures + round-trip + legacy `<null>` root tests live in
+`system/src/test/java/com/percussion/services/system/data/PSSystemDataXmlSerializationTest`
+(alongside #1920 / #1993 system data coverage). Existing interface tests remain in
+`PSMimeContentAdapterTest`.
+
+## Approved / intentional deviations vs historical Betwixt
+
+|                      Deviation                       |                                                                       Notes                                                                       |
+|------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| No Betwixt graph-identity `id="…"` attributes        | Same as #1887 facade / other domain batches.                                                                                                      |
+| No XML declaration                                   | `PSJacksonXmlSerializationHelper` default.                                                                                                        |
+| `InputStream` content is **not** a wire type         | API keeps `getContent()` / `setContent(InputStream)`; design XML uses base64 string via `getContentBase64` / `setContentBase64`.                  |
+| Wire element remains `content`                       | Matches historical property name; value is standard Base64 (no MIME line wrapping), same intent as SOAP `PSMimeContentAdapterConverter`.          |
+| Content buffered as `byte[]`                         | `setContent` reads the stream into a buffer; `getContent` always returns a fresh `ByteArrayInputStream`. Avoids BeanUtils/toXML stream EOF races. |
+| `setContent(null)` clears (null-safe)                | BeanUtils may copy null `content` before `attachment-id` during `fromXML`; same pattern as `PSSharedProperty#setVersion(null)`.                   |
+| Attachment mode omits inline `content`               | When `attachment-id >= 0`, `content` serializes as null / omitted; buffer cleared by `setAttachmentId`.                                           |
+| Derived / alias properties suppressed                | `label` (name alias), `content-attached` (href ≥ 0), `description` (always null API) are `@JsonIgnore`.                                           |
+| `guid` is `CONFIGURATION` type only                  | Existing `setGUID` validation unchanged; wire form is `PSGuid` string (e.g. `0-34-100`).                                                          |
+| `transfer-encoding` field not auto-cleared on attach | Historical bean field retained as-is; javadoc claimed null when attached but code never enforced that.                                            |
+
+## Residual
+
+Not in this PR:
+
+1. Betwixt POM removal (#1824)
+2. Types already done in #1920 / #1993 (`PSAudit*`, `PSSharedProperty`, `PSHierarchyNode*`, `PSDependency` / `PSDependent`)
+3. SOAP / Axis-generated `com.percussion.webservices.system.PSMimeContentAdapter` (separate converter; not design-object XML)
+
+## Out of scope
+
+- filter (#1915), sitemgr (#1918), publisher/pubserver (#1919)
+- content leftovers (#1921)
+- Live CMS configuration file I/O (`PSSystemService.loadConfiguration` / `saveConfiguration`)
+
+## Tests
+
+|               Suite                |                                    Coverage                                    |
+|------------------------------------|--------------------------------------------------------------------------------|
+| `PSSystemDataXmlSerializationTest` | mime-content-adapter golden + inline RT + attachment RT + legacy null root     |
+| `PSMimeContentAdapterTest`         | Existing programming-interface coverage (defaults, setters, attachment toggle) |
+

--- a/system/services/src/com/percussion/services/system/data/PSMimeContentAdapter.java
+++ b/system/services/src/com/percussion/services/system/data/PSMimeContentAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,346 +16,397 @@
  */
 package com.percussion.services.system.data;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.percussion.content.IPSMimeContentTypes;
 import com.percussion.services.catalog.IPSCatalogItem;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.utils.xml.PSXmlSerializationHelper;
-import com.percussion.util.IOTools;
 import com.percussion.util.PSCharSetsConstants;
 import com.percussion.utils.guid.IPSGuid;
-
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
+import java.util.Base64;
 import java.util.Objects;
-
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.xml.sax.SAXException;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
- * This mime content adapter is mainly used for file transport but can handle
- * any type of content.
+ * This mime content adapter is mainly used for file transport but can handle any type of content.
+ *
+ * <p>Design-object XML root is {@code mime-content-adapter}. Jackson opt-in property surface (issue
+ * #1994 / epic #505). Binary payload is carried as a base64 string under {@code content} when not
+ * attachment-referenced; the live {@link InputStream} surface stays API-only ({@link
+ * #getContent()}/{@link #setContent(InputStream)}). Payload bytes are buffered so XML restore via
+ * BeanUtils property copy is order-safe and streams remain re-readable after {@link #toXML()}.
  */
-public class PSMimeContentAdapter implements Serializable, IPSCatalogSummary, 
-   IPSCatalogItem
-{
-   /**
-    * Compiler generated serial version ID used for serialization.
-    */
-   private static final long serialVersionUID = 6520345876079600993L;
-   
-   /**
-    * This references an attachment in webservice calls for this content.
-    * If -1 then the content is transferred with this objects xml 
-    * representation, otherwise the content for this object is transferred as 
-    * attachment.
-    */
-   private long m_href = -1;
-   
-   /**
-    * The name for this content is typically a file name but it may be an
-    * unstructured descriptive name as well.
-    */
-   private String m_name = null;
-   
-   /**
-    * The mime type of this content, defaults to 
-    * <code>application/octet-stream</code>.
-    */
-   private String m_mimeType = IPSMimeContentTypes.MIME_TYPE_OCTET_STREAM;
-   
-   /**
-    * The length of this content, -1 if unknown.
-    */
-   private long m_contentLength = -1;
-   
-   /**
-    * The character encoding of this content, defaults to <code>UTF-8</code>.
-    */
-   private String m_characterEncoding = PSCharSetsConstants.rxStdEnc();
-   
-   /**
-    * The transfer encoding for this content, <code>null</code> if an 
-    * attachment id is supplied, defaults to 
-    * {@link IPSMimeContentTypes#MIME_ENC_BASE64}.
-    */
-   private String m_transferEncoding = IPSMimeContentTypes.MIME_ENC_BASE64;
-   
-   /**
-    * The input stream to the content that this object represents.
-    */
-   private InputStream m_content = null;
-   
-   /**
-    * A description about the content, may be <code>null</code> or empty.
-    */
-   private String m_description = null;
-   
-   /**
-    * The guid of this adapter, may be <code>null</code> if not set.
-    */
-   private IPSGuid m_guid = null;
-   
-   /**
-    * Get the id that references the content as attachment.
-    * 
-    * @return the attachment id, &lt; 0 if the content is contained in this object.
-    */
-   public long getAttachmentId()
-   {
-      return m_href;
-   }
-   
-   /**
-    * Set the new attchment id.
-    * 
-    * @param href the new attachment id, &lt; 0 to indicate that the
-    *    content is transferred with this object and not as attachment, 
-    *    otherwise any content already set on this object is cleared
-    */
-   public void setAttachmentId(long href)
-   {
-      m_href = href;
-      m_content = null;
-   }
-   
-   /**
-    * Is the content of this object transferred as attachment?
-    * 
-    * @return <code>true</code> if it is, <code>false</code> otherwise.
-    */
-   public boolean isContentAttached()
-   {
-      return m_href >= 0;
-   }
+@JacksonXmlRootElement(localName = "mime-content-adapter")
+@JsonAutoDetect(
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+    fieldVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonPropertyOrder({
+  "attachmentId",
+  "characterEncoding",
+  "content",
+  "contentLength",
+  "guid",
+  "mimeType",
+  "name",
+  "transferEncoding"
+})
+public class PSMimeContentAdapter implements Serializable, IPSCatalogSummary, IPSCatalogItem {
+  /** Compiler generated serial version ID used for serialization. */
+  private static final long serialVersionUID = 6520345876079600993L;
 
-   /* (non-Javadoc)
-    * @see IPSCatalogSummary#getName()
-    */
-   public String getName()
-   {
-      if (m_name == null)
-         throw new IllegalStateException("setName() was never called");
-      
-      return m_name;
-   }
-   
-   /**
-    * Set the name of this content.
-    * 
-    * @param name The name to set, never <code>null</code> or empty.
-    */
-   public void setName(String name)
-   {
-      if (StringUtils.isBlank(name))
-         throw new IllegalArgumentException("name may not be null or empty");
-      
-      m_name = name;
-   }
+  /**
+   * This references an attachment in webservice calls for this content. If -1 then the content is
+   * transferred with this objects xml representation, otherwise the content for this object is
+   * transferred as attachment.
+   */
+  private long m_href = -1;
 
-   /* (non-Javadoc)
-    * @see IPSCatalogSummary#getLabel()
-    */
-   public String getLabel()
-   {
-      return getName();
-   }
-   
-   /**
-    * Get the mime type of the content.
-    * 
-    * @return The mime type of this content, defaults to 
-    * {@link IPSMimeContentTypes#MIME_TYPE_OCTET_STREAM}, never 
-    * <code>null</code> or empty.
-    */
-   public String getMimeType()
-   {
-      return m_mimeType;
-   }
-   
-   /**
-    * Set the new mime type for this content.
-    * 
-    * @param mimeType The mime type, may not be <code>null</code> or empty.
-    */
-   public void setMimeType(String mimeType)
-   {
-      if (StringUtils.isBlank(mimeType))
-         throw new IllegalArgumentException(
-            "mimeType may not be null or empty");
-      m_mimeType = mimeType;
-   }
+  /**
+   * The name for this content is typically a file name but it may be an unstructured descriptive
+   * name as well.
+   */
+  private String m_name = null;
 
-   /**
-    * Get the content length.
-    * 
-    * @return the length, -1 if not known.
-    */
-   public long getContentLength()
-   {
-      return m_contentLength;
-   }
-   
-   /**
-    * Set the content length.
-    * 
-    * @param length The length, may not be &lt; -1
-    */
-   public void setContentLength(long length)
-   {
-      if (length < -1)
-         throw new IllegalArgumentException("length may not be < -1");
+  /**
+   * The mime type of this content, defaults to {@code application/octet-stream}.
+   */
+  private String m_mimeType = IPSMimeContentTypes.MIME_TYPE_OCTET_STREAM;
 
-      m_contentLength = length;
-   }
-   
-   /**
-    * Get the character encoding.
-    * 
-    * @return the encoding, defaults to {@link PSCharSetsConstants#rxStdEnc()}
-    * Never <code>null</code> or empty.
-    */
-   public String getCharacterEncoding()
-   {
-      return m_characterEncoding;
-   }
-   
-   /**
-    * Set the character encoding.
-    * 
-    * @param encoding The encoding, may not be <code>null</code> or empty.
-    */
-   public void setCharacterEncoding(String encoding)
-   {
-      if (StringUtils.isBlank(encoding))
-         throw new IllegalArgumentException(
-            "encoding may not be null or empty");
-      
-      m_characterEncoding = encoding;
-   }
-   
-   /**
-    * Get the transfer encoding.
-    * 
-    * @return The encoding, or <code>null</code> if 
-    * {@link #isContentAttached()} is <code>true</code>.
-    */
-   public String getTransferEncoding()
-   {
-      return m_transferEncoding;
-   }
-   
-   /**
-    * Set the transfer encoding
-    * 
-    * @param encoding The encoding, may be <code>null</code> if 
-    * {@link #isContentAttached()} is <code>true</code>, defaults to 
-    * {@link IPSMimeContentTypes#MIME_ENC_BASE64}
-    */
-   public void setTransferEncoding(String encoding)
-   {
-      m_transferEncoding = encoding;
-   }
-   
-   /* (non-Javadoc)
-    * @see IPSCatalogSummary#getDescription()
-    */
-   public String getDescription()
-   {
+  /** The length of this content, -1 if unknown. */
+  private long m_contentLength = -1;
+
+  /** The character encoding of this content, defaults to {@code UTF-8}. */
+  private String m_characterEncoding = PSCharSetsConstants.rxStdEnc();
+
+  /**
+   * The transfer encoding for this content, {@code null} if an attachment id is supplied, defaults
+   * to {@link IPSMimeContentTypes#MIME_ENC_BASE64}.
+   */
+  private String m_transferEncoding = IPSMimeContentTypes.MIME_ENC_BASE64;
+
+  /**
+   * Buffered content bytes for this object. {@code null} when unset or when content is
+   * attachment-referenced. Using a buffer (instead of a single-pass {@link InputStream}) keeps
+   * {@link #toXML()} / BeanUtils restore / repeated {@link #getContent()} order-safe.
+   */
+  private byte[] m_contentBytes = null;
+
+  /** A description about the content, may be {@code null} or empty. */
+  private String m_description = null;
+
+  /** The guid of this adapter, may be {@code null} if not set. */
+  private IPSGuid m_guid = null;
+
+  /**
+   * Get the id that references the content as attachment.
+   *
+   * @return the attachment id, &lt; 0 if the content is contained in this object.
+   */
+  @JsonProperty("attachment-id")
+  public long getAttachmentId() {
+    return m_href;
+  }
+
+  /**
+   * Set the new attchment id.
+   *
+   * @param href the new attachment id, &lt; 0 to indicate that the content is transferred with this
+   *     object and not as attachment, otherwise any content already set on this object is cleared
+   */
+  public void setAttachmentId(long href) {
+    m_href = href;
+    if (href >= 0) {
+      m_contentBytes = null;
+    }
+  }
+
+  /**
+   * Is the content of this object transferred as attachment?
+   *
+   * @return {@code true} if it is, {@code false} otherwise.
+   */
+  @JsonIgnore
+  public boolean isContentAttached() {
+    return m_href >= 0;
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogSummary#getName()
+   */
+  @JsonProperty
+  public String getName() {
+    if (m_name == null) throw new IllegalStateException("setName() was never called");
+
+    return m_name;
+  }
+
+  /**
+   * Set the name of this content.
+   *
+   * @param name The name to set, never {@code null} or empty.
+   */
+  public void setName(String name) {
+    if (StringUtils.isBlank(name))
+      throw new IllegalArgumentException("name may not be null or empty");
+
+    m_name = name;
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogSummary#getLabel()
+   */
+  @JsonIgnore
+  public String getLabel() {
+    return getName();
+  }
+
+  /**
+   * Get the mime type of the content.
+   *
+   * @return The mime type of this content, defaults to {@link
+   *     IPSMimeContentTypes#MIME_TYPE_OCTET_STREAM}, never {@code null} or empty.
+   */
+  @JsonProperty("mime-type")
+  public String getMimeType() {
+    return m_mimeType;
+  }
+
+  /**
+   * Set the new mime type for this content.
+   *
+   * @param mimeType The mime type, may not be {@code null} or empty.
+   */
+  public void setMimeType(String mimeType) {
+    if (StringUtils.isBlank(mimeType))
+      throw new IllegalArgumentException("mimeType may not be null or empty");
+    m_mimeType = mimeType;
+  }
+
+  /**
+   * Get the content length.
+   *
+   * @return the length, -1 if not known.
+   */
+  @JsonProperty("content-length")
+  public long getContentLength() {
+    return m_contentLength;
+  }
+
+  /**
+   * Set the content length.
+   *
+   * @param length The length, may not be &lt; -1
+   */
+  public void setContentLength(long length) {
+    if (length < -1) throw new IllegalArgumentException("length may not be < -1");
+
+    m_contentLength = length;
+  }
+
+  /**
+   * Get the character encoding.
+   *
+   * @return the encoding, defaults to {@link PSCharSetsConstants#rxStdEnc()} Never {@code null} or
+   *     empty.
+   */
+  @JsonProperty("character-encoding")
+  public String getCharacterEncoding() {
+    return m_characterEncoding;
+  }
+
+  /**
+   * Set the character encoding.
+   *
+   * @param encoding The encoding, may not be {@code null} or empty.
+   */
+  public void setCharacterEncoding(String encoding) {
+    if (StringUtils.isBlank(encoding))
+      throw new IllegalArgumentException("encoding may not be null or empty");
+
+    m_characterEncoding = encoding;
+  }
+
+  /**
+   * Get the transfer encoding.
+   *
+   * @return The encoding, or {@code null} if {@link #isContentAttached()} is {@code true}.
+   */
+  @JsonProperty("transfer-encoding")
+  public String getTransferEncoding() {
+    return m_transferEncoding;
+  }
+
+  /**
+   * Set the transfer encoding
+   *
+   * @param encoding The encoding, may be {@code null} if {@link #isContentAttached()} is {@code
+   *     true}, defaults to {@link IPSMimeContentTypes#MIME_ENC_BASE64}
+   */
+  public void setTransferEncoding(String encoding) {
+    m_transferEncoding = encoding;
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogSummary#getDescription()
+   */
+  @JsonIgnore
+  public String getDescription() {
+    return null;
+  }
+
+  /**
+   * Get the content.
+   *
+   * @return An input stream to the content, or {@code null} if {@link #isContentAttached()} is
+   *     {@code true}. Each call returns a fresh stream over the buffered bytes.
+   */
+  @JsonIgnore
+  public InputStream getContent() {
+    if (isContentAttached()) {
       return null;
-   }
+    }
+    if (m_contentBytes == null) {
+      return new ByteArrayInputStream(new byte[0]);
+    }
+    return new ByteArrayInputStream(m_contentBytes);
+  }
 
-   /**
-    * Get the content.
-    * 
-    * @return An input stream to the content, or <code>null</code> if 
-    * {@link #isContentAttached()} is <code>true</code>.
-    */
-   public InputStream getContent()
-   {
-      InputStream content = m_content;
-      if (content == null && !isContentAttached())
-         content = new ByteArrayInputStream(new byte[0]);
-      
-      return content;
-   }
-   
-   /**
-    * Set the content.
-    * 
-    * @param content The content, may be <code>null</code> if an attachment
-    * id has been supplied.
-    */
-   public void setContent(InputStream content)
-   {
-      if (content == null && m_href == -1)
-         throw new IllegalArgumentException(
-            "content may not be null if an attachment id is not specified.");
-      
-      m_content = content;
-      m_href = -1;
-   }
+  /**
+   * Set the content. Reads and buffers the stream so subsequent {@link #getContent()} and design
+   * XML serialization remain independent of the caller's stream lifecycle.
+   *
+   * <p>Pass {@code null} to clear buffered content (BeanUtils XML restore may copy a null {@code
+   * content} property before {@code attachment-id} is applied — same null-safe pattern as {@code
+   * PSSharedProperty#setVersion}).
+   *
+   * @param content The content stream, may be {@code null} to clear.
+   */
+  @JsonIgnore
+  public void setContent(InputStream content) {
+    if (content == null) {
+      m_contentBytes = null;
+      return;
+    }
+    try {
+      m_contentBytes = content.readAllBytes();
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Failed to read content stream", e);
+    }
+    m_href = -1;
+  }
 
-   /* (non-Javadoc)
-    * @see IPSCatalogSummary#getGUID()
-    */
-   public IPSGuid getGUID()
-   {
-      if (m_guid == null)
-         throw new IllegalStateException("guid has not been set");
-      
-      return m_guid;
-   }
+  /**
+   * Design-XML accessor for inline payload: base64 of the buffered content bytes when not
+   * attachment-bound.
+   *
+   * @return base64 text, empty string when content is empty/unset and not attached, or {@code null}
+   *     when content is attachment-referenced (property omitted on write)
+   */
+  @JsonProperty("content")
+  public String getContentBase64() {
+    if (isContentAttached()) {
+      return null;
+    }
+    if (m_contentBytes == null || m_contentBytes.length == 0) {
+      return "";
+    }
+    return Base64.getEncoder().encodeToString(m_contentBytes);
+  }
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#setGUID(IPSGuid)
-    */
-   public void setGUID(IPSGuid newguid) throws IllegalStateException
-   {
-      if (newguid == null)
-         throw new IllegalArgumentException("newguid may not be null");
-      
-      if (m_guid != null)
-         throw new IllegalStateException("guid has already been set");
-      
-      if (newguid.getType() != PSTypeEnum.CONFIGURATION.getOrdinal())
-         throw new IllegalArgumentException("invalid guid type");
-      
-      m_guid = newguid;
-   }
+  /**
+   * Design-XML mutator for inline payload. Decodes base64 into the content buffer and clears any
+   * attachment id (inline content wins).
+   *
+   * @param encoded base64 text, may be {@code null} (clears buffer) or empty (empty buffer)
+   */
+  @JsonProperty("content")
+  public void setContentBase64(String encoded) {
+    if (encoded == null) {
+      m_contentBytes = null;
+      return;
+    }
+    m_contentBytes = encoded.isEmpty() ? new byte[0] : Base64.getDecoder().decode(encoded);
+    m_href = -1;
+  }
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#fromXML(String)
-    */
-   public void fromXML(String xmlsource) throws IOException, SAXException
-   {
-      PSXmlSerializationHelper.readFromXML(xmlsource, this);
-   }
+  /* (non-Javadoc)
+   * @see IPSCatalogSummary#getGUID()
+   */
+  @JsonProperty("guid")
+  public IPSGuid getGUID() {
+    if (m_guid == null) throw new IllegalStateException("guid has not been set");
 
-   /* (non-Javadoc)
-    * @see IPSCatalogItem#toXML()
-    */
-   public String toXML() throws IOException, SAXException
-   {
-      return PSXmlSerializationHelper.writeToXml(this);
-   }
+    return m_guid;
+  }
 
-   @Override
-   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof PSMimeContentAdapter)) return false;
-      PSMimeContentAdapter that = (PSMimeContentAdapter) o;
-      return m_href == that.m_href && m_contentLength == that.m_contentLength && Objects.equals(m_name, that.m_name) && Objects.equals(m_mimeType, that.m_mimeType) && Objects.equals(m_characterEncoding, that.m_characterEncoding) && Objects.equals(m_transferEncoding, that.m_transferEncoding) && Objects.equals(m_content, that.m_content) && Objects.equals(m_description, that.m_description) && Objects.equals(m_guid, that.m_guid);
-   }
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#setGUID(IPSGuid)
+   */
+  public void setGUID(IPSGuid newguid) throws IllegalStateException {
+    if (newguid == null) throw new IllegalArgumentException("newguid may not be null");
 
-   @Override
-   public int hashCode() {
-      return Objects.hash(m_href, m_name, m_mimeType, m_contentLength, m_characterEncoding, m_transferEncoding, m_content, m_description, m_guid);
-   }
+    if (m_guid != null) throw new IllegalStateException("guid has already been set");
+
+    if (newguid.getType() != PSTypeEnum.CONFIGURATION.getOrdinal())
+      throw new IllegalArgumentException("invalid guid type");
+
+    m_guid = newguid;
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#fromXML(String)
+   */
+  public void fromXML(String xmlsource) throws IOException, SAXException {
+    PSXmlSerializationHelper.readFromXML(xmlsource, this);
+  }
+
+  /* (non-Javadoc)
+   * @see IPSCatalogItem#toXML()
+   */
+  public String toXML() throws IOException, SAXException {
+    return PSXmlSerializationHelper.writeToXml(this);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof PSMimeContentAdapter)) return false;
+    PSMimeContentAdapter that = (PSMimeContentAdapter) o;
+    return m_href == that.m_href
+        && m_contentLength == that.m_contentLength
+        && Objects.equals(m_name, that.m_name)
+        && Objects.equals(m_mimeType, that.m_mimeType)
+        && Objects.equals(m_characterEncoding, that.m_characterEncoding)
+        && Objects.equals(m_transferEncoding, that.m_transferEncoding)
+        && Objects.deepEquals(m_contentBytes, that.m_contentBytes)
+        && Objects.equals(m_description, that.m_description)
+        && Objects.equals(m_guid, that.m_guid);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        m_href,
+        m_name,
+        m_mimeType,
+        m_contentLength,
+        m_characterEncoding,
+        m_transferEncoding,
+        java.util.Arrays.hashCode(m_contentBytes),
+        m_description,
+        m_guid);
+  }
 }
-

--- a/system/src/test/java/com/percussion/services/system/data/PSMimeContentAdapterTest.java
+++ b/system/src/test/java/com/percussion/services/system/data/PSMimeContentAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,11 @@
  */
 package com.percussion.services.system.data;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.content.IPSMimeContentTypes;
 import com.percussion.services.catalog.PSTypeEnum;
@@ -26,39 +30,32 @@ import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.tools.PSTestUtils;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
 
-/** Unit tests for the {@link PSMimeContentAdapter} class. */
-public class PSMimeContentAdapterTest {
+/** Unit tests for the {@link PSMimeContentAdapter} class (programming interface + buffering). */
+class PSMimeContentAdapterTest {
+
   /**
    * Tests the programming interface.
    *
    * @throws Exception If the test fails
    */
-  public void testInterface() throws Exception {
+  @Test
+  void testInterface() throws Exception {
     String data = "some content...";
-    ByteArrayInputStream in = new ByteArrayInputStream(data.getBytes());
+    ByteArrayInputStream in = new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
 
     PSMimeContentAdapter content = new PSMimeContentAdapter();
     // test defaults
-    assertEquals(content.getCharacterEncoding(), PSCharSetsConstants.rxStdEnc());
-    assertEquals(content.getMimeType(), IPSMimeContentTypes.MIME_TYPE_OCTET_STREAM);
-    assertEquals(content.getTransferEncoding(), IPSMimeContentTypes.MIME_ENC_BASE64);
+    assertEquals(PSCharSetsConstants.rxStdEnc(), content.getCharacterEncoding());
+    assertEquals(IPSMimeContentTypes.MIME_TYPE_OCTET_STREAM, content.getMimeType());
+    assertEquals(IPSMimeContentTypes.MIME_ENC_BASE64, content.getTransferEncoding());
     assertNotNull(content.getContent());
-    assertTrue(content.getContentLength() == -1);
+    assertEquals(-1, content.getContentLength());
 
-    try {
-      content.getGUID();
-      fail("should have thrown");
-    } catch (IllegalStateException e) {
-      // TODO: handle exception
-    }
-
-    try {
-      content.getName();
-      fail("should have thrown");
-    } catch (IllegalStateException e) {
-      // TODO: handle exception
-    }
+    assertThrows(IllegalStateException.class, content::getGUID);
+    assertThrows(IllegalStateException.class, content::getName);
 
     // test setters
     PSTestUtils.testSetter(content, "GUID", null, IPSGuid.class, true);
@@ -69,28 +66,32 @@ public class PSMimeContentAdapterTest {
     PSTestUtils.testSetter(content, "Name", null, true);
     PSTestUtils.testSetter(content, "Name", "", true);
     PSTestUtils.testSetter(content, "Name", "test", false);
-    PSTestUtils.testSetter(content, "Content", null, InputStream.class, true);
+    // Null content clears the buffer (BeanUtils-safe for XML restore property order).
+    content.setContent(null);
+    assertNotNull(content.getContent());
+    assertEquals(0, content.getContent().readAllBytes().length);
     PSTestUtils.testSetter(content, "Content", in, InputStream.class, false);
-    PSTestUtils.testSetter(content, "ContentLength", new Long(-2), long.class, true);
-    PSTestUtils.testSetter(content, "ContentLength", new Long(100), long.class, false);
+    assertEquals(data, new String(content.getContent().readAllBytes(), StandardCharsets.UTF_8));
+    // Stream is buffered — second read still returns the payload.
+    assertEquals(data, new String(content.getContent().readAllBytes(), StandardCharsets.UTF_8));
+    PSTestUtils.testSetter(content, "ContentLength", Long.valueOf(-2), long.class, true);
+    PSTestUtils.testSetter(content, "ContentLength", Long.valueOf(100), long.class, false);
     PSTestUtils.testSetter(content, "MimeType", null, true);
     PSTestUtils.testSetter(content, "MimeType", "", true);
     PSTestUtils.testSetter(content, "MimeType", "test", false);
 
-    try {
-      content.setGUID(new PSGuid(PSTypeEnum.CONFIGURATION, 456));
-      fail("should have thrown");
-    } catch (IllegalStateException e) {
-      // TODO: handle exception
-    }
+    assertThrows(
+        IllegalStateException.class,
+        () -> content.setGUID(new PSGuid(PSTypeEnum.CONFIGURATION, 456)));
 
     PSTestUtils.testSetter(content, "CharacterEncoding", null, true);
     PSTestUtils.testSetter(content, "CharacterEncoding", "", true);
 
-    PSTestUtils.testSetter(content, "AttachmentId", new Long(1), long.class, false);
+    PSTestUtils.testSetter(content, "AttachmentId", Long.valueOf(1), long.class, false);
     assertNull(content.getContent());
+    assertTrue(content.isContentAttached());
 
-    content.setContent(in);
-    assertEquals(content.getAttachmentId(), -1);
+    content.setContent(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)));
+    assertEquals(-1, content.getAttachmentId());
   }
 }

--- a/system/src/test/java/com/percussion/services/system/data/PSSystemDataXmlSerializationTest.java
+++ b/system/src/test/java/com/percussion/services/system/data/PSSystemDataXmlSerializationTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -40,7 +41,7 @@ import org.xml.sax.InputSource;
 
 /**
  * Golden / round-trip tests for system design objects under the Jackson-backed {@code
- * PSXmlSerializationHelper} (issues #1920 / #1993, epic #505). Offline only — no live CMS.
+ * PSXmlSerializationHelper} (issues #1920 / #1993 / #1994, epic #505). Offline only — no live CMS.
  */
 class PSSystemDataXmlSerializationTest {
 
@@ -248,10 +249,12 @@ class PSSystemDataXmlSerializationTest {
     assertNull(property.getVersion());
     property.setVersion(2);
     assertEquals(2, property.getVersion());
-    assertThrows(IllegalArgumentException.class, () -> {
-      property.setVersion(null);
-      property.setVersion(-1);
-    });
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          property.setVersion(null);
+          property.setVersion(-1);
+        });
   }
 
   @Test
@@ -363,6 +366,108 @@ class PSSystemDataXmlSerializationTest {
     assertEquals(PSTypeEnum.CONTENT_LIST.name(), restored.getDependents().get(0).getType());
   }
 
+  @Test
+  void mimeContentAdapterWriteShapeAndGolden() throws Exception {
+    PSMimeContentAdapter original = sampleMimeContentInline();
+    String xml = original.toXML();
+
+    assertNotNull(xml);
+    assertFalse(xml.trim().startsWith("<null"), xml);
+    assertTrue(containsTag(xml, "mime-content-adapter"), "root: " + xml);
+    assertTrue(containsTag(xml, "attachment-id"), xml);
+    assertTrue(containsTag(xml, "character-encoding"), xml);
+    assertTrue(containsTag(xml, "content"), xml);
+    assertTrue(containsTag(xml, "content-length"), xml);
+    assertTrue(containsTag(xml, "guid"), xml);
+    assertTrue(containsTag(xml, "mime-type"), xml);
+    assertTrue(containsTag(xml, "name"), xml);
+    assertTrue(containsTag(xml, "transfer-encoding"), xml);
+    assertFalse(containsTag(xml, "label"), "label alias suppressed: " + xml);
+    assertFalse(containsTag(xml, "content-attached"), "derived flag suppressed: " + xml);
+    assertFalse(containsTag(xml, "description"), "always-null description suppressed: " + xml);
+    // base64 of UTF-8 "sample-config-body"
+    assertTrue(xml.contains("c2FtcGxlLWNvbmZpZy1ib2R5"), xml);
+    assertTrue(xml.contains("WORKFLOW_CONFIG"), xml);
+
+    String golden =
+        loadResource("com/percussion/services/system/data/ps-mime-content-adapter-golden.xml");
+    assertLogicalXmlParity(golden, xml);
+  }
+
+  @Test
+  void mimeContentAdapterRoundTripRestoresInlineBase64Content() throws Exception {
+    PSMimeContentAdapter original = sampleMimeContentInline();
+    byte[] originalBytes = original.getContent().readAllBytes();
+    String xml = original.toXML();
+
+    PSMimeContentAdapter restored = new PSMimeContentAdapter();
+    restored.fromXML(xml);
+
+    assertEquals(original.getAttachmentId(), restored.getAttachmentId());
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getMimeType(), restored.getMimeType());
+    assertEquals(original.getContentLength(), restored.getContentLength());
+    assertEquals(original.getCharacterEncoding(), restored.getCharacterEncoding());
+    assertEquals(original.getTransferEncoding(), restored.getTransferEncoding());
+    assertEquals(original.getGUID().toString(), restored.getGUID().toString());
+    assertFalse(restored.isContentAttached());
+    byte[] restoredBytes = restored.getContent().readAllBytes();
+    assertEquals(
+        new String(originalBytes, StandardCharsets.UTF_8),
+        new String(restoredBytes, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void mimeContentAdapterRoundTripRestoresAttachmentHref() throws Exception {
+    PSMimeContentAdapter original = sampleMimeContentAttached();
+    String xml = original.toXML();
+
+    assertTrue(containsTag(xml, "attachment-id"), xml);
+    // Null content property is omitted (or empty) when attachment-referenced.
+    assertFalse(xml.contains("c2FtcGxl"), "no inline body when attached: " + xml);
+
+    PSMimeContentAdapter restored = new PSMimeContentAdapter();
+    restored.fromXML(xml);
+
+    assertEquals(42L, restored.getAttachmentId());
+    assertTrue(restored.isContentAttached());
+    assertNull(restored.getContent());
+    assertEquals("ATTACHED_CONFIG", restored.getName());
+    assertEquals(original.getGUID().toString(), restored.getGUID().toString());
+  }
+
+  @Test
+  void mimeContentAdapterFromXmlAcceptsLegacyNullRoot() throws Exception {
+    String legacy =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <null>
+          <attachment-id>-1</attachment-id>
+          <character-encoding>UTF-8</character-encoding>
+          <content>c2FtcGxlLWNvbmZpZy1ib2R5</content>
+          <content-length>18</content-length>
+          <guid>0-34-100</guid>
+          <mime-type>text/xml</mime-type>
+          <name>LEGACY_CONFIG</name>
+          <transfer-encoding>base64</transfer-encoding>
+        </null>
+        """;
+
+    PSMimeContentAdapter restored = new PSMimeContentAdapter();
+    restored.fromXML(legacy);
+
+    assertEquals(-1L, restored.getAttachmentId());
+    assertEquals("LEGACY_CONFIG", restored.getName());
+    assertEquals("text/xml", restored.getMimeType());
+    assertEquals(18L, restored.getContentLength());
+    assertEquals("UTF-8", restored.getCharacterEncoding());
+    assertEquals("base64", restored.getTransferEncoding());
+    assertEquals(100L, restored.getGUID().getUUID());
+    assertEquals(
+        "sample-config-body",
+        new String(restored.getContent().readAllBytes(), StandardCharsets.UTF_8));
+  }
+
   private static PSAudit sampleAudit() {
     PSAudit audit = new PSAudit();
     audit.setId(1001L);
@@ -437,6 +542,31 @@ class PSSystemDataXmlSerializationTest {
     dependency.addDependent(sampleDependent(2001L, PSTypeEnum.TEMPLATE.name()));
     dependency.addDependent(sampleDependent(2002L, PSTypeEnum.ITEM_FILTER.name()));
     return dependency;
+  }
+
+  private static PSMimeContentAdapter sampleMimeContentInline() {
+    PSMimeContentAdapter content = new PSMimeContentAdapter();
+    content.setGUID(new PSGuid(PSTypeEnum.CONFIGURATION, 100L));
+    content.setName("WORKFLOW_CONFIG");
+    content.setMimeType("text/xml");
+    content.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    content.setTransferEncoding("base64");
+    byte[] body = "sample-config-body".getBytes(StandardCharsets.UTF_8);
+    content.setContent(new ByteArrayInputStream(body));
+    content.setContentLength(body.length);
+    return content;
+  }
+
+  private static PSMimeContentAdapter sampleMimeContentAttached() {
+    PSMimeContentAdapter content = new PSMimeContentAdapter();
+    content.setGUID(new PSGuid(PSTypeEnum.CONFIGURATION, 200L));
+    content.setName("ATTACHED_CONFIG");
+    content.setMimeType("application/octet-stream");
+    content.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    content.setTransferEncoding("base64");
+    content.setAttachmentId(42L);
+    content.setContentLength(-1);
+    return content;
   }
 
   /** 2024-01-15T12:00:00.000Z as {@link Date}. */

--- a/system/src/test/resources/com/percussion/services/system/data/ps-mime-content-adapter-golden.xml
+++ b/system/src/test/resources/com/percussion/services/system/data/ps-mime-content-adapter-golden.xml
@@ -1,0 +1,13 @@
+<!-- Golden snapshot for production PSMimeContentAdapter Jackson wire shape
+	(issue #1994 / epic #505). Inline content is base64; label/description/ content-attached
+	suppressed. -->
+<mime-content-adapter>
+	<attachment-id>-1</attachment-id>
+	<character-encoding>UTF-8</character-encoding>
+	<content>c2FtcGxlLWNvbmZpZy1ib2R5</content>
+	<content-length>18</content-length>
+	<guid>0-34-100</guid>
+	<mime-type>text/xml</mime-type>
+	<name>WORKFLOW_CONFIG</name>
+	<transfer-encoding>base64</transfer-encoding>
+</mime-content-adapter>


### PR DESCRIPTION
## Summary

Jackson-migrate `PSMimeContentAdapter` (system design-object XML) for epic #505 residual of #1920.

- Opt-in Jackson annotations; root `mime-content-adapter`
- Inline payload as standard **base64** under `content` (`getContentBase64` / `setContentBase64`)
- API `InputStream` surface remains; content buffered as `byte[]` for BeanUtils-safe restore and re-readable streams after `toXML`
- Attachment mode via `attachment-id` (inline content omitted)
- Suppress `label`, `content-attached`, `description`
- Golden + RT (inline + attachment) + legacy `<null>` root tests
- Interface test migrated to JUnit 5
- Deviations: `docs/ai-generated/tasks/505-betwixt-jackson/1994-mime-content-adapter-deviations.md`

**Fixes #1994**  
Related: #1920 #1892 #1823 #505

Operator: Grok: night-issue-prs (model grok-4.5)

## Out of scope

- PSDependency / PSDependent (#1993 — separate)
- Betwixt POM removal (#1824)
- SOAP webservice DTO / converter

## Test plan

- [x] `cd system && ../mvnw clean install` → **BUILD SUCCESS**
- [x] `PSSystemDataXmlSerializationTest` — 20 tests (incl. 4 mime-content-adapter)
- [x] `PSMimeContentAdapterTest` — 1 test (JUnit 5 interface)
- [x] Spotless: `cd system && ../mvnw spotless:apply` then `spotless:check` for in-scope files; out-of-scope monorepo reformats not included
- [x] Erlang self-review: `docs/ai-generated/code-reviews/issue-1994-mime-content-adapter-jackson-erlang.md` → PASS

### Gates evidence

| Gate | Result |
|------|--------|
| Module clean install | `cd system; ..\mvnw.cmd clean install` → BUILD SUCCESS |
| Focused tests | 21/21 green (`PSSystemDataXmlSerializationTest` + `PSMimeContentAdapterTest`) |
| Spotless | apply then check on system; feature PR contains only in-scope files |
| Erlang | PASS (see code-review doc) |
| Cross-platform paths | No new filesystem path construction |

## Residuals

None for this slice. #1824 remains epic residual (Betwixt POM).