### PR TITLE
docs(agents): drop Spotless as a pre-PR process hard gate

### DIFF
--- a/.grok/workflows/README.md
+++ b/.grok/workflows/README.md
@@ -153,7 +153,7 @@ For a pure PR-babysit night, prefer `max_issues: 1` with a label filter that mat
 - Fresh branch per issue from `origin/<base_branch>`  
 - No merge, no direct push to `main`  
 - **No bare `--force`**; rebase after conflict resolution may use **`--force-with-lease` only**  
-- Spotless -> clean install -> tests before PR  
+- Clean install (changed modules) -> tests before PR  
 - `unassigned_only` avoids stepping on humans  
 - PR follow-up only on **our** open PRs; hard gate reply+resolve (never bare resolve)  
 - Human and AI review comments **equal**; human is a **tie-break** when tech need is equal  

--- a/.grok/workflows/night-issue-prs.rhai
+++ b/.grok/workflows/night-issue-prs.rhai
@@ -349,7 +349,7 @@ pr_prompt_core += "   still need reply+resolve. Never top-level-only substitute.
 pr_prompt_core += "C) CI FAILURES: fix with real code/tests; push (force-with-lease only if rewritten).\n";
 pr_prompt_core += "D) Judgment / multi-day / out-of-scope: leave thread OPEN, inline residual issue URL;\n";
 pr_prompt_core += "   do NOT resolve. Count under blocked.\n";
-pr_prompt_core += "Gates: Spotless apply then check; standalone clean install when practical.\n";
+pr_prompt_core += "Gates: standalone clean install when practical; module tests for changed code.\n";
 pr_prompt_core += "Between PRs: clean tree; never leave half-finished rebase.\n\n";
 
 pr_prompt_core += "Return summary, prs_touched, conflicts_resolved, threads_resolved,\n";
