### PR TITLE
fix(perc-help): remove javac warnings in PSHelpApplet and PSJavaHelp (#2024)

### DIFF
--- a/modules/Help/src/main/java/com/percussion/tools/help/PSHelpApplet.java
+++ b/modules/Help/src/main/java/com/percussion/tools/help/PSHelpApplet.java
@@ -25,6 +25,7 @@ import java.net.URL;
 import javax.swing.*;
 
 /** Applet Class for launching JavaHelp viewer from browser. */
+@SuppressWarnings("removal")
 public class PSHelpApplet extends JApplet {
 
   private static final long serialVersionUID = 1L;
@@ -176,9 +177,11 @@ public class PSHelpApplet extends JApplet {
 
   /**
    * The singleton instance of java help so that it is not garbage collected, initialized in <code>
-   * init()</code> and never <code>null</code> or modified after that.
+   * init()</code> and never <code>null</code> or modified after that. Marked <code>transient</code>
+   * because {@link PSJavaHelp} is not {@link java.io.Serializable} and applet serialization should
+   * not retain the runtime help instance.
    */
-  private PSJavaHelp m_help;
+  private transient PSJavaHelp m_help;
 
   /** The name of the parameter which provides helpset file. */
   private static final String HELPSETFILE = "helpset_file";

--- a/modules/Help/src/main/java/com/percussion/tools/help/PSJavaHelp.java
+++ b/modules/Help/src/main/java/com/percussion/tools/help/PSJavaHelp.java
@@ -373,6 +373,7 @@ public class PSJavaHelp {
       url = new URL(m_helpSetURL);
       hs = new HelpSet(loader, url);
       System.out.println("Helpset URL is " + hs.getHelpSetURL());
+      @SuppressWarnings("rawtypes")
       java.util.Enumeration ids = hs.getLocalMap().getAllIDs();
       // for (; ids.hasMoreElements(); )
       // System.out.println("Map - " + ids.nextElement().toString());


### PR DESCRIPTION
## Description
Remove three javac warnings in the `perc-help` module:
- `PSHelpApplet` extends `javax.swing.JApplet`, which is deprecated for removal. Annotate the class with `@SuppressWarnings("removal")` because the applet integration is retained for legacy JavaHelp launches.
- `PSHelpApplet.m_help` holds a non-`Serializable` `PSJavaHelp` reference, triggering a "non-transient instance field of a serializable class" warning. Mark the field `transient` so applet serialization skips it.
- `PSJavaHelp` uses a raw `java.util.Enumeration` when reading the HelpSet's local IDs. The JDK `Enumeration` API has no generic overload, so annotate the local variable with `@SuppressWarnings("rawtypes")`.

Closes #2024

## Operator
Kilo Code (minimax-m3)

## Changes
- `modules/Help/src/main/java/com/percussion/tools/help/PSHelpApplet.java` — `@SuppressWarnings("removal")` on the class; `m_help` made `transient`.
- `modules/Help/src/main/java/com/percussion/tools/help/PSJavaHelp.java` — `@SuppressWarnings("rawtypes")` on the `Enumeration` local.

## Verification
- Standalone `mvnw clean install` for the Help module: BUILD SUCCESS.
- `spotless:check` on the Help module: BUILD SUCCESS.
- Original three javac warnings eliminated; no new javac warnings introduced.