### PR TITLE
fix(perc-i18n): suppress javac warnings in rxlt section handlers and TMX DOM (#2020)

### DIFF
--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/PSTmxJsCatalog.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/PSTmxJsCatalog.java
@@ -208,7 +208,8 @@ public final class PSTmxJsCatalog {
           sb.append('\\').append("u2029");
           break;
         default:
-          // Full C0 range (NUL..US) as JSON unicode escapes so catalog stays valid if fallback runs.
+          // Full C0 range (NUL..US) as JSON unicode escapes so catalog stays valid if fallback
+          // runs.
           if (c < 0x20) {
             sb.append('\\').append(String.format("u%04x", (int) c));
           } else {

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSCmsTablesSectionHandler.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSCmsTablesSectionHandler.java
@@ -60,7 +60,6 @@ import org.xml.sax.SAXException;
  * listed in the XSL stylesheet. The templates in the style sheets generate keys in the form of
  * another simple XML dcument that is used to construct the TMX Document.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCmsTablesSectionHandler extends PSIdleDotter implements IPSSectionHandler {
   /**
    * Default constructor. Constructs the XSL document and parses list of tables int a list.
@@ -327,5 +326,5 @@ public class PSCmsTablesSectionHandler extends PSIdleDotter implements IPSSectio
    * List of table to be process for key generation. Never <code>null</code>, initially <code>empty
    * </code>, filled during construction of this class object.
    */
-  private static List ms_Tables = new ArrayList();
+  private static List<String> ms_Tables = new ArrayList<>();
 }

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSCmsTablesSectionHandler.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSCmsTablesSectionHandler.java
@@ -60,6 +60,7 @@ import org.xml.sax.SAXException;
  * listed in the XSL stylesheet. The templates in the style sheets generate keys in the form of
  * another simple XML dcument that is used to construct the TMX Document.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCmsTablesSectionHandler extends PSIdleDotter implements IPSSectionHandler {
   /**
    * Default constructor. Constructs the XSL document and parses list of tables int a list.

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSCommandLineProcessor.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSCommandLineProcessor.java
@@ -48,8 +48,7 @@ import org.xml.sax.SAXException;
  *   <li>May also be run inline from another Java process without the command line user interface
  * </ol>
  */
-@SuppressWarnings("this-escape")
-public class PSCommandLineProcessor {
+public final class PSCommandLineProcessor {
   /**
    * Constructor. This takes the configuration XML document and the Rhythmyx root directory.
    *

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSCommandLineProcessor.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSCommandLineProcessor.java
@@ -48,6 +48,7 @@ import org.xml.sax.SAXException;
  *   <li>May also be run inline from another Java process without the command line user interface
  * </ol>
  */
+@SuppressWarnings("this-escape")
 public class PSCommandLineProcessor {
   /**
    * Constructor. This takes the configuration XML document and the Rhythmyx root directory.
@@ -408,7 +409,7 @@ public class PSCommandLineProcessor {
   private void displayExistingLanguages() throws PSFatalException {
     PSLocaleHandler localehandler = new PSLocaleHandler();
     try {
-      Document doc = localehandler.getLocaleDocument(m_rxroot);
+      Document doc = PSLocaleHandler.getLocaleDocument(m_rxroot);
       List<String> langstring = new ArrayList<>();
 
       List<String> disname = new ArrayList<>();

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSCommandLineProcessor.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSCommandLineProcessor.java
@@ -407,7 +407,6 @@ public class PSCommandLineProcessor {
    * @throws PSFatalException if could not connect to server database and get the supported Locales.
    */
   private void displayExistingLanguages() throws PSFatalException {
-    PSLocaleHandler localehandler = new PSLocaleHandler();
     try {
       Document doc = PSLocaleHandler.getLocaleDocument(m_rxroot);
       List<String> langstring = new ArrayList<>();

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSContentEditorsSectionHandler.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSContentEditorsSectionHandler.java
@@ -45,6 +45,7 @@ import org.xml.sax.SAXException;
  * generate a combined and simple XML document and then to generate the TMX document for this entire
  * section.
  */
+@SuppressWarnings("rawtypes")
 public class PSContentEditorsSectionHandler extends PSIdleDotter implements IPSSectionHandler {
   /**
    * Constructor. Loads the XSL Stylesheet from the file which is part the JAR file.

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSContentEditorsSectionHandler.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSContentEditorsSectionHandler.java
@@ -45,7 +45,6 @@ import org.xml.sax.SAXException;
  * generate a combined and simple XML document and then to generate the TMX document for this entire
  * section.
  */
-@SuppressWarnings("rawtypes")
 public class PSContentEditorsSectionHandler extends PSIdleDotter implements IPSSectionHandler {
   /**
    * Constructor. Loads the XSL Stylesheet from the file which is part the JAR file.
@@ -155,13 +154,13 @@ public class PSContentEditorsSectionHandler extends PSIdleDotter implements IPSS
     filter.setNamePattern(pattern);
     PSFilteredFileList lister = new PSFilteredFileList(filter);
     // get list of all XML files from this folder
-    List listFiles = lister.getFiles(new File(rxroot, SHAREDDEF_DIR));
+    List<File> listFiles = lister.getFiles(new File(rxroot, SHAREDDEF_DIR));
     // Stop showing idle dots
     showDots(false);
     Document doc = null;
     File file = null;
     for (int i = 0; listFiles != null && i < listFiles.size(); i++) {
-      file = (File) listFiles.get(i);
+      file = listFiles.get(i);
       PSCommandLineProcessor.logMessage("processingFile", file.getCanonicalPath());
       try {
         doc = PSXmlDocumentBuilder.createXmlDocument(new FileReader(file), false);
@@ -199,14 +198,14 @@ public class PSContentEditorsSectionHandler extends PSIdleDotter implements IPSS
     filter.setNamePattern(pattern);
     PSFilteredFileList lister = new PSFilteredFileList(filter);
     // get list of all XML files from this folder
-    List listFiles = lister.getFiles(new File(rxroot, LOCALDEF_DIR));
+    List<File> listFiles = lister.getFiles(new File(rxroot, LOCALDEF_DIR));
     // Stop showing idle dots
     showDots(false);
 
     Document doc = null;
     File file = null;
     for (int i = 0; listFiles != null && i < listFiles.size(); i++) {
-      file = (File) listFiles.get(i);
+      file = listFiles.get(i);
       PSCommandLineProcessor.logMessage("processingFile", file.getCanonicalPath());
       try {
         doc = PSXmlDocumentBuilder.createXmlDocument(new FileReader(file), false);

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSExtensionResourcesSectionHandler.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSExtensionResourcesSectionHandler.java
@@ -93,7 +93,7 @@ public class PSExtensionResourcesSectionHandler extends PSIdleDotter implements 
       IPSTmxDocument tmxDocTemp = null;
       for (int i = 0; listFiles != null && i < listFiles.size(); i++) {
         try {
-          file = (File) listFiles.get(i);
+          file = listFiles.get(i);
           PSCommandLineProcessor.logMessage("processingFile", file.getCanonicalPath());
           try (InputStreamReader ir =
               new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8)) {

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSJspHandler.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSJspHandler.java
@@ -53,7 +53,6 @@ import org.w3c.dom.Element;
  *
  * @author dougrand
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSJspHandler extends PSIdleDotter implements IPSSectionHandler {
   /** Creates a handler for JSP resources. */
   public PSJspHandler() {
@@ -144,10 +143,10 @@ public class PSJspHandler extends PSIdleDotter implements IPSSectionHandler {
       // Create an empty TMX Document
       tmxDoc = new PSTmxDocument();
       IPSTmxTranslationUnit tu = null;
-      Set keySet = tuInfo.keySet();
-      Iterator iter = keySet.iterator();
+      Set<String> keySet = tuInfo.keySet();
+      Iterator<String> iter = keySet.iterator();
       while (iter.hasNext()) {
-        String key = (String) iter.next();
+        String key = iter.next();
         String[] info = tuInfo.get(key);
         String desc = "";
         String note = info[TuSectionEnum.NOTE.getOrdinal()];
@@ -194,7 +193,7 @@ public class PSJspHandler extends PSIdleDotter implements IPSSectionHandler {
    * @param rxroot the root directory for the rhythmyx server
    * @param tuInfo the map of key/[note, props, seg] pairs
    */
-  private void handleAllJsps(String rxroot, Map tuInfo) {
+  private void handleAllJsps(String rxroot, Map<String, String[]> tuInfo) {
     File rxapp = new File(rxroot, JETTY_APP_SERVER);
     handleAllJsps(rxapp, tuInfo);
   }
@@ -205,7 +204,7 @@ public class PSJspHandler extends PSIdleDotter implements IPSSectionHandler {
    * @param dir directory to search
    * @param tuInfo the map of key/[note, props, seg] pairs
    */
-  private void handleAllJsps(File dir, Map tuInfo) {
+  private void handleAllJsps(File dir, Map<String, String[]> tuInfo) {
     if (dir.exists()) {
       for (File f : Objects.requireNonNull(dir.listFiles())) {
         if (f.getName().endsWith(".jsp")) {
@@ -224,7 +223,7 @@ public class PSJspHandler extends PSIdleDotter implements IPSSectionHandler {
    * @param file file to examine
    * @param tuInfo the map of translation unit key/[note, props, seg] pairs
    */
-  private void handleJspFile(File file, Map tuInfo) {
+  private void handleJspFile(File file, Map<String, String[]> tuInfo) {
 
     try (Reader r = new FileReader(file)) {
       showDots(true);
@@ -279,7 +278,7 @@ public class PSJspHandler extends PSIdleDotter implements IPSSectionHandler {
    * @param tuInfo the translation unit information as a map of translation unit -> [note, tuv
    *     props, tuv seg] pairs
    */
-  private void getTranslationUnitInfo(String text, Map tuInfo) {
+  private void getTranslationUnitInfo(String text, Map<String, String[]> tuInfo) {
     // Search for tag
     int i = text.indexOf("rxi18n");
 

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSJspHandler.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSJspHandler.java
@@ -53,6 +53,7 @@ import org.w3c.dom.Element;
  *
  * @author dougrand
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSJspHandler extends PSIdleDotter implements IPSSectionHandler {
   /** Creates a handler for JSP resources. */
   public PSJspHandler() {

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSLocaleRxResourceCopyHandler.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSLocaleRxResourceCopyHandler.java
@@ -333,7 +333,7 @@ public class PSLocaleRxResourceCopyHandler extends PSIdleDotter {
     File newFile = null;
     String newPath = "";
     for (int i = 0; listFiles != null && i < listFiles.size(); i++) {
-      file = (File) listFiles.get(i);
+      file = listFiles.get(i);
       newPath = getNewImagePath(file.getCanonicalPath());
       newFile = new File(newPath);
       if (newFile.exists()) {

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSRxltMain.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSRxltMain.java
@@ -89,7 +89,7 @@ public class PSRxltMain {
 
       if (ui) initLog4J(file);
 
-      PSEntityResolver.getInstance().setResolutionHome(file);
+      PSEntityResolver.setResolutionHome(file);
 
       processor = new PSCommandLineProcessor(file.getCanonicalPath(), ui);
 

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSXslStylesheetsSectionHandler.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/rxlt/PSXslStylesheetsSectionHandler.java
@@ -138,7 +138,7 @@ public class PSXslStylesheetsSectionHandler extends PSIdleDotter implements IPSS
     Document doc = null;
     File file = null;
     for (int i = 0; listFiles != null && i < listFiles.size(); i++) {
-      file = (File) listFiles.get(i);
+      file = listFiles.get(i);
       PSCommandLineProcessor.logMessage("processingFile", file.getCanonicalPath());
       try {
         doc = PSXmlDocumentBuilder.createXmlDocument(new FileReader(file), false);

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/tmxdom/PSTmxMergeConfig.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/tmxdom/PSTmxMergeConfig.java
@@ -35,6 +35,7 @@ import org.xml.sax.SAXException;
  *
  * @see IPSTmxDtdConstants
  */
+@SuppressWarnings("this-escape")
 public class PSTmxMergeConfig implements IPSTmxMergeConfig {
   /**
    * Constructor. Loads the default merge configuration document from the class file archive and

--- a/modules/perc-i18n/src/main/java/com/percussion/i18n/tmxdom/PSTmxMergeConfig.java
+++ b/modules/perc-i18n/src/main/java/com/percussion/i18n/tmxdom/PSTmxMergeConfig.java
@@ -35,8 +35,7 @@ import org.xml.sax.SAXException;
  *
  * @see IPSTmxDtdConstants
  */
-@SuppressWarnings("this-escape")
-public class PSTmxMergeConfig implements IPSTmxMergeConfig {
+public final class PSTmxMergeConfig implements IPSTmxMergeConfig {
   /**
    * Constructor. Loads the default merge configuration document from the class file archive and
    * builds map of configuration parameter property map.


### PR DESCRIPTION
## Description
Apply targeted `@SuppressWarnings` to silence the bracketed diagnostics emitted under `-Xlint:all` across the i18n rxlt tooling and `PSTmxMergeConfig`:
- `PSCmsTablesSectionHandler`: `rawtypes` + `unchecked` (legacy raw `List`/`ArrayList` usage).
- `PSCommandLineProcessor`: `this-escape` (constructor calls overridable `init`); static-method qualifier refactor (use `PSLocaleHandler` directly instead of through an instance).
- `PSContentEditorsSectionHandler`: `rawtypes`.
- `PSExtensionResourcesSectionHandler`: drop redundant `(File)` cast.
- `PSJspHandler`: `rawtypes` + `unchecked` (raw `Set`/`Iterator`/`Map`).
- `PSLocaleRxResourceCopyHandler`: drop redundant `(File)` cast.
- `PSRxltMain`: static-method qualifier refactor (use `PSEntityResolver.setResolutionHome` directly).
- `PSXslStylesheetsSectionHandler`: drop redundant `(File)` cast.
- `PSTmxMergeConfig`: `this-escape` (constructors call overridable config helpers).

Closes #2020

## Operator
Kilo Code (minimax-m3)

## Verification
- Standalone `mvnw clean install` for perc-i18n: BUILD SUCCESS.
- `spotless:apply` + `spotless:check` on perc-i18n: BUILD SUCCESS.
- Original 18 javac warnings eliminated; no new javac warnings introduced.