### PR TITLE
fix(perc-metadata-services): suppress javac warnings in metadata service (#2041)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/impl/PSCriteriaElement.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/impl/PSCriteriaElement.java
@@ -246,6 +246,7 @@ public class PSCriteriaElement {
     NOT_EQUAL
   }
 
+  @SuppressWarnings("unchecked")
   private static final Map<String, OPERATION_TYPE> OPERATORS =
       MapUtils.orderedMap(new HashMap<String, OPERATION_TYPE>());
 


### PR DESCRIPTION
## Description
Apply targeted `@SuppressWarnings` to silence the bracketed diagnostics emitted under `-Xlint:all` across the metadata service:
- `PSDbBlogPostVisit`, `PSDbCookieConsent`, `PSDbMetadataEntry`, `PSDbMetadataProperty`: `this-escape` (constructors call overridable setters before the subclass is fully initialized).
- `PSDbMetadataEntry`: `serial` + `this-escape`.
- `PSMetadataEntry`: `serial`.
- `PSCookieConsent`, `PSCookieConsentQuery`: `this-escape`.
- `PSCriteriaElement`: `unchecked` (`MapUtils.orderedMap` returns raw Map).
- `PSPair.equals`: `unchecked` (cast to generic `PSPair<A, B>`).
- `PSMetadataQueryServiceHelper`: replace deprecated `new Double(s)` with `Double.valueOf(s)`.
- `PSMetadataDao`: `rawtypes` + `unchecked` for the Hibernate Query creation; `removal` suppression for `session.get(Class, Object)` (deprecated Hibernate API).
- `PSMetadataQueryService`: `rawtypes` + `unchecked` (raw Hibernate Query and result List throughout).

Closes #2041

## Operator
Kilo Code (minimax-m3)

## Notes
- `PSMetadataRestEntry.java:[209,25]` still has an unchecked cast to `List<String>` that cannot be silenced on an expression statement; structural fix requires parameterizing the properties map.
- `PSBlogsHelperTest.testBlogProcess` fails because `hibernate-configuration-3.0.dtd` is missing from the module's classpath; unrelated to this fix.

## Verification
- Standalone `mvnw clean install` for metadata: compilation succeeds; one pre-existing test failure (unrelated DTD missing).
- `spotless:apply` + `spotless:check` on metadata: BUILD SUCCESS.
- 22 of 23 javac warnings eliminated; one structural warning remains (tracked separately).