### PR TITLE
fix(perc-exceptions-spring): suppress this-escape, serial, unchecked-cast warnings (#2017)

### DIFF
--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSBeanValidationException.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSBeanValidationException.java
@@ -24,6 +24,7 @@ import org.springframework.validation.BeanPropertyBindingResult;
  *
  * @author adamgent
  */
+@SuppressWarnings("this-escape")
 public class PSBeanValidationException extends PSSpringValidationException {
 
   private static final long serialVersionUID = 8097878230304938879L;

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSErrorUtils.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSErrorUtils.java
@@ -28,6 +28,7 @@ import com.percussion.share.validation.PSErrors.PSObjectError;
  *
  * @author adamgent
  */
+@SuppressWarnings("serial")
 public class PSErrorUtils {
 
   /**

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSPropertiesValidationException.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSPropertiesValidationException.java
@@ -27,6 +27,7 @@ import org.springframework.validation.MapBindingResult;
  *
  * @author adamgent
  */
+@SuppressWarnings({"serial", "this-escape"})
 public class PSPropertiesValidationException extends PSSpringValidationException {
 
   private static final long serialVersionUID = 1L;

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSSpringValidationException.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSSpringValidationException.java
@@ -31,6 +31,7 @@ import org.springframework.validation.ObjectError;
  *
  * @author adamgent
  */
+@SuppressWarnings({"serial", "this-escape"})
 public abstract class PSSpringValidationException extends PSValidationException
     implements Errors, IPSValidationException {
 

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSValidationException.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSValidationException.java
@@ -30,6 +30,7 @@ import com.percussion.share.validation.PSValidationErrors;
  * @see PSValidationErrors
  * @author adamgent
  */
+@SuppressWarnings({"serial", "this-escape"})
 public abstract class PSValidationException extends PSDataServiceException
     implements IPSValidationException {
 

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSAbstractBeanValidator.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSAbstractBeanValidator.java
@@ -107,6 +107,7 @@ public abstract class PSAbstractBeanValidator<FULL> implements Validator {
         try {
           // This cast is safe because the validator only accepts objects of type FULL
 
+          @SuppressWarnings("unchecked")
           FULL fullObject = (FULL) object;
           doValidation(fullObject, (PSBeanValidationException) errors);
         } catch (PSValidationException e) {

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSAbstractPropertiesValidator.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSAbstractPropertiesValidator.java
@@ -92,6 +92,7 @@ public abstract class PSAbstractPropertiesValidator<PROPERTIES> implements Valid
    * @param errors the {@link PSPropertiesValidationException} container to populate, never {@code
    *     null}.
    */
+  @SuppressWarnings("unchecked")
   public void validate(Object properties, Errors errors) {
     doValidation((PROPERTIES) properties, (PSPropertiesValidationException) errors);
   }

--- a/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSErrorCause.java
+++ b/modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSErrorCause.java
@@ -32,6 +32,7 @@ import org.apache.logging.log4j.Logger;
  * @author adamgent
  */
 @XmlRootElement(name = "ErrorCause")
+@SuppressWarnings("this-escape")
 public class PSErrorCause {
 
   private static final Logger log = LogManager.getLogger("Server");


### PR DESCRIPTION
## Description
Annotate the validation framework's exception hierarchy and helper classes with targeted `@SuppressWarnings` to silence the bracketed diagnostics exposed by javac under `-Xlint:all`:
- `PSBeanValidationException`: `this-escape` (constructor delegates to overridable setters).
- `PSPropertiesValidationException`, `PSSpringValidationException`, `PSValidationException`: `serial` + `this-escape` (non-`Serializable` fields, overridable setters invoked from constructors).
- `PSErrorUtils`: `serial` (`PSErrors` field is not `Serializable`).
- `PSErrorCause`: `this-escape` (constructor calls overridable init).
- `PSAbstractBeanValidator`, `PSAbstractPropertiesValidator`: unchecked cast to a generic type parameter on object passed from the `Validator` contract.

Closes #2017

## Operator
Kilo Code (minimax-m3)

## Changes
- `modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSBeanValidationException.java` — `@SuppressWarnings("this-escape")` on class.
- `modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSErrorUtils.java` — `@SuppressWarnings("serial")` on class.
- `modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSPropertiesValidationException.java` — `@SuppressWarnings({"serial","this-escape"})` on class.
- `modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSSpringValidationException.java` — `@SuppressWarnings({"serial","this-escape"})` on class.
- `modules/perc-exceptions-spring/src/main/java/com/percussion/share/service/exception/PSValidationException.java` — `@SuppressWarnings({"serial","this-escape"})` on class.
- `modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSAbstractBeanValidator.java` — `@SuppressWarnings("unchecked")` on cast site.
- `modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSAbstractPropertiesValidator.java` — `@SuppressWarnings("unchecked")` on `validate`.
- `modules/perc-exceptions-spring/src/main/java/com/percussion/share/validation/PSErrorCause.java` — `@SuppressWarnings("this-escape")` on class.

## Verification
- Standalone `mvnw clean install` for perc-exceptions-spring: BUILD SUCCESS.
- `spotless:apply` + `spotless:check` on perc-exceptions-spring: BUILD SUCCESS.
- Original 14 javac warnings eliminated; no new javac warnings introduced.