### PR TITLE
test: RET-06 packaging verification prep (redirect stubs + inventory freeze) (#1820)

### DIFF
--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/PublishingDeepPagePackagingTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/PublishingDeepPagePackagingTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.distribution.install;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * RET-06 / issue #1820 packaging verification prep for JSF Publishing Design and Runtime deep-page
+ * retirement.
+ *
+ * <p><strong>Hard gate:</strong> this class does <em>not</em> delete product JSPs. Deep-page
+ * removal is owned by #1819 (Design) and #1818 (Runtime) after #1371 UAT or explicit human ack on
+ * parent #1372. Tests here must stay green on {@code main} while residual deep pages remain
+ * packaged.
+ *
+ * <p>Coverage:
+ *
+ * <ul>
+ *   <li>Entry redirect stubs {@code ui/publishing/index.jsp} and {@code ui/pubruntime/index.jsp}
+ *       remain and target modern Publishing shell paths.
+ *   <li>Current residual JSP inventory is frozen (exact basename set) so accidental adds/removes
+ *       surface in packaging tests.
+ *   <li>{@link Disabled} absence assertions ready to enable after #1819/#1818 land.
+ *   <li>Installer peer still lists {@code publishing-faces-config.xml} for upgrade cleanup
+ *       (lockstep with {@link ObsoleteWebInfArtifactsCleanupTest}).
+ * </ul>
+ *
+ * <p>Paths use {@link Path#of(String, String...)} / {@link Path#resolve(String)} only (portable
+ * Windows/Unix). Redirect targets are URL strings with {@code '/'} separators only.
+ *
+ * <p>Inventory checklist: {@code specs/990-unified-publishing-ui/checklists/removal-inventory.md}.
+ */
+@Tag("UnitTest")
+class PublishingDeepPagePackagingTest {
+
+  /** Relative to module CWD when Surefire runs standalone {@code clean install}. */
+  private static final Path WEB_UI_WEBAPP = Path.of("..", "..", "WebUI", "src", "main", "webapp");
+
+  private static final Path DESIGN_DIR = WEB_UI_WEBAPP.resolve(Path.of("ui", "publishing"));
+
+  private static final Path RUNTIME_DIR = WEB_UI_WEBAPP.resolve(Path.of("ui", "pubruntime"));
+
+  private static final String INSTALL_XML = "/distribution/rxconfig/Installer/install.xml";
+
+  /** Modern shell targets — must match the redirect stubs on disk. */
+  static final String DESIGN_REDIRECT_TARGET = "/cm/app/?view=publish&section=design";
+
+  static final String RUNTIME_REDIRECT_TARGET = "/cm/app/?view=publish&section=runtime";
+
+  /**
+   * Frozen inventory of Design-tree JSPs still packaged on {@code main} (audit #1817 / inventory
+   * 2026-08-04). Update only when #1819 deletes exclusive deep pages (or intentional KEEP changes).
+   */
+  static final Set<String> FROZEN_DESIGN_JSPS =
+      Set.of(
+          "AddContextVariable.jsp",
+          "AssociateContentlist.jsp",
+          "ContentlistEditor.jsp",
+          "ContentlistView.jsp",
+          "ContextEditor.jsp",
+          "ContextList.jsp",
+          "DeliveryTypeEditor.jsp",
+          "DeliveryTypeList.jsp",
+          "EditionEditor.jsp",
+          "EditionList.jsp",
+          "error.jsp",
+          "index.jsp",
+          "ItemBrowser.jsp",
+          "LocationSchemeEditor.jsp",
+          "LocationSchemeLegacyEditor.jsp",
+          "LocationSchemeParamEditor.jsp",
+          "menu.jsp",
+          "NoSchemeParameterSelectionWarning.jsp",
+          "NoSelectionWarning.jsp",
+          "PubDesignAuthentication.jsp",
+          "publish.jsp",
+          "RemoveConfirmation.jsp",
+          "RemoveLocationScheme.jsp",
+          "SaveChildSchemeChangesWarning.jsp",
+          "SelectEditionFromOtherSite.jsp",
+          "SiteEditor.jsp",
+          "SiteList.jsp",
+          "SiteRootBrowser.jsp");
+
+  /**
+   * Frozen inventory of Runtime-tree JSPs still packaged on {@code main} (audit #1817 / inventory
+   * 2026-08-04). Update only when #1818 deletes exclusive deep pages.
+   */
+  static final Set<String> FROZEN_RUNTIME_JSPS =
+      Set.of(
+          "ActiveJobStatus.jsp",
+          "AllPubLogs.jsp",
+          "DeleteSiteItemLogsWarning.jsp",
+          "DemandPublish.jsp",
+          "ErrorMessage.jsp",
+          "index.jsp",
+          "ItemPubLog.jsp",
+          "JobPubLog.jsp",
+          "NoSelectionWarning.jsp",
+          "PubRuntimeAuthentication.jsp",
+          "RuntimeEdition.jsp",
+          "RuntimeEditionList.jsp",
+          "SitePubLogs.jsp");
+
+  /**
+   * Basenames that must remain after Design deep-page retirement (#1819). Today only the modern
+   * Design redirect stub is a hard KEEP; {@code publish.jsp} is optional KEEP per inventory.
+   */
+  static final Set<String> POST_RETIREMENT_DESIGN_KEEP = Set.of("index.jsp");
+
+  /** Basenames that must remain after Runtime deep-page retirement (#1818). */
+  static final Set<String> POST_RETIREMENT_RUNTIME_KEEP = Set.of("index.jsp");
+
+  // --- Redirect stubs ---------------------------------------------------
+
+  @Test
+  @DisplayName("ui/publishing/index.jsp redirect stub targets modern Design shell")
+  void designIndexRedirectStubTargetsModernShell() throws IOException {
+    Path index = DESIGN_DIR.resolve("index.jsp");
+    assertTrue(Files.isRegularFile(index), "missing Design redirect stub: " + abs(index));
+    String text = Files.readString(index, StandardCharsets.UTF_8);
+    assertTrue(
+        text.contains(DESIGN_REDIRECT_TARGET),
+        "Design index.jsp must redirect to "
+            + DESIGN_REDIRECT_TARGET
+            + "; content snippet="
+            + snippet(text));
+    assertTrue(text.contains("301") || text.contains("setStatus(301)"), "must send HTTP 301");
+    assertFalse(text.contains("\\"), "redirect Location must use URL '/' separators only");
+  }
+
+  @Test
+  @DisplayName("ui/pubruntime/index.jsp redirect stub targets modern Runtime shell")
+  void runtimeIndexRedirectStubTargetsModernShell() throws IOException {
+    Path index = RUNTIME_DIR.resolve("index.jsp");
+    assertTrue(Files.isRegularFile(index), "missing Runtime redirect stub: " + abs(index));
+    String text = Files.readString(index, StandardCharsets.UTF_8);
+    assertTrue(
+        text.contains(RUNTIME_REDIRECT_TARGET),
+        "Runtime index.jsp must redirect to "
+            + RUNTIME_REDIRECT_TARGET
+            + "; content snippet="
+            + snippet(text));
+    assertTrue(text.contains("301") || text.contains("setStatus(301)"), "must send HTTP 301");
+    assertFalse(text.contains("\\"), "redirect Location must use URL '/' separators only");
+  }
+
+  // --- Inventory freeze (must pass on main today) -----------------------
+
+  @Test
+  @DisplayName("Design deep-page inventory matches frozen expected set (no accidental drift)")
+  void designDeepPageInventoryIsFrozen() throws IOException {
+    assertInventoryFreeze(DESIGN_DIR, FROZEN_DESIGN_JSPS, "ui/publishing");
+  }
+
+  @Test
+  @DisplayName("Runtime deep-page inventory matches frozen expected set (no accidental drift)")
+  void runtimeDeepPageInventoryIsFrozen() throws IOException {
+    assertInventoryFreeze(RUNTIME_DIR, FROZEN_RUNTIME_JSPS, "ui/pubruntime");
+  }
+
+  // --- Installer faces-config peer --------------------------------------
+
+  @Test
+  @DisplayName("install.xml still deletes publishing-faces-config.xml on upgrade (peer cleanup)")
+  void installXmlStillCleansPublishingFacesConfig() throws IOException {
+    try (InputStream in = getClass().getResourceAsStream(INSTALL_XML)) {
+      assertNotNull(in, INSTALL_XML + " must be on the test classpath");
+      String xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+      assertTrue(
+          xml.contains("publishing-faces-config.xml"),
+          "install.xml must keep upgrade delete of publishing-faces-config.xml"
+              + " (peer ObsoleteWebInfArtifactsCleanupTest / #1817)");
+      assertTrue(
+          xml.contains("deleteObsoleteRhythmyxWebInfArtifacts"),
+          "install.xml must retain deleteObsoleteRhythmyxWebInfArtifacts target");
+    }
+  }
+
+  // --- Future absence (enable after #1819 / #1818) ----------------------
+
+  /**
+   * Enable after #1819 lands: exclusive Design deep pages must be gone; only intentional KEEP files
+   * (redirect stub, optional publish.jsp) remain.
+   */
+  @Test
+  @Disabled(
+      "Enable after #1819 Design deep-page delete lands; until then inventory freeze above is the"
+          + " live contract. Parent #1372 / UAT #1371 gate product deletes.")
+  @DisplayName("AFTER #1819: exclusive Design deep pages absent; redirect stub remains")
+  void afterDesignRetirementOnlyKeepFilesRemain() throws IOException {
+    assertOnlyKeepFilesRemain(DESIGN_DIR, POST_RETIREMENT_DESIGN_KEEP, "ui/publishing");
+    // Redirect stub still targets modern Design
+    designIndexRedirectStubTargetsModernShell();
+  }
+
+  /**
+   * Enable after #1818 lands: exclusive Runtime deep pages must be gone; only the Runtime redirect
+   * stub remains.
+   */
+  @Test
+  @Disabled(
+      "Enable after #1818 Runtime deep-page delete lands; until then inventory freeze above is the"
+          + " live contract. Parent #1372 / UAT #1371 gate product deletes.")
+  @DisplayName("AFTER #1818: exclusive Runtime deep pages absent; redirect stub remains")
+  void afterRuntimeRetirementOnlyKeepFilesRemain() throws IOException {
+    assertOnlyKeepFilesRemain(RUNTIME_DIR, POST_RETIREMENT_RUNTIME_KEEP, "ui/pubruntime");
+    runtimeIndexRedirectStubTargetsModernShell();
+  }
+
+  // --- helpers ----------------------------------------------------------
+
+  private static void assertInventoryFreeze(Path dir, Set<String> expected, String label)
+      throws IOException {
+    assertTrue(Files.isDirectory(dir), "missing " + label + " tree: " + abs(dir));
+    Set<String> actual = listJspBasenames(dir);
+    Set<String> missing = new TreeSet<>(expected);
+    missing.removeAll(actual);
+    Set<String> unexpected = new TreeSet<>(actual);
+    unexpected.removeAll(expected);
+    if (!missing.isEmpty() || !unexpected.isEmpty()) {
+      fail(
+          label
+              + " JSP inventory drifted from freeze (issue #1820 / removal-inventory.md)."
+              + " missing="
+              + missing
+              + " unexpected="
+              + unexpected
+              + " actual="
+              + actual
+              + " — update freeze only with intentional #1819/#1818 or KEEP changes.");
+    }
+    assertEquals(expected.size(), actual.size(), label + " inventory size must match freeze");
+  }
+
+  private static void assertOnlyKeepFilesRemain(Path dir, Set<String> keep, String label)
+      throws IOException {
+    assertTrue(Files.isDirectory(dir), "missing " + label + " tree: " + abs(dir));
+    Set<String> actual = listJspBasenames(dir);
+    for (String required : keep) {
+      assertTrue(
+          actual.contains(required),
+          label + " must retain KEEP file " + required + "; actual=" + actual);
+    }
+    Set<String> extras = new TreeSet<>(actual);
+    extras.removeAll(keep);
+    // publish.jsp is an optional Design KEEP per inventory — allow it without failing absence.
+    if ("ui/publishing".equals(label)) {
+      extras.remove("publish.jsp");
+    }
+    assertTrue(
+        extras.isEmpty(),
+        label
+            + " must not package exclusive deep pages after retirement; leftovers="
+            + extras
+            + " (keep="
+            + keep
+            + ")");
+  }
+
+  private static Set<String> listJspBasenames(Path dir) throws IOException {
+    try (Stream<Path> stream = Files.list(dir)) {
+      return stream
+          .filter(Files::isRegularFile)
+          .map(p -> p.getFileName().toString())
+          .filter(name -> name.endsWith(".jsp"))
+          .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+  }
+
+  private static String abs(Path p) {
+    return p.toAbsolutePath().normalize().toString();
+  }
+
+  private static String snippet(String text) {
+    String oneLine = text.replace('\r', ' ').replace('\n', ' ').trim();
+    return oneLine.length() <= 160 ? oneLine : oneLine.substring(0, 160) + "...";
+  }
+}

--- a/specs/990-unified-publishing-ui/checklists/removal-inventory.md
+++ b/specs/990-unified-publishing-ui/checklists/removal-inventory.md
@@ -2,7 +2,7 @@
 
 **Feature**: `990-unified-publishing-ui`  
 **Purpose**: Durable proof for US8 / FR-015 and RET-06 packaging retirement.  
-**Status**: Updated 2026-08-04 (#1817 faces-config + consumer audit).
+**Status**: Updated 2026-08-05 (#1820 packaging verification prep: redirect stubs + inventory freeze).
 
 |              Slice               | Issue |                              Role                               |   Status    |
 |----------------------------------|-------|-----------------------------------------------------------------|-------------|
@@ -10,8 +10,10 @@
 | A — Inventory / consumer audit   | #1817 | Faces-config + grep audit + deletion checklists (this update)   | **Done**    |
 | B — Design deep-page delete      | #1819 | Delete exclusive `ui/publishing/**` deep JSPs (keep redirects)  | Blocked\*   |
 | C — Runtime deep-page delete     | #1818 | Delete exclusive `ui/pubruntime/**` deep JSPs (keep redirects)  | Blocked\*   |
-| D — Packaging / WAR verification | #1820 | Installer/WAR assertions + RET-06 closure                       | Pending B+C |
+| D — Packaging / WAR verification | #1820 | Installer/WAR assertions + inventory freeze (prep)              | **Prep**†   |
 | UAT gate                         | #1371 | SC-001 / SC-003 / SC-008 sign-off before product deletes        | Open        |
+
+†Child D **prep** (#1820): packaging unit tests + docs land without product deep-page deletes. Full RET-06 Done still requires #1819+#1818, then enable absence assertions and re-check this table.
 
 \*Hard gate: no product deep-page deletes without #1371 UAT sign-off or explicit human ack on #1372. Also rewire non-nav residual consumers listed below before deleting the pages they call.
 
@@ -233,7 +235,8 @@ These are **not** product-nav, but are **product/engine** callers. Deleting the 
 | Upgrade cleanup target | `modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/install.xml` | Already deletes residual `publishing-faces-config.xml` on upgrade |
 | Cleanup unit test      | `.../ObsoleteWebInfArtifactsCleanupTest.java`                                                   | Guards the install.xml contract                                   |
 | Seed menu URL          | `cmsTableData.xml` / `RxffTableData.xml`                                                        | **Rewired (#1843)** + **upgrade replace (#1884)** for ACTION 217  |
-| WAR packaging          | WebUI war packages `ui/publishing/**` and `ui/pubruntime/**` as static webapp files             | #1820 asserts only redirects remain after B+C                     |
+| WAR packaging          | WebUI war packages `ui/publishing/**` and `ui/pubruntime/**` as static webapp files             | #1820 freeze + redirect tests live; absence assertions after B+C  |
+| Packaging unit test    | `PublishingDeepPagePackagingTest` (#1820)                                                       | Redirect stubs + inventory freeze + disabled post-delete checks   |
 
 ### Docs / bookmark / external refs (preserve or redirect)
 
@@ -340,8 +343,28 @@ These are **not** product-nav, but are **product/engine** callers. Deleting the 
 
 ## Packaging verification notes — Child D (#1820)
 
-- Assert WAR / WebUI package contains only `ui/publishing/index.jsp` (+ any intentional KEEP files) and `ui/pubruntime/index.jsp` (+ intentional KEEP) after B+C.
-- Keep `ObsoleteWebInfArtifactsCleanupTest` expectations for faces-config upgrade deletes.
-- Mark RET-06 / T124 Done in this file with PR links when closed.
-- Cross-platform: packaging path assertions must not hardcode Unix-only separators.
+**Prep status (2026-08-05)** — packaging verification tests and docs only; **no product deep-page deletes**. Design/Runtime deep pages remain **Deferred** pending #1371 UAT (or human ack on #1372) and Child B/C (#1819 / #1818).
+
+### Test classes (`modules/perc-distribution-tree`)
+
+| Class | Role |
+|-------|------|
+| `com.percussion.distribution.install.PublishingDeepPagePackagingTest` | **#1820 primary**: assert `ui/publishing/index.jsp` + `ui/pubruntime/index.jsp` 301 redirect stubs still target modern shell (`/cm/app/?view=publish&section=design\|runtime`); freeze residual Design (28) / Runtime (13) JSP basename inventory; confirm `install.xml` still deletes `publishing-faces-config.xml`; `@Disabled` absence tests ready to enable after #1819/#1818 |
+| `com.percussion.distribution.install.ObsoleteWebInfArtifactsCleanupTest` | Peer: upgrade cleanup target still covers `publishing-faces-config.xml` (+ JSF lib/TLD families) |
+| `com.percussion.distribution.install.PublishNowActionSeedUrlTest` | Peer: Publish_Now / EI_Publish_Now seeds stay on `/publisher/demandpublishing` (not legacy `publish.jsp`) |
+
+### Live contract on `main` today
+
+- Redirect stubs **must remain** and keep modern shell targets (enabled assertions).
+- Residual deep JSP sets are an **explicit freeze** — accidental add/remove fails CI until freeze or product change is intentional.
+- Exclusive deep-page **absence** assertions are present but **disabled** until B+C land; then re-enable and update Surface A/B rows → Done.
+- Installer faces-config cleanup expectations **unchanged** (upgrade safety).
+
+### After #1819 + #1818
+
+- [ ] Enable `afterDesignRetirementOnlyKeepFilesRemain` / `afterRuntimeRetirementOnlyKeepFilesRemain` in `PublishingDeepPagePackagingTest` (or replace freeze with KEEP-only sets).
+- [ ] Assert WAR / WebUI package contains only `ui/publishing/index.jsp` (+ optional `publish.jsp` KEEP) and `ui/pubruntime/index.jsp`.
+- [ ] Keep `ObsoleteWebInfArtifactsCleanupTest` expectations for faces-config upgrade deletes.
+- [ ] Mark RET-06 / T124 Done in this file with PR/issue links; parent #1372 acceptance checkoff.
+- Cross-platform: packaging path assertions use `Path.of` / `Path.resolve` only (no Unix-only separators).
 

--- a/specs/990-unified-publishing-ui/checklists/removal-inventory.md
+++ b/specs/990-unified-publishing-ui/checklists/removal-inventory.md
@@ -343,13 +343,14 @@ These are **not** product-nav, but are **product/engine** callers. Deleting the 
 
 ## Packaging verification notes — Child D (#1820)
 
-**Prep status (2026-08-05)** — packaging verification tests and docs only; **no product deep-page deletes**. Design/Runtime deep pages remain **Deferred** pending #1371 UAT (or human ack on #1372) and Child B/C (#1819 / #1818).
+**Prep status (2026-08-05)** — packaging verification tests and docs only; **no product deep-page deletes**. Design/Runtime deep pages remain **Deferred** pending #1371 UAT (or human ack on #1372) and Child B/C (#1819 / #1818).  
+**PR**: [#2095](https://github.com/intersoftdatalabs-in/percussioncms/pull/2095) · issue [#1820](https://github.com/intersoftdatalabs-in/percussioncms/issues/1820)
 
 ### Test classes (`modules/perc-distribution-tree`)
 
 | Class | Role |
 |-------|------|
-| `com.percussion.distribution.install.PublishingDeepPagePackagingTest` | **#1820 primary**: assert `ui/publishing/index.jsp` + `ui/pubruntime/index.jsp` 301 redirect stubs still target modern shell (`/cm/app/?view=publish&section=design\|runtime`); freeze residual Design (28) / Runtime (13) JSP basename inventory; confirm `install.xml` still deletes `publishing-faces-config.xml`; `@Disabled` absence tests ready to enable after #1819/#1818 |
+| `com.percussion.distribution.install.PublishingDeepPagePackagingTest` | **#1820 / PR #2095 primary**: assert `ui/publishing/index.jsp` + `ui/pubruntime/index.jsp` 301 redirect stubs still target modern shell (`/cm/app/?view=publish&section=design\|runtime`); freeze residual Design (28) / Runtime (13) JSP basename inventory; confirm `install.xml` still deletes `publishing-faces-config.xml`; `@Disabled` absence tests ready to enable after #1819/#1818 |
 | `com.percussion.distribution.install.ObsoleteWebInfArtifactsCleanupTest` | Peer: upgrade cleanup target still covers `publishing-faces-config.xml` (+ JSF lib/TLD families) |
 | `com.percussion.distribution.install.PublishNowActionSeedUrlTest` | Peer: Publish_Now / EI_Publish_Now seeds stay on `/publisher/demandpublishing` (not legacy `publish.jsp`) |
 


### PR DESCRIPTION
## Summary

**Partial** for [#1820](https://github.com/intersoftdatalabs-in/percussioncms/issues/1820) (Child D / slice 4 of parent RET-06 [#1372](https://github.com/intersoftdatalabs-in/percussioncms/issues/1372)).

Packaging **verification prep only** — no product deep-page deletes (hard gate: #1371 UAT or human ack on #1372 before #1819/#1818).

### Changes

1. **`PublishingDeepPagePackagingTest`** (`modules/perc-distribution-tree`)
   - Assert `ui/publishing/index.jsp` and `ui/pubruntime/index.jsp` 301 redirect stubs remain and target `/cm/app/?view=publish&section=design|runtime`
   - Freeze residual Design (28) / Runtime (13) JSP basename inventory (must match tree on `main` today)
   - Confirm `install.xml` still deletes `publishing-faces-config.xml` on upgrade (peer of `ObsoleteWebInfArtifactsCleanupTest`)
   - `@Disabled` absence tests ready to enable after #1819 / #1818 land

2. **`removal-inventory.md`** Child D notes
   - Document test class names, prep status, post-B+C enable checklist
   - Design/Runtime deep pages remain **Deferred** pending UAT

### Not in this PR

- Deleting `ui/publishing/**` or `ui/pubruntime/**` deep JSPs (#1819 / #1818)
- Enabling post-delete absence assertions (full RET-06 Done)

## Test plan

- [x] `PublishingDeepPagePackagingTest`: 7 tests, 0 failures, 2 skipped (disabled absence)
- [x] `modules/perc-distribution-tree` standalone `mvnw clean install`
- [x] Spotless apply then check (module)
- [x] Portable paths only (`Path.of` / `Path.resolve`); URL targets use `/`
- [x] Erlang self-review: no product deletes; freeze must pass on current main inventory

## Gates evidence

| Gate | Result |
|------|--------|
| Unit tests (new class) | PASS (5 enabled + 2 disabled) |
| Module clean install | PASS `perc-distribution-tree` |
| Spotless apply → check | PASS (in-scope only) |
| Erlang | PASS — packaging assertions, portable paths, behavioral tests present |
| Product JSP deletes | None (hard gate honored) |

## Residual (full RET-06 Done)

Full Child D / RET-06 closure remains after #1819 + #1818:

1. Enable absence assertions in `PublishingDeepPagePackagingTest`
2. Update inventory freeze → KEEP-only sets; Surface A/B → Done
3. Re-run packaging suite green; check off parent #1372

No separate residual issue filed: work is already tracked by open #1819, #1818, and parent #1372 (plus UAT #1371).

## Links

- Parent tracker: #1372
- This slice: #1820
- Depends: #1817 (Done), blocked product deletes: #1819, #1818, UAT #1371

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.