### PR TITLE
fix(feeds): suppress this-escape warning in PSFeedsApplication (#2027)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/PSFeedsApplication.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/PSFeedsApplication.java
@@ -43,6 +43,7 @@ public class PSFeedsApplication extends ResourceConfig {
    * Registers the request-scoped filter, Spring component provider, lifecycle listeners, the feed
    * REST service, JSON binding provider, and exception mappers used by the feeds application.
    */
+  @SuppressWarnings("this-escape")
   public PSFeedsApplication() {
     register(RequestContextFilter.class);
     register(SpringComponentProvider.class);


### PR DESCRIPTION
## Description
The constructor of `PSFeedsApplication` calls the overridable `ResourceConfig#register` method to wire up JAX-RS providers and resources, triggering javac's `this escape` warning because overridable methods are invoked before the subclass is fully initialized.

Annotate the constructor with `@SuppressWarnings("this-escape")` to document that the constructor intentionally delegates registration to `ResourceConfig` and is not designed for further subclassing.

Closes #2027

## Operator
Kilo Code (minimax-m3)

## Changes
- `deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/PSFeedsApplication.java` — `@SuppressWarnings("this-escape")` on the constructor.

## Verification
- Standalone `mvnw clean install` for the feeds module: BUILD SUCCESS.
- `spotless:check` on the feeds module: BUILD SUCCESS.
- Original `[47,13] this escape` warning eliminated; no new javac warnings introduced.