### PR TITLE
docs(agents): load AGENTS.local.md from primary worktree parent

### DIFF
--- a/.kilo/rules/agents-local-from-parent.md
+++ b/.kilo/rules/agents-local-from-parent.md
@@ -1,0 +1,75 @@
+# AGENTS.local.md from primary checkout (worktrees)
+
+Applies to **every** agent session in this repository (Kilo Code implementers,
+reviewers, and other tools that load `.kilo/rules/`).
+
+## Problem
+
+`AGENTS.local.md` is **gitignored** personal/operator override. Git worktrees
+created for agent work (`.kilo/worktrees/*`, `.worktrees/*`,
+`~/.grok/worktrees/*`, etc.) **do not copy** that file from the primary
+checkout. Sessions that only read the worktree root silently miss GH identity,
+commit footers, machine shell notes, and other hard preferences.
+
+## Rule (HARD GATE — session start)
+
+At the **start of the session** (before implement / PR / `gh` work that depends
+on personal overrides):
+
+1. Resolve the **current worktree root**:
+   ```bash
+   git rev-parse --show-toplevel
+   ```
+2. Look for `AGENTS.local.md` in this order (stop at first readable file):
+   1. `<worktree-root>/AGENTS.local.md`
+   2. **Primary checkout** (main worktree) `/AGENTS.local.md` — see resolution
+      below
+   3. Optional: walk parents only if they are still the same monorepo root
+3. **Read** that file with the file tool and treat it as higher priority than
+   root `AGENTS.md` for personal/operator overrides (same hierarchy as
+   **Rule Discovery Protocol** in root `AGENTS.md`).
+4. If no `AGENTS.local.md` exists anywhere in that chain, continue with
+   `AGENTS.md` only — do **not** invent contents.
+
+### Resolving the primary (parent) checkout
+
+Prefer:
+
+```bash
+git worktree list --porcelain
+```
+
+- The first `worktree <path>` entry is the **primary** checkout for this
+  repository (the main working tree that owns `.git`).
+- Use `<primary>/AGENTS.local.md` when the current toplevel’s copy is missing.
+
+Fallback when porcelain is unavailable:
+
+```bash
+# common dir is usually <primary>/.git (or a .git file’s real common path)
+git rev-parse --path-format=absolute --git-common-dir
+# primary root ≈ parent of that .git directory
+```
+
+Examples (illustrative):
+
+| Session cwd | Missing local file | Read instead |
+|-------------|--------------------|--------------|
+| `…/percussioncms/.kilo/worktrees/feat-foo` | worktree has no `AGENTS.local.md` | `…/percussioncms/AGENTS.local.md` |
+| `~/.grok/worktrees/…/night-issue-prs` | worktree has no `AGENTS.local.md` | primary clone’s `AGENTS.local.md` |
+
+## Hard bans
+
+* **Do not** assume “no `AGENTS.local.md` in this worktree” means none exists.
+* **Do not** copy `AGENTS.local.md` into the worktree and **commit** it (it is
+  gitignored and personal).
+* **Do not** skip this read because the worktree has a root `AGENTS.md` only.
+
+## Why
+
+Personal overrides (GitHub account for `gh`, commit email, co-author footers,
+host shell/WSL notes) live only on the developer machine’s primary tree.
+Disposable agent worktrees must still honor them.
+
+Canonical policy: root `AGENTS.md` → **Rule Discovery Protocol** and
+**AGENTS.local.md across git worktrees**.

--- a/.kilo/rules/worktree-hygiene.md
+++ b/.kilo/rules/worktree-hygiene.md
@@ -38,6 +38,14 @@ When your task used a **git worktree** (for example under `.kilo/worktrees/`,
    - a worktree that still has an **open** PR (unless the human ordered cleanup)
    - the worktree you are currently running in (switch to main first)
 
+## Session start (related HARD GATE)
+
+Disposable worktrees do **not** receive gitignored `AGENTS.local.md` from the
+primary checkout. At session start, read personal overrides from the **primary**
+tree when the worktree copy is missing — see
+`.kilo/rules/agents-local-from-parent.md` and root `AGENTS.md` →
+**AGENTS.local.md across git worktrees**.
+
 ## Why
 
 This monorepo is large. Nested agent worktrees under `.kilo/worktrees/` are

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,27 @@ This gate is **stricter than Erlang**: even a clean code review does not authori
    * `AGENTS.local.md` takes precedence over `AGENTS.md`.
    * If no local files are found, default strictly to the root-level instructions.
 
+### AGENTS.local.md across git worktrees (HARD GATE)
+
+Root `AGENTS.local.md` is **gitignored** and is **not** copied into agent git
+worktrees (`.kilo/worktrees/`, `.worktrees/`, `~/.grok/worktrees/`, overnight
+workflow worktrees, etc.).
+
+**At session start**, every agent (Kilo, Grok, others) **must**:
+
+1. Resolve the current worktree root (`git rev-parse --show-toplevel`).
+2. If `<worktree>/AGENTS.local.md` is missing, resolve the **primary** checkout
+   (`git worktree list --porcelain` → first `worktree` path, or the directory
+   that owns `git rev-parse --git-common-dir`) and read
+   `<primary>/AGENTS.local.md` when it exists.
+3. Apply those personal/operator overrides (GH identity, commit footers, host
+   shell notes, etc.) for the rest of the session.
+4. **Do not** commit `AGENTS.local.md` into a worktree. **Do not** assume
+   “absent in this worktree” means no overrides exist.
+
+Tracked tool rules: `.kilo/rules/agents-local-from-parent.md` (Kilo). Grok
+user-global: `~/.grok/rules/05-agents-local-from-parent-worktree.md`.
+
 ## Pre-commit code review (Erlang)
 
 Before `git commit`, `git push`, or opening/updating a GitHub PR for changes you authored:


### PR DESCRIPTION
## Summary
- Root `AGENTS.md`: hard gate to resolve/read `AGENTS.local.md` from the **primary** git checkout when the current worktree lacks it (gitignored; not copied into agent worktrees).
- New tracked Kilo rule: `.kilo/rules/agents-local-from-parent.md`.
- Cross-link from `.kilo/rules/worktree-hygiene.md`.

## Also (local only, not in this PR)
- User Grok rules: `~/.grok/rules/05-agents-local-from-parent-worktree.md` + note in `01-local-first-coding.md`.
- Note at top of personal `AGENTS.local.md`.

## Test plan
- [x] Rule files present and linked from AGENTS.md
- [ ] Agent session started inside a `.kilo/worktrees/*` or `~/.grok/worktrees/*` tree still picks up primary `AGENTS.local.md` (manual)

> Co-Authored by Grok Build using grok-4.5 with agent main.