### PR TITLE
fix(WebUI): login/app entry default view honors effective landing (#2210)

### DIFF
--- a/WebUI/src/main/java/com/percussion/webui/util/PSDefaultLandingView.java
+++ b/WebUI/src/main/java/com/percussion/webui/util/PSDefaultLandingView.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.webui.util;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Maps effective CMS homepage types (and view-key aliases) to {@code index.jsp} {@code view=} keys
+ * and fails closed when the mapped target is not allowed for the current user.
+ *
+ * <p>Used from app-entry JSPs so mapping + authorization fallback is unit-testable outside the JSP
+ * container. Callers should pass the effective landing from {@code PSRoleService.getUserHomepage()}
+ * (user override when set — see issue #2209 — else role resolve else Home).
+ *
+ * <p>Product #959 slice 3 (issue #2210).
+ */
+public final class PSDefaultLandingView {
+
+  /** Safe default when unset, unknown, or unauthorized. */
+  public static final String VIEW_HOME = "home";
+
+  public static final String VIEW_DASH = "dash";
+  public static final String VIEW_EDITOR = "editor";
+  public static final String VIEW_DESIGN = "design";
+  public static final String VIEW_ARCH = "arch";
+  public static final String VIEW_PUBLISH = "publish";
+  public static final String VIEW_WORKFLOW = "workflow";
+  public static final String VIEW_WIDGET_BUILDER = "widgetbuilder";
+
+  /** Canonical product homepage types (PascalCase), peer to role/user service constants. */
+  public static final String TYPE_HOME = "Home";
+
+  public static final String TYPE_DASHBOARD = "Dashboard";
+  public static final String TYPE_EDITOR = "Editor";
+  public static final String TYPE_DESIGNER = "Designer";
+  public static final String TYPE_ARCHITECTURE = "Architecture";
+  public static final String TYPE_PUBLISH = "Publish";
+  public static final String TYPE_WORKFLOW = "Workflow";
+  public static final String TYPE_WIDGET_BUILDER = "WidgetBuilder";
+
+  /**
+   * Views that require Admin. Designer may open a subset ({@link #DESIGNER_ALLOWED_VIEWS});
+   * workflow and admin SPA entry remain Admin-only.
+   */
+  private static final Set<String> ADMIN_REQUIRED_VIEWS =
+      Set.of(
+          VIEW_DESIGN,
+          VIEW_ARCH,
+          VIEW_PUBLISH,
+          VIEW_WORKFLOW,
+          VIEW_WIDGET_BUILDER,
+          "developer",
+          "admin");
+
+  /** Subset of admin-gated views that Designers may open (matches index.jsp designerViews). */
+  private static final Set<String> DESIGNER_ALLOWED_VIEWS =
+      Set.of(VIEW_DESIGN, VIEW_ARCH, VIEW_PUBLISH, VIEW_WIDGET_BUILDER, "developer");
+
+  /** Canonical type → view key. */
+  private static final Map<String, String> TYPE_TO_VIEW =
+      Map.of(
+          TYPE_HOME,
+          VIEW_HOME,
+          TYPE_DASHBOARD,
+          VIEW_DASH,
+          TYPE_EDITOR,
+          VIEW_EDITOR,
+          TYPE_DESIGNER,
+          VIEW_DESIGN,
+          TYPE_ARCHITECTURE,
+          VIEW_ARCH,
+          TYPE_PUBLISH,
+          VIEW_PUBLISH,
+          TYPE_WORKFLOW,
+          VIEW_WORKFLOW,
+          TYPE_WIDGET_BUILDER,
+          VIEW_WIDGET_BUILDER);
+
+  private PSDefaultLandingView() {}
+
+  /**
+   * Map a homepage type or view-key alias to an {@code index.jsp} {@code view} key.
+   *
+   * <p>Unknown / blank → {@link #VIEW_HOME}. Does not apply role authorization (use {@link
+   * #resolveAuthorizedView(String, boolean, boolean)}).
+   *
+   * @param homepageType product type (Home, Dashboard, …) or view key (home, dash, …); may be null
+   * @return never null view key
+   */
+  public static String homepageTypeToViewKey(String homepageType) {
+    if (homepageType == null) {
+      return VIEW_HOME;
+    }
+    String trimmed = homepageType.trim();
+    if (trimmed.isEmpty()) {
+      return VIEW_HOME;
+    }
+    // Exact canonical product types first
+    String fromType = TYPE_TO_VIEW.get(trimmed);
+    if (fromType != null) {
+      return fromType;
+    }
+    // Already a known view key or alias (case-insensitive)
+    String lower = trimmed.toLowerCase(Locale.ROOT);
+    switch (lower) {
+      case "home":
+        return VIEW_HOME;
+      case "dash":
+      case "dashboard":
+        return VIEW_DASH;
+      case "editor":
+      case "pageeditor":
+      case "webmgt":
+        return VIEW_EDITOR;
+      case "design":
+      case "designer":
+      case "siteadmin":
+      case "admin":
+        return VIEW_DESIGN;
+      case "arch":
+      case "architecture":
+      case "navigation":
+        return VIEW_ARCH;
+      case "publish":
+        return VIEW_PUBLISH;
+      case "workflow":
+        return VIEW_WORKFLOW;
+      case "widgetbuilder":
+      case "widget-builder":
+        return VIEW_WIDGET_BUILDER;
+      default:
+        return VIEW_HOME;
+    }
+  }
+
+  /**
+   * Whether the given view key requires Admin (and is not open to Designer alone).
+   *
+   * @param viewKey index.jsp view key; may be null
+   * @return true when only Admin may open it
+   */
+  public static boolean isAdminOnlyView(String viewKey) {
+    if (viewKey == null || viewKey.isBlank()) {
+      return false;
+    }
+    String key = viewKey.trim().toLowerCase(Locale.ROOT);
+    return ADMIN_REQUIRED_VIEWS.contains(key) && !DESIGNER_ALLOWED_VIEWS.contains(key);
+  }
+
+  /**
+   * Whether the given view key is gated (Admin or Designer).
+   *
+   * @param viewKey index.jsp view key; may be null
+   * @return true when Admin is required (Designer may still open if in designer-allowed set)
+   */
+  public static boolean isRoleGatedView(String viewKey) {
+    if (viewKey == null || viewKey.isBlank()) {
+      return false;
+    }
+    return ADMIN_REQUIRED_VIEWS.contains(viewKey.trim().toLowerCase(Locale.ROOT));
+  }
+
+  /**
+   * True when the user may open {@code viewKey} given Admin/Designer flags (same rules as
+   * index.jsp).
+   *
+   * @param viewKey index.jsp view key; may be null/blank (treated as allowed / home)
+   * @param isAdmin current user is Admin
+   * @param isDesigner current user is Designer
+   * @return true if allowed
+   */
+  public static boolean isViewAuthorized(String viewKey, boolean isAdmin, boolean isDesigner) {
+    if (viewKey == null || viewKey.isBlank()) {
+      return true;
+    }
+    String key = viewKey.trim().toLowerCase(Locale.ROOT);
+    if (!ADMIN_REQUIRED_VIEWS.contains(key)) {
+      return true;
+    }
+    if (isAdmin) {
+      return true;
+    }
+    return isDesigner && DESIGNER_ALLOWED_VIEWS.contains(key);
+  }
+
+  /**
+   * Map effective homepage type to a view key the current user is allowed to open.
+   *
+   * <p>Unauthorized targets (e.g. Designer override for a non-designer) fail closed to {@link
+   * #VIEW_HOME} so login / {@code /cm/app/} without {@code view} never redirect-loops.
+   *
+   * @param homepageType from {@code getUserHomepage()} (or equivalent); may be null
+   * @param isAdmin current user is Admin
+   * @param isDesigner current user is Designer
+   * @return never null authorized view key
+   */
+  public static String resolveAuthorizedView(
+      String homepageType, boolean isAdmin, boolean isDesigner) {
+    String view = homepageTypeToViewKey(homepageType);
+    if (isViewAuthorized(view, isAdmin, isDesigner)) {
+      return view;
+    }
+    return VIEW_HOME;
+  }
+}

--- a/WebUI/src/main/webapp/cm/app/index.jsp
+++ b/WebUI/src/main/webapp/cm/app/index.jsp
@@ -3,6 +3,7 @@
 <%@ page import="com.percussion.sitemanage.service.impl.PSSiteDataService" %>
 <%@ page import="com.percussion.user.data.PSCurrentUser" %>
 <%@ page import="com.percussion.user.service.impl.PSUserService" %>
+<%@ page import="com.percussion.webui.util.PSDefaultLandingView" %>
 
 <%@ page import="com.percussion.utils.PSSpringBeanProvider" %>
 <%@ page import="com.percussion.utils.container.IPSConnector" %>
@@ -352,20 +353,23 @@
             throw new JspException(e);
         }
     }
