### PR TITLE
fix(perc-polls-services): suppress this-escape and serial warnings (#2042)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/polls/src/main/java/com/percussion/delivery/polls/PSPollsApplication.java
+++ b/deliverytiersuite/delivery-tier-suite/polls/src/main/java/com/percussion/delivery/polls/PSPollsApplication.java
@@ -38,6 +38,7 @@ public class PSPollsApplication extends ResourceConfig {
    * service, request/response logging, roles-based access control, the standard error mappers and
    * the JSON binding provider.
    */
+  @SuppressWarnings("this-escape")
   public PSPollsApplication() {
     // RequestContextFilter registration removed; Jersey 2.x Spring integration does not require it.
     // Removed AutowiredInjectResolver registration; not required for Jersey 2.x Spring integration.

--- a/deliverytiersuite/delivery-tier-suite/polls/src/main/java/com/percussion/delivery/polls/service/rdbms/PSPoll.java
+++ b/deliverytiersuite/delivery-tier-suite/polls/src/main/java/com/percussion/delivery/polls/service/rdbms/PSPoll.java
@@ -30,6 +30,7 @@ import java.util.Set;
  */
 @Entity
 @Table(name = "PERC_POLLS")
+@SuppressWarnings("serial")
 public class PSPoll implements IPSPoll, Serializable {
 
   private static final long serialVersionUID = 1L;


### PR DESCRIPTION
## Description
- `PSPollsApplication` constructor calls the overridable `ResourceConfig#register` method before the subclass is fully initialized, triggering javac's "this escape" warning. Annotate the constructor with `@SuppressWarnings("this-escape")`.
- `PSPoll` holds a `Set<IPSPollAnswer>` field whose declared element type does not explicitly extend `Serializable`, triggering a "serial" warning even though `IPSPollAnswer` does extend `Serializable` in this module. Annotate the class with `@SuppressWarnings("serial")`.

Closes #2042

## Operator
Kilo Code (minimax-m3)

## Changes
- `deliverytiersuite/delivery-tier-suite/polls/src/main/java/com/percussion/delivery/polls/PSPollsApplication.java` — `@SuppressWarnings("this-escape")` on constructor.
- `deliverytiersuite/delivery-tier-suite/polls/src/main/java/com/percussion/delivery/polls/service/rdbms/PSPoll.java` — `@SuppressWarnings("serial")` on class.

## Verification
- Standalone `mvnw clean install` for polls: BUILD SUCCESS.
- `spotless:apply` + `spotless:check` on polls: BUILD SUCCESS.
- Original two javac warnings eliminated; no new javac warnings introduced.