### PR TITLE
fix(rest): ViewResource requireAdaptor null→503 + unit tests (#2128)

### DIFF
--- a/rest/src/main/java/com/percussion/rest/views/ViewResource.java
+++ b/rest/src/main/java/com/percussion/rest/views/ViewResource.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,6 +55,7 @@ public class ViewResource {
             description = "OK",
             content =
                 @Content(array = @ArraySchema(schema = @Schema(implementation = ViewDef.class)))),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public List<ViewDef> listViews() {
@@ -81,6 +83,7 @@ public class ViewResource {
             description = "OK",
             content = @Content(schema = @Schema(implementation = ViewDef.class))),
         @ApiResponse(responseCode = "404", description = "View not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public ViewDef getView(@PathParam("idOrName") String idOrName) {
@@ -91,6 +94,7 @@ public class ViewResource {
       }
       return view;
     } catch (WebApplicationException e) {
+      // Preserve mapped HTTP errors (e.g. 503 misconfiguration from requireAdaptor)
       throw e;
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
@@ -99,8 +103,9 @@ public class ViewResource {
 
   private IViewAdaptor requireAdaptor() {
     if (adaptor == null) {
-      throw new IllegalStateException(
-          "View adaptor not configured (resource constructed without injection)");
+      // Misconfiguration — not a transient handler failure (align with Slots/Locales/Keywords/Searches)
+      throw new WebApplicationException(
+          "View adaptor not configured", Response.Status.SERVICE_UNAVAILABLE);
     }
     return adaptor;
   }

--- a/rest/src/test/java/com/percussion/rest/views/ViewResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/views/ViewResourceTest.java
@@ -5,7 +5,6 @@
 package com.percussion.rest.views;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -33,17 +32,59 @@ public class ViewResourceTest {
   }
 
   @Test
-  public void listViewsDelegates() {
+  public void listViewsSuccess() {
     ViewDef v = new ViewDef();
     v.setName("My View");
     when(adaptor.listViews()).thenReturn(List.of(v));
-    assertEquals("My View", resource.listViews().get(0).getName());
+    List<ViewDef> out = resource.listViews();
+    assertEquals(1, out.size());
+    assertEquals("My View", out.get(0).getName());
+    verify(adaptor).listViews();
   }
 
   @Test
   public void listViewsNullSafe() {
     when(adaptor.listViews()).thenReturn(null);
     assertTrue(resource.listViews().isEmpty());
+  }
+
+  @Test
+  public void listViewsWrapsUnexpectedFailuresAs500() {
+    IllegalStateException boom = new IllegalStateException("boom");
+    when(adaptor.listViews()).thenThrow(boom);
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.listViews());
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(boom, ex.getCause());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnList() {
+    ViewResource bare = new ViewResource();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, bare::listViews);
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnGet() {
+    // getView must rethrow WebApplicationException from requireAdaptor (not re-wrap as 500)
+    ViewResource bare = new ViewResource();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.getView("any"));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void getViewRethrowsWebApplicationException() {
+    WebApplicationException mapped = new WebApplicationException("from adaptor", 404);
+    when(adaptor.findViewByKey(eq("xx"))).thenThrow(mapped);
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.getView("xx"));
+    assertSame(mapped, ex);
+    assertEquals(404, ex.getResponse().getStatus());
   }
 
   @Test
@@ -72,17 +113,5 @@ public class ViewResourceTest {
         assertThrows(WebApplicationException.class, () -> resource.getView("My View"));
     assertEquals(500, ex.getResponse().getStatus());
     assertSame(boom, ex.getCause());
-  }
-
-  @Test
-  public void withoutInjectionFailsWithDiagnostic() {
-    ViewResource bare = new ViewResource();
-    WebApplicationException listEx = assertThrows(WebApplicationException.class, bare::listViews);
-    assertEquals(500, listEx.getResponse().getStatus());
-    assertInstanceOf(IllegalStateException.class, listEx.getCause());
-    WebApplicationException getEx =
-        assertThrows(WebApplicationException.class, () -> bare.getView("x"));
-    assertEquals(500, getEx.getResponse().getStatus());
-    assertInstanceOf(IllegalStateException.class, getEx.getCause());
   }
 }


### PR DESCRIPTION
## Summary
**Slice C3** of parent tracker **#2117** (epic **#1694**): harden `GET /services/views` resource path.

- `ViewResource.requireAdaptor()`: null adaptor → `WebApplicationException` **503 SERVICE_UNAVAILABLE** (misconfiguration), matching Slots/Locales/Keywords/Searches peers. Previously threw `IllegalStateException` which the handlers re-wrapped as **500**.
- OpenAPI annotations document **503** on list + detail.
- `ViewResourceTest` hardened to the slots/keywords peer ladder: list success, null-safe list, unexpected 500, missing-adaptor 503 on list/get (rethrow, not re-wrap), WAE rethrow from adaptor, 404, get 500 wrap.

**Rest-only.** No sitemanage multi-module product fix without a live stack (per #2128 / #2117 approach).

## Live residual
- #2144 — confirm `GET /services/views` **2xx** on QA after redeploy, or capture stack.

## Test plan
- [x] `cd rest && ../mvnw clean install` (standalone) — green
- [x] `ViewResourceTest`: 9 tests, 0 failures
- [x] Erlang self-review: approve (no path I/O; peer pattern match)

## Gates evidence
| Gate | Result |
|------|--------|
| A Implement + behavioral unit tests | Yes |
| B Erlang self-review | Approve |
| C rest `mvnw clean install` | Pass |
| D In-scope files only | 2 files under `rest/.../views/` |
| Spotless | Optional per AGENTS.md (not hard gate); not run |

## Fixes / Partial
**Partial for #2128** — unit-test harden + requireAdaptor 503 complete. Live QA 2xx tracked in residual **#2144**.

Parent trackers: #2117 #1694

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.