### PR TITLE
docs(505): close-out #1920 catalog/system/ui Jackson re-inventory

### DIFF
--- a/docs/ai-generated/tasks/505-betwixt-jackson/1920-catalog-system-ui-domain-deviations.md
+++ b/docs/ai-generated/tasks/505-betwixt-jackson/1920-catalog-system-ui-domain-deviations.md
@@ -1,8 +1,76 @@
-# Issue #1920 — Catalog / system / ui leftovers (first sub-batch)
+# Issue #1920 — Catalog / system / ui leftovers
 
 Parent: #1892 · Grandparent: #1823 · Epic: #505 · Inventory: #1821
 
-## Scope delivered (this PR)
+> **Status: CLOSED (2026-08-05 re-inventory)** — all inventory **RW** types for this
+> slice are on Jackson-backed `PSXmlSerializationHelper` with golden/RT tests.
+> Remaining items are **A-only suppress** (`PSLegacyGuid`, `PSLocale`) — no further
+> RW sub-batch required. Betwixt POM / leftover `.betwixt` purge remains #1824 / #2062.
+
+## Delivery roll-up
+
+|           Class           |       Root element        |                 Sub-batch                  |                                    PR                                    |
+|---------------------------|---------------------------|--------------------------------------------|--------------------------------------------------------------------------|
+| `PSAudit`                 | `audit`                   | first (#1920)                              | [#1995](https://github.com/intersoftdatalabs-in/percussioncms/pull/1995) |
+| `PSAuditTrail`            | `audit-trail`             | first (#1920)                              | [#1995](https://github.com/intersoftdatalabs-in/percussioncms/pull/1995) |
+| `PSSharedProperty`        | `shared-property`         | first (#1920)                              | [#1995](https://github.com/intersoftdatalabs-in/percussioncms/pull/1995) |
+| `PSHierarchyNode`         | `hierarchy-node`          | first (#1920)                              | [#1995](https://github.com/intersoftdatalabs-in/percussioncms/pull/1995) |
+| `PSHierarchyNodeProperty` | `hierarchy-node-property` | first (#1920); dropped obsolete `.betwixt` | [#1995](https://github.com/intersoftdatalabs-in/percussioncms/pull/1995) |
+| `PSDependent`             | `dependent`               | residual #1993                             | [#2013](https://github.com/intersoftdatalabs-in/percussioncms/pull/2013) |
+| `PSDependency`            | `dependency`              | residual #1993                             | [#2013](https://github.com/intersoftdatalabs-in/percussioncms/pull/2013) |
+| `PSMimeContentAdapter`    | `mime-content-adapter`    | residual #1994                             | [#2047](https://github.com/intersoftdatalabs-in/percussioncms/pull/2047) |
+
+Tracked separately (not this issue): `PSObjectSummary` / `PSObjectLockSummary` — #1903
+(closed).
+
+### Sub-batch deviation docs
+
+|             Sub-batch              |                                         Doc                                          |
+|------------------------------------|--------------------------------------------------------------------------------------|
+| First (audit / shared / hierarchy) | this file (sections below)                                                           |
+| Dependency                         | [1993-dependency-domain-deviations.md](./1993-dependency-domain-deviations.md)       |
+| Mime content adapter               | [1994-mime-content-adapter-deviations.md](./1994-mime-content-adapter-deviations.md) |
+
+## Re-inventory proof (2026-08-05)
+
+Cross-check of inventory §6.9 (`docs/ai-generated/tasks/505-betwixt-jackson/00-inventory.md`)
+and workspace sources on `main`:
+
+|        Inventory class         |    Role    |                                        Disposition                                        |
+|--------------------------------|------------|-------------------------------------------------------------------------------------------|
+| `PSObjectSummary`              | RW + A + T | #1903 closed (not in #1920 scope)                                                         |
+| `PSAudit` / `PSAuditTrail`     | RW         | Jackson + goldens — PR #1995                                                              |
+| `PSDependency` / `PSDependent` | RW         | Jackson + goldens — PR #2013 / #1993 closed                                               |
+| `PSMimeContentAdapter`         | RW         | Jackson + goldens — PR #2047 / #1994 closed                                               |
+| `PSSharedProperty`             | RW         | Jackson + goldens — PR #1995                                                              |
+| `PSHierarchyNode`              | RW + A     | Jackson + goldens — PR #1995                                                              |
+| `PSHierarchyNodeProperty`      | RW         | Jackson + goldens; production `.betwixt` removed — PR #1995                               |
+| `PSLegacyGuid`                 | **A only** | suppress properties only — no design RW surface                                           |
+| `PSLocale`                     | **A only** | suppress properties only — nested in security tests via `addType`; no standalone RW slice |
+
+### Production `*.betwixt` remaining (not #1920)
+
+Repo-wide source scan (excluding `target/` and utils junit fixtures):
+
+|                      File                      |             Owning domain / issue             |
+|------------------------------------------------|-----------------------------------------------|
+| `system/.../content/data/PSKeyword.betwixt`    | keywords (#1888 line) — not catalog leftovers |
+| `system/.../guidmgr/data/PSGuid.betwixt`       | guid pilot / shared                           |
+| `system/.../security/data/PSCommunity.betwixt` | security (#1889)                              |
+
+No remaining production `.betwixt` under `services/ui`, `services/system`, or
+`services/catalog`. `PSHierarchyNodeProperty.betwixt` was dropped in #1995.
+
+### Grep holdouts
+
+- Catalog package: only `PSObjectSummary` is RW design XML (done under #1903).
+- System data package: all RW types above carry `@JacksonXmlRootElement` +
+  `PSXmlSerializationHelper` `fromXML`/`toXML`.
+- UI data package: `PSHierarchyNode*` Jackson + goldens.
+- `PSLegacyGuid` / `PSLocale`: `@IPSXmlSerialization(suppress=true)` only — **no**
+  new golden/RT batch required.
+
+## Scope delivered (first sub-batch — PR #1995)
 
 |           Class           |       Root element        |                              Nested / notes                              |
 |---------------------------|---------------------------|--------------------------------------------------------------------------|
@@ -14,10 +82,10 @@ Parent: #1892 · Grandparent: #1823 · Epic: #505 · Inventory: #1821
 
 Golden fixtures + round-trip + legacy `<null>` root tests:
 
-- `system/.../system/data/PSSystemDataXmlSerializationTest`
+- `system/.../system/data/PSSystemDataXmlSerializationTest` (also hosts #1993 / #1994 cases)
 - `system/.../ui/data/PSHierarchyNodeXmlSerializationTest`
 
-## Approved / intentional deviations vs historical Betwixt
+## Approved / intentional deviations vs historical Betwixt (first sub-batch)
 
 |                          Deviation                           |                                                          Notes                                                           |
 |--------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
@@ -35,26 +103,36 @@ Golden fixtures + round-trip + legacy `<null>` root tests:
 | Null-safe `setVersion`                                       | BeanUtils copy after Jackson restore may pass null.                                                                      |
 | `setNodeType` + idempotent `setType`                         | BeanUtils property `nodeType` must round-trip enum form.                                                                 |
 
-## Residual (file as children of #1920)
+See [1993-dependency-domain-deviations.md](./1993-dependency-domain-deviations.md) and
+[1994-mime-content-adapter-deviations.md](./1994-mime-content-adapter-deviations.md) for
+residual sub-batch deviations.
 
-Not in this PR:
+## Residual
 
-1. **PSDependency / PSDependent** — system dependency graph leftovers
-2. **PSMimeContentAdapter** — system content adapter design XML
-3. Any other catalog/system/ui holdouts discovered after re-inventory (e.g. `PSLegacyGuid` A-only, `PSLocale` A-only are suppress-only and may not need a slice)
+**None for #1920.** Historical residuals shipped:
+
+1. ~~PSDependency / PSDependent~~ → #1993 closed / PR #2013
+2. ~~PSMimeContentAdapter~~ → #1994 closed / PR #2047
+3. ~~Other catalog/system/ui RW holdouts~~ → re-inventory found none
+4. `PSLegacyGuid` / `PSLocale` A-only — intentionally **not** sliced (suppress-only)
+
+Epic residual (not this issue): Betwixt POM removal / leftover `.betwixt` files →
+
+# 1824 / #2062. Do **not** remove `commons-betwixt` from this slice.
 
 ## Out of scope
 
 - filter (#1915), sitemgr (#1918), publisher/pubserver (#1919)
 - content leftovers (#1921)
 - `PSObjectSummary` (#1903 closed)
-- Betwixt POM removal (#1824)
+- Betwixt POM removal (#1824 / #2062)
 - Facade engine deletion
 
 ## Tests
 
-|                 Suite                 |                                Coverage                                 |
-|---------------------------------------|-------------------------------------------------------------------------|
-| `PSSystemDataXmlSerializationTest`    | audit / audit-trail / shared-property golden + RT + legacy null root    |
-| `PSHierarchyNodeXmlSerializationTest` | hierarchy-node / hierarchy-node-property golden + RT + legacy null root |
+|                 Suite                 |                                                       Coverage                                                       |
+|---------------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| `PSSystemDataXmlSerializationTest`    | audit / audit-trail / shared-property / dependent / dependency / mime-content-adapter golden + RT + legacy null root |
+| `PSHierarchyNodeXmlSerializationTest` | hierarchy-node / hierarchy-node-property golden + RT + legacy null root                                              |
+| `PSMimeContentAdapterTest`            | interface programming surface (JUnit 5; #1994)                                                                       |
 


### PR DESCRIPTION
## Summary

**Closes #1920** (slice 6d catalog/system/ui leftovers) after re-inventory — **no new domain migration code**.

### Re-inventory result (inventory §6.9 + workspace `main`)

| Inventory class | Role | Disposition |
|-----------------|------|-------------|
| `PSAudit` / `PSAuditTrail` / `PSSharedProperty` / `PSHierarchyNode*` | RW | Shipped PR [#1995](https://github.com/intersoftdatalabs-in/percussioncms/pull/1995) |
| `PSDependency` / `PSDependent` | RW | Shipped PR [#2013](https://github.com/intersoftdatalabs-in/percussioncms/pull/2013) · #1993 closed |
| `PSMimeContentAdapter` | RW | Shipped PR [#2047](https://github.com/intersoftdatalabs-in/percussioncms/pull/2047) · #1994 closed |
| `PSObjectSummary` | RW | #1903 closed (separate track) |
| `PSLegacyGuid` / `PSLocale` | **A only** | Suppress-only — no RW golden/RT slice required |

Production `.betwixt` remaining are **not** catalog/system/ui leftovers (`PSKeyword`, `PSGuid`, `PSCommunity`). `PSHierarchyNodeProperty.betwixt` already dropped in #1995.

### This PR

- Updates `docs/ai-generated/tasks/505-betwixt-jackson/1920-catalog-system-ui-domain-deviations.md` with CLOSED status, delivery roll-up, and re-inventory proof.
- Does **not** remove `commons-betwixt` (#1824 / #2062).

### Links

- **Fixes #1920**
- Parent tracker: #1892 (slice 6) · Grandparent #1823 · Epic #505
- Prior sub-batch PRs: #1995 · #2013 · #2047

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] Re-grep production `*.betwixt` (system + monorepo, exclude `target/`) — no ui/system/catalog leftover mappings
- [x] Confirm `@JacksonXmlRootElement` on system/ui RW types; A-only suppress on `PSLegacyGuid` / `PSLocale`
- [x] Confirm residual issues #1993 / #1994 closed and PRs merged
- [x] Spotless: `mvnw -N spotless:apply` **then** `spotless:check` — **only in-scope** deviations doc committed (out-of-scope Spotless rewrites discarded)
- [x] Maven clean install: **N/A** (docs-only change; no module sources/tests/resources/pom)
- [x] Erlang: docs-only status roll-up — no production logic change

## Gates evidence

| Gate | Result |
|------|--------|
| Module clean install | N/A — docs only |
| Spotless | apply then check; feature PR = 1 file |
| Erlang | approve for docs close-out (no new RW type, no path I/O) |
| Change-class | inventory proof + deviations status (companions already shipped on prior PRs) |

## Residuals

None for #1920. Epic residual: #1824 / #2062 (Betwixt POM purge).