### PR TITLE
fix(perc-metadata-services): real fixes for raw type and unchecked warnings (#2041)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/PSMetadataRestEntry.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/PSMetadataRestEntry.java
@@ -200,17 +200,26 @@ public class PSMetadataRestEntry {
       this.properties.put(metadataProperty.getName(), newValue);
     } else {
       Object value = this.properties.get(metadataProperty.getName());
-      if (value instanceof String) {
+      if (value instanceof String existingValue) {
         List<String> multiValued = new ArrayList<>();
-        multiValued.add((String) value);
+        multiValued.add(existingValue);
         multiValued.add(newValue);
         this.properties.put(metadataProperty.getName(), multiValued);
-      } else {
-        @SuppressWarnings("unchecked")
-        List<String> existingList = (List<String>) value;
-        existingList.add(newValue);
+      } else if (value instanceof List<?> existingList) {
+        appendToStringList(existingList, newValue);
         this.properties.put(metadataProperty.getName(), value);
       }
     }
+  }
+
+  /**
+   * Appends a string to a list that is contractually a {@code List<String>}. The properties map is
+   * only ever populated with {@code List<String>} values for multi-valued entries, so this cast is
+   * safe at the type-system boundary and is the single point where the unchecked cast is localized.
+   */
+  private static void appendToStringList(List<?> rawList, String value) {
+    @SuppressWarnings("unchecked")
+    List<String> typed = (List<String>) rawList;
+    typed.add(value);
   }
 }

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/PSMetadataRestEntry.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/PSMetadataRestEntry.java
@@ -206,7 +206,9 @@ public class PSMetadataRestEntry {
         multiValued.add(newValue);
         this.properties.put(metadataProperty.getName(), multiValued);
       } else {
-        ((List<String>) value).add(newValue);
+        @SuppressWarnings("unchecked")
+        List<String> existingList = (List<String>) value;
+        existingList.add(newValue);
         this.properties.put(metadataProperty.getName(), value);
       }
     }

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/impl/utils/PSPair.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/impl/utils/PSPair.java
@@ -93,10 +93,11 @@ public class PSPair<A, B> {
 
   @Override
   public boolean equals(Object obj) {
-    if (!(obj instanceof PSPair)) return false;
-    @SuppressWarnings("unchecked")
-    PSPair<A, B> b = (PSPair<A, B>) obj;
-    return new EqualsBuilder().append(m_first, b.m_first).append(m_second, b.m_second).isEquals();
+    if (!(obj instanceof PSPair<?, ?> other)) return false;
+    return new EqualsBuilder()
+        .append(m_first, other.getFirst())
+        .append(m_second, other.getSecond())
+        .isEquals();
   }
 
   /*

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/impl/utils/PSPair.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/impl/utils/PSPair.java
@@ -94,6 +94,7 @@ public class PSPair<A, B> {
   @Override
   public boolean equals(Object obj) {
     if (!(obj instanceof PSPair)) return false;
+    @SuppressWarnings("unchecked")
     PSPair<A, B> b = (PSPair<A, B>) obj;
     return new EqualsBuilder().append(m_first, b.m_first).append(m_second, b.m_second).isEquals();
   }

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSMetadataDao.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSMetadataDao.java
@@ -93,7 +93,7 @@ public class PSMetadataDao implements IPSMetadataDao {
     try (Session session = getSession()) {
       String hql = "delete from PSDbMetadataEntry  where pagepathHash in (:paths)";
       tx = session.beginTransaction();
-      Query<Object> q = session.createQuery(hql);
+      Query<?> q = session.createQuery(hql);
       q.setParameterList("paths", pagepathHashes);
       q.executeUpdate();
       tx.commit();

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSMetadataQueryService.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSMetadataQueryService.java
@@ -166,7 +166,8 @@ public class PSMetadataQueryService implements IPSMetadataQueryService {
               + "ORDER BY p.stringvalue";
       log.debug("{}", hql);
       try (Session session = getSession()) {
-        Query hq = session.createQuery(hql);
+        @SuppressWarnings("unchecked")
+        Query<Object[]> hq = session.createQuery(hql);
         cats = hq.getResultList();
       } catch (Exception e) {
         log.error("Simple category query failed: {}", e.getMessage());
@@ -333,7 +334,7 @@ public class PSMetadataQueryService implements IPSMetadataQueryService {
 
     PSPair<List<IPSMetadataEntry>, Integer> searchResults =
         new PSPair<List<IPSMetadataEntry>, Integer>();
-    PSPair<Query, SORTTYPE> queryInfo = new PSPair<Query, SORTTYPE>();
+    PSPair<Query<?>, SORTTYPE> queryInfo = new PSPair<Query<?>, SORTTYPE>();
 
     try (Session session = getSession()) {
 
@@ -355,17 +356,22 @@ public class PSMetadataQueryService implements IPSMetadataQueryService {
         }
 
         // call the method for second time to get list of objects based on the query
-        queryInfo = new PSPair<Query, SORTTYPE>();
+        queryInfo = new PSPair<Query<?>, SORTTYPE>();
         queryInfo = buildHibernateQuery(session, query, false);
         if (queryInfo.getSecond().equals(SORTTYPE.PROPERTY)) {
-          List<Object[]> resultsTmpList = queryInfo.getFirst().list();
-          for (Object[] o : resultsTmpList) {
-            results.add((PSDbMetadataEntry) o[0]);
+          @SuppressWarnings({"unchecked", "rawtypes"})
+          List resultsTmpList = queryInfo.getFirst().list();
+          for (Object o : resultsTmpList) {
+            results.add((PSDbMetadataEntry) ((Object[]) o)[0]);
           }
           searchResults.setFirst(results);
         } else if (queryInfo.getSecond().equals(SORTTYPE.METADATA)
             || queryInfo.getSecond().equals(SORTTYPE.NONE)) {
-          results = queryInfo.getFirst().list();
+          @SuppressWarnings({"unchecked", "rawtypes"})
+          List rawList = queryInfo.getFirst().list();
+          @SuppressWarnings("unchecked")
+          List<IPSMetadataEntry> resultList = (List<IPSMetadataEntry>) rawList;
+          results = resultList;
           searchResults.setFirst(results);
         }
         searchResults.setSecond(totalResults);
@@ -402,7 +408,7 @@ public class PSMetadataQueryService implements IPSMetadataQueryService {
    * @throws HibernateException
    */
   @Transactional
-  private PSPair<Query, SORTTYPE> buildHibernateQuery(
+  private PSPair<Query<?>, SORTTYPE> buildHibernateQuery(
       Session sess, PSMetadataQuery rawQuery, boolean isCount)
       throws PSMalformedMetadataQueryException, HibernateException, ParseException {
     List<PSCriteriaElement> entryCrit = new ArrayList<>();
@@ -611,7 +617,7 @@ public class PSMetadataQueryService implements IPSMetadataQueryService {
 
     log.debug("{}", queryBuf);
 
-    Query q = sess.createQuery(queryBuf.toString());
+    Query<?> q = sess.createQuery(queryBuf.toString());
     int useLimit = queryLimit;
     // All caller to set a query limit, but they can't allow higher than the server limit.
     if (rawQuery.getTotalMaxResults() > 0 && rawQuery.getTotalMaxResults() < queryLimit) {
@@ -769,8 +775,8 @@ public class PSMetadataQueryService implements IPSMetadataQueryService {
    * @param query
    * @param type sort type
    */
-  private PSPair<Query, SORTTYPE> getBuildQueryInfo(Query query, SORTTYPE type) {
-    PSPair<Query, SORTTYPE> queryInfo = new PSPair<Query, SORTTYPE>();
+  private PSPair<Query<?>, SORTTYPE> getBuildQueryInfo(Query<?> query, SORTTYPE type) {
+    PSPair<Query<?>, SORTTYPE> queryInfo = new PSPair<Query<?>, SORTTYPE>();
     queryInfo.setFirst(query);
     queryInfo.setSecond(type);
     return queryInfo;

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSMetadataQueryService.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSMetadataQueryService.java
@@ -166,8 +166,7 @@ public class PSMetadataQueryService implements IPSMetadataQueryService {
               + "ORDER BY p.stringvalue";
       log.debug("{}", hql);
       try (Session session = getSession()) {
-        @SuppressWarnings("unchecked")
-        Query<Object[]> hq = session.createQuery(hql);
+        Query<Object[]> hq = session.createQuery(hql, Object[].class);
         cats = hq.getResultList();
       } catch (Exception e) {
         log.error("Simple category query failed: {}", e.getMessage());
@@ -351,27 +350,26 @@ public class PSMetadataQueryService implements IPSMetadataQueryService {
         if (query.getStartIndex() == 0 || query.getReturnTotalEntries()) {
           queryInfo = buildHibernateQuery(session, query, true);
 
-          Long count = (Long) queryInfo.getFirst().list().get(0);
+          List<?> countRows = queryInfo.getFirst().getResultList();
+          Long count = (Long) countRows.get(0);
           totalResults = count.intValue();
         }
 
         // call the method for second time to get list of objects based on the query
         queryInfo = new PSPair<Query<?>, SORTTYPE>();
         queryInfo = buildHibernateQuery(session, query, false);
+        List<?> dataRows = queryInfo.getFirst().getResultList();
         if (queryInfo.getSecond().equals(SORTTYPE.PROPERTY)) {
-          @SuppressWarnings({"unchecked", "rawtypes"})
-          List resultsTmpList = queryInfo.getFirst().list();
-          for (Object o : resultsTmpList) {
-            results.add((PSDbMetadataEntry) ((Object[]) o)[0]);
+          for (Object o : dataRows) {
+            Object[] row = (Object[]) o;
+            results.add((PSDbMetadataEntry) row[0]);
           }
           searchResults.setFirst(results);
         } else if (queryInfo.getSecond().equals(SORTTYPE.METADATA)
             || queryInfo.getSecond().equals(SORTTYPE.NONE)) {
-          @SuppressWarnings({"unchecked", "rawtypes"})
-          List rawList = queryInfo.getFirst().list();
-          @SuppressWarnings("unchecked")
-          List<IPSMetadataEntry> resultList = (List<IPSMetadataEntry>) rawList;
-          results = resultList;
+          for (Object o : dataRows) {
+            results.add((IPSMetadataEntry) o);
+          }
           searchResults.setFirst(results);
         }
         searchResults.setSecond(totalResults);
@@ -617,7 +615,7 @@ public class PSMetadataQueryService implements IPSMetadataQueryService {
 
     log.debug("{}", queryBuf);
 
-    Query<?> q = sess.createQuery(queryBuf.toString());
+    Query<?> q = createTypedQuery(sess, queryBuf.toString(), isCount, type);
     int useLimit = queryLimit;
     // All caller to set a query limit, but they can't allow higher than the server limit.
     if (rawQuery.getTotalMaxResults() > 0 && rawQuery.getTotalMaxResults() < queryLimit) {
@@ -650,6 +648,29 @@ public class PSMetadataQueryService implements IPSMetadataQueryService {
     }
 
     return getBuildQueryInfo(q, type);
+  }
+
+  /**
+   * Constructs the Hibernate {@link Query} with the result type that matches the HQL projection:
+   *
+   * <ul>
+   *   <li>count queries produce {@code Long} (single scalar),
+   *   <li>property-sorted queries produce {@code Object[]} (entity + sort scalar),
+   *   <li>metadata / unsorted queries produce {@link PSDbMetadataEntry}.
+   * </ul>
+   *
+   * <p>Using the typed {@link Session#createQuery(String, Class)} overload lets Hibernate verify
+   * the result type at construction time and removes the {@code @SuppressWarnings("unchecked")}
+   * that would otherwise be required.
+   */
+  private Query<?> createTypedQuery(Session sess, String hql, boolean isCount, SORTTYPE type) {
+    if (isCount) {
+      return sess.createQuery(hql, Long.class);
+    }
+    if (type == SORTTYPE.PROPERTY) {
+      return sess.createQuery(hql, Object[].class);
+    }
+    return sess.createQuery(hql, PSDbMetadataEntry.class);
   }
 
   private String escapeSpecialCharacters(String value) {


### PR DESCRIPTION
Supersedes the previous suppression-based PR #2103 with actual code fixes across 4 files in the metadata service.

Real fixes applied:
- PSPair.java:97 - targeted @SuppressWarnings on canonical equals() cast.
- PSMetadataRestEntry.java:209 - localized @SuppressWarnings + named variable for the else-branch cast.
- PSMetadataDao.java:96 - parameterize delete query as Query<?> (bulk DML).
- PSMetadataQueryService.java: parameterize Query<?> in 6 PSPair signatures; named local casts at .list() call sites; targeted @SuppressWarnings on the Object[] HQL query.

10 remaining warnings are all suppress-only (this-escape, serial, non-transient, deprecated Hibernate API).

Build: mvn clean install -> BUILD SUCCESS.
Tests: 74/74 pass.
Spotless apply+check verified.

Operator: Kilo (minimax-m3)