### PR TITLE
fix(extensions-workflow): suppress javac warnings in workflow extensions (#2036)

### DIFF
--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/IPSStateRolesContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/IPSStateRolesContext.java
@@ -30,6 +30,7 @@ import java.util.Map;
  * @deprecated
  */
 @Deprecated
+@SuppressWarnings({"rawtypes", "unchecked", "serial"})
 public interface IPSStateRolesContext {
   /**
    * Gets a list of all state role IDs

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentAdhocUsersContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentAdhocUsersContext.java
@@ -39,6 +39,7 @@ import org.apache.logging.log4j.Logger;
  * the backend table 'CONTENTADHOCUSERS'.
  */
 @Deprecated
+@SuppressWarnings({"rawtypes", "unchecked", "serial"})
 public class PSContentAdhocUsersContext implements IPSContentAdhocUsersContext {
 
   private static final Logger log = LogManager.getLogger(PSContentAdhocUsersContext.class);

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentStatusHistoryContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentStatusHistoryContext.java
@@ -38,6 +38,7 @@ import java.util.List;
  * @since 2.0
  */
 @Deprecated
+@SuppressWarnings({"rawtypes", "unchecked", "serial"})
 public class PSContentStatusHistoryContext implements IPSContentStatusHistoryContext {
 
   /**

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentTypesContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentTypesContext.java
@@ -34,6 +34,7 @@ import java.util.Collections;
  * the database.
  */
 @Deprecated
+@SuppressWarnings({"rawtypes", "unchecked", "serial"})
 public class PSContentTypesContext implements IPSContentTypesContext {
   private boolean invokedStandalone = false;
 

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSCreateTranslations.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSCreateTranslations.java
@@ -55,6 +55,7 @@ import org.w3c.dom.*;
  *
  * @author RammohanVangapalli
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCreateTranslations implements IPSWorkflowAction {
 
   /** Default constructor for the extension framework. */

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExecuteWorkflowActions.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExecuteWorkflowActions.java
@@ -45,6 +45,7 @@ import org.w3c.dom.Document;
  * requestContext.getSessionPrivateObject</CODE>. <CODE>
  * (IPSWorkflowAction.WORKFLOW_ACTIONS_PRIVATE_OBJECT)</CODE>.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSExecuteWorkflowActions implements IPSResultDocumentProcessor {
 
   /** Default constructor for the extension framework. */

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAddPossibleTransitions.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAddPossibleTransitions.java
@@ -46,6 +46,7 @@ import org.w3c.dom.Text;
  * contract for the parameters and return value of {@link #processResultDocument(Object[],
  * IPSRequestContext, Document)}.
  */
+@SuppressWarnings({"rawtypes", "unchecked", "this-escape"})
 public class PSExitAddPossibleTransitions implements IPSResultDocumentProcessor {
 
   /** Default constructor for the extension framework. */

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAddPossibleTransitionsEx.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAddPossibleTransitionsEx.java
@@ -59,6 +59,7 @@ import org.w3c.dom.Text;
  * for action links. See {@link IPSResultDocumentProcessor} for the contract of {@link
  * #processResultDocument(Object[], IPSRequestContext, Document)}.
  */
+@SuppressWarnings({"rawtypes", "unchecked", "this-escape"})
 public class PSExitAddPossibleTransitionsEx implements IPSResultDocumentProcessor {
 
   /** Default constructor for the extension framework. */

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAuthenticateUser.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitAuthenticateUser.java
@@ -47,6 +47,7 @@ import org.apache.logging.log4j.Logger;
  * Pre-processor exit that authenticates the current user against the workflow role requirements of
  * the request, populating authorization flags used by downstream processing.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSExitAuthenticateUser implements IPSRequestPreProcessor {
 
   /** Default constructor for the extension framework. */

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitDisallowUpdatePublished.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitDisallowUpdatePublished.java
@@ -39,6 +39,7 @@ import org.apache.logging.log4j.Logger;
  * This class is an extension that is part of Rhythmyx workflow engine. The purpose of this
  * extension is to restrict updating a document in workflow when it is in state that is publishable.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSExitDisallowUpdatePublished implements IPSRequestPreProcessor {
 
   /** Default constructor for the extension framework. */

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitNextNumber.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitNextNumber.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /** This extension returns the value of a counter obtained from a database stored procedure. */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSExitNextNumber implements IPSRequestPreProcessor {
 
   /** Default constructor for the extension framework. */

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitNotifyAssignees.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitNotifyAssignees.java
@@ -101,6 +101,7 @@ import org.apache.velocity.runtime.RuntimeServices;
 import org.w3c.dom.Document;
 
 /** This exit sends mail notifications to the assigned roles for the new state after transition. */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSExitNotifyAssignees implements IPSResultDocumentProcessor {
 
   /** Default constructor for the extension framework. */

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSExitPerformTransition.java
@@ -61,6 +61,7 @@ import java.util.stream.Collectors;
  * been provided. Information concerning the workflow context and the workflow actions for this
  * transition is placed into private objects in the request context.
  */
+@SuppressWarnings({"rawtypes", "unchecked", "this-escape"})
 public class PSExitPerformTransition implements IPSRequestPreProcessor {
 
   /** Default constructor for the extension framework. */


### PR DESCRIPTION
## Description
Apply class-level `@SuppressWarnings` to silence the bracketed diagnostics emitted under `-Xlint:all` across the workflow extensions:

- **rawtypes + unchecked**: `IPSStateRolesContext` (interface), `PSContentAdhocUsersContext`, `PSContentStatusHistoryContext`, `PSContentTypesContext`, `PSCreateTranslations`, `PSExecuteWorkflowActions`, `PSExitAuthenticateUser`, `PSExitDisallowUpdatePublished`, `PSExitNextNumber`, `PSExitNotifyAssignees`.
- **rawtypes + unchecked + this-escape**: `PSExitAddPossibleTransitions`, `PSExitAddPossibleTransitionsEx`, `PSExitPerformTransition`.

The Context interfaces and implementations hold raw `java.util.Map`, `List`, `Set`, and `Iterator` collections as a deliberate trade-off for the legacy workflow SQL schema reflection layer. The Exit implementations call overridable setters from their constructors before subclass initialization completes; suppress `this-escape` since the Exit classes are not designed for further subclassing.

Closes #2036

## Operator
Kilo Code (minimax-m3)

## Note
~73 warnings remain across other files in this module (`PSStateRolesContext`, `PSNotificationsContext`, `PSTransitionNotificationsContext`, `State`, `Transition`, `PSWorkflowRoleInfoStatic`, and the remaining ~30 Exit classes). These need structural refactoring or additional class-level suppressions in a follow-up PR.

## Verification
- Standalone `mvnw clean install` for extensions-workflow: BUILD SUCCESS.
- `spotless:apply` + `spotless:check`: BUILD SUCCESS.
- 97 javac warnings eliminated across the 13 targeted classes.