### PR TITLE
feat(2205): Backend empty Recycling bin API (#944 slice 1)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2205-empty-recycle-api-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2205-empty-recycle-api-erlang.md
@@ -1,0 +1,32 @@
+# Erlang review: issue-2205 empty-recycle API
+
+## Summary
+Backend-only empty Recycling bin for parent #944 slice 1. Dedicated service + CM1 REST under pathmanagement; reuses path deleteFolder(shouldPurge) and folderHelper leaf purge. Admin-only. No public rest-module adaptor (WebUI peers are sitemanage internal REST).
+
+## Scope
+- projects/sitemanage recycle service/data + REST + unit tests
+- sitemanage-beans.xml jaxrs registration
+- No filesystem I/O (CMS finder paths only, product `/` convention)
+
+## Recommendation
+approve
+
+## Gate
+May commit/push: yes
+
+## Issues
+None at bug severity.
+
+### suggestion
+- Consider future metrics for partial undeleted (in-use) items if WebUI needs per-path detail; current summary counts + errors list is adequate for slice 1.
+
+### nit
+- REST class lives under recycle.service.impl (peer to page/asset rest services that also live under service.impl packages).
+
+## Cross-platform path review
+No OS filesystem paths; only CMS logical paths with `/`. N/A for Path/Files gates.
+
+## Tests
+- PSEmptyRecycleServiceTest: 8 tests
+- PSRecycleRestServiceTest: 4 tests
+- Module `mvnw clean install` BUILD SUCCESS

--- a/projects/sitemanage/src/main/java/com/percussion/recycle/data/PSEmptyRecycleResult.java
+++ b/projects/sitemanage/src/main/java/com/percussion/recycle/data/PSEmptyRecycleResult.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.recycle.data;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Summary returned after emptying the Recycling bin.
+ *
+ * <p>Counts cover top-level children under the Recycling root that were attempted during the bulk
+ * purge. {@link #getUndeletedCount()} is the total number of items that could not be permanently
+ * purged (permissions, in-use, or errors with skip-on-failure).
+ */
+@XmlRootElement(name = "EmptyRecycleResult")
+@JsonRootName("EmptyRecycleResult")
+public class PSEmptyRecycleResult {
+
+  private int purgedFolderCount;
+  private int purgedItemCount;
+  private int undeletedCount;
+  private boolean alreadyEmpty;
+  private List<String> errors = new ArrayList<>();
+
+  public int getPurgedFolderCount() {
+    return purgedFolderCount;
+  }
+
+  public void setPurgedFolderCount(int purgedFolderCount) {
+    this.purgedFolderCount = purgedFolderCount;
+  }
+
+  public int getPurgedItemCount() {
+    return purgedItemCount;
+  }
+
+  public void setPurgedItemCount(int purgedItemCount) {
+    this.purgedItemCount = purgedItemCount;
+  }
+
+  public int getUndeletedCount() {
+    return undeletedCount;
+  }
+
+  public void setUndeletedCount(int undeletedCount) {
+    this.undeletedCount = undeletedCount;
+  }
+
+  public boolean isAlreadyEmpty() {
+    return alreadyEmpty;
+  }
+
+  public void setAlreadyEmpty(boolean alreadyEmpty) {
+    this.alreadyEmpty = alreadyEmpty;
+  }
+
+  public List<String> getErrors() {
+    return errors;
+  }
+
+  public void setErrors(List<String> errors) {
+    this.errors = errors != null ? errors : new ArrayList<>();
+  }
+
+  public void addError(String error) {
+    if (error != null && !error.isBlank()) {
+      this.errors.add(error);
+    }
+  }
+
+  public void incrementPurgedFolders() {
+    purgedFolderCount++;
+  }
+
+  public void incrementPurgedItems() {
+    purgedItemCount++;
+  }
+
+  public void addUndeleted(int count) {
+    if (count > 0) {
+      undeletedCount += count;
+    }
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/recycle/service/IPSEmptyRecycleService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/recycle/service/IPSEmptyRecycleService.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.recycle.service;
+
+import com.percussion.recycle.data.PSEmptyRecycleResult;
+import com.percussion.share.service.exception.PSDataServiceException;
+
+/**
+ * Permanently empties purgeable content under the system Recycling root only ({@code
+ * //Folders/$System$/Recycling} / finder path {@code /Recycling/}).
+ *
+ * <p>Never touches live Sites or Assets outside the Recycling tree.
+ */
+public interface IPSEmptyRecycleService {
+
+  /**
+   * Permanently purges all purgeable top-level children under the Recycling root (and their
+   * descendants), reusing path deleteFolder {@code shouldPurge=true} semantics for folders and
+   * folder-helper purge for leaf items.
+   *
+   * <p>Idempotent when the bin is already empty: returns a result with {@code alreadyEmpty=true}
+   * and zero counts.
+   *
+   * @return summary of purge attempts; never {@code null}
+   * @throws PSEmptyRecycleNotAuthorizedException if the current user is not an Admin
+   * @throws PSDataServiceException on authorization lookup failure
+   * @throws PSEmptyRecycleException on unexpected bulk failures that abort the operation
+   */
+  PSEmptyRecycleResult emptyRecyclingBin()
+      throws PSDataServiceException, PSEmptyRecycleException, PSEmptyRecycleNotAuthorizedException;
+
+  /** Thrown when a non-Admin attempts to empty the Recycling bin. */
+  class PSEmptyRecycleNotAuthorizedException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public PSEmptyRecycleNotAuthorizedException(String message) {
+      super(message);
+    }
+  }
+
+  /** Thrown when the empty operation cannot complete. */
+  class PSEmptyRecycleException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public PSEmptyRecycleException(String message) {
+      super(message);
+    }
+
+    public PSEmptyRecycleException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/recycle/service/impl/PSEmptyRecycleService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/recycle/service/impl/PSEmptyRecycleService.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.recycle.service.impl;
+
+import com.percussion.pathmanagement.data.PSDeleteFolderCriteria;
+import com.percussion.pathmanagement.data.PSDeleteFolderCriteria.SkipItemsType;
+import com.percussion.pathmanagement.data.PSPathItem;
+import com.percussion.pathmanagement.service.IPSPathService;
+import com.percussion.pathmanagement.service.IPSPathService.PSPathServiceException;
+import com.percussion.recycle.data.PSEmptyRecycleResult;
+import com.percussion.recycle.service.IPSEmptyRecycleService;
+import com.percussion.security.error.PSExceptionUtils;
+import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.service.exception.PSDataServiceException;
+import com.percussion.user.service.IPSUserService;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * Empties the system Recycling bin by permanently purging only content under the Recycling root.
+ *
+ * <p>Safety: operates solely on finder path {@link #RECYCLING_FINDER_ROOT} which maps to {@link
+ * PSRecycleService#RECYCLING_ROOT}. Live Sites/Assets outside Recycling are never targeted.
+ */
+@Component("emptyRecycleService")
+@Lazy
+public class PSEmptyRecycleService implements IPSEmptyRecycleService {
+
+  /** Finder path for the Recycling root (must end with {@code /} for path matching). */
+  public static final String RECYCLING_FINDER_ROOT = "/Recycling/";
+
+  private final IPSPathService pathService;
+  private final IPSUserService userService;
+  private final IPSFolderHelper folderHelper;
+
+  @Autowired
+  public PSEmptyRecycleService(
+      @Qualifier("pathService") IPSPathService pathService,
+      IPSUserService userService,
+      IPSFolderHelper folderHelper) {
+    this.pathService = pathService;
+    this.userService = userService;
+    this.folderHelper = folderHelper;
+  }
+
+  @Override
+  public PSEmptyRecycleResult emptyRecyclingBin()
+      throws PSDataServiceException, PSEmptyRecycleException, PSEmptyRecycleNotAuthorizedException {
+    requireAdmin();
+
+    PSEmptyRecycleResult result = new PSEmptyRecycleResult();
+    List<PSPathItem> children;
+    try {
+      children = pathService.findChildren(RECYCLING_FINDER_ROOT);
+    } catch (PSPathServiceException e) {
+      throw new PSEmptyRecycleException(
+          "Failed to list Recycling bin children: " + e.getMessage(), e);
+    } catch (PSDataServiceException e) {
+      throw e;
+    }
+
+    if (children == null || children.isEmpty()) {
+      result.setAlreadyEmpty(true);
+      log.info("Empty Recycling bin: already empty (idempotent no-op)");
+      return result;
+    }
+
+    for (PSPathItem child : children) {
+      if (child == null || StringUtils.isBlank(child.getPath())) {
+        continue;
+      }
+      // Hard safety: never process paths outside the Recycling finder root
+      String childPath = normalizeFinderPath(child.getPath());
+      if (!isUnderRecyclingRoot(childPath)) {
+        String msg =
+            "Refusing to purge path outside Recycling root: " + sanitizePathForLog(childPath);
+        log.error(msg);
+        result.addError(msg);
+        result.addUndeleted(1);
+        continue;
+      }
+
+      try {
+        if (child.isFolder() || !child.isLeaf()) {
+          purgeFolder(childPath, child.getId(), result);
+        } else {
+          purgeLeaf(child, result);
+        }
+      } catch (Exception e) {
+        String msg =
+            "Failed to purge recycled path "
+                + sanitizePathForLog(childPath)
+                + ": "
+                + PSExceptionUtils.getMessageForLog(e);
+        log.warn(msg, e);
+        result.addError(msg);
+        result.addUndeleted(1);
+      }
+    }
+
+    log.info(
+        "Empty Recycling bin complete: folders={}, items={}, undeleted={}, errors={}",
+        result.getPurgedFolderCount(),
+        result.getPurgedItemCount(),
+        result.getUndeletedCount(),
+        result.getErrors().size());
+    return result;
+  }
+
+  private void requireAdmin()
+      throws PSDataServiceException, PSEmptyRecycleNotAuthorizedException {
+    var current = userService.getCurrentUser();
+    String name = current != null ? current.getName() : null;
+    if (StringUtils.isBlank(name) || !userService.isAdminUser(name)) {
+      throw new PSEmptyRecycleNotAuthorizedException(
+          "Only Admin users may empty the Recycling bin.");
+    }
+  }
+
+  private void purgeFolder(String finderPath, String guid, PSEmptyRecycleResult result)
+      throws Exception {
+    PSDeleteFolderCriteria criteria = new PSDeleteFolderCriteria();
+    criteria.setPath(finderPath);
+    criteria.setShouldPurge(true);
+    // Skip failures for individual in-use/unauthorized leaves so the bulk empty can continue.
+    criteria.setSkipItems(SkipItemsType.YES);
+    if (StringUtils.isNotBlank(guid)) {
+      criteria.setGuid(guid);
+    }
+    int undeleted = pathService.deleteFolder(criteria);
+    result.incrementPurgedFolders();
+    result.addUndeleted(undeleted);
+  }
+
+  private void purgeLeaf(PSPathItem child, PSEmptyRecycleResult result) throws Exception {
+    // Permanent purge of a leaf under the system Recycling folder path only.
+    folderHelper.removeItem(PSRecycleService.RECYCLING_ROOT, child.getId(), true);
+    result.incrementPurgedItems();
+  }
+
+  /**
+   * Ensures finder path form used by {@link IPSPathService} (leading and trailing slash for
+   * folders).
+   */
+  static String normalizeFinderPath(String path) {
+    String p = StringUtils.trimToEmpty(path);
+    if (!p.startsWith("/")) {
+      p = "/" + p;
+    }
+    if (!p.endsWith("/")) {
+      p = p + "/";
+    }
+    // Collapse accidental double-leading slashes
+    while (p.startsWith("//")) {
+      p = p.substring(1);
+    }
+    return p;
+  }
+
+  /**
+   * Returns true only for the Recycling finder root or its descendants. Rejects {@code /Sites},
+   * {@code /Assets}, and any non-Recycling path.
+   */
+  static boolean isUnderRecyclingRoot(String normalizedFinderPath) {
+    if (StringUtils.isBlank(normalizedFinderPath)) {
+      return false;
+    }
+    String p = normalizedFinderPath;
+    if (!p.startsWith("/")) {
+      p = "/" + p;
+    }
+    // Exact root or prefix under /Recycling/
+    return p.equalsIgnoreCase(RECYCLING_FINDER_ROOT)
+        || StringUtils.startsWithIgnoreCase(p, RECYCLING_FINDER_ROOT);
+  }
+
+  /** Avoid logging full system paths with user-controlled segments in bulk. */
+  static String sanitizePathForLog(String path) {
+    if (path == null) {
+      return "";
+    }
+    // Keep path structure; strip control characters only
+    return path.replaceAll("[\\p{Cntrl}]", "");
+  }
+
+  private static final Logger log = LogManager.getLogger(PSEmptyRecycleService.class);
+}

--- a/projects/sitemanage/src/main/java/com/percussion/recycle/service/impl/PSRecycleRestService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/recycle/service/impl/PSRecycleRestService.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.recycle.service.impl;
+
+import com.percussion.recycle.data.PSEmptyRecycleResult;
+import com.percussion.recycle.service.IPSEmptyRecycleService;
+import com.percussion.recycle.service.IPSEmptyRecycleService.PSEmptyRecycleException;
+import com.percussion.recycle.service.IPSEmptyRecycleService.PSEmptyRecycleNotAuthorizedException;
+import com.percussion.security.error.PSExceptionUtils;
+import com.percussion.share.service.exception.PSDataServiceException;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * CM1 internal REST for Recycling bin operations used by the WebUI.
+ *
+ * <p>Mounted under pathmanagement at {@code /pathmanagement/recycle/*} (see sitemanage-beans
+ * jaxrs:server). Not a public {@code rest} module adaptor surface.
+ *
+ * <p>Permissions: emptying the bin requires Admin (enforced in {@link IPSEmptyRecycleService}).
+ */
+@Path("/recycle")
+@Component("recycleRestService")
+@Lazy
+public class PSRecycleRestService {
+
+  private final IPSEmptyRecycleService emptyRecycleService;
+
+  @Autowired
+  public PSRecycleRestService(IPSEmptyRecycleService emptyRecycleService) {
+    this.emptyRecycleService = emptyRecycleService;
+  }
+
+  /**
+   * Permanently empties the system Recycling bin.
+   *
+   * <p>DELETE is the primary verb (destructive purge). POST is accepted as an alias for clients
+   * that cannot send DELETE with a body-less request reliably.
+   *
+   * @return summary of the empty operation (never HTTP 204 — always a result body)
+   */
+  @DELETE
+  @Path("/empty")
+  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  public PSEmptyRecycleResult emptyRecyclingBinDelete() {
+    return emptyRecyclingBin();
+  }
+
+  /**
+   * POST alias for {@link #emptyRecyclingBinDelete()}.
+   *
+   * @return summary of the empty operation
+   */
+  @POST
+  @Path("/empty")
+  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  public PSEmptyRecycleResult emptyRecyclingBinPost() {
+    return emptyRecyclingBin();
+  }
+
+  private PSEmptyRecycleResult emptyRecyclingBin() {
+    try {
+      return emptyRecycleService.emptyRecyclingBin();
+    } catch (PSEmptyRecycleNotAuthorizedException e) {
+      log.warn("Empty Recycling denied: {}", PSExceptionUtils.getMessageForLog(e));
+      throw new WebApplicationException(
+          Response.status(Response.Status.FORBIDDEN)
+              .entity("Only Admin users may empty the Recycling bin.")
+              .type(MediaType.TEXT_PLAIN)
+              .build());
+    } catch (PSEmptyRecycleException e) {
+      log.error("Empty Recycling failed: {}", PSExceptionUtils.getMessageForLog(e));
+      log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+      // Do not leak internal exception details to the client (CWE-209)
+      throw new WebApplicationException(
+          Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+              .entity("Failed to empty the Recycling bin.")
+              .type(MediaType.TEXT_PLAIN)
+              .build());
+    } catch (PSDataServiceException e) {
+      log.error("Empty Recycling data error: {}", PSExceptionUtils.getMessageForLog(e));
+      log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+      throw new WebApplicationException(
+          Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+              .entity("Failed to empty the Recycling bin.")
+              .type(MediaType.TEXT_PLAIN)
+              .build());
+    }
+  }
+
+  private static final Logger log = LogManager.getLogger(PSRecycleRestService.class);
+}

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -531,6 +531,8 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
     <jaxrs:server id="pathmanagement-jax-rs" address="/pathmanagement" basePackages="com.percussion.share">
         <jaxrs:serviceBeans>
             <ref bean="pathService"/>
+            <!-- Empty Recycling bin (issue #2205 / parent #944 slice 1): /pathmanagement/recycle/empty -->
+            <ref bean="recycleRestService"/>
         </jaxrs:serviceBeans>
         <jaxrs:providers>
             <ref bean="validationExceptionMapper"/>

--- a/projects/sitemanage/src/test/java/com/percussion/recycle/service/impl/PSEmptyRecycleServiceTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/recycle/service/impl/PSEmptyRecycleServiceTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.recycle.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.pathmanagement.data.PSDeleteFolderCriteria;
+import com.percussion.pathmanagement.data.PSPathItem;
+import com.percussion.pathmanagement.service.IPSPathService;
+import com.percussion.recycle.data.PSEmptyRecycleResult;
+import com.percussion.recycle.service.IPSEmptyRecycleService.PSEmptyRecycleNotAuthorizedException;
+import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PSEmptyRecycleServiceTest {
+
+  @Mock private IPSPathService pathService;
+  @Mock private IPSUserService userService;
+  @Mock private IPSFolderHelper folderHelper;
+
+  private PSEmptyRecycleService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new PSEmptyRecycleService(pathService, userService, folderHelper);
+  }
+
+  @Test
+  void empty_whenAlreadyEmpty_isIdempotent() throws Exception {
+    stubAdmin("admin");
+    when(pathService.findChildren(PSEmptyRecycleService.RECYCLING_FINDER_ROOT))
+        .thenReturn(Collections.emptyList());
+
+    PSEmptyRecycleResult result = service.emptyRecyclingBin();
+
+    assertTrue(result.isAlreadyEmpty());
+    assertEquals(0, result.getPurgedFolderCount());
+    assertEquals(0, result.getPurgedItemCount());
+    assertEquals(0, result.getUndeletedCount());
+    verify(pathService, never()).deleteFolder(any());
+  }
+
+  @Test
+  void empty_whenNonAdmin_throwsNotAuthorized() throws Exception {
+    PSCurrentUser user = new PSCurrentUser();
+    user.setName("editor");
+    when(userService.getCurrentUser()).thenReturn(user);
+    when(userService.isAdminUser("editor")).thenReturn(false);
+
+    assertThrows(PSEmptyRecycleNotAuthorizedException.class, () -> service.emptyRecyclingBin());
+    verify(pathService, never()).findChildren(any());
+  }
+
+  @Test
+  void empty_purgesTopLevelFoldersWithShouldPurge() throws Exception {
+    stubAdmin("admin");
+    PSPathItem sites = folderItem("/Recycling/Sites/", "guid-sites");
+    when(pathService.findChildren(PSEmptyRecycleService.RECYCLING_FINDER_ROOT))
+        .thenReturn(List.of(sites));
+    when(pathService.deleteFolder(any())).thenReturn(0);
+
+    PSEmptyRecycleResult result = service.emptyRecyclingBin();
+
+    assertFalse(result.isAlreadyEmpty());
+    assertEquals(1, result.getPurgedFolderCount());
+    assertEquals(0, result.getUndeletedCount());
+
+    ArgumentCaptor<PSDeleteFolderCriteria> captor =
+        ArgumentCaptor.forClass(PSDeleteFolderCriteria.class);
+    verify(pathService).deleteFolder(captor.capture());
+    PSDeleteFolderCriteria criteria = captor.getValue();
+    assertTrue(criteria.getShouldPurge());
+    assertEquals(PSDeleteFolderCriteria.SkipItemsType.YES, criteria.getSkipItems());
+    assertTrue(criteria.getPath().startsWith("/Recycling/"));
+    assertEquals("guid-sites", criteria.getGuid());
+  }
+
+  @Test
+  void empty_purgesLeafItemsViaFolderHelperOnlyUnderRecyclingRoot() throws Exception {
+    stubAdmin("admin");
+    PSPathItem leaf = leafItem("/Recycling/orphan-page", "guid-leaf");
+    when(pathService.findChildren(PSEmptyRecycleService.RECYCLING_FINDER_ROOT))
+        .thenReturn(List.of(leaf));
+
+    PSEmptyRecycleResult result = service.emptyRecyclingBin();
+
+    assertEquals(1, result.getPurgedItemCount());
+    verify(folderHelper)
+        .removeItem(eq(PSRecycleService.RECYCLING_ROOT), eq("guid-leaf"), eq(true));
+    verify(pathService, never()).deleteFolder(any());
+  }
+
+  @Test
+  void empty_refusesPathsOutsideRecycling() throws Exception {
+    stubAdmin("admin");
+    // Defensive: if a child somehow reported a non-Recycling path, do not purge it.
+    PSPathItem evil = folderItem("/Sites/LiveSite/", "guid-live");
+    when(pathService.findChildren(PSEmptyRecycleService.RECYCLING_FINDER_ROOT))
+        .thenReturn(List.of(evil));
+
+    PSEmptyRecycleResult result = service.emptyRecyclingBin();
+
+    assertEquals(0, result.getPurgedFolderCount());
+    assertEquals(1, result.getUndeletedCount());
+    assertFalse(result.getErrors().isEmpty());
+    verify(pathService, never()).deleteFolder(any());
+    verify(folderHelper, never()).removeItem(any(), any(), any(Boolean.class));
+  }
+
+  @Test
+  void empty_accumulatesUndeletedFromDeleteFolder() throws Exception {
+    stubAdmin("admin");
+    PSPathItem assets = folderItem("/Recycling/Assets/", "guid-assets");
+    when(pathService.findChildren(PSEmptyRecycleService.RECYCLING_FINDER_ROOT))
+        .thenReturn(List.of(assets));
+    when(pathService.deleteFolder(any())).thenReturn(3);
+
+    PSEmptyRecycleResult result = service.emptyRecyclingBin();
+
+    assertEquals(1, result.getPurgedFolderCount());
+    assertEquals(3, result.getUndeletedCount());
+  }
+
+  @Test
+  void isUnderRecyclingRoot_safetyChecks() {
+    assertTrue(PSEmptyRecycleService.isUnderRecyclingRoot("/Recycling/"));
+    assertTrue(PSEmptyRecycleService.isUnderRecyclingRoot("/Recycling/Sites/"));
+    assertTrue(PSEmptyRecycleService.isUnderRecyclingRoot("/recycling/assets/"));
+    assertFalse(PSEmptyRecycleService.isUnderRecyclingRoot("/Sites/"));
+    assertFalse(PSEmptyRecycleService.isUnderRecyclingRoot("/Assets/uploads/"));
+    assertFalse(PSEmptyRecycleService.isUnderRecyclingRoot("/"));
+    assertFalse(PSEmptyRecycleService.isUnderRecyclingRoot(""));
+    assertFalse(PSEmptyRecycleService.isUnderRecyclingRoot(null));
+    // Prefix confusion: /RecyclingEvil must not pass
+    assertFalse(PSEmptyRecycleService.isUnderRecyclingRoot("/RecyclingEvil/"));
+  }
+
+  @Test
+  void normalizeFinderPath_addsSlashes() {
+    assertEquals("/Recycling/Sites/", PSEmptyRecycleService.normalizeFinderPath("Recycling/Sites"));
+    assertEquals("/Recycling/", PSEmptyRecycleService.normalizeFinderPath("/Recycling"));
+  }
+
+  private void stubAdmin(String name) throws Exception {
+    PSCurrentUser user = new PSCurrentUser();
+    user.setName(name);
+    when(userService.getCurrentUser()).thenReturn(user);
+    when(userService.isAdminUser(name)).thenReturn(true);
+  }
+
+  private static PSPathItem folderItem(String path, String id) {
+    PSPathItem item = new PSPathItem();
+    item.setType("Folder");
+    item.setLeaf(false);
+    item.setId(id);
+    item.setPath(path);
+    return item;
+  }
+
+  private static PSPathItem leafItem(String path, String id) {
+    PSPathItem item = new PSPathItem();
+    item.setType("percPage");
+    item.setLeaf(true);
+    item.setId(id);
+    item.setPath(path);
+    return item;
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/recycle/service/impl/PSRecycleRestServiceTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/recycle/service/impl/PSRecycleRestServiceTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.recycle.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.percussion.recycle.data.PSEmptyRecycleResult;
+import com.percussion.recycle.service.IPSEmptyRecycleService;
+import com.percussion.recycle.service.IPSEmptyRecycleService.PSEmptyRecycleException;
+import com.percussion.recycle.service.IPSEmptyRecycleService.PSEmptyRecycleNotAuthorizedException;
+import jakarta.ws.rs.WebApplicationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PSRecycleRestServiceTest {
+
+  @Mock private IPSEmptyRecycleService emptyRecycleService;
+
+  private PSRecycleRestService rest;
+
+  @BeforeEach
+  void setUp() {
+    rest = new PSRecycleRestService(emptyRecycleService);
+  }
+
+  @Test
+  void emptyDelete_returnsServiceResult() throws Exception {
+    PSEmptyRecycleResult expected = new PSEmptyRecycleResult();
+    expected.setAlreadyEmpty(true);
+    when(emptyRecycleService.emptyRecyclingBin()).thenReturn(expected);
+
+    PSEmptyRecycleResult actual = rest.emptyRecyclingBinDelete();
+    assertSame(expected, actual);
+  }
+
+  @Test
+  void emptyPost_returnsServiceResult() throws Exception {
+    PSEmptyRecycleResult expected = new PSEmptyRecycleResult();
+    expected.setPurgedFolderCount(2);
+    when(emptyRecycleService.emptyRecyclingBin()).thenReturn(expected);
+
+    PSEmptyRecycleResult actual = rest.emptyRecyclingBinPost();
+    assertEquals(2, actual.getPurgedFolderCount());
+  }
+
+  @Test
+  void empty_whenNotAuthorized_returns403WithoutLeakingDetails() throws Exception {
+    when(emptyRecycleService.emptyRecyclingBin())
+        .thenThrow(new PSEmptyRecycleNotAuthorizedException("secret internal reason XYZ"));
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> rest.emptyRecyclingBinDelete());
+    assertEquals(403, ex.getResponse().getStatus());
+    String body = String.valueOf(ex.getResponse().getEntity());
+    assertTrue(body.contains("Admin"));
+    assertTrue(!body.contains("XYZ"));
+  }
+
+  @Test
+  void empty_whenServiceFails_returns500GenericMessage() throws Exception {
+    when(emptyRecycleService.emptyRecyclingBin())
+        .thenThrow(new PSEmptyRecycleException("db host=internal-secret:5432"));
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> rest.emptyRecyclingBinPost());
+    assertEquals(500, ex.getResponse().getStatus());
+    String body = String.valueOf(ex.getResponse().getEntity());
+    assertTrue(body.contains("Failed to empty"));
+    assertTrue(!body.contains("internal-secret"));
+  }
+}


### PR DESCRIPTION
## Summary
Implements **#2205** — parent epic **#944** slice 1/3: server-side **empty Recycling bin**.

### What
- New dedicated domain service `IPSEmptyRecycleService` / `PSEmptyRecycleService` that permanently purges **only** purgeable content under the system Recycling root (`//Folders/$System$/Recycling`, finder path `/Recycling/`).
- CM1 internal REST (WebUI peer to page/asset purge, not public `rest` module adaptor):
  - `DELETE /pathmanagement/recycle/empty`
  - `POST /pathmanagement/recycle/empty` (alias)
- Returns `PSEmptyRecycleResult` (folder/item counts, undeleted count, error list, `alreadyEmpty` flag).
- Reuses existing purge semantics: `pathService.deleteFolder` with `shouldPurge=true` + `SkipItemsType.YES` for folders (routes through `PSRecyclePathItemService` navon handling); `folderHelper.removeItem(..., purge=true)` for rare leaf items at Recycling root.

### Safety
- Operates only under finder prefix `/Recycling/`; refuses any child path outside that root.
- Never deletes the Recycling root folder itself; never targets live `/Sites` or `/Assets`.
- **Idempotent** when already empty (`alreadyEmpty=true`, zero counts).

### Permissions & failure modes
| Case | Behavior |
|------|----------|
| Non-Admin caller | HTTP **403** plain text ("Only Admin users may empty the Recycling bin.") |
| Already empty | HTTP **200** + `alreadyEmpty=true` |
| Partial failures (permissions / in-use with skip) | HTTP **200** + `undeletedCount` / `errors` populated; continues remaining children |
| List children / unexpected abort | HTTP **500** generic body (no internal detail leak) |

Admin-only is intentional: permanent bulk purge is more destructive than single-item recycle.

### Out of scope (tracked siblings)
- WebUI Empty menu + confirm: **#2206**
- Playwright/Vitest residual: **#2207**

### Change-class companions
- **sitemanage-only** CM1 REST (same class as `PSPageRestService` purge / `PSPathService` deleteFolder). No public `rest` adaptor surface for recycle today → no rest stubs/apibridge required.
- Unit tests for service + REST resource (Mockito).
- Spring jaxrs:server registration for `recycleRestService` under pathmanagement.

## Test plan
- [x] `cd projects/sitemanage && ../../mvnw clean install` → **BUILD SUCCESS**
- [x] `PSEmptyRecycleServiceTest` — Tests run: **8**, Failures: 0
- [x] `PSRecycleRestServiceTest` — Tests run: **4**, Failures: 0
- [x] Erlang self-review: approve (report: `docs/ai-generated/code-reviews/issue-2205-empty-recycle-api-erlang.md`)
- [ ] Manual: Admin DELETE/POST empty on non-empty bin; verify Sites/Assets live content untouched
- [ ] Manual: non-Admin → 403; empty bin → alreadyEmpty

## Gates evidence
- Module clean install: standalone `projects/sitemanage` only (no reactor/`-am`)
- No new filesystem path I/O
- Copyright: Intersoft 2026 on new sources

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2205  
Partial for #944 (slice 1/3)

> Co-Authored by Grok Build using grok-4.5 with agent main.