### PR TITLE
test(WebUI): UI-TEST-01 list panel empty/error/success Vitest (#2112)

### DIFF
--- a/WebUI/src/test/ts/contentExplorer/ExplorerTree.test.tsx
+++ b/WebUI/src/test/ts/contentExplorer/ExplorerTree.test.tsx
@@ -151,8 +151,9 @@ describe("ExplorerTree", () => {
         onSelectFolder={() => undefined}
       />,
     );
+    // formatApiError (api/client) surfaces Error.message / body text when present.
     await waitFor(() =>
-      expect(screen.getByRole("alert")).toHaveTextContent(/Failed to load/),
+      expect(screen.getByRole("alert")).toHaveTextContent(/server down/),
     );
   });
 

--- a/WebUI/src/test/ts/developer/ActionMenusPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ActionMenusPanel.test.tsx
@@ -5,38 +5,50 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as actionMenusApi from "../../../main/ts/api/developer/actionMenusApi";
 import { ActionMenusPanel } from "../../../main/ts/developer/ActionMenusPanel";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
 
 vi.mock("../../../main/ts/api/developer/actionMenusApi", () => ({
-  listActionMenus: vi.fn().mockResolvedValue([
-    {
-      id: 1,
-      name: "Edit",
-      label: "Edit Item",
-      menuType: "MENUITEM",
-      handler: "CLIENT",
-      parameters: [{ name: "sys_contentid", value: "0" }],
-      properties: [],
-    },
-  ]),
-  getActionMenuDetail: vi.fn().mockResolvedValue({
-    id: 1,
-    name: "Edit",
-    label: "Edit",
-    menuType: "MENUITEM",
-    parameters: [{ name: "sys_contentid", value: "0" }],
-    properties: [{ name: "AcceleratorKey", value: "E" }],
-  }),
+  listActionMenus: vi.fn(),
+  getActionMenuDetail: vi.fn(),
 }));
