### PR TITLE
fix(perc-ant): real fixes for raw type, redundant cast, and varargs warnings (#2023)

### DIFF
--- a/modules/perc-ant/src/main/java/com/percussion/ant/PSCheckTmxFile.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/PSCheckTmxFile.java
@@ -199,7 +199,7 @@ public class PSCheckTmxFile extends Task {
    * @throws BuildException if an IO error occurs
    */
   private void checkForDupesInPropertyFiles() throws BuildException {
-    Iterator it = m_propertyFiles.iterator();
+    Iterator<String> it = m_propertyFiles.iterator();
     File file = null;
     Properties props = null;
     boolean foundErrors = false;
@@ -211,7 +211,7 @@ public class PSCheckTmxFile extends Task {
         throw new BuildException("Property file does not exist: " + file.getAbsolutePath());
       try {
         props = loadProperties(file);
-        Enumeration keys = props.keys();
+        Enumeration<Object> keys = props.keys();
         while (keys.hasMoreElements()) {
           String key = (String) keys.nextElement();
           if (m_tmxIds.contains(key)) {

--- a/modules/perc-ant/src/main/java/com/percussion/ant/PSCreateSharedClassList.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/PSCreateSharedClassList.java
@@ -83,9 +83,9 @@ public class PSCreateSharedClassList extends Task {
       getAllPackageNmkPaths(m_dir);
       addComment(TOP_COMMENT);
       addFileSetStart();
-      Iterator it = m_paths.iterator();
+      Iterator<File> it = m_paths.iterator();
       while (it.hasNext()) {
-        File current = (File) it.next();
+        File current = it.next();
         PSMakefileInterpreter interp = new PSMakefileInterpreter(current);
         interp.interpret();
         createEntries(interp.getMacros());

--- a/modules/perc-ant/src/main/java/com/percussion/ant/PSDelete.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/PSDelete.java
@@ -160,7 +160,7 @@ public class PSDelete extends Delete {
 
     // delete the files in the filesets
     for (int i = 0; i < filesets.size(); i++) {
-      FileSet fs = (FileSet) filesets.elementAt(i);
+      FileSet fs = filesets.elementAt(i);
       try {
         DirectoryScanner ds = fs.getDirectoryScanner(getProject());
         String[] files = ds.getIncludedFiles();

--- a/modules/perc-ant/src/main/java/com/percussion/ant/PSGetReleaseDocumentsPath.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/PSGetReleaseDocumentsPath.java
@@ -132,7 +132,7 @@ public class PSGetReleaseDocumentsPath extends Task {
 
     String version = m_major + "." + m_minor;
     if (Integer.parseInt(m_micro) > 0) version += "." + m_micro;
-    List versionDirs = getAllVersionDirectories(rootDir);
+    List<String> versionDirs = getAllVersionDirectories(rootDir);
 
     if (!versionDirs.contains(version)) return;
 
@@ -149,7 +149,7 @@ public class PSGetReleaseDocumentsPath extends Task {
    *     <code>null</code>.
    * @return a list of all version directories, never <code>null</code>, and should not be empty.
    */
-  private List getAllVersionDirectories(File rootdir) {
+  private List<String> getAllVersionDirectories(File rootdir) {
     if (rootdir == null) throw new IllegalArgumentException("rootdir cannot be null.");
     List<String> dirs = new ArrayList<String>();
     File[] children = rootdir.listFiles();

--- a/modules/perc-ant/src/main/java/com/percussion/ant/PSHelpHintFileCreator.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/PSHelpHintFileCreator.java
@@ -71,10 +71,8 @@ public class PSHelpHintFileCreator {
     validatePaths();
     Properties mappings = loadMappings();
     final Map<String, String> sortedMappings = new TreeMap<String, String>();
-    Iterator it = mappings.keySet().iterator();
-    while (it.hasNext()) {
-      String key = (String) it.next();
-      sortedMappings.put(key, (String) mappings.get(key));
+    for (String key : mappings.stringPropertyNames()) {
+      sortedMappings.put(key, mappings.getProperty(key));
     }
 
     PrintStream out = null;
@@ -292,10 +290,10 @@ public class PSHelpHintFileCreator {
    * @param source assumed not <code>null</code>.
    * @return list of all the field description p tags, never <code>null</code>, may be empty.
    */
-  private List getAllFieldDescStartTags(Source source) {
-    List tags = new ArrayList();
-    for (Iterator it = source.findAllStartTags(ELEM_P).iterator(); it.hasNext(); ) {
-      StartTag sTag = (StartTag) it.next();
+  private List<StartTag> getAllFieldDescStartTags(Source source) {
+    List<StartTag> tags = new ArrayList<>();
+    for (Iterator<StartTag> it = source.findAllStartTags(ELEM_P).iterator(); it.hasNext(); ) {
+      StartTag sTag = it.next();
       if (isFieldDescription(sTag)) {
         tags.add(sTag);
       }

--- a/modules/perc-ant/src/main/java/com/percussion/ant/PSJunitFileSelector.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/PSJunitFileSelector.java
@@ -278,7 +278,7 @@ public class PSJunitFileSelector extends BaseExtendSelector {
    *
    * @see org.apache.tools.ant.types.Parameterizable#setParameters(Parameter[])
    */
-  public void setParameters(Parameter parameters[]) {
+  public void setParameters(Parameter... parameters) {
     super.setParameters(parameters);
 
     // clear lists

--- a/modules/perc-ant/src/main/java/com/percussion/ant/PSMakefileInterpreter.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/PSMakefileInterpreter.java
@@ -47,8 +47,9 @@ public class PSMakefileInterpreter {
    *
    * @return a copy of the macro map, never <code>null</code>.
    */
-  public Map getMacros() {
-    return (Map) m_macros.clone();
+  @SuppressWarnings("unchecked")
+  public Map<String, String> getMacros() {
+    return (Map<String, String>) m_macros.clone();
   }
 
   /**
@@ -99,7 +100,7 @@ public class PSMakefileInterpreter {
         // a heuristic to tell if the right side is ok - won't always work
         if (!right.startsWith("=")) {
           if (shouldAppend) {
-            String str = (String) m_macros.get(left);
+            String str = m_macros.get(left);
             if (str == null) str = "";
             left = str + left;
           }
@@ -132,7 +133,7 @@ public class PSMakefileInterpreter {
 
           if (c == ')') {
             String varName = buf.substring(startVar + 2, endVar);
-            String varValue = (String) m_macros.get(varName);
+            String varValue = m_macros.get(varName);
             if (varValue == null) varValue = "";
             buf.replace(startVar, endVar + 1, varValue);
             pos = startVar - 1;


### PR DESCRIPTION
fix(perc-ant): real fixes for raw type, redundant cast, and varargs warnings (#2023)

Real code fixes for 10 of 93 fixable warnings in perc-ant:
- PSCheckTmxFile.java: parameterize Iterator<String> and Enumeration<Object>.
- PSDelete.java: remove redundant (FileSet) cast since Ant's Task#filesets is already Vector<FileSet>.
- PSCreateSharedClassList.java: parameterize Iterator<File>.
- PSGetReleaseDocumentsPath.java: parameterize List<String> at declaration and call site.
- PSHelpHintFileCreator.java: replace raw Iterator+cast loop with `for (String key : mappings.stringPropertyNames())` foreach; parameterize getAllFieldDescStartTags return List<StartTag>.
- PSJunitFileSelector.java: change setParameters(Parameter[]) to Parameter... to match parent varargs.
- PSMakefileInterpreter.java: parameterize Map<String, String> getMacros() with @SuppressWarnings on clone(); remove 2 redundant (String) casts.

83 fixable warnings remain (mostly raw Class<?> / Iterator in PSJunitFileSelector and PSHelpHintFileCreator). Tracked as follow-up.

Build: mvn clean install -> BUILD SUCCESS.
Tests: pass.
Spotless apply+check verified.

Operator: Kilo (minimax-m3)