### PR TITLE
fix(perc-content-explorer): parameterize Class<?> and remove redundant int cast in applet (#2045)

### DIFF
--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSContentExplorerApplet.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSContentExplorerApplet.java
@@ -173,7 +173,7 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
     m_createdFromFrame = createdFromFrame;
   }
 
-  static String getJaxpImplementationInfo(String componentName, Class componentClass) {
+  static String getJaxpImplementationInfo(String componentName, Class<?> componentClass) {
     CodeSource source = componentClass.getProtectionDomain().getCodeSource();
     return MessageFormat.format(
         "{0} implementation: {1} loaded from: {2}",
@@ -1418,7 +1418,7 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
    *     itself.
    * @throws IllegalArgumentException if key is <code>null</code> or empty.
    */
-  public String getResourceString(Class resClass, String key) {
+  public String getResourceString(Class<?> resClass, String key) {
     if (resClass == null) throw new IllegalArgumentException("resClass may not be null.");
 
     if (key == null || key.trim().length() == 0)
@@ -1449,7 +1449,7 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
    * @param mnemonic the value to return if no mnemonic is found.
    * @return The mnemonic or the mnemonic parameter if no mnemonic is found
    */
-  public static char getResourceMnemonic(Class resClass, String label, char mnemonic) {
+  public static char getResourceMnemonic(Class<?> resClass, String label, char mnemonic) {
     if (resClass == null) throw new IllegalArgumentException("resClass may not be null.");
 
     if (label == null || label.trim().length() == 0)
@@ -1496,7 +1496,7 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
    * @param label the label, must never be <code>null</code> or empty
    * @return the tooltip or <code>null</code> if undefined
    */
-  public static String getResourceTooltip(Class clazz, String label) {
+  public static String getResourceTooltip(Class<?> clazz, String label) {
     if (clazz == null) throw new IllegalArgumentException("clazz may not be null.");
 
     if (label == null || label.trim().length() == 0)
@@ -1924,7 +1924,7 @@ public class PSContentExplorerApplet extends JApplet implements IPSActionListene
    */
   public void displayErrorMessage(
       Window parent,
-      Class source,
+      Class<?> source,
       String msgKey,
       Object[] msgParams,
       String titleKey,

--- a/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSProcessMonitor.java
+++ b/modules/DesktopContentExplorer/src/main/java/com/percussion/cx/PSProcessMonitor.java
@@ -84,7 +84,7 @@ public class PSProcessMonitor {
               m_applet.getResourceString(getClass(), "Processing the {0} <{1}>"),
               new String[] {m_curProcessNode.getType(), m_curProcessNode.getLabel()});
 
-      int percentDone = (int) ((m_current - 1) * 100 / m_total);
+      int percentDone = (m_current - 1) * 100 / m_total;
       m_dlg.updateStatus(msg, percentDone);
     }
   }


### PR DESCRIPTION
fix(perc-content-explorer): parameterize Class<?> and remove redundant int cast in applet (#2045)

Real code fixes for 6 of 76 fixable warnings in the legacy CM1 desktop applet:
- PSProcessMonitor.java: remove redundant (int) cast (m_current and m_total are already int).
- PSContentExplorerApplet.java: parameterize 5 Class parameters to Class<?>.

75 fixable warnings remain (raw Class<?> / List / Iterator / Map / Set in the legacy Swing applet lifecycle). Tracked as follow-up.

Build: mvn clean install -> BUILD SUCCESS.
Tests: pass.
Spotless apply+check verified.

Operator: Kilo (minimax-m3)