### PR TITLE
fix(WebUI): Finder root display labels via perc.ui.finder.root@* (#2093)

### DIFF
--- a/WebUI/src/main/webapp/cm/app/includes/finder_js.jsp
+++ b/WebUI/src/main/webapp/cm/app/includes/finder_js.jsp
@@ -31,6 +31,7 @@
 <script src="../widgets/perc_actions_button.js"></script>
 <script src="../widgets/perc_delete_page_button.js"></script>
 <script src="../widgets/perc_preview_button.js"></script>
+<script src="../plugins/perc_finder_root_display.js"></script>
 <script src="../widgets/perc_finder.js"></script>
 <script src="../widgets/perc_finder_buttons.js"></script>
 <script src="../plugins/perc_upload_theme_file_dialog.js"></script>

--- a/WebUI/src/main/webapp/cm/pages/app/includes/finder_js.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/includes/finder_js.jsp
@@ -31,6 +31,7 @@
 <script src="../widgets/perc_actions_button.js"></script>
 <script src="../widgets/perc_delete_page_button.js"></script>
 <script src="../widgets/perc_preview_button.js"></script>
+<script src="../plugins/perc_finder_root_display.js"></script>
 <script src="../widgets/perc_finder.js"></script>
 <script src="../widgets/perc_finder_buttons.js"></script>
 <script src="../plugins/perc_upload_theme_file_dialog.js"></script>

--- a/WebUI/src/main/webapp/cm/plugins/perc_finder_root_display.js
+++ b/WebUI/src/main/webapp/cm/plugins/perc_finder_root_display.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Display-only labels for classic Finder repository roots.
+ *
+ * Path identity (REST/folder segments, perc_path_constants, bookmarks,
+ * path bar values) stays English. Only visible label / title / alt text
+ * should use {@link displayLabelForFinderRoot}.
+ *
+ * TMX keys (shipped by #2092 / PR #2092):
+ *   perc.ui.finder.root@Sites|Assets|Design|Search|Recycling
+ *
+ * Exposes {@code globalThis.percFinderRootDisplay}.
+ */
+(function (global) {
+  "use strict";
+
+  var FINDER_ROOT_I18N_KEYS = {
+    Sites: "perc.ui.finder.root@Sites",
+    Assets: "perc.ui.finder.root@Assets",
+    Design: "perc.ui.finder.root@Design",
+    Search: "perc.ui.finder.root@Search",
+    Recycling: "perc.ui.finder.root@Recycling",
+  };
+
+  /**
+   * @param {*} englishName repository root English name (path segment)
+   * @return {string|null} TMX key, or null when not a known root
+   */
+  function i18nKeyForFinderRoot(englishName) {
+    if (englishName == null || englishName === "") {
+      return null;
+    }
+    return FINDER_ROOT_I18N_KEYS[String(englishName)] || null;
+  }
+
+  /**
+   * Map known English Finder root names to locale display labels.
+   * Unknown names pass through unchanged.
+   *
+   * @param {*} englishName English root name (e.g. "Sites")
+   * @param {function(string):*} [messageFn] optional I18N.message-compatible
+   *        lookup; defaults to global I18N.message when present
+   * @return {string} localized label, or the original English name
+   */
+  function displayLabelForFinderRoot(englishName, messageFn) {
+    if (englishName == null) {
+      return "";
+    }
+    var name = String(englishName);
+    var key = i18nKeyForFinderRoot(name);
+    if (!key) {
+      return name;
+    }
+    var lookup = messageFn;
+    if (typeof lookup !== "function") {
+      if (
+        typeof global.I18N !== "undefined" &&
+        global.I18N &&
+        typeof global.I18N.message === "function"
+      ) {
+        lookup = function (k) {
+          return global.I18N.message(k);
+        };
+      } else {
+        return name;
+      }
+    }
+    try {
+      var translated = lookup(key);
+      if (translated != null && String(translated).length > 0) {
+        return String(translated);
+      }
+    } catch (e) {
+      // Fall through to English identity when TMX lookup fails.
+    }
+    return name;
+  }
+
+  global.percFinderRootDisplay = {
+    FINDER_ROOT_I18N_KEYS: FINDER_ROOT_I18N_KEYS,
+    i18nKeyForFinderRoot: i18nKeyForFinderRoot,
+    displayLabelForFinderRoot: displayLabelForFinderRoot,
+  };
+})(
+  typeof globalThis !== "undefined"
+    ? globalThis
+    : typeof window !== "undefined"
+      ? window
+      : this,
+);

--- a/WebUI/src/main/webapp/cm/widgets/PercContentBrowserWidget.js
+++ b/WebUI/src/main/webapp/cm/widgets/PercContentBrowserWidget.js
@@ -275,6 +275,13 @@
       var path_end = ut.extract_path_end(spec.path);
       var item_path = ut.extract_path(spe.path);
       var icon = ut.choose_icon(spec.type, spec.icon, item_path);
+      // Display-only root labels; path_end / data stay English.
+      var displayLabel =
+        typeof percFinderRootDisplay !== "undefined" &&
+        percFinderRootDisplay &&
+        typeof percFinderRootDisplay.displayLabelForFinderRoot === "function"
+          ? percFinderRootDisplay.displayLabelForFinderRoot(spec.name)
+          : spec.name;
 
       if (settings.siteIcon != "" && spec.type == "site")
         icon = settings.siteIcon;
@@ -298,7 +305,7 @@
               "' />",
           ),
         )
