### PR TITLE
fix(rest): SlotsResource list/null-adaptor unit tests (#2115)

### DIFF
--- a/rest/src/main/java/com/percussion/rest/slots/SlotsResource.java
+++ b/rest/src/main/java/com/percussion/rest/slots/SlotsResource.java
@@ -33,6 +33,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
@@ -115,6 +116,9 @@ public class SlotsResource {
     SlotDetail detail;
     try {
       detail = requireAdaptor().getSlot(uriInfo.getBaseUri(), idOrName);
+    } catch (WebApplicationException e) {
+      // Preserve mapped HTTP errors (e.g. 503 misconfiguration from requireAdaptor)
+      throw e;
     } catch (Exception e) {
       // 404 is thrown outside this try; do not re-wrap mapped HTTP errors here
       log.error(
@@ -167,8 +171,9 @@ public class SlotsResource {
 
   private ISlotsAdaptor requireAdaptor() {
     if (adaptor == null) {
-      throw new IllegalStateException(
-          "Slots adaptor not configured (resource constructed without injection)");
+      // Misconfiguration — not a transient handler failure (align with KeywordsResource)
+      throw new WebApplicationException(
+          "Slots adaptor not configured", Response.Status.SERVICE_UNAVAILABLE);
     }
     return adaptor;
   }

--- a/rest/src/test/java/com/percussion/rest/slots/SlotsResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/slots/SlotsResourceDetailTest.java
@@ -20,6 +20,7 @@ package com.percussion.rest.slots;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.when;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.UriInfo;
 import java.net.URI;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -46,6 +48,68 @@ public class SlotsResourceDetailTest {
     UriInfo uriInfo = mock(UriInfo.class);
     when(uriInfo.getBaseUri()).thenReturn(URI.create("http://localhost/services/"));
     resource.setUriInfo(uriInfo);
+  }
+
+  @Test
+  public void listSlotsSuccess() {
+    SlotSummary s = new SlotSummary();
+    s.setName("rffList");
+    s.setLabel("List");
+    when(adaptor.listSlots(any())).thenReturn(List.of(s));
+    List<SlotSummary> out = resource.listSlots();
+    assertEquals(1, out.size());
+    assertEquals("rffList", out.get(0).getName());
+    assertEquals("List", out.get(0).getLabel());
+  }
+
+  @Test
+  public void listSlotsEmpty() {
+    when(adaptor.listSlots(any())).thenReturn(List.of());
+    assertTrue(resource.listSlots().isEmpty());
+  }
+
+  @Test
+  public void listSlotsWrapsUnexpectedFailures() {
+    RuntimeException cause = new IllegalStateException("Failed to list slots");
+    when(adaptor.listSlots(any())).thenThrow(cause);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.listSlots());
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(cause, ex.getCause());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnList() {
+    SlotsResource bare = newSlotsResourceWithoutAdaptor();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.listSlots());
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnGet() {
+    // getSlot must rethrow WebApplicationException from requireAdaptor (not re-wrap as 500)
+    SlotsResource bare = newSlotsResourceWithoutAdaptor();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.getSlot("any"));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnUpdate() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> newSlotsResourceWithoutAdaptor().updateSlot("any", new SlotDetail()));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  private static SlotsResource newSlotsResourceWithoutAdaptor() {
+    SlotsResource bare = new SlotsResource();
+    UriInfo uriInfo = mock(UriInfo.class);
+    when(uriInfo.getBaseUri()).thenReturn(URI.create("http://localhost/services/"));
+    bare.setUriInfo(uriInfo);
+    return bare;
   }
 
   @Test


### PR DESCRIPTION
## Summary
**Partial for #2115** (Slice A of parent **#1694**, part of **#1690**).

Unit-test-first hardening of the slots catalog REST resource:
- `requireAdaptor()` null mapping aligned with **KeywordsResource**: HTTP **503 SERVICE_UNAVAILABLE** (misconfiguration) instead of `IllegalStateException` wrapped as 500.
- `getSlot` now rethrows `WebApplicationException` so mapped statuses (503) are not re-wrapped as 500.
- Extended `SlotsResourceDetailTest`: `listSlots` success, empty, exception→500; bare no-arg ctor 503 on list/get/update.

### Static wiring audit (no sitemanage code change)
| Layer | Slots | Working peer |
|-------|-------|--------------|
| Resource bean | `restSlotsResource` `@PSSiteManageBean` | `restContentTypesResource` / `restTemplatesResource` |
| Interface | `ISlotsAdaptor` ctor `@Autowired` | same pattern |
| Impl | sitemanage `SlotsAdaptor` `@PSSiteManageBean` | `ContentTypeAdaptor` / `TemplateAdaptor` |
| Backend | `IPSAssemblyDesignWs` via locator | content design WS / assembly service |
| Test stub | `TestSlotsAdaptor` | present |

No clear static root cause for live QA 500s without server stacks; design-WS path in `SlotsAdaptor` already unit-tested (`SlotsAdaptorDesignWsTest`). Live **GET /services/slots 2xx** deferred to residual **#2121** (ties to **#2118** / **#2065**).

## Test plan
- [x] `SlotsResourceDetailTest` 16 tests green (list + detail + null-adaptor)
- [x] `rest` module `mvnw clean install` green
- [x] Spotless apply → check from repo root (only in-scope files committed)
- [ ] Live QA `GET /services/slots` 2xx after redeploy — residual #2121

## Gates evidence
- Erlang-style self-review: behavioral tests for new 503 mapping + getSlot rethrow; portable paths N/A (no file I/O)
- Module: `rest` standalone clean install SUCCESS
- Spotless: apply then check SUCCESS; out-of-scope Spotless hits not committed

## Links
- Fixes partial: #2115
- Parent tracker: #1694
- Epic: #1690
- Residual live 2xx: #2121

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.