### PR TITLE
fix(rest): suppress this-escape and serial warnings in exception and summary DTOs (#2026)

### DIFF
--- a/rest/src/main/java/com/percussion/rest/Guid.java
+++ b/rest/src/main/java/com/percussion/rest/Guid.java
@@ -135,6 +135,7 @@ public class Guid {
    *
    * @param guid the guid string, must not be null
    */
+  @SuppressWarnings("this-escape")
   public Guid(String guid) {
     Objects.requireNonNull(guid, "guid must not be null");
     var temp = new PSGuid(guid);

--- a/rest/src/main/java/com/percussion/rest/errors/FolderNotFoundException.java
+++ b/rest/src/main/java/com/percussion/rest/errors/FolderNotFoundException.java
@@ -28,6 +28,7 @@ public class FolderNotFoundException extends RestExceptionBase {
     this((Throwable) null);
   }
 
+  @SuppressWarnings("this-escape")
   public FolderNotFoundException(Throwable cause) {
     // always set the folder not found code, attach cause if present
     super(RestErrorCode.FOLDER_NOT_FOUND, null, null, null, null);

--- a/rest/src/main/java/com/percussion/rest/errors/RestExceptionBase.java
+++ b/rest/src/main/java/com/percussion/rest/errors/RestExceptionBase.java
@@ -27,6 +27,7 @@ import java.util.ResourceBundle;
 
 /** Base class for REST exceptions in Percussion CMS. Sunny Sal: "Exception ka baap yeh hai!" */
 @XmlRootElement(name = "Error")
+@SuppressWarnings("serial")
 public class RestExceptionBase extends WebApplicationException {
 
   private static final long serialVersionUID = 1L;

--- a/rest/src/main/java/com/percussion/share/relationship/data/PSLocalDependencySummary.java
+++ b/rest/src/main/java/com/percussion/share/relationship/data/PSLocalDependencySummary.java
@@ -38,6 +38,7 @@ import java.util.List;
  */
 @XmlRootElement(name = "PSLocalDependencySummary")
 @JsonRootName("PSLocalDependencySummary")
+@SuppressWarnings("serial")
 public class PSLocalDependencySummary extends PSAbstractDataObject {
 
   private static final long serialVersionUID = 1L;

--- a/rest/src/main/java/com/percussion/share/relationship/data/PSRelationshipSummary.java
+++ b/rest/src/main/java/com/percussion/share/relationship/data/PSRelationshipSummary.java
@@ -51,6 +51,7 @@ import java.util.Objects;
  */
 @XmlRootElement(name = "PSRelationshipSummary")
 @JsonRootName("PSRelationshipSummary")
+@SuppressWarnings("serial")
 public class PSRelationshipSummary extends PSAbstractDataObject {
 
   private static final long serialVersionUID = 1L;

--- a/rest/src/main/java/com/percussion/share/relationship/data/PSTaxonomySummary.java
+++ b/rest/src/main/java/com/percussion/share/relationship/data/PSTaxonomySummary.java
@@ -38,6 +38,7 @@ import java.util.List;
  */
 @XmlRootElement(name = "PSTaxonomySummary")
 @JsonRootName("PSTaxonomySummary")
+@SuppressWarnings("serial")
 public class PSTaxonomySummary extends PSAbstractDataObject {
 
   private static final long serialVersionUID = 1L;


### PR DESCRIPTION
## Description
- `FolderNotFoundException` constructor calls `Throwable.initCause` via `super(...)` chain before the subclass is fully initialized. Annotate with `@SuppressWarnings("this-escape")`.
- `Guid(String)` constructor invokes overridable setters (`setStringValue`, `setHostId`, `setLongValue`, `setType`, `setUuid`, `setUntypedString`) before the subclass is fully initialized. Annotate with `@SuppressWarnings("this-escape")`.
- `RestExceptionBase`, `PSLocalDependencySummary`, `PSRelationshipSummary`, `PSTaxonomySummary` inherit `Serializable` from `WebApplicationException` or `PSAbstractDataObject` but hold non-`Serializable` fields (`RestErrorCode`, `Object errorData`, `List<D>`, `List<String>`). Annotate each class with `@SuppressWarnings("serial")`.

Closes #2026

## Operator
Kilo Code (minimax-m3)

## Changes
- `rest/src/main/java/com/percussion/rest/errors/FolderNotFoundException.java` — `@SuppressWarnings("this-escape")` on constructor.
- `rest/src/main/java/com/percussion/rest/errors/RestExceptionBase.java` — `@SuppressWarnings("serial")` on class.
- `rest/src/main/java/com/percussion/rest/Guid.java` — `@SuppressWarnings("this-escape")` on `Guid(String)` constructor.
- `rest/src/main/java/com/percussion/share/relationship/data/PSLocalDependencySummary.java` — `@SuppressWarnings("serial")` on class.
- `rest/src/main/java/com/percussion/share/relationship/data/PSRelationshipSummary.java` — `@SuppressWarnings("serial")` on class.
- `rest/src/main/java/com/percussion/share/relationship/data/PSTaxonomySummary.java` — `@SuppressWarnings("serial")` on class.

## Verification
- Standalone `mvnw clean install` for rest: BUILD SUCCESS (includes `MainTest` Spring context test).
- `spotless:apply` + `spotless:check` on rest: BUILD SUCCESS.
- Original six javac warnings eliminated; no new javac warnings introduced.