### PR TITLE
fix(rest): CE controls requireAdaptor null returns 503 (#2130)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2130-cecontrols-catalog-503-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2130-cecontrols-catalog-503-erlang.md
@@ -1,0 +1,44 @@
+# Erlang review: issue #2130 CE controls catalog 503
+
+**Branch:** `fix/issue-2130-cecontrols-catalog-503`  
+**Scope:** `rest/src/main/java/com/percussion/rest/cecontrols/ControlsResource.java`,  
+`rest/src/test/java/com/percussion/rest/cecontrols/ControlsResourceTest.java`  
+**Peers:** `ExtensionsResource` / `KeywordsResource` (`requireAdaptor` → 503)  
+**Parent:** #2117 / #1694 slice C5
+
+## Summary
+
+Align `ControlsResource.requireAdaptor()` misconfiguration with catalog peers: throw
+`WebApplicationException` **503 SERVICE_UNAVAILABLE** instead of `IllegalStateException`
+(previously re-wrapped as **500**). Document 503 in OpenAPI; rethrow comments on both
+handlers. Harden mocked unit tests for list/get success, null-safe list, 404, unexpected
+→500, WAE rethrow, bare no-arg ctor →503 on list and get.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs | none |
+| Behavioral unit tests for changed logic | yes (9 tests, all green) |
+| Non-portable path/file I/O | N/A (no path I/O) |
+| Change-class companions | rest resource + Mockito resource test only; no multi-module ControlAdaptor invent without stack (per issue) |
+| Standalone `rest` clean install | pass |
+
+**May commit/push: yes**
+
+## Issues
+
+None.
+
+## Cross-platform path review
+
+Not applicable — HTTP status / adaptor wiring only.
+
+## Test evidence
+
+- `cd rest && ../mvnw clean install` — BUILD SUCCESS  
+- `ControlsResourceTest`: tests=9, failures=0, errors=0

--- a/rest/src/main/java/com/percussion/rest/cecontrols/ControlsResource.java
+++ b/rest/src/main/java/com/percussion/rest/cecontrols/ControlsResource.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,6 +35,10 @@ public class ControlsResource {
 
   private final IControlAdaptor adaptor;
 
+  /**
+   * No-arg constructor for bean-discovery edge cases. Production uses {@link
+   * #ControlsResource(IControlAdaptor)}; catalog methods call {@link #requireAdaptor()}.
+   */
   public ControlsResource() {
     this.adaptor = null;
   }
@@ -57,6 +62,7 @@ public class ControlsResource {
             content =
                 @Content(
                     array = @ArraySchema(schema = @Schema(implementation = ControlDef.class)))),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public List<ControlDef> listControls() {
@@ -64,6 +70,7 @@ public class ControlsResource {
       List<ControlDef> list = requireAdaptor().listControls();
       return list != null ? list : List.of();
     } catch (WebApplicationException e) {
+      // Preserve mapped HTTP errors (e.g. 503 misconfiguration from requireAdaptor)
       throw e;
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
@@ -82,6 +89,7 @@ public class ControlsResource {
             description = "OK",
             content = @Content(schema = @Schema(implementation = ControlDef.class))),
         @ApiResponse(responseCode = "404", description = "Control not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public ControlDef getControl(@PathParam("name") String name) {
@@ -92,6 +100,7 @@ public class ControlsResource {
       }
       return def;
     } catch (WebApplicationException e) {
+      // Preserve mapped HTTP errors (e.g. 503 misconfiguration from requireAdaptor)
       throw e;
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
@@ -100,8 +109,9 @@ public class ControlsResource {
 
   private IControlAdaptor requireAdaptor() {
     if (adaptor == null) {
-      throw new IllegalStateException(
-          "Control adaptor not configured (resource constructed without injection)");
+      // Misconfiguration — not a transient handler failure (align with Extensions/Keywords peers)
+      throw new WebApplicationException(
+          "Control adaptor not configured", Response.Status.SERVICE_UNAVAILABLE);
     }
     return adaptor;
   }

--- a/rest/src/test/java/com/percussion/rest/cecontrols/ControlsResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/cecontrols/ControlsResourceTest.java
@@ -5,7 +5,6 @@
 package com.percussion.rest.cecontrols;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -37,13 +36,27 @@ public class ControlsResourceTest {
     ControlDef c = new ControlDef();
     c.setName("sys_EditBox");
     when(adaptor.listControls()).thenReturn(List.of(c));
-    assertEquals("sys_EditBox", resource.listControls().get(0).getName());
+    List<ControlDef> out = resource.listControls();
+    assertEquals(1, out.size());
+    assertEquals("sys_EditBox", out.get(0).getName());
+    verify(adaptor).listControls();
   }
 
   @Test
   public void listControlsNullSafe() {
     when(adaptor.listControls()).thenReturn(null);
     assertTrue(resource.listControls().isEmpty());
+  }
+
+  @Test
+  public void listControlsWrapsUnexpectedAs500() {
+    IllegalStateException boom = new IllegalStateException("boom");
+    when(adaptor.listControls()).thenThrow(boom);
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.listControls());
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(boom, ex.getCause());
   }
 
   @Test
@@ -75,11 +88,30 @@ public class ControlsResourceTest {
   }
 
   @Test
-  public void withoutInjectionFailsWithDiagnostic() {
+  public void getControlRethrowsWebApplicationException() {
+    WebApplicationException mapped = new WebApplicationException("from adaptor", 404);
+    when(adaptor.findControlByName(eq("xx"))).thenThrow(mapped);
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.getControl("xx"));
+    assertSame(mapped, ex);
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnList() {
     ControlsResource bare = new ControlsResource();
-    WebApplicationException listEx =
+    WebApplicationException ex =
         assertThrows(WebApplicationException.class, bare::listControls);
-    assertEquals(500, listEx.getResponse().getStatus());
-    assertInstanceOf(IllegalStateException.class, listEx.getCause());
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnGet() {
+    // getControl must rethrow WebApplicationException from requireAdaptor (not re-wrap as 500)
+    ControlsResource bare = new ControlsResource();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.getControl("any"));
+    assertEquals(503, ex.getResponse().getStatus());
   }
 }


### PR DESCRIPTION
## Summary

**Issue:** #2130 (Parent #2117 / Epic #1694 slice C5 — CE controls catalog)

Align `ControlsResource.requireAdaptor()` with Extensions/Keywords catalog peers: missing adaptor is **503 Service Unavailable** (misconfiguration), not **500** from wrapping `IllegalStateException`.

- `requireAdaptor()` throws `WebApplicationException(..., Response.Status.SERVICE_UNAVAILABLE)`
- OpenAPI documents 503 on list + get
- Explicit rethrow comments so 503 is not re-wrapped as 500
- Harden mocked `ControlsResourceTest` (list/get success, null-safe, 404, exception→500, WAE rethrow, bare 503)

**Out of scope (per issue):** No `ControlAdaptor` multi-module invent without live QA stack. Live `GET /services/cecontrols` 2xx residual remains stack-driven if still failing after wiring.

**Operator:** Grok: night-issue-prs (model grok-4.5)

**Parent trackers:** #2117, #1694

## Test plan

- [x] `ControlsResourceTest` — 9 tests, 0 failures (list/get, null-safe, 404, 500, bare 503)
- [x] Standalone `cd rest && ../mvnw clean install` — BUILD SUCCESS
- [x] Erlang strict self-review — approve (report: `docs/ai-generated/code-reviews/issue-2130-cecontrols-catalog-503-erlang.md`)
- Spotless not required by AGENTS.md pre-PR gates (optional only)

## Gates evidence

| Gate | Evidence |
|------|----------|
| A Implement + behavioral tests | requireAdaptor 503 + 9 unit tests |
| B Erlang self-review | approve; no bugs / path I/O |
| C Module clean install | `rest` standalone green |
| D In-scope commit only | resource + test + erlang report |
| E Issue ref | Fixes #2130 |
| F Operator labels | operator:grok, operator:night-issue-prs, model:grok-4.5 |

Fixes #2130