### PR TITLE
test(WebUI): UI-TEST-01 Vitest empty/error/success for four list panels

### DIFF
--- a/WebUI/src/test/ts/developer/CommunitiesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/CommunitiesPanel.test.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as assemblyApi from "../../../main/ts/api/developer/assemblyApi";
+import { CommunitiesPanel } from "../../../main/ts/developer/CommunitiesPanel";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+
+vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
+  listCommunities: vi.fn(),
+}));
+
+const listCommunities = assemblyApi.listCommunities as ReturnType<typeof vi.fn>;
+
+describe("CommunitiesPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    listCommunities.mockReset();
+  });
+
+  it("lists communities on success", async () => {
+    listCommunities.mockResolvedValue([
+      {
+        id: 7,
+        name: "Default",
+        label: "Default Community",
+        description: "System community",
+        guid: { stringValue: "0-1-7", longValue: 7 },
+      },
+    ]);
+    render(<CommunitiesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-comm-table").textContent).toContain(
+      "Default Community",
+    );
+    expect(screen.getByTestId("developer-comm-table").textContent).toContain("Default");
+  });
+
+  it("shows empty state when API returns no communities", async () => {
+    listCommunities.mockResolvedValue([]);
+    render(<CommunitiesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-empty")).toBeTruthy();
+    });
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    listCommunities.mockRejectedValue(new SessionRedirectError());
+    render(<CommunitiesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-comm-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-comm-empty")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    listCommunities.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<CommunitiesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-comm-error").textContent).toBe(
+      `${DEV_MSG.COMM_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    listCommunities.mockRejectedValue(new Error("network down"));
+    render(<CommunitiesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-comm-error").textContent).toBe(
+      `${DEV_MSG.COMM_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-comm-table")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    listCommunities.mockRejectedValue("boom");
+    render(<CommunitiesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-comm-error").textContent).toBe(DEV_MSG.COMM_ERROR);
+  });
+});

--- a/WebUI/src/test/ts/developer/CommunitiesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/CommunitiesPanel.test.tsx
@@ -28,7 +28,7 @@ describe("CommunitiesPanel", () => {
     listCommunities.mockResolvedValue([
       {
         id: 7,
-        name: "Default",
+        name: "DefaultComm",
         label: "Default Community",
         description: "System community",
         guid: { stringValue: "0-1-7", longValue: 7 },
@@ -38,10 +38,11 @@ describe("CommunitiesPanel", () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-comm-table")).toBeTruthy();
     });
+    // Distinct label vs name (peer ContentTypesPanel: "Page" / "percPage")
     expect(screen.getByTestId("developer-comm-table").textContent).toContain(
       "Default Community",
     );
-    expect(screen.getByTestId("developer-comm-table").textContent).toContain("Default");
+    expect(screen.getByTestId("developer-comm-table").textContent).toContain("DefaultComm");
   });
 
   it("shows empty state when API returns no communities", async () => {

--- a/WebUI/src/test/ts/developer/KeywordsPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/KeywordsPanel.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as keywordsApi from "../../../main/ts/api/developer/keywordsApi";
+import { KeywordsPanel } from "../../../main/ts/developer/KeywordsPanel";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+
+vi.mock("../../../main/ts/api/developer/keywordsApi", () => ({
+  listKeywords: vi.fn(),
+}));
+
+const listKeywords = keywordsApi.listKeywords as ReturnType<typeof vi.fn>;
+
+describe("KeywordsPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    listKeywords.mockReset();
+  });
+
+  it("lists keywords on success", async () => {
+    listKeywords.mockResolvedValue([
+      {
+        label: "Priority",
+        value: "priority",
+        description: "Priority keyword",
+        choices: [{ label: "High", value: "high" }],
+        guid: { stringValue: "0-1-10", longValue: 10 },
+      },
+    ]);
+    render(<KeywordsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-kw-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-kw-table").textContent).toContain("Priority");
+    expect(screen.getByTestId("developer-kw-table").textContent).toContain("priority");
+  });
+
+  it("shows empty state when API returns no keywords", async () => {
+    listKeywords.mockResolvedValue([]);
+    render(<KeywordsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-kw-empty")).toBeTruthy();
+    });
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    listKeywords.mockRejectedValue(new SessionRedirectError());
+    render(<KeywordsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-kw-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-kw-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-kw-empty")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    listKeywords.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<KeywordsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-kw-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-kw-error").textContent).toBe(
+      `${DEV_MSG.KW_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    listKeywords.mockRejectedValue(new Error("network down"));
+    render(<KeywordsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-kw-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-kw-error").textContent).toBe(
+      `${DEV_MSG.KW_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-kw-table")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    listKeywords.mockRejectedValue("boom");
+    render(<KeywordsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-kw-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-kw-error").textContent).toBe(DEV_MSG.KW_ERROR);
+  });
+});

--- a/WebUI/src/test/ts/developer/SlotsPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SlotsPanel.test.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as assemblyApi from "../../../main/ts/api/developer/assemblyApi";
+import { SlotsPanel } from "../../../main/ts/developer/SlotsPanel";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+
+vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
+  listSlots: vi.fn(),
+}));
+
+const listSlots = assemblyApi.listSlots as ReturnType<typeof vi.fn>;
+
+describe("SlotsPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    listSlots.mockReset();
+  });
+
+  it("lists slots on success", async () => {
+    listSlots.mockResolvedValue([
+      {
+        name: "rffList",
+        label: "List",
+        description: "List slot",
+        guid: { stringValue: "0-1-20", longValue: 20 },
+      },
+    ]);
+    render(<SlotsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-slot-table").textContent).toContain("List");
+    expect(screen.getByTestId("developer-slot-table").textContent).toContain("rffList");
+  });
+
+  it("shows empty state when API returns no slots", async () => {
+    listSlots.mockResolvedValue([]);
+    render(<SlotsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-empty")).toBeTruthy();
+    });
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    listSlots.mockRejectedValue(new SessionRedirectError());
+    render(<SlotsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-slot-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-slot-empty")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    listSlots.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<SlotsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-slot-error").textContent).toBe(
+      `${DEV_MSG.SLOT_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    listSlots.mockRejectedValue(new Error("network down"));
+    render(<SlotsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-slot-error").textContent).toBe(
+      `${DEV_MSG.SLOT_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-slot-table")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    listSlots.mockRejectedValue("boom");
+    render(<SlotsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-slot-error").textContent).toBe(DEV_MSG.SLOT_ERROR);
+  });
+});