-        .append(spec.name)
+        .append(displayLabel)
         .data("name", path_end)
         .data("tag", spec.name);
 

--- a/WebUI/src/main/webapp/cm/widgets/perc_finder.js
+++ b/WebUI/src/main/webapp/cm/widgets/perc_finder.js
@@ -1066,6 +1066,14 @@ var assetPagination = null;
       var item_path = ut.extract_path(spec.path);
       var isSystemCategory = false;
       var icon;
+      // Display-only: map known English repository roots to TMX labels.
+      // Path identity (spec.name, data name/path, REST) stays English.
+      var displayLabel =
+        typeof percFinderRootDisplay !== "undefined" &&
+        percFinderRootDisplay &&
+        typeof percFinderRootDisplay.displayLabelForFinderRoot === "function"
+          ? percFinderRootDisplay.displayLabelForFinderRoot(spec.name)
+          : spec.name;
       if (
         spec &&
         spec.category &&
@@ -1100,7 +1108,7 @@ var assetPagination = null;
       }
       var listing = $("<a />")
         .addClass("mcol-listing")
-        .attr("alt", spec.name)
+        .attr("alt", displayLabel)
         .attr("id", idFromItem(spec))
         //.attr('tabindex', tabindex)
         .append(
@@ -1119,11 +1127,11 @@ var assetPagination = null;
         .append(
           $(
             "<div class='perc-finder-item-name' style='cursor: default; text-overflow : ellipsis;overflow : hidden'>" +
-              spec.name +
+              displayLabel +
               "</div>",
           ),
         )
-        .attr("title", spec.name)
+        .attr("title", displayLabel)
         .data("tag", pref + (spec.name + "").toLowerCase())
         .data("name", item_path[item_path.length - 1])
         .data("spec", spec);

--- a/WebUI/src/main/webapp/cm/widgets/perc_save_as.js
+++ b/WebUI/src/main/webapp/cm/widgets/perc_save_as.js
@@ -383,6 +383,13 @@
       var pref = spec["type"] == "Folder" ? "a" : "z";
       var item_path = ut.extract_path(spec["path"]);
       var icon = ut.choose_icon(spec["type"], spec["icon"], item_path);
+      // Display-only root labels; path_end / asset values stay English.
+      var displayLabel =
+        typeof percFinderRootDisplay !== "undefined" &&
+        percFinderRootDisplay &&
+        typeof percFinderRootDisplay.displayLabelForFinderRoot === "function"
+          ? percFinderRootDisplay.displayLabelForFinderRoot(spec["name"])
+          : spec["name"];
       var anchor = $("<a href='#'/>")
         .addClass("mcol-listing")
         .attr("id", "perc-saveas-dialog-listing" + ut.path_id(item_path))
@@ -399,7 +406,7 @@
               "' />",
           ),
         )
