### PR TITLE
test(qa): Playwright residual Sample Site under Sites after demo-sites (#2194)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2194-demo-sites-playwright-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2194-demo-sites-playwright-erlang.md
@@ -1,0 +1,51 @@
+# Erlang review: issue #2194 demo-sites Playwright residual
+
+**Date:** 2026-08-06  
+**Branch:** `fix/issue-2194-demo-sites-playwright-sample-site`  
+**Reviewer persona:** Erlang (self-review before commit)
+
+## Summary
+
+Adds black-box Playwright residual for parent #1750: REST `path/folder/Sites` and
+Explorer UI assert Corporate/Enterprise Investments after demo-sites install.
+Pure helpers + unit tests; soft skip-with-BUG when sample data absent (default
+qa-up / pre-#2192 image); hard fail when `EXPECT_DEMO_SITES=1`.
+
+## Scope
+
+- `modules/perc-qa-automation/frontend/tests/helpers/demo-sites.js` (new)
+- `modules/perc-qa-automation/frontend/tests/unit/demo-sites.test.js` (new)
+- `modules/perc-qa-automation/frontend/tests/bugs/bug-1750-demo-sites-sample-site.spec.js` (new)
+- `modules/perc-qa-automation/frontend/package.json` (test:unit paths)
+- `modules/perc-qa-automation/README.md` (env recipe)
+
+Cross-platform path review: no new filesystem path I/O; URL builders use BASE_URL
+string concat consistent with peer bug-1622; portable.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none
+- Behavioral unit tests: yes (`demo-sites.test.js`; empty Sites fails helpers;
+  skip reason embeds durable issue URLs)
+- Non-portable paths: none
+- May commit/push: **yes**
+
+## Issues
+
+None blocking.
+
+### suggestion (docs)
+
+Live H2 silent `--demo-sites` re-verify still depends on #2192 merge into the
+image under test; residual correctly documents `EXPECT_DEMO_SITES=1` rather than
+claiming full E2E install in CI.
+
+## Gates evidence
+
+- `npm run test:unit` — 91 pass (includes demo-sites + pathmanagement-url)
+- `npx playwright test --list tests/bugs/bug-1750-demo-sites-sample-site.spec.js` — 2 tests
+- `cd modules/perc-qa-automation && ../../mvnw clean install` — BUILD SUCCESS

--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -113,6 +113,37 @@ python docker\scripts\perc-devctl.py qa-down
 **Hard bans:** do not commit passwords; do not hardcode host port `:9993` as the only URL
 (use freeport `TEST_CMS_URL` from `qa-up`).
 
+### Demo-sites Sample Site residual (#1750 / #2194)
+
+Regression coverage that **Corporate Investments** and **Enterprise Investments**
+appear under **Sites** after a demo-sites install (REST `path/folder/Sites` + Explorer UI).
+Peers of `tests/bugs/bug-1622-explorer-root-folders.spec.js`.
+
+| Item | Value |
+|------|--------|
+| Spec | `frontend/tests/bugs/bug-1750-demo-sites-sample-site.spec.js` |
+| Helpers / unit | `frontend/tests/helpers/demo-sites.js`, `npm run test:unit` |
+| Product fix | Installer seed flag propagation (#2192) must be in the image under test |
+| Soft skip | Without sample data, tests `test.skip` with `BUG:` + issue URL (skip-with-BUG) |
+| Hard fail | Set `EXPECT_DEMO_SITES=1` (alias `TEST_EXPECT_DEMO_SITES`) so empty Sites fails |
+
+```bash
+# After #2192 is in the installer/image: silent H2 with sample sites, then CMS up.
+# java -jar <installer>.jar --install-dir=<path> --silent --db.type=h2 --demo-sites
+
+cd modules/perc-qa-automation/frontend
+TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+  ADMIN_USERNAME=Admin ADMIN_PASSWORD=<from-qa-up-or-install> \
+  EXPECT_DEMO_SITES=1 \
+  npm test -- tests/bugs/bug-1750-demo-sites-sample-site.spec.js
+
+# Default qa-up without demo-sites: soft skip when Sites empty (not a suite red)
+TEST_CMS_URL=… ADMIN_PASSWORD=… npm test -- tests/bugs/bug-1750-demo-sites-sample-site.spec.js
+```
+
+Evidence / install flags: `docs/ai-generated/issue-2191-demo-sites-empty-sites-repro.md`,
+module `perc-distribution-tree` AGENTS.md § Installing Sample Sites.
+
 ### Developer entry + critical catalogs smoke gate (#2188 / epic #2089)
 
 Inventory of Developer SPA entry + critical catalog specs that must be **green** or

--- a/modules/perc-qa-automation/frontend/package.json
+++ b/modules/perc-qa-automation/frontend/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "test": "playwright test",
-    "test:unit": "node --test tests/unit/resolve-cms-env.test.js tests/unit/surface-filter.test.js tests/unit/pick-locale-tag.test.js tests/unit/developer-catalog-selectors.test.js tests/unit/developer-smoke-set.test.js",
+    "test:unit": "node --test tests/unit/resolve-cms-env.test.js tests/unit/surface-filter.test.js tests/unit/pick-locale-tag.test.js tests/unit/developer-catalog-selectors.test.js tests/unit/developer-smoke-set.test.js tests/unit/pathmanagement-url.test.js tests/unit/demo-sites.test.js",
     "test:list": "playwright test --list",
     "test:golden": "playwright test tests/golden-unattended-smoke.spec.js",
     "test:surface": "node scripts/run-surface.js",

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-1750-demo-sites-sample-site.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-1750-demo-sites-sample-site.spec.js
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Residual automation: Sample Site(s) visible under Sites after demo install
+ * (GH-1750 / residual #2194; product seed fix #2192).
+ *
+ * <p>Peers of {@code bug-1622-explorer-root-folders.spec.js}: REST
+ * pathmanagement {@code path/folder/Sites} plus modern Explorer tree UI.</p>
+ *
+ * <p>Coverage:</p>
+ * <ul>
+ *   <li>REST: Sites children include Corporate / Enterprise Investments</li>
+ *   <li>UI: expand Sites in Content Explorer; sample site tree nodes present</li>
+ * </ul>
+ *
+ * <p><strong>Env gate</strong> — default H2 {@code qa-up} images often omit
+ * demo-sites seed (or lack #2192 until merge). Without enforcement:</p>
+ * <ul>
+ *   <li>If Sites is empty / missing samples → {@code test.skip} with BUG +
+ *       durable issue URL (skip-with-BUG; not a silent flake)</li>
+ *   <li>If samples already present → hard assert (green)</li>
+ * </ul>
+ * <p>Set {@code EXPECT_DEMO_SITES=1} (alias {@code TEST_EXPECT_DEMO_SITES})
+ * after a demo-sites install so empty Sites <strong>fails</strong> (original
+ * #1750 regression shape).</p>
+ *
+ * <p>Recipe (after #2192 is in the image / installer under test):</p>
+ * <pre>
+ *   # Silent H2 install with sample sites (product modules / distribution)
+ *   java -jar &lt;installer&gt;.jar --install-dir=&lt;path&gt; --silent --db.type=h2 --demo-sites
+ *   # or interactive wizard: Yes to Install sample sites …
+ *
+ *   # Bring CMS up (host install or Docker cell that uses that install)
+ *   # Then Playwright QA mode:
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \\
+ *     ADMIN_USERNAME=Admin ADMIN_PASSWORD=... \\
+ *     EXPECT_DEMO_SITES=1 \\
+ *     npm test -- tests/bugs/bug-1750-demo-sites-sample-site.spec.js
+ *
+ *   # Optional: standard H2 stack without demo-sites — soft skip when empty:
+ *   python docker/scripts/perc-devctl.py qa-up
+ *   TEST_CMS_URL=… ADMIN_PASSWORD=… npm test -- tests/bugs/bug-1750-demo-sites-sample-site.spec.js
+ * </pre>
+ *
+ * @see helpers/demo-sites.js
+ * @see docs/ai-generated/issue-2191-demo-sites-empty-sites-repro.md
+ */
+
+const { test, expect } = require("@playwright/test");
+const {
+  loginAsAdmin,
+  BASE_URL,
+  adminBasicAuthHeaders,
+} = require("../helpers/auth");
+const {
+  EXPECTED_SAMPLE_SITE_NAMES,
+  pathItemNames,
+  hasAllExpectedSampleSites,
+  hasAnyExpectedSampleSite,
+  shouldEnforceDemoSites,
+  demoSitesSkipReason,
+  normalizeSiteName,
+} = require("../helpers/demo-sites");
+
+const EXPLORER_URL = `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?entry=explorer&_=${Date.now()}`;
+const PATH_FOLDER = `${BASE_URL}/Rhythmyx/services/pathmanagement/path/folder`;
+
+/**
+ * @param {import("@playwright/test").APIRequestContext} request
+ * @returns {Promise<string[]>}
+ */
+async function fetchSitesChildNames(request) {
+  const headers = adminBasicAuthHeaders();
+  const res = await request.get(`${PATH_FOLDER}/Sites`, { headers });
+  expect(
+    res.status(),
+    `GET ${PATH_FOLDER}/Sites must be 200 (path valid even when empty)`,
+  ).toBe(200);
+  const body = await res.json();
+  return pathItemNames(body);
+}
+
+/**
+ * Soft gate: skip with BUG when samples missing and not enforcing.
+ * Hard fail when EXPECT_DEMO_SITES=1 (regression gate).
+ *
+ * @param {string[]} names
+ */
+function gateSampleSitesOrSkip(names) {
+  if (hasAllExpectedSampleSites(names)) {
+    return;
+  }
+  // Empty / no samples: stock non-demo or pre-#2192 image — skip-with-BUG
+  // unless operator set EXPECT_DEMO_SITES=1 (hard regression gate).
+  if (!shouldEnforceDemoSites() && !hasAnyExpectedSampleSite(names)) {
+    test.skip(true, demoSitesSkipReason());
+  }
+  expect(
+    names,
+    `Sites must list sample sites after demo-sites install; got [${names.join(", ")}]. ` +
+      `Expected: ${EXPECTED_SAMPLE_SITE_NAMES.join(", ")}`,
+  ).not.toEqual([]);
+  expect(
+    hasAllExpectedSampleSites(names),
+    `Sites children missing Corporate/Enterprise Investments; got [${names.join(", ")}]`,
+  ).toBe(true);
+}
+
+test.describe("GH-1750 demo-sites Sample Site under Sites (#2194 residual)", () => {
+  test("REST: path/folder/Sites lists Corporate + Enterprise Investments", async ({
+    request,
+  }) => {
+    test.setTimeout(30_000);
+    const names = await fetchSitesChildNames(request);
+    gateSampleSitesOrSkip(names);
+
+    for (const expected of EXPECTED_SAMPLE_SITE_NAMES) {
+      const hit = names.some(
+        (n) => normalizeSiteName(n) === normalizeSiteName(expected),
+      );
+      expect(
+        hit,
+        `Sites should include ${expected}; got [${names.join(", ")}]`,
+      ).toBe(true);
+    }
+  });
+
+  test("UI: Content Explorer Sites expands to sample site nodes", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+
+    // REST probe first — same soft/hard gate as pure API test (cheap skip).
+    const probe = await page.request.get(`${PATH_FOLDER}/Sites`, {
+      headers: adminBasicAuthHeaders(),
+    });
+    expect(probe.status()).toBe(200);
+    const restNames = pathItemNames(await probe.json());
+    gateSampleSitesOrSkip(restNames);
+
+    await loginAsAdmin(page);
+    await page.goto(EXPLORER_URL, { waitUntil: "networkidle" });
+
+    const shell = page.locator('[data-testid="content-explorer-shell"]');
+    await expect(shell).toBeVisible({ timeout: 20_000 });
+
+    const tree = page.locator('[data-testid="explorer-tree"]');
+    await expect(tree).toBeVisible({ timeout: 15_000 });
+
+    const treeErr = page.locator(
+      '[data-testid="explorer-tree-error"], [data-testid="explorer-tree"] [role="alert"]',
+    );
+    if ((await treeErr.count()) > 0 && (await treeErr.first().isVisible())) {
+      const text = await treeErr.first().innerText();
+      throw new Error(`Explorer tree failed to load: ${text}`);
+    }
+
+    // Root Sites node — testids use CMS paths (tree-node-/Sites/ peer of #1622).
+    const sitesRoot = tree.locator(
+      '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid*="tree-node-/Sites"]',
+    );
+    await expect(sitesRoot.first()).toBeVisible({ timeout: 20_000 });
+    await sitesRoot.first().click();
+
+    // Wait for at least one child under Sites (sample sites or nested folders).
+    const childUnderSites = tree.locator(
+      '[data-testid^="tree-node-/Sites/"]:not([data-testid="tree-node-/Sites/"])',
+    );
+    await expect(childUnderSites.first()).toBeVisible({ timeout: 20_000 });
+
+    const nodeTestIds = await tree
+      .locator('[data-testid^="tree-node-"]')
+      .evaluateAll((els) =>
+        els.map((el) => el.getAttribute("data-testid") || ""),
+      );
+    const joined = nodeTestIds.join(" ");
+
+    for (const expected of EXPECTED_SAMPLE_SITE_NAMES) {
+      const spaced = expected;
+      const underscored = expected.replace(/ /g, "_");
+      const hasNode =
+        joined.includes(`/Sites/${spaced}`) ||
+        joined.includes(`/Sites/${underscored}`) ||
+        nodeTestIds.some((id) =>
+          normalizeSiteName(id).includes(normalizeSiteName(expected)),
+        );
+      expect(
+        hasNode,
+        `expected explorer tree node for ${expected}; testids=${JSON.stringify(nodeTestIds)}`,
+      ).toBe(true);
+    }
+
+    // Belt-and-suspenders: REST already had samples; UI must not show empty Sites.
+    const childCount = await childUnderSites.count();
+    expect(
+      childCount,
+      "Sites expansion should show sample site children after demo-sites seed",
+    ).toBeGreaterThan(0);
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-1750-demo-sites-sample-site.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-1750-demo-sites-sample-site.spec.js
@@ -108,7 +108,9 @@ function gateSampleSitesOrSkip(names) {
   // Empty / no samples: stock non-demo or pre-#2192 image — skip-with-BUG
   // unless operator set EXPECT_DEMO_SITES=1 (hard regression gate).
   if (!shouldEnforceDemoSites() && !hasAnyExpectedSampleSite(names)) {
-    test.skip(true, demoSitesSkipReason());
+    // Message-only skip so the BUG reason is the reported description (not "true").
+    test.skip(demoSitesSkipReason());
+    return;
   }
   expect(
     names,
@@ -170,9 +172,10 @@ test.describe("GH-1750 demo-sites Sample Site under Sites (#2194 residual)", () 
       throw new Error(`Explorer tree failed to load: ${text}`);
     }
 
-    // Root Sites node — testids use CMS paths (tree-node-/Sites/ peer of #1622).
+    // Root Sites node only — exact testids (avoid *= which can match SitesArchive).
+    // Peers: bug-1622 / bug-2094 use tree-node-/Sites[/].
     const sitesRoot = tree.locator(
-      '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"], [data-testid*="tree-node-/Sites"]',
+      '[data-testid="tree-node-/Sites/"], [data-testid="tree-node-/Sites"]',
     );
     await expect(sitesRoot.first()).toBeVisible({ timeout: 20_000 });
     await sitesRoot.first().click();
@@ -188,20 +191,28 @@ test.describe("GH-1750 demo-sites Sample Site under Sites (#2194 residual)", () 
       .evaluateAll((els) =>
         els.map((el) => el.getAttribute("data-testid") || ""),
       );
-    const joined = nodeTestIds.join(" ");
+
+    // Immediate children of /Sites only: tree-node-/Sites/<name>[/...]
+    const sitesChildNames = nodeTestIds
+      .map((id) => {
+        const m = /^tree-node-\/Sites\/([^/]+)/.exec(id);
+        return m ? m[1] : null;
+      })
+      .filter((n) => typeof n === "string" && n.length > 0);
+
+    // REST already gated samples; UI tree should expose the same set (exact path segment).
+    expect(
+      hasAllExpectedSampleSites(sitesChildNames),
+      `explorer tree under /Sites missing sample sites; children=${JSON.stringify(sitesChildNames)}; testids=${JSON.stringify(nodeTestIds)}`,
+    ).toBe(true);
 
     for (const expected of EXPECTED_SAMPLE_SITE_NAMES) {
-      const spaced = expected;
-      const underscored = expected.replace(/ /g, "_");
-      const hasNode =
-        joined.includes(`/Sites/${spaced}`) ||
-        joined.includes(`/Sites/${underscored}`) ||
-        nodeTestIds.some((id) =>
-          normalizeSiteName(id).includes(normalizeSiteName(expected)),
-        );
+      const hasNode = sitesChildNames.some(
+        (n) => normalizeSiteName(n) === normalizeSiteName(expected),
+      );
       expect(
         hasNode,
-        `expected explorer tree node for ${expected}; testids=${JSON.stringify(nodeTestIds)}`,
+        `expected explorer tree node for ${expected}; children=${JSON.stringify(sitesChildNames)}`,
       ).toBe(true);
     }
 

--- a/modules/perc-qa-automation/frontend/tests/helpers/demo-sites.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/demo-sites.js
@@ -1,0 +1,165 @@
+/**
+ * Pure helpers for demo-sites / Sample Site residual (#1750 / #2194).
+ *
+ * Used by Playwright bug-1750 (Sites under Explorer after --demo-sites) and
+ * covered by Node unit tests under tests/unit/ (no live CMS).
+ *
+ * Stock seed names (Corporate / Enterprise Investments) come from
+ * installRepository installSampleSites / Rxff sample data. Folder labels under
+ * pathmanagement typically use spaces; RXSITES.SITENAME may use underscores —
+ * normalize before compare.
+ *
+ * @see tests/bugs/bug-1750-demo-sites-sample-site.spec.js
+ * @see docs/ai-generated/issue-2191-demo-sites-empty-sites-repro.md
+ */
+
+"use strict";
+
+/** Canonical folder labels for the two stock sample sites. */
+const EXPECTED_SAMPLE_SITE_NAMES = Object.freeze([
+  "Corporate Investments",
+  "Enterprise Investments",
+]);
+
+/**
+ * Env keys that force hard assertions (fail on empty Sites after demo-sites).
+ * Set after a silent install with --demo-sites (or interactive Yes) once
+ * product fix #2192 is in the image under test.
+ */
+const EXPECT_DEMO_SITES_ENV_KEYS = Object.freeze([
+  "EXPECT_DEMO_SITES",
+  "TEST_EXPECT_DEMO_SITES",
+]);
+
+const PRODUCT_FIX_ISSUE = 2192;
+const PARENT_ISSUE = 1750;
+const RESIDUAL_ISSUE = 2194;
+const REPO_ISSUES =
+  "https://github.com/intersoftdatalabs-in/percussioncms/issues";
+
+/**
+ * @param {string | undefined | null} value
+ * @returns {string}
+ */
+function normalizeSiteName(value) {
+  return String(value || "")
+    .trim()
+    .replace(/_/g, " ")
+    .replace(/\s+/g, " ")
+    .toLowerCase();
+}
+
+/**
+ * Extract folder/item names from a pathmanagement path/folder JSON body.
+ * Accepts PathItem wrapper or bare array peers of bug-1622.
+ *
+ * @param {unknown} body
+ * @returns {string[]}
+ */
+function pathItemNames(body) {
+  if (body == null) {
+    return [];
+  }
+  const items = Array.isArray(body.PathItem)
+    ? body.PathItem
+    : Array.isArray(body)
+      ? body
+      : [];
+  return items
+    .map((it) => (it && typeof it === "object" ? it.name : null))
+    .filter((n) => typeof n === "string" && n.trim().length > 0)
+    .map((n) => String(n).trim());
+}
+
+/**
+ * Whether {@code names} includes every expected sample site (normalized).
+ *
+ * @param {readonly string[]} names
+ * @param {readonly string[]} [expected]
+ * @returns {boolean}
+ */
+function hasAllExpectedSampleSites(
+  names,
+  expected = EXPECTED_SAMPLE_SITE_NAMES,
+) {
+  const normalized = new Set(
+    (names || []).map(normalizeSiteName).filter(Boolean),
+  );
+  return expected.every((exp) => normalized.has(normalizeSiteName(exp)));
+}
+
+/**
+ * Whether {@code names} includes at least one expected sample site.
+ *
+ * @param {readonly string[]} names
+ * @param {readonly string[]} [expected]
+ * @returns {boolean}
+ */
+function hasAnyExpectedSampleSite(
+  names,
+  expected = EXPECTED_SAMPLE_SITE_NAMES,
+) {
+  const normalized = new Set(
+    (names || []).map(normalizeSiteName).filter(Boolean),
+  );
+  return expected.some((exp) => normalized.has(normalizeSiteName(exp)));
+}
+
+/**
+ * @param {string | undefined | null} raw
+ * @returns {boolean}
+ */
+function isTruthyEnvFlag(raw) {
+  if (raw == null) {
+    return false;
+  }
+  const v = String(raw).trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes" || v === "on";
+}
+
+/**
+ * When true, empty Sites / missing sample names must fail (regression gate).
+ *
+ * @param {NodeJS.ProcessEnv | Record<string, string | undefined>} [env]
+ * @returns {boolean}
+ */
+function shouldEnforceDemoSites(env = process.env) {
+  for (const key of EXPECT_DEMO_SITES_ENV_KEYS) {
+    if (isTruthyEnvFlag(env[key])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Skip reason when demo sample sites are not present and enforcement is off.
+ * Durable issue URLs required (skip-with-BUG pattern).
+ *
+ * @returns {string}
+ */
+function demoSitesSkipReason() {
+  return (
+    `BUG: Sample Site(s) not under Sites — empty/missing seed after install ` +
+    `(parent #${PARENT_ISSUE}). Requires product fix #${PRODUCT_FIX_ISSUE} ` +
+    `(${REPO_ISSUES}/${PRODUCT_FIX_ISSUE}) in the image under test and a ` +
+    `demo-sites install (--demo-sites / wizard Yes), then set EXPECT_DEMO_SITES=1. ` +
+    `Residual automation: #${RESIDUAL_ISSUE} (${REPO_ISSUES}/${RESIDUAL_ISSUE}).`
+  );
+}
+
+module.exports = {
+  EXPECTED_SAMPLE_SITE_NAMES,
+  EXPECT_DEMO_SITES_ENV_KEYS,
+  PRODUCT_FIX_ISSUE,
+  PARENT_ISSUE,
+  RESIDUAL_ISSUE,
+  REPO_ISSUES,
+  normalizeSiteName,
+  pathItemNames,
+  hasAllExpectedSampleSites,
+  hasAnyExpectedSampleSite,
+  isTruthyEnvFlag,
+  shouldEnforceDemoSites,
+  demoSitesSkipReason,
+};

--- a/modules/perc-qa-automation/frontend/tests/unit/demo-sites.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/demo-sites.test.js
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for demo-sites sample site helpers (no live CMS).
+ *
+ * Run: npm run test:unit (from frontend/)
+ */
+
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  EXPECTED_SAMPLE_SITE_NAMES,
+  normalizeSiteName,
+  pathItemNames,
+  hasAllExpectedSampleSites,
+  hasAnyExpectedSampleSite,
+  isTruthyEnvFlag,
+  shouldEnforceDemoSites,
+  demoSitesSkipReason,
+} = require("../helpers/demo-sites");
+
+describe("normalizeSiteName", () => {
+  it("trims, collapses space, and maps underscores", () => {
+    assert.equal(normalizeSiteName("  Corporate_Investments "), "corporate investments");
+    assert.equal(normalizeSiteName("Enterprise Investments"), "enterprise investments");
+  });
+
+  it("handles empty values", () => {
+    assert.equal(normalizeSiteName(null), "");
+    assert.equal(normalizeSiteName(""), "");
+  });
+});
+
+describe("pathItemNames", () => {
+  it("reads PathItem wrapper", () => {
+    assert.deepEqual(
+      pathItemNames({
+        PathItem: [
+          { name: "Corporate Investments" },
+          { name: "Enterprise Investments" },
+        ],
+      }),
+      ["Corporate Investments", "Enterprise Investments"],
+    );
+  });
+
+  it("reads bare array and skips empties", () => {
+    assert.deepEqual(
+      pathItemNames([{ name: "A" }, { name: "  " }, {}, { name: "B" }]),
+      ["A", "B"],
+    );
+  });
+
+  it("returns [] for null/empty bodies", () => {
+    assert.deepEqual(pathItemNames(null), []);
+    assert.deepEqual(pathItemNames({}), []);
+    assert.deepEqual(pathItemNames([]), []);
+  });
+});
+
+describe("hasAllExpectedSampleSites / hasAnyExpectedSampleSite", () => {
+  it("matches underscore and spaced names", () => {
+    const names = ["Corporate_Investments", "Enterprise Investments"];
+    assert.equal(hasAllExpectedSampleSites(names), true);
+    assert.equal(hasAnyExpectedSampleSite(names), true);
+  });
+
+  it("fails when Sites empty (original #1750 regression shape)", () => {
+    assert.equal(hasAllExpectedSampleSites([]), false);
+    assert.equal(hasAnyExpectedSampleSite([]), false);
+  });
+
+  it("any vs all when only one sample present", () => {
+    const names = ["Corporate Investments"];
+    assert.equal(hasAnyExpectedSampleSite(names), true);
+    assert.equal(hasAllExpectedSampleSites(names), false);
+  });
+});
+
+describe("shouldEnforceDemoSites", () => {
+  it("accepts truthy aliases on both env keys", () => {
+    assert.equal(shouldEnforceDemoSites({ EXPECT_DEMO_SITES: "1" }), true);
+    assert.equal(shouldEnforceDemoSites({ TEST_EXPECT_DEMO_SITES: "true" }), true);
+    assert.equal(shouldEnforceDemoSites({ EXPECT_DEMO_SITES: "yes" }), true);
+    assert.equal(shouldEnforceDemoSites({ EXPECT_DEMO_SITES: "0" }), false);
+    assert.equal(shouldEnforceDemoSites({}), false);
+  });
+});
+
+describe("isTruthyEnvFlag", () => {
+  it("accepts 1/true/yes/on", () => {
+    assert.equal(isTruthyEnvFlag("1"), true);
+    assert.equal(isTruthyEnvFlag("TRUE"), true);
+    assert.equal(isTruthyEnvFlag("no"), false);
+  });
+});
+
+describe("demoSitesSkipReason", () => {
+  it("embeds durable issue URLs (skip-with-BUG)", () => {
+    const reason = demoSitesSkipReason();
+    assert.match(reason, /^BUG:/);
+    assert.match(reason, /#2192/);
+    assert.match(reason, /#1750/);
+    assert.match(reason, /#2194/);
+    assert.match(
+      reason,
+      /https:\/\/github\.com\/intersoftdatalabs-in\/percussioncms\/issues\/2192/,
+    );
+  });
+});
+
+describe("EXPECTED_SAMPLE_SITE_NAMES", () => {
+  it("lists Corporate and Enterprise Investments", () => {
+    assert.ok(EXPECTED_SAMPLE_SITE_NAMES.includes("Corporate Investments"));
+    assert.ok(EXPECTED_SAMPLE_SITE_NAMES.includes("Enterprise Investments"));
+    assert.equal(EXPECTED_SAMPLE_SITE_NAMES.length, 2);
+  });
+});


### PR DESCRIPTION
## Summary

Slice 4 residual automation for parent **#1750** (this issue **#2194**): Playwright/REST asserts that **Corporate Investments** and **Enterprise Investments** appear under **Sites** after a demo-sites install.

Depends on product fix **#2192** (PR #2202, still open at ship time) being present in the image/installer under test for hard enforcement. Per split plan: ship test + documented recipe; soft **skip-with-BUG** when seed data is absent (default `qa-up` / pre-fix image).

### Changes
- Spec: `modules/perc-qa-automation/frontend/tests/bugs/bug-1750-demo-sites-sample-site.spec.js`
  - REST: `GET pathmanagement/path/folder/Sites` lists both sample sites
  - UI: modern Explorer expands Sites and shows sample site tree nodes
- Pure helpers: `tests/helpers/demo-sites.js` + unit tests
- Env: `EXPECT_DEMO_SITES=1` (alias `TEST_EXPECT_DEMO_SITES`) hard-fails empty Sites (original #1750 regression)
- Soft path: empty Sites → `test.skip` with durable BUG URLs (#2192 / #1750 / #2194)
- Module README: silent `--demo-sites` + `TEST_CMS_URL` / `qa-up` recipe

Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #1750

## Test plan
- [x] `npm run test:unit` (frontend/) — 91 pass including `demo-sites.test.js` + pathmanagement-url
- [x] `npx playwright test --list tests/bugs/bug-1750-demo-sites-sample-site.spec.js` — 2 tests listed
- [x] Module gate: `cd modules/perc-qa-automation && ../../mvnw clean install` — BUILD SUCCESS
- [ ] Live: after #2192 merge + silent H2 `--demo-sites`, run with `EXPECT_DEMO_SITES=1` and confirm green
- [ ] Live soft: default `qa-up` without demo-sites → skip-with-BUG (not red)

## Gates evidence
- Erlang self-review: approve — `docs/ai-generated/code-reviews/issue-2194-demo-sites-playwright-erlang.md`
- Portable: no new path I/O; peers of bug-1622
- Behavioral unit tests for helper logic (empty Sites, underscore names, skip reason URLs)
- Commit: `9dee978125`

Fixes #2194
Partial #1750
