### PR TITLE
fix(rest): locales requireAdaptor null returns 503 (#2126)

### DIFF
--- a/rest/src/main/java/com/percussion/rest/locales/LocalesResource.java
+++ b/rest/src/main/java/com/percussion/rest/locales/LocalesResource.java
@@ -31,9 +31,12 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -47,10 +50,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 @Tag(name = "Locales", description = "CMS locale design catalog (read-only)")
 public class LocalesResource {
 
+  private static final Logger log = LogManager.getLogger(LocalesResource.class);
+
   private final ILocalesAdaptor adaptor;
 
   @Context private UriInfo uriInfo;
 
+  /**
+   * No-arg constructor for bean-discovery edge cases. Production uses {@link
+   * #LocalesResource(ILocalesAdaptor)}; list/detail methods call {@link #requireAdaptor()}.
+   */
   public LocalesResource() {
     this.adaptor = null;
   }
@@ -58,6 +67,11 @@ public class LocalesResource {
   @Autowired
   public LocalesResource(ILocalesAdaptor adaptor) {
     this.adaptor = adaptor;
+  }
+
+  /** Package-private test hook so unit tests need not reflect on {@code uriInfo}. */
+  void setUriInfo(UriInfo uriInfo) {
+    this.uriInfo = uriInfo;
   }
 
   @GET
@@ -74,6 +88,7 @@ public class LocalesResource {
             content =
                 @Content(
                     array = @ArraySchema(schema = @Schema(implementation = LocaleSummary.class)))),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public List<LocaleSummary> listLocales() {
@@ -82,6 +97,7 @@ public class LocalesResource {
     } catch (WebApplicationException e) {
       throw e;
     } catch (Exception e) {
+      log.error("Failed to list locales ({}): {}", e.getClass().getName(), e.getMessage(), e);
       throw new WebApplicationException(e, 500);
     }
   }
@@ -100,6 +116,7 @@ public class LocalesResource {
             description = "OK",
             content = @Content(schema = @Schema(implementation = LocaleDetail.class))),
         @ApiResponse(responseCode = "404", description = "Locale not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public LocaleDetail getLocale(@PathParam("idOrLang") String idOrLang) {
@@ -110,16 +127,20 @@ public class LocalesResource {
       }
       return detail;
     } catch (WebApplicationException e) {
+      // Preserve mapped HTTP errors (e.g. 503 misconfiguration from requireAdaptor)
       throw e;
     } catch (Exception e) {
+      log.error(
+          "Failed to load locale {} ({}): {}", idOrLang, e.getClass().getName(), e.getMessage(), e);
       throw new WebApplicationException(e, 500);
     }
   }
 
   private ILocalesAdaptor requireAdaptor() {
     if (adaptor == null) {
-      throw new IllegalStateException(
-          "Locales adaptor not configured (resource constructed without injection)");
+      // Misconfiguration — not a transient handler failure (align with Slots/Keywords)
+      throw new WebApplicationException(
+          "Locales adaptor not configured", Response.Status.SERVICE_UNAVAILABLE);
     }
     return adaptor;
   }

--- a/rest/src/main/java/com/percussion/rest/locales/LocalesResource.java
+++ b/rest/src/main/java/com/percussion/rest/locales/LocalesResource.java
@@ -50,7 +50,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 @Tag(name = "Locales", description = "CMS locale design catalog (read-only)")
 public class LocalesResource {
 
-  private static final Logger log = LogManager.getLogger(LocalesResource.class);
+  /**
+   * Package-private and non-final so unit tests can install a mock {@link Logger} and assert
+   * unexpected-failure diagnostics (log4j-core ListAppender is not on the rest test classpath).
+   */
+  static Logger log = LogManager.getLogger(LocalesResource.class);
 
   private final ILocalesAdaptor adaptor;
 
@@ -138,7 +142,7 @@ public class LocalesResource {
 
   private ILocalesAdaptor requireAdaptor() {
     if (adaptor == null) {
-      // Misconfiguration — not a transient handler failure (align with Slots/Keywords)
+      // Misconfiguration — not a transient handler failure (align with slots/keywords)
       throw new WebApplicationException(
           "Locales adaptor not configured", Response.Status.SERVICE_UNAVAILABLE);
     }

--- a/rest/src/test/java/com/percussion/rest/locales/LocalesResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/locales/LocalesResourceTest.java
@@ -23,7 +23,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -31,6 +33,8 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.util.List;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -40,14 +44,25 @@ public class LocalesResourceTest {
 
   private ILocalesAdaptor adaptor;
   private LocalesResource resource;
+  private Logger previousLog;
+  private Logger mockLog;
 
   @BeforeEach
   public void setUp() {
+    previousLog = LocalesResource.log;
+    mockLog = mock(Logger.class);
+    LocalesResource.log = mockLog;
+
     adaptor = mock(ILocalesAdaptor.class);
     resource = new LocalesResource(adaptor);
     UriInfo uriInfo = mock(UriInfo.class);
     when(uriInfo.getBaseUri()).thenReturn(URI.create("http://localhost/services/"));
     resource.setUriInfo(uriInfo);
+  }
+
+  @AfterEach
+  public void restoreLog() {
+    LocalesResource.log = previousLog;
   }
 
   @Test
@@ -63,6 +78,7 @@ public class LocalesResourceTest {
     assertEquals("en-us", out.get(0).getLanguageString());
     assertEquals(Boolean.TRUE, out.get(0).getHasFormatProfile());
     verify(adaptor).listLocales(any());
+    verify(mockLog, never()).error(any(String.class), any(), any(), any());
   }
 
   @Test
@@ -80,6 +96,12 @@ public class LocalesResourceTest {
         assertThrows(WebApplicationException.class, () -> resource.listLocales());
     assertEquals(500, ex.getResponse().getStatus());
     assertSame(boom, ex.getCause());
+    verify(mockLog)
+        .error(
+            eq("Failed to list locales ({}): {}"),
+            eq(IllegalStateException.class.getName()),
+            eq("boom"),
+            same(boom));
   }
 
   @Test
@@ -88,6 +110,8 @@ public class LocalesResourceTest {
     WebApplicationException ex =
         assertThrows(WebApplicationException.class, bare::listLocales);
     assertEquals(503, ex.getResponse().getStatus());
+    // Misconfiguration path must not log as unexpected failure
+    verify(mockLog, never()).error(any(String.class), any(), any(), any());
   }
 
   @Test
@@ -97,6 +121,7 @@ public class LocalesResourceTest {
     WebApplicationException ex =
         assertThrows(WebApplicationException.class, () -> bare.getLocale("any"));
     assertEquals(503, ex.getResponse().getStatus());
+    verify(mockLog, never()).error(any(String.class), any(), any(), any());
   }
 
   @Test
@@ -109,6 +134,7 @@ public class LocalesResourceTest {
         assertThrows(WebApplicationException.class, () -> resource.getLocale("xx"));
     assertSame(mapped, ex);
     assertEquals(404, ex.getResponse().getStatus());
+    verify(mockLog, never()).error(any(String.class), any(), any(), any());
   }
 
   @Test
@@ -129,6 +155,7 @@ public class LocalesResourceTest {
         assertThrows(WebApplicationException.class, () -> resource.getLocale("xx"));
     assertEquals(404, ex.getResponse().getStatus());
     assertEquals("Locale not found", ex.getMessage());
+    verify(mockLog, never()).error(any(String.class), any(), any(), any());
   }
 
   @Test
@@ -140,6 +167,13 @@ public class LocalesResourceTest {
         assertThrows(WebApplicationException.class, () -> resource.getLocale("en-us"));
     assertEquals(500, ex.getResponse().getStatus());
     assertSame(boom, ex.getCause());
+    verify(mockLog)
+        .error(
+            eq("Failed to load locale {} ({}): {}"),
+            eq("en-us"),
+            eq(IllegalStateException.class.getName()),
+            eq("cms down"),
+            same(boom));
   }
 
   private static LocalesResource newLocalesResourceWithoutAdaptor() {

--- a/rest/src/test/java/com/percussion/rest/locales/LocalesResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/locales/LocalesResourceTest.java
@@ -18,9 +18,9 @@
 package com.percussion.rest.locales;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.UriInfo;
-import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,18 +42,16 @@ public class LocalesResourceTest {
   private LocalesResource resource;
 
   @BeforeEach
-  public void setUp() throws Exception {
+  public void setUp() {
     adaptor = mock(ILocalesAdaptor.class);
     resource = new LocalesResource(adaptor);
     UriInfo uriInfo = mock(UriInfo.class);
     when(uriInfo.getBaseUri()).thenReturn(URI.create("http://localhost/services/"));
-    Field f = LocalesResource.class.getDeclaredField("uriInfo");
-    f.setAccessible(true);
-    f.set(resource, uriInfo);
+    resource.setUriInfo(uriInfo);
   }
 
   @Test
-  public void listLocalesDelegatesToAdaptor() {
+  public void listLocalesSuccess() {
     LocaleSummary s = new LocaleSummary();
     s.setLanguageString("en-us");
     s.setBaseLocale(false);
@@ -69,7 +66,13 @@ public class LocalesResourceTest {
   }
 
   @Test
-  public void listLocalesWrapsFailures() {
+  public void listLocalesEmpty() {
+    when(adaptor.listLocales(any())).thenReturn(List.of());
+    assertTrue(resource.listLocales().isEmpty());
+  }
+
+  @Test
+  public void listLocalesWrapsUnexpectedFailuresAs500() {
     IllegalStateException boom = new IllegalStateException("boom");
     when(adaptor.listLocales(any())).thenThrow(boom);
 
@@ -80,11 +83,32 @@ public class LocalesResourceTest {
   }
 
   @Test
-  public void listLocalesWithoutInjectionFailsWithDiagnostic() {
-    LocalesResource bare = new LocalesResource();
-    WebApplicationException ex = assertThrows(WebApplicationException.class, bare::listLocales);
-    assertEquals(500, ex.getResponse().getStatus());
-    assertInstanceOf(IllegalStateException.class, ex.getCause());
+  public void missingAdaptorReturnsServiceUnavailableOnList() {
+    LocalesResource bare = newLocalesResourceWithoutAdaptor();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, bare::listLocales);
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnGet() {
+    // getLocale must rethrow WebApplicationException from requireAdaptor (not re-wrap as 500)
+    LocalesResource bare = newLocalesResourceWithoutAdaptor();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.getLocale("any"));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void getLocaleRethrowsWebApplicationException() {
+    WebApplicationException mapped =
+        new WebApplicationException("from adaptor", 404);
+    when(adaptor.getLocale(any(), eq("xx"))).thenThrow(mapped);
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.getLocale("xx"));
+    assertSame(mapped, ex);
+    assertEquals(404, ex.getResponse().getStatus());
   }
 
   @Test
@@ -116,5 +140,13 @@ public class LocalesResourceTest {
         assertThrows(WebApplicationException.class, () -> resource.getLocale("en-us"));
     assertEquals(500, ex.getResponse().getStatus());
     assertSame(boom, ex.getCause());
+  }
+
+  private static LocalesResource newLocalesResourceWithoutAdaptor() {
+    LocalesResource bare = new LocalesResource();
+    UriInfo uriInfo = mock(UriInfo.class);
+    when(uriInfo.getBaseUri()).thenReturn(URI.create("http://localhost/services/"));
+    bare.setUriInfo(uriInfo);
+    return bare;
   }
 }


### PR DESCRIPTION
## Summary
Slice **C1 locales** for parent tracker **#2117** (epic **#1694** / **#1690**).

- **`LocalesResource.requireAdaptor()`**: null adaptor now throws `WebApplicationException` with **503 SERVICE_UNAVAILABLE** (peer to Slots/Keywords), instead of `IllegalStateException` rewrapped as 500.
- Package-private `setUriInfo` test hook; error logging on unexpected failures; OpenAPI 503.
- **`LocalesResourceTest`** hardened: list success/empty, exception→500, bare-ctor 503 on list and get, get rethrows `WebApplicationException`, detail success/404/500.

**No sitemanage rewrites** — live stack not available this session.

## Fixes / Partial
- **Fixes #2126** (unit harden + 503 mapping).
- Live QA residual: **#2140** for `GET /services/locales` live **2xx** after redeploy.

Parent trackers: #2117, #1694

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] `cd rest && ../mvnw clean install` (standalone) — **PASS**
- [x] `LocalesResourceTest` — 9 tests, 0 failures
- [x] Full rest Surefire suite green
- [ ] Live `GET /services/locales` 2xx on QA — residual #2140

## Gates evidence
| Gate | Result |
|------|--------|
| A) Behavioral unit tests | list/empty/500/503 list+get/WAE rethrow/404 |
| B) Erlang self-review | Peer-aligned 503; WAE not re-wrapped; no path I/O |
| C) Module clean install | `rest` standalone green |
| D) In-scope only | 2 files under `rest/.../locales/` |

## Residual
- #2140 — live `GET /services/locales` 2xx / stack after redeploy
