### PR TITLE
docs(GH-2067): document live perc-service-wrapper Linux entry points

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -564,7 +564,7 @@ A list of child modules in this repository. Each bullet contains: Module name �
 - **perc-rxapps** — `./modules/perc-rxapps` — Packaging module used by the installer to package files required in the cms deployment.
 - **webservices** — `./modules/webservices` — Legacy Rhythmyx SOAP web services API migrated from Apache Axis to CXF.
 - **perc-system** — `./system` — The core CMS module representing Rhythmyx functionality.  Contains the core XML application server and content managenent implementation.
-- **perc-service-wrapper** — `./modules/perc-service-wrapper` — Legacy module that was intended to be used for Windows service management. Currently not used in deployments.
+- **perc-service-wrapper** — `./modules/perc-service-wrapper` — CMS/DTS process start/stop jar (`PSServiceWrapper`). Packaged into CMS and DTS distributions; **live** on classic Linux SysV/init.d service install (`system/release/installer/Linux/percussion-service.sh` + `install-service.sh`). Not the modern Jetty systemd path (`modules/perc-jetty` dual-ship, GH-962/#1978); do not remove until init.d deprecation (GH-1976).
 - **rest** — `./rest` — Public REST API (JAX-RS resources, wire DTOs, `IXxxAdaptor` interfaces). **Must not** depend on `sitemanage` (reactor cycle). See `rest/AGENTS.md`. Workbench-replacement REST + **dev/QA test modes**: `docs/developer-module/workbench-rest-and-qa-modes.md`.
 - **perc-tinymce** — `./modules/perc-tinymce` — Packaging module for the TinyMCE rich text editor used in the CMS ui to edit content.
 - **perc-toolkit** — `./modules/perc-toolkit` — Legacy module containing

--- a/modules/perc-service-wrapper/README.md
+++ b/modules/perc-service-wrapper/README.md
@@ -1,20 +1,78 @@
 # perc-service-wrapper
 
-This module contains backend support for the mechanism that controls the startup and shutdown of the percussion services.
+Process start/stop control jar for Percussion CMS and co-located Delivery Tier
+Service (DTS) processes. Main class: `com.percussion.wrapper.PSServiceWrapper`.
 
-Usage: java -jar perc-service-wrapper.jar [options...] [jetty properties...] [jetty configs...]
+**Status (8.2.x / GH-2067):** **USED** on supported classic Linux SysV/init.d
+service install paths. The jar is staged into shipping CMS and DTS layouts and
+invoked by Linux service scripts. It is **not** the modern Jetty native systemd
+entry point (that lives under `modules/perc-jetty`). Do **not** delete this
+module or its packaging copies until the init.d path is formally deprecated
+(see GH-1976; dual-ship policy GH-962 / GH-1978).
 
-The perc-service-wrapper.jar controls the startup and shutdown of the percussion services.
-The location of the root distribution directory is discovered based upon the location of the jar file unless a system
--Drxdeploydir system property is provided.
+## Usage
 
-Extra options and properties files can be passed through to the Jetty start.jar if this is not a standalone DTS Server
-this is useful to check the jetty configuration in particular the --list-config option can help diagnosis of problems.
+```text
+java -jar perc-service-wrapper.jar [options...] [jetty properties...] [jetty configs...]
+```
 
-To see the full list of jetty options you can pass the --jettyHelp option to this command.
+The wrapper discovers the distribution root from the jar location unless
+`-Drxdeploydir` is set. It can start/stop/status:
 
-* for more details see usage.txt under resources directory in this module.
+- Jetty CMS (`JettyStartWrapper`)
+- Production DTS (`DtsStartWrapper`)
+- Staging DTS (`DtsStartWrapper`)
+
+Extra options are forwarded to Jetty `start.jar` when applicable (for example
+`--list-config`). Use `--jettyHelp` for Jetty's own help.
+
+Full CLI flags: `src/main/resources/com/percussion/wrapper/usage.txt`.
+
+## Live entry points (8.2)
+
+|                          Surface                           |                                                                           Role                                                                           |
+|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `system/release/installer/Linux/percussion-service.sh`     | SysV service script; default `SVC_WRAPPER=$PERC_ROOT/perc-service-wrapper.jar`; `start`/`stop`/`status` run `java -jar … --start|--stop|--status`        |
+| `system/release/installer/Linux/install-service.sh`        | Installs `/etc/init.d/<ServiceName>` from the percussion-service template and writes `/etc/default/<ServiceName>` with `SVC_WRAPPER` / `SVC_WRAPPER_CMD` |
+| `modules/perc-distribution-tree/pom.xml`                   | Dependency + copy to CMS assembly as `perc-service-wrapper.jar` at distribution root                                                                     |
+| `deliverytiersuite/.../delivery-tier-distribution/pom.xml` | Stages `perc-service-wrapper.jar` into the DTS distribution layout                                                                                       |
+
+## Not used by (inventory GH-2067)
+
+Static inventory found **no** callers in:
+
+- Modern Jetty systemd dual-ship (`modules/perc-jetty` `install-jetty-service.sh`,
+  `percussion-cms.service.in`, `rxjetty.sh`) — preferred Linux service path on
+  systemd hosts
+- Windows Procrun / Jetty service install under `modules/perc-jetty`
+- Docker / `perc-devctl` scripts
+- QA automation (`modules/perc-qa-automation`)
+
+Those paths start Jetty (and related processes) without this jar. Coexistence is
+intentional while init.d remains dual-shipped.
+
+## Overlap with Jetty systemd (GH-962)
+
+|                Path                |                                  Mechanism                                  | Wrapper jar  |
+|------------------------------------|-----------------------------------------------------------------------------|--------------|
+| Classic Linux init.d (this module) | `install-service.sh` → init.d → `java -jar perc-service-wrapper.jar`        | **Required** |
+| Modern Jetty service               | `install-jetty-service.sh` → systemd unit and/or init helper → `rxjetty.sh` | **Not used** |
+
+Removal of this module would break the classic Linux service install path. Defer
+removal until ops signs off init.d deprecation (GH-1976) after dual-ship soak
+(GH-1978).
 
 ## Building
 
-mvn clean install
+From this module directory (JDK 21, repo Maven wrapper):
+
+```bash
+../../mvnw clean install
+```
+
+Windows:
+
+```bat
+..\..\mvnw.cmd clean install
+```
+


### PR DESCRIPTION
## Summary

**Finding (GH-2067): USED** — perc-service-wrapper is still required on the classic Linux SysV/init.d service path. Root `AGENTS.md` incorrectly described it as a Windows-service leftover that is “Currently not used in deployments.”

This PR is **docs/inventory only**: correct the module blurb and expand the module README. **Does not** remove the module, reactor entry, or packaging copy steps (that would break supported Linux service install).

### Live callers (static inventory)

| Location | Role |
|----------|------|
| `system/release/installer/Linux/percussion-service.sh` | `SVC_WRAPPER=/perc-service-wrapper.jar`; start/stop/status via `java -jar` |
| `system/release/installer/Linux/install-service.sh` | Installs init.d + `/etc/default` with wrapper cmd |
| `modules/perc-distribution-tree/pom.xml` | Stages jar into CMS distribution root |
| `deliverytiersuite/.../delivery-tier-distribution/pom.xml` | Stages jar into DTS distribution |

### Not used by

- Modern Jetty systemd dual-ship (`modules/perc-jetty` / GH-962 / GH-1978) — preferred path on systemd hosts
- Windows Procrun / Jetty service under `perc-jetty`
- Docker / `perc-devctl` / QA automation

### Relationship to dual-ship / removal

| Track | Notes |
|-------|--------|
| GH-962 / GH-1978 | systemd dual-ship with init.d retained until soak |
| GH-1976 | init.d deprecation after soak — **gate for any future wrapper removal** |

Parent tracker: #2067 (self).

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2067

## Test plan

- [x] Repo-wide grep for `perc-service-wrapper` / `PSServiceWrapper` / `JettyStartWrapper`
- [x] Confirmed Linux service scripts invoke the jar
- [x] Confirmed packaging POMs stage the jar (CMS + DTS)
- [x] Confirmed no callers in docker, QA automation, or modern jetty systemd templates
- [x] Spotless: `mvnw -pl modules/perc-service-wrapper spotless:apply` then `spotless:check` (README)
- [x] Docs-only change — no Maven `clean install` required for product modules
- [x] In-scope files only (no monorepo Spotless dump)

## Gates evidence

- **Change class:** docs/inventory correction (AGENTS module list + module README)
- **Erlang:** docs-only; no new code paths; portable path notes in README use product script paths as-is
- **Spotless:** apply then check on `modules/perc-service-wrapper`; only in-scope files committed
- **Maven clean install:** N/A (docs/AGENTS only; no sources/tests/POM changes)
- **Rule file note:** root `AGENTS.md` module blurb corrected per issue acceptance; human directed via #2067 disposition