### PR TITLE
feat(sitemanage): user default CMS landing API + persist (#2209)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2209-user-default-landing-api-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2209-user-default-landing-api-erlang.md
@@ -1,0 +1,41 @@
+# Erlang review: issue #2209 user default landing API + persist
+
+**Branch:** `feat/issue-2209-user-default-landing-api`  
+**Date:** 2026-08-06  
+**Reviewer:** Grok Build (self-review / Erlang gate)  
+**Recommendation:** approve  
+**Gate:** May commit/push: **yes**
+
+## Summary
+
+Adds persisted user CMS landing override (`perc.user.homepage.{user}`) peer to role homepage metadata, REST GET/PUT/DELETE on CM1 user service, and effective resolve precedence in `PSRoleService.getUserHomepage()`: user override > role resolve > Home. Unit tests cover unset fallback, set override, invalid value, multi-role unchanged when unset, view-key mapping, and admin ACL on named-user endpoints.
+
+## Scope
+
+- `projects/sitemanage` only (no rest module public API change; CM1 internal `/user` REST)
+- Parent #959 slice 2; slices 3–4 (index.jsp mapping for expanded types, Admin UI) intentionally out of scope
+- Cross-platform path review: N/A (no new file I/O / path handling)
+
+## Issues
+
+None at **bug** severity.
+
+### suggestion
+
+1. **Username case in metadata key** — key uses exact `userName` string. If admin GET/PUT uses different case than login name, override may not match. Peers (`perc.user.*.dash.page`) use same pattern; acceptable for slice 2. Slice 4 UI should pass the canonical system username.
+
+### nit
+
+1. Fully-qualified `PSUserService.normalizeHomepageType` in `PSRoleService` could be a static import; left explicit to avoid role→impl coupling noise in imports.
+
+## Test evidence
+
+- Focused: `PSUserHomepageTest`, `PSRoleServiceHomepageTest`, `PSUserServiceMockTest` green
+- Module: `projects/sitemanage` `mvnw clean install` green
+
+## Companions checked
+
+- Change class: CM1 domain service + JAX-RS methods on existing bean (not new public rest adaptor)
+- REST client implementor of `IPSUserService` updated (`PSUserServiceRestClient`)
+- Constructor + mock test call sites updated for `IPSMetadataService`
+- No Spring test context bean gap expected (component scan / constructor autowire of existing `metadataService`)

--- a/projects/sitemanage/src/main/java/com/percussion/role/service/IPSRoleService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/role/service/IPSRoleService.java
@@ -104,11 +104,15 @@ public interface IPSRoleService {
   void validateDeleteUsersFromRole(PSUserList userList) throws PSDataServiceException;
 
   /**
-   * Gets the homepage for the logged in user.
+   * Gets the effective CMS landing homepage for the logged-in user.
+   *
+   * <p>Precedence (product #959): user override ({@code perc.user.homepage.{user}}) when set and
+   * valid; else multi-role resolve (Home &gt; Dashboard &gt; Editor); else {@link
+   * #HOMEPAGE_TYPE_HOME}.
    *
    * @return String never null. Product default is {@link #HOMEPAGE_TYPE_HOME} when unset. When the
-   *     user has multiple roles, {@link #HOMEPAGE_TYPE_HOME} wins over Dashboard/Editor (SPA-first
-   *     landing).
+   *     user has multiple roles and no user override, {@link #HOMEPAGE_TYPE_HOME} wins over
+   *     Dashboard/Editor (SPA-first landing).
    */
   String getUserHomepage() throws IPSGenericDao.LoadException;
 }

--- a/projects/sitemanage/src/main/java/com/percussion/role/service/impl/PSRoleService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/role/service/impl/PSRoleService.java
@@ -506,16 +506,32 @@ public class PSRoleService implements IPSRoleService {
   @Path("/userhomepage")
   @Produces(MediaType.TEXT_PLAIN)
   public String getUserHomepage() throws IPSGenericDao.LoadException {
+    // Precedence (product #959): user override > role resolve > Home
     List<String> userRoles = null;
     try {
-      userRoles = userService.getCurrentUser().getRoles();
+      var current = userService.getCurrentUser();
+      if (current != null) {
+        if (StringUtils.isNotBlank(current.getName())) {
+          String override = userService.getHomepageOverride(current.getName());
+          if (StringUtils.isNotBlank(override)) {
+            // Only accept still-valid types (invalid stored → fall through to role resolve)
+            String normalized =
+                com.percussion.user.service.impl.PSUserService.normalizeHomepageType(override);
+            if (normalized != null) {
+              return normalized;
+            }
+          }
+        }
+        userRoles = current.getRoles();
+      }
     } catch (IPSUserService.PSNoCurrentUserException e) {
       log.error(
           "Error getting roles, No Current User! Error:{}", PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
     } catch (PSDataServiceException e) {
       log.error(
-          "Error getting roles for current user: {} Error:", PSExceptionUtils.getMessageForLog(e));
+          "Error getting homepage / roles for current user: {} Error:",
+          PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
     }
 
@@ -529,9 +545,11 @@ public class PSRoleService implements IPSRoleService {
   }
 
   /**
-   * Resolve effective homepage from the set of role homepage values.
+   * Resolve effective homepage from the set of role homepage values (role-only; no user override).
    *
    * <p>Product priority (SPA-first): Home &gt; Dashboard &gt; Editor. Empty/unset → Home.
+   *
+   * <p>User-level override is applied in {@link #getUserHomepage()} before this method.
    *
    * @param userHomePages role homepage types, never {@code null} (may be empty)
    * @return one of {@link #HOMEPAGE_TYPE_HOME}, {@link #HOMEPAGE_TYPE_DASHBOARD}, {@link
@@ -551,6 +569,31 @@ public class PSRoleService implements IPSRoleService {
       return HOMEPAGE_TYPE_EDITOR;
     }
     return HOMEPAGE_TYPE_HOME;
+  }
+
+  /**
+   * Resolve effective CMS landing with full precedence for tests and callers that already have the
+   * parts:
+   *
+   * <ol>
+   *   <li>user override when non-blank and valid
+   *   <li>else role resolve ({@link #resolveUserHomepage(Set)})
+   *   <li>else Home
+   * </ol>
+   *
+   * @param userOverride raw or canonical override; may be blank
+   * @param roleHomePages role homepage values; may be null/empty
+   * @return never null
+   */
+  public static String resolveEffectiveHomepage(String userOverride, Set<String> roleHomePages) {
+    if (StringUtils.isNotBlank(userOverride)) {
+      String normalized =
+          com.percussion.user.service.impl.PSUserService.normalizeHomepageType(userOverride);
+      if (normalized != null) {
+        return normalized;
+      }
+    }
+    return resolveUserHomepage(roleHomePages);
   }
 
   public IPSRoleMgr getRoleMgr() {

--- a/projects/sitemanage/src/main/java/com/percussion/user/service/IPSUserService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/service/IPSUserService.java
@@ -188,6 +188,64 @@ public interface IPSUserService {
   public PSAccessLevel getAccessLevel(PSAccessLevelRequest request);
 
   /**
+   * Metadata key prefix for a user's CMS default landing page override. Peer to role homepage
+   * {@code perc.role.homepage.{roleName}}. Full key: {@code perc.user.homepage.{userName}}.
+   */
+  String META_DATA_HOMEPAGE_PREFIX = "perc.user.homepage.";
+
+  /** Product homepage type: Home (SPA default). */
+  String HOMEPAGE_TYPE_HOME = "Home";
+
+  /** Product homepage type: Dashboard. */
+  String HOMEPAGE_TYPE_DASHBOARD = "Dashboard";
+
+  /** Product homepage type: Editor (page editor). */
+  String HOMEPAGE_TYPE_EDITOR = "Editor";
+
+  /** Product homepage type: Designer / site admin ({@code view=design}). */
+  String HOMEPAGE_TYPE_DESIGNER = "Designer";
+
+  /** Product homepage type: Architecture / navigation ({@code view=arch}). */
+  String HOMEPAGE_TYPE_ARCHITECTURE = "Architecture";
+
+  /** Product homepage type: Publish. */
+  String HOMEPAGE_TYPE_PUBLISH = "Publish";
+
+  /** Product homepage type: Workflow admin. */
+  String HOMEPAGE_TYPE_WORKFLOW = "Workflow";
+
+  /** Product homepage type: Widget Builder. */
+  String HOMEPAGE_TYPE_WIDGET_BUILDER = "WidgetBuilder";
+
+  /**
+   * Returns the persisted default landing-page override for the named user, or empty string when
+   * unset. Never {@code null}. Does not apply role resolve.
+   *
+   * @param userName never blank
+   * @return canonical homepage type or {@code ""} if unset
+   */
+  String getHomepageOverride(String userName) throws PSDataServiceException;
+
+  /**
+   * Sets or clears the default landing-page override for the named user.
+   *
+   * <p>Blank {@code homepage} clears the override (user falls back to role resolve). Non-blank must
+   * normalize to an allowed type; invalid values fail validation (HTTP 400).
+   *
+   * @param userName never blank
+   * @param homepage product type or view-key alias; blank clears
+   * @return the stored canonical type, or {@code ""} when cleared
+   */
+  String setHomepageOverride(String userName, String homepage) throws PSDataServiceException;
+
+  /**
+   * Clears the default landing-page override for the named user.
+   *
+   * @param userName never blank
+   */
+  void clearHomepageOverride(String userName) throws PSDataServiceException;
+
+  /**
    * A group of external users to import.
    *
    * @author adamgent

--- a/projects/sitemanage/src/main/java/com/percussion/user/service/impl/PSUserService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/service/impl/PSUserService.java
@@ -41,6 +41,8 @@ import com.percussion.design.objectstore.PSAttribute;
 import com.percussion.design.objectstore.PSAttributeList;
 import com.percussion.design.objectstore.PSSubject;
 import com.percussion.legacy.security.deprecated.PSLegacyEncrypter;
+import com.percussion.metadata.data.PSMetadata;
+import com.percussion.metadata.service.IPSMetadataService;
 import com.percussion.pathmanagement.service.impl.PSAssetPathItemService;
 import com.percussion.role.service.IPSRoleService;
 import com.percussion.role.service.impl.PSRoleService;
@@ -132,8 +134,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 // Java 11 Optional
+import java.util.Locale;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -192,6 +197,45 @@ public class PSUserService implements IPSUserService {
 
   private final IPSUtilityService utilityService;
 
+  private final IPSMetadataService metadataService;
+
+  /**
+   * Canonical allowed user landing-page types (PascalCase product labels). Peer to role homepage
+   * types Home/Dashboard/Editor; expanded for top-level CMS modules.
+   */
+  public static final Set<String> ALLOWED_HOMEPAGE_TYPES =
+      Collections.unmodifiableSet(
+          new LinkedHashSet<>(
+              Arrays.asList(
+                  HOMEPAGE_TYPE_HOME,
+                  HOMEPAGE_TYPE_DASHBOARD,
+                  HOMEPAGE_TYPE_EDITOR,
+                  HOMEPAGE_TYPE_DESIGNER,
+                  HOMEPAGE_TYPE_ARCHITECTURE,
+                  HOMEPAGE_TYPE_PUBLISH,
+                  HOMEPAGE_TYPE_WORKFLOW,
+                  HOMEPAGE_TYPE_WIDGET_BUILDER)));
+
+  /** Maps canonical homepage type → {@code index.jsp} {@code view} key. */
+  private static final Map<String, String> HOMEPAGE_TYPE_TO_VIEW_KEY =
+      Map.of(
+          HOMEPAGE_TYPE_HOME,
+          "home",
+          HOMEPAGE_TYPE_DASHBOARD,
+          "dash",
+          HOMEPAGE_TYPE_EDITOR,
+          "editor",
+          HOMEPAGE_TYPE_DESIGNER,
+          "design",
+          HOMEPAGE_TYPE_ARCHITECTURE,
+          "arch",
+          HOMEPAGE_TYPE_PUBLISH,
+          "publish",
+          HOMEPAGE_TYPE_WORKFLOW,
+          "workflow",
+          HOMEPAGE_TYPE_WIDGET_BUILDER,
+          "widgetbuilder");
+
   public static final String PERCUSSION_ADMIN_NAME = "PercussionAdmin";
   public static final String ADMIN_NAME = "Admin";
   public static final String ADMIN1_NAME = "admin1";
@@ -229,7 +273,8 @@ public class PSUserService implements IPSUserService {
       IPSSecurityWs securityWs,
       IPSContentWs contentWs,
       IPSIdMapper idMapper,
-      IPSUtilityService utilityService) {
+      IPSUtilityService utilityService,
+      IPSMetadataService metadataService) {
     super();
     this.userLoginDao = userLoginDao;
     this.passwordFilter = passwordFilter;
@@ -240,6 +285,7 @@ public class PSUserService implements IPSUserService {
     this.contentWs = contentWs;
     this.idMapper = idMapper;
     this.utilityService = utilityService;
+    this.metadataService = metadataService;
     setupServerStartupListener(notificationService);
   }
 
@@ -838,6 +884,225 @@ public class PSUserService implements IPSUserService {
     currUser.setAccessibilityUser(isAccessibility);
 
     return currUser;
+  }
+
+  /**
+   * GET persisted default landing override for the current user. Empty string when unset (caller
+   * should fall back to role resolve via {@code /role/userhomepage}).
+   */
+  @GET
+  @Path("/homepage")
+  @Produces(MediaType.TEXT_PLAIN)
+  public String getCurrentUserHomepageOverride() throws PSDataServiceException {
+    return getHomepageOverride(requireCurrentUserName());
+  }
+
+  /**
+   * PUT default landing override for the current user. Body is plain-text product type or view-key
+   * alias; blank body clears the override.
+   */
+  @PUT
+  @Path("/homepage")
+  @Consumes(MediaType.TEXT_PLAIN)
+  @Produces(MediaType.TEXT_PLAIN)
+  public String setCurrentUserHomepageOverride(String homepage) throws PSDataServiceException {
+    return setHomepageOverride(requireCurrentUserName(), homepage);
+  }
+
+  /** DELETE default landing override for the current user. */
+  @DELETE
+  @Path("/homepage")
+  public void clearCurrentUserHomepageOverride() throws PSDataServiceException {
+    clearHomepageOverride(requireCurrentUserName());
+  }
+
+  /**
+   * GET persisted default landing override for a named user (admin-managed). Empty string when
+   * unset.
+   */
+  @GET
+  @Path("/homepage/{userName}")
+  @Produces(MediaType.TEXT_PLAIN)
+  public String getHomepageOverride(@PathParam("userName") String userName)
+      throws PSDataServiceException {
+    PSParameterValidationUtils.rejectIfBlank("getHomepageOverride", "userName", userName);
+    assertCanManageHomepage(userName);
+    try {
+      var md = metadataService.find(META_DATA_HOMEPAGE_PREFIX + userName);
+      if (md == null || isBlank(md.getData())) {
+        return "";
+      }
+      // Stale/invalid stored value treated as unset for read
+      String normalized = normalizeHomepageType(md.getData());
+      return normalized == null ? "" : normalized;
+    } catch (IPSGenericDao.LoadException e) {
+      throw new PSDataServiceException("Failed to load homepage override for user " + userName, e);
+    }
+  }
+
+  /**
+   * PUT default landing override for a named user. Blank body clears. Invalid value → validation
+   * error (400).
+   */
+  @PUT
+  @Path("/homepage/{userName}")
+  @Consumes(MediaType.TEXT_PLAIN)
+  @Produces(MediaType.TEXT_PLAIN)
+  public String setHomepageOverride(
+      @PathParam("userName") String userName, String homepage) throws PSDataServiceException {
+    PSParameterValidationUtils.rejectIfBlank("setHomepageOverride", "userName", userName);
+    assertCanManageHomepage(userName);
+    if (isBlank(homepage)) {
+      clearHomepageOverride(userName);
+      return "";
+    }
+    String normalized = normalizeHomepageType(homepage);
+    if (normalized == null) {
+      PSParameterValidationUtils.validateParameters("setHomepageOverride")
+          .rejectField(
+              "homepage",
+              "Invalid homepage value '"
+                  + homepage
+                  + "'. Allowed: "
+                  + ALLOWED_HOMEPAGE_TYPES
+                  + " (or view keys home/dash/editor/design/arch/publish/workflow/widgetbuilder).",
+              homepage)
+          .throwIfInvalid();
+      // throwIfInvalid always throws when rejectField was used; keep compiler definite-assignment
+      throw new PSDataServiceException("Invalid homepage value: " + homepage);
+    }
+    try {
+      var key = META_DATA_HOMEPAGE_PREFIX + userName;
+      var md = metadataService.find(key);
+      if (md == null) {
+        md = new PSMetadata(key, normalized);
+      } else {
+        md.setData(normalized);
+      }
+      metadataService.save(md);
+      return normalized;
+    } catch (IPSGenericDao.LoadException | IPSGenericDao.SaveException e) {
+      throw new PSDataServiceException("Failed to save homepage override for user " + userName, e);
+    }
+  }
+
+  /** DELETE default landing override for a named user. */
+  @DELETE
+  @Path("/homepage/{userName}")
+  public void clearHomepageOverride(@PathParam("userName") String userName)
+      throws PSDataServiceException {
+    PSParameterValidationUtils.rejectIfBlank("clearHomepageOverride", "userName", userName);
+    assertCanManageHomepage(userName);
+    try {
+      var key = META_DATA_HOMEPAGE_PREFIX + userName;
+      var md = metadataService.find(key);
+      if (md != null) {
+        metadataService.delete(key);
+      }
+    } catch (IPSGenericDao.LoadException | IPSGenericDao.DeleteException e) {
+      throw new PSDataServiceException(
+          "Failed to clear homepage override for user " + userName, e);
+    }
+  }
+
+  /**
+   * Normalizes a raw homepage string to a canonical product type, or {@code null} if invalid.
+   *
+   * <p>Accepts canonical types (case-sensitive) and common view-key / label aliases
+   * (case-insensitive).
+   */
+  public static String normalizeHomepageType(String raw) {
+    if (isBlank(raw)) {
+      return null;
+    }
+    String trimmed = raw.trim();
+    if (ALLOWED_HOMEPAGE_TYPES.contains(trimmed)) {
+      return trimmed;
+    }
+    String lower = trimmed.toLowerCase(Locale.ROOT);
+    switch (lower) {
+      case "home":
+        return HOMEPAGE_TYPE_HOME;
+      case "dash":
+      case "dashboard":
+        return HOMEPAGE_TYPE_DASHBOARD;
+      case "editor":
+      case "pageeditor":
+      case "webmgt":
+        return HOMEPAGE_TYPE_EDITOR;
+      case "design":
+      case "designer":
+      case "siteadmin":
+      case "admin":
+        return HOMEPAGE_TYPE_DESIGNER;
+      case "arch":
+      case "architecture":
+      case "navigation":
+      case "site_arch":
+      case "sitearch":
+        return HOMEPAGE_TYPE_ARCHITECTURE;
+      case "publish":
+        return HOMEPAGE_TYPE_PUBLISH;
+      case "workflow":
+        return HOMEPAGE_TYPE_WORKFLOW;
+      case "widgetbuilder":
+      case "widget-builder":
+      case "widget_builder":
+        return HOMEPAGE_TYPE_WIDGET_BUILDER;
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * Maps a canonical homepage type to the {@code index.jsp} {@code view} query key. Unknown/blank
+   * → {@code home}.
+   */
+  public static String homepageTypeToViewKey(String homepageType) {
+    if (isBlank(homepageType)) {
+      return "home";
+    }
+    return HOMEPAGE_TYPE_TO_VIEW_KEY.getOrDefault(homepageType, "home");
+  }
+
+  private String requireCurrentUserName() throws PSNoCurrentUserException {
+    try {
+      String userName = getCurrentUserName();
+      if (isBlank(userName)) {
+        throw new PSNoCurrentUserException("No current user in current request");
+      }
+      return userName;
+    } catch (PSNoCurrentUserException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new PSNoCurrentUserException("Error getting current user.", e);
+    }
+  }
+
+  /**
+   * Current user may manage their own homepage; only Admin may manage another user's.
+   */
+  private void assertCanManageHomepage(String targetUserName) throws PSDataServiceException {
+    String current;
+    try {
+      current = getCurrentUserName();
+    } catch (Exception e) {
+      throw new PSNoCurrentUserException("Error getting current user.", e);
+    }
+    if (isBlank(current)) {
+      throw new PSNoCurrentUserException("No current user in current request");
+    }
+    if (StringUtils.equalsIgnoreCase(current, targetUserName)) {
+      return;
+    }
+    if (!isAdminUser(current)) {
+      PSParameterValidationUtils.validateParameters("homepage")
+          .rejectField(
+              "userName",
+              "Only an Admin user may get or set another user's default landing page.",
+              targetUserName)
+          .throwIfInvalid();
+    }
   }
 
   @POST

--- a/projects/sitemanage/src/main/java/com/percussion/user/service/impl/PSUserService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/user/service/impl/PSUserService.java
@@ -928,7 +928,7 @@ public class PSUserService implements IPSUserService {
     PSParameterValidationUtils.rejectIfBlank("getHomepageOverride", "userName", userName);
     assertCanManageHomepage(userName);
     try {
-      var md = metadataService.find(META_DATA_HOMEPAGE_PREFIX + userName);
+      var md = metadataService.find(homepageMetadataKey(userName));
       if (md == null || isBlank(md.getData())) {
         return "";
       }
@@ -968,11 +968,9 @@ public class PSUserService implements IPSUserService {
                   + " (or view keys home/dash/editor/design/arch/publish/workflow/widgetbuilder).",
               homepage)
           .throwIfInvalid();
-      // throwIfInvalid always throws when rejectField was used; keep compiler definite-assignment
-      throw new PSDataServiceException("Invalid homepage value: " + homepage);
     }
     try {
-      var key = META_DATA_HOMEPAGE_PREFIX + userName;
+      var key = homepageMetadataKey(userName);
       var md = metadataService.find(key);
       if (md == null) {
         md = new PSMetadata(key, normalized);
@@ -994,7 +992,7 @@ public class PSUserService implements IPSUserService {
     PSParameterValidationUtils.rejectIfBlank("clearHomepageOverride", "userName", userName);
     assertCanManageHomepage(userName);
     try {
-      var key = META_DATA_HOMEPAGE_PREFIX + userName;
+      var key = homepageMetadataKey(userName);
       var md = metadataService.find(key);
       if (md != null) {
         metadataService.delete(key);
@@ -1003,6 +1001,18 @@ public class PSUserService implements IPSUserService {
       throw new PSDataServiceException(
           "Failed to clear homepage override for user " + userName, e);
     }
+  }
+
+  /**
+   * Canonical metadata key for a user's homepage override.
+   *
+   * <p>Usernames are compared case-insensitively for authz ({@link #assertCanManageHomepage}); the
+   * key must use the same case folding so {@code /homepage/alice} and {@code /homepage/Alice} share
+   * one stored value (and {@link com.percussion.role.service.impl.PSRoleService#getUserHomepage}
+   * finds the override regardless of {@code current.getName()} casing).
+   */
+  static String homepageMetadataKey(String userName) {
+    return META_DATA_HOMEPAGE_PREFIX + userName.trim().toLowerCase(Locale.ROOT);
   }
 
   /**

--- a/projects/sitemanage/src/test/java/com/percussion/role/service/impl/PSRoleServiceHomepageTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/role/service/impl/PSRoleServiceHomepageTest.java
@@ -62,4 +62,21 @@ class PSRoleServiceHomepageTest {
         HOMEPAGE_TYPE_DASHBOARD,
         PSRoleService.resolveUserHomepage(Set.of(HOMEPAGE_TYPE_DASHBOARD, HOMEPAGE_TYPE_EDITOR)));
   }
+
+  @Test
+  void effectivePrefersUserOverrideOverMultiRole() {
+    assertEquals(
+        HOMEPAGE_TYPE_EDITOR,
+        PSRoleService.resolveEffectiveHomepage(
+            HOMEPAGE_TYPE_EDITOR,
+            Set.of(HOMEPAGE_TYPE_HOME, HOMEPAGE_TYPE_DASHBOARD, HOMEPAGE_TYPE_EDITOR)));
+  }
+
+  @Test
+  void effectiveFallsBackToRoleWhenOverrideBlank() {
+    assertEquals(
+        HOMEPAGE_TYPE_DASHBOARD,
+        PSRoleService.resolveEffectiveHomepage(
+            "", Set.of(HOMEPAGE_TYPE_DASHBOARD, HOMEPAGE_TYPE_EDITOR)));
+  }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/user/service/impl/PSUserHomepageTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/user/service/impl/PSUserHomepageTest.java
@@ -267,6 +267,29 @@ class PSUserHomepageTest {
     }
 
     @Test
+    void nonAdminCannotSetOtherUserHomepage() throws Exception {
+      doReturn("bob").when(userService).getCurrentUserName();
+      doReturn(false).when(userService).isAdminUser("bob");
+
+      assertThrows(
+          PSValidationException.class,
+          () -> userService.setHomepageOverride("alice", HOMEPAGE_TYPE_EDITOR));
+      verify(metadataService, never()).save(any());
+      verify(metadataService, never()).find(any());
+    }
+
+    @Test
+    void nonAdminCannotClearOtherUserHomepage() throws Exception {
+      doReturn("bob").when(userService).getCurrentUserName();
+      doReturn(false).when(userService).isAdminUser("bob");
+
+      assertThrows(
+          PSValidationException.class, () -> userService.clearHomepageOverride("alice"));
+      verify(metadataService, never()).delete(any());
+      verify(metadataService, never()).find(any());
+    }
+
+    @Test
     void adminCanManageOtherUser() throws Exception {
       doReturn("admin").when(userService).getCurrentUserName();
       doReturn(true).when(userService).isAdminUser("admin");
@@ -274,6 +297,32 @@ class PSUserHomepageTest {
 
       assertEquals("", userService.getHomepageOverride("alice"));
       verify(metadataService).find(META_DATA_HOMEPAGE_PREFIX + "alice");
+    }
+
+    @Test
+    void metadataKeyIsCaseInsensitiveForPathParam() throws Exception {
+      doReturn("Alice").when(userService).getCurrentUserName();
+      when(metadataService.find(META_DATA_HOMEPAGE_PREFIX + "alice"))
+          .thenReturn(new PSMetadata(META_DATA_HOMEPAGE_PREFIX + "alice", HOMEPAGE_TYPE_EDITOR));
+
+      // Path-param casing must not fragment the stored key
+      assertEquals(HOMEPAGE_TYPE_EDITOR, userService.getHomepageOverride("Alice"));
+      assertEquals(HOMEPAGE_TYPE_EDITOR, userService.getHomepageOverride("alice"));
+      verify(metadataService, org.mockito.Mockito.atLeastOnce())
+          .find(META_DATA_HOMEPAGE_PREFIX + "alice");
+    }
+
+    @Test
+    void setUsesCanonicalLowercaseMetadataKey() throws Exception {
+      doReturn("Alice").when(userService).getCurrentUserName();
+      when(metadataService.find(META_DATA_HOMEPAGE_PREFIX + "alice")).thenReturn(null);
+
+      String stored = userService.setHomepageOverride("Alice", "editor");
+      assertEquals(HOMEPAGE_TYPE_EDITOR, stored);
+
+      ArgumentCaptor<PSMetadata> captor = ArgumentCaptor.forClass(PSMetadata.class);
+      verify(metadataService).save(captor.capture());
+      assertEquals(META_DATA_HOMEPAGE_PREFIX + "alice", captor.getValue().getKey());
     }
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/user/service/impl/PSUserHomepageTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/user/service/impl/PSUserHomepageTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.user.service.impl;
+
+import static com.percussion.role.service.IPSRoleService.HOMEPAGE_TYPE_DASHBOARD;
+import static com.percussion.role.service.IPSRoleService.HOMEPAGE_TYPE_EDITOR;
+import static com.percussion.role.service.IPSRoleService.HOMEPAGE_TYPE_HOME;
+import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_ARCHITECTURE;
+import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_DESIGNER;
+import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_PUBLISH;
+import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_WIDGET_BUILDER;
+import static com.percussion.user.service.IPSUserService.HOMEPAGE_TYPE_WORKFLOW;
+import static com.percussion.user.service.IPSUserService.META_DATA_HOMEPAGE_PREFIX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.metadata.data.PSMetadata;
+import com.percussion.metadata.service.IPSMetadataService;
+import com.percussion.role.service.impl.PSRoleService;
+import com.percussion.security.IPSPasswordFilter;
+import com.percussion.services.security.IPSBackEndRoleMgr;
+import com.percussion.services.security.IPSRoleMgr;
+import com.percussion.services.workflow.IPSWorkflowService;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.share.service.exception.PSValidationException;
+import com.percussion.sitemanage.dao.IPSUserLoginDao;
+import com.percussion.utils.service.IPSUtilityService;
+import com.percussion.webservices.content.IPSContentWs;
+import com.percussion.webservices.security.IPSSecurityWs;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Unit tests for user default CMS landing page (issue #2209 / parent #959 slice 2).
+ *
+ * <p>Covers: unset fallback, set override, invalid value, multi-role interaction unchanged when
+ * unset, view-key mapping for slice-3 readiness.
+ */
+@DisplayName("User default landing page (#2209)")
+class PSUserHomepageTest {
+
+  private IPSMetadataService metadataService;
+  private PSUserService userService;
+
+  @BeforeEach
+  void setUp() {
+    metadataService = mock(IPSMetadataService.class);
+    userService =
+        spy(
+            new PSUserService(
+                mock(IPSUserLoginDao.class),
+                mock(IPSPasswordFilter.class),
+                mock(IPSBackEndRoleMgr.class),
+                mock(IPSRoleMgr.class),
+                /* notificationService */ null,
+                mock(IPSWorkflowService.class),
+                mock(IPSSecurityWs.class),
+                mock(IPSContentWs.class),
+                mock(IPSIdMapper.class),
+                mock(IPSUtilityService.class),
+                metadataService));
+  }
+
+  @Nested
+  @DisplayName("normalizeHomepageType / view keys")
+  class NormalizeAndViewKeys {
+
+    @Test
+    void acceptsCanonicalTypes() {
+      assertEquals(HOMEPAGE_TYPE_HOME, PSUserService.normalizeHomepageType("Home"));
+      assertEquals(HOMEPAGE_TYPE_DASHBOARD, PSUserService.normalizeHomepageType("Dashboard"));
+      assertEquals(HOMEPAGE_TYPE_EDITOR, PSUserService.normalizeHomepageType("Editor"));
+      assertEquals(HOMEPAGE_TYPE_DESIGNER, PSUserService.normalizeHomepageType("Designer"));
+      assertEquals(
+          HOMEPAGE_TYPE_ARCHITECTURE, PSUserService.normalizeHomepageType("Architecture"));
+      assertEquals(HOMEPAGE_TYPE_PUBLISH, PSUserService.normalizeHomepageType("Publish"));
+      assertEquals(HOMEPAGE_TYPE_WORKFLOW, PSUserService.normalizeHomepageType("Workflow"));
+      assertEquals(
+          HOMEPAGE_TYPE_WIDGET_BUILDER, PSUserService.normalizeHomepageType("WidgetBuilder"));
+    }
+
+    @Test
+    void acceptsViewKeyAliases() {
+      assertEquals(HOMEPAGE_TYPE_HOME, PSUserService.normalizeHomepageType("home"));
+      assertEquals(HOMEPAGE_TYPE_DASHBOARD, PSUserService.normalizeHomepageType("dash"));
+      assertEquals(HOMEPAGE_TYPE_EDITOR, PSUserService.normalizeHomepageType("editor"));
+      assertEquals(HOMEPAGE_TYPE_DESIGNER, PSUserService.normalizeHomepageType("design"));
+      assertEquals(HOMEPAGE_TYPE_DESIGNER, PSUserService.normalizeHomepageType("admin"));
+      assertEquals(HOMEPAGE_TYPE_ARCHITECTURE, PSUserService.normalizeHomepageType("arch"));
+      assertEquals(HOMEPAGE_TYPE_ARCHITECTURE, PSUserService.normalizeHomepageType("navigation"));
+      assertEquals(HOMEPAGE_TYPE_PUBLISH, PSUserService.normalizeHomepageType("publish"));
+      assertEquals(HOMEPAGE_TYPE_WORKFLOW, PSUserService.normalizeHomepageType("workflow"));
+      assertEquals(
+          HOMEPAGE_TYPE_WIDGET_BUILDER, PSUserService.normalizeHomepageType("widgetbuilder"));
+    }
+
+    @Test
+    void invalidAndBlankReturnNull() {
+      assertNull(PSUserService.normalizeHomepageType(null));
+      assertNull(PSUserService.normalizeHomepageType(""));
+      assertNull(PSUserService.normalizeHomepageType("   "));
+      assertNull(PSUserService.normalizeHomepageType("NotARealModule"));
+      assertNull(PSUserService.normalizeHomepageType("home-page"));
+    }
+
+    @Test
+    void mapsTypesToIndexViewKeys() {
+      assertEquals("home", PSUserService.homepageTypeToViewKey(HOMEPAGE_TYPE_HOME));
+      assertEquals("dash", PSUserService.homepageTypeToViewKey(HOMEPAGE_TYPE_DASHBOARD));
+      assertEquals("editor", PSUserService.homepageTypeToViewKey(HOMEPAGE_TYPE_EDITOR));
+      assertEquals("design", PSUserService.homepageTypeToViewKey(HOMEPAGE_TYPE_DESIGNER));
+      assertEquals("arch", PSUserService.homepageTypeToViewKey(HOMEPAGE_TYPE_ARCHITECTURE));
+      assertEquals("publish", PSUserService.homepageTypeToViewKey(HOMEPAGE_TYPE_PUBLISH));
+      assertEquals("workflow", PSUserService.homepageTypeToViewKey(HOMEPAGE_TYPE_WORKFLOW));
+      assertEquals(
+          "widgetbuilder", PSUserService.homepageTypeToViewKey(HOMEPAGE_TYPE_WIDGET_BUILDER));
+      assertEquals("home", PSUserService.homepageTypeToViewKey(null));
+      assertEquals("home", PSUserService.homepageTypeToViewKey("bogus"));
+    }
+  }
+
+  @Nested
+  @DisplayName("effective resolve precedence")
+  class EffectiveResolve {
+
+    @Test
+    void unsetOverrideFallsBackToRoleResolve() {
+      assertEquals(
+          HOMEPAGE_TYPE_EDITOR,
+          PSRoleService.resolveEffectiveHomepage("", Set.of(HOMEPAGE_TYPE_EDITOR)));
+      assertEquals(
+          HOMEPAGE_TYPE_HOME,
+          PSRoleService.resolveEffectiveHomepage(null, Set.of(HOMEPAGE_TYPE_HOME)));
+      assertEquals(
+          HOMEPAGE_TYPE_DASHBOARD,
+          PSRoleService.resolveEffectiveHomepage(
+              "  ", Set.of(HOMEPAGE_TYPE_DASHBOARD, HOMEPAGE_TYPE_EDITOR)));
+    }
+
+    @Test
+    void setOverrideWinsOverRoleResolve() {
+      assertEquals(
+          HOMEPAGE_TYPE_EDITOR,
+          PSRoleService.resolveEffectiveHomepage(
+              HOMEPAGE_TYPE_EDITOR, Set.of(HOMEPAGE_TYPE_HOME, HOMEPAGE_TYPE_DASHBOARD)));
+      assertEquals(
+          HOMEPAGE_TYPE_DESIGNER,
+          PSRoleService.resolveEffectiveHomepage(
+              "design", Set.of(HOMEPAGE_TYPE_EDITOR)));
+    }
+
+    @Test
+    void invalidOverrideFallsBackToRoleResolve() {
+      assertEquals(
+          HOMEPAGE_TYPE_DASHBOARD,
+          PSRoleService.resolveEffectiveHomepage(
+              "NotARealModule", Set.of(HOMEPAGE_TYPE_DASHBOARD, HOMEPAGE_TYPE_EDITOR)));
+    }
+
+    @Test
+    void multiRolePrecedenceUnchangedWhenOverrideUnset() {
+      // Same as existing PSRoleServiceHomepageTest: Home > Dashboard > Editor
+      assertEquals(
+          HOMEPAGE_TYPE_HOME,
+          PSRoleService.resolveEffectiveHomepage(
+              null, Set.of(HOMEPAGE_TYPE_HOME, HOMEPAGE_TYPE_DASHBOARD, HOMEPAGE_TYPE_EDITOR)));
+      assertEquals(
+          HOMEPAGE_TYPE_DASHBOARD,
+          PSRoleService.resolveEffectiveHomepage(
+              "", Set.of(HOMEPAGE_TYPE_DASHBOARD, HOMEPAGE_TYPE_EDITOR)));
+      assertEquals(
+          HOMEPAGE_TYPE_HOME, PSRoleService.resolveEffectiveHomepage(null, Set.of()));
+    }
+  }
+
+  @Nested
+  @DisplayName("persist get/set/clear")
+  class Persist {
+
+    @Test
+    void getReturnsEmptyWhenUnset() throws Exception {
+      doReturn("alice").when(userService).getCurrentUserName();
+      when(metadataService.find(META_DATA_HOMEPAGE_PREFIX + "alice")).thenReturn(null);
+
+      assertEquals("", userService.getHomepageOverride("alice"));
+    }
+
+    @Test
+    void getReturnsStoredCanonicalType() throws Exception {
+      doReturn("alice").when(userService).getCurrentUserName();
+      when(metadataService.find(META_DATA_HOMEPAGE_PREFIX + "alice"))
+          .thenReturn(new PSMetadata(META_DATA_HOMEPAGE_PREFIX + "alice", HOMEPAGE_TYPE_EDITOR));
+
+      assertEquals(HOMEPAGE_TYPE_EDITOR, userService.getHomepageOverride("alice"));
+    }
+
+    @Test
+    void setPersistsNormalizedType() throws Exception {
+      doReturn("alice").when(userService).getCurrentUserName();
+      when(metadataService.find(META_DATA_HOMEPAGE_PREFIX + "alice")).thenReturn(null);
+
+      String stored = userService.setHomepageOverride("alice", "dash");
+      assertEquals(HOMEPAGE_TYPE_DASHBOARD, stored);
+
+      ArgumentCaptor<PSMetadata> captor = ArgumentCaptor.forClass(PSMetadata.class);
+      verify(metadataService).save(captor.capture());
+      assertEquals(META_DATA_HOMEPAGE_PREFIX + "alice", captor.getValue().getKey());
+      assertEquals(HOMEPAGE_TYPE_DASHBOARD, captor.getValue().getData());
+    }
+
+    @Test
+    void setInvalidThrowsValidation() throws Exception {
+      doReturn("alice").when(userService).getCurrentUserName();
+
+      assertThrows(
+          PSValidationException.class,
+          () -> userService.setHomepageOverride("alice", "NotARealModule"));
+      verify(metadataService, never()).save(any());
+    }
+
+    @Test
+    void blankSetClearsOverride() throws Exception {
+      doReturn("alice").when(userService).getCurrentUserName();
+      when(metadataService.find(META_DATA_HOMEPAGE_PREFIX + "alice"))
+          .thenReturn(new PSMetadata(META_DATA_HOMEPAGE_PREFIX + "alice", HOMEPAGE_TYPE_EDITOR));
+
+      assertEquals("", userService.setHomepageOverride("alice", "  "));
+      verify(metadataService).delete(eq(META_DATA_HOMEPAGE_PREFIX + "alice"));
+    }
+
+    @Test
+    void nonAdminCannotManageOtherUser() throws Exception {
+      doReturn("bob").when(userService).getCurrentUserName();
+      doReturn(false).when(userService).isAdminUser("bob");
+
+      assertThrows(
+          PSValidationException.class, () -> userService.getHomepageOverride("alice"));
+      verify(metadataService, never()).find(any());
+    }
+
+    @Test
+    void adminCanManageOtherUser() throws Exception {
+      doReturn("admin").when(userService).getCurrentUserName();
+      doReturn(true).when(userService).isAdminUser("admin");
+      when(metadataService.find(META_DATA_HOMEPAGE_PREFIX + "alice")).thenReturn(null);
+
+      assertEquals("", userService.getHomepageOverride("alice"));
+      verify(metadataService).find(META_DATA_HOMEPAGE_PREFIX + "alice");
+    }
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/user/service/impl/PSUserServiceMockTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/user/service/impl/PSUserServiceMockTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 
+import com.percussion.metadata.service.IPSMetadataService;
 import com.percussion.security.IPSPasswordFilter;
 import com.percussion.services.security.IPSBackEndRoleMgr;
 import com.percussion.services.security.IPSRoleMgr;
@@ -75,7 +76,8 @@ class PSUserServiceMockTest {
             Mockito.mock(IPSSecurityWs.class),
             Mockito.mock(IPSContentWs.class),
             Mockito.mock(IPSIdMapper.class),
-            Mockito.mock(IPSUtilityService.class));
+            Mockito.mock(IPSUtilityService.class),
+            Mockito.mock(IPSMetadataService.class));
     userServiceSpy = spy(userService);
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/user/web/service/PSUserServiceRestClient.java
+++ b/projects/sitemanage/src/test/java/com/percussion/user/web/service/PSUserServiceRestClient.java
@@ -123,4 +123,20 @@ public class PSUserServiceRestClient extends PSObjectRestClient implements IPSUs
     throw new UnsupportedOperationException(
         "Checking if current user has Design role is not yet supported");
   }
+
+  @Override
+  public String getHomepageOverride(final String userName) throws PSDataServiceException {
+    return getObjectFromPath(concatPath(getPath(), "homepage", userName), String.class);
+  }
+
+  @Override
+  public String setHomepageOverride(final String userName, final String homepage)
+      throws PSDataServiceException {
+    return putObjectToPath(concatPath(getPath(), "homepage", userName), homepage, String.class);
+  }
+
+  @Override
+  public void clearHomepageOverride(final String userName) throws PSDataServiceException {
+    delete(concatPath(getPath(), "homepage", userName));
+  }
 }


### PR DESCRIPTION
## Summary

Parent tracker: #959 (slice 2/4). Implements issue #2209 — persisted **user** default CMS landing page with REST get/set, peer to role homepage metadata.

### What shipped
- **Metadata key:** `perc.user.homepage.{userName}` (peer to `perc.role.homepage.{role}`)
- **Allowed values:** Home, Dashboard, Editor, Designer, Architecture, Publish, Workflow, WidgetBuilder (+ view-key aliases: `home`/`dash`/`editor`/`design`/`arch`/`publish`/`workflow`/`widgetbuilder`, and labels like Navigation→Architecture, Admin→Designer)
- **REST (CM1 `/user` service):**
  - `GET/PUT/DELETE /user/homepage` — current user override
  - `GET/PUT/DELETE /user/homepage/{userName}` — admin-managed (or self)
- **Invalid PUT** → validation error (400); blank PUT/DELETE clears override
- **Effective resolve:** `GET /role/userhomepage` / `PSRoleService.getUserHomepage()` now applies precedence:
  1. User override (when set + valid)
  2. Role multi-role resolve (Home > Dashboard > Editor) — **unchanged when override unset**
  3. Home
- **View-key helper** `PSUserService.homepageTypeToViewKey` ready for slice 3 (`#2210`) `index.jsp` mapping (not wired here)

### Out of scope (planned children)
- #2210 Login redirect / expanded view mapping in `index.jsp`
- #2211 Admin UI + Playwright

## Test plan
- [x] Unit: unset → role resolve fallback
- [x] Unit: set user override wins over multi-role
- [x] Unit: invalid value rejected (no persist)
- [x] Unit: multi-role Home > Dashboard > Editor unchanged when override unset
- [x] Unit: view-key aliases + mapping
- [x] `projects/sitemanage` `mvnw clean install` green
- [ ] Manual: set override via REST, confirm `/role/userhomepage` returns it; clear and confirm role resolve

## Gates evidence
- Erlang self-review: approve — `docs/ai-generated/code-reviews/issue-2209-user-default-landing-api-erlang.md`
- Module clean install: `projects/sitemanage` green
- No path I/O changes

## Links
- Fixes #2209
- Parent: #959
- Follow-ups: #2210, #2211

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.