### PR TITLE
fix: use HTTP URL for Hibernate DTD in test config

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/metadata/src/test/resources/hibernate.cfg.xml
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/test/resources/hibernate.cfg.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE hibernate-configuration PUBLIC
 		"-//Hibernate/Hibernate Configuration DTD 3.0//EN"
-		"file:hibernate-configuration-3.0.dtd">
+		"http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
 <hibernate-configuration>
 
 	<session-factory>


### PR DESCRIPTION
The test hibernate.cfg.xml was using an invalid file: reference (file:hibernate-configuration-3.0.dtd) which caused all metadata service tests to fail with 'Error accessing StAX stream'. Changed to use the standard HTTP URL that Hibernate can resolve.