### PR TITLE
test(qa): #2118 developer-catalog-smoke REST matrix re-probe (#1694 slice D)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2118-catalog-smoke-reprobe-matrix-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2118-catalog-smoke-reprobe-matrix-erlang.md
@@ -1,0 +1,39 @@
+# Erlang review: issue-2118 catalog smoke re-probe matrix (slice D)
+
+## Summary
+Consolidates developer-catalog-smoke REST coverage for the nine #1694
+catalog endpoints after live H2 qa-up re-probe confirmed HTTP 200 on all
+cells. Reuses residual assertion patterns from #2121/#2124/#2140/#2142/
+#2146 (and peer C residuals) rather than duplicating product jaxrs work
+(product registration remains #2162 and peers).
+
+## Scope
+- modules/perc-qa-automation/frontend/tests/developer-catalog-smoke.spec.js
+- Base: origin/main (includes #2155 slots REST smoke + #2065 golden path)
+- Live evidence: perc-matrix-cms-h2 `http://127.0.0.1:9993` — all nine → 200
+
+## Recommendation
+approve
+
+## Gate
+May commit/push: **yes**
+
+## Cross-platform path review
+N/A — no file I/O or path construction; uses BASE_URL + string URL path and
+adminBasicAuthHeaders peer pattern from #2121 / residual smokes.
+
+## Issues
+None (bug/suggestion/nit).
+
+## Behavioral coverage
+- Table-driven REST 2xx + Jackson wrapper for slots, keywords, locales,
+  searches, views, extensions/catalog, cecontrols, serverconfigs,
+  relationshiptypes.
+- keywords includeChoices=true retains #2161 choices embedding assert.
+- SPA section smoke retained (#1690); content-types row locator updated to
+  indexed `developer-ct-row-*` (CatalogTable contract) so H2 rows count.
+- Empty wrappers (SearchDef:[], Extension:[]) accepted as valid 2xx.
+
+## Memory patterns
+No new durable pattern; consolidates RX_USEBASICAUTH + Authorization Basic
+and Jackson wrapper unwrap from residual #2121 family PRs.

--- a/modules/perc-qa-automation/frontend/tests/developer-catalog-smoke.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-catalog-smoke.spec.js
@@ -22,12 +22,15 @@
  * Content-types also asserts table body cells are not only empty / "—"
  * placeholders (empty DTOs); any other cell text counts as real data.
  *
- * Also includes **REST** probes for critical catalogs (slots, keywords) via
- * Basic auth + {@code RX_USEBASICAUTH} — residuals #2121 / #2124 after unit
- * slices #2115 / #2116.
+ * Also includes **REST** probes for critical catalogs via Basic auth +
+ * {@code RX_USEBASICAUTH}:
+ * - slots residual #2121 after unit-test slice #2115 / #2122
+ * - keywords residual #2124 after unit slice #2116 / #2125
+ * - searches + C-slice peers residual #2142 after unit slice #2127 (and common
+ *   jaxrs registration fix for views/cecontrols/serverconfigs/relationshiptypes)
  *
  * Entry: spa.jsp?entry=developer&section=<slug>
- * Refs #1690 (design-WS retargets #1700–#1704), #1694, #2121, #2124.
+ * Refs #1690 (design-WS retargets #1700–#1704), #1694, #2117, #2121, #2124, #2142.
  *
  * Live REST probe (after {@code perc-devctl qa-up}):
  * <pre>
@@ -94,88 +97,125 @@ function developerUrl(section) {
 }
 
 /**
- * Critical REST catalog residuals of #1694 slices A/B (#2121 slots, #2124 keywords).
+ * Critical REST catalog residuals under #1694 / #2117.
  *
- * Live H2 qa-up (2026-08-06):
- * - GET /Rhythmyx/services/slots → HTTP 200 Jackson {@code Slot} array
- * - GET /Rhythmyx/services/keywords → HTTP 200 Jackson {@code Keyword} array
- * - GET …/keywords?includeChoices=true → HTTP 200 with embedded choices
+ * Live H2 qa-up:
+ * - GET /services/slots → 200 Jackson {@code Slot} array (residual #2121)
+ * - GET /services/keywords → 200 {@code Keyword} (residual #2124)
+ * - GET /services/searches → 200 {@code SearchDef} (residual #2142). Was CXF
+ *   404 until restSearchResource listed on rest-jax-rs serviceBeans (same class
+ *   as #1714). Empty {@code SearchDef: []} is valid when no CX searches exist.
+ * - Peers views/cecontrols/serverconfigs/relationshiptypes share the same
+ *   missing-registration root and go green with the same sitemanage-beans fix.
  *
- * No product stack fix on either residual — static wiring healthy after unit
- * slices #2122 / #2125. Auth: Basic + {@code RX_USEBASICAUTH: true}.
- *
+ * Auth: {@code Authorization: Basic …} + {@code RX_USEBASICAUTH: true}.
  * Kept outside the SPA describe so page login beforeEach does not run.
  */
-test.describe("Developer catalog REST smoke (#2121 / #2124 / #1694)", () => {
-  test("REST: GET /services/slots returns 2xx (#2121)", async ({ request }) => {
-    test.setTimeout(30_000);
-    const headers = {
-      ...adminBasicAuthHeaders(),
-      Accept: "application/json",
-    };
-    const url = `${BASE_URL}/Rhythmyx/services/slots`;
-    const res = await request.get(url, { headers });
-    expect(
-      res.status(),
-      `GET ${url} must be 2xx (catalog residual #2121; was 500 on older QA)`,
-    ).toBeGreaterThanOrEqual(200);
-    expect(res.status(), `GET ${url} must not be error`).toBeLessThan(300);
+test.describe("Developer catalog REST smoke (#2121 / #2124 / #2142 / #1694)", () => {
+  /**
+   * @type {{
+   *   path: string,
+   *   wrapperKey: string,
+   *   issue: string,
+   *   nameFields?: string[],
+   * }[]}
+   */
+  const REST_CATALOGS = [
+    {
+      path: "slots",
+      wrapperKey: "Slot",
+      issue: "#2121",
+      nameFields: ["name", "label"],
+    },
+    {
+      path: "keywords",
+      wrapperKey: "Keyword",
+      issue: "#2124",
+      nameFields: ["label", "value", "description"],
+    },
+    {
+      path: "searches",
+      wrapperKey: "SearchDef",
+      issue: "#2142",
+      nameFields: ["name", "label"],
+    },
+    {
+      path: "views",
+      wrapperKey: "ViewDef",
+      issue: "#2144",
+      nameFields: ["name", "label"],
+    },
+    {
+      path: "cecontrols",
+      wrapperKey: "ControlDef",
+      issue: "#2149",
+      nameFields: ["name", "label"],
+    },
+    {
+      path: "serverconfigs",
+      wrapperKey: "ServerConfig",
+      issue: "#2151",
+      nameFields: ["name", "displayName", "fileName"],
+    },
+    {
+      path: "relationshiptypes",
+      wrapperKey: "RelationshipType",
+      issue: "#2152",
+      nameFields: ["name", "label"],
+    },
+    {
+      path: "locales",
+      wrapperKey: "Locale",
+      issue: "#2140",
+      nameFields: ["languageString", "displayName", "label"],
+    },
+    {
+      path: "extensions/catalog",
+      wrapperKey: "Extension",
+      issue: "#2146",
+      nameFields: ["name", "label"],
+    },
+  ];
 
-    const body = await res.json();
-    // Wire format is Jackson-wrapped list under "Slot" (see SlotSummary root).
-    const slots = Array.isArray(body) ? body : body?.Slot;
-    expect(
-      slots,
-      "slots response must be a JSON array or { Slot: [...] } wrapper",
-    ).toBeTruthy();
-    expect(Array.isArray(slots), "slots payload must be an array").toBe(true);
-    // Stock H2 / package install ships system + rff slots; empty list is still
-    // a valid 2xx catalog (adaptor findSlots → empty), but assert structure.
-    if (slots.length > 0) {
-      const first = slots[0];
+  for (const cat of REST_CATALOGS) {
+    test(`REST: GET /services/${cat.path} returns 2xx (${cat.issue})`, async ({
+      request,
+    }) => {
+      test.setTimeout(30_000);
+      const headers = {
+        ...adminBasicAuthHeaders(),
+        Accept: "application/json",
+      };
+      const url = `${BASE_URL}/Rhythmyx/services/${cat.path}`;
+      const res = await request.get(url, { headers });
       expect(
-        first.name || first.label,
-        "first slot should expose name or label",
-      ).toBeTruthy();
-    }
-  });
+        res.status(),
+        `GET ${url} must be 2xx (catalog residual ${cat.issue}; was 404/500 on older QA)`,
+      ).toBeGreaterThanOrEqual(200);
+      expect(res.status(), `GET ${url} must not be error`).toBeLessThan(300);
 
-  test("REST: GET /services/keywords returns 2xx (#2124)", async ({
-    request,
-  }) => {
-    test.setTimeout(30_000);
-    const headers = {
-      ...adminBasicAuthHeaders(),
-      Accept: "application/json",
-    };
-    const url = `${BASE_URL}/Rhythmyx/services/keywords`;
-    const res = await request.get(url, { headers });
-    expect(
-      res.status(),
-      `GET ${url} must be 2xx (catalog residual #2124; was 500 on older QA)`,
-    ).toBeGreaterThanOrEqual(200);
-    expect(res.status(), `GET ${url} must not be error`).toBeLessThan(300);
-
-    const body = await res.json();
-    // Wire format is Jackson-wrapped list under "Keyword" (KeywordSummary root).
-    const keywords = Array.isArray(body) ? body : body?.Keyword;
-    expect(
-      keywords,
-      "keywords response must be a JSON array or { Keyword: [...] } wrapper",
-    ).toBeTruthy();
-    expect(Array.isArray(keywords), "keywords payload must be an array").toBe(
-      true,
-    );
-    // Stock H2 ships design keywords (e.g. Adhoc_Type); empty list is still a
-    // valid 2xx catalog, but assert structure when data is present.
-    if (keywords.length > 0) {
-      const first = keywords[0];
+      const body = await res.json();
+      // Wire format is often Jackson-wrapped under the element name.
+      const rows = Array.isArray(body) ? body : body?.[cat.wrapperKey];
       expect(
-        first.label || first.value != null || first.description,
-        "first keyword should expose label, value, or description",
+        rows,
+        `${cat.path} response must be a JSON array or { ${cat.wrapperKey}: [...] } wrapper`,
       ).toBeTruthy();
-    }
-  });
+      expect(
+        Array.isArray(rows),
+        `${cat.path} payload must be an array`,
+      ).toBe(true);
+      // Empty catalog is still a valid 2xx (e.g. SearchDef:[] on stock H2).
+      if (rows.length > 0 && cat.nameFields?.length) {
+        const first = rows[0];
+        const hasLabel = cat.nameFields.some((f) => first?.[f] != null && first?.[f] !== "");
+        expect(
+          hasLabel,
+          `first ${cat.path} row should expose one of: ${cat.nameFields.join(", ")}`,
+        ).toBe(true);
+      }
+    });
+  }
 
   test("REST: GET /services/keywords?includeChoices=true returns 2xx with choices (#2124)", async ({
     request,


### PR DESCRIPTION
## Summary

**Slice D consolidator** for epic **#1694** / parent tracker work under **#1690**.

After H2 `perc-devctl qa-up` (#2065 path), re-probed the nine #1694 catalog REST endpoints with Basic auth + `RX_USEBASICAUTH` and expanded `developer-catalog-smoke` to a full REST matrix. Assertions reuse residual PR patterns (#2121 slots, #2124 keywords, #2140 locales, #2146 extensions, #2142/#2144/#2149/#2151/#2152 C-path) rather than duplicating product jaxrs registration (product fix remains **#2162** and peers).

### Live re-probe matrix (H2 `http://127.0.0.1:9993`, 2026-08-06)

| Endpoint | Status | Notes |
|----------|--------|-------|
| `/services/slots` | **200** | `Slot` array (rff* stock) — critical |
| `/services/keywords` | **200** | `Keyword` array — critical |
| `/services/keywords?includeChoices=true` | **200** | choices embedded |
| `/services/locales` | **200** | `LocaleSummary` |
| `/services/searches` | **200** | `SearchDef:[]` empty OK |
| `/services/views` | **200** | `ViewDef` |
| `/services/extensions/catalog` | **200** | `Extension:[]` empty OK |
| `/services/cecontrols` | **200** | `ControlDef` |
| `/services/serverconfigs` | **200** | `ServerConfig` |
| `/services/relationshiptypes` | **200** | `RelationshipType` |

No remaining 500s on this H2 install (C-path jaxrs beans hot-present; product registration PR #2162 still needed on main for cold installs).

### Changes

- `modules/perc-qa-automation/frontend/tests/developer-catalog-smoke.spec.js`
  - Table-driven REST 2xx + Jackson wrapper for all nine endpoints
  - keywords `includeChoices=true` choices assert (from #2161)
  - SPA content-types row locator → indexed `developer-ct-row-*` (CatalogTable)
- Erlang: `docs/ai-generated/code-reviews/issue-2118-catalog-smoke-reprobe-matrix-erlang.md`

**Out of scope (per #2118):** product multi-module jaxrs fixes (land on A/B/C residuals).

## Test plan

- [x] Live re-probe nine endpoints → all 200 (matrix above)
- [x] `npx playwright test tests/developer-catalog-smoke.spec.js -g "REST: GET /services/"` → **10 passed**
- [x] Full `developer-catalog-smoke.spec.js` → **16 passed** (REST + SPA slots/keywords/locales/content-types/…)
- [x] `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS**

## Gates evidence

| Gate | Result |
|------|--------|
| Erlang review | approve — issue-2118-catalog-smoke-reprobe-matrix-erlang.md |
| Maven perc-qa-automation clean install | BUILD SUCCESS |
| Live behavioral tests | 16/16 Playwright green on H2 qa-up |
| Product mega-PR avoided | QA module only |

## Parent / closes

- Parent tracker: **#1694** (epic closed; slice D residual)
- Related: **#1690**, residuals #2121/#2124/#2140/#2142–#2152, product jaxrs **#2162**
- **Fixes #2118**
- Does **not** close residual product PRs (#2161–#2167); those remain independent

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.