### PR TITLE
test(qa): REST smoke GET /services/keywords 2xx after live H2 probe (#2124)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2124-keywords-live-2xx-smoke-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2124-keywords-live-2xx-smoke-erlang.md
@@ -1,0 +1,36 @@
+# Erlang review: issue-2124 keywords live 2xx smoke
+
+## Summary
+Adds REST probes for GET /services/keywords and
+GET /services/keywords?includeChoices=true (2xx + JSON Keyword wrapper /
+embedded choices) to developer-catalog-smoke after live H2 qa-up confirmed
+HTTP 200. No product/resource/adaptor code change — static wiring already
+healthy after merged unit slice #2125 (PR #2125).
+
+## Scope
+- modules/perc-qa-automation/frontend/tests/developer-catalog-smoke.spec.js
+- Base: origin/main (includes #2155 slots REST smoke + #2125 keywords unit)
+- Live evidence: perc-devctl qa-up H2 → keywords 200 / includeChoices 200 JSON
+
+## Recommendation
+approve
+
+## Gate
+May commit/push: **yes**
+
+## Cross-platform path review
+N/A — no file I/O or path construction; uses BASE_URL + string URL path and
+adminBasicAuthHeaders peer pattern from #2121 / bug-1622.
+
+## Issues
+None (bug/suggestion/nit).
+
+## Behavioral coverage
+- New Playwright REST tests assert 2xx + Keyword array/wrapper payload.
+- includeChoices=true asserts non-empty choices on at least one keyword when
+  catalog is non-empty.
+- Live run against H2 qa-up (TEST_CMS_URL freeport).
+
+## Memory patterns
+No new durable pattern; reuses RX_USEBASICAUTH + Authorization Basic from
+auth.js / slots residual #2121.

--- a/modules/perc-qa-automation/frontend/tests/developer-catalog-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-catalog-smoke.spec.js
@@ -22,17 +22,18 @@
  * Content-types also asserts table body cells are not only empty / "—"
  * placeholders (empty DTOs); any other cell text counts as real data.
  *
- * Also includes a **REST** probe for critical catalogs (slots) via Basic auth +
- * {@code RX_USEBASICAUTH} — residual #2121 after unit-test slice #2115 / #2122.
+ * Also includes **REST** probes for critical catalogs (slots, keywords) via
+ * Basic auth + {@code RX_USEBASICAUTH} — residuals #2121 / #2124 after unit
+ * slices #2115 / #2116.
  *
  * Entry: spa.jsp?entry=developer&section=<slug>
- * Refs #1690 (design-WS retargets #1700–#1704), #1694, #2121.
+ * Refs #1690 (design-WS retargets #1700–#1704), #1694, #2121, #2124.
  *
  * Live REST probe (after {@code perc-devctl qa-up}):
  * <pre>
  *   cd modules/perc-qa-automation/frontend
  *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=… \
- *     npm test -- tests/developer-catalog-smoke.spec.js -g "REST: GET /services/slots"
+ *     npm test -- tests/developer-catalog-smoke.spec.js -g "REST: GET /services/"
  * </pre>
  */
 
@@ -93,16 +94,19 @@ function developerUrl(section) {
 }
 
 /**
- * Critical REST catalog residual of #2115 / #1694 slice A (#2121).
+ * Critical REST catalog residuals of #1694 slices A/B (#2121 slots, #2124 keywords).
  *
- * Live H2 qa-up (2026-08-06): GET /Rhythmyx/services/slots → HTTP 200 with
- * Jackson-wrapped {@code Slot} array (stock rff* slots). No product stack
- * required beyond merged unit-test slice #2122 — wiring already healthy.
- * Auth: {@code Authorization: Basic …} + {@code RX_USEBASICAUTH: true}.
+ * Live H2 qa-up (2026-08-06):
+ * - GET /Rhythmyx/services/slots → HTTP 200 Jackson {@code Slot} array
+ * - GET /Rhythmyx/services/keywords → HTTP 200 Jackson {@code Keyword} array
+ * - GET …/keywords?includeChoices=true → HTTP 200 with embedded choices
+ *
+ * No product stack fix on either residual — static wiring healthy after unit
+ * slices #2122 / #2125. Auth: Basic + {@code RX_USEBASICAUTH: true}.
  *
  * Kept outside the SPA describe so page login beforeEach does not run.
  */
-test.describe("Developer catalog REST smoke (#2121 / #1694)", () => {
+test.describe("Developer catalog REST smoke (#2121 / #2124 / #1694)", () => {
   test("REST: GET /services/slots returns 2xx (#2121)", async ({ request }) => {
     test.setTimeout(30_000);
     const headers = {
@@ -132,6 +136,87 @@ test.describe("Developer catalog REST smoke (#2121 / #1694)", () => {
       expect(
         first.name || first.label,
         "first slot should expose name or label",
+      ).toBeTruthy();
+    }
+  });
+
+  test("REST: GET /services/keywords returns 2xx (#2124)", async ({
+    request,
+  }) => {
+    test.setTimeout(30_000);
+    const headers = {
+      ...adminBasicAuthHeaders(),
+      Accept: "application/json",
+    };
+    const url = `${BASE_URL}/Rhythmyx/services/keywords`;
+    const res = await request.get(url, { headers });
+    expect(
+      res.status(),
+      `GET ${url} must be 2xx (catalog residual #2124; was 500 on older QA)`,
+    ).toBeGreaterThanOrEqual(200);
+    expect(res.status(), `GET ${url} must not be error`).toBeLessThan(300);
+
+    const body = await res.json();
+    // Wire format is Jackson-wrapped list under "Keyword" (KeywordSummary root).
+    const keywords = Array.isArray(body) ? body : body?.Keyword;
+    expect(
+      keywords,
+      "keywords response must be a JSON array or { Keyword: [...] } wrapper",
+    ).toBeTruthy();
+    expect(Array.isArray(keywords), "keywords payload must be an array").toBe(
+      true,
+    );
+    // Stock H2 ships design keywords (e.g. Adhoc_Type); empty list is still a
+    // valid 2xx catalog, but assert structure when data is present.
+    if (keywords.length > 0) {
+      const first = keywords[0];
+      expect(
+        first.label || first.value != null || first.description,
+        "first keyword should expose label, value, or description",
+      ).toBeTruthy();
+    }
+  });
+
+  test("REST: GET /services/keywords?includeChoices=true returns 2xx with choices (#2124)", async ({
+    request,
+  }) => {
+    test.setTimeout(30_000);
+    const headers = {
+      ...adminBasicAuthHeaders(),
+      Accept: "application/json",
+    };
+    const url = `${BASE_URL}/Rhythmyx/services/keywords?includeChoices=true`;
+    const res = await request.get(url, { headers });
+    expect(
+      res.status(),
+      `GET ${url} must be 2xx (includeChoices residual #2124)`,
+    ).toBeGreaterThanOrEqual(200);
+    expect(res.status(), `GET ${url} must not be error`).toBeLessThan(300);
+
+    const body = await res.json();
+    const keywords = Array.isArray(body) ? body : body?.Keyword;
+    expect(
+      keywords,
+      "includeChoices response must be a JSON array or { Keyword: [...] }",
+    ).toBeTruthy();
+    expect(Array.isArray(keywords), "keywords payload must be an array").toBe(
+      true,
+    );
+
+    // When the catalog is non-empty, at least one stock keyword should embed a
+    // non-empty choices list (design-WS findKeywords + choice mapping).
+    if (keywords.length > 0) {
+      const withChoices = keywords.find(
+        (kw) => Array.isArray(kw.choices) && kw.choices.length > 0,
+      );
+      expect(
+        withChoices,
+        "includeChoices=true should embed at least one keyword with choices",
+      ).toBeTruthy();
+      const choice = withChoices.choices[0];
+      expect(
+        choice.label != null || choice.value != null || choice.description,
+        "choice entries should expose label, value, or description",
       ).toBeTruthy();
     }
   });


### PR DESCRIPTION
## Summary

**Residual #2124** of unit-test slice **#2116** (PR #2125, parent **#1694** / epic **#1690**).

Live probe on H2 `perc-devctl qa-up` (path from #2065) with Basic auth + `RX_USEBASICAUTH`:

| Endpoint | Status | Notes |
|----------|--------|-------|
| `GET /Rhythmyx/services/keywords` | **200** | Jackson `{ Keyword: [...] }`; stock design keywords |
| `GET /Rhythmyx/services/keywords?includeChoices=true` | **200** | Embedded non-empty `choices` on stock keywords |
| `GET /Rhythmyx/services/slots` | 200 | peer critical catalog (already #2155) |
| `GET /Rhythmyx/services/contenttypes` | 200 | working peer |

**No product code fix** (resource / `KeywordsAdaptor` / design WS). Static wiring was already correct; unit slice #2125 hardened null-adaptor 503 + list/choice mapping. Live stack returns 2xx without further rest/sitemanage changes.

This PR ships the acceptance gate artifact: `developer-catalog-smoke` **REST** assertions for keywords 2xx (+ includeChoices).

## Changes

- `modules/perc-qa-automation/frontend/tests/developer-catalog-smoke.spec.js`
  - Extend describe `Developer catalog REST smoke (#2121 / #2124 / #1694)`
  - `REST: GET /services/keywords returns 2xx` via `adminBasicAuthHeaders()`
  - `REST: GET /services/keywords?includeChoices=true returns 2xx with choices`
  - Asserts HTTP 2xx + JSON array / `Keyword` wrapper; choices structure when catalog non-empty
- Erlang report: `docs/ai-generated/code-reviews/issue-2124-keywords-live-2xx-smoke-erlang.md`

## Test plan

- [x] `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993`
- [x] curl Basic + `RX_USEBASICAUTH: true` → keywords **200** / includeChoices **200** JSON
- [x] `cd modules/perc-qa-automation/frontend` + env → `npx playwright test tests/developer-catalog-smoke.spec.js -g \"REST: GET /services/\"` → **3 passed**
- [x] `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (no Java sources; npm ci + jar)

## Gates evidence

| Gate | Result |
|------|--------|
| Erlang review | approve — `docs/ai-generated/code-reviews/issue-2124-keywords-live-2xx-smoke-erlang.md` |
| Maven module clean install | `perc-qa-automation` BUILD SUCCESS |
| Live behavioral test | Playwright REST keywords (+ includeChoices) 2xx green on H2 qa-up |
| Product stack fix | N/A (no 500; no stack) |

## Parent / closes

- Parent tracker: **#1694**
- Prior unit slice: **#2116** / PR #2125
- **Fixes #2124**
- #2116 acceptance (live 2xx + unit tests) is met; can close #2116 when this lands
- Does **not** close #1694 (remaining C residuals + #2118 smoke matrix still open)

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.