### PR TITLE
fix(servlet-utils): suppress this-escape and qualify static field (#2021)

### DIFF
--- a/modules/servletutils/src/main/java/com/percussion/servlet_utils/servlet/PSMockHttpServletRequest.java
+++ b/modules/servletutils/src/main/java/com/percussion/servlet_utils/servlet/PSMockHttpServletRequest.java
@@ -90,6 +90,7 @@ public class PSMockHttpServletRequest implements HttpServletRequest {
    * @param method the HTTP method, defaults to {@code GET} when {@code null}
    * @param requestURI the request URI, defaults to empty when {@code null}
    */
+  @SuppressWarnings("this-escape")
   public PSMockHttpServletRequest(String method, String requestURI) {
     this.method = method != null ? method : "GET";
     setRequestURI(requestURI != null ? requestURI : "");

--- a/modules/servletutils/src/main/java/com/percussion/servlet_utils/tomcat/PSTomcatUtils.java
+++ b/modules/servletutils/src/main/java/com/percussion/servlet_utils/tomcat/PSTomcatUtils.java
@@ -67,7 +67,8 @@ public class PSTomcatUtils {
     if (root == null || !root.getNodeName().equals(SERVER_NODE_NAME))
       throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_MISSING, SERVER_NODE_NAME);
 
-    Element serviceEl = tree.getNextElement(SERVICE_NODE_NAME, tree.GET_NEXT_ALLOW_CHILDREN);
+    Element serviceEl =
+        tree.getNextElement(SERVICE_NODE_NAME, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (serviceEl == null)
       throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_MISSING, SERVICE_NODE_NAME);
 


### PR DESCRIPTION
## Description
- `PSMockHttpServletRequest(String, String)` calls the overridable `setRequestURI` setter before the subclass is fully initialized. Annotate the constructor with `@SuppressWarnings("this-escape")`.
- `PSTomcatUtils.getTomcatConnectors` reads the static `PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN` via an instance expression (`tree.GET_NEXT_ALLOW_CHILDREN`). javac prefers the type-qualified form to make the static access unambiguous.

Closes #2021

## Operator
Kilo Code (minimax-m3)

## Changes
- `modules/servletutils/src/main/java/com/percussion/servlet_utils/servlet/PSMockHttpServletRequest.java` — `@SuppressWarnings("this-escape")` on the two-arg constructor.
- `modules/servletutils/src/main/java/com/percussion/servlet_utils/tomcat/PSTomcatUtils.java` — qualify static field access.

## Verification
- Standalone `mvnw clean install` for servlet-utils: BUILD SUCCESS.
- `spotless:apply` + `spotless:check` on servlet-utils: BUILD SUCCESS.
- Original two production javac warnings eliminated; no new javac warnings introduced.