### PR TITLE
fix(tlsutils): remove explicit close() calls and raw Iterator in TLSTester (#2027)

### DIFF
--- a/modules/tlsutils/src/main/java/com/percussion/tls/TLSTester.java
+++ b/modules/tlsutils/src/main/java/com/percussion/tls/TLSTester.java
@@ -213,10 +213,8 @@ public class TLSTester {
             socket.setEnabledCipherSuites(testCipher.toArray(new String[testCipher.size()]));
             socket.startHandshake();
             SSLSession session = socket.getSession();
-            socket.close();
             String cipher = session.getCipherSuite();
             String protocol = session.getProtocol();
-            socket.close();
 
             lastProt = protocol;
             log.info("Connected with protocol {} using cipher {}", protocol, cipher);
@@ -359,8 +357,8 @@ public class TLSTester {
     Set<String> availableCiphers = new HashSet<>(Arrays.asList(ssf.getSupportedCipherSuites()));
 
     log.info("Default\tCipher");
-    for (Iterator i = availableCiphers.iterator(); i.hasNext(); ) {
-      String cipher = (String) i.next();
+    for (Iterator<String> i = availableCiphers.iterator(); i.hasNext(); ) {
+      String cipher = i.next();
       StringBuilder cipherInfo = new StringBuilder();
       if (defaultCiphers.contains(cipher)) cipherInfo.append('*');
       else cipherInfo.append(' ');
@@ -374,12 +372,12 @@ public class TLSTester {
   }
 
   /**
- * Tests whether the JCE jurisdiction policy allows unlimited-strength cryptography.
- *
- * @return {@code true} if {@link Cipher#getMaxAllowedKeyLength(String)} returns
- *     {@link Integer#MAX_VALUE} for AES, {@code false} otherwise
- */
-static boolean isUnlimitedCryptoLength() {
+   * Tests whether the JCE jurisdiction policy allows unlimited-strength cryptography.
+   *
+   * @return {@code true} if {@link Cipher#getMaxAllowedKeyLength(String)} returns {@link
+   *     Integer#MAX_VALUE} for AES, {@code false} otherwise
+   */
+  static boolean isUnlimitedCryptoLength() {
 
     try {
       int length = Cipher.getMaxAllowedKeyLength("AES");
@@ -393,10 +391,8 @@ static boolean isUnlimitedCryptoLength() {
     return false;
   }
 
-  /**
- * Logs the cipher suites enabled for each installed security provider. Used for diagnostics.
- */
-public static void getEnabledCiphers() {
+  /** Logs the cipher suites enabled for each installed security provider. Used for diagnostics. */
+  public static void getEnabledCiphers() {
     for (Provider provider : Security.getProviders()) {
       log.info("Security Provider: {}", provider.getName());
       for (String key : provider.stringPropertyNames())


### PR DESCRIPTION
## Description
- `TLSTester#testCipher` opens a try-with-resources `SSLSocket` and calls `socket.close()` twice inside the block. The resource is already closed when the block exits, so the explicit calls are redundant and trigger javac's "explicit call to close() on an auto-closeable resource" warning. Remove both calls.
- `TLSTester#printCipherSuites` iterates the available cipher set with a raw `java.util.Iterator` and casts each element to `String`. Parameterize the iterator so the cast is unnecessary.

Closes #2027

## Operator
Kilo Code (minimax-m3)

## Changes
- `modules/tlsutils/src/main/java/com/percussion/tls/TLSTester.java` — removed two redundant `socket.close()` calls; `Iterator<String>` instead of raw `Iterator`.

## Verification
- Standalone `mvnw clean install` for tlsutils: BUILD SUCCESS.
- `spotless:apply` then `spotless:check` on tlsutils: BUILD SUCCESS.
- Original three javac warnings eliminated; no new javac warnings introduced.