+    /**
+     * Effective default {@code view=} for login / app entry when {@code view} is omitted.
+     *
+     * <p>Uses {@link PSRoleService#getUserHomepage()} (user override when set — issue #2209 — else
+     * role resolve else Home), maps product homepage types to view keys, and fails closed to
+     * {@code home} when the target is role-gated and the current user lacks Admin/Designer rights
+     * (issue #2210 / parent #959 slice 3). Explicit {@code ?view=} deep links are unchanged.
+     */
     protected String getDefaultView(HttpServletRequest request, HttpServletResponse response) throws JspException
     {
         try
         {
             PSRoleService roleService = (PSRoleService) PSSpringBeanProvider.getBean("roleService");
             String uhp = roleService.getUserHomepage();
-            String view = "home";
-            if(uhp.equals("Dashboard")){
-                view = "dash";
-            }
-            else if(uhp.equals("Editor")){
-                view = "editor";
-            }
-            return view;
+            boolean isAdmin = Boolean.TRUE.equals(request.getAttribute(IS_ADMIN_KEY));
+            boolean isDesigner = Boolean.TRUE.equals(request.getAttribute(IS_DESIGNER_KEY));
+            return PSDefaultLandingView.resolveAuthorizedView(uhp, isAdmin, isDesigner);
         }
         catch(Exception e)
         {

--- a/WebUI/src/main/webapp/cm/pages/app/index.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/index.jsp
@@ -3,6 +3,7 @@
 <%@ page import="com.percussion.sitemanage.service.impl.PSSiteDataService" %>
 <%@ page import="com.percussion.user.data.PSCurrentUser" %>
 <%@ page import="com.percussion.user.service.impl.PSUserService" %>
+<%@ page import="com.percussion.webui.util.PSDefaultLandingView" %>
 
 <%@ page import="com.percussion.utils.PSSpringBeanProvider" %>
 <%@ page import="com.percussion.utils.container.IPSConnector" %>
@@ -352,20 +353,23 @@
             throw new JspException(e);
         }
     }
