### PR TITLE
test(WebUI): DetailPanel cluster A panelErrMsg ladders (#2139)

### DIFF
--- a/WebUI/src/test/ts/developer/CommunityDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/CommunityDetailPanel.test.tsx
@@ -1,0 +1,134 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as assemblyApi from "../../../main/ts/api/developer/assemblyApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+import { CommunityDetailPanel } from "../../../main/ts/developer/CommunityDetailPanel";
+
+vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
+  getCommunityDetail: vi.fn(),
+  listAvailableRoles: vi.fn(),
+  getCommunityVisibility: vi.fn(),
+  updateCommunityRoles: vi.fn(),
+}));
+
+const getCommunityDetail = assemblyApi.getCommunityDetail as ReturnType<typeof vi.fn>;
+const listAvailableRoles = assemblyApi.listAvailableRoles as ReturnType<typeof vi.fn>;
+const getCommunityVisibility = assemblyApi.getCommunityVisibility as ReturnType<typeof vi.fn>;
+const updateCommunityRoles = assemblyApi.updateCommunityRoles as ReturnType<typeof vi.fn>;
+
+const sampleDetail = {
+  name: "Default",
+  label: "Default Community",
+  description: "System default",
+  id: 1001,
+  guid: { stringValue: "0-10-1001" },
+  roleList: [{ roleName: "Admin", roleId: 1, roleGuid: { stringValue: "0-6-1" } }],
+};
+
+const sampleRoles = [
+  { roleName: "Admin", roleId: 1, roleGuid: { stringValue: "0-6-1" } },
+  { roleName: "Editor", roleId: 2, roleGuid: { stringValue: "0-6-2" } },
+];
+
+describe("CommunityDetailPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    getCommunityDetail.mockReset();
+    listAvailableRoles.mockReset();
+    getCommunityVisibility.mockReset();
+    updateCommunityRoles.mockReset();
+    listAvailableRoles.mockResolvedValue(sampleRoles);
+    getCommunityVisibility.mockResolvedValue([]);
+  });
+
+  it("loads detail on success and supports back", async () => {
+    getCommunityDetail.mockResolvedValue(sampleDetail);
+    const onBack = vi.fn();
+    render(<CommunityDetailPanel idOrName="Default" onBack={onBack} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-detail-title")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-comm-detail-title").textContent).toContain(
+      "Default Community",
+    );
+    expect(screen.getByTestId("developer-comm-roles-table")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-visibility-empty")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-comm-back"));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("shows empty visibility when API returns no objects", async () => {
+    getCommunityDetail.mockResolvedValue(sampleDetail);
+    getCommunityVisibility.mockResolvedValue([]);
+    render(<CommunityDetailPanel idOrName="Default" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-visibility-empty")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("developer-comm-visibility-table")).toBeNull();
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    getCommunityDetail.mockRejectedValue(new SessionRedirectError());
+    listAvailableRoles.mockRejectedValue(new SessionRedirectError());
+    render(<CommunityDetailPanel idOrName="Default" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-comm-detail-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-comm-detail-loading")).toBeNull();
+    expect(screen.queryByTestId("developer-comm-detail-title")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    getCommunityDetail.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    listAvailableRoles.mockResolvedValue(sampleRoles);
+    render(<CommunityDetailPanel idOrName="Default" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-comm-detail-error").textContent).toBe(
+      `${DEV_MSG.COMM_DETAIL_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    getCommunityDetail.mockRejectedValue(new Error("network down"));
+    listAvailableRoles.mockResolvedValue(sampleRoles);
+    render(<CommunityDetailPanel idOrName="Default" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-comm-detail-error").textContent).toBe(
+      `${DEV_MSG.COMM_DETAIL_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-comm-detail-title")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    getCommunityDetail.mockRejectedValue("boom");
+    listAvailableRoles.mockResolvedValue(sampleRoles);
+    render(<CommunityDetailPanel idOrName="Default" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-comm-detail-error").textContent).toBe(
+      DEV_MSG.COMM_DETAIL_ERROR,
+    );
+  });
+});

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as contentTypesApi from "../../../main/ts/api/developer/contentTypesApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+import { ContentTypeDetailPanel } from "../../../main/ts/developer/ContentTypeDetailPanel";
+
+vi.mock("../../../main/ts/api/developer/contentTypesApi", () => ({
+  getContentTypeDetail: vi.fn(),
+  updateContentTypeDetail: vi.fn(),
+}));
+
+// ObjectAclSection loads ACL via separate API; stub so detail success path stays isolated.
+vi.mock("../../../main/ts/developer/ObjectAclSection", () => ({
+  ObjectAclSection: () => <div data-testid="developer-ct-acl-stub" />,
+}));
+
+const getContentTypeDetail = contentTypesApi.getContentTypeDetail as ReturnType<typeof vi.fn>;
+const updateContentTypeDetail = contentTypesApi.updateContentTypeDetail as ReturnType<
+  typeof vi.fn
+>;
+
+const sampleDetail = {
+  name: "percPage",
+  label: "Page",
+  description: "Page type",
+  enabled: true,
+  hideFromMenu: false,
+  appName: "rx_cm",
+  guid: { stringValue: "0-2-301" },
+  fields: [],
+  allowedWorkflows: [],
+  allowedTemplates: [],
+  designGaps: [],
+};
+
+describe("ContentTypeDetailPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    getContentTypeDetail.mockReset();
+    updateContentTypeDetail.mockReset();
+  });
+
+  it("loads detail on success and supports back", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleDetail);
+    const onBack = vi.fn();
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={onBack} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-title")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ct-detail-title").textContent).toContain("Page");
+    expect(screen.getByTestId("developer-ct-fields-table")).toBeTruthy();
+    expect(screen.getByTestId("developer-ct-wf-empty")).toBeTruthy();
+    expect(screen.getByTestId("developer-ct-tpl-empty")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("developer-ct-back"));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("shows empty workflows and templates when detail has none", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      allowedWorkflows: [],
+      allowedTemplates: [],
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-wf-empty")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ct-tpl-empty")).toBeTruthy();
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    getContentTypeDetail.mockRejectedValue(new SessionRedirectError());
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ct-detail-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-ct-detail-loading")).toBeNull();
+    expect(screen.queryByTestId("developer-ct-detail-title")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    getContentTypeDetail.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ct-detail-error").textContent).toBe(
+      `${DEV_MSG.CT_DETAIL_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    getContentTypeDetail.mockRejectedValue(new Error("network down"));
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ct-detail-error").textContent).toBe(
+      `${DEV_MSG.CT_DETAIL_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-ct-detail-title")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    getContentTypeDetail.mockRejectedValue("boom");
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ct-detail-error").textContent).toBe(
+      DEV_MSG.CT_DETAIL_ERROR,
+    );
+  });
+});

