### PR TITLE
test(qa): verify Explorer encodePath live + non-empty tree (#1695)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-1695-explorer-encodepath-verify-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-1695-explorer-encodepath-verify-erlang.md
@@ -1,0 +1,60 @@
+# Erlang review — issue #1695 explorer encodePath verify (Playwright)
+
+**Branch:** `fix/issue-1695-explorer-encodepath-verify`  
+**Date:** 2026-08-06  
+**Reviewer persona:** Erlang (strict gate)  
+**Scope:** `modules/perc-qa-automation/frontend` only (verify PR; no product churn)
+
+## Summary
+
+Thin verification residual after encodePath (#1680) and formatApiError (#1691). Extends `bug-1622-explorer-root-folders` with REST root-name checks, SPA network capture (no `folder//`), human-readable tree error assertion, and pure helpers + Node unit tests.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs in new logic | none |
+| Behavioral unit tests for new helpers | yes (`tests/unit/pathmanagement-url.test.js`) |
+| Cross-platform path/file I/O | n/a — pure URL string helpers; no filesystem I/O |
+| Module standalone clean install | `modules/perc-qa-automation` `mvnw clean install` green |
+| Live evidence | H2 qa-up `TEST_CMS_URL=http://127.0.0.1:9993` — 2 Playwright + unit suite green |
+
+**May commit/push: yes**
+
+## Scope (files)
+
+| Path | Change |
+|------|--------|
+| `modules/perc-qa-automation/frontend/tests/bugs/bug-1622-explorer-root-folders.spec.js` | extend REST + UI network / roots / error readability |
+| `modules/perc-qa-automation/frontend/tests/helpers/pathmanagement-url.js` | pure double-slash + human-error helpers |
+| `modules/perc-qa-automation/frontend/tests/unit/pathmanagement-url.test.js` | Node unit coverage |
+| `modules/perc-qa-automation/frontend/package.json` | include unit file in `test:unit` |
+
+## Issues
+
+None (bug/suggestion).
+
+### Nits
+
+- **nit** — UI root-node match is slightly loose (testid substring). Acceptable for stock CMS paths; REST already hard-asserts names.
+
+## Cross-platform path review
+
+No file I/O or OS path joins in this diff. Regexes operate on URL strings with `/` separators (HTTP URLs), which is correct and portable.
+
+## Live run evidence (agent)
+
+```
+TEST_CMS_URL=http://127.0.0.1:9993 ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from docker>
+npx playwright test tests/bugs/bug-1622-explorer-root-folders.spec.js
+→ 2 passed (~1.9s)
+
+npm run test:unit → 55 pass (includes pathmanagement-url)
+```
+
+REST root children observed: Sites, Assets, Design, Search, Recycling.  
+`folder//Sites` → 400; SPA requests used single-slash `folder/` / `folder/Sites`.

--- a/modules/perc-qa-automation/frontend/package.json
+++ b/modules/perc-qa-automation/frontend/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "test": "playwright test",
-    "test:unit": "node --test tests/unit/resolve-cms-env.test.js tests/unit/surface-filter.test.js",
+    "test:unit": "node --test tests/unit/resolve-cms-env.test.js tests/unit/surface-filter.test.js tests/unit/pathmanagement-url.test.js",
     "test:list": "playwright test --list",
     "test:golden": "playwright test tests/golden-unattended-smoke.spec.js",
     "test:surface": "node scripts/run-surface.js",

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-1622-explorer-root-folders.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-1622-explorer-root-folders.spec.js
@@ -22,19 +22,23 @@
  * {@code folder//Sites} which the pathmanagement service rejects with
  * HTTP 400. The React tree then rendered with no children.</p>
  *
- * <p>Coverage:</p>
+ * <p>Coverage (issue #1695 / parent #1690):</p>
  * <ul>
  *   <li>REST: root {@code path/folder/} returns 200 with well-known roots</li>
- *   <li>REST: double-slash {@code path/folder//Sites} must not be the
- *       client contract (assert correct Sites URL works)</li>
- *   <li>UI: explorer tree is non-empty after shell mount (requires WebUI
- *       with encodePath fix deployed to the CMS install)</li>
+ *   <li>REST: double-slash {@code path/folder//Sites} is rejected (400) —
+ *       the SPA must not emit this shape</li>
+ *   <li>UI: explorer tree is non-empty after shell mount</li>
+ *   <li>UI network: SPA pathmanagement requests never use {@code folder//}</li>
+ *   <li>UI: if load fails, error chrome is human-readable (not
+ *       {@code [object Object]} — formatApiError #1691)</li>
  * </ul>
  *
- * <p>Run against a live CMS (e.g. {@code C:\Installs\8.2-july-29} or docker):</p>
+ * <p>Run against H2 qa-up or a host install with current WebUI (#1680):</p>
  * <pre>
  *   cd modules/perc-qa-automation/frontend
- *   npm test -- tests/bugs/bug-1622-explorer-root-folders.spec.js
+ *   TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \\
+ *     ADMIN_USERNAME=Admin ADMIN_PASSWORD=... \\
+ *     npm test -- tests/bugs/bug-1622-explorer-root-folders.spec.js
  * </pre>
  */
 
@@ -44,6 +48,11 @@ const {
   BASE_URL,
   adminBasicAuthHeaders,
 } = require("../helpers/auth");
+const {
+  isDoubleSlashPathmanagementUrl,
+  isHumanReadableErrorText,
+  EXPECTED_ROOT_FOLDER_NAMES,
+} = require("../helpers/pathmanagement-url");
 
 const EXPLORER_URL = `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${Date.now()}`;
 const PATH_FOLDER = `${BASE_URL}/Rhythmyx/services/pathmanagement/path/folder`;
@@ -60,6 +69,20 @@ test.describe("GH-1622 explorer root folders (encodePath / no double-slash)", ()
       `GET ${PATH_FOLDER}/ should be 200 (double-slash form is 400)`,
     ).toBe(200);
 
+    const body = await root.json();
+    const items = Array.isArray(body?.PathItem)
+      ? body.PathItem
+      : Array.isArray(body)
+        ? body
+        : [];
+    const names = items.map((it) => it?.name).filter(Boolean);
+    for (const expected of EXPECTED_ROOT_FOLDER_NAMES) {
+      expect(
+        names,
+        `root folder list should include ${expected}; got [${names.join(", ")}]`,
+      ).toContain(expected);
+    }
+
     const sites = await request.get(`${PATH_FOLDER}/Sites`, { headers });
     // Sites may be empty on a fresh install, but the path must be valid.
     expect(
@@ -72,13 +95,25 @@ test.describe("GH-1622 explorer root folders (encodePath / no double-slash)", ()
     expect(bad.status()).toBe(400);
   });
 
-  test("UI: Content Explorer tree is not empty at root", async ({ page }) => {
-    test.setTimeout(60_000);
+  test("UI: Content Explorer tree is not empty at root (no folder// network)", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
     await loginAsAdmin(page);
+
+    /** @type {string[]} */
+    const pathFolderRequests = [];
+    page.on("request", (req) => {
+      const url = req.url();
+      if (url.includes("/pathmanagement/path/")) {
+        pathFolderRequests.push(url);
+      }
+    });
+
     await page.goto(EXPLORER_URL, { waitUntil: "networkidle" });
 
     const shell = page.locator('[data-testid="content-explorer-shell"]');
-    await expect(shell).toBeVisible({ timeout: 15_000 });
+    await expect(shell).toBeVisible({ timeout: 20_000 });
 
     const tree = page.locator('[data-testid="explorer-tree"]');
     await expect(tree).toBeVisible({ timeout: 15_000 });
@@ -90,6 +125,11 @@ test.describe("GH-1622 explorer root folders (encodePath / no double-slash)", ()
     );
     if ((await treeErr.count()) > 0 && (await treeErr.first().isVisible())) {
       const text = await treeErr.first().innerText();
+      // #1691: formatApiError must yield a human string, not [object Object].
+      expect(
+        isHumanReadableErrorText(text),
+        `Explorer tree error must be human-readable, got: ${JSON.stringify(text)}`,
+      ).toBe(true);
       throw new Error(
         `Explorer tree failed to load: ${text}. If the network URL was path/folder//, redeploy WebUI with encodePath fix (#1680).`,
       );
@@ -97,8 +137,50 @@ test.describe("GH-1622 explorer root folders (encodePath / no double-slash)", ()
 
     // Root children render as tree-node-* rows (paths like /Sites/, /Assets/).
     const nodes = tree.locator('[data-testid^="tree-node-"]');
-    await expect(nodes.first()).toBeVisible({ timeout: 15_000 });
+    await expect(nodes.first()).toBeVisible({ timeout: 20_000 });
     const count = await nodes.count();
     expect(count, "explorer tree should list root folders").toBeGreaterThan(0);
+
+    // Prefer well-known roots when present (stock CMS).
+    const nodeTestIds = await nodes.evaluateAll((els) =>
+      els.map((el) => el.getAttribute("data-testid") || ""),
+    );
+    const joined = nodeTestIds.join(" ");
+    for (const expected of EXPECTED_ROOT_FOLDER_NAMES) {
+      const hasRoot =
+        joined.includes(`tree-node-/${expected}/`) ||
+        joined.includes(`tree-node-/${expected}`) ||
+        nodeTestIds.some((id) =>
+          id.toLowerCase().includes(expected.toLowerCase()),
+        );
+      expect(
+        hasRoot,
+        `expected root node for ${expected}; testids=${JSON.stringify(nodeTestIds)}`,
+      ).toBe(true);
+    }
+
+    // Network contract: SPA must never call pathmanagement with // after resource.
+    const doubleSlash = pathFolderRequests.filter(
+      isDoubleSlashPathmanagementUrl,
+    );
+    expect(
+      doubleSlash,
+      `SPA must not request double-slash pathmanagement URLs (encodePath #1680). Seen: ${JSON.stringify(pathFolderRequests)}`,
+    ).toEqual([]);
+
+    // At least one root folder/ request should have been issued (encodePath → folder/).
+    const folderGets = pathFolderRequests.filter((u) =>
+      /\/pathmanagement\/path\/folder(\/|$|\?)/.test(u),
+    );
+    expect(
+      folderGets.length,
+      `expected SPA to call path/folder…; captured=${JSON.stringify(pathFolderRequests)}`,
+    ).toBeGreaterThan(0);
+    for (const u of folderGets) {
+      expect(u, `folder URL must not contain folder//: ${u}`).not.toContain(
+        "folder//",
+      );
+    }
   });
 });
+

--- a/modules/perc-qa-automation/frontend/tests/helpers/pathmanagement-url.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/pathmanagement-url.js
@@ -1,0 +1,54 @@
+/**
+ * Pure helpers for pathmanagement URL / explorer error assertions.
+ *
+ * Used by Playwright bug-1622 (encodePath / folder// regression) and covered
+ * by Node unit tests under tests/unit/ (no live CMS).
+ *
+ * @see tests/bugs/bug-1622-explorer-root-folders.spec.js
+ * @see WebUI pathApi encodePath / joinPathUrl (#1680)
+ */
+
+"use strict";
+
+/**
+ * True when a pathmanagement URL uses the double-slash form that causes HTTP
+ * 400 (encodePath regression): folder//, paginatedFolder//, item//, etc.
+ *
+ * @param {string | null | undefined} url
+ * @returns {boolean}
+ */
+function isDoubleSlashPathmanagementUrl(url) {
+  if (!url || typeof url !== "string") {
+    return false;
+  }
+  // Match …/pathmanagement/path/<resource>//… (resource may have query after).
+  return /\/pathmanagement\/path\/[^/?#]+\/\//.test(url);
+}
+
+/**
+ * True when explorer tree error chrome text is human-readable (not empty and
+ * not bare object coercion from formatApiError regression).
+ *
+ * @param {string | null | undefined} text
+ * @returns {boolean}
+ */
+function isHumanReadableErrorText(text) {
+  const t = String(text || "").trim();
+  if (!t) {
+    return false;
+  }
+  // formatApiError (#1691) must never leave bare object coercion.
+  if (/\[object\s+Object\]/i.test(t)) {
+    return false;
+  }
+  return t.length >= 3;
+}
+
+/** Well-known CMS root folders returned by path/folder/ on a stock install. */
+const EXPECTED_ROOT_FOLDER_NAMES = Object.freeze(["Sites", "Assets", "Design"]);
+
+module.exports = {
+  isDoubleSlashPathmanagementUrl,
+  isHumanReadableErrorText,
+  EXPECTED_ROOT_FOLDER_NAMES,
+};

--- a/modules/perc-qa-automation/frontend/tests/unit/pathmanagement-url.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/pathmanagement-url.test.js
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for pathmanagement URL / explorer error helpers (no live CMS).
+ *
+ * Run: npm run test:unit (from frontend/)
+ */
+
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  isDoubleSlashPathmanagementUrl,
+  isHumanReadableErrorText,
+  EXPECTED_ROOT_FOLDER_NAMES,
+} = require("../helpers/pathmanagement-url");
+
+describe("isDoubleSlashPathmanagementUrl", () => {
+  it("detects folder// and folder//Sites (encodePath regression)", () => {
+    assert.equal(
+      isDoubleSlashPathmanagementUrl(
+        "http://localhost:9993/Rhythmyx/services/pathmanagement/path/folder//",
+      ),
+      true,
+    );
+    assert.equal(
+      isDoubleSlashPathmanagementUrl(
+        "http://x/Rhythmyx/services/pathmanagement/path/folder//Sites",
+      ),
+      true,
+    );
+  });
+
+  it("detects double slash on other path resources", () => {
+    assert.equal(
+      isDoubleSlashPathmanagementUrl(
+        "http://x/Rhythmyx/services/pathmanagement/path/paginatedFolder//Sites",
+      ),
+      true,
+    );
+    assert.equal(
+      isDoubleSlashPathmanagementUrl(
+        "http://x/Rhythmyx/services/pathmanagement/path/item//Sites/Foo",
+      ),
+      true,
+    );
+  });
+
+  it("accepts correct single-slash folder URLs", () => {
+    assert.equal(
+      isDoubleSlashPathmanagementUrl(
+        "http://x/Rhythmyx/services/pathmanagement/path/folder/",
+      ),
+      false,
+    );
+    assert.equal(
+      isDoubleSlashPathmanagementUrl(
+        "http://x/Rhythmyx/services/pathmanagement/path/folder/Sites",
+      ),
+      false,
+    );
+    assert.equal(
+      isDoubleSlashPathmanagementUrl(
+        "http://x/Rhythmyx/services/pathmanagement/path/folder/Sites/Foo%20Bar?x=1",
+      ),
+      false,
+    );
+  });
+
+  it("rejects non-strings and unrelated URLs", () => {
+    assert.equal(isDoubleSlashPathmanagementUrl(null), false);
+    assert.equal(isDoubleSlashPathmanagementUrl(undefined), false);
+    assert.equal(isDoubleSlashPathmanagementUrl(""), false);
+    assert.equal(
+      isDoubleSlashPathmanagementUrl("http://x/other//double"),
+      false,
+    );
+  });
+});
+
+describe("isHumanReadableErrorText", () => {
+  it("accepts normal error messages", () => {
+    assert.equal(
+      isHumanReadableErrorText("Failed to load folders: Invalid path"),
+      true,
+    );
+    assert.equal(isHumanReadableErrorText("server down"), true);
+  });
+
+  it("rejects empty and [object Object] (formatApiError regression)", () => {
+    assert.equal(isHumanReadableErrorText(""), false);
+    assert.equal(isHumanReadableErrorText("   "), false);
+    assert.equal(isHumanReadableErrorText(null), false);
+    assert.equal(
+      isHumanReadableErrorText("Failed to load folders: [object Object]"),
+      false,
+    );
+    assert.equal(isHumanReadableErrorText("[object Object]"), false);
+  });
+});
+
+describe("EXPECTED_ROOT_FOLDER_NAMES", () => {
+  it("includes Sites, Assets, Design", () => {
+    assert.ok(EXPECTED_ROOT_FOLDER_NAMES.includes("Sites"));
+    assert.ok(EXPECTED_ROOT_FOLDER_NAMES.includes("Assets"));
+    assert.ok(EXPECTED_ROOT_FOLDER_NAMES.includes("Design"));
+  });
+});


### PR DESCRIPTION
## Summary

Verification residual for Explorer **encodePath** after #1680 / #1691 (parent **#1690**). Prefer green verify PR over product churn — no WebUI changes required.

Against **H2 qa-up** (perc-matrix-cms-h2 → host `http://127.0.0.1:9993`):

| Check | Result |
|-------|--------|
| REST `GET …/path/folder/` | **200** with Sites, Assets, Design, Search, Recycling |
| REST `GET …/path/folder/Sites` | **200** (not double-slash form) |
| REST `GET …/path/folder//Sites` | **400** (server contract SPA must avoid) |
| SPA tree non-empty | **pass** — root nodes Sites/Assets/Design visible |
| SPA network | **no** `path/folder//` requests captured |
| Tree error human-readable | asserted if chrome shows (formatApiError #1691) |

## Changes

- Extend `modules/perc-qa-automation/frontend/tests/bugs/bug-1622-explorer-root-folders.spec.js`
  - REST asserts well-known root names
  - UI captures pathmanagement requests; fails on double-slash
  - Root `data-testid` includes Sites/Assets/Design
  - Human-readable error gate if load fails
- Pure helpers `tests/helpers/pathmanagement-url.js` + Node unit tests
- Erlang report: `docs/ai-generated/code-reviews/issue-1695-explorer-encodepath-verify-erlang.md`

**No product fix** — encodePath already live in H2 WebUI image.

## Test plan / gates evidence

```bash
cd modules/perc-qa-automation/frontend
npm run test:unit
# 55 pass (includes pathmanagement-url)

TEST_CMS_URL=http://127.0.0.1:9993 ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from qa-up/docker> \
  npx playwright test tests/bugs/bug-1622-explorer-root-folders.spec.js
# 2 passed (~1.9s)

cd modules/perc-qa-automation && ../../mvnw clean install
# green (standalone)
```

- Erlang self-review: **approve** (see code-reviews report)
- Operator: Grok: night-issue-prs (model grok-4.5)

## Fixes

Fixes #1695  
Refs #1690  
Related: #1680 (encodePath fix), #1691 (formatApiError + harness)