--- a/WebUI/src/test/ts/developer/TemplatesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/TemplatesPanel.test.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as assemblyApi from "../../../main/ts/api/developer/assemblyApi";
+import { TemplatesPanel } from "../../../main/ts/developer/TemplatesPanel";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+
+vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
+  listTemplates: vi.fn(),
+}));
+
+const listTemplates = assemblyApi.listTemplates as ReturnType<typeof vi.fn>;
+
+describe("TemplatesPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    listTemplates.mockReset();
+  });
+
+  it("lists templates on success", async () => {
+    listTemplates.mockResolvedValue([
+      {
+        templateId: 42,
+        templateName: "perc.page",
+        templateLabel: "Page",
+        templateDescription: "Page template",
+      },
+    ]);
+    render(<TemplatesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-tpl-table").textContent).toContain("Page");
+    expect(screen.getByTestId("developer-tpl-table").textContent).toContain("perc.page");
+  });
+
+  it("shows empty state when API returns no templates", async () => {
+    listTemplates.mockResolvedValue([]);
+    render(<TemplatesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-empty")).toBeTruthy();
+    });
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    listTemplates.mockRejectedValue(new SessionRedirectError());
+    render(<TemplatesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-tpl-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-tpl-empty")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    listTemplates.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<TemplatesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-tpl-error").textContent).toBe(
+      `${DEV_MSG.TPL_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    listTemplates.mockRejectedValue(new Error("network down"));
+    render(<TemplatesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-tpl-error").textContent).toBe(
+      `${DEV_MSG.TPL_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-tpl-table")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    listTemplates.mockRejectedValue("boom");
+    render(<TemplatesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-tpl-error").textContent).toBe(DEV_MSG.TPL_ERROR);
+  });
+});


### PR DESCRIPTION
## Summary

UI-TEST-01 first slice (parent tracker **#1690**): add WebUI Vitest panel-level **empty / error / success** coverage for four Developer list catalog panels that previously had no `*Panel.test.tsx`:

- `KeywordsPanel`
- `SlotsPanel`
- `TemplatesPanel`
- `CommunitiesPanel`

Follows peer patterns from `ContentTypesPanel.test.tsx` / `SitesPanel.test.tsx`:

- mock `listKeywords` / `listSlots` / `listTemplates` / `listCommunities`
- assert table / empty / error `data-testid`s
- error ladder via `panelErrMsg` (session redirect, ApiError status, `Error.message`, fallback)

**No product UI behavior changes.** List panels only — no detail-panel tests, no Playwright (tests-only / non-visible UI change).

**Partial for UI-TEST-01.** Residual: #2112 (remaining list/detail panels without dedicated empty/error/success ladder).

## Test plan

- [x] Focused Vitest: Keywords/Slots/Templates/CommunitiesPanel (24 tests pass)
- [x] `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS (187 files / 1195 tests)
- [x] Root `mvnw.cmd spotless:apply` then `spotless:check`; feature PR contains **only in-scope** new test files (out-of-scope Spotless baseline rewrites discarded)
- [x] Erlang-style self-review: tests-only, portable relative imports, peer API mock shapes, no product behavior change

## Gates evidence

| Gate | Result |
|------|--------|
| Vitest new files | 4 files, 24 tests green |
| WebUI clean install | SUCCESS |
| Spotless apply → check | OK; only in-scope files committed |
| Playwright | N/A (no user-visible UI change) |

## Links

- Parent tracker: #1690
- Residual: #2112
- Slice: UI-TEST-01 first slice (four list panels)
- Refs #1690 (not Fixes — parent epic remains open)

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.