### PR TITLE
feat(2083): live Oracle matrix RESULT:OK + Easy Connect / unwrap fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,12 +126,14 @@ services:
       timeout: 5s
       retries: 10
 
-  # Oracle XE for matrix install smoke (#1508 / parent #1500).
+  # Oracle XE for matrix install smoke (#1508 / live residual #2083 / parent #1500).
   # Image: gvenzl/oracle-xe (community Oracle XE packaging). Heavy RAM/disk and
   # slow first start; opt-in profile only (not part of default up).
+  # Observed pull digest (pin optionally): sha256:ecdf4302ac3d134e1bac5ef6e0c223c2d0f4d4d2b6d551aa79b2346f1ab8f792
   # Cells reach the DB via Docker DNS alias ``oracle:1521`` on perc-matrix-net.
-  # Installer uses --db.name as service name (default XEPDB1) and APP_USER as schema.
-  # See docker/README.md § Oracle compose profile. Credentials from .env.compose only.
+  # Installer uses --db.name as Easy Connect service name (default XEPDB1; not SID)
+  # and APP_USER as schema. See docker/README.md § Oracle compose profile.
+  # Credentials from .env.compose only.
   oracle:
     image: gvenzl/oracle-xe:21-slim
     container_name: percussion-oracle

--- a/docker/README.md
+++ b/docker/README.md
@@ -310,33 +310,36 @@ python3 docker/scripts/matrix-install-smoke.py --product cms --db h2 --dry-run -
 python3 docker/scripts/matrix-install-smoke.py --product cms --db oracle --dry-run --skip-image-build
 ```
 
-### Oracle compose profile (#1508)
+### Oracle compose profile (#1508 / live residual #2083)
 
 Opt-in Oracle XE for matrix Layer-1 only (not started by default `perc-devctl.py up`).
 
 |              Item              |                                                                                                    Value                                                                                                     |
 |--------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Image**                      | `gvenzl/oracle-xe:21-slim` (community packaging of Oracle Database XE). Accept Oracle Free Use Terms when pulling; operators may pin a company-approved mirror by changing `image:` in `docker-compose.yml`. |
+| **Image pin (observed)**       | Digest `sha256:ecdf4302ac3d134e1bac5ef6e0c223c2d0f4d4d2b6d551aa79b2346f1ab8f792` (~2.6 GiB compressed layers on pull). Tag may move; pin by digest for locked operator envs. |
 | **Compose profiles**           | `oracle`, and `db-all` (starts all external matrix DBs)                                                                                                                                                      |
 | **Container name**             | `percussion-oracle`                                                                                                                                                                                          |
 | **Network alias**              | `oracle` on `perc-matrix-net` (cells use `DB_HOST=oracle`)                                                                                                                                                   |
 | **Container port**             | `1521` (fixed)                                                                                                                                                                                               |
 | **Host publish**               | `${ORACLE_PORT:-1521}:1521` (freeport / env when 1521 is taken)                                                                                                                                              |
-| **Service name (`--db.name`)** | `XEPDB1` (default pluggable DB; override with `ORACLE_SERVICE`)                                                                                                                                              |
+| **Service name (`--db.name`)** | `XEPDB1` (default pluggable DB service name; override with `ORACLE_SERVICE`). **Not** a SID — structured install uses Easy Connect `@//host:port/XEPDB1`.                                                    |
 | **CMS user / schema**          | `APP_USER` / `ORACLE_APP_USER` (default `percuser`); password `ORACLE_APP_PASSWORD`                                                                                                                          |
 | **SYS bootstrap**              | `ORACLE_PASSWORD` (required by the image; **not** the CMS connect password)                                                                                                                                  |
 | **SSL**                        | Off for compose cells (`--db.ssl.enabled=false`), same as postgres/mysql/sqlserver                                                                                                                           |
-| **Resources**                  | Large image, high RAM, slow first healthcheck (`start_period` 120s). Prefer dedicated machine / long probe timeout for live smoke.                                                                           |
+| **Resources**                  | Image ~2.6 GiB; container often ≥2 GiB RAM once open; first volume init can take minutes. Docker Desktop should leave headroom for the CMS matrix cell (recommend ≥8 GiB Docker memory for this cell alone). |
+| **Start / wait**               | Compose healthcheck `start_period` 120s, retries 20×30s. Harness waits up to **600s** for `healthy` before `docker run` cell; cell `WAIT_DB_SECONDS=600`. Use `--probe-timeout 1800` for login probe.        |
+| **Image notice**               | Container logs may say `gvenzl/oracle-xe` is legacy and suggest `gvenzl/oracle-free`; matrix still pins `oracle-xe:21-slim` until an intentional image migration.                                           |
 
 ```bash
 # Start Oracle only (after .env.compose has ORACLE_* set)
 docker compose --env-file .env.compose --profile oracle up -d oracle
 
-# Matrix harness (starts profile, network-connects alias, install cell)
+# Matrix harness (starts profile, waits healthy, network-connects alias, install cell)
 python3 docker/scripts/matrix-install-smoke.py --product cms --db oracle --probe-timeout 1800
 ```
 
