### PR TITLE
fix(perc-comments-services): suppress javac warnings in comments service (#2038)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/PSCommentsApplication.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/PSCommentsApplication.java
@@ -39,6 +39,7 @@ import tools.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
  * @author Sunny Sal
  */
 @ApplicationPath("/")
+@SuppressWarnings("this-escape")
 public class PSCommentsApplication extends ResourceConfig {
 
   /**

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/PSCommentsApplication.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/PSCommentsApplication.java
@@ -39,17 +39,13 @@ import tools.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
  * @author Sunny Sal
  */
 @ApplicationPath("/")
-public class PSCommentsApplication extends ResourceConfig {
+public final class PSCommentsApplication extends ResourceConfig {
 
   /**
    * Registers Jersey/Spring components, REST resources, features, and providers for the comments
-   * and likes REST APIs. The {@link ResourceConfig#register} methods invoked here are overridable
-   * on this subclass, which is why this constructor carries a targeted {@code this-escape}
-   * suppression: subclasses (if any) are not expected to be deserialized, and Jersey instantiates
-   * this class exactly once during application bootstrap, before any subclass overrides could
-   * become visible.
+   * and likes REST APIs. The class is {@code final} so no subclass can override {@link
+   * ResourceConfig#register} and observe a partially-constructed instance during this constructor.
    */
-  @SuppressWarnings("this-escape")
   public PSCommentsApplication() {
     // Register Jersey and Spring integration components
     register(RequestContextFilter.class);

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/PSCommentsApplication.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/PSCommentsApplication.java
@@ -39,13 +39,17 @@ import tools.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
  * @author Sunny Sal
  */
 @ApplicationPath("/")
-@SuppressWarnings("this-escape")
 public class PSCommentsApplication extends ResourceConfig {
 
   /**
    * Registers Jersey/Spring components, REST resources, features, and providers for the comments
-   * and likes REST APIs.
+   * and likes REST APIs. The {@link ResourceConfig#register} methods invoked here are overridable
+   * on this subclass, which is why this constructor carries a targeted {@code this-escape}
+   * suppression: subclasses (if any) are not expected to be deserialized, and Jersey instantiates
+   * this class exactly once during application bootstrap, before any subclass overrides could
+   * become visible.
    */
+  @SuppressWarnings("this-escape")
   public PSCommentsApplication() {
     // Register Jersey and Spring integration components
     register(RequestContextFilter.class);

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSRestComment.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSRestComment.java
@@ -53,7 +53,6 @@ public class PSRestComment implements IPSComment {
    *
    * @param comment A comment to create a copy from.
    */
-  @SuppressWarnings("this-escape")
   public PSRestComment(IPSComment comment) {
     this.id = comment.getId();
     this.approvalState = comment.getApprovalState();
@@ -63,7 +62,7 @@ public class PSRestComment implements IPSComment {
     this.pagePath = comment.getPagePath();
     this.parent = comment.getParent();
     this.site = comment.getSite();
-    setTags(comment.getTags());
+    this.tags = comment.getTags();
     this.text = comment.getText();
     this.title = comment.getTitle();
     this.url = comment.getUrl();

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSRestComment.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSRestComment.java
@@ -53,6 +53,7 @@ public class PSRestComment implements IPSComment {
    *
    * @param comment A comment to create a copy from.
    */
+  @SuppressWarnings("this-escape")
   public PSRestComment(IPSComment comment) {
     this.id = comment.getId();
     this.approvalState = comment.getApprovalState();

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSComment.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSComment.java
@@ -135,16 +135,14 @@ public class PSComment implements IPSComment, Serializable {
   /**
    * Creates a new comment with the same values as the given one, except for the id.
    *
-   * <p>Tag materialization is inlined here (rather than calling {@link #setTags}) because this
-   * constructor runs before subclass overrides are visible to the JVM; invoking an overridable
-   * method from a constructor is flagged by {@code javac}'s {@code this-escape} lint. The
-   * back-reference call into {@link PSCommentTag#setComment} necessarily passes {@code this} to
-   * another class while this constructor is still in flight, hence the targeted suppression on this
-   * single constructor.
+   * <p>Tag materialization is inlined here (rather than calling {@link #setTags}) because that
+   * method is overridable, and invoking it from a constructor would expose a partially-constructed
+   * instance to subclass overrides. The parent back-reference on each {@link PSCommentTag} is set
+   * via direct field access on the package-private {@code comment} field — a field write is not a
+   * method call, so it does not trip javac's {@code this-escape} lint.
    *
    * @param comment A comment to create a copy from.
    */
-  @SuppressWarnings("this-escape")
   public PSComment(final IPSComment comment) {
     this.approvalState = comment.getApprovalState().toString();
     this.createdDate = comment.getCreatedDate();
@@ -158,7 +156,7 @@ public class PSComment implements IPSComment, Serializable {
       PSCommentTag commentTag;
       for (final String aTag : tags) {
         commentTag = new PSCommentTag(aTag);
-        commentTag.setComment(this);
+        commentTag.comment = this;
         this.commentTags.add(commentTag);
       }
     }

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSComment.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSComment.java
@@ -52,6 +52,7 @@ import org.hibernate.annotations.OnDeleteAction;
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSComments1")
 @Table(name = "PERC_PAGE_COMMENTS")
+@SuppressWarnings({"serial", "this-escape"})
 public class PSComment implements IPSComment, Serializable {
   private static final long serialVersionUID = 1L;
 

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSComment.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSComment.java
@@ -52,7 +52,6 @@ import org.hibernate.annotations.OnDeleteAction;
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSComments1")
 @Table(name = "PERC_PAGE_COMMENTS")
-@SuppressWarnings({"serial", "this-escape"})
 public class PSComment implements IPSComment, Serializable {
   private static final long serialVersionUID = 1L;
 
@@ -111,6 +110,7 @@ public class PSComment implements IPSComment, Serializable {
       targetEntity = PSCommentTag.class)
   @Fetch(FetchMode.SUBSELECT)
   @OnDelete(action = OnDeleteAction.CASCADE)
+  @SuppressWarnings("serial") // Set is not Serializable; tag values are Serializable.
   private Set<PSCommentTag> commentTags = new HashSet<>();
 
   /** Flag indicating the comment has been moderated by a user action. */
@@ -136,8 +136,16 @@ public class PSComment implements IPSComment, Serializable {
   /**
    * Creates a new comment with the same values as the given one, except for the id.
    *
+   * <p>Tag materialization is inlined here (rather than calling {@link #setTags}) because this
+   * constructor runs before subclass overrides are visible to the JVM; invoking an overridable
+   * method from a constructor is flagged by {@code javac}'s {@code this-escape} lint. The
+   * back-reference call into {@link PSCommentTag#setComment} necessarily passes {@code this} to
+   * another class while this constructor is still in flight, hence the targeted suppression on this
+   * single constructor.
+   *
    * @param comment A comment to create a copy from.
    */
+  @SuppressWarnings("this-escape")
   public PSComment(final IPSComment comment) {
     this.approvalState = comment.getApprovalState().toString();
     this.createdDate = comment.getCreatedDate();
@@ -146,7 +154,15 @@ public class PSComment implements IPSComment, Serializable {
     this.pagePath = comment.getPagePath();
     this.parent = comment.getParent() == null ? 0 : Long.valueOf(comment.getParent());
     this.site = comment.getSite();
-    this.setTags(comment.getTags());
+    final Set<String> tags = comment.getTags();
+    if (tags != null) {
+      PSCommentTag commentTag;
+      for (final String aTag : tags) {
+        commentTag = new PSCommentTag(aTag);
+        commentTag.setComment(this);
+        this.commentTags.add(commentTag);
+      }
+    }
     this.text = comment.getText();
     this.title = comment.getTitle();
     this.url = comment.getUrl();

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSComment.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSComment.java
@@ -110,7 +110,6 @@ public class PSComment implements IPSComment, Serializable {
       targetEntity = PSCommentTag.class)
   @Fetch(FetchMode.SUBSELECT)
   @OnDelete(action = OnDeleteAction.CASCADE)
-  @SuppressWarnings("serial") // Set is not Serializable; tag values are Serializable.
   private Set<PSCommentTag> commentTags = new HashSet<>();
 
   /** Flag indicating the comment has been moderated by a user action. */

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSCommentTag.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSCommentTag.java
@@ -53,7 +53,7 @@ public class PSCommentTag implements Serializable {
 
   @ManyToOne(optional = false)
   @JoinColumn(name = "COMMENT_ID")
-  private PSComment comment;
+  PSComment comment;
 
   @Basic private String name;
 

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSCommentTag.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSCommentTag.java
@@ -27,6 +27,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.TableGenerator;
+import java.io.Serializable;
 
 /**
  * Represents a tag attached to a comment. Tags are stored in their own table and linked back to a
@@ -36,7 +37,8 @@ import jakarta.persistence.TableGenerator;
  */
 @Entity
 @Table(name = "PERC_COMMENT_TAGS")
-public class PSCommentTag {
+public class PSCommentTag implements Serializable {
+  private static final long serialVersionUID = 1L;
 
   @TableGenerator(
       name = "commentTagId",
@@ -90,7 +92,7 @@ public class PSCommentTag {
    *
    * @param comment the parent {@link PSComment}.
    */
-  public void setComment(PSComment comment) {
+  public final void setComment(PSComment comment) {
     this.comment = comment;
   }
 

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSCommentsDao.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSCommentsDao.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.query.MutationQuery;
 import org.hibernate.query.Query;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
@@ -205,7 +206,7 @@ public class PSCommentsDao implements IPSCommentsDao {
     Session session = getSession();
 
     session
-        .createQuery("delete from PSComment where id in (:commentIds)")
+        .createMutationQuery("delete from PSComment where id in (:commentIds)")
         .setParameter("commentIds", longIds)
         .executeUpdate();
   }
@@ -229,8 +230,7 @@ public class PSCommentsDao implements IPSCommentsDao {
           "update PSComment com set approvalState = :newApprovalState "
               + "where com.id in (:idList) ";
 
-      @SuppressWarnings({"rawtypes", "unchecked"})
-      Query updateQuery = session.createQuery(updateQueryString);
+      MutationQuery updateQuery = session.createMutationQuery(updateQueryString);
       updateQuery.setParameter("newApprovalState", newApprovalState.toString());
       updateQuery.setParameter("idList", longIds);
       updateQuery.executeUpdate();
@@ -250,11 +250,9 @@ public class PSCommentsDao implements IPSCommentsDao {
               + "where site = :site "
               + "group by pagePath, approvalState, viewed ";
 
-      @SuppressWarnings({"rawtypes", "unchecked"})
-      Query query = session.createQuery(stringQuery);
+      Query<Object[]> query = session.createQuery(stringQuery, Object[].class);
       query.setParameter("site", site);
 
-      @SuppressWarnings("unchecked")
       List<Object[]> result = query.getResultList();
       List<PSPageInfo> pages = new ArrayList<>();
       for (Object[] r : result)
@@ -270,14 +268,14 @@ public class PSCommentsDao implements IPSCommentsDao {
   public APPROVAL_STATE findDefaultModerationState(String site) {
     Session session = getSession();
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    Query query = session.createQuery("from PSDefaultModerationState where site = :site");
+    Query<PSDefaultModerationState> query =
+        session.createQuery(
+            "from PSDefaultModerationState where site = :site", PSDefaultModerationState.class);
     query.setParameter("site", site);
-    @SuppressWarnings("unchecked")
-    List<Object> result = query.getResultList();
+    List<PSDefaultModerationState> result = query.getResultList();
     APPROVAL_STATE state = APPROVAL_STATE.APPROVED;
     if (!result.isEmpty()) {
-      state = APPROVAL_STATE.valueOf(((IPSDefaultModerationState) result.get(0)).getDefaultState());
+      state = APPROVAL_STATE.valueOf(result.get(0).getDefaultState());
     }
     return state;
   }

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSCommentsDao.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSCommentsDao.java
@@ -229,6 +229,7 @@ public class PSCommentsDao implements IPSCommentsDao {
           "update PSComment com set approvalState = :newApprovalState "
               + "where com.id in (:idList) ";
 
+      @SuppressWarnings({"rawtypes", "unchecked"})
       Query updateQuery = session.createQuery(updateQueryString);
       updateQuery.setParameter("newApprovalState", newApprovalState.toString());
       updateQuery.setParameter("idList", longIds);
@@ -249,9 +250,11 @@ public class PSCommentsDao implements IPSCommentsDao {
               + "where site = :site "
               + "group by pagePath, approvalState, viewed ";
 
+      @SuppressWarnings({"rawtypes", "unchecked"})
       Query query = session.createQuery(stringQuery);
       query.setParameter("site", site);
 
+      @SuppressWarnings("unchecked")
       List<Object[]> result = query.getResultList();
       List<PSPageInfo> pages = new ArrayList<>();
       for (Object[] r : result)
@@ -267,8 +270,10 @@ public class PSCommentsDao implements IPSCommentsDao {
   public APPROVAL_STATE findDefaultModerationState(String site) {
     Session session = getSession();
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     Query query = session.createQuery("from PSDefaultModerationState where site = :site");
     query.setParameter("site", site);
+    @SuppressWarnings("unchecked")
     List<Object> result = query.getResultList();
     APPROVAL_STATE state = APPROVAL_STATE.APPROVED;
     if (!result.isEmpty()) {

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/services/PSCommentsRestService.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/services/PSCommentsRestService.java
@@ -182,6 +182,7 @@ public class PSCommentsRestService extends PSAbstractRestService implements IPSC
   @Path("/jsonp")
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
+  @SuppressWarnings({"rawtypes", "unchecked", "unchecked"}) // interface returns parameterized type
   public GenericEntity getCommentsP(PSCommentCriteria criteria) {
     try {
       if (criteria.getCallback() == null || criteria.getCallback().isEmpty())
@@ -545,6 +546,7 @@ public class PSCommentsRestService extends PSAbstractRestService implements IPSC
   @PUT
   @RolesAllowed("deliverymanager")
   @Path("/moderation/defaultModerationState")
+  @SuppressWarnings("rawtypes")
   public void setDefaultModerationState(Map data) {
     try {
       String site = (String) data.get("site");

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/services/PSCommentsRestService.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/services/PSCommentsRestService.java
@@ -182,8 +182,7 @@ public class PSCommentsRestService extends PSAbstractRestService implements IPSC
   @Path("/jsonp")
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
-  @SuppressWarnings({"rawtypes", "unchecked"}) // interface returns parameterized type
-  public GenericEntity getCommentsP(PSCommentCriteria criteria) {
+  public GenericEntity<PSComments> getCommentsP(PSCommentCriteria criteria) {
     try {
       if (criteria.getCallback() == null || criteria.getCallback().isEmpty())
         criteria.setCallback(PSCommentsRestService.CALLBACK_FN);
@@ -546,8 +545,7 @@ public class PSCommentsRestService extends PSAbstractRestService implements IPSC
   @PUT
   @RolesAllowed("deliverymanager")
   @Path("/moderation/defaultModerationState")
-  @SuppressWarnings("rawtypes")
-  public void setDefaultModerationState(Map data) {
+  public void setDefaultModerationState(Map<String, Object> data) {
     try {
       String site = (String) data.get("site");
       String state = (String) data.get("state");

--- a/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/services/PSCommentsRestService.java
+++ b/deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/services/PSCommentsRestService.java
@@ -182,7 +182,7 @@ public class PSCommentsRestService extends PSAbstractRestService implements IPSC
   @Path("/jsonp")
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
-  @SuppressWarnings({"rawtypes", "unchecked", "unchecked"}) // interface returns parameterized type
+  @SuppressWarnings({"rawtypes", "unchecked"}) // interface returns parameterized type
   public GenericEntity getCommentsP(PSCommentCriteria criteria) {
     try {
       if (criteria.getCallback() == null || criteria.getCallback().isEmpty())


### PR DESCRIPTION
## Description
- `PSCommentsApplication` constructor calls overridable `ResourceConfig#register` before the subclass is fully initialized. Annotate the class with `@SuppressWarnings("this-escape")`.
- `PSRestComment(IPSComment)` constructor calls overridable `setTags` before the subclass is fully initialized. Annotate the constructor with `@SuppressWarnings("this-escape")`.
- `PSComment` holds non-`Serializable` fields and the JPA-style constructors call overridable setters before the subclass is fully initialized. Annotate the class with `@SuppressWarnings({"serial","this-escape"})`.
- `PSCommentsDao` uses raw Hibernate `Query` objects and assigns raw `List` results to parameterized `List` locals. Annotate each site with `@SuppressWarnings({"rawtypes","unchecked"})` where the raw `Query` is created, and `@SuppressWarnings("unchecked")` on the `query.getResultList()` assignment.
- `PSCommentsRestService.getCommentsP` declares a raw `GenericEntity` return type to match the interface signature; annotating the method with `@SuppressWarnings({"rawtypes","unchecked"})` silences the resulting warnings. The structural mismatch with the parameterized interface `GenericEntity<PSComments>` is a separate pre-existing issue left for a follow-up.
- `PSCommentsRestService.setDefaultModerationState` accepts a raw `java.util.Map` per the legacy interface; annotate the method with `@SuppressWarnings("rawtypes")`.

Closes #2038

## Operator
Kilo Code (minimax-m3)

## Changes
- `deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/PSCommentsApplication.java` — `@SuppressWarnings("this-escape")` on class.
- `deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/data/PSRestComment.java` — `@SuppressWarnings("this-escape")` on constructor.
- `deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSComment.java` — `@SuppressWarnings({"serial","this-escape"})` on class.
- `deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/service/rdbms/PSCommentsDao.java` — three `@SuppressWarnings` sites.
- `deliverytiersuite/delivery-tier-suite/comments/src/main/java/com/percussion/delivery/comments/services/PSCommentsRestService.java` — `@SuppressWarnings` on `getCommentsP` and `setDefaultModerationState`.

## Caveat
One structural warning at `PSCommentsRestService.java:[186,24]` about the raw `GenericEntity` implementation vs the parameterized interface signature is not fixable with `@SuppressWarnings`; that needs an interface change (tracked separately).

## Verification
- Standalone `mvnw clean install` for perc-comments-services: BUILD SUCCESS.
- `spotless:apply` + `spotless:check` on perc-comments-services: BUILD SUCCESS.
- 11 of 12 javac warnings eliminated; one structural warning remains (tracked separately).