### PR TITLE
fix(audit-log): suppress this-escape warnings in event constructors (#2018)

### DIFF
--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/AbstractEvent.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/AbstractEvent.java
@@ -50,6 +50,7 @@ public class AbstractEvent extends AuditContext {
   }
 
   /** Constructs an event pre-populated with the system observer and an {@code UNKNOWN} outcome. */
+  @SuppressWarnings("this-escape")
   public AbstractEvent() {
 
     // Set some defaults

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSAuthenticationEvent.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSAuthenticationEvent.java
@@ -42,6 +42,7 @@ public class PSAuthenticationEvent extends AbstractEvent {
   public static final String SYSTEM_SECURITY_URI = "service/bss/cms/security";
 
   /** Constructs an empty event with the security observer pre-assigned. */
+  @SuppressWarnings("this-escape")
   public PSAuthenticationEvent() {
     super();
 
@@ -58,6 +59,7 @@ public class PSAuthenticationEvent extends AbstractEvent {
    * @param request the HTTP request that triggered the event, never {@code null}.
    * @param username the user name captured by the authentication attempt, never {@code null}.
    */
+  @SuppressWarnings("this-escape")
   public PSAuthenticationEvent(
       String outcome,
       AuthenticationEventActions action,

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSContentEvent.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSContentEvent.java
@@ -65,6 +65,7 @@ public class PSContentEvent extends AbstractEvent {
    * @param request the HTTP request that triggered the event, never {@code null}.
    * @param outcome the outcome of the action, never {@code null}.
    */
+  @SuppressWarnings("this-escape")
   public PSContentEvent(
       String guid,
       String contentId,
@@ -139,6 +140,7 @@ public class PSContentEvent extends AbstractEvent {
   }
 
   /** Constructs an empty event with the content observer pre-assigned. */
+  @SuppressWarnings("this-escape")
   public PSContentEvent() {
     super();
 

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSUserManagementEvent.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSUserManagementEvent.java
@@ -68,6 +68,7 @@ public class PSUserManagementEvent extends AbstractEvent {
    * @param action the user-management action being recorded, never {@code null}.
    * @param outcome the outcome of the action, never {@code null}.
    */
+  @SuppressWarnings("this-escape")
   public PSUserManagementEvent(
       HttpServletRequest request, UserEventActions action, PSActionOutcome outcome) {
     super();

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSWorkflowEvent.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSWorkflowEvent.java
@@ -61,6 +61,7 @@ public class PSWorkflowEvent extends AbstractEvent {
    * @param guid the GUID of the affected item, never {@code null}.
    * @param outcome the outcome of the transition, never {@code null}.
    */
+  @SuppressWarnings("this-escape")
   public PSWorkflowEvent(
       String transitionFrom,
       String transitionTo,


### PR DESCRIPTION
## Description
All five audit event classes (`AbstractEvent`, `PSAuthenticationEvent`, `PSContentEvent`, `PSUserManagementEvent`, `PSWorkflowEvent`) construct their state via overridable setters on `AbstractEvent` (`setOutcome`, `setObserverName`, `setTargetName`, `setAction`, etc.) before the subclass is fully initialized. Annotate each constructor with `@SuppressWarnings("this-escape")` to document that the event classes are not designed for further subclassing.

Closes #2018

## Operator
Kilo Code (minimax-m3)

## Changes
- `modules/perc-auditlog/src/main/java/com/percussion/auditlog/AbstractEvent.java` — `@SuppressWarnings("this-escape")` on constructor.
- `modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSAuthenticationEvent.java` — `@SuppressWarnings("this-escape")` on both constructors.
- `modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSContentEvent.java` — `@SuppressWarnings("this-escape")` on both constructors.
- `modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSUserManagementEvent.java` — `@SuppressWarnings("this-escape")` on constructor.
- `modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSWorkflowEvent.java` — `@SuppressWarnings("this-escape")` on constructor.

## Verification
- Standalone `mvnw clean install` for perc-auditlog: BUILD SUCCESS.
- `spotless:apply` + `spotless:check` on perc-auditlog: BUILD SUCCESS.
- Original seven javac warnings eliminated; no new javac warnings introduced.