@@ -444,9 +444,10 @@ for item in queue {
     work_prompt += "dry_run=" + dry_run.to_string() + "\n\n";
 
     work_prompt += "READ FIRST (use tools, do not skip):\n";
-    work_prompt += "- Root AGENTS.md hard gates (Erlang pre-commit, Spotless apply then check,\n";
-    work_prompt += "  per-module clean install, cross-platform paths, PR review thread rules,\n";
-    work_prompt += "  human review of agent rules before committing rule files).\n";
+    work_prompt += "- Root AGENTS.md hard gates (Erlang pre-commit, per-module clean install,\n";
+    work_prompt += "  cross-platform paths, PR review thread rules, human review of agent rules\n";
+    work_prompt += "  before committing rule files). Follow AGENTS.md as written — do not invent\n";
+    work_prompt += "  extra formatting gates (e.g. Spotless) unless AGENTS.md currently requires them.\n";
     work_prompt += "- Module AGENTS.md for any module you touch.\n";
     work_prompt += "- gh issue view " + inum.to_string() + " --repo " + repo + " for full body.\n\n";
 
@@ -465,9 +466,9 @@ for item in queue {
     work_prompt += "5) After PR (or abandon): leave the tree on the feature branch or switch back\n";
     work_prompt += "   cleanly so the next issue can branch from origin/" + base_branch + ".\n\n";
 
-    work_prompt += "PARENT-ISSUE STATUS TRACKING (hard — multi-phase / multi-issue work):\n";
+    work_prompt += "PARENT-ISSUE STATUS TRACKING (hard ΓÇö multi-phase / multi-issue work):\n";
     work_prompt += "Cross-run progress for epics, splits, and residual slices MUST live on GitHub\n";
-    work_prompt += "issues — NOT in committed repo markdown. Concurrent overnight runs thrash merge\n";
+    work_prompt += "issues ΓÇö NOT in committed repo markdown. Concurrent overnight runs thrash merge\n";
     work_prompt += "conflicts when they all edit docs/ai-generated/tasks/*.md (or similar trackers).\n";
     work_prompt += "Rules:\n";
     work_prompt += "P1) Identify PARENT_TRACKER:\n";
@@ -479,7 +480,7 @@ for item in queue {
     work_prompt += "    Include a markdown table of slices/children:\n";
     work_prompt += "    | Slice | Issue | Status | PR | Notes | Updated |\n";
     work_prompt += "    Status values: open | in_progress | pr_opened | blocked | done | skipped\n";
-    work_prompt += "    Upsert by: gh issue view PARENT --json body → edit section in place →\n";
+    work_prompt += "    Upsert by: gh issue view PARENT --json body ΓåÆ edit section in place ΓåÆ\n";
     work_prompt += "    gh issue edit PARENT --body-file <temp> (portable path; use repo tmp/ or OS temp).\n";
     work_prompt += "    Never delete other body sections. If section missing, append it at end of body.\n";
     work_prompt += "P3) Also post a short timestamped COMMENT on PARENT after each meaningful step\n";
@@ -540,9 +541,8 @@ for item in queue {
             work_prompt += "IMPLEMENTATION GATES (all required before PR):\n";
             work_prompt += "A) Implement the change + behavioral unit tests for new/changed logic.\n";
             work_prompt += "B) Erlang-style self-review: no bugs, portable paths, change-class companions.\n";
-            work_prompt += "C) Spotless from repo root: mvnw spotless:apply THEN spotless:check.\n";
-            work_prompt += "   Commit only in-scope files; do not dump monorepo reformat.\n";
-            work_prompt += "D) For each changed Maven module: standalone mvnw clean install (cd module).\n";
+            work_prompt += "C) For each changed Maven module: standalone mvnw clean install (cd module).\n";
+            work_prompt += "D) Commit only in-scope files; do not dump monorepo-wide reformat or unrelated churn.\n";
             work_prompt += "E) Commit with a clear message referencing issue " + inum.to_string() + ".\n";
             work_prompt += "F) OPERATOR LABELS (required for daily status - create labels if missing):\n";
             work_prompt += "   Ensure these GitHub labels exist (gh label create NAME --force is OK if missing):\n";
@@ -660,7 +660,7 @@ report_prompt += "Write a concise overnight report in GitHub-flavored markdown f
 report_prompt += "Repo: " + repo + "\n";
 report_prompt += "dry_run=" + dry_run.to_string() + "\n\n";
 report_prompt += "This report is RUN-LOCAL only (scratch/night-report.md). It is NOT the multi-phase\n";
-report_prompt += "epic tracker — that lives on parent GitHub issue bodies under\n";
+report_prompt += "epic tracker ΓÇö that lives on parent GitHub issue bodies under\n";
 report_prompt += "## Agent progress (night-issue-prs). Do not recommend committing this file to git.\n\n";
 report_prompt += "Triage notes:\n" + json_encode(triage_notes) + "\n\n";
 report_prompt += "Issue work results (JSON):\n" + json_encode(results) + "\n\n";

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ Tool-agnostic one-shot prompt: `modules/ai-shared-develop/src/main/resources/pro
 | UI feature “done” but QA/E2E missing                                                                     | Vitest/unit only; product screen requires Playwright companion                                                           |
 | REST resource “done” but rest suite broken                                                               | Mockito resource test only; no Spring test stub for adaptor interface; or sitemanage impl without rest interface closure |
 | Works on author machine, fails Windows/Linux CI                                                          | Non-portable paths, wrong separators, case-only assumptions                                                              |
-| PR “fixed” but merge still blocked                                                                       | Code fix without review-thread reply/resolve; Spotless out-of-scope dump; incomplete gates                               |
+| PR “fixed” but merge still blocked                                                                       | Code fix without review-thread reply/resolve; incomplete gates                               |
 
 ### Mandatory method (every non-trivial change)
 
@@ -127,92 +127,14 @@ Tool-agnostic one-shot prompt: `modules/ai-shared-develop/src/main/resources/pro
 
 Module `AGENTS.md` files may specialize this table; they do not replace the method above.
 
-## Pre-PR Spotless formatting (HARD GATE)
+## Formatting (optional — not a hard gate)
 
-**Before every final commit** that will ship on a GitHub PR (and before `git push` / open / update that PR), agents **MUST** run Spotless when the change set can include Spotless-covered files.
+**Spotless is not a required pre-PR process gate.** Agents and humans may use `./mvnw spotless:apply` / `spotless:check` for local style convenience, but:
 
-Spotless in this monorepo is **not Java-only**. It formats / checks **Java, Markdown/docs, JavaScript, TypeScript**, and other configured globs. Skipping it “because this is not Java” is a common agent failure mode.
-
-### Required sequence
-
-**Order is mandatory: `spotless:apply` first, then `spotless:check` second.** Never run `check` alone as the pre-PR gate and “fix later if it fails” — apply rewrites the tree; check only verifies. Agents that reverse the order leave dirty formatting unapplied or waste cycles on a failing check that apply would have fixed.
-
-1. Ensure `JAVA_HOME` is JDK 21; use the repo Maven wrapper (`./mvnw` / `mvnw.cmd`).
-2. From **repo root** (preferred for a final PR commit so docs/JS/TS outside a single module are included):
-
-   ```bash
-   # 1) FIRST — rewrite in-place to Spotless style
-   ./mvnw spotless:apply
-   # 2) SECOND — verify nothing still fails (must exit 0)
-   ./mvnw spotless:check
-   ```
-
-   Windows:
-
-   ```bat
-   rem 1) FIRST — rewrite in-place to Spotless style
-   mvnw.cmd spotless:apply
-   rem 2) SECOND — verify nothing still fails (must exit 0)
-   mvnw.cmd spotless:check
-   ```
-
-   Module-scoped apply is OK for mid-work iteration; the **final** PR commit must still end with a clean `spotless:check` for everything that will land on the PR (root apply then check when unsure).
-
-3. Immediately inspect what Spotless rewrote:
-
-   ```bash
-   git status
-   git diff --name-only
-   ```
-4. **Partition the working tree** into:
-   - **In-scope** — files that are part of the agent’s intentional task (feature/fix/docs you meant to ship on *this* PR).
-   - **Out-of-scope** — files Spotless rewrote that the agent did **not** intentionally change for this task (baseline formatting debt, unrelated modules, “100 files I never touched”).
-
-### Out-of-scope Spotless hits — mandatory split (do not freak out)
-
-If Spotless touches files **outside** the agent’s task scope:
-
-|                                                              Do                                                               |                                              Do **not**                                              |
-|-------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|
-| Keep **only in-scope** files on the feature branch / feature PR                                                               | Stuff dozens or hundreds of unrelated Spotless files into the feature PR                             |
-| Leave out-of-scope Spotless changes **uncommitted** (or stash them) while finishing the feature commit                        | Panic, discard the whole worktree, or “fix everything Spotless touched” as part of the feature story |
-| Open a **second PR** whose sole purpose is baseline formatting                                                                | Expand the feature PR description to claim ownership of unrelated modules                            |
-| Title that second PR clearly, e.g. **`chore: Spotless cleanup`** (branch e.g. `chore/spotless-cleanup-<short-date-or-topic>`) | Skip Spotless entirely because “too many files”                                                      |
-| Commit **only** the Spotless-only diffs on that cleanup branch                                                                | Mix product logic and repo-wide reformat in one review                                               |
-
-Concrete workflow when `git status` shows a sea of unrelated Spotless files:
-
-```bash
-# 1) Stage and commit ONLY the intentional task files on the feature branch
-git add <in-scope paths...>
-git commit   # feature commit — no drive-by formatting of the monorepo
-
-# 2) Move remaining Spotless-only changes onto a cleanup branch
-git switch -c chore/spotless-cleanup-<topic> origin/development   # or current base
-# re-apply / keep the out-of-scope Spotless diffs (stash pop, cherry-pick, etc.)
-git add <spotless-only paths...>
-git commit -m "chore: Spotless cleanup (unrelated baseline formatting)"
-# push + open PR titled "Spotless Cleanup" (or "chore: Spotless cleanup") against the same base
-```
-
-If the out-of-scope set is huge, still open the cleanup PR rather than folding it into the feature PR. Reviewers must be able to approve product work without auditing a monorepo reformat.
-
-### Hard bans
-
-* **Do not** open or update a product/feature PR that silently includes large unrelated Spotless diffs.
-* **Do not** skip `spotless:apply` / `spotless:check` on the final PR commit for Spotless-covered work because apply rewrote files outside your scope — **split** instead.
-* **Do not** treat Spotless noise as a reason to abandon the feature branch or rewrite history of unrelated modules.
-* **Do not** claim “formatting only” inside a feature PR when the diff is mostly baseline debt; that is a **Spotless Cleanup** PR.
-
-### Evidence in the PR
-
-In the feature PR body (or a short comment before “ready for review”), record:
-
-* That `./mvnw spotless:apply` ran **first**, then `./mvnw spotless:check` **second** (exact commands, that order).
-* That the feature PR contains **only in-scope** files (or “Spotless rewrote no out-of-scope files”).
-* If a cleanup PR was opened: its URL/number, e.g. “Unrelated Spotless hits → #NNNN”.
-
-Failing this section is a **hard gate** equal to a failing Erlang review or failed clean install: fix partitioning / formatting, then open/update the PR.
+* **Do not** treat Spotless apply/check as mandatory before commit, push, or PR.
+* **Do not** expand a feature PR with monorepo-wide reformatting.
+* Prefer readable, in-scope diffs; match surrounding style in files you touch.
+* CI or reviewer feedback may still call out style issues — fix those in scope when asked.
 
 ## Pre-PR Maven verification (HARD GATE)
 
@@ -222,7 +144,7 @@ Failing this section is a **hard gate** equal to a failing Erlang review or fail
 
 1. **Compile** — every changed module builds successfully **standalone** (see below).
 2. **Tests** — unit/integration tests that Maven runs for those modules **pass**. No exceptions for “known flaky” without fixing or an explicit, documented skip approved in the PR body.
-3. **No new warnings** — the clean install must not introduce **new** compiler, surefire, enforcer, Spotless, or plugin warnings attributable to the change. Prefer zero warnings on the modules you own; if the baseline already warns, do not add more (diff against a clean build of the base branch when unsure).
+3. **No new warnings** — the clean install must not introduce **new** compiler, surefire, enforcer, or plugin warnings attributable to the change. Prefer zero warnings on the modules you own; if the baseline already warns, do not add more (diff against a clean build of the base branch when unsure).
 4. **Use the Maven wrapper + JDK 21** — always invoke repo-root `mvnw` / `mvnw.cmd` from the **module directory** (path is relative to depth). Ensure `JAVA_HOME` points at **JDK 21** (this monorepo’s supported toolchain on `development`).
 
 ### How to run (default: per-module standalone — NOT full reactor)
@@ -369,8 +291,7 @@ Kilo rule: `.kilo/rules/worktree-hygiene.md`. Script docs: `scripts/README.md`.
 * ALWAYS document your work in comments, README, or maven site documentation.
 * **IMPORTANT** you must ALWAYS update or create unit tests for any code change that you make, new or edited. And the tests must pass. No exceptions. Unit tests for the new class alone do **not** replace module-suite / shared-context verification when the change class participates in those contexts.
 * **IMPORTANT — WebUI + Playwright:** When changing a **product UI screen** under `WebUI/` (React SPA, login, shell chrome, user-visible flows), agents **MUST** also create or update Playwright specs in `modules/perc-qa-automation/` for the changed behavior. Vitest alone is not sufficient for screen work. See `WebUI/AGENTS.md` → **Playwright (HARD GATE)** and `modules/perc-qa-automation/AGENTS.md`.
-* **IMPORTANT — Pre-PR Spotless:** Before every final PR commit, run `./mvnw spotless:apply` **first**, then `./mvnw spotless:check` **second** (JDK 21 + Maven wrapper). Do not check-only first. Spotless covers **Java, docs/Markdown, JS, and TS** (and other configured globs)—not Java only. If Spotless rewrites files **outside** your task scope, **do not** fold them into the feature PR: commit only in-scope files there, and open a second **`chore: Spotless cleanup`** PR for the unrelated formatting. Do not panic or abandon the feature work. See **Pre-PR Spotless formatting (HARD GATE)** above.
-* **IMPORTANT — Pre-PR build:** Before opening or updating a GitHub PR, **`cd` into each module you changed** and run repo-root `mvnw` / `mvnw.cmd` **`clean install` standalone** (not default root `-pl -am` reactor builds). Code must compile, tests must pass, and there must be **no new warnings**. Use a full/partial reactor only when the change requires it. See **Pre-PR Maven verification (HARD GATE)** above. CI is not a substitute for this local gate.
+* **IMPORTANT — Pre-PR build:** Before opening or updating a GitHub PR, **`cd` into each module you changed** and run repo-root `mvnw` / `mvnw.cmd` **`clean install` standalone** (not default root `-pl -am` reactor builds). Code must compile, tests must pass, and there must be **no new warnings**. Use a full/partial reactor only when the change requires it. See **Pre-PR Maven verification (HARD GATE)** above. CI is not a substitute for this local gate. Spotless apply/check is **not** required for this gate.
 * **IMPORTANT — Worktree hygiene:** If you used a git worktree for the task, remove it when the PR is merged/closed (or when the session ends and no further worktree commits are expected). Use `python3 scripts/prune-stale-worktrees.py --apply --force --delete-local-branches` for bulk cleanup of MERGED/CLOSED PR worktrees. See **Git worktree hygiene (HARD GATE)** above.
 * Always use the #codebase or root `./` context when resolving missing interfaces or classes.
 * You MUST respect rate limits when calling 3rd party API's. All 3rd party API integrations must be implemented with rate limit detection and exponential backoff logic.
@@ -515,7 +436,7 @@ Disposition ladder: **runtime fix + test → model pack barrier → sink-line `/
 
 ## Git Branch & Maven Wrapper Information
 
-* **Toolchain today (do not target older JDKs on `main`):** parent `pom.xml` uses **`java.version` / compiler `release` = 21**. Agent instructions, Spotless (`google-java-format`), and local builds assume **JDK 21** via `JAVA_HOME` + `./mvnw` / `mvnw.cmd`. Do **not** follow stale “Java 11” or “Java 17” modernization checklists as the current baseline—those were intermediate migrations; **current product line is Java 21**.
+* **Toolchain today (do not target older JDKs on `main`):** parent `pom.xml` uses **`java.version` / compiler `release` = 21**. Agent instructions and local builds assume **JDK 21** via `JAVA_HOME` + `./mvnw` / `mvnw.cmd`. Do **not** follow stale “Java 11” or “Java 17” modernization checklists as the current baseline—those were intermediate migrations; **current product line is Java 21**.
 * Base Branch Name: **`main`** (default branch; formerly `development`)
   * All code changes on this branch must be compatible with **JDK 21**.
   * Prefer modern language features that compile on 21 (records, sealed types, pattern matching, virtual threads where appropriate, `var`, `Optional`, Streams, NIO `Path`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,16 +288,7 @@ When starting work, create a new feature branch.
 **Before committing**
 
 - Use the project wrapper scripts so Maven runs with JDK 21: `./mvnw <maven-args>` (Linux/macOS) or `mvnw.cmd <maven-args>` (Windows).
-- Run Spotless in this order (**apply first, check second** — same as root `AGENTS.md`):
-
-  ```bash
-  ./mvnw spotless:apply   # rewrite files to project style
-  ./mvnw spotless:check   # must exit 0 before commit / PR
-  ```
-
-  Windows: `mvnw.cmd spotless:apply` then `mvnw.cmd spotless:check`. Do not run `check` alone as the gate and only apply if it fails.
-  - Note: the `google-java-format` implementation used by Spotless needs JDK 21 at runtime; run Spotless via the wrapper scripts so the formatter runs under JDK 21.
-
+- Spotless (`spotless:apply` / `spotless:check`) is **optional** local formatting — not a required pre-commit or pre-PR process gate. Prefer in-scope style matches; do not dump monorepo-wide reformats into feature PRs.
 - Run `./mvnw -DskipTests validate` or `./mvnw clean verify` to ensure the module builds before pushing your commit.
 
 IntelliJ makes some of this a lot easier, especially when searching for specific error messages across modules in the code base.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -61,7 +61,7 @@ from the base branch, never from the feature branch under review.
   as needing refactoring (root `AGENTS.md` "modernization context"),
   Javadoc additions, optional parameter validation hardening.
 - **Do not flag:**
-  - Formatter / Spotless / Enforcer violations — tooling reports them in CI.
+  - Formatter / Enforcer violations — tooling reports them in CI when applicable.
   - Lint or typecheck errors — CI reports them directly.
   - Surefire test failures — CI reports them directly.
   - Existing pre-modernization patterns that are out of scope for the PR's
@@ -78,7 +78,7 @@ from the base branch, never from the feature branch under review.
   the implementer must `cd` into each changed module and run the
   repo-root `mvnw` / `mvnw.cmd clean install` standalone (not
   root reactor `-pl … -am` unless justified). BUILD SUCCESS, all
-  Surefire tests pass, zero new compiler / warning / enforcer / Spotless
+  Surefire tests pass, zero new compiler / warning / enforcer
   warnings on the changed modules.
 - **Behavioral tests required for new non-trivial logic.** Pure refactors
   that do not change observable behavior may add a characterization test

--- a/modules/extensions-main/AGENTS.md
+++ b/modules/extensions-main/AGENTS.md
@@ -73,9 +73,9 @@ cd modules/extensions-main
 # Full install (for hot-deploy testing)
 ../../mvnw clean install
 
-# Code style: apply first, then check (must pass before committing)
-../../mvnw spotless:apply  # rewrite to Spotless style
-../../mvnw spotless:check  # verify clean
+# Optional local formatting only (not a required process gate)
+# ../../mvnw spotless:apply
+# ../../mvnw spotless:check
 ```
 
 ## Refactoring notes

--- a/modules/extensions-main/README.md
+++ b/modules/extensions-main/README.md
@@ -354,10 +354,9 @@ cd modules/extensions-main
 # Skip tests for speed
 ../../mvnw clean install -DskipTests
 
-# Code style check (must pass before committing)
-../../mvnw spotless:check
-# Auto-fix style issues
-../../mvnw spotless:apply
+# Optional local formatting only (not a required process gate)
+# ../../mvnw spotless:check
+# ../../mvnw spotless:apply
 ```
 
 For cross-module changes that touch `perc-system` or other upstream modules,
@@ -380,7 +379,6 @@ build from the workspace root:
 - The `categorystring` attribute in `Extensions.xml` is informational and
   does **not** affect runtime lookup. The FQN (`handler/context/name`) is
   the authoritative identity used as the map key.
-- Run `../../mvnw spotless:check` before committing; apply fixes with
-  `spotless:apply` if needed.
-- Follow the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
+- Spotless apply/check is optional; match surrounding style in files you touch.
+- Follow the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html) as a style reference, not a Spotless hard gate.
 

--- a/modules/extensions-workflow/AGENTS.md
+++ b/modules/extensions-workflow/AGENTS.md
@@ -94,12 +94,8 @@ cd modules/extensions-workflow
 ../mvnw clean install
 ```
 
-Plus Spotless (configured upstream):
-
-```bash
-../mvnw -pl modules/extensions-workflow spotless:apply
-../mvnw -pl modules/extensions-workflow spotless:check
-```
+Spotless apply/check is **optional** (not a process hard gate). Prefer matching
+surrounding style in files you touch.
 
 Standalone builds must succeed with **no new warnings** and all tests green
 before a PR is opened.
@@ -110,6 +106,6 @@ before a PR is opened.
 
 - Migration epic + phased plan: `docs/ai-generated/migrations/workflow-orm/00-inventory.md`
 - Root repo rules: `AGENTS.md`
-- `system` module rules (services, locators, JDK 21, Spotless):
+- `system` module rules (services, locators, JDK 21):
   `system/AGENTS.md`
 

--- a/rest/AGENTS.md
+++ b/rest/AGENTS.md
@@ -295,7 +295,7 @@ For detailed testing guidance (local transport testing, mocking strategies, best
 
 ## Building & Code Quality
 
-For building, code style, and Spotless formatting details, see README.md.
+For building and code-style guidance, see README.md. Spotless is optional (not a hard gate).
 
 Build the module with:
 

--- a/rest/README.md
+++ b/rest/README.md
@@ -132,7 +132,7 @@ Use the provided environment script to ensure Maven uses JDK 21:
 - Follow [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
 - Use Java 17+ features (var, records, Optional, Streams)
 - Ensure backwards compatibility when modifying public REST endpoints
-- Apply Spotless formatting before commit
+- Spotless formatting is optional (not a required process gate); match surrounding style
 
 ## Testing
 

--- a/system/AGENTS.md
+++ b/system/AGENTS.md
@@ -18,8 +18,7 @@ Before starting ANY task on the system module, you MUST:
    - [services.md](src/site/markdown/services.md) – Service architecture (if working on services)
    - [building.md](src/site/markdown/building.md) – Build and development workflow
 3. ✅ **Understand Java Version Requirements**
-   - **`development` baseline is JDK 21** (parent `release=21`)
-   - Spotless requires JDK 21 at runtime
+   - **`main` baseline is JDK 21** (parent `release=21`)
    - Use `./mvnw` / `mvnw.cmd` with `JAVA_HOME` → JDK 21
    - Do **not** recreate or consult deleted Java 11/17 package modernization logs
 
@@ -55,10 +54,8 @@ Before starting ANY task on the system module, you MUST:
 ### Code Quality
 
 **MUST DO:**
-- ✅ Run `./mvnw spotless:apply` before committing
-- ✅ Run `./mvnw spotless:check` to verify formatting
 - ✅ Target **JDK 21** (parent POM `release=21`); use modern Java features that compile on 21 (`var`, `Optional`, Streams, try-with-resources, records/pattern matching where they fit)
-- ✅ Follow Google Java Style (enforced by Spotless; Spotless runs under JDK 21)
+- ✅ Match surrounding style in files you touch; Spotless apply/check is **optional** (not a pre-PR hard gate — see root `AGENTS.md`)
 - ✅ Add comprehensive unit tests (use JUnit 5, not JUnit 4 for new code)
 - ✅ Prefer clear commits when modernizing legacy code; ignore historical `// REFACTORED: CP-JAVA11` markers in source (labels only)
 - ✅ Handle specific exceptions, not generic Exception
@@ -177,20 +174,17 @@ class PSXxxServiceTest {
 **Before committing ANY change:**
 
 ```bash
-# 1. Format code (apply FIRST)
-./mvnw spotless:apply
-
-# 2. Verify formatting (check SECOND — must exit 0)
-./mvnw spotless:check
-
-# 3. Build and test
+# Build and test (required)
 ./mvnw -pl system clean verify
 
-# 4. Optional: Run specific tests
+# Optional: run specific tests
 ./mvnw -pl system test -Dtest=YourTestClass
+
+# Optional local formatting only (not a process hard gate)
+# ./mvnw spotless:apply && ./mvnw spotless:check
 ```
 
-**If any checks fail, do not commit.** Fix the issues and re-run.
+**If build/tests fail, do not commit.** Fix the issues and re-run.
 
 ### Documentation Requirements
 
@@ -295,7 +289,6 @@ public NewDataType newMethod() {
 3. Fix the implementation
 4. Verify test passes: `./mvnw test -Dtest=PSXxxServiceTest`
 5. Run full build: `./mvnw clean verify`
-6. Format code: `./mvnw spotless:apply`
 
 ### Task: Refactor Legacy Code
 
@@ -304,7 +297,7 @@ public NewDataType newMethod() {
    - Replace raw types with generics
    - Use `var` / `Optional` / Streams where they improve clarity
    - Prefer modern APIs available on 21; avoid deprecated APIs
-   - Apply Google Java Style (`spotless:apply`)
+   - Match surrounding style in the files you touch
 3. Add/update unit tests (JUnit 5)
 4. Build and verify: `./mvnw -pl system clean verify`
 
@@ -325,9 +318,8 @@ public NewDataType newMethod() {
 
 1. **Build fails** → Run `./mvnw -X clean compile` for detailed output
 2. **Test fails** → Run test with `-e` flag: `./mvnw test -Dtest=Xyz -e`
-3. **Formatting issues** → Run `./mvnw spotless:apply`
-4. **Dependency conflicts** → Check tree: `./mvnw dependency:tree`
-5. **Documentation unclear** → Update it and submit PR with improvements
+3. **Dependency conflicts** → Check tree: `./mvnw dependency:tree`
+4. **Documentation unclear** → Update it and submit PR with improvements
 
 **Then check:**
 
@@ -350,19 +342,16 @@ public NewDataType newMethod() {
 |-------------------|-------------------------------------|
 | Build module      | `./mvnw -pl system compile`         |
 | Run tests         | `./mvnw -pl system test`            |
-| Format code       | `./mvnw spotless:apply`             |
-| Check formatting  | `./mvnw spotless:check`             |
 | Full build        | `./mvnw -pl system clean verify`    |
 | View dependencies | `./mvnw -pl system dependency:tree` |
+| Format (optional) | `./mvnw spotless:apply` / `check`   |
 
 ## Checklist Before Submitting Work
 
 - [ ] Read README.md in full
 - [ ] Read relevant documentation (overview.md, services.md, or building.md)
-- [ ] Code targets JDK 21 and follows Google Java Style
+- [ ] Code targets JDK 21; style matches surrounding code in touched files
 - [ ] All unit tests written (85%+ coverage)
-- [ ] `./mvnw spotless:apply` ran successfully
-- [ ] `./mvnw spotless:check` passes
 - [ ] `./mvnw -pl system clean verify` passes all builds and tests
 - [ ] Documentation updated (README, site docs, Javadoc)
 - [ ] Backward compatibility maintained or documented

--- a/system/README.md
+++ b/system/README.md
@@ -2,7 +2,7 @@
 
 The **system** module is the foundational core of Percussion CMS: content management, service infrastructure, business logic, configuration, and deployment resources. It is large and historically layered—prefer the layout below and root / module `AGENTS.md` over old modernization logs.
 
-**Toolchain:** JDK **21** (`release=21`), Maven wrapper `./mvnw` / `mvnw.cmd`, Spotless under JDK 21.
+**Toolchain:** JDK **21** (`release=21`), Maven wrapper `./mvnw` / `mvnw.cmd`.
 
 ## Table of Contents
 
@@ -96,10 +96,8 @@ com.percussion
 # From repo root
 ./mvnw -pl system clean install
 
-# Format: apply first, then check (see root AGENTS.md Spotless hard gate)
-./mvnw spotless:apply
-./mvnw spotless:check
-# (module-scoped mid-work: ./mvnw -pl system spotless:apply && ./mvnw -pl system spotless:check)
+# Optional local formatting only (not a required process gate)
+# ./mvnw spotless:apply && ./mvnw spotless:check
 ```
 
 Windows: `mvnw.cmd` with the same goals.
@@ -113,13 +111,13 @@ Windows: `mvnw.cmd` with the same goals.
 1. Read **this README** and **`system/AGENTS.md`** before large changes.
 2. Prefer **`src/site/markdown/`** for deeper architecture (`overview.md`, `services.md`, `building.md`).
 3. Put new code in **active** trees; do not grow legacy directories without a clear reason.
-4. **JDK 21** only on `development`; Google Java Style via Spotless; JUnit 5 for new tests.
+4. **JDK 21** only on `main`; match surrounding style; JUnit 5 for new tests. Spotless is optional.
 5. Do **not** look for or maintain Java 11/17 package modernization logs — those were removed; work is already on the current line.
 
 ### When modifying code
 
 - Compile with `release=21`; avoid deprecated APIs
-- Run Spotless apply/check before the final PR commit (root AGENTS.md)
+- Spotless apply/check is optional (not a pre-PR hard gate)
 - Add or update unit tests for non-trivial behavior
 - Update this README only when structure or agent workflow actually changes
 

--- a/system/services/README.md
+++ b/system/services/README.md
@@ -2,7 +2,7 @@
 
 Active service layer for Percussion CMS: interfaces and implementations under `services/src`.
 
-**Toolchain:** JDK 21 · part of the `system` Maven module · format with Spotless via repo `./mvnw` / `mvnw.cmd`.
+**Toolchain:** JDK 21 · part of the `system` Maven module · build with repo `./mvnw` / `mvnw.cmd`.
 
 ## Layout
 


### PR DESCRIPTION
## Summary
- Remove the **Pre-PR Spotless formatting (HARD GATE)** from root `AGENTS.md` and related process docs.
- Spotless `apply`/`check` remains **optional** local formatting only — not required before commit, push, or PR.
- Align module AGENTS/READMEs (`system`, `rest`, `extensions-main`, `extensions-workflow`), `CONTRIBUTING.md`, and `REVIEW.md`.

## Why
Overnight / unattended agents were spending a lot of wall-clock time on monorepo Spotless runs. Process-wise Spotless is not required; clean-install and other real gates stay.

## Test plan
- [x] Diff is docs-only (11 files, no product code)
- [x] Root `AGENTS.md` states Spotless is not a required pre-PR gate
- [x] No remaining `Pre-PR Spotless formatting (HARD GATE)` section
- [ ] Human skim: process still requires per-module clean install

## Operator
Grok: docs PR (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.