### PR TITLE
feat(perc-doctor): clean-install-backups CLI + unit tests (slice 2 of #2213)

### DIFF
--- a/modules/perc-doctor/README.md
+++ b/modules/perc-doctor/README.md
@@ -2,11 +2,11 @@
 
 Operator CLI for diagnosing and safely cleaning Percussion CMS install trees.
 
-**Issue:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213)  
+**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`)  
 **Package:** `com.intsof.percussioncms.doctor`  
-**Slice 1:** module scaffold + `clean-heap-dumps` with global `--dry-run`
+**Shipped commands:** `clean-heap-dumps`, `clean-install-backups` with global `--dry-run` / `--install-root` / `-v`
 
-Later slices (tracked on #2213 / residual issues): `clean-install-backups`, `clean-logs`, admin HTTP API, distribution `bin` packaging.
+Later slices (tracked on #2213 / residual issues): `clean-logs`, admin HTTP API, distribution `bin` packaging.
 
 ## Build
 
@@ -39,7 +39,7 @@ Or with the compiled classes on the classpath (after install).
 | `-v` / `--verbose` | Path-level detail |
 | `-h` / `--help` | Usage |
 
-### Commands (slice 1)
+### Commands
 
 #### `clean-heap-dumps`
 
@@ -61,17 +61,43 @@ java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar ^
   --install-root C:\Percussion -v clean-heap-dumps
 ```
 
+#### `clean-install-backups`
+
+Remove allowlisted installer / upgrade backup artifacts left in the install tree.
+
+Patterns are documented from `modules/perc-distribution-tree` (`install.xml` `zip_AppServer`, assembly/install `**/*.bak` / `**/*.backup` excludes, and known upgrade copies such as `Navigation.properties.backup`). **No arbitrary user globs.**
+
+| Pattern | Source |
+|---------|--------|
+| `AppServer_backup_<timestamp>.zip` | `install.xml` target `zip_AppServer` |
+| `**/*.bak` | assembly / install excludes (e.g. `ResourceBundle.tmx.bak`) |
+| `**/*.backup` | assembly / install excludes (includes `*.properties.backup`) |
+
+- **Scope:** only under `--install-root`; paths outside the root are never deleted
+- **Dry-run:** inventories candidates + sizes without deleting
+
+Examples:
+
+```bash
+# Preview reclaimable install backups (safe)
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
+  --install-root /opt/Percussion --dry-run -v clean-install-backups
+
+# Apply (Windows example)
+java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar ^
+  --install-root C:\Percussion -v clean-install-backups
+```
+
 ## Safety model
 
 1. Resolve and validate install root (must exist and be a directory).
 2. Walk only under that root; skip / reject candidates that escape the root.
-3. Match allowlisted patterns only (`*.hprof` for this command).
+3. Match allowlisted patterns only (per command; no user-supplied globs).
 4. If `--dry-run`, stop after inventory.
 5. On apply, re-check containment immediately before each delete.
 
-## Deferred (not in this slice)
+## Deferred (not in this module slice)
 
