### PR TITLE
fix(rest): TemplateSummary list emits templateName/templateLabel (#2189)

### DIFF
--- a/rest/src/main/java/com/percussion/rest/templates/TemplateSummary.java
+++ b/rest/src/main/java/com/percussion/rest/templates/TemplateSummary.java
@@ -8,10 +8,16 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
-import java.util.Optional;
 
 /**
  * Represents a lightweight summary of a template. Sunny Sal: "Summary ka hero, template ka zero!"
+ *
+ * <p>Wire getters return plain {@link String} types (not {@code Optional}) so Jackson/CXF JSON
+ * always emits {@code templateName}, {@code templateLabel}, and {@code templateDescription} when
+ * set. Optional-returning getters historically dropped those fields under {@code
+ * @JsonInclude(NON_NULL)} when the mapper did not unwrap {@code Optional}, leaving only {@code
+ * templateId} on the list wire shape (issue #2189). Matches {@link
+ * com.percussion.rest.contenttypes.ContentType} getter style (issue #1693).
  */
 @XmlRootElement(name = "TemplateSummary")
 @JsonRootName(value = "TemplateSummary")
@@ -41,24 +47,24 @@ public class TemplateSummary {
     this.templateId = templateId;
   }
 
-  public Optional<String> getTemplateName() {
-    return Optional.ofNullable(templateName);
+  public String getTemplateName() {
+    return templateName;
   }
 
   public void setTemplateName(String templateName) {
     this.templateName = templateName;
   }
 
-  public Optional<String> getTemplateLabel() {
-    return Optional.ofNullable(templateLabel);
+  public String getTemplateLabel() {
+    return templateLabel;
   }
 
   public void setTemplateLabel(String templateLabel) {
     this.templateLabel = templateLabel;
   }
 
-  public Optional<String> getTemplateDescription() {
-    return Optional.ofNullable(templateDescription);
+  public String getTemplateDescription() {
+    return templateDescription;
   }
 
   public void setTemplateDescription(String templateDescription) {

--- a/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
+++ b/rest/src/test/java/com/percussion/rest/JacksonContextResolverOptionalTest.java
@@ -16,11 +16,13 @@
 
 package com.percussion.rest;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeList;
 import com.percussion.rest.templates.TemplateSummary;
+import com.percussion.rest.templates.TemplateSummaryList;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -29,8 +31,8 @@ import tools.jackson.databind.ObjectMapper;
 /**
  * Catalog DTOs must serialize names (and related fields) for Developer SPA tables. ContentType list
  * historically collapsed to hideFromMenu-only when Optional getters were not unwrapped (issue
- * #1693). ContentType now uses plain getters; TemplateSummary still uses Optional and relies on
- * Jackson 3 databind unwrapping.
+ * #1693). TemplateSummary similarly collapsed to templateId-only (issue #2189). Both now use plain
+ * getters under {@code @JsonInclude(NON_NULL)}.
  */
 @Tag("UnitTest")
 class JacksonContextResolverOptionalTest {
@@ -78,10 +80,36 @@ class JacksonContextResolverOptionalTest {
     t.setTemplateId(1018);
     t.setTemplateName("perc.page");
     t.setTemplateLabel("Page");
+    t.setTemplateDescription("Page template");
 
     String json = mapper.writeValueAsString(t);
     assertTrue(json.contains("perc.page"), json);
     assertTrue(json.contains("Page"), json);
     assertTrue(json.contains("1018"), json);
+    // Property names (not only values) — live H2 list was templateId-only (issue #2189)
+    assertTrue(json.contains("\"templateName\""), json);
+    assertTrue(json.contains("\"templateLabel\""), json);
+    assertTrue(json.contains("\"templateDescription\""), json);
+    assertTrue(json.contains("\"templateId\""), json);
+    assertFalse(
+        json.replaceAll("\\s", "").matches(".*\\{\"templateId\":1018\\}.*")
+            && !json.contains("\"templateName\""),
+        "Summary JSON must not be templateId-only: " + json);
+  }
+
+  @Test
+  void templateSummaryList_serializesNamesNotIdOnly() {
+    TemplateSummary t = new TemplateSummary();
+    t.setTemplateId(1037);
+    t.setTemplateName("perc.page");
+    t.setTemplateLabel("Page");
+
+    TemplateSummaryList list = new TemplateSummaryList(List.of(t));
+    String json = mapper.writeValueAsString(list);
+    assertTrue(json.contains("perc.page"), json);
+    assertTrue(json.contains("\"templateName\""), json);
+    assertTrue(json.contains("\"templateLabel\""), json);
+    assertTrue(json.contains("1037"), json);
+    assertTrue(json.contains("TemplateSummary") || json.startsWith("["), json);
   }
 }


### PR DESCRIPTION
## Summary
Live H2 qa-up showed `GET /services/templates` returning `TemplateSummaryList` items with only `templateId` — no `templateName` / `templateLabel` / description. Developer SPA Templates tab rendered Label/Name as ""—"".

**Root cause:** `TemplateSummary` used `Optional<String>` getters under `@JsonInclude(NON_NULL)`. Without reliable Optional unwrapping on the wire path, name/label/description were dropped (same class of bug as ContentType list #1693).

**Fix (rest only):**
- Replace Optional-returning getters with plain `String` getters on `TemplateSummary` (keep `NON_NULL`).
- Expand `JacksonContextResolverOptionalTest` to assert JSON property names (`templateName` / `templateLabel` / `templateDescription`) and list wrap.

**Not changed:** `ApiUtils.convertTemplateSummary` already maps name/label/description from catalog summaries; no sitemanage refactor needed.

## Links
- Fixes #2189
- Parent epic #2089 / bucket #2187 / grandparent #1690
- Peer pattern: ContentType #1693

## Test plan
- [x] `cd rest && ../mvnw clean install` (standalone) — green
- [x] `JacksonContextResolverOptionalTest` — 4 tests pass (single + list property names)
- [x] Full rest surefire suite green
- [ ] Live H2 after deploy: list JSON includes `templateName`/`templateLabel` for stock templates
- [ ] SPA Templates table shows non-placeholder Label/Name (may still need #2186 selector for Playwright)

## Gates evidence
| Gate | Result |
|------|--------|
| Erlang self-review | approve — plain getters, peer #1693, no path I/O, behavioral Jackson tests |
| Change-class companions | REST DTO + Jackson unit tests; mapping already correct in sitemanage |
| Maven | `cd rest` → `../mvnw.cmd clean install` exit 0 |
| Scope | 2 files, rest module only |

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Leave unassigned for human review. Do not merge from agent.