### PR TITLE
test(WebUI): DetailPanel cluster D panelErrMsg ladders (#2158)

### DIFF
--- a/WebUI/src/test/ts/developer/ControlDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ControlDetailPanel.test.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as controlsApi from "../../../main/ts/api/developer/controlsApi";
+import { ControlDetailPanel } from "../../../main/ts/developer/ControlDetailPanel";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+
+vi.mock("../../../main/ts/api/developer/controlsApi", () => ({
+  listControls: vi.fn(),
+  getControlDetail: vi.fn(),
+}));
+
+const getControlDetail = controlsApi.getControlDetail as ReturnType<typeof vi.fn>;
+
+const sampleDetail = {
+  name: "sys_EditBox",
+  displayName: "Edit Box",
+  scope: "system",
+  dimension: "single",
+  choiceSet: null,
+  description: "Text edit control",
+  parameters: [{ name: "maxlength", dataType: "number", required: false, defaultValue: "255" }],
+  designGaps: ["gap-a"],
+};
+
+describe("ControlDetailPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    getControlDetail.mockReset();
+  });
+
+  it("loads detail on success and supports back", async () => {
+    getControlDetail.mockResolvedValue(sampleDetail);
+    const onBack = vi.fn();
+    render(<ControlDetailPanel name="sys_EditBox" onBack={onBack} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ctl-detail-title")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ctl-detail-title").textContent).toContain("Edit Box");
+    expect(screen.getByTestId("developer-ctl-params-table")).toBeTruthy();
+    expect(screen.getByTestId("developer-ctl-gaps").textContent).toContain("gap-a");
+    expect(getControlDetail).toHaveBeenCalledWith("sys_EditBox");
+    fireEvent.click(screen.getByTestId("developer-ctl-back"));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("shows empty params section when detail has none", async () => {
+    getControlDetail.mockResolvedValue({
+      ...sampleDetail,
+      parameters: [],
+    });
+    render(<ControlDetailPanel name="sys_EditBox" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ctl-params")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ctl-params").textContent).toContain(DEV_MSG.CTL_NONE);
+    expect(screen.queryByTestId("developer-ctl-params-table")).toBeNull();
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    getControlDetail.mockRejectedValue(new SessionRedirectError());
+    render(<ControlDetailPanel name="sys_EditBox" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ctl-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ctl-detail-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-ctl-detail-loading")).toBeNull();
+    expect(screen.queryByTestId("developer-ctl-detail-title")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    getControlDetail.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<ControlDetailPanel name="sys_EditBox" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ctl-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ctl-detail-error").textContent).toBe(
+      `${DEV_MSG.CTL_DETAIL_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    getControlDetail.mockRejectedValue(new Error("network down"));
+    render(<ControlDetailPanel name="sys_EditBox" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ctl-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ctl-detail-error").textContent).toBe(
+      `${DEV_MSG.CTL_DETAIL_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-ctl-detail-title")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    getControlDetail.mockRejectedValue("boom");
+    render(<ControlDetailPanel name="sys_EditBox" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ctl-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ctl-detail-error").textContent).toBe(
+      DEV_MSG.CTL_DETAIL_ERROR,
+    );
+  });
+});

--- a/WebUI/src/test/ts/developer/ExtensionDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ExtensionDetailPanel.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as extensionsApi from "../../../main/ts/api/developer/extensionsApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+import { ExtensionDetailPanel } from "../../../main/ts/developer/ExtensionDetailPanel";
+
+vi.mock("../../../main/ts/api/developer/extensionsApi", () => ({
+  listExtensions: vi.fn(),
+  getExtensionDetail: vi.fn(),
+}));
+
+const getExtensionDetail = extensionsApi.getExtensionDetail as ReturnType<typeof vi.fn>;
+
+const sampleDetail = {
+  extensionName: "sys_add",
+  fqn: "Java/global/percussion/sys_add",
+  handlerName: "Java",
+  context: "global/percussion/",
+  version: 1,
+  supportedInterfaces: ["com.percussion.extension.IPSExtension"],
+  runtimeParameters: [{ name: "htmlParams", dataType: "java.util.Map" }],
+};
+
+describe("ExtensionDetailPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    getExtensionDetail.mockReset();
+  });
+
+  it("loads detail on success and supports back", async () => {
+    getExtensionDetail.mockResolvedValue(sampleDetail);
+    const onBack = vi.fn();
+    render(<ExtensionDetailPanel idOrName="sys_add" onBack={onBack} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ex-detail-title")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ex-detail-title").textContent).toContain("sys_add");
+    expect(screen.getByTestId("developer-ex-params-table")).toBeTruthy();
+    expect(screen.getByTestId("developer-ex-ifaces").textContent).toContain(
+      "com.percussion.extension.IPSExtension",
+    );
+    expect(getExtensionDetail).toHaveBeenCalledWith("sys_add");
+    fireEvent.click(screen.getByTestId("developer-ex-back"));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("shows empty params section when detail has none", async () => {
+    getExtensionDetail.mockResolvedValue({
+      ...sampleDetail,
+      runtimeParameters: [],
+      supportedInterfaces: [],
+    });
+    render(<ExtensionDetailPanel idOrName="sys_add" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ex-params-empty")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ex-params-empty").textContent).toBe(DEV_MSG.EX_NONE);
+    expect(screen.queryByTestId("developer-ex-params-table")).toBeNull();
+    expect(screen.getByTestId("developer-ex-ifaces").textContent).toContain(DEV_MSG.EX_NONE);
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    getExtensionDetail.mockRejectedValue(new SessionRedirectError());
+    render(<ExtensionDetailPanel idOrName="sys_add" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ex-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ex-detail-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-ex-detail-loading")).toBeNull();
+    expect(screen.queryByTestId("developer-ex-detail-title")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    getExtensionDetail.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<ExtensionDetailPanel idOrName="sys_add" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ex-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ex-detail-error").textContent).toBe(
+      `${DEV_MSG.EX_DETAIL_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    getExtensionDetail.mockRejectedValue(new Error("network down"));
+    render(<ExtensionDetailPanel idOrName="sys_add" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ex-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ex-detail-error").textContent).toBe(
+      `${DEV_MSG.EX_DETAIL_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-ex-detail-title")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    getExtensionDetail.mockRejectedValue("boom");
+    render(<ExtensionDetailPanel idOrName="sys_add" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ex-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ex-detail-error").textContent).toBe(
+      DEV_MSG.EX_DETAIL_ERROR,
+    );
+  });
+});

--- a/WebUI/src/test/ts/developer/LocaleDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/LocaleDetailPanel.test.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as localesApi from "../../../main/ts/api/developer/localesApi";
+import { LocaleDetailPanel } from "../../../main/ts/developer/LocaleDetailPanel";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+
+vi.mock("../../../main/ts/api/developer/localesApi", () => ({
+  listLocales: vi.fn(),
+  getLocaleDetail: vi.fn(),
+}));
+
+const getLocaleDetail = localesApi.getLocaleDetail as ReturnType<typeof vi.fn>;
+
+const sampleDetail = {
+  id: 1,
+  languageString: "en-us",
+  label: "English",
+  status: "active",
+  baseLocale: false,
+  hasFormatProfile: true,
+  description: "US English",
+  format: {
+    languageString: "en-us",
+    textDir: "ltr",
+    datePattern: "MM/dd/yyyy",
+    currencyCode: "USD",
+  },
+  designGaps: ["write not supported"],
+};
+
+describe("LocaleDetailPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    getLocaleDetail.mockReset();
+  });
+
+  it("loads detail on success and supports back", async () => {
+    getLocaleDetail.mockResolvedValue(sampleDetail);
+    const onBack = vi.fn();
+    render(<LocaleDetailPanel idOrLang="en-us" onBack={onBack} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-loc-detail-title")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-loc-detail-title").textContent).toContain("English");
+    expect(screen.getByTestId("developer-loc-format-grid")).toBeTruthy();
+    expect(screen.getByText("MM/dd/yyyy")).toBeTruthy();
+    expect(screen.getByTestId("developer-loc-gaps")).toBeTruthy();
+    expect(getLocaleDetail).toHaveBeenCalledWith("en-us");
+    fireEvent.click(screen.getByTestId("developer-loc-back"));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("shows empty format section when detail has no format", async () => {
+    getLocaleDetail.mockResolvedValue({
+      ...sampleDetail,
+      hasFormatProfile: false,
+      format: undefined,
+      designGaps: [],
+    });
+    render(<LocaleDetailPanel idOrLang="en-us" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-loc-format-empty")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-loc-format-empty").textContent).toBe(
+      DEV_MSG.LOC_FORMAT_EMPTY,
+    );
+    expect(screen.queryByTestId("developer-loc-format-grid")).toBeNull();
+    expect(screen.queryByTestId("developer-loc-gaps")).toBeNull();
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    getLocaleDetail.mockRejectedValue(new SessionRedirectError());
+    render(<LocaleDetailPanel idOrLang="en-us" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-loc-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-loc-detail-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-loc-detail-loading")).toBeNull();
+    expect(screen.queryByTestId("developer-loc-detail-title")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    getLocaleDetail.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<LocaleDetailPanel idOrLang="en-us" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-loc-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-loc-detail-error").textContent).toBe(
+      `${DEV_MSG.LOC_DETAIL_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    getLocaleDetail.mockRejectedValue(new Error("network down"));
+    render(<LocaleDetailPanel idOrLang="en-us" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-loc-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-loc-detail-error").textContent).toBe(
+      `${DEV_MSG.LOC_DETAIL_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-loc-detail-title")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    getLocaleDetail.mockRejectedValue("boom");
+    render(<LocaleDetailPanel idOrLang="en-us" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-loc-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-loc-detail-error").textContent).toBe(
+      DEV_MSG.LOC_DETAIL_ERROR,
+    );
+  });
+});

--- a/WebUI/src/test/ts/developer/ServerConfigDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ServerConfigDetailPanel.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as serverConfigsApi from "../../../main/ts/api/developer/serverConfigsApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+import { ServerConfigDetailPanel } from "../../../main/ts/developer/ServerConfigDetailPanel";
+
+vi.mock("../../../main/ts/api/developer/serverConfigsApi", () => ({
+  listServerConfigs: vi.fn(),
+  getServerConfigDetail: vi.fn(),
+}));
+
+const getServerConfigDetail = serverConfigsApi.getServerConfigDetail as ReturnType<typeof vi.fn>;
+
+const sampleDetail = {
+  name: "LOG_CONFIG",
+  displayName: "Logging configuration",
+  fileName: "log4j.xml",
+  mimeType: "application/xml",
+  characterEncoding: "UTF-8",
+  content: "<Configuration/>",
+  designGaps: ["gap-save"],
+};
+
+describe("ServerConfigDetailPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    getServerConfigDetail.mockReset();
+  });
+
+  it("loads detail on success and supports back", async () => {
+    getServerConfigDetail.mockResolvedValue(sampleDetail);
+    const onBack = vi.fn();
+    render(<ServerConfigDetailPanel name="LOG_CONFIG" onBack={onBack} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cfg-detail-title")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-cfg-detail-title").textContent).toContain(
+      "Logging configuration",
+    );
+    expect(screen.getByTestId("developer-cfg-content-pre").textContent).toContain("Configuration");
+    expect(screen.getByTestId("developer-cfg-gaps").textContent).toContain("gap-save");
+    expect(getServerConfigDetail).toHaveBeenCalledWith("LOG_CONFIG");
+    fireEvent.click(screen.getByTestId("developer-cfg-back"));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("shows empty content when detail has none", async () => {
+    getServerConfigDetail.mockResolvedValue({
+      ...sampleDetail,
+      content: "",
+    });
+    render(<ServerConfigDetailPanel name="LOG_CONFIG" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cfg-content-empty")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-cfg-content-empty").textContent).toBe(
+      DEV_MSG.CFG_CONTENT_EMPTY,
+    );
+    expect(screen.queryByTestId("developer-cfg-content-pre")).toBeNull();
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    getServerConfigDetail.mockRejectedValue(new SessionRedirectError());
+    render(<ServerConfigDetailPanel name="LOG_CONFIG" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cfg-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-cfg-detail-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-cfg-detail-loading")).toBeNull();
+    expect(screen.queryByTestId("developer-cfg-detail-title")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    getServerConfigDetail.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<ServerConfigDetailPanel name="LOG_CONFIG" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cfg-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-cfg-detail-error").textContent).toBe(
+      `${DEV_MSG.CFG_DETAIL_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    getServerConfigDetail.mockRejectedValue(new Error("network down"));
+    render(<ServerConfigDetailPanel name="LOG_CONFIG" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cfg-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-cfg-detail-error").textContent).toBe(
+      `${DEV_MSG.CFG_DETAIL_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-cfg-detail-title")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    getServerConfigDetail.mockRejectedValue("boom");
+    render(<ServerConfigDetailPanel name="LOG_CONFIG" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cfg-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-cfg-detail-error").textContent).toBe(
+      DEV_MSG.CFG_DETAIL_ERROR,
+    );
+  });
+});

--- a/WebUI/src/test/ts/developer/SharedFieldGroupDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SharedFieldGroupDetailPanel.test.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as sharedFieldsApi from "../../../main/ts/api/developer/sharedFieldsApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+import { SharedFieldGroupDetailPanel } from "../../../main/ts/developer/SharedFieldGroupDetailPanel";
+
+vi.mock("../../../main/ts/api/developer/sharedFieldsApi", () => ({
+  listSharedFieldGroups: vi.fn(),
+  getSharedFieldGroupDetail: vi.fn(),
+}));
+
+const getSharedFieldGroupDetail = sharedFieldsApi.getSharedFieldGroupDetail as ReturnType<
+  typeof vi.fn
+>;
+
+const sampleDetail = {
+  name: "shared",
+  filename: "shared.xml",
+  fields: [
+    {
+      name: "rx_title",
+      dataType: "text",
+      required: true,
+      searchable: true,
+      readOnly: false,
+      occurrence: "required",
+    },
+  ],
+  designGaps: ["write not supported"],
+};
+
+describe("SharedFieldGroupDetailPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    getSharedFieldGroupDetail.mockReset();
+  });
+
+  it("loads detail on success and supports back", async () => {
+    getSharedFieldGroupDetail.mockResolvedValue(sampleDetail);
+    const onBack = vi.fn();
+    render(<SharedFieldGroupDetailPanel name="shared" onBack={onBack} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sf-detail-title")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sf-detail-title").textContent).toBe("shared");
+    expect(screen.getByTestId("developer-sf-fields-table")).toBeTruthy();
+    expect(screen.getByText("rx_title")).toBeTruthy();
+    expect(screen.getByTestId("developer-sf-gaps")).toBeTruthy();
+    expect(getSharedFieldGroupDetail).toHaveBeenCalledWith("shared");
+    fireEvent.click(screen.getByTestId("developer-sf-back"));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("shows empty fields section when detail has none", async () => {
+    getSharedFieldGroupDetail.mockResolvedValue({
+      ...sampleDetail,
+      fields: [],
+    });
+    render(<SharedFieldGroupDetailPanel name="shared" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sf-fields-empty")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sf-fields-empty").textContent).toBe(DEV_MSG.SF_NONE);
+    expect(screen.queryByTestId("developer-sf-fields-table")).toBeNull();
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    getSharedFieldGroupDetail.mockRejectedValue(new SessionRedirectError());
+    render(<SharedFieldGroupDetailPanel name="shared" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sf-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sf-detail-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-sf-detail-loading")).toBeNull();
+    expect(screen.queryByTestId("developer-sf-detail-title")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    getSharedFieldGroupDetail.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<SharedFieldGroupDetailPanel name="shared" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sf-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sf-detail-error").textContent).toBe(
+      `${DEV_MSG.SF_DETAIL_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    getSharedFieldGroupDetail.mockRejectedValue(new Error("network down"));
+    render(<SharedFieldGroupDetailPanel name="shared" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sf-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sf-detail-error").textContent).toBe(
+      `${DEV_MSG.SF_DETAIL_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-sf-detail-title")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    getSharedFieldGroupDetail.mockRejectedValue("boom");
+    render(<SharedFieldGroupDetailPanel name="shared" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sf-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sf-detail-error").textContent).toBe(
+      DEV_MSG.SF_DETAIL_ERROR,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Implements **#2158** (UI-TEST-01 residual B cluster D / parent **#2139** / **#2119** / **#1690**).

Vitest empty/error/success ladders for detail-load `panelErrMsg` on:

- `ServerConfigDetailPanel`
- `ExtensionDetailPanel`
- `ControlDetailPanel`
- `SharedFieldGroupDetailPanel`
- `LocaleDetailPanel`

Each covers:

- session-redirect via `panelErrMsg`
- ApiError status (`(500)`)
- `Error.message`
- non-Error fallback
- success path (+ empty content / params / fields / format where applicable)

No product UI changes; uses existing `data-testid`s. Mirrors Cluster A (PR #2160), Cluster C (PR #2174), and list-panel peers (`ServerConfigsPanel` / `ExtensionsPanel` / `ControlsPanel` / `SharedFieldsPanel` / `LocalesPanel`).

## Test plan

- [x] Focused Vitest: 5 files / **30 tests** green
- [x] WebUI standalone `mvnw clean install` green (**195** files / **1315** tests)
- [x] No product code changes

## Gates evidence

- Erlang-style self-review: pure tests, peer-mirrored ladders, no path I/O, no UI expansion
- Change class: Vitest companions only (no Playwright — no product UI change)
- Module: `WebUI` clean install SUCCESS

Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2139

Fixes #2158.