### PR TITLE
fix(extensions-linkback): suppress this-escape and raw List warnings (#2037)

### DIFF
--- a/modules/extensions-linkback/src/main/java/com/percussion/soln/linkback/codec/impl/StringLinkBackTokenImpl.java
+++ b/modules/extensions-linkback/src/main/java/com/percussion/soln/linkback/codec/impl/StringLinkBackTokenImpl.java
@@ -140,6 +140,7 @@ public class StringLinkBackTokenImpl implements LinkbackTokenCodec {
    * @param value a string, string array, list, or other object
    * @return the first value represented as a string, or {@code null} when the input is null
    */
+  @SuppressWarnings("rawtypes")
   public static String simplifyValue(Object value) {
     if (value == null) {
       log.debug("null value");

--- a/modules/extensions-linkback/src/main/java/com/percussion/soln/linkback/servlet/ActionPanelLinkbackController.java
+++ b/modules/extensions-linkback/src/main/java/com/percussion/soln/linkback/servlet/ActionPanelLinkbackController.java
@@ -35,6 +35,7 @@ public class ActionPanelLinkbackController extends GenericLinkbackController {
   private static final String REDIRECT_PATH = "/ui/actionpage/panel";
 
   /** Creates a controller configured for the Action Panel redirect. */
+  @SuppressWarnings("this-escape")
   public ActionPanelLinkbackController() {
     super();
     setRedirectPath(REDIRECT_PATH);

--- a/modules/extensions-linkback/src/main/java/com/percussion/soln/linkback/servlet/ContentExplorerLinkbackController.java
+++ b/modules/extensions-linkback/src/main/java/com/percussion/soln/linkback/servlet/ContentExplorerLinkbackController.java
@@ -35,6 +35,7 @@ public class ContentExplorerLinkbackController extends GenericLinkbackController
   private static final String REDIRECT_PATH = "/sys_cx/mainpage.html";
 
   /** Creates a controller configured for the Content Explorer redirect. */
+  @SuppressWarnings("this-escape")
   public ContentExplorerLinkbackController() {
     super();
     setRedirectPath(REDIRECT_PATH);


### PR DESCRIPTION
## Description
- `ActionPanelLinkbackController` and `ContentExplorerLinkbackController` call overridable setters (`setRedirectPath`, `setRequiredParameterNames`) from their constructors, triggering javac's "this escape" warning. Annotate both constructors with `@SuppressWarnings("this-escape")`.
- `StringLinkBackTokenImpl.simplifyValue` handles `Object` values typed by the caller; the `instanceof List` branch uses a raw `java.util.List` reference. The handler is intentionally type-agnostic, so annotate the method with `@SuppressWarnings("rawtypes")`.

Closes #2037

## Operator
Kilo Code (minimax-m3)

## Changes
- `modules/extensions-linkback/src/main/java/com/percussion/soln/linkback/servlet/ActionPanelLinkbackController.java` — `@SuppressWarnings("this-escape")` on constructor.
- `modules/extensions-linkback/src/main/java/com/percussion/soln/linkback/servlet/ContentExplorerLinkbackController.java` — `@SuppressWarnings("this-escape")` on constructor.
- `modules/extensions-linkback/src/main/java/com/percussion/soln/linkback/codec/impl/StringLinkBackTokenImpl.java` — `@SuppressWarnings("rawtypes")` on `simplifyValue`.

## Verification
- Standalone `mvnw clean install` for extensions-linkback: BUILD SUCCESS.
- `spotless:apply` + `spotless:check` on extensions-linkback: BUILD SUCCESS.
- Original three javac warnings eliminated; no new javac warnings introduced.