### PR TITLE
fix(perc-distribution-tree): remove javac warnings in preinstall (#2043)

### DIFF
--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
@@ -778,9 +778,7 @@ public class Main {
               if (s.contains("<CategoryTree")) {
                 topLevelNodeToReplace.set(s);
               }
-              if (s.contains("</CategoryTree"))
-                ;
-              {
+              if (s.contains("</CategoryTree")) {
                 topLevelNodeEndToReplace.set(s);
               }
               if (s.contains("topLevelNodes")) {

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java
@@ -196,6 +196,7 @@ public final class JavaInstallSelection {
   }
 
   /** Thrown when no candidate is found or selection is invalid. */
+  @SuppressWarnings("serial")
   public static final class JavaSelectionException extends Exception {
     /**
      * Creates an exception with the supplied message.


### PR DESCRIPTION
## Description
- `JavaInstallSelection.JavaSelectionException` extends `Exception` without declaring a `serialVersionUID`. Annotate the class with `@SuppressWarnings("serial")` since the exception is never expected to be serialized.
- `Main` contained an "empty statement after if" followed by an unrelated block. Remove the stray semicolon so the code runs when the `</CategoryTree>` tag is found.

Closes #2043

## Operator
Kilo Code (minimax-m3)

## Changes
- `modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/java/JavaInstallSelection.java` — `@SuppressWarnings("serial")` on `JavaSelectionException`.
- `modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java` — removed empty statement after if.

## Verification
- `mvn test`: BUILD SUCCESS, 213 tests, 0 failures, 0 errors, 3 skipped.
- `mvn install -DskipTests=true -Dexec.skip=true`: BUILD SUCCESS (the `exec:java verify-jdbc-drivers` step hangs in this sandbox; unrelated to this fix).
- `spotless:apply` + `spotless:check`: BUILD SUCCESS.
- Original two javac warnings eliminated; no new javac warnings introduced.