### PR TITLE
feat(perc-doctor): clean-logs CLI with --older-than / --keep-current (slice 3 of #2213)

### DIFF
--- a/modules/perc-doctor/README.md
+++ b/modules/perc-doctor/README.md
@@ -2,11 +2,11 @@
 
 Operator CLI for diagnosing and safely cleaning Percussion CMS install trees.
 
-**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`)  
+**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`)  
 **Package:** `com.intsof.percussioncms.doctor`  
-**Shipped commands:** `clean-heap-dumps`, `clean-install-backups` with global `--dry-run` / `--install-root` / `-v`
+**Shipped commands:** `clean-heap-dumps`, `clean-install-backups`, `clean-logs` with global `--dry-run` / `--install-root` / `-v`
 
-Later slices (tracked on #2213 / residual issues): `clean-logs`, admin HTTP API, distribution `bin` packaging.
+Later slices (tracked on #2213 / residual issues): admin HTTP API, distribution `bin` packaging.
 
 ## Build
 
@@ -25,7 +25,7 @@ Windows:
 ## Run
 
 ```bash
-java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar [options] <command>
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar [options] <command> [command-options]
 ```
 
 Or with the compiled classes on the classpath (after install).
@@ -88,16 +88,58 @@ java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar ^
   --install-root C:\Percussion -v clean-install-backups
 ```
 
+#### `clean-logs`
+
+Reclaim space from **known** log directories under the install root without nuking active server logs carelessly.
+
+##### Target log locations (relative to `--install-root`)
+
+| Relative path | Role |
+|---------------|------|
+| `jetty/base/logs` | Jetty / CMS logs (`install.xml` mkdirs; Log4j2 `server.log`, rotations, `audit/`) |
+| `jetty/base/modules/perc-logging/logs` | Log4j2 default relative to perc-logging module config |
+| `Deployment/Server/logs` | DTS Tomcat (`catalina.base`/logs — `catalina.log`, gzipped rotations, etc.) |
+
+Missing directories are skipped (not an error). Only files under these roots whose names end with `.log`, `.log.gz`, or `.out` are candidates. **No user-supplied globs; no walk of the entire install for arbitrary logs.**
+
+##### Options
+
+| Flag | Meaning |
+|------|---------|
+| `--older-than <duration>` | Only files with last-modified **older** than the duration. Units: `s`, `m`, `h`, `d`, `w` (e.g. `7d`, `24h`, `30m`). Omit to ignore age. |
+| `--keep-current` | **Default.** Never delete identifiable active current logs (`server.log`, `catalina.log`, `catalina.out`, … — non-dated `*.log` / `*.out`). |
+| `--no-keep-current` | Allow deleting those active basenames (still subject to `--older-than` if set). |
+
+- **Scope:** only under `--install-root` and the allowlisted log dirs
+- **Dry-run:** inventories candidates + sizes without deleting
+- Rotated / compressed names (embedded `yyyy-MM-dd`, `*.log.gz`, `name.log.N`) are not treated as current
+
+Examples:
+
+```bash
+# Preview logs older than 7 days (keep active *.log)
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
+  --install-root /opt/Percussion --dry-run -v clean-logs --older-than 7d
+
+# Apply (Windows example)
+java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar ^
+  --install-root C:\Percussion -v clean-logs --older-than 14d
+
+# Delete all non-current log candidates (no age filter)
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
+  --install-root /opt/Percussion --dry-run -v clean-logs
+```
+
 ## Safety model
 
 1. Resolve and validate install root (must exist and be a directory).
-2. Walk only under that root; skip / reject candidates that escape the root.
+2. Walk only under that root (and for `clean-logs`, only under allowlisted log dirs); skip / reject candidates that escape the root.
 3. Match allowlisted patterns only (per command; no user-supplied globs).
 4. If `--dry-run`, stop after inventory.
 5. On apply, re-check containment immediately before each delete.
+6. For `clean-logs`, apply `--keep-current` and `--older-than` before any delete.
 
 ## Deferred (not in this module slice)
 
-- `clean-logs` — age / keep-current log cleanup
 - Admin-authenticated HTTP API mirroring CLI
 - Distribution packaging (`bin/perc-doctor` / fat jar in install tree)

--- a/modules/perc-doctor/pom.xml
+++ b/modules/perc-doctor/pom.xml
@@ -30,7 +30,7 @@
     <name>Percussion CMS Doctor</name>
     <description>
         Operator CLI for diagnosing and safely cleaning Percussion CMS install trees
-        (heap dumps, install backups, logs — slice 1: clean-heap-dumps).
+        (heap dumps, install backups, logs).
     </description>
 
     <dependencies>

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanLogsCommand.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanLogsCommand.java
@@ -69,8 +69,9 @@ public final class CleanLogsCommand {
   /**
    * Options for {@link #execute(Path, boolean, Options)}.
    *
-   * <p>{@code olderThan} — when non-null, only files with last-modified before {@code now -
-   * olderThan}. {@code keepCurrent} — when true, skip identifiable current / active log files.
+   * <p>{@code olderThan} — when non-null, only files whose last-modified is older than this
+   * duration relative to the time each file is evaluated (per-candidate {@code Instant.now()}).
+   * {@code keepCurrent} — when true, skip identifiable current / active log files.
    */
   public static final class Options {
     private final Duration olderThan;
@@ -134,17 +135,17 @@ public final class CleanLogsCommand {
     Path root = InstallRootGuard.requireInstallRoot(installRoot);
     CleanReport report = new CleanReport(COMMAND_NAME, root, dryRun);
 
-    Instant cutoff =
-        options.getOlderThan() == null ? null : Instant.now().minus(options.getOlderThan());
-
     List<Path> candidates = new ArrayList<>();
     for (Path logDir : InstallRootGuard.existingLogDirs(root)) {
       walkLogDir(root, logDir, candidates, report);
     }
     candidates.sort(Comparator.comparing(p -> p.toString()));
 
+    // Age cutoff is evaluated per candidate (Instant.now() at process time), not once at
+    // walk-start, so a long walk does not leave a stale threshold for later files.
     for (Path candidate : candidates) {
-      processCandidate(report, root, candidate, dryRun, options.isKeepCurrent(), cutoff);
+      processCandidate(
+          report, root, candidate, dryRun, options.isKeepCurrent(), options.getOlderThan());
     }
     return report;
   }
@@ -231,7 +232,7 @@ public final class CleanLogsCommand {
       Path candidate,
       boolean dryRun,
       boolean keepCurrent,
-      Instant cutoff) {
+      Duration olderThan) {
     Objects.requireNonNull(candidate, "candidate");
     try {
       InstallRootGuard.requireUnderInstallRoot(root, candidate);
@@ -258,7 +259,7 @@ public final class CleanLogsCommand {
       return;
     }
 
-    if (cutoff != null) {
+    if (olderThan != null) {
       Instant mtime;
       try {
         FileTime ft = Files.getLastModifiedTime(candidate);
@@ -269,6 +270,8 @@ public final class CleanLogsCommand {
                 candidate, 0L, CleanReport.EntryStatus.FAILED, "mtime: " + e.getMessage()));
         return;
       }
+      // Per-file age reference: now is sampled when this candidate is evaluated.
+      Instant cutoff = Instant.now().minus(olderThan);
       if (!mtime.isBefore(cutoff)) {
         long size = sizeOrZero(candidate);
         report.add(

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanLogsCommand.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanLogsCommand.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Remove (or inventory) aged log files under known CMS / Jetty / DTS log directories.
+ *
+ * <p>Target roots (relative to install root; missing dirs skipped):
+ *
+ * <ul>
+ *   <li>{@code jetty/base/logs}
+ *   <li>{@code jetty/base/modules/perc-logging/logs}
+ *   <li>{@code Deployment/Server/logs}
+ * </ul>
+ *
+ * <p>Only allowlisted log file names ({@link InstallRootGuard#isLogFileName(String)}) under those
+ * roots are considered. Safety options:
+ *
+ * <ul>
+ *   <li>{@code --older-than &lt;duration&gt;} — only files with mtime older than the duration
+ *   <li>{@code --keep-current} (default true) — never delete identifiable active {@code *.log} /
+ *       {@code *.out} files
+ * </ul>
+ *
+ * <p>Dry-run never deletes. Paths outside the install root are never deleted.
+ */
+public final class CleanLogsCommand {
+
+  /** CLI command token. */
+  public static final String COMMAND_NAME = "clean-logs";
+
+  /** Duration token: one or more digits plus unit {@code w|d|h|m|s} (case-insensitive). */
+  private static final Pattern DURATION_PATTERN =
+      Pattern.compile("^(\\d+)([smhdw])$", Pattern.CASE_INSENSITIVE);
+
+  private CleanLogsCommand() {}
+
+  /**
+   * Options for {@link #execute(Path, boolean, Options)}.
+   *
+   * <p>{@code olderThan} — when non-null, only files with last-modified before {@code now -
+   * olderThan}. {@code keepCurrent} — when true, skip identifiable current / active log files.
+   */
+  public static final class Options {
+    private final Duration olderThan;
+    private final boolean keepCurrent;
+
+    /**
+     * Create clean-logs filter options.
+     *
+     * @param olderThan optional minimum age; null means no age filter
+     * @param keepCurrent retain current active logs (recommended default true)
+     */
+    public Options(Duration olderThan, boolean keepCurrent) {
+      this.olderThan = olderThan;
+      this.keepCurrent = keepCurrent;
+      if (olderThan != null && (olderThan.isNegative() || olderThan.isZero())) {
+        throw new IllegalArgumentException("--older-than must be a positive duration");
+      }
+    }
+
+    /**
+     * Age threshold, or null when unset.
+     *
+     * @return age threshold, or null when unset
+     */
+    public Duration getOlderThan() {
+      return olderThan;
+    }
+
+    /**
+     * Whether current active logs are retained.
+     *
+     * @return whether current active logs are retained
+     */
+    public boolean isKeepCurrent() {
+      return keepCurrent;
+    }
+
+    /**
+     * Default: no age filter, keep current active logs.
+     *
+     * @return default options instance
+     */
+    public static Options defaults() {
+      return new Options(null, true);
+    }
+  }
+
+  /**
+   * Inventory log candidates under known log dirs and optionally delete them.
+   *
+   * @param installRoot resolved install root (must exist)
+   * @param dryRun when true, only inventory (no deletes)
+   * @param options age / keep-current filters
+   * @return report of candidates and actions
+   * @throws IOException on walk failures that cannot be recovered
+   * @throws IllegalArgumentException if install root or options are invalid
+   */
+  public static CleanReport execute(Path installRoot, boolean dryRun, Options options)
+      throws IOException {
+    Objects.requireNonNull(options, "options");
+    Path root = InstallRootGuard.requireInstallRoot(installRoot);
+    CleanReport report = new CleanReport(COMMAND_NAME, root, dryRun);
+
+    Instant cutoff =
+        options.getOlderThan() == null ? null : Instant.now().minus(options.getOlderThan());
+
+    List<Path> candidates = new ArrayList<>();
+    for (Path logDir : InstallRootGuard.existingLogDirs(root)) {
+      walkLogDir(root, logDir, candidates, report);
+    }
+    candidates.sort(Comparator.comparing(p -> p.toString()));
+
+    for (Path candidate : candidates) {
+      processCandidate(report, root, candidate, dryRun, options.isKeepCurrent(), cutoff);
+    }
+    return report;
+  }
+
+  /**
+   * Inventory log candidates under known log dirs without recording walk failures (test helper).
+   * Does not apply age / keep-current filters — returns all allowlisted log file names found.
+   */
+  static List<Path> findLogFiles(Path root) throws IOException {
+    Path installRoot = InstallRootGuard.requireInstallRoot(root);
+    List<Path> found = new ArrayList<>();
+    for (Path logDir : InstallRootGuard.existingLogDirs(installRoot)) {
+      walkLogDir(installRoot, logDir, found, null);
+    }
+    return found;
+  }
+
+  /**
+   * Walk a single log directory tree. When {@code report} is non-null, I/O failures during the walk
+   * are appended as {@link CleanReport.EntryStatus#FAILED}.
+   */
+  static void walkLogDir(Path installRoot, Path logDir, List<Path> found, CleanReport report)
+      throws IOException {
+    Objects.requireNonNull(installRoot, "installRoot");
+    Objects.requireNonNull(logDir, "logDir");
+    Objects.requireNonNull(found, "found");
+    if (!InstallRootGuard.isUnderInstallRoot(installRoot, logDir)) {
+      return;
+    }
+    if (!Files.isDirectory(logDir)) {
+      return;
+    }
+    Files.walkFileTree(
+        logDir,
+        new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+            if (!InstallRootGuard.isUnderInstallRoot(installRoot, dir)) {
+              return FileVisitResult.SKIP_SUBTREE;
+            }
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+            if (!attrs.isRegularFile()) {
+              return FileVisitResult.CONTINUE;
+            }
+            if (!InstallRootGuard.isUnderInstallRoot(installRoot, file)) {
+              return FileVisitResult.CONTINUE;
+            }
+            Path fileName = file.getFileName();
+            if (fileName == null || !InstallRootGuard.isLogFileName(fileName.toString())) {
+              return FileVisitResult.CONTINUE;
+            }
+            found.add(file);
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult visitFileFailed(Path file, IOException exc) {
+            recordVisitFailure(report, file, exc);
+            return FileVisitResult.CONTINUE;
+          }
+        });
+  }
+
+  /** Record a walk I/O failure on the report when one is provided (package-visible for tests). */
+  static void recordVisitFailure(CleanReport report, Path file, IOException exc) {
+    if (report == null || file == null) {
+      return;
+    }
+    String detail = exc != null ? exc.getMessage() : "unknown I/O error";
+    if (detail == null || detail.isBlank()) {
+      detail = exc != null ? exc.getClass().getSimpleName() : "unknown I/O error";
+    }
+    report.add(
+        new CleanReport.Entry(file, 0L, CleanReport.EntryStatus.FAILED, "walk: " + detail));
+  }
+
+  private static void processCandidate(
+      CleanReport report,
+      Path root,
+      Path candidate,
+      boolean dryRun,
+      boolean keepCurrent,
+      Instant cutoff) {
+    Objects.requireNonNull(candidate, "candidate");
+    try {
+      InstallRootGuard.requireUnderInstallRoot(root, candidate);
+    } catch (IllegalArgumentException outside) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, 0L, CleanReport.EntryStatus.FAILED, outside.getMessage()));
+      return;
+    }
+
+    Path name = candidate.getFileName();
+    if (name == null || !InstallRootGuard.isLogFileName(name.toString())) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, 0L, CleanReport.EntryStatus.SKIPPED, "not an allowlisted log file"));
+      return;
+    }
+
+    if (keepCurrent && InstallRootGuard.isCurrentLogFileName(name.toString())) {
+      long size = sizeOrZero(candidate);
+      report.add(
+          new CleanReport.Entry(
+              candidate, size, CleanReport.EntryStatus.SKIPPED, "keep-current: active log"));
+      return;
+    }
+
+    if (cutoff != null) {
+      Instant mtime;
+      try {
+        FileTime ft = Files.getLastModifiedTime(candidate);
+        mtime = ft.toInstant();
+      } catch (IOException e) {
+        report.add(
+            new CleanReport.Entry(
+                candidate, 0L, CleanReport.EntryStatus.FAILED, "mtime: " + e.getMessage()));
+        return;
+      }
+      if (!mtime.isBefore(cutoff)) {
+        long size = sizeOrZero(candidate);
+        report.add(
+            new CleanReport.Entry(
+                candidate,
+                size,
+                CleanReport.EntryStatus.SKIPPED,
+                "newer than --older-than cutoff"));
+        return;
+      }
+    }
+
+    long size = 0L;
+    try {
+      if (Files.isRegularFile(candidate)) {
+        size = Files.size(candidate);
+      }
+    } catch (IOException e) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, 0L, CleanReport.EntryStatus.FAILED, "size: " + e.getMessage()));
+      return;
+    }
+
+    if (dryRun) {
+      report.add(
+          new CleanReport.Entry(candidate, size, CleanReport.EntryStatus.WOULD_DELETE, null));
+      return;
+    }
+
+    try {
+      // Re-check containment immediately before delete (TOCTOU-resistant enough for ops tool).
+      InstallRootGuard.requireUnderInstallRoot(root, candidate);
+      boolean deleted = Files.deleteIfExists(candidate);
+      if (deleted) {
+        report.add(new CleanReport.Entry(candidate, size, CleanReport.EntryStatus.DELETED, null));
+      } else {
+        report.add(
+            new CleanReport.Entry(
+                candidate, size, CleanReport.EntryStatus.SKIPPED, "already absent"));
+      }
+    } catch (IOException e) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, size, CleanReport.EntryStatus.FAILED, "delete: " + e.getMessage()));
+    } catch (IllegalArgumentException outside) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, size, CleanReport.EntryStatus.FAILED, outside.getMessage()));
+    }
+  }
+
+  private static long sizeOrZero(Path candidate) {
+    try {
+      if (Files.isRegularFile(candidate)) {
+        return Files.size(candidate);
+      }
+    } catch (IOException ignored) {
+      // best-effort for skip reporting
+    }
+    return 0L;
+  }
+
+  /**
+   * Parse a simple duration token for {@code --older-than}.
+   *
+   * <p>Accepted forms (case-insensitive unit): {@code &lt;digits&gt;&lt;unit&gt;} where unit is
+   * {@code s} (seconds), {@code m} (minutes), {@code h} (hours), {@code d} (days), or {@code w}
+   * (weeks). Examples: {@code 7d}, {@code 24h}, {@code 30m}, {@code 90s}, {@code 2w}.
+   *
+   * @param token duration string
+   * @return positive {@link Duration}
+   * @throws IllegalArgumentException if the token is null, empty, malformed, or non-positive
+   */
+  public static Duration parseOlderThan(String token) {
+    if (token == null || token.isBlank()) {
+      throw new IllegalArgumentException(
+          "--older-than requires a duration like 7d, 24h, 30m, 90s, or 2w");
+    }
+    String trimmed = token.trim();
+    Matcher m = DURATION_PATTERN.matcher(trimmed);
+    if (!m.matches()) {
+      throw new IllegalArgumentException(
+          "invalid --older-than duration '"
+              + token
+              + "' (expected <number><s|m|h|d|w>, e.g. 7d)");
+    }
+    long amount;
+    try {
+      amount = Long.parseLong(m.group(1));
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("invalid --older-than duration '" + token + "'", e);
+    }
+    if (amount <= 0L) {
+      throw new IllegalArgumentException("--older-than must be a positive duration");
+    }
+    char unit = m.group(2).toLowerCase(Locale.ROOT).charAt(0);
+    switch (unit) {
+      case 's':
+        return Duration.ofSeconds(amount);
+      case 'm':
+        return Duration.ofMinutes(amount);
+      case 'h':
+        return Duration.ofHours(amount);
+      case 'd':
+        return Duration.ofDays(amount);
+      case 'w':
+        return Duration.ofDays(Math.multiplyExact(amount, 7L));
+      default:
+        throw new IllegalArgumentException("invalid --older-than unit in '" + token + "'");
+    }
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
@@ -19,15 +19,17 @@ package com.intsof.percussioncms.doctor;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Path;
+import java.time.Duration;
 
 /**
  * CLI entry for {@code perc-doctor}.
  *
  * <pre>
- * perc-doctor [--install-root &lt;path&gt;] [--dry-run] [-v|--verbose] &lt;command&gt;
+ * perc-doctor [--install-root &lt;path&gt;] [--dry-run] [-v|--verbose]
+ *   &lt;command&gt; [command-options]
  * </pre>
  *
- * <p>Commands: {@code clean-heap-dumps}, {@code clean-install-backups}.
+ * <p>Commands: {@code clean-heap-dumps}, {@code clean-install-backups}, {@code clean-logs}.
  */
 public final class DoctorCli {
 
@@ -75,8 +77,10 @@ public final class DoctorCli {
       err.println(
           "Error: missing command. Try: "
               + CleanHeapDumpsCommand.COMMAND_NAME
-              + " or "
-              + CleanInstallBackupsCommand.COMMAND_NAME);
+              + ", "
+              + CleanInstallBackupsCommand.COMMAND_NAME
+              + ", or "
+              + CleanLogsCommand.COMMAND_NAME);
       printHelp(err);
       return EXIT_USAGE;
     }
@@ -97,12 +101,21 @@ public final class DoctorCli {
         printReport(report, parsed.verbose, out);
         return report.getFailedCount() > 0 ? EXIT_ERROR : EXIT_OK;
       }
+      if (CleanLogsCommand.COMMAND_NAME.equals(parsed.command)) {
+        CleanLogsCommand.Options options =
+            new CleanLogsCommand.Options(parsed.olderThan, parsed.keepCurrent);
+        CleanReport report = CleanLogsCommand.execute(installRoot, parsed.dryRun, options);
+        printReport(report, parsed.verbose, out);
+        return report.getFailedCount() > 0 ? EXIT_ERROR : EXIT_OK;
+      }
       err.println("Error: unknown command: " + parsed.command);
       err.println(
           "Supported commands: "
               + CleanHeapDumpsCommand.COMMAND_NAME
               + ", "
-              + CleanInstallBackupsCommand.COMMAND_NAME);
+              + CleanInstallBackupsCommand.COMMAND_NAME
+              + ", "
+              + CleanLogsCommand.COMMAND_NAME);
       printHelp(err);
       return EXIT_USAGE;
     } catch (IllegalArgumentException e) {
@@ -120,11 +133,15 @@ public final class DoctorCli {
     boolean verbose;
     boolean help;
     String command;
+    /** Optional age filter for {@code clean-logs}; null when unset. */
+    Duration olderThan;
+    /** Default true for {@code clean-logs}. */
+    boolean keepCurrent = true;
   }
 
   /**
    * Minimal argv parser (no external CLI library). Supports long options and {@code -v}/{@code
-   * -h}.
+   * -h}. Global and command-specific options may appear before or after the command token.
    */
   static ParsedArgs parseArgs(String[] args) {
     ParsedArgs parsed = new ParsedArgs();
@@ -144,6 +161,16 @@ public final class DoctorCli {
           throw new IllegalArgumentException("--install-root requires a path argument");
         }
         parsed.installRoot = args[++i];
+      } else if ("--older-than".equals(a)) {
+        if (i + 1 >= args.length) {
+          throw new IllegalArgumentException(
+              "--older-than requires a duration argument (e.g. 7d)");
+        }
+        parsed.olderThan = CleanLogsCommand.parseOlderThan(args[++i]);
+      } else if ("--keep-current".equals(a)) {
+        parsed.keepCurrent = true;
+      } else if ("--no-keep-current".equals(a)) {
+        parsed.keepCurrent = false;
       } else if (a.startsWith("-")) {
         throw new IllegalArgumentException("unknown option: " + a);
       } else if (parsed.command == null) {
@@ -156,11 +183,11 @@ public final class DoctorCli {
   }
 
   private static void printHelp(PrintStream stream) {
-    stream.println("usage: perc-doctor [options] <command>");
+    stream.println("usage: perc-doctor [options] <command> [command-options]");
     stream.println();
     stream.println(
         "CMS Doctor — safe install-tree maintenance"
-            + " (clean-heap-dumps, clean-install-backups).");
+            + " (clean-heap-dumps, clean-install-backups, clean-logs).");
     stream.println();
     stream.println("Options:");
     stream.println("  --install-root <path>  CMS install root (default: current working directory)");
@@ -173,6 +200,16 @@ public final class DoctorCli {
     stream.println(
         "  clean-install-backups  Remove allowlisted installer/upgrade backups"
             + " (*.bak, *.backup, AppServer_backup_*.zip)");
+    stream.println(
+        "  clean-logs             Remove aged logs under known Jetty/CMS/DTS log dirs");
+    stream.println();
+    stream.println("clean-logs options:");
+    stream.println(
+        "  --older-than <dur>     Only files older than duration (e.g. 7d, 24h, 30m)");
+    stream.println(
+        "  --keep-current         Never delete active current *.log/*.out (default)");
+    stream.println(
+        "  --no-keep-current      Allow deleting active current log basenames");
     stream.println();
     stream.println("Examples:");
     stream.println("  perc-doctor --install-root /opt/Percussion --dry-run clean-heap-dumps");
@@ -180,6 +217,10 @@ public final class DoctorCli {
     stream.println(
         "  perc-doctor --install-root /opt/Percussion --dry-run -v clean-install-backups");
     stream.println("  perc-doctor --install-root C:\\Percussion -v clean-install-backups");
+    stream.println(
+        "  perc-doctor --install-root /opt/Percussion --dry-run -v clean-logs --older-than 7d");
+    stream.println(
+        "  perc-doctor --install-root C:\\Percussion -v clean-logs --older-than 14d");
   }
 
   static void printReport(CleanReport report, boolean verbose, PrintStream out) {

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
@@ -90,6 +90,24 @@ public final class DoctorCli {
             ? Path.of(parsed.installRoot)
             : Path.of("").toAbsolutePath().normalize();
 
+    // clean-logs-only options: warn (do not hard-fail) when used with other commands.
+    if (parsed.olderThan != null
+        && !CleanLogsCommand.COMMAND_NAME.equals(parsed.command)) {
+      err.println(
+          "Warning: --older-than is only used by "
+              + CleanLogsCommand.COMMAND_NAME
+              + "; ignoring for "
+              + parsed.command);
+    }
+    if (parsed.keepCurrentExplicit
+        && !CleanLogsCommand.COMMAND_NAME.equals(parsed.command)) {
+      err.println(
+          "Warning: --keep-current / --no-keep-current are only used by "
+              + CleanLogsCommand.COMMAND_NAME
+              + "; ignoring for "
+              + parsed.command);
+    }
+
     try {
       if (CleanHeapDumpsCommand.COMMAND_NAME.equals(parsed.command)) {
         CleanReport report = CleanHeapDumpsCommand.execute(installRoot, parsed.dryRun);
@@ -137,6 +155,8 @@ public final class DoctorCli {
     Duration olderThan;
     /** Default true for {@code clean-logs}. */
     boolean keepCurrent = true;
+    /** True when the user passed {@code --keep-current} or {@code --no-keep-current}. */
+    boolean keepCurrentExplicit;
   }
 
   /**
@@ -169,8 +189,10 @@ public final class DoctorCli {
         parsed.olderThan = CleanLogsCommand.parseOlderThan(args[++i]);
       } else if ("--keep-current".equals(a)) {
         parsed.keepCurrent = true;
+        parsed.keepCurrentExplicit = true;
       } else if ("--no-keep-current".equals(a)) {
         parsed.keepCurrent = false;
+        parsed.keepCurrentExplicit = true;
       } else if (a.startsWith("-")) {
         throw new IllegalArgumentException("unknown option: " + a);
       } else if (parsed.command == null) {

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/InstallRootGuard.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/InstallRootGuard.java
@@ -177,4 +177,159 @@ public final class InstallRootGuard {
     int midLen = lowerFileName.length() - prefix.length() - suffix.length();
     return midLen > 0;
   }
+
+  /**
+   * Relative log directory roots under a CMS install (portable segments joined with {@link
+   * Path#of(String, String...)}). Documented in the module README.
+   *
+   * <ul>
+   *   <li>{@code jetty/base/logs} — Jetty / CMS Log4j2 and install layout ({@code install.xml})
+   *   <li>{@code jetty/base/modules/perc-logging/logs} — Log4j2 default relative to
+   *       perc-logging module config
+   *   <li>{@code Deployment/Server/logs} — DTS / Tomcat ({@code catalina.base}/logs)
+   * </ul>
+   *
+   * <p>Missing directories are skipped at walk time (not an error).
+   */
+  public static final String[] LOG_DIR_RELATIVE = {
+    "jetty/base/logs",
+    "jetty/base/modules/perc-logging/logs",
+    "Deployment/Server/logs"
+  };
+
+  /**
+   * Resolve allowlisted log directory roots that exist under {@code installRoot}. Only existing
+   * directories that stay under the install root are returned.
+   *
+   * @param installRoot resolved install root
+   * @return list of existing log dir paths under the root (may be empty)
+   */
+  public static java.util.List<Path> existingLogDirs(Path installRoot) {
+    Objects.requireNonNull(installRoot, "installRoot");
+    Path root = installRoot.toAbsolutePath().normalize();
+    java.util.List<Path> dirs = new java.util.ArrayList<>();
+    for (String relative : LOG_DIR_RELATIVE) {
+      Path dir = resolveRelativeUnderRoot(root, relative);
+      if (dir == null) {
+        continue;
+      }
+      if (Files.isDirectory(dir) && isUnderInstallRoot(root, dir)) {
+        dirs.add(dir);
+      }
+    }
+    return dirs;
+  }
+
+  /**
+   * Join a forward-slash relative path under {@code root}. Rejects {@code ..} segments and
+   * absolute relative inputs so the result cannot escape the root via the relative string.
+   *
+   * @return resolved path under root, or null if the relative path is invalid
+   */
+  static Path resolveRelativeUnderRoot(Path root, String relativeSlashPath) {
+    if (relativeSlashPath == null || relativeSlashPath.isEmpty()) {
+      return null;
+    }
+    if (relativeSlashPath.indexOf('\\') >= 0) {
+      return null;
+    }
+    String[] parts = relativeSlashPath.split("/");
+    Path resolved = root;
+    for (String part : parts) {
+      if (part.isEmpty() || ".".equals(part)) {
+        continue;
+      }
+      if ("..".equals(part)) {
+        return null;
+      }
+      resolved = resolved.resolve(part);
+    }
+    Path normalized = resolved.toAbsolutePath().normalize();
+    if (!pathStartsWithRoot(normalized, root.toAbsolutePath().normalize())) {
+      return null;
+    }
+    return normalized;
+  }
+
+  /**
+   * Allowlisted log file name for {@code clean-logs}: ends with {@code .log}, {@code .log.gz}, or
+   * {@code .out} (e.g. {@code catalina.out}). Case-insensitive. Path separators rejected.
+   *
+   * @param fileName bare file name (not a path)
+   * @return true if the name is a log candidate
+   */
+  public static boolean isLogFileName(String fileName) {
+    if (fileName == null || fileName.isEmpty()) {
+      return false;
+    }
+    if (fileName.indexOf('/') >= 0 || fileName.indexOf('\\') >= 0) {
+      return false;
+    }
+    String lower = fileName.toLowerCase(Locale.ROOT);
+    return lower.endsWith(".log")
+        || lower.endsWith(".log.gz")
+        || lower.endsWith(".out");
+  }
+
+  /**
+   * Whether {@code fileName} is an identifiable <em>current / active</em> log that {@code
+   * --keep-current} should retain.
+   *
+   * <p>Current logs are non-compressed {@code *.log} / {@code *.out} basenames that do not embed a
+   * rolled date token ({@code yyyy-MM-dd}) and are not numbered backups like {@code name.log.1}.
+   * Examples kept: {@code server.log}, {@code catalina.log}, {@code catalina.out}. Examples not
+   * current: {@code server-2024-01-15-1.log}, {@code catalina.2024-01-15.log.gz}.
+   *
+   * @param fileName bare file name
+   * @return true if the file should be treated as the active log
+   */
+  public static boolean isCurrentLogFileName(String fileName) {
+    if (fileName == null || fileName.isEmpty()) {
+      return false;
+    }
+    if (fileName.indexOf('/') >= 0 || fileName.indexOf('\\') >= 0) {
+      return false;
+    }
+    String lower = fileName.toLowerCase(Locale.ROOT);
+    // Compressed / explicitly rolled archives are never "current active"
+    if (lower.endsWith(".gz")) {
+      return false;
+    }
+    // name.log.N style (common Tomcat / JUL rotation)
+    if (lower.matches(".*\\.log\\.\\d+$") || lower.matches(".*\\.out\\.\\d+$")) {
+      return false;
+    }
+    // Embedded ISO date token used by Log4j2 / Tomcat rolled names
+    if (containsIsoDateToken(lower)) {
+      return false;
+    }
+    return lower.endsWith(".log") || lower.endsWith(".out");
+  }
+
+  /** True when {@code lowerName} contains a {@code yyyy-MM-dd} token. */
+  static boolean containsIsoDateToken(String lowerName) {
+    if (lowerName == null || lowerName.length() < 10) {
+      return false;
+    }
+    // Lightweight scan for yyyy-mm-dd without regex overhead on every file
+    for (int i = 0; i <= lowerName.length() - 10; i++) {
+      if (isDigit(lowerName.charAt(i))
+          && isDigit(lowerName.charAt(i + 1))
+          && isDigit(lowerName.charAt(i + 2))
+          && isDigit(lowerName.charAt(i + 3))
+          && lowerName.charAt(i + 4) == '-'
+          && isDigit(lowerName.charAt(i + 5))
+          && isDigit(lowerName.charAt(i + 6))
+          && lowerName.charAt(i + 7) == '-'
+          && isDigit(lowerName.charAt(i + 8))
+          && isDigit(lowerName.charAt(i + 9))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isDigit(char c) {
+    return c >= '0' && c <= '9';
+  }
 }

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CleanLogsCommandTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CleanLogsCommandTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CleanLogsCommandTest {
+
+  @TempDir Path tempDir;
+
+  private Path installRoot;
+  private Path jettyLogs;
+  private Path dtsLogs;
+  private Path serverLog;
+  private Path rolledServerLog;
+  private Path oldRolledLog;
+  private Path catalinaGz;
+  private Path outsideLog;
+  private Path nonLogInLogDir;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    installRoot = Files.createDirectories(tempDir.resolve("cms-install"));
+    jettyLogs =
+        Files.createDirectories(
+            installRoot.resolve("jetty").resolve("base").resolve("logs"));
+    dtsLogs =
+        Files.createDirectories(
+            installRoot.resolve("Deployment").resolve("Server").resolve("logs"));
+
+    serverLog = jettyLogs.resolve("server.log");
+    rolledServerLog = jettyLogs.resolve("server-2024-01-15-1.log");
+    oldRolledLog = jettyLogs.resolve("server-2023-06-01-1.log");
+    catalinaGz = dtsLogs.resolve("catalina.2024-01-10.log.gz");
+    nonLogInLogDir = jettyLogs.resolve("readme.txt");
+
+    Files.writeString(serverLog, "active-server");
+    Files.writeString(rolledServerLog, "rolled-recent");
+    Files.writeString(oldRolledLog, "rolled-old");
+    Files.write(catalinaGz, new byte[] {(byte) 0x1f, (byte) 0x8b});
+    Files.writeString(nonLogInLogDir, "not-a-log");
+
+    // Make old rolled file aged beyond 7d; leave rolledServerLog "recent"
+    Instant now = Instant.now();
+    Files.setLastModifiedTime(oldRolledLog, FileTime.from(now.minus(Duration.ofDays(30))));
+    Files.setLastModifiedTime(rolledServerLog, FileTime.from(now.minus(Duration.ofHours(2))));
+    Files.setLastModifiedTime(catalinaGz, FileTime.from(now.minus(Duration.ofDays(20))));
+    Files.setLastModifiedTime(serverLog, FileTime.from(now.minus(Duration.ofDays(40))));
+
+    Path outside = Files.createDirectories(tempDir.resolve("not-install").resolve("logs"));
+    outsideLog = outside.resolve("escape.log");
+    Files.writeString(outsideLog, "outside");
+    Files.setLastModifiedTime(outsideLog, FileTime.from(now.minus(Duration.ofDays(40))));
+  }
+
+  @Test
+  void dryRunNeverDeletesWithAgeAndKeepCurrent() throws Exception {
+    CleanLogsCommand.Options opts =
+        new CleanLogsCommand.Options(Duration.ofDays(7), true);
+    CleanReport report = CleanLogsCommand.execute(installRoot, true, opts);
+
+    assertTrue(report.isDryRun());
+    assertEquals(0, report.getDeletedCount());
+    assertTrue(Files.exists(serverLog));
+    assertTrue(Files.exists(rolledServerLog));
+    assertTrue(Files.exists(oldRolledLog));
+    assertTrue(Files.exists(catalinaGz));
+    assertTrue(Files.exists(outsideLog));
+    assertTrue(Files.exists(nonLogInLogDir));
+
+    // keep-current skips server.log; age skips recent rolled; old rolled + catalina gz would delete
+    int wouldDelete = 0;
+    int skipped = 0;
+    for (CleanReport.Entry e : report.getEntries()) {
+      assertTrue(InstallRootGuard.isUnderInstallRoot(installRoot, e.getPath()));
+      if (e.getStatus() == CleanReport.EntryStatus.WOULD_DELETE) {
+        wouldDelete++;
+      } else if (e.getStatus() == CleanReport.EntryStatus.SKIPPED) {
+        skipped++;
+      }
+    }
+    assertEquals(2, wouldDelete, "old rolled + catalina.gz");
+    assertTrue(skipped >= 2, "keep-current + age skip at least current + recent rolled");
+  }
+
+  @Test
+  void applyDeletesOnlyAgedNonCurrentUnderRoot() throws Exception {
+    CleanLogsCommand.Options opts =
+        new CleanLogsCommand.Options(Duration.ofDays(7), true);
+    CleanReport report = CleanLogsCommand.execute(installRoot, false, opts);
+
+    assertFalse(report.isDryRun());
+    assertEquals(2, report.getDeletedCount());
+    assertEquals(0, report.getFailedCount());
+    assertTrue(Files.exists(serverLog), "keep-current must retain active server.log");
+    assertTrue(Files.exists(rolledServerLog), "recent rolled must be retained by age filter");
+    assertFalse(Files.exists(oldRolledLog), "old rolled log should be deleted");
+    assertFalse(Files.exists(catalinaGz), "old catalina.gz should be deleted");
+    assertTrue(Files.exists(outsideLog), "outside install root must not be deleted");
+    assertTrue(Files.exists(nonLogInLogDir), "non-log files in log dir must not be deleted");
+  }
+
+  @Test
+  void keepCurrentFalseAllowsDeletingActiveLogWhenAged() throws Exception {
+    CleanLogsCommand.Options opts =
+        new CleanLogsCommand.Options(Duration.ofDays(7), false);
+    CleanReport report = CleanLogsCommand.execute(installRoot, false, opts);
+
+    assertFalse(Files.exists(serverLog), "active log deletable when keep-current off and aged");
+    assertFalse(Files.exists(oldRolledLog));
+    assertFalse(Files.exists(catalinaGz));
+    assertTrue(Files.exists(rolledServerLog), "recent rolled still protected by age");
+    assertTrue(report.getDeletedCount() >= 3);
+  }
+
+  @Test
+  void noAgeFilterWithKeepCurrentDeletesRolledOnly() throws Exception {
+    CleanLogsCommand.Options opts = CleanLogsCommand.Options.defaults();
+    CleanReport report = CleanLogsCommand.execute(installRoot, false, opts);
+
+    assertTrue(Files.exists(serverLog), "current retained");
+    assertFalse(Files.exists(rolledServerLog));
+    assertFalse(Files.exists(oldRolledLog));
+    assertFalse(Files.exists(catalinaGz));
+    assertEquals(3, report.getDeletedCount());
+  }
+
+  @Test
+  void findLogFilesOnlyUnderKnownDirsAndRoot() throws Exception {
+    List<Path> found = CleanLogsCommand.findLogFiles(installRoot);
+    assertEquals(4, found.size()); // server + 2 rolled + catalina.gz; not readme.txt
+    for (Path p : found) {
+      assertTrue(InstallRootGuard.isUnderInstallRoot(installRoot, p));
+      assertFalse(p.equals(outsideLog));
+      assertTrue(InstallRootGuard.isLogFileName(p.getFileName().toString()));
+    }
+  }
+
+  @Test
+  void executeRejectsMissingInstallRoot() {
+    Path missing = tempDir.resolve("missing-root");
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            CleanLogsCommand.execute(
+                missing, true, new CleanLogsCommand.Options(Duration.ofDays(1), true)));
+  }
+
+  @Test
+  void missingLogDirsIsEmptyReportNotError() throws Exception {
+    Path emptyRoot = Files.createDirectories(tempDir.resolve("empty-install"));
+    CleanReport report =
+        CleanLogsCommand.execute(emptyRoot, true, CleanLogsCommand.Options.defaults());
+    assertEquals(0, report.getCandidateCount());
+    assertEquals(0, report.getFailedCount());
+  }
+
+  @Test
+  void parseOlderThanAcceptsUnits() {
+    assertEquals(Duration.ofDays(7), CleanLogsCommand.parseOlderThan("7d"));
+    assertEquals(Duration.ofHours(24), CleanLogsCommand.parseOlderThan("24h"));
+    assertEquals(Duration.ofMinutes(30), CleanLogsCommand.parseOlderThan("30m"));
+    assertEquals(Duration.ofSeconds(90), CleanLogsCommand.parseOlderThan("90s"));
+    assertEquals(Duration.ofDays(14), CleanLogsCommand.parseOlderThan("2w"));
+    assertEquals(Duration.ofDays(7), CleanLogsCommand.parseOlderThan("7D"));
+  }
+
+  @Test
+  void parseOlderThanRejectsInvalid() {
+    assertThrows(IllegalArgumentException.class, () -> CleanLogsCommand.parseOlderThan(""));
+    assertThrows(IllegalArgumentException.class, () -> CleanLogsCommand.parseOlderThan("7"));
+    assertThrows(IllegalArgumentException.class, () -> CleanLogsCommand.parseOlderThan("d7"));
+    assertThrows(IllegalArgumentException.class, () -> CleanLogsCommand.parseOlderThan("0d"));
+    assertThrows(IllegalArgumentException.class, () -> CleanLogsCommand.parseOlderThan("-1d"));
+    assertThrows(IllegalArgumentException.class, () -> CleanLogsCommand.parseOlderThan("1x"));
+  }
+
+  @Test
+  void logFileNameAndCurrentHelpers() {
+    assertTrue(InstallRootGuard.isLogFileName("server.log"));
+    assertTrue(InstallRootGuard.isLogFileName("catalina.2024-01-01.log.gz"));
+    assertTrue(InstallRootGuard.isLogFileName("catalina.out"));
+    assertFalse(InstallRootGuard.isLogFileName("readme.txt"));
+    assertFalse(InstallRootGuard.isLogFileName("a/b.log"));
+
+    assertTrue(InstallRootGuard.isCurrentLogFileName("server.log"));
+    assertTrue(InstallRootGuard.isCurrentLogFileName("catalina.out"));
+    assertFalse(InstallRootGuard.isCurrentLogFileName("server-2024-01-15-1.log"));
+    assertFalse(InstallRootGuard.isCurrentLogFileName("catalina.2024-01-15.log.gz"));
+    assertFalse(InstallRootGuard.isCurrentLogFileName("server.log.1"));
+  }
+
+  @Test
+  void visitFileFailedRecordsFailedEntryOnReport() {
+    CleanReport report = new CleanReport(CleanLogsCommand.COMMAND_NAME, installRoot, true);
+    Path failed = jettyLogs.resolve("unreadable.log");
+    CleanLogsCommand.recordVisitFailure(report, failed, new java.io.IOException("Access denied"));
+
+    assertEquals(1, report.getFailedCount());
+    CleanReport.Entry e = report.getEntries().get(0);
+    assertEquals(CleanReport.EntryStatus.FAILED, e.getStatus());
+    assertTrue(e.getDetail().contains("walk:"));
+  }
+
+  @Test
+  void optionsRejectNonPositiveOlderThan() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new CleanLogsCommand.Options(Duration.ZERO, true));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new CleanLogsCommand.Options(Duration.ofSeconds(-1), true));
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
@@ -258,4 +258,34 @@ class DoctorCliTest {
             new PrintStream(errBuf, true, StandardCharsets.UTF_8));
     assertEquals(DoctorCli.EXIT_USAGE, code);
   }
+
+  @Test
+  void olderThanOnNonCleanLogsCommandWarnsAndContinues() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-older-warn"));
+    Path dump = root.resolve("warn.hprof");
+    Files.write(dump, "abc".getBytes(StandardCharsets.UTF_8));
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root",
+              root.toString(),
+              "--dry-run",
+              "--older-than",
+              "7d",
+              "clean-heap-dumps"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    String err = errBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(
+        err.contains("--older-than") && err.toLowerCase().contains("ignoring"),
+        "expected ignore warning for --older-than on non-clean-logs: " + err);
+    assertTrue(Files.exists(dump));
+    assertTrue(outBuf.toString(StandardCharsets.UTF_8).contains("candidates=1"));
+  }
 }

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
@@ -178,4 +178,84 @@ class DoctorCliTest {
     String out = outBuf.toString(StandardCharsets.UTF_8);
     assertTrue(out.contains("deleted=1"));
   }
+
+  @Test
+  void cleanLogsDryRunViaCliDoesNotDelete() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-logs"));
+    Path logs =
+        Files.createDirectories(root.resolve("jetty").resolve("base").resolve("logs"));
+    Path current = logs.resolve("server.log");
+    Path rolled = logs.resolve("server-2020-01-01-1.log");
+    Files.writeString(current, "cur");
+    Files.writeString(rolled, "old");
+    Files.setLastModifiedTime(
+        rolled, java.nio.file.attribute.FileTime.from(java.time.Instant.now().minusSeconds(86400L * 30)));
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root",
+              root.toString(),
+              "--dry-run",
+              "-v",
+              "clean-logs",
+              "--older-than",
+              "7d"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    assertTrue(Files.exists(current));
+    assertTrue(Files.exists(rolled));
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("command=clean-logs"));
+    assertTrue(out.contains("dry-run=true"));
+    assertTrue(out.contains("WOULD_DELETE"));
+  }
+
+  @Test
+  void cleanLogsApplyViaCliKeepsCurrentDeletesAgedRolled() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-logs-apply"));
+    Path logs =
+        Files.createDirectories(root.resolve("jetty").resolve("base").resolve("logs"));
+    Path current = logs.resolve("server.log");
+    Path rolled = logs.resolve("server-2020-02-02-1.log");
+    Files.writeString(current, "cur");
+    Files.writeString(rolled, "old");
+    Files.setLastModifiedTime(
+        rolled, java.nio.file.attribute.FileTime.from(java.time.Instant.now().minusSeconds(86400L * 30)));
+    Files.setLastModifiedTime(
+        current, java.nio.file.attribute.FileTime.from(java.time.Instant.now().minusSeconds(86400L * 30)));
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root", root.toString(), "clean-logs", "--older-than", "7d"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    assertTrue(Files.exists(current), "keep-current default retains server.log");
+    assertFalse(Files.exists(rolled));
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("deleted=1"));
+  }
+
+  @Test
+  void cleanLogsInvalidOlderThanIsUsageError() {
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"clean-logs", "--older-than", "not-a-duration"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+    assertEquals(DoctorCli.EXIT_USAGE, code);
+  }
 }

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/InstallRootGuardTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/InstallRootGuardTest.java
@@ -125,4 +125,42 @@ class InstallRootGuardTest {
         InstallRootGuard.isUnderInstallRoot(root, siblingPrefix),
         "must not treat InstallExtra as under Install");
   }
+
+  @Test
+  void logFileNameAllowlistAndCurrentDetection() {
+    assertTrue(InstallRootGuard.isLogFileName("server.log"));
+    assertTrue(InstallRootGuard.isLogFileName("SERVER.LOG"));
+    assertTrue(InstallRootGuard.isLogFileName("catalina.out"));
+    assertTrue(InstallRootGuard.isLogFileName("catalina.2024-01-15.log.gz"));
+    assertFalse(InstallRootGuard.isLogFileName("notes.txt"));
+    assertFalse(InstallRootGuard.isLogFileName("../evil.log"));
+    assertFalse(InstallRootGuard.isLogFileName(null));
+
+    assertTrue(InstallRootGuard.isCurrentLogFileName("server.log"));
+    assertTrue(InstallRootGuard.isCurrentLogFileName("globaltemplate.log"));
+    assertTrue(InstallRootGuard.isCurrentLogFileName("catalina.out"));
+    assertFalse(InstallRootGuard.isCurrentLogFileName("server-2024-01-15-1.log"));
+    assertFalse(InstallRootGuard.isCurrentLogFileName("catalina.2024-01-15.log.gz"));
+    assertFalse(InstallRootGuard.isCurrentLogFileName("server.log.1"));
+  }
+
+  @Test
+  void existingLogDirsOnlyReturnsPresentDirsUnderRoot() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("cms-logs"));
+    Path jettyLogs =
+        Files.createDirectories(root.resolve("jetty").resolve("base").resolve("logs"));
+    // DTS dir intentionally missing
+    java.util.List<Path> dirs = InstallRootGuard.existingLogDirs(root);
+    assertEquals(1, dirs.size());
+    assertEquals(jettyLogs.toAbsolutePath().normalize(), dirs.get(0));
+  }
+
+  @Test
+  void resolveRelativeUnderRootRejectsDotDot() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("cms-rel")).toAbsolutePath().normalize();
+    Path resolved = InstallRootGuard.resolveRelativeUnderRoot(root, "jetty/base/logs");
+    assertTrue(resolved.startsWith(root));
+    assertEquals(null, InstallRootGuard.resolveRelativeUnderRoot(root, "../escape"));
+    assertEquals(null, InstallRootGuard.resolveRelativeUnderRoot(root, "a\\b"));
+  }
 }


### PR DESCRIPTION
## Summary

Implements **`clean-logs`** for `modules/perc-doctor` (slice 3 of parent tracker **#2213**, residual **#2218**).

- Documented log dirs under install root: `jetty/base/logs`, `jetty/base/modules/perc-logging/logs`, `Deployment/Server/logs`
- Allowlisted file names: `*.log`, `*.log.gz`, `*.out` only under those dirs
- `--older-than <duration>` (`7d`, `24h`, `30m`, `90s`, `2w`)
- `--keep-current` default true (skip active undated `*.log` / `*.out`); `--no-keep-current` to override
- Global `--dry-run` / `--install-root` / `-v`
- Dry-run never deletes; root containment re-checked before delete

**Stacked on:** #2226 (`feat/issue-2217-clean-install-backups`) which itself stacks on #2221 scaffold. Merge after those land (or rebase onto `main` once merged).

**Parent tracker:** #2213  
**Fixes:** #2218  
**Partial:** #2213 (CLI MVP residual: API + dist packaging remain on #2219 / #2220)

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] Unit tests: age filter, keep-current, root containment, dry-run never deletes, duration parse, CLI wiring
- [x] `cd modules/perc-doctor && ../../mvnw clean install` green
- [ ] Reviewer: dry-run then apply against a throwaway install tree fixture

## Gates evidence

| Gate | Result |
|------|--------|
| Behavioral unit tests | `CleanLogsCommandTest`, `DoctorCliTest` clean-logs cases, `InstallRootGuardTest` log helpers |
| Erlang self-review | Portable `Path` only; allowlisted dirs/names; no user globs; dry-run path never calls delete |
| Module clean install | `modules/perc-doctor` `mvnw clean install` exit 0 |
| Scope | perc-doctor only |

## Residual (not this PR)

- #2219 Admin HTTP API
- #2220 Dist bin + install docs

> Co-Authored by Grok Build using grok-4.5 with agent main.