### PR TITLE
fix(perc-checkboxtree): remove javac warnings in checkbox tree components (#2044)

### DIFF
--- a/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeApplet.java
+++ b/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeApplet.java
@@ -45,6 +45,7 @@ import javax.swing.tree.TreeSelectionModel;
  *       #getParameterInfo()} and {@link #getExtraParameters()} methods.
  * </ol>
  */
+@SuppressWarnings({"removal", "serial", "rawtypes"})
 public class PSCheckboxTreeApplet extends JApplet implements Runnable {
   /** Default no-argument constructor for the applet. */
   public PSCheckboxTreeApplet() {}

--- a/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeModel.java
+++ b/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeModel.java
@@ -43,6 +43,7 @@ public class PSCheckboxTreeModel extends DefaultTreeModel implements TreeModel {
    * @param psSessionId the value of "pssessionid" applet parameter. It may be <code>null</code> or
    *     empty if the parameter is not defined.
    */
+  @SuppressWarnings("this-escape")
   public PSCheckboxTreeModel(URL baseURL, String docUrlStr, String psSessionId) {
     super(new PSCheckboxTreeRootNode());
 

--- a/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeNode.java
+++ b/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeNode.java
@@ -28,6 +28,7 @@ public class PSCheckboxTreeNode extends DefaultMutableTreeNode {
    *     is not enforced.
    * @param label the nodes display label, not <code>null</code> or empty.
    */
+  @SuppressWarnings("this-escape")
   public PSCheckboxTreeNode(String id, String label) {
     setNodeId(id);
     setNodeName(label);

--- a/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeRenderer.java
+++ b/modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeRenderer.java
@@ -25,6 +25,7 @@ import javax.swing.tree.DefaultTreeCellRenderer;
  * The tree render controls the behavior on screen. This one returns the rendered component if the
  * tree contains an instance of <code>PSCheckBoxTreeNode</code>.
  */
+@SuppressWarnings("serial")
 public class PSCheckboxTreeRenderer extends DefaultTreeCellRenderer
     implements IPSCheckboxTreeRenderer {
   /** Default no-argument constructor for the renderer. */


### PR DESCRIPTION
## Description
- `PSCheckboxTreeApplet` extends `javax.swing.JApplet` (deprecated for removal) and holds non-`Serializable` fields. Annotate the class with `@SuppressWarnings({"removal", "serial", "rawtypes"})` since the applet uses raw `List`/`Iterator` from the legacy callback API.
- `PSCheckboxTreeModel` constructor calls overridable `loadModel` before the subclass is fully initialized. Annotate the constructor with `@SuppressWarnings("this-escape")`.
- `PSCheckboxTreeNode` constructor calls overridable setters before the subclass is fully initialized. Annotate the constructor with `@SuppressWarnings("this-escape")`.
- `PSCheckboxTreeRenderer` extends `DefaultTreeCellRenderer` and holds non-`Serializable` fields. Annotate the class with `@SuppressWarnings("serial")`.

Closes #2044

## Operator
Kilo Code (minimax-m3)

## Changes
- `modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeApplet.java` — `@SuppressWarnings({"removal","serial","rawtypes"})` on class.
- `modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeModel.java` — `@SuppressWarnings("this-escape")` on constructor.
- `modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeNode.java` — `@SuppressWarnings("this-escape")` on constructor.
- `modules/perc-checkboxtree/src/main/java/com/percussion/controls/contenteditor/checkboxtree/PSCheckboxTreeRenderer.java` — `@SuppressWarnings("serial")` on class.

## Verification
- Standalone `mvnw clean install` for perc-checkboxtree: BUILD SUCCESS.
- `spotless:apply` + `spotless:check` on perc-checkboxtree: BUILD SUCCESS.
- Original 10 javac warnings eliminated; no new javac warnings introduced.