### PR TITLE
test(WebUI): UI-TEST-01 residual A list panelErrMsg ladder (#2119)

### DIFF
--- a/WebUI/src/test/ts/developer/ControlsPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ControlsPanel.test.tsx
@@ -5,8 +5,10 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ControlsPanel } from "../../../main/ts/developer/ControlsPanel";
+import { SessionRedirectError } from "../../../main/ts/api/client";
 import * as controlsApi from "../../../main/ts/api/developer/controlsApi";
+import { ControlsPanel } from "../../../main/ts/developer/ControlsPanel";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
 
 vi.mock("../../../main/ts/api/developer/controlsApi", () => ({
   listControls: vi.fn(),
@@ -53,7 +55,7 @@ describe("ControlsPanel", () => {
     expect(screen.getByTestId("developer-ctl-gaps").textContent).toContain("gap-a");
   });
 
-  it("shows loading empty and error states", async () => {
+  it("shows loading empty and empty state", async () => {
     let resolveList!: (v: unknown) => void;
     listControls.mockReturnValue(
       new Promise((resolve) => {
@@ -67,11 +69,51 @@ describe("ControlsPanel", () => {
       expect(screen.getByTestId("developer-ctl-empty")).toBeTruthy();
     });
     unmount();
+  });
 
-    listControls.mockRejectedValueOnce(new Error("down"));
+  it("shows session-redirect message via panelErrMsg", async () => {
+    listControls.mockRejectedValue(new SessionRedirectError());
     render(<ControlsPanel />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-ctl-error")).toBeTruthy();
     });
+    expect(screen.getByTestId("developer-ctl-error").textContent).toBe(DEV_MSG.SESSION_REDIRECT);
+    expect(screen.queryByTestId("developer-ctl-empty")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    listControls.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<ControlsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ctl-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ctl-error").textContent).toBe(
+      `${DEV_MSG.CTL_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    listControls.mockRejectedValue(new Error("network down"));
+    render(<ControlsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ctl-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ctl-error").textContent).toBe(
+      `${DEV_MSG.CTL_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-ctl-table")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    listControls.mockRejectedValue("boom");
+    render(<ControlsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ctl-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ctl-error").textContent).toBe(DEV_MSG.CTL_ERROR);
   });
 });

--- a/WebUI/src/test/ts/developer/PipelinesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/PipelinesPanel.test.tsx
@@ -5,10 +5,12 @@
 import React from "react";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
 import {
   getApplicationDetail,
   listApplications,
 } from "../../../main/ts/api/developer/pipelinesApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
 import { PipelinesPanel } from "../../../main/ts/developer/PipelinesPanel";
 
 vi.mock("../../../main/ts/api/developer/pipelinesApi", () => ({
@@ -21,6 +23,9 @@ const getApplicationDetailMock = vi.mocked(getApplicationDetail);
 
 describe("PipelinesPanel", () => {
   beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
     listApplicationsMock.mockReset();
     getApplicationDetailMock.mockReset();
   });
@@ -110,12 +115,49 @@ describe("PipelinesPanel", () => {
     });
   });
 
-  it("shows error UI when pipelines fetch fails", async () => {
-    listApplicationsMock.mockRejectedValue({ status: 500, statusText: "Error" });
+  it("shows session-redirect message via panelErrMsg", async () => {
+    listApplicationsMock.mockRejectedValue(new SessionRedirectError());
     render(<PipelinesPanel />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-pipe-error")).toBeTruthy();
     });
-    expect(screen.getByTestId("developer-pipe-error").textContent).toMatch(/500/);
+    expect(screen.getByTestId("developer-pipe-error").textContent).toBe(DEV_MSG.SESSION_REDIRECT);
+    expect(screen.queryByTestId("developer-pipe-empty")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    listApplicationsMock.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<PipelinesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-pipe-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-pipe-error").textContent).toBe(
+      `${DEV_MSG.PIPE_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    listApplicationsMock.mockRejectedValue(new Error("network down"));
+    render(<PipelinesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-pipe-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-pipe-error").textContent).toBe(
+      `${DEV_MSG.PIPE_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-pipe-table")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    listApplicationsMock.mockRejectedValue("boom");
+    render(<PipelinesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-pipe-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-pipe-error").textContent).toBe(DEV_MSG.PIPE_ERROR);
   });
 });

--- a/WebUI/src/test/ts/developer/ServerConfigsPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ServerConfigsPanel.test.tsx
@@ -5,8 +5,10 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ServerConfigsPanel } from "../../../main/ts/developer/ServerConfigsPanel";
+import { SessionRedirectError } from "../../../main/ts/api/client";
 import * as api from "../../../main/ts/api/developer/serverConfigsApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+import { ServerConfigsPanel } from "../../../main/ts/developer/ServerConfigsPanel";
 
 vi.mock("../../../main/ts/api/developer/serverConfigsApi", () => ({
   listServerConfigs: vi.fn(),
@@ -53,17 +55,57 @@ describe("ServerConfigsPanel", () => {
     );
   });
 
-  it("shows empty and error states", async () => {
-    listServerConfigs.mockResolvedValueOnce([]);
-    const { unmount } = render(<ServerConfigsPanel />);
+  it("shows empty state when API returns no configs", async () => {
+    listServerConfigs.mockResolvedValue([]);
+    render(<ServerConfigsPanel />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-cfg-empty")).toBeTruthy();
     });
-    unmount();
-    listServerConfigs.mockRejectedValueOnce(new Error("down"));
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    listServerConfigs.mockRejectedValue(new SessionRedirectError());
     render(<ServerConfigsPanel />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-cfg-error")).toBeTruthy();
     });
+    expect(screen.getByTestId("developer-cfg-error").textContent).toBe(DEV_MSG.SESSION_REDIRECT);
+    expect(screen.queryByTestId("developer-cfg-empty")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    listServerConfigs.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<ServerConfigsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cfg-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-cfg-error").textContent).toBe(
+      `${DEV_MSG.CFG_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    listServerConfigs.mockRejectedValue(new Error("network down"));
+    render(<ServerConfigsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cfg-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-cfg-error").textContent).toBe(
+      `${DEV_MSG.CFG_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-cfg-table")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    listServerConfigs.mockRejectedValue("boom");
+    render(<ServerConfigsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cfg-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-cfg-error").textContent).toBe(DEV_MSG.CFG_ERROR);
   });
 });

--- a/WebUI/src/test/ts/developer/SharedFieldsPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SharedFieldsPanel.test.tsx
@@ -5,10 +5,12 @@
 import React from "react";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
 import {
   getSharedFieldGroupDetail,
   listSharedFieldGroups,
 } from "../../../main/ts/api/developer/sharedFieldsApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
 import { SharedFieldsPanel } from "../../../main/ts/developer/SharedFieldsPanel";
 
 vi.mock("../../../main/ts/api/developer/sharedFieldsApi", () => ({
@@ -21,6 +23,9 @@ const detailMock = vi.mocked(getSharedFieldGroupDetail);
 
 describe("SharedFieldsPanel", () => {
   beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
     listMock.mockReset();
     detailMock.mockReset();
   });
@@ -88,11 +93,49 @@ describe("SharedFieldsPanel", () => {
     });
   });
 
-  it("shows error UI when list fails", async () => {
-    listMock.mockRejectedValue({ status: 500, statusText: "Error" });
+  it("shows session-redirect message via panelErrMsg", async () => {
+    listMock.mockRejectedValue(new SessionRedirectError());
     render(<SharedFieldsPanel />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-sf-error")).toBeTruthy();
     });
+    expect(screen.getByTestId("developer-sf-error").textContent).toBe(DEV_MSG.SESSION_REDIRECT);
+    expect(screen.queryByTestId("developer-sf-empty")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    listMock.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<SharedFieldsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sf-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sf-error").textContent).toBe(
+      `${DEV_MSG.SF_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    listMock.mockRejectedValue(new Error("network down"));
+    render(<SharedFieldsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sf-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sf-error").textContent).toBe(
+      `${DEV_MSG.SF_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-sf-table")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    listMock.mockRejectedValue("boom");
+    render(<SharedFieldsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sf-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sf-error").textContent).toBe(DEV_MSG.SF_ERROR);
   });
 });

--- a/WebUI/src/test/ts/developer/SitesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SitesPanel.test.tsx
@@ -5,8 +5,10 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { SitesPanel } from "../../../main/ts/developer/SitesPanel";
+import { SessionRedirectError } from "../../../main/ts/api/client";
 import * as sitesApi from "../../../main/ts/api/developer/sitesApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+import { SitesPanel } from "../../../main/ts/developer/SitesPanel";
 
 vi.mock("../../../main/ts/api/developer/sitesApi", () => ({
   listSites: vi.fn(),
@@ -66,12 +68,50 @@ describe("SitesPanel", () => {
     });
   });
 
-  it("shows error without treating as empty", async () => {
+  it("shows session-redirect message via panelErrMsg", async () => {
+    listSites.mockRejectedValue(new SessionRedirectError());
+    render(<SitesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-site-error").textContent).toBe(DEV_MSG.SESSION_REDIRECT);
+    expect(screen.queryByTestId("developer-site-empty")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    listSites.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<SitesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-site-error").textContent).toBe(
+      `${DEV_MSG.SITE_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
     listSites.mockRejectedValue(new Error("sites down"));
     render(<SitesPanel />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-site-error")).toBeTruthy();
     });
+    expect(screen.getByTestId("developer-site-error").textContent).toBe(
+      `${DEV_MSG.SITE_ERROR} sites down`,
+    );
     expect(screen.queryByTestId("developer-site-empty")).toBeNull();
+    expect(screen.queryByTestId("developer-site-table")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    listSites.mockRejectedValue("boom");
+    render(<SitesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-site-error").textContent).toBe(DEV_MSG.SITE_ERROR);
   });
 });

--- a/WebUI/src/test/ts/developer/SystemDefPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SystemDefPanel.test.tsx
@@ -5,7 +5,9 @@
 import React from "react";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
 import { getSystemDef } from "../../../main/ts/api/developer/systemDefApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
 import { SystemDefPanel } from "../../../main/ts/developer/SystemDefPanel";
 
 vi.mock("../../../main/ts/api/developer/systemDefApi", () => ({
@@ -16,6 +18,9 @@ const getMock = vi.mocked(getSystemDef);
 
 describe("SystemDefPanel", () => {
   beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
     getMock.mockReset();
   });
 
@@ -55,11 +60,49 @@ describe("SystemDefPanel", () => {
     });
   });
 
-  it("shows error UI when fetch fails", async () => {
-    getMock.mockRejectedValue({ status: 500, statusText: "Error" });
+  it("shows session-redirect message via panelErrMsg", async () => {
+    getMock.mockRejectedValue(new SessionRedirectError());
     render(<SystemDefPanel />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-sys-error")).toBeTruthy();
     });
+    expect(screen.getByTestId("developer-sys-error").textContent).toBe(DEV_MSG.SESSION_REDIRECT);
+    expect(screen.queryByTestId("developer-sys-empty")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    getMock.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<SystemDefPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sys-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sys-error").textContent).toBe(
+      `${DEV_MSG.SYS_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    getMock.mockRejectedValue(new Error("network down"));
+    render(<SystemDefPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sys-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sys-error").textContent).toBe(
+      `${DEV_MSG.SYS_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-sys-fields-table")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    getMock.mockRejectedValue("boom");
+    render(<SystemDefPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sys-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sys-error").textContent).toBe(DEV_MSG.SYS_ERROR);
   });
 });

--- a/WebUI/src/test/ts/developer/WorkflowsPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/WorkflowsPanel.test.tsx
@@ -5,8 +5,10 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { WorkflowsPanel } from "../../../main/ts/developer/WorkflowsPanel";
+import { SessionRedirectError } from "../../../main/ts/api/client";
 import * as workflowsApi from "../../../main/ts/api/developer/workflowsApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+import { WorkflowsPanel } from "../../../main/ts/developer/WorkflowsPanel";
 
 vi.mock("../../../main/ts/api/developer/workflowsApi", () => ({
   listWorkflows: vi.fn(),
@@ -99,13 +101,50 @@ describe("WorkflowsPanel", () => {
     });
   });
 
-  it("shows error state when list fails (items stay unloaded)", async () => {
+  it("shows session-redirect message via panelErrMsg", async () => {
+    listWorkflows.mockRejectedValue(new SessionRedirectError());
+    render(<WorkflowsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-wf-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-wf-error").textContent).toBe(DEV_MSG.SESSION_REDIRECT);
+    expect(screen.queryByTestId("developer-wf-empty")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    listWorkflows.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<WorkflowsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-wf-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-wf-error").textContent).toBe(
+      `${DEV_MSG.WF_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
     listWorkflows.mockRejectedValue(new Error("network down"));
     render(<WorkflowsPanel />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-wf-error")).toBeTruthy();
     });
+    expect(screen.getByTestId("developer-wf-error").textContent).toBe(
+      `${DEV_MSG.WF_ERROR} network down`,
+    );
     expect(screen.queryByTestId("developer-wf-empty")).toBeNull();
     expect(screen.queryByTestId("developer-wf-table")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    listWorkflows.mockRejectedValue("boom");
+    render(<WorkflowsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-wf-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-wf-error").textContent).toBe(DEV_MSG.WF_ERROR);
   });
 });

--- a/docs/ai-generated/code-reviews/issue-2119-list-panel-errmsg-ladder-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2119-list-panel-errmsg-ladder-erlang.md
@@ -1,0 +1,41 @@
+# Erlang review: issue #2119 UI-TEST-01 residual A list panelErrMsg
+
+**Branch:** `fix/issue-2119-list-panel-errmsg-ladder`  
+**Date:** 2026-08-06  
+**Reviewer persona:** Erlang (strict, independent)
+
+## Summary
+
+Expands seven Developer list-panel Vitest files to the full `panelErrMsg` ladder already used by `SearchesPanel` / `ContentTypesPanel` / `ViewsPanel`: session-redirect, ApiError status, `Error.message`, and non-Error fallback. No production UI or API changes.
+
+## Scope
+
+- `WebUI/src/test/ts/developer/ServerConfigsPanel.test.tsx`
+- `WebUI/src/test/ts/developer/ControlsPanel.test.tsx`
+- `WebUI/src/test/ts/developer/SitesPanel.test.tsx`
+- `WebUI/src/test/ts/developer/WorkflowsPanel.test.tsx`
+- `WebUI/src/test/ts/developer/PipelinesPanel.test.tsx`
+- `WebUI/src/test/ts/developer/SharedFieldsPanel.test.tsx`
+- `WebUI/src/test/ts/developer/SystemDefPanel.test.tsx`
+
+**Base:** `origin/main`  
+**Memory patterns hit:** peer-test closure (UI-TEST-01 ladder)  
+**Cross-platform path review:** N/A — test-only, no file I/O or path joins.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs | none |
+| Behavioral tests for new logic | N/A — tests only; production already uses `panelErrMsg` |
+| Non-portable paths | none |
+| Change-class companions | Mirrors full ladder from Searches/ContentTypes peers |
+| May commit/push | **yes** |
+
+## Issues
+
+None.


### PR DESCRIPTION
## Summary
- **Partial for #2119 / parent #1690 (UI-TEST-01 residual A):** full `panelErrMsg` ladder Vitest for remaining Developer list panels: ServerConfigs, Controls, Sites, Workflows, Pipelines, SharedFields, SystemDef.
- Mirrors `SearchesPanel.test.tsx` / `ContentTypesPanel.test.tsx`: session-redirect, ApiError `(status)`, `Error.message`, non-Error fallback; keeps existing success/empty coverage.
- No product UI changes (tests only).

## Parent tracker
- #1690 (UI-TEST-01 / developer post-P0)
- Slice of residual #2119

## Test plan
- [x] Focused Vitest: 7 panel files, **45 tests passed**
- [x] `cd WebUI && ..\mvnw.cmd clean install` green
- [x] Erlang self-review: approve (test-only peer ladder)

## Gates evidence
- Focused: `npm test -- --run` on the seven `*Panel.test.tsx` files → 7 files / 45 tests pass
- Module clean install: WebUI standalone `mvnw clean install` exit 0
- Erlang report: `docs/ai-generated/code-reviews/issue-2119-list-panel-errmsg-ladder-erlang.md`

## Residual
- Detail-panel Vitest ladders (residual B of #2119): https://github.com/intersoftdatalabs-in/percussioncms/issues/2139 (unassigned)

Operator: Grok: night-issue-prs (model grok-4.5)

Partial #2119

> Co-Authored by Grok Build using grok-4.5 with agent main.
