### PR TITLE
fix(system): align @JsonPropertyOrder with golden XML fixtures

### DIFF
--- a/system/services/src/com/percussion/services/publisher/data/PSContentList.java
+++ b/system/services/src/com/percussion/services/publisher/data/PSContentList.java
@@ -73,13 +73,13 @@ import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
   "description",
   "editionType",
   "expander",
-  "expanderArguments",
   "filterId",
   "generator",
-  "generatorArguments",
   "guid",
   "name",
-  "url"
+  "url",
+  "generator-arguments",
+  "expander-arguments"
 })
 public class PSContentList implements IPSContentList {
 

--- a/system/services/src/com/percussion/services/pubserver/data/PSPubServer.java
+++ b/system/services/src/com/percussion/services/pubserver/data/PSPubServer.java
@@ -86,12 +86,12 @@ import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
   "guid",
   "hasFullPublished",
   "name",
-  "properties",
   "publishType",
   "serverId",
   "siteId",
   "siteRenamed",
-  "serverTypeXml"
+  "serverTypeXml",
+  "properties"
 })
 public class PSPubServer extends PSAbstractDataObject implements Serializable, IPSCatalogIdentifier, IPSPubServer
 {


### PR DESCRIPTION
$
## Summary
Reordered Jackson `@JsonPropertyOrder` on `PSContentList` and `PSPubServer` so design-object XML serialization matches the golden fixtures.

## Changes
- `system/services/src/com/percussion/services/publisher/data/PSContentList.java` — reordered `@JsonPropertyOrder` so `generator-arguments` serializes before `expander-arguments`, matching fixture order
- `system/services/src/com/percussion/services/pubserver/data/PSPubServer.java` — reordered `@JsonPropertyOrder` so `publish-type` serializes before `properties`, matching fixture order

## Root cause
Jackson was emitting `<expander-arguments>` before `<generator-arguments>` in `PSContentList`, and `<properties>` before `publish-type` in `PSPubServer`, causing golden-fixture parity tests to fail.

## Verification
- `PSPublisherXmlSerializationTest` — 10/10 green
- `PSPubServerXmlSerializationTest` — 4/4 green
- `system` module full suite — 1138 tests, 0 failures, 240 skipped

Operator: Kilo (kilo-auto/free)