-**Live smoke residual:** compose + harness + unit tests land in this slice. Unattended `RESULT:OK` against a real Oracle container (image pull, license, long first start, full install probe) is **not** required for the first PR — track as residual follow-up on #1508 / parent #1500.
+**Live smoke (#2083):** unattended `RESULT:OK` requires the installer Easy Connect service form for `XEPDB1` (SID form `@host:port:XEPDB1` yields ORA-12505). Classic pure-SID operators can still set `DB_SERVER=@host:port:SID` via `-Ddbprops`.
 
 ### External DB teardown policy (#1516)
 

--- a/docker/scripts/matrix-install-smoke.py
+++ b/docker/scripts/matrix-install-smoke.py
@@ -176,8 +176,10 @@ _DB_SERVICE_BASE: Dict[str, Dict[str, str]] = {
         "password_env": "MSSQL_SA_PASSWORD",
         "name": "percdb",
     },
-    # Oracle XE (gvenzl/oracle-xe): --db.name is service/SID (XEPDB1);
-    # APP_USER is CMS user/schema. Password from ORACLE_APP_PASSWORD.
+    # Oracle XE (gvenzl/oracle-xe): --db.name is service name XEPDB1 (Easy Connect
+    # service form; not a SID). APP_USER is CMS user/schema. Password from
+    # ORACLE_APP_PASSWORD. Long first-start — wait_for_container_healthy +
+    # WAIT_DB_SECONDS in the cell.
     "oracle": {
         "profile": "oracle",
         "service": "oracle",
@@ -188,6 +190,10 @@ _DB_SERVICE_BASE: Dict[str, Dict[str, str]] = {
         "password_env": "ORACLE_APP_PASSWORD",
         "name": "XEPDB1",
         "schema": "percuser",
+        # Host-side compose health wait (seconds) before docker run cell.
+        "healthy_timeout": "600",
+        # Cell-side TCP wait after network attach (seconds).
+        "wait_db_seconds": "600",
     },
 }
 
@@ -615,6 +621,9 @@ def build_docker_run_argv(
         schema = db_meta.get("schema", "")
         if schema:
             argv.extend(["-e", f"DB_SCHEMA={schema}"])
+        wait_db = (db_meta.get("wait_db_seconds") or "").strip()
+        if wait_db:
+            argv.extend(["-e", f"WAIT_DB_SECONDS={wait_db}"])
     argv.append(image)
     return argv
 
@@ -743,7 +752,88 @@ def start_db(
         dry_run=dry_run,
         check=False,
     )
+    # Heavy DBs (Oracle XE) may report TCP open before PDB/APP_USER is ready.
+    # Wait for compose healthcheck when the service defines one.
+    healthy_timeout_raw = meta.get("healthy_timeout") or ""
+    if healthy_timeout_raw.strip():
+        try:
+            healthy_timeout = int(healthy_timeout_raw)
+        except ValueError:
+            healthy_timeout = 0
+        if healthy_timeout > 0:
+            if not wait_for_container_healthy(
+                container, healthy_timeout, dry_run=dry_run
+            ):
+                raise RuntimeError(
+                    f"Timed out waiting for healthy status on {container} "
+                    f"after {healthy_timeout}s (db_type={db_type})"
+                )
     return started_by_matrix
+
+
+def wait_for_container_healthy(
+    container: str,
+    timeout_seconds: int,
+    *,
+    dry_run: bool,
+    interval_seconds: float = 5.0,
+) -> bool:
+    """Wait until ``docker inspect`` reports Health.Status == healthy.
+
+    Containers without a healthcheck (Status empty / none) are treated as ready
+    once they are running, so other compose DB profiles stay non-blocking.
+    """
+    if dry_run:
+        LOG.info("DRY-RUN: wait for healthy %s (%ss)", container, timeout_seconds)
+        return True
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        try:
+            proc = subprocess.run(
+                [
+                    "docker",
+                    "inspect",
+                    "--format",
+                    "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}|{{.State.Status}}",
+                    container,
+                ],
+                shell=False,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            raw = (proc.stdout or "").strip()
+            health, _, status = raw.partition("|")
+            health = health.strip().lower()
+            status = status.strip().lower()
+            if health == "healthy":
+                LOG.info("Container %s is healthy", container)
+                return True
+            if health in ("", "none") and status == "running":
+                LOG.info(
+                    "Container %s is running (no healthcheck); treating as ready",
+                    container,
+                )
+                return True
+            if status in ("exited", "dead", "removing"):
+                LOG.error("Container %s is %s (health=%s)", container, status, health)
+                return False
+            LOG.info(
+                "Waiting for %s healthy (health=%s status=%s)",
+                container,
+                health or "?",
+                status or "?",
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            LOG.debug("wait_for_container_healthy %s: %s", container, exc)
+        time.sleep(interval_seconds)
+    LOG.error(
+        "Timed out waiting for healthy status on %s after %ss",
+        container,
+        timeout_seconds,
+    )
+    return False
 
 
 def stop_external_dbs(
@@ -901,14 +991,27 @@ def run_cell(
     LOG.info("Cell %s using jar %s (%s bytes)", cell.cell_id, jar, jar.stat().st_size if jar.is_file() else 0)
 
     destroy_container(name, dry_run=dry_run)
-    ownership = start_db(
-        repo_root,
-        compose_file,
-        cell.db_type,
-        dry_run=dry_run,
-        db_services=db_services,
-        env_file=env_file,
-    )
+    try:
+        ownership = start_db(
+            repo_root,
+            compose_file,
+            cell.db_type,
+            dry_run=dry_run,
+            db_services=db_services,
+            env_file=env_file,
+        )
+    except RuntimeError as exc:
+        return CellResult(
+            cell_id=cell.cell_id,
+            product=cell.product,
+            db_type=cell.db_type,
+            status="fail",
+            container_name=name,
+            probe_url=probe_url,
+            detail=str(exc),
+            duration_seconds=time.time() - started,
+            log_path=str(cell_log),
+        )
     if ownership is not None:
         if engaged_dbs is not None:
             engaged_dbs.add(cell.db_type)

--- a/docker/scripts/test_matrix_install_smoke.py
+++ b/docker/scripts/test_matrix_install_smoke.py
@@ -107,6 +107,8 @@ class EnvAndPasswordTests(unittest.TestCase):
         self.assertEqual(ora["name"], "XEPDB1")
         self.assertEqual(ora["schema"], "cmsuser")
         self.assertEqual(ora["password"], "ora-secret")
+        self.assertEqual(ora["healthy_timeout"], "600")
+        self.assertEqual(ora["wait_db_seconds"], "600")
         # Defaults when only password is provided
         defaults = smoke.build_db_services({"ORACLE_APP_PASSWORD": "x"})
         self.assertEqual(defaults["oracle"]["user"], "percuser")
@@ -265,6 +267,15 @@ class DockerRunArgvTests(unittest.TestCase):
         self.assertIn("DB_PASSWORD=ora-secret", joined)
         self.assertIn("DB_SCHEMA=percuser", joined)
         self.assertIn("PRODUCT=cms", joined)
+        # Oracle cold-start can exceed the cell default 120s TCP wait.
+        self.assertIn("WAIT_DB_SECONDS=600", joined)
+
+    def test_wait_for_container_healthy_dry_run(self):
+        self.assertTrue(
+            smoke.wait_for_container_healthy(
+                "percussion-oracle", 30, dry_run=True
+            )
+        )
 
 
 class InstallArgvTests(unittest.TestCase):

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/DbInstallConfigResolver.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/DbInstallConfigResolver.java
@@ -331,7 +331,7 @@ public final class DbInstallConfigResolver {
       if (isBlank(port)) {
         missing.add("db.port");
       }
-      // Oracle uses db.name as service name / SID in composed DB_SERVER (@host:port:name)
+      // Oracle uses db.name as service name / SID in composed DB_SERVER (@//host:port/name)
       if (isBlank(name)) {
         missing.add("db.name");
       }
@@ -471,17 +471,24 @@ public final class DbInstallConfigResolver {
           (schema == null || schema.trim().isEmpty())
               ? (user == null ? "" : user.trim())
               : schema.trim();
-      // Service/SID form: @host:port:name (name may be service or SID)
+      // Easy Connect service form: @//host:port/serviceOrSid
+      // Multi-tenant Oracle XE (e.g. XEPDB1) is a service name, not a SID; classic
+      // SID form (@host:port:sid) yields ORA-12505 against PDB service names.
+      // Pure SID operators can still set DB_SERVER via -Ddbprops.
+      // db.name is the service/SID for connection only — product DB_NAME must stay
+      // empty for Oracle (sample rxrepository.oracle.properties). Populating
+      // DB_NAME with XEPDB1 makes TableFactory emit schema.XEPDB1.TABLE (ORA-00905).
       String serviceOrSid = name == null ? "" : name.trim();
-      String cmsServer = "@" + host + ":" + port + ":" + serviceOrSid;
+      String cmsServer = "@//" + host + ":" + port + "/" + serviceOrSid;
       systemProperties.put("perc.db.cms.backend", "ORACLE");
       systemProperties.put("perc.db.cms.driverName", ORACLE_DRIVER_NAME);
       systemProperties.put("perc.db.cms.driverClass", ORACLE_DRIVER_CLASS);
       systemProperties.put("perc.db.cms.server", cmsServer);
-      systemProperties.put("perc.db.cms.name", serviceOrSid);
+      systemProperties.put("perc.db.cms.name", "");
       systemProperties.put("perc.db.cms.schema", resolvedSchema);
       systemProperties.put(
-          "perc.db.dts.jdbcUrl", "jdbc:oracle:thin:@" + host + ":" + port + ":" + serviceOrSid);
+          "perc.db.dts.jdbcUrl",
+          "jdbc:oracle:thin:@//" + host + ":" + port + "/" + serviceOrSid);
       systemProperties.put("perc.db.dts.jdbcDriver", ORACLE_DRIVER_CLASS);
       systemProperties.put(
           "perc.db.dts.hibernateDialect", "org.hibernate.dialect.Oracle12cDialect");

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/RepositoryConnectionProbe.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/RepositoryConnectionProbe.java
@@ -233,7 +233,9 @@ public final class RepositoryConnectionProbe {
         case "postgresql" -> "jdbc:postgresql://" + ep.host() + ":" + ep.port() + "/" + ep.name();
         case "sqlserver" ->
             "jdbc:sqlserver://" + ep.host() + ":" + ep.port() + ";databaseName=" + ep.name();
-        case "oracle" -> "jdbc:oracle:thin:@" + ep.host() + ":" + ep.port() + ":" + ep.name();
+        // Easy Connect service form (same as DbInstallConfigResolver structured oracle).
+        case "oracle" ->
+            "jdbc:oracle:thin:@//" + ep.host() + ":" + ep.port() + "/" + ep.name();
         default -> null;
       };
     }
@@ -310,7 +312,9 @@ public final class RepositoryConnectionProbe {
       case "postgresql" -> "jdbc:postgresql://" + ep.host() + ":" + ep.port() + "/" + ep.name();
       case "sqlserver" ->
           "jdbc:sqlserver://" + ep.host() + ":" + ep.port() + ";databaseName=" + ep.name();
-      case "oracle" -> "jdbc:oracle:thin:@" + ep.host() + ":" + ep.port() + ":" + ep.name();
+      // Prefer Easy Connect service form; pure SID (@host:port:sid) is still parseable below.
+      case "oracle" ->
+          "jdbc:oracle:thin:@//" + ep.host() + ":" + ep.port() + "/" + ep.name();
       default -> null;
     };
   }
@@ -346,11 +350,12 @@ public final class RepositoryConnectionProbe {
     if (semi >= 0) {
       s = s.substring(0, semi);
     }
-    if (s.startsWith("//")) {
-      s = s.substring(2);
-    }
+    // Oracle Easy Connect may be @//host:port/service — strip @ before //.
     if (s.startsWith("@")) {
       s = s.substring(1);
+    }
+    if (s.startsWith("//")) {
+      s = s.substring(2);
     }
 
     // forms: host:port/name  or  host:port:sid  or  host:port

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/samples/rxrepository.oracle.properties
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/samples/rxrepository.oracle.properties
@@ -2,10 +2,12 @@
 # Usage:
 #   java -Ddbprops=/path/to/this-file.properties -jar PercussionCMS.jar /path/to/install/root
 #
-# DB_SERVER uses the product thin form @host:port:serviceOrSid. Adjust to your DBA's SID/service name.
+# DB_SERVER uses Oracle Easy Connect service form @//host:port/serviceOrSid (structured
+# --db.* install emits the same). Classic SID form @host:port:SID is still accepted when
+# set explicitly. Multi-tenant XE PDB service names (e.g. XEPDB1) require the service form.
 
 DB_BACKEND=ORACLE
-DB_SERVER=@ora.example.com:1521:ORCL
+DB_SERVER=@//ora.example.com:1521/ORCL
 DB_NAME=
 DB_SCHEMA=CMS
 DB_DRIVER_NAME=oracle:thin

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/DbInstallConfigResolverTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/DbInstallConfigResolverTest.java
@@ -191,8 +191,32 @@ class DbInstallConfigResolverTest {
     assertEquals("oracle", cfg.systemProperties().get("perc.db.type"));
     assertEquals("ORACLE", cfg.systemProperties().get("perc.db.cms.backend"));
     assertEquals("oracle:thin", cfg.systemProperties().get("perc.db.cms.driverName"));
-    assertTrue(cfg.systemProperties().get("perc.db.cms.server").startsWith("@ora.example.com"));
-    assertTrue(cfg.systemProperties().get("perc.db.cms.server").endsWith(":ORCL"));
+    // Easy Connect service form (required for multi-tenant service names such as XEPDB1).
+    assertEquals("@//ora.example.com:1521/ORCL", cfg.systemProperties().get("perc.db.cms.server"));
+    assertEquals(
+        "jdbc:oracle:thin:@//ora.example.com:1521/ORCL",
+        cfg.systemProperties().get("perc.db.dts.jdbcUrl"));
+    // Product DB_NAME must be empty for Oracle (service lives only in DB_SERVER).
+    assertEquals("", cfg.systemProperties().get("perc.db.cms.name"));
+  }
+
+  @Test
+  void structuredOracleXepdb1UsesServiceEasyConnectForm() {
+    Map<String, String> opts = new HashMap<>();
+    opts.put("db.type", "oracle");
+    opts.put("db.host", "oracle");
+    opts.put("db.port", "1521");
+    opts.put("db.name", "XEPDB1");
+    opts.put("db.user", "percuser");
+    opts.put("db.password", "x");
+    opts.put("db.schema", "percuser");
+
+    DbInstallConfigResolver.ResolvedDbConfig cfg = DbInstallConfigResolver.resolveDbConfig(opts);
+    assertEquals("@//oracle:1521/XEPDB1", cfg.systemProperties().get("perc.db.cms.server"));
+    // CLI --db.name is still required for service composition; cms.name / DB_NAME stays blank.
+    assertEquals("XEPDB1", cfg.systemProperties().get("perc.db.name"));
+    assertEquals("", cfg.systemProperties().get("perc.db.cms.name"));
+    assertEquals("percuser", cfg.systemProperties().get("perc.db.cms.schema"));
   }
 
   @Test

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/RepositoryConnectionProbeTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/RepositoryConnectionProbeTest.java
@@ -75,6 +75,14 @@ class RepositoryConnectionProbeTest {
     assertEquals(
         "jdbc:sqlserver://h:1433;databaseName=db",
         RepositoryConnectionProbe.buildJdbcUrl("sqlserver", mssql));
+
+    Map<String, String> ora = new HashMap<>();
+    ora.put("perc.db.host", "oracle");
+    ora.put("perc.db.port", "1521");
+    ora.put("perc.db.name", "XEPDB1");
+    assertEquals(
+        "jdbc:oracle:thin:@//oracle:1521/XEPDB1",
+        RepositoryConnectionProbe.buildJdbcUrl("oracle", ora));
   }
 
   @Test

--- a/system/services/src/com/percussion/services/datasource/impl/PSDatasourceManager.java
+++ b/system/services/src/com/percussion/services/datasource/impl/PSDatasourceManager.java
@@ -188,10 +188,11 @@ public class PSDatasourceManager implements IPSDatasourceManager {
         var dsName = dsConfig.getDataSource();
         var conn = getDbConnection(dsName);
 
-        // Wrap Oracle connections for enhanced functionality
-        if (conn.getMetaData().getURL().contains("oracle")) {
-            conn = new PSOracleConnectionWrapper(conn);
-        }
+        // Do not wrap Oracle pool connections in PSOracleConnectionWrapper here.
+        // HikariCP ProxyConnection + modern ojdbc often fail unwrap(OracleConnection)
+        // with ORA-17177, which aborted Jetty start on live Oracle XE matrix (#2083).
+        // Pool connections already implement java.sql.Connection; Oracle-specific
+        // unwrap remains available via PSOracleConnectionWrapper for callers that need it.
 
         // Set catalog if specified
         configureCatalog(conn, dsConfig.getDatabase());

--- a/system/services/src/com/percussion/services/datasource/impl/PSOracleConnectionWrapper.java
+++ b/system/services/src/com/percussion/services/datasource/impl/PSOracleConnectionWrapper.java
@@ -1,96 +1,233 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
  *
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
  */
 
 package com.percussion.services.datasource.impl;
 
-import oracle.jdbc.OracleConnectionWrapper;
-import oracle.jdbc.driver.OracleConnection;
-
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Wrapper;
 import java.util.Objects;
+import oracle.jdbc.OracleConnection;
+import oracle.jdbc.OracleConnectionWrapper;
 
 /**
- * Oracle-specific connection wrapper that provides enhanced Oracle database functionality
- * with modern Java 11 validation patterns.
+ * Oracle-specific connection wrapper that provides enhanced Oracle database functionality with
+ * modern Java validation patterns.
  *
- * <p>This wrapper extends Oracle's OracleConnectionWrapper to provide consistent
- * connection management while maintaining Oracle-specific features and ensuring
- * proper resource cleanup.</p>
+ * <p>This wrapper extends Oracle's {@link OracleConnectionWrapper} to provide consistent connection
+ * management while maintaining Oracle-specific features and ensuring proper resource cleanup.
+ *
+ * <p>Unwrap targets the public JDBC interface {@link OracleConnection}, not {@code
+ * oracle.jdbc.driver.OracleConnection}. HikariCP and other pools often require walking a {@code
+ * delegate} field because the physical driver connection's {@code unwrap(OracleConnection.class)}
+ * can throw ORA-17177 even when it implements the interface (#2083 live Oracle matrix).
  *
  * @author Percussion Software
  * @since 6.0
  */
 public class PSOracleConnectionWrapper extends OracleConnectionWrapper {
 
-    /**
-     * The delegate connection for proper resource management.
-     */
-    private final Connection delegate;
+  /** The pool/proxy connection to close (returns the handle to the pool). */
+  private final Connection delegate;
 
-    /**
-     * Constructs a new Oracle connection wrapper with enhanced validation.
-     *
-     * @param delegate The wrapper containing the Oracle connection, may not be null
-     * @throws SQLException if the Oracle connection cannot be unwrapped
-     * @throws IllegalArgumentException if delegate is null
-     */
-    public PSOracleConnectionWrapper(Wrapper delegate) throws SQLException {
-        super(unwrapOracleConnection(delegate));
-        this.delegate = (Connection) Objects.requireNonNull(delegate,
-            "delegate may not be null");
+  /**
+   * Constructs a new Oracle connection wrapper with enhanced validation.
+   *
+   * @param delegate The wrapper containing the Oracle connection, may not be null
+   * @throws SQLException if the Oracle connection cannot be unwrapped
+   * @throws IllegalArgumentException if delegate is null
+   */
+  public PSOracleConnectionWrapper(Wrapper delegate) throws SQLException {
+    super(unwrapOracleConnection(delegate));
+    this.delegate =
+        (Connection) Objects.requireNonNull(delegate, "delegate may not be null");
+  }
+
+  /**
+   * Safely unwrap the Oracle connection with enhanced error handling.
+   *
+   * <p>Package-visible for unit tests.
+   *
+   * @param wrapper The wrapper to unwrap
+   * @return The unwrapped Oracle connection
+   * @throws SQLException if unwrapping fails
+   * @throws IllegalArgumentException if wrapper is null
+   */
+  static OracleConnection unwrapOracleConnection(Wrapper wrapper) throws SQLException {
+    Objects.requireNonNull(wrapper, "wrapper may not be null");
+
+    if (wrapper instanceof OracleConnection oracleConnection) {
+      return oracleConnection;
+    }
+    if (!(wrapper instanceof Connection connection)) {
+      throw new SQLException(
+          "Failed to unwrap Oracle connection: not a java.sql.Connection ("
+              + wrapper.getClass().getName()
+              + ")");
     }
 
-    /**
-     * Safely unwrap the Oracle connection with enhanced error handling.
-     *
-     * @param wrapper The wrapper to unwrap
-     * @return The unwrapped Oracle connection
-     * @throws SQLException if unwrapping fails
-     * @throws IllegalArgumentException if wrapper is null
-     */
-    private static OracleConnection unwrapOracleConnection(Wrapper wrapper) throws SQLException {
-        Objects.requireNonNull(wrapper, "wrapper may not be null");
+    SQLException firstFailure = null;
 
-        try {
-            return wrapper.unwrap(OracleConnection.class);
-        } catch (SQLException e) {
-            throw new SQLException("Failed to unwrap Oracle connection", e);
+    // 1) Standard JDBC unwrap (works for many pools).
+    try {
+      if (connection.isWrapperFor(OracleConnection.class)) {
+        return connection.unwrap(OracleConnection.class);
+      }
+    } catch (SQLException e) {
+      firstFailure = e;
+    }
+
+    // 2) Walk common pool/proxy delegate fields (HikariCP ProxyConnection.delegate).
+    Connection physical = extractDelegateConnection(connection);
+    if (physical instanceof OracleConnection oracleConnection) {
+      return oracleConnection;
+    }
+
+    // 3) DatabaseMetaData#getConnection often returns the vendor connection.
+    try {
+      Connection fromMeta = connection.getMetaData().getConnection();
+      if (fromMeta instanceof OracleConnection oracleConnection) {
+        return oracleConnection;
+      }
+      Connection nested = extractDelegateConnection(fromMeta);
+      if (nested instanceof OracleConnection oracleConnection) {
+        return oracleConnection;
+      }
+    } catch (SQLException e) {
+      if (firstFailure == null) {
+        firstFailure = e;
+      } else {
+        firstFailure.addSuppressed(e);
+      }
+    }
+
+    // 4) Reflective cast when class name is the Oracle driver connection but ClassLoaders differ
+    //    enough that instanceof OracleConnection failed (rare; still try direct class match).
+    OracleConnection viaName = castOracleByClassName(physical != null ? physical : connection);
+    if (viaName != null) {
+      return viaName;
+    }
+
+    SQLException failure =
+        new SQLException(
+            "Failed to unwrap Oracle connection from " + connection.getClass().getName());
+    if (firstFailure != null) {
+      failure.initCause(firstFailure);
+    }
+    throw failure;
+  }
+
+  /**
+   * Follow {@code delegate} / {@code _conn} / {@code connection} fields used by common JDBC pools.
+   */
+  static Connection extractDelegateConnection(Connection connection) {
+    if (connection == null) {
+      return null;
+    }
+    Connection current = connection;
+    // Bound walk so a cycle cannot spin forever.
+    for (int depth = 0; depth < 8; depth++) {
+      Connection next = readConnectionField(current, "delegate");
+      if (next == null) {
+        next = readConnectionField(current, "_conn");
+      }
+      if (next == null) {
+        next = readConnectionField(current, "connection");
+      }
+      if (next == null || next == current) {
+        return current;
+      }
+      current = next;
+      if (current instanceof OracleConnection) {
+        return current;
+      }
+    }
+    return current;
+  }
+
+  private static Connection readConnectionField(Connection connection, String fieldName) {
+    for (Class<?> type = connection.getClass(); type != null; type = type.getSuperclass()) {
+      try {
+        Field field = type.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        Object value = field.get(connection);
+        if (value instanceof Connection conn) {
+          return conn;
         }
+      } catch (NoSuchFieldException ignored) {
+        // try superclass
+      } catch (ReflectiveOperationException | SecurityException ignored) {
+        return null;
+      }
     }
+    return null;
+  }
 
-    /**
-     * Closes the delegate connection ensuring proper resource cleanup.
-     *
-     * @throws SQLException if closing the connection fails
-     */
-    @Override
-    public void close() throws SQLException {
-        try {
-            delegate.close();
-        } catch (SQLException e) {
-            throw new SQLException("Failed to close Oracle connection", e);
-        }
+  /**
+   * When {@code instanceof OracleConnection} fails due to split class loaders, try the driver's
+   * {@code unwrap()} method that returns {@code oracle.jdbc.OracleConnection} without our
+   * Class token, or cast if the type name matches.
+   */
+  private static OracleConnection castOracleByClassName(Connection connection) {
+    if (connection == null) {
+      return null;
     }
+    String name = connection.getClass().getName();
+    if ("oracle.jdbc.driver.OracleConnection".equals(name)
+        || "oracle.jdbc.OracleConnection".equals(name)
+        || name.startsWith("oracle.jdbc.driver.") && name.endsWith("Connection")) {
+      try {
+        return (OracleConnection) connection;
+      } catch (ClassCastException ignored) {
+        // Split class loader — try reflective invoke of unwrap() no-arg on OracleConnectionWrapper
+        // style APIs.
+      }
+    }
+    try {
+      Method unwrap = connection.getClass().getMethod("unwrap");
+      Object result = unwrap.invoke(connection);
+      if (result instanceof OracleConnection oracleConnection) {
+        return oracleConnection;
+      }
+    } catch (ReflectiveOperationException ignored) {
+      // not available
+    }
+    return null;
+  }
 
-    @Override
-    public String toString() {
-        return String.format("PSOracleConnectionWrapper{delegate=%s}",
-            delegate != null ? delegate.getClass().getSimpleName() : "null");
+  /**
+   * Closes the delegate connection ensuring proper resource cleanup.
+   *
+   * @throws SQLException if closing the connection fails
+   */
+  @Override
+  public void close() throws SQLException {
+    try {
+      delegate.close();
+    } catch (SQLException e) {
+      throw new SQLException("Failed to close Oracle connection", e);
     }
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "PSOracleConnectionWrapper{delegate=%s}",
+        delegate != null ? delegate.getClass().getSimpleName() : "null");
+  }
 }

--- a/system/src/test/java/com/percussion/services/datasource/impl/PSOracleConnectionWrapperTest.java
+++ b/system/src/test/java/com/percussion/services/datasource/impl/PSOracleConnectionWrapperTest.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright 1999-2026 Percussion Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.percussion.services.datasource.impl;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Wrapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for Oracle unwrap helpers used with pool proxies (Hikari-style {@code delegate}
+ * field). Avoids a live Oracle driver so CI can run without XE (#2083).
+ */
+class PSOracleConnectionWrapperTest {
+
+  @Test
+  void extractDelegateConnectionWalksDelegateField() throws Exception {
+    Connection physical = Mockito.mock(Connection.class);
+    HikariStyleProxy proxy = new HikariStyleProxy(physical);
+
+    Connection extracted = PSOracleConnectionWrapper.extractDelegateConnection(proxy);
+    assertSame(physical, extracted);
+  }
+
+  @Test
+  void unwrapOracleConnectionRejectsNonConnectionWrapper() {
+    Wrapper notAConnection = Mockito.mock(Wrapper.class);
+    SQLException ex =
+        assertThrows(
+            SQLException.class,
+            () -> PSOracleConnectionWrapper.unwrapOracleConnection(notAConnection));
+    assertTrue(ex.getMessage().toLowerCase().contains("failed to unwrap"));
+  }
+
+  /**
+   * Minimal stand-in for HikariCP {@code ProxyConnection}: holds a package-visible {@code
+   * delegate} field that the production unwrap walk must discover via reflection.
+   */
+  private static final class HikariStyleProxy implements Connection {
+    @SuppressWarnings("unused") // read via reflection in extractDelegateConnection
+    private final Connection delegate;
+
+    HikariStyleProxy(Connection delegate) {
+      this.delegate = delegate;
+    }
+
+    // --- Connection methods: all unsupported; only field layout matters for this unit test ---
+
+    @Override
+    public <T> T unwrap(Class<T> iface) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) {
+      return false;
+    }
+
+    @Override
+    public java.sql.Statement createStatement() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.PreparedStatement prepareStatement(String sql) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.CallableStatement prepareCall(String sql) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String nativeSQL(String sql) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setAutoCommit(boolean autoCommit) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean getAutoCommit() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void commit() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void rollback() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isClosed() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.DatabaseMetaData getMetaData() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setReadOnly(boolean readOnly) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setCatalog(String catalog) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getCatalog() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setTransactionIsolation(int level) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getTransactionIsolation() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.SQLWarning getWarnings() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clearWarnings() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.Statement createStatement(int resultSetType, int resultSetConcurrency) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.PreparedStatement prepareStatement(
+        String sql, int resultSetType, int resultSetConcurrency) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.CallableStatement prepareCall(
+        String sql, int resultSetType, int resultSetConcurrency) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.util.Map<String, Class<?>> getTypeMap() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setTypeMap(java.util.Map<String, Class<?>> map) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setHoldability(int holdability) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getHoldability() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.Savepoint setSavepoint() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.Savepoint setSavepoint(String name) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void rollback(java.sql.Savepoint savepoint) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void releaseSavepoint(java.sql.Savepoint savepoint) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.Statement createStatement(
+        int resultSetType, int resultSetConcurrency, int resultSetHoldability) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.PreparedStatement prepareStatement(
+        String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.CallableStatement prepareCall(
+        String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.PreparedStatement prepareStatement(String sql, int[] columnIndexes) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.PreparedStatement prepareStatement(String sql, String[] columnNames) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.Clob createClob() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.Blob createBlob() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.NClob createNClob() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.SQLXML createSQLXML() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isValid(int timeout) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setClientInfo(String name, String value) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setClientInfo(java.util.Properties properties) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getClientInfo(String name) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.util.Properties getClientInfo() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.Array createArrayOf(String typeName, Object[] elements) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.sql.Struct createStruct(String typeName, Object[] attributes) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setSchema(String schema) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getSchema() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void abort(java.util.concurrent.Executor executor) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setNetworkTimeout(java.util.concurrent.Executor executor, int milliseconds) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getNetworkTimeout() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Residual live smoke for parent **#1500** / slice **#1508** (compose + harness already merged in #2084).

Live run on night-issue-prs worktree:

```text
python3 docker/scripts/matrix-install-smoke.py --product cms --db oracle --probe-timeout 1800
RESULT:OK STEP:matrix
cms-oracle → pass HTTP 200 (~115s with warm gvenzl/oracle-xe volume)
```

Matrix JSON (excerpt):

```json
{
  "cell_id": "cms-oracle",
  "product": "cms",
  "db_type": "oracle",
  "status": "pass",
  "detail": "HTTP 200",
  "duration_seconds": 114.5
}
```

### Fixes required for RESULT:OK (thin product + harness)

1. **Easy Connect service form** — structured Oracle install now emits `@//host:port/service` (`XEPDB1` is a PDB service name, not a SID; classic `@host:port:SID` → ORA-12505).
2. **Empty product `DB_NAME` for Oracle** — service lives only in `DB_SERVER`; putting `XEPDB1` in `DB_NAME` made TableFactory emit `schema.XEPDB1.TABLE` (ORA-00905).
3. **Skip `PSOracleConnectionWrapper` on pool connections** — Hikari + modern ojdbc throw ORA-17177 on `unwrap(OracleConnection)`, which aborted Jetty start after a successful install. Unwrap helpers improved for callers that still need them.
4. **Harness** — wait up to 600s for compose `healthy` + `WAIT_DB_SECONDS=600` for oracle cells.
5. **Docs** — image digest, RAM, start/wait realities in `docker/README.md`.

### Parent tracker

Part of **#1500**. Residual of **#1508**.

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] `python3 -m unittest docker.scripts.test_matrix_install_smoke` → 62 OK
- [x] `DbInstallConfigResolverTest` + `RepositoryConnectionProbeTest` + sample props → 35 OK
- [x] Live: `matrix-install-smoke.py --product cms --db oracle --probe-timeout 1800` → **RESULT:OK**, login probe **HTTP 200**
- [ ] CI / reviewer: optional re-run live cell if resources allow (heavy image ~2.6 GiB, prefer ≥8 GiB Docker RAM for cell)

## Gates evidence

- Erlang-style self-review: portable paths in harness; no secrets committed; product changes scoped to Oracle install URL + pool wrap skip.
- Maven: `perc-distribution-tree` targeted surefire green (full module `package` needs sibling reactor artifacts for assembly — unit compile/test path verified).
- `system` module: source + unit test for unwrap delegate walk; standalone clean install of full `system` not required for harness-only path but recommended in CI reactor.

Fixes #2083