-- `clean-install-backups` — allowlisted installer/upgrade backup patterns
 - `clean-logs` — age / keep-current log cleanup
 - Admin-authenticated HTTP API mirroring CLI
 - Distribution packaging (`bin/perc-doctor` / fat jar in install tree)

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanInstallBackupsCommand.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanInstallBackupsCommand.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Remove (or inventory) allowlisted installer / upgrade backup artifacts under a CMS install root.
+ *
+ * <p>Allowlist (see {@link InstallRootGuard#isInstallBackupFileName(String)}):
+ *
+ * <ul>
+ *   <li>{@code AppServer_backup_&lt;timestamp&gt;.zip}
+ *   <li>any {@code .bak} file under the install tree
+ *   <li>any {@code .backup} file under the install tree (includes known {@code
+ *       *.properties.backup} such as {@code Navigation.properties.backup})
+ * </ul>
+ *
+ * <p>Safety: only allowlisted names; every candidate is re-checked against the install root before
+ * delete. Dry-run never deletes. No arbitrary user-supplied globs.
+ */
+public final class CleanInstallBackupsCommand {
+
+  /** CLI command token. */
+  public static final String COMMAND_NAME = "clean-install-backups";
+
+  private CleanInstallBackupsCommand() {}
+
+  /**
+   * Inventory allowlisted install-backup files under {@code installRoot} and optionally delete
+   * them.
+   *
+   * @param installRoot resolved install root (must exist)
+   * @param dryRun when true, only inventory (no deletes)
+   * @return report of candidates and actions
+   * @throws IOException on walk failures that cannot be recovered
+   * @throws IllegalArgumentException if install root is invalid
+   */
+  public static CleanReport execute(Path installRoot, boolean dryRun) throws IOException {
+    Path root = InstallRootGuard.requireInstallRoot(installRoot);
+    CleanReport report = new CleanReport(COMMAND_NAME, root, dryRun);
+
+    List<Path> candidates = new ArrayList<>();
+    walkInstallBackups(root, candidates, report);
+    candidates.sort(Comparator.comparing(p -> p.toString()));
+
+    for (Path candidate : candidates) {
+      processCandidate(report, root, candidate, dryRun);
+    }
+    return report;
+  }
+
+  /**
+   * Inventory allowlisted install backups under {@code root} without recording walk failures (test
+   * helper).
+   */
+  static List<Path> findInstallBackups(Path root) throws IOException {
+    List<Path> found = new ArrayList<>();
+    walkInstallBackups(root, found, null);
+    return found;
+  }
+
+  /**
+   * Walk install tree for allowlisted install backups. When {@code report} is non-null, I/O
+   * failures during the walk are appended as {@link CleanReport.EntryStatus#FAILED} so operators
+   * see skipped paths.
+   */
+  static void walkInstallBackups(Path root, List<Path> found, CleanReport report)
+      throws IOException {
+    Objects.requireNonNull(root, "root");
+    Objects.requireNonNull(found, "found");
+    Files.walkFileTree(
+        root,
+        new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+            // Skip trees that escape the install root (e.g. unexpected symlink targets).
+            if (!InstallRootGuard.isUnderInstallRoot(root, dir)) {
+              return FileVisitResult.SKIP_SUBTREE;
+            }
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+            if (!attrs.isRegularFile()) {
+              return FileVisitResult.CONTINUE;
+            }
+            if (!InstallRootGuard.isUnderInstallRoot(root, file)) {
+              return FileVisitResult.CONTINUE;
+            }
+            Path fileName = file.getFileName();
+            if (fileName == null
+                || !InstallRootGuard.isInstallBackupFileName(fileName.toString())) {
+              return FileVisitResult.CONTINUE;
+            }
+            found.add(file);
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult visitFileFailed(Path file, IOException exc) {
+            recordVisitFailure(report, file, exc);
+            return FileVisitResult.CONTINUE;
+          }
+        });
+  }
+
+  /** Record a walk I/O failure on the report when one is provided (package-visible for tests). */
+  static void recordVisitFailure(CleanReport report, Path file, IOException exc) {
+    if (report == null || file == null) {
+      return;
+    }
+    String detail = exc != null ? exc.getMessage() : "unknown I/O error";
+    if (detail == null || detail.isBlank()) {
+      detail = exc != null ? exc.getClass().getSimpleName() : "unknown I/O error";
+    }
+    report.add(
+        new CleanReport.Entry(
+            file, 0L, CleanReport.EntryStatus.FAILED, "walk: " + detail));
+  }
+
+  private static void processCandidate(
+      CleanReport report, Path root, Path candidate, boolean dryRun) {
+    Objects.requireNonNull(candidate, "candidate");
+    try {
+      InstallRootGuard.requireUnderInstallRoot(root, candidate);
+    } catch (IllegalArgumentException outside) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, 0L, CleanReport.EntryStatus.FAILED, outside.getMessage()));
+      return;
+    }
+
+    Path name = candidate.getFileName();
+    if (name == null || !InstallRootGuard.isInstallBackupFileName(name.toString())) {
+      report.add(
+          new CleanReport.Entry(
+              candidate,
+              0L,
+              CleanReport.EntryStatus.SKIPPED,
+              "not an allowlisted install-backup file"));
+      return;
+    }
+
+    long size = 0L;
+    try {
+      if (Files.isRegularFile(candidate)) {
+        size = Files.size(candidate);
+      }
+    } catch (IOException e) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, 0L, CleanReport.EntryStatus.FAILED, "size: " + e.getMessage()));
+      return;
+    }
+
+    if (dryRun) {
+      report.add(
+          new CleanReport.Entry(candidate, size, CleanReport.EntryStatus.WOULD_DELETE, null));
+      return;
+    }
+
+    try {
+      // Re-check containment immediately before delete (TOCTOU-resistant enough for ops tool).
+      InstallRootGuard.requireUnderInstallRoot(root, candidate);
+      boolean deleted = Files.deleteIfExists(candidate);
+      if (deleted) {
+        report.add(new CleanReport.Entry(candidate, size, CleanReport.EntryStatus.DELETED, null));
+      } else {
+        report.add(
+            new CleanReport.Entry(
+                candidate, size, CleanReport.EntryStatus.SKIPPED, "already absent"));
+      }
+    } catch (IOException e) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, size, CleanReport.EntryStatus.FAILED, "delete: " + e.getMessage()));
+    } catch (IllegalArgumentException outside) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, size, CleanReport.EntryStatus.FAILED, outside.getMessage()));
+    }
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
@@ -27,7 +27,7 @@ import java.nio.file.Path;
  * perc-doctor [--install-root &lt;path&gt;] [--dry-run] [-v|--verbose] &lt;command&gt;
  * </pre>
  *
