### PR TITLE
feat(1508): Oracle matrix compose profile + harness unit tests

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -23,6 +23,18 @@ POSTGRES_PORT=5433
 MSSQL_SA_PASSWORD=LocalDev_ChangeMe_1a!
 MSSQL_PORT=1433
 
+# --- Oracle XE (compose profile: oracle / db-all) — matrix Layer-1 (#1508) ---
+# Image: gvenzl/oracle-xe:21-slim (see docker/README.md). Heavy; opt-in only.
+# ORACLE_PASSWORD = SYS/SYSTEM (image bootstrap). CMS uses APP_USER credentials.
+# Service name for --db.name defaults to XEPDB1 (pluggable DB in Oracle XE 21).
+ORACLE_PASSWORD=LocalDev_ChangeMe_1a!
+ORACLE_APP_USER=percuser
+ORACLE_APP_PASSWORD=LocalDev_ChangeMe_1a!
+ORACLE_SERVICE=XEPDB1
+ORACLE_PORT=1521
+# Optional schema override (defaults to APP_USER / percuser in harness).
+# ORACLE_SCHEMA=percuser
+
 CMS_PORT=9992
 DTS_PORT=9980
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,7 +126,41 @@ services:
       timeout: 5s
       retries: 10
 
+  # Oracle XE for matrix install smoke (#1508 / parent #1500).
+  # Image: gvenzl/oracle-xe (community Oracle XE packaging). Heavy RAM/disk and
+  # slow first start; opt-in profile only (not part of default up).
+  # Cells reach the DB via Docker DNS alias ``oracle:1521`` on perc-matrix-net.
+  # Installer uses --db.name as service name (default XEPDB1) and APP_USER as schema.
+  # See docker/README.md § Oracle compose profile. Credentials from .env.compose only.
+  oracle:
+    image: gvenzl/oracle-xe:21-slim
+    container_name: percussion-oracle
+    restart: unless-stopped
+    profiles:
+      - oracle
+      - db-all
+    environment:
+      # SYS/SYSTEM password (required by the image). Not used as CMS login.
+      ORACLE_PASSWORD: ${ORACLE_PASSWORD:?Set ORACLE_PASSWORD in .env.compose}
+      # Application user created on first start (CMS connect user / schema).
+      APP_USER: ${ORACLE_APP_USER:-percuser}
+      APP_USER_PASSWORD: ${ORACLE_APP_PASSWORD:?Set ORACLE_APP_PASSWORD in .env.compose}
+    ports:
+      # Host 1521 is often taken by a local Oracle listener; freeport / ORACLE_PORT
+      # can reallocate. Cells use container DNS, not this host publish.
+      - "${ORACLE_PORT:-1521}:1521"
+    volumes:
+      - oracle-data:/opt/oracle/oradata
+    healthcheck:
+      # healthcheck.sh ships with gvenzl/oracle-xe images.
+      test: ["CMD", "healthcheck.sh"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
+      start_period: 120s
+
 volumes:
   mysql-data:
   postgres-data:
   sqlserver-data:
+  oracle-data:

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,7 +10,7 @@ DB passwords are **not** hardcoded in `docker-compose.yml`. Copy the example env
 
 ```bash
 cp .env.compose.example .env.compose
-# edit MYSQL_*/POSTGRES_*/MSSQL_* passwords as needed
+# edit MYSQL_*/POSTGRES_*/MSSQL_*/ORACLE_* passwords as needed
 docker compose --env-file .env.compose --profile postgres up -d
 ```
 
@@ -66,19 +66,19 @@ Each subcommand writes full output to a timestamped file under `docker/logs/<lab
 
 1. **Env override** (wins):
    - Dev stack: `CMS_PORT`, `DTS_PORT` (compose already maps these), or full `VERIFY_CMS_URL` / `VERIFY_DTS_URL`
-   - Compose DB host publishes: `MYSQL_PORT`, `POSTGRES_PORT`, `MSSQL_PORT` (compose maps `${*_PORT:-…}:container`)
+   - Compose DB host publishes: `MYSQL_PORT`, `POSTGRES_PORT`, `MSSQL_PORT`, `ORACLE_PORT` (compose maps `${*_PORT:-…}:container`)
    - QA / matrix CMS cell: `QA_CMS_HOST_PORT` or `CMS_HOST_PORT`
    - Matrix DTS cell: `DTS_HOST_PORT`
-2. **Preferred baseline when free** on loopback: compose CMS `9992`, compose DTS `9980`, matrix/QA CMS `9993`, matrix DTS `9983`, MySQL `3306`, Postgres `5433`, SQL Server `1433`
+2. **Preferred baseline when free** on loopback: compose CMS `9992`, compose DTS `9980`, matrix/QA CMS `9993`, matrix DTS `9983`, MySQL `3306`, Postgres `5433`, SQL Server `1433`, Oracle `1521`
 3. Else **ephemeral freeport** so a second worktree does not hit `address already in use`
 
-Process-env pins override `.env.compose` / `.env.compose.example` defaults when `docker compose` interpolates host ports. **Container listen ports stay fixed** (MySQL `3306`, Postgres `5432`, SQL Server `1433`); matrix cells reach DBs via Docker DNS on `perc-matrix-net`, not the host publish side.
+Process-env pins override `.env.compose` / `.env.compose.example` defaults when `docker compose` interpolates host ports. **Container listen ports stay fixed** (MySQL `3306`, Postgres `5432`, SQL Server `1433`, Oracle `1521`); matrix cells reach DBs via Docker DNS on `perc-matrix-net`, not the host publish side.
 
 **Discover allocated ports:**
 
 - `perc-devctl.py up` prints `CMS_PORT=…`, `DTS_PORT=…`, `MYSQL_PORT` / `POSTGRES_PORT` / `MSSQL_PORT`, and the resolved `VERIFY_*_URL` lines
 - `perc-devctl.py qa-up` prints `QA_CMS_HOST_PORT=…` and `TEST_CMS_URL=http://127.0.0.1:<port>`
-- `matrix-install-smoke.py` pins `CMS_HOST_PORT` / `QA_CMS_HOST_PORT` / `DTS_HOST_PORT` for the cell it starts; probe URL and docker `-p` always use that same port. External DB cells also pin and print `MYSQL_PORT` / `POSTGRES_PORT` / `MSSQL_PORT` before compose up.
+- `matrix-install-smoke.py` pins `CMS_HOST_PORT` / `QA_CMS_HOST_PORT` / `DTS_HOST_PORT` for the cell it starts; probe URL and docker `-p` always use that same port. External DB cells also pin and print `MYSQL_PORT` / `POSTGRES_PORT` / `MSSQL_PORT` / `ORACLE_PORT` before compose up.
 
 **Playwright / `TEST_CMS_URL` contract:**
 
@@ -284,8 +284,12 @@ python3 docker/scripts/matrix-install-smoke.py --product cms --db postgresql
 # Both products × H2 and PostgreSQL
 python3 docker/scripts/matrix-install-smoke.py --product cms,dts --db h2,postgresql
 
-# DTS only × full Layer-1 DB matrix (H2 + external compose profiles)
+# DTS only × Layer-1 DB matrix without Oracle (H2 + common external profiles)
 python3 docker/scripts/matrix-install-smoke.py --product dts --db h2,postgresql,mysql,sqlserver
+
+# CMS + Oracle XE (opt-in; heavy image — see Oracle section below)
+# Requires ORACLE_PASSWORD + ORACLE_APP_PASSWORD in .env.compose
+python3 docker/scripts/matrix-install-smoke.py --product cms --db oracle
 
 # Leave cell up for Playwright Layer 2 (perc-qa-automation)
 python3 docker/scripts/matrix-install-smoke.py --product cms --db postgresql --keep
@@ -302,12 +306,42 @@ python3 docker/scripts/matrix-install-smoke.py --product cms --db postgresql,mys
 
 # Dry-run (no docker)
 python3 docker/scripts/matrix-install-smoke.py --product cms --db h2 --dry-run --skip-image-build
+# Dry-run Oracle cell metadata (still needs passwords in env / .env.compose)
+python3 docker/scripts/matrix-install-smoke.py --product cms --db oracle --dry-run --skip-image-build
 ```
+
+### Oracle compose profile (#1508)
+
+Opt-in Oracle XE for matrix Layer-1 only (not started by default `perc-devctl.py up`).
+
+|              Item              |                                                                                                    Value                                                                                                     |
+|--------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Image**                      | `gvenzl/oracle-xe:21-slim` (community packaging of Oracle Database XE). Accept Oracle Free Use Terms when pulling; operators may pin a company-approved mirror by changing `image:` in `docker-compose.yml`. |
+| **Compose profiles**           | `oracle`, and `db-all` (starts all external matrix DBs)                                                                                                                                                      |
+| **Container name**             | `percussion-oracle`                                                                                                                                                                                          |
+| **Network alias**              | `oracle` on `perc-matrix-net` (cells use `DB_HOST=oracle`)                                                                                                                                                   |
+| **Container port**             | `1521` (fixed)                                                                                                                                                                                               |
+| **Host publish**               | `${ORACLE_PORT:-1521}:1521` (freeport / env when 1521 is taken)                                                                                                                                              |
+| **Service name (`--db.name`)** | `XEPDB1` (default pluggable DB; override with `ORACLE_SERVICE`)                                                                                                                                              |
+| **CMS user / schema**          | `APP_USER` / `ORACLE_APP_USER` (default `percuser`); password `ORACLE_APP_PASSWORD`                                                                                                                          |
+| **SYS bootstrap**              | `ORACLE_PASSWORD` (required by the image; **not** the CMS connect password)                                                                                                                                  |
+| **SSL**                        | Off for compose cells (`--db.ssl.enabled=false`), same as postgres/mysql/sqlserver                                                                                                                           |
+| **Resources**                  | Large image, high RAM, slow first healthcheck (`start_period` 120s). Prefer dedicated machine / long probe timeout for live smoke.                                                                           |
+
+```bash
+# Start Oracle only (after .env.compose has ORACLE_* set)
+docker compose --env-file .env.compose --profile oracle up -d oracle
+
+# Matrix harness (starts profile, network-connects alias, install cell)
+python3 docker/scripts/matrix-install-smoke.py --product cms --db oracle --probe-timeout 1800
+```
+
+**Live smoke residual:** compose + harness + unit tests land in this slice. Unattended `RESULT:OK` against a real Oracle container (image pull, license, long first start, full install probe) is **not** required for the first PR — track as residual follow-up on #1508 / parent #1500.
 
 ### External DB teardown policy (#1516)
 
 Matrix cells (`perc-matrix-*`) are destroyed after each cell unless `--keep`.
-External compose DBs (`percussion-postgres` / `percussion-mysql` / `percussion-sqlserver`) follow a separate ownership rule:
+External compose DBs (`percussion-postgres` / `percussion-mysql` / `percussion-sqlserver` / `percussion-oracle`) follow a separate ownership rule:
 
 |    Flag     |            Cells            |                              External DBs                               |
 |-------------|-----------------------------|-------------------------------------------------------------------------|

--- a/docker/matrix/cell-entrypoint.py
+++ b/docker/matrix/cell-entrypoint.py
@@ -146,7 +146,7 @@ def build_install_argv(
             argv.append(f"--db.password={db_password}")
         if db_schema:
             argv.append(f"--db.schema={db_schema}")
-        # Compose matrix DBs (postgres/mysql/sqlserver profiles) do not terminate TLS.
+        # Compose matrix DBs (postgres/mysql/sqlserver/oracle profiles) do not terminate TLS.
         # Installer defaults db.ssl.enabled=true, which makes MySQL requireSSL and SQL Server
         # encrypt=true fail with "Communications link failure" against plain Docker DBs.
         argv.append("--db.ssl.enabled=false")

--- a/docker/scripts/matrix-install-smoke.py
+++ b/docker/scripts/matrix-install-smoke.py
@@ -17,8 +17,9 @@ Layer 1 harness:
 
 DB lifecycle (#1516)
 --------------------
-External compose DBs (``percussion-postgres`` / ``-mysql`` / ``-sqlserver``) are
-started only when not already running. After the matrix report is written:
+External compose DBs (``percussion-postgres`` / ``-mysql`` / ``-sqlserver`` /
+``-oracle``) are started only when not already running. After the matrix report
+is written:
 
 * **Default** — stop services this process brought up (``compose stop``, no ``-v``).
 * ``--keep`` — leave cells **and** DBs up (Playwright Layer 2 / debugging).
@@ -38,6 +39,9 @@ Usage
 
     # CMS + PostgreSQL
     python3 docker/scripts/matrix-install-smoke.py --product cms --db postgresql
+
+    # CMS + Oracle XE (compose profile oracle; heavy image — see docker/README.md)
+    python3 docker/scripts/matrix-install-smoke.py --product cms --db oracle
 
     # Both products × H2 and PostgreSQL
     python3 docker/scripts/matrix-install-smoke.py --product cms,dts --db h2,postgresql
@@ -106,19 +110,21 @@ CMS_PROBE_PATH = "/Rhythmyx/login"
 DTS_PROBE_PATH = "/"
 
 # Compose DB published host ports (docker-compose.yml ``${*_PORT:-…}:container``).
-# Container listen ports and matrix cell DB_PORT stay fixed (3306/5432/1433);
+# Container listen ports and matrix cell DB_PORT stay fixed (3306/5432/1433/1521);
 # cells reach DBs via Docker DNS on perc-matrix-net, not host publish ports.
-# Multi-worktree: set MYSQL_PORT / POSTGRES_PORT / MSSQL_PORT or leave unset
-# so freeport allocates — see ensure_compose_db_host_ports / docker/README.md.
+# Multi-worktree: set MYSQL_PORT / POSTGRES_PORT / MSSQL_PORT / ORACLE_PORT or
+# leave unset so freeport allocates — see ensure_compose_db_host_ports / README.
 PREFERRED_MYSQL_HOST_PORT = 3306
 PREFERRED_POSTGRES_HOST_PORT = 5433
 PREFERRED_MSSQL_HOST_PORT = 1433
+PREFERRED_ORACLE_HOST_PORT = 1521
 
 # matrix db_type → (compose env key, preferred host port)
 COMPOSE_DB_HOST_PORT_SPEC: Dict[str, Tuple[str, int]] = {
     "mysql": ("MYSQL_PORT", PREFERRED_MYSQL_HOST_PORT),
     "postgresql": ("POSTGRES_PORT", PREFERRED_POSTGRES_HOST_PORT),
     "sqlserver": ("MSSQL_PORT", PREFERRED_MSSQL_HOST_PORT),
+    "oracle": ("ORACLE_PORT", PREFERRED_ORACLE_HOST_PORT),
 }
 
 # Compose service name → stable container_name from docker-compose.yml
@@ -126,6 +132,7 @@ CONTAINER_BY_SERVICE: Dict[str, str] = {
     "postgres": "percussion-postgres",
     "mysql": "percussion-mysql",
     "sqlserver": "percussion-sqlserver",
+    "oracle": "percussion-oracle",
 }
 
 PRODUCTS = ("cms", "dts")
@@ -168,6 +175,19 @@ _DB_SERVICE_BASE: Dict[str, Dict[str, str]] = {
         "user": "sa",
         "password_env": "MSSQL_SA_PASSWORD",
         "name": "percdb",
+    },
+    # Oracle XE (gvenzl/oracle-xe): --db.name is service/SID (XEPDB1);
+    # APP_USER is CMS user/schema. Password from ORACLE_APP_PASSWORD.
+    "oracle": {
+        "profile": "oracle",
+        "service": "oracle",
+        "host": "localhost",
+        "port": "1521",
+        "container_host": "oracle",
+        "user": "percuser",
+        "password_env": "ORACLE_APP_PASSWORD",
+        "name": "XEPDB1",
+        "schema": "percuser",
     },
 }
 
@@ -231,6 +251,18 @@ def build_db_services(env: Mapping[str, str]) -> Dict[str, Dict[str, str]]:
             meta["name"] = _pick_env(env, "MYSQL_DATABASE", default=meta.get("name", "percdb"))
         elif name == "sqlserver":
             meta["user"] = "sa"
+        elif name == "oracle":
+            # APP_USER / service name / schema — never hardcode secrets.
+            meta["user"] = _pick_env(
+                env, "ORACLE_APP_USER", "APP_USER", default=meta.get("user", "percuser")
+            )
+            meta["name"] = _pick_env(
+                env, "ORACLE_SERVICE", default=meta.get("name", "XEPDB1")
+            )
+            # Schema defaults to the app user (Oracle unquoted identifiers).
+            meta["schema"] = _pick_env(
+                env, "ORACLE_SCHEMA", default=meta.get("user", "percuser")
+            )
         services[name] = meta
     return services
 
@@ -478,8 +510,9 @@ def resolve_compose_db_host_port(db_type: str) -> int:
 
     Resolution order (via :func:`resolve_host_port`):
 
-      1. Env override: ``MYSQL_PORT`` / ``POSTGRES_PORT`` / ``MSSQL_PORT``
-      2. Preferred baseline when free (3306 / 5433 / 1433)
+      1. Env override: ``MYSQL_PORT`` / ``POSTGRES_PORT`` / ``MSSQL_PORT`` /
+         ``ORACLE_PORT``
+      2. Preferred baseline when free (3306 / 5433 / 1433 / 1521)
       3. Ephemeral freeport
 
     Does not pin env — use :func:`ensure_compose_db_host_ports` before
@@ -500,8 +533,8 @@ def resolve_compose_db_host_port(db_type: str) -> int:
 def ensure_compose_db_host_ports(db_types: Iterable[str]) -> Dict[str, int]:
     """Resolve and pin compose DB host ports for external DBs in ``db_types``.
 
-    Pins ``MYSQL_PORT`` / ``POSTGRES_PORT`` / ``MSSQL_PORT`` into
-    ``os.environ`` so concurrent worktrees and ``docker compose`` publish
+    Pins ``MYSQL_PORT`` / ``POSTGRES_PORT`` / ``MSSQL_PORT`` / ``ORACLE_PORT``
+    into ``os.environ`` so concurrent worktrees and ``docker compose`` publish
     / probe stay consistent (#2004). Skips H2 and unknown non-external types.
     Returns mapping of matrix ``db_type`` → resolved host port.
     """
@@ -667,8 +700,8 @@ def start_db(
     started_by_matrix = False
 
     # Pin freeport/env host publish before compose so multi-worktree cells do
-    # not collide on MYSQL_PORT / POSTGRES_PORT / MSSQL_PORT (#2004). Process
-    # env overrides .env.compose defaults for docker compose interpolation.
+    # not collide on MYSQL_PORT / POSTGRES_PORT / MSSQL_PORT / ORACLE_PORT
+    # (#2004). Process env overrides .env.compose defaults for compose.
     ensure_compose_db_host_ports([db_type])
 
     # If compose DB is already running (common on long-lived dev hosts), skip
@@ -981,7 +1014,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--db",
         default="h2",
-        help="Comma list: h2,postgresql,mysql,sqlserver (default: h2)",
+        help="Comma list: h2,postgresql,mysql,sqlserver,oracle (default: h2)",
     )
     p.add_argument(
         "--compose-file",

--- a/docker/scripts/test_matrix_install_smoke.py
+++ b/docker/scripts/test_matrix_install_smoke.py
@@ -23,6 +23,7 @@ _PORT_ENV_KEYS = (
     "MYSQL_PORT",
     "POSTGRES_PORT",
     "MSSQL_PORT",
+    "ORACLE_PORT",
 )
 
 
@@ -78,12 +79,39 @@ class EnvAndPasswordTests(unittest.TestCase):
                 "POSTGRES_PASSWORD": "pg-secret",
                 "MYSQL_PASSWORD": "my-secret",
                 "MSSQL_SA_PASSWORD": "sa-secret",
+                "ORACLE_APP_PASSWORD": "ora-secret",
             }
         )
         self.assertEqual(services["postgresql"]["password"], "pg-secret")
         self.assertEqual(services["mysql"]["password"], "my-secret")
         self.assertEqual(services["sqlserver"]["password"], "sa-secret")
+        self.assertEqual(services["oracle"]["password"], "ora-secret")
         self.assertEqual(services["h2"].get("password", ""), "")
+
+    def test_build_db_services_oracle_metadata_shape(self):
+        """Oracle harness metadata: service alias, XEPDB1, schema, no secrets in base."""
+        services = smoke.build_db_services(
+            {
+                "ORACLE_APP_PASSWORD": "ora-secret",
+                "ORACLE_APP_USER": "cmsuser",
+                "ORACLE_SERVICE": "XEPDB1",
+                "ORACLE_SCHEMA": "cmsuser",
+            }
+        )
+        ora = services["oracle"]
+        self.assertEqual(ora["profile"], "oracle")
+        self.assertEqual(ora["service"], "oracle")
+        self.assertEqual(ora["container_host"], "oracle")
+        self.assertEqual(ora["port"], "1521")
+        self.assertEqual(ora["user"], "cmsuser")
+        self.assertEqual(ora["name"], "XEPDB1")
+        self.assertEqual(ora["schema"], "cmsuser")
+        self.assertEqual(ora["password"], "ora-secret")
+        # Defaults when only password is provided
+        defaults = smoke.build_db_services({"ORACLE_APP_PASSWORD": "x"})
+        self.assertEqual(defaults["oracle"]["user"], "percuser")
+        self.assertEqual(defaults["oracle"]["name"], "XEPDB1")
+        self.assertEqual(defaults["oracle"]["schema"], "percuser")
 
     def test_require_db_passwords_fails_when_missing(self):
         services = smoke.build_db_services({})
@@ -91,9 +119,19 @@ class EnvAndPasswordTests(unittest.TestCase):
             smoke.require_db_passwords(services, ["postgresql"])
         self.assertIn("POSTGRES_PASSWORD", str(ctx.exception))
 
+    def test_require_db_passwords_fails_for_oracle_when_missing(self):
+        services = smoke.build_db_services({})
+        with self.assertRaises(ValueError) as ctx:
+            smoke.require_db_passwords(services, ["oracle"])
+        self.assertIn("ORACLE_APP_PASSWORD", str(ctx.exception))
+
     def test_require_db_passwords_allows_h2(self):
         services = smoke.build_db_services({})
         smoke.require_db_passwords(services, ["h2"])  # no raise
+
+    def test_db_types_includes_oracle(self):
+        self.assertIn("oracle", smoke.DB_TYPES)
+        self.assertEqual(smoke.CONTAINER_BY_SERVICE["oracle"], "percussion-oracle")
 
 
 class ResolveJarTests(unittest.TestCase):
@@ -197,6 +235,37 @@ class DockerRunArgvTests(unittest.TestCase):
         self.assertIn("DB_TYPE=h2", joined)
         self.assertNotIn("DB_HOST=", joined)
 
+    def test_cms_oracle_argv(self):
+        jar = Path("/tmp/fake-cms.jar")
+        db_meta = smoke.build_db_services(
+            {
+                "ORACLE_APP_PASSWORD": "ora-secret",
+                "ORACLE_APP_USER": "percuser",
+                "ORACLE_SERVICE": "XEPDB1",
+            }
+        )["oracle"]
+        argv = smoke.build_docker_run_argv(
+            image=smoke.MATRIX_IMAGE_TAG,
+            container_name="perc-matrix-cms-oracle",
+            product="cms",
+            db_type="oracle",
+            installer_jar_host=jar,
+            host_port=9993,
+            network=smoke.MATRIX_NETWORK,
+            db_meta=db_meta,
+            keep=False,
+        )
+        joined = " ".join(argv)
+        self.assertIn("--name perc-matrix-cms-oracle", joined)
+        self.assertIn("DB_TYPE=oracle", joined)
+        self.assertIn("DB_HOST=oracle", joined)
+        self.assertIn("DB_PORT=1521", joined)
+        self.assertIn("DB_NAME=XEPDB1", joined)
+        self.assertIn("DB_USER=percuser", joined)
+        self.assertIn("DB_PASSWORD=ora-secret", joined)
+        self.assertIn("DB_SCHEMA=percuser", joined)
+        self.assertIn("PRODUCT=cms", joined)
+
 
 class InstallArgvTests(unittest.TestCase):
     def test_cms_postgres_silent_argv(self):
@@ -249,6 +318,34 @@ class InstallArgvTests(unittest.TestCase):
         self.assertIn("--db.type=h2", argv)
         self.assertNotIn("--db.host=ignored", argv)
         self.assertNotIn("--db.ssl.enabled=false", argv)
+
+    def test_oracle_install_argv_service_schema_ssl_off(self):
+        """Oracle cell: host/port/service/user/password/schema + SSL off (compose)."""
+        argv = cell.build_install_argv(
+            java="java",
+            installer_jar=Path("/installer/installer.jar"),
+            install_root=Path("/opt/Percussion"),
+            product="cms",
+            db_type="oracle",
+            db_host="oracle",
+            db_port="1521",
+            db_name="XEPDB1",
+            db_user="percuser",
+            db_password="test-db-password",
+            db_schema="percuser",
+            silent=True,
+        )
+        self.assertIn("--db.type=oracle", argv)
+        self.assertIn("--db.host=oracle", argv)
+        self.assertIn("--db.port=1521", argv)
+        self.assertIn("--db.name=XEPDB1", argv)
+        self.assertIn("--db.user=percuser", argv)
+        self.assertIn("--db.password=test-db-password", argv)
+        self.assertIn("--db.schema=percuser", argv)
+        self.assertIn("--db.ssl.enabled=false", argv)
+        self.assertIn("--db.ssl.verify=false", argv)
+        self.assertIn("--silent", argv)
+        self.assertIn("--no-tty", argv)
 
 
 class ProbeUrlTests(unittest.TestCase):
@@ -367,6 +464,7 @@ class ComposeDbHostPortFreeportTests(unittest.TestCase):
         self.assertEqual(smoke.PREFERRED_MYSQL_HOST_PORT, 3306)
         self.assertEqual(smoke.PREFERRED_POSTGRES_HOST_PORT, 5433)
         self.assertEqual(smoke.PREFERRED_MSSQL_HOST_PORT, 1433)
+        self.assertEqual(smoke.PREFERRED_ORACLE_HOST_PORT, 1521)
         self.assertEqual(
             smoke.COMPOSE_DB_HOST_PORT_SPEC["mysql"],
             ("MYSQL_PORT", 3306),
@@ -378,6 +476,10 @@ class ComposeDbHostPortFreeportTests(unittest.TestCase):
         self.assertEqual(
             smoke.COMPOSE_DB_HOST_PORT_SPEC["sqlserver"],
             ("MSSQL_PORT", 1433),
+        )
+        self.assertEqual(
+            smoke.COMPOSE_DB_HOST_PORT_SPEC["oracle"],
+            ("ORACLE_PORT", 1521),
         )
 
     def test_env_override_mysql(self):
@@ -392,6 +494,10 @@ class ComposeDbHostPortFreeportTests(unittest.TestCase):
         os.environ["MSSQL_PORT"] = "11433"
         self.assertEqual(smoke.resolve_compose_db_host_port("sqlserver"), 11433)
 
+    def test_env_override_oracle(self):
+        os.environ["ORACLE_PORT"] = "11521"
+        self.assertEqual(smoke.resolve_compose_db_host_port("oracle"), 11521)
+
     def test_invalid_env_raises(self):
         os.environ["MYSQL_PORT"] = "not-a-port"
         with self.assertRaises(ValueError):
@@ -401,7 +507,7 @@ class ComposeDbHostPortFreeportTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             smoke.resolve_compose_db_host_port("h2")
         with self.assertRaises(ValueError):
-            smoke.resolve_compose_db_host_port("oracle")
+            smoke.resolve_compose_db_host_port("cockroach")
 
     def test_preferred_when_free(self):
         preferred = smoke.find_free_port()
@@ -423,8 +529,9 @@ class ComposeDbHostPortFreeportTests(unittest.TestCase):
         os.environ["MYSQL_PORT"] = "13306"
         os.environ["POSTGRES_PORT"] = "15433"
         os.environ["MSSQL_PORT"] = "11433"
+        os.environ["ORACLE_PORT"] = "11521"
         resolved = smoke.ensure_compose_db_host_ports(
-            ["h2", "mysql", "postgresql", "sqlserver"]
+            ["h2", "mysql", "postgresql", "sqlserver", "oracle"]
         )
         self.assertEqual(
             resolved,
@@ -432,12 +539,14 @@ class ComposeDbHostPortFreeportTests(unittest.TestCase):
                 "mysql": 13306,
                 "postgresql": 15433,
                 "sqlserver": 11433,
+                "oracle": 11521,
             },
         )
         self.assertNotIn("h2", resolved)
         self.assertEqual(os.environ["MYSQL_PORT"], "13306")
         self.assertEqual(os.environ["POSTGRES_PORT"], "15433")
         self.assertEqual(os.environ["MSSQL_PORT"], "11433")
+        self.assertEqual(os.environ["ORACLE_PORT"], "11521")
 
     def test_ensure_skips_h2_only(self):
         resolved = smoke.ensure_compose_db_host_ports(["h2"])
@@ -483,7 +592,9 @@ class ComposeDbHostPortFreeportTests(unittest.TestCase):
             (root / ".env.compose.example").write_text(
                 "POSTGRES_PASSWORD=test-local-only\n"
                 "MYSQL_PASSWORD=test-local-only\n"
-                "MSSQL_SA_PASSWORD=test-local-only\n",
+                "MSSQL_SA_PASSWORD=test-local-only\n"
+                "ORACLE_APP_PASSWORD=test-local-only\n"
+                "ORACLE_PASSWORD=test-local-only\n",
                 encoding="utf-8",
             )
             os.environ["POSTGRES_PORT"] = "15444"
@@ -514,12 +625,15 @@ class DbOwnershipAndTeardownTests(unittest.TestCase):
         self.assertEqual(smoke.db_container_name("postgres"), "percussion-postgres")
         self.assertEqual(smoke.db_container_name("mysql"), "percussion-mysql")
         self.assertEqual(smoke.db_container_name("sqlserver"), "percussion-sqlserver")
+        self.assertEqual(smoke.db_container_name("oracle"), "percussion-oracle")
         self.assertEqual(smoke.db_container_name("other"), "percussion-other")
 
     def test_external_db_types_skips_h2(self):
         self.assertEqual(
-            smoke.external_db_types(["h2", "postgresql", "mysql", "sqlserver"]),
-            {"postgresql", "mysql", "sqlserver"},
+            smoke.external_db_types(
+                ["h2", "postgresql", "mysql", "sqlserver", "oracle"]
+            ),
+            {"postgresql", "mysql", "sqlserver", "oracle"},
         )
         self.assertEqual(smoke.external_db_types(["h2"]), set())
 
@@ -635,10 +749,13 @@ class DryRunCliTests(unittest.TestCase):
         )
         (root / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
         # Credentials for external DB matrix cells (mirrors .env.compose.example).
+        # Placeholders only — never real secrets (matrix harness unit tests).
         (root / ".env.compose.example").write_text(
             "POSTGRES_PASSWORD=test-local-only\n"
             "MYSQL_PASSWORD=test-local-only\n"
-            "MSSQL_SA_PASSWORD=test-local-only\n",
+            "MSSQL_SA_PASSWORD=test-local-only\n"
+            "ORACLE_APP_PASSWORD=test-local-only\n"
+            "ORACLE_PASSWORD=test-local-only\n",
             encoding="utf-8",
         )
 
@@ -680,6 +797,39 @@ class DryRunCliTests(unittest.TestCase):
                 ]
             )
             self.assertEqual(rc, 0)
+
+    def test_dry_run_oracle_exits_zero(self):
+        """Oracle cell accepted by CLI; dry-run exercises compose port pin (#1508)."""
+        import io
+        from contextlib import redirect_stdout
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            self._stub_repo(root)
+            os.environ["ORACLE_PORT"] = "11521"
+            self.addCleanup(lambda: os.environ.pop("ORACLE_PORT", None))
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = smoke.main(
+                    [
+                        "--repo-root",
+                        str(root),
+                        "--product",
+                        "cms",
+                        "--db",
+                        "oracle",
+                        "--dry-run",
+                        "--skip-image-build",
+                    ]
+                )
+            self.assertEqual(rc, 0)
+            self.assertIn("ORACLE_PORT=11521", buf.getvalue())
+
+    def test_parse_csv_accepts_oracle(self):
+        self.assertEqual(
+            smoke.parse_csv("oracle", smoke.DB_TYPES, "db"),
+            ["oracle"],
+        )
 
     def test_keep_db_and_stop_db_are_mutually_exclusive(self):
         with self.assertRaises(SystemExit) as ctx:


### PR DESCRIPTION
## Summary
Partial implement for **#1508** (parent **#1500** matrix initiative): first PR-sized Oracle Layer-1 matrix cell.

### In this PR
- **Compose:** opt-in `oracle` / `db-all` profile with `gvenzl/oracle-xe:21-slim`, container `percussion-oracle`, host `ORACLE_PORT` (preferred 1521), healthcheck, named volume — credentials only from `.env.compose` (see `.env.compose.example`)
- **Harness:** `DB_SERVICES["oracle"]`, `--db oracle`, network alias `oracle`, freeport pin `ORACLE_PORT`, install env (host/port/service XEPDB1/user/password/schema)
- **Cell:** SSL off for compose (same as PG/MySQL/SQL Server); TCP wait already supported on 1521
- **Docs:** `docker/README.md` Oracle section (image choice, ports, opt-in, residual note)
- **Tests:** unit coverage for oracle metadata, docker-run argv, install argv, freeport, dry-run CLI

### Not in this PR (residual)
Live unattended `matrix-install-smoke.py --db oracle` → `RESULT:OK` — tracked as **#2083** (image weight / license / long start).

## Test plan
- [x] `python -m pytest docker/scripts/test_matrix_install_smoke.py -v` → **61 passed**
- [x] Spotless: `mvnw spotless:apply` then `spotless:check` (in-scope only committed; out-of-scope rewrites discarded)
- [x] No Maven module sources changed → no module `clean install` required
- [ ] Optional operator: live `--db oracle` smoke (#2083)

## Gates evidence
| Gate | Evidence |
|------|----------|
| Unit tests | 61 passed (matrix harness) |
| Spotless | apply then check; only 6 intentional files committed |
| Maven clean install | N/A (docker/compose/Python/docs only) |
| Cross-platform paths | Path/as_posix cell patterns unchanged; no new OS path literals |
| Erlang self-review | No secrets in fixtures; peer-matched compose/harness/test companions |

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

## Links
- Partial for #1508
- Parent tracker #1500
- Residual live smoke #2083

Fixes: none (partial — residual #2083 keeps live smoke open; leave #1508 open until residual lands or human closes).