### PR TITLE
test(WebUI): DetailPanel cluster C Site/Workflow/Pipeline Vitest (#2157)

### DIFF
--- a/WebUI/src/test/ts/developer/PipelineDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/PipelineDetailPanel.test.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as pipelinesApi from "../../../main/ts/api/developer/pipelinesApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+import { PipelineDetailPanel } from "../../../main/ts/developer/PipelineDetailPanel";
+
+vi.mock("../../../main/ts/api/developer/pipelinesApi", () => ({
+  getApplicationDetail: vi.fn(),
+  listApplications: vi.fn(),
+}));
+
+const getApplicationDetail = pipelinesApi.getApplicationDetail as ReturnType<typeof vi.fn>;
+
+const sampleDetail = {
+  id: 1,
+  name: "sys_cmpDocuments",
+  description: "System content editor app",
+  enabled: true,
+  hidden: false,
+  appType: "CONTENT_EDITOR",
+  appRoot: "sys_cmpDocuments",
+  version: "8.2",
+  dataSets: [
+    {
+      name: "contenteditor",
+      kind: "DATASET",
+      requestPage: "contenteditor.html",
+      description: "CE",
+    },
+  ],
+  designGaps: ["Pipe IR not exposed"],
+};
+
+describe("PipelineDetailPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    getApplicationDetail.mockReset();
+  });
+
+  it("loads detail on success and supports back", async () => {
+    getApplicationDetail.mockResolvedValue(sampleDetail);
+    const onBack = vi.fn();
+    render(<PipelineDetailPanel idOrName="sys_cmpDocuments" onBack={onBack} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-pipe-detail-title")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-pipe-detail-title").textContent).toBe(
+      "sys_cmpDocuments",
+    );
+    expect(screen.getByTestId("developer-pipe-datasets-table")).toBeTruthy();
+    expect(screen.getByText("contenteditor.html")).toBeTruthy();
+    expect(screen.getByTestId("developer-pipe-gaps").textContent).toContain(
+      "Pipe IR not exposed",
+    );
+    expect(getApplicationDetail).toHaveBeenCalledWith("sys_cmpDocuments");
+    fireEvent.click(screen.getByTestId("developer-pipe-back"));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("shows empty datasets section when detail has none", async () => {
+    getApplicationDetail.mockResolvedValue({
+      ...sampleDetail,
+      dataSets: [],
+      designGaps: undefined,
+    });
+    render(<PipelineDetailPanel idOrName="sys_cmpDocuments" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-pipe-datasets-empty")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-pipe-datasets-empty").textContent).toBe(
+      DEV_MSG.PIPE_NONE,
+    );
+    expect(screen.queryByTestId("developer-pipe-datasets-table")).toBeNull();
+    expect(screen.queryByTestId("developer-pipe-gaps")).toBeNull();
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    getApplicationDetail.mockRejectedValue(new SessionRedirectError());
+    render(<PipelineDetailPanel idOrName="sys_cmpDocuments" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-pipe-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-pipe-detail-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-pipe-detail-loading")).toBeNull();
+    expect(screen.queryByTestId("developer-pipe-detail-title")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    getApplicationDetail.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<PipelineDetailPanel idOrName="sys_cmpDocuments" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-pipe-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-pipe-detail-error").textContent).toBe(
+      `${DEV_MSG.PIPE_DETAIL_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    getApplicationDetail.mockRejectedValue(new Error("network down"));
+    render(<PipelineDetailPanel idOrName="sys_cmpDocuments" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-pipe-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-pipe-detail-error").textContent).toBe(
+      `${DEV_MSG.PIPE_DETAIL_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-pipe-detail-title")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    getApplicationDetail.mockRejectedValue("boom");
+    render(<PipelineDetailPanel idOrName="sys_cmpDocuments" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-pipe-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-pipe-detail-error").textContent).toBe(
+      DEV_MSG.PIPE_DETAIL_ERROR,
+    );
+  });
+});

--- a/WebUI/src/test/ts/developer/SiteDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SiteDetailPanel.test.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SiteDef } from "../../../main/ts/api/developer/types";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+import { SiteDetailPanel } from "../../../main/ts/developer/SiteDetailPanel";
+
+/**
+ * SiteDetailPanel is prop-driven from the Sites list payload (no separate detail GET).
+ * panelErrMsg ladders for load failures live on SitesPanel; this suite covers success +
+ * default design-gaps empty fallback for the detail view itself.
+ */
+const sampleSite: SiteDef = {
+  name: "Corporate",
+  description: "Main site",
+  baseUrl: "https://example.com",
+  siteProtocol: "https",
+  defaultDocument: "index.html",
+  defaultFileExtention: "html",
+  pageBasedSite: true,
+  designGaps: ["gap-a"],
+};
+
+describe("SiteDetailPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+  });
+
+  it("renders site detail from list payload and supports back", () => {
+    const onBack = vi.fn();
+    render(<SiteDetailPanel site={sampleSite} onBack={onBack} />);
+    expect(screen.getByTestId("developer-site-detail")).toBeTruthy();
+    expect(screen.getByTestId("developer-site-detail-title").textContent).toContain("Corporate");
+    expect(screen.getByTestId("developer-site-gaps").textContent).toContain("gap-a");
+    expect(screen.getByText("https://example.com")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("developer-site-back"));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("shows default design gaps when site has none", () => {
+    const site: SiteDef = {
+      name: "Bare",
+      description: "",
+      designGaps: [],
+    };
+    render(<SiteDetailPanel site={site} onBack={() => undefined} />);
+    const gaps = screen.getByTestId("developer-site-gaps");
+    expect(gaps.textContent).toContain(DEV_MSG.SITE_GAP_WRITE);
+    expect(gaps.textContent).toContain(DEV_MSG.SITE_GAP_PUBLISH);
+    expect(gaps.textContent).toContain(DEV_MSG.SITE_GAP_WF);
+  });
+
+  it("renders em-dash placeholders for missing optional fields", () => {
+    const site: SiteDef = {
+      name: "Minimal",
+    };
+    render(<SiteDetailPanel site={site} onBack={() => undefined} />);
+    expect(screen.getByTestId("developer-site-detail-title").textContent).toContain("Minimal");
+    // description / url / protocol empty → "—" in the meta grid
+    const detail = screen.getByTestId("developer-site-detail");
+    expect(detail.textContent).toMatch(/—/);
+    expect(screen.getByTestId("developer-site-gaps").textContent).toContain(
+      DEV_MSG.SITE_GAP_WRITE,
+    );
+  });
+});

--- a/WebUI/src/test/ts/developer/WorkflowDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/WorkflowDetailPanel.test.tsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as workflowsApi from "../../../main/ts/api/developer/workflowsApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+import { WorkflowDetailPanel } from "../../../main/ts/developer/WorkflowDetailPanel";
+
+vi.mock("../../../main/ts/api/developer/workflowsApi", () => ({
+  getWorkflowDetail: vi.fn(),
+  listWorkflows: vi.fn(),
+  WORKFLOW_DESIGN_GAPS: [
+    "Full workflow graph design is not exposed in the Developer catalog",
+    "Workflow create / update / delete is not supported from this Developer surface",
+    "Content type workflow association is edited on the content type detail panel",
+  ],
+}));
+
+const getWorkflowDetail = workflowsApi.getWorkflowDetail as ReturnType<typeof vi.fn>;
+
+const sampleDetail = {
+  workflowName: "Simple Workflow",
+  workflowDescription: "Default",
+  defaultWorkflow: true,
+  stagingRoleNames: "Admin;Editor",
+  workflowSteps: [
+    {
+      stepName: "Draft",
+      permissionNames: ["Read", "Write"],
+      stepRoles: [{ roleName: "Author" }],
+    },
+    {
+      stepName: "Approved",
+      permissionNames: ["Read"],
+      stepRoles: [{ roleName: "Admin" }],
+    },
+  ],
+  designGaps: ["gap-a"],
+};
+
+describe("WorkflowDetailPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    getWorkflowDetail.mockReset();
+  });
+
+  it("loads detail on success and supports back", async () => {
+    getWorkflowDetail.mockResolvedValue(sampleDetail);
+    const onBack = vi.fn();
+    render(<WorkflowDetailPanel name="Simple Workflow" onBack={onBack} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-wf-detail-title")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-wf-detail-title").textContent).toContain(
+      "Simple Workflow",
+    );
+    expect(screen.getByTestId("developer-wf-steps-table")).toBeTruthy();
+    expect(screen.getByTestId("developer-wf-gaps").textContent).toContain("gap-a");
+    expect(getWorkflowDetail).toHaveBeenCalledWith("Simple Workflow");
+    fireEvent.click(screen.getByTestId("developer-wf-back"));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("shows empty steps section when detail has none", async () => {
+    getWorkflowDetail.mockResolvedValue({
+      ...sampleDetail,
+      workflowSteps: [],
+    });
+    render(<WorkflowDetailPanel name="Simple Workflow" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-wf-steps")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-wf-steps").textContent).toContain(DEV_MSG.WF_NONE);
+    expect(screen.queryByTestId("developer-wf-steps-table")).toBeNull();
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    getWorkflowDetail.mockRejectedValue(new SessionRedirectError());
+    render(<WorkflowDetailPanel name="Simple Workflow" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-wf-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-wf-detail-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-wf-detail-loading")).toBeNull();
+    expect(screen.queryByTestId("developer-wf-detail-title")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    getWorkflowDetail.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<WorkflowDetailPanel name="Simple Workflow" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-wf-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-wf-detail-error").textContent).toBe(
+      `${DEV_MSG.WF_DETAIL_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    getWorkflowDetail.mockRejectedValue(new Error("network down"));
+    render(<WorkflowDetailPanel name="Simple Workflow" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-wf-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-wf-detail-error").textContent).toBe(
+      `${DEV_MSG.WF_DETAIL_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-wf-detail-title")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    getWorkflowDetail.mockRejectedValue("boom");
+    render(<WorkflowDetailPanel name="Simple Workflow" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-wf-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-wf-detail-error").textContent).toBe(
+      DEV_MSG.WF_DETAIL_ERROR,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

**Fixes #2157** — DetailPanel Vitest cluster C residual of **#2139** / parent **#2119** / grandparent **#1690** (UI-TEST-01 residual B).

Adds empty/error/success Vitest ladders for:

| Panel | Coverage |
|-------|----------|
| `WorkflowDetailPanel` | Full detail-load `panelErrMsg` ladder + success + empty steps |
| `PipelineDetailPanel` | Full detail-load `panelErrMsg` ladder + success + empty datasets |
| `SiteDetailPanel` | Success + default design-gaps + missing-field placeholders (prop-driven from list payload; no separate detail GET / no `panelErrMsg` on this panel — list errors stay on `SitesPanel`) |

Each async detail panel covers:

- session-redirect via `panelErrMsg`
- ApiError status (`(500)`)
- `Error.message`
- non-Error fallback
- success path + empty subsection where applicable

No product UI changes; uses existing `data-testid`s. Mirrors Cluster A (PR #2160) and list-panel peers.

## Test plan

- [x] Focused Vitest: WorkflowDetailPanel (6) + PipelineDetailPanel (6) + SiteDetailPanel (3) = **15 tests**
- [x] WebUI standalone `mvnw clean install` green (193 files / 1300 tests)
- [x] No product code changes

## Gates evidence

- Erlang-style self-review: pure tests, peer-mirrored ladders, no path I/O, no UI expansion
- Change class: Vitest companions only (no Playwright — no product UI change)
- Module: `WebUI` clean install SUCCESS

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2157. Partial for #2139 (cluster C only; leave B/D open).