### PR TITLE
feat(docker): freeport compose DB host ports for multi-worktree (#2004)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -60,22 +60,25 @@ perc-devctl.py qa-down [--container NAME]
 
 Each subcommand writes full output to a timestamped file under `docker/logs/<label>-<ts>.log` and emits a single `RESULT:OK STEP:<label> LOG:<path>` (or `RESULT:FAIL`) line on stdout so agent workflows can parse the result without parsing free-form output.
 
-#### Host ports / freeport (multi-worktree) — #2001 / #2005
+#### Host ports / freeport (multi-worktree) — #2001 / #2005 / #2004
 
 `perc-devctl.py` and `matrix-install-smoke.py` resolve published host ports via shared helpers in `docker/scripts/perc_host_ports.py` (cross-platform stdlib `socket` bind to port `0` — no Unix-only tooling):
 
 1. **Env override** (wins):
    - Dev stack: `CMS_PORT`, `DTS_PORT` (compose already maps these), or full `VERIFY_CMS_URL` / `VERIFY_DTS_URL`
+   - Compose DB host publishes: `MYSQL_PORT`, `POSTGRES_PORT`, `MSSQL_PORT` (compose maps `${*_PORT:-…}:container`)
    - QA / matrix CMS cell: `QA_CMS_HOST_PORT` or `CMS_HOST_PORT`
    - Matrix DTS cell: `DTS_HOST_PORT`
-2. **Preferred baseline when free** on loopback: compose CMS `9992`, compose DTS `9980`, matrix/QA CMS `9993`, matrix DTS `9983`
+2. **Preferred baseline when free** on loopback: compose CMS `9992`, compose DTS `9980`, matrix/QA CMS `9993`, matrix DTS `9983`, MySQL `3306`, Postgres `5433`, SQL Server `1433`
 3. Else **ephemeral freeport** so a second worktree does not hit `address already in use`
+
+Process-env pins override `.env.compose` / `.env.compose.example` defaults when `docker compose` interpolates host ports. **Container listen ports stay fixed** (MySQL `3306`, Postgres `5432`, SQL Server `1433`); matrix cells reach DBs via Docker DNS on `perc-matrix-net`, not the host publish side.
 
 **Discover allocated ports:**
 
-- `perc-devctl.py up` prints `CMS_PORT=…`, `DTS_PORT=…`, and the resolved `VERIFY_*_URL` lines
+- `perc-devctl.py up` prints `CMS_PORT=…`, `DTS_PORT=…`, `MYSQL_PORT` / `POSTGRES_PORT` / `MSSQL_PORT`, and the resolved `VERIFY_*_URL` lines
 - `perc-devctl.py qa-up` prints `QA_CMS_HOST_PORT=…` and `TEST_CMS_URL=http://127.0.0.1:<port>`
-- `matrix-install-smoke.py` pins `CMS_HOST_PORT` / `QA_CMS_HOST_PORT` / `DTS_HOST_PORT` for the cell it starts; probe URL and docker `-p` always use that same port
+- `matrix-install-smoke.py` pins `CMS_HOST_PORT` / `QA_CMS_HOST_PORT` / `DTS_HOST_PORT` for the cell it starts; probe URL and docker `-p` always use that same port. External DB cells also pin and print `MYSQL_PORT` / `POSTGRES_PORT` / `MSSQL_PORT` before compose up.
 
 **Playwright / `TEST_CMS_URL` contract:**
 
@@ -86,6 +89,10 @@ Each subcommand writes full output to a timestamped file under `docker/logs/<lab
 | CI / local override   | Export `TEST_CMS_URL` **and** matching `QA_CMS_HOST_PORT` / `CMS_HOST_PORT` before `qa-up` so publish + probe + Playwright agree |
 
 Do **not** hardcode `http://127.0.0.1:9993` in agent scripts — 9993 is only the preferred baseline when free. Pin ports across sessions by exporting those env vars before `up` / `qa-up` / `matrix-install-smoke` / `verify`. Tear-down (`down` / `qa-down` / cell destroy) frees the docker publish mapping; the host port itself is not reserved after the container exits.
+
+**Host-side installer + MySQL freeport:** if `MYSQL_PORT` freeports away from `3306` and you run `scripts/install-cms-dev.py` against published MySQL on localhost, also set `PERC_DB_PORT` to the same host port (matrix cells do not need this — they use container DNS).
+
+**Remaining multi-worktree gaps** (parent [#2001](https://github.com/intersoftdatalabs-in/percussioncms/issues/2001)): fixed compose `container_name` values still limit true concurrent full stacks; freeport alone does not rename containers. Operator two-worktree checklist: [#2006](https://github.com/intersoftdatalabs-in/percussioncms/issues/2006) when present.
 
 #### QA mode (`qa-up` / `qa-health` / `qa-down`)
 

--- a/docker/scripts/matrix-install-smoke.py
+++ b/docker/scripts/matrix-install-smoke.py
@@ -105,6 +105,22 @@ DTS_HOST_PORT = PREFERRED_DTS_HOST_PORT
 CMS_PROBE_PATH = "/Rhythmyx/login"
 DTS_PROBE_PATH = "/"
 
+# Compose DB published host ports (docker-compose.yml ``${*_PORT:-…}:container``).
+# Container listen ports and matrix cell DB_PORT stay fixed (3306/5432/1433);
+# cells reach DBs via Docker DNS on perc-matrix-net, not host publish ports.
+# Multi-worktree: set MYSQL_PORT / POSTGRES_PORT / MSSQL_PORT or leave unset
+# so freeport allocates — see ensure_compose_db_host_ports / docker/README.md.
+PREFERRED_MYSQL_HOST_PORT = 3306
+PREFERRED_POSTGRES_HOST_PORT = 5433
+PREFERRED_MSSQL_HOST_PORT = 1433
+
+# matrix db_type → (compose env key, preferred host port)
+COMPOSE_DB_HOST_PORT_SPEC: Dict[str, Tuple[str, int]] = {
+    "mysql": ("MYSQL_PORT", PREFERRED_MYSQL_HOST_PORT),
+    "postgresql": ("POSTGRES_PORT", PREFERRED_POSTGRES_HOST_PORT),
+    "sqlserver": ("MSSQL_PORT", PREFERRED_MSSQL_HOST_PORT),
+}
+
 # Compose service name → stable container_name from docker-compose.yml
 CONTAINER_BY_SERVICE: Dict[str, str] = {
     "postgres": "percussion-postgres",
@@ -457,6 +473,56 @@ def ensure_matrix_host_port(product: str) -> int:
     return port
 
 
+def resolve_compose_db_host_port(db_type: str) -> int:
+    """Resolve published host port for a compose external DB (env or freeport).
+
+    Resolution order (via :func:`resolve_host_port`):
+
+      1. Env override: ``MYSQL_PORT`` / ``POSTGRES_PORT`` / ``MSSQL_PORT``
+      2. Preferred baseline when free (3306 / 5433 / 1433)
+      3. Ephemeral freeport
+
+    Does not pin env — use :func:`ensure_compose_db_host_ports` before
+    ``docker compose up`` so shell env overrides ``.env.compose`` defaults.
+    H2 and unknown types raise ``ValueError``.
+    """
+    db_type = db_type.lower().strip()
+    spec = COMPOSE_DB_HOST_PORT_SPEC.get(db_type)
+    if spec is None:
+        raise ValueError(
+            f"No compose host-port mapping for db_type={db_type!r}; "
+            f"known: {sorted(COMPOSE_DB_HOST_PORT_SPEC)}"
+        )
+    env_key, preferred = spec
+    return resolve_host_port(env_key, preferred=preferred)
+
+
+def ensure_compose_db_host_ports(db_types: Iterable[str]) -> Dict[str, int]:
+    """Resolve and pin compose DB host ports for external DBs in ``db_types``.
+
+    Pins ``MYSQL_PORT`` / ``POSTGRES_PORT`` / ``MSSQL_PORT`` into
+    ``os.environ`` so concurrent worktrees and ``docker compose`` publish
+    / probe stay consistent (#2004). Skips H2 and unknown non-external types.
+    Returns mapping of matrix ``db_type`` → resolved host port.
+    """
+    resolved: Dict[str, int] = {}
+    for raw in db_types:
+        db_type = raw.lower().strip()
+        if db_type not in COMPOSE_DB_HOST_PORT_SPEC:
+            continue
+        env_key, _preferred = COMPOSE_DB_HOST_PORT_SPEC[db_type]
+        port = resolve_compose_db_host_port(db_type)
+        os.environ[env_key] = str(port)
+        resolved[db_type] = port
+        LOG.info(
+            "Compose DB host publish %s %s=%s (container port unchanged)",
+            db_type,
+            env_key,
+            port,
+        )
+    return resolved
+
+
 def build_docker_run_argv(
     *,
     image: str,
@@ -599,6 +665,11 @@ def start_db(
     # compose service name (e.g. "postgres") so cells can use DB_HOST=postgres.
     container = db_container_name(service)
     started_by_matrix = False
+
+    # Pin freeport/env host publish before compose so multi-worktree cells do
+    # not collide on MYSQL_PORT / POSTGRES_PORT / MSSQL_PORT (#2004). Process
+    # env overrides .env.compose defaults for docker compose interpolation.
+    ensure_compose_db_host_ports([db_type])
 
     # If compose DB is already running (common on long-lived dev hosts), skip
     # ``compose up`` so a host port clash (e.g. local Postgres on 5432) does not
@@ -1004,6 +1075,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     LOG.info("Using compose env file %s", env_file)
     cells = expand_matrix(products, dbs)
+    # Pin compose DB host publishes once for the whole matrix so concurrent
+    # worktrees get a stable freeport set before any compose up (#2004).
+    db_host_ports = ensure_compose_db_host_ports(dbs)
+    for db_type, port in sorted(db_host_ports.items()):
+        env_key = COMPOSE_DB_HOST_PORT_SPEC[db_type][0]
+        print(f"{env_key}={port}")
     # Engaged = external DBs we actually start_db()'d for a cell (not merely selected).
     engaged_external: Set[str] = set()
     started_by_matrix: Set[str] = set()

--- a/docker/scripts/perc-devctl.py
+++ b/docker/scripts/perc-devctl.py
@@ -95,6 +95,10 @@ VERIFY_FIX_TIMEOUT_SECONDS_DEFAULT = 240
 PREFERRED_VERIFY_CMS_HOST_PORT = 9992
 PREFERRED_VERIFY_DTS_HOST_PORT = 9980
 PREFERRED_QA_CMS_HOST_PORT = 9993
+# Compose DB host publishes (docker-compose.yml ${*_PORT:-…}); #2004.
+PREFERRED_MYSQL_HOST_PORT = 3306
+PREFERRED_POSTGRES_HOST_PORT = 5433
+PREFERRED_MSSQL_HOST_PORT = 1433
 
 VERIFY_CMS_PATH = "/Rhythmyx/rest/folders/by-path/Assets"
 VERIFY_DTS_PATH = "/"
@@ -175,18 +179,44 @@ def qa_cms_probe_url(port: int) -> str:
     return f"{qa_cms_base_url(port)}{QA_CMS_PROBE_PATH}"
 
 
+def ensure_compose_db_host_ports() -> dict[str, int]:
+    """Resolve compose DB host ports and pin them in ``os.environ`` (#2004).
+
+    Compose maps ``${MYSQL_PORT:-3306}:3306``, ``${POSTGRES_PORT:-5433}:5432``,
+    and ``${MSSQL_PORT:-1433}:1433``. Process-env pins override ``.env.compose``
+    defaults so concurrent worktrees do not fail with address-already-in-use.
+    Returns mapping of env key → resolved host port.
+    """
+    specs = (
+        ("MYSQL_PORT", PREFERRED_MYSQL_HOST_PORT),
+        ("POSTGRES_PORT", PREFERRED_POSTGRES_HOST_PORT),
+        ("MSSQL_PORT", PREFERRED_MSSQL_HOST_PORT),
+    )
+    resolved: dict[str, int] = {}
+    for env_key, preferred in specs:
+        port = resolve_host_port(env_key, preferred=preferred)
+        os.environ[env_key] = str(port)
+        resolved[env_key] = port
+    return resolved
+
+
 def ensure_compose_host_ports() -> tuple[int, int]:
-    """Resolve CMS/DTS host ports for compose and pin them in ``os.environ``.
+    """Resolve CMS/DTS (and DB) host ports for compose and pin ``os.environ``.
 
     Compose already maps ``${CMS_PORT:-9992}:9992`` and
     ``${DTS_PORT:-9980}:9980``. Pinning the resolved values into the process
     environment makes ``docker compose`` and later ``verify`` in the same
     session use the same published ports (critical for multi-worktree freeport).
+
+    Also pins ``MYSQL_PORT`` / ``POSTGRES_PORT`` / ``MSSQL_PORT`` via
+    :func:`ensure_compose_db_host_ports` so full compose stacks share the
+    freeport contract (#2004).
     """
     cms = resolve_host_port("CMS_PORT", preferred=PREFERRED_VERIFY_CMS_HOST_PORT)
     dts = resolve_host_port("DTS_PORT", preferred=PREFERRED_VERIFY_DTS_HOST_PORT)
     os.environ["CMS_PORT"] = str(cms)
     os.environ["DTS_PORT"] = str(dts)
+    ensure_compose_db_host_ports()
     return cms, dts
 
 
@@ -512,6 +542,11 @@ def cmd_up(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
     repo_root, env_file, compose_file = paths
     log_dir = _log_dir(repo_root)
     cms_port, dts_port = ensure_compose_host_ports()
+    db_ports = {
+        key: int(os.environ[key])
+        for key in ("MYSQL_PORT", "POSTGRES_PORT", "MSSQL_PORT")
+        if os.environ.get(key)
+    }
     compose_argv = _docker_compose(env_file, compose_file, "up", "-d")
     if args.build:
         compose_argv.append("--build")
@@ -525,6 +560,9 @@ def cmd_up(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
     # Agent/operator discovery: published host ports for this worktree cell.
     print(f"CMS_PORT={cms_port}")
     print(f"DTS_PORT={dts_port}")
+    for key in ("MYSQL_PORT", "POSTGRES_PORT", "MSSQL_PORT"):
+        if key in db_ports:
+            print(f"{key}={db_ports[key]}")
     print(f"VERIFY_CMS_URL={resolve_verify_cms_url()}")
     print(f"VERIFY_DTS_URL={resolve_verify_dts_url()}")
     return rc

--- a/docker/scripts/perc_host_ports.py
+++ b/docker/scripts/perc_host_ports.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Shared host-port / freeport helpers for docker scripts (#2001 / #2005).
+"""Shared host-port / freeport helpers for docker scripts (#2001 / #2005 / #2004).
 
 Cross-platform (Windows / Linux / macOS). Uses stdlib ``socket`` only —
-no Unix-only tooling. Callers: ``perc-devctl.py``, ``matrix-install-smoke.py``.
+no Unix-only tooling. Callers: ``perc-devctl.py``, ``matrix-install-smoke.py``
+(product CMS/DTS publish ports and compose DB host publishes).
 
 Resolution order for :func:`resolve_host_port`:
 

--- a/docker/scripts/test_matrix_install_smoke.py
+++ b/docker/scripts/test_matrix_install_smoke.py
@@ -20,6 +20,9 @@ _PORT_ENV_KEYS = (
     "QA_CMS_HOST_PORT",
     "CMS_HOST_PORT",
     "DTS_HOST_PORT",
+    "MYSQL_PORT",
+    "POSTGRES_PORT",
+    "MSSQL_PORT",
 )
 
 
@@ -351,6 +354,157 @@ class MatrixHostPortFreeportTests(unittest.TestCase):
     def test_unknown_product_raises(self):
         with self.assertRaises(ValueError):
             smoke.resolve_matrix_host_port("oracle")
+
+
+class ComposeDbHostPortFreeportTests(unittest.TestCase):
+    """#2004 — compose MYSQL/POSTGRES/MSSQL host ports from env or freeport."""
+
+    def setUp(self):
+        _clear_port_env()
+        self.addCleanup(_clear_port_env)
+
+    def test_preferred_baselines(self):
+        self.assertEqual(smoke.PREFERRED_MYSQL_HOST_PORT, 3306)
+        self.assertEqual(smoke.PREFERRED_POSTGRES_HOST_PORT, 5433)
+        self.assertEqual(smoke.PREFERRED_MSSQL_HOST_PORT, 1433)
+        self.assertEqual(
+            smoke.COMPOSE_DB_HOST_PORT_SPEC["mysql"],
+            ("MYSQL_PORT", 3306),
+        )
+        self.assertEqual(
+            smoke.COMPOSE_DB_HOST_PORT_SPEC["postgresql"],
+            ("POSTGRES_PORT", 5433),
+        )
+        self.assertEqual(
+            smoke.COMPOSE_DB_HOST_PORT_SPEC["sqlserver"],
+            ("MSSQL_PORT", 1433),
+        )
+
+    def test_env_override_mysql(self):
+        os.environ["MYSQL_PORT"] = "13306"
+        self.assertEqual(smoke.resolve_compose_db_host_port("mysql"), 13306)
+
+    def test_env_override_postgres(self):
+        os.environ["POSTGRES_PORT"] = "15433"
+        self.assertEqual(smoke.resolve_compose_db_host_port("postgresql"), 15433)
+
+    def test_env_override_mssql(self):
+        os.environ["MSSQL_PORT"] = "11433"
+        self.assertEqual(smoke.resolve_compose_db_host_port("sqlserver"), 11433)
+
+    def test_invalid_env_raises(self):
+        os.environ["MYSQL_PORT"] = "not-a-port"
+        with self.assertRaises(ValueError):
+            smoke.resolve_compose_db_host_port("mysql")
+
+    def test_h2_and_unknown_raise(self):
+        with self.assertRaises(ValueError):
+            smoke.resolve_compose_db_host_port("h2")
+        with self.assertRaises(ValueError):
+            smoke.resolve_compose_db_host_port("oracle")
+
+    def test_preferred_when_free(self):
+        preferred = smoke.find_free_port()
+        # Direct resolve_host_port path used by compose DB helpers.
+        self.assertEqual(
+            smoke.resolve_host_port("MYSQL_PORT", preferred=preferred),
+            preferred,
+        )
+
+    def test_falls_back_when_preferred_taken(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            taken = int(sock.getsockname()[1])
+            resolved = smoke.resolve_host_port("POSTGRES_PORT", preferred=taken)
+            self.assertNotEqual(resolved, taken)
+            self.assertGreater(resolved, 0)
+
+    def test_ensure_pins_all_external_dbs(self):
+        os.environ["MYSQL_PORT"] = "13306"
+        os.environ["POSTGRES_PORT"] = "15433"
+        os.environ["MSSQL_PORT"] = "11433"
+        resolved = smoke.ensure_compose_db_host_ports(
+            ["h2", "mysql", "postgresql", "sqlserver"]
+        )
+        self.assertEqual(
+            resolved,
+            {
+                "mysql": 13306,
+                "postgresql": 15433,
+                "sqlserver": 11433,
+            },
+        )
+        self.assertNotIn("h2", resolved)
+        self.assertEqual(os.environ["MYSQL_PORT"], "13306")
+        self.assertEqual(os.environ["POSTGRES_PORT"], "15433")
+        self.assertEqual(os.environ["MSSQL_PORT"], "11433")
+
+    def test_ensure_skips_h2_only(self):
+        resolved = smoke.ensure_compose_db_host_ports(["h2"])
+        self.assertEqual(resolved, {})
+        self.assertNotIn("MYSQL_PORT", os.environ)
+
+    def test_ensure_freeport_when_preferred_taken(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            taken = int(sock.getsockname()[1])
+            # Force preferred to the held port via a temporary preferred override
+            # by pre-setting env empty and monkeypatching preferred in resolve path:
+            # Call resolve_host_port with taken preferred through ensure after
+            # temporarily swapping COMPOSE_DB_HOST_PORT_SPEC preferred.
+            original = smoke.COMPOSE_DB_HOST_PORT_SPEC["mysql"]
+            smoke.COMPOSE_DB_HOST_PORT_SPEC["mysql"] = ("MYSQL_PORT", taken)
+            self.addCleanup(
+                lambda: smoke.COMPOSE_DB_HOST_PORT_SPEC.__setitem__(
+                    "mysql", original
+                )
+            )
+            resolved = smoke.ensure_compose_db_host_ports(["mysql"])
+            self.assertEqual(list(resolved.keys()), ["mysql"])
+            self.assertNotEqual(resolved["mysql"], taken)
+            self.assertEqual(os.environ["MYSQL_PORT"], str(resolved["mysql"]))
+
+    def test_dry_run_postgresql_prints_postgres_port(self):
+        """Dry-run external DB path pins and prints POSTGRES_PORT (#2004)."""
+        import io
+        from contextlib import redirect_stdout
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            target = root / "modules" / "perc-distribution-tree" / "target"
+            target.mkdir(parents=True)
+            (target / "perc-distribution-tree.jar").write_bytes(b"stub-jar-content")
+            (root / "docker" / "logs").mkdir(parents=True)
+            (root / "docker" / "matrix").mkdir(parents=True)
+            (root / "docker" / "matrix" / "Dockerfile").write_text(
+                "FROM scratch\n", encoding="utf-8"
+            )
+            (root / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+            (root / ".env.compose.example").write_text(
+                "POSTGRES_PASSWORD=test-local-only\n"
+                "MYSQL_PASSWORD=test-local-only\n"
+                "MSSQL_SA_PASSWORD=test-local-only\n",
+                encoding="utf-8",
+            )
+            os.environ["POSTGRES_PORT"] = "15444"
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = smoke.main(
+                    [
+                        "--repo-root",
+                        str(root),
+                        "--product",
+                        "cms",
+                        "--db",
+                        "postgresql",
+                        "--dry-run",
+                        "--skip-image-build",
+                    ]
+                )
+            self.assertEqual(rc, 0)
+            out = buf.getvalue()
+            self.assertIn("POSTGRES_PORT=15444", out)
+            self.assertEqual(os.environ["POSTGRES_PORT"], "15444")
 
 
 class DbOwnershipAndTeardownTests(unittest.TestCase):

--- a/docker/scripts/test_perc_devctl.py
+++ b/docker/scripts/test_perc_devctl.py
@@ -29,6 +29,9 @@ _PORT_ENV_KEYS = (
     "DTS_HOST_PORT",
     "CMS_PORT",
     "DTS_PORT",
+    "MYSQL_PORT",
+    "POSTGRES_PORT",
+    "MSSQL_PORT",
     "VERIFY_CMS_URL",
     "VERIFY_DTS_URL",
 )
@@ -685,6 +688,40 @@ class TestFreeportAndUrlWiring(unittest.TestCase):
         self.assertEqual((cms, dts), (18881, 18882))
         self.assertEqual(os.environ["CMS_PORT"], "18881")
         self.assertEqual(os.environ["DTS_PORT"], "18882")
+        # #2004 — CMS/DTS ensure also pins compose DB host publishes.
+        self.assertIn("MYSQL_PORT", os.environ)
+        self.assertIn("POSTGRES_PORT", os.environ)
+        self.assertIn("MSSQL_PORT", os.environ)
+        self.assertGreater(int(os.environ["MYSQL_PORT"]), 0)
+
+    def test_ensure_compose_db_host_ports_env_override(self):
+        os.environ["MYSQL_PORT"] = "13306"
+        os.environ["POSTGRES_PORT"] = "15433"
+        os.environ["MSSQL_PORT"] = "11433"
+        resolved = pdc.ensure_compose_db_host_ports()
+        self.assertEqual(
+            resolved,
+            {
+                "MYSQL_PORT": 13306,
+                "POSTGRES_PORT": 15433,
+                "MSSQL_PORT": 11433,
+            },
+        )
+        self.assertEqual(os.environ["MYSQL_PORT"], "13306")
+
+    def test_ensure_compose_db_host_ports_freeport_when_taken(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            taken = int(sock.getsockname()[1])
+            # Prefer a held port for MYSQL only via temporary preferred constant.
+            original = pdc.PREFERRED_MYSQL_HOST_PORT
+            pdc.PREFERRED_MYSQL_HOST_PORT = taken
+            self.addCleanup(
+                lambda: setattr(pdc, "PREFERRED_MYSQL_HOST_PORT", original)
+            )
+            resolved = pdc.ensure_compose_db_host_ports()
+            self.assertNotEqual(resolved["MYSQL_PORT"], taken)
+            self.assertEqual(os.environ["MYSQL_PORT"], str(resolved["MYSQL_PORT"]))
 
     def test_qa_up_dry_run_honors_env_port(self):
         os.environ["QA_CMS_HOST_PORT"] = "16666"

--- a/docs/ai-generated/code-reviews/issue-2004-compose-db-freeport-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2004-compose-db-freeport-erlang.md
@@ -1,0 +1,27 @@
+# Erlang review — issue #2004 compose DB freeport
+
+**Branch:** `feat/issue-2004-compose-db-freeport`  
+**Scope:** `docker/scripts/*` freeport for compose DB host ports + docs  
+**Verdict:** Pass (implement)
+
+## Change class
+
+Host-side Docker operator scripts: extend existing freeport contract (`perc_host_ports.resolve_host_port`) to compose published DB ports (`MYSQL_PORT` / `POSTGRES_PORT` / `MSSQL_PORT`), pin process env before `docker compose up`, unit-test allocation + override.
+
+## Checklist
+
+|         Gate         |                                                              Result                                                               |
+|----------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| Bugs / correctness   | Pass — env → preferred-when-free → freeport; pin into `os.environ` so compose shell env overrides `.env.compose`                  |
+| Cross-platform paths | Pass — stdlib `socket` only; no path construction; no Unix-only tools                                                             |
+| Behavioral tests     | Pass — `test_matrix_install_smoke.py` ComposeDbHostPortFreeportTests; `test_perc_devctl.py` DB pin/freeport tests; 98 tests green |
+| Companions           | Pass — matrix + perc-devctl peer consumers; README freeport section; docker-compose already exposes `${*_PORT:-…}`                |
+| Secrets              | Pass — no credentials in freeport path                                                                                            |
+| Scope                | Pass — no live multi-DB install required; residual container_name concurrency remains parent/#2006                                |
+
+## Notes
+
+- Container listen ports and matrix `DB_PORT` stay fixed; cells use Docker DNS.
+- Fixed `container_name` still prevents two simultaneous full stacks on one host; freeport only fixes publish port collisions.
+- Host installer `PERC_DB_PORT` alignment documented in README when MYSQL freeports away from 3306.
+


### PR DESCRIPTION
## Summary

Implements residual freeport for matrix/compose **DB host publish ports** (issue #2004, parent #2001).

docker-compose.yml already maps `:3306`, `:5432`, and `:1433`. This PR wires **matrix-install-smoke** and **perc-devctl** to resolve those via the same contract as CMS/DTS:

1. **Env override** wins (MYSQL_PORT / POSTGRES_PORT / MSSQL_PORT)
2. **Preferred baseline when free** (3306 / 5433 / 1433)
3. Else **ephemeral freeport** (stdlib `socket` in `perc_host_ports.py`)

Resolved values are **pinned into process env** so concurrent worktrees and `docker compose` publish stay consistent (shell env overrides `.env.compose` defaults).

- Container listen ports and matrix cell `DB_PORT` stay fixed; cells reach DBs via Docker DNS on `perc-matrix-net`.
- DTS/CMS product freeport already landed (#2005 / #2014); this slice is DB + remaining compose host publishes.

**Fixes #2004**  
**Related #2001**

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] `python -m pytest docker/scripts/test_matrix_install_smoke.py docker/scripts/test_perc_devctl.py -q` → **98 passed**
- [x] Unit coverage: env override, preferred-when-free, freeport when preferred held, pin to env, dry-run prints `POSTGRES_PORT`, h2 skip
- [x] Erlang self-review: `docs/ai-generated/code-reviews/issue-2004-compose-db-freeport-erlang.md` (pass)
- [x] Spotless: `mvnw spotless:apply` then `spotless:check`; **only in-scope files committed** (baseline Spotless debt in unrelated code-reviews/Java left uncommitted — not folded into this PR)
- [x] No Maven module sources changed → module `clean install` N/A

### Manual (optional)

`ash
# Preferred free
python docker/scripts/matrix-install-smoke.py --product cms --db postgresql --dry-run --skip-image-build
# Expect POSTGRES_PORT=5433 (or freeport if 5433 busy)

# Env override
# Unix: export POSTGRES_PORT=15433
# Windows: =15433
python docker/scripts/matrix-install-smoke.py --product cms --db postgresql --dry-run --skip-image-build
# Expect POSTGRES_PORT=15433
`

## Gates evidence

| Gate | Evidence |
|------|----------|
| Behavioral tests | 98 passed (matrix + perc-devctl freeport suites) |
| Erlang | Pass — portable stdlib freeport; no Unix-only tools |
| Spotless | apply → check; PR contains only docker/* + this erlang review |
| Maven clean install | N/A (Python/docs only under `docker/`) |
| Cross-platform | `socket` bind only; no path separators |

## Residual / out of scope

- Fixed compose `container_name` values still block true concurrent full stacks (freeport does not rename containers) — parent #2001 / operator checklist #2006 when present.
- Live multi-DB two-worktree install not required for acceptance (unit tests + dry-run pin proof).
- Unrelated monorepo Spotless baseline debt not shipped here.