### PR TITLE
fix(installer): propagate phase1 demo-sites into ANT install.demo.sites (#2192)

### DIFF
--- a/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/preinstall/Main.java
@@ -277,7 +277,8 @@ public class Main {
       // secrets live only in rxrepository.properties and the encrypted
       // perc-ds.properties written by PSConfigureDatasource.
 
-      Integer antExit = execJar(installAntJarPath, execPath, installPath, resolvedDbConfig);
+      Integer antExit =
+          execJar(installAntJarPath, execPath, installPath, resolvedDbConfig, options);
       deleteOldJDBCJars(installPath);
 
       int exitCode = resolveInstallExitCode(antExit, error, processCode);
@@ -523,12 +524,48 @@ public class Main {
   }
 
   /**
+   * Resolve the ANT-visible {@code install.demo.sites} value from Phase-1 installer options (wizard
+   * Yes/No or CLI {@code --demo-sites} / {@code --no-demo-sites}), with fallback to the JVM system
+   * property of the same name via {@link DbInstallConfigResolver#parseDemoSitesFlag}.
+   *
+   * <p>Phase-1 stores the operator choice under {@link DbInstallConfigResolver#DEMO_SITES_KEY}
+   * ({@code "demo-sites"}). Prior to #2192, {@link #execJar} only consulted {@link
+   * System#getProperties()}, so interactive Yes / bare {@code --demo-sites} never reached ANT and
+   * sample sites were not seeded (empty {@code RXSITES}).
+   *
+   * <p>Honored on both new installs and upgrades; locale tables are protected by the ANT {@code
+   * stripSampleLocales} step, not by install-type gating.
+   *
+   * @param phase1Options options map from {@link InteractiveInstallWizard#runPhase1}; may be null
+   * @return {@code true} when the ANT child should seed sample sites
+   */
+  static boolean resolveDemoSitesForAnt(Map<String, String> phase1Options) {
+    return DbInstallConfigResolver.parseDemoSitesFlag(phase1Options);
+  }
+
+  /**
+   * Build the {@code -Dinstall.demo.sites=…} token that must appear on the ANT child JVM command
+   * line. Package-visible for unit tests that assert options propagation without spawning a
+   * process.
+   *
+   * @param phase1Options options map from Phase 1; may be null
+   * @return a single command-line argument of the form {@code -Dinstall.demo.sites=true|false}
+   */
+  static String demoSitesAntSystemPropertyArg(Map<String, String> phase1Options) {
+    return "-D"
+        + DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY
+        + "="
+        + resolveDemoSitesForAnt(phase1Options);
+  }
+
+  /**
    * Executes the bundled installer JAR with the supplied resolved DB configuration.
    *
    * @param jar path to the bundled installer JAR.
    * @param execPath working directory for the spawned process.
    * @param installDir target install directory passed to the installer.
    * @param resolvedDbConfig DB configuration to surface via system properties on the child JVM.
+   * @param phase1Options Phase-1 options (wizard / CLI), including {@code demo-sites}; may be null.
    * @return process exit code returned by the spawned JVM.
    * @throws IOException if the child process cannot be started.
    * @throws InterruptedException if the wait is interrupted.
@@ -537,7 +574,8 @@ public class Main {
       Path jar,
       Path execPath,
       Path installDir,
-      DbInstallConfigResolver.ResolvedDbConfig resolvedDbConfig)
+      DbInstallConfigResolver.ResolvedDbConfig resolvedDbConfig,
+      Map<String, String> phase1Options)
       throws IOException, InterruptedException {
 
     try {
@@ -567,17 +605,11 @@ public class Main {
       command.add("-Dfile.encoding=UTF-8");
       command.add("-Dsun.jnu.encoding=UTF-8");
       command.add("-Dinstall.dir=" + installDir.toAbsolutePath());
-      // Propagate the --demo-sites flag so the ANT installer can decide whether to chain
-      // a sample-site seeding pass (RxffTableData/RxffTableDef) after the core schema/data
-      // load. Upgrades always ignore the flag to protect existing repositories.
-      boolean demoSites =
-          DbInstallConfigResolver.parseDemoSitesFlag(
-              System.getProperties().entrySet().stream()
-                  .collect(
-                      java.util.stream.Collectors.toMap(
-                          e -> e.getKey().toString(),
-                          e -> e.getValue() == null ? null : e.getValue().toString())));
-      command.add("-D" + DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY + "=" + demoSites);
+      // Propagate demo-sites from Phase-1 options (wizard / --demo-sites) so ANT can chain
+      // installSampleSites after core schema load. Also honors -Dinstall.demo.sites on this JVM
+      // when the options map does not set the flag. Runs on new installs and upgrades; RXLOCALE
+      // protection is stripSampleLocales in installRepository.xml, not install-type gating.
+      command.add(demoSitesAntSystemPropertyArg(phase1Options));
       for (Map.Entry<String, String> entry : resolvedDbConfig.systemProperties().entrySet()) {
         command.add("-D" + entry.getKey() + "=" + entry.getValue());
       }

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml
@@ -201,12 +201,13 @@
 			failonerror="true" silenceerrors="false" />
 
 		<!-- Optional sample sites (Corporate Investments / Enterprise Investments).
-			Driven by the Java preinstall's demo-sites flag, propagated to ANT as -Dinstall.demo.sites=true.
-			On a new install only: the second PSTableAction run chains an RxffTableData/RxffTableDef
-			pass that seeds the two sample sites plus their ACLs, content types, nav,
-			etc. The processSampleSites target is also invoked explicitly from the install
-			chain in install.xml; this in-target guard is defensive so the chain wiring
-			and the system property remain in sync. -->
+			Driven by the Java preinstall's demo-sites flag, propagated to ANT as -Dinstall.demo.sites=true
+			from Phase-1 options (wizard Yes / --demo-sites) via Main.execJar (#2192).
+			When true on new installs and upgrades: antcall installSampleSites chains an
+			RxffTableData/RxffTableDef PSTableAction pass that seeds the two sample sites plus
+			their ACLs, content types, nav, etc. RXLOCALE / RXLOCALEFORMAT are protected by
+			stripSampleLocales, not by install-type gating. This in-target guard is defensive
+			so the chain wiring and the system property remain in sync. -->
 		<if>
 			<equals arg1="${install.demo.sites}" arg2="true" />
 			<then>

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/MainDemoSitesAntFlagTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/preinstall/MainDemoSitesAntFlagTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package com.percussion.preinstall;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for #2192 / #1750: Phase-1 {@code demo-sites} options must drive ANT {@code
+ * -Dinstall.demo.sites=…} even when the preinstall JVM has no matching system property.
+ *
+ * <p>Slice-1 evidence (#2191) showed {@code cms.demo-sites=true} in last-install while ANT received
+ * {@code install.demo.sites=false} because {@code Main.execJar} only read {@link System}
+ * properties.
+ */
+@Tag("UnitTest")
+class MainDemoSitesAntFlagTest {
+
+  private String prevDemoSitesSysProp;
+
+  @BeforeEach
+  void captureSysProp() {
+    prevDemoSitesSysProp =
+        System.getProperty(DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY);
+  }
+
+  @AfterEach
+  void restoreSysProp() {
+    if (prevDemoSitesSysProp == null) {
+      System.clearProperty(DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY);
+    } else {
+      System.setProperty(
+          DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY, prevDemoSitesSysProp);
+    }
+  }
+
+  @Test
+  void optionsDemoSitesTrueYieldsTrueAntArgWithoutJvmSystemProperty() {
+    System.clearProperty(DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY);
+
+    Map<String, String> options = new HashMap<>();
+    options.put(DbInstallConfigResolver.DEMO_SITES_KEY, "true");
+
+    assertTrue(Main.resolveDemoSitesForAnt(options));
+    assertEquals(
+        "-D" + DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY + "=true",
+        Main.demoSitesAntSystemPropertyArg(options));
+  }
+
+  @Test
+  void optionsDemoSitesFalseYieldsFalseAntArg() {
+    System.clearProperty(DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY);
+
+    Map<String, String> options = Map.of(DbInstallConfigResolver.DEMO_SITES_KEY, "false");
+
+    assertFalse(Main.resolveDemoSitesForAnt(options));
+    assertEquals(
+        "-D" + DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY + "=false",
+        Main.demoSitesAntSystemPropertyArg(options));
+  }
+
+  @Test
+  void emptyOptionsWithoutSysPropDefaultsFalse() {
+    System.clearProperty(DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY);
+
+    assertFalse(Main.resolveDemoSitesForAnt(Map.of()));
+    assertFalse(Main.resolveDemoSitesForAnt(null));
+    assertEquals(
+        "-D" + DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY + "=false",
+        Main.demoSitesAntSystemPropertyArg(null));
+  }
+
+  @Test
+  void systemPropertyAloneStillHonoredWhenOptionsOmitKey() {
+    System.setProperty(DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY, "true");
+
+    assertTrue(Main.resolveDemoSitesForAnt(Map.of()));
+    assertEquals(
+        "-D" + DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY + "=true",
+        Main.demoSitesAntSystemPropertyArg(Map.of()));
+  }
+
+  @Test
+  void optionsKeyWinsOverConflictingSystemProperty() {
+    // parseDemoSitesFlag prefers CLI/options over System property when both set.
+    System.setProperty(DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY, "true");
+    Map<String, String> options = Map.of(DbInstallConfigResolver.DEMO_SITES_KEY, "false");
+
+    assertFalse(Main.resolveDemoSitesForAnt(options));
+    assertEquals(
+        "-D" + DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY + "=false",
+        Main.demoSitesAntSystemPropertyArg(options));
+  }
+
+  @Test
+  void truthyAliasesFromWizardOptionsPropagate() {
+    System.clearProperty(DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY);
+
+    assertTrue(
+        Main.resolveDemoSitesForAnt(
+            Map.of(DbInstallConfigResolver.DEMO_SITES_KEY, "yes")));
+    assertTrue(
+        Main.resolveDemoSitesForAnt(Map.of(DbInstallConfigResolver.DEMO_SITES_KEY, "Y")));
+    assertTrue(
+        Main.resolveDemoSitesForAnt(Map.of(DbInstallConfigResolver.DEMO_SITES_KEY, "1")));
+  }
+
+  @Test
+  void installDemoSitesAliasInOptionsMapPropagates() {
+    System.clearProperty(DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY);
+
+    // parseDemoSitesFlag also accepts the ANT property name as an options key.
+    assertTrue(
+        Main.resolveDemoSitesForAnt(
+            Map.of(DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY, "true")));
+    assertEquals(
+        "-D" + DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY + "=true",
+        Main.demoSitesAntSystemPropertyArg(
+            Map.of(DbInstallConfigResolver.DEMO_SITES_SYSTEM_PROPERTY, "true")));
+  }
+}


### PR DESCRIPTION
## Summary

Fixes **#2192** (slice 2 of parent **#1750**): sample sites never seeded when the operator chose Yes / `--demo-sites` because `Main.execJar` only read JVM system properties, not Phase-1 options.

Evidence from #2191 / PR #2198:
- `cms.demo-sites=true` in last-install (options path worked)
- ANT `install.demo.sites=false` → `installSampleSites` never antcall'd → `RXSITES` count 0

### Changes
- Pass `phase1.options()` into `Main.execJar`
- Resolve `-Dinstall.demo.sites=…` via `DbInstallConfigResolver.parseDemoSitesFlag(options)` (options / wizard first; still honors outer `-Dinstall.demo.sites` when options omit the key)
- Package-visible helpers for unit assertion without spawning ANT
- Align comments: flag honored on **new installs and upgrades**; locale protection is `stripSampleLocales`, not install-type gating (`installRepository.xml` + `Main`)

### Residual / follow-on
- **Live H2 silent install** with `--demo-sites` and post-install `RXSITES` probe still recommended after merge (unit proof is in this PR; full silent install not re-run overnight).
- Leave **#2193** skipped until a demo-sites install shows non-empty `RXSITES` **and** Explorer still empty.
- Re-queue **#2194** (Playwright residual) after this merges and product seed is confirmed.

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] `MainDemoSitesAntFlagTest` — options `demo-sites=true` yields `-Dinstall.demo.sites=true` **without** JVM `-D`
- [x] Defaults false; system property alone still honored; options win over conflicting sysprop; truthy aliases
- [x] Peer suite: `DbInstallConfigResolverTest`, `InteractiveInstallWizardTest`, `InstallerUserSettingsTest`, `DbInstallSamplePropertiesTest`
- [x] Module gate: `cd modules/perc-distribution-tree && ../../mvnw clean install` — **BUILD SUCCESS** (Tests run: 229, Failures: 0, Skipped: 5)
- [ ] Post-merge live: silent H2 `--demo-sites` → `install.demo.sites=true` in install.log + `RXSITES` non-empty

## Gates evidence
- Erlang self-review: single-module installer wiring; portable (no new path I/O); behavioral unit tests for new helpers; comment/docs companions only in installRepository.
- No AGENTS.md rule commits (human-review gate).
- Commit: `9825a3a89f`

Fixes #2192  
Partial #1750