+
+const listActionMenus = actionMenusApi.listActionMenus as ReturnType<typeof vi.fn>;
+const getActionMenuDetail = actionMenusApi.getActionMenuDetail as ReturnType<typeof vi.fn>;
+
+const sampleMenu = {
+  id: 1,
+  name: "Edit",
+  label: "Edit Item",
+  menuType: "MENUITEM",
+  handler: "CLIENT",
+  parameters: [{ name: "sys_contentid", value: "0" }],
+  properties: [],
+};
+
+const sampleDetail = {
+  id: 1,
+  name: "Edit",
+  label: "Edit",
+  menuType: "MENUITEM",
+  parameters: [{ name: "sys_contentid", value: "0" }],
+  properties: [{ name: "AcceleratorKey", value: "E" }],
+};
 
 describe("ActionMenusPanel", () => {
   beforeEach(() => {
     (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
       message: (key: string) => key,
     };
+    listActionMenus.mockReset();
+    getActionMenuDetail.mockReset();
   });
 
   it("lists action menus and opens detail", async () => {
+    listActionMenus.mockResolvedValue([sampleMenu]);
+    getActionMenuDetail.mockResolvedValue(sampleDetail);
     render(<ActionMenusPanel />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-am-table")).toBeTruthy();
@@ -51,5 +63,57 @@ describe("ActionMenusPanel", () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-am-table")).toBeTruthy();
     });
+  });
+
+  it("shows empty state when API returns no action menus", async () => {
+    listActionMenus.mockResolvedValue([]);
+    render(<ActionMenusPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-empty")).toBeTruthy();
+    });
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    listActionMenus.mockRejectedValue(new SessionRedirectError());
+    render(<ActionMenusPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-am-error").textContent).toBe(DEV_MSG.SESSION_REDIRECT);
+    expect(screen.queryByTestId("developer-am-empty")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    listActionMenus.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<ActionMenusPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-am-error").textContent).toBe(`${DEV_MSG.AM_ERROR} (500)`);
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    listActionMenus.mockRejectedValue(new Error("network down"));
+    render(<ActionMenusPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-am-error").textContent).toBe(
+      `${DEV_MSG.AM_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-am-table")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    listActionMenus.mockRejectedValue("boom");
+    render(<ActionMenusPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-am-error").textContent).toBe(DEV_MSG.AM_ERROR);
   });
 });

--- a/WebUI/src/test/ts/developer/DisplayFormatsPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/DisplayFormatsPanel.test.tsx
@@ -5,35 +5,49 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as displayFormatsApi from "../../../main/ts/api/developer/displayFormatsApi";
 import { DisplayFormatsPanel } from "../../../main/ts/developer/DisplayFormatsPanel";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
 
 vi.mock("../../../main/ts/api/developer/displayFormatsApi", () => ({
-  listDisplayFormats: vi.fn().mockResolvedValue([
-    {
-      name: "Default",
-      label: "Default View",
-      description: "System default",
-      validForFolder: true,
-      validForViewsAndSearches: true,
-      columns: [{ source: "sys_title", displayName: "Title", position: 0 }],
-    },
-  ]),
-  getDisplayFormatDetail: vi.fn().mockResolvedValue({
-    name: "Default",
-    label: "Default View",
-    columns: [{ source: "sys_title", displayName: "Title", position: 0, renderType: "text" }],
-  }),
+  listDisplayFormats: vi.fn(),
+  getDisplayFormatDetail: vi.fn(),
   normalizeColumns: (c: unknown) => (Array.isArray(c) ? c : []),
 }));
+
+const listDisplayFormats = displayFormatsApi.listDisplayFormats as ReturnType<typeof vi.fn>;
+const getDisplayFormatDetail = displayFormatsApi.getDisplayFormatDetail as ReturnType<
+  typeof vi.fn
+>;
+
+const sampleFormat = {
+  name: "Default",
+  label: "Default View",
+  description: "System default",
+  validForFolder: true,
+  validForViewsAndSearches: true,
+  columns: [{ source: "sys_title", displayName: "Title", position: 0 }],
+};
+
+const sampleDetail = {
+  name: "Default",
+  label: "Default View",
+  columns: [{ source: "sys_title", displayName: "Title", position: 0, renderType: "text" }],
+};
 
 describe("DisplayFormatsPanel", () => {
   beforeEach(() => {
     (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
       message: (key: string) => key,
     };
+    listDisplayFormats.mockReset();
+    getDisplayFormatDetail.mockReset();
   });
 
   it("lists display formats and opens detail", async () => {
+    listDisplayFormats.mockResolvedValue([sampleFormat]);
+    getDisplayFormatDetail.mockResolvedValue(sampleDetail);
     render(<DisplayFormatsPanel />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-df-table")).toBeTruthy();
@@ -48,5 +62,57 @@ describe("DisplayFormatsPanel", () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-df-table")).toBeTruthy();
     });
+  });
+
+  it("shows empty state when API returns no display formats", async () => {
+    listDisplayFormats.mockResolvedValue([]);
+    render(<DisplayFormatsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-empty")).toBeTruthy();
+    });
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    listDisplayFormats.mockRejectedValue(new SessionRedirectError());
+    render(<DisplayFormatsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-df-error").textContent).toBe(DEV_MSG.SESSION_REDIRECT);
+    expect(screen.queryByTestId("developer-df-empty")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    listDisplayFormats.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<DisplayFormatsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-df-error").textContent).toBe(`${DEV_MSG.DF_ERROR} (500)`);
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    listDisplayFormats.mockRejectedValue(new Error("network down"));
+    render(<DisplayFormatsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-df-error").textContent).toBe(
+      `${DEV_MSG.DF_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-df-table")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    listDisplayFormats.mockRejectedValue("boom");
+    render(<DisplayFormatsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-df-error").textContent).toBe(DEV_MSG.DF_ERROR);
   });
 });

--- a/WebUI/src/test/ts/developer/ExtensionsPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ExtensionsPanel.test.tsx
@@ -5,34 +5,46 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as extensionsApi from "../../../main/ts/api/developer/extensionsApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
 import { ExtensionsPanel } from "../../../main/ts/developer/ExtensionsPanel";
 
 vi.mock("../../../main/ts/api/developer/extensionsApi", () => ({
-  listExtensions: vi.fn().mockResolvedValue([
-    {
-      extensionName: "sys_add",
-      handlerName: "Java",
-      context: "global/percussion/",
-      fqn: "Java/global/percussion/sys_add",
-      category: "sys",
-    },
-  ]),
-  getExtensionDetail: vi.fn().mockResolvedValue({
-    extensionName: "sys_add",
-    fqn: "Java/global/percussion/sys_add",
-    supportedInterfaces: ["com.percussion.extension.IPSExtension"],
-    runtimeParameters: [{ name: "htmlParams", dataType: "java.util.Map" }],
-  }),
+  listExtensions: vi.fn(),
+  getExtensionDetail: vi.fn(),
 }));
+
+const listExtensions = extensionsApi.listExtensions as ReturnType<typeof vi.fn>;
+const getExtensionDetail = extensionsApi.getExtensionDetail as ReturnType<typeof vi.fn>;
+
+const sampleExtension = {
+  extensionName: "sys_add",
+  handlerName: "Java",
+  context: "global/percussion/",
+  fqn: "Java/global/percussion/sys_add",
+  category: "sys",
+};
+
+const sampleDetail = {
+  extensionName: "sys_add",
+  fqn: "Java/global/percussion/sys_add",
+  supportedInterfaces: ["com.percussion.extension.IPSExtension"],
+  runtimeParameters: [{ name: "htmlParams", dataType: "java.util.Map" }],
+};
 
 describe("ExtensionsPanel", () => {
   beforeEach(() => {
     (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
       message: (key: string) => key,
     };
+    listExtensions.mockReset();
+    getExtensionDetail.mockReset();
   });
 
   it("lists extensions and opens detail", async () => {
+    listExtensions.mockResolvedValue([sampleExtension]);
+    getExtensionDetail.mockResolvedValue(sampleDetail);
     render(<ExtensionsPanel />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-ex-table")).toBeTruthy();
@@ -47,5 +59,57 @@ describe("ExtensionsPanel", () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-ex-table")).toBeTruthy();
     });
+  });
+
+  it("shows empty state when API returns no extensions", async () => {
+    listExtensions.mockResolvedValue([]);
+    render(<ExtensionsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ex-empty")).toBeTruthy();
+    });
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    listExtensions.mockRejectedValue(new SessionRedirectError());
+    render(<ExtensionsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ex-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ex-error").textContent).toBe(DEV_MSG.SESSION_REDIRECT);
+    expect(screen.queryByTestId("developer-ex-empty")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    listExtensions.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<ExtensionsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ex-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ex-error").textContent).toBe(`${DEV_MSG.EX_ERROR} (500)`);
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    listExtensions.mockRejectedValue(new Error("network down"));
+    render(<ExtensionsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ex-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ex-error").textContent).toBe(
+      `${DEV_MSG.EX_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-ex-table")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    listExtensions.mockRejectedValue("boom");
+    render(<ExtensionsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ex-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ex-error").textContent).toBe(DEV_MSG.EX_ERROR);
   });
 });

--- a/WebUI/src/test/ts/developer/ItemFiltersPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ItemFiltersPanel.test.tsx
@@ -5,11 +5,13 @@
 import React from "react";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
 import {
   getItemFilterDetail,
   listItemFilters,
 } from "../../../main/ts/api/developer/itemFiltersApi";
 import { ItemFiltersPanel } from "../../../main/ts/developer/ItemFiltersPanel";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
 
 vi.mock("../../../main/ts/api/developer/itemFiltersApi", () => ({
   listItemFilters: vi.fn(),
@@ -21,6 +23,9 @@ const detailMock = vi.mocked(getItemFilterDetail);
 
 describe("ItemFiltersPanel", () => {
   beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
     listMock.mockReset();
     detailMock.mockReset();
   });
@@ -68,11 +73,55 @@ describe("ItemFiltersPanel", () => {
     expect(screen.getByText("sys_IsPublic")).toBeTruthy();
   });
 
-  it("shows error UI when list fails", async () => {
-    listMock.mockRejectedValue({ status: 500, statusText: "Error" });
+  it("shows empty state when API returns no item filters", async () => {
+    listMock.mockResolvedValue([]);
+    render(<ItemFiltersPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-if-empty")).toBeTruthy();
+    });
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    listMock.mockRejectedValue(new SessionRedirectError());
     render(<ItemFiltersPanel />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-if-error")).toBeTruthy();
     });
+    expect(screen.getByTestId("developer-if-error").textContent).toBe(DEV_MSG.SESSION_REDIRECT);
+    expect(screen.queryByTestId("developer-if-empty")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    listMock.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<ItemFiltersPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-if-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-if-error").textContent).toBe(`${DEV_MSG.IF_ERROR} (500)`);
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    listMock.mockRejectedValue(new Error("network down"));
+    render(<ItemFiltersPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-if-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-if-error").textContent).toBe(
+      `${DEV_MSG.IF_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-if-table")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    listMock.mockRejectedValue("boom");
+    render(<ItemFiltersPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-if-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-if-error").textContent).toBe(DEV_MSG.IF_ERROR);
   });
 });

--- a/WebUI/src/test/ts/developer/LocalesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/LocalesPanel.test.tsx
@@ -5,8 +5,10 @@
 import React from "react";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
 import { getLocaleDetail, listLocales } from "../../../main/ts/api/developer/localesApi";
 import { LocalesPanel } from "../../../main/ts/developer/LocalesPanel";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
 
 vi.mock("../../../main/ts/api/developer/localesApi", () => ({
   listLocales: vi.fn(),
@@ -18,6 +20,9 @@ const detailMock = vi.mocked(getLocaleDetail);
 
 describe("LocalesPanel", () => {
   beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
     listMock.mockReset();
     detailMock.mockReset();
   });
@@ -92,11 +97,57 @@ describe("LocalesPanel", () => {
     expect(screen.getByTestId("developer-loc-gaps")).toBeTruthy();
   });
 
-  it("shows error UI when list fails", async () => {
-    listMock.mockRejectedValue({ status: 500, statusText: "Error" });
+  it("shows empty state when API returns no locales", async () => {
+    listMock.mockResolvedValue([]);
+    render(<LocalesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-loc-empty")).toBeTruthy();
+    });
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    listMock.mockRejectedValue(new SessionRedirectError());
     render(<LocalesPanel />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-loc-error")).toBeTruthy();
     });
+    expect(screen.getByTestId("developer-loc-error").textContent).toBe(DEV_MSG.SESSION_REDIRECT);
+    expect(screen.queryByTestId("developer-loc-empty")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    listMock.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<LocalesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-loc-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-loc-error").textContent).toBe(
+      `${DEV_MSG.LOC_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    listMock.mockRejectedValue(new Error("network down"));
+    render(<LocalesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-loc-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-loc-error").textContent).toBe(
+      `${DEV_MSG.LOC_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-loc-table")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    listMock.mockRejectedValue("boom");
+    render(<LocalesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-loc-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-loc-error").textContent).toBe(DEV_MSG.LOC_ERROR);
   });
 });

--- a/WebUI/src/test/ts/developer/RelationshipTypesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/RelationshipTypesPanel.test.tsx
@@ -5,46 +5,62 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as relationshipTypesApi from "../../../main/ts/api/developer/relationshipTypesApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
 import { RelationshipTypesPanel } from "../../../main/ts/developer/RelationshipTypesPanel";
 
 vi.mock("../../../main/ts/api/developer/relationshipTypesApi", () => ({
-  listRelationshipTypes: vi.fn().mockResolvedValue([
-    {
-      name: "ActiveAssembly",
-      label: "Active Assembly",
-      category: "rs_activeassembly",
-      categoryLabel: "Active Assembly",
-      type: "system",
-      systemType: true,
-      allowCloning: true,
-    },
-  ]),
-  getRelationshipTypeDetail: vi.fn().mockResolvedValue({
-    name: "ActiveAssembly",
-    label: "Active Assembly",
-    categoryLabel: "Active Assembly",
-    type: "system",
-    effects: [
-      {
-        name: "sys_aaEffect",
-        activationEndPoint: "owner",
-        extensionRef: "Java/global/percussion/sys_aaEffect",
-      },
-    ],
-    systemProperties: [{ name: "rs_allowcloning", value: "yes" }],
-    userProperties: [],
-    designGaps: ["Relationship type create / update / delete not supported via this API"],
-  }),
+  listRelationshipTypes: vi.fn(),
+  getRelationshipTypeDetail: vi.fn(),
 }));
+
+const listRelationshipTypes = relationshipTypesApi.listRelationshipTypes as ReturnType<
+  typeof vi.fn
+>;
+const getRelationshipTypeDetail = relationshipTypesApi.getRelationshipTypeDetail as ReturnType<
+  typeof vi.fn
+>;
+
+const sampleType = {
+  name: "ActiveAssembly",
+  label: "Active Assembly",
+  category: "rs_activeassembly",
+  categoryLabel: "Active Assembly",
+  type: "system",
+  systemType: true,
+  allowCloning: true,
+};
+
+const sampleDetail = {
+  name: "ActiveAssembly",
+  label: "Active Assembly",
+  categoryLabel: "Active Assembly",
+  type: "system",
+  effects: [
+    {
+      name: "sys_aaEffect",
+      activationEndPoint: "owner",
+      extensionRef: "Java/global/percussion/sys_aaEffect",
+    },
+  ],
+  systemProperties: [{ name: "rs_allowcloning", value: "yes" }],
+  userProperties: [],
+  designGaps: ["Relationship type create / update / delete not supported via this API"],
+};
 
 describe("RelationshipTypesPanel", () => {
   beforeEach(() => {
     (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
       message: (key: string) => key,
     };
+    listRelationshipTypes.mockReset();
+    getRelationshipTypeDetail.mockReset();
   });
 
   it("lists relationship types and opens detail", async () => {
+    listRelationshipTypes.mockResolvedValue([sampleType]);
+    getRelationshipTypeDetail.mockResolvedValue(sampleDetail);
     render(<RelationshipTypesPanel />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-rt-table")).toBeTruthy();
@@ -59,5 +75,57 @@ describe("RelationshipTypesPanel", () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-rt-table")).toBeTruthy();
     });
+  });
+
+  it("shows empty state when API returns no relationship types", async () => {
+    listRelationshipTypes.mockResolvedValue([]);
+    render(<RelationshipTypesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-rt-empty")).toBeTruthy();
+    });
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    listRelationshipTypes.mockRejectedValue(new SessionRedirectError());
+    render(<RelationshipTypesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-rt-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-rt-error").textContent).toBe(DEV_MSG.SESSION_REDIRECT);
+    expect(screen.queryByTestId("developer-rt-empty")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    listRelationshipTypes.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<RelationshipTypesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-rt-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-rt-error").textContent).toBe(`${DEV_MSG.RT_ERROR} (500)`);
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    listRelationshipTypes.mockRejectedValue(new Error("network down"));
+    render(<RelationshipTypesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-rt-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-rt-error").textContent).toBe(
+      `${DEV_MSG.RT_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-rt-table")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    listRelationshipTypes.mockRejectedValue("boom");
+    render(<RelationshipTypesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-rt-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-rt-error").textContent).toBe(DEV_MSG.RT_ERROR);
   });
 });

--- a/WebUI/src/test/ts/developer/SearchesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SearchesPanel.test.tsx
@@ -5,33 +5,45 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as searchesApi from "../../../main/ts/api/developer/searchesApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
 import { SearchesPanel } from "../../../main/ts/developer/SearchesPanel";
 
 vi.mock("../../../main/ts/api/developer/searchesApi", () => ({
-  listSearches: vi.fn().mockResolvedValue([
-    {
-      name: "All Content",
-      label: "All Content",
-      standardSearch: true,
-      fields: [{ fieldName: "sys_title", operator: "=", fieldValue: "*" }],
-    },
-  ]),
-  getSearchDetail: vi.fn().mockResolvedValue({
-    name: "All Content",
-    label: "All Content",
-    fields: [{ fieldName: "sys_title", operator: "=", fieldValue: "*" }],
-    designGaps: ["gap"],
-  }),
+  listSearches: vi.fn(),
+  getSearchDetail: vi.fn(),
 }));
+
+const listSearches = searchesApi.listSearches as ReturnType<typeof vi.fn>;
+const getSearchDetail = searchesApi.getSearchDetail as ReturnType<typeof vi.fn>;
+
+const sampleSearch = {
+  name: "All Content",
+  label: "All Content",
+  standardSearch: true,
+  fields: [{ fieldName: "sys_title", operator: "=", fieldValue: "*" }],
+};
+
+const sampleDetail = {
+  name: "All Content",
+  label: "All Content",
+  fields: [{ fieldName: "sys_title", operator: "=", fieldValue: "*" }],
+  designGaps: ["gap"],
+};
 
 describe("SearchesPanel", () => {
   beforeEach(() => {
     (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
       message: (key: string) => key,
     };
+    listSearches.mockReset();
+    getSearchDetail.mockReset();
   });
 
   it("lists searches and opens detail", async () => {
+    listSearches.mockResolvedValue([sampleSearch]);
+    getSearchDetail.mockResolvedValue(sampleDetail);
     render(<SearchesPanel />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-sr-table")).toBeTruthy();
@@ -46,5 +58,57 @@ describe("SearchesPanel", () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-sr-table")).toBeTruthy();
     });
+  });
+
+  it("shows empty state when API returns no searches", async () => {
+    listSearches.mockResolvedValue([]);
+    render(<SearchesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-empty")).toBeTruthy();
+    });
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    listSearches.mockRejectedValue(new SessionRedirectError());
+    render(<SearchesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sr-error").textContent).toBe(DEV_MSG.SESSION_REDIRECT);
+    expect(screen.queryByTestId("developer-sr-empty")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    listSearches.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<SearchesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sr-error").textContent).toBe(`${DEV_MSG.SR_ERROR} (500)`);
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    listSearches.mockRejectedValue(new Error("network down"));
+    render(<SearchesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sr-error").textContent).toBe(
+      `${DEV_MSG.SR_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-sr-table")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    listSearches.mockRejectedValue("boom");
+    render(<SearchesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sr-error").textContent).toBe(DEV_MSG.SR_ERROR);
   });
 });

--- a/WebUI/src/test/ts/developer/ViewsPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ViewsPanel.test.tsx
@@ -5,33 +5,45 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as viewsApi from "../../../main/ts/api/developer/viewsApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
 import { ViewsPanel } from "../../../main/ts/developer/ViewsPanel";
 
 vi.mock("../../../main/ts/api/developer/viewsApi", () => ({
-  listViews: vi.fn().mockResolvedValue([
-    {
-      name: "My View",
-      label: "My View",
-      standardView: true,
-      fields: [{ fieldName: "sys_title", operator: "=", fieldValue: "*" }],
-    },
-  ]),
-  getViewDetail: vi.fn().mockResolvedValue({
-    name: "My View",
-    label: "My View",
-    fields: [{ fieldName: "sys_title", operator: "=", fieldValue: "*" }],
-    designGaps: ["gap"],
-  }),
+  listViews: vi.fn(),
+  getViewDetail: vi.fn(),
 }));
+
+const listViews = viewsApi.listViews as ReturnType<typeof vi.fn>;
+const getViewDetail = viewsApi.getViewDetail as ReturnType<typeof vi.fn>;
+
+const sampleView = {
+  name: "My View",
+  label: "My View",
+  standardView: true,
+  fields: [{ fieldName: "sys_title", operator: "=", fieldValue: "*" }],
+};
+
+const sampleDetail = {
+  name: "My View",
+  label: "My View",
+  fields: [{ fieldName: "sys_title", operator: "=", fieldValue: "*" }],
+  designGaps: ["gap"],
+};
 
 describe("ViewsPanel", () => {
   beforeEach(() => {
     (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
       message: (key: string) => key,
     };
+    listViews.mockReset();
+    getViewDetail.mockReset();
   });
 
   it("lists views and opens detail", async () => {
+    listViews.mockResolvedValue([sampleView]);
+    getViewDetail.mockResolvedValue(sampleDetail);
     render(<ViewsPanel />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-vw-table")).toBeTruthy();
@@ -46,5 +58,57 @@ describe("ViewsPanel", () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-vw-table")).toBeTruthy();
     });
+  });
+
+  it("shows empty state when API returns no views", async () => {
+    listViews.mockResolvedValue([]);
+    render(<ViewsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-empty")).toBeTruthy();
+    });
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    listViews.mockRejectedValue(new SessionRedirectError());
+    render(<ViewsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-vw-error").textContent).toBe(DEV_MSG.SESSION_REDIRECT);
+    expect(screen.queryByTestId("developer-vw-empty")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    listViews.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<ViewsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-vw-error").textContent).toBe(`${DEV_MSG.VW_ERROR} (500)`);
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    listViews.mockRejectedValue(new Error("network down"));
+    render(<ViewsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-vw-error").textContent).toBe(
+      `${DEV_MSG.VW_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-vw-table")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    listViews.mockRejectedValue("boom");
+    render(<ViewsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-vw-error").textContent).toBe(DEV_MSG.VW_ERROR);
   });
 });


### PR DESCRIPTION
## Summary

Thin **UI-TEST-01** residual PR for parent **#1690** / issue **#2112**.

Extends Developer catalog **list** panel Vitest coverage to the full success / empty / `panelErrMsg` ladder (session-redirect, ApiError status, Error.message, fallback), mirroring `ContentTypesPanel.test.tsx` and the #2111 panels (Keywords/Slots/Templates/Communities).

### Panels covered

| Panel | Change |
|-------|--------|
| SearchesPanel | Controllable mocks + empty + full error ladder (kept open-detail) |
| ViewsPanel | same |
| ExtensionsPanel | same |
| RelationshipTypesPanel | same |
| ActionMenusPanel | same |
| DisplayFormatsPanel | same |
| LocalesPanel | tightened empty + full error ladder |
| ItemFiltersPanel | tightened empty + full error ladder |

### Companion (module green)

- `ExplorerTree.test.tsx`: assert `formatApiError` surfaces response body text (`server down`) so pre-existing main mismatch does not fail `WebUI` clean install.

### Not in this PR (residual)

Detail-panel ladders + remaining partial list panels (ServerConfigs, Controls, Sites, Workflows, Pipelines, SharedFields, SystemDef): **#2119**.

## Test plan

- [x] Focused Vitest: 8 panel files — 50 tests passed
- [x] Spotless: `mvnw spotless:apply` then `spotless:check` (in-scope only committed)
- [x] `cd WebUI && ../mvnw clean install` — BUILD SUCCESS (190 files / 1262 tests)
- [ ] CI green on PR

## Gates evidence

- Change class: tests-only Vitest (no product UI behavior change)
- Erlang-style self-review: mirrors peer panel tests; portable paths N/A; no rule-file commits
- Operator: Grok: night-issue-prs (model grok-4.5)

## Links

- Parent tracker: #1690
- Fixes / Partial: **Partial** for #2112 (list cluster); residual #2119
- Refs #1690 #2112 #2119

> Co-Authored by Grok Build using grok-4.5 with agent main.