### PR TITLE
feat(perc-doctor): dist bin packaging + install guide docs (slice 5 of #2213)

### DIFF
--- a/docs/ai-generated/code-reviews/2220-perc-doctor-dist-packaging-erlang.md
+++ b/docs/ai-generated/code-reviews/2220-perc-doctor-dist-packaging-erlang.md
@@ -1,0 +1,61 @@
+# Erlang review: #2220 perc-doctor dist packaging + install guide
+
+**Branch:** `feat/issue-2220-perc-doctor-dist-packaging` (stacked on `feat/issue-2218-clean-logs`)  
+**Date:** 2026-08-06  
+**Reviewer persona:** Erlang (pre-commit gate)
+
+## Summary
+
+Adds operator distribution packaging for `perc-doctor`: Unix + Windows `bin` launchers, stable `bin/perc-doctor.jar`, Maven assembly classifier `dist` zip, `perc-distribution-tree` unpack wiring, `install.xml` upgrade.overwrite lockstep for extensionless Unix launcher + jar, operator install guide with dry-run-first examples, and structural packaging tests in both modules.
+
+## Scope
+
+| Area | Paths |
+|------|--------|
+| perc-doctor packaging | `modules/perc-doctor/pom.xml`, `src/main/scripts/*`, `src/main/assembly/dist-bin.xml` |
+| perc-doctor docs | `modules/perc-doctor/README.md`, `docs/operator-install-guide.md` |
+| perc-doctor tests | `PercDoctorPackagingTest.java` |
+| dist-tree | `modules/perc-distribution-tree/pom.xml`, `install.xml`, `PercDoctorDistPackagingTest.java` |
+
+Prior report / Memory: no prior #2220 report. Patterns: packaging lockstep tests (JettyServiceDualShip, BundledGcmNatives), cross-platform paths, no hardcoded user homes.
+
+**Cross-platform path review:** Launchers resolve install root from script directory (`%~dp0` / `BASH_SOURCE`), not hardcoded homes. Docs use generic `/opt/Percussion` and `C:\Percussion`. Assembly sets Unix line endings + `0755` on shell script and Windows line endings on `.bat`. Packaging tests forbid personal profile path shapes. Install tree layout is `<install-root>/bin/*` on both platforms.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+- No bug findings
+- Behavioral/structural packaging tests present for new packaging logic
+- Portable path I/O in launchers and docs
+- Module clean installs: `modules/perc-doctor` BUILD SUCCESS (Tests run: 53); `modules/perc-distribution-tree` BUILD SUCCESS including `PercDoctorDistPackagingTest` and full assembly with `bin/perc-doctor{.bat,.jar}` present
+
+## Issues
+
+_None at bug severity._
+
+### suggestion
+
+1. **`modules/perc-doctor/src/main/scripts/perc-doctor.bat`** — `for %%A in (%*)` flag scan can mishandle unusual quoting; acceptable for operator flags like `--install-root`. No change required for v1.
+
+2. **dependency:analyze unused `perc-doctor` zip** — same class as existing `perc-service-wrapper` provided packaging deps; pre-existing warn style.
+
+### nit
+
+1. Assembly `dir` format cannot be attached to install (Maven warning only); zip classifier is what dist-tree consumes.
+
+## Evidence
+
+```text
+cd modules/perc-doctor && ../../mvnw clean install
+# Tests run: 53, Failures: 0 — BUILD SUCCESS
+# attaches perc-doctor-*-dist.zip
+
+cd modules/perc-distribution-tree && ../../mvnw clean install
+# BUILD SUCCESS; target/classes/distribution/bin/{perc-doctor,perc-doctor.bat,perc-doctor.jar}
+# java -jar …/perc-doctor.jar --dry-run -v clean-heap-dumps → WOULD_DELETE (smoke)
+```

--- a/modules/perc-distribution-tree/pom.xml
+++ b/modules/perc-distribution-tree/pom.xml
@@ -95,6 +95,15 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- Build-time only: operator CMS doctor dist zip (bin/perc-doctor{.bat,.jar}); issue #2220. -->
+        <dependency>
+            <groupId>com.percussion</groupId>
+            <artifactId>perc-doctor</artifactId>
+            <version>${project.version}</version>
+            <classifier>dist</classifier>
+            <type>zip</type>
+            <scope>provided</scope>
+        </dependency>
         <!-- Build-time only: 234 MB shaded uber-jar copied as artifact, not imported by preinstall Java code.
              The antrun plugin declares its own perc-ant dependency for Ant task execution. -->
         <dependency>
@@ -486,6 +495,27 @@
                             <outputDirectory>${project.build.directory}/wars</outputDirectory>
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                    <!-- issue #2220: unpack perc-doctor dist zip → assembly bin/perc-doctor{.bat,.jar} -->
+                    <execution>
+                        <id>unpack-perc-doctor-dist</id>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.percussion</groupId>
+                                    <artifactId>perc-doctor</artifactId>
+                                    <version>${project.version}</version>
+                                    <classifier>dist</classifier>
+                                    <type>zip</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${assembly-directory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
                         </configuration>
                     </execution>
                     <execution>

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/install.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/install.xml
@@ -592,6 +592,11 @@
 		<include name="jetty/base/webapps/Rhythmyx.xml" />
 		<include name="**/*.bat" />
 		<include name="**/*.sh" />
+		<!-- issue #2220: Unix launcher has no extension (not matched by **/*.sh);
+			jar is not covered by bat/sh globs. Keep all three bin entries in lockstep. -->
+		<include name="bin/perc-doctor" />
+		<include name="bin/perc-doctor.bat" />
+		<include name="bin/perc-doctor.jar" />
 	</patternset>
 	<patternset id="upgrade.excludes">
 		<exclude

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/PercDoctorDistPackagingTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/PercDoctorDistPackagingTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.distribution.install;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #2220 / parent #2213 slice 5: CMS distribution must ship operator {@code perc-doctor}
+ * under {@code bin/} and refresh it on upgrade.
+ *
+ * <p>Structural packaging assertions (source POM / install.xml / sibling module scripts) — does not
+ * require a full distribution assembly when SNAPSHOT deps are missing.
+ */
+class PercDoctorDistPackagingTest {
+
+  private static final Path POM = Path.of("pom.xml");
+  private static final Path INSTALL_XML =
+      Path.of("src", "main", "resources", "distribution", "rxconfig", "Installer", "install.xml");
+  private static final Path SIBLING_UNIX =
+      Path.of("..", "perc-doctor", "src", "main", "scripts", "perc-doctor");
+  private static final Path SIBLING_WIN =
+      Path.of("..", "perc-doctor", "src", "main", "scripts", "perc-doctor.bat");
+  private static final Path SIBLING_ASSEMBLY =
+      Path.of("..", "perc-doctor", "src", "main", "assembly", "dist-bin.xml");
+
+  @Test
+  @DisplayName("pom declares perc-doctor dist zip and unpacks it into the assembly")
+  void pomUnpacksPercDoctorDist() throws Exception {
+    assertTrue(Files.isRegularFile(POM), () -> "missing " + POM.toAbsolutePath().normalize());
+    String pom = Files.readString(POM, StandardCharsets.UTF_8);
+
+    assertTrue(
+        pom.contains("<artifactId>perc-doctor</artifactId>"),
+        "pom must depend on perc-doctor (dist packaging)");
+    assertTrue(
+        pom.contains("<classifier>dist</classifier>") && pom.contains("perc-doctor"),
+        "pom must consume perc-doctor classifier dist");
+    assertTrue(
+        pom.contains("unpack-perc-doctor-dist")
+            || (pom.contains("perc-doctor")
+                && pom.contains("<type>zip</type>")
+                && pom.contains("${assembly-directory}")),
+        "pom must unpack perc-doctor dist zip into assembly-directory");
+    assertTrue(
+        pom.contains("<id>unpack-perc-doctor-dist</id>"),
+        "unpack execution id unpack-perc-doctor-dist must exist for lockstep greps");
+  }
+
+  @Test
+  @DisplayName("install.xml upgrade.overwrite refreshes bin/perc-doctor{.bat,.jar}")
+  void installXmlUpgradeOverwritesPercDoctorBin() throws Exception {
+    assertTrue(
+        Files.isRegularFile(INSTALL_XML), () -> "missing " + INSTALL_XML.toAbsolutePath().normalize());
+    String xml = Files.readString(INSTALL_XML, StandardCharsets.UTF_8);
+
+    assertTrue(xml.contains("upgrade.overwrite"), "install.xml must define upgrade.overwrite");
+    assertTrue(
+        xml.contains("bin/perc-doctor")
+            && xml.contains("bin/perc-doctor.bat")
+            && xml.contains("bin/perc-doctor.jar"),
+        "upgrade.overwrite must include Unix launcher, Windows .bat, and jar (extensionless script)");
+    assertFalse(
+        xml.contains("<exclude name=\"bin/perc-doctor")
+            || xml.contains("<exclude name=\"**/perc-doctor"),
+        "must not exclude perc-doctor from install/upgrade packaging");
+  }
+
+  @Test
+  @DisplayName("sibling perc-doctor module ships scripts + dist assembly (lockstep)")
+  void siblingModuleShipsWrappersAndAssembly() {
+    assertTrue(
+        Files.isRegularFile(SIBLING_UNIX),
+        () -> "missing sibling Unix launcher " + SIBLING_UNIX.toAbsolutePath().normalize());
+    assertTrue(
+        Files.isRegularFile(SIBLING_WIN),
+        () -> "missing sibling Windows launcher " + SIBLING_WIN.toAbsolutePath().normalize());
+    assertTrue(
+        Files.isRegularFile(SIBLING_ASSEMBLY),
+        () -> "missing sibling dist assembly " + SIBLING_ASSEMBLY.toAbsolutePath().normalize());
+  }
+}

--- a/modules/perc-doctor/README.md
+++ b/modules/perc-doctor/README.md
@@ -2,11 +2,13 @@
 
 Operator CLI for diagnosing and safely cleaning Percussion CMS install trees.
 
-**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`)  
+**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`), [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (dist packaging + install guide)  
 **Package:** `com.intsof.percussioncms.doctor`  
 **Shipped commands:** `clean-heap-dumps`, `clean-install-backups`, `clean-logs` with global `--dry-run` / `--install-root` / `-v`
 
-Later slices (tracked on #2213 / residual issues): admin HTTP API, distribution `bin` packaging.
+**Operator install guide (dry-run-first examples):** [docs/operator-install-guide.md](docs/operator-install-guide.md)
+
+Later slices (tracked on #2213 / residual issues): admin HTTP API.
 
 ## Build
 
@@ -22,19 +24,51 @@ Windows:
 ..\..\mvnw.cmd clean install
 ```
 
-## Run
+Produces:
+
+| Output | Description |
+|--------|-------------|
+| `target/perc-doctor-8.2.0-SNAPSHOT.jar` | Runnable jar (`Main-Class` = `DoctorCli`; no runtime deps) |
+| `target/perc-doctor-8.2.0-SNAPSHOT-dist.zip` | Install layout: `bin/perc-doctor`, `bin/perc-doctor.bat`, `bin/perc-doctor.jar` |
+| `target/perc-doctor-8.2.0-SNAPSHOT-dist/` | Exploded dist layout |
+
+CMS distribution (`modules/perc-distribution-tree`) unpacks the `dist` classifier zip into the install assembly so operators get the launchers under `<install-root>/bin`.
+
+## Run from a CMS install (preferred)
+
+```bash
+# Linux / macOS — dry-run first
+/opt/Percussion/bin/perc-doctor --dry-run -v clean-heap-dumps
+
+# Windows — dry-run first
+C:\Percussion\bin\perc-doctor.bat --dry-run -v clean-heap-dumps
+```
+
+Wrappers default `--install-root` to the parent of `bin/` (portable; no hardcoded user home). Override with `--install-root` when needed.
+
+## Run from a module build
 
 ```bash
 java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar [options] <command> [command-options]
 ```
 
-Or with the compiled classes on the classpath (after install).
+Or via the exploded dist:
+
+```bash
+./target/perc-doctor-8.2.0-SNAPSHOT-dist/bin/perc-doctor --help
+```
+
+Windows:
+
+```bat
+target\perc-doctor-8.2.0-SNAPSHOT-dist\bin\perc-doctor.bat --help
+```
 
 ### Global options
 
 | Flag | Meaning |
 |------|---------|
-| `--install-root <path>` | CMS install root (default: current working directory) |
+| `--install-root <path>` | CMS install root (default: current working directory for raw jar; parent of `bin/` for wrappers) |
 | `--dry-run` | Report only — **never** deletes or writes |
 | `-v` / `--verbose` | Path-level detail |
 | `-h` / `--help` | Usage |
@@ -141,5 +175,4 @@ java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
 
 ## Deferred (not in this module slice)
 
-- Admin-authenticated HTTP API mirroring CLI
-- Distribution packaging (`bin/perc-doctor` / fat jar in install tree)
+- Admin-authenticated HTTP API mirroring CLI ([#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219))

--- a/modules/perc-doctor/docs/operator-install-guide.md
+++ b/modules/perc-doctor/docs/operator-install-guide.md
@@ -1,0 +1,173 @@
+# perc-doctor operator install guide
+
+**Module:** `modules/perc-doctor`  
+**Issues:** [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (packaging), [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent)
+
+This guide is for operators running **perc-doctor** against a CMS install on Windows or Linux. Prefer **dry-run first** for every command; only apply after you review the candidate list and sizes.
+
+## Install layout
+
+After a CMS distribution build that includes this module, the install tree ships:
+
+```text
+<install-root>/
+  bin/
+    perc-doctor          # Unix launcher (executable)
+    perc-doctor.bat      # Windows launcher
+    perc-doctor.jar      # Runnable jar (Main-Class = DoctorCli)
+```
+
+The launchers set `--install-root` to the **parent of `bin/`** (the install root) when you do not pass `--install-root` yourself. Paths are resolved from the script location — never from a hardcoded user home.
+
+### Cross-platform path rules
+
+| Do | Do not |
+|----|--------|
+| Use `<install-root>` (e.g. `/opt/Percussion` or `C:\Percussion`) | Embed a personal profile directory path |
+| Prefer `bin/perc-doctor` / `bin\perc-doctor.bat` from the install | Assume a fixed drive letter or username |
+| Pass `--install-root` only when the tree is not the parent of `bin/` | Embed machine-specific absolute paths in scripts or runbooks |
+| Use JDK 21+ via `JAVA_HOME` or `PATH` | Rely on an optional bundled JRE path that may not exist |
+
+### Alternate: module build / java -jar
+
+From a developer or support workstation after `mvnw clean install` in this module:
+
+```bash
+# Exploded dist (created by assembly)
+java -jar target/perc-doctor-*-dist/bin/perc-doctor.jar --help
+
+# Or the versioned module jar
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar --help
+```
+
+Windows:
+
+```bat
+java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar --help
+```
+
+## Global options
+
+| Flag | Meaning |
+|------|---------|
+| `--install-root <path>` | CMS install root (wrapper default: parent of `bin/`; jar default: current working directory) |
+| `--dry-run` | **Report only** — list what would change; **no deletes / writes** |
+| `-v` / `--verbose` | Path-level detail (recommended with dry-run) |
+| `-h` / `--help` | Usage |
+
+## Safety first: dry-run then apply
+
+For every command:
+
+1. Run with `--dry-run -v` and read `candidates=` / `bytes=` / path list.
+2. Confirm only intended allowlisted paths appear under the install root.
+3. Re-run **without** `--dry-run` to apply.
+4. Prefer off-hours for apply when reclaiming large log trees.
+
+## Commands
+
+### `clean-heap-dumps`
+
+Removes recursive `*.hprof` under the install root (case-insensitive). Scope is hard-limited to `--install-root`.
+
+**Dry-run first (Linux / macOS install):**
+
+```bash
+cd /opt/Percussion
+./bin/perc-doctor --dry-run -v clean-heap-dumps
+```
+
+**Dry-run first (Windows install):**
+
+```bat
+cd /d C:\Percussion
+bin\perc-doctor.bat --dry-run -v clean-heap-dumps
+```
+
+**Apply (only after review):**
+
+```bash
+./bin/perc-doctor -v clean-heap-dumps
+```
+
+```bat
+bin\perc-doctor.bat -v clean-heap-dumps
+```
+
+### `clean-install-backups`
+
+Removes **allowlisted** installer/upgrade backup artifacts only (`AppServer_backup_*.zip`, `*.bak`, `*.backup`). No user-supplied globs.
+
+**Dry-run first:**
+
+```bash
+./bin/perc-doctor --install-root /opt/Percussion --dry-run -v clean-install-backups
+```
+
+```bat
+bin\perc-doctor.bat --install-root C:\Percussion --dry-run -v clean-install-backups
+```
+
+**Apply:**
+
+```bash
+./bin/perc-doctor --install-root /opt/Percussion -v clean-install-backups
+```
+
+```bat
+bin\perc-doctor.bat --install-root C:\Percussion -v clean-install-backups
+```
+
+### `clean-logs`
+
+Reclaims space under known log directories only:
+
+| Relative path | Role |
+|---------------|------|
+| `jetty/base/logs` | Jetty / CMS logs |
+| `jetty/base/modules/perc-logging/logs` | perc-logging module logs |
+| `Deployment/Server/logs` | DTS Tomcat logs |
+
+| Flag | Meaning |
+|------|---------|
+| `--older-than <duration>` | Only files older than duration (`7d`, `24h`, `30m`, …) |
+| `--keep-current` | Default: never delete active current `*.log` / `*.out` basenames |
+| `--no-keep-current` | Allow deleting those basenames (still subject to age filter if set) |
+
+**Dry-run first (keep current logs, older than 7 days):**
+
+```bash
+./bin/perc-doctor --install-root /opt/Percussion --dry-run -v clean-logs --older-than 7d
+```
+
+```bat
+bin\perc-doctor.bat --install-root C:\Percussion --dry-run -v clean-logs --older-than 7d
+```
+
+**Apply:**
+
+```bash
+./bin/perc-doctor --install-root /opt/Percussion -v clean-logs --older-than 14d
+```
+
+```bat
+bin\perc-doctor.bat --install-root C:\Percussion -v clean-logs --older-than 14d
+```
+
+## Distribution packaging (developers)
+
+Module `mvnw clean install` attaches:
+
+| Artifact | Role |
+|----------|------|
+| `perc-doctor-<version>.jar` | Runnable Main-Class jar (no runtime deps) |
+| `perc-doctor-<version>-dist.zip` | `bin/perc-doctor`, `bin/perc-doctor.bat`, `bin/perc-doctor.jar` |
+| `target/perc-doctor-<version>-dist/` | Exploded copy of the same layout |
+
+`modules/perc-distribution-tree` unpacks the `dist` zip into the CMS assembly so operators receive the launchers under `<install-root>/bin`.
+
+## Related
+
+- Module README: [../README.md](../README.md)
+- Parent epic: [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213)
+- Admin HTTP API: deferred ([#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219))

--- a/modules/perc-doctor/pom.xml
+++ b/modules/perc-doctor/pom.xml
@@ -54,6 +54,31 @@
                     </archive>
                 </configuration>
             </plugin>
+            <!--
+              Operator dist layout (issue #2220): bin/perc-doctor{.bat} + bin/perc-doctor.jar.
+              Attached as classifier "dist" (zip + exploded dir under target). Zero runtime deps,
+              so the Main-Class jar is the runnable "fat" artifact for distribution.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>perc-doctor-dist</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/dist-bin.xml</descriptor>
+                            </descriptors>
+                            <appendAssemblyId>true</appendAssemblyId>
+                            <attach>true</attach>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/modules/perc-doctor/src/main/assembly/dist-bin.xml
+++ b/modules/perc-doctor/src/main/assembly/dist-bin.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2026 Intersoft Data Labs, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!--
+  Distribution layout for CMS install / operator zip:
+
+    bin/perc-doctor
+    bin/perc-doctor.bat
+    bin/perc-doctor.jar   (stable name; versioned main jar is copied here)
+
+  Attached as classifier "dist" (zip). perc-distribution-tree unpacks this into
+  the assembly install tree.
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+    <id>dist</id>
+    <formats>
+        <format>zip</format>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/src/main/scripts</directory>
+            <outputDirectory>bin</outputDirectory>
+            <includes>
+                <include>perc-doctor</include>
+            </includes>
+            <fileMode>0755</fileMode>
+            <lineEnding>unix</lineEnding>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/src/main/scripts</directory>
+            <outputDirectory>bin</outputDirectory>
+            <includes>
+                <include>perc-doctor.bat</include>
+            </includes>
+            <lineEnding>windows</lineEnding>
+        </fileSet>
+    </fileSets>
+    <files>
+        <file>
+            <source>${project.build.directory}/${project.build.finalName}.jar</source>
+            <outputDirectory>bin</outputDirectory>
+            <destName>perc-doctor.jar</destName>
+        </file>
+    </files>
+</assembly>

--- a/modules/perc-doctor/src/main/scripts/perc-doctor
+++ b/modules/perc-doctor/src/main/scripts/perc-doctor
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Intersoft Data Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Operator launcher for perc-doctor on Unix-like hosts.
+# Layout (CMS install or dist zip):
+#   <install-root>/bin/perc-doctor
+#   <install-root>/bin/perc-doctor.jar
+#
+# Default --install-root is the parent of this script's directory (the install
+# root). Operators may still pass --install-root explicitly to override.
+# Never hardcodes a user home path.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+JAR="${SCRIPT_DIR}/perc-doctor.jar"
+
+if [[ ! -f "${JAR}" ]]; then
+  echo "perc-doctor: jar not found at ${JAR}" >&2
+  echo "Expected layout: <install-root>/bin/perc-doctor.jar next to this script." >&2
+  exit 1
+fi
+
+if [[ -n "${JAVA_HOME:-}" && -x "${JAVA_HOME}/bin/java" ]]; then
+  JAVA="${JAVA_HOME}/bin/java"
+elif command -v java >/dev/null 2>&1; then
+  JAVA="$(command -v java)"
+else
+  echo "perc-doctor: java not found. Set JAVA_HOME (JDK 21+) or put java on PATH." >&2
+  exit 1
+fi
+
+has_install_root=0
+for arg in "$@"; do
+  if [[ "${arg}" == "--install-root" ]]; then
+    has_install_root=1
+    break
+  fi
+done
+
+if [[ "${has_install_root}" -eq 0 ]]; then
+  exec "${JAVA}" -jar "${JAR}" --install-root "${INSTALL_ROOT}" "$@"
+else
+  exec "${JAVA}" -jar "${JAR}" "$@"
+fi

--- a/modules/perc-doctor/src/main/scripts/perc-doctor.bat
+++ b/modules/perc-doctor/src/main/scripts/perc-doctor.bat
@@ -1,0 +1,64 @@
+@echo off
+REM Copyright (c) 2026 Intersoft Data Labs, Inc.
+REM
+REM Licensed under the Apache License, Version 2.0 (the "License");
+REM you may not use this file except in compliance with the License.
+REM You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+REM
+REM Operator launcher for perc-doctor on Windows.
+REM Layout (CMS install or dist zip):
+REM   <install-root>\bin\perc-doctor.bat
+REM   <install-root>\bin\perc-doctor.jar
+REM
+REM Default --install-root is the parent of this script's directory (the install
+REM root). Operators may still pass --install-root explicitly to override.
+REM Never hardcodes a user home path.
+
+setlocal EnableExtensions EnableDelayedExpansion
+
+set "SCRIPT_DIR=%~dp0"
+if "%SCRIPT_DIR:~-1%"=="\" set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+for %%I in ("%SCRIPT_DIR%\..") do set "INSTALL_ROOT=%%~fI"
+set "JAR=%SCRIPT_DIR%\perc-doctor.jar"
+
+if not exist "%JAR%" (
+  echo perc-doctor: jar not found at %JAR% 1>&2
+  echo Expected layout: ^<install-root^>\bin\perc-doctor.jar next to this script. 1>&2
+  exit /b 1
+)
+
+set "JAVA_EXE="
+if defined JAVA_HOME (
+  if exist "%JAVA_HOME%\bin\java.exe" set "JAVA_EXE=%JAVA_HOME%\bin\java.exe"
+)
+if not defined JAVA_EXE (
+  where java >nul 2>&1
+  if not errorlevel 1 (
+    set "JAVA_EXE=java"
+  )
+)
+if not defined JAVA_EXE (
+  echo perc-doctor: java not found. Set JAVA_HOME ^(JDK 21+^) or put java on PATH. 1>&2
+  exit /b 1
+)
+
+set "HAS_INSTALL_ROOT=0"
+for %%A in (%*) do (
+  if /I "%%~A"=="--install-root" set "HAS_INSTALL_ROOT=1"
+)
+
+if "%HAS_INSTALL_ROOT%"=="0" (
+  "%JAVA_EXE%" -jar "%JAR%" --install-root "%INSTALL_ROOT%" %*
+) else (
+  "%JAVA_EXE%" -jar "%JAR%" %*
+)
+set "EXIT_CODE=%ERRORLEVEL%"
+endlocal & exit /b %EXIT_CODE%

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/PercDoctorPackagingTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/PercDoctorPackagingTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Structural packaging contracts for operator {@code bin/perc-doctor} launchers and the dist
+ * assembly (issue #2220 / parent #2213 slice 5).
+ *
+ * <p>Does not require a built jar; asserts source scripts and Maven assembly wiring stay portable
+ * (no hardcoded user homes) and resolve install root relative to the script location.
+ */
+class PercDoctorPackagingTest {
+
+  private static final Path UNIX_SCRIPT = Path.of("src", "main", "scripts", "perc-doctor");
+  private static final Path WINDOWS_SCRIPT = Path.of("src", "main", "scripts", "perc-doctor.bat");
+  private static final Path ASSEMBLY = Path.of("src", "main", "assembly", "dist-bin.xml");
+  private static final Path POM = Path.of("pom.xml");
+
+  /**
+   * Hardcoded user-home shapes that must never appear in operator launchers or docs. Avoid matching
+   * instructional prose; focus on absolute personal profile paths and this developer's home.
+   */
+  private static final Pattern HARDCODED_USER_HOME =
+      Pattern.compile("(?i)(C:\\\\Users\\\\[A-Za-z]|/home/[a-zA-Z0-9._-]+|/Users/[A-Za-z]|\\\\Users\\\\Nate)");
+
+  @Test
+  @DisplayName("Unix and Windows bin wrappers exist")
+  void wrappersExist() {
+    assertTrue(Files.isRegularFile(UNIX_SCRIPT), () -> "missing " + UNIX_SCRIPT.toAbsolutePath());
+    assertTrue(
+        Files.isRegularFile(WINDOWS_SCRIPT), () -> "missing " + WINDOWS_SCRIPT.toAbsolutePath());
+  }
+
+  @Test
+  @DisplayName("wrappers resolve install root from script directory, not hardcoded homes")
+  void wrappersResolveInstallRootPortably() throws Exception {
+    String unix = Files.readString(UNIX_SCRIPT, StandardCharsets.UTF_8);
+    String win = Files.readString(WINDOWS_SCRIPT, StandardCharsets.UTF_8);
+
+    assertTrue(unix.startsWith("#!/"), "Unix wrapper must be a shell script with shebang");
+    assertTrue(
+        unix.contains("SCRIPT_DIR") && unix.contains("INSTALL_ROOT"),
+        "Unix wrapper must derive SCRIPT_DIR / INSTALL_ROOT");
+    assertTrue(
+        unix.contains("perc-doctor.jar"),
+        "Unix wrapper must invoke stable bin/perc-doctor.jar name");
+    assertTrue(
+        unix.contains("--install-root"),
+        "Unix wrapper must pass --install-root when operator omits it");
+    assertFalse(
+        HARDCODED_USER_HOME.matcher(unix).find(),
+        "Unix wrapper must not hardcode a user home path");
+
+    assertTrue(win.toLowerCase().contains("@echo off"), "Windows wrapper must be a .bat");
+    assertTrue(
+        win.contains("SCRIPT_DIR") && win.contains("INSTALL_ROOT"),
+        "Windows wrapper must derive SCRIPT_DIR / INSTALL_ROOT");
+    assertTrue(
+        win.contains("perc-doctor.jar"),
+        "Windows wrapper must invoke stable bin/perc-doctor.jar name");
+    assertTrue(
+        win.contains("--install-root"),
+        "Windows wrapper must pass --install-root when operator omits it");
+    assertFalse(
+        HARDCODED_USER_HOME.matcher(win).find(),
+        "Windows wrapper must not hardcode a user home path");
+  }
+
+  @Test
+  @DisplayName("dist assembly packs bin wrappers + versionless perc-doctor.jar")
+  void distAssemblyLayout() throws Exception {
+    assertTrue(Files.isRegularFile(ASSEMBLY), () -> "missing " + ASSEMBLY.toAbsolutePath());
+    String xml = Files.readString(ASSEMBLY, StandardCharsets.UTF_8);
+    assertTrue(xml.contains("<id>dist</id>"), "assembly id must be dist");
+    assertTrue(xml.contains("perc-doctor.jar"), "assembly must ship perc-doctor.jar");
+    assertTrue(xml.contains("destName>perc-doctor.jar"), "stable dest name for operators");
+    assertTrue(
+        xml.contains("perc-doctor.bat") && xml.contains("<include>perc-doctor</include>"),
+        "assembly must include both platform wrappers");
+    assertTrue(xml.contains("<outputDirectory>bin</outputDirectory>"), "layout under bin/");
+  }
+
+  @Test
+  @DisplayName("module pom attaches dist assembly and Main-Class on jar")
+  void pomWiresAssemblyAndMainClass() throws Exception {
+    assertTrue(Files.isRegularFile(POM), () -> "missing " + POM.toAbsolutePath());
+    String pom = Files.readString(POM, StandardCharsets.UTF_8);
+    assertTrue(
+        pom.contains("com.intsof.percussioncms.doctor.DoctorCli"),
+        "jar Main-Class must be DoctorCli");
+    assertTrue(
+        pom.contains("maven-assembly-plugin") && pom.contains("dist-bin.xml"),
+        "pom must run assembly descriptor dist-bin.xml");
+    assertTrue(
+        pom.contains("<classifier>dist</classifier>")
+            || pom.contains("descriptor>src/main/assembly/dist-bin.xml"),
+        "dist packaging must be wired for consumers (perc-distribution-tree)");
+  }
+
+  @Test
+  @DisplayName("operator docs emphasize dry-run-first and portable install-root examples")
+  void installGuideDryRunFirst() throws Exception {
+    Path guide = Path.of("docs", "operator-install-guide.md");
+    Path readme = Path.of("README.md");
+    assertTrue(Files.isRegularFile(guide), () -> "missing " + guide.toAbsolutePath());
+    assertTrue(Files.isRegularFile(readme), () -> "missing " + readme.toAbsolutePath());
+
+    String guideText = Files.readString(guide, StandardCharsets.UTF_8);
+    String readmeText = Files.readString(readme, StandardCharsets.UTF_8);
+
+    for (String text : List.of(guideText, readmeText)) {
+      assertFalse(
+          HARDCODED_USER_HOME.matcher(text).find(),
+          "docs must not hardcode a developer user home path");
+    }
+
+    assertTrue(guideText.contains("--dry-run"), "install guide must show --dry-run");
+    assertTrue(
+        guideText.contains("clean-heap-dumps")
+            && guideText.contains("clean-install-backups")
+            && guideText.contains("clean-logs"),
+        "install guide must cover all shipped commands");
+    assertTrue(
+        guideText.contains("bin/perc-doctor") || guideText.contains("bin\\perc-doctor"),
+        "install guide must document install-tree bin wrappers");
+    assertTrue(
+        guideText.contains("/opt/") || guideText.contains("C:\\Percussion"),
+        "install guide should use generic install-root examples (not a user home)");
+  }
+}


### PR DESCRIPTION
## Summary

**Parent tracker:** #2213 (slice 5 — dist bin + install docs)  
**Stacked on:** #2227 / `feat/issue-2218-clean-logs` (CLI commands: clean-heap-dumps, clean-install-backups, clean-logs)

Packages runnable **perc-doctor** for CMS install and adds operator docs:

- `bin/perc-doctor` (Unix) and `bin/perc-doctor.bat` (Windows) resolve `--install-root` from the parent of `bin/` (portable; no hardcoded user home)
- Stable `bin/perc-doctor.jar` (Main-Class jar; zero runtime deps = runnable artifact)
- Maven assembly classifier `dist` zip for operator/module consumers
- `perc-distribution-tree` unpacks the dist zip into the assembly; `install.xml` `upgrade.overwrite` includes extensionless Unix launcher + jar (bat already covered by `**/*.bat`)
- Operator install guide with **dry-run-first** examples for every command
- Structural packaging unit tests in both modules

Fixes #2220  
Partial #2213

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] `cd modules/perc-doctor && ../../mvnw clean install` — **BUILD SUCCESS**, Tests run: **53**, Failures: 0
- [x] `cd modules/perc-distribution-tree && ../../mvnw clean install` — **BUILD SUCCESS** (includes `PercDoctorDistPackagingTest`; assembly contains `bin/perc-doctor`, `bin/perc-doctor.bat`, `bin/perc-doctor.jar`)
- [x] Smoke: `java -jar …/bin/perc-doctor.jar --dry-run -v clean-heap-dumps` against temp tree → `WOULD_DELETE`
- [x] Erlang pre-commit review: approve — `docs/ai-generated/code-reviews/2220-perc-doctor-dist-packaging-erlang.md`
- [x] Cross-platform path review: launchers use script-relative install root; docs use generic `/opt/Percussion` / `C:\Percussion`

### Gates evidence

| Gate | Result |
|------|--------|
| perc-doctor standalone clean install | BUILD SUCCESS, 53 tests |
| perc-distribution-tree standalone clean install | BUILD SUCCESS (~2m43s) |
| Erlang | approve / May commit-push: yes |
| New warnings attributable to change | dependency:analyze unused `perc-doctor` zip (same class as existing provided packaging deps e.g. `perc-service-wrapper`) |

## Stack note

Merge order after main: #2221 → #2226 → #2227 → **this PR**. Base is `feat/issue-2218-clean-logs` until the stack lands on `main`.

## Residual

None for #2220 acceptance (packaging + dry-run docs). Parent residual remains #2219 (admin HTTP API).