### PR TITLE
test(qa): Spanish locale smoke for Finder roots + default gadgets (#2094)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2094-spanish-locale-playwright-smoke-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2094-spanish-locale-playwright-smoke-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review — issue #2094 Spanish locale Playwright smoke
+
+**Date:** 2026-08-06  
+**Branch:** `fix/issue-2094-spanish-locale-playwright-smoke`  
+**Scope:** uncommitted changes under `modules/perc-qa-automation/`  
+**Recommendation:** approve  
+**Gate:** May commit/push: **yes**  
+**Memory patterns hit:** QA TEST_CMS_URL freeport (not hard-coded :9993); companion Playwright for i18n surface residual; no monorepo reformat.
+
+## Summary
+
+Adds Playwright Spanish locale smoke residual for #961 after TMX (#2092) and Finder display wiring (#2105):
+
+- `auth.js`: optional `{ locale }` on login helpers; `pickSpanishLoginLocale`; modern LocaleSelect option by testid.
+- `bug-2094-spanish-locale-finder-dashboard.spec.js`: (1) I18N + optional classic Finder display helper / DOM for root labels; English path identity on explorer tree; (2) default Dashboard gadgets Spanish chrome (License Monitor optional).
+
+## Issues
+
+None (bug / missing behavioral test / non-portable path).
+
+### Nits (non-blocking)
+
+- `expectHiddenLocale` is best-effort; login still proceeds if hidden lag — acceptable for smoke.
+- Modern Content Explorer tree still renders API `folder.name` (English); smoke gates TMX residual + path identity + classic helper when present. Full modern-tree label wiring is out of this residual's product scope.
+
+## Cross-platform path checklist
+
+No new file I/O or path joins. Env URL via existing `resolveCmsBaseUrl` / `BASE_URL`. **Clean.**
+
+## Gates evidence
+
+| Gate | Result |
+|------|--------|
+| Live Playwright (`TEST_CMS_URL=http://127.0.0.1:9993`) | 2 passed |
+| `npm run test:unit` | 48 passed |
+| `cd modules/perc-qa-automation && ../../mvnw clean install` | BUILD SUCCESS |
+| Surface filter list | 2 tests listed |

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-2094-spanish-locale-finder-dashboard.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-2094-spanish-locale-finder-dashboard.spec.js
@@ -156,18 +156,23 @@ test.describe("Spanish locale smoke — Finder roots + default gadgets (#2094) @
     await page.goto(explorerUrl(), { waitUntil: "networkidle" });
 
     // Session TMX must load Spanish residual keys (not English-only chrome).
+    // Poll the full key set so an incremental TMX load cannot race a Sites-only
+    // gate followed by a single re-read of the remaining roots.
     const keyList = Object.values(FINDER_ROOT_KEYS);
+    /** @type {Record<string, string>} */
+    let msgs = {};
     await expect
       .poll(
         async () => {
-          const msgs = await readI18nMessages(page, keyList);
-          return msgs[FINDER_ROOT_KEYS.Sites];
+          msgs = await readI18nMessages(page, keyList);
+          return Object.entries(FINDER_ROOT_KEYS).every(
+            ([english, key]) => msgs[key] === ES_FINDER_ROOTS[english],
+          );
         },
         { timeout: 30_000 },
       )
-      .toBe(ES_FINDER_ROOTS.Sites);
+      .toBe(true);
 
-    const msgs = await readI18nMessages(page, keyList);
     for (const [english, key] of Object.entries(FINDER_ROOT_KEYS)) {
       expect(
         msgs[key],
@@ -252,11 +257,14 @@ test.describe("Spanish locale smoke — Finder roots + default gadgets (#2094) @
       timeout: 45_000,
     });
 
-    // Welcome (no dedicated testid — match title chrome).
+    // Welcome (no dedicated testid — match title chrome inside gadgets section).
+    const gadgets = page.getByTestId("home-gadgets-section");
     await expect(
-      page.getByText(ES_GADGET_TITLES.welcome, { exact: true }).first(),
+      gadgets.getByText(ES_GADGET_TITLES.welcome, { exact: true }).first(),
     ).toBeVisible({ timeout: 30_000 });
-    await expect(page.getByText("WELCOME", { exact: true })).toHaveCount(0);
+    // Scope English absence to the gadgets section so unrelated page chrome
+    // cannot mask or falsely satisfy the assertion.
+    await expect(gadgets.getByText("WELCOME", { exact: true })).toHaveCount(0);
 
     // Process Monitor + Pages By Status (default layout).
     const processWidget = page.getByTestId("process-monitor-widget");

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-2094-spanish-locale-finder-dashboard.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-2094-spanish-locale-finder-dashboard.spec.js
@@ -1,0 +1,288 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Spanish locale smoke residual (#2094 / parent #961).
+ *
+ * <p>After TMX residual (#2092) + Finder display wiring (#2105), log in with a
+ * product Spanish locale (prefer {@code es-es}) and assert:</p>
+ * <ol>
+ *   <li>Finder root <strong>display</strong> labels resolve to Spanish
+ *       (Sitios / Activos / Diseño / Buscar / Reciclaje) while repository
+ *       path identity stays English ({@code /Sites/}, …).</li>
+ *   <li>Default Dashboard gadgets Welcome / Process Monitor / Pages By Status
+ *       show non-English (Spanish) chrome. License Monitor only when present.</li>
+ * </ol>
+ *
+ * <p>Golden / QA mode (no {@code DEV_PERCUSSION_INSTALL}):</p>
+ * <pre>
+ *   python docker/scripts/perc-devctl.py qa-up
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+ *     ADMIN_USERNAME=Admin ADMIN_PASSWORD=&lt;from-qa-up&gt; TEST_DB_TYPE=h2 \
+ *     npm run test:surface -- --path tests/bugs/bug-2094-spanish-locale-finder-dashboard.spec.js
+ * </pre>
+ *
+ * <p>Failure artifacts: {@code test-results/}, {@code playwright-report/}.</p>
+ */
+
+const { test, expect } = require("@playwright/test");
+const {
+  loginAsAdmin,
+  pickSpanishLoginLocale,
+  BASE_URL,
+} = require("../helpers/auth");
+
+/** CmsUi.tmx Spanish residual (#2092) for finder.root + default gadgets. */
+const ES_FINDER_ROOTS = {
+  Sites: "Sitios",
+  Assets: "Activos",
+  Design: "Diseño",
+  Search: "Buscar",
+  Recycling: "Reciclaje",
+};
+
+const ES_GADGET_TITLES = {
+  welcome: "BIENVENIDO",
+  processMonitor: "MONITOREO DE PROCESO",
+  pagesByStatus: "PÁGINAS POR ESTADO",
+  licenseMonitor: "Monitor de licencia",
+};
+
+const FINDER_ROOT_KEYS = {
+  Sites: "perc.ui.finder.root@Sites",
+  Assets: "perc.ui.finder.root@Assets",
+  Design: "perc.ui.finder.root@Design",
+  Search: "perc.ui.finder.root@Search",
+  Recycling: "perc.ui.finder.root@Recycling",
+};
+
+function explorerUrl() {
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${Date.now()}`;
+}
+
+function homeGadgetsUrl() {
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=home&section=gadgets&_=${Date.now()}`;
+}
+
+/**
+ * Read live I18N catalog messages after spa/tmx load.
+ * @param {import("@playwright/test").Page} page
+ * @param {string[]} keys
+ * @returns {Promise<Record<string, string|null>>}
+ */
+async function readI18nMessages(page, keys) {
+  return page.evaluate((messageKeys) => {
+    const out = {};
+    const i18n =
+      typeof window !== "undefined" && window.I18N && window.I18N.message
+        ? window.I18N
+        : null;
+    for (const k of messageKeys) {
+      if (!i18n) {
+        out[k] = null;
+        continue;
+      }
+      try {
+        out[k] = i18n.message(k);
+      } catch {
+        out[k] = null;
+      }
+    }
+    return out;
+  }, keys);
+}
+
+/**
+ * Classic Finder display helper when the page loads perc_finder_root_display.js.
+ * @param {import("@playwright/test").Page} page
+ * @param {string[]} englishRoots
+ * @returns {Promise<Record<string, string|null>>}
+ */
+async function readFinderDisplayLabels(page, englishRoots) {
+  return page.evaluate((roots) => {
+    const out = {};
+    const api =
+      typeof globalThis !== "undefined" && globalThis.percFinderRootDisplay
+        ? globalThis.percFinderRootDisplay
+        : typeof window !== "undefined" && window.percFinderRootDisplay
+          ? window.percFinderRootDisplay
+          : null;
+    for (const name of roots) {
+      if (
+        api &&
+        typeof api.displayLabelForFinderRoot === "function"
+      ) {
+        try {
+          out[name] = api.displayLabelForFinderRoot(name);
+        } catch {
+          out[name] = null;
+        }
+      } else {
+        out[name] = null;
+      }
+    }
+    return out;
+  }, englishRoots);
+}
+
+test.describe("Spanish locale smoke — Finder roots + default gadgets (#2094) @smoke @i18n", () => {
+  test("Finder root display labels + path identity stay English paths @smoke @i18n", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+
+    const locale = await pickSpanishLoginLocale(page);
+    expect(
+      locale,
+      "install must expose a Spanish login locale (es-es / es / es-mx)",
+    ).toBeTruthy();
+
+    await loginAsAdmin(page, { locale });
+
+    await page.goto(explorerUrl(), { waitUntil: "networkidle" });
+
+    // Session TMX must load Spanish residual keys (not English-only chrome).
+    const keyList = Object.values(FINDER_ROOT_KEYS);
+    await expect
+      .poll(
+        async () => {
+          const msgs = await readI18nMessages(page, keyList);
+          return msgs[FINDER_ROOT_KEYS.Sites];
+        },
+        { timeout: 30_000 },
+      )
+      .toBe(ES_FINDER_ROOTS.Sites);
+
+    const msgs = await readI18nMessages(page, keyList);
+    for (const [english, key] of Object.entries(FINDER_ROOT_KEYS)) {
+      expect(
+        msgs[key],
+        `I18N.message(${key}) after Spanish login`,
+      ).toBe(ES_FINDER_ROOTS[english]);
+      expect(msgs[key]).not.toBe(english);
+    }
+
+    // Path identity: modern explorer tree-node testids use English paths.
+    const shell = page.locator('[data-testid="content-explorer-shell"]');
+    if ((await shell.count()) > 0) {
+      await expect(shell).toBeVisible({ timeout: 30_000 });
+      const tree = page.locator('[data-testid="explorer-tree"]');
+      await expect(tree).toBeVisible({ timeout: 15_000 });
+
+      const sitesNode = tree.locator(
+        '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid^="tree-node-/Sites"]',
+      );
+      // Fresh H2 may still expose root children; path segment must stay English.
+      if ((await sitesNode.count()) > 0) {
+        await expect(sitesNode.first()).toBeVisible({ timeout: 15_000 });
+        const testId = await sitesNode.first().getAttribute("data-testid");
+        expect(testId, "path identity stays English Sites").toMatch(/Sites/i);
+        expect(testId).not.toMatch(/Sitios/i);
+      }
+    }
+
+    // Classic Finder display wiring (#2105): when percFinderRootDisplay is on
+    // the page, display labels must use TMX (not English-only chrome).
+    const displayLabels = await readFinderDisplayLabels(
+      page,
+      Object.keys(ES_FINDER_ROOTS),
+    );
+    const helperPresent = Object.values(displayLabels).some((v) => v != null);
+    if (helperPresent) {
+      for (const [english, spanish] of Object.entries(ES_FINDER_ROOTS)) {
+        expect(
+          displayLabels[english],
+          `percFinderRootDisplay.displayLabelForFinderRoot(${english})`,
+        ).toBe(spanish);
+      }
+    }
+
+    // Classic miller-column DOM when still mounted on a residual surface.
+    const classicNames = page.locator(".perc-finder-item-name");
+    if ((await classicNames.count()) > 0) {
+      const texts = (await classicNames.allTextContents()).map((t) =>
+        t.trim(),
+      );
+      for (const spanish of Object.values(ES_FINDER_ROOTS)) {
+        expect(
+          texts,
+          `classic Finder chrome should include ${spanish}`,
+        ).toContain(spanish);
+      }
+      // English path segment names must not be the only chrome for roots.
+      for (const english of Object.keys(ES_FINDER_ROOTS)) {
+        expect(texts).not.toContain(english);
+      }
+    }
+  });
+
+  test("default Dashboard gadgets show Spanish chrome @smoke @i18n", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+
+    const locale = await pickSpanishLoginLocale(page);
+    expect(locale).toBeTruthy();
+    await loginAsAdmin(page, { locale });
+
+    await page.goto(homeGadgetsUrl(), { waitUntil: "networkidle" });
+
+    // Prefer modern Home gadgets section; fall back to /cm/app/home.
+    const gadgetsSection = page.getByTestId("home-gadgets-section");
+    if ((await gadgetsSection.count()) === 0) {
+      await page.goto(`${BASE_URL}/Rhythmyx/cm/app/home`, {
+        waitUntil: "networkidle",
+      });
+    }
+    await expect(page.getByTestId("home-gadgets-section")).toBeVisible({
+      timeout: 45_000,
+    });
+
+    // Welcome (no dedicated testid — match title chrome).
+    await expect(
+      page.getByText(ES_GADGET_TITLES.welcome, { exact: true }).first(),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText("WELCOME", { exact: true })).toHaveCount(0);
+
+    // Process Monitor + Pages By Status (default layout).
+    const processWidget = page.getByTestId("process-monitor-widget");
+    await expect(processWidget).toBeVisible({ timeout: 30_000 });
+    await expect(processWidget).toContainText(ES_GADGET_TITLES.processMonitor);
+    await expect(processWidget).not.toContainText(/^PROCESS MONITOR$/m);
+    await expect(processWidget).not.toContainText(/^Process Monitor$/m);
+
+    const workflowWidget = page.getByTestId("workflow-status-widget");
+    await expect(workflowWidget).toBeVisible({ timeout: 30_000 });
+    await expect(workflowWidget).toContainText(ES_GADGET_TITLES.pagesByStatus);
+    await expect(workflowWidget).not.toContainText(/^PAGES BY STATUS$/m);
+
+    // License Monitor only if still shipped on this install / layout.
+    const licenseChrome = page.getByText(ES_GADGET_TITLES.licenseMonitor, {
+      exact: false,
+    });
+    const englishLicense = page.getByText("License Monitor", { exact: true });
+    if ((await licenseChrome.count()) > 0) {
+      await expect(licenseChrome.first()).toBeVisible();
+      await expect(englishLicense).toHaveCount(0);
+    } else if ((await englishLicense.count()) > 0) {
+      throw new Error(
+        "License Monitor is present but still English — expected Spanish title when shipped",
+      );
+    }
+    // else: not in default modern layout — skip (issue allows optional).
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/helpers/auth.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/auth.js
@@ -272,11 +272,24 @@ const SPANISH_LOCALE_CANDIDATES = ["es-es", "es", "es-mx"];
  * @param {string} password
  * @param {LoginOptions} [options]
  */
+/**
+ * Escape a locale/tag string for safe interpolation into {@code RegExp}.
+ * Locale tags are normally alphanumeric + hyphen, but callers may pass
+ * arbitrary strings; metacharacters must not change match semantics.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+function escapeRegExp(s) {
+  return String(s).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 async function fillLoginForm(page, username, password, options = {}) {
   const targetLocale = (options.locale || "en-us").trim() || "en-us";
   const modernRoot = page.locator('[data-testid="perc-login-root"]');
   const modernForm = page.locator('[data-testid="perc-login-form"]');
   const legacyUser = page.locator('input[name="j_username"]');
+  const legacyPassword = page.locator('input[name="j_password"]');
 
   // Prefer modern React login (#2065 H2 qa-up ships rxlogin → perc-login-root).
   if ((await modernRoot.count()) > 0 || (await modernForm.count()) > 0) {
@@ -299,13 +312,11 @@ async function fillLoginForm(page, username, password, options = {}) {
           await byTestId.click();
         } else {
           // Fallback: option text often looks like "es-es - español (España)".
+          const escaped = escapeRegExp(targetLocale);
           await page
             .locator('[role="option"]')
             .filter({
-              hasText: new RegExp(
-                `^${targetLocale}\\b|${targetLocale}\\s*-`,
-                "i",
-              ),
+              hasText: new RegExp(`^${escaped}\\b|${escaped}\\s*-`, "i"),
             })
             .first()
             .click();
@@ -318,8 +329,8 @@ async function fillLoginForm(page, username, password, options = {}) {
 
   // Legacy native form (select[name=j_locale]).
   await legacyUser.waitFor({ state: "visible", timeout: 30_000 });
-  await page.fill('input[name="j_username"]', username);
-  await page.fill('input[name="j_password"]', password);
+  await legacyUser.fill(username);
+  await legacyPassword.fill(password);
   const nativeLocale = page.locator('select[name="j_locale"]');
   if ((await nativeLocale.count()) > 0) {
     const values = await nativeLocale
@@ -340,9 +351,6 @@ async function fillLoginForm(page, username, password, options = {}) {
  * @param {string} locale
  */
 async function expectHiddenLocale(page, locale) {
-  const hidden = page.locator(
-    'input[type="hidden"][name="j_locale"], input[name="j_locale"]',
-  );
   // Soft wait: LocaleSelect updates the hidden input on option commit.
   await page
     .waitForFunction(
@@ -355,10 +363,21 @@ async function expectHiddenLocale(page, locale) {
       locale,
       { timeout: 5_000 },
     )
-    .catch(() => {
-      /* submit may still work if click selected the option */
+    .catch(async () => {
+      // Soft: submit may still work if the option click selected correctly
+      // but the hidden field lags. Surface a clear diagnostic for debugging.
+      const actual = await page
+        .locator(
+          'input[type="hidden"][name="j_locale"], input[name="j_locale"]',
+        )
+        .first()
+        .inputValue()
+        .catch(() => "(missing)");
+      // eslint-disable-next-line no-console -- Playwright helper diagnostic
+      console.warn(
+        `[auth] j_locale hidden input still "${actual}" after selecting "${locale}" (continuing)`,
+      );
     });
-  void hidden;
 }
 
 /**
@@ -452,10 +471,14 @@ async function pickSpanishLoginLocale(page) {
       if ((await opt.count()) > 0) {
         // Close list without selecting — caller logs in with the tag.
         await page.keyboard.press("Escape");
+        await list
+          .waitFor({ state: "hidden", timeout: 5_000 })
+          .catch(() => {});
         return tag;
       }
     }
     await page.keyboard.press("Escape");
+    await list.waitFor({ state: "hidden", timeout: 5_000 }).catch(() => {});
     return null;
   }
   const nativeLocale = page.locator('select[name="j_locale"]');

--- a/modules/perc-qa-automation/frontend/tests/helpers/auth.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/auth.js
@@ -251,6 +251,18 @@ function missingPasswordMessage(username) {
 }
 
 /**
+ * Preferred product Spanish locale tags, in order, for login smoke.
+ * Install may expose {@code es-es} without base {@code es} (and vice versa).
+ * TMX residual keys ship under {@code xml:lang="es"} and resolve for es-*.
+ */
+const SPANISH_LOCALE_CANDIDATES = ["es-es", "es", "es-mx"];
+
+/**
+ * @typedef {object} LoginOptions
+ * @property {string} [locale] target j_locale (e.g. {@code es-es}, {@code en-us})
+ */
+
+/**
  * Fill Admin/role credentials on either the modern React login (data-testid)
  * or the legacy JSP form (name= attributes). Locale defaults to en-us when
  * the modern LocaleSelect already posts a hidden j_locale.
@@ -258,8 +270,10 @@ function missingPasswordMessage(username) {
  * @param {import("@playwright/test").Page} page
  * @param {string} username
  * @param {string} password
+ * @param {LoginOptions} [options]
  */
-async function fillLoginForm(page, username, password) {
+async function fillLoginForm(page, username, password, options = {}) {
+  const targetLocale = (options.locale || "en-us").trim() || "en-us";
   const modernRoot = page.locator('[data-testid="perc-login-root"]');
   const modernForm = page.locator('[data-testid="perc-login-form"]');
   const legacyUser = page.locator('input[name="j_username"]');
@@ -270,19 +284,33 @@ async function fillLoginForm(page, username, password) {
     await page.locator('[data-testid="perc-login-username"]').fill(username);
     await page.locator('[data-testid="perc-login-password"]').fill(password);
     // LocaleSelect posts hidden input[name=j_locale]; default bootstrap is en-us.
-    // Only open the combobox when we must force a non-default locale.
+    // Open the combobox when the requested locale differs from the hidden value.
     const hiddenLocale = page.locator(
       'input[type="hidden"][name="j_locale"], input[name="j_locale"]',
     );
     if ((await hiddenLocale.count()) > 0) {
       const current = await hiddenLocale.first().inputValue().catch(() => "");
-      if (current && current !== "en-us") {
+      if (current !== targetLocale) {
         await page.locator('[data-testid="perc-login-locale"]').click();
-        await page
-          .locator('[role="option"]')
-          .filter({ hasText: /en-us|English \(United States\)/i })
-          .first()
-          .click();
+        const byTestId = page.getByTestId(
+          `perc-login-locale-option-${targetLocale}`,
+        );
+        if ((await byTestId.count()) > 0) {
+          await byTestId.click();
+        } else {
+          // Fallback: option text often looks like "es-es - español (España)".
+          await page
+            .locator('[role="option"]')
+            .filter({
+              hasText: new RegExp(
+                `^${targetLocale}\\b|${targetLocale}\\s*-`,
+                "i",
+              ),
+            })
+            .first()
+            .click();
+        }
+        await expectHiddenLocale(page, targetLocale);
       }
     }
     return { submit: page.locator('[data-testid="perc-login-submit"]') };
@@ -294,12 +322,52 @@ async function fillLoginForm(page, username, password) {
   await page.fill('input[name="j_password"]', password);
   const nativeLocale = page.locator('select[name="j_locale"]');
   if ((await nativeLocale.count()) > 0) {
-    await nativeLocale.selectOption("en-us");
+    const values = await nativeLocale
+      .locator("option")
+      .evaluateAll((opts) => opts.map((o) => o.value));
+    const pick = values.includes(targetLocale)
+      ? targetLocale
+      : values.find((v) => v === "en-us") || values[0];
+    if (pick) {
+      await nativeLocale.selectOption(pick);
+    }
   }
   return { submit: page.locator('button[type="submit"]') };
 }
 
-async function login(page, username, password) {
+/**
+ * @param {import("@playwright/test").Page} page
+ * @param {string} locale
+ */
+async function expectHiddenLocale(page, locale) {
+  const hidden = page.locator(
+    'input[type="hidden"][name="j_locale"], input[name="j_locale"]',
+  );
+  // Soft wait: LocaleSelect updates the hidden input on option commit.
+  await page
+    .waitForFunction(
+      (wanted) => {
+        const el = document.querySelector(
+          'input[type="hidden"][name="j_locale"], input[name="j_locale"]',
+        );
+        return el && /** @type {HTMLInputElement} */ (el).value === wanted;
+      },
+      locale,
+      { timeout: 5_000 },
+    )
+    .catch(() => {
+      /* submit may still work if click selected the option */
+    });
+  void hidden;
+}
+
+/**
+ * @param {import("@playwright/test").Page} page
+ * @param {string} username
+ * @param {string} password
+ * @param {LoginOptions} [options]
+ */
+async function login(page, username, password, options = {}) {
   if (!password) {
     throw new Error(missingPasswordMessage(username));
   }
@@ -307,7 +375,7 @@ async function login(page, username, password) {
   await page.goto(`${PERCUSSION_URL}/Rhythmyx/login`);
   // Wait for SPA mount or legacy form before filling.
   await page.waitForLoadState("domcontentloaded");
-  const { submit } = await fillLoginForm(page, username, password);
+  const { submit } = await fillLoginForm(page, username, password, options);
 
   // The CMS uses a multipart/form-data POST with OWASP-CSRFTOKEN. Modern
   // login may land at /cm/app/spa.jsp?entry=home; legacy lands at index.jsp.
@@ -338,16 +406,70 @@ async function login(page, username, password) {
   }
 }
 
-async function loginAsAdmin(page) {
-  await login(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+/**
+ * @param {import("@playwright/test").Page} page
+ * @param {LoginOptions} [options]
+ */
+async function loginAsAdmin(page, options = {}) {
+  await login(page, ADMIN_USERNAME, ADMIN_PASSWORD, options);
 }
 
-async function loginAsEditor(page) {
-  await login(page, USERNAME_EDITOR, EDITOR_PASSWORD);
+/**
+ * @param {import("@playwright/test").Page} page
+ * @param {LoginOptions} [options]
+ */
+async function loginAsEditor(page, options = {}) {
+  await login(page, USERNAME_EDITOR, EDITOR_PASSWORD, options);
 }
 
-async function loginAsContributor(page) {
-  await login(page, USERNAME_CONTRIBUTOR, CONTRIBUTOR_PASSWORD);
+/**
+ * @param {import("@playwright/test").Page} page
+ * @param {LoginOptions} [options]
+ */
+async function loginAsContributor(page, options = {}) {
+  await login(page, USERNAME_CONTRIBUTOR, CONTRIBUTOR_PASSWORD, options);
+}
+
+/**
+ * Pick the first Spanish locale tag present on the modern login dropdown.
+ * Returns null when no Spanish option is exposed (install without es*).
+ *
+ * @param {import("@playwright/test").Page} page
+ * @returns {Promise<string|null>}
+ */
+async function pickSpanishLoginLocale(page) {
+  await page.goto(`${PERCUSSION_URL}/Rhythmyx/login`);
+  await page.waitForLoadState("domcontentloaded");
+  const modernRoot = page.locator('[data-testid="perc-login-root"]');
+  const modernForm = page.locator('[data-testid="perc-login-form"]');
+  if ((await modernRoot.count()) > 0 || (await modernForm.count()) > 0) {
+    await modernForm.or(modernRoot).first().waitFor({ state: "visible", timeout: 30_000 });
+    await page.locator('[data-testid="perc-login-locale"]').click();
+    const list = page.getByTestId("perc-login-locale-list");
+    await list.waitFor({ state: "visible", timeout: 10_000 });
+    for (const tag of SPANISH_LOCALE_CANDIDATES) {
+      const opt = page.getByTestId(`perc-login-locale-option-${tag}`);
+      if ((await opt.count()) > 0) {
+        // Close list without selecting — caller logs in with the tag.
+        await page.keyboard.press("Escape");
+        return tag;
+      }
+    }
+    await page.keyboard.press("Escape");
+    return null;
+  }
+  const nativeLocale = page.locator('select[name="j_locale"]');
+  if ((await nativeLocale.count()) > 0) {
+    const values = await nativeLocale
+      .locator("option")
+      .evaluateAll((opts) => opts.map((o) => o.value));
+    for (const tag of SPANISH_LOCALE_CANDIDATES) {
+      if (values.includes(tag)) {
+        return tag;
+      }
+    }
+  }
+  return null;
 }
 
 /**
@@ -388,9 +510,11 @@ module.exports = {
   ADMIN_PASSWORD,
   EDITOR_PASSWORD,
   CONTRIBUTOR_PASSWORD,
+  SPANISH_LOCALE_CANDIDATES,
   loginAsAdmin,
   loginAsEditor,
   loginAsContributor,
+  pickSpanishLoginLocale,
   basicAuthHeaders,
   adminBasicAuthHeaders,
   // Re-export pure helpers for specs / tests that want the same precedence.


### PR DESCRIPTION
## Summary

Parent tracker: **#961** (Spanish residual UI — Finder roots + default gadgets).

Live Playwright smoke residual after:
- TMX residual **#2092** (perc.ui.finder.root@* + default gadget titles)
- Finder display wiring **#2105** (percFinderRootDisplay)
- H2 qa-up golden path **#2065** / **#1827**

### What this adds
- `loginAsAdmin(page, { locale })` + `pickSpanishLoginLocale` (prefer `es-es`, then `es` / `es-mx`)
- Spec `tests/bugs/bug-2094-spanish-locale-finder-dashboard.spec.js` `@smoke @i18n`:
  1. **Finder roots** — session TMX resolves Sitios / Activos / Diseño / Buscar / Reciclaje; path identity stays English (`tree-node-/Sites…`); classic `percFinderRootDisplay` / `.perc-finder-item-name` when present
  2. **Default gadgets** — Welcome (BIENVENIDO), Process Monitor (MONITOREO DE PROCESO), Pages By Status (PÁGINAS POR ESTADO); License Monitor only if still on layout

Does **not** expand full #961 product string audit. Does **not** re-wire modern Content Explorer tree labels (API `folder.name` remains English path names by design of #2105 display-only classic Finder).

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2094  
Refs #961

## Test plan

- [x] Live green against H2 matrix CMS (`TEST_CMS_URL=http://127.0.0.1:9993`, freeport map 9993→9992):
  `
  npm run test:surface -- --path tests/bugs/bug-2094-spanish-locale-finder-dashboard.spec.js
  → 2 passed (4.5s)
  `
- [x] `npm run test:unit` → 48 passed
- [x] `npm run test:surface:list -- --path tests/bugs/bug-2094-spanish-locale-finder-dashboard.spec.js` → 2 tests
- [x] `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → BUILD SUCCESS
- [x] Erlang self-review approve — `docs/ai-generated/code-reviews/issue-2094-spanish-locale-playwright-smoke-erlang.md`

### Failure artifacts (on fail)
`modules/perc-qa-automation/frontend/test-results/` and `playwright-report/` (runbook: `docs/developer-module/playwright-failure-artifacts.md`)

## Gates evidence

| Gate | Result |
|------|--------|
| Implementation + behavioral smoke | yes (live 2/2) |
| Erlang self-review | approve |
| Module standalone clean install | BUILD SUCCESS |
| Surface filter conventions (#2064/#2065) | test:surface path |
| No force-push / no merge | yes |

> Co-Authored by Grok Build using grok-4.5 with agent main.