### PR TITLE
fix(rest): ExtensionsResource requireAdaptor null→503 + unit tests (#2129)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2129-extensions-catalog-503-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2129-extensions-catalog-503-erlang.md
@@ -1,0 +1,26 @@
+# Erlang review: fix/issue-2129-extensions-catalog-503
+
+## Summary
+Align `ExtensionsResource` with View/Slots peers: constructor-inject `IExtensionAdaptor`, `requireAdaptor()` returns **503 SERVICE_UNAVAILABLE** (not `IllegalStateException` → 500) when uninjected, catalog list/detail rethrow `WebApplicationException`, unexpected failures stay 500, null list → empty. Harden `ExtensionsResourceTest` to the peer ladder (success, null-safe, list 500 wrap, missing-adaptor 503 on list+get, WAE rethrow, 404, get 500 wrap). OpenAPI documents 503. `getExtensions` (POST /list) also uses `requireAdaptor` + same catch ladder for consistency.
+
+## Scope
+- Branch: `fix/issue-2129-extensions-catalog-503` vs `origin/main`
+- Files: `rest/.../extensions/ExtensionsResource.java`, `rest/.../extensions/ExtensionsResourceTest.java`
+- Module: rest only (standalone `mvnw clean install` BUILD SUCCESS)
+- Cross-platform path review: N/A (no file I/O / paths)
+- Prior peer: issue #2128 ViewResource 503 align
+
+## Recommendation
+approve
+
+## Gate
+May commit/push: **yes**
+
+## Issues
+None (bug/suggestion/nit).
+
+### Checklist
+- [x] Behavioral unit tests for new/changed logic (503 ladder + rethrow + 500 wrap + null-safe)
+- [x] Peer pattern match (ViewResource / SlotsResource)
+- [x] No portable-path concerns
+- [x] No multi-module sprawl / ExtensionAdaptor rewrite without live stack

--- a/rest/src/main/java/com/percussion/rest/extensions/ExtensionsResource.java
+++ b/rest/src/main/java/com/percussion/rest/extensions/ExtensionsResource.java
@@ -36,6 +36,7 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
@@ -51,12 +52,26 @@ import org.springframework.beans.factory.annotation.Autowired;
 @Tag(name = "Extensions", description = "Extension operations")
 public class ExtensionsResource {
 
-  @Autowired private IExtensionAdaptor adaptor;
+  private final IExtensionAdaptor adaptor;
 
   @Context private UriInfo uriInfo;
 
+  /**
+   * No-arg constructor for bean-discovery edge cases. Production uses {@link
+   * #ExtensionsResource(IExtensionAdaptor)}; catalog methods call {@link #requireAdaptor()}.
+   */
   public ExtensionsResource() {
-    // Default constructor
+    this.adaptor = null;
+  }
+
+  @Autowired
+  public ExtensionsResource(IExtensionAdaptor adaptor) {
+    this.adaptor = adaptor;
+  }
+
+  /** Package-private test hook so unit tests need not reflect on {@code uriInfo}. */
+  void setUriInfo(UriInfo uriInfo) {
+    this.uriInfo = uriInfo;
   }
 
   /**
@@ -79,6 +94,7 @@ public class ExtensionsResource {
             description = "OK",
             content =
                 @Content(array = @ArraySchema(schema = @Schema(implementation = Extension.class)))),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public List<Extension> listExtensionsCatalog() {
@@ -86,6 +102,7 @@ public class ExtensionsResource {
       List<Extension> list = requireAdaptor().listExtensions(uriInfo.getBaseUri());
       return list != null ? list : List.of();
     } catch (WebApplicationException e) {
+      // Preserve mapped HTTP errors (e.g. 503 misconfiguration from requireAdaptor)
       throw e;
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
@@ -107,6 +124,7 @@ public class ExtensionsResource {
             description = "OK",
             content = @Content(schema = @Schema(implementation = Extension.class))),
         @ApiResponse(responseCode = "404", description = "Extension not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public Extension getExtensionCatalogItem(
@@ -120,6 +138,7 @@ public class ExtensionsResource {
       }
       return ext;
     } catch (WebApplicationException e) {
+      // Preserve mapped HTTP errors (e.g. 503 misconfiguration from requireAdaptor)
       throw e;
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
@@ -128,8 +147,9 @@ public class ExtensionsResource {
 
   private IExtensionAdaptor requireAdaptor() {
     if (adaptor == null) {
-      throw new IllegalStateException(
-          "Extension adaptor not configured (resource constructed without injection)");
+      // Misconfiguration — not a transient handler failure (align with View/Slots/Locales peers)
+      throw new WebApplicationException(
+          "Extension adaptor not configured", Response.Status.SERVICE_UNAVAILABLE);
     }
     return adaptor;
   }
@@ -153,6 +173,7 @@ public class ExtensionsResource {
             description = "OK",
             content =
                 @Content(array = @ArraySchema(schema = @Schema(implementation = Extension.class)))),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
         @ApiResponse(responseCode = "404", description = "No Extensions found")
       })
   public List<Extension> getExtensions(
@@ -161,7 +182,13 @@ public class ExtensionsResource {
               description = "An extension filter options object",
               required = true)
           ExtensionFilterOptions filter) {
-    var extensions = adaptor.getExtensions(uriInfo.getBaseUri(), filter);
-    return new ExtensionList(extensions);
+    try {
+      var extensions = requireAdaptor().getExtensions(uriInfo.getBaseUri(), filter);
+      return new ExtensionList(extensions);
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
   }
 }

--- a/rest/src/test/java/com/percussion/rest/extensions/ExtensionsResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/extensions/ExtensionsResourceTest.java
@@ -5,7 +5,6 @@
 package com.percussion.rest.extensions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -31,17 +30,12 @@ public class ExtensionsResourceTest {
   private UriInfo uriInfo;
 
   @BeforeEach
-  public void setUp() throws Exception {
+  public void setUp() {
     adaptor = mock(IExtensionAdaptor.class);
     uriInfo = mock(UriInfo.class);
     when(uriInfo.getBaseUri()).thenReturn(URI.create("http://localhost/"));
-    resource = new ExtensionsResource();
-    var af = ExtensionsResource.class.getDeclaredField("adaptor");
-    af.setAccessible(true);
-    af.set(resource, adaptor);
-    var uf = ExtensionsResource.class.getDeclaredField("uriInfo");
-    uf.setAccessible(true);
-    uf.set(resource, uriInfo);
+    resource = new ExtensionsResource(adaptor);
+    resource.setUriInfo(uriInfo);
   }
 
   @Test
@@ -52,12 +46,57 @@ public class ExtensionsResourceTest {
     List<Extension> out = resource.listExtensionsCatalog();
     assertEquals(1, out.size());
     assertEquals("sys_add", out.get(0).getExtensionName());
+    verify(adaptor).listExtensions(any());
   }
 
   @Test
   public void listExtensionsCatalogNullSafe() {
     when(adaptor.listExtensions(any())).thenReturn(null);
     assertTrue(resource.listExtensionsCatalog().isEmpty());
+  }
+
+  @Test
+  public void listExtensionsCatalogWrapsUnexpectedFailuresAs500() {
+    IllegalStateException boom = new IllegalStateException("boom");
+    when(adaptor.listExtensions(any())).thenThrow(boom);
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.listExtensionsCatalog());
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(boom, ex.getCause());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnList() {
+    ExtensionsResource bare = new ExtensionsResource();
+    bare.setUriInfo(uriInfo);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, bare::listExtensionsCatalog);
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnGet() {
+    // getExtensionCatalogItem must rethrow WebApplicationException from requireAdaptor (not
+    // re-wrap as 500)
+    ExtensionsResource bare = new ExtensionsResource();
+    bare.setUriInfo(uriInfo);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> bare.getExtensionCatalogItem("any"));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void getExtensionCatalogItemRethrowsWebApplicationException() {
+    WebApplicationException mapped = new WebApplicationException("from adaptor", 404);
+    when(adaptor.findExtensionByKey(any(), eq("xx"))).thenThrow(mapped);
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.getExtensionCatalogItem("xx"));
+    assertSame(mapped, ex);
+    assertEquals(404, ex.getResponse().getStatus());
   }
 
   @Test
@@ -88,21 +127,5 @@ public class ExtensionsResourceTest {
             WebApplicationException.class, () -> resource.getExtensionCatalogItem("sys_add"));
     assertEquals(500, ex.getResponse().getStatus());
     assertSame(boom, ex.getCause());
-  }
-
-  @Test
-  public void withoutInjectionFailsWithDiagnostic() {
-    ExtensionsResource bare = new ExtensionsResource();
-    try {
-      var uf = ExtensionsResource.class.getDeclaredField("uriInfo");
-      uf.setAccessible(true);
-      uf.set(bare, uriInfo);
-    } catch (ReflectiveOperationException e) {
-      throw new RuntimeException(e);
-    }
-    WebApplicationException listEx =
-        assertThrows(WebApplicationException.class, bare::listExtensionsCatalog);
-    assertEquals(500, listEx.getResponse().getStatus());
-    assertInstanceOf(IllegalStateException.class, listEx.getCause());
   }
 }


### PR DESCRIPTION
## Summary
**#2117 / C4** — Harden `ExtensionsResource` for `GET /services/extensions/catalog` (+ catalog item) so missing adaptor is misconfiguration **503**, not `IllegalStateException` re-wrapped as 500. Align with View/Slots ctor-inject + `requireAdaptor()` peers. Behavioral unit tests cover success, null-safe list, unexpected 500, missing-adaptor 503 (list+get), WAE rethrow, and 404.

**Operator:** Grok: night-issue-prs (model grok-4.5)

Parent trackers: #2117 (slice C), epic #1694. Fixes #2129.

Live 2xx on QA is residual (no stack this session; unit-first per issue): **#2146**.

## Changes
- `ExtensionsResource`: final ctor-injected `IExtensionAdaptor`; no-arg leaves adaptor null; `requireAdaptor()` → `WebApplicationException` **503**; catalog list/detail rethrow WAE; `setUriInfo` test hook; OpenAPI 503; `POST /list` also uses requireAdaptor + catch ladder
- `ExtensionsResourceTest`: peer ladder tests (no field reflection)
- Erlang review note under `docs/ai-generated/code-reviews/`

## Test plan
- [x] `cd rest && ../mvnw clean install` — BUILD SUCCESS
- [x] `ExtensionsResourceTest` green (list/get success, null-safe, 500 wrap, 503 missing adaptor, WAE rethrow, 404)
- [ ] Live residual: `GET /services/extensions/catalog` 2xx after redeploy — #2146

## Gates evidence
- Erlang self-review: **approve** (`docs/ai-generated/code-reviews/issue-2129-extensions-catalog-503-erlang.md`)
- Standalone rest clean install: **pass**
- Spotless not required by AGENTS.md hard gates; style matches View/Slots peers
- No ExtensionAdaptor / IPSExtensionService rewrite without live stack

## Residual
- #2146 — live GET /services/extensions/catalog 2xx after redeploy (leave unassigned)