### PR TITLE
feat(qa): #2065 golden unattended Playwright smoke vs H2 qa-up

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2065-golden-unattended-smoke-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2065-golden-unattended-smoke-erlang.md
@@ -1,0 +1,36 @@
+# Erlang self-review — #2065 golden unattended Playwright smoke
+
+**Branch:** `feat/issue-2065-golden-unattended-smoke`  
+**Date:** 2026-08-06  
+**Reviewer persona:** Erlang (pre-commit gate)
+
+## Change class
+
+| Class | Artifacts |
+|-------|-----------|
+| Playwright golden smoke (QA mode) | `tests/golden-unattended-smoke.spec.js`, `npm run test:golden`, README + workbench one-shot docs |
+| Installer antlib task registration | `perc-ant` antlib.xml + unit test (unblock silent H2 `qa-up`) |
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs | No logic bugs found in golden path; reuses `loginAsAdmin` + stable `data-testid` explorer selectors |
+| Portable paths | Docs use `path`-agnostic `python docker/scripts/...`; Windows cmd uses `\` only in examples |
+| Secrets | No passwords committed; placeholders only |
+| Behavioral tests | `AntlibTaskRegistrationTest`; existing `PSGenerateRepositoryPasswordTest`; frontend `test:unit` 48 pass |
+| Module clean install | `perc-ant` BUILD SUCCESS; `perc-qa-automation` BUILD SUCCESS |
+| AGENTS rule commits | None (issue forbids; human-review gate) |
+| Scope | No full suite / surface matrix / CI workflow |
+
+## Live H2 evidence (session)
+
+1. Pre-fix: `qa-up` failed mid-install: `failed to create task or type PSGenerateRepositoryPassword` (antlib missing taskdef).
+2. Post-fix: silent install completed; Jetty connector up on freeport; `/Rhythmyx/login` returned **HTTP 503** because Rhythmyx webapp Spring context failed: `Cannot locate BeanDefinitionParser for element [logging]` in `sitemanage-beans.xml` (CXF nested `<logging>`).
+3. `var/config/generated/passwords` only had `cmdb=` (no `Admin=`).
+
+**Residual:** product readiness of H2 matrix cell after install (Spring CXF logging + Admin password emission) — track as follow-up issues; not expanded in this PR.
+
+## Verdict
+
+**Ship** golden smoke + antlib registration. **Partial** vs full acceptance (live green login+explorer deferred on residual stack defects).

--- a/docs/ai-generated/code-reviews/issue-2065-golden-unattended-smoke-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2065-golden-unattended-smoke-erlang.md
@@ -25,12 +25,11 @@
 
 ## Live H2 evidence (session)
 
-1. Pre-fix: `qa-up` failed mid-install: `failed to create task or type PSGenerateRepositoryPassword` (antlib missing taskdef).
-2. Post-fix: silent install completed; Jetty connector up on freeport; `/Rhythmyx/login` returned **HTTP 503** because Rhythmyx webapp Spring context failed: `Cannot locate BeanDefinitionParser for element [logging]` in `sitemanage-beans.xml` (CXF nested `<logging>`).
-3. `var/config/generated/passwords` only had `cmdb=` (no `Admin=`).
-
-**Residual:** product readiness of H2 matrix cell after install (Spring CXF logging + Admin password emission) — track as follow-up issues; not expanded in this PR.
+1. Pre-fix: `qa-up` failed mid-install: `failed to create task or type PSGenerateRepositoryPassword` (antlib missing taskdef) → fixed in this PR.
+2. After antlib only: silent install completed; Jetty up; `/Rhythmyx/login` **HTTP 503** — Spring `Cannot locate BeanDefinitionParser for element [logging]` from legacy `<cxf:logging/>` in `sitemanage-beans.xml` → fixed via `LoggingFeature` bean + `cxf-rt-features-logging` (WebUI WAR repackage required for installer).
+3. Modern React login: auth helper updated for `data-testid` form (no native `select[name=j_locale]`).
+4. **Live green:** `RESULT:OK STEP:qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993` → `npm run test:golden` → **2 passed** (env resolve + Admin login + Content Explorer shell) → `qa-down`.
 
 ## Verdict
 
-**Ship** golden smoke + antlib registration. **Partial** vs full acceptance (live green login+explorer deferred on residual stack defects).
+**Ship** golden smoke + antlib + CXF login stack fixes. **Acceptance met** for live H2 golden path.

--- a/docs/developer-module/workbench-rest-and-qa-modes.md
+++ b/docs/developer-module/workbench-rest-and-qa-modes.md
@@ -126,8 +126,8 @@ python docker/scripts/perc-devctl.py qa-up
 python docker/scripts/perc-devctl.py qa-health
 # optional: --timeout-seconds 120  --interval-seconds 5
 
-# 3) Playwright surface subset against the stack only — no DEV_PERCUSSION_INSTALL
-#    (#2064 / #1928 slice A + #1929 surface filter)
+# 3) Playwright against the stack only — no DEV_PERCUSSION_INSTALL
+#    (#2064 env + #2065 golden smoke + #1929 surface filter)
 #    Use the TEST_CMS_URL printed by qa-up (do not hardcode :9993 — multi-worktree freeport).
 #    Auth helpers resolve: TEST_CMS_URL > QA_CMS_HOST_PORT/CMS_HOST_PORT > DEV_PERCUSSION_URL
 #    > install discovery > fallback. Unit tests: npm run test:unit in perc-qa-automation/frontend.
@@ -135,9 +135,12 @@ python docker/scripts/perc-devctl.py qa-health
 #    cd modules/perc-qa-automation/frontend
 #    TEST_CMS_URL=http://127.0.0.1:$QA_CMS_HOST_PORT  TEST_DB_TYPE=h2  TEST_PRODUCT=cms
 #    ADMIN_USERNAME=Admin  ADMIN_PASSWORD=... (from qa-up output / docker exec — never commit)
-#    npm run test:surface -- --path tests/login.spec.js
+#    # Golden unattended smoke (#2065): login + Content Explorer product screen
+#    npm run test:golden
+#    # or surface filter: npm run test:surface -- --path tests/golden-unattended-smoke.spec.js
+#    # or: npm run test:surface -- --path tests/login.spec.js
 #    # or: npx playwright test tests/login.spec.js --grep "Admin"
-#    # or: npm run test:surface -- --tag smoke
+#    # or: npm run test:surface -- --tag golden
 #    Failure artifacts: modules/perc-qa-automation/frontend/test-results/ (+ playwright-report/)
 #    Attach conventions: docs/developer-module/playwright-failure-artifacts.md (#2066)
 
@@ -279,7 +282,7 @@ Night-issue attach conventions (when not using GHA): [playwright-failure-artifac
 ##### Dependencies / first green caveats
 
 - **Installer package:** live mode runs `modules/perc-distribution-tree` `mvnw package -DskipTests` unless `skip_package=true`. This is the heavy step on free GHA runners (disk/time). Self-hosted or pre-baked installer + `skip_package` is supported.
-- **Golden smoke (#2065):** default surface is `tests/login.spec.js` (login). Broader login+product-screen golden may land under #2065; re-run with that path when available.
+- **Golden smoke (#2065):** `tests/golden-unattended-smoke.spec.js` (Admin login + Content Explorer shell). npm: `npm run test:golden`. Optional CI default may still use `tests/login.spec.js`; prefer the golden path for agent one-shot proof.
 - **Docker:** live job needs Docker on the runner (`ubuntu-latest` provides it). Dry-run / PR path does **not**.
 
 ##### Windows-local parity (same product path, no GHA)
@@ -299,7 +302,10 @@ set ADMIN_USERNAME=Admin
 set ADMIN_PASSWORD=<from-qa-up>
 npm ci
 npx playwright install chromium
-npm run test:surface -- --path tests/login.spec.js -- --trace=retain-on-failure --screenshot=only-on-failure --reporter=line,html
+REM Golden unattended smoke (#2065): login + Content Explorer product screen
+npm run test:golden
+REM Or surface path: npm run test:surface -- --path tests/golden-unattended-smoke.spec.js
+REM Or login-only: npm run test:surface -- --path tests/login.spec.js -- --trace=retain-on-failure --screenshot=only-on-failure --reporter=line,html
 cd ..\..\..
 python docker\scripts\perc-devctl.py qa-down
 ```

