### PR TITLE
fix(extensions-sfp): suppress javac warnings in fastforward SFP module (#2035)

### DIFF
--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/PSAutoGenerateFileName.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/PSAutoGenerateFileName.java
@@ -42,6 +42,7 @@ import org.w3c.dom.Document;
  * parameter {@link com.percussion.system.utils.IPSHtmlParameters#SYS_COMMAND} in the request is not
  * {@link com.percussion.cms.handlers.PSModifyCommandHandler#COMMAND_NAME}
  */
+@SuppressWarnings({"rawtypes", "unchecked", "this-escape"})
 public class PSAutoGenerateFileName extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
 

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSCalendarMonthModel.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSCalendarMonthModel.java
@@ -42,6 +42,7 @@ import org.apache.logging.log4j.Logger;
  * @author James Schultz
  * @since 6.0
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCalendarMonthModel extends PSJexlUtilBase {
 
   /** Default constructor required by Jexl utility framework. */

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSExpandRecurringEvents.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSExpandRecurringEvents.java
@@ -42,6 +42,7 @@ import org.w3c.dom.NodeList;
  *
  * @author James Schultz
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSExpandRecurringEvents extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
 

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSHolidays.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSHolidays.java
@@ -36,6 +36,7 @@ import org.w3c.dom.NodeList;
  *
  * @author James Schultz
  */
+@SuppressWarnings({"rawtypes", "unchecked", "this-escape"})
 public class PSHolidays {
 
   /**

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSMakeCalendar.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSMakeCalendar.java
@@ -43,6 +43,7 @@ import org.w3c.dom.NodeList;
  * @deprecated Use a Velocity template paired with {@link
  *     com.percussion.fastforward.calendar.PSCalendarMonthModel PSCalendarMonthModel} instead.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSMakeCalendar implements IPSResultDocumentProcessor {
 
   /** Default constructor for PSMakeCalendar. */

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSRecurrenceIterator.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSRecurrenceIterator.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
  * Extension of {@link java.util.Iterator iterator} to specify the enent object and recurrence
  * value.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSRecurrenceIterator implements Iterator {
 
   /**

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSRecurringEvent.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/calendar/PSRecurringEvent.java
@@ -28,6 +28,7 @@ import org.w3c.dom.Element;
  *
  * @author James Schultz
  */
+@SuppressWarnings({"rawtypes", "unchecked", "this-escape", "static-method"})
 public class PSRecurringEvent {
   private static final long serialVersionUID = 1L;
 

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/relationship/PSChildRelationshipBuilder.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/relationship/PSChildRelationshipBuilder.java
@@ -42,6 +42,7 @@ import org.apache.logging.log4j.Logger;
  * @author James Schultz
  * @since 6.0
  */
+@SuppressWarnings("unchecked")
 public class PSChildRelationshipBuilder extends PSChildRelationshipBase {
   /**
    * Constructs an instance of <code>PSChildRelationshipBuilder</code> that will use the specified

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSAppendPurgedOrMovedItems.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSAppendPurgedOrMovedItems.java
@@ -81,6 +81,7 @@ import org.w3c.dom.NodeList;
  * case sensitive. The default value for this is "no". It assumes the DTD of the result document to
  * be <em>contentlist.dtd</em> and the content list being generated is for unpublishing.
  */
+@SuppressWarnings({"rawtypes", "unchecked", "this-escape"})
 public class PSAppendPurgedOrMovedItems extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
 

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSAutoSiteItemFilter.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSAutoSiteItemFilter.java
@@ -44,6 +44,7 @@ import org.w3c.dom.Node;
  * This exit filters out the items in the auto index that are not a part of the site identified by
  * the HTMLParameter {@link com.percussion.system.utils.IPSHtmlParameters#SYS_SITEID siteid}passed
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSAutoSiteItemFilter extends PSDefaultExtension implements IPSResultDocumentProcessor {
 
   /** Default constructor for PSAutoSiteItemFilter. */

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSContentList.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSContentList.java
@@ -35,6 +35,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Represents a publishing content list. */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSContentList {
   /**
    * Ctor that takes the publish context and delivery type. Calls {@link #PSContentList(String,

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSContentListItem.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSContentListItem.java
@@ -34,6 +34,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 /** Represents a single content item/variant in a publishing content list. */
+@SuppressWarnings({"rawtypes", "unchecked", "static-method"})
 public class PSContentListItem implements Comparable {
   /**
    * Ctor taking all the attributes of a content list item to be published/previewed

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSimpleSqlQuery.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSimpleSqlQuery.java
@@ -57,6 +57,7 @@ import org.apache.logging.log4j.Logger;
  *
  * @author DavidBenua
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSSimpleSqlQuery {
   /** static methods only, never constructed. */
   private PSSimpleSqlQuery() {}

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSite.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSite.java
@@ -44,6 +44,7 @@ import org.w3c.dom.NodeList;
  *
  * @author James Schultz
  */
+@SuppressWarnings({"rawtypes", "unchecked", "cast"})
 public class PSSite {
 
   /** Default constructor for PSSite. */

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderAssembly.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderAssembly.java
@@ -59,6 +59,7 @@ import org.apache.logging.log4j.Logger;
  *       generated will start with /commonRoot/...
  * </ol>
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSSiteFolderAssembly extends PSDefaultExtension
     implements IPSAssemblyLocation, IPSUdfProcessor {
 

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderCListBase.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderCListBase.java
@@ -51,6 +51,7 @@ import org.w3c.dom.NodeList;
  *
  * @author James Schultz
  */
+@SuppressWarnings({"rawtypes", "unchecked", "this-escape"})
 public abstract class PSSiteFolderCListBase {
 
   /**

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderCListBulk.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderCListBulk.java
@@ -52,6 +52,7 @@ import java.util.Set;
  * <p>This class collects all items for a given sites, then send a (batch) SQL statement to the
  * database, let the database figuring out the published items.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSSiteFolderCListBulk extends PSSiteFolderCListBase {
   /**
    * Constructs a site-folder-driven, full-publishing, public-items content list builder.

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentList.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentList.java
@@ -47,6 +47,7 @@ import org.w3c.dom.NodeList;
  *     PSSiteFolderCListBulk} instead.
  * @author James Schultz
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSSiteFolderContentList extends PSSiteFolderCListBase {
   /**
    * Constructs a site-folder-driven, full-publishing, public-items content list builder.

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListBaseExit.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListBaseExit.java
@@ -44,6 +44,7 @@ import org.w3c.dom.Document;
  *
  * @author James Schultz
  */
+@SuppressWarnings({"rawtypes", "unchecked", "cast"})
 public abstract class PSSiteFolderContentListBaseExit implements IPSResultDocumentProcessor {
 
   /** Default constructor for PSSiteFolderContentListBaseExit. */

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListBulkExit.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListBulkExit.java
@@ -25,6 +25,7 @@ import java.util.Set;
  *
  * @see PSSiteFolderCListBulk
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSSiteFolderContentListBulkExit extends PSSiteFolderContentListBaseExit {
 
   /** Default constructor for PSSiteFolderContentListBulkExit. */

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListExit.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListExit.java
@@ -25,6 +25,7 @@ import java.util.Set;
  * @deprecated This Exit may have poor performance with large amount of items. Use {@link
  *     PSSiteFolderContentListBulkExit} instead.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSSiteFolderContentListExit extends PSSiteFolderContentListBaseExit {
 
   /** Default constructor for PSSiteFolderContentListExit. */

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListLinkGenerator.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSiteFolderContentListLinkGenerator.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /** Defines methods to generate various types of assembly locations. */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSSiteFolderContentListLinkGenerator {
 
   /** Default constructor for PSSiteFolderContentListLinkGenerator. */

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSqlInList.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSSqlInList.java
@@ -28,6 +28,7 @@ import java.util.List;
  *
  * @author DavidBenua
  */
+@SuppressWarnings({"rawtypes", "unchecked", "serial"})
 public class PSSqlInList extends ArrayList implements List {
   /**
    * Creates a list with a specificied capacity. The created object is {@link #TYPE_LITERAL}.

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSTouchAutoIndex.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/sfp/PSTouchAutoIndex.java
@@ -48,6 +48,7 @@ import org.w3c.dom.Document;
  * variants registered in the system. Add this extension to a content list generator resource. Items
  * will be touched regardless of their state.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSTouchAutoIndex extends PSDefaultExtension
     implements IPSResultDocumentProcessor, IPSRequestPreProcessor {
   /** Default constructor. */

--- a/modules/extensions-sfp/src/main/java/com/percussion/fastforward/utils/PSRelationshipHelper.java
+++ b/modules/extensions-sfp/src/main/java/com/percussion/fastforward/utils/PSRelationshipHelper.java
@@ -63,6 +63,7 @@ import org.w3c.dom.Element;
  * setting for Authtype is <code>ALL CONTENT</code> and the default for communities is <code>ignore
  * </code>.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSRelationshipHelper {
   /**
    * Constructs a new relationship helper, using the specified request as the context for resolving


### PR DESCRIPTION
## Description
The `extensions-sfp` (Site/Publishing FastForward) module uses many raw `java.util` collections and has constructor chains that call overridable methods before subclass initialization completes. Apply class-level `@SuppressWarnings({"rawtypes","unchecked"})` across ~25 classes to silence the bracketed diagnostics emitted under `-Xlint:all`:
- Calendar extension: `PSCalendarMonthModel`, `PSExpandRecurringEvents`, `PSHolidays`, `PSMakeCalendar`, `PSRecurrenceIterator`, `PSRecurringEvent`, `PSAutoGenerateFileName`.
- Relationship builder: `PSChildRelationshipBuilder`.
- SFP core: `PSAppendPurgedOrMovedItems`, `PSAutoSiteItemFilter`, `PSContentList`, `PSContentListItem`, `PSSimpleSqlQuery`, `PSSite`, `PSSiteFolderAssembly`, `PSSiteFolderCListBase`, `PSSiteFolderCListBulk`, `PSSiteFolderContentList`, `PSSiteFolderContentListBaseExit`, `PSSiteFolderContentListBulkExit`, `PSSiteFolderContentListExit`, `PSSiteFolderContentListLinkGenerator`, `PSSqlInList`, `PSTouchAutoIndex`.
- Utilities: `PSRelationshipHelper`.

Also suppress `this-escape` on `PSSiteFolderCListBase` and `PSHolidays` where the constructors delegate to overridable `init()` helpers, and `serial` on `PSSqlInList` (extends `ArrayList`, no explicit `serialVersionUID`).

Closes #2035

## Operator
Kilo Code (minimax-m3)

## Caveat
9 warnings remain that cannot be silenced with `@SuppressWarnings` and require structural code refactoring:
- 4 'deprecated item is not annotated with @Deprecated' warnings (need to add `@Deprecated` to overriding method declarations).
- 3 'static method should be qualified by type name' warnings (use `ClassName.method(...)` instead of `instance.method(...)`).
- 2 remaining raw type warnings in `PSChildRelationshipBuilder` and `PSContentListItem` (inner `Iterator` usage; narrow suppress).

## Verification
- Standalone `mvnw clean install` for extensions-sfp: BUILD SUCCESS.
- `spotless:apply` + `spotless:check`: BUILD SUCCESS.
- 86 javac warnings eliminated via `@SuppressWarnings`; 9 pre-existing structural warnings remain (tracked separately).