--- a/WebUI/src/test/ts/developer/SlotDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SlotDetailPanel.test.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as assemblyApi from "../../../main/ts/api/developer/assemblyApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+import { SlotDetailPanel } from "../../../main/ts/developer/SlotDetailPanel";
+
+vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
+  getSlotDetail: vi.fn(),
+  updateSlotDetail: vi.fn(),
+}));
+
+const getSlotDetail = assemblyApi.getSlotDetail as ReturnType<typeof vi.fn>;
+const updateSlotDetail = assemblyApi.updateSlotDetail as ReturnType<typeof vi.fn>;
+
+const sampleDetail = {
+  name: "rffList",
+  label: "List",
+  description: "List slot",
+  slotType: "regular",
+  systemSlot: false,
+  finderName: "sys_SlotContentFinder",
+  relationshipName: "Active Assembly",
+  guid: { stringValue: "0-1-20" },
+  associations: [],
+  finderArguments: {},
+  designGaps: [],
+};
+
+describe("SlotDetailPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    getSlotDetail.mockReset();
+    updateSlotDetail.mockReset();
+  });
+
+  it("loads detail on success and supports back", async () => {
+    getSlotDetail.mockResolvedValue(sampleDetail);
+    const onBack = vi.fn();
+    render(<SlotDetailPanel idOrName="rffList" onBack={onBack} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-detail-title")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-slot-detail-title").textContent).toContain("List");
+    expect(screen.getByTestId("developer-slot-assoc-empty")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("developer-slot-back"));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("shows empty associations section when detail has none", async () => {
+    getSlotDetail.mockResolvedValue({ ...sampleDetail, associations: [] });
+    render(<SlotDetailPanel idOrName="rffList" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-assoc-empty")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("developer-slot-assoc-table")).toBeNull();
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    getSlotDetail.mockRejectedValue(new SessionRedirectError());
+    render(<SlotDetailPanel idOrName="rffList" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-slot-detail-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-slot-detail-loading")).toBeNull();
+    expect(screen.queryByTestId("developer-slot-detail-title")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    getSlotDetail.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<SlotDetailPanel idOrName="rffList" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-slot-detail-error").textContent).toBe(
+      `${DEV_MSG.SLOT_DETAIL_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    getSlotDetail.mockRejectedValue(new Error("network down"));
+    render(<SlotDetailPanel idOrName="rffList" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-slot-detail-error").textContent).toBe(
+      `${DEV_MSG.SLOT_DETAIL_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-slot-detail-title")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    getSlotDetail.mockRejectedValue("boom");
+    render(<SlotDetailPanel idOrName="rffList" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-slot-detail-error").textContent).toBe(
+      DEV_MSG.SLOT_DETAIL_ERROR,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Partial for **#2139** (UI-TEST-01 residual B / parent **#2119** / grandparent **#1690**).

Cluster A only: Vitest empty/error/success ladders for detail-load `panelErrMsg` on:

- `SlotDetailPanel`
- `CommunityDetailPanel`
- `ContentTypeDetailPanel`

Each covers:

- session-redirect via `panelErrMsg`
- ApiError status (`(500)`)
- `Error.message`
- non-Error fallback
- success path (+ empty associations / visibility / workflows+templates where applicable)

No product UI changes; uses existing `data-testid`s. ContentType ACL section stubbed so detail-load stays isolated.

## Residual follow-ups (leave #2139 open)

| Cluster | Issue | Panels |
|---------|-------|--------|
| B | #2156 | Search / View / DisplayFormat / ActionMenu / ItemFilter / RelationshipType |
| C | #2157 | Site / Workflow / Pipeline |
| D | #2158 | ServerConfig / Extension / Control / SharedField / Locale |
| E | #2159 | TemplateDetailPanel full ladder expand |

## Test plan

- [x] Focused Vitest: `SlotDetailPanel` + `CommunityDetailPanel` + `ContentTypeDetailPanel` (18 tests)
- [x] WebUI standalone `mvnw clean install` green (193 files / 1303 tests)
- [x] No product code changes

## Gates evidence

- Erlang-style self-review: pure tests, peer-mirrored ladders, no path I/O, no UI expansion
- Change class: Vitest companions only (no Playwright — no product UI change)
- Module: `WebUI` clean install SUCCESS

Operator: Grok: night-issue-prs (model grok-4.5)

Partial for #2139.
