### PR TITLE
feat(2206): Empty Recycling finder action + confirm (#944 slice 2)

### DIFF
--- a/WebUI/src/main/resources/minify/common-bundles.json
+++ b/WebUI/src/main/resources/minify/common-bundles.json
@@ -85,6 +85,7 @@
         "widgets/perc_new_page_button.js",
         "widgets/perc_copy_page_button.js",
         "widgets/perc_restore_button.js",
+        "widgets/perc_empty_recycling_button.js",
         "widgets/perc_download_button.js",
         "widgets/perc_upload_button.js",
         "widgets/perc_folderproperties_button.js",

--- a/WebUI/src/main/webapp/cm/app/includes/finder_js.jsp
+++ b/WebUI/src/main/webapp/cm/app/includes/finder_js.jsp
@@ -25,6 +25,7 @@
 <script src="../widgets/perc_new_page_button.js"></script>
 <script src="../widgets/perc_copy_page_button.js"></script>
 <script src="../widgets/perc_restore_button.js"></script>
+<script src="../widgets/perc_empty_recycling_button.js"></script>
 <script src="../widgets/perc_download_button.js"></script>
 <script src="../widgets/perc_upload_button.js"></script>
 <script src="../widgets/perc_folderproperties_button.js"></script>

--- a/WebUI/src/main/webapp/cm/app/js/legacy/plugins/perc_path_constants.js
+++ b/WebUI/src/main/webapp/cm/app/js/legacy/plugins/perc_path_constants.js
@@ -80,6 +80,8 @@
     GET_ASSET_PAGINATION_CONFIG:
       SERVICES.PATHMGT + "/path/getAssetPaginationConfig",
     PATH_RESTORE_FOLDER: SERVICES.PATHMGT + "/path/restoreFolder",
+    // Bulk empty Recycling bin (Admin-only; peer to #2205 PSRecycleRestService)
+    RECYCLE_EMPTY: SERVICES.PATHMGT + "/recycle/empty",
     PATH_RENAME_FOLDER: SERVICES.PATHMGT + "/path/renameFolder",
     PATH_GET_FOLDER_PROPERTIES: SERVICES.PATHMGT + "/path/folderProperties",
     PATH_SAVE_FOLDER_PROPERTIES:

--- a/WebUI/src/main/webapp/cm/app/js/legacy/services/PercRecycleService.js
+++ b/WebUI/src/main/webapp/cm/app/js/legacy/services/PercRecycleService.js
@@ -19,6 +19,7 @@
   $.PercRecycleService = {
     restoreItem: restoreItem,
     purgeItem: purgeItem,
+    emptyRecycling: emptyRecycling,
   };
 
   function restoreItem(id, path, callback) {
@@ -42,6 +43,33 @@
   function purgeItem(id, path, callback) {
     $.PercServiceUtils.makeJsonRequest(
       path + "/" + id,
+      $.PercServiceUtils.TYPE_DELETE,
+      false,
+      function (status, result) {
+        if (status === $.PercServiceUtils.STATUS_SUCCESS) {
+          callback($.PercServiceUtils.STATUS_SUCCESS, result.data);
+        } else {
+          var defaultMsg = $.PercServiceUtils.extractDefaultErrorMessage(
+            result.request,
+          );
+          callback($.PercServiceUtils.STATUS_ERROR, defaultMsg);
+        }
+      },
+    );
+  }
+
+  /**
+   * Permanently empties the system Recycling bin via #2205 API.
+   * DELETE /pathmanagement/recycle/empty (Admin-only).
+   *
+   * @param {function} callback (status, dataOrMessage)
+   *   On success, data is PSEmptyRecycleResult-shaped object.
+   *   On error, data is a string error message.
+   */
+  function emptyRecycling(callback) {
+    var url = $.perc_paths.RECYCLE_EMPTY;
+    $.PercServiceUtils.makeJsonRequest(
+      url,
       $.PercServiceUtils.TYPE_DELETE,
       false,
       function (status, result) {

--- a/WebUI/src/main/webapp/cm/plugins/perc_path_constants.js
+++ b/WebUI/src/main/webapp/cm/plugins/perc_path_constants.js
@@ -80,6 +80,8 @@
     GET_ASSET_PAGINATION_CONFIG:
       SERVICES.PATHMGT + "/path/getAssetPaginationConfig",
     PATH_RESTORE_FOLDER: SERVICES.PATHMGT + "/path/restoreFolder",
+    // Bulk empty Recycling bin (Admin-only; peer to #2205 PSRecycleRestService)
+    RECYCLE_EMPTY: SERVICES.PATHMGT + "/recycle/empty",
     PATH_RENAME_FOLDER: SERVICES.PATHMGT + "/path/renameFolder",
     PATH_GET_FOLDER_PROPERTIES: SERVICES.PATHMGT + "/path/folderProperties",
     PATH_SAVE_FOLDER_PROPERTIES:

--- a/WebUI/src/main/webapp/cm/services/PercRecycleService.js
+++ b/WebUI/src/main/webapp/cm/services/PercRecycleService.js
@@ -19,6 +19,7 @@
   $.PercRecycleService = {
     restoreItem: restoreItem,
     purgeItem: purgeItem,
+    emptyRecycling: emptyRecycling,
   };
 
   function restoreItem(id, path, callback) {
@@ -42,6 +43,33 @@
   function purgeItem(id, path, callback) {
     $.PercServiceUtils.makeJsonRequest(
       path + "/" + id,
+      $.PercServiceUtils.TYPE_DELETE,
+      false,
+      function (status, result) {
+        if (status === $.PercServiceUtils.STATUS_SUCCESS) {
+          callback($.PercServiceUtils.STATUS_SUCCESS, result.data);
+        } else {
+          var defaultMsg = $.PercServiceUtils.extractDefaultErrorMessage(
+            result.request,
+          );
+          callback($.PercServiceUtils.STATUS_ERROR, defaultMsg);
+        }
+      },
+    );
+  }
+
+  /**
+   * Permanently empties the system Recycling bin via #2205 API.
+   * DELETE /pathmanagement/recycle/empty (Admin-only).
+   *
+   * @param {function} callback (status, dataOrMessage)
+   *   On success, data is PSEmptyRecycleResult-shaped object.
+   *   On error, data is a string error message.
+   */
+  function emptyRecycling(callback) {
+    var url = $.perc_paths.RECYCLE_EMPTY;
+    $.PercServiceUtils.makeJsonRequest(
+      url,
       $.PercServiceUtils.TYPE_DELETE,
       false,
       function (status, result) {

--- a/WebUI/src/main/webapp/cm/widgets/perc_actions_button.js
+++ b/WebUI/src/main/webapp/cm/widgets/perc_actions_button.js
@@ -32,8 +32,9 @@
     var db = $.perc_build_download_button(finder, contentViewer);
     var ub = $.perc_build_upload_button(finder, contentViewer);
     var ri = $.perc_build_restore_button(finder, contentViewer);
+    var er = $.perc_build_empty_recycling_button(finder, contentViewer);
 
-    var menuEntries = [cp, fp, db, ub, ri];
+    var menuEntries = [cp, fp, db, ub, ri, er];
     // Create the menu and the button
     var menu = createMenuHTML(menuEntries)
       .on("mouseenter", function (e) {

--- a/WebUI/src/main/webapp/cm/widgets/perc_empty_recycling_button.js
+++ b/WebUI/src/main/webapp/cm/widgets/perc_empty_recycling_button.js
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Finder Actions menu entry: Empty Recycling bin (bulk permanent purge).
+ *
+ * Depends on #2205 DELETE /pathmanagement/recycle/empty (Admin-only).
+ * Peer of perc_restore_button.js / perc_delete_page_button.js purge flow.
+ */
+(function ($) {
+  /**
+   * Pure enablement rule (exported for unit tests via $.perc_empty_recycling_enabled).
+   * Enabled only for Admin users when the finder path is under Recycling.
+   *
+   * @param {string[]} path finder path segments (e.g. ['', 'Recycling'] or ['', 'Recycling', 'Sites'])
+   * @param {boolean} isAdmin whether the current user is Admin
+   * @returns {boolean}
+   */
+  function isEmptyRecyclingEnabled(path, isAdmin) {
+    if (!isAdmin) {
+      return false;
+    }
+    if (!path || path.length < 2) {
+      return false;
+    }
+    return path[1] === $.perc_paths.RECYCLING_ROOT_NO_SLASH;
+  }
+
+  /**
+   * Summarize a successful empty-recycle result for optional user feedback.
+   * Pure helper for tests.
+   *
+   * @param {object|null} data PSEmptyRecycleResult-shaped
+   * @returns {{alreadyEmpty: boolean, partial: boolean, messageKey: string|null, messageArgs: string[]}}
+   */
+  function summarizeEmptyResult(data) {
+    if (!data || typeof data !== "object") {
+      return {
+        alreadyEmpty: false,
+        partial: false,
+        messageKey: null,
+        messageArgs: [],
+      };
+    }
+    var undeleted =
+      typeof data.undeletedCount === "number" ? data.undeletedCount : 0;
+    if (data.alreadyEmpty === true) {
+      return {
+        alreadyEmpty: true,
+        partial: false,
+        messageKey: "perc.ui.empty.recycling@Already Empty",
+        messageArgs: [],
+      };
+    }
+    if (undeleted > 0) {
+      return {
+        alreadyEmpty: false,
+        partial: true,
+        messageKey: "perc.ui.empty.recycling@Partial",
+        messageArgs: [String(undeleted)],
+      };
+    }
+    return {
+      alreadyEmpty: false,
+      partial: false,
+      messageKey: null,
+      messageArgs: [],
+    };
+  }
+
+  // Expose pure helpers for Vitest without requiring full finder bootstrap.
+  $.perc_empty_recycling_enabled = isEmptyRecyclingEnabled;
+  $.perc_empty_recycling_summarize = summarizeEmptyResult;
+
+  $.perc_build_empty_recycling_button = function (finderRef, content) {
+    var label = I18N.message("perc.ui.empty.recycling@Label");
+    var tooltip = I18N.message("perc.ui.empty.recycling@Click");
+    // Build via DOM APIs so i18n strings never flow through HTML parse (CWE-79).
+    var btn = $("<a></a>")
+      .attr({
+        id: "perc-finder-empty-recycling",
+        "data-testid": "perc-finder-empty-recycling",
+        href: "#",
+        title: tooltip,
+      })
+      .text(label)
+      .on("click", function (event) {
+        emptyRecyclingClick(event);
+      });
+
+    function emptyRecyclingClick(evt) {
+      if (btn.hasClass("ui-disabled")) {
+        return false;
+      }
+      if (!$.PercNavigationManager.isAdmin()) {
+        $.perc_utils.alert_dialog({
+          title: I18N.message("perc.ui.page.general@Warning"),
+          content: I18N.message("perc.ui.empty.recycling@Not Authorized"),
+        });
+        return false;
+      }
+
+      var options = {
+        id: "perc-finder-empty-recycling-confirm",
+        title: I18N.message("perc.ui.empty.recycling@Title"),
+        question:
+          "<span id='perc-empty-recycling-warn-msg'>" +
+          I18N.message("perc.ui.empty.recycling@Confirm") +
+          "</span>",
+        success: function () {
+          performEmptyRecycling();
+        },
+        yes: I18N.message("perc.ui.empty.recycling@Empty"),
+      };
+      $.perc_utils.confirm_dialog(options);
+      return false;
+    }
+
+    function performEmptyRecycling() {
+      $.PercBlockUI($.PercBlockUIMode.CURSORONLY);
+      $.PercRecycleService.emptyRecycling(function (status, data) {
+        $.unblockUI();
+        if (status === $.PercServiceUtils.STATUS_ERROR) {
+          $.perc_utils.alert_dialog({
+            title: I18N.message("perc.ui.publish.title@Error"),
+            content:
+              data || I18N.message("perc.ui.empty.recycling@Error"),
+          });
+          return;
+        }
+
+        var summary = summarizeEmptyResult(data);
+        if (summary.messageKey) {
+          var msg = I18N.message(summary.messageKey, summary.messageArgs);
+          $.perc_utils.alert_dialog({
+            title: I18N.message("perc.ui.empty.recycling@Title"),
+            content: msg,
+          });
+        }
+
+        if (finderRef && typeof finderRef.refresh === "function") {
+          finderRef.refresh();
+        }
+      });
+    }
+
+    /**
+     * Enable only under Recycling for Admin users.
+     * @param {string[]} path finder path segments
+     */
+    function update_empty_recycling_btn(path) {
+      var enabled = isEmptyRecyclingEnabled(
+        path,
+        $.PercNavigationManager.isAdmin(),
+      );
+      enableButton(enabled);
+    }
+
+    function enableButton(flag) {
+      if (flag) {
+        btn
+          .removeClass("ui-disabled")
+          .addClass("ui-enabled")
+          .off("click")
+          .on("click", function (evt) {
+            emptyRecyclingClick(evt);
+          });
+      } else {
+        btn.addClass("ui-disabled").removeClass("ui-enabled").off("click");
+      }
+      btn.trigger("actions-change-enabled-state");
+    }
+
+    finderRef.addPathChangedListener(update_empty_recycling_btn);
+    // Start disabled until path listener fires.
+    enableButton(false);
+    return btn;
+  };
+})(jQuery);

--- a/WebUI/src/test/js/percEmptyRecycling.test.js
+++ b/WebUI/src/test/js/percEmptyRecycling.test.js
@@ -1,0 +1,291 @@
+/**
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Behavioral tests for Empty Recycling finder action (#2206 / parent #944 slice 2).
+ *
+ * Covers:
+ *   - PercRecycleService.emptyRecycling → DELETE RECYCLE_EMPTY
+ *   - Enablement rule (Admin + Recycling path only)
+ *   - Result summarization (alreadyEmpty / partial / clean)
+ *   - Dual-tree lockstep (src ↔ war ↔ legacy service)
+ */
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import jquery from "jquery";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CM_ROOT = resolve(__dirname, "../../main/webapp/cm");
+const SERVICE_SRC = resolve(CM_ROOT, "services/PercRecycleService.js");
+const BUTTON_SRC = resolve(CM_ROOT, "widgets/perc_empty_recycling_button.js");
+const WAR_SERVICE = resolve(
+  __dirname,
+  "../../../war/services/PercRecycleService.js",
+);
+const WAR_BUTTON = resolve(
+  __dirname,
+  "../../../war/widgets/perc_empty_recycling_button.js",
+);
+const LEGACY_SERVICE = resolve(
+  CM_ROOT,
+  "app/js/legacy/services/PercRecycleService.js",
+);
+
+let $;
+let makeJsonRequestSpy;
+
+function installServiceEnvironment() {
+  document.body.innerHTML = "";
+  if (typeof jquery === "function") {
+    $ = jquery(globalThis.window);
+    if (typeof $ !== "function" || !$.fn) {
+      $ = jquery;
+      if (!$.fn) $.fn = $.prototype;
+    }
+  } else {
+    $ = globalThis.window.jQuery || globalThis.window.$;
+    if (!$.fn) $.fn = $.prototype;
+  }
+
+  makeJsonRequestSpy = vi.fn(function (url, type, sync, callback) {
+    makeJsonRequestSpy.last = { url, type, sync, callback };
+  });
+
+  $.PercServiceUtils = {
+    STATUS_SUCCESS: "success",
+    STATUS_ERROR: "error",
+    TYPE_DELETE: "DELETE",
+    TYPE_PUT: "PUT",
+    makeJsonRequest: makeJsonRequestSpy,
+    extractDefaultErrorMessage: vi.fn(() => "default error"),
+  };
+  $.perc_paths = {
+    RECYCLE_EMPTY: "/Rhythmyx/services/pathmanagement/recycle/empty",
+    RECYCLING_ROOT_NO_SLASH: "Recycling",
+  };
+
+  const factory = new Function(
+    "jQuery",
+    "$",
+    readFileSync(SERVICE_SRC, "utf8") + "\nreturn $.PercRecycleService;",
+  );
+  return factory($, $);
+}
+
+function installButtonHelpers() {
+  document.body.innerHTML = "";
+  if (typeof jquery === "function") {
+    $ = jquery(globalThis.window);
+    if (typeof $ !== "function" || !$.fn) {
+      $ = jquery;
+      if (!$.fn) $.fn = $.prototype;
+    }
+  } else {
+    $ = globalThis.window.jQuery || globalThis.window.$;
+    if (!$.fn) $.fn = $.prototype;
+  }
+
+  $.perc_paths = {
+    RECYCLING_ROOT_NO_SLASH: "Recycling",
+  };
+  globalThis.I18N = {
+    message: (key) => key,
+  };
+  $.perc_utils = {
+    confirm_dialog: vi.fn(),
+    alert_dialog: vi.fn(),
+  };
+  $.PercBlockUI = vi.fn();
+  $.PercBlockUIMode = { CURSORONLY: "cursor" };
+  $.unblockUI = vi.fn();
+  $.PercNavigationManager = { isAdmin: vi.fn(() => true) };
+  $.PercServiceUtils = {
+    STATUS_SUCCESS: "success",
+    STATUS_ERROR: "error",
+  };
+  $.PercRecycleService = { emptyRecycling: vi.fn() };
+
+  const factory = new Function(
+    "jQuery",
+    "$",
+    "I18N",
+    readFileSync(BUTTON_SRC, "utf8") +
+      "\nreturn { enabled: $.perc_empty_recycling_enabled, summarize: $.perc_empty_recycling_summarize, build: $.perc_build_empty_recycling_button };",
+  );
+  return factory($, $, globalThis.I18N);
+}
+
+describe("PercRecycleService.emptyRecycling", () => {
+  let service;
+
+  beforeEach(() => {
+    service = installServiceEnvironment();
+  });
+
+  it("issues DELETE against RECYCLE_EMPTY path constant", () => {
+    const cb = vi.fn();
+    service.emptyRecycling(cb);
+
+    expect(makeJsonRequestSpy).toHaveBeenCalledTimes(1);
+    const args = makeJsonRequestSpy.mock.calls[0];
+    expect(args[0]).toBe($.perc_paths.RECYCLE_EMPTY);
+    expect(args[1]).toBe($.PercServiceUtils.TYPE_DELETE);
+    expect(args[2]).toBe(false);
+    expect(typeof args[3]).toBe("function");
+  });
+
+  it("forwards success payload to callback", () => {
+    const cb = vi.fn();
+    service.emptyRecycling(cb);
+    const result = {
+      alreadyEmpty: false,
+      purgedFolderCount: 2,
+      purgedItemCount: 1,
+      undeletedCount: 0,
+    };
+    makeJsonRequestSpy.last.callback("success", { data: result });
+    expect(cb).toHaveBeenCalledWith("success", result);
+  });
+
+  it("forwards extracted error message on failure", () => {
+    const cb = vi.fn();
+    service.emptyRecycling(cb);
+    makeJsonRequestSpy.last.callback("error", {
+      request: { status: 403, responseText: "Only Admin" },
+    });
+    expect($.PercServiceUtils.extractDefaultErrorMessage).toHaveBeenCalled();
+    expect(cb).toHaveBeenCalledWith("error", "default error");
+  });
+});
+
+describe("Empty Recycling enablement + summary helpers", () => {
+  let helpers;
+
+  beforeEach(() => {
+    helpers = installButtonHelpers();
+  });
+
+  it("enables only for Admin under Recycling path", () => {
+    expect(helpers.enabled(["", "Recycling"], true)).toBe(true);
+    expect(helpers.enabled(["", "Recycling", "Sites"], true)).toBe(true);
+    expect(helpers.enabled(["", "Sites"], true)).toBe(false);
+    expect(helpers.enabled(["", "Recycling"], false)).toBe(false);
+    expect(helpers.enabled(["", "Assets"], true)).toBe(false);
+    expect(helpers.enabled([], true)).toBe(false);
+    expect(helpers.enabled(null, true)).toBe(false);
+  });
+
+  it("summarizes alreadyEmpty / partial / clean results", () => {
+    expect(helpers.summarize({ alreadyEmpty: true })).toEqual({
+      alreadyEmpty: true,
+      partial: false,
+      messageKey: "perc.ui.empty.recycling@Already Empty",
+      messageArgs: [],
+    });
+    expect(
+      helpers.summarize({
+        alreadyEmpty: false,
+        undeletedCount: 3,
+      }),
+    ).toEqual({
+      alreadyEmpty: false,
+      partial: true,
+      messageKey: "perc.ui.empty.recycling@Partial",
+      messageArgs: ["3"],
+    });
+    expect(
+      helpers.summarize({
+        alreadyEmpty: false,
+        undeletedCount: 0,
+        purgedFolderCount: 1,
+      }),
+    ).toEqual({
+      alreadyEmpty: false,
+      partial: false,
+      messageKey: null,
+      messageArgs: [],
+    });
+    expect(helpers.summarize(null).messageKey).toBe(null);
+  });
+
+  it("builds menu entry with stable id/testid and confirms before purge", () => {
+    const pathListener = vi.fn();
+    const finderRef = {
+      addPathChangedListener: pathListener,
+      refresh: vi.fn(),
+    };
+    const btn = helpers.build(finderRef, null);
+    expect(btn.attr("id")).toBe("perc-finder-empty-recycling");
+    expect(btn.attr("data-testid")).toBe("perc-finder-empty-recycling");
+    expect(pathListener).toHaveBeenCalledTimes(1);
+
+    // Simulate Admin + Recycling path so button is enabled, then click.
+    pathListener.mock.calls[0][0](["", "Recycling"]);
+    expect(btn.hasClass("ui-enabled")).toBe(true);
+
+    btn.trigger("click");
+    expect($.perc_utils.confirm_dialog).toHaveBeenCalledTimes(1);
+    const opts = $.perc_utils.confirm_dialog.mock.calls[0][0];
+    expect(opts.id).toBe("perc-finder-empty-recycling-confirm");
+    expect(opts.question).toContain("perc.ui.empty.recycling@Confirm");
+
+    // Confirm success path calls service then refreshes finder.
+    $.PercRecycleService.emptyRecycling.mockImplementation((cb) => {
+      cb("success", {
+        alreadyEmpty: false,
+        undeletedCount: 0,
+        purgedFolderCount: 1,
+      });
+    });
+    opts.success();
+    expect($.PercRecycleService.emptyRecycling).toHaveBeenCalledTimes(1);
+    expect(finderRef.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-enable delete of SYSTEM roots — enablement never uses Sites/Assets roots", () => {
+    // Guardrail: empty is Recycling-only; not a generalized delete of system roots.
+    expect(helpers.enabled(["", "Sites"], true)).toBe(false);
+    expect(helpers.enabled(["", "Assets"], true)).toBe(false);
+    expect(helpers.enabled(["", "Design"], true)).toBe(false);
+  });
+});
+
+describe("dual-tree lockstep Empty Recycling surface", () => {
+  it("keeps war service + button in sync with src for emptyRecycling markers", () => {
+    const srcService = readFileSync(SERVICE_SRC, "utf8");
+    const warService = readFileSync(WAR_SERVICE, "utf8");
+    const legacyService = readFileSync(LEGACY_SERVICE, "utf8");
+    const srcButton = readFileSync(BUTTON_SRC, "utf8");
+    const warButton = readFileSync(WAR_BUTTON, "utf8");
+
+    for (const body of [srcService, warService, legacyService]) {
+      expect(body).toMatch(/emptyRecycling/);
+      expect(body).toMatch(/RECYCLE_EMPTY/);
+      expect(body).toMatch(/TYPE_DELETE/);
+    }
+    for (const body of [srcButton, warButton]) {
+      expect(body).toMatch(/perc-finder-empty-recycling/);
+      expect(body).toMatch(/perc_build_empty_recycling_button/);
+      expect(body).toMatch(/perc\.ui\.empty\.recycling@Confirm/);
+      // No multi-call client purge walk
+      expect(body).not.toMatch(/purgeItem\s*\(/);
+    }
+  });
+});

--- a/WebUI/war/app/includes/finder_js.jsp
+++ b/WebUI/war/app/includes/finder_js.jsp
@@ -25,6 +25,7 @@
 <script src="../widgets/perc_new_page_button.js"></script>
 <script src="../widgets/perc_copy_page_button.js"></script>
 <script src="../widgets/perc_restore_button.js"></script>
+<script src="../widgets/perc_empty_recycling_button.js"></script>
 <script src="../widgets/perc_download_button.js"></script>
 <script src="../widgets/perc_upload_button.js"></script>
 <script src="../widgets/perc_folderproperties_button.js"></script>

--- a/WebUI/war/plugins/perc_path_constants.js
+++ b/WebUI/war/plugins/perc_path_constants.js
@@ -78,6 +78,8 @@
         PATH_DELETE_FOLDER                  : SERVICES.PATHMGT + "/path/deleteFolder",
         GET_ASSET_PAGINATION_CONFIG         : SERVICES.PATHMGT + "/path/getAssetPaginationConfig",
         PATH_RESTORE_FOLDER                 : SERVICES.PATHMGT + "/path/restoreFolder",
+        // Bulk empty Recycling bin (Admin-only; peer to #2205 PSRecycleRestService)
+        RECYCLE_EMPTY                       : SERVICES.PATHMGT + "/recycle/empty",
         PATH_RENAME_FOLDER                  : SERVICES.PATHMGT + "/path/renameFolder",
         PATH_GET_FOLDER_PROPERTIES          : SERVICES.PATHMGT + "/path/folderProperties",
         PATH_SAVE_FOLDER_PROPERTIES         : SERVICES.PATHMGT + "/path/saveFolderProperties",

--- a/WebUI/war/services/PercRecycleService.js
+++ b/WebUI/war/services/PercRecycleService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2023 Percussion Software, Inc.
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,51 +15,73 @@
  * limitations under the License.
  */
 
-(function($)
-{
-    $.PercRecycleService = {
-        restoreItem: restoreItem,
-        purgeItem: purgeItem
-    };
+(function ($) {
+  $.PercRecycleService = {
+    restoreItem: restoreItem,
+    purgeItem: purgeItem,
+    emptyRecycling: emptyRecycling,
+  };
 
-    function restoreItem(id, path, callback) {
-        $.PercServiceUtils.makeJsonRequest(
-            path + '/' + id,
-            $.PercServiceUtils.TYPE_PUT,
-            false,
-            function(status, result)
-            {
-                if(status === $.PercServiceUtils.STATUS_SUCCESS)
-                {
-                    callback($.PercServiceUtils.STATUS_SUCCESS, result.data);
-                }
-                else
-                {
-                    var defaultMsg = $.PercServiceUtils.extractDefaultErrorMessage(result.request);
-                    callback($.PercServiceUtils.STATUS_ERROR, defaultMsg);
-                }
-            }
-        );
-    }
+  function restoreItem(id, path, callback) {
+    $.PercServiceUtils.makeJsonRequest(
+      path + "/" + id,
+      $.PercServiceUtils.TYPE_PUT,
+      false,
+      function (status, result) {
+        if (status === $.PercServiceUtils.STATUS_SUCCESS) {
+          callback($.PercServiceUtils.STATUS_SUCCESS, result.data);
+        } else {
+          var defaultMsg = $.PercServiceUtils.extractDefaultErrorMessage(
+            result.request,
+          );
+          callback($.PercServiceUtils.STATUS_ERROR, defaultMsg);
+        }
+      },
+    );
+  }
 
-    function purgeItem(id, path, callback) {
-        $.PercServiceUtils.makeJsonRequest(
-            path + '/' + id,
-            $.PercServiceUtils.TYPE_DELETE,
-            false,
-            function(status, result)
-            {
-                if(status === $.PercServiceUtils.STATUS_SUCCESS)
-                {
-                    callback($.PercServiceUtils.STATUS_SUCCESS, result.data);
-                }
-                else
-                {
-                    var defaultMsg = $.PercServiceUtils.extractDefaultErrorMessage(result.request);
-                    callback($.PercServiceUtils.STATUS_ERROR, defaultMsg);
-                }
-            }
-        );
-    }
+  function purgeItem(id, path, callback) {
+    $.PercServiceUtils.makeJsonRequest(
+      path + "/" + id,
+      $.PercServiceUtils.TYPE_DELETE,
+      false,
+      function (status, result) {
+        if (status === $.PercServiceUtils.STATUS_SUCCESS) {
+          callback($.PercServiceUtils.STATUS_SUCCESS, result.data);
+        } else {
+          var defaultMsg = $.PercServiceUtils.extractDefaultErrorMessage(
+            result.request,
+          );
+          callback($.PercServiceUtils.STATUS_ERROR, defaultMsg);
+        }
+      },
+    );
+  }
 
+  /**
+   * Permanently empties the system Recycling bin via #2205 API.
+   * DELETE /pathmanagement/recycle/empty (Admin-only).
+   *
+   * @param {function} callback (status, dataOrMessage)
+   *   On success, data is PSEmptyRecycleResult-shaped object.
+   *   On error, data is a string error message.
+   */
+  function emptyRecycling(callback) {
+    var url = $.perc_paths.RECYCLE_EMPTY;
+    $.PercServiceUtils.makeJsonRequest(
+      url,
+      $.PercServiceUtils.TYPE_DELETE,
+      false,
+      function (status, result) {
+        if (status === $.PercServiceUtils.STATUS_SUCCESS) {
+          callback($.PercServiceUtils.STATUS_SUCCESS, result.data);
+        } else {
+          var defaultMsg = $.PercServiceUtils.extractDefaultErrorMessage(
+            result.request,
+          );
+          callback($.PercServiceUtils.STATUS_ERROR, defaultMsg);
+        }
+      },
+    );
+  }
 })(jQuery);

--- a/WebUI/war/widgets/perc_actions_button.js
+++ b/WebUI/war/widgets/perc_actions_button.js
@@ -34,8 +34,9 @@
         var db = $.perc_build_download_button( finder, contentViewer );
         var ub = $.perc_build_upload_button( finder, contentViewer );
         var ri = $.perc_build_restore_button( finder, contentViewer );
+        var er = $.perc_build_empty_recycling_button( finder, contentViewer );
 
-        var menuEntries = [cp, fp, db, ub, ri];
+        var menuEntries = [cp, fp, db, ub, ri, er];
         // Create the menu and the button
         var menu = createMenuHTML(menuEntries)
             .on("mouseenter",function(e){

--- a/WebUI/war/widgets/perc_empty_recycling_button.js
+++ b/WebUI/war/widgets/perc_empty_recycling_button.js
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Finder Actions menu entry: Empty Recycling bin (bulk permanent purge).
+ *
+ * Depends on #2205 DELETE /pathmanagement/recycle/empty (Admin-only).
+ * Peer of perc_restore_button.js / perc_delete_page_button.js purge flow.
+ */
+(function ($) {
+  /**
+   * Pure enablement rule (exported for unit tests via $.perc_empty_recycling_enabled).
+   * Enabled only for Admin users when the finder path is under Recycling.
+   *
+   * @param {string[]} path finder path segments (e.g. ['', 'Recycling'] or ['', 'Recycling', 'Sites'])
+   * @param {boolean} isAdmin whether the current user is Admin
+   * @returns {boolean}
+   */
+  function isEmptyRecyclingEnabled(path, isAdmin) {
+    if (!isAdmin) {
+      return false;
+    }
+    if (!path || path.length < 2) {
+      return false;
+    }
+    return path[1] === $.perc_paths.RECYCLING_ROOT_NO_SLASH;
+  }
+
+  /**
+   * Summarize a successful empty-recycle result for optional user feedback.
+   * Pure helper for tests.
+   *
+   * @param {object|null} data PSEmptyRecycleResult-shaped
+   * @returns {{alreadyEmpty: boolean, partial: boolean, messageKey: string|null, messageArgs: string[]}}
+   */
+  function summarizeEmptyResult(data) {
+    if (!data || typeof data !== "object") {
+      return {
+        alreadyEmpty: false,
+        partial: false,
+        messageKey: null,
+        messageArgs: [],
+      };
+    }
+    var undeleted =
+      typeof data.undeletedCount === "number" ? data.undeletedCount : 0;
+    if (data.alreadyEmpty === true) {
+      return {
+        alreadyEmpty: true,
+        partial: false,
+        messageKey: "perc.ui.empty.recycling@Already Empty",
+        messageArgs: [],
+      };
+    }
+    if (undeleted > 0) {
+      return {
+        alreadyEmpty: false,
+        partial: true,
+        messageKey: "perc.ui.empty.recycling@Partial",
+        messageArgs: [String(undeleted)],
+      };
+    }
+    return {
+      alreadyEmpty: false,
+      partial: false,
+      messageKey: null,
+      messageArgs: [],
+    };
+  }
+
+  // Expose pure helpers for Vitest without requiring full finder bootstrap.
+  $.perc_empty_recycling_enabled = isEmptyRecyclingEnabled;
+  $.perc_empty_recycling_summarize = summarizeEmptyResult;
+
+  $.perc_build_empty_recycling_button = function (finderRef, content) {
+    var label = I18N.message("perc.ui.empty.recycling@Label");
+    var tooltip = I18N.message("perc.ui.empty.recycling@Click");
+    // Build via DOM APIs so i18n strings never flow through HTML parse (CWE-79).
+    var btn = $("<a></a>")
+      .attr({
+        id: "perc-finder-empty-recycling",
+        "data-testid": "perc-finder-empty-recycling",
+        href: "#",
+        title: tooltip,
+      })
+      .text(label)
+      .on("click", function (event) {
+        emptyRecyclingClick(event);
+      });
+
+    function emptyRecyclingClick(evt) {
+      if (btn.hasClass("ui-disabled")) {
+        return false;
+      }
+      if (!$.PercNavigationManager.isAdmin()) {
+        $.perc_utils.alert_dialog({
+          title: I18N.message("perc.ui.page.general@Warning"),
+          content: I18N.message("perc.ui.empty.recycling@Not Authorized"),
+        });
+        return false;
+      }
+
+      var options = {
+        id: "perc-finder-empty-recycling-confirm",
+        title: I18N.message("perc.ui.empty.recycling@Title"),
+        question:
+          "<span id='perc-empty-recycling-warn-msg'>" +
+          I18N.message("perc.ui.empty.recycling@Confirm") +
+          "</span>",
+        success: function () {
+          performEmptyRecycling();
+        },
+        yes: I18N.message("perc.ui.empty.recycling@Empty"),
+      };
+      $.perc_utils.confirm_dialog(options);
+      return false;
+    }
+
+    function performEmptyRecycling() {
+      $.PercBlockUI($.PercBlockUIMode.CURSORONLY);
+      $.PercRecycleService.emptyRecycling(function (status, data) {
+        $.unblockUI();
+        if (status === $.PercServiceUtils.STATUS_ERROR) {
+          $.perc_utils.alert_dialog({
+            title: I18N.message("perc.ui.publish.title@Error"),
+            content:
+              data || I18N.message("perc.ui.empty.recycling@Error"),
+          });
+          return;
+        }
+
+        var summary = summarizeEmptyResult(data);
+        if (summary.messageKey) {
+          var msg = I18N.message(summary.messageKey, summary.messageArgs);
+          $.perc_utils.alert_dialog({
+            title: I18N.message("perc.ui.empty.recycling@Title"),
+            content: msg,
+          });
+        }
+
+        if (finderRef && typeof finderRef.refresh === "function") {
+          finderRef.refresh();
+        }
+      });
+    }
+
+    /**
+     * Enable only under Recycling for Admin users.
+     * @param {string[]} path finder path segments
+     */
+    function update_empty_recycling_btn(path) {
+      var enabled = isEmptyRecyclingEnabled(
+        path,
+        $.PercNavigationManager.isAdmin(),
+      );
+      enableButton(enabled);
+    }
+
+    function enableButton(flag) {
+      if (flag) {
+        btn
+          .removeClass("ui-disabled")
+          .addClass("ui-enabled")
+          .off("click")
+          .on("click", function (evt) {
+            emptyRecyclingClick(evt);
+          });
+      } else {
+        btn.addClass("ui-disabled").removeClass("ui-enabled").off("click");
+      }
+      btn.trigger("actions-change-enabled-state");
+    }
+
+    finderRef.addPathChangedListener(update_empty_recycling_btn);
+    // Start disabled until path listener fires.
+    enableButton(false);
+    return btn;
+  };
+})(jQuery);

--- a/docs/ai-generated/code-reviews/issue-2206-empty-recycling-menu-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2206-empty-recycling-menu-erlang.md
@@ -1,0 +1,59 @@
+# Erlang review — issue #2206 Empty Recycling menu + confirm
+
+**Branch:** `feat/issue-2206-empty-recycling-menu`  
+**Scope:** WebUI finder Empty Recycling action + i18n + dual-tree sync  
+**Parent:** #944 slice 2/3  
+**Depends on:** #2205 / PR #2215 (`DELETE /pathmanagement/recycle/empty`)  
+**Date:** 2026-08-06  
+**Reviewer:** Erlang (pre-commit gate)
+
+## Summary
+
+Adds Admin-only finder Actions menu entry **Empty Recycling** with permanent-purge confirm dialog, client call to bulk empty API, path constant, dual-tree (src/war/legacy) lockstep, CmsUi.tmx keys, and Vitest behavioral coverage. Does not re-enable delete of SYSTEM / Sites / Assets roots.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none found  
+- Behavioral unit tests: present (`WebUI/src/test/js/percEmptyRecycling.test.js`, 8 tests)  
+- Cross-platform path I/O: N/A (no filesystem path handling)  
+- **May commit/push: yes**
+
+## Memory patterns hit
+
+- Dual-tree WebUI lockstep (src ↔ war; legacy service mirror)  
+- Confirm-dialog severity for permanent purge peers  
+- Admin-only destructive bulk action alignment with backend 403  
+- Prefer pure helpers for enablement/summary unit tests  
+
+## Issues
+
+None blocking.
+
+### Suggestions (non-blocking)
+
+1. **#2205 merge order** — UI PR should not be merged before #2215 lands (or will 404/500 at runtime). Documented in PR body.  
+2. **Full multi-locale TMX** — new keys ship `en-us` only; runtime falls back via `PSTmxResourceBundle` language chain. Residual translations optional.  
+3. **Playwright E2E** — deferred to #2207 per split plan; `data-testid="perc-finder-empty-recycling"` is ready for slice 3.
+
+## Change-class companions checked
+
+| Companion | Status |
+|-----------|--------|
+| Path constant `RECYCLE_EMPTY` | src + war + legacy |
+| `PercRecycleService.emptyRecycling` | src + war + legacy |
+| Finder Actions menu wiring | src + war `perc_actions_button.js` |
+| Script include `finder_js.jsp` | src + war |
+| Minify bundle `common-bundles.json` | yes |
+| i18n `CmsUi.tmx` | en-us keys |
+| Vitest behavioral | 8 tests green |
+| No SYSTEM-root delete re-enable | delete button untouched |
+
+## Test evidence
+
+- `npx vitest run ../../test/js/percEmptyRecycling.test.js` → 8 passed  
+- `cd WebUI && ../mvnw clean install` → BUILD SUCCESS (war produced)  
+- `cd modules/perc-i18n && ../../mvnw clean install` → BUILD SUCCESS  

--- a/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
@@ -18789,6 +18789,33 @@ Niet-opgeslagen wijzigingen in '{1}' kunnen verloren gaan.</seg></tuv>
       <tuv xml:lang="zh-cn"><seg>警告：</seg></tuv>
       <tuv xml:lang="zh-tw"><seg>警告：</seg></tuv>
     <tuv xml:lang="ru"><seg>Предупреждение:</seg></tuv><tuv xml:lang="he"><seg>אַזהָרָה:</seg></tuv><tuv xml:lang="uk"><seg>УВАГА:</seg></tuv></tu>
+    <tu tuid="perc.ui.empty.recycling@Label">
+      <tuv xml:lang="en-us"><seg>Empty Recycling</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.empty.recycling@Click">
+      <tuv xml:lang="en-us"><seg>Permanently empty the Recycling bin</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.empty.recycling@Title">
+      <tuv xml:lang="en-us"><seg>Empty Recycling</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.empty.recycling@Confirm">
+      <tuv xml:lang="en-us"><seg>This will permanently delete all items in the Recycling bin. This action cannot be undone. Are you sure you want to empty the Recycling bin?</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.empty.recycling@Empty">
+      <tuv xml:lang="en-us"><seg>Empty</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.empty.recycling@Not Authorized">
+      <tuv xml:lang="en-us"><seg>Only Admin users may empty the Recycling bin.</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.empty.recycling@Error">
+      <tuv xml:lang="en-us"><seg>Failed to empty the Recycling bin.</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.empty.recycling@Already Empty">
+      <tuv xml:lang="en-us"><seg>The Recycling bin is already empty.</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.empty.recycling@Partial">
+      <tuv xml:lang="en-us"><seg>Some items could not be permanently deleted ({0}). The Recycling bin has been refreshed.</seg></tuv>
+    </tu>
     <tu tuid="perc.ui.restore.messsage@Restore Not Allowed">
       <tuv xml:lang="en-us"><seg>Please select parent folder to restore. </seg></tuv>
       <tuv xml:lang="ar"><seg>الرجاء تحديد المجلد الأصلي لاستعادته.</seg></tuv>


### PR DESCRIPTION
## Summary
Implements **#2206** — parent epic **#944** slice 2/3: finder **Empty Recycling** Actions menu entry + permanent-purge confirm dialog.

### What
- Path constant `$.perc_paths.RECYCLE_EMPTY` → `DELETE /Rhythmyx/services/pathmanagement/recycle/empty` (#2205 API).
- `PercRecycleService.emptyRecycling(callback)` client method (dual-tree: `WebUI/src`, `war/`, legacy mirror).
- New Actions menu entry `perc_empty_recycling_button.js` (`#perc-finder-empty-recycling`, `data-testid` for #2207):
  - **Admin-only** + enabled only under Recycling path
  - `confirm_dialog` with permanent delete warning; Cancel leaves bin unchanged
  - On success: refresh finder; alreadyEmpty / partial undeleted feedback via alert
  - Errors via existing `alert_dialog`
- i18n keys in `CmsUi.tmx` (`perc.ui.empty.recycling@*`)
- Wired into `perc_actions_button.js`, `finder_js.jsp`, `common-bundles.json`
- **Does not** re-enable delete of SYSTEM / Sites / Assets roots

### Dependency
**Requires #2205 / PR #2215** backend empty-recycle API. Do not merge this PR before the backend lands (or runtime empty will 404).

### Out of scope
- Full Playwright / residual client E2E: **#2207**
- Backend bulk purge algorithm: **#2205**

## Test plan
- [x] Vitest `percEmptyRecycling.test.js` — **8 passed** (service DELETE, enablement, summary, confirm→refresh, dual-tree lockstep)
- [x] `cd WebUI && ../mvnw clean install` → BUILD SUCCESS
- [x] `cd modules/perc-i18n && ../../mvnw clean install` → BUILD SUCCESS
- [x] Erlang self-review: approve (`docs/ai-generated/code-reviews/issue-2206-empty-recycling-menu-erlang.md`)
- [ ] Manual (after #2205 merge): Admin under Recycling → Empty → confirm → bin empty + finder refresh
- [ ] Manual: non-Admin → action disabled; Cancel confirm → no change

## Gates evidence
- Module clean installs: WebUI + perc-i18n standalone
- Dual-tree lockstep: src/war/legacy for service + path constant; src/war for button/actions/jsp
- Copyright: Intersoft 2026 on new sources
- No fragile multi-call client purge walk

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #944  
Depends on: #2205 / https://github.com/intersoftdatalabs-in/percussioncms/pull/2215  
Residual: #2207 (Playwright/Vitest residual)

Fixes #2206  
Partial for #944 (slice 2/3)

> Co-Authored by Grok Build using grok-4.5 with agent main.