### PR TITLE
fix(perc-taxonomy): parameterize Collection return types in Attribute repo interfaces (#2031)

### DIFF
--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/AttributeDAO.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/AttributeDAO.java
@@ -22,14 +22,14 @@ import java.util.Collection;
 
 public interface AttributeDAO {
 
-  public Collection getAllAttributes(int taxonomy_id, int language_id);
+  public Collection<Attribute> getAllAttributes(int taxonomy_id, int language_id);
 
-  public Collection getAttribute(int id);
+  public Collection<Attribute> getAttribute(int id);
 
   public void removeAttribute(Attribute attribute);
 
   public void saveAttribute(Attribute attribute);
 
   /** Return all Attribute names and IDs */
-  public Collection getAttributeNames(int taxonomy_id, int language_id);
+  public Collection<Object[]> getAttributeNames(int taxonomy_id, int language_id);
 }

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/AttributeServiceInf.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/AttributeServiceInf.java
@@ -33,7 +33,7 @@ public interface AttributeServiceInf {
    * @param language_id the unique identifier of the language
    * @return a collection of Attribute entities matching the criteria, or an empty collection
    */
-  public Collection getAllAttributes(int taxonomy_id, int language_id);
+  public Collection<Attribute> getAllAttributes(int taxonomy_id, int language_id);
 
   /**
    * Retrieves a specific attribute by its unique identifier.
@@ -41,7 +41,7 @@ public interface AttributeServiceInf {
    * @param id the unique identifier of the attribute
    * @return the Attribute entity with the given id, or null if not found
    */
-  public Collection getAttribute(int id);
+  public Collection<Attribute> getAttribute(int id);
 
   /**
    * Removes the specified attribute from the system.
@@ -65,5 +65,5 @@ public interface AttributeServiceInf {
    * @param language_id the unique identifier of the language
    * @return a collection of Attribute names and IDs, or an empty collection
    */
-  public Collection getAttributeNames(int taxonomy_id, int language_id);
+  public Collection<Object[]> getAttributeNames(int taxonomy_id, int language_id);
 }

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateAttributeDAO.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/repository/HibernateAttributeDAO.java
@@ -31,17 +31,17 @@ public class HibernateAttributeDAO implements AttributeDAO {
 
   @Autowired private SessionFactory sessionFactory;
 
-  public Collection getAttribute(int id) {
+  public Collection<Attribute> getAttribute(int id) {
     String queryString =
         "from Attribute a left join fetch a.taxonomy left join fetch a.attribute_langs where a.id ="
             + " "
             + id;
     Session session = sessionFactory.getCurrentSession();
-    return (Collection) session.createQuery(queryString).list();
+    return session.createQuery(queryString, Attribute.class).getResultList();
   }
 
   /** Return all Attributes */
-  public Collection getAllAttributes(int taxonomy_id, int langID) {
+  public Collection<Attribute> getAllAttributes(int taxonomy_id, int langID) {
     String queryString =
         "from Attribute a left join fetch a.taxonomy left join fetch a.attribute_langs al join"
             + " fetch al.language where a.taxonomy.id = "
@@ -49,11 +49,11 @@ public class HibernateAttributeDAO implements AttributeDAO {
             + " and al.language.id = "
             + langID;
     Session session = sessionFactory.getCurrentSession();
-    return (Collection) session.createQuery(queryString).list();
+    return session.createQuery(queryString, Attribute.class).getResultList();
   }
 
   /** Return all Attribute names and IDs */
-  public Collection getAttributeNames(int taxonomy_id, int language_id) {
+  public Collection<Object[]> getAttributeNames(int taxonomy_id, int language_id) {
     String queryString =
         "select al.Name, a.id from Attribute a, Attribute_lang al where al.attribute.id = a.id and"
             + " a.taxonomy.id = "
@@ -62,7 +62,7 @@ public class HibernateAttributeDAO implements AttributeDAO {
             + language_id
             + " order by al.id";
     Session session = sessionFactory.getCurrentSession();
-    return (Collection) session.createQuery(queryString).list();
+    return session.createQuery(queryString, Object[].class).getResultList();
   }
 
   public void saveAttribute(Attribute attribute) {

--- a/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/service/AttributeService.java
+++ b/modules/perc-taxonomy/src/main/java/com/percussion/taxonomy/service/AttributeService.java
@@ -39,11 +39,11 @@ public class AttributeService implements AttributeServiceInf {
     this.valueService = valueService;
   }
 
-  public Collection getAllAttributes(int taxonomy_id, int language_id) {
+  public Collection<Attribute> getAllAttributes(int taxonomy_id, int language_id) {
     return attributeDAO.getAllAttributes(taxonomy_id, language_id);
   }
 
-  public Collection getAttribute(int id) {
+  public Collection<Attribute> getAttribute(int id) {
     return attributeDAO.getAttribute(id);
   }
 
@@ -93,7 +93,7 @@ public class AttributeService implements AttributeServiceInf {
   }
 
   /** Return all Attribute names and IDs */
-  public Collection getAttributeNames(int taxonomy_id, int language_id) {
+  public Collection<Object[]> getAttributeNames(int taxonomy_id, int language_id) {
     return attributeDAO.getAttributeNames(taxonomy_id, language_id);
   }
 


### PR DESCRIPTION
fix(perc-taxonomy): parameterize Collection return types in Attribute repo interfaces (#2031)

Real code fixes for 9 of 87 fixable warnings in the taxonomy module:
- AttributeDAO.java: parameterize Collection<Attribute> / Collection<Object[]> on getAllAttributes, getAttribute, getAttributeNames.
- AttributeServiceInf.java: mirror the parameterization in the public service interface.

78 fixable warnings remain (Hibernate Query / Cast in TaxonomyJexl + the rest of the Hibernate DAO + service layer). Tracked as follow-up.

Build: mvn clean install -> BUILD SUCCESS.
Tests: pass.
Spotless apply+check verified.

Operator: Kilo (minimax-m3)