### PR TITLE
docs(docker): two-worktree concurrent freeport smoke checklist (#2006)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -25,14 +25,14 @@ docker compose --env-file .env.compose --profile postgres up -d
 
 ## Layout
 
-|     Path      |                                 Purpose                                  |
-|---------------|--------------------------------------------------------------------------|
-| `cms/`        | Dockerfile + image for the long-lived cms-dts **dev** container          |
-| `matrix/`     | Dockerfile + in-cell entrypoint for ephemeral install matrix cells       |
-| `dev-data/`   | Persistent bind-mount volume (CMS install + DB) for **dev** only         |
-| `entrypoint/` | Dev container service-start scripts (`install-update.py`)                |
-| `scripts/`    | Host-side operator control (`perc-devctl.py`, `matrix-install-smoke.py`) |
-| `logs/`       | Timestamped logs + matrix JSON results                                   |
+|     Path      |                                                    Purpose                                                    |
+|---------------|---------------------------------------------------------------------------------------------------------------|
+| `cms/`        | Dockerfile + image for the long-lived cms-dts **dev** container                                               |
+| `matrix/`     | Dockerfile + in-cell entrypoint for ephemeral install matrix cells                                            |
+| `dev-data/`   | Persistent bind-mount volume (CMS install + DB) for **dev** only                                              |
+| `entrypoint/` | Dev container service-start scripts (`install-update.py`)                                                     |
+| `scripts/`    | Host-side operator control (`perc-devctl.py`, `matrix-install-smoke.py`, freeport helpers / concurrent smoke) |
+| `logs/`       | Timestamped logs + matrix JSON results                                                                        |
 
 ## Host-side scripts
 
@@ -87,9 +87,148 @@ Each subcommand writes full output to a timestamped file under `docker/logs/<lab
 
 Do **not** hardcode `http://127.0.0.1:9993` in agent scripts — 9993 is only the preferred baseline when free. Pin ports across sessions by exporting those env vars before `up` / `qa-up` / `matrix-install-smoke` / `verify`. Tear-down (`down` / `qa-down` / cell destroy) frees the docker publish mapping; the host port itself is not reserved after the container exits.
 
+**Remaining multi-worktree gaps** (parent [#2001](https://github.com/intersoftdatalabs-in/percussioncms/issues/2001), sibling [#2004](https://github.com/intersoftdatalabs-in/percussioncms/issues/2004)): fixed compose `container_name` values and some DB host ports still limit true concurrent full stacks; freeport alone does not rename containers. Prefer the allocation dry-run below for CI; use the live checklist when container names do not already collide on the host.
+
+#### Two-worktree concurrent freeport smoke (#2006)
+
+Operator / agent checklist proving freeport multi-cell stacks do not collide on **published host ports**. Parent [#2001](https://github.com/intersoftdatalabs-in/percussioncms/issues/2001); freeport implementation [#2003](https://github.com/intersoftdatalabs-in/percussioncms/pull/2003) / matrix wire-up [#2014](https://github.com/intersoftdatalabs-in/percussioncms/pull/2014) (issue #2005). Sibling residual surface: [#2004](https://github.com/intersoftdatalabs-in/percussioncms/issues/2004). Companion notes also in [workbench-rest-and-qa-modes.md](../docs/developer-module/workbench-rest-and-qa-modes.md).
+
+##### Tier 0 — allocation dry-run (no Docker, no CMS install)
+
+Fast, CI-friendly proof of the freeport contract (preferred → freeport fallback → env override → tear-down frees):
+
+```bash
+# From repo root (Windows: py -3 or python)
+python docker/scripts/freeport-concurrent-smoke.py
+# optional: --quiet  (RESULT line only)
+# Expected: RESULT:OK STEP:freeport-concurrent-smoke
+
+python -m pytest docker/scripts/test_freeport_concurrent_smoke.py -q
+```
+
+What it asserts (simulates two “worktree cells” by holding ports with stdlib sockets):
+
+|         Check          |                     Expected                      |
+|------------------------|---------------------------------------------------|
+| Cell A, no env pin     | Preferred baseline when free                      |
+| Cell B, preferred held | Distinct freeport (not cell A)                    |
+| Env override           | `QA_CMS_HOST_PORT` / `CMS_PORT` / `DTS_PORT` wins |
+| Compose pair freeport  | Second CMS+DTS pair distinct from first           |
+| After release          | Preferred free again (when this process held it)  |
+
+##### Tier 1 — dry-run CLI discovery (no real containers)
+
+Use two shells / two worktree checkouts of the same repo. Do **not** set port env vars (unless testing override).
+
+```bash
+# Worktree A (or terminal 1)
+cd /path/to/worktree-a
+python docker/scripts/perc-devctl.py qa-up --dry-run
+# Note QA_CMS_HOST_PORT=… (often 9993 when free) and TEST_CMS_URL=…
+
+python docker/scripts/perc-devctl.py up --dry-run
+# Note CMS_PORT=… DTS_PORT=… and VERIFY_*_URL=…
+
+# Worktree B — hold preferred first so freeport must kick in, then dry-run
+# (Tier 0 script already holds preferred; or start a real cell in A first)
+cd /path/to/worktree-b
+# Unset any pin:
+#   Unix: unset QA_CMS_HOST_PORT CMS_HOST_PORT CMS_PORT DTS_PORT
+#   Windows PowerShell: Remove-Item Env:QA_CMS_HOST_PORT -ErrorAction SilentlyContinue  (etc.)
+python docker/scripts/perc-devctl.py qa-up --dry-run
+# Assert QA_CMS_HOST_PORT differs from worktree A when A still holds preferred
+```
+
+**Env override wins** (either worktree):
+
+```bash
+# Unix
+export QA_CMS_HOST_PORT=18001
+python docker/scripts/perc-devctl.py qa-up --dry-run
+# Expect QA_CMS_HOST_PORT=18001 and TEST_CMS_URL=http://127.0.0.1:18001
+
+export CMS_PORT=19111 DTS_PORT=19112
+python docker/scripts/perc-devctl.py up --dry-run
+# Expect CMS_PORT=19111 DTS_PORT=19112 in printed VERIFY_* URLs
+```
+
+##### Tier 2 — live stacks (optional; real Docker + probes)
+
+Requires Docker, packaged CMS installer for QA (`modules/perc-distribution-tree` assembly jar), and free machine resources. **Container names are still global** (`perc-matrix-cms-h2`, `percussion-cms-dts`); two checkouts cannot both keep the same named container. Live concurrent smoke therefore uses **sequential ownership of the shared name** or **one live cell + freeport dry-run for the second** unless #2004 / follow-ups add worktree-scoped names.
+
+**Path A — sequential QA (same host, prove freeport + probes + tear-down):**
+
+```bash
+# 1) Worktree A — no port pin
+cd /path/to/worktree-a
+python docker/scripts/perc-devctl.py qa-up
+# Record PORT_A from QA_CMS_HOST_PORT=… ; curl/qa-health the printed TEST_CMS_URL
+python docker/scripts/perc-devctl.py qa-health
+
+# 2) Tear-down A; confirm publish freed
+python docker/scripts/perc-devctl.py qa-down
+# Port PORT_A should be free for bind again (Tier 0 or a short Python is_port_free check)
+
+# 3) Worktree B — no port pin (gets preferred when free)
+cd /path/to/worktree-b
+python docker/scripts/perc-devctl.py qa-up
+python docker/scripts/perc-devctl.py qa-health
+python docker/scripts/perc-devctl.py qa-down
+```
+
+**Path B — concurrent freeport under a live holder (port collision only):**
+
+```bash
+# Terminal A — occupy preferred QA port without full install (or leave a cell up)
+python -c "import socket;s=socket.socket();s.bind(('127.0.0.1',9993));s.listen(1);input('holding 9993; Enter to release')"
+
+# Terminal B — worktree B, no pin
+python docker/scripts/perc-devctl.py qa-up --dry-run
+# Expect QA_CMS_HOST_PORT != 9993
+# Optional full: qa-up (if no other perc-matrix-cms-h2), qa-health, qa-down
+```
+
+**Path C — dev compose `up` / `verify` (single container name `percussion-cms-dts`):**
+
+```bash
+# Worktree A
+python docker/scripts/perc-devctl.py up
+# Record CMS_PORT / DTS_PORT; perc-devctl.py verify when stack ready
+python docker/scripts/perc-devctl.py down
+
+# Worktree B (after A down, or with preferred held) — no pin
+python docker/scripts/perc-devctl.py up --dry-run   # assert freeport when preferred taken
+# Env override: CMS_PORT=19111 DTS_PORT=19112 python docker/scripts/perc-devctl.py up
+python docker/scripts/perc-devctl.py down
+```
+
+**Pass criteria (summary):**
+
+|          Step           |                             Pass when                             |
+|-------------------------|-------------------------------------------------------------------|
+| No pin, preferred free  | Cell uses preferred baseline                                      |
+| No pin, preferred taken | Second cell uses freeport ≠ first                                 |
+| Env set                 | Printed / published port equals env                               |
+| Probe (live)            | `qa-health` / `verify` RESULT:OK (or HTTP 200/302 on login)       |
+| Tear-down               | `qa-down` / `down`; host ports free; no orphan cell for that name |
+
+##### Related helpers
+
+|                   Artifact                    |                                            Role                                            |
+|-----------------------------------------------|--------------------------------------------------------------------------------------------|
+| `docker/scripts/perc_host_ports.py`           | `find_free_port` / `is_port_free` / `resolve_host_port`                                    |
+| `docker/scripts/perc-devctl.py`               | `up` / `verify` / `qa-up` pin + print ports                                                |
+| `docker/scripts/matrix-install-smoke.py`      | Matrix CMS/DTS freeport publish + probe                                                    |
+| `docker/scripts/freeport-concurrent-smoke.py` | Tier 0 allocation smoke (#2006)                                                            |
+| Unit tests                                    | `test_perc_devctl.py`, `test_matrix_install_smoke.py`, `test_freeport_concurrent_smoke.py` |
+
 #### QA mode (`qa-up` / `qa-health` / `qa-down`)
 
-Starts an ephemeral **CMS + H2** matrix cell (same stack as `matrix-install-smoke.py --product cms --db h2 --keep`), waits for the resolved probe URL (`http://127.0.0.1:<QA_CMS_HOST_PORT>/Rhythmyx/login`), prints `TEST_CMS_URL` / admin username (password from generated install file when available), and tears down with `docker rm -f perc-matrix-cms-h2` so ports and disk are freed (no multi-GB named volume by default). Full operator flow: [workbench-rest-and-qa-modes.md](../docs/developer-module/workbench-rest-and-qa-modes.md) → **QA mode** section.
+Starts an ephemeral **CMS + H2** matrix cell (same stack as `matrix-install-smoke.py --product cms --db h2 --keep`), waits for the resolved probe URL (`http://127.0.0.1:<QA_CMS_HOST_PORT>/Rhythmyx/login`), prints `TEST_CMS_URL` / admin username (password from generated install file when available), and tears down with `docker rm -f perc-matrix-cms-h2` so ports and disk are freed (no multi-GB named volume by default). Full operator flow: [workbench-rest-and-qa-modes.md](../docs/developer-module/workbench-rest-and-qa-modes.md) → **QA mode** section. Concurrent freeport checklist: **Two-worktree concurrent freeport smoke** above.
+
+### `docker/scripts/freeport-concurrent-smoke.py`
+
+Allocation-only smoke for multi-worktree freeport (#2006). No Docker and no CMS install — holds preferred ports with stdlib sockets, asserts second-cell freeport and env override, prints `RESULT:OK|FAIL STEP:freeport-concurrent-smoke`. See **Two-worktree concurrent freeport smoke** above. Unit tests: `test_freeport_concurrent_smoke.py`.
 
 ### `docker/scripts/hot-deploy-jar.py`
 

--- a/docker/scripts/freeport-concurrent-smoke.py
+++ b/docker/scripts/freeport-concurrent-smoke.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Two-cell freeport concurrent allocation smoke (#2006).
+
+CI-friendly / operator dry-run that **does not** start Docker or install CMS.
+It proves the shared freeport contract used by ``perc-devctl`` and
+``matrix-install-smoke`` (``perc_host_ports.py``):
+
+1. **Preferred baseline** is chosen when free and env is unset.
+2. **Second cell** with the preferred port held gets a **distinct** freeport
+   (simulates two worktrees without env pin).
+3. **Env override wins** over preferred and freeport.
+4. After holders release, preferred ports are free again (tear-down analogy).
+
+Agent-parseable stdout ends with::
+
+    RESULT:OK STEP:freeport-concurrent-smoke
+    RESULT:FAIL STEP:freeport-concurrent-smoke REASON:...
+
+Exit codes: 0 success, 1 failure / invocation error.
+
+Full live two-worktree stacks (real ``qa-up`` / ``up`` + probes) remain an
+operator checklist in ``docker/README.md`` — this script only checks
+allocation wiring so overnight agents can green-check freeport without a
+multi-GB install.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import socket
+import sys
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+# Sibling freeport helpers (stdlib only).
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+from perc_host_ports import find_free_port, is_port_free, resolve_host_port  # noqa: E402
+
+EXIT_OK = 0
+EXIT_FAIL = 1
+
+# Preferred baselines match perc-devctl / matrix (#2001 / #2003 / #2005).
+PREFERRED_QA_CMS = 9993
+PREFERRED_CMS = 9992
+PREFERRED_DTS = 9980
+
+STEP = "freeport-concurrent-smoke"
+
+# Env keys this smoke may set or clear — never leave process polluted.
+_SMOKE_ENV_KEYS = (
+    "QA_CMS_HOST_PORT",
+    "CMS_HOST_PORT",
+    "CMS_PORT",
+    "DTS_PORT",
+    "DTS_HOST_PORT",
+)
+
+
+def _clear_port_env() -> None:
+    for key in _SMOKE_ENV_KEYS:
+        os.environ.pop(key, None)
+
+
+def _hold_port(port: int, host: str = "127.0.0.1") -> socket.socket:
+    """Bind and hold ``port`` so freeport consumers treat it as taken."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    # Reuse helps on Windows when a previous run left TIME_WAIT; fail loud if busy.
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    except OSError:
+        pass
+    sock.bind((host, port))
+    sock.listen(1)
+    return sock
+
+
+def run_smoke() -> Tuple[bool, List[str]]:
+    """Execute allocation checks. Returns ``(ok, log_lines)``."""
+    lines: List[str] = []
+    holders: List[socket.socket] = []
+
+    def log(msg: str) -> None:
+        lines.append(msg)
+
+    try:
+        _clear_port_env()
+
+        # --- 1) Preferred when free (cell A baseline) ---
+        # Ensure preferred QA is free for this assertion when possible.
+        preferred_qa = PREFERRED_QA_CMS
+        if not is_port_free(preferred_qa):
+            # Cannot assert preferred-when-free for 9993; use ephemeral as preferred.
+            preferred_qa = find_free_port()
+            log(f"NOTE preferred {PREFERRED_QA_CMS} busy; using ephemeral preferred={preferred_qa}")
+        port_a = resolve_host_port(preferred=preferred_qa)
+        if port_a != preferred_qa:
+            return False, lines + [
+                f"FAIL cell-A preferred: expected {preferred_qa}, got {port_a}"
+            ]
+        log(f"OK cell-A preferred QA_CMS_HOST_PORT={port_a}")
+
+        # Hold cell-A's port (simulates published docker mapping still live).
+        holders.append(_hold_port(port_a))
+        log(f"OK cell-A holding port {port_a}")
+
+        # --- 2) Second cell without env pin → distinct freeport ---
+        port_b = resolve_host_port(preferred=preferred_qa)
+        if port_b == port_a:
+            return False, lines + [
+                f"FAIL cell-B freeport: got same port as cell-A ({port_a})"
+            ]
+        if not is_port_free(port_b):
+            # resolve released the ephemeral bind; should still be free for docker.
+            # If not free, something else raced — soft note only if bind fails later.
+            pass
+        log(f"OK cell-B freeport QA_CMS_HOST_PORT={port_b} (distinct from {port_a})")
+
+        # Hold B too and resolve a third to show multi-cell uniqueness continues.
+        holders.append(_hold_port(port_b))
+        port_c = resolve_host_port(preferred=preferred_qa)
+        if port_c in (port_a, port_b):
+            return False, lines + [
+                f"FAIL cell-C freeport: collided with A/B ({port_a}/{port_b}) got {port_c}"
+            ]
+        log(f"OK cell-C freeport QA_CMS_HOST_PORT={port_c}")
+
+        # --- 3) Env override wins (even when preferred free) ---
+        # Free a high ephemeral and pin it via env while preferred is free after
+        # we only hold A/B (preferred may still be held if it was port_a).
+        override = find_free_port()
+        os.environ["QA_CMS_HOST_PORT"] = str(override)
+        resolved_override = resolve_host_port(
+            "QA_CMS_HOST_PORT",
+            "CMS_HOST_PORT",
+            preferred=preferred_qa,
+        )
+        if resolved_override != override:
+            return False, lines + [
+                f"FAIL env override: expected {override}, got {resolved_override}"
+            ]
+        log(f"OK env override QA_CMS_HOST_PORT={override} wins over preferred")
+        del os.environ["QA_CMS_HOST_PORT"]
+
+        # Compose CMS/DTS pair (dev stack) — both freeport when preferred held.
+        preferred_cms = PREFERRED_CMS
+        preferred_dts = PREFERRED_DTS
+        if not is_port_free(preferred_cms):
+            preferred_cms = find_free_port()
+        if not is_port_free(preferred_dts):
+            preferred_dts = find_free_port()
+        cms_a = resolve_host_port("CMS_PORT", preferred=preferred_cms)
+        dts_a = resolve_host_port("DTS_PORT", preferred=preferred_dts)
+        holders.append(_hold_port(cms_a))
+        holders.append(_hold_port(dts_a))
+        cms_b = resolve_host_port("CMS_PORT", preferred=preferred_cms)
+        dts_b = resolve_host_port("DTS_PORT", preferred=preferred_dts)
+        if cms_b == cms_a or dts_b == dts_a:
+            return False, lines + [
+                f"FAIL compose second cell: CMS {cms_a}->{cms_b} DTS {dts_a}->{dts_b}"
+            ]
+        if cms_b == dts_b:
+            return False, lines + [
+                f"FAIL compose second cell: CMS and DTS collided on {cms_b}"
+            ]
+        log(
+            f"OK compose freeport cell-A CMS_PORT={cms_a} DTS_PORT={dts_a}; "
+            f"cell-B CMS_PORT={cms_b} DTS_PORT={dts_b}"
+        )
+
+        os.environ["CMS_PORT"] = "19111"
+        os.environ["DTS_PORT"] = "19112"
+        if resolve_host_port("CMS_PORT", preferred=preferred_cms) != 19111:
+            return False, lines + ["FAIL CMS_PORT env override"]
+        if resolve_host_port("DTS_PORT", preferred=preferred_dts) != 19112:
+            return False, lines + ["FAIL DTS_PORT env override"]
+        log("OK compose env override CMS_PORT=19111 DTS_PORT=19112")
+        del os.environ["CMS_PORT"]
+        del os.environ["DTS_PORT"]
+
+        # --- 4) Tear-down: release holders; preferred free again when it was ours ---
+        for sock in holders:
+            sock.close()
+        holders.clear()
+        # Only assert preferred free if nothing else on the machine holds it.
+        if preferred_qa == PREFERRED_QA_CMS or is_port_free(preferred_qa):
+            if not is_port_free(preferred_qa):
+                return False, lines + [
+                    f"FAIL after tear-down: preferred {preferred_qa} still not free"
+                ]
+            log(f"OK after tear-down preferred {preferred_qa} free")
+        else:
+            log(f"NOTE after tear-down preferred {preferred_qa} still busy (external holder)")
+
+        log("OK freeport concurrent smoke complete")
+        return True, lines
+    except OSError as exc:
+        return False, lines + [f"FAIL OSError: {exc}"]
+    finally:
+        for sock in holders:
+            try:
+                sock.close()
+            except OSError:
+                pass
+        _clear_port_env()
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="freeport-concurrent-smoke.py",
+        description=(
+            "Dry-run two-cell freeport allocation smoke (no docker / CMS install). "
+            "See docker/README.md → Two-worktree concurrent freeport smoke."
+        ),
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Only print the RESULT line.",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    ok, lines = run_smoke()
+    if not args.quiet:
+        for line in lines:
+            print(line)
+    if ok:
+        print(f"RESULT:OK STEP:{STEP}")
+        return EXIT_OK
+    reason = "see log above"
+    for line in reversed(lines):
+        if line.startswith("FAIL"):
+            reason = line
+            break
+    print(f"RESULT:FAIL STEP:{STEP} REASON:{reason}")
+    return EXIT_FAIL
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker/scripts/test_freeport_concurrent_smoke.py
+++ b/docker/scripts/test_freeport_concurrent_smoke.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Unit tests for freeport-concurrent-smoke.py (#2006)."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    # Ensure sibling perc_host_ports is importable the same way as the script.
+    import sys
+
+    if str(SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS))
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+smoke = _load(SCRIPTS / "freeport-concurrent-smoke.py", "freeport_concurrent_smoke")
+
+
+class FreeportConcurrentSmokeTests(unittest.TestCase):
+    def setUp(self):
+        smoke._clear_port_env()
+        self.addCleanup(smoke._clear_port_env)
+
+    def test_run_smoke_ok(self):
+        ok, lines = smoke.run_smoke()
+        self.assertTrue(ok, msg="\n".join(lines))
+        joined = "\n".join(lines)
+        self.assertIn("OK cell-A preferred", joined)
+        self.assertIn("OK cell-B freeport", joined)
+        self.assertIn("OK env override", joined)
+        self.assertIn("OK compose freeport", joined)
+        self.assertIn("OK freeport concurrent smoke complete", joined)
+
+    def test_main_prints_result_ok(self):
+        # Capture via return code; main prints RESULT line.
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = smoke.main(["--quiet"])
+        self.assertEqual(rc, smoke.EXIT_OK)
+        self.assertIn(f"RESULT:OK STEP:{smoke.STEP}", buf.getvalue())
+
+    def test_hold_port_makes_is_port_free_false(self):
+        from perc_host_ports import find_free_port, is_port_free
+
+        free = find_free_port()
+        holder = smoke._hold_port(free)
+        self.addCleanup(holder.close)
+        self.assertFalse(is_port_free(free))
+        holder.close()
+        self.assertTrue(is_port_free(free))
+
+    def test_clear_port_env_removes_keys(self):
+        os.environ["QA_CMS_HOST_PORT"] = "1"
+        os.environ["CMS_PORT"] = "2"
+        smoke._clear_port_env()
+        self.assertNotIn("QA_CMS_HOST_PORT", os.environ)
+        self.assertNotIn("CMS_PORT", os.environ)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/developer-module/workbench-rest-and-qa-modes.md
+++ b/docs/developer-module/workbench-rest-and-qa-modes.md
@@ -149,6 +149,16 @@ python docker/scripts/perc-devctl.py qa-down
 
 **Dry-run (no docker):** `python docker/scripts/perc-devctl.py qa-up --dry-run` (and `qa-health` / `qa-down` likewise). Unit tests: `python -m pytest docker/scripts/test_perc_devctl.py -q`.
 
+**Two-worktree concurrent freeport smoke (#2006):** when two agent worktrees share a host, published ports must not collide. Operator checklist + CI dry-run (no CMS install):
+
+```bash
+# Allocation-only (preferred → freeport → env override → tear-down)
+python docker/scripts/freeport-concurrent-smoke.py
+# Expect: RESULT:OK STEP:freeport-concurrent-smoke
+```
+
+Full tiers (CLI dry-run, live sequential `qa-up` / `up`, env override, tear-down port free): see [docker/README.md](../../docker/README.md) → **Two-worktree concurrent freeport smoke**. Shared helpers: `docker/scripts/perc_host_ports.py` (used by `perc-devctl` + `matrix-install-smoke`). Parent freeport epic [#2001](https://github.com/intersoftdatalabs-in/percussioncms/issues/2001); sibling residual [#2004](https://github.com/intersoftdatalabs-in/percussioncms/issues/2004).
+
 Equivalent low-level harness (same cell): `python docker/scripts/matrix-install-smoke.py --product cms --db h2 --keep` then destroy with `docker rm -f perc-matrix-cms-h2`. Prefer `perc-devctl.py qa-*` for agents.
 
 Playwright env defaults, surface filters, and CI jobs are **later slices** of #1827 (#1928–#1930).


### PR DESCRIPTION
## Summary

Documents and scripts a **two-worktree concurrent freeport smoke** checklist so multi-cell stacks do not collide on published host ports.

- **Operator checklist** in `docker/README.md` → *Two-worktree concurrent freeport smoke* (#2006):
  - **Tier 0** — allocation dry-run (no Docker / CMS install)
  - **Tier 1** — `perc-devctl` `qa-up` / `up` `--dry-run` discovery across two worktrees
  - **Tier 2** — optional live sequential `qa-up` / `up` + probes + tear-down (notes fixed container names)
  - Env override wins; tear-down frees ports; pass criteria table
- **Cross-link** in `docs/developer-module/workbench-rest-and-qa-modes.md` (QA mode section)
- **CI-friendly script** `docker/scripts/freeport-concurrent-smoke.py` + unit tests — exercises shared `perc_host_ports` (preferred → freeport → env override → release)

References: parent #2001; freeport slice PR #2003; matrix freeport #2005 / #2014; sibling residual #2004 (DB/compose host ports + still-fixed `container_name`).

Fixes #2006

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] `python -m pytest docker/scripts/test_freeport_concurrent_smoke.py docker/scripts/test_perc_devctl.py docker/scripts/test_matrix_install_smoke.py -q` → **88 passed**
- [x] `python docker/scripts/freeport-concurrent-smoke.py` → `RESULT:OK STEP:freeport-concurrent-smoke`
- [ ] Optional live: two worktrees / terminals follow Tier 1–2 checklist in `docker/README.md`

## Gates evidence

| Gate | Result |
|------|--------|
| Behavioral unit tests | Pass — new freeport concurrent smoke tests + existing freeport suites (88 total) |
| Portable paths | Pass — stdlib socket only; no OS path construction for ports; `pathlib` for scripts dir |
| Change-class companions | Docs checklist + dry-run script + tests + workbench cross-link; references existing helpers |
| Spotless | `mvnw.cmd -N spotless:apply` **first**, then `spotless:check` **second** (BUILD SUCCESS). **In-scope only** committed (`docker/README.md`, workbench doc, smoke script + tests). Out-of-scope baseline Spotless rewrites under `docs/ai-generated/code-reviews/*` left **uncommitted** (not folded into this PR) |
| Maven clean install | N/A — docs + Python docker scripts only (no Maven module sources) |
| Erlang self-review | No bugs; honest residual note that fixed container names still limit true concurrent full `qa-up`/`up` (tracked under #2001 / #2004) |

## Residual

None for #2006 acceptance (checklist + optional dry-run). Parent #2001 still tracks #2004 for remaining compose/DB freeport and worktree-scoped container names.