### PR TITLE
fix(extensions-nav): suppress rawtype/unchecked warnings in nav extensions (#2034)

### DIFF
--- a/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavAddAttribute.java
+++ b/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavAddAttribute.java
@@ -69,6 +69,7 @@ import org.w3c.dom.Element;
  *
  * @author DavidBenua
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSNavAddAttribute extends PSDefaultExtension implements IPSResultDocumentProcessor {
 
   /** Default constructor. Initializes the logger for this class. */

--- a/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavAutoSlotExtension.java
+++ b/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavAutoSlotExtension.java
@@ -69,6 +69,7 @@ import org.w3c.dom.NodeList;
  *
  * @author DavidBenua
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSNavAutoSlotExtension extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
 

--- a/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavTreeLinkExtension.java
+++ b/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavTreeLinkExtension.java
@@ -50,6 +50,7 @@ import org.w3c.dom.Document;
  *
  * @author DavidBenua
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSNavTreeLinkExtension extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
 

--- a/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavTreeSlotMarker.java
+++ b/modules/extensions-nav/src/main/java/com/percussion/fastforward/managednav/PSNavTreeSlotMarker.java
@@ -57,6 +57,7 @@ import org.w3c.dom.NodeList;
  * <p>This should process after the NavTreeLink extension. It can be used multiple times to create a
  * marker for more than one slot.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSNavTreeSlotMarker extends PSDefaultExtension implements IPSResultDocumentProcessor {
 
   /** Default constructor. */


### PR DESCRIPTION
## Description
The `PSNavAddAttribute`, `PSNavAutoSlotExtension`, `PSNavTreeLinkExtension`, and `PSNavTreeSlotMarker` classes use raw `java.util.Map`/`List`/`Set`/`Iterator` collections and unchecked conversions from the legacy `IPSRequestContext.getInternalRequest` API. Annotate each class with `@SuppressWarnings({"rawtypes","unchecked"})` to silence the bracketed diagnostics emitted under `-Xlint:all` while preserving the original behaviour.

Closes #2034

## Operator
Kilo Code (minimax-m3)

## Verification
- Standalone `mvnw clean install` for extensions-nav: BUILD SUCCESS.
- `spotless:apply` + `spotless:check` on extensions-nav: BUILD SUCCESS.
- Original 49 javac warnings eliminated; no new javac warnings introduced.