- * <p>Slice 1 command: {@code clean-heap-dumps}.
+ * <p>Commands: {@code clean-heap-dumps}, {@code clean-install-backups}.
  */
 public final class DoctorCli {
 
@@ -72,7 +72,11 @@ public final class DoctorCli {
     }
 
     if (parsed.command == null || parsed.command.isEmpty()) {
-      err.println("Error: missing command. Try: clean-heap-dumps");
+      err.println(
+          "Error: missing command. Try: "
+              + CleanHeapDumpsCommand.COMMAND_NAME
+              + " or "
+              + CleanInstallBackupsCommand.COMMAND_NAME);
       printHelp(err);
       return EXIT_USAGE;
     }
@@ -88,8 +92,17 @@ public final class DoctorCli {
         printReport(report, parsed.verbose, out);
         return report.getFailedCount() > 0 ? EXIT_ERROR : EXIT_OK;
       }
+      if (CleanInstallBackupsCommand.COMMAND_NAME.equals(parsed.command)) {
+        CleanReport report = CleanInstallBackupsCommand.execute(installRoot, parsed.dryRun);
+        printReport(report, parsed.verbose, out);
+        return report.getFailedCount() > 0 ? EXIT_ERROR : EXIT_OK;
+      }
       err.println("Error: unknown command: " + parsed.command);
-      err.println("Supported commands (slice 1): " + CleanHeapDumpsCommand.COMMAND_NAME);
+      err.println(
+          "Supported commands: "
+              + CleanHeapDumpsCommand.COMMAND_NAME
+              + ", "
+              + CleanInstallBackupsCommand.COMMAND_NAME);
       printHelp(err);
       return EXIT_USAGE;
     } catch (IllegalArgumentException e) {
@@ -145,7 +158,9 @@ public final class DoctorCli {
   private static void printHelp(PrintStream stream) {
     stream.println("usage: perc-doctor [options] <command>");
     stream.println();
-    stream.println("CMS Doctor — safe install-tree maintenance (slice 1: clean-heap-dumps).");
+    stream.println(
+        "CMS Doctor — safe install-tree maintenance"
+            + " (clean-heap-dumps, clean-install-backups).");
     stream.println();
     stream.println("Options:");
     stream.println("  --install-root <path>  CMS install root (default: current working directory)");
@@ -155,10 +170,16 @@ public final class DoctorCli {
     stream.println();
     stream.println("Commands:");
     stream.println("  clean-heap-dumps       Remove recursive *.hprof under install root");
+    stream.println(
+        "  clean-install-backups  Remove allowlisted installer/upgrade backups"
+            + " (*.bak, *.backup, AppServer_backup_*.zip)");
     stream.println();
     stream.println("Examples:");
     stream.println("  perc-doctor --install-root /opt/Percussion --dry-run clean-heap-dumps");
     stream.println("  perc-doctor --install-root C:\\Percussion -v clean-heap-dumps");
+    stream.println(
+        "  perc-doctor --install-root /opt/Percussion --dry-run -v clean-install-backups");
+    stream.println("  perc-doctor --install-root C:\\Percussion -v clean-install-backups");
   }
 
   static void printReport(CleanReport report, boolean verbose, PrintStream out) {

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/InstallRootGuard.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/InstallRootGuard.java
@@ -129,4 +129,52 @@ public final class InstallRootGuard {
     String lower = fileName.toLowerCase(Locale.ROOT);
     return lower.endsWith(".hprof");
   }
+
+  /**
+   * Allowlisted installer / upgrade backup file name for {@code clean-install-backups}.
+   *
+   * <p>Patterns are drawn from {@code perc-distribution-tree} installer and assembly excludes —
+   * not arbitrary user globs:
+   *
+   * <ul>
+   *   <li>{@code AppServer_backup_&lt;timestamp&gt;.zip} (see {@code install.xml} {@code
+   *       zip_AppServer})
+   *   <li>any file ending with {@code .bak} (assembly / install excludes)
+   *   <li>any file ending with {@code .backup} (assembly / install excludes; includes known
+   *       {@code *.properties.backup} such as {@code Navigation.properties.backup})
+   * </ul>
+   *
+   * <p>Matching is case-insensitive. Path separators in {@code fileName} are rejected.
+   *
+   * @param fileName bare file name (not a path)
+   * @return true if the name matches an allowlisted install-backup pattern
+   */
+  public static boolean isInstallBackupFileName(String fileName) {
+    if (fileName == null || fileName.isEmpty()) {
+      return false;
+    }
+    // Reject path separators smuggled into a "name"
+    if (fileName.indexOf('/') >= 0 || fileName.indexOf('\\') >= 0) {
+      return false;
+    }
+    String lower = fileName.toLowerCase(Locale.ROOT);
+    if (lower.endsWith(".bak") || lower.endsWith(".backup")) {
+      return true;
+    }
+    // AppServer_backup_${timestamp}.zip — require non-empty timestamp segment
+    return isAppServerBackupZipName(lower);
+  }
+
+  /**
+   * {@code AppServer_backup_<timestamp>.zip} with a non-empty timestamp (case already folded).
+   */
+  static boolean isAppServerBackupZipName(String lowerFileName) {
+    final String prefix = "appserver_backup_";
+    final String suffix = ".zip";
+    if (!lowerFileName.startsWith(prefix) || !lowerFileName.endsWith(suffix)) {
+      return false;
+    }
+    int midLen = lowerFileName.length() - prefix.length() - suffix.length();
+    return midLen > 0;
+  }
 }

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CleanInstallBackupsCommandTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CleanInstallBackupsCommandTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CleanInstallBackupsCommandTest {
+
+  @TempDir Path tempDir;
+
+  private Path installRoot;
+  private Path appServerZip;
+  private Path bakFile;
+  private Path backupFile;
+  private Path propertiesBackup;
+  private Path keepLog;
+  private Path outsideBak;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    installRoot = Files.createDirectories(tempDir.resolve("cms-install"));
+    Path rxconfig = Files.createDirectories(installRoot.resolve("rxconfig").resolve("Server"));
+
+    appServerZip = installRoot.resolve("AppServer_backup_20240115_120000.zip");
+    bakFile = installRoot.resolve("ResourceBundle.tmx.bak");
+    backupFile = installRoot.resolve("misc.config.backup");
+    propertiesBackup = rxconfig.resolve("Navigation.properties.backup");
+    keepLog = installRoot.resolve("server.log");
+
+    Files.write(appServerZip, "ZIP".getBytes(StandardCharsets.UTF_8));
+    Files.writeString(bakFile, "bak");
+    Files.writeString(backupFile, "backup");
+    Files.writeString(propertiesBackup, "nav-backup");
+    Files.writeString(keepLog, "active log");
+
+    Path outside = Files.createDirectories(tempDir.resolve("not-install"));
+    outsideBak = outside.resolve("escape.bak");
+    Files.writeString(outsideBak, "outside");
+  }
+
+  @Test
+  void dryRunInventoriesAllowlistedBackupsOnlyAndDoesNotDelete() throws Exception {
+    CleanReport report = CleanInstallBackupsCommand.execute(installRoot, true);
+
+    assertTrue(report.isDryRun());
+    assertEquals(4, report.getCandidateCount());
+    assertEquals(0, report.getDeletedCount());
+    assertTrue(Files.exists(appServerZip));
+    assertTrue(Files.exists(bakFile));
+    assertTrue(Files.exists(backupFile));
+    assertTrue(Files.exists(propertiesBackup));
+    assertTrue(Files.exists(keepLog));
+    assertTrue(Files.exists(outsideBak));
+
+    for (CleanReport.Entry e : report.getEntries()) {
+      assertEquals(CleanReport.EntryStatus.WOULD_DELETE, e.getStatus());
+      assertTrue(InstallRootGuard.isUnderInstallRoot(installRoot, e.getPath()));
+      assertTrue(
+          InstallRootGuard.isInstallBackupFileName(e.getPath().getFileName().toString()));
+    }
+
+    long expectedBytes =
+        Files.size(appServerZip)
+            + Files.size(bakFile)
+            + Files.size(backupFile)
+            + Files.size(propertiesBackup);
+    assertEquals(expectedBytes, report.getTotalBytes());
+  }
+
+  @Test
+  void applyDeletesAllowlistedBackupsUnderRootOnlyLeavesOtherFiles() throws Exception {
+    CleanReport report = CleanInstallBackupsCommand.execute(installRoot, false);
+
+    assertFalse(report.isDryRun());
+    assertEquals(4, report.getDeletedCount());
+    assertEquals(0, report.getFailedCount());
+    assertFalse(Files.exists(appServerZip));
+    assertFalse(Files.exists(bakFile));
+    assertFalse(Files.exists(backupFile));
+    assertFalse(Files.exists(propertiesBackup));
+    assertTrue(Files.exists(keepLog), "non-backup files must not be deleted");
+    assertTrue(Files.exists(outsideBak), "files outside install root must not be deleted");
+  }
+
+  @Test
+  void findInstallBackupsDoesNotIncludeOutsideInstallRoot() throws Exception {
+    List<Path> found = CleanInstallBackupsCommand.findInstallBackups(installRoot);
+    assertEquals(4, found.size());
+    for (Path p : found) {
+      assertTrue(InstallRootGuard.isUnderInstallRoot(installRoot, p));
+      assertFalse(p.equals(outsideBak));
+    }
+  }
+
+  @Test
+  void executeRejectsMissingInstallRoot() {
+    Path missing = tempDir.resolve("missing-root");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> CleanInstallBackupsCommand.execute(missing, true));
+  }
+
+  @Test
+  void allowlistRejectsNonBackupNamesAndHeapDumps() throws Exception {
+    Path hprof = installRoot.resolve("java_pid1.hprof");
+    Path txt = installRoot.resolve("notes.txt");
+    Path emptyZip = installRoot.resolve("AppServer_backup_.zip");
+    Path wrongPrefix = installRoot.resolve("OtherServer_backup_1.zip");
+    Files.writeString(hprof, "heap");
+    Files.writeString(txt, "txt");
+    Files.writeString(emptyZip, "bad");
+    Files.writeString(wrongPrefix, "bad");
+
+    CleanReport dry = CleanInstallBackupsCommand.execute(installRoot, true);
+    // still only the 4 allowlisted fixtures from setUp
+    assertEquals(4, dry.getCandidateCount());
+
+    CleanInstallBackupsCommand.execute(installRoot, false);
+    assertTrue(Files.exists(hprof));
+    assertTrue(Files.exists(txt));
+    assertTrue(Files.exists(emptyZip));
+    assertTrue(Files.exists(wrongPrefix));
+  }
+
+  @Test
+  void visitFileFailedRecordsFailedEntryOnReport() {
+    CleanReport report =
+        new CleanReport(CleanInstallBackupsCommand.COMMAND_NAME, installRoot, true);
+    Path failed = installRoot.resolve("unreadable.bak");
+    CleanInstallBackupsCommand.recordVisitFailure(
+        report, failed, new java.io.IOException("Access denied"));
+
+    assertEquals(1, report.getFailedCount());
+    CleanReport.Entry e = report.getEntries().get(0);
+    assertEquals(CleanReport.EntryStatus.FAILED, e.getStatus());
+    assertEquals(failed, e.getPath());
+    assertTrue(e.getDetail().contains("walk:"));
+    assertTrue(e.getDetail().toLowerCase().contains("access denied"));
+  }
+
+  @Test
+  void recordVisitFailureNoopsWhenReportNull() {
+    CleanInstallBackupsCommand.recordVisitFailure(
+        null, installRoot.resolve("x.bak"), new java.io.IOException("x"));
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
@@ -127,4 +127,55 @@ class DoctorCliTest {
     assertEquals(DoctorCli.EXIT_ERROR, code);
     assertTrue(errBuf.toString(StandardCharsets.UTF_8).toLowerCase().contains("install root"));
   }
+
+  @Test
+  void cleanInstallBackupsDryRunViaCliDoesNotDelete() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-bak"));
+    Path bak = root.resolve("config.properties.backup");
+    Path zip = root.resolve("AppServer_backup_20260101.zip");
+    Files.writeString(bak, "bak");
+    Files.write(zip, "zip".getBytes(StandardCharsets.UTF_8));
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root", root.toString(), "--dry-run", "-v", "clean-install-backups"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    assertTrue(Files.exists(bak));
+    assertTrue(Files.exists(zip));
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("command=clean-install-backups"));
+    assertTrue(out.contains("dry-run=true"));
+    assertTrue(out.contains("candidates=2"));
+    assertTrue(out.contains("WOULD_DELETE"));
+  }
+
+  @Test
+  void cleanInstallBackupsApplyViaCliDeletesAllowlistedOnly() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-bak-apply"));
+    Path bak = root.resolve("x.bak");
+    Path keep = root.resolve("server.log");
+    Files.writeString(bak, "bak");
+    Files.writeString(keep, "log");
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"--install-root", root.toString(), "clean-install-backups"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    assertFalse(Files.exists(bak));
+    assertTrue(Files.exists(keep));
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("deleted=1"));
+  }
 }

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/InstallRootGuardTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/InstallRootGuardTest.java
@@ -91,6 +91,28 @@ class InstallRootGuardTest {
   }
 
   @Test
