### PR TITLE
test(rest,sitemanage): keywords catalog unit/adaptor harden (#2116)

### DIFF
--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/KeywordsAdaptorDesignWsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/KeywordsAdaptorDesignWsTest.java
@@ -26,11 +26,13 @@ import com.percussion.rest.keywords.KeywordSummary;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.content.data.PSKeyword;
+import com.percussion.services.content.data.PSKeywordChoice;
 import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfoBase;
 import com.percussion.webservices.PSErrorResultsException;
 import com.percussion.webservices.content.IPSContentDesignWs;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -79,12 +81,49 @@ class KeywordsAdaptorDesignWsTest {
 
     assertEquals(1, list.size());
     assertEquals("Colors", list.get(0).getLabel());
+    // includeChoices=false leaves the default empty list unset by toSummary
+    assertTrue(list.get(0).getChoices() == null || list.get(0).getChoices().isEmpty());
     verify(designWs).findKeywords(null);
     @SuppressWarnings("unchecked")
     ArgumentCaptor<List<IPSGuid>> ids = ArgumentCaptor.forClass(List.class);
     verify(designWs).loadKeywords(ids.capture(), eq(false), eq(false), any(), any());
     assertEquals(1, ids.getValue().size());
     assertEquals(guid, ids.getValue().get(0));
+  }
+
+  @Test
+  void listKeywords_includeChoices_embedsSortedChoices() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    IPSGuid guid = new PSGuid(PSTypeEnum.KEYWORD_DEF, 42L);
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    when(sum.getGUID()).thenReturn(guid);
+
+    PSKeywordChoice late = new PSKeywordChoice();
+    late.setLabel("Blue");
+    late.setValue("blue");
+    late.setSequence(2);
+    PSKeywordChoice early = new PSKeywordChoice();
+    early.setLabel("Red");
+    early.setValue("red");
+    early.setSequence(1);
+
+    PSKeyword kw = new PSKeyword();
+    kw.setLabel("Colors");
+    kw.setValue("colors");
+    kw.setChoices(List.of(late, early));
+
+    when(designWs.findKeywords(isNull())).thenReturn(List.of(sum));
+    when(designWs.loadKeywords(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(kw));
+
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+    List<KeywordSummary> list = adaptor.listKeywords(null, true);
+
+    assertEquals(1, list.size());
+    assertNotNull(list.get(0).getChoices());
+    assertEquals(2, list.get(0).getChoices().size());
+    assertEquals("Red", list.get(0).getChoices().get(0).getLabel());
+    assertEquals("Blue", list.get(0).getChoices().get(1).getLabel());
   }
 
   @Test
@@ -99,6 +138,73 @@ class KeywordsAdaptorDesignWsTest {
     assertTrue(list.isEmpty());
     verify(designWs).findKeywords(null);
     verify(designWs, never()).loadKeywords(anyList(), anyBoolean(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void listKeywords_nullFind_returnsEmptyWithoutLoad() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    when(designWs.findKeywords(isNull())).thenReturn(null);
+
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+    assertTrue(adaptor.listKeywords(null, false).isEmpty());
+    verify(designWs, never()).loadKeywords(anyList(), anyBoolean(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void listKeywords_skipsNullSummariesNullGuidsAndNonKeywordDefs() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    IPSGuid goodGuid = new PSGuid(PSTypeEnum.KEYWORD_DEF, 10L);
+    IPSGuid choiceGuid = new PSGuid(PSTypeEnum.KEYWORD_DEF, 11L);
+    IPSCatalogSummary goodSum = mock(IPSCatalogSummary.class);
+    when(goodSum.getGUID()).thenReturn(goodGuid);
+    IPSCatalogSummary nullGuidSum = mock(IPSCatalogSummary.class);
+    when(nullGuidSum.getGUID()).thenReturn(null);
+    IPSCatalogSummary choiceSum = mock(IPSCatalogSummary.class);
+    when(choiceSum.getGUID()).thenReturn(choiceGuid);
+
+    PSKeyword def = new PSKeyword();
+    def.setLabel("Status");
+    def.setValue("status");
+    def.setKeywordType(PSKeyword.KEYWORD_TYPE);
+
+    PSKeyword choiceRow = new PSKeyword();
+    choiceRow.setLabel("Open");
+    choiceRow.setValue("open");
+    // Choice rows use the parent keyword value as keywordType, not KEYWORD_TYPE
+    choiceRow.setKeywordType("status");
+
+    when(designWs.findKeywords(isNull()))
+        .thenReturn(Arrays.asList(null, nullGuidSum, goodSum, choiceSum));
+    when(designWs.loadKeywords(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(Arrays.asList(def, choiceRow, null));
+
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+    List<KeywordSummary> list = adaptor.listKeywords(null, false);
+
+    assertEquals(1, list.size());
+    assertEquals("Status", list.get(0).getLabel());
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<IPSGuid>> ids = ArgumentCaptor.forClass(List.class);
+    verify(designWs).loadKeywords(ids.capture(), eq(false), eq(false), any(), any());
+    assertEquals(2, ids.getValue().size());
+    assertEquals(goodGuid, ids.getValue().get(0));
+    assertEquals(choiceGuid, ids.getValue().get(1));
+  }
+
+  @Test
+  void listKeywords_designWsError_throwsIllegalState() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    IPSGuid guid = new PSGuid(PSTypeEnum.KEYWORD_DEF, 1L);
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    when(sum.getGUID()).thenReturn(guid);
+    when(designWs.findKeywords(isNull())).thenReturn(List.of(sum));
+    when(designWs.loadKeywords(anyList(), eq(false), eq(false), any(), any()))
+        .thenThrow(new PSErrorResultsException());
+
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> adaptor.listKeywords(null, false));
+    assertTrue(ex.getMessage().contains("Failed to list keywords"));
   }
 
   @Test
@@ -244,7 +350,27 @@ class KeywordsAdaptorDesignWsTest {
 
     assertNotNull(out);
     assertEquals("Colors", out.getLabel());
+    // get always embeds choices
+    assertNotNull(out.getChoices());
     verify(designWs).loadKeywords(eq(List.of(guid)), eq(false), eq(false), any(), any());
+  }
+
+  @Test
+  void getKeyword_byGuidShape_usesLoadKeywords() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    IPSGuid guid = new PSGuid(PSTypeEnum.KEYWORD_DEF, 42L);
+    PSKeyword kw = new PSKeyword();
+    kw.setGUID(guid);
+    kw.setLabel("ByGuid");
+    kw.setValue("byguid");
+    when(designWs.loadKeywords(eq(List.of(guid)), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(kw));
+
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+    KeywordSummary out = adaptor.getKeyword(null, guid.toString());
+
+    assertNotNull(out);
+    assertEquals("ByGuid", out.getLabel());
   }
 
   @Test
@@ -267,6 +393,100 @@ class KeywordsAdaptorDesignWsTest {
 
     assertNotNull(out);
     assertEquals("seasons", out.getValue());
+  }
+
+  @Test
+  void getKeyword_byValue_loadsAllAndMatches() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    IPSGuid guid = new PSGuid(PSTypeEnum.KEYWORD_DEF, 4L);
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    when(sum.getGUID()).thenReturn(guid);
+    PSKeyword kw = new PSKeyword();
+    kw.setGUID(guid);
+    kw.setLabel("Priority");
+    kw.setValue("priority");
+
+    when(designWs.findKeywords(isNull())).thenReturn(List.of(sum));
+    when(designWs.loadKeywords(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(kw));
+
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+    KeywordSummary out = adaptor.getKeyword(null, "priority");
+
+    assertNotNull(out);
+    assertEquals("Priority", out.getLabel());
+  }
+
+  @Test
+  void getKeyword_blank_returnsNullWithoutDesignCall() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+
+    assertNull(adaptor.getKeyword(null, null));
+    assertNull(adaptor.getKeyword(null, "   "));
+    verify(designWs, never()).findKeywords(any());
+    verify(designWs, never()).loadKeywords(anyList(), anyBoolean(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void createKeyword_nullOrBlankLabel_throwsBeforeDesignWs() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+
+    assertThrows(IllegalArgumentException.class, () -> adaptor.createKeyword(null, null));
+    KeywordSummary blank = new KeywordSummary();
+    blank.setLabel("  ");
+    assertThrows(IllegalArgumentException.class, () -> adaptor.createKeyword(null, blank));
+    verify(designWs, never()).createKeywords(anyList(), any(), any());
+  }
+
+  @Test
+  void updateKeyword_validationErrors_throwBeforeDesignWs() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+    KeywordSummary body = new KeywordSummary();
+    body.setLabel("X");
+
+    assertThrows(IllegalArgumentException.class, () -> adaptor.updateKeyword(null, "  ", body));
+    assertThrows(IllegalArgumentException.class, () -> adaptor.updateKeyword(null, "9", null));
+    assertThrows(
+        IllegalArgumentException.class, () -> adaptor.updateKeyword(null, "not-a-guid", body));
+    verify(designWs, never()).loadKeywords(anyList(), anyBoolean(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void deleteKeyword_validationErrors_throwBeforeDesignWs() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+
+    assertThrows(IllegalArgumentException.class, () -> adaptor.deleteKeyword(null, " "));
+    assertThrows(IllegalArgumentException.class, () -> adaptor.deleteKeyword(null, "xyz"));
+    verify(designWs, never()).loadKeywords(anyList(), anyBoolean(), anyBoolean(), any(), any());
+    verify(designWs, never()).deleteKeywords(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void writeOperations_requireSessionAndUser() throws Exception {
+    PSRequestInfoBase.resetRequestInfo();
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    // no KEY_JSESSIONID / KEY_USER
+
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+    KeywordSummary body = new KeywordSummary();
+    body.setLabel("NeedsSession");
+
+    IllegalStateException createEx =
+        assertThrows(IllegalStateException.class, () -> adaptor.createKeyword(null, body));
+    assertTrue(createEx.getMessage().contains("session and user"));
+
+    IllegalStateException updateEx =
+        assertThrows(IllegalStateException.class, () -> adaptor.updateKeyword(null, "9", body));
+    assertTrue(updateEx.getMessage().contains("session and user"));
+
+    IllegalStateException deleteEx =
+        assertThrows(IllegalStateException.class, () -> adaptor.deleteKeyword(null, "9"));
+    assertTrue(deleteEx.getMessage().contains("session and user"));
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/KeywordsAdaptorDesignWsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/KeywordsAdaptorDesignWsTest.java
@@ -81,8 +81,9 @@ class KeywordsAdaptorDesignWsTest {
 
     assertEquals(1, list.size());
     assertEquals("Colors", list.get(0).getLabel());
-    // includeChoices=false leaves the default empty list unset by toSummary
-    assertTrue(list.get(0).getChoices() == null || list.get(0).getChoices().isEmpty());
+    // includeChoices=false leaves KeywordSummary choices as the default empty list
+    assertNotNull(list.get(0).getChoices());
+    assertTrue(list.get(0).getChoices().isEmpty());
     verify(designWs).findKeywords(null);
     @SuppressWarnings("unchecked")
     ArgumentCaptor<List<IPSGuid>> ids = ArgumentCaptor.forClass(List.class);
@@ -146,7 +147,9 @@ class KeywordsAdaptorDesignWsTest {
     when(designWs.findKeywords(isNull())).thenReturn(null);
 
     KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
+    // Early return on null find is independent of includeChoices
     assertTrue(adaptor.listKeywords(null, false).isEmpty());
+    assertTrue(adaptor.listKeywords(null, true).isEmpty());
     verify(designWs, never()).loadKeywords(anyList(), anyBoolean(), anyBoolean(), any(), any());
   }
 
@@ -181,8 +184,13 @@ class KeywordsAdaptorDesignWsTest {
     KeywordsAdaptor adaptor = new KeywordsAdaptor(designWs);
     List<KeywordSummary> list = adaptor.listKeywords(null, false);
 
+    // Only KEYWORD_TYPE def rows appear; choice rows (keywordType="status") excluded
     assertEquals(1, list.size());
     assertEquals("Status", list.get(0).getLabel());
+    assertEquals("status", list.get(0).getValue());
+    assertTrue(
+        list.stream().noneMatch(s -> "Open".equals(s.getLabel())),
+        "non-keyword-def choice rows must not appear in list output");
     @SuppressWarnings("unchecked")
     ArgumentCaptor<List<IPSGuid>> ids = ArgumentCaptor.forClass(List.class);
     verify(designWs).loadKeywords(ids.capture(), eq(false), eq(false), any(), any());
@@ -371,6 +379,8 @@ class KeywordsAdaptorDesignWsTest {
 
     assertNotNull(out);
     assertEquals("ByGuid", out.getLabel());
+    // get always embeds choices (toSummary(..., true))
+    assertNotNull(out.getChoices());
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/keywords/KeywordsResourceCrudTest.java
+++ b/rest/src/test/java/com/percussion/rest/keywords/KeywordsResourceCrudTest.java
@@ -18,7 +18,9 @@
 package com.percussion.rest.keywords;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -51,21 +53,58 @@ public class KeywordsResourceCrudTest {
   }
 
   @Test
-  public void listKeywordsDelegates() {
+  public void listKeywordsDelegatesWithIncludeChoicesTrue() {
     KeywordSummary kw = new KeywordSummary();
     kw.setLabel("Status");
+    KeywordChoiceSummary choice = new KeywordChoiceSummary();
+    choice.setLabel("Open");
+    choice.setValue("open");
+    kw.setChoices(List.of(choice));
     when(adaptor.listKeywords(any(), eq(true))).thenReturn(List.of(kw));
     List<KeywordSummary> out = resource.listKeywords(true);
     assertEquals(1, out.size());
     assertEquals("Status", out.get(0).getLabel());
+    assertEquals(1, out.get(0).getChoices().size());
+    assertEquals("Open", out.get(0).getChoices().get(0).getLabel());
+    verify(adaptor).listKeywords(any(), eq(true));
+  }
+
+  @Test
+  public void listKeywordsDelegatesWithIncludeChoicesFalse() {
+    KeywordSummary kw = new KeywordSummary();
+    kw.setLabel("Status");
+    when(adaptor.listKeywords(any(), eq(false))).thenReturn(List.of(kw));
+    List<KeywordSummary> out = resource.listKeywords(false);
+    assertEquals(1, out.size());
+    assertEquals("Status", out.get(0).getLabel());
+    verify(adaptor).listKeywords(any(), eq(false));
+  }
+
+  @Test
+  public void listKeywordsEmpty() {
+    when(adaptor.listKeywords(any(), eq(false))).thenReturn(List.of());
+    assertTrue(resource.listKeywords(false).isEmpty());
   }
 
   @Test
   public void listKeywordsWrapsUnexpectedFailures() {
-    when(adaptor.listKeywords(any(), eq(false))).thenThrow(new RuntimeException("boom"));
+    RuntimeException cause = new RuntimeException("boom");
+    when(adaptor.listKeywords(any(), eq(false))).thenThrow(cause);
     WebApplicationException ex =
         assertThrows(WebApplicationException.class, () -> resource.listKeywords(false));
     assertEquals(500, ex.getResponse().getStatus());
+    assertSame(cause, ex.getCause());
+  }
+
+  @Test
+  public void listKeywordsRethrowsWebApplicationException() {
+    WebApplicationException mapped =
+        new WebApplicationException("pre-mapped", Response.Status.SERVICE_UNAVAILABLE);
+    when(adaptor.listKeywords(any(), eq(false))).thenThrow(mapped);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.listKeywords(false));
+    assertSame(mapped, ex);
+    assertEquals(503, ex.getResponse().getStatus());
   }
 
   @Test
@@ -101,6 +140,27 @@ public class KeywordsResourceCrudTest {
   }
 
   @Test
+  public void getKeywordWrapsUnexpectedFailures() {
+    RuntimeException cause = new IllegalStateException("Failed to load keyword");
+    when(adaptor.getKeyword(any(), eq("boom"))).thenThrow(cause);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.getKeyword("boom"));
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(cause, ex.getCause());
+  }
+
+  @Test
+  public void getKeywordRethrowsWebApplicationException() {
+    WebApplicationException mapped =
+        new WebApplicationException("pre-mapped", Response.Status.BAD_GATEWAY);
+    when(adaptor.getKeyword(any(), eq("x"))).thenThrow(mapped);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.getKeyword("x"));
+    assertSame(mapped, ex);
+    assertEquals(502, ex.getResponse().getStatus());
+  }
+
+  @Test
   public void createKeywordRequiresLabel() {
     when(adaptor.createKeyword(any(), any()))
         .thenThrow(new IllegalArgumentException("label is required"));
@@ -122,6 +182,27 @@ public class KeywordsResourceCrudTest {
   }
 
   @Test
+  public void createKeywordWrapsUnexpectedFailures() {
+    RuntimeException cause = new IllegalStateException("design ws down");
+    when(adaptor.createKeyword(any(), any())).thenThrow(cause);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.createKeyword(new KeywordSummary()));
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(cause, ex.getCause());
+  }
+
+  @Test
+  public void updateKeywordSuccess() {
+    KeywordSummary body = new KeywordSummary();
+    body.setLabel("Updated");
+    KeywordSummary updated = new KeywordSummary();
+    updated.setLabel("Updated");
+    when(adaptor.updateKeyword(any(), eq("9"), any())).thenReturn(updated);
+    assertEquals("Updated", resource.updateKeyword("9", body).getLabel());
+  }
+
+  @Test
   public void updateKeywordNotFound() {
     when(adaptor.updateKeyword(any(), eq("9"), any())).thenReturn(null);
     WebApplicationException ex =
@@ -137,6 +218,17 @@ public class KeywordsResourceCrudTest {
     WebApplicationException ex =
         assertThrows(WebApplicationException.class, () -> resource.updateKeyword("9", null));
     assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateKeywordWrapsUnexpectedFailures() {
+    RuntimeException cause = new IllegalStateException("Failed to update keyword");
+    when(adaptor.updateKeyword(any(), eq("9"), any())).thenThrow(cause);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.updateKeyword("9", new KeywordSummary()));
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(cause, ex.getCause());
   }
 
   @Test
@@ -167,13 +259,61 @@ public class KeywordsResourceCrudTest {
   }
 
   @Test
-  public void missingAdaptorReturnsServiceUnavailable() {
+  public void deleteKeywordWrapsUnexpectedFailures() {
+    RuntimeException cause = new IllegalStateException("Failed to delete keyword");
+    doThrow(cause).when(adaptor).deleteKeyword(any(), eq("7"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteKeyword("7"));
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(cause, ex.getCause());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnList() {
+    KeywordsResource bare = newKeywordsResourceWithoutAdaptor();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.listKeywords(false));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnGet() {
+    KeywordsResource bare = newKeywordsResourceWithoutAdaptor();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.getKeyword("status"));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnCreate() {
+    KeywordsResource bare = newKeywordsResourceWithoutAdaptor();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.createKeyword(new KeywordSummary()));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnUpdate() {
+    KeywordsResource bare = newKeywordsResourceWithoutAdaptor();
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> bare.updateKeyword("9", new KeywordSummary()));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnDelete() {
+    KeywordsResource bare = newKeywordsResourceWithoutAdaptor();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.deleteKeyword("9"));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  private static KeywordsResource newKeywordsResourceWithoutAdaptor() {
     KeywordsResource bare = new KeywordsResource();
     UriInfo uriInfo = mock(UriInfo.class);
     when(uriInfo.getBaseUri()).thenReturn(URI.create("http://localhost/services/"));
     bare.setUriInfo(uriInfo);
-    WebApplicationException ex =
-        assertThrows(WebApplicationException.class, () -> bare.listKeywords(false));
-    assertEquals(503, ex.getResponse().getStatus());
+    return bare;
   }
 }

--- a/rest/src/test/java/com/percussion/rest/keywords/KeywordsResourceCrudTest.java
+++ b/rest/src/test/java/com/percussion/rest/keywords/KeywordsResourceCrudTest.java
@@ -196,10 +196,19 @@ public class KeywordsResourceCrudTest {
   public void updateKeywordSuccess() {
     KeywordSummary body = new KeywordSummary();
     body.setLabel("Updated");
+    KeywordChoiceSummary choice = new KeywordChoiceSummary();
+    choice.setLabel("Open");
+    choice.setValue("open");
+    body.setChoices(List.of(choice));
     KeywordSummary updated = new KeywordSummary();
     updated.setLabel("Updated");
+    updated.setChoices(List.of(choice));
     when(adaptor.updateKeyword(any(), eq("9"), any())).thenReturn(updated);
-    assertEquals("Updated", resource.updateKeyword("9", body).getLabel());
+    KeywordSummary out = resource.updateKeyword("9", body);
+    assertEquals("Updated", out.getLabel());
+    assertEquals(1, out.getChoices().size());
+    assertEquals("Open", out.getChoices().get(0).getLabel());
+    assertEquals("open", out.getChoices().get(0).getValue());
   }
 
   @Test


### PR DESCRIPTION
## Summary
**Partial for #2116** (Slice B of parent **#1694**, part of **#1690**).

Unit/adaptor hardening for the keywords catalog REST surface (no production code change — static wiring matches working content-type path):

### rest — `KeywordsResourceCrudTest`
- `includeChoices` true/false delegation + empty list
- WAE rethrow (preserve pre-mapped status) on list/get
- Unexpected exception → 500 with cause on list/get/create/update/delete
- Bare no-arg ctor → **503 SERVICE_UNAVAILABLE** on all verbs (misconfiguration)

### sitemanage — `KeywordsAdaptorDesignWsTest`
- `includeChoices` embeds/sorts choices; false leaves choices empty
- null/empty `findKeywords` without load
- skip null summaries/guids and non-keyword-def rows
- `PSErrorResultsException` → `IllegalStateException` on list
- get by numeric id / guid shape / label / value / blank
- create/update/delete validation before design WS
- write ops require session + user

### Static wiring audit (no sitemanage product change)
| Layer | Keywords | Working peer |
|-------|----------|--------------|
| Resource bean | `restKeywordsResource` `@PSSiteManageBean` + `@Autowired` ctor | `restContentTypesResource` |
| Interface | `IKeywordsAdaptor` | `IContentTypesAdaptor` |
| Impl | `KeywordsAdaptor` `@PSSiteManageBean` | `ContentTypeAdaptor` `@PSSiteManageBean` |
| Backend | `IPSContentDesignWs` via `PSContentWsLocator.getContentDesignWebservice()` | same locator / content design WS |
| CXF list | `sitemanage-beans.xml` ref `restKeywordsResource` | `restContentTypesResource` |
| Test stub | `TestKeywordsAdaptor` | `TestContentTypeAdaptor` |

No clear static root cause for live QA 500s without server stacks. Live **GET /services/keywords 2xx** deferred to residual **#2124** (ties **#2118** / **#2065**).

## Test plan
- [x] `KeywordsResourceCrudTest` green (includeChoices + edge mapping + 503)
- [x] `KeywordsAdaptorDesignWsTest` green (find/load/choices/validation/session)
- [x] `rest` module `mvnw clean install` SUCCESS
- [x] `projects/sitemanage` module `mvnw clean install` SUCCESS
- [x] Spotless apply from root; **only in-scope** test files committed (baseline Spotless debt elsewhere not included)
- [ ] Live QA `GET /services/keywords` 2xx after redeploy — residual #2124

## Gates evidence
- Erlang-style self-review: behavioral tests for new edge paths; portable paths N/A (no file I/O)
- Modules: rest + sitemanage standalone clean install SUCCESS
- Spotless: apply first then check; feature PR contains only the two test files above

## Links
- Partial: #2116
- Parent tracker: #1694
- Epic: #1690
- Residual live 2xx: #2124

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.