### PR TITLE
fix(rest): C7 relationshiptypes requireAdaptor 503 + unit ladder (#2132)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2132-relationshiptypes-catalog-503-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2132-relationshiptypes-catalog-503-erlang.md
@@ -1,0 +1,46 @@
+# Erlang review: issue #2132 C7 relationshiptypes catalog 503
+
+**Date:** 2026-08-06  
+**Branch:** `fix/issue-2132-relationshiptypes-catalog-503`  
+**Scope:** `rest` only — `RelationshipTypeResource` + `RelationshipTypeResourceTest`  
+**Peers:** C6 `ServerConfigsResource` / Slots / Keywords `requireAdaptor` → 503 ladder  
+**Parent:** #2117 / epic #1694
+
+## Summary
+
+Align `RelationshipTypeResource.requireAdaptor()` with catalog peers: missing adaptor is **503 Service Unavailable** (`WebApplicationException`), not an `IllegalStateException` re-wrapped as **500**. OpenAPI documents 503. Unit tests match peer ladder (delegate, null-safe list, 404, 500 wrap, WAE rethrow, bare 503 list/get).
+
+## Scope
+
+| Path | Change |
+|------|--------|
+| `rest/src/main/java/.../relationshiptypes/RelationshipTypeResource.java` | requireAdaptor → 503; OpenAPI 503; preserve WAE comments |
+| `rest/src/test/java/.../relationshiptypes/RelationshipTypeResourceTest.java` | peer ladder tests |
+
+No file I/O / path handling in this diff.  
+Cross-platform path review: N/A (no path/file I/O).
+
+Memory patterns: REST resource null-adaptor must map to 503 not 500; catch blocks must rethrow `WebApplicationException` before generic Exception→500 wrap.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none  
+- Behavioral unit tests for changed logic: present (9 tests, peer ladder)  
+- Portable paths: N/A  
+- **May commit/push: yes**
+
+## Issues
+
+None.
+
+## Verification
+
+```text
+cd rest && ../mvnw clean install
+BUILD SUCCESS
+RelationshipTypeResourceTest: Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
+```

--- a/rest/src/main/java/com/percussion/rest/relationshiptypes/RelationshipTypeResource.java
+++ b/rest/src/main/java/com/percussion/rest/relationshiptypes/RelationshipTypeResource.java
@@ -30,6 +30,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,6 +48,11 @@ public class RelationshipTypeResource {
 
   private final IRelationshipTypeAdaptor adaptor;
 
+  /**
+   * No-arg constructor for bean-discovery edge cases. Production uses {@link
+   * #RelationshipTypeResource(IRelationshipTypeAdaptor)}; catalog methods call {@link
+   * #requireAdaptor()}.
+   */
   public RelationshipTypeResource() {
     this.adaptor = null;
   }
@@ -71,6 +77,7 @@ public class RelationshipTypeResource {
                 @Content(
                     array =
                         @ArraySchema(schema = @Schema(implementation = RelationshipType.class)))),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public List<RelationshipType> listRelationshipTypes() {
@@ -78,6 +85,7 @@ public class RelationshipTypeResource {
       List<RelationshipType> list = requireAdaptor().listRelationshipTypes();
       return list != null ? list : List.of();
     } catch (WebApplicationException e) {
+      // Preserve mapped HTTP errors (e.g. 503 misconfiguration from requireAdaptor)
       throw e;
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
@@ -98,6 +106,7 @@ public class RelationshipTypeResource {
             description = "OK",
             content = @Content(schema = @Schema(implementation = RelationshipType.class))),
         @ApiResponse(responseCode = "404", description = "Relationship type not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public RelationshipType getRelationshipType(@PathParam("idOrName") String idOrName) {
@@ -108,6 +117,7 @@ public class RelationshipTypeResource {
       }
       return type;
     } catch (WebApplicationException e) {
+      // Preserve mapped HTTP errors (e.g. 503 misconfiguration from requireAdaptor)
       throw e;
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
@@ -116,8 +126,9 @@ public class RelationshipTypeResource {
 
   private IRelationshipTypeAdaptor requireAdaptor() {
     if (adaptor == null) {
-      throw new IllegalStateException(
-          "Relationship type adaptor not configured (resource constructed without injection)");
+      // Misconfiguration — not a transient handler failure (align with ServerConfigs/Slots peers)
+      throw new WebApplicationException(
+          "Relationship type adaptor not configured", Response.Status.SERVICE_UNAVAILABLE);
     }
     return adaptor;
   }

--- a/rest/src/test/java/com/percussion/rest/relationshiptypes/RelationshipTypeResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/relationshiptypes/RelationshipTypeResourceTest.java
@@ -18,7 +18,6 @@
 package com.percussion.rest.relationshiptypes;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -54,12 +53,24 @@ public class RelationshipTypeResourceTest {
     List<RelationshipType> out = resource.listRelationshipTypes();
     assertEquals(1, out.size());
     assertEquals("ActiveAssembly", out.get(0).getName());
+    verify(adaptor).listRelationshipTypes();
   }
 
   @Test
   public void listRelationshipTypesNullSafe() {
     when(adaptor.listRelationshipTypes()).thenReturn(null);
     assertTrue(resource.listRelationshipTypes().isEmpty());
+  }
+
+  @Test
+  public void listRelationshipTypesWrapsUnexpectedAs500() {
+    IllegalStateException boom = new IllegalStateException("boom");
+    when(adaptor.listRelationshipTypes()).thenThrow(boom);
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.listRelationshipTypes());
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(boom, ex.getCause());
   }
 
   @Test
@@ -95,16 +106,31 @@ public class RelationshipTypeResourceTest {
   }
 
   @Test
-  public void withoutInjectionFailsWithDiagnostic() {
-    RelationshipTypeResource bare = new RelationshipTypeResource();
-    WebApplicationException listEx =
-        assertThrows(WebApplicationException.class, bare::listRelationshipTypes);
-    assertEquals(500, listEx.getResponse().getStatus());
-    assertInstanceOf(IllegalStateException.class, listEx.getCause());
+  public void getRelationshipTypeRethrowsWebApplicationException() {
+    WebApplicationException mapped = new WebApplicationException("from adaptor", 404);
+    when(adaptor.findRelationshipType(eq("xx"))).thenThrow(mapped);
 
-    WebApplicationException getEx =
-        assertThrows(WebApplicationException.class, () -> bare.getRelationshipType("x"));
-    assertEquals(500, getEx.getResponse().getStatus());
-    assertInstanceOf(IllegalStateException.class, getEx.getCause());
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.getRelationshipType("xx"));
+    assertSame(mapped, ex);
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnList() {
+    RelationshipTypeResource bare = new RelationshipTypeResource();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, bare::listRelationshipTypes);
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnGet() {
+    // getRelationshipType must rethrow WebApplicationException from requireAdaptor (not re-wrap as
+    // 500)
+    RelationshipTypeResource bare = new RelationshipTypeResource();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.getRelationshipType("any"));
+    assertEquals(503, ex.getResponse().getStatus());
   }
 }


### PR DESCRIPTION
## Summary
**Partial for #2132** (slice **C7** of parent tracker **#2117** / epic **#1694**).

Aligns `GET /services/relationshiptypes` resource with catalog peers:
- `RelationshipTypeResource.requireAdaptor()` throws `WebApplicationException` **503** when adaptor is null (misconfiguration), instead of `IllegalStateException` re-wrapped as **500**.
- OpenAPI documents **503** on list/detail.
- `RelationshipTypeResourceTest` hardened to peer ladder (ServerConfigs/Slots/Keywords pattern).

**Out of scope / residual:** live QA **2xx** proof and design-WS stack-driven thin fix → **#2152**.

Operator: Grok: night-issue-prs (model grok-4.5)

## Changes
| File | What |
|------|------|
| `rest/.../relationshiptypes/RelationshipTypeResource.java` | requireAdaptor → 503; preserve WAE; OpenAPI 503 |
| `rest/.../relationshiptypes/RelationshipTypeResourceTest.java` | peer unit ladder (9 tests) |
| `docs/ai-generated/code-reviews/issue-2132-...-erlang.md` | Erlang approve |

## Test plan
- [x] Mocked resource unit tests green
- [ ] Live residual #2152: `GET /services/relationshiptypes` 2xx on QA after deploy

## Gates evidence
- **Erlang:** approve — report `docs/ai-generated/code-reviews/issue-2132-relationshiptypes-catalog-503-erlang.md`
- **Maven (standalone):**
  ```text
  cd rest
  ../mvnw clean install
  BUILD SUCCESS
  RelationshipTypeResourceTest: Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
  rest module suite: Tests total: 202 (all green)
  ```
- **No new warnings** attributable to this change (baseline javadoc/dependency-analyze warnings unchanged)
- Spotless not required per AGENTS.md (optional only)

## Links
- Fixes unit-harden portion of #2132
- Parent tracker: #2117
- Epic: #1694
- Live residual: #2152
- Commit: `cfa3fb2be0`

> Co-Authored by Grok Build using grok-4.5 with agent main.