### PR TITLE
feat(perc-doctor): admin HTTP API mirror of CLI (slice 4 of #2213)

### DIFF
--- a/modules/perc-doctor/README.md
+++ b/modules/perc-doctor/README.md
@@ -2,11 +2,12 @@
 
 Operator CLI for diagnosing and safely cleaning Percussion CMS install trees.
 
-**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`)  
-**Package:** `com.intsof.percussioncms.doctor`  
-**Shipped commands:** `clean-heap-dumps`, `clean-install-backups`, `clean-logs` with global `--dry-run` / `--install-root` / `-v`
+**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`), [#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219) (admin HTTP API)  
+**Package:** `com.intsof.percussioncms.doctor` (+ `...doctor.api` for HTTP)  
+**Shipped commands:** `clean-heap-dumps`, `clean-install-backups`, `clean-logs` with global `--dry-run` / `--install-root` / `-v`  
+**HTTP:** Admin-only `POST .../maintenance/doctor/{command}` (wired in sitemanage)
 
-Later slices (tracked on #2213 / residual issues): admin HTTP API, distribution `bin` packaging.
+Later slices (tracked on #2213 / residual issues): distribution `bin` packaging.
 
 ## Build
 
@@ -139,7 +140,70 @@ java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
 5. On apply, re-check containment immediately before each delete.
 6. For `clean-logs`, apply `--keep-current` and `--older-than` before any delete.
 
+## Admin HTTP API (slice #2219)
+
+When the CMS server is running, doctor commands are also available as an **Admin-only** REST surface next to the existing maintenance manager.
+
+| | |
+|--|--|
+| **Method / path** | `POST /Rhythmyx/services/maintenance/doctor/{command}` |
+| **Commands** | `clean-heap-dumps`, `clean-install-backups`, `clean-logs` (same tokens as CLI) |
+| **Auth hard gate** | **Admin role only.** Anonymous and non-admin callers receive **HTTP 403**. |
+| **Content-Type** | `application/json` (XML also accepted/produced by the host stack) |
+
+### Request body (`DoctorRequest`)
+
+| Field | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `dryRun` | boolean | **`true` when omitted/null** | Report only — **no deletes**. Explicit apply requires `"dryRun": false`. |
+| `installRoot` | string | Server RX install root (`rxdeploydir` / resolved install dir) | Optional override of the CMS install tree |
+| `olderThan` | string | unset | `clean-logs` only — e.g. `"7d"`, `"24h"` |
+| `keepCurrent` | boolean | `true` when omitted/null | `clean-logs` only — retain active current logs |
+
+**Dry-run is the default on the API** (unlike the CLI, where `--dry-run` is opt-in). This reduces risk of accidental deletes from HTTP clients. Document this to operators: inventory is safe by default; destructive apply is opt-in via `"dryRun": false`.
+
+### Response (`DoctorReportView`)
+
+Same structured report the CLI produces (candidate paths, sizes, status `WOULD_DELETE` / `DELETED` / `SKIPPED` / `FAILED`, totals).
+
+Example (safe inventory):
+
+```http
+POST /Rhythmyx/services/maintenance/doctor/clean-heap-dumps
+Content-Type: application/json
+Authorization: (Admin session)
+
+{"dryRun": true}
+```
+
+```json
+{
+  "command": "clean-heap-dumps",
+  "installRoot": "/opt/Percussion",
+  "dryRun": true,
+  "candidateCount": 2,
+  "deletedCount": 0,
+  "failedCount": 0,
+  "totalBytes": 12345678,
+  "entries": [
+    {"path": "/opt/Percussion/java_pid1.hprof", "sizeBytes": 1000, "status": "WOULD_DELETE", "detail": null}
+  ]
+}
+```
+
+Example apply (Admin only; deletes under install root):
+
+```json
+{"dryRun": false}
+```
+
+### Host wiring
+
+- Resource class: `com.intsof.percussioncms.doctor.api.DoctorRestService` (`@Path("/doctor")`)
+- Mounted on the **maintenance** JAX-RS server in sitemanage (`address="/maintenance"`)
+- Admin gate: `com.percussion.doctor.PSDoctorAdminChecker` (`IPSUserService.isAdminUser`)
+- Default install root: `com.percussion.doctor.PSDoctorInstallRootProvider` (`PathUtils.getRxDir()`)
+
 ## Deferred (not in this module slice)
 
-- Admin-authenticated HTTP API mirroring CLI
-- Distribution packaging (`bin/perc-doctor` / fat jar in install tree)
+- Distribution packaging (`bin/perc-doctor` / fat jar in install tree) — see #2220

--- a/modules/perc-doctor/pom.xml
+++ b/modules/perc-doctor/pom.xml
@@ -29,14 +29,29 @@
     <packaging>jar</packaging>
     <name>Percussion CMS Doctor</name>
     <description>
-        Operator CLI for diagnosing and safely cleaning Percussion CMS install trees
-        (heap dumps, install backups, logs).
+        Operator CLI and admin HTTP API for diagnosing and safely cleaning Percussion CMS
+        install trees (heap dumps, install backups, logs).
     </description>
 
     <dependencies>
+        <!-- JAX-RS annotations for DoctorRestService; provided by the CMS server (CXF).
+             Maven "provided" is on the compile and test classpaths. -->
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>${jakarta.ws.rs.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- RuntimeDelegate for jakarta.ws.rs.core.Response in unit tests -->
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>3.1.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorAdminChecker.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorAdminChecker.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+/**
+ * Host-provided admin authorization gate for the doctor HTTP API.
+ *
+ * <p>Implementations must return {@code false} for anonymous / unauthenticated callers and for
+ * authenticated non-Admin users.
+ */
+@FunctionalInterface
+public interface DoctorAdminChecker {
+
+  /**
+   * @return {@code true} only when the current request principal is an Admin user
+   */
+  boolean isCurrentUserAdmin();
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorApiService.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorApiService.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+import com.intsof.percussioncms.doctor.CleanHeapDumpsCommand;
+import com.intsof.percussioncms.doctor.CleanInstallBackupsCommand;
+import com.intsof.percussioncms.doctor.CleanLogsCommand;
+import com.intsof.percussioncms.doctor.CleanReport;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Executes doctor clean commands for the HTTP API. Reuses the same command implementations as the
+ * CLI ({@link CleanHeapDumpsCommand}, {@link CleanInstallBackupsCommand}, {@link
+ * CleanLogsCommand}).
+ *
+ * <p>Authorization is enforced by the caller ({@link DoctorRestService}); this class only runs
+ * commands.
+ */
+public final class DoctorApiService {
+
+  private final DoctorInstallRootProvider installRootProvider;
+
+  /**
+   * @param installRootProvider default install root when the request omits {@code installRoot}
+   */
+  public DoctorApiService(DoctorInstallRootProvider installRootProvider) {
+    this.installRootProvider =
+        Objects.requireNonNull(installRootProvider, "installRootProvider");
+  }
+
+  /**
+   * Run a doctor command and return a JSON-friendly report.
+   *
+   * @param command CLI command token (e.g. {@code clean-heap-dumps})
+   * @param request body; null treated as empty request (dry-run default)
+   * @return structured report
+   * @throws DoctorUnknownCommandException if the command is not supported
+   * @throws IllegalArgumentException if options or install root are invalid
+   * @throws IOException on unrecoverable walk failures
+   */
+  public DoctorReportView execute(String command, DoctorRequest request)
+      throws IOException, DoctorUnknownCommandException {
+    DoctorRequest body = request != null ? request : new DoctorRequest();
+    String cmd = command == null ? "" : command.trim();
+    if (cmd.isEmpty()) {
+      throw new DoctorUnknownCommandException("(empty)");
+    }
+
+    Path installRoot = resolveInstallRoot(body);
+    boolean dryRun = body.isEffectiveDryRun();
+
+    CleanReport report;
+    if (CleanHeapDumpsCommand.COMMAND_NAME.equals(cmd)) {
+      report = CleanHeapDumpsCommand.execute(installRoot, dryRun);
+    } else if (CleanInstallBackupsCommand.COMMAND_NAME.equals(cmd)) {
+      report = CleanInstallBackupsCommand.execute(installRoot, dryRun);
+    } else if (CleanLogsCommand.COMMAND_NAME.equals(cmd)) {
+      Duration olderThan = null;
+      if (body.getOlderThan() != null && !body.getOlderThan().isBlank()) {
+        olderThan = CleanLogsCommand.parseOlderThan(body.getOlderThan().trim());
+      }
+      CleanLogsCommand.Options options =
+          new CleanLogsCommand.Options(olderThan, body.isEffectiveKeepCurrent());
+      report = CleanLogsCommand.execute(installRoot, dryRun, options);
+    } else {
+      throw new DoctorUnknownCommandException(cmd);
+    }
+    return DoctorReportView.from(report);
+  }
+
+  private Path resolveInstallRoot(DoctorRequest body) {
+    String explicit = body.getInstallRoot();
+    if (explicit != null && !explicit.isBlank()) {
+      return Path.of(explicit.trim());
+    }
+    return installRootProvider.getDefaultInstallRoot();
+  }
+
+  /**
+   * Normalize a path-style command token to the CLI form if callers use underscores or mixed case.
+   * Currently the API expects the same tokens as the CLI (lowercase with hyphens).
+   *
+   * @param command raw path segment
+   * @return trimmed command token
+   */
+  public static String normalizeCommand(String command) {
+    if (command == null) {
+      return "";
+    }
+    return command.trim().toLowerCase(Locale.ROOT);
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorInstallRootProvider.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorInstallRootProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+import java.nio.file.Path;
+
+/**
+ * Supplies the default CMS install root when a doctor request omits {@code installRoot}.
+ *
+ * <p>Server hosts typically resolve {@code rxdeploydir} / RX install directory. CLI does not use
+ * this interface.
+ */
+@FunctionalInterface
+public interface DoctorInstallRootProvider {
+
+  /**
+   * @return absolute install root path; never null
+   * @throws IllegalStateException if the host cannot resolve an install root
+   */
+  Path getDefaultInstallRoot();
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorReportView.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorReportView.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+import com.intsof.percussioncms.doctor.CleanReport;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * JSON-serializable structured report matching CLI clean command output ({@link CleanReport}).
+ *
+ * <p>Paths are absolute path strings for portable JSON (no {@link java.nio.file.Path} type).
+ */
+public class DoctorReportView {
+
+  /** One inventoried / acted-on file. */
+  public static class EntryView {
+    private String path;
+    private long sizeBytes;
+    private String status;
+    private String detail;
+
+    public EntryView() {}
+
+    public EntryView(String path, long sizeBytes, String status, String detail) {
+      this.path = path;
+      this.sizeBytes = sizeBytes;
+      this.status = status;
+      this.detail = detail;
+    }
+
+    public String getPath() {
+      return path;
+    }
+
+    public void setPath(String path) {
+      this.path = path;
+    }
+
+    public long getSizeBytes() {
+      return sizeBytes;
+    }
+
+    public void setSizeBytes(long sizeBytes) {
+      this.sizeBytes = sizeBytes;
+    }
+
+    public String getStatus() {
+      return status;
+    }
+
+    public void setStatus(String status) {
+      this.status = status;
+    }
+
+    public String getDetail() {
+      return detail;
+    }
+
+    public void setDetail(String detail) {
+      this.detail = detail;
+    }
+  }
+
+  private String command;
+  private String installRoot;
+  private boolean dryRun;
+  private int candidateCount;
+  private int deletedCount;
+  private int failedCount;
+  private long totalBytes;
+  private List<EntryView> entries = new ArrayList<>();
+
+  public DoctorReportView() {}
+
+  /**
+   * Convert a CLI {@link CleanReport} into a JSON view.
+   *
+   * @param report command report; never null
+   * @return view for REST response
+   */
+  public static DoctorReportView from(CleanReport report) {
+    Objects.requireNonNull(report, "report");
+    DoctorReportView view = new DoctorReportView();
+    view.command = report.getCommand();
+    view.installRoot = report.getInstallRoot().toString();
+    view.dryRun = report.isDryRun();
+    view.candidateCount = report.getCandidateCount();
+    view.deletedCount = report.getDeletedCount();
+    view.failedCount = report.getFailedCount();
+    view.totalBytes = report.getTotalBytes();
+    List<EntryView> list = new ArrayList<>();
+    for (CleanReport.Entry e : report.getEntries()) {
+      list.add(
+          new EntryView(
+              e.getPath().toString(),
+              e.getSizeBytes(),
+              e.getStatus().name(),
+              e.getDetail()));
+    }
+    view.entries = list;
+    return view;
+  }
+
+  public String getCommand() {
+    return command;
+  }
+
+  public void setCommand(String command) {
+    this.command = command;
+  }
+
+  public String getInstallRoot() {
+    return installRoot;
+  }
+
+  public void setInstallRoot(String installRoot) {
+    this.installRoot = installRoot;
+  }
+
+  public boolean isDryRun() {
+    return dryRun;
+  }
+
+  public void setDryRun(boolean dryRun) {
+    this.dryRun = dryRun;
+  }
+
+  public int getCandidateCount() {
+    return candidateCount;
+  }
+
+  public void setCandidateCount(int candidateCount) {
+    this.candidateCount = candidateCount;
+  }
+
+  public int getDeletedCount() {
+    return deletedCount;
+  }
+
+  public void setDeletedCount(int deletedCount) {
+    this.deletedCount = deletedCount;
+  }
+
+  public int getFailedCount() {
+    return failedCount;
+  }
+
+  public void setFailedCount(int failedCount) {
+    this.failedCount = failedCount;
+  }
+
+  public long getTotalBytes() {
+    return totalBytes;
+  }
+
+  public void setTotalBytes(long totalBytes) {
+    this.totalBytes = totalBytes;
+  }
+
+  public List<EntryView> getEntries() {
+    return entries == null ? Collections.emptyList() : entries;
+  }
+
+  public void setEntries(List<EntryView> entries) {
+    this.entries = entries;
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorRequest.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorRequest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+/**
+ * JSON body for {@code POST .../doctor/{command}}.
+ *
+ * <p><strong>Dry-run default:</strong> when {@link #dryRun} is {@code null} or omitted, the API
+ * treats the request as a dry-run ({@code true}). Explicit apply requires {@code "dryRun": false}.
+ * This is the safer default for an admin HTTP surface that can delete install-tree files.
+ */
+public class DoctorRequest {
+
+  /**
+   * When {@code true} or omitted/null, inventory only (no deletes). When {@code false}, perform
+   * deletes after inventory.
+   */
+  private Boolean dryRun;
+
+  /**
+   * Optional CMS install root. When blank/null, the host supplies the server install root
+   * ({@code rxdeploydir} / resolved RX dir).
+   */
+  private String installRoot;
+
+  /**
+   * Optional age filter for {@code clean-logs} only (e.g. {@code 7d}, {@code 24h}). Ignored by
+   * other commands.
+   */
+  private String olderThan;
+
+  /**
+   * Optional keep-current flag for {@code clean-logs}. When null, defaults to {@code true} (same as
+   * CLI).
+   */
+  private Boolean keepCurrent;
+
+  /** @return dry-run flag as sent by client; may be null */
+  public Boolean getDryRun() {
+    return dryRun;
+  }
+
+  /** @param dryRun dry-run flag; null means default true */
+  public void setDryRun(Boolean dryRun) {
+    this.dryRun = dryRun;
+  }
+
+  /**
+   * Effective dry-run: {@code true} when the field is null or true.
+   *
+   * @return whether this request must not delete
+   */
+  public boolean isEffectiveDryRun() {
+    return dryRun == null || Boolean.TRUE.equals(dryRun);
+  }
+
+  /** @return optional install root path string */
+  public String getInstallRoot() {
+    return installRoot;
+  }
+
+  /** @param installRoot optional install root */
+  public void setInstallRoot(String installRoot) {
+    this.installRoot = installRoot;
+  }
+
+  /** @return optional older-than duration token for clean-logs */
+  public String getOlderThan() {
+    return olderThan;
+  }
+
+  /** @param olderThan optional duration token */
+  public void setOlderThan(String olderThan) {
+    this.olderThan = olderThan;
+  }
+
+  /** @return keep-current flag; may be null */
+  public Boolean getKeepCurrent() {
+    return keepCurrent;
+  }
+
+  /** @param keepCurrent keep-current flag for clean-logs */
+  public void setKeepCurrent(Boolean keepCurrent) {
+    this.keepCurrent = keepCurrent;
+  }
+
+  /**
+   * Effective keep-current for clean-logs: defaults to {@code true} when null.
+   *
+   * @return whether active current logs are retained
+   */
+  public boolean isEffectiveKeepCurrent() {
+    return keepCurrent == null || Boolean.TRUE.equals(keepCurrent);
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorRestService.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorRestService.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Admin-only HTTP mirror of the perc-doctor CLI.
+ *
+ * <p>Mounted by the host under the maintenance JAX-RS server, e.g. {@code
+ * POST /Rhythmyx/services/maintenance/doctor/{command}} with JSON body {@link DoctorRequest}.
+ *
+ * <p><strong>Hard gate:</strong> only Admin users may invoke any command. Anonymous and non-admin
+ * callers receive HTTP 403.
+ *
+ * <p><strong>Dry-run default:</strong> omitted or null {@code dryRun} is treated as {@code true}
+ * (report only; no deletes). Apply requires explicit {@code "dryRun": false}.
+ */
+@Path("/doctor")
+public class DoctorRestService {
+
+  private final DoctorAdminChecker adminChecker;
+  private final DoctorApiService apiService;
+
+  /**
+   * @param adminChecker host admin gate; never null
+   * @param installRootProvider default install root when request omits it; never null
+   */
+  public DoctorRestService(
+      DoctorAdminChecker adminChecker, DoctorInstallRootProvider installRootProvider) {
+    this(
+        adminChecker,
+        new DoctorApiService(Objects.requireNonNull(installRootProvider, "installRootProvider")));
+  }
+
+  /**
+   * Package-visible for tests that inject a custom {@link DoctorApiService}.
+   *
+   * @param adminChecker host admin gate
+   * @param apiService command runner
+   */
+  DoctorRestService(DoctorAdminChecker adminChecker, DoctorApiService apiService) {
+    this.adminChecker = Objects.requireNonNull(adminChecker, "adminChecker");
+    this.apiService = Objects.requireNonNull(apiService, "apiService");
+  }
+
+  /**
+   * Execute a doctor command.
+   *
+   * @param command CLI command token ({@code clean-heap-dumps}, {@code clean-install-backups},
+   *     {@code clean-logs})
+   * @param request JSON body; may be null (treated as empty dry-run request)
+   * @return structured report (same fields as CLI inventory/action report)
+   */
+  @POST
+  @Path("/{command}")
+  @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  public DoctorReportView runCommand(
+      @PathParam("command") String command, DoctorRequest request) {
+    requireAdmin();
+
+    String normalized = DoctorApiService.normalizeCommand(command);
+    try {
+      return apiService.execute(normalized, request);
+    } catch (DoctorUnknownCommandException e) {
+      throw new WebApplicationException(
+          Response.status(Response.Status.NOT_FOUND)
+              .entity("Unknown doctor command: " + safeCommand(normalized))
+              .type(MediaType.TEXT_PLAIN)
+              .build());
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(
+          Response.status(Response.Status.BAD_REQUEST)
+              .entity("Invalid doctor request: " + safeMessage(e))
+              .type(MediaType.TEXT_PLAIN)
+              .build());
+    } catch (IOException e) {
+      throw new WebApplicationException(
+          Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+              .entity("Doctor command failed.")
+              .type(MediaType.TEXT_PLAIN)
+              .build());
+    }
+  }
+
+  private void requireAdmin() {
+    boolean admin;
+    try {
+      admin = adminChecker.isCurrentUserAdmin();
+    } catch (RuntimeException e) {
+      // Treat auth resolution failures as forbidden (do not leak internals).
+      throw forbidden();
+    }
+    if (!admin) {
+      throw forbidden();
+    }
+  }
+
+  private static WebApplicationException forbidden() {
+    return new WebApplicationException(
+        Response.status(Response.Status.FORBIDDEN)
+            .entity("Only Admin users may run doctor commands.")
+            .type(MediaType.TEXT_PLAIN)
+            .build());
+  }
+
+  private static String safeCommand(String command) {
+    if (command == null || command.isBlank()) {
+      return "(empty)";
+    }
+    // Bound length so a crafted path segment cannot flood logs/responses.
+    String c = command.trim();
+    return c.length() > 64 ? c.substring(0, 64) : c;
+  }
+
+  private static String safeMessage(IllegalArgumentException e) {
+    String msg = e.getMessage();
+    if (msg == null || msg.isBlank()) {
+      return "bad request";
+    }
+    // Avoid leaking raw paths in overly long messages.
+    return msg.length() > 200 ? msg.substring(0, 200) : msg;
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorUnknownCommandException.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorUnknownCommandException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+/** Thrown when the doctor HTTP API receives an unsupported command token. */
+public class DoctorUnknownCommandException extends Exception {
+
+  private final String command;
+
+  /**
+   * @param command the unsupported command token
+   */
+  public DoctorUnknownCommandException(String command) {
+    super("Unknown doctor command: " + command);
+    this.command = command;
+  }
+
+  /** @return the unsupported command token */
+  public String getCommand() {
+    return command;
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/api/DoctorApiServiceTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/api/DoctorApiServiceTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.doctor.CleanHeapDumpsCommand;
+import com.intsof.percussioncms.doctor.CleanReport;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Behavioral tests for doctor HTTP command runner (dry-run default + inventory). */
+class DoctorApiServiceTest {
+
+  @TempDir Path tempDir;
+
+  private Path installRoot;
+  private Path heapDump;
+  private DoctorApiService service;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    installRoot = Files.createDirectories(tempDir.resolve("cms-install"));
+    heapDump = installRoot.resolve("java_pid9.hprof");
+    Files.write(heapDump, "HEAP".getBytes(StandardCharsets.UTF_8));
+    service = new DoctorApiService(() -> installRoot);
+  }
+
+  @Test
+  void dryRunDefaultWhenBodyNullInventoriesAndDoesNotDelete() throws Exception {
+    DoctorReportView view =
+        service.execute(CleanHeapDumpsCommand.COMMAND_NAME, null);
+
+    assertTrue(view.isDryRun());
+    assertEquals(1, view.getCandidateCount());
+    assertEquals(0, view.getDeletedCount());
+    assertEquals(CleanReport.EntryStatus.WOULD_DELETE.name(), view.getEntries().get(0).getStatus());
+    assertTrue(Files.exists(heapDump), "dry-run must not delete");
+  }
+
+  @Test
+  void dryRunDefaultWhenDryRunFieldOmitted() throws Exception {
+    DoctorRequest req = new DoctorRequest();
+    // dryRun left null → effective dry-run
+    DoctorReportView view = service.execute(CleanHeapDumpsCommand.COMMAND_NAME, req);
+
+    assertTrue(view.isDryRun());
+    assertTrue(Files.exists(heapDump));
+    assertEquals(0, view.getDeletedCount());
+  }
+
+  @Test
+  void explicitDryRunTrueDoesNotDelete() throws Exception {
+    DoctorRequest req = new DoctorRequest();
+    req.setDryRun(true);
+    DoctorReportView view = service.execute(CleanHeapDumpsCommand.COMMAND_NAME, req);
+
+    assertTrue(view.isDryRun());
+    assertTrue(Files.exists(heapDump));
+    assertEquals(Files.size(heapDump), view.getTotalBytes());
+  }
+
+  @Test
+  void dryRunFalseAppliesDeletes() throws Exception {
+    DoctorRequest req = new DoctorRequest();
+    req.setDryRun(false);
+    DoctorReportView view = service.execute(CleanHeapDumpsCommand.COMMAND_NAME, req);
+
+    assertFalse(view.isDryRun());
+    assertEquals(1, view.getDeletedCount());
+    assertFalse(Files.exists(heapDump));
+  }
+
+  @Test
+  void explicitInstallRootOverridesProvider() throws Exception {
+    Path otherRoot = Files.createDirectories(tempDir.resolve("other-install"));
+    Path otherDump = otherRoot.resolve("x.hprof");
+    Files.write(otherDump, "X".getBytes(StandardCharsets.UTF_8));
+
+    DoctorRequest req = new DoctorRequest();
+    req.setDryRun(true);
+    req.setInstallRoot(otherRoot.toString());
+
+    DoctorReportView view = service.execute(CleanHeapDumpsCommand.COMMAND_NAME, req);
+    assertEquals(1, view.getCandidateCount());
+    assertTrue(view.getInstallRoot().contains("other-install") || view.getInstallRoot().equals(otherRoot.toString()));
+    assertTrue(Files.exists(heapDump), "default install root dump untouched");
+    assertTrue(Files.exists(otherDump), "dry-run");
+  }
+
+  @Test
+  void unknownCommandThrows() {
+    assertThrows(
+        DoctorUnknownCommandException.class,
+        () -> service.execute("not-a-real-command", new DoctorRequest()));
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/api/DoctorRequestTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/api/DoctorRequestTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class DoctorRequestTest {
+
+  @Test
+  void effectiveDryRunDefaultsTrue() {
+    DoctorRequest r = new DoctorRequest();
+    assertTrue(r.isEffectiveDryRun());
+    r.setDryRun(true);
+    assertTrue(r.isEffectiveDryRun());
+    r.setDryRun(false);
+    assertFalse(r.isEffectiveDryRun());
+  }
+
+  @Test
+  void effectiveKeepCurrentDefaultsTrue() {
+    DoctorRequest r = new DoctorRequest();
+    assertTrue(r.isEffectiveKeepCurrent());
+    r.setKeepCurrent(false);
+    assertFalse(r.isEffectiveKeepCurrent());
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/api/DoctorRestServiceTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/api/DoctorRestServiceTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.doctor.CleanHeapDumpsCommand;
+import jakarta.ws.rs.WebApplicationException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Auth rejection + happy-path dry-run inventory for doctor REST resource. */
+class DoctorRestServiceTest {
+
+  @TempDir Path tempDir;
+
+  private Path installRoot;
+  private Path heapDump;
+  private AtomicBoolean admin;
+  private DoctorRestService rest;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    installRoot = Files.createDirectories(tempDir.resolve("cms-install"));
+    heapDump = installRoot.resolve("crash.hprof");
+    Files.write(heapDump, "HEAP".getBytes(StandardCharsets.UTF_8));
+    admin = new AtomicBoolean(true);
+    rest = new DoctorRestService(admin::get, () -> installRoot);
+  }
+
+  @Test
+  void adminDryRunInventoryHappyPath() {
+    DoctorRequest req = new DoctorRequest();
+    req.setDryRun(true);
+
+    DoctorReportView view = rest.runCommand(CleanHeapDumpsCommand.COMMAND_NAME, req);
+
+    assertTrue(view.isDryRun());
+    assertEquals(1, view.getCandidateCount());
+    assertEquals(0, view.getDeletedCount());
+    assertTrue(Files.exists(heapDump));
+    assertEquals(CleanHeapDumpsCommand.COMMAND_NAME, view.getCommand());
+  }
+
+  @Test
+  void omittedBodyDefaultsToDryRun() {
+    DoctorReportView view = rest.runCommand(CleanHeapDumpsCommand.COMMAND_NAME, null);
+    assertTrue(view.isDryRun());
+    assertTrue(Files.exists(heapDump));
+  }
+
+  @Test
+  void nonAdminRejectedWith403() {
+    admin.set(false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> rest.runCommand(CleanHeapDumpsCommand.COMMAND_NAME, new DoctorRequest()));
+    assertEquals(403, ex.getResponse().getStatus());
+    String body = String.valueOf(ex.getResponse().getEntity());
+    assertTrue(body.contains("Admin"));
+    assertTrue(Files.exists(heapDump), "rejected request must not delete");
+  }
+
+  @Test
+  void anonymousStyleGateFalseIs403() {
+    // Admin checker returns false when no current user / anonymous.
+    rest = new DoctorRestService(() -> false, () -> installRoot);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> rest.runCommand(CleanHeapDumpsCommand.COMMAND_NAME, null));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void unknownCommandIs404() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> rest.runCommand("wipe-everything", new DoctorRequest()));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void adminCheckerExceptionIs403WithoutLeak() {
+    rest =
+        new DoctorRestService(
+            () -> {
+              throw new IllegalStateException("secret-db-host=internal");
+            },
+            () -> installRoot);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> rest.runCommand(CleanHeapDumpsCommand.COMMAND_NAME, null));
+    assertEquals(403, ex.getResponse().getStatus());
+    String body = String.valueOf(ex.getResponse().getEntity());
+    assertTrue(!body.contains("secret-db-host"));
+  }
+}

--- a/projects/sitemanage/pom.xml
+++ b/projects/sitemanage/pom.xml
@@ -49,6 +49,12 @@
             <artifactId>rest</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <!-- CMS Doctor admin HTTP API (issue #2219): reuses CLI command implementations -->
+        <dependency>
+            <groupId>com.percussion</groupId>
+            <artifactId>perc-doctor</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
         <!-- TEMP DISABLED until mkd-gcm-sdk / mkd-gcm-natives are on Maven Central.
              GCM language corrections: thin JNA SDK. Native mkd_gcm_ffi is packaged into
              <installdir>/bin by perc-distribution-tree (StartJetty -Djna.library.path);

--- a/projects/sitemanage/src/main/java/com/percussion/doctor/PSDoctorAdminChecker.java
+++ b/projects/sitemanage/src/main/java/com/percussion/doctor/PSDoctorAdminChecker.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.doctor;
+
+import com.intsof.percussioncms.doctor.api.DoctorAdminChecker;
+import com.percussion.share.service.exception.PSDataServiceException;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
+import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Admin gate for perc-doctor HTTP API using the CMS user service.
+ *
+ * <p>Returns {@code false} for anonymous callers, missing principals, and non-Admin users.
+ */
+public class PSDoctorAdminChecker implements DoctorAdminChecker {
+
+  private final IPSUserService userService;
+
+  /**
+   * @param userService CMS user service; never null
+   */
+  public PSDoctorAdminChecker(IPSUserService userService) {
+    this.userService = Objects.requireNonNull(userService, "userService");
+  }
+
+  @Override
+  public boolean isCurrentUserAdmin() {
+    try {
+      PSCurrentUser current = userService.getCurrentUser();
+      if (current == null) {
+        return false;
+      }
+      String name = current.getName();
+      if (StringUtils.isBlank(name)) {
+        return false;
+      }
+      return userService.isAdminUser(name);
+    } catch (PSDataServiceException e) {
+      log.warn("Doctor admin check failed: {}", e.getMessage());
+      return false;
+    } catch (RuntimeException e) {
+      // Includes PSNoCurrentUserException when no authenticated principal.
+      log.debug("Doctor admin check: no current admin user ({})", e.toString());
+      return false;
+    }
+  }
+
+  private static final Logger log = LogManager.getLogger(PSDoctorAdminChecker.class);
+}

--- a/projects/sitemanage/src/main/java/com/percussion/doctor/PSDoctorInstallRootProvider.java
+++ b/projects/sitemanage/src/main/java/com/percussion/doctor/PSDoctorInstallRootProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.doctor;
+
+import com.intsof.percussioncms.doctor.api.DoctorInstallRootProvider;
+import com.percussion.utils.io.PathUtils;
+import java.io.File;
+import java.nio.file.Path;
+
+/**
+ * Resolves the default CMS install root for doctor HTTP requests via {@link PathUtils#getRxDir()}.
+ *
+ * <p>Uses portable {@link File}/{@link Path} APIs (no hardcoded drive letters or user home paths).
+ */
+public class PSDoctorInstallRootProvider implements DoctorInstallRootProvider {
+
+  @Override
+  public Path getDefaultInstallRoot() {
+    File rxDir = PathUtils.getRxDir();
+    if (rxDir == null) {
+      throw new IllegalStateException("CMS install root is not available");
+    }
+    return rxDir.toPath().toAbsolutePath().normalize();
+  }
+}

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -1008,9 +1008,21 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
     </jaxrs:server>
 
 
+    <!-- perc-doctor admin HTTP API (issue #2219 / parent #2213 slice 4):
+         POST /maintenance/doctor/{command} — Admin only; dryRun defaults to true. -->
+    <bean id="doctorAdminChecker" class="com.percussion.doctor.PSDoctorAdminChecker">
+        <constructor-arg ref="userService"/>
+    </bean>
+    <bean id="doctorInstallRootProvider" class="com.percussion.doctor.PSDoctorInstallRootProvider"/>
+    <bean id="doctorRestService" class="com.intsof.percussioncms.doctor.api.DoctorRestService">
+        <constructor-arg ref="doctorAdminChecker"/>
+        <constructor-arg ref="doctorInstallRootProvider"/>
+    </bean>
+
     <jaxrs:server id="maintenance-jax-rs" address="/maintenance">
         <jaxrs:serviceBeans>
             <ref bean="maintenanceManagerRestService"/>
+            <ref bean="doctorRestService"/>
         </jaxrs:serviceBeans>
         <jaxrs:extensionMappings>
             <entry key="json" value="application/json"/>

--- a/projects/sitemanage/src/test/java/com/percussion/doctor/PSDoctorAdminCheckerTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/doctor/PSDoctorAdminCheckerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.percussion.share.service.exception.PSDataServiceException;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
+import com.percussion.user.service.IPSUserService.PSNoCurrentUserException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PSDoctorAdminCheckerTest {
+
+  @Mock private IPSUserService userService;
+
+  private PSDoctorAdminChecker checker;
+
+  @BeforeEach
+  void setUp() {
+    checker = new PSDoctorAdminChecker(userService);
+  }
+
+  @Test
+  void adminUserAllowed() throws Exception {
+    PSCurrentUser user = new PSCurrentUser();
+    user.setName("admin1");
+    when(userService.getCurrentUser()).thenReturn(user);
+    when(userService.isAdminUser("admin1")).thenReturn(true);
+
+    assertTrue(checker.isCurrentUserAdmin());
+  }
+
+  @Test
+  void nonAdminRejected() throws Exception {
+    PSCurrentUser user = new PSCurrentUser();
+    user.setName("editor");
+    when(userService.getCurrentUser()).thenReturn(user);
+    when(userService.isAdminUser("editor")).thenReturn(false);
+
+    assertFalse(checker.isCurrentUserAdmin());
+  }
+
+  @Test
+  void anonymousNoCurrentUserRejected() throws Exception {
+    when(userService.getCurrentUser()).thenThrow(new PSNoCurrentUserException("none"));
+
+    assertFalse(checker.isCurrentUserAdmin());
+  }
+
+  @Test
+  void blankUserNameRejected() throws Exception {
+    PSCurrentUser user = new PSCurrentUser();
+    user.setName("  ");
+    when(userService.getCurrentUser()).thenReturn(user);
+
+    assertFalse(checker.isCurrentUserAdmin());
+  }
+
+  @Test
+  void dataServiceFailureRejected() throws Exception {
+    when(userService.getCurrentUser()).thenThrow(new PSDataServiceException("boom"));
+
+    assertFalse(checker.isCurrentUserAdmin());
+  }
+}


### PR DESCRIPTION
## Summary

Admin-only HTTP API mirroring perc-doctor CLI commands (parent tracker **#2213**, slice **#2219**).

- `POST /Rhythmyx/services/maintenance/doctor/{command}` with JSON body
- Commands: `clean-heap-dumps`, `clean-install-backups`, `clean-logs` (same tokens / implementations as CLI)
- **Hard gate:** Admin role only (`IPSUserService.isAdminUser`); anonymous / non-admin → HTTP 403
- **Dry-run default:** omitted/`null` `dryRun` is treated as **`true`** (inventory only). Explicit apply requires "dryRun": false`
- Structured JSON report (`DoctorReportView`) matches CLI `CleanReport` fields
- Host wiring: sitemanage maintenance JAX-RS server + `PSDoctorAdminChecker` / `PSDoctorInstallRootProvider`
- Documented in `modules/perc-doctor/README.md`

**Stacked on:** `feat/issue-2218-clean-logs` (PR #2227) so CLI commands are present. Merge after #2221/#2226/#2227.

## Test plan

- [x] `modules/perc-doctor`: `mvnw clean install` — API unit tests (auth 403, dry-run non-delete, happy-path inventory, unknown command 404)
- [x] `projects/sitemanage`: `mvnw clean install` — `PSDoctorAdminCheckerTest` (admin / non-admin / anonymous / blank / data error)
- [ ] Manual (server up): Admin session dry-run inventory of heap dumps; non-admin receives 403

## Gates evidence

| Gate | Result |
|------|--------|
| Erlang self-review | Pass — admin hard gate, dry-run default, portable Path/PathUtils, no secret leakage on 403/500, Intersoft 2026 headers on new files |
| perc-doctor clean install | BUILD SUCCESS |
| sitemanage clean install | BUILD SUCCESS |
| Behavioral tests | DoctorRestServiceTest, DoctorApiServiceTest, DoctorRequestTest, PSDoctorAdminCheckerTest |

## Links

- **Fixes** #2219
- **Partial** #2213 (slice 4 — Admin HTTP API)
- Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.