+    /**
+     * Effective default {@code view=} for login / app entry when {@code view} is omitted.
+     *
+     * <p>Uses {@link PSRoleService#getUserHomepage()} (user override when set — issue #2209 — else
+     * role resolve else Home), maps product homepage types to view keys, and fails closed to
+     * {@code home} when the target is role-gated and the current user lacks Admin/Designer rights
+     * (issue #2210 / parent #959 slice 3). Explicit {@code ?view=} deep links are unchanged.
+     */
     protected String getDefaultView(HttpServletRequest request, HttpServletResponse response) throws JspException
     {
         try
         {
             PSRoleService roleService = (PSRoleService) PSSpringBeanProvider.getBean("roleService");
             String uhp = roleService.getUserHomepage();
-            String view = "home";
-            if(uhp.equals("Dashboard")){
-                view = "dash";
-            }
-            else if(uhp.equals("Editor")){
-                view = "editor";
-            }
-            return view;
+            boolean isAdmin = Boolean.TRUE.equals(request.getAttribute(IS_ADMIN_KEY));
+            boolean isDesigner = Boolean.TRUE.equals(request.getAttribute(IS_DESIGNER_KEY));
+            return PSDefaultLandingView.resolveAuthorizedView(uhp, isAdmin, isDesigner);
         }
         catch(Exception e)
         {

--- a/WebUI/src/test/java/com/percussion/webui/util/PSDefaultLandingViewTest.java
+++ b/WebUI/src/test/java/com/percussion/webui/util/PSDefaultLandingViewTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.webui.util;
+
+import static com.percussion.webui.util.PSDefaultLandingView.TYPE_ARCHITECTURE;
+import static com.percussion.webui.util.PSDefaultLandingView.TYPE_DASHBOARD;
+import static com.percussion.webui.util.PSDefaultLandingView.TYPE_DESIGNER;
+import static com.percussion.webui.util.PSDefaultLandingView.TYPE_EDITOR;
+import static com.percussion.webui.util.PSDefaultLandingView.TYPE_HOME;
+import static com.percussion.webui.util.PSDefaultLandingView.TYPE_PUBLISH;
+import static com.percussion.webui.util.PSDefaultLandingView.TYPE_WIDGET_BUILDER;
+import static com.percussion.webui.util.PSDefaultLandingView.TYPE_WORKFLOW;
+import static com.percussion.webui.util.PSDefaultLandingView.VIEW_ARCH;
+import static com.percussion.webui.util.PSDefaultLandingView.VIEW_DASH;
+import static com.percussion.webui.util.PSDefaultLandingView.VIEW_DESIGN;
+import static com.percussion.webui.util.PSDefaultLandingView.VIEW_EDITOR;
+import static com.percussion.webui.util.PSDefaultLandingView.VIEW_HOME;
+import static com.percussion.webui.util.PSDefaultLandingView.VIEW_PUBLISH;
+import static com.percussion.webui.util.PSDefaultLandingView.VIEW_WIDGET_BUILDER;
+import static com.percussion.webui.util.PSDefaultLandingView.VIEW_WORKFLOW;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Behavioral tests for default CMS landing → {@code view=} mapping and unauthorized fail-closed
+ * (issue #2210 / parent #959 slice 3).
+ */
+public class PSDefaultLandingViewTest {
+
+  @Test
+  public void mapsCanonicalRoleTypesUnchangedForRegression() {
+    assertEquals(VIEW_HOME, PSDefaultLandingView.homepageTypeToViewKey(TYPE_HOME));
+    assertEquals(VIEW_DASH, PSDefaultLandingView.homepageTypeToViewKey(TYPE_DASHBOARD));
+    assertEquals(VIEW_EDITOR, PSDefaultLandingView.homepageTypeToViewKey(TYPE_EDITOR));
+  }
+
+  @Test
+  public void mapsExpandedUserLandingTypes() {
+    assertEquals(VIEW_DESIGN, PSDefaultLandingView.homepageTypeToViewKey(TYPE_DESIGNER));
+    assertEquals(VIEW_ARCH, PSDefaultLandingView.homepageTypeToViewKey(TYPE_ARCHITECTURE));
+    assertEquals(VIEW_PUBLISH, PSDefaultLandingView.homepageTypeToViewKey(TYPE_PUBLISH));
+    assertEquals(VIEW_WORKFLOW, PSDefaultLandingView.homepageTypeToViewKey(TYPE_WORKFLOW));
+    assertEquals(
+        VIEW_WIDGET_BUILDER, PSDefaultLandingView.homepageTypeToViewKey(TYPE_WIDGET_BUILDER));
+  }
+
+  @Test
+  public void mapsViewKeyAliases() {
+    assertEquals(VIEW_HOME, PSDefaultLandingView.homepageTypeToViewKey("home"));
+    assertEquals(VIEW_DASH, PSDefaultLandingView.homepageTypeToViewKey("dash"));
+    assertEquals(VIEW_DASH, PSDefaultLandingView.homepageTypeToViewKey("dashboard"));
+    assertEquals(VIEW_EDITOR, PSDefaultLandingView.homepageTypeToViewKey("editor"));
+    assertEquals(VIEW_DESIGN, PSDefaultLandingView.homepageTypeToViewKey("design"));
+    assertEquals(VIEW_DESIGN, PSDefaultLandingView.homepageTypeToViewKey("admin"));
+    assertEquals(VIEW_ARCH, PSDefaultLandingView.homepageTypeToViewKey("arch"));
+    assertEquals(VIEW_ARCH, PSDefaultLandingView.homepageTypeToViewKey("navigation"));
+    assertEquals(VIEW_PUBLISH, PSDefaultLandingView.homepageTypeToViewKey("publish"));
+    assertEquals(VIEW_WORKFLOW, PSDefaultLandingView.homepageTypeToViewKey("workflow"));
+    assertEquals(VIEW_WIDGET_BUILDER, PSDefaultLandingView.homepageTypeToViewKey("widgetbuilder"));
+  }
+
+  @Test
+  public void blankUnknownFallsBackToHome() {
+    assertEquals(VIEW_HOME, PSDefaultLandingView.homepageTypeToViewKey(null));
+    assertEquals(VIEW_HOME, PSDefaultLandingView.homepageTypeToViewKey(""));
+    assertEquals(VIEW_HOME, PSDefaultLandingView.homepageTypeToViewKey("   "));
+    assertEquals(VIEW_HOME, PSDefaultLandingView.homepageTypeToViewKey("NotARealModule"));
+  }
+
+  @Test
+  public void roleOnlyUsersResolveHomeDashEditorWithoutGating() {
+    // Contributor / Editor users: Home, Dashboard, Editor always allowed
+    assertEquals(
+        VIEW_HOME, PSDefaultLandingView.resolveAuthorizedView(TYPE_HOME, false, false));
+    assertEquals(
+        VIEW_DASH, PSDefaultLandingView.resolveAuthorizedView(TYPE_DASHBOARD, false, false));
+    assertEquals(
+        VIEW_EDITOR, PSDefaultLandingView.resolveAuthorizedView(TYPE_EDITOR, false, false));
+  }
+
+  @Test
+  public void unauthorizedDesignArchPublishFailClosedToHome() {
+    assertEquals(
+        VIEW_HOME, PSDefaultLandingView.resolveAuthorizedView(TYPE_DESIGNER, false, false));
+    assertEquals(
+        VIEW_HOME, PSDefaultLandingView.resolveAuthorizedView(TYPE_ARCHITECTURE, false, false));
+    assertEquals(
+        VIEW_HOME, PSDefaultLandingView.resolveAuthorizedView(TYPE_PUBLISH, false, false));
+    assertEquals(
+        VIEW_HOME, PSDefaultLandingView.resolveAuthorizedView(TYPE_WIDGET_BUILDER, false, false));
+  }
+
+  @Test
+  public void workflowIsAdminOnlyDesignerCannotOpen() {
+    assertEquals(
+        VIEW_HOME, PSDefaultLandingView.resolveAuthorizedView(TYPE_WORKFLOW, false, true));
+    assertEquals(
+        VIEW_WORKFLOW, PSDefaultLandingView.resolveAuthorizedView(TYPE_WORKFLOW, true, false));
+    assertEquals(
+        VIEW_WORKFLOW, PSDefaultLandingView.resolveAuthorizedView(TYPE_WORKFLOW, true, true));
+  }
+
+  @Test
+  public void designerMayOpenDesignArchPublishWidgetBuilder() {
+    assertEquals(
+        VIEW_DESIGN, PSDefaultLandingView.resolveAuthorizedView(TYPE_DESIGNER, false, true));
+    assertEquals(
+        VIEW_ARCH, PSDefaultLandingView.resolveAuthorizedView(TYPE_ARCHITECTURE, false, true));
+    assertEquals(
+        VIEW_PUBLISH, PSDefaultLandingView.resolveAuthorizedView(TYPE_PUBLISH, false, true));
+    assertEquals(
+        VIEW_WIDGET_BUILDER,
+        PSDefaultLandingView.resolveAuthorizedView(TYPE_WIDGET_BUILDER, false, true));
+  }
+
+  @Test
+  public void adminMayOpenAllGatedLandings() {
+    assertEquals(
+        VIEW_DESIGN, PSDefaultLandingView.resolveAuthorizedView(TYPE_DESIGNER, true, false));
+    assertEquals(
+        VIEW_ARCH, PSDefaultLandingView.resolveAuthorizedView(TYPE_ARCHITECTURE, true, false));
+    assertEquals(
+        VIEW_PUBLISH, PSDefaultLandingView.resolveAuthorizedView(TYPE_PUBLISH, true, false));
+    assertEquals(
+        VIEW_WORKFLOW, PSDefaultLandingView.resolveAuthorizedView(TYPE_WORKFLOW, true, false));
+    assertEquals(
+        VIEW_WIDGET_BUILDER,
+        PSDefaultLandingView.resolveAuthorizedView(TYPE_WIDGET_BUILDER, true, false));
+  }
+
+  @Test
+  public void isViewAuthorizedMatchesIndexJspRules() {
+    assertTrue(PSDefaultLandingView.isViewAuthorized(VIEW_HOME, false, false));
+    assertTrue(PSDefaultLandingView.isViewAuthorized(VIEW_DASH, false, false));
+    assertTrue(PSDefaultLandingView.isViewAuthorized(VIEW_EDITOR, false, false));
+    assertFalse(PSDefaultLandingView.isViewAuthorized(VIEW_DESIGN, false, false));
+    assertTrue(PSDefaultLandingView.isViewAuthorized(VIEW_DESIGN, false, true));
+    assertTrue(PSDefaultLandingView.isViewAuthorized(VIEW_DESIGN, true, false));
+    assertFalse(PSDefaultLandingView.isViewAuthorized(VIEW_WORKFLOW, false, true));
+    assertTrue(PSDefaultLandingView.isViewAuthorized(VIEW_WORKFLOW, true, false));
+  }
+
+  @Test
+  public void roleGatedClassification() {
+    assertFalse(PSDefaultLandingView.isRoleGatedView(VIEW_HOME));
+    assertFalse(PSDefaultLandingView.isRoleGatedView(VIEW_DASH));
+    assertTrue(PSDefaultLandingView.isRoleGatedView(VIEW_DESIGN));
+    assertTrue(PSDefaultLandingView.isAdminOnlyView(VIEW_WORKFLOW));
+    assertFalse(PSDefaultLandingView.isAdminOnlyView(VIEW_DESIGN));
+  }
+}

--- a/WebUI/war/app/index.jsp
+++ b/WebUI/war/app/index.jsp
@@ -3,6 +3,7 @@
 <%@ page import="com.percussion.sitemanage.service.impl.PSSiteDataService" %>
 <%@ page import="com.percussion.user.data.PSCurrentUser" %>
 <%@ page import="com.percussion.user.service.impl.PSUserService" %>
+<%@ page import="com.percussion.webui.util.PSDefaultLandingView" %>
 
 <%@ page import="com.percussion.utils.PSSpringBeanProvider" %>
 <%@ page import="com.percussion.utils.container.IPSConnector" %>
@@ -185,20 +186,23 @@
             throw new JspException(e);
         }
     }
+    /**
+     * Effective default {@code view=} for login / app entry when {@code view} is omitted.
+     *
+     * <p>Uses {@link PSRoleService#getUserHomepage()} (user override when set — issue #2209 — else
+     * role resolve else Home), maps product homepage types to view keys, and fails closed to
+     * {@code home} when the target is role-gated and the current user lacks Admin/Designer rights
+     * (issue #2210 / parent #959 slice 3). Explicit {@code ?view=} deep links are unchanged.
+     */
     protected String getDefaultView(HttpServletRequest request, HttpServletResponse response) throws JspException
     {
         try
         {
             PSRoleService roleService = (PSRoleService) PSSpringBeanProvider.getBean("roleService");
             String uhp = roleService.getUserHomepage();
-            String view = "home";
-            if(uhp.equals("Dashboard")){
-                view = "dash";
-            }
-            else if(uhp.equals("Editor")){
-                view = "editor";
-            }
-            return view;
+            boolean isAdmin = Boolean.TRUE.equals(request.getAttribute(IS_ADMIN_KEY));
+            boolean isDesigner = Boolean.TRUE.equals(request.getAttribute(IS_DESIGNER_KEY));
+            return PSDefaultLandingView.resolveAuthorizedView(uhp, isAdmin, isDesigner);
         }
         catch(Exception e)
         {

--- a/docs/ai-generated/code-reviews/issue-2210-login-default-landing-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2210-login-default-landing-erlang.md
@@ -1,0 +1,52 @@
+# Erlang review: issue #2210 login/app entry default landing
+
+**Branch:** `feat/issue-2210-login-default-landing`  
+**Date:** 2026-08-06  
+**Reviewer:** Grok Build (self-review / Erlang gate)  
+**Recommendation:** approve  
+**Gate:** May commit/push: **yes**
+
+## Summary
+
+Wires `index.jsp` `getDefaultView` to map effective homepage types (from
+`PSRoleService.getUserHomepage()`) to full `view=` keys and fail closed when the
+target is role-gated and the user lacks Admin/Designer rights. Logic lives in
+unit-testable `PSDefaultLandingView` (peer pattern to `PSProxyHostScheme`).
+
+## Scope
+
+- `WebUI` only (helper + tests + JSP dual-ship mirrors)
+- Parent #959 slice 3; depends on #2209 / PR #2216 for user-override values on
+  `getUserHomepage()` — mapping/regression works on main for role-only types
+- Cross-platform path review: N/A (no new file I/O / path handling)
+
+## Issues
+
+None at **bug** severity.
+
+### suggestion
+
+1. **Stacked merge order** — full user-override landing requires #2216 merged
+   first (or stacked). This PR remains safe alone: role-only Home/Dashboard/Editor
+   mapping is unchanged; expanded types only appear once effective landing returns
+   them.
+
+### nit
+
+1. `WebUI/war/app/index.jsp` is not the packaged WAR source (`src/main/webapp`);
+   kept in sync per issue dual-ship note.
+
+## Test evidence
+
+- `PSDefaultLandingViewTest`: 11 tests, 0 failures (mapping + unauthorized
+  fail-closed + role-only regression + admin/designer matrix)
+- Module: `WebUI` `mvnw clean install` green
+
+## Companions checked
+
+- Change class: pure util extracted from JSP for unit tests (peer:
+  `PSProxyHostScheme` / `PSProxyHostSchemeTest`)
+- Dual-ship: `cm/app/index.jsp`, `cm/pages/app/index.jsp`, residual `war/app`
+- Playwright not required for this server-side redirect helper (Admin UI surface
+  is slice 4 / #2211)
+- No Spring bean / rest adaptor surface change


### PR DESCRIPTION
## Summary

Parent tracker: #959 (slice 3/4). Implements issue #2210 — login / `/cm/app/` entry without `view` honors effective default landing and maps expanded homepage types to `view=` keys.

### What shipped
- **`PSDefaultLandingView`** (WebUI util, unit-tested): maps product types Home/Dashboard/Editor/Designer/Architecture/Publish/Workflow/WidgetBuilder (+ view-key aliases) → `view=` keys
- **`getDefaultView` in index.jsp** (canonical `cm/app`, dual-ship `cm/pages/app`, residual `war/app`): uses `PSRoleService.getUserHomepage()` then `resolveAuthorizedView(...)` with Admin/Designer fail-closed to `home`
- **Explicit `?view=`** deep links unchanged; existing role-gated unauthorized reset still applies
- **Regression:** role-only Home/Dashboard/Editor mapping unchanged when no user override

### Dependency
- Full **user override** values on `getUserHomepage()` come from slice 2: #2209 / PR #2216. This PR is safe on main alone (role-only path); once #2216 merges, overrides flow through without further WebUI changes.

## Test plan
- [x] Unit: canonical Home/Dashboard/Editor → home/dash/editor (regression)
- [x] Unit: expanded types → design/arch/publish/workflow/widgetbuilder
- [x] Unit: unauthorized design/arch/publish/workflow/widgetbuilder fail closed to home
- [x] Unit: Designer may open design/arch/publish/widgetbuilder; workflow Admin-only
- [x] `WebUI` `mvnw clean install` green
- [ ] Manual (after #2216): set user homepage override via REST, login without `view`, confirm redirect; clear override, confirm role resolve; try unauthorized override

## Gates evidence
- Erlang self-review: approve — `docs/ai-generated/code-reviews/issue-2210-login-default-landing-erlang.md`
- Module clean install: `WebUI` green (`PSDefaultLandingViewTest` 11/11)
- No path I/O changes

## Links
- Fixes #2210
- Parent: #959
- Depends on: #2209 / https://github.com/intersoftdatalabs-in/percussioncms/pull/2216
- Follow-up: #2211 (Admin UI + Playwright)

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
