### PR TITLE
test(WebUI): DetailPanel cluster B panelErrMsg ladders (#2156)

### DIFF
--- a/WebUI/src/test/ts/developer/ActionMenuDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ActionMenuDetailPanel.test.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as actionMenusApi from "../../../main/ts/api/developer/actionMenusApi";
+import { ActionMenuDetailPanel } from "../../../main/ts/developer/ActionMenuDetailPanel";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+
+vi.mock("../../../main/ts/api/developer/actionMenusApi", () => ({
+  listActionMenus: vi.fn(),
+  getActionMenuDetail: vi.fn(),
+}));
+
+const getActionMenuDetail = actionMenusApi.getActionMenuDetail as ReturnType<typeof vi.fn>;
+
+const sampleDetail = {
+  id: 1,
+  name: "Edit",
+  label: "Edit Item",
+  description: "Edit content item",
+  menuType: "MENUITEM",
+  handler: "CLIENT",
+  url: "/Rhythmyx/edit",
+  sortRank: 10,
+  parameters: [{ name: "sys_contentid", value: "0" }],
+  properties: [{ name: "AcceleratorKey", value: "E" }],
+};
+
+describe("ActionMenuDetailPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    getActionMenuDetail.mockReset();
+  });
+
+  it("loads detail on success and supports back", async () => {
+    getActionMenuDetail.mockResolvedValue(sampleDetail);
+    const onBack = vi.fn();
+    render(<ActionMenuDetailPanel idOrName="Edit" onBack={onBack} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-detail-title")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-am-detail-title").textContent).toContain("Edit Item");
+    expect(screen.getByTestId("developer-am-params-table")).toBeTruthy();
+    expect(screen.getByTestId("developer-am-props-table")).toBeTruthy();
+    expect(screen.getByTestId("developer-am-gaps")).toBeTruthy();
+    expect(getActionMenuDetail).toHaveBeenCalledWith("Edit");
+    fireEvent.click(screen.getByTestId("developer-am-back"));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("shows empty params and props sections when detail has none", async () => {
+    getActionMenuDetail.mockResolvedValue({
+      ...sampleDetail,
+      parameters: [],
+      properties: [],
+    });
+    render(<ActionMenuDetailPanel idOrName="Edit" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-params-empty")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-am-props-empty")).toBeTruthy();
+    expect(screen.queryByTestId("developer-am-params-table")).toBeNull();
+    expect(screen.queryByTestId("developer-am-props-table")).toBeNull();
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    getActionMenuDetail.mockRejectedValue(new SessionRedirectError());
+    render(<ActionMenuDetailPanel idOrName="Edit" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-am-detail-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-am-detail-loading")).toBeNull();
+    expect(screen.queryByTestId("developer-am-detail-title")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    getActionMenuDetail.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<ActionMenuDetailPanel idOrName="Edit" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-am-detail-error").textContent).toBe(
+      `${DEV_MSG.AM_DETAIL_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    getActionMenuDetail.mockRejectedValue(new Error("network down"));
+    render(<ActionMenuDetailPanel idOrName="Edit" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-am-detail-error").textContent).toBe(
+      `${DEV_MSG.AM_DETAIL_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-am-detail-title")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    getActionMenuDetail.mockRejectedValue("boom");
+    render(<ActionMenuDetailPanel idOrName="Edit" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-am-detail-error").textContent).toBe(
+      DEV_MSG.AM_DETAIL_ERROR,
+    );
+  });
+});

--- a/WebUI/src/test/ts/developer/DisplayFormatDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/DisplayFormatDetailPanel.test.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as displayFormatsApi from "../../../main/ts/api/developer/displayFormatsApi";
+import { DisplayFormatDetailPanel } from "../../../main/ts/developer/DisplayFormatDetailPanel";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+
+vi.mock("../../../main/ts/api/developer/displayFormatsApi", () => ({
+  listDisplayFormats: vi.fn(),
+  getDisplayFormatDetail: vi.fn(),
+  normalizeColumns: (c: unknown) => (Array.isArray(c) ? c : []),
+}));
+
+const getDisplayFormatDetail = displayFormatsApi.getDisplayFormatDetail as ReturnType<
+  typeof vi.fn
+>;
+
+const sampleDetail = {
+  name: "Default",
+  label: "Default View",
+  description: "System default",
+  guid: { stringValue: "0-1-100" },
+  validForFolder: true,
+  validForViewsAndSearches: true,
+  validForRelatedContent: false,
+  columns: [
+    { source: "sys_title", displayName: "Title", position: 0, renderType: "text", width: 200 },
+  ],
+};
+
+describe("DisplayFormatDetailPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    getDisplayFormatDetail.mockReset();
+  });
+
+  it("loads detail on success and supports back", async () => {
+    getDisplayFormatDetail.mockResolvedValue(sampleDetail);
+    const onBack = vi.fn();
+    render(<DisplayFormatDetailPanel idOrName="Default" onBack={onBack} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-detail-title")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-df-detail-title").textContent).toContain("Default View");
+    expect(screen.getByTestId("developer-df-columns-table")).toBeTruthy();
+    expect(screen.getByTestId("developer-df-gaps")).toBeTruthy();
+    expect(getDisplayFormatDetail).toHaveBeenCalledWith("Default");
+    fireEvent.click(screen.getByTestId("developer-df-back"));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("shows empty columns section when detail has none", async () => {
+    getDisplayFormatDetail.mockResolvedValue({ ...sampleDetail, columns: [] });
+    render(<DisplayFormatDetailPanel idOrName="Default" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-columns-empty")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("developer-df-columns-table")).toBeNull();
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    getDisplayFormatDetail.mockRejectedValue(new SessionRedirectError());
+    render(<DisplayFormatDetailPanel idOrName="Default" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-df-detail-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-df-detail-loading")).toBeNull();
+    expect(screen.queryByTestId("developer-df-detail-title")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    getDisplayFormatDetail.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<DisplayFormatDetailPanel idOrName="Default" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-df-detail-error").textContent).toBe(
+      `${DEV_MSG.DF_DETAIL_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    getDisplayFormatDetail.mockRejectedValue(new Error("network down"));
+    render(<DisplayFormatDetailPanel idOrName="Default" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-df-detail-error").textContent).toBe(
+      `${DEV_MSG.DF_DETAIL_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-df-detail-title")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    getDisplayFormatDetail.mockRejectedValue("boom");
+    render(<DisplayFormatDetailPanel idOrName="Default" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-df-detail-error").textContent).toBe(
+      DEV_MSG.DF_DETAIL_ERROR,
+    );
+  });
+});

--- a/WebUI/src/test/ts/developer/ItemFilterDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ItemFilterDetailPanel.test.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as itemFiltersApi from "../../../main/ts/api/developer/itemFiltersApi";
+import { ItemFilterDetailPanel } from "../../../main/ts/developer/ItemFilterDetailPanel";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+
+vi.mock("../../../main/ts/api/developer/itemFiltersApi", () => ({
+  listItemFilters: vi.fn(),
+  getItemFilterDetail: vi.fn(),
+}));
+
+const getItemFilterDetail = itemFiltersApi.getItemFilterDetail as ReturnType<typeof vi.fn>;
+
+const sampleDetail = {
+  name: "publicItems",
+  description: "Public content filter",
+  filterId: { stringValue: "0-1-50" },
+  legacyAuthtype: 1,
+  parentFilter: { name: "allItems" },
+  rules: [
+    {
+      name: "sys_filterByPublishable",
+      ruleId: { stringValue: "0-1-51" },
+      params: [{ name: "state", value: "public" }],
+    },
+  ],
+};
+
+describe("ItemFilterDetailPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    getItemFilterDetail.mockReset();
+  });
+
+  it("loads detail on success and supports back", async () => {
+    getItemFilterDetail.mockResolvedValue(sampleDetail);
+    const onBack = vi.fn();
+    render(<ItemFilterDetailPanel idOrName="publicItems" onBack={onBack} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-if-detail-title")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-if-detail-title").textContent).toContain("publicItems");
+    expect(screen.getByTestId("developer-if-rules-table")).toBeTruthy();
+    expect(screen.getByTestId("developer-if-gaps")).toBeTruthy();
+    expect(getItemFilterDetail).toHaveBeenCalledWith("publicItems");
+    fireEvent.click(screen.getByTestId("developer-if-back"));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("shows empty rules section when detail has none", async () => {
+    getItemFilterDetail.mockResolvedValue({ ...sampleDetail, rules: [] });
+    render(<ItemFilterDetailPanel idOrName="publicItems" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-if-rules-empty")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("developer-if-rules-table")).toBeNull();
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    getItemFilterDetail.mockRejectedValue(new SessionRedirectError());
+    render(<ItemFilterDetailPanel idOrName="publicItems" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-if-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-if-detail-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-if-detail-loading")).toBeNull();
+    expect(screen.queryByTestId("developer-if-detail-title")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    getItemFilterDetail.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<ItemFilterDetailPanel idOrName="publicItems" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-if-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-if-detail-error").textContent).toBe(
+      `${DEV_MSG.IF_DETAIL_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    getItemFilterDetail.mockRejectedValue(new Error("network down"));
+    render(<ItemFilterDetailPanel idOrName="publicItems" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-if-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-if-detail-error").textContent).toBe(
+      `${DEV_MSG.IF_DETAIL_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-if-detail-title")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    getItemFilterDetail.mockRejectedValue("boom");
+    render(<ItemFilterDetailPanel idOrName="publicItems" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-if-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-if-detail-error").textContent).toBe(
+      DEV_MSG.IF_DETAIL_ERROR,
+    );
+  });
+});

--- a/WebUI/src/test/ts/developer/RelationshipTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/RelationshipTypeDetailPanel.test.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as relationshipTypesApi from "../../../main/ts/api/developer/relationshipTypesApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+import { RelationshipTypeDetailPanel } from "../../../main/ts/developer/RelationshipTypeDetailPanel";
+
+vi.mock("../../../main/ts/api/developer/relationshipTypesApi", () => ({
+  listRelationshipTypes: vi.fn(),
+  getRelationshipTypeDetail: vi.fn(),
+}));
+
+const getRelationshipTypeDetail = relationshipTypesApi.getRelationshipTypeDetail as ReturnType<
+  typeof vi.fn
+>;
+
+const sampleDetail = {
+  name: "ActiveAssembly",
+  label: "Active Assembly",
+  category: "rs_activeassembly",
+  categoryLabel: "Active Assembly",
+  type: "system",
+  description: "AA relationship",
+  effects: [
+    {
+      name: "sys_PublishRequired",
+      activationEndPoint: "owner",
+      extensionRef: "Java/global/percussion/relationship/sys_PublishRequired",
+    },
+  ],
+  systemProperties: [{ name: "rs_useownerrevision", value: "yes" }],
+  userProperties: [{ name: "slotid", value: "0" }],
+  designGaps: ["gap-a"],
+};
+
+describe("RelationshipTypeDetailPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    getRelationshipTypeDetail.mockReset();
+  });
+
+  it("loads detail on success and supports back", async () => {
+    getRelationshipTypeDetail.mockResolvedValue(sampleDetail);
+    const onBack = vi.fn();
+    render(<RelationshipTypeDetailPanel idOrName="ActiveAssembly" onBack={onBack} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-rt-detail-title")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-rt-detail-title").textContent).toContain(
+      "Active Assembly",
+    );
+    expect(screen.getByTestId("developer-rt-effects-table")).toBeTruthy();
+    expect(screen.getByTestId("developer-rt-sysprops-table")).toBeTruthy();
+    expect(screen.getByTestId("developer-rt-userprops-table")).toBeTruthy();
+    expect(screen.getByTestId("developer-rt-gaps").textContent).toContain("gap-a");
+    expect(getRelationshipTypeDetail).toHaveBeenCalledWith("ActiveAssembly");
+    fireEvent.click(screen.getByTestId("developer-rt-back"));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("shows empty effects/props sections when detail has none", async () => {
+    getRelationshipTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      effects: [],
+      systemProperties: [],
+      userProperties: [],
+    });
+    render(<RelationshipTypeDetailPanel idOrName="ActiveAssembly" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-rt-effects")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-rt-effects").textContent).toContain(DEV_MSG.RT_NONE);
+    expect(screen.getByTestId("developer-rt-sysprops").textContent).toContain(DEV_MSG.RT_NONE);
+    expect(screen.getByTestId("developer-rt-userprops").textContent).toContain(DEV_MSG.RT_NONE);
+    expect(screen.queryByTestId("developer-rt-effects-table")).toBeNull();
+    expect(screen.queryByTestId("developer-rt-sysprops-table")).toBeNull();
+    expect(screen.queryByTestId("developer-rt-userprops-table")).toBeNull();
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    getRelationshipTypeDetail.mockRejectedValue(new SessionRedirectError());
+    render(<RelationshipTypeDetailPanel idOrName="ActiveAssembly" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-rt-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-rt-detail-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-rt-detail-loading")).toBeNull();
+    expect(screen.queryByTestId("developer-rt-detail-title")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    getRelationshipTypeDetail.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<RelationshipTypeDetailPanel idOrName="ActiveAssembly" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-rt-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-rt-detail-error").textContent).toBe(
+      `${DEV_MSG.RT_DETAIL_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    getRelationshipTypeDetail.mockRejectedValue(new Error("network down"));
+    render(<RelationshipTypeDetailPanel idOrName="ActiveAssembly" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-rt-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-rt-detail-error").textContent).toBe(
+      `${DEV_MSG.RT_DETAIL_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-rt-detail-title")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    getRelationshipTypeDetail.mockRejectedValue("boom");
+    render(<RelationshipTypeDetailPanel idOrName="ActiveAssembly" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-rt-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-rt-detail-error").textContent).toBe(
+      DEV_MSG.RT_DETAIL_ERROR,
+    );
+  });
+});

--- a/WebUI/src/test/ts/developer/SearchDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SearchDetailPanel.test.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as searchesApi from "../../../main/ts/api/developer/searchesApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+import { SearchDetailPanel } from "../../../main/ts/developer/SearchDetailPanel";
+
+vi.mock("../../../main/ts/api/developer/searchesApi", () => ({
+  listSearches: vi.fn(),
+  getSearchDetail: vi.fn(),
+}));
+
+const getSearchDetail = searchesApi.getSearchDetail as ReturnType<typeof vi.fn>;
+
+const sampleDetail = {
+  name: "All Content",
+  label: "All Content",
+  description: "System search",
+  displayFormatId: "Default",
+  maximumResultSize: 100,
+  caseSensitive: false,
+  fields: [{ fieldName: "sys_title", operator: "=", fieldValue: "*", fieldType: "text" }],
+  designGaps: ["gap-a"],
+};
+
+describe("SearchDetailPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    getSearchDetail.mockReset();
+  });
+
+  it("loads detail on success and supports back", async () => {
+    getSearchDetail.mockResolvedValue(sampleDetail);
+    const onBack = vi.fn();
+    render(<SearchDetailPanel idOrName="All Content" onBack={onBack} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-detail-title")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sr-detail-title").textContent).toContain("All Content");
+    expect(screen.getByTestId("developer-sr-fields-table")).toBeTruthy();
+    expect(screen.getByTestId("developer-sr-gaps").textContent).toContain("gap-a");
+    expect(getSearchDetail).toHaveBeenCalledWith("All Content");
+    fireEvent.click(screen.getByTestId("developer-sr-back"));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("shows empty fields section when detail has none", async () => {
+    getSearchDetail.mockResolvedValue({ ...sampleDetail, fields: [] });
+    render(<SearchDetailPanel idOrName="All Content" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-fields-empty")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("developer-sr-fields-table")).toBeNull();
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    getSearchDetail.mockRejectedValue(new SessionRedirectError());
+    render(<SearchDetailPanel idOrName="All Content" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sr-detail-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-sr-detail-loading")).toBeNull();
+    expect(screen.queryByTestId("developer-sr-detail-title")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    getSearchDetail.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<SearchDetailPanel idOrName="All Content" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sr-detail-error").textContent).toBe(
+      `${DEV_MSG.SR_DETAIL_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    getSearchDetail.mockRejectedValue(new Error("network down"));
+    render(<SearchDetailPanel idOrName="All Content" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sr-detail-error").textContent).toBe(
+      `${DEV_MSG.SR_DETAIL_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-sr-detail-title")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    getSearchDetail.mockRejectedValue("boom");
+    render(<SearchDetailPanel idOrName="All Content" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sr-detail-error").textContent).toBe(
+      DEV_MSG.SR_DETAIL_ERROR,
+    );
+  });
+});

--- a/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionRedirectError } from "../../../main/ts/api/client";
+import * as viewsApi from "../../../main/ts/api/developer/viewsApi";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+import { ViewDetailPanel } from "../../../main/ts/developer/ViewDetailPanel";
+
+vi.mock("../../../main/ts/api/developer/viewsApi", () => ({
+  listViews: vi.fn(),
+  getViewDetail: vi.fn(),
+}));
+
+const getViewDetail = viewsApi.getViewDetail as ReturnType<typeof vi.fn>;
+
+const sampleDetail = {
+  name: "My View",
+  label: "My View",
+  description: "Custom view",
+  displayFormatId: "Default",
+  maximumResultSize: 50,
+  caseSensitive: true,
+  fields: [{ fieldName: "sys_contentid", operator: "=", fieldValue: "1", fieldType: "number" }],
+  designGaps: ["gap-a"],
+};
+
+describe("ViewDetailPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    getViewDetail.mockReset();
+  });
+
+  it("loads detail on success and supports back", async () => {
+    getViewDetail.mockResolvedValue(sampleDetail);
+    const onBack = vi.fn();
+    render(<ViewDetailPanel idOrName="My View" onBack={onBack} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-detail-title")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-vw-detail-title").textContent).toContain("My View");
+    expect(screen.getByTestId("developer-vw-fields-table")).toBeTruthy();
+    expect(screen.getByTestId("developer-vw-gaps").textContent).toContain("gap-a");
+    expect(getViewDetail).toHaveBeenCalledWith("My View");
+    fireEvent.click(screen.getByTestId("developer-vw-back"));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("shows empty fields section when detail has none", async () => {
+    getViewDetail.mockResolvedValue({ ...sampleDetail, fields: [] });
+    render(<ViewDetailPanel idOrName="My View" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-fields-empty")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("developer-vw-fields-table")).toBeNull();
+  });
+
+  it("shows session-redirect message via panelErrMsg", async () => {
+    getViewDetail.mockRejectedValue(new SessionRedirectError());
+    render(<ViewDetailPanel idOrName="My View" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-vw-detail-error").textContent).toBe(
+      DEV_MSG.SESSION_REDIRECT,
+    );
+    expect(screen.queryByTestId("developer-vw-detail-loading")).toBeNull();
+    expect(screen.queryByTestId("developer-vw-detail-title")).toBeNull();
+  });
+
+  it("shows ApiError status via panelErrMsg", async () => {
+    getViewDetail.mockRejectedValue({
+      status: 500,
+      statusText: "Internal Server Error",
+      body: null,
+    });
+    render(<ViewDetailPanel idOrName="My View" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-vw-detail-error").textContent).toBe(
+      `${DEV_MSG.VW_DETAIL_ERROR} (500)`,
+    );
+  });
+
+  it("shows Error.message via panelErrMsg", async () => {
+    getViewDetail.mockRejectedValue(new Error("network down"));
+    render(<ViewDetailPanel idOrName="My View" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-vw-detail-error").textContent).toBe(
+      `${DEV_MSG.VW_DETAIL_ERROR} network down`,
+    );
+    expect(screen.queryByTestId("developer-vw-detail-title")).toBeNull();
+  });
+
+  it("shows fallback when rejection has no message", async () => {
+    getViewDetail.mockRejectedValue("boom");
+    render(<ViewDetailPanel idOrName="My View" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-vw-detail-error").textContent).toBe(
+      DEV_MSG.VW_DETAIL_ERROR,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Implements **DetailPanel cluster B** Vitest ladders for issue #2156 (UI-TEST-01 residual B).

Adds empty/error/success panelErrMsg coverage for:

- `SearchDetailPanel`
- `ViewDetailPanel`
- `DisplayFormatDetailPanel`
- `ActionMenuDetailPanel`
- `ItemFilterDetailPanel`
- `RelationshipTypeDetailPanel`

Each panel gets the same ladder as cluster A (#2160) and list-panel peers: session-redirect, ApiError status, Error.message, non-Error fallback, success + back, and empty secondary sections.

**No product UI changes** — test-only.

Parent trackers: #2139 / #2119 / #1690.

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] Focused Vitest (6 files / 36 tests) green
- [x] `WebUI` standalone `mvnw clean install` green (196 test files / 1321 tests)
- [x] Erlang self-review: test-only, mirrors peers, no path I/O, no product churn

## Gates evidence

- Focused: `npm test -- --run SearchDetailPanel ViewDetailPanel DisplayFormatDetailPanel ActionMenuDetailPanel ItemFilterDetailPanel RelationshipTypeDetailPanel` → 36 passed
- Module: `cd WebUI && ../mvnw clean install` → BUILD SUCCESS
- Commit: `26e1b8424e`

Fixes #2156