-        .append(spec["name"])
+        .append(displayLabel)
         .data("name", path_end)
         .data("tag", pref + (spec["name"] + "").toLowerCase());
 

--- a/WebUI/src/test/js/percFinderRootDisplay.test.js
+++ b/WebUI/src/test/js/percFinderRootDisplay.test.js
@@ -1,0 +1,159 @@
+/**
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for classic Finder root display-label mapping
+ * (WebUI/src/main/webapp/cm/plugins/perc_finder_root_display.js).
+ *
+ * Paths / identity stay English; only display labels use
+ * perc.ui.finder.root@* TMX keys.
+ */
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { beforeEach, afterEach, describe, it, expect } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC_PATH = resolve(
+  __dirname,
+  "../../main/webapp/cm/plugins/perc_finder_root_display.js",
+);
+const FINDER_SRC = resolve(
+  __dirname,
+  "../../main/webapp/cm/widgets/perc_finder.js",
+);
+
+const KNOWN_ROOTS = ["Sites", "Assets", "Design", "Search", "Recycling"];
+
+function loadHelper() {
+  const code = readFileSync(SRC_PATH, "utf8");
+  (0, eval)(code);
+  return globalThis.percFinderRootDisplay;
+}
+
+describe("percFinderRootDisplay", () => {
+  let api;
+  let prevI18N;
+  let prevApi;
+
+  beforeEach(() => {
+    prevI18N = globalThis.I18N;
+    prevApi = globalThis.percFinderRootDisplay;
+    delete globalThis.I18N;
+    delete globalThis.percFinderRootDisplay;
+    api = loadHelper();
+  });
+
+  afterEach(() => {
+    if (prevI18N === undefined) {
+      delete globalThis.I18N;
+    } else {
+      globalThis.I18N = prevI18N;
+    }
+    if (prevApi === undefined) {
+      delete globalThis.percFinderRootDisplay;
+    } else {
+      globalThis.percFinderRootDisplay = prevApi;
+    }
+  });
+
+  it("maps each known English root to perc.ui.finder.root@* key", () => {
+    for (const root of KNOWN_ROOTS) {
+      expect(api.i18nKeyForFinderRoot(root)).toBe(
+        `perc.ui.finder.root@${root}`,
+      );
+    }
+  });
+
+  it("returns null for non-root folder names and empty input", () => {
+    expect(api.i18nKeyForFinderRoot("MySite")).toBeNull();
+    expect(api.i18nKeyForFinderRoot("sites")).toBeNull(); // case-sensitive
+    expect(api.i18nKeyForFinderRoot("")).toBeNull();
+    expect(api.i18nKeyForFinderRoot(null)).toBeNull();
+    expect(api.i18nKeyForFinderRoot(undefined)).toBeNull();
+  });
+
+  it("displayLabel uses injected messageFn for known roots only", () => {
+    const es = {
+      "perc.ui.finder.root@Sites": "Sitios",
+      "perc.ui.finder.root@Assets": "Activos",
+      "perc.ui.finder.root@Design": "Diseño",
+      "perc.ui.finder.root@Search": "Buscar",
+      "perc.ui.finder.root@Recycling": "Reciclaje",
+    };
+    const messageFn = (key) => es[key];
+    expect(api.displayLabelForFinderRoot("Sites", messageFn)).toBe("Sitios");
+    expect(api.displayLabelForFinderRoot("Assets", messageFn)).toBe("Activos");
+    expect(api.displayLabelForFinderRoot("Design", messageFn)).toBe("Diseño");
+    expect(api.displayLabelForFinderRoot("Search", messageFn)).toBe("Buscar");
+    expect(api.displayLabelForFinderRoot("Recycling", messageFn)).toBe(
+      "Reciclaje",
+    );
+    // Non-root: identity preserved (path segment / folder name).
+    expect(api.displayLabelForFinderRoot("MySite", messageFn)).toBe("MySite");
+  });
+
+  it("falls back to English when messageFn missing / empty / throws", () => {
+    expect(api.displayLabelForFinderRoot("Sites")).toBe("Sites");
+    expect(api.displayLabelForFinderRoot("Sites", () => "")).toBe("Sites");
+    expect(api.displayLabelForFinderRoot("Sites", () => null)).toBe("Sites");
+    expect(
+      api.displayLabelForFinderRoot("Sites", () => {
+        throw new Error("tmx down");
+      }),
+    ).toBe("Sites");
+  });
+
+  it("uses global I18N.message when messageFn omitted", () => {
+    globalThis.I18N = {
+      message(key) {
+        if (key === "perc.ui.finder.root@Design") return "Diseño";
+        return key;
+      },
+    };
+    // Reload so closure binds to current global (already bound via global param).
+    expect(api.displayLabelForFinderRoot("Design")).toBe("Diseño");
+    expect(api.displayLabelForFinderRoot("Other")).toBe("Other");
+  });
+
+  it("nullish englishName becomes empty string on display", () => {
+    expect(api.displayLabelForFinderRoot(null)).toBe("");
+    expect(api.displayLabelForFinderRoot(undefined)).toBe("");
+  });
+
+  it("FINDER_ROOT_I18N_KEYS covers exactly the five repository roots", () => {
+    expect(Object.keys(api.FINDER_ROOT_I18N_KEYS).sort()).toEqual(
+      [...KNOWN_ROOTS].sort(),
+    );
+  });
+});
+
+describe("perc_finder.js make_item wiring (source contract)", () => {
+  it("uses percFinderRootDisplay for visible name and keeps data/spec English", () => {
+    const src = readFileSync(FINDER_SRC, "utf8");
+    // Display path: alt / title / item-name div use displayLabel
+    expect(src).toMatch(/displayLabelForFinderRoot\s*\(\s*spec\.name\s*\)/);
+    expect(src).toMatch(/\.attr\(\s*["']alt["']\s*,\s*displayLabel\s*\)/);
+    expect(src).toMatch(/\.attr\(\s*["']title["']\s*,\s*displayLabel\s*\)/);
+    // Identity: data name and tag still from English path/name
+    expect(src).toMatch(/\.data\(\s*["']spec["']\s*,\s*spec\s*\)/);
+    expect(src).toMatch(
+      /\.data\(\s*["']name["']\s*,\s*item_path\[\s*item_path\.length\s*-\s*1\s*\]\s*\)/,
+    );
+  });
+});

--- a/WebUI/war/app/includes/finder_js.jsp
+++ b/WebUI/war/app/includes/finder_js.jsp
@@ -31,6 +31,7 @@
 <script src="../widgets/perc_actions_button.js"></script>
 <script src="../widgets/perc_delete_page_button.js"></script>
 <script src="../widgets/perc_preview_button.js"></script>
+<script src="../plugins/perc_finder_root_display.js"></script>
 <script src="../widgets/perc_finder.js"></script>
 <script src="../widgets/perc_finder_buttons.js"></script>
 <script src="../plugins/perc_upload_theme_file_dialog.js"></script>

--- a/WebUI/war/plugins/perc_finder_root_display.js
+++ b/WebUI/war/plugins/perc_finder_root_display.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Display-only labels for classic Finder repository roots.
+ *
+ * Path identity (REST/folder segments, perc_path_constants, bookmarks,
+ * path bar values) stays English. Only visible label / title / alt text
+ * should use {@link displayLabelForFinderRoot}.
+ *
+ * TMX keys (shipped by #2092 / PR #2092):
+ *   perc.ui.finder.root@Sites|Assets|Design|Search|Recycling
+ *
+ * Exposes {@code globalThis.percFinderRootDisplay}.
+ */
+(function (global) {
+  "use strict";
+
+  var FINDER_ROOT_I18N_KEYS = {
+    Sites: "perc.ui.finder.root@Sites",
+    Assets: "perc.ui.finder.root@Assets",
+    Design: "perc.ui.finder.root@Design",
+    Search: "perc.ui.finder.root@Search",
+    Recycling: "perc.ui.finder.root@Recycling",
+  };
+
+  /**
+   * @param {*} englishName repository root English name (path segment)
+   * @return {string|null} TMX key, or null when not a known root
+   */
+  function i18nKeyForFinderRoot(englishName) {
+    if (englishName == null || englishName === "") {
+      return null;
+    }
+    return FINDER_ROOT_I18N_KEYS[String(englishName)] || null;
+  }
+
+  /**
+   * Map known English Finder root names to locale display labels.
+   * Unknown names pass through unchanged.
+   *
+   * @param {*} englishName English root name (e.g. "Sites")
+   * @param {function(string):*} [messageFn] optional I18N.message-compatible
+   *        lookup; defaults to global I18N.message when present
+   * @return {string} localized label, or the original English name
+   */
+  function displayLabelForFinderRoot(englishName, messageFn) {
+    if (englishName == null) {
+      return "";
+    }
+    var name = String(englishName);
+    var key = i18nKeyForFinderRoot(name);
+    if (!key) {
+      return name;
+    }
+    var lookup = messageFn;
+    if (typeof lookup !== "function") {
+      if (
+        typeof global.I18N !== "undefined" &&
+        global.I18N &&
+        typeof global.I18N.message === "function"
+      ) {
+        lookup = function (k) {
+          return global.I18N.message(k);
+        };
+      } else {
+        return name;
+      }
+    }
+    try {
+      var translated = lookup(key);
+      if (translated != null && String(translated).length > 0) {
+        return String(translated);
+      }
+    } catch (e) {
+      // Fall through to English identity when TMX lookup fails.
+    }
+    return name;
+  }
+
+  global.percFinderRootDisplay = {
+    FINDER_ROOT_I18N_KEYS: FINDER_ROOT_I18N_KEYS,
+    i18nKeyForFinderRoot: i18nKeyForFinderRoot,
+    displayLabelForFinderRoot: displayLabelForFinderRoot,
+  };
+})(
+  typeof globalThis !== "undefined"
+    ? globalThis
+    : typeof window !== "undefined"
+      ? window
+      : this,
+);

--- a/WebUI/war/widgets/PercContentBrowserWidget.js
+++ b/WebUI/war/widgets/PercContentBrowserWidget.js
@@ -277,6 +277,13 @@
             var path_end = ut.extract_path_end( spec.path );
             var item_path = ut.extract_path( spe.path );
             var icon = ut.choose_icon( spec.type, spec.icon,    item_path  );
+            // Display-only root labels; path_end / data stay English.
+            var displayLabel =
+                (typeof percFinderRootDisplay !== 'undefined' &&
+                 percFinderRootDisplay &&
+                 typeof percFinderRootDisplay.displayLabelForFinderRoot === 'function')
+                    ? percFinderRootDisplay.displayLabelForFinderRoot(spec.name)
+                    : spec.name;
 			
 			if(settings.siteIcon != "" && spec.type == "site")
 				icon = settings.siteIcon;
@@ -289,7 +296,7 @@
             //    } JGA
                 .attr('id',"perc-saveas-dialog-listing"+ ut.path_id( item_path ))
                 .append($("<img src='"+ icon.src +"' style='float:left' alt='"+ icon.alt + "' title='" + icon.title + "' aria-hidden='" + icon.decorative + "' />" ))
-                .append( spec.name )
+                .append( displayLabel )
                 .data( 'name', path_end )
                 .data( 'tag', spec.name );
 

--- a/WebUI/war/widgets/perc_finder.js
+++ b/WebUI/war/widgets/perc_finder.js
@@ -945,6 +945,14 @@ var assetPagination = null;
             var item_path = ut.extract_path( spec.path );
             var isSystemCategory = false;
             var icon;
+            // Display-only: map known English repository roots to TMX labels.
+            // Path identity (spec.name, data name/path, REST) stays English.
+            var displayLabel =
+                (typeof percFinderRootDisplay !== 'undefined' &&
+                 percFinderRootDisplay &&
+                 typeof percFinderRootDisplay.displayLabelForFinderRoot === 'function')
+                    ? percFinderRootDisplay.displayLabelForFinderRoot(spec.name)
+                    : spec.name;
             if(spec && spec.category && spec.category ==='SYSTEM' && spec.type && spec.type ==='FSFile' &&
                 spec.name && spec.name.indexOf('.') !==-1){
                 // customizing for case of category:system && it is a file type or image type.
@@ -959,11 +967,11 @@ var assetPagination = null;
                 icon = ut.choose_icon( spec.type, spec.icon, item_path );
             }
             var listing = $("<a />").addClass('mcol-listing')
-                .attr("alt",  spec.name )
+                .attr("alt",  displayLabel )
                 .attr('id', idFromItem(spec))
                 //.attr('tabindex', tabindex)
                 .append($("<img src='"+ icon.src +"' style='float:left' alt='"+ icon.alt + "' title='" + icon.title + "' aria-hidden='" + icon.decorative + "' />" ))
-                .append($("<div class='perc-finder-item-name' style='cursor: default; text-overflow : ellipsis;overflow : hidden'>" + spec.name + "</div>" )).attr('title', spec.name)
+                .append($("<div class='perc-finder-item-name' style='cursor: default; text-overflow : ellipsis;overflow : hidden'>" + displayLabel + "</div>" )).attr('title', displayLabel)
                 .data( 'tag', pref + (spec.name + "").toLowerCase() )
                 .data( 'name', item_path[ item_path.length - 1 ] )
                 .data( 'spec', spec );

--- a/WebUI/war/widgets/perc_save_as.js
+++ b/WebUI/war/widgets/perc_save_as.js
@@ -375,11 +375,18 @@
             var pref = (spec['type'] == 'Folder') ? 'a' : 'z';
             var item_path = ut.extract_path( spec['path'] );
             var icon = ut.choose_icon( spec['type'], spec['icon'],    item_path  );
+            // Display-only root labels; path_end / asset values stay English.
+            var displayLabel =
+                (typeof percFinderRootDisplay !== 'undefined' &&
+                 percFinderRootDisplay &&
+                 typeof percFinderRootDisplay.displayLabelForFinderRoot === 'function')
+                    ? percFinderRootDisplay.displayLabelForFinderRoot(spec['name'])
+                    : spec['name'];
             var anchor = $("<a href='#'/>")
                 .addClass('mcol-listing')
                 .attr('id',"perc-saveas-dialog-listing"+ ut.path_id( item_path ))
                 .append($("<img src='"+ icon.src +"' style='float:left' alt='"+ icon.alt + "' title='" + icon.title + "' aria-hidden='" + icon.decorative + "' />" ))
-                .append( spec[ 'name' ] )
+                .append( displayLabel )
                 .data( 'name', path_end )
                 .data( 'tag', pref + (spec['name'] + "").toLowerCase() );
 

--- a/docs/ai-generated/code-reviews/issue-2093-finder-root-display-labels-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2093-finder-root-display-labels-erlang.md
@@ -1,0 +1,45 @@
+# Erlang review: issue #2093 Finder root display labels
+
+**Branch:** `fix/issue-2093-finder-root-display-labels`  
+**Date:** 2026-08-06  
+**Reviewer persona:** Erlang (agent self-review before PR)
+
+## Summary
+
+Display-only I18N for classic Finder repository roots (Sites/Assets/Design/Search/Recycling) via pure helper `perc_finder_root_display.js` and `make_item` wiring. Path identity stays English.
+
+## Scope
+
+- `WebUI/src/main/webapp/cm/plugins/perc_finder_root_display.js` (new)
+- `WebUI/src/main/webapp/cm/widgets/perc_finder.js` (+ war dual-ship)
+- Peers: `perc_save_as.js`, `PercContentBrowserWidget.js` (+ war)
+- `finder_js.jsp` includes (src app, pages, war)
+- `WebUI/src/test/js/percFinderRootDisplay.test.js`
+
+Cross-platform path review: no file I/O or path joining in this change (browser display strings only). Clean.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none found
+- Behavioral unit tests: yes (pure map + source-contract wiring)
+- Non-portable paths: N/A / clean
+- **May commit/push: yes**
+
+## Issues
+
+None at `bug` severity.
+
+### suggestion (non-blocking)
+
+1. **HTML concatenation of `displayLabel`** in `make_item` inherits pre-existing pattern of injecting names into HTML strings. Translated roots from TMX are trusted product strings (no user HTML). Follow-up could use `.text()` for the name div if/when Finder listing construction is modernized.
+2. **Playwright Spanish smoke** deferred to #2094 by design (issue triage / residual).
+
+## Tests
+
+- `npm test -- --run src/test/js/percFinderRootDisplay.test.js` (8 passed)
+- WebUI `mvnw clean install` (see PR gates evidence)
+- Spotless apply+check on WebUI module (in-scope only)


### PR DESCRIPTION
## Summary

Parent tracker: #961 (Spanish residual UI — Finder roots + default gadgets).

After PR #2092 shipped TMX keys `perc.ui.finder.root@Sites|Assets|Design|Search|Recycling`, this wires **display-only** labels in classic Finder:

- New pure helper `WebUI/src/main/webapp/cm/plugins/perc_finder_root_display.js` (`percFinderRootDisplay.displayLabelForFinderRoot`)
- `perc_finder.js` `make_item` uses the helper for **alt / title / visible name** only
- Peers that echo root names the same way: `perc_save_as.js`, `PercContentBrowserWidget.js`
- Dual-ship `war/` copies kept in sync; `finder_js.jsp` loads helper before `perc_finder.js`
- **Paths stay English**: `spec` data, `data-name`, path bar, `perc_path_constants`, REST/folder segments

Does **not** redesign Finder UX. Live Playwright Spanish smoke remains #2094.

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2093  
Refs #961

## Test plan

- [x] Vitest: `npm test -- --run src/test/js/percFinderRootDisplay.test.js` (8 passed)
- [x] WebUI `mvnw clean install` — BUILD SUCCESS (1171 frontend tests)
- [x] Spotless apply + check on WebUI module (in-scope only)
- [x] Erlang self-review approve — `docs/ai-generated/code-reviews/issue-2093-finder-root-display-labels-erlang.md`
- [ ] Manual: Spanish locale login → Finder roots show Sitios / Activos / Diseño / Buscar / Reciclaje; path bar still English
- [ ] Playwright residual #2094 after H2 QA path

## Gates evidence

| Gate | Result |
|------|--------|
| Implementation + unit tests | yes |
| Erlang self-review | approve |
| Spotless (WebUI apply then check) | BUILD SUCCESS |
| `cd WebUI && ../mvnw clean install` | BUILD SUCCESS |
| No force-push / no merge | yes |

> Co-Authored by Grok Build using grok-4.5 with agent main.