### PR TITLE
fix(rest): serverconfigs requireAdaptor returns 503 (#2131)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2131-serverconfigs-catalog-503-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2131-serverconfigs-catalog-503-erlang.md
@@ -1,0 +1,56 @@
+# Erlang review: issue #2131 serverconfigs catalog 503
+
+**Date:** 2026-08-06  
+**Branch:** `fix/issue-2131-serverconfigs-catalog-503`  
+**Reviewer persona:** Erlang (pre-commit gate)  
+**Recommendation:** approve  
+**Gate:** May commit/push: **yes**
+
+## Summary
+
+Aligns `ServerConfigsResource.requireAdaptor()` with catalog peers (`ControlsResource`,
+`KeywordsResource`, `SlotsResource`): missing adaptor is **503 Service Unavailable** via
+`WebApplicationException`, not `IllegalStateException` wrapped as 500. OpenAPI documents 503.
+`ServerConfigsResourceTest` hardened to the peer ladder (delegate, null-safe, 500 wrap, WAE
+rethrow, 503 bare resource on list + get).
+
+## Scope
+
+| Item | Value |
+|------|--------|
+| Files | `rest/src/main/java/com/percussion/rest/serverconfigs/ServerConfigsResource.java` |
+| | `rest/src/test/java/com/percussion/rest/serverconfigs/ServerConfigsResourceTest.java` |
+| Base | `origin/main` |
+| Prior report / memory | Peer slice C5-style cecontrols (#2130) pattern; catalog requireAdaptor→503 |
+| Cross-platform path review | N/A — no file I/O or path handling in diff |
+
+## Issues
+
+None (no `bug`, no missing behavioral tests for changed logic, no path concerns).
+
+### Notes (not gate-blocking)
+
+- **suggestion (out of scope):** Live QA `GET /services/serverconfigs` 2xx and any
+  `@Lazy` / `IPSSystemService` wiring remain residual without stack evidence (per issue body).
+- **nit:** `listConfigs` does not have a dedicated “rethrow WAE from adaptor” test; peer
+  `ControlsResourceTest` also only asserts rethrow on get; list bare-resource 503 covers the
+  requireAdaptor path used by list.
+
+## Verification
+
+- `cd rest && ../mvnw.cmd clean install` — exit 0
+- `ServerConfigsResourceTest`: Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
+
+## Change-class companions
+
+| Companion | Status |
+|-----------|--------|
+| Resource `requireAdaptor` → 503 | Done |
+| OpenAPI 503 responses | Done |
+| Mockito resource unit tests (peer ladder) | Done |
+| Rest Spring `TestServerConfigAdaptor` stub | Pre-existing; unchanged |
+| sitemanage `ServerConfigAdaptor` rework | Out of scope without live stack |
+
+## Operator
+
+Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/rest/src/main/java/com/percussion/rest/serverconfigs/ServerConfigsResource.java
+++ b/rest/src/main/java/com/percussion/rest/serverconfigs/ServerConfigsResource.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,6 +35,10 @@ public class ServerConfigsResource {
 
   private final IServerConfigAdaptor adaptor;
 
+  /**
+   * No-arg constructor for bean-discovery edge cases. Production uses {@link
+   * #ServerConfigsResource(IServerConfigAdaptor)}; catalog methods call {@link #requireAdaptor()}.
+   */
   public ServerConfigsResource() {
     this.adaptor = null;
   }
@@ -59,6 +64,7 @@ public class ServerConfigsResource {
                     array =
                         @ArraySchema(
                             schema = @Schema(implementation = ServerConfigSummary.class)))),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public List<ServerConfigSummary> listConfigs() {
@@ -66,6 +72,7 @@ public class ServerConfigsResource {
       List<ServerConfigSummary> list = requireAdaptor().listConfigs();
       return list != null ? list : List.of();
     } catch (WebApplicationException e) {
+      // Preserve mapped HTTP errors (e.g. 503 misconfiguration from requireAdaptor)
       throw e;
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
@@ -86,6 +93,7 @@ public class ServerConfigsResource {
             description = "OK",
             content = @Content(schema = @Schema(implementation = ServerConfigSummary.class))),
         @ApiResponse(responseCode = "404", description = "Configuration not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public ServerConfigSummary getConfig(@PathParam("name") String name) {
@@ -96,6 +104,7 @@ public class ServerConfigsResource {
       }
       return cfg;
     } catch (WebApplicationException e) {
+      // Preserve mapped HTTP errors (e.g. 503 misconfiguration from requireAdaptor)
       throw e;
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
@@ -104,8 +113,9 @@ public class ServerConfigsResource {
 
   private IServerConfigAdaptor requireAdaptor() {
     if (adaptor == null) {
-      throw new IllegalStateException(
-          "Server config adaptor not configured (resource constructed without injection)");
+      // Misconfiguration — not a transient handler failure (align with Extensions/Keywords peers)
+      throw new WebApplicationException(
+          "Server config adaptor not configured", Response.Status.SERVICE_UNAVAILABLE);
     }
     return adaptor;
   }

--- a/rest/src/test/java/com/percussion/rest/serverconfigs/ServerConfigsResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/serverconfigs/ServerConfigsResourceTest.java
@@ -5,7 +5,6 @@
 package com.percussion.rest.serverconfigs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -37,13 +36,27 @@ public class ServerConfigsResourceTest {
     ServerConfigSummary s = new ServerConfigSummary();
     s.setName("LOG_CONFIG");
     when(adaptor.listConfigs()).thenReturn(List.of(s));
-    assertEquals("LOG_CONFIG", resource.listConfigs().get(0).getName());
+    List<ServerConfigSummary> out = resource.listConfigs();
+    assertEquals(1, out.size());
+    assertEquals("LOG_CONFIG", out.get(0).getName());
+    verify(adaptor).listConfigs();
   }
 
   @Test
   public void listConfigsNullSafe() {
     when(adaptor.listConfigs()).thenReturn(null);
     assertTrue(resource.listConfigs().isEmpty());
+  }
+
+  @Test
+  public void listConfigsWrapsUnexpectedAs500() {
+    IllegalStateException boom = new IllegalStateException("boom");
+    when(adaptor.listConfigs()).thenThrow(boom);
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.listConfigs());
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(boom, ex.getCause());
   }
 
   @Test
@@ -75,10 +88,30 @@ public class ServerConfigsResourceTest {
   }
 
   @Test
-  public void withoutInjectionFailsWithDiagnostic() {
+  public void getConfigRethrowsWebApplicationException() {
+    WebApplicationException mapped = new WebApplicationException("from adaptor", 404);
+    when(adaptor.findConfigByName(eq("xx"))).thenThrow(mapped);
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.getConfig("xx"));
+    assertSame(mapped, ex);
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnList() {
     ServerConfigsResource bare = new ServerConfigsResource();
-    WebApplicationException listEx = assertThrows(WebApplicationException.class, bare::listConfigs);
-    assertEquals(500, listEx.getResponse().getStatus());
-    assertInstanceOf(IllegalStateException.class, listEx.getCause());
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, bare::listConfigs);
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnGet() {
+    // getConfig must rethrow WebApplicationException from requireAdaptor (not re-wrap as 500)
+    ServerConfigsResource bare = new ServerConfigsResource();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.getConfig("any"));
+    assertEquals(503, ex.getResponse().getStatus());
   }
 }


### PR DESCRIPTION
## Summary

**Parent:** #2117 (slice C6 — serverconfigs catalog) / epic #1694 / #1690

Aligns `ServerConfigsResource` with catalog peers so a missing `IServerConfigAdaptor` maps to **HTTP 503** instead of wrapping `IllegalStateException` as **500**.

### Changes
- `requireAdaptor()` throws `WebApplicationException` with `Response.Status.SERVICE_UNAVAILABLE` (same shape as `ControlsResource` / `KeywordsResource` / `SlotsResource`)
- OpenAPI responses document **503** on list + get
- Harden `ServerConfigsResourceTest` to peer ladder:
  - list/get delegate + null-safe list
  - unexpected exception → 500 (list + get)
  - rethrow mapped `WebApplicationException` on get
  - bare (no-arg) resource → **503** on list and get

### Out of scope (per triage / issue)
- No rework of `ServerConfigAdaptor` / `@Lazy` / `IPSSystemService` without live stack evidence
- Live QA `GET /services/serverconfigs` **2xx** verification: residual **#2151**

## Test plan
- [x] `cd rest && ../mvnw.cmd clean install` (standalone) — green
- [x] `ServerConfigsResourceTest` — 9 tests, 0 failures
- [ ] Live QA: `GET /services/serverconfigs` returns 2xx (or capture stack) — #2151

## Gates evidence
| Gate | Result |
|------|--------|
| Erlang self-review | approve — `docs/ai-generated/code-reviews/issue-2131-serverconfigs-catalog-503-erlang.md` |
| rest module clean install | pass |
| Behavioral unit tests | peer ladder for new 503 + rethrow behavior |
| Spotless | not required by AGENTS.md (optional only) |

## Residual
- #2151 — live QA 2xx / stack capture for serverconfigs after redeploy

## Fixes
Fixes #2131

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.