### PR TITLE
fix(rest): SearchResource requireAdaptor 503 + unit tests (#2127)

### DIFF
--- a/rest/src/main/java/com/percussion/rest/searches/SearchResource.java
+++ b/rest/src/main/java/com/percussion/rest/searches/SearchResource.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,6 +57,7 @@ public class SearchResource {
             description = "OK",
             content =
                 @Content(array = @ArraySchema(schema = @Schema(implementation = SearchDef.class)))),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public List<SearchDef> listSearches() {
@@ -83,6 +85,7 @@ public class SearchResource {
             description = "OK",
             content = @Content(schema = @Schema(implementation = SearchDef.class))),
         @ApiResponse(responseCode = "404", description = "Search not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public SearchDef getSearch(@PathParam("idOrName") String idOrName) {
@@ -93,6 +96,7 @@ public class SearchResource {
       }
       return search;
     } catch (WebApplicationException e) {
+      // Preserve mapped HTTP errors (e.g. 503 misconfiguration from requireAdaptor)
       throw e;
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
@@ -101,8 +105,9 @@ public class SearchResource {
 
   private ISearchAdaptor requireAdaptor() {
     if (adaptor == null) {
-      throw new IllegalStateException(
-          "Search adaptor not configured (resource constructed without injection)");
+      // Misconfiguration — not a transient handler failure (align with Slots/Locales/Keywords)
+      throw new WebApplicationException(
+          "Search adaptor not configured", Response.Status.SERVICE_UNAVAILABLE);
     }
     return adaptor;
   }

--- a/rest/src/test/java/com/percussion/rest/searches/SearchResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/searches/SearchResourceTest.java
@@ -5,7 +5,6 @@
 package com.percussion.rest.searches;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -33,19 +32,59 @@ public class SearchResourceTest {
   }
 
   @Test
-  public void listSearchesDelegates() {
+  public void listSearchesSuccess() {
     SearchDef s = new SearchDef();
     s.setName("All Content");
     when(adaptor.listSearches()).thenReturn(List.of(s));
     List<SearchDef> out = resource.listSearches();
     assertEquals(1, out.size());
     assertEquals("All Content", out.get(0).getName());
+    verify(adaptor).listSearches();
   }
 
   @Test
   public void listSearchesNullSafe() {
     when(adaptor.listSearches()).thenReturn(null);
     assertTrue(resource.listSearches().isEmpty());
+  }
+
+  @Test
+  public void listSearchesWrapsUnexpectedFailuresAs500() {
+    IllegalStateException boom = new IllegalStateException("boom");
+    when(adaptor.listSearches()).thenThrow(boom);
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.listSearches());
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(boom, ex.getCause());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnList() {
+    SearchResource bare = new SearchResource();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, bare::listSearches);
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnGet() {
+    // getSearch must rethrow WebApplicationException from requireAdaptor (not re-wrap as 500)
+    SearchResource bare = new SearchResource();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.getSearch("any"));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void getSearchRethrowsWebApplicationException() {
+    WebApplicationException mapped = new WebApplicationException("from adaptor", 404);
+    when(adaptor.findSearchByKey(eq("xx"))).thenThrow(mapped);
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.getSearch("xx"));
+    assertSame(mapped, ex);
+    assertEquals(404, ex.getResponse().getStatus());
   }
 
   @Test
@@ -74,18 +113,5 @@ public class SearchResourceTest {
         assertThrows(WebApplicationException.class, () -> resource.getSearch("All Content"));
     assertEquals(500, ex.getResponse().getStatus());
     assertSame(boom, ex.getCause());
-  }
-
-  @Test
-  public void withoutInjectionFailsWithDiagnostic() {
-    SearchResource bare = new SearchResource();
-    WebApplicationException listEx =
-        assertThrows(WebApplicationException.class, bare::listSearches);
-    assertEquals(500, listEx.getResponse().getStatus());
-    assertInstanceOf(IllegalStateException.class, listEx.getCause());
-    WebApplicationException getEx =
-        assertThrows(WebApplicationException.class, () -> bare.getSearch("x"));
-    assertEquals(500, getEx.getResponse().getStatus());
-    assertInstanceOf(IllegalStateException.class, getEx.getCause());
   }
 }


### PR DESCRIPTION
## Summary
Issue **#2127** — parent **#2117** / epic **#1694** slice **C2** (`GET /services/searches`).

Thin rest-only alignment with Slots/Locales peers (same pattern as #2126 C1):

- `SearchResource.requireAdaptor()` null → `WebApplicationException` **503** `SERVICE_UNAVAILABLE` (was `IllegalStateException` re-wrapped as 500)
- OpenAPI documents 503 on list/get
- `getSearch` documents rethrow of mapped `WebApplicationException` (preserves 503)
- Harden `SearchResourceTest` to peer `SlotsResourceDetailTest` / `LocalesResourceTest`:
  - list success, null-safe, exception→500
  - bare adaptor → 503 on list and get
  - get rethrows adaptor WAE, delegates, 404, exception→500

No sitemanage / mega-PR across C siblings.

## Residual
Live QA 2xx after redeploy: **#2142**

## Test plan
- [x] `cd rest && ../mvnw clean install` (standalone) — BUILD SUCCESS
- [x] `SearchResourceTest` — 9 tests, 0 failures
- [x] Erlang-style self-review: no path I/O; behavioral unit tests for 503/500/404 paths; peer closure (resource + mock unit test only for this change class)
- Spotless: optional (not AGENTS hard gate); in-scope style matches peers

## Gates evidence
| Gate | Result |
|------|--------|
| A Implement + unit tests | Done |
| B Erlang self-review | Pass (no bugs / portable-path N/A) |
| C rest `mvnw clean install` | BUILD SUCCESS |
| D In-scope commit only | 2 files under rest searches |
| E Commit refs #2127 | a6b9bb05db |
| F Operator labels | operator:grok, operator:night-issue-prs, model:grok-4.5 |
| G PR base main | this PR |
| H Do not merge | agent will not merge |
| I Residual | #2142 |
| L No docs/ai-generated progress trackers | progress on GH issues only |

**Operator:** Grok: night-issue-prs (model grok-4.5)

Fixes #2127 (unit-test harden + 503 alignment; live 2xx tracked in #2142)
Partial for live endpoint 2xx on QA until #2142 closed.

> Co-Authored by Grok Build using grok-4.5 with agent main.