+  void installBackupAllowlistAcceptsDocumentedPatternsOnly() {
+    assertTrue(InstallRootGuard.isInstallBackupFileName("AppServer_backup_20240115_120000.zip"));
+    assertTrue(InstallRootGuard.isInstallBackupFileName("appserver_backup_1.zip"));
+    assertTrue(InstallRootGuard.isInstallBackupFileName("ResourceBundle.tmx.bak"));
+    assertTrue(InstallRootGuard.isInstallBackupFileName("file.BAK"));
+    assertTrue(InstallRootGuard.isInstallBackupFileName("misc.config.backup"));
+    assertTrue(InstallRootGuard.isInstallBackupFileName("Navigation.properties.backup"));
+    assertTrue(InstallRootGuard.isInstallBackupFileName("FOO.PROPERTIES.BACKUP"));
+
+    assertFalse(InstallRootGuard.isInstallBackupFileName("AppServer_backup_.zip"));
+    assertFalse(InstallRootGuard.isInstallBackupFileName("AppServer_backup.zip"));
+    assertFalse(InstallRootGuard.isInstallBackupFileName("OtherServer_backup_1.zip"));
+    assertFalse(InstallRootGuard.isInstallBackupFileName("java_pid123.hprof"));
+    assertFalse(InstallRootGuard.isInstallBackupFileName("server.log"));
+    assertFalse(InstallRootGuard.isInstallBackupFileName("notes.txt"));
+    assertFalse(InstallRootGuard.isInstallBackupFileName(""));
+    assertFalse(InstallRootGuard.isInstallBackupFileName(null));
+    assertFalse(InstallRootGuard.isInstallBackupFileName("../evil.bak"));
+    assertFalse(InstallRootGuard.isInstallBackupFileName("dir/file.bak"));
+  }
+
+  @Test
   @EnabledOnOs(OS.WINDOWS)
   void isUnderInstallRootIsCaseInsensitiveOnWindows() {
     // Path.startsWith is case-sensitive; Windows FS is not — guard must fold.


### PR DESCRIPTION
## Summary

Implements **slice 2** of parent tracker **#2213**: `clean-install-backups` for `modules/perc-doctor`.

**Depends on:** #2221 (scaffold + `clean-heap-dumps`) — this PR is stacked on `feat/issue-2213-perc-doctor-scaffold`. Retarget to `main` after #2221 merges if preferred.

- Allowlisted installer/upgrade backup patterns only (from `perc-distribution-tree` `install.xml` / assembly excludes):
  - `AppServer_backup_<timestamp>.zip`
  - `*.bak`
  - `*.backup` (includes known `*.properties.backup` e.g. `Navigation.properties.backup`)
- No arbitrary user globs
- Global `--install-root` / `--dry-run` / `-v` via `DoctorCli`
- Dry-run inventories path+size; apply deletes only under `InstallRootGuard`
- README examples updated

## Test plan

- [x] Unit tests: allowlist match/reject (`InstallRootGuard.isInstallBackupFileName`)
- [x] Unit tests: dry-run vs apply (`CleanInstallBackupsCommandTest`)
- [x] Unit tests: outside-root rejection (inventory never includes sibling tree)
- [x] CLI wiring tests for dry-run and apply
- [x] `cd modules/perc-doctor && ../../mvnw.cmd clean install` — **BUILD SUCCESS**, Tests run: 30, Failures: 0

## Gates evidence

| Gate | Result |
|------|--------|
| Erlang-style self-review | Pass: root containment, TOCTOU re-check before delete, portable `Path` API, Intersoft 2026 headers on new files |
| Module clean install | `modules/perc-doctor` standalone `mvnw clean install` green |
| Behavioral unit tests | Allowlist / dry-run / apply / outside-root covered |
| Scope | Only `modules/perc-doctor` |

## Issue links

- **Fixes #2217**
- **Partial #2213** (parent tracker; remaining slices #2218 clean-logs, #2219 API, #2220 dist/docs)

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.