### PR TITLE
test(WebUI): TemplateDetailPanel full panelErrMsg ladder (#2159)

### DIFF
--- a/WebUI/src/test/ts/developer/TemplateDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/TemplateDetailPanel.test.tsx
@@ -5,11 +5,13 @@
 import React from "react";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
 import {
   getTemplateDetail,
   listSlots,
 } from "../../../main/ts/api/developer/assemblyApi";
 import { TemplateDetailPanel } from "../../../main/ts/developer/TemplateDetailPanel";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
 import * as sourceViewer from "../../../main/ts/developer/templateSourceViewer";
 
 vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
@@ -18,13 +20,31 @@ vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
   updateTemplateDetail: vi.fn(),
 }));
 
+// ObjectAclSection loads ACL via separate API; stub so detail-load stays isolated.
+vi.mock("../../../main/ts/developer/ObjectAclSection", () => ({
+  ObjectAclSection: () => <div data-testid="developer-tpl-acl-stub" />,
+}));
+
 const getTemplateDetailMock = vi.mocked(getTemplateDetail);
 const listSlotsMock = vi.mocked(listSlots);
 
 const multiLineSource = "<html>\n<body>$sys.variables\n</body>\n</html>";
 
+const sampleDetail = {
+  name: "perc.page",
+  label: "Page",
+  description: "Page template",
+  templateSource: multiLineSource,
+  bindings: [{ executionOrder: 1, variable: "$x", expression: "1" }],
+  slots: [{ name: "target", label: "Target" }],
+  designGaps: ["read-only"],
+};
+
 describe("TemplateDetailPanel", () => {
   beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
     getTemplateDetailMock.mockReset();
     listSlotsMock.mockReset();
     listSlotsMock.mockResolvedValue([]);
@@ -35,25 +55,21 @@ describe("TemplateDetailPanel", () => {
     vi.restoreAllMocks();
   });
 
-  it("renders bindings slots and source", async () => {
-    getTemplateDetailMock.mockResolvedValue({
-      name: "perc.page",
-      label: "Page",
-      bindings: [{ executionOrder: 1, variable: "$x", expression: "1" }],
-      slots: [{ name: "target", label: "Target" }],
-      templateSource: multiLineSource,
-      designGaps: ["read-only"],
-    });
+  it("loads detail on success with bindings slots and source", async () => {
+    getTemplateDetailMock.mockResolvedValue(sampleDetail);
     listSlotsMock.mockResolvedValue([
       { name: "target", label: "Target", description: "Main slot" },
     ]);
     const onBack = vi.fn();
     render(<TemplateDetailPanel idOrName="perc.page" onBack={onBack} />);
     await waitFor(() => {
-      expect(screen.getByTestId("developer-tpl-detail")).toBeTruthy();
+      expect(screen.getByTestId("developer-tpl-detail-title")).toBeTruthy();
     });
+    expect(screen.getByTestId("developer-tpl-detail-title").textContent).toContain("Page");
     expect(screen.getByTestId("developer-tpl-bindings")).toBeTruthy();
+    expect(screen.getByTestId("developer-tpl-bindings-table")).toBeTruthy();
     expect(screen.getByTestId("developer-tpl-slots")).toBeTruthy();
+    expect(screen.getByTestId("developer-tpl-slots-table")).toBeTruthy();
     expect(screen.getByTestId("developer-tpl-source")).toBeTruthy();
     expect(screen.getByTestId("developer-tpl-source-edit")).toBeTruthy();
     expect(screen.getByTestId("developer-tpl-source-lines")).toBeTruthy();
@@ -62,6 +78,33 @@ describe("TemplateDetailPanel", () => {
     expect(screen.getByTestId("developer-tpl-source-copy")).toBeTruthy();
     fireEvent.click(screen.getByTestId("developer-tpl-back"));
     expect(onBack).toHaveBeenCalled();
+  });
+
+  it("shows empty bindings slots and source sections when detail has none", async () => {
+    getTemplateDetailMock.mockResolvedValue({
+      name: "perc.empty",
+      label: "Empty",
+      bindings: [],
+      slots: [],
+      templateSource: "",
+      designGaps: [],
+    });
+    listSlotsMock.mockResolvedValue([]);
+    render(<TemplateDetailPanel idOrName="perc.empty" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-detail-title")).toBeTruthy();
+    });
+    const bindings = screen.getByTestId("developer-tpl-bindings");
+    expect(bindings.textContent).toContain(DEV_MSG.TPL_NONE);
+    expect(screen.queryByTestId("developer-tpl-bindings-table")).toBeNull();
+
+    const slots = screen.getByTestId("developer-tpl-slots");
+    expect(slots.textContent).toContain(DEV_MSG.TPL_NONE);
+    expect(screen.queryByTestId("developer-tpl-slots-table")).toBeNull();
+
+    expect(screen.getByTestId("developer-tpl-source")).toBeTruthy();
+    const sourceEdit = screen.getByTestId("developer-tpl-source-edit") as HTMLTextAreaElement;
+    expect(sourceEdit.value).toBe("");
   });
 
   it("toggles preview highlight and copy feedback", async () => {
@@ -97,12 +140,54 @@ describe("TemplateDetailPanel", () => {
     });
   });
 
-  it("shows error when detail load fails", async () => {
-    getTemplateDetailMock.mockRejectedValue({ status: 404, statusText: "Not Found" });
+  it("shows session-redirect message via panelErrMsg", async () => {
+    getTemplateDetailMock.mockRejectedValue(new SessionRedirectError());
+    render(<TemplateDetailPanel idOrName="perc.page" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-tpl-detail-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-tpl-detail-loading")).toBeNull();
+    expect(screen.queryByTestId("developer-tpl-detail-title")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    getTemplateDetailMock.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<TemplateDetailPanel idOrName="perc.page" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-tpl-detail-error").textContent).toBe(
+      `${DEV_MSG.TPL_DETAIL_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    getTemplateDetailMock.mockRejectedValue(new Error("network down"));
+    render(<TemplateDetailPanel idOrName="perc.page" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-tpl-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-tpl-detail-error").textContent).toBe(
+      `${DEV_MSG.TPL_DETAIL_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-tpl-detail-title")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    getTemplateDetailMock.mockRejectedValue("boom");
     render(<TemplateDetailPanel idOrName="missing" onBack={() => undefined} />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-tpl-detail-error")).toBeTruthy();
     });
-    expect(screen.getByTestId("developer-tpl-detail-error").textContent).toMatch(/404/);
+    expect(screen.getByTestId("developer-tpl-detail-error").textContent).toBe(
+      DEV_MSG.TPL_DETAIL_ERROR,
+    );
   });
 });

--- a/WebUI/src/test/ts/developer/TemplateDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/TemplateDetailPanel.test.tsx
@@ -53,6 +53,7 @@ describe("TemplateDetailPanel", () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+    delete (window as { I18N?: unknown }).I18N;
   });
 
   it("loads detail on success with bindings slots and source", async () => {
@@ -180,7 +181,7 @@ describe("TemplateDetailPanel", () => {
     expect(screen.queryByTestId("developer-tpl-detail-title")).toBeNull();
   });
 
-  it("shows fallback when rejection has no message", async () => {
+  it("shows fallback for non-Error rejection", async () => {
     getTemplateDetailMock.mockRejectedValue("boom");
     render(<TemplateDetailPanel idOrName="missing" onBack={() => undefined} />);
     await waitFor(() => {


### PR DESCRIPTION
## Summary

Implements **#2159** (DetailPanel cluster E residual of **#2139** / parent **#2119** / grandparent **#1690**).

Expand TemplateDetailPanel.test.tsx from success + single 404-style failure to full detail-load panelErrMsg ladder matching Slot/Community/ContentType peers (PR #2160) and list-panel ladders:

- session-redirect via SessionRedirectError
- ApiError status ((500))
- Error.message
- non-Error fallback
- success + empty bindings/slots/source sections where applicable

Also keeps existing source-viewer toggle/copy coverage. Stubs ObjectAclSection so detail-load stays isolated. **No product UI changes.**

## Test plan

- [x] Focused Vitest: TemplateDetailPanel.test.tsx (7 tests green)
- [x] WebUI standalone mvnw clean install green (190 files / 1289 tests)
- [x] No product code changes; Vitest companions only (no Playwright required)

## Gates evidence

- Erlang-style self-review: pure tests, peer-mirrored ladders, no path I/O, no UI expansion
- Change class: Vitest companions only
- Module: WebUI clean install SUCCESS

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2159.
Partial for #2139 / #2119 / #1690.