--- a/modules/perc-ant/src/main/resources/com/percussion/ant/antlib.xml
+++ b/modules/perc-ant/src/main/resources/com/percussion/ant/antlib.xml
@@ -120,6 +120,11 @@
 		classname="com.percussion.ant.install.PSMakeLasagna" />
 	<taskdef name="PSValidateRepositoryConnection"
 		classname="com.percussion.ant.install.PSValidateRepositoryConnection" />
+	<!-- Silent / H2 matrix installs (#548/#1500): random cmdb.password when unset.
+		Must be registered here — installRepository.xml uses <PSGenerateRepositoryPassword>
+		via taskdef resource="com/percussion/ant/antlib.xml" (qa-up blocker if missing). -->
+	<taskdef name="PSGenerateRepositoryPassword"
+		classname="com.percussion.ant.install.PSGenerateRepositoryPassword" />
 	<taskdef name="PSCopyDirectory"
 		classname="com.percussion.ant.packagetool.PSCopyDirectory" />
 	<taskdef name="PSUnZipPackage"

--- a/modules/perc-ant/src/test/java/com/percussion/ant/AntlibTaskRegistrationTest.java
+++ b/modules/perc-ant/src/test/java/com/percussion/ant/AntlibTaskRegistrationTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.ant;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards installer silent-path taskdefs shipped via {@code com/percussion/ant/antlib.xml}.
+ *
+ * <p>Matrix / {@code perc-devctl qa-up} H2 installs load tasks only through this antlib resource.
+ * A task class present on the classpath but missing from antlib fails with {@code failed to create
+ * task or type &lt;Name&gt;} mid-install (see #2065 golden smoke / #548 repository password).
+ */
+@Tag("UnitTest")
+public class AntlibTaskRegistrationTest {
+
+  private static final String ANTLIB = "com/percussion/ant/antlib.xml";
+
+  @Test
+  void antlibRegistersGenerateRepositoryPassword() throws Exception {
+    String xml;
+    try (InputStream in = getClass().getClassLoader().getResourceAsStream(ANTLIB)) {
+      assertNotNull(in, "classpath must contain " + ANTLIB);
+      xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+    assertTrue(
+        xml.contains("name=\"PSGenerateRepositoryPassword\""),
+        "antlib must register PSGenerateRepositoryPassword for silent H2 install");
+    assertTrue(
+        xml.contains("com.percussion.ant.install.PSGenerateRepositoryPassword"),
+        "antlib classname must match install package");
+  }
+}

--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -40,6 +40,79 @@ TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
 python docker/scripts/perc-devctl.py qa-down
 ```
 
+### Golden unattended smoke (#2065 / #1928 slice B)
+
+**One** reference Playwright path for agents: Admin **login + modern Content Explorer**
+(product screen). Env-only (`TEST_CMS_URL` + admin creds); **no** `DEV_PERCUSSION_INSTALL`.
+Not the full suite.
+
+**Prereq (once / after installer changes):** package the customer CMS assembly:
+
+```bash
+cd modules/perc-distribution-tree && ../../mvnw package -DskipTests
+# Windows: cd modules\perc-distribution-tree && ..\..\mvnw.cmd package -DskipTests
+```
+
+**Unix (bash) one-shot** from repo root:
+
+```bash
+python docker/scripts/perc-devctl.py qa-up
+# Capture TEST_CMS_URL=… QA_CMS_HOST_PORT=… ADMIN_PASSWORD=… from stdout (freeport).
+
+cd modules/perc-qa-automation/frontend
+npm ci
+npx playwright install chromium
+
+export TEST_CMS_URL="${TEST_CMS_URL:-http://127.0.0.1:${QA_CMS_HOST_PORT}}"
+export ADMIN_USERNAME=Admin
+export ADMIN_PASSWORD   # set from qa-up stdout — never commit
+export TEST_DB_TYPE=h2
+export TEST_PRODUCT=cms
+
+npm run test:golden
+# equivalent:
+# npm run test:surface -- --path tests/golden-unattended-smoke.spec.js
+# npx playwright test tests/golden-unattended-smoke.spec.js --grep @golden
+
+cd ../../..
+python docker/scripts/perc-devctl.py qa-down
+```
+
+**Windows (cmd) one-shot** from repo root:
+
+```bat
+python docker\scripts\perc-devctl.py qa-up
+REM Capture TEST_CMS_URL / QA_CMS_HOST_PORT / ADMIN_PASSWORD from stdout (do not hardcode 9993)
+
+cd modules\perc-qa-automation\frontend
+call npm ci
+call npx playwright install chromium
+
+set TEST_CMS_URL=http://127.0.0.1:%QA_CMS_HOST_PORT%
+set ADMIN_USERNAME=Admin
+set ADMIN_PASSWORD=<from-qa-up>
+set TEST_DB_TYPE=h2
+set TEST_PRODUCT=cms
+
+call npm run test:golden
+
+cd ..\..\..
+python docker\scripts\perc-devctl.py qa-down
+```
+
+| Item | Value |
+|------|--------|
+| Spec | `frontend/tests/golden-unattended-smoke.spec.js` |
+| npm | `npm run test:golden` |
+| Tags | `@smoke` / `@golden` (also via `npm run test:surface -- --tag golden`) |
+| Failure artifacts | `modules/perc-qa-automation/frontend/test-results/` |
+| HTML report | `modules/perc-qa-automation/frontend/playwright-report/` |
+| Attach runbook | [playwright-failure-artifacts.md](../../docs/developer-module/playwright-failure-artifacts.md) |
+| Stack lifecycle | [workbench-rest-and-qa-modes.md](../../docs/developer-module/workbench-rest-and-qa-modes.md) §2 |
+
+**Hard bans:** do not commit passwords; do not hardcode host port `:9993` as the only URL
+(use freeport `TEST_CMS_URL` from `qa-up`).
+
 **Admin creds (QA):** default username `Admin` (`ADMIN_USERNAME`). Password comes
 from `qa-up` output, process env, or `docker exec` into the QA cell — **never
 commit secrets**. No passwords are stored in this repo.

--- a/modules/perc-qa-automation/frontend/package.json
+++ b/modules/perc-qa-automation/frontend/package.json
@@ -9,6 +9,7 @@
     "test": "playwright test",
     "test:unit": "node --test tests/unit/resolve-cms-env.test.js tests/unit/surface-filter.test.js",
     "test:list": "playwright test --list",
+    "test:golden": "playwright test tests/golden-unattended-smoke.spec.js",
     "test:surface": "node scripts/run-surface.js",
     "test:surface:print": "node scripts/run-surface.js --print-only",
     "test:surface:list": "node scripts/run-surface.js --list"

--- a/modules/perc-qa-automation/frontend/tests/golden-unattended-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/golden-unattended-smoke.spec.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Golden unattended smoke (#2065 / #1928 slice B, epic #1827).
+ *
+ * <p>One reference path for overnight / agent QA mode against the H2 Docker
+ * stack from {@code perc-devctl qa-up}: Admin login + one stable product
+ * screen (modern Content Explorer shell). Env-only — no
+ * {@code DEV_PERCUSSION_INSTALL}.</p>
+ *
+ * <p>From repo root (Unix):</p>
+ * <pre>
+ *   python docker/scripts/perc-devctl.py qa-up
+ *   # capture TEST_CMS_URL + ADMIN_PASSWORD from stdout
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+ *     ADMIN_USERNAME=Admin ADMIN_PASSWORD=&lt;from-qa-up&gt; TEST_DB_TYPE=h2 \
+ *     npm run test:golden
+ *   python docker/scripts/perc-devctl.py qa-down
+ * </pre>
+ *
+ * <p>Windows (cmd) one-shot: see module README → Golden unattended smoke.</p>
+ *
+ * <p>Failure artifacts: {@code test-results/}, {@code playwright-report/}
+ * under this frontend directory. Attach runbook:
+ * docs/developer-module/playwright-failure-artifacts.md</p>
+ */
+
+const { test, expect } = require("@playwright/test");
+const {
+  loginAsAdmin,
+  BASE_URL,
+  BASE_URL_SOURCE,
+  ADMIN_USERNAME,
+} = require("./helpers/auth");
+
+/** Modern Content Explorer SPA entry (stable product screen for golden). */
+function explorerUrl() {
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${Date.now()}`;
+}
+
+test.describe("golden unattended smoke @smoke @golden", () => {
+  test("QA env resolves without host install", async () => {
+    // Documents the unattended contract: freeport URL from TEST_CMS_URL or
+    // host-port env, never hard-coded :9993 alone (#2005/#2014).
+    expect(BASE_URL).toMatch(/^https?:\/\/[^/]+:\d+$/);
+    expect(ADMIN_USERNAME).toBeTruthy();
+    // Prefer QA sources when operators set them; fallback is allowed only for
+    // local accidental runs (will fail login without a live CMS).
+    if (process.env.TEST_CMS_URL || process.env.QA_CMS_URL || process.env.CMS_BASE_URL) {
+      expect(BASE_URL_SOURCE).toBe("TEST_CMS_URL");
+    } else if (process.env.QA_CMS_HOST_PORT || process.env.CMS_HOST_PORT) {
+      expect(BASE_URL_SOURCE).toBe("CMS_HOST_PORT");
+    }
+  });
+
+  test("Admin login + Content Explorer shell @smoke @golden", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+
+    await loginAsAdmin(page);
+
+    const postLoginUrl = page.url();
+    expect(postLoginUrl).not.toMatch(/\/Rhythmyx\/login(\?|$)/);
+    expect(postLoginUrl).toMatch(/\/Rhythmyx\/|\/cm\//);
+
+    await page.goto(explorerUrl(), { waitUntil: "networkidle" });
+
+    const shell = page.locator('[data-testid="content-explorer-shell"]');
+    await expect(shell).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator('[data-testid="explorer-tree"]')).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.locator('[data-testid="detail-list"]')).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.locator('[data-testid="reduced-actions"]')).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/helpers/auth.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/auth.js
@@ -250,40 +250,90 @@ function missingPasswordMessage(username) {
   );
 }
 
+/**
+ * Fill Admin/role credentials on either the modern React login (data-testid)
+ * or the legacy JSP form (name= attributes). Locale defaults to en-us when
+ * the modern LocaleSelect already posts a hidden j_locale.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @param {string} username
+ * @param {string} password
+ */
+async function fillLoginForm(page, username, password) {
+  const modernRoot = page.locator('[data-testid="perc-login-root"]');
+  const modernForm = page.locator('[data-testid="perc-login-form"]');
+  const legacyUser = page.locator('input[name="j_username"]');
+
+  // Prefer modern React login (#2065 H2 qa-up ships rxlogin → perc-login-root).
+  if ((await modernRoot.count()) > 0 || (await modernForm.count()) > 0) {
+    await modernForm.or(modernRoot).first().waitFor({ state: "visible", timeout: 30_000 });
+    await page.locator('[data-testid="perc-login-username"]').fill(username);
+    await page.locator('[data-testid="perc-login-password"]').fill(password);
+    // LocaleSelect posts hidden input[name=j_locale]; default bootstrap is en-us.
+    // Only open the combobox when we must force a non-default locale.
+    const hiddenLocale = page.locator(
+      'input[type="hidden"][name="j_locale"], input[name="j_locale"]',
+    );
+    if ((await hiddenLocale.count()) > 0) {
+      const current = await hiddenLocale.first().inputValue().catch(() => "");
+      if (current && current !== "en-us") {
+        await page.locator('[data-testid="perc-login-locale"]').click();
+        await page
+          .locator('[role="option"]')
+          .filter({ hasText: /en-us|English \(United States\)/i })
+          .first()
+          .click();
+      }
+    }
+    return { submit: page.locator('[data-testid="perc-login-submit"]') };
+  }
+
+  // Legacy native form (select[name=j_locale]).
+  await legacyUser.waitFor({ state: "visible", timeout: 30_000 });
+  await page.fill('input[name="j_username"]', username);
+  await page.fill('input[name="j_password"]', password);
+  const nativeLocale = page.locator('select[name="j_locale"]');
+  if ((await nativeLocale.count()) > 0) {
+    await nativeLocale.selectOption("en-us");
+  }
+  return { submit: page.locator('button[type="submit"]') };
+}
+
 async function login(page, username, password) {
   if (!password) {
     throw new Error(missingPasswordMessage(username));
   }
 
   await page.goto(`${PERCUSSION_URL}/Rhythmyx/login`);
-  await page.fill('input[name="j_username"]', username);
-  await page.fill('input[name="j_password"]', password);
-  await page.selectOption('select[name="j_locale"]', "en-us");
+  // Wait for SPA mount or legacy form before filling.
+  await page.waitForLoadState("domcontentloaded");
+  const { submit } = await fillLoginForm(page, username, password);
 
-  // The CMS uses a multipart/form-data POST with OWASP-CSRFTOKEN. The
-  // server returns 302 → /Rhythmyx/index.jsp (JSP welcome). We submit
-  // and poll page.url() until we leave the login path, with a hard
-  // timeout. This avoids any race with Playwright's navigation events
-  // on multipart responses.
+  // The CMS uses a multipart/form-data POST with OWASP-CSRFTOKEN. Modern
+  // login may land at /cm/app/spa.jsp?entry=home; legacy lands at index.jsp.
+  // Poll until we leave the login path, with a hard timeout.
   await Promise.all([
     page
       .waitForFunction(
-        () => !window.location.pathname.endsWith("/Rhythmyx/login"),
+        () => {
+          const p = window.location.pathname;
+          return !p.endsWith("/Rhythmyx/login") && !p.endsWith("/login");
+        },
         null,
-        { timeout: 15_000 },
+        { timeout: 30_000 },
       )
       .catch(async () => {
         // networkidle sometimes fires before the JS function evaluates;
         // fall back to a short poll.
         await page.waitForTimeout(1500);
       }),
-    page.click('button[type="submit"]'),
+    submit.click(),
   ]);
 
   const url = page.url();
-  if (url.includes("/Rhythmyx/login")) {
+  if (url.includes("/Rhythmyx/login") || /\/login(\?|$)/.test(url)) {
     throw new Error(
-      `Login did not navigate away from /Rhythmyx/login (still at ${url})`,
+      `Login did not navigate away from login page (still at ${url})`,
     );
   }
 }

--- a/projects/sitemanage/pom.xml
+++ b/projects/sitemanage/pom.xml
@@ -189,6 +189,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Runtime: org.apache.cxf.ext.logging.LoggingFeature bean in sitemanage-beans.xml -->
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-features-logging</artifactId>
+            <scope>runtime</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -119,7 +119,9 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
             <ref bean="authorizationFilter" />
         </jaxrs:providers>
         <jaxrs:features>
-            <cxf:logging/>
+            <!-- CXF 3.1+/4.x: use LoggingFeature bean (requires cxf-rt-features-logging).
+                 Legacy <cxf:logging/> under core NS has no BeanDefinitionParser without that module. -->
+            <bean class="org.apache.cxf.ext.logging.LoggingFeature"/>
         </jaxrs:features>
     </jaxrs:server>
 


### PR DESCRIPTION
## Summary

**Fixes #2065** — Parent **#1928** slice B (epic **#1827**). Ship one golden unattended Playwright path (Admin **login + modern Content Explorer**) green against H2 `perc-devctl qa-up` with **env-only** invocation (no `DEV_PERCUSSION_INSTALL`).

Also unblocks silent H2 install / Rhythmyx startup defects found while running the live path:

| Fix | Why |
|-----|-----|
| Register `PSGenerateRepositoryPassword` in `perc-ant` antlib | Silent install failed: *failed to create task or type PSGenerateRepositoryPassword* |
| Replace legacy `<cxf:logging/>` with `LoggingFeature` + `cxf-rt-features-logging` | Jetty up but `/Rhythmyx/login` **503** — Spring could not parse CXF logging element |
| Modern React login selectors in `auth.js` | Login form is SPA `data-testid` (no native `select[name=j_locale]`) |

### Delivered

| Item | Location |
|------|----------|
| Golden smoke spec | `modules/perc-qa-automation/frontend/tests/golden-unattended-smoke.spec.js` |
| npm script | `npm run test:golden` |
| One-shot docs (Unix + Windows) + artifact paths | module `README.md`, `docs/developer-module/workbench-rest-and-qa-modes.md` |
| antlib registration + unit test | `modules/perc-ant` antlib + `AntlibTaskRegistrationTest` |
| CXF logging readiness | `projects/sitemanage` beans + pom |
| Auth helper dual path (modern + legacy) | `frontend/tests/helpers/auth.js` |

### Out of scope (siblings)

- Full Playwright suite / surface matrix / CI promotion → other #1827 slices
- AGENTS rule commits (human-review gate; not included)

## Live smoke evidence

`	ext
python docker/scripts/perc-devctl.py qa-up --skip-image-build
# RESULT:OK STEP:qa-up
# TEST_CMS_URL=http://127.0.0.1:9993  ADMIN_USERNAME=Admin  (password from stdout)

cd modules/perc-qa-automation/frontend
='http://127.0.0.1:9993'
='Admin'
=<from-qa-up>
='h2'
npm run test:golden
# 2 passed (2.3s) — env resolve + Admin login + Content Explorer shell

python docker/scripts/perc-devctl.py qa-down
# RESULT:OK STEP:qa-down
`

Failure artifacts (if red): `modules/perc-qa-automation/frontend/test-results/`, `playwright-report/` — attach runbook [playwright-failure-artifacts.md](https://github.com/intersoftdatalabs-in/percussioncms/blob/main/docs/developer-module/playwright-failure-artifacts.md).

## Test plan

- [x] `cd modules/perc-qa-automation/frontend && npm run test:unit` — **48 passed**
- [x] `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] `cd modules/perc-ant && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [x] Live H2 golden: `npm run test:golden` against `qa-up` — **2 passed**
- [x] No secrets committed

## Gates evidence

| Gate | Result |
|------|--------|
| Live golden smoke | 2 passed vs H2 freeport cell |
| Module clean install | perc-qa-automation, perc-ant, sitemanage SUCCESS |
| Unit tests | 48 frontend; AntlibTaskRegistrationTest + PSGenerateRepositoryPasswordTest |
| Cross-platform | Docs document bash + cmd; freeport `TEST_CMS_URL` only |
| Secrets | None in git; password from qa-up stdout only |

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #1928 · Epic: #1827