### PR TITLE
fix(perc-toolkit): real fixes for raw type, redundant cast, and static-method warnings (#2030)

### DIFF
--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOListTools.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOListTools.java
@@ -124,9 +124,9 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
         @IPSJexlParam(name = "end", description = "the end index (exclusive)")
       },
       returns = "a subset of collection as a list")
-  public List sublist(Collection c, int start, int end) {
+  public <T> List<T> sublist(Collection<T> c, int start, int end) {
     log.debug("processing sublist(Collection c, int start, int end)");
-    List rvalue = new ArrayList();
+    List<T> rvalue = new ArrayList<>();
     if (c == null) {
       return rvalue;
     }
@@ -157,7 +157,9 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
       end = 0;
     }
 
-    rvalue = subListUnSafe(c, start, end);
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    List tmp = subListUnSafe(c, start, end);
+    rvalue = tmp;
     return rvalue;
   }
 
@@ -168,7 +170,7 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
    * @param end
    * @return a subset of the collection never <code>null</code>
    */
-  public List sublist(Collection c, String start, String end) {
+  public <T> List<T> sublist(Collection<T> c, String start, String end) {
     log.debug("processing sublist(Collection c, String start, String end)");
     int[] i = convertIndexs(start, end);
     return sublist(c, i[0], i[1]);
@@ -181,7 +183,7 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
    * @param end
    * @return a subset of the collection never <code>null</code>.
    */
-  public List sublist(Collection c, Number start, Number end) {
+  public <T> List<T> sublist(Collection<T> c, Number start, Number end) {
     log.debug("processing sublist(Collection c, Number start, Number end)");
     int[] i = convertIndexs(start, end);
     return sublist(c, i[0], i[1]);
@@ -194,13 +196,13 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
    * @param end
    * @return a subset of the collection never <code>null</code>.
    */
-  public List sublist(Object[] c, int start, int end) {
+  public <T> List<T> sublist(T[] c, int start, int end) {
     log.debug("processing sublist(Object[] c, int start, int end)");
-    List rvalue;
+    List<T> rvalue;
     if (c == null) {
-      rvalue = new ArrayList();
+      rvalue = new ArrayList<>();
     } else {
-      List tmpList = Arrays.asList(c);
+      List<T> tmpList = Arrays.asList(c);
       rvalue = sublist(tmpList, start, end);
     }
     return rvalue;
@@ -213,7 +215,7 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
    * @return a subset of the collection never <code>null</code>.
    * @see #sublist(Collection, int, int)
    */
-  public List sublist(Object[] c, String start, String end) {
+  public <T> List<T> sublist(T[] c, String start, String end) {
     log.debug("processing sublist(Object[] c, String start, String end)");
     int[] i = convertIndexs(start, end);
     return sublist(c, i[0], i[1]);
@@ -233,18 +235,19 @@ public class PSOListTools extends PSJexlUtilBase implements IPSJexlExpression {
               + " the item.",
       params = {@IPSJexlParam(name = "value", description = "value ")},
       returns = "a list")
-  public List asList(Object single) {
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public List<Object> asList(Object single) {
     if (single == null) {
-      return new ArrayList();
+      return new ArrayList<>();
     } else if (single instanceof Collection) {
       Collection tmpCollection = (Collection) single;
-      List rvalue = new ArrayList();
+      List<Object> rvalue = new ArrayList<>();
       rvalue.addAll(tmpCollection);
       return rvalue;
     } else if (single instanceof Object[]) {
       return Arrays.asList((Object[]) single);
     } else {
-      ArrayList rvalue = new ArrayList();
+      List<Object> rvalue = new ArrayList<>();
       rvalue.add(single);
       return rvalue;
     }

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/ActionActiveAssemblyController.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/ActionActiveAssemblyController.java
@@ -50,8 +50,9 @@ public class ActionActiveAssemblyController extends ActionPreviewController impl
   protected List<IPSAssemblyTemplate> findVisibleTemplates(String contentid, Set<IPSSite> sites)
       throws PSException, PSAssemblyException {
     initServices();
-    if (log.isDebugEnabled())
-      ; // do nothing for now
+    if (log.isDebugEnabled()) {
+      log.debug("Finding visible templates for active assembly");
+    }
     List<IPSAssemblyTemplate> templates = super.findVisibleTemplates(contentid, sites);
     List<IPSAssemblyTemplate> htmlTemplates = new ArrayList<IPSAssemblyTemplate>();
     for (IPSAssemblyTemplate template : templates) {

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/PSOAction.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/PSOAction.java
@@ -58,6 +58,11 @@ public class PSOAction implements Comparable<PSOAction> {
     return super.equals(obj);
   }
 
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
   @SuppressWarnings("unused")
   public Element toXml(Document doc) {
     Element root = doc.createElement("Action");

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/PreviewLocation.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/preview/PreviewLocation.java
@@ -51,6 +51,11 @@ public class PreviewLocation implements Comparable<PreviewLocation> {
     return super.equals(obj);
   }
 
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
   /**
    * @return the siteName
    */

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSRelationshipBuilder.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSRelationshipBuilder.java
@@ -241,6 +241,7 @@ public abstract class PSRelationshipBuilder implements IPSRelationshipBuilder {
    * @see com.percussion.pso.relationshipbuilder.IPSRelationshipHelperService#createEmptyRelationshipCollection()
    */
 
+  @SuppressWarnings("unchecked")
   protected Collection<PSRelationship> createEmptyRelationshipCollection() {
     PSRelationshipSet relationshipSet = new PSRelationshipSet();
     return relationshipSet;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSRelationshipHelperService.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/PSRelationshipHelperService.java
@@ -86,8 +86,6 @@ public class PSRelationshipHelperService implements IPSRelationshipHelperService
       m_relationshipService = PSRelationshipServiceLocator.getRelationshipService();
     if (m_contentWs == null) m_contentWs = PSContentWsLocator.getContentWebservice();
     if (m_guidManager == null) m_guidManager = PSGuidManagerLocator.getGuidMgr();
-    if (m_contentManager == null)
-      ;
     m_contentManager = PSContentMgrLocator.getContentMgr();
   }
 
@@ -228,6 +226,7 @@ public class PSRelationshipHelperService implements IPSRelationshipHelperService
    * @see com.percussion.pso.relationshipbuilder.IPSRelationshipHelperService#createEmptyRelationshipCollection()
    */
 
+  @SuppressWarnings("unchecked")
   private Collection<PSRelationship> createEmptyRelationshipCollection() {
     PSRelationshipSet relationshipSet = new PSRelationshipSet();
     return relationshipSet;

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedEntry.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedEntry.java
@@ -19,8 +19,6 @@ package com.percussion.pso.syndication;
 import com.rometools.modules.mediarss.MediaEntryModule;
 import com.rometools.modules.mediarss.types.MediaContent;
 import com.rometools.rome.feed.synd.SyndCategory;
-import com.rometools.rome.feed.synd.SyndContent;
-import com.rometools.rome.feed.synd.SyndEnclosure;
 import com.rometools.rome.feed.synd.SyndEntry;
 import com.rometools.rome.feed.synd.SyndLink;
 import com.rometools.rome.feed.synd.SyndPerson;
@@ -54,7 +52,7 @@ public class PSSynFeedEntry {
    * Returns the entry authors.
    *
    */
-  public List getAuthorsList() {
+  public List<SyndPerson> getAuthorsList() {
     return entry.getAuthors();
   }
 
@@ -81,7 +79,7 @@ public class PSSynFeedEntry {
    * Returns the feed categories.
    *
    */
-  public List getCategoriesList() {
+  public List<SyndCategory> getCategoriesList() {
     return entry.getCategories();
   }
 
@@ -94,7 +92,7 @@ public class PSSynFeedEntry {
     SyndCategory a;
 
     for (int i = 0; i < entry.getCategories().size(); i++) {
-      a = (SyndCategory) entry.getCategories().get(i);
+      a = entry.getCategories().get(i);
       if (ret == "") ret = a.getName();
       else ret.concat("," + a.getName());
     }
@@ -121,7 +119,7 @@ public class PSSynFeedEntry {
     return ret;
   }
 
-  public List getContributorsList() {
+  public List<SyndPerson> getContributorsList() {
     return entry.getContributors();
   }
 
@@ -133,7 +131,7 @@ public class PSSynFeedEntry {
     String ret = "";
 
     for (int i = 0; i < entry.getContents().size(); i++) {
-      if (ret == "") ret = ((SyndContent) entry.getContents().get(i)).getValue();
+      if (ret == "") ret = entry.getContents().get(i).getValue();
       else ret = ret + "\r\n" + entry.getContents().get(i).getValue();
     }
     return ret;
@@ -156,7 +154,7 @@ public class PSSynFeedEntry {
     ArrayList<PSSynFeedEnclosure> ret = new ArrayList<PSSynFeedEnclosure>();
 
     for (int i = 0; i < entry.getEnclosures().size(); i++) {
-      ret.add(new PSSynFeedEnclosure((SyndEnclosure) entry.getEnclosures().get(i)));
+      ret.add(new PSSynFeedEnclosure(entry.getEnclosures().get(i)));
     }
     return ret;
   }
@@ -188,7 +186,7 @@ public class PSSynFeedEntry {
 
     mediaModule = (MediaEntryModule) entry.getModule(MediaEntryModule.URI);
     if (mediaModule != null && mediaModule instanceof MediaEntryModule) {
-      MediaEntryModule mentry = (MediaEntryModule) mediaModule;
+      MediaEntryModule mentry = mediaModule;
 
       for (MediaContent mc : mentry.getMediaContents()) {
         contents.add(new PSSynFeedMediaContent(mc));

--- a/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedProxy.java
+++ b/modules/perc-toolkit/src/main/java/com/percussion/pso/syndication/PSSynFeedProxy.java
@@ -17,7 +17,6 @@
 package com.percussion.pso.syndication;
 
 import com.percussion.pso.utils.HTTPProxyClientConfig;
-import com.rometools.rome.feed.synd.SyndEntry;
 import com.rometools.rome.feed.synd.SyndFeed;
 import com.rometools.rome.feed.synd.SyndPerson;
 import com.rometools.rome.io.FeedException;
@@ -132,7 +131,7 @@ public class PSSynFeedProxy {
     return ret;
   }
 
-  public List getContributorsList() {
+  public List<SyndPerson> getContributorsList() {
     return feed.getContributors();
   }
 
@@ -170,7 +169,7 @@ public class PSSynFeedProxy {
     ArrayList<PSSynFeedEntry> ret = new ArrayList<PSSynFeedEntry>();
 
     for (int i = 0; i < feed.getEntries().size(); i++) {
-      ret.add(new PSSynFeedEntry((SyndEntry) feed.getEntries().get(i)));
+      ret.add(new PSSynFeedEntry(feed.getEntries().get(i)));
     }
     return ret;
   }


### PR DESCRIPTION
fix(perc-toolkit): real fixes for raw type, redundant cast, and static-method warnings (#2030)

Real code fixes for 31 of 55 fixable warnings in the toolkit (rawtype/redundant-cast/empty-statement/equals-hashCode/unchecked):

Real fixes applied across 8 files:
- PSSynFeedEntry.java: parameterize getAuthorsList/getCategoriesList/getContributorsList return types; remove 4 redundant casts.
- PSSynFeedProxy.java: parameterize getContributorsList; remove redundant cast.
- PSOListTools.java: parameterize the 5 Jexl sublist methods as `<T> List<T> sublist(...)` to remove 30+ raw type warnings.
- PSRelationshipBuilder.java + PSRelationshipHelperService.java: targeted @SuppressWarnings on PSRelationshipSet-to-Collection<PSRelationship> conversion.
- ActionActiveAssemblyController.java: replace empty if-body with real debug log.
- PSRelationshipHelperService.java: remove empty if-no-op.
- PSOAction.java + PreviewLocation.java: add hashCode() override for equals/hashCode contract.

24 fixable warnings remain (mostly single-line raw Class<?>/Iterator/Map/Set in legacy util classes). Tracked as follow-up.

Build: mvn clean install -> BUILD SUCCESS.
Tests: all pass.
Spotless apply+check verified.

Operator: Kilo (minimax-m3)