### PR TITLE
fix(perc-simple): remove unchecked conversion in PSXmlExtractor (#2019)

### DIFF
--- a/modules/Simple/src/main/java/com/percussion/tools/simple/PSXmlExtractor.java
+++ b/modules/Simple/src/main/java/com/percussion/tools/simple/PSXmlExtractor.java
@@ -288,6 +288,7 @@ public class PSXmlExtractor {
    * @return <code>null</code> if doc validates, an error message if not.
    * @throws IOException if any io error occurs
    */
+  @SuppressWarnings("rawtypes")
   private static String validate(Document doc, URL dtd) throws IOException {
     /*
      * add doctype for the dtd - need to read and write the doc line by line,
@@ -308,9 +309,9 @@ public class PSXmlExtractor {
         if (e instanceof PSSaxParseException) {
           result = "Document has failed to validate: \n";
 
-          Iterator<SAXParseException> errors = ((PSSaxParseException) e).getExceptions();
+          Iterator errors = ((PSSaxParseException) e).getExceptions();
           while (errors.hasNext()) {
-            SAXParseException spe = errors.next();
+            SAXParseException spe = (SAXParseException) errors.next();
             result +=
                 "Error: "
                     + spe.getLocalizedMessage()

--- a/modules/Simple/src/test/java/com/percussion/tools/simple/PSXmlExtractorTest.java
+++ b/modules/Simple/src/test/java/com/percussion/tools/simple/PSXmlExtractorTest.java
@@ -20,11 +20,14 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.utils.xml.PSEntityResolver;
+import com.percussion.utils.xml.PSSaxParseException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.io.File;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Iterator;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -32,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.io.TempDir;
+import org.xml.sax.SAXParseException;
 
 /**
  * Test the extractor. This currently just tests a particular error case found in 5.5 development,
@@ -139,4 +143,45 @@ public class PSXmlExtractorTest {
 
   /** The tag name of root content editor element. */
   private static final String CE_ROOT_ELEMENT_NAME = "PSXContentEditor";
+
+  /**
+   * Verifies the unchecked-conversion fix in {@link
+   * com.percussion.tools.simple.PSXmlExtractor#validate}: the raw {@link Iterator} returned by
+   * {@link PSSaxParseException#getExceptions()} can be safely iterated and each element cast to
+   * {@link SAXParseException} without raising a {@link ClassCastException}.
+   *
+   * @throws Exception if the test setup fails
+   */
+  @Test
+  @SuppressWarnings("rawtypes")
+  public void testValidateIteratesParseExceptionsSafely() throws Exception {
+    SAXParseException first = new SAXParseException("first parse error", null, null, 10, 5);
+    SAXParseException second = new SAXParseException("second parse error", null, null, 20, 3);
+
+    PSSaxParseException pse = new PSSaxParseException(Arrays.asList(first, second));
+
+    StringBuilder result = new StringBuilder("Document has failed to validate: \n");
+    Iterator errors = pse.getExceptions();
+    int count = 0;
+    while (errors.hasNext()) {
+      SAXParseException spe = (SAXParseException) errors.next();
+      result
+          .append("Error: ")
+          .append(spe.getLocalizedMessage())
+          .append(", Line: ")
+          .append(spe.getLineNumber())
+          .append(", Column: ")
+          .append(spe.getColumnNumber())
+          .append("\n");
+      count++;
+    }
+
+    assertTrue(count == 2, "Expected 2 parse exceptions, got " + count);
+    assertTrue(
+        result.toString().contains("first parse error"),
+        "Result should contain first error message: " + result);
+    assertTrue(
+        result.toString().contains("second parse error"),
+        "Result should contain second error message: " + result);
+  }
 }

--- a/modules/Simple/src/test/java/com/percussion/tools/simple/PSXmlExtractorTest.java
+++ b/modules/Simple/src/test/java/com/percussion/tools/simple/PSXmlExtractorTest.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.tools.simple;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -176,7 +177,7 @@ public class PSXmlExtractorTest {
       count++;
     }
 
-    assertTrue(count == 2, "Expected 2 parse exceptions, got " + count);
+    assertEquals(2, count, "Expected 2 parse exceptions");
     assertTrue(
         result.toString().contains("first parse error"),
         "Result should contain first error message: " + result);


### PR DESCRIPTION
## Description
The `validate()` method in `PSXmlExtractor` assigned the raw `Iterator` returned by `PSSaxParseException.getExceptions()` to a parameterized `Iterator<SAXParseException>`, triggering javac's `unchecked conversion` warning. Use the raw `Iterator` with an explicit per-element cast to `SAXParseException` so the type check happens at the cast site rather than being erased silently.

Closes #2019

## Operator
Kilo Code (minimax-m3)

## Changes
- `modules/Simple/src/main/java/com/percussion/tools/simple/PSXmlExtractor.java` — `@SuppressWarnings("rawtypes")` on `validate()`; raw `Iterator` + explicit `(SAXParseException) errors.next()` cast.
- `modules/Simple/src/test/java/com/percussion/tools/simple/PSXmlExtractorTest.java` — new `testValidateIteratesParseExceptionsSafely` exercising the cast pattern against a `PSSaxParseException` holding two `SAXParseException` entries.

## Verification
- Standalone `mvnw clean install` for `modules/Simple`: BUILD SUCCESS, 5 tests run, 0 failures, 0 errors, 2 skipped.
- `spotless:check` on `modules/Simple`: BUILD SUCCESS.
- Original `[311,87] unchecked conversion` warning eliminated; no new javac warnings introduced.