### PR TITLE
fix(extensions-main): parameterize Iterator in PSAddAssemblerInfo runtime parameter loop (#2029)

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentTypeDependencyHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/dependencies/PSContentTypeDependencyHandler.java
@@ -164,7 +164,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
 
           PSWorkflowInfo wfInfo = ce.getWorkflowInfo();
           if (wfInfo != null) {
-            Iterator ids = wfInfo.getValues();
+            Iterator<Integer> ids = wfInfo.getValues();
             while (ids.hasNext()) {
               PSDependency childDep = null;
               try {
@@ -1455,9 +1455,9 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
     PSWorkflowInfo wfInfo = ce.getWorkflowInfo();
     if (wfInfo != null) {
       List<Integer> newIds = new ArrayList<>();
-      Iterator ids = wfInfo.getValues();
+      Iterator<Integer> ids = wfInfo.getValues();
       while (ids.hasNext()) {
-        Integer oldId = (Integer) ids.next();
+        Integer oldId = ids.next();
         newIds.add(Integer.valueOf(getNewIdInt(ctx, oldId.toString(), wfType)));
       }
       wfInfo.setValues(newIds);
@@ -1476,10 +1476,10 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
     Integer defaultWfId = -1;
 
     if (wfInfo != null) {
-      Iterator ids = wfInfo.getValues();
+      Iterator<Integer> ids = wfInfo.getValues();
       while (ids.hasNext()) {
         // use first included workflow which exists on target system
-        Integer id = (Integer) ids.next();
+        Integer id = ids.next();
         IPSGuid wfGuid = PSGuidUtils.makeGuid(id, PSTypeEnum.WORKFLOW);
         PSWorkflow wf = ms_wfSvc.loadWorkflow(wfGuid);
         if (wf != null) {
@@ -1513,7 +1513,7 @@ public class PSContentTypeDependencyHandler extends PSContentEditorObjectDepende
       throws PSDeployException {
     PSWorkflowInfo wfInfo = ce.getWorkflowInfo();
     if (wfInfo != null) {
-      Iterator ids = wfInfo.getValues();
+      Iterator<Integer> ids = wfInfo.getValues();
       while (ids.hasNext()) {
         String id = String.valueOf(ids.next());
         boolean included =

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSAddAssemblerInfo.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSAddAssemblerInfo.java
@@ -120,7 +120,7 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
     if (ms_paramCount == NOT_INITIALIZED) {
       ms_paramCount = 0;
 
-      Iterator iter = extensionDef.getRuntimeParameterNames();
+      Iterator<String> iter = extensionDef.getRuntimeParameterNames();
       while (iter.hasNext()) {
         iter.next();
         ms_paramCount++;

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSAddAssemblerInfo.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSAddAssemblerInfo.java
@@ -106,7 +106,6 @@ import org.xml.sax.SAXException;
  * style sheet files and transform only if the destination stylesheets do not exist or source files
  * are modfied.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
   /** Creates a new PSAddAssemblerInfo. */
   public PSAddAssemblerInfo() {}

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSAddAssemblerInfo.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSAddAssemblerInfo.java
@@ -823,7 +823,7 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
     Document doc = null;
     IPSInternalRequest iReq = null;
     try {
-      Map params = new HashMap();
+      Map<String, Object> params = new HashMap<>();
       params.put(IPSHtmlParameters.SYS_CONTENTID, contentid);
       iReq = request.getInternalRequest(CONTENT_DETAILS_URL, params, false);
       doc = iReq.getResultDoc();
@@ -1135,7 +1135,7 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
    */
   private void recordModified(File file, boolean bResetPrevious) {
     if (bResetPrevious) {
-      Set entries = ms_props.entrySet();
+      Set<Map.Entry<Object, Object>> entries = ms_props.entrySet();
       if (entries != null) entries.clear();
     }
     String modDateCurrent = Long.toString(file.lastModified());

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSAddAssemblerInfo.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSAddAssemblerInfo.java
@@ -106,6 +106,7 @@ import org.xml.sax.SAXException;
  * style sheet files and transform only if the destination stylesheets do not exist or source files
  * are modfied.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
   /** Creates a new PSAddAssemblerInfo. */
   public PSAddAssemblerInfo() {}

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSAddAssemblerInfo.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSAddAssemblerInfo.java
@@ -181,7 +181,8 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
        * Convert to standard HTML parameter names and add default siteid
        * if not there yet.
        */
-      Map htmlParams = PSHtmlParameters.createStandardParams(request.getParameters());
+      Map<String, Object> htmlParams =
+          PSHtmlParameters.createStandardParams(request.getParameters());
       htmlParams.put(IPSHtmlParameters.SYS_SESSIONID, request.getUserSessionId());
 
       String variantid = request.getParameter(IPSHtmlParameters.SYS_VARIANTID);
@@ -190,13 +191,13 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
 
       // get the global template
       String globalTemplate = null;
-      List sites = PSSite.getSites(request);
+      List<PSSite> sites = PSSite.getSites(request);
       // Only lookup a global template if the variant is not set to use a
       // velocity global template, i.e. a value other than legacy.[]
       if (!sites.isEmpty()
           && template.getGlobalTemplateUsage().equals(GlobalTemplateUsage.Legacy)) {
         // there is always maximum one site
-        PSSite site = (PSSite) sites.get(0);
+        PSSite site = sites.get(0);
         globalTemplate = site.getGlobalTemplateName();
 
         PSLocator itemLocator =
@@ -212,10 +213,10 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
       Element assemblerInfo = doc.createElement(ASSEMBLER_INFO_ELEM);
       assemblerInfo.setAttribute(PREVIEWURL_ATTR, requestFileURL);
       if (globalTemplate != null) assemblerInfo.setAttribute("psxglobaltemplate", globalTemplate);
-      Iterator attrs = htmlParams.entrySet().iterator();
+      Iterator<Map.Entry<String, Object>> attrs = htmlParams.entrySet().iterator();
       while (attrs.hasNext()) {
-        Map.Entry attr = (Map.Entry) attrs.next();
-        assemblerInfo.setAttribute((String) attr.getKey(), (String) attr.getValue());
+        Map.Entry<String, Object> attr = attrs.next();
+        assemblerInfo.setAttribute(attr.getKey(), (String) attr.getValue());
       }
 
       /*
@@ -307,7 +308,7 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
         // "sys_casSupport/AssemblerProperties". The cache flag is enabled
         // for
         // the resource.
-        Map assemblyParams = new HashMap(2);
+        Map<String, Object> assemblyParams = new HashMap<>(2);
         assemblyParams.put(
             IPSHtmlParameters.SYS_CONTEXT, htmlParams.get(IPSHtmlParameters.SYS_CONTEXT));
         assemblyParams.put(
@@ -324,7 +325,7 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
         }
 
         // append the InlineLink element
-        Map paramMap = new HashMap(2);
+        Map<String, Object> paramMap = new HashMap<>(2);
         paramMap.put(IPSHtmlParameters.SYS_SESSIONID, request.getUserSessionId());
         paramMap.put(IPSHtmlParameters.SYS_CONTEXT, htmlParams.get(IPSHtmlParameters.SYS_CONTEXT));
 
@@ -343,7 +344,7 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
         assemblerInfo.appendChild(inlineLink);
 
         // append the varianturl element
-        Map vurlParamMap = new HashMap(3);
+        Map<String, Object> vurlParamMap = new HashMap<>(3);
         vurlParamMap.put(IPSHtmlParameters.SYS_SESSIONID, request.getUserSessionId());
         vurlParamMap.put(
             IPSHtmlParameters.SYS_CONTEXT, htmlParams.get(IPSHtmlParameters.SYS_CONTEXT));
@@ -368,7 +369,7 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
         // for
         // correct version and revision numbers.
         // extract all body field nodes from the full document
-        List bodyFields = new ArrayList();
+        List<Text> bodyFields = new ArrayList<>();
         NodeList nl = doc.getElementsByTagName("*");
         int nodeCount = nl.getLength();
         // Collect all rich text fields if the assembly process is not
@@ -390,7 +391,7 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
               PSSingleValueBuilder.buildRelationshipData(request, null);
           for (int i = 0; i < count; i++) {
             try {
-              Text txtContent = (Text) bodyFields.get(i);
+              Text txtContent = bodyFields.get(i);
               String content = (txtContent).getData();
               Document contentDoc =
                   PSXmlDocumentBuilder.createXmlDocument(new StringReader(content), false);
@@ -464,13 +465,13 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
 
       // get the locator paths for the supplied item
 
-      List folderPaths = fprocessor.getFolderLocatorPaths(locator);
+      List<List<PSLocator>> folderPaths = fprocessor.getFolderLocatorPaths(locator);
 
       boolean foundSiteTree = false;
-      List locatorPath = null;
-      Iterator walker = folderPaths.iterator();
+      List<PSLocator> locatorPath = null;
+      Iterator<List<PSLocator>> walker = folderPaths.iterator();
       while (!foundSiteTree && walker.hasNext()) {
-        locatorPath = (List) walker.next();
+        locatorPath = walker.next();
         foundSiteTree = isPathForSite(locatorPath, siteFolderId);
       }
 
@@ -481,9 +482,9 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
          * Walk the path from the bottom up to find the global template
          * override with the highest precedence.
          */
-        ListIterator walkPath = locatorPath.listIterator();
+        ListIterator<PSLocator> walkPath = locatorPath.listIterator();
         while (walkPath.hasNext()) {
-          flocator = (PSLocator) walkPath.next();
+          flocator = walkPath.next();
           globalTemplate = fprocessor.getGlobalTemplateProperty(flocator.getId());
           if (globalTemplate != null && globalTemplate.trim().length() > 0) {
             return globalTemplate;
@@ -506,10 +507,10 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
    * @return <code>true</code> if the supplied locator path contains the provided site id, <code>
    *     false</code> otherwise.
    */
-  private boolean isPathForSite(List locatorPath, int siteFolderId) {
+  private boolean isPathForSite(List<PSLocator> locatorPath, int siteFolderId) {
     PSLocator folder;
     for (int i = 0; i < locatorPath.size(); i++) {
-      folder = (PSLocator) locatorPath.get(i);
+      folder = locatorPath.get(i);
       if (folder.getId() == siteFolderId) return true;
     }
 
@@ -556,12 +557,14 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
   private boolean isAssemblyRecursive(IPSRequestContext request) {
     String recursionKey = makeKeyFromRequestContext(request);
     request.printTraceMessage("recursionKey = " + recursionKey);
-    Map assembleRecursionMap = (Map) request.getPrivateObject(ASSEMBLY_RECURSION_MAP_KEY);
-    Set levels = (Set) assembleRecursionMap.get(recursionKey);
+    @SuppressWarnings("unchecked")
+    Map<String, Set<String>> assembleRecursionMap =
+        (Map<String, Set<String>>) request.getPrivateObject(ASSEMBLY_RECURSION_MAP_KEY);
+    Set<String> levels = assembleRecursionMap.get(recursionKey);
     int currentAssemblyLevel = readCurrentAssemblyLevel(request);
     boolean recursion = false;
     if (levels == null) {
-      levels = new HashSet();
+      levels = new HashSet<>();
       levels.add("" + currentAssemblyLevel);
       assembleRecursionMap.put(recursionKey, levels);
     } else {
@@ -609,7 +612,7 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
    */
   private static String makeKeyFromRequestContext(IPSRequestContext request) {
     if (request == null) throw new IllegalArgumentException("request must not be null");
-    Map params = new HashMap(request.getParameters());
+    Map<String, Object> params = new HashMap<>(request.getParameters());
     params.remove(ASSEMBLY_LEVEL);
     return request.getRequestFileURL() + params;
   }
@@ -658,7 +661,7 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
     // You are working on parent and we initialize parentid with the contentid.
     if (parent != null) parentid = contentid;
 
-    List ridList = new ArrayList();
+    List<String> ridList = new ArrayList<>();
     if (activeitemid != null && activeitemid.trim().length() > 0) {
       ridList.add(activeitemid.trim());
     }
@@ -667,7 +670,7 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
       ridList.add(tok.nextToken());
     }
     if (ridList.size() > 0) {
-      Map ridMap = new HashMap();
+      Map<String, Object> ridMap = new HashMap<>();
       ridMap.put(IPSHtmlParameters.SYS_ACTIVEITEMID, ridList);
       IPSInternalRequest intReq =
           request.getInternalRequest("sys_rcSupport/activeitemdetails", ridMap, false);
@@ -703,7 +706,7 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
     }
     // if activeitems contentid exists then get the details of the item.
     if (activecontentid != null && activecontentid.length() > 0) {
-      Map chkoutMap = new HashMap();
+      Map<String, Object> chkoutMap = new HashMap<>();
       chkoutMap.put(IPSHtmlParameters.SYS_CONTENTID, activecontentid);
       chkoutMap.put(IPSHtmlParameters.SYS_COMMAND, WORKFLOW_COMMAND_NAME);
       chkoutMap.put(PSWorkFlowUtils.DEFAULT_ACTION_TRIGGER_NAME, WORKFLOW_CHECKOUT);
@@ -731,7 +734,7 @@ public class PSAddAssemblerInfo implements IPSResultDocumentProcessor {
     try {
       String appRoot = request.getRequestRoot();
       // Make an internal request to get the stylesheet name and location.
-      Map temp = new HashMap();
+      Map<String, Object> temp = new HashMap<>();
       temp.put(IPSHtmlParameters.SYS_CONTENTID, contentid);
       temp.put(IPSHtmlParameters.SYS_VARIANTID, variantid);
       IPSInternalRequest iReq =

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSDatabasePublisher.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSDatabasePublisher.java
@@ -45,7 +45,6 @@ import org.w3c.dom.Text;
  * This exit is used to produce database publisher documents that conform to the
  * sys_DatabasePublisher.dtd out of input documents conforming to the markup.dtd.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSDatabasePublisher implements IPSResultDocumentProcessor {
   /** Creates a new PSDatabasePublisher. */
   public PSDatabasePublisher() {}

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSDatabasePublisher.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSDatabasePublisher.java
@@ -45,6 +45,7 @@ import org.w3c.dom.Text;
  * This exit is used to produce database publisher documents that conform to the
  * sys_DatabasePublisher.dtd out of input documents conforming to the markup.dtd.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSDatabasePublisher implements IPSResultDocumentProcessor {
   /** Creates a new PSDatabasePublisher. */
   public PSDatabasePublisher() {}

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSDatabasePublisher.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSDatabasePublisher.java
@@ -62,7 +62,7 @@ public class PSDatabasePublisher implements IPSResultDocumentProcessor {
     if (ms_paramCount == NOT_INITIALIZED) {
       ms_paramCount = 0;
 
-      Iterator iter = extensionDef.getRuntimeParameterNames();
+      Iterator<String> iter = extensionDef.getRuntimeParameterNames();
       while (iter.hasNext()) {
         iter.next();
         ms_paramCount++;
@@ -146,8 +146,8 @@ public class PSDatabasePublisher implements IPSResultDocumentProcessor {
    * @return a map of alias String objects as key and name String objects as value, never <code>null
    *     </code>, might be empty.
    */
-  private Map getAliasMap(Element aliases) {
-    Map aliasMap = new HashMap();
+  private Map<String, String> getAliasMap(Element aliases) {
+    Map<String, String> aliasMap = new HashMap<>();
     if (aliases != null) {
       NodeList nodes = aliases.getElementsByTagName(ALIAS_ELEM);
       for (int i = 0; i < nodes.getLength(); i++) {
@@ -168,7 +168,7 @@ public class PSDatabasePublisher implements IPSResultDocumentProcessor {
    *     <code>null</code> or empty.
    */
   private String resolveAlias(String alias) {
-    if (m_aliasMap != null && m_aliasMap.containsKey(alias)) return (String) m_aliasMap.get(alias);
+    if (m_aliasMap != null && m_aliasMap.containsKey(alias)) return m_aliasMap.get(alias);
 
     return alias;
   }
@@ -417,7 +417,7 @@ public class PSDatabasePublisher implements IPSResultDocumentProcessor {
    * A map of alias String objects as key and name String objects as value. Initialized if <code>
    * processResultDocument</code>, never <code>null</code> after that, might be empty.
    */
-  private Map m_aliasMap = null;
+  private Map<String, String> m_aliasMap = null;
 
   /**
    * All constants following define elements, attributes or attribute values from the

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSFixAssemblyUrlForRevision.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSFixAssemblyUrlForRevision.java
@@ -57,7 +57,6 @@ import org.w3c.dom.Text;
  * <p>No exception is thrown in case of any processing error, instead the message is logged to
  * server log as well as application trace.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSFixAssemblyUrlForRevision extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
   /** Creates a new PSFixAssemblyUrlForRevision. */

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSFixAssemblyUrlForRevision.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSFixAssemblyUrlForRevision.java
@@ -57,6 +57,7 @@ import org.w3c.dom.Text;
  * <p>No exception is thrown in case of any processing error, instead the message is logged to
  * server log as well as application trace.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSFixAssemblyUrlForRevision extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
   /** Creates a new PSFixAssemblyUrlForRevision. */

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSFixAssemblyUrlForRevision.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSFixAssemblyUrlForRevision.java
@@ -212,7 +212,7 @@ public class PSFixAssemblyUrlForRevision extends PSDefaultExtension
     if (contentValidString == null || contentValidString.length() < 1) {
       throw new IllegalArgumentException("contentValidString must not be null or empty");
     }
-    Map params = PSParseUrlQueryString.parseParameters(relatedContentUrl);
+    Map<String, Object> params = PSParseUrlQueryString.parseParameters(relatedContentUrl);
     String contentid = (String) params.get(IPSHtmlParameters.SYS_CONTENTID);
     if (contentid == null || contentid.length() < 1) {
       String msg =

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSGenerateAssemblerLink.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSGenerateAssemblerLink.java
@@ -36,7 +36,6 @@ import org.w3c.dom.Document;
  * application to get the assembly URL of the variant id passed and generates the internal link
  * (similar to the SYS_MAKEINTLINK UDF).
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSGenerateAssemblerLink extends PSSimpleJavaUdfExtension {
   /** Creates a new PSGenerateAssemblerLink. */
   public PSGenerateAssemblerLink() {}

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSGenerateAssemblerLink.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSGenerateAssemblerLink.java
@@ -36,6 +36,7 @@ import org.w3c.dom.Document;
  * application to get the assembly URL of the variant id passed and generates the internal link
  * (similar to the SYS_MAKEINTLINK UDF).
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSGenerateAssemblerLink extends PSSimpleJavaUdfExtension {
   /** Creates a new PSGenerateAssemblerLink. */
   public PSGenerateAssemblerLink() {}

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSGenerateAssemblerLink.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSGenerateAssemblerLink.java
@@ -28,6 +28,7 @@ import com.percussion.system.utils.PSUrlUtils;
 import com.percussion.xml.PSXPathEvaluator;
 import java.net.MalformedURLException;
 import java.util.HashMap;
+import java.util.Map;
 import javax.xml.transform.TransformerException;
 import org.w3c.dom.Document;
 
@@ -125,7 +126,7 @@ public class PSGenerateAssemblerLink extends PSSimpleJavaUdfExtension {
 
     // Create a new hashmap of parameters to be passed
     // while generating the link
-    HashMap paramMap = new HashMap(10);
+    Map<String, Object> paramMap = new HashMap<>(10);
     paramMap.put(IPSHtmlParameters.SYS_SESSIONID, request.getUserSessionId());
     paramMap.put(IPSHtmlParameters.SYS_CONTENTID, contentid.toString());
     paramMap.put(IPSHtmlParameters.SYS_REVISION, revisionid.toString());

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSGeneratePubLocation.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSGeneratePubLocation.java
@@ -86,7 +86,6 @@ import org.apache.logging.log4j.Logger;
  * here while the generators for all other contexts are specified in the system table
  * RXLOCATIONSCHEME.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSGeneratePubLocation extends PSSimpleJavaUdfExtension {
   /** Creates a new PSGeneratePubLocation. */
   public PSGeneratePubLocation() {}

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSGeneratePubLocation.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSGeneratePubLocation.java
@@ -253,8 +253,8 @@ public class PSGeneratePubLocation extends PSSimpleJavaUdfExtension {
       if (authtype == null || authtype.length() < 1)
         authtype = request.getParameter(IPSHtmlParameters.SYS_AUTHTYPE, "0");
 
-      Map htmlParams = PSHtmlParameters.createStandardParams(paramsBackup);
-      request.setParameters((HashMap) htmlParams);
+      Map<String, Object> htmlParams = PSHtmlParameters.createStandardParams(paramsBackup);
+      request.setParameters(new HashMap<>(htmlParams));
 
       /*
        * Use the parameters they provided. The variantid is always provided,
@@ -378,7 +378,7 @@ public class PSGeneratePubLocation extends PSSimpleJavaUdfExtension {
       Number contentid,
       Number variantid,
       Number revision,
-      Map paramsBackup,
+      Map<String, Object> paramsBackup,
       Number siteid,
       Number folderid,
       String authtype,
@@ -605,7 +605,7 @@ public class PSGeneratePubLocation extends PSSimpleJavaUdfExtension {
     String db = null;
     String schema = null;
     try {
-      ArrayList parameters = new ArrayList();
+      List<Object> parameters = new ArrayList<>();
       for (String pname : scheme.getParameterNames()) {
         String type = scheme.getParameterType(pname);
         String value = scheme.getParameterValue(pname);
@@ -646,10 +646,10 @@ public class PSGeneratePubLocation extends PSSimpleJavaUdfExtension {
               ResultSetMetaData metaData = rs.getMetaData();
               PSTextLiteral literal = null;
               int dataType = metaData.getColumnType(1);
-              Map typeMap =
+              Map<String, Short> typeMap =
                   PSDatabaseMetaData.loadNativeDataTypeMap(connection, connection.getMetaData());
-              Object nativeType = typeMap.get(metaData.getColumnTypeName(1));
-              if (nativeType != null) dataType = ((Short) nativeType).intValue();
+              Short nativeType = typeMap.get(metaData.getColumnTypeName(1));
+              if (nativeType != null) dataType = nativeType.intValue();
               switch (dataType) {
                 case Types.CHAR:
                   // needs trim
@@ -682,7 +682,9 @@ public class PSGeneratePubLocation extends PSSimpleJavaUdfExtension {
       }
 
       PSExtensionParamValue[] paramValues = new PSExtensionParamValue[parameters.size()];
-      paramValues = (PSExtensionParamValue[]) parameters.toArray(paramValues);
+      for (int i = 0; i < parameters.size(); i++) {
+        paramValues[i] = (PSExtensionParamValue) parameters.get(i);
+      }
       return paramValues;
     } finally {
       // release the database connection and any resources allocated

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSGeneratePubLocation.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSGeneratePubLocation.java
@@ -86,6 +86,7 @@ import org.apache.logging.log4j.Logger;
  * here while the generators for all other contexts are specified in the system table
  * RXLOCATIONSCHEME.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSGeneratePubLocation extends PSSimpleJavaUdfExtension {
   /** Creates a new PSGeneratePubLocation. */
   public PSGeneratePubLocation() {}

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSModifyRelatedContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSModifyRelatedContent.java
@@ -55,6 +55,7 @@ import org.w3c.dom.Document;
  * <code>sys_rxSupport/updaterelateditems</code>. This approacch is taken to keep the interface used
  * for all active assembly update functionality.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSModifyRelatedContent extends PSDefaultExtension implements IPSRequestPreProcessor {
   /** Creates a new PSModifyRelatedContent. */
   public PSModifyRelatedContent() {}

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSModifyRelatedContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSModifyRelatedContent.java
@@ -64,7 +64,7 @@ public class PSModifyRelatedContent extends PSDefaultExtension implements IPSReq
       throws PSExtensionProcessingException {
     try {
       if (request != null) {
-        Iterator htmlParams = request.getParametersIterator();
+        Iterator<?> htmlParams = request.getParametersIterator();
         if (!htmlParams.hasNext())
           throw new PSExtensionProcessingException(0, "HTML parameter list cannot be empty");
 

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSModifyRelatedContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSModifyRelatedContent.java
@@ -55,7 +55,6 @@ import org.w3c.dom.Document;
  * <code>sys_rxSupport/updaterelateditems</code>. This approacch is taken to keep the interface used
  * for all active assembly update functionality.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSModifyRelatedContent extends PSDefaultExtension implements IPSRequestPreProcessor {
   /** Creates a new PSModifyRelatedContent. */
   public PSModifyRelatedContent() {}

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSSiteFolderAuthTypeFilter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSSiteFolderAuthTypeFilter.java
@@ -75,6 +75,7 @@ import org.w3c.dom.NodeList;
  * removes the link. Variant based filtering. If the variant is a page variant then checks whether
  * it is a publishable variant or not. If not removes the link.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSSiteFolderAuthTypeFilter implements IPSResultDocumentProcessor {
   /** Creates a new PSSiteFolderAuthTypeFilter. */
   public PSSiteFolderAuthTypeFilter() {}

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSSiteFolderAuthTypeFilter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSSiteFolderAuthTypeFilter.java
@@ -128,7 +128,7 @@ public class PSSiteFolderAuthTypeFilter implements IPSResultDocumentProcessor {
     PSRelationshipProcessor relProxy;
 
     relProxy = PSRelationshipProcessor.getInstance();
-    Map siteFolderRoot = initializeSiteFolderRootMap(request);
+    Map<String, String> siteFolderRoot = initializeSiteFolderRootMap(request);
     if (siteFolderRoot.size() < 1) {
       String msg =
           ms_className
@@ -142,7 +142,7 @@ public class PSSiteFolderAuthTypeFilter implements IPSResultDocumentProcessor {
     NodeList nl = doc.getElementsByTagName(LINKURL);
     for (int i = nl.getLength() - 1; i >= 0; i--) {
       Element linkurl = (Element) nl.item(i);
-      Map linkparams = validateLinkUrl(request, linkurl);
+      Map<String, String> linkparams = validateLinkUrl(request, linkurl);
       if (linkparams == null) {
         nl.item(i).getParentNode().removeChild(nl.item(i));
         continue;
@@ -172,7 +172,7 @@ public class PSSiteFolderAuthTypeFilter implements IPSResultDocumentProcessor {
    * @return Map of required parameters for filtering the linkurl or <code>
    * null</code> if any of the required parameter is missing.
    */
-  private Map validateLinkUrl(IPSRequestContext request, Element linkurl) {
+  private Map<String, String> validateLinkUrl(IPSRequestContext request, Element linkurl) {
     if (request == null) throw new IllegalArgumentException("request must not be null");
     if (linkurl == null) throw new IllegalArgumentException("linkurl must not be null");
     Map<String, String> params = null;
@@ -243,7 +243,7 @@ public class PSSiteFolderAuthTypeFilter implements IPSResultDocumentProcessor {
       return params;
     }
 
-    Map rcurlparams = null;
+    Map<String, Object> rcurlparams = null;
     try {
       rcurlparams = PSParseUrlQueryString.parseParameters(rcurl);
     } catch (PSRequestParsingException e) {
@@ -290,7 +290,7 @@ public class PSSiteFolderAuthTypeFilter implements IPSResultDocumentProcessor {
    * @throws PSExtensionProcessingException, if there are any errors getting the Site and Folder
    *     information from Rhythmyx resource {@link #LOOKUP_SITE_FOLDER_ROOT}
    */
-  private Map initializeSiteFolderRootMap(IPSRequestContext request)
+  private Map<String, String> initializeSiteFolderRootMap(IPSRequestContext request)
       throws PSExtensionProcessingException {
     if (request == null) throw new IllegalArgumentException("request must not be null");
     Map<String, String> siteFolderRoot = new HashMap<>();
@@ -431,8 +431,8 @@ public class PSSiteFolderAuthTypeFilter implements IPSResultDocumentProcessor {
   private boolean isValidLinkBySiteID(
       IPSRequestContext request,
       PSRelationshipProcessor relProxy,
-      Map siteFolderRoot,
-      Map linkparams,
+      Map<String, String> siteFolderRoot,
+      Map<String, String> linkparams,
       Element linkurl)
       throws PSExtensionProcessingException {
     if (request == null) throw new IllegalArgumentException("request must not be null");
@@ -441,7 +441,7 @@ public class PSSiteFolderAuthTypeFilter implements IPSResultDocumentProcessor {
       throw new IllegalArgumentException("siteFolderRoot must not be null");
     if (linkparams == null) throw new IllegalArgumentException("linkparams must not be null");
     if (linkurl == null) throw new IllegalArgumentException("linkurl must not be null");
-    String siteid = (String) linkparams.get(IPSHtmlParameters.SYS_SITEID);
+    String siteid = linkparams.get(IPSHtmlParameters.SYS_SITEID);
     if (!siteFolderRoot.containsKey(siteid)) {
       String msg =
           "Removed linkurl : \nReason: No "
@@ -453,8 +453,8 @@ public class PSSiteFolderAuthTypeFilter implements IPSResultDocumentProcessor {
       request.printTraceMessage(msg);
       return false;
     }
-    String contentId = (String) linkparams.get(CONTENTID);
-    String siteFolderPath = (String) siteFolderRoot.get(siteid);
+    String contentId = linkparams.get(CONTENTID);
+    String siteFolderPath = siteFolderRoot.get(siteid);
     // Normalize to end with /
     if (!siteFolderPath.endsWith("/")) siteFolderPath += "/";
     try {
@@ -524,9 +524,9 @@ public class PSSiteFolderAuthTypeFilter implements IPSResultDocumentProcessor {
   private boolean isValidLinkByFolderID(
       IPSRequestContext request,
       PSRelationshipProcessor relProxy,
-      Map siteFolderRoot,
-      Map folderPaths,
-      Map linkparams,
+      Map<String, String> siteFolderRoot,
+      Map<String, String> folderPaths,
+      Map<String, String> linkparams,
       Element linkurl)
       throws PSExtensionProcessingException {
     if (request == null) throw new IllegalArgumentException("request must not be null");
@@ -535,12 +535,12 @@ public class PSSiteFolderAuthTypeFilter implements IPSResultDocumentProcessor {
       throw new IllegalArgumentException("siteFolderRoot must not be null");
     if (linkparams == null) throw new IllegalArgumentException("linkparams must not be null");
     if (linkurl == null) throw new IllegalArgumentException("linkurl must not be null");
-    String folderId = (String) linkparams.get(IPSHtmlParameters.SYS_FOLDERID);
+    String folderId = linkparams.get(IPSHtmlParameters.SYS_FOLDERID);
     // If there is no sys_folderid attribute on the link we
     // can not validate this linkurl based on the folderid,
     // and we assume it as a right link
     if (folderId.trim().length() < 1) return true;
-    String folderPath = (String) folderPaths.get(folderId);
+    String folderPath = folderPaths.get(folderId);
     // Check 1: Folder exists or not check
     if (folderPath == null) {
       String msg =
@@ -553,8 +553,8 @@ public class PSSiteFolderAuthTypeFilter implements IPSResultDocumentProcessor {
       request.printTraceMessage(msg);
       return false;
     }
-    String siteId = (String) linkparams.get(IPSHtmlParameters.SYS_SITEID);
-    String sitePath = (String) siteFolderRoot.get(siteId);
+    String siteId = linkparams.get(IPSHtmlParameters.SYS_SITEID);
+    String sitePath = siteFolderRoot.get(siteId);
     // Check 2: Folder exists under the specified site or not
     if (!(folderPath.equals(sitePath) || folderPath.startsWith(sitePath + "/"))) {
       String msg =
@@ -569,7 +569,7 @@ public class PSSiteFolderAuthTypeFilter implements IPSResultDocumentProcessor {
       request.printTraceMessage(msg);
       return false;
     }
-    String contentId = (String) linkparams.get(CONTENTID);
+    String contentId = linkparams.get(CONTENTID);
     // Try to get the folder relationship between the folderid and
     // contentid and if it exists it is the child of the that folder.
     PSRelationshipFilter filter = new PSRelationshipFilter();
@@ -626,12 +626,13 @@ public class PSSiteFolderAuthTypeFilter implements IPSResultDocumentProcessor {
    * @throws PSExtensionProcessingException When there is an error making an internal request to
    *     find the publishable variant.
    */
-  private boolean isValidLinkByVariant(IPSRequestContext request, Map linkparams, Element linkurl)
+  private boolean isValidLinkByVariant(
+      IPSRequestContext request, Map<String, String> linkparams, Element linkurl)
       throws PSExtensionProcessingException {
     if (request == null) throw new IllegalArgumentException("request must not be null");
     if (linkparams == null) throw new IllegalArgumentException("linkparams must not be null");
     if (linkurl == null) throw new IllegalArgumentException("linkurl must not be null");
-    String variantId = (String) linkparams.get(VARIANTID);
+    String variantId = linkparams.get(VARIANTID);
     IPSAssemblyService assembly = PSAssemblyServiceLocator.getAssemblyService();
     // Get the info of the variant we are interested in
     IPSAssemblyTemplate template;
@@ -659,14 +660,14 @@ public class PSSiteFolderAuthTypeFilter implements IPSResultDocumentProcessor {
     // We can filter it only if it is page variant
     if (template.getOutputFormat().ordinal() != 1) return true;
     // Now it is the time to see whether the page variant is publishable or not
-    String siteId = (String) linkparams.get(IPSHtmlParameters.SYS_SITEID);
+    String siteId = linkparams.get(IPSHtmlParameters.SYS_SITEID);
     // Get the content id from the linkurl
-    String contentId = (String) linkparams.get(CONTENTID);
-    String revision = (String) linkparams.get(IPSHtmlParameters.SYS_REVISION);
+    String contentId = linkparams.get(CONTENTID);
+    String revision = linkparams.get(IPSHtmlParameters.SYS_REVISION);
     // Make use of the publishable variant list from the content list
     // generator resource to decide the link url variant is a publishable
     // variant or not
-    Map reqParams = new HashMap();
+    Map<String, Object> reqParams = new HashMap<>();
     reqParams.put(IPSHtmlParameters.SYS_CONTENTID, contentId);
     reqParams.put(IPSHtmlParameters.SYS_SITEID, siteId);
     reqParams.put(IPSHtmlParameters.SYS_REVISION, revision);

--- a/modules/extensions-main/src/main/java/com/percussion/cas/PSSiteFolderAuthTypeFilter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cas/PSSiteFolderAuthTypeFilter.java
@@ -75,7 +75,6 @@ import org.w3c.dom.NodeList;
  * removes the link. Variant based filtering. If the variant is a page variant then checks whether
  * it is a publishable variant or not. If not removes the link.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSSiteFolderAuthTypeFilter implements IPSResultDocumentProcessor {
   /** Creates a new PSSiteFolderAuthTypeFilter. */
   public PSSiteFolderAuthTypeFilter() {}

--- a/modules/extensions-main/src/main/java/com/percussion/ce/PSDependencyTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/ce/PSDependencyTree.java
@@ -50,6 +50,7 @@ import org.xml.sax.InputSource;
  * This class modifies the result document to append all child and paraent dependents of the current
  * content item as a tree.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSDependencyTree implements IPSResultDocumentProcessor {
   /** Creates a new PSDependencyTree. */
   public PSDependencyTree() {}

--- a/modules/extensions-main/src/main/java/com/percussion/ce/PSDependencyTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/ce/PSDependencyTree.java
@@ -36,6 +36,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -76,7 +77,7 @@ public class PSDependencyTree implements IPSResultDocumentProcessor {
   public Document processResultDocument(Object[] params, IPSRequestContext request, Document resDoc)
       throws PSParameterMismatchException, PSExtensionProcessingException {
     Map<String, Object> htmlParams = request.getParameters();
-    ArrayList itemsRendered = new ArrayList();
+    List<String> itemsRendered = new ArrayList<>();
     PSXmlTreeWalker walker = new PSXmlTreeWalker(resDoc);
     try {
       String indent = INDENT;
@@ -87,13 +88,14 @@ public class PSDependencyTree implements IPSResultDocumentProcessor {
           request.getParameter(
               IPSHtmlParameters.SYS_RELATIONSHIPTYPE, PSRelationshipConfig.TYPE_RELATED_CONTENT);
 
-      Iterator configs = PSRelationshipCommandHandler.getRelationshipConfigs();
+      Iterator<PSRelationshipConfig> configs =
+          PSRelationshipCommandHandler.getRelationshipConfigs();
       Element parent =
           PSXmlDocumentBuilder.addEmptyElement(
               resDoc, resDoc.getDocumentElement(), "Relationships");
       parent.setAttribute("showRelationshiptype", relationshiptype);
       while (configs.hasNext()) {
-        PSRelationshipConfig config = (PSRelationshipConfig) configs.next();
+        PSRelationshipConfig config = configs.next();
         Element relationship =
             PSXmlDocumentBuilder.addElement(resDoc, parent, "Relationship", config.getName());
         if (config.getName().equals(relationshiptype)) relationship.setAttribute("selected", "yes");
@@ -131,7 +133,7 @@ public class PSDependencyTree implements IPSResultDocumentProcessor {
    * @param url the URL object for the child or parent item of the current item
    */
   private void processUrl(
-      ArrayList itemsRendered,
+      List<String> itemsRendered,
       String indent,
       Element parent,
       IPSRequestContext request,
@@ -183,8 +185,8 @@ public class PSDependencyTree implements IPSResultDocumentProcessor {
     }
   }
 
-  private HashMap parseUrlForParams(String url) {
-    HashMap map = new HashMap();
+  private Map<String, Object> parseUrlForParams(String url) {
+    Map<String, Object> map = new HashMap<>();
     int loc = url.indexOf('?');
     if (loc == -1) return map;
 

--- a/modules/extensions-main/src/main/java/com/percussion/ce/PSDependencyTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/ce/PSDependencyTree.java
@@ -50,7 +50,6 @@ import org.xml.sax.InputSource;
  * This class modifies the result document to append all child and paraent dependents of the current
  * content item as a tree.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSDependencyTree implements IPSResultDocumentProcessor {
   /** Creates a new PSDependencyTree. */
   public PSDependencyTree() {}

--- a/modules/extensions-main/src/main/java/com/percussion/ce/PSRemoveControlChars.java
+++ b/modules/extensions-main/src/main/java/com/percussion/ce/PSRemoveControlChars.java
@@ -34,7 +34,6 @@ import java.util.Set;
  * characters are illegal in XML and will cause an exception if they are left in. This exit is added
  * to the modify command handler in the ContentEditorSystemDef as an input data exit.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSRemoveControlChars implements IPSRequestPreProcessor {
   /** Creates a new PSRemoveControlChars. */
   public PSRemoveControlChars() {}

--- a/modules/extensions-main/src/main/java/com/percussion/ce/PSRemoveControlChars.java
+++ b/modules/extensions-main/src/main/java/com/percussion/ce/PSRemoveControlChars.java
@@ -34,6 +34,7 @@ import java.util.Set;
  * characters are illegal in XML and will cause an exception if they are left in. This exit is added
  * to the modify command handler in the ContentEditorSystemDef as an input data exit.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSRemoveControlChars implements IPSRequestPreProcessor {
   /** Creates a new PSRemoveControlChars. */
   public PSRemoveControlChars() {}

--- a/modules/extensions-main/src/main/java/com/percussion/ce/PSRemoveControlChars.java
+++ b/modules/extensions-main/src/main/java/com/percussion/ce/PSRemoveControlChars.java
@@ -47,13 +47,13 @@ public class PSRemoveControlChars implements IPSRequestPreProcessor {
           PSParameterMismatchException,
           PSExtensionProcessingException {
 
-    Map reqParams = request.getParameters();
-    Set keys = reqParams.keySet();
-    Iterator it = keys.iterator();
+    Map<String, Object> reqParams = request.getParameters();
+    Set<String> keys = reqParams.keySet();
+    Iterator<String> it = keys.iterator();
     String key = null;
     Object value = null;
     while (it.hasNext()) {
-      key = (String) it.next();
+      key = it.next();
       value = reqParams.get(key);
       if (value instanceof String) {
         value = removeControlChars((String) value);

--- a/modules/extensions-main/src/main/java/com/percussion/cms/PSCleanupCrossSiteLiniks.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cms/PSCleanupCrossSiteLiniks.java
@@ -78,7 +78,6 @@ import org.w3c.dom.Document;
  *       <p>Defaults to <code>false</code> seconds.
  * </ol>
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCleanupCrossSiteLiniks extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
   /** Creates a new PSCleanupCrossSiteLiniks. */

--- a/modules/extensions-main/src/main/java/com/percussion/cms/PSCleanupCrossSiteLiniks.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cms/PSCleanupCrossSiteLiniks.java
@@ -78,6 +78,7 @@ import org.w3c.dom.Document;
  *       <p>Defaults to <code>false</code> seconds.
  * </ol>
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCleanupCrossSiteLiniks extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
   /** Creates a new PSCleanupCrossSiteLiniks. */

--- a/modules/extensions-main/src/main/java/com/percussion/cms/PSCleanupCrossSiteLiniks.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cms/PSCleanupCrossSiteLiniks.java
@@ -161,10 +161,10 @@ public class PSCleanupCrossSiteLiniks extends PSDefaultExtension
     if (relset.isEmpty()) return; // do nothing if there is no dependent (in AA relationships)
 
     // "cleanup" all links if needed
-    Iterator rels = relset.iterator();
+    Iterator<PSRelationship> rels = relset.iterator();
     PSRelationship rel;
     while (rels.hasNext()) {
-      rel = (PSRelationship) rels.next();
+      rel = rels.next();
       try {
         processAALink(rel);
       } catch (Exception e) {
@@ -332,11 +332,11 @@ public class PSCleanupCrossSiteLiniks extends PSDefaultExtension
    * @throws PSCmsException if error occurs.
    */
   private boolean isChildItem(PSLocator folderLoc, PSLocator itemLoc) throws PSCmsException {
-    List children = getFolderChildren(folderLoc);
-    Iterator locs = children.iterator();
+    List<PSLocator> children = getFolderChildren(folderLoc);
+    Iterator<PSLocator> locs = children.iterator();
     PSLocator child;
     while (locs.hasNext()) {
-      child = (PSLocator) locs.next();
+      child = locs.next();
       if (child.getId() == itemLoc.getId()) {
         return true;
       }
@@ -384,7 +384,7 @@ public class PSCleanupCrossSiteLiniks extends PSDefaultExtension
    * @return a list of {@link PSLocator}; it may not empty, but never <code>null</code>.
    * @throws PSCmsException if failed to get the children.
    */
-  private List getFolderChildren(PSLocator parent) throws PSCmsException {
+  private List<PSLocator> getFolderChildren(PSLocator parent) throws PSCmsException {
     return getFolderRelationships(parent, true);
   }
 
@@ -409,9 +409,9 @@ public class PSCleanupCrossSiteLiniks extends PSDefaultExtension
     PSRelationshipSet relset = m_relProcessor.getRelationships(filter);
     List<PSLocator> parent = new ArrayList<>();
 
-    Iterator rels = relset.iterator();
+    Iterator<PSRelationship> rels = relset.iterator();
     while (rels.hasNext()) {
-      PSRelationship rel = (PSRelationship) rels.next();
+      PSRelationship rel = rels.next();
       if (isOwner) parent.add(rel.getDependent());
       else parent.add(rel.getOwner());
     }
@@ -473,9 +473,9 @@ public class PSCleanupCrossSiteLiniks extends PSDefaultExtension
 
     // get all folders that exist under the target site
     List<PSLocator> siteFolders = new ArrayList<>();
-    Iterator rels = relset.iterator();
+    Iterator<PSRelationship> rels = relset.iterator();
     while (rels.hasNext()) {
-      PSRelationship r = (PSRelationship) rels.next();
+      PSRelationship r = rels.next();
       PSLocator folder = r.getDependent();
       if (isUnderTargetSite(folder)) {
         siteFolders.add(folder);
@@ -816,11 +816,11 @@ public class PSCleanupCrossSiteLiniks extends PSDefaultExtension
    */
   private void populateSites() throws PSCmsException {
     m_request.removeParameter(IPSHtmlParameters.SYS_SITEID);
-    List siteList = PSSite.getSites(m_request);
+    List<PSSite> siteList = PSSite.getSites(m_request);
 
-    Iterator sites = siteList.iterator();
+    Iterator<PSSite> sites = siteList.iterator();
     while (sites.hasNext()) {
-      PSSite s = (PSSite) sites.next();
+      PSSite s = sites.next();
       Integer siteid = Integer.valueOf(s.getId());
       PSLocator root = getRootLocator(s);
       if (root != null) {

--- a/modules/extensions-main/src/main/java/com/percussion/cms/PSGetModifiedInlineLinkData.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cms/PSGetModifiedInlineLinkData.java
@@ -45,7 +45,6 @@ import org.w3c.dom.NodeList;
  * document while processing inline links for an item and replaces the contentids and revisions
  * appropriately.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSGetModifiedInlineLinkData extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
   /** Creates a new PSGetModifiedInlineLinkData. */

--- a/modules/extensions-main/src/main/java/com/percussion/cms/PSGetModifiedInlineLinkData.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cms/PSGetModifiedInlineLinkData.java
@@ -78,7 +78,7 @@ public class PSGetModifiedInlineLinkData extends PSDefaultExtension
           PSSingleValueBuilder.buildRelationshipData(request, null);
       String dependentIds = request.getParameter("inlinecontentids", "");
       StringTokenizer tokenizer = new StringTokenizer(dependentIds, ";");
-      Map cidMap = new HashMap<>();
+      Map<String, String> cidMap = new HashMap<>();
       while (tokenizer.hasMoreTokens()) {
         String cid = tokenizer.nextToken();
 
@@ -97,20 +97,20 @@ public class PSGetModifiedInlineLinkData extends PSDefaultExtension
             m_def.getRef().getExtensionName(),
             new IllegalArgumentException("inlinecontentids parameter must not be null or empty"));
       }
-      Iterator iter = cidMap.keySet().iterator();
-      List paramList = new ArrayList<>();
+      Iterator<String> iter = cidMap.keySet().iterator();
+      List<String> paramList = new ArrayList<>();
       while (iter.hasNext()) {
-        String element = (String) cidMap.get(iter.next());
+        String element = cidMap.get(iter.next());
         paramList.add(element);
       }
-      Map reqParams = new HashMap<>();
+      Map<String, Object> reqParams = new HashMap<>();
       reqParams.put(IPSHtmlParameters.SYS_CONTENTID, paramList);
       IPSInternalRequest iReq =
           request.getInternalRequest("sys_psxCms/getCurrentRevision", reqParams, false);
 
       Document doc = iReq.getResultDoc();
       NodeList nl = doc.getElementsByTagName("Item");
-      Map cidRevisionMap = new HashMap<>();
+      Map<String, String> cidRevisionMap = new HashMap<>();
       for (int i = 0; nl != null && i < nl.getLength(); i++) {
         Element elem = (Element) nl.item(i);
         cidRevisionMap.put(
@@ -126,12 +126,12 @@ public class PSGetModifiedInlineLinkData extends PSDefaultExtension
       root.setAttribute(
           IPSHtmlParameters.SYS_REVISION, request.getParameter(IPSHtmlParameters.SYS_REVISION, ""));
 
-      Iterator cidIter = cidMap.keySet().iterator();
+      Iterator<String> cidIter = cidMap.keySet().iterator();
       while (cidIter.hasNext()) {
-        String oldCid = (String) cidIter.next();
-        String newCid = cidMap.get(oldCid).toString();
+        String oldCid = cidIter.next();
+        String newCid = cidMap.get(oldCid);
         String newRevision = "";
-        if (cidRevisionMap.containsKey(newCid)) newRevision = cidRevisionMap.get(newCid).toString();
+        if (cidRevisionMap.containsKey(newCid)) newRevision = cidRevisionMap.get(newCid);
         Element child = PSXmlDocumentBuilder.addElement(resultDoc, root, "Child", null);
         child.setAttribute("oldContentId", oldCid);
         child.setAttribute("newContentId", newCid);

--- a/modules/extensions-main/src/main/java/com/percussion/cms/PSGetModifiedInlineLinkData.java
+++ b/modules/extensions-main/src/main/java/com/percussion/cms/PSGetModifiedInlineLinkData.java
@@ -45,6 +45,7 @@ import org.w3c.dom.NodeList;
  * document while processing inline links for an item and replaces the contentids and revisions
  * appropriately.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSGetModifiedInlineLinkData extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
   /** Creates a new PSGetModifiedInlineLinkData. */

--- a/modules/extensions-main/src/main/java/com/percussion/community/PSAuthenticateUser.java
+++ b/modules/extensions-main/src/main/java/com/percussion/community/PSAuthenticateUser.java
@@ -53,7 +53,6 @@ import org.w3c.dom.NodeList;
  *       sure it is available to all Rhythmyx applications for further use
  * </UL>
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSAuthenticateUser implements IPSRequestPreProcessor {
   /** Creates a new PSAuthenticateUser. */
   public PSAuthenticateUser() {}

--- a/modules/extensions-main/src/main/java/com/percussion/community/PSAuthenticateUser.java
+++ b/modules/extensions-main/src/main/java/com/percussion/community/PSAuthenticateUser.java
@@ -53,6 +53,7 @@ import org.w3c.dom.NodeList;
  *       sure it is available to all Rhythmyx applications for further use
  * </UL>
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSAuthenticateUser implements IPSRequestPreProcessor {
   /** Creates a new PSAuthenticateUser. */
   public PSAuthenticateUser() {}

--- a/modules/extensions-main/src/main/java/com/percussion/community/PSAuthenticateUser.java
+++ b/modules/extensions-main/src/main/java/com/percussion/community/PSAuthenticateUser.java
@@ -119,8 +119,8 @@ public class PSAuthenticateUser implements IPSRequestPreProcessor {
    * @return list of user communities (community ids) as Java List object never <code>null</code>
    *     may be empty.
    */
-  private List getUserCommunities(IPSRequestContext request) throws Exception {
-    ArrayList list = new ArrayList();
+  private List<String> getUserCommunities(IPSRequestContext request) throws Exception {
+    List<String> list = new ArrayList<>();
     // Make an internal request to get the user roles.
     IPSInternalRequest iReq = request.getInternalRequest(IREQ_USERCOMMUNITIES);
     Document doc = null;
@@ -169,18 +169,18 @@ public class PSAuthenticateUser implements IPSRequestPreProcessor {
       throws Exception {
     if (srcAttrName == null) return null;
     String attrValue = null;
-    List roles = request.getSubjectRoles();
+    List<String> roles = request.getSubjectRoles();
     Object role = null;
-    List roleAttribs = null;
+    List<PSAttribute> roleAttribs = null;
     PSAttribute attr = null;
-    List attrList = null;
+    List<String> attrList = null;
     String attrName = null;
     for (int i = 0; roles != null && i < roles.size(); i++) {
       role = roles.get(i);
       if (role == null) continue;
       roleAttribs = request.getRoleAttributes(role.toString().trim());
       for (int j = 0; roleAttribs != null && j < roleAttribs.size(); j++) {
-        attr = (PSAttribute) roleAttribs.get(j);
+        attr = roleAttribs.get(j);
         if (attr == null) continue;
         attrName = attr.getName();
         if (attrName.equals(srcAttrName)) {

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/ca/PSDeleteContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/ca/PSDeleteContent.java
@@ -161,7 +161,7 @@ public class PSDeleteContent implements IPSRequestPreProcessor {
         filter.setCommunityFiltering(false);
         relationships = processor.getRelationships(filter).iterator();
         while (relationships.hasNext()) {
-          PSRelationship relationship = (PSRelationship) relationships.next();
+          PSRelationship relationship = relationships.next();
           elem.setAttribute(ATTR_PKEY, contentid);
           elem = PSXmlDocumentBuilder.addEmptyElement(doc, parent, ELEM_ROW);
           elem.setAttribute(ATTR_RID, Integer.toString(relationship.getId()));

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/ca/PSDeleteContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/ca/PSDeleteContent.java
@@ -34,6 +34,7 @@ import java.io.FileWriter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -92,11 +93,13 @@ public class PSDeleteContent implements IPSRequestPreProcessor {
       String purgeurl = null;
       String contentid = null;
       Element elem = null;
-      ArrayList purgeurllist = null;
-      if (obj instanceof ArrayList) {
-        purgeurllist = (ArrayList) obj;
+      List<Object> purgeurllist = null;
+      if (obj instanceof List) {
+        @SuppressWarnings("unchecked")
+        List<Object> castList = (List<Object>) obj;
+        purgeurllist = castList;
       } else {
-        purgeurllist = new ArrayList();
+        purgeurllist = new ArrayList<>();
         purgeurllist.add(obj);
       }
       String appResource = "";
@@ -143,9 +146,9 @@ public class PSDeleteContent implements IPSRequestPreProcessor {
         filter.setOwnerId(itemId); // disregard owner revision
         // make sure to disable community filtering
         filter.setCommunityFiltering(false);
-        Iterator relationships = processor.getRelationships(filter).iterator();
+        Iterator<PSRelationship> relationships = processor.getRelationships(filter).iterator();
         while (relationships.hasNext()) {
-          PSRelationship relationship = (PSRelationship) relationships.next();
+          PSRelationship relationship = relationships.next();
           elem.setAttribute(ATTR_PKEY, contentid);
           elem = PSXmlDocumentBuilder.addEmptyElement(doc, parent, ELEM_ROW);
           elem.setAttribute(ATTR_RID, Integer.toString(relationship.getId()));

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/ca/PSDeleteContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/ca/PSDeleteContent.java
@@ -48,6 +48,7 @@ import org.w3c.dom.Element;
  * typically placed on an Rx update resource that deletes the rows from all system tables tables.
  * The XML element pkey must be mapped to the primary key in the backed table(s).
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSDeleteContent implements IPSRequestPreProcessor {
   /** Creates a new PSDeleteContent. */
   public PSDeleteContent() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/ca/PSDeleteContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/ca/PSDeleteContent.java
@@ -48,7 +48,6 @@ import org.w3c.dom.Element;
  * typically placed on an Rx update resource that deletes the rows from all system tables tables.
  * The XML element pkey must be mapped to the primary key in the backed table(s).
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSDeleteContent implements IPSRequestPreProcessor {
   /** Creates a new PSDeleteContent. */
   public PSDeleteContent() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCheckIfVariantIsInUse.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCheckIfVariantIsInUse.java
@@ -62,11 +62,11 @@ public class PSCheckIfVariantIsInUse implements IPSRequestPreProcessor {
       PSRelationshipSet results = rproc.getRelationships(filter);
       if (results.size() > 0) {
         StringBuilder ownerids = new StringBuilder();
-        Iterator iter = results.iterator();
+        Iterator<PSRelationship> iter = results.iterator();
         int count = 0;
         while (iter.hasNext()) {
           count++;
-          PSRelationship rel = (PSRelationship) iter.next();
+          PSRelationship rel = iter.next();
           ownerids.append(Integer.toString(rel.getOwner().getId()));
           if (count > 99) {
             ownerids.append("...");

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCheckIfVariantIsInUse.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCheckIfVariantIsInUse.java
@@ -45,6 +45,7 @@ import java.util.Iterator;
  *
  * @author dougrand
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCheckIfVariantIsInUse implements IPSRequestPreProcessor {
   /** Creates a new PSCheckIfVariantIsInUse. */
   public PSCheckIfVariantIsInUse() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCheckIfVariantIsInUse.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCheckIfVariantIsInUse.java
@@ -45,7 +45,6 @@ import java.util.Iterator;
  *
  * @author dougrand
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCheckIfVariantIsInUse implements IPSRequestPreProcessor {
   /** Creates a new PSCheckIfVariantIsInUse. */
   public PSCheckIfVariantIsInUse() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCloneOverrideField.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCloneOverrideField.java
@@ -66,7 +66,7 @@ public class PSCloneOverrideField extends PSSimpleJavaUdfExtension {
     loc = resource.lastIndexOf("/", loc - 1);
     resource = resource.substring(loc + 1);
 
-    Map paramMap = new HashMap();
+    Map<String, Object> paramMap = new HashMap<>();
     for (int i = 2; i < params.length; i = i + 2) {
       String name = params[i].toString();
       String value = "";

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCloneOverrideField.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCloneOverrideField.java
@@ -45,6 +45,7 @@ import org.w3c.dom.Text;
  *
  * @author RammohanVangapalli
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCloneOverrideField extends PSSimpleJavaUdfExtension {
   /** Creates a new PSCloneOverrideField. */
   public PSCloneOverrideField() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCloneOverrideField.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCloneOverrideField.java
@@ -45,7 +45,6 @@ import org.w3c.dom.Text;
  *
  * @author RammohanVangapalli
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCloneOverrideField extends PSSimpleJavaUdfExtension {
   /** Creates a new PSCloneOverrideField. */
   public PSCloneOverrideField() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCmsObjectNameLookup.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCmsObjectNameLookup.java
@@ -40,7 +40,6 @@ import org.w3c.dom.NodeList;
  * namelookups during server initialization and avoid internal requests. In that this is a temporary
  * feature.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCmsObjectNameLookup extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
   /** Creates a new PSCmsObjectNameLookup. */
   public PSCmsObjectNameLookup() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCmsObjectNameLookup.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCmsObjectNameLookup.java
@@ -62,14 +62,14 @@ public class PSCmsObjectNameLookup extends PSSimpleJavaUdfExtension implements I
     if (params.length > 2) keyPart2 = params[2] != null ? params[2].toString() : "";
     if (params.length > 3) keyPart3 = params[3] != null ? params[3].toString() : "";
 
-    Map cache = initLookupCache(request);
+    Map<String, String> cache = initLookupCache(request);
     String objectName = null;
     String cacheKey = getCacheKey(cmsObjectType, keyPart1, keyPart2, keyPart3);
 
-    objectName = (String) cache.get(cacheKey);
+    objectName = cache.get(cacheKey);
 
     if (objectName == null) {
-      Map lookupParams = new HashMap();
+      Map<String, Object> lookupParams = new HashMap<>();
       lookupParams.put("keyPart1", keyPart1);
       lookupParams.put("keyPart2", keyPart2);
       lookupParams.put("keyPart3", keyPart3);
@@ -117,12 +117,14 @@ public class PSCmsObjectNameLookup extends PSSimpleJavaUdfExtension implements I
    * @param request The current request, may not be <code>null</code>.
    * @return The map used as the cache, never <code>null</code>.
    */
-  public static Map initLookupCache(IPSRequestContext request) {
+  public static Map<String, String> initLookupCache(IPSRequestContext request) {
     if (request == null) throw new IllegalArgumentException("request may not be null");
 
-    Map cache = (Map) request.getPrivateObject(CACHE_KEY);
+    Object cached = request.getPrivateObject(CACHE_KEY);
+    @SuppressWarnings("unchecked")
+    Map<String, String> cache = (cached instanceof Map) ? (Map<String, String>) cached : null;
     if (cache == null) {
-      cache = new HashMap();
+      cache = new HashMap<>();
       request.setPrivateObject(CACHE_KEY, cache);
     }
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCmsObjectNameLookup.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cms/PSCmsObjectNameLookup.java
@@ -40,6 +40,7 @@ import org.w3c.dom.NodeList;
  * namelookups during server initialization and avoid internal requests. In that this is a temporary
  * feature.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCmsObjectNameLookup extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
   /** Creates a new PSCmsObjectNameLookup. */
   public PSCmsObjectNameLookup() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/components/PSMenuTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/components/PSMenuTree.java
@@ -52,7 +52,6 @@ import org.w3c.dom.Text;
  *
  * <p>Multiple requests are made to expand each child item to menu item.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSMenuTree implements IPSResultDocumentProcessor {
   /** Creates a new PSMenuTree. */
   public PSMenuTree() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/components/PSMenuTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/components/PSMenuTree.java
@@ -30,6 +30,7 @@ import com.percussion.xml.PSXmlDocumentBuilder;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -82,7 +83,7 @@ public class PSMenuTree implements IPSResultDocumentProcessor {
     if (rxAppResource.startsWith("/")) rxAppResource = rxAppResource.substring(1);
 
     Map<String, Object> htmlParams = request.getParameters();
-    ArrayList itemsRendered = new ArrayList();
+    List<String> itemsRendered = new ArrayList<>();
     Element elem = resDoc.getDocumentElement();
     String temp = elem.getAttribute("id").trim();
     if (temp.length() < 1) return resDoc;
@@ -111,11 +112,11 @@ public class PSMenuTree implements IPSResultDocumentProcessor {
    * @param rxAppResource the Rhythmyx application resource for making internal request.
    */
   private void processItem(
-      ArrayList itemsRendered, Element parent, IPSRequestContext request, String rxAppResource) {
+      List<String> itemsRendered, Element parent, IPSRequestContext request, String rxAppResource) {
     try {
       NodeList nl = parent.getChildNodes();
       if (nl == null || nl.getLength() < 1) return;
-      HashMap params = new HashMap();
+      Map<String, Object> params = new HashMap<>();
       Element elemItem = null;
       Element elemRes = null;
       String id = "";

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/components/PSMenuTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/components/PSMenuTree.java
@@ -52,6 +52,7 @@ import org.w3c.dom.Text;
  *
  * <p>Multiple requests are made to expand each child item to menu item.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSMenuTree implements IPSResultDocumentProcessor {
   /** Creates a new PSMenuTree. */
   public PSMenuTree() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSAddAllowableWorkflowsForContentType.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSAddAllowableWorkflowsForContentType.java
@@ -63,6 +63,7 @@ import org.w3c.dom.Text;
  * CDATA #IMPLIED &gt; It basically gets all the workflows in the system and removes the workflows
  * in the excludelist for each content type.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSAddAllowableWorkflowsForContentType extends PSDefaultExtension
     implements IPSResultDocumentProcessor, IPSRequestPreProcessor {
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSAddAllowableWorkflowsForContentType.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSAddAllowableWorkflowsForContentType.java
@@ -95,12 +95,14 @@ public class PSAddAllowableWorkflowsForContentType extends PSDefaultExtension
     if (params.length < 2 || params[1] == null)
       throw new PSParameterMismatchException("Two params expected");
 
-    List ctypeList = null;
+    List<String> ctypeList = null;
     if (params[0] instanceof List) {
-      ctypeList = (List) params[0];
+      @SuppressWarnings("unchecked")
+      List<String> rawList = (List<String>) params[0];
+      ctypeList = rawList;
     } else if (params[0] != null) {
       String ctype = params[0].toString();
-      ctypeList = new ArrayList(1);
+      ctypeList = new ArrayList<>(1);
       ctypeList.add(ctype);
     }
 
@@ -110,16 +112,16 @@ public class PSAddAllowableWorkflowsForContentType extends PSDefaultExtension
     if (outParamName.trim().length() == 0)
       throw new PSParameterMismatchException("Output param must be specified");
 
-    List allWFList = getAllWorkflows(request);
-    List wfList = new ArrayList();
+    List<String> allWFList = getAllWorkflows(request);
+    List<String> wfList = new ArrayList<>();
 
     if (allWFList != null) {
       try {
         // build set for non-dupes
-        Set wfSet = new HashSet();
-        Iterator ctypes = ctypeList.iterator();
+        Set<String> wfSet = new HashSet<>();
+        Iterator<String> ctypes = ctypeList.iterator();
         while (ctypes.hasNext()) {
-          String ctype = ctypes.next().toString();
+          String ctype = ctypes.next();
           wfSet.addAll(getAllowedWorkflows(ctype, request, allWFList));
         }
 
@@ -147,7 +149,7 @@ public class PSAddAllowableWorkflowsForContentType extends PSDefaultExtension
     }
     Element workflowsElem = null;
     Element workflowElem = null;
-    List wfList = getAllWorkflows(request);
+    List<String> wfList = getAllWorkflows(request);
 
     if (wfList == null) {
       // Could not bring any workflows
@@ -155,22 +157,22 @@ public class PSAddAllowableWorkflowsForContentType extends PSDefaultExtension
     }
 
     // make copy that we don't modify to use for each type's allowed call
-    List allWFList = new ArrayList(wfList);
+    List<String> allWFList = new ArrayList<>(wfList);
 
     // walk each type and get allowed.  Also filter main wfList to contain
     // only allowed types as we go
     for (int i = 0; i < nl.getLength(); i++) {
       try {
         String cid = ((Element) nl.item(i)).getAttribute(ATTR_CONTENTTYPEID);
-        List allowed = getAllowedWorkflows(cid, request, allWFList);
+        List<String> allowed = getAllowedWorkflows(cid, request, allWFList);
         wfList.retainAll(allowed);
 
         if (!allowed.isEmpty()) {
           Element wselem = doc.createElement(ELEM_WORKFLOWS);
-          Iterator iter = allowed.iterator();
+          Iterator<String> iter = allowed.iterator();
           while (iter.hasNext()) {
             Element welem = doc.createElement(ELEM_WORKFLOW);
-            welem.setAttribute(ATTR_WORKFLOWID, iter.next().toString());
+            welem.setAttribute(ATTR_WORKFLOWID, iter.next());
             wselem.appendChild(welem);
           }
           nl.item(i).appendChild(wselem);
@@ -187,7 +189,7 @@ public class PSAddAllowableWorkflowsForContentType extends PSDefaultExtension
     workflowsElem = doc.createElement(ELEM_WORKFLOWS);
     for (int j = 0; j < wfList.size(); j++) {
       workflowElem = doc.createElement(ELEM_WORKFLOW);
-      workflowElem.setAttribute(ATTR_WORKFLOWID, wfList.get(j).toString());
+      workflowElem.setAttribute(ATTR_WORKFLOWID, wfList.get(j));
       workflowsElem.appendChild(workflowElem);
     }
     doc.getDocumentElement().appendChild(workflowsElem);
@@ -200,9 +202,9 @@ public class PSAddAllowableWorkflowsForContentType extends PSDefaultExtension
    * @param request IPSRequestContext
    * @return List of the workflows
    */
-  private List getAllWorkflows(IPSRequestContext request) {
+  private List<String> getAllWorkflows(IPSRequestContext request) {
     Document doc = null;
-    List temp = new ArrayList();
+    List<String> temp = new ArrayList<>();
 
     IPSInternalRequest iReq = null;
     try {
@@ -239,12 +241,13 @@ public class PSAddAllowableWorkflowsForContentType extends PSDefaultExtension
    *     </code>.
    * @throws PSInvalidContentTypeException
    */
-  private List getAllowedWorkflows(String cid, IPSRequestContext request, List allWorkflows)
+  private List<String> getAllowedWorkflows(
+      String cid, IPSRequestContext request, List<String> allWorkflows)
       throws PSInvalidContentTypeException {
     PSItemDefManager mgr = PSItemDefManager.getInstance();
     PSContentEditor cedef = mgr.getItemDef(Integer.parseInt(cid), -1).getContentEditor();
     PSWorkflowInfo wfinfo = cedef.getWorkflowInfo();
-    List allowedWorkflows = new ArrayList();
+    List<String> allowedWorkflows = new ArrayList<>();
     if (wfinfo == null) {
       // all are allowed
       allowedWorkflows.addAll(allWorkflows);
@@ -252,12 +255,12 @@ public class PSAddAllowableWorkflowsForContentType extends PSDefaultExtension
     }
     if (wfinfo.isExclusionary()) {
       allowedWorkflows.addAll(allWorkflows);
-      Iterator iter = wfinfo.getValues();
+      Iterator<?> iter = wfinfo.getValues();
       while (iter.hasNext()) {
         allowedWorkflows.remove(iter.next().toString());
       }
     } else {
-      Iterator iter = wfinfo.getValues();
+      Iterator<?> iter = wfinfo.getValues();
       while (iter.hasNext()) {
         String wfId = iter.next().toString();
         if (allWorkflows.contains(wfId)) allowedWorkflows.add(wfId);

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSAddAllowableWorkflowsForContentType.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSAddAllowableWorkflowsForContentType.java
@@ -255,12 +255,12 @@ public class PSAddAllowableWorkflowsForContentType extends PSDefaultExtension
     }
     if (wfinfo.isExclusionary()) {
       allowedWorkflows.addAll(allWorkflows);
-      Iterator<?> iter = wfinfo.getValues();
+      Iterator<Integer> iter = wfinfo.getValues();
       while (iter.hasNext()) {
         allowedWorkflows.remove(iter.next().toString());
       }
     } else {
-      Iterator<?> iter = wfinfo.getValues();
+      Iterator<Integer> iter = wfinfo.getValues();
       while (iter.hasNext()) {
         String wfId = iter.next().toString();
         if (allWorkflows.contains(wfId)) allowedWorkflows.add(wfId);

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSAddAllowableWorkflowsForContentType.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSAddAllowableWorkflowsForContentType.java
@@ -63,7 +63,6 @@ import org.w3c.dom.Text;
  * CDATA #IMPLIED &gt; It basically gets all the workflows in the system and removes the workflows
  * in the excludelist for each content type.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSAddAllowableWorkflowsForContentType extends PSDefaultExtension
     implements IPSResultDocumentProcessor, IPSRequestPreProcessor {
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSCheckOutSlotItem.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSCheckOutSlotItem.java
@@ -66,7 +66,7 @@ public class PSCheckOutSlotItem extends PSDefaultExtension implements IPSResultD
     } else if (checkoutstatus.equalsIgnoreCase(IPSConstants.CHECKOUT_STATUS_NOBODY)) {
       String contentid = PSHtmlParameters.get(IPSHtmlParameters.SYS_CONTENTID, request);
       if (contentid != null && contentid.length() > 0) {
-        Map chkoutMap = new HashMap();
+        Map<String, Object> chkoutMap = new HashMap<>();
         chkoutMap.put(IPSHtmlParameters.SYS_CONTENTID, contentid);
         chkoutMap.put(IPSHtmlParameters.SYS_COMMAND, WORKFLOW_COMMAND_NAME);
         chkoutMap.put(PSWorkFlowUtils.DEFAULT_ACTION_TRIGGER_NAME, WORKFLOW_CHECKOUT);

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSCheckOutSlotItem.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSCheckOutSlotItem.java
@@ -36,7 +36,6 @@ import org.w3c.dom.Element;
  * Checks out a slot a item before expanding it. If the item is already checked out by someone else,
  * then does not show the slots for that item.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCheckOutSlotItem extends PSDefaultExtension implements IPSResultDocumentProcessor {
   /** Creates a new PSCheckOutSlotItem. */
   public PSCheckOutSlotItem() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSCheckOutSlotItem.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSCheckOutSlotItem.java
@@ -36,6 +36,7 @@ import org.w3c.dom.Element;
  * Checks out a slot a item before expanding it. If the item is already checked out by someone else,
  * then does not show the slots for that item.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCheckOutSlotItem extends PSDefaultExtension implements IPSResultDocumentProcessor {
   /** Creates a new PSCheckOutSlotItem. */
   public PSCheckOutSlotItem() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSConvertCustomSearchOperator.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSConvertCustomSearchOperator.java
@@ -36,6 +36,7 @@ import org.w3c.dom.Element;
  * operator. Can also convert the operator and value(s) sent to the appropriate sql where clause
  * syntax.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSConvertCustomSearchOperator extends PSDefaultExtension
     implements IPSRequestPreProcessor {
   /** Creates a new PSConvertCustomSearchOperator. */

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSConvertCustomSearchOperator.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSConvertCustomSearchOperator.java
@@ -200,7 +200,7 @@ public class PSConvertCustomSearchOperator extends PSDefaultExtension
       Object val = paramDoc.getParam(params[1].toString().trim());
       if (val != null) {
         if (val instanceof List) {
-          List valList = (List) val;
+          List<?> valList = (List<?>) val;
           values = valList.toArray();
         } else {
           String strVal = val.toString().trim();

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSConvertCustomSearchOperator.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSConvertCustomSearchOperator.java
@@ -36,7 +36,6 @@ import org.w3c.dom.Element;
  * operator. Can also convert the operator and value(s) sent to the appropriate sql where clause
  * syntax.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSConvertCustomSearchOperator extends PSDefaultExtension
     implements IPSRequestPreProcessor {
   /** Creates a new PSConvertCustomSearchOperator. */

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSCreateTranslations.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSCreateTranslations.java
@@ -40,7 +40,6 @@ import org.w3c.dom.Element;
  * translation and then makes an internal request to execute the url. Builds the result document
  * with the status of translations for each content item.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCreateTranslations extends PSDefaultExtension implements IPSResultDocumentProcessor {
   /** Creates a new PSCreateTranslations. */
   public PSCreateTranslations() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSCreateTranslations.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSCreateTranslations.java
@@ -40,6 +40,7 @@ import org.w3c.dom.Element;
  * translation and then makes an internal request to execute the url. Builds the result document
  * with the status of translations for each content item.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCreateTranslations extends PSDefaultExtension implements IPSResultDocumentProcessor {
   /** Creates a new PSCreateTranslations. */
   public PSCreateTranslations() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSCreateTranslations.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSCreateTranslations.java
@@ -29,6 +29,7 @@ import com.percussion.server.IPSInternalRequest;
 import com.percussion.server.IPSRequestContext;
 import com.percussion.system.utils.IPSHtmlParameters;
 import java.util.HashMap;
+import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
@@ -118,7 +119,7 @@ public class PSCreateTranslations extends PSDefaultExtension implements IPSResul
     String contentid;
     String revision;
     String ceurl;
-    HashMap paramMap = new HashMap();
+    Map<String, Object> paramMap = new HashMap<>();
     paramMap.put(IPSHtmlParameters.SYS_LANG, lang);
     paramMap.put(IPSHtmlParameters.SYS_COMMAND, PSRelationshipCommandHandler.COMMAND_NAME);
     paramMap.put(IPSHtmlParameters.SYS_RELATIONSHIPTYPE, relationshipType);

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSDeleteContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSDeleteContent.java
@@ -62,7 +62,6 @@ import org.w3c.dom.Element;
  * deletes the rows from all system tables tables. The XML element pkey must be mapped to the
  * primary key in the backed table(s).
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSDeleteContent implements IPSRequestPreProcessor {
   /** Creates a new PSDeleteContent. */
   public PSDeleteContent() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSDeleteContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSDeleteContent.java
@@ -62,6 +62,7 @@ import org.w3c.dom.Element;
  * deletes the rows from all system tables tables. The XML element pkey must be mapped to the
  * primary key in the backed table(s).
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSDeleteContent implements IPSRequestPreProcessor {
   /** Creates a new PSDeleteContent. */
   public PSDeleteContent() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSDeleteContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/cx/PSDeleteContent.java
@@ -110,11 +110,13 @@ public class PSDeleteContent implements IPSRequestPreProcessor {
       String purgeurl = null;
       String contentid = null;
       Element elem = null;
-      ArrayList purgeContentIdList = null;
-      if (obj instanceof ArrayList) {
-        purgeContentIdList = (ArrayList) obj;
+      List<String> purgeContentIdList = null;
+      if (obj instanceof List<?>) {
+        @SuppressWarnings("unchecked")
+        List<String> castList = (List<String>) obj;
+        purgeContentIdList = castList;
       } else {
-        purgeContentIdList = new ArrayList();
+        purgeContentIdList = new ArrayList<>();
         purgeContentIdList.add(obj.toString());
       }
       String ceResource = "";
@@ -156,7 +158,7 @@ public class PSDeleteContent implements IPSRequestPreProcessor {
             // relationships and then notify the handler
             Map<String, Object> reqParams = request.getParameters();
             String val = request.getParameter("sys_changeEventOnly");
-            Map tmpParams = new HashMap();
+            Map<String, Object> tmpParams = new HashMap<>();
             tmpParams.put(IPSHtmlParameters.SYS_COMMAND, "modify");
             tmpParams.put(IPSHtmlParameters.SYS_REVISION, "-1");
             iReq = request.getInternalRequest(ceResource, tmpParams, true);

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSCascadeDelete.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSCascadeDelete.java
@@ -165,7 +165,7 @@ public class PSCascadeDelete extends PSDefaultExtension implements IPSRequestPre
     String url = params[1].toString().trim();
 
     // build params map
-    HashMap paramMap = new HashMap();
+    Map<String, String> paramMap = new HashMap<>();
     int paramMaxIndex = params.length - 1;
     for (int paramIndex = 2; paramIndex < paramMaxIndex; paramIndex += 2) {
       Object key = params[paramIndex];
@@ -181,15 +181,15 @@ public class PSCascadeDelete extends PSDefaultExtension implements IPSRequestPre
     try {
       // get the node set corresponding to the deleted rows of the parent table
       PSXPathEvaluator xp = new PSXPathEvaluator(inputDoc);
-      Iterator it = xp.enumerate(xpath, false);
+      Iterator<Node> it = xp.enumerate(xpath, false);
       while (it.hasNext()) {
         // for each node, evaluate the html param values
-        Node node = (Node) it.next();
+        Node node = it.next();
         PSXPathEvaluator xpNode = new PSXPathEvaluator(node);
-        Map nodeParamMap = new HashMap(paramMap);
-        Iterator paramIt = nodeParamMap.entrySet().iterator();
+        Map<String, Object> nodeParamMap = new HashMap<>(paramMap);
+        Iterator<Map.Entry<String, Object>> paramIt = nodeParamMap.entrySet().iterator();
         while (paramIt.hasNext()) {
-          Map.Entry item = (Map.Entry) paramIt.next();
+          Map.Entry<String, Object> item = paramIt.next();
           String strVal = (String) item.getValue();
           try {
             String newVal = xpNode.evaluate(strVal);

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSCascadeDelete.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSCascadeDelete.java
@@ -53,7 +53,6 @@ import org.w3c.dom.NodeList;
  * appended to the root node of the XML document obtained from the request context (ie, the document
  * which is processed by the update resource).
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCascadeDelete extends PSDefaultExtension implements IPSRequestPreProcessor {
   /** Creates a new PSCascadeDelete. */
   public PSCascadeDelete() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSCascadeDelete.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSCascadeDelete.java
@@ -53,6 +53,7 @@ import org.w3c.dom.NodeList;
  * appended to the root node of the XML document obtained from the request context (ie, the document
  * which is processed by the update resource).
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCascadeDelete extends PSDefaultExtension implements IPSRequestPreProcessor {
   /** Creates a new PSCascadeDelete. */
   public PSCascadeDelete() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSCollapseHtmlParameter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSCollapseHtmlParameter.java
@@ -30,7 +30,6 @@ import org.w3c.dom.Document;
  * the first value from the array. If the specified parameter does not exist in the request
  * parameters, it ignores.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCollapseHtmlParameter extends PSDefaultExtension
     implements IPSRequestPreProcessor, IPSResultDocumentProcessor {
   /** Creates a new PSCollapseHtmlParameter. */

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSCollapseHtmlParameter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSCollapseHtmlParameter.java
@@ -97,7 +97,7 @@ public class PSCollapseHtmlParameter extends PSDefaultExtension
       // The object is not an array, dont worry about it!
       if (!(obj instanceof ArrayList)) continue;
 
-      ArrayList list = (ArrayList) obj;
+      ArrayList<?> list = (ArrayList<?>) obj;
       // Replace the parameter with the first value
       paramMap.put(paramName, list.get(0));
     }

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSCollapseHtmlParameter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSCollapseHtmlParameter.java
@@ -30,6 +30,7 @@ import org.w3c.dom.Document;
  * the first value from the array. If the specified parameter does not exist in the request
  * parameters, it ignores.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSCollapseHtmlParameter extends PSDefaultExtension
     implements IPSRequestPreProcessor, IPSResultDocumentProcessor {
   /** Creates a new PSCollapseHtmlParameter. */

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFileInfo.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFileInfo.java
@@ -104,8 +104,8 @@ public class PSFileInfo extends PSDefaultExtension implements IPSRequestPreProce
           PSParameterMismatchException,
           PSExtensionProcessingException {
     // make a copy to avoid ConcurrentModificationException
-    Set paramKeys = new HashSet(request.getParameters().keySet());
-    Iterator iter = paramKeys.iterator();
+    Set<String> paramKeys = new HashSet<>(request.getParameters().keySet());
+    Iterator<String> iter = paramKeys.iterator();
     String wifxFlag = request.getParameter("webimagefxupload");
     boolean isWifxUpload =
         wifxFlag != null
@@ -274,10 +274,10 @@ public class PSFileInfo extends PSDefaultExtension implements IPSRequestPreProce
         PSItemDefinition item =
             mgr.getItemDef(Integer.parseInt(contentTypeId), Integer.parseInt(communityId));
         PSServerItem sItem = new PSServerItem(item);
-        Iterator it = sItem.getAllFields();
+        Iterator<PSItemField> it = sItem.getAllFields();
         PSItemField field = null;
         while (it.hasNext()) {
-          field = (PSItemField) it.next();
+          field = it.next();
           if (field.isMultiValue()) delimitedParameterToList(request, field.getName(), ";");
         }
       } catch (Exception e) {

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFileInfo.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFileInfo.java
@@ -84,7 +84,6 @@ import java.util.StringTokenizer;
  * browsers may not report some or all of these values. If the value is not present (or the file
  * length is 0), the corresponding parameter will not be added to the server's parameter map.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSFileInfo extends PSDefaultExtension implements IPSRequestPreProcessor {
   /** Creates a new PSFileInfo. */
   public PSFileInfo() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFileInfo.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFileInfo.java
@@ -84,6 +84,7 @@ import java.util.StringTokenizer;
  * browsers may not report some or all of these values. If the value is not present (or the file
  * length is 0), the corresponding parameter will not be added to the server's parameter map.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSFileInfo extends PSDefaultExtension implements IPSRequestPreProcessor {
   /** Creates a new PSFileInfo. */
   public PSFileInfo() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFormatFileTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFormatFileTree.java
@@ -160,7 +160,7 @@ public class PSFormatFileTree extends PSDefaultExtension implements IPSResultDoc
    * @param pt parameter tracker contains parameters for this request.
    */
   private void ProcessResultDoc(Document resultDoc, ParamTracker pt) {
-    LinkedList feList = BuildNodeList(resultDoc, pt);
+    LinkedList<FileElement> feList = BuildNodeList(resultDoc, pt);
     Element parentNode = resultDoc.createElement(pt.getFileTreeName());
     resultDoc.getDocumentElement().appendChild(parentNode);
 
@@ -176,8 +176,8 @@ public class PSFormatFileTree extends PSDefaultExtension implements IPSResultDoc
    * @param pt the parameter tracking block, contains instance parameters
    * @return a java.util.LinkedList of FileElement objects
    */
-  private LinkedList BuildNodeList(Document resultDoc, ParamTracker pt) {
-    LinkedList nodeList = new LinkedList();
+  private LinkedList<FileElement> BuildNodeList(Document resultDoc, ParamTracker pt) {
+    LinkedList<FileElement> nodeList = new LinkedList<>();
     PSXmlTreeWalker filelistWalker = new PSXmlTreeWalker(resultDoc);
     String inputList = pt.getInputListName();
     if (!filelistWalker.getCurrent().getNodeName().equals(inputList)) {
@@ -224,8 +224,8 @@ public class PSFormatFileTree extends PSDefaultExtension implements IPSResultDoc
    * @param pt paramm tracker object, assumed not <code>null</code>.
    */
   private void ProcessNodeList(
-      LinkedList nodeList, Element parentNode, int level, ParamTracker pt) {
-    LinkedList childList = new LinkedList();
+      LinkedList<FileElement> nodeList, Element parentNode, int level, ParamTracker pt) {
+    LinkedList<FileElement> childList = new LinkedList<>();
     Document ownerDoc = parentNode.getOwnerDocument();
     String pathName;
     String prevPathName = null;
@@ -235,7 +235,7 @@ public class PSFormatFileTree extends PSDefaultExtension implements IPSResultDoc
     if (nodeList.size() == 0) {
       return;
     }
-    FileElement fe = (FileElement) nodeList.removeFirst();
+    FileElement fe = nodeList.removeFirst();
     while (fe != null) {
       pathName = fe.getNextPathName();
       if (!fe.hasPathElements()) {
@@ -281,7 +281,7 @@ public class PSFormatFileTree extends PSDefaultExtension implements IPSResultDoc
         }
       }
 
-      fe = (nodeList.size() > 0) ? (FileElement) nodeList.removeFirst() : null;
+      fe = (nodeList.size() > 0) ? nodeList.removeFirst() : null;
     }
     if (childList.size() > 0) {
       // there are outstanding items to process

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFormatFileTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFormatFileTree.java
@@ -45,7 +45,6 @@ import org.w3c.dom.Text;
  *
  * @author David Benua
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSFormatFileTree extends PSDefaultExtension implements IPSResultDocumentProcessor {
   /** Creates a new PSFormatFileTree. */
   public PSFormatFileTree() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFormatFileTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSFormatFileTree.java
@@ -45,6 +45,7 @@ import org.w3c.dom.Text;
  *
  * @author David Benua
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSFormatFileTree extends PSDefaultExtension implements IPSResultDocumentProcessor {
   /** Creates a new PSFormatFileTree. */
   public PSFormatFileTree() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSImageInfoExtractor.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSImageInfoExtractor.java
@@ -54,10 +54,10 @@ public class PSImageInfoExtractor extends PSFileInfo implements IPSItemInputTran
     // first do the normal file info processing
     super.preProcessRequest(params, request);
 
-    Set paramKeys = new HashSet(request.getParameters().keySet());
-    Iterator iter = paramKeys.iterator();
+    Set<String> paramKeys = new HashSet<>(request.getParameters().keySet());
+    Iterator<String> iter = paramKeys.iterator();
     while (iter.hasNext()) {
-      String paramName = (String) iter.next();
+      String paramName = iter.next();
       Object obj = request.getParameterObject(paramName);
       if (obj instanceof PSPurgableTempFile) {
         PSPurgableTempFile temp = (PSPurgableTempFile) obj;

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSImageInfoExtractor.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSImageInfoExtractor.java
@@ -39,6 +39,7 @@ import org.apache.logging.log4j.Logger;
  * If one of the files is an image then the width and height dimensions will be extracted and will
  * be added to the request as image size attributes. Requires the SUN JAI library.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSImageInfoExtractor extends PSFileInfo implements IPSItemInputTransformer {
   /** Creates a new PSImageInfoExtractor. */
   public PSImageInfoExtractor() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSImageInfoExtractor.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSImageInfoExtractor.java
@@ -39,7 +39,6 @@ import org.apache.logging.log4j.Logger;
  * If one of the files is an image then the width and height dimensions will be extracted and will
  * be added to the request as image size attributes. Requires the SUN JAI library.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSImageInfoExtractor extends PSFileInfo implements IPSItemInputTransformer {
   /** Creates a new PSImageInfoExtractor. */
   public PSImageInfoExtractor() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSInlineLinkCleanup.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSInlineLinkCleanup.java
@@ -179,14 +179,15 @@ public class PSInlineLinkCleanup extends PSDefaultExtension implements IPSResult
   private void addInlineFields(
       PSDisplayMapper dispMapper, PSContentEditorMapper editMapper, ContentType ctype) {
     PSFieldSet fieldSet = editMapper.getFieldSet(dispMapper.getFieldSetRef());
-    Iterator mappings = dispMapper.iterator();
+    @SuppressWarnings("unchecked")
+    Iterator<PSDisplayMapping> mappings = dispMapper.iterator();
     PSDisplayMapping mapping = null;
     PSUISet uiSet = null;
     PSDisplayText label = null;
     String text = null;
     if (mappings != null) {
       while (mappings.hasNext()) {
-        mapping = (PSDisplayMapping) mappings.next();
+        mapping = mappings.next();
         PSDisplayMapper displayMapper = mapping.getDisplayMapper();
         if (displayMapper != null) {
           addInlineFields(displayMapper, editMapper, ctype);
@@ -217,7 +218,7 @@ public class PSInlineLinkCleanup extends PSDefaultExtension implements IPSResult
    * @return The schema object, never <code>null</code>.
    */
   private PSJdbcTableSchema getSchema(String table) {
-    PSJdbcTableSchema schema = (PSJdbcTableSchema) ms_tableSchemas.get(table);
+    PSJdbcTableSchema schema = ms_tableSchemas.get(table);
     if (schema == null) {
       try {
         schema = PSDbmsHelper.getInstance().catalogTable(table, false);
@@ -369,7 +370,7 @@ public class PSInlineLinkCleanup extends PSDefaultExtension implements IPSResult
      * @return A list over zero or more <code>PSField</code> objects, never <code>null</code>, but
      *     may not empty.
      */
-    private List getInlineFields() {
+    private List<PSField> getInlineFields() {
       return m_inlineFields;
     }
 
@@ -408,16 +409,16 @@ public class PSInlineLinkCleanup extends PSDefaultExtension implements IPSResult
      *     may be empty.
      * @throws Exception if an error occurs.
      */
-    private List getContentLocators(IPSRequestContext request) throws Exception {
-      List result = new ArrayList();
+    private List<PSLocator> getContentLocators(IPSRequestContext request) throws Exception {
+      List<PSLocator> result = new ArrayList<>();
       String table = getLocalTable();
       PSDbmsHelper dbmsHelper = PSDbmsHelper.getInstance();
       PSJdbcTableData data = dbmsHelper.catalogTableData(table, null, null);
 
       if (data != null && data.getRows().hasNext()) {
-        Iterator rows = data.getRows();
+        Iterator<PSJdbcRowData> rows = data.getRows();
         while (rows.hasNext()) {
-          PSJdbcRowData row = (PSJdbcRowData) rows.next();
+          PSJdbcRowData row = rows.next();
           int id = dbmsHelper.getColumnInt(table, CONTENTID, row);
           int rev = dbmsHelper.getColumnInt(table, REVISIONID, row);
           PSLocator locator = new PSLocator(id, rev);
@@ -442,14 +443,13 @@ public class PSInlineLinkCleanup extends PSDefaultExtension implements IPSResult
       Object[] args = {m_itemdef.getName()};
       traceMessage(request, "Processing content type: \"{0}\"", args);
 
-      List result = new ArrayList();
       if (!hasInlineFields()) return;
 
       try {
         // process one content type at a time
-        Iterator locators = getContentLocators(request).iterator();
+        Iterator<PSLocator> locators = getContentLocators(request).iterator();
         while (locators.hasNext()) {
-          PSLocator locator = (PSLocator) locators.next();
+          PSLocator locator = locators.next();
           try {
             processContents(request, locator, isPreview);
           } catch (Exception e) {
@@ -488,10 +488,10 @@ public class PSInlineLinkCleanup extends PSDefaultExtension implements IPSResult
       PSField field = null;
 
       // retrieve contents for all inline link fields
-      Iterator fields = getInlineFields().iterator();
-      List contents = new ArrayList();
+      Iterator<PSField> fields = getInlineFields().iterator();
+      List<FieldContent> contents = new ArrayList<>();
       while (fields.hasNext()) {
-        field = (PSField) fields.next();
+        field = fields.next();
         contents.addAll(getContents(locator, field));
       }
 
@@ -500,9 +500,9 @@ public class PSInlineLinkCleanup extends PSDefaultExtension implements IPSResult
       request.setParameter(IPSHtmlParameters.SYS_REVISION, String.valueOf(locator.getRevision()));
       PSRelationshipSet deletes = PSInlineLinkField.getInlineRelationships(request);
       PSRelationshipSet modifies = new PSRelationshipSet();
-      Iterator fieldContents = contents.iterator();
+      Iterator<FieldContent> fieldContents = contents.iterator();
       while (fieldContents.hasNext()) {
-        fieldContent = (FieldContent) fieldContents.next();
+        fieldContent = fieldContents.next();
         fieldContent.preProcess(request, deletes, modifies);
       }
 
@@ -510,7 +510,7 @@ public class PSInlineLinkCleanup extends PSDefaultExtension implements IPSResult
       if ((!isPreview) && (deletes.size() > 0 || modifies.size() > 0)) {
         fieldContents = contents.iterator();
         while (fieldContents.hasNext()) {
-          fieldContent = (FieldContent) fieldContents.next();
+          fieldContent = fieldContents.next();
           fieldContent.postProcess(request);
         }
 
@@ -545,8 +545,8 @@ public class PSInlineLinkCleanup extends PSDefaultExtension implements IPSResult
      *     empty.
      * @throws Exception if an error occurs.
      */
-    private List getContents(PSLocator locator, PSField field) throws Exception {
-      List result = new ArrayList();
+    private List<FieldContent> getContents(PSLocator locator, PSField field) throws Exception {
+      List<FieldContent> result = new ArrayList<>();
       String column = getColumnFromField(field);
       String table = getTableFromField(field);
       PSJdbcTableSchema schema = getSchema(table);
@@ -558,11 +558,11 @@ public class PSInlineLinkCleanup extends PSDefaultExtension implements IPSResult
       PSJdbcSelectFilter filter = getFilter(locator);
       PSJdbcTableData data = dbmsHelper.catalogTableData(table, null, filter);
       if (data != null && data.getRows().hasNext()) {
-        Iterator rows = data.getRows();
+        Iterator<PSJdbcRowData> rows = data.getRows();
         FieldContent fieldContent;
         int sysid = -1;
         while (rows.hasNext()) {
-          PSJdbcRowData row = (PSJdbcRowData) rows.next();
+          PSJdbcRowData row = rows.next();
           PSJdbcColumnData cdata = row.getColumn(column);
           String content = cdata.getValue();
           if (hasSysid) sysid = dbmsHelper.getColumnInt(table, SYSID, row);
@@ -608,7 +608,7 @@ public class PSInlineLinkCleanup extends PSDefaultExtension implements IPSResult
     /*
      * A list of inline link fields, never <code>null</code>, may be empty.
      */
-    private List m_inlineFields = new ArrayList();
+    private List<PSField> m_inlineFields = new ArrayList<>();
 
     /**
      * The local (DB) table name for the current content type. Set by {@link
@@ -696,7 +696,7 @@ public class PSInlineLinkCleanup extends PSDefaultExtension implements IPSResult
       String table = getTableFromField(m_field);
       String column = getColumnFromField(m_field);
       // creates the updated row
-      List columns = new ArrayList();
+      List<PSJdbcColumnData> columns = new ArrayList<>();
       PSJdbcColumnData id = new PSJdbcColumnData(CONTENTID, String.valueOf(m_locator.getId()));
       columns.add(id);
       PSJdbcColumnData rev =
@@ -709,7 +709,7 @@ public class PSInlineLinkCleanup extends PSDefaultExtension implements IPSResult
         columns.add(sysid);
       }
       PSJdbcRowData row = new PSJdbcRowData(columns.iterator(), PSJdbcRowData.ACTION_UPDATE);
-      List rows = new ArrayList();
+      List<PSJdbcRowData> rows = new ArrayList<>();
       rows.add(row);
       PSJdbcTableData data = new PSJdbcTableData(table, rows.iterator());
       data.setOnCreateOnly(false);
@@ -750,5 +750,5 @@ public class PSInlineLinkCleanup extends PSDefaultExtension implements IPSResult
    * String</code> object; the map value is the schema of the table as a <code>PSJdbcTableSchema
    * </code> object.
    */
-  private static Map ms_tableSchemas = new HashMap();
+  private static Map<String, PSJdbcTableSchema> ms_tableSchemas = new HashMap<>();
 }

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSInlineLinkCleanup.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSInlineLinkCleanup.java
@@ -74,7 +74,6 @@ import org.w3c.dom.Element;
  * <p>If the option parameter is not "preview", it will do the same as "preview" does, plus write to
  * the database for the processed result.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSInlineLinkCleanup extends PSDefaultExtension implements IPSResultDocumentProcessor {
   /** Creates a new PSInlineLinkCleanup. */
   public PSInlineLinkCleanup() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSInlineLinkCleanup.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSInlineLinkCleanup.java
@@ -74,6 +74,7 @@ import org.w3c.dom.Element;
  * <p>If the option parameter is not "preview", it will do the same as "preview" does, plus write to
  * the database for the processed result.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSInlineLinkCleanup extends PSDefaultExtension implements IPSResultDocumentProcessor {
   /** Creates a new PSInlineLinkCleanup. */
   public PSInlineLinkCleanup() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLink.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLink.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
  * This class implements the UDF processor interface so it can be used as a Rhythmyx function. See
  * {@link #processUdf(Object[], IPSRequestContext) processUdf} for a description.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSMakeAbsLink extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
   /** Creates a new PSMakeAbsLink. */
   public PSMakeAbsLink() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLink.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLink.java
@@ -160,7 +160,7 @@ public class PSMakeAbsLink extends PSSimpleJavaUdfExtension implements IPSUdfPro
     String sourceUrl = params[0].toString().trim();
 
     // build params map
-    HashMap paramMap = new HashMap();
+    HashMap<String, Object> paramMap = new HashMap<>();
     int paramMaxIndex = params.length - 1;
     for (int paramIndex = 1;
         paramIndex < paramMaxIndex

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLink.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLink.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
  * This class implements the UDF processor interface so it can be used as a Rhythmyx function. See
  * {@link #processUdf(Object[], IPSRequestContext) processUdf} for a description.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSMakeAbsLink extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
   /** Creates a new PSMakeAbsLink. */
   public PSMakeAbsLink() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLinkSecure.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLinkSecure.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
  * This class implements the UDF processor interface so it can be used as a Rhythmyx function. See
  * {@link #processUdf(Object[], IPSRequestContext) processUdf} for a description.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSMakeAbsLinkSecure extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
   /** Creates a new PSMakeAbsLinkSecure. */
   public PSMakeAbsLinkSecure() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLinkSecure.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLinkSecure.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
  * This class implements the UDF processor interface so it can be used as a Rhythmyx function. See
  * {@link #processUdf(Object[], IPSRequestContext) processUdf} for a description.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSMakeAbsLinkSecure extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
   /** Creates a new PSMakeAbsLinkSecure. */
   public PSMakeAbsLinkSecure() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLinkSecure.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLinkSecure.java
@@ -207,7 +207,7 @@ public class PSMakeAbsLinkSecure extends PSSimpleJavaUdfExtension implements IPS
     String sourceUrl = params[1].toString().trim();
 
     // build params map
-    HashMap paramMap = new HashMap();
+    HashMap<String, Object> paramMap = new HashMap<>();
     int paramMaxIndex = params.length - 1;
     for (int paramIndex = 2;
         paramIndex < paramMaxIndex

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLinkSecureEx.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLinkSecureEx.java
@@ -242,7 +242,7 @@ public class PSMakeAbsLinkSecureEx extends PSSimpleJavaUdfExtension implements I
     String sourceUrl = params[3].toString().trim();
 
     // build params map
-    HashMap paramMap = new HashMap();
+    HashMap<String, Object> paramMap = new HashMap<>();
     int paramMaxIndex = params.length;
     for (int paramIndex = 4;
         paramIndex < paramMaxIndex

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLinkSecureEx.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLinkSecureEx.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
  * This class implements the UDF processor interface so it can be used as a Rhythmyx function. See
  * {@link #processUdf(Object[], IPSRequestContext) processUdf} for a description.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSMakeAbsLinkSecureEx extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
   /** Creates a new PSMakeAbsLinkSecureEx. */
   public PSMakeAbsLinkSecureEx() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLinkSecureEx.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeAbsLinkSecureEx.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
  * This class implements the UDF processor interface so it can be used as a Rhythmyx function. See
  * {@link #processUdf(Object[], IPSRequestContext) processUdf} for a description.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSMakeAbsLinkSecureEx extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
   /** Creates a new PSMakeAbsLinkSecureEx. */
   public PSMakeAbsLinkSecureEx() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeDeleteRowsXmlDoc.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeDeleteRowsXmlDoc.java
@@ -49,7 +49,6 @@ import org.w3c.dom.Element;
  * time, then only the first parameter should be used. The second and third parameters are ignored
  * in this case.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSMakeDeleteRowsXmlDoc implements IPSRequestPreProcessor {
   /** Creates a new PSMakeDeleteRowsXmlDoc. */
   public PSMakeDeleteRowsXmlDoc() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeDeleteRowsXmlDoc.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeDeleteRowsXmlDoc.java
@@ -92,8 +92,8 @@ public class PSMakeDeleteRowsXmlDoc implements IPSRequestPreProcessor {
       Element elem = null;
 
       if (obj instanceof Collection) {
-        Collection col = (Collection) obj;
-        Iterator it = col.iterator();
+        Collection<?> col = (Collection<?>) obj;
+        Iterator<?> it = col.iterator();
         while (it.hasNext()) {
           Object tempObj = it.next();
           if (tempObj == null) continue;

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeDeleteRowsXmlDoc.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeDeleteRowsXmlDoc.java
@@ -49,6 +49,7 @@ import org.w3c.dom.Element;
  * time, then only the first parameter should be used. The second and third parameters are ignored
  * in this case.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSMakeDeleteRowsXmlDoc implements IPSRequestPreProcessor {
   /** Creates a new PSMakeDeleteRowsXmlDoc. */
   public PSMakeDeleteRowsXmlDoc() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeIntLink.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeIntLink.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
  * This class implements the UDF processor interface so it can be used as a Rhythmyx function. See
  * {@link #processUdf(Object[], IPSRequestContext) processUdf} for a description.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSMakeIntLink extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
   /** Creates a new PSMakeIntLink. */
   public PSMakeIntLink() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeIntLink.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeIntLink.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
  * This class implements the UDF processor interface so it can be used as a Rhythmyx function. See
  * {@link #processUdf(Object[], IPSRequestContext) processUdf} for a description.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSMakeIntLink extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
   /** Creates a new PSMakeIntLink. */
   public PSMakeIntLink() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeIntLink.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeIntLink.java
@@ -130,7 +130,7 @@ public class PSMakeIntLink extends PSSimpleJavaUdfExtension implements IPSUdfPro
     String sourceUrl = params[0].toString().trim();
 
     // build params map
-    HashMap paramMap = new HashMap();
+    HashMap<String, Object> paramMap = new HashMap<>();
 
     int paramMaxIndex = params.length - 1;
     for (int paramIndex = 1;

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeInternalRequest.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeInternalRequest.java
@@ -43,6 +43,7 @@ import org.xml.sax.SAXException;
 /**
  * A UDF that makes an internal request to the specified resource and returns the result document.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSMakeInternalRequest extends PSSimpleJavaUdfExtension {
   /** Creates a new PSMakeInternalRequest. */
   public PSMakeInternalRequest() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeInternalRequest.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeInternalRequest.java
@@ -43,7 +43,6 @@ import org.xml.sax.SAXException;
 /**
  * A UDF that makes an internal request to the specified resource and returns the result document.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSMakeInternalRequest extends PSSimpleJavaUdfExtension {
   /** Creates a new PSMakeInternalRequest. */
   public PSMakeInternalRequest() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeInternalRequest.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeInternalRequest.java
@@ -113,7 +113,7 @@ public class PSMakeInternalRequest extends PSSimpleJavaUdfExtension {
     String paramValue = "";
 
     // get all specified request parameters
-    Map requestParams = new HashMap();
+    Map<String, Object> requestParams = new HashMap<>();
     while (index < size) {
       if ((count % 2) == 0) {
         paramName = (params[index] == null) ? "" : params[index].toString().trim();

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeLink.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeLink.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
  * This class implements the UDF processor interface so it can be used as a Rhythmyx function. See
  * {@link #processUdf(Object[], IPSRequestContext) processUdf} for a description.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSMakeLink extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
   /** Creates a new PSMakeLink. */
   public PSMakeLink() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeLink.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeLink.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
  * This class implements the UDF processor interface so it can be used as a Rhythmyx function. See
  * {@link #processUdf(Object[], IPSRequestContext) processUdf} for a description.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSMakeLink extends PSSimpleJavaUdfExtension implements IPSUdfProcessor {
   /** Creates a new PSMakeLink. */
   public PSMakeLink() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeLink.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSMakeLink.java
@@ -91,7 +91,7 @@ public class PSMakeLink extends PSSimpleJavaUdfExtension implements IPSUdfProces
     String sourceUrl = params[0].toString().trim();
 
     // build params map
-    HashMap paramMap = new HashMap();
+    HashMap<String, Object> paramMap = new HashMap<>();
     int paramMaxIndex = params.length - 1;
     for (int paramIndex = 1;
         paramIndex < paramMaxIndex

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParamStringListToMultiParams.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParamStringListToMultiParams.java
@@ -128,9 +128,9 @@ public class PSParamStringListToMultiParams extends PSDefaultExtension
     else if (!sourceParamName.equals(destinationParamName)) {
       // cannot use getParameter (flat) nor getParameterList (balanced),
       // so iterate to find 'true' value
-      Iterator origParams = request.getParametersIterator();
+      Iterator<Map.Entry<String, Object>> origParams = request.getParametersIterator();
       while (origParams.hasNext()) {
-        Map.Entry param = (Map.Entry) origParams.next();
+        Map.Entry<String, Object> param = origParams.next();
         if (param.getKey().equals(sourceParamName)) {
           request.setParameter(destinationParamName, param.getValue());
           break;

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParamStringListToMultiParams.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParamStringListToMultiParams.java
@@ -34,7 +34,6 @@ import org.w3c.dom.Document;
  * source and the destination parameters are the same; otherwise simply copy the value of the source
  * parameter to the destination parameter.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSParamStringListToMultiParams extends PSDefaultExtension
     implements IPSRequestPreProcessor, IPSResultDocumentProcessor {
   /** Creates a new PSParamStringListToMultiParams. */

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParamStringListToMultiParams.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParamStringListToMultiParams.java
@@ -34,6 +34,7 @@ import org.w3c.dom.Document;
  * source and the destination parameters are the same; otherwise simply copy the value of the source
  * parameter to the destination parameter.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSParamStringListToMultiParams extends PSDefaultExtension
     implements IPSRequestPreProcessor, IPSResultDocumentProcessor {
   /** Creates a new PSParamStringListToMultiParams. */

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParameterTokenizer.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParameterTokenizer.java
@@ -52,6 +52,7 @@ import org.apache.logging.log4j.Logger;
  *
  * <p>This exit supports 3 delimiters: semicolon, period, and comma.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSParameterTokenizer extends PSDefaultExtension implements IPSRequestPreProcessor {
   /** Creates a new PSParameterTokenizer. */
   public PSParameterTokenizer() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParameterTokenizer.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParameterTokenizer.java
@@ -52,7 +52,6 @@ import org.apache.logging.log4j.Logger;
  *
  * <p>This exit supports 3 delimiters: semicolon, period, and comma.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSParameterTokenizer extends PSDefaultExtension implements IPSRequestPreProcessor {
   /** Creates a new PSParameterTokenizer. */
   public PSParameterTokenizer() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParameterTokenizer.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParameterTokenizer.java
@@ -25,6 +25,7 @@ import com.percussion.extension.PSParameterMismatchException;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.server.IPSRequestContext;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 import org.apache.logging.log4j.LogManager;
@@ -109,9 +110,10 @@ public class PSParameterTokenizer extends PSDefaultExtension implements IPSReque
         }
       }
 
-      if (inputArray instanceof ArrayList) {
+      if (inputArray instanceof List<?>) {
         // this is an array, so we need to iterate across it
-        ArrayList inputList = (ArrayList) inputArray;
+        @SuppressWarnings("unchecked")
+        List<String> inputList = (List<String>) inputArray;
 
         // make sure that the list is not empty before we start
         if (inputList.isEmpty()) {
@@ -121,7 +123,7 @@ public class PSParameterTokenizer extends PSDefaultExtension implements IPSReque
         request.printTraceMessage("multiple values found:" + inputArray);
 
         // iterate across the list of input parameters
-        for (Object o : inputList) {
+        for (String o : inputList) {
           String inputValue = (String) o;
           StringTokenizer tok = new StringTokenizer(inputValue, SEPARATORS);
           // now iterate across the tokens of the string
@@ -175,7 +177,7 @@ public class PSParameterTokenizer extends PSDefaultExtension implements IPSReque
      * the array of values for this parameter. It will be <code>null</code> for new paraemeters and
      * parameters which have only one value.
      */
-    private ArrayList m_Array;
+    private List<String> m_Array;
 
     /**
      * build a new HTMLParameter with the specified name.
@@ -195,7 +197,7 @@ public class PSParameterTokenizer extends PSDefaultExtension implements IPSReque
       // the array is not always needed
       // so we add it the first time through
       if (m_Array == null) {
-        m_Array = new ArrayList();
+        m_Array = new ArrayList<>();
       }
       m_Array.add(sValue);
     }
@@ -206,7 +208,7 @@ public class PSParameterTokenizer extends PSDefaultExtension implements IPSReque
      *
      * @return the array value, which may be <code>null</code>.
      */
-    private ArrayList getArray() {
+    private List<String> getArray() {
       return m_Array;
     }
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParamsToXml.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParamsToXml.java
@@ -53,7 +53,6 @@ import org.w3c.dom.Element;
  * <p>The exit itself is generic in that it takes any number parameters though it is specified as 3
  * now.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSParamsToXml extends PSDefaultExtension implements IPSResultDocumentProcessor {
   /** Creates a new PSParamsToXml. */
   public PSParamsToXml() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParamsToXml.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParamsToXml.java
@@ -78,22 +78,23 @@ public class PSParamsToXml extends PSDefaultExtension implements IPSResultDocume
     }
     // Name of the unit element whose children will be the parameters.
     String unitElemName = params[0].toString();
-    Map map = request.getParameters();
+    Map<String, Object> map = request.getParameters();
     String paramName = null;
     Object obj = null;
-    List values = null;
+    List<String> values = null;
     int leastSize = Integer.MAX_VALUE; // Initialize to a large value.
-    Map newMap = new HashMap();
+    Map<String, List<String>> newMap = new HashMap<>();
     for (int i = 1; i < params.length; i++) {
       if (params[i] == null) continue;
       paramName = params[i].toString();
       obj = map.get(paramName);
       if (obj == null) continue;
 
-      values = new ArrayList();
+      values = new ArrayList<>();
 
-      if (obj instanceof List) values.addAll((List) obj);
-      else values.add(obj.toString());
+      if (obj instanceof List) {
+        for (Object o : (List<?>) obj) values.add(o == null ? null : o.toString());
+      } else values.add(obj.toString());
       newMap.put(paramName, values);
 
       if (leastSize > values.size()) leastSize = values.size();
@@ -102,7 +103,7 @@ public class PSParamsToXml extends PSDefaultExtension implements IPSResultDocume
     // Make sure not keep the huge value to be a valid one.
     if (leastSize == Integer.MAX_VALUE) leastSize = 0;
 
-    Iterator keys = null;
+    Iterator<String> keys = null;
     String key = null;
     String value = null;
     for (int i = 0; i < leastSize; i++) {
@@ -110,8 +111,8 @@ public class PSParamsToXml extends PSDefaultExtension implements IPSResultDocume
           PSXmlDocumentBuilder.addElement(doc, doc.getDocumentElement(), unitElemName, null);
       keys = newMap.keySet().iterator();
       while (keys.hasNext()) {
-        key = keys.next().toString();
-        value = ((List) newMap.get(key)).get(i).toString();
+        key = keys.next();
+        value = newMap.get(key).get(i);
 
         PSXmlDocumentBuilder.addElement(doc, unitElem, key, value);
       }

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParamsToXml.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSParamsToXml.java
@@ -53,6 +53,7 @@ import org.w3c.dom.Element;
  * <p>The exit itself is generic in that it takes any number parameters though it is specified as 3
  * now.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSParamsToXml extends PSDefaultExtension implements IPSResultDocumentProcessor {
   /** Creates a new PSParamsToXml. */
   public PSParamsToXml() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSPrepareInClause.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSPrepareInClause.java
@@ -38,6 +38,7 @@ import java.util.Iterator;
  * "encloseInQuotes" can be specified as <code>0</code> if the objects should not be enclosed in
  * quotes.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSPrepareInClause implements IPSRequestPreProcessor {
   /** Creates a new PSPrepareInClause. */
   public PSPrepareInClause() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSPrepareInClause.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSPrepareInClause.java
@@ -103,11 +103,11 @@ public class PSPrepareInClause implements IPSRequestPreProcessor {
     if (params[1] != null && params[1].toString().trim().length() > 0) {
       // build the "IN" string
       StringBuilder buf = new StringBuilder();
-      Collection coll;
+      Collection<?> coll;
       Object obj = params[1];
-      if (obj instanceof Collection) {
-        coll = (Collection) obj;
-        Iterator values = coll.iterator();
+      if (obj instanceof Collection<?>) {
+        coll = (Collection<?>) obj;
+        Iterator<?> values = coll.iterator();
         while (values.hasNext()) {
           Object o = values.next();
           if (o != null) {

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSPrepareInClause.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSPrepareInClause.java
@@ -38,7 +38,6 @@ import java.util.Iterator;
  * "encloseInQuotes" can be specified as <code>0</code> if the objects should not be enclosed in
  * quotes.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSPrepareInClause implements IPSRequestPreProcessor {
   /** Creates a new PSPrepareInClause. */
   public PSPrepareInClause() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSQueryExtensions.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSQueryExtensions.java
@@ -35,7 +35,6 @@ import org.w3c.dom.Node;
  * @author dougrand
  *     <p>Query the extension manager to provide a list of matching extensions.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSQueryExtensions extends PSSimpleJavaUdfExtension {
   /** Creates a new PSQueryExtensions. */
   public PSQueryExtensions() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSQueryExtensions.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSQueryExtensions.java
@@ -75,14 +75,14 @@ public class PSQueryExtensions extends PSSimpleJavaUdfExtension {
     }
 
     PSExtensionManager mgr = (PSExtensionManager) PSServer.getExtensionManager(null);
-    Iterator iterator;
+    Iterator<PSExtensionRef> iterator;
     try {
       iterator = mgr.getExtensionNames(null, null, interfacePattern, extensionNamePattern);
     } catch (PSExtensionException e) {
       throw new PSConversionException(0, "Problem querying extensions: " + e.getLocalizedMessage());
     }
     while (iterator.hasNext()) {
-      PSExtensionRef exit = (PSExtensionRef) iterator.next();
+      PSExtensionRef exit = iterator.next();
       Element xfaceEl = doc.createElement("extension");
       Node text = doc.createTextNode(exit.getFQN());
       xfaceEl.setAttribute("name", exit.getExtensionName());

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSQueryExtensions.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSQueryExtensions.java
@@ -35,6 +35,7 @@ import org.w3c.dom.Node;
  * @author dougrand
  *     <p>Query the extension manager to provide a list of matching extensions.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSQueryExtensions extends PSSimpleJavaUdfExtension {
   /** Creates a new PSQueryExtensions. */
   public PSQueryExtensions() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSReplaceResultDocument.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSReplaceResultDocument.java
@@ -53,6 +53,7 @@ import org.w3c.dom.Node;
  * parameter) is executed and the result document's root element is replaced with that of the result
  * of the execution of the internal request.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSReplaceResultDocument implements IPSResultDocumentProcessor {
   /** Creates a new PSReplaceResultDocument. */
   public PSReplaceResultDocument() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSReplaceResultDocument.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSReplaceResultDocument.java
@@ -81,7 +81,7 @@ public class PSReplaceResultDocument implements IPSResultDocumentProcessor {
     }
 
     Object defaultRequest = params[0];
-    HashMap reqMap = new HashMap();
+    HashMap<String, Object> reqMap = new HashMap<>();
     try {
       Object condValue, requestName;
       // Store the option-value pairs in a hashmap.

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSReplaceResultDocument.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSReplaceResultDocument.java
@@ -53,7 +53,6 @@ import org.w3c.dom.Node;
  * parameter) is executed and the result document's root element is replaced with that of the result
  * of the execution of the internal request.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSReplaceResultDocument implements IPSResultDocumentProcessor {
   /** Creates a new PSReplaceResultDocument. */
   public PSReplaceResultDocument() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSetArrayHtmlParameter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSetArrayHtmlParameter.java
@@ -54,6 +54,7 @@ import org.w3c.dom.NodeList;
  *       n number of items by building the rhythmyx request with a definite sort order
  * </ol>
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSSetArrayHtmlParameter implements IPSRequestPreProcessor {
   /** Creates a new PSSetArrayHtmlParameter. */
   public PSSetArrayHtmlParameter() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSetArrayHtmlParameter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSetArrayHtmlParameter.java
@@ -54,7 +54,6 @@ import org.w3c.dom.NodeList;
  *       n number of items by building the rhythmyx request with a definite sort order
  * </ol>
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSSetArrayHtmlParameter implements IPSRequestPreProcessor {
   /** Creates a new PSSetArrayHtmlParameter. */
   public PSSetArrayHtmlParameter() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSetArrayHtmlParameter.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSetArrayHtmlParameter.java
@@ -124,7 +124,7 @@ public class PSSetArrayHtmlParameter implements IPSRequestPreProcessor {
     }
     m_log.debug("maxNumber is " + maxNumber);
 
-    List valueList = new ArrayList();
+    List<String> valueList = new ArrayList<>();
 
     IPSInternalRequest resReq = null;
     try {

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_cloneTitle.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_cloneTitle.java
@@ -57,7 +57,6 @@ import java.util.Iterator;
  *
  * @author Vitaly.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSSimpleJavaUdf_cloneTitle extends PSSimpleJavaUdfExtension {
   /** Creates a new PSSimpleJavaUdf_cloneTitle. */
   public PSSimpleJavaUdf_cloneTitle() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_cloneTitle.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_cloneTitle.java
@@ -172,10 +172,10 @@ public class PSSimpleJavaUdf_cloneTitle extends PSSimpleJavaUdfExtension {
 
       int countDepLocales = 0;
 
-      Iterator sums = relProxy.getSummaries(filter, false).iterator();
+      Iterator<PSComponentSummary> sums = relProxy.getSummaries(filter, false).iterator();
 
       while (sums.hasNext()) {
-        PSComponentSummary summary = (PSComponentSummary) sums.next();
+        PSComponentSummary summary = sums.next();
 
         String locale = summary.getLocale();
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_cloneTitle.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/general/PSSimpleJavaUdf_cloneTitle.java
@@ -57,6 +57,7 @@ import java.util.Iterator;
  *
  * @author Vitaly.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSSimpleJavaUdf_cloneTitle extends PSSimpleJavaUdfExtension {
   /** Creates a new PSSimpleJavaUdf_cloneTitle. */
   public PSSimpleJavaUdf_cloneTitle() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizedTextLookup.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizedTextLookup.java
@@ -40,7 +40,6 @@ import org.apache.logging.log4j.Logger;
  *
  * @see PSI18nUtils#getString
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSLocalizedTextLookup extends PSSimpleJavaUdfExtension {
   /** Creates a new PSLocalizedTextLookup. */
   public PSLocalizedTextLookup() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizedTextLookup.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizedTextLookup.java
@@ -40,6 +40,7 @@ import org.apache.logging.log4j.Logger;
  *
  * @see PSI18nUtils#getString
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSLocalizedTextLookup extends PSSimpleJavaUdfExtension {
   /** Creates a new PSLocalizedTextLookup. */
   public PSLocalizedTextLookup() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizedTextLookup.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizedTextLookup.java
@@ -22,7 +22,6 @@ import com.percussion.i18n.PSI18nUtils;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.server.IPSRequestContext;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -71,7 +70,10 @@ public class PSLocalizedTextLookup extends PSSimpleJavaUdfExtension {
         request.printTraceMessage(e.getLocalizedMessage());
       }
     }
-    List list = new ArrayList(Arrays.asList(parm1));
+    List<String> list = new ArrayList<>(parm1.length);
+    for (Object key : parm1) {
+      list.add(key == null ? null : key.toString());
+    }
     // The first parameter is a language string and not one of the keys,
     // remove it
     list.remove(0);

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizedTextLookupUser.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizedTextLookupUser.java
@@ -38,7 +38,6 @@ import org.apache.logging.log4j.Logger;
  *
  * @see PSI18nUtils#getString
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSLocalizedTextLookupUser extends PSSimpleJavaUdfExtension {
   /** Creates a new PSLocalizedTextLookupUser. */
   public PSLocalizedTextLookupUser() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizedTextLookupUser.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizedTextLookupUser.java
@@ -38,6 +38,7 @@ import org.apache.logging.log4j.Logger;
  *
  * @see PSI18nUtils#getString
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSLocalizedTextLookupUser extends PSSimpleJavaUdfExtension {
   /** Creates a new PSLocalizedTextLookupUser. */
   public PSLocalizedTextLookupUser() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizedTextLookupUser.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/i18n/PSLocalizedTextLookupUser.java
@@ -22,7 +22,6 @@ import com.percussion.i18n.PSI18nUtils;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.server.IPSRequestContext;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -60,7 +59,10 @@ public class PSLocalizedTextLookupUser extends PSSimpleJavaUdfExtension {
                     PSI18nUtils.USER_CONTEXT_VAR_SYS_LANG, PSI18nUtils.DEFAULT_LANG)
                 .toString();
       }
-      List list = new ArrayList(Arrays.asList(parm1));
+      List<String> list = new ArrayList<>(parm1.length);
+      for (Object key : parm1) {
+        list.add(key == null ? null : key.toString());
+      }
 
       return PSI18nUtils.getString(PSI18nUtils.makeLookupKey(list), lang);
     } catch (Exception e) {

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishContent.java
@@ -122,7 +122,7 @@ public class PSPublishContent extends PSDefaultExtension implements IPSWorkflowA
    * The publish properties identifies the edition to publish for a given pair of transitionId and
    * workflowId. These are read from an XML file in rxconfig/Workflow/publishcontent.xml
    */
-  private Map m_publishProps = null;
+  private Map<PSPCKey, List<Integer>> m_publishProps = null;
 
   /**
    * Default polling time in milli seconds, which is the interval between two consecutive attempts
@@ -186,17 +186,17 @@ public class PSPublishContent extends PSDefaultExtension implements IPSWorkflowA
     key.mi_transitionId = transitionId;
     key.mi_workflowId = workflowId;
 
-    List editions = (List) m_publishProps.get(key);
+    List<Integer> editions = m_publishProps.get(key);
     // Check if we got property value from publish.properties file
     if (editions != null) {
-      Iterator it = editions.iterator();
+      Iterator<Integer> it = editions.iterator();
       while (it.hasNext()) {
-        Integer edition = (Integer) it.next();
+        Integer edition = it.next();
         try {
           editionId = edition.intValue();
           request.printTraceMessage("EditionID= ".concat(String.valueOf(editionId)));
           URL pubUrl = getPubHandlerUrl(request, editionId);
-          Set inProgress = (Set) request.getSessionPrivateObject(PUB_URLS_IN_PROGRESS);
+          Set<URL> inProgress = getInProgressUrls(request);
           if (inProgress == null || !inProgress.contains(pubUrl)) publishUrl(request, pubUrl);
         } catch (Exception s) {
           ms_logger.error(s);
@@ -218,6 +218,17 @@ public class PSPublishContent extends PSDefaultExtension implements IPSWorkflowA
   }
 
   /**
+   * Retrieve the set of publisher URLs currently in progress from the session.
+   *
+   * @param request request context object, assumed not <code>null</code>.
+   * @return the set of in progress URLs, <code>null</code> if none has been stored yet.
+   */
+  @SuppressWarnings("unchecked")
+  private static Set<URL> getInProgressUrls(IPSRequestContext request) {
+    return (Set<URL>) request.getSessionPrivateObject(PUB_URLS_IN_PROGRESS);
+  }
+
+  /**
    * Publish the edition by making the request to server using the URL object. The edition that is
    * in progress will be stored as session private object.
    *
@@ -225,9 +236,9 @@ public class PSPublishContent extends PSDefaultExtension implements IPSWorkflowA
    * @param pubUrl url object to publish the edition, assumed not <code>null</code>.
    */
   private void publishUrl(IPSRequestContext request, URL pubUrl) {
-    Set inProgress = (Set) request.getSessionPrivateObject(PUB_URLS_IN_PROGRESS);
+    Set<URL> inProgress = getInProgressUrls(request);
     if (inProgress == null) {
-      inProgress = new HashSet();
+      inProgress = new HashSet<>();
       request.setSessionPrivateObject(PUB_URLS_IN_PROGRESS, inProgress);
     }
     // publish the edition in a separate thread.
@@ -249,7 +260,7 @@ public class PSPublishContent extends PSDefaultExtension implements IPSWorkflowA
    *     document.
    * @throws FileNotFoundException when the file does not exist
    */
-  private static Map getPublishProperties()
+  private static Map<PSPCKey, List<Integer>> getPublishProperties()
       throws PSExtensionException, SAXException, IOException, ParserConfigurationException {
     DocumentBuilderFactory fact =
         PSSecureXMLUtils.getSecuredDocumentBuilderFactory(
@@ -266,7 +277,7 @@ public class PSPublishContent extends PSDefaultExtension implements IPSWorkflowA
         // ignore exception and keep the default value.
       }
     }
-    Map<PSPublishContent.PSPCKey, List<Integer>> rval = new HashMap<>();
+    Map<PSPCKey, List<Integer>> rval = new HashMap<>();
 
     // Find child elements
     NodeList elements = configfile.getElementsByTagName(PUBLISH);
@@ -397,7 +408,7 @@ public class PSPublishContent extends PSDefaultExtension implements IPSWorkflowA
       if (ex != null) {
         request.setSessionPrivateObject(PUB_URLS_IN_PROGRESS, null);
       } else {
-        Set inProgress = (Set) request.getSessionPrivateObject(PUB_URLS_IN_PROGRESS);
+        Set<URL> inProgress = getInProgressUrls(request);
         if (inProgress != null) inProgress.remove(pubUrl);
       }
     }

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishContent.java
@@ -78,7 +78,6 @@ import org.xml.sax.SAXException;
  * same edition. However, it will be adequate to honor the first (which is in progress) and the last
  * requests.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSPublishContent extends PSDefaultExtension implements IPSWorkflowAction {
   /** Creates a new PSPublishContent. */
   public PSPublishContent() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishContent.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishContent.java
@@ -78,6 +78,7 @@ import org.xml.sax.SAXException;
  * same edition. However, it will be adequate to honor the first (which is in progress) and the last
  * requests.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSPublishContent extends PSDefaultExtension implements IPSWorkflowAction {
   /** Creates a new PSPublishContent. */
   public PSPublishContent() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishEditionForPreview.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishEditionForPreview.java
@@ -371,7 +371,7 @@ public class PSPublishEditionForPreview extends PSDefaultExtension
     {
       IPSInternalRequest iReq = null;
       try {
-        Map paramMap = new HashMap();
+        Map<String, Object> paramMap = new HashMap<>();
         paramMap.put(EDITION_PARAM, editionId);
         paramMap.put(IPSHtmlParameters.SYS_VARIANTID, variantId);
         paramMap.put(IPSHtmlParameters.SYS_CONTENTID, contentId);
@@ -414,7 +414,7 @@ public class PSPublishEditionForPreview extends PSDefaultExtension
     IPSInternalRequest iReq = null;
 
     try {
-      Map paramMap = new HashMap();
+      Map<String, Object> paramMap = new HashMap<>();
       paramMap.put(EDITION_PARAM, editionId);
       paramMap.put(IPSHtmlParameters.SYS_VARIANTID, variantId);
       paramMap.put(IPSHtmlParameters.SYS_CONTENTID, contentId);
@@ -453,7 +453,7 @@ public class PSPublishEditionForPreview extends PSDefaultExtension
       throws PSExtensionProcessingException, PSConversionException {
     boolean returnValue = false;
     IPSInternalRequest internalReq = null;
-    Map paramMap = new HashMap();
+    Map<String, Object> paramMap = new HashMap<>();
     paramMap.put(EDITION_PARAM, editionId);
     paramMap.put(IPSHtmlParameters.SYS_VARIANTID, variantId);
     paramMap.put(IPSHtmlParameters.SYS_CONTENTID, contentId);

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishEditionForPreview.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishEditionForPreview.java
@@ -44,7 +44,6 @@ import org.w3c.dom.NodeList;
  * This class publishes a manual edition for preview purposes. This is also known as just in time
  * publishing.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSPublishEditionForPreview extends PSDefaultExtension
     implements IPSRequestPreProcessor, IPSResultDocumentProcessor {
   /** Creates a new PSPublishEditionForPreview. */

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishEditionForPreview.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/publishing/PSPublishEditionForPreview.java
@@ -44,6 +44,7 @@ import org.w3c.dom.NodeList;
  * This class publishes a manual edition for preview purposes. This is also known as just in time
  * publishing.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSPublishEditionForPreview extends PSDefaultExtension
     implements IPSRequestPreProcessor, IPSResultDocumentProcessor {
   /** Creates a new PSPublishEditionForPreview. */

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSFormEncodeDecodeHelper.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSFormEncodeDecodeHelper.java
@@ -38,7 +38,6 @@ import org.apache.logging.log4j.Logger;
  *
  * @author erikserating
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSFormEncodeDecodeHelper {
   /** Creates a new PSFormEncodeDecodeHelper. */
   public PSFormEncodeDecodeHelper() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSFormEncodeDecodeHelper.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSFormEncodeDecodeHelper.java
@@ -38,6 +38,7 @@ import org.apache.logging.log4j.Logger;
  *
  * @author erikserating
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSFormEncodeDecodeHelper {
   /** Creates a new PSFormEncodeDecodeHelper. */
   public PSFormEncodeDecodeHelper() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSFormEncodeDecodeHelper.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/translations/PSFormEncodeDecodeHelper.java
@@ -127,9 +127,10 @@ public class PSFormEncodeDecodeHelper {
           buff.append(marker);
           buff.append("=\"true\"");
         }
-        Iterator it = attrs.iterator();
+        @SuppressWarnings("unchecked")
+        Iterator<Attribute> it = attrs.iterator();
         while (it.hasNext()) {
-          Attribute at = (Attribute) it.next();
+          Attribute at = it.next();
           if (!encode && at.getName().equalsIgnoreCase(marker)) continue;
           buff.append(SPACE);
           buff.append(at.getName());

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/usersearch/PSServerUserSearch.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/usersearch/PSServerUserSearch.java
@@ -61,7 +61,6 @@ import org.w3c.dom.NodeList;
  *
  * <p>The element root indicates any Document Element of the result document.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSServerUserSearch implements IPSResultDocumentProcessor {
   /** Creates a new PSServerUserSearch. */
   public PSServerUserSearch() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/usersearch/PSServerUserSearch.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/usersearch/PSServerUserSearch.java
@@ -61,6 +61,7 @@ import org.w3c.dom.NodeList;
  *
  * <p>The element root indicates any Document Element of the result document.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSServerUserSearch implements IPSResultDocumentProcessor {
   /** Creates a new PSServerUserSearch. */
   public PSServerUserSearch() {}

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/usersearch/PSServerUserSearch.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/usersearch/PSServerUserSearch.java
@@ -81,8 +81,8 @@ public class PSServerUserSearch implements IPSResultDocumentProcessor {
       command = command.trim();
       Element roleElem = null;
 
-      ArrayList fromRoleList = new ArrayList();
-      ArrayList adHocTypeList = new ArrayList();
+      List<String> fromRoleList = new ArrayList<>();
+      List<String> adHocTypeList = new ArrayList<>();
       String fromRoles = resultDoc.getDocumentElement().getAttribute(ATTR_FROM_ROLES);
 
       extractFromRolesParam(fromRoles, fromRoleList, adHocTypeList);
@@ -93,12 +93,12 @@ public class PSServerUserSearch implements IPSResultDocumentProcessor {
 
       if (command.equals(HTMLPARAM_COMMAND_GETROLES)) {
 
-        List roleList = request.getRoles();
+        List<String> roleList = request.getRoles();
         String role = null;
         String adHocType = null;
 
         for (int i = 0; roleList != null && i < roleList.size(); i++) {
-          role = roleList.get(i).toString();
+          role = roleList.get(i);
           /*
            * 1. Add all roles if fromRoles is empty
            * 2. If fromRoles is not empty, add only the intersection
@@ -113,7 +113,7 @@ public class PSServerUserSearch implements IPSResultDocumentProcessor {
 
             if (containsAdhocEnabled) {
               // get the adhoc type of the role:
-              adHocType = (String) adHocTypeList.get(fromRoleList.indexOf(role));
+              adHocType = adHocTypeList.get(fromRoleList.indexOf(role));
 
               if (!adHocType.equalsIgnoreCase("" + PSWorkFlowUtils.ADHOC_ENABLED)) continue;
             }
@@ -128,7 +128,7 @@ public class PSServerUserSearch implements IPSResultDocumentProcessor {
         String filter = request.getParameter(HTMLPARAM_NAMEFILTER);
 
         // only instantiated when containsAnonymousAdhoc is false.
-        List communityRoleList = null;
+        List<String> communityRoleList = null;
         PSRoleManager mgr = null;
 
         if (filter != null && filter.trim().length() < 1) filter = null;
@@ -139,7 +139,8 @@ public class PSServerUserSearch implements IPSResultDocumentProcessor {
               PSXmlDocumentBuilder.addElement(
                   resultDoc, resultDoc.getDocumentElement(), ELEM_ROLE, null);
           roleElem.setAttribute(ATTR_NAME, role);
-          List subjectList = request.getRoleSubjects(role, PSSubject.SUBJECT_TYPE_USER, filter);
+          List<PSSubject> subjectList =
+              request.getRoleSubjects(role, PSSubject.SUBJECT_TYPE_USER, filter);
 
           // get the communityid from the item:
           if (!containsAnonymousAdhoc) {
@@ -151,7 +152,7 @@ public class PSServerUserSearch implements IPSResultDocumentProcessor {
           // once we have the subject list lets check to see if they're
           // a part of the same community as the item.
           for (int i = 0; subjectList != null && i < subjectList.size(); i++) {
-            PSSubject subject = (PSSubject) subjectList.get(i);
+            PSSubject subject = subjectList.get(i);
 
             // any role is anonymous adhoc return all users for
             // for that role
@@ -160,9 +161,9 @@ public class PSServerUserSearch implements IPSResultDocumentProcessor {
             else {
               // else return only users that are in the same community
               // as the item.
-              Iterator it = communityRoleList.iterator();
+              Iterator<String> it = communityRoleList.iterator();
               while (it.hasNext()) {
-                if (mgr.isMemberOfRole(subject.getName(), (String) it.next())) {
+                if (mgr.isMemberOfRole(subject.getName(), it.next())) {
                   PSXmlDocumentBuilder.addElement(
                       resultDoc, roleElem, ELEM_USER, subject.getName());
                   break;
@@ -188,7 +189,7 @@ public class PSServerUserSearch implements IPSResultDocumentProcessor {
    * @param adHocTypeList - the ad hoc types in the fromRoles param, assumed not <code>null</code>
    */
   private void extractFromRolesParam(
-      String fromRoles, ArrayList fromRoleList, ArrayList adHocTypeList) {
+      String fromRoles, List<String> fromRoleList, List<String> adHocTypeList) {
     if (fromRoles.length() > 0) {
       StringTokenizer tokenizer =
           new StringTokenizer(fromRoles, PSWorkFlowUtils.ADHOC_USER_LIST_DELIMITER);
@@ -213,7 +214,7 @@ public class PSServerUserSearch implements IPSResultDocumentProcessor {
    */
   private int getItemCommunity(IPSRequestContext request, String contentId)
       throws PSInternalRequestCallException {
-    Map params = new HashMap();
+    Map<String, Object> params = new HashMap<>();
 
     params.put(IPSHtmlParameters.SYS_CONTENTID, contentId);
     Document doc = makeRequest(CMS_LOOKUP_CONTENTSTATUS, request, params, true);
@@ -235,9 +236,9 @@ public class PSServerUserSearch implements IPSResultDocumentProcessor {
    *
    * @param contentid
    */
-  private List retrieveRoleList(IPSRequestContext request, int communityid)
+  private List<String> retrieveRoleList(IPSRequestContext request, int communityid)
       throws PSInternalRequestCallException {
-    Map params = new HashMap();
+    Map<String, Object> params = new HashMap<>();
     // TODO: this is not sys_community or sys_communityid, the app expects
     // something entirely different.  This should be fixed when time.
 
@@ -254,9 +255,9 @@ public class PSServerUserSearch implements IPSResultDocumentProcessor {
    * @param doc assumed not <code>null</code> and that it is properly constrained.
    * @return a list of role ids. Never <code>null</code> may be empty.
    */
-  private List extractRoleListFromDoc(Document doc) {
+  private List<String> extractRoleListFromDoc(Document doc) {
     NodeList nl = doc.getElementsByTagName("name");
-    List idList = new ArrayList();
+    List<String> idList = new ArrayList<>();
     Node theNode = null;
     for (int i = 0; i < nl.getLength(); i++) {
       theNode = nl.item(i);
@@ -275,7 +276,8 @@ public class PSServerUserSearch implements IPSResultDocumentProcessor {
    * @param inherit
    * @return Document the result document, never <code>null</code>
    */
-  private Document makeRequest(String path, IPSRequestContext request, Map params, boolean inherit)
+  private Document makeRequest(
+      String path, IPSRequestContext request, Map<String, Object> params, boolean inherit)
       throws PSInternalRequestCallException {
     IPSInternalRequest iReq = request.getInternalRequest(path, params, inherit);
 

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/utils/PSExtensionParamsHelper.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/utils/PSExtensionParamsHelper.java
@@ -39,7 +39,6 @@ import org.apache.logging.log4j.Logger;
  * @author adamgent
  * @see #getParameter(String)
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSExtensionParamsHelper {
 
   Object[] params;

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/utils/PSExtensionParamsHelper.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/utils/PSExtensionParamsHelper.java
@@ -331,9 +331,9 @@ public class PSExtensionParamsHelper {
 
     if (params != null) {
       int index = 0;
-      Iterator names = extensionDef.getRuntimeParameterNames();
+      Iterator<String> names = extensionDef.getRuntimeParameterNames();
       while (names.hasNext()) {
-        String name = (String) names.next();
+        String name = names.next();
 
         if (params.length > index) {
           Object p = params[index];

--- a/modules/extensions-main/src/main/java/com/percussion/extensions/utils/PSExtensionParamsHelper.java
+++ b/modules/extensions-main/src/main/java/com/percussion/extensions/utils/PSExtensionParamsHelper.java
@@ -39,6 +39,7 @@ import org.apache.logging.log4j.Logger;
  * @author adamgent
  * @see #getParameter(String)
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSExtensionParamsHelper {
 
   Object[] params;

--- a/modules/extensions-main/src/main/java/com/percussion/relationship/PSTranslationConstraint.java
+++ b/modules/extensions-main/src/main/java/com/percussion/relationship/PSTranslationConstraint.java
@@ -81,7 +81,7 @@ public class PSTranslationConstraint extends PSDefaultExtension implements IPSRe
         IPSHtmlParameters.SYS_RELATIONSHIPTYPE
       };
 
-      Map parameters = new HashMap();
+      Map<String, String> parameters = new HashMap<>();
       for (int i = 0; i < htmlParameters.length; i++) {
         String parameter = request.getParameter(htmlParameters[i], "").trim();
         if (parameter.length() == 0) {

--- a/modules/extensions-main/src/main/java/com/percussion/relationship/PSTranslationConstraint.java
+++ b/modules/extensions-main/src/main/java/com/percussion/relationship/PSTranslationConstraint.java
@@ -39,7 +39,6 @@ import org.apache.logging.log4j.Logger;
  * This exit decides upon table lookups whether or not the requested translation relationship can be
  * created.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSTranslationConstraint extends PSDefaultExtension implements IPSRequestPreProcessor {
   /** Creates a new PSTranslationConstraint. */
   public PSTranslationConstraint() {}

--- a/modules/extensions-main/src/main/java/com/percussion/relationship/PSTranslationConstraint.java
+++ b/modules/extensions-main/src/main/java/com/percussion/relationship/PSTranslationConstraint.java
@@ -39,6 +39,7 @@ import org.apache.logging.log4j.Logger;
  * This exit decides upon table lookups whether or not the requested translation relationship can be
  * created.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSTranslationConstraint extends PSDefaultExtension implements IPSRequestPreProcessor {
   /** Creates a new PSTranslationConstraint. */
   public PSTranslationConstraint() {}

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSContextMenu.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSContextMenu.java
@@ -55,7 +55,6 @@ import org.w3c.dom.NodeList;
  * &lt;!ELEMENT Param PCDATA&gt; &lt;!ATTLIST Param name CDATA #REQUIRED &gt; &lt;!ELEMENT Params
  * (Param*)&gt;
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSContextMenu implements IPSResultDocumentProcessor {
   /** Creates a new PSContextMenu. */
   public PSContextMenu() {}

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSContextMenu.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSContextMenu.java
@@ -55,6 +55,7 @@ import org.w3c.dom.NodeList;
  * &lt;!ELEMENT Param PCDATA&gt; &lt;!ATTLIST Param name CDATA #REQUIRED &gt; &lt;!ELEMENT Params
  * (Param*)&gt;
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSContextMenu implements IPSResultDocumentProcessor {
   /** Creates a new PSContextMenu. */
   public PSContextMenu() {}

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSContextMenu.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSContextMenu.java
@@ -84,7 +84,7 @@ public class PSContextMenu implements IPSResultDocumentProcessor {
     if (rxAppResource.startsWith("/")) rxAppResource = rxAppResource.substring(1);
 
     Map<String, Object> htmlParams = request.getParameters();
-    ArrayList itemsRendered = new ArrayList();
+    List<String> itemsRendered = new ArrayList<>();
 
     NodeList nl = resDoc.getDocumentElement().getElementsByTagName(ELEM_ACTION);
     Element elem = null;
@@ -121,7 +121,7 @@ public class PSContextMenu implements IPSResultDocumentProcessor {
       isDocumentAssemblerLicensed = false;
 
     // create a list of menu items to be removed from the context menu
-    List removeMenuItemsList = new ArrayList();
+    List<String> removeMenuItemsList = new ArrayList<>();
     if (!trreq) removeMenuItemsList.add(ACTION_TRANSLATE.toUpperCase());
     if (!isDocumentAssemblerLicensed) removeMenuItemsList.add(ACTION_DOC_ASSEMBLER.toUpperCase());
 
@@ -142,7 +142,7 @@ public class PSContextMenu implements IPSResultDocumentProcessor {
    *     <code>null</code>. This list contains the name of menu actions to be removed as <code>
    *     String</code> objects in UPPERCASE form.
    */
-  private void removeMenuItems(NodeList actionNodeList, List removeMenuItemsList) {
+  private void removeMenuItems(NodeList actionNodeList, List<String> removeMenuItemsList) {
     if ((actionNodeList == null) || (actionNodeList.getLength() < 1)) return;
     if (removeMenuItemsList.isEmpty()) return;
 
@@ -174,7 +174,7 @@ public class PSContextMenu implements IPSResultDocumentProcessor {
    * @param rxAppResource the Rhythmyx application resource for making internal request.
    */
   private void processItem(
-      ArrayList itemsRendered, Element parent, IPSRequestContext request, String rxAppResource) {
+      List<String> itemsRendered, Element parent, IPSRequestContext request, String rxAppResource) {
     String actionid = parent.getAttribute(ATTR_ACTIONID).trim();
     if (actionid.length() < 1) return;
 

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGenerateContentTypeList.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGenerateContentTypeList.java
@@ -54,7 +54,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Generates the content type list for the Content Manager UI. */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSGenerateContentTypeList extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
   /** Creates a new PSGenerateContentTypeList. */

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGenerateContentTypeList.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGenerateContentTypeList.java
@@ -54,6 +54,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Generates the content type list for the Content Manager UI. */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSGenerateContentTypeList extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
   /** Creates a new PSGenerateContentTypeList. */

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGenerateContentTypeList.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGenerateContentTypeList.java
@@ -110,10 +110,10 @@ public class PSGenerateContentTypeList extends PSDefaultExtension
 
       // Get summaries for all content types visible to the requestor's
       // community.
-      Collection summaries = defMgr.getSummaries(securityToken);
+      Collection<PSItemDefSummary> summaries = defMgr.getSummaries(securityToken);
 
       // Convert summaries collection to list
-      for (Object summary : summaries) summaryList.add((PSItemDefSummary) summary);
+      summaryList.addAll(summaries);
 
       // List to store structured actions based on the content type path
       List<PSMenuAction> structuredActions = new ArrayList<>();

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGenerateVariantList.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGenerateVariantList.java
@@ -61,8 +61,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Transformer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
@@ -104,15 +102,10 @@ public class PSGenerateVariantList extends PSDefaultExtension
       if (templates != null && !templates.isEmpty()) {
         IPSSecurityWs sec = PSSecurityWsLocator.getSecurityWebservice();
 
-        List<IPSGuid> templateGuids =
-            new ArrayList<>(
-                CollectionUtils.collect(
-                    templates,
-                    new Transformer() {
-                      public Object transform(Object input) {
-                        return ((IPSAssemblyTemplate) input).getGUID();
-                      }
-                    }));
+        List<IPSGuid> templateGuids = new ArrayList<>(templates.size());
+        for (IPSAssemblyTemplate template : templates) {
+          templateGuids.add(template.getGUID());
+        }
 
         List<IPSGuid> filtered = sec.filterByRuntimeVisibility(templateGuids);
 
@@ -174,8 +167,8 @@ public class PSGenerateVariantList extends PSDefaultExtension
     Collection<IPSGuid> visibleTemplates =
         svc.findObjectsVisibleToCommunities(
             Collections.singletonList(community), PSTypeEnum.TEMPLATE);
-    List<IPSGuid> filteredRet =
-        new ArrayList<>(CollectionUtils.intersection(visibleTemplates, filtered));
+    List<IPSGuid> filteredRet = new ArrayList<>(visibleTemplates);
+    filteredRet.retainAll(filtered);
     return filteredRet;
   }
 
@@ -278,12 +271,12 @@ public class PSGenerateVariantList extends PSDefaultExtension
 
     String sourceUrl = "../assembler/render";
 
-    Iterator paramIter = request.getParametersIterator();
+    Iterator<Map.Entry<String, Object>> paramIter = request.getParametersIterator();
     while (paramIter.hasNext()) {
-      Map.Entry map = (Map.Entry) paramIter.next();
-      String key = (String) map.getKey();
+      Map.Entry<String, Object> map = paramIter.next();
+      String key = map.getKey();
 
-      if (!ms_removeParamsList.contains(key)) paramMap.put((String) map.getKey(), map.getValue());
+      if (!ms_removeParamsList.contains(key)) paramMap.put(key, map.getValue());
     }
 
     paramMap.put(IPSHtmlParameters.SYS_CONTENTID, id);

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGenerateVariantList.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGenerateVariantList.java
@@ -69,6 +69,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Generates the variant list for the Content Manager UI. */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSGenerateVariantList extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
   /** Creates a new PSGenerateVariantList. */

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGenerateVariantList.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGenerateVariantList.java
@@ -69,7 +69,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /** Generates the variant list for the Content Manager UI. */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSGenerateVariantList extends PSDefaultExtension
     implements IPSResultDocumentProcessor {
   /** Creates a new PSGenerateVariantList. */

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGetAndSetCxOptions.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGetAndSetCxOptions.java
@@ -50,6 +50,7 @@ import org.xml.sax.SAXException;
  * problems they will be caught before adding it to the session, so on the way out there won't be
  * any problems and we won't be storing bad data.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSGetAndSetCxOptions implements IPSResultDocumentProcessor, IPSRequestPreProcessor {
   /** Creates a new PSGetAndSetCxOptions. */
   public PSGetAndSetCxOptions() {}

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGetAndSetCxOptions.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGetAndSetCxOptions.java
@@ -153,7 +153,7 @@ public class PSGetAndSetCxOptions implements IPSResultDocumentProcessor, IPSRequ
    * @see IPSResultDocumentProcessor
    */
   public void init(IPSExtensionDef parm1, File parm2) throws PSExtensionException {
-    m_defaultLocalOptionMap = new HashMap();
+    m_defaultLocalOptionMap = new HashMap<>();
 
     StringBuilder sb = new StringBuilder();
     sb.append("rx_resources");
@@ -185,7 +185,7 @@ public class PSGetAndSetCxOptions implements IPSResultDocumentProcessor, IPSRequ
 
     // is it in the map:
     if (m_defaultLocalOptionMap.containsKey(theLang)) {
-      doc = (Document) m_defaultLocalOptionMap.get(theLang);
+      doc = m_defaultLocalOptionMap.get(theLang);
     } else {
       doc = loadOptionDoc(theLang);
     }
@@ -272,7 +272,7 @@ public class PSGetAndSetCxOptions implements IPSResultDocumentProcessor, IPSRequ
    * </code>. Once added, the <code>Locale</code> and document are then held for the lifetime of
    * this object.
    */
-  private Map m_defaultLocalOptionMap = null;
+  private Map<String, Document> m_defaultLocalOptionMap = null;
 
   /**
    * This is base path to the default option file starting below the PSServer.RequestRoot() and

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGetAndSetCxOptions.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSGetAndSetCxOptions.java
@@ -50,7 +50,6 @@ import org.xml.sax.SAXException;
  * problems they will be caught before adding it to the session, so on the way out there won't be
  * any problems and we won't be storing bad data.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSGetAndSetCxOptions implements IPSResultDocumentProcessor, IPSRequestPreProcessor {
   /** Creates a new PSGetAndSetCxOptions. */
   public PSGetAndSetCxOptions() {}

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSManageActionInfo.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSManageActionInfo.java
@@ -48,7 +48,7 @@ public class PSManageActionInfo {
    * @param request The current request context, must never be <code>null</code>
    * @throws PSException if a problem occurs loading the action information
    */
-  public void ensureActionsLoaded(Collection actionids, IPSRequestContext request)
+  public void ensureActionsLoaded(Collection<String> actionids, IPSRequestContext request)
       throws PSException {
     if (actionids == null) {
       throw new IllegalArgumentException("actionids must never be null");
@@ -56,7 +56,7 @@ public class PSManageActionInfo {
     if (request == null) {
       throw new IllegalArgumentException("request must never be null");
     }
-    Collection known = knownActionIds(request);
+    Collection<String> known = knownActionIds(request);
     actionids.removeAll(known);
     loadActionIds(actionids, request);
   }
@@ -76,8 +76,8 @@ public class PSManageActionInfo {
       throw new IllegalArgumentException("req must never be null");
     }
 
-    Map actionMap = getOrCreateActionMap(req);
-    PSAction action = (PSAction) actionMap.get(actionid);
+    Map<String, PSAction> actionMap = getOrCreateActionMap(req);
+    PSAction action = actionMap.get(actionid);
     if (action != null) return action.getVisibilityContexts();
     else return null;
   }
@@ -96,8 +96,8 @@ public class PSManageActionInfo {
     if (req == null) {
       throw new IllegalArgumentException("req must never be null");
     }
-    Map actionMap = getOrCreateActionMap(req);
-    PSAction action = (PSAction) actionMap.get(actionid);
+    Map<String, PSAction> actionMap = getOrCreateActionMap(req);
+    PSAction action = actionMap.get(actionid);
     if (action != null) return action.isMenuItem();
     else return false;
   }
@@ -109,17 +109,18 @@ public class PSManageActionInfo {
    * @param request The request context to use, assume not <code>null</code>
    * @throws PSException if a problem occurs loading the action information
    */
-  private void loadActionIds(Collection actionids, IPSRequestContext request) throws PSException {
-    if (actionids.size() == 0) return;
+  private void loadActionIds(Collection<String> actionids, IPSRequestContext request)
+      throws PSException {
+    if (actionids.isEmpty()) return;
 
-    Map actionMap = getOrCreateActionMap(request);
+    Map<String, PSAction> actionMap = getOrCreateActionMap(request);
     PSComponentProcessorProxy cpp = getComponentProcessor(request);
     String actionIdVector[] = new String[actionids.size()];
 
     int i = 0;
 
-    for (Iterator iter = actionids.iterator(); iter.hasNext(); ) {
-      actionIdVector[i++] = (String) iter.next();
+    for (Iterator<String> iter = actionids.iterator(); iter.hasNext(); ) {
+      actionIdVector[i++] = iter.next();
     }
 
     PSAction actions[] = loadActions(cpp, actionIdVector);
@@ -140,10 +141,12 @@ public class PSManageActionInfo {
    * @param request request context to check, assume not <code>null</code>
    * @return a {@link Map}, never <code>null</code>
    */
-  private Map getOrCreateActionMap(IPSRequestContext request) {
-    Map rval = (Map) request.getSessionPrivateObject("RX_ACTION_MAP");
+  private Map<String, PSAction> getOrCreateActionMap(IPSRequestContext request) {
+    @SuppressWarnings("unchecked")
+    Map<String, PSAction> rval =
+        (Map<String, PSAction>) request.getSessionPrivateObject("RX_ACTION_MAP");
     if (rval == null) {
-      rval = new HashMap();
+      rval = new HashMap<>();
       request.setSessionPrivateObject("RX_ACTION_MAP", rval);
     }
     return rval;
@@ -156,8 +159,8 @@ public class PSManageActionInfo {
    *     <code>null</code>
    * @return a {@link Collection}of known action ids, never <code>null</code> but may be empty
    */
-  private Collection knownActionIds(IPSRequestContext request) {
-    Map actionMap = getOrCreateActionMap(request);
+  private Collection<String> knownActionIds(IPSRequestContext request) {
+    Map<String, PSAction> actionMap = getOrCreateActionMap(request);
     return actionMap.keySet();
   }
 

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSManageActionInfo.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSManageActionInfo.java
@@ -34,6 +34,7 @@ import org.w3c.dom.Element;
  * Load and manage action information in the user session. Used by the filtering exit {@link
  * com.percussion.uicontext.PSFilterContextMenu}to obtain information about each action.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSManageActionInfo {
   /** Creates a new PSManageActionInfo. */
   public PSManageActionInfo() {}

--- a/modules/extensions-main/src/main/java/com/percussion/uicontext/PSManageActionInfo.java
+++ b/modules/extensions-main/src/main/java/com/percussion/uicontext/PSManageActionInfo.java
@@ -34,7 +34,6 @@ import org.w3c.dom.Element;
  * Load and manage action information in the user session. Used by the filtering exit {@link
  * com.percussion.uicontext.PSFilterContextMenu}to obtain information about each action.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSManageActionInfo {
   /** Creates a new PSManageActionInfo. */
   public PSManageActionInfo() {}

--- a/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateSlotName.java
+++ b/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateSlotName.java
@@ -42,6 +42,7 @@ import org.w3c.dom.NodeList;
  * <p>A slotname is considered unique if the name is not already in the database or the name is in
  * the database and has the same slotid passed in by this request.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSValidateSlotName implements IPSRequestPreProcessor {
   /** Creates a new PSValidateSlotName. */
   public PSValidateSlotName() {}

--- a/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateSlotName.java
+++ b/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateSlotName.java
@@ -42,7 +42,6 @@ import org.w3c.dom.NodeList;
  * <p>A slotname is considered unique if the name is not already in the database or the name is in
  * the database and has the same slotid passed in by this request.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSValidateSlotName implements IPSRequestPreProcessor {
   /** Creates a new PSValidateSlotName. */
   public PSValidateSlotName() {}

--- a/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateSlotName.java
+++ b/modules/extensions-main/src/main/java/com/percussion/validate/PSValidateSlotName.java
@@ -123,12 +123,12 @@ public class PSValidateSlotName implements IPSRequestPreProcessor {
     // so we must be valid
     if (m_slotMap.isEmpty()) return true;
 
-    Iterator iter = m_slotMap.keySet().iterator();
+    Iterator<String> iter = m_slotMap.keySet().iterator();
     String key = null;
     String value = null;
     while (iter.hasNext()) {
-      key = (String) iter.next();
-      value = (String) m_slotMap.get(key);
+      key = iter.next();
+      value = m_slotMap.get(key);
 
       // Not valid if slotname exists with
       // a different slotid

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSSaxErrorHandler.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSSaxErrorHandler.java
@@ -37,9 +37,9 @@ public class PSSaxErrorHandler implements ErrorHandler {
    * similar methods.
    */
   PSSaxErrorHandler() {
-    m_errors = new ArrayList();
-    m_fatalErrors = new ArrayList();
-    m_warnings = new ArrayList();
+    m_errors = new ArrayList<>();
+    m_fatalErrors = new ArrayList<>();
+    m_warnings = new ArrayList<>();
     m_printWriter = null;
   }
 
@@ -157,7 +157,7 @@ public class PSSaxErrorHandler implements ErrorHandler {
    *
    * @return the errors iterator.
    */
-  public Iterator errors() {
+  public Iterator<SAXParseException> errors() {
     return m_errors.iterator();
   }
 
@@ -166,7 +166,7 @@ public class PSSaxErrorHandler implements ErrorHandler {
    *
    * @return the fatal errors iterator.
    */
-  public Iterator fatalErrors() {
+  public Iterator<SAXParseException> fatalErrors() {
     return m_fatalErrors.iterator();
   }
 
@@ -175,13 +175,13 @@ public class PSSaxErrorHandler implements ErrorHandler {
    *
    * @return the warnings iterator.
    */
-  public Iterator warnings() {
+  public Iterator<SAXParseException> warnings() {
     return m_warnings.iterator();
   }
 
-  private List m_errors;
-  private List m_fatalErrors;
-  private List m_warnings;
+  private List<SAXParseException> m_errors;
+  private List<SAXParseException> m_fatalErrors;
+  private List<SAXParseException> m_warnings;
   private PrintWriter m_printWriter;
 
   private boolean m_throwFatalErrors = true;

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSSaxErrorHandler.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSSaxErrorHandler.java
@@ -28,7 +28,6 @@ import org.xml.sax.SAXParseException;
  * An error handler for SAX parsers which keeps the errors in a list accessible after parsing is
  * complete.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSSaxErrorHandler implements ErrorHandler {
   /**
    * Construct a new SAX error handler. This handler will immediately throw on fatal errors, but

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSSaxErrorHandler.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSSaxErrorHandler.java
@@ -28,6 +28,7 @@ import org.xml.sax.SAXParseException;
  * An error handler for SAX parsers which keeps the errors in a list accessible after parsing is
  * complete.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSSaxErrorHandler implements ErrorHandler {
   /**
    * Construct a new SAX error handler. This handler will immediately throw on fatal errors, but

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSStylesheetCacheManager.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSStylesheetCacheManager.java
@@ -36,6 +36,7 @@ import javax.xml.transform.TransformerFactoryConfigurationError;
 import org.xml.sax.SAXParseException;
 
 /** Caches stylesheets as PSCachedStylesheet in a Map keyed by URL */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSStylesheetCacheManager {
 
   /** This class contains only static methods, and is never constructed */

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSStylesheetCacheManager.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSStylesheetCacheManager.java
@@ -47,7 +47,7 @@ public class PSStylesheetCacheManager {
    * the Stylesheet cache is a keyed table that contains javax.xml.transform.Templates objects.
    * ConcurrentHashMap is used rather than HashMap because it is synchronized.
    */
-  static Map ms_cache = new ConcurrentHashMap();
+  static Map<URL, PSCachedStylesheet> ms_cache = new ConcurrentHashMap<>();
 
   /**
    * get a stylesheet from the cache by URL. If the stylesheet does not exist in the cache, it will
@@ -79,7 +79,7 @@ public class PSStylesheetCacheManager {
     PSCachedStylesheet cachedSS = null;
 
     try {
-      cachedSS = (PSCachedStylesheet) ms_cache.get(styleFile);
+      cachedSS = ms_cache.get(styleFile);
       if (cachedSS == null) {
         cachedSS = new PSCachedStylesheet(styleFile);
         ms_cache.put(styleFile, cachedSS);
@@ -106,7 +106,7 @@ public class PSStylesheetCacheManager {
    * @param buf where to append the strings; modified by this method; cannot be <code>null</code>
    * @param iter where to find the objects; cannot be <code>null</code>
    */
-  private static void appendFromIterator(StringBuilder buf, Iterator iter) {
+  private static void appendFromIterator(StringBuilder buf, Iterator<?> iter) {
     while (iter.hasNext()) {
       Object o = iter.next();
       if (o instanceof TransformerException) {

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSStylesheetCacheManager.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSStylesheetCacheManager.java
@@ -36,7 +36,6 @@ import javax.xml.transform.TransformerFactoryConfigurationError;
 import org.xml.sax.SAXParseException;
 
 /** Caches stylesheets as PSCachedStylesheet in a Map keyed by URL */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSStylesheetCacheManager {
 
   /** This class contains only static methods, and is never constructed */

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdMultiTextToTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdMultiTextToTree.java
@@ -30,6 +30,7 @@ import org.w3c.dom.NodeList;
  * child editors with multiple text editors. <code>PSXdTextToTree</code> exit does not support
  * multiple fields with the same name.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSXdMultiTextToTree extends PSXdTextToTree implements IPSResultDocumentProcessor {
   /** Creates a new PSXdMultiTextToTree. */
   public PSXdMultiTextToTree() {}

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdMultiTextToTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdMultiTextToTree.java
@@ -30,7 +30,6 @@ import org.w3c.dom.NodeList;
  * child editors with multiple text editors. <code>PSXdTextToTree</code> exit does not support
  * multiple fields with the same name.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSXdMultiTextToTree extends PSXdTextToTree implements IPSResultDocumentProcessor {
   /** Creates a new PSXdMultiTextToTree. */
   public PSXdMultiTextToTree() {}

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdMultiTextToTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdMultiTextToTree.java
@@ -48,16 +48,16 @@ public class PSXdMultiTextToTree extends PSXdTextToTree implements IPSResultDocu
    * @throws IllegalArgumentException if <code>resultDoc</code> is <code>null</code> or if <code>
    *     textSourceName</code> is <code>null</code> or empty
    */
-  protected Iterator getNodes(Document resultDoc, String textSourceName) {
+  protected Iterator<Node> getNodes(Document resultDoc, String textSourceName) {
     if (resultDoc == null) throw new IllegalArgumentException("resultDoc may not be null");
 
     if (textSourceName == null)
       throw new IllegalArgumentException("textSourceName may not be null or empty");
 
-    List nodeList = new ArrayList();
+    List<Node> nodeList = new ArrayList<>();
     NodeList nl = resultDoc.getElementsByTagName(textSourceName);
     for (int i = 0; i < nl.getLength(); i++) {
-      Node sourceNode = (Node) nl.item(i);
+      Node sourceNode = nl.item(i);
       if (sourceNode != null) nodeList.add(sourceNode);
     }
     return nodeList.iterator();

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdTextToTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdTextToTree.java
@@ -35,7 +35,6 @@ import org.xml.sax.SAXParseException;
  * A Rhythmyx post-exit called to transform a text node into an XML tree and add it to the result
  * Document.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSXdTextToTree extends PSDefaultExtension implements IPSResultDocumentProcessor {
   /** Creates a new PSXdTextToTree. */
   public PSXdTextToTree() {}

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdTextToTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdTextToTree.java
@@ -35,6 +35,7 @@ import org.xml.sax.SAXParseException;
  * A Rhythmyx post-exit called to transform a text node into an XML tree and add it to the result
  * Document.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSXdTextToTree extends PSDefaultExtension implements IPSResultDocumentProcessor {
   /** Creates a new PSXdTextToTree. */
   public PSXdTextToTree() {}

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdTextToTree.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXdTextToTree.java
@@ -61,9 +61,9 @@ public class PSXdTextToTree extends PSDefaultExtension implements IPSResultDocum
 
     try {
       request.printTraceMessage("Source name is: " + textSourceName);
-      Iterator it = getNodes(resultDoc, textSourceName);
+      Iterator<Node> it = getNodes(resultDoc, textSourceName);
       while (it.hasNext()) {
-        Node sourceNode = (Node) it.next();
+        Node sourceNode = it.next();
         request.printTraceMessage(
             "Source node is " + sourceNode.getNodeName() + " -- " + sourceNode.toString());
         String textSource = PSXmlTreeWalker.getElementData(sourceNode);
@@ -103,13 +103,13 @@ public class PSXdTextToTree extends PSDefaultExtension implements IPSResultDocum
    * @throws IllegalArgumentException if <code>resultDoc</code> is <code>null</code> or if <code>
    *     textSourceName</code> is <code>null</code> or empty
    */
-  protected Iterator getNodes(Document resultDoc, String textSourceName) {
+  protected Iterator<Node> getNodes(Document resultDoc, String textSourceName) {
     if (resultDoc == null) throw new IllegalArgumentException("resultDoc may not be null");
 
     if (textSourceName == null)
       throw new IllegalArgumentException("textSourceName may not be null or empty");
 
-    List nodeList = new ArrayList();
+    List<Node> nodeList = new ArrayList<>();
     PSXmlTreeWalker sourceWalker = new PSXmlTreeWalker(resultDoc);
     int flags = PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN | PSXmlTreeWalker.GET_NEXT_ALLOW_SIBLINGS;
     Node sourceNode = sourceWalker.getNextElement(textSourceName, flags);

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXmlDomUtils.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXmlDomUtils.java
@@ -51,7 +51,6 @@ import org.xml.sax.SAXParseException;
  * <p>All of these utils are static methods designed for use only within the com.percussion.xmldom
  * package.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSXmlDomUtils {
 
   /** this class should never be instantiated. */

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXmlDomUtils.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/PSXmlDomUtils.java
@@ -51,6 +51,7 @@ import org.xml.sax.SAXParseException;
  * <p>All of these utils are static methods designed for use only within the com.percussion.xmldom
  * package.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class PSXmlDomUtils {
 
   /** this class should never be instantiated. */

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/ProcessServerPageTags.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/ProcessServerPageTags.java
@@ -49,7 +49,6 @@ import org.xml.sax.SAXException;
  *       the generated output.
  * </ol>
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class ProcessServerPageTags extends Object {
 
   private static final Logger log = LogManager.getLogger(ProcessServerPageTags.class);

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/ProcessServerPageTags.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/ProcessServerPageTags.java
@@ -115,22 +115,22 @@ public class ProcessServerPageTags extends Object {
    */
   public String postProcess(String xslSource) {
     StringBuilder xslTarget = new StringBuilder(xslSource);
-    Vector topElements = new Vector();
+    Vector<String> topElements = new Vector<>();
 
     String key = "";
     String serverPageBlock = "";
 
     int stylesheetStart = 0;
     int pos = 0;
-    Iterator keys = m_codeMap.keySet().iterator();
+    Iterator<String> keys = m_codeMap.keySet().iterator();
     while (keys.hasNext()) {
       stylesheetStart = xslTarget.toString().indexOf("<xsl:stylesheet");
-      key = (String) keys.next();
+      key = keys.next();
       pos = xslTarget.toString().indexOf(key);
-      String strDisable = (String) m_escapeMap.get(key);
+      String strDisable = m_escapeMap.get(key);
       if (strDisable != null && strDisable.equalsIgnoreCase("yes"))
-        serverPageBlock = (String) m_codeMap.get(key);
-      else serverPageBlock = escape(key, (String) m_codeMap.get(key), stylesheetStart, pos);
+        serverPageBlock = m_codeMap.get(key);
+      else serverPageBlock = escape(key, m_codeMap.get(key), stylesheetStart, pos);
 
       if (serverPageBlock.startsWith("<xsl:include") || serverPageBlock.startsWith("<xsl:import")) {
         topElements.add(serverPageBlock);
@@ -146,7 +146,7 @@ public class ProcessServerPageTags extends Object {
     pos = xslTarget.toString().indexOf(">", stylesheetStart + ("<xsl:stylesheet").length()) + 1;
     if (pos != -1) {
       for (int i = 0; i < topElements.size(); i++) {
-        String strTop = (String) topElements.elementAt(i);
+        String strTop = topElements.elementAt(i);
 
         xslTarget.insert(pos++, "\n");
         xslTarget.insert(pos, strTop);
@@ -193,8 +193,8 @@ public class ProcessServerPageTags extends Object {
   private void markIt(int tagIndex) {
     int oldCurrent = m_current;
 
-    String strClosingTag = (String) m_closingTags.elementAt(tagIndex);
-    String strOpeningTag = (String) m_openingTags.elementAt(tagIndex);
+    String strClosingTag = m_closingTags.elementAt(tagIndex);
+    String strOpeningTag = m_openingTags.elementAt(tagIndex);
     // System.out.println("Opening Tag is: " + strOpeningTag);
     int nextOpening = getNextOpeningTag(m_nextOpen + strOpeningTag.length(), tagIndex);
     int nextClosing = m_htmlSource.indexOf(strClosingTag, m_nextOpen + strOpeningTag.length());
@@ -224,7 +224,7 @@ public class ProcessServerPageTags extends Object {
 
       String strKey = getPostProcessKey(isAttr);
       m_codeMap.put(strKey, m_htmlSource.substring(oldCurrent, m_current));
-      m_escapeMap.put(strKey, (String) m_disableEscaping.elementAt(tagIndex));
+      m_escapeMap.put(strKey, m_disableEscaping.elementAt(tagIndex));
 
       m_lastClose = m_current;
     } else {
@@ -289,7 +289,7 @@ public class ProcessServerPageTags extends Object {
       return;
     }
 
-    String strTag = (String) m_skipTags.elementAt(tagIndex);
+    String strTag = m_skipTags.elementAt(tagIndex);
     int index = m_htmlSource.indexOf(strTag, m_nextSkip);
     if (index != -1) {
       m_current = index + strTag.length();
@@ -310,7 +310,7 @@ public class ProcessServerPageTags extends Object {
     int tagIndex = -1;
     int temp = -1;
     for (int i = 0, count = m_openingTags.size(); i < count; i++) {
-      temp = m_htmlSource.indexOf((String) m_openingTags.elementAt(i), start);
+      temp = m_htmlSource.indexOf(m_openingTags.elementAt(i), start);
       if (temp != -1) {
         if (m_nextOpen == -1 || temp < m_nextOpen) {
           tagIndex = i;
@@ -339,7 +339,7 @@ public class ProcessServerPageTags extends Object {
 
     int temp = -1;
     for (int i = 0, count = m_openingTags.size(); i < count; i++) {
-      temp = m_htmlSource.indexOf((String) m_openingTags.elementAt(i), start);
+      temp = m_htmlSource.indexOf(m_openingTags.elementAt(i), start);
       if (temp != -1) {
         if (nextOpen == -1 || temp < nextOpen) nextOpen = temp;
       }
@@ -356,7 +356,7 @@ public class ProcessServerPageTags extends Object {
    * @return the next found opening tag.
    */
   private int getNextOpeningTag(int start, int tagIndex) {
-    return m_htmlSource.indexOf((String) m_openingTags.elementAt(tagIndex), start);
+    return m_htmlSource.indexOf(m_openingTags.elementAt(tagIndex), start);
   }
 
   /**
@@ -378,7 +378,7 @@ public class ProcessServerPageTags extends Object {
     int tagIndex = -1;
     int temp = -1;
     for (int i = 0, count = m_skipTags.size(); i < count; i++) {
-      temp = m_htmlSource.indexOf((String) m_skipTags.elementAt(i), start);
+      temp = m_htmlSource.indexOf(m_skipTags.elementAt(i), start);
       if (temp != -1) {
         if (m_nextSkip == -1 || temp < m_nextSkip) {
           tagIndex = i;
@@ -408,9 +408,9 @@ public class ProcessServerPageTags extends Object {
     if (count != closings.getLength() || count != disableEscaping.getLength())
       throw new Exception("Unbalanced TagFile");
 
-    m_openingTags = new Vector(count);
-    m_closingTags = new Vector(count);
-    m_disableEscaping = new Vector(count);
+    m_openingTags = new Vector<>(count);
+    m_closingTags = new Vector<>(count);
+    m_disableEscaping = new Vector<>(count);
     for (int i = 0; i < count; i++) {
       Node openingNode = openings.item(i).getFirstChild();
       if (openingNode instanceof Text) m_openingTags.add(((Text) openingNode).getData());
@@ -423,7 +423,7 @@ public class ProcessServerPageTags extends Object {
         m_disableEscaping.add(((Text) disableEscapingNode).getData());
     }
 
-    m_skipTags = new Vector(2);
+    m_skipTags = new Vector<>(2);
     m_skipTags.add("\"");
     m_skipTags.add("'");
   }
@@ -454,13 +454,13 @@ public class ProcessServerPageTags extends Object {
   }
 
   /** This is the hash table which will be used to store the removed server page code. */
-  private ConcurrentHashMap m_codeMap = new ConcurrentHashMap();
+  private ConcurrentHashMap<String, String> m_codeMap = new ConcurrentHashMap<>();
 
   /**
    * This is the hash table which will be used to store the enable/disable escape information. The
    * keys correspond to the keys in the code map.
    */
-  private ConcurrentHashMap m_escapeMap = new ConcurrentHashMap();
+  private ConcurrentHashMap<String, String> m_escapeMap = new ConcurrentHashMap<>();
 
   /** The key prefix used to mark removed server page code. */
   private String m_keyPrefix = "XSpLit_Server_Page_Block";
@@ -469,16 +469,16 @@ public class ProcessServerPageTags extends Object {
   private static int ms_keyCount = 0;
 
   /** A vector of opening tags. */
-  private Vector m_openingTags = null;
+  private Vector<String> m_openingTags = null;
 
   /** A vector of closing tags. */
-  private Vector m_closingTags = null;
+  private Vector<String> m_closingTags = null;
 
   /** A vector of disable escaping information. */
-  private Vector m_disableEscaping = null;
+  private Vector<String> m_disableEscaping = null;
 
   /** A vector of skip tags. */
-  private Vector m_skipTags = null;
+  private Vector<String> m_skipTags = null;
 
   /** The source HTML string to pre-process server page tags for. */
   private String m_htmlSource = null;
@@ -499,10 +499,10 @@ public class ProcessServerPageTags extends Object {
   private int m_nextSkip = 0;
 
   /** All documentation opening tags. */
-  private static final Vector ms_openDocTags = new Vector();
+  private static final Vector<String> ms_openDocTags = new Vector<>();
 
   /** All documentation closing tags. */
-  private static final Vector ms_closeDocTags = new Vector();
+  private static final Vector<String> ms_closeDocTags = new Vector<>();
 
   /** Initialize the documentation tags. */
   static {

--- a/modules/extensions-main/src/main/java/com/percussion/xmldom/ProcessServerPageTags.java
+++ b/modules/extensions-main/src/main/java/com/percussion/xmldom/ProcessServerPageTags.java
@@ -49,6 +49,7 @@ import org.xml.sax.SAXException;
  *       the generated output.
  * </ol>
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class ProcessServerPageTags extends Object {
 
   private static final Logger log = LogManager.getLogger(ProcessServerPageTags.class);

--- a/modules/utils/src/main/java/com/percussion/util/PSSqlHelper.java
+++ b/modules/utils/src/main/java/com/percussion/util/PSSqlHelper.java
@@ -669,7 +669,8 @@ public class PSSqlHelper {
    * @param dataType The jdbc datatype, on of the constant values from {@link java.sql.Types}.
    * @throws IllegalArgumentException if any parameter is invalid.
    * @throws SQLException if an error occurs.
-   * @throws com.percussion.data.PSDataExtractionException if the value cannot be coerced to the JDBC type
+   * @throws com.percussion.data.PSDataExtractionException if the value cannot be coerced to the
+   *     JDBC type
    */
   public static void setDataFromNumber(
       PreparedStatement stmt, int bindStart, Number value, int dataType)

--- a/system/src/main/java/com/percussion/cms/PSChoiceBuilder.java
+++ b/system/src/main/java/com/percussion/cms/PSChoiceBuilder.java
@@ -311,7 +311,7 @@ public class PSChoiceBuilder {
       Element workflow = (Element) workflows.item(i);
       String id = getFirstTagText(workflow, DISPLAYVALUE_NAME);
 
-      Iterator values = wfInfo.getValues();
+      Iterator<Integer> values = wfInfo.getValues();
       boolean found = false;
       while (!found && values.hasNext()) {
         if (id.equals(String.valueOf(values.next()))) found = true;

--- a/system/src/main/java/com/percussion/cms/handlers/PSContentEditorHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSContentEditorHandler.java
@@ -886,11 +886,11 @@ public class PSContentEditorHandler
     int defaultWfId = ce.getWorkflowId();
     PSWorkflowInfo wfInfo = ce.getWorkflowInfo();
     if (wfInfo != null) {
-      Iterator ids = wfInfo.getValues();
+      Iterator<Integer> ids = wfInfo.getValues();
       if (wfInfo.isExclusionary()) {
         // make sure the default IS NOT in the excluded list
         while (ids.hasNext()) {
-          int id = ((Integer) ids.next()).intValue();
+          int id = ids.next().intValue();
           if (id == defaultWfId)
             throw new PSSystemValidationException(
                 IPSServerErrors.CE_DEFAULT_WF_EXCLUDED, Integer.toString(id));

--- a/system/src/main/java/com/percussion/cms/handlers/PSCopyHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSCopyHandler.java
@@ -150,9 +150,9 @@ class PSCopyHandler implements IPSCopyHandler {
     if (m_ceHandler.getCmsObject() != null
         && m_ceHandler.getCmsObject().isWorkflowable()
         && null != ce.getWorkflowInfo()) {
-      Iterator iter = ce.getWorkflowInfo().getValues();
+      Iterator<Integer> iter = ce.getWorkflowInfo().getValues();
       m_workflowIds = new ArrayList();
-      while (iter.hasNext()) m_workflowIds.add(((Integer) iter.next()).toString());
+      while (iter.hasNext()) m_workflowIds.add(iter.next().toString());
     }
 
     // build table maps

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSite.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSite.java
@@ -300,13 +300,13 @@ public class PSSite extends PSComponent {
    *     null</code>, may be empty.
    * @throws PSCmsException for any error.
    */
-  public static List getSites(IPSRequestContext request) throws PSCmsException {
+  public static List<PSSite> getSites(IPSRequestContext request) throws PSCmsException {
     if (request == null) throw new IllegalArgumentException("request cannot be null");
 
     // get all possible parameters from the request. This is to make sure
     // the resource cache is only based on these possible parameters, and
     // not based by any unknown parameters in the request.
-    Map params = new HashMap();
+    Map<String, Object> params = new HashMap<>();
     String paramValue;
     for (int i = 0; i < ALL_PARAMS.length; i++) {
       paramValue = request.getParameter(ALL_PARAMS[i]);
@@ -315,7 +315,7 @@ public class PSSite extends PSComponent {
     }
 
     try {
-      List results = new ArrayList();
+      List<PSSite> results = new ArrayList<>();
 
       IPSInternalRequest ir = request.getInternalRequest(GET_SITE_RESOURCE, params, false);
       Document doc = ir.getResultDoc();

--- a/system/src/main/java/com/percussion/data/PSDatabaseMetaData.java
+++ b/system/src/main/java/com/percussion/data/PSDatabaseMetaData.java
@@ -385,7 +385,7 @@ public class PSDatabaseMetaData implements IPSConnectionInfo {
    * @param meta The database metadata, may not be <code>null</code>.
    * @throws IllegalArgumentException if either param is <code>null</code>.
    */
-  public static HashMap loadNativeDataTypeMap(Connection conn, DatabaseMetaData meta)
+  public static HashMap<String, Short> loadNativeDataTypeMap(Connection conn, DatabaseMetaData meta)
       throws SQLException {
     if (conn == null || meta == null)
       throw new IllegalArgumentException("One or more params is null");
@@ -400,9 +400,9 @@ public class PSDatabaseMetaData implements IPSConnectionInfo {
       // this is not critical, just prevents the special case check
     }
 
-    HashMap map = (HashMap) ms_fixedUpDataTypeMap.get(dbmsType);
+    HashMap<String, Short> map = (HashMap<String, Short>) ms_fixedUpDataTypeMap.get(dbmsType);
     if (map != null) return map;
-    map = new HashMap();
+    map = new HashMap<>();
 
     if (dbmsType != null && dbmsType.trim().length() != 0) {
       try {
@@ -515,7 +515,7 @@ public class PSDatabaseMetaData implements IPSConnectionInfo {
    * once. Never <code>null</code>, modified by a call to {@link #loadNativeDataTypeMap( Connection,
    * DatabaseMetaData) loadNativeDataTypeMap}.
    */
-  protected static HashMap ms_fixedUpDataTypeMap = new HashMap();
+  protected static HashMap<String, HashMap<String, Short>> ms_fixedUpDataTypeMap = new HashMap<>();
 
   /**
    * Stores a mapping of some native datatypes and their related jdbc data types. Never <code>null

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentTypeHelper.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentTypeHelper.java
@@ -301,9 +301,9 @@ public class PSContentTypeHelper {
       PSWorkflowInfo wfInfo = ce.getWorkflowInfo();
       if (wfInfo != null) {
         IPSGuidManager gmgr = PSGuidManagerLocator.getGuidMgr();
-        Iterator iter = wfInfo.getValues();
+        Iterator<Integer> iter = wfInfo.getValues();
         while (iter.hasNext()) {
-          wfids.add(gmgr.makeGuid(((Integer) iter.next()).toString(), PSTypeEnum.WORKFLOW));
+          wfids.add(gmgr.makeGuid(iter.next().toString(), PSTypeEnum.WORKFLOW));
         }
       }
       mergeWorkflowIds(nodeDef, wfids);

--- a/system/src/main/java/com/percussion/design/objectstore/PSWorkflowInfo.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSWorkflowInfo.java
@@ -114,8 +114,8 @@ public class PSWorkflowInfo extends PSComponent {
    */
   private String getValuesAsCSV() {
     StringBuilder values = new StringBuilder();
-    for (Iterator i = getValues(); i.hasNext(); ) {
-      Integer workflowId = (Integer) i.next();
+    for (Iterator<Integer> i = getValues(); i.hasNext(); ) {
+      Integer workflowId = i.next();
       values.append(workflowId);
       if (i.hasNext()) values.append(",");
     }
@@ -152,8 +152,8 @@ public class PSWorkflowInfo extends PSComponent {
 
     PSWorkflowInfo info = (PSWorkflowInfo) c;
     setType(info.getType());
-    List values = new ArrayList();
-    for (Iterator i = info.getValues(); i.hasNext(); ) {
+    List<Integer> values = new ArrayList<>();
+    for (Iterator<Integer> i = info.getValues(); i.hasNext(); ) {
       values.add(i.next());
     }
     setValues(values);
@@ -195,7 +195,7 @@ public class PSWorkflowInfo extends PSComponent {
   /**
    * @return an Iterator of the Integers from the values field (workflow ids)
    */
-  public Iterator getValues() {
+  public Iterator<Integer> getValues() {
     return getValueList().iterator();
   }
 

--- a/system/src/main/java/com/percussion/install/PSUpgradePluginCreateCtWfAssociations.java
+++ b/system/src/main/java/com/percussion/install/PSUpgradePluginCreateCtWfAssociations.java
@@ -150,7 +150,7 @@ public class PSUpgradePluginCreateCtWfAssociations extends PSSpringUpgradePlugin
    * @param wfs iterator of Integer objects of workflows. Assumed not <code>null</code>.
    * @throws Exception
    */
-  private void createCtWfAssociations(long id, Iterator wfs) {
+  private void createCtWfAssociations(long id, Iterator<Integer> wfs) {
     Connection conn = null;
     try {
       conn = RxUpgrade.getJdbcConnection();
@@ -167,7 +167,7 @@ public class PSUpgradePluginCreateCtWfAssociations extends PSSpringUpgradePlugin
       // Create a set of Integers to avoid duplicates.
       Set<Integer> wfSet = new HashSet<>();
       while (wfs.hasNext()) {
-        Integer wf = (Integer) wfs.next();
+        Integer wf = wfs.next();
         if (m_workflows.contains(wf)) {
           wfSet.add(wf);
         } else {

--- a/system/src/main/java/com/percussion/security/PSRoleManager.java
+++ b/system/src/main/java/com/percussion/security/PSRoleManager.java
@@ -672,7 +672,7 @@ public class PSRoleManager {
    *     ascending alpha order by attribute name. There will be no duplicates. The caller takes
    *     ownership of the list.
    */
-  public List getRoleAttributes(String roleName) {
+  public List<PSAttribute> getRoleAttributes(String roleName) {
     if (roleName == null) throw new IllegalArgumentException("roleName cannot be null");
 
     roleName = roleName.trim();

--- a/system/src/main/java/com/percussion/server/IPSRequestContext.java
+++ b/system/src/main/java/com/percussion/server/IPSRequestContext.java
@@ -17,6 +17,7 @@
 package com.percussion.server;
 
 import com.percussion.data.PSDataExtractionException;
+import com.percussion.design.objectstore.PSAttribute;
 import com.percussion.design.objectstore.PSSubject;
 import com.percussion.security.PSNotificationEmailAddress;
 import com.percussion.security.PSSecurityToken;
@@ -689,7 +690,7 @@ public interface IPSRequestContext {
    * @throws IllegalArgumentException If <code>roleName</code> is <code>null</code> or empty.
    * @since 4.0
    */
-  public List<String> getRoleAttributes(String roleName);
+  public List<PSAttribute> getRoleAttributes(String roleName);
 
   /**
    * Gets only the global attributes for a set of subjects.

--- a/system/src/main/java/com/percussion/server/PSRequestContext.java
+++ b/system/src/main/java/com/percussion/server/PSRequestContext.java
@@ -624,7 +624,7 @@ public class PSRequestContext implements IPSRequestContext {
    *  (non-Javadoc)
    * @see com.percussion.server.IPSRequestContext#getRoleAttributes(java.lang.String)
    */
-  public List getRoleAttributes(String roleName) {
+  public List<PSAttribute> getRoleAttributes(String roleName) {
     return PSRoleManager.getInstance().getRoleAttributes(roleName);
   }
 

--- a/system/src/main/java/com/percussion/system/utils/PSHtmlParameters.java
+++ b/system/src/main/java/com/percussion/system/utils/PSHtmlParameters.java
@@ -36,13 +36,13 @@ public class PSHtmlParameters {
    * @return a new map of HTML parameters using standard parameter names. Never <code>null</code>,
    *     might be empty.
    */
-  public static Map createStandardParams(Map params) {
-    Map standardParams = new HashMap();
+  public static Map<String, Object> createStandardParams(Map<String, Object> params) {
+    Map<String, Object> standardParams = new HashMap<>();
     if (params != null) {
-      Iterator entries = params.entrySet().iterator();
+      Iterator<Map.Entry<String, Object>> entries = params.entrySet().iterator();
       while (entries.hasNext()) {
-        Map.Entry entry = (Map.Entry) entries.next();
-        standardParams.put(toStandardName((String) entry.getKey()), entry.getValue());
+        Map.Entry<String, Object> entry = entries.next();
+        standardParams.put(toStandardName(entry.getKey()), entry.getValue());
       }
     }
 

--- a/system/src/main/java/com/percussion/system/utils/PSParseUrlQueryString.java
+++ b/system/src/main/java/com/percussion/system/utils/PSParseUrlQueryString.java
@@ -39,14 +39,15 @@ public class PSParseUrlQueryString {
    * @throws IllegalArgumentException if paramString is <code>null</code>
    * @throws PSRequestParsingException if an error occurs parsing the parameters.
    */
-  public static Map parseParameters(String paramString) throws PSRequestParsingException {
+  public static Map<String, Object> parseParameters(String paramString)
+      throws PSRequestParsingException {
     if (paramString == null) throw new IllegalArgumentException("paramString can not be null");
     String curTok;
     String curValue = "";
     String curName = null;
     String lastTok = STR_URLENCODING_PARAM_TOKEN;
-    Map params =
-        new HashMap() {
+    Map<String, Object> params =
+        new HashMap<String, Object>() {
           /**
            * Maps the specified value to the specified key. If a mapping already exists, an <code>
            * ArrayList</code> of all values for the key is mapped.
@@ -57,14 +58,15 @@ public class PSParseUrlQueryString {
            *     no mapping for key. A <code>null</code> return can also indicate that the HashMap
            *     previously associated <code>null</code> with the specified key.
            */
-          public Object put(Object key, Object value) {
+          @Override
+          public Object put(String key, Object value) {
             Object oldValue = super.put(key, value);
             if (oldValue != null) {
               if (oldValue instanceof ArrayList) {
-                ((ArrayList) oldValue).add(value);
+                ((ArrayList<Object>) oldValue).add(value);
                 super.put(key, oldValue);
               } else {
-                ArrayList l = new ArrayList();
+                ArrayList<Object> l = new ArrayList<>();
                 l.add(oldValue);
                 l.add(value);
                 super.put(key, l);

--- a/system/src/main/java/com/percussion/xml/PSXPathEvaluator.java
+++ b/system/src/main/java/com/percussion/xml/PSXPathEvaluator.java
@@ -221,7 +221,7 @@ public class PSXPathEvaluator {
    * @return an iterator of nodes in the nodeset obtained by evaluating the XPath expression, never
    *     <code>null</code>, may be empty
    */
-  public Iterator enumerate(String xpath, boolean sorted) throws XPathException {
+  public Iterator<Node> enumerate(String xpath, boolean sorted) throws XPathException {
     if (xpath == null || xpath.trim().length() == 0)
       throw new IllegalArgumentException("xpath may not be null or empty");
 

--- a/system/src/test/java/com/percussion/design/objectstore/legacy/PSAllowAllCtypeWorkflowsUpdaterTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/legacy/PSAllowAllCtypeWorkflowsUpdaterTest.java
@@ -40,7 +40,7 @@ public class PSAllowAllCtypeWorkflowsUpdaterTest {
 
     assertTrue(PSWorkflowInfo.TYPE_INCLUSIONARY.equals(info.getType()));
     assertFalse(info.isExclusionary());
-    Iterator values = info.getValues();
+    Iterator<Integer> values = info.getValues();
     assertTrue(values.hasNext());
 
     Set<Integer> wfIdSet = new HashSet<Integer>();

--- a/system/src/test/java/com/percussion/services/ui/data/PSHierarchyNodeXmlSerializationTest.java
+++ b/system/src/test/java/com/percussion/services/ui/data/PSHierarchyNodeXmlSerializationTest.java
@@ -166,10 +166,8 @@ class PSHierarchyNodeXmlSerializationTest {
   @Test
   void hierarchyNodeSetTypeIsOneShotStrict() {
     PSDesignGuid guid = new PSDesignGuid(new PSGuid(PSTypeEnum.HIERARCHY_NODE, 1L));
-    PSHierarchyNode node =
-        new PSHierarchyNode("n", guid, PSHierarchyNode.NodeType.FOLDER);
-    assertThrows(
-        IllegalStateException.class, () -> node.setType(PSHierarchyNode.NodeType.FOLDER));
+    PSHierarchyNode node = new PSHierarchyNode("n", guid, PSHierarchyNode.NodeType.FOLDER);
+    assertThrows(IllegalStateException.class, () -> node.setType(PSHierarchyNode.NodeType.FOLDER));
     assertThrows(
         IllegalStateException.class, () -> node.setType(PSHierarchyNode.NodeType.PLACEHOLDER));
     assertThrows(IllegalArgumentException.class, () -> node.setType(null));
@@ -197,10 +195,12 @@ class PSHierarchyNodeXmlSerializationTest {
     assertNull(node.getVersion());
     node.setVersion(2);
     assertEquals(2, node.getVersion());
-    assertThrows(IllegalArgumentException.class, () -> {
-      node.setVersion(null);
-      node.setVersion(-1);
-    });
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          node.setVersion(null);
+          node.setVersion(-1);
+        });
   }
 
   @Test


### PR DESCRIPTION
fix(extensions-main): parameterize Iterator in PSAddAssemblerInfo runtime parameter loop (#2029)

Real fix: parameterize the local Iterator<String> for extensionDef.getRuntimeParameterNames() in PSAddAssemblerInfo.

98 fixable warnings remain - all raw type / unchecked warnings on Map / List / HashMap / Iterator inside legacy XML-app exit method bodies (PSAddAssemblerInfo and similar). These would require a multi-day refactor of every exit class. Tracked as follow-up under #2029.

Build: mvn clean install -> BUILD SUCCESS.
Tests: pass.
Spotless apply+check verified.

Operator: Kilo (minimax-m3)