### PR TITLE
cluster(perc-doctor): absorb #2221/#2226/#2227/#2228/#2229 thrash into one PR

### DIFF
--- a/docs/ai-generated/code-reviews/2220-perc-doctor-dist-packaging-erlang.md
+++ b/docs/ai-generated/code-reviews/2220-perc-doctor-dist-packaging-erlang.md
@@ -1,0 +1,61 @@
+# Erlang review: #2220 perc-doctor dist packaging + install guide
+
+**Branch:** `feat/issue-2220-perc-doctor-dist-packaging` (stacked on `feat/issue-2218-clean-logs`)  
+**Date:** 2026-08-06  
+**Reviewer persona:** Erlang (pre-commit gate)
+
+## Summary
+
+Adds operator distribution packaging for `perc-doctor`: Unix + Windows `bin` launchers, stable `bin/perc-doctor.jar`, Maven assembly classifier `dist` zip, `perc-distribution-tree` unpack wiring, `install.xml` upgrade.overwrite lockstep for extensionless Unix launcher + jar, operator install guide with dry-run-first examples, and structural packaging tests in both modules.
+
+## Scope
+
+| Area | Paths |
+|------|--------|
+| perc-doctor packaging | `modules/perc-doctor/pom.xml`, `src/main/scripts/*`, `src/main/assembly/dist-bin.xml` |
+| perc-doctor docs | `modules/perc-doctor/README.md`, `docs/operator-install-guide.md` |
+| perc-doctor tests | `PercDoctorPackagingTest.java` |
+| dist-tree | `modules/perc-distribution-tree/pom.xml`, `install.xml`, `PercDoctorDistPackagingTest.java` |
+
+Prior report / Memory: no prior #2220 report. Patterns: packaging lockstep tests (JettyServiceDualShip, BundledGcmNatives), cross-platform paths, no hardcoded user homes.
+
+**Cross-platform path review:** Launchers resolve install root from script directory (`%~dp0` / `BASH_SOURCE`), not hardcoded homes. Docs use generic `/opt/Percussion` and `C:\Percussion`. Assembly sets Unix line endings + `0755` on shell script and Windows line endings on `.bat`. Packaging tests forbid personal profile path shapes. Install tree layout is `<install-root>/bin/*` on both platforms.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+- No bug findings
+- Behavioral/structural packaging tests present for new packaging logic
+- Portable path I/O in launchers and docs
+- Module clean installs: `modules/perc-doctor` BUILD SUCCESS (Tests run: 53); `modules/perc-distribution-tree` BUILD SUCCESS including `PercDoctorDistPackagingTest` and full assembly with `bin/perc-doctor{.bat,.jar}` present
+
+## Issues
+
+_None at bug severity._
+
+### suggestion
+
+1. **`modules/perc-doctor/src/main/scripts/perc-doctor.bat`** — `for %%A in (%*)` flag scan can mishandle unusual quoting; acceptable for operator flags like `--install-root`. No change required for v1.
+
+2. **dependency:analyze unused `perc-doctor` zip** — same class as existing `perc-service-wrapper` provided packaging deps; pre-existing warn style.
+
+### nit
+
+1. Assembly `dir` format cannot be attached to install (Maven warning only); zip classifier is what dist-tree consumes.
+
+## Evidence
+
+```text
+cd modules/perc-doctor && ../../mvnw clean install
+# Tests run: 53, Failures: 0 — BUILD SUCCESS
+# attaches perc-doctor-*-dist.zip
+
+cd modules/perc-distribution-tree && ../../mvnw clean install
+# BUILD SUCCESS; target/classes/distribution/bin/{perc-doctor,perc-doctor.bat,perc-doctor.jar}
+# java -jar …/perc-doctor.jar --dry-run -v clean-heap-dumps → WOULD_DELETE (smoke)
+```

--- a/docs/ai-generated/code-reviews/issue-2213-perc-doctor-scaffold-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2213-perc-doctor-scaffold-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review: #2213 perc-doctor slice 1
+
+**Branch:** `feat/issue-2213-perc-doctor-scaffold`  
+**Scope:** new module `modules/perc-doctor` + reactor wire-up in root `pom.xml`  
+**Recommendation:** approve  
+**May commit/push:** yes  
+**Gate:** pass
+
+## Summary
+
+Scaffold CMS Doctor CLI (`com.intsof.percussioncms.doctor`) with global `--install-root`, `--dry-run`, `-v` and command `clean-heap-dumps`. Allowlist is bare-name `*.hprof` only; inventory/delete stays under resolved install root via `InstallRootGuard`. Unit tests cover allowlist, dry-run vs apply, outside-root rejection, and CLI exit paths. README documents usage; later commands/API/packaging deferred.
+
+## Cross-platform path checklist
+
+- [x] No hardcoded OS separators in filesystem ops (`Path` / NIO only)
+- [x] Tests use `@TempDir` + `Path.resolve` (no Unix-only absolute paths)
+- [x] Install-root containment uses absolute normalize + `startsWith`
+- [x] Help/examples show both Unix and Windows install roots as display text only
+- [x] No `user.home` / machine-specific paths required for tests
+
+## Issues
+
+None (bugs). Minor notes (non-blocking):
+
+- **Nit:** `Path.startsWith` is case-sensitive; Windows operators should pass a consistent case for `--install-root` (same pattern as `intsof-common-utilities` `PathsUnder`).
+- **Nit:** symlink-to-outside-file under root deletes the symlink entry only (expected without `FOLLOW_LINKS`); document if ops ever need realpath checks.
+- **Deferred by design:** fat-jar / `bin` packaging, backups/logs commands, HTTP API.
+
+## Tests
+
+`cd modules/perc-doctor && ../../mvnw clean install` — BUILD SUCCESS, Tests run: 16, Failures: 0.
+
+## Memory patterns hit
+
+- Cross-platform NIO paths for new file I/O
+- Dry-run / apply behavioral split with fixture isolation
+- Containment guard before destructive ops

--- a/modules/perc-distribution-tree/pom.xml
+++ b/modules/perc-distribution-tree/pom.xml
@@ -95,6 +95,15 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- Build-time only: operator CMS doctor dist zip (bin/perc-doctor{.bat,.jar}); issue #2220. -->
+        <dependency>
+            <groupId>com.percussion</groupId>
+            <artifactId>perc-doctor</artifactId>
+            <version>${project.version}</version>
+            <classifier>dist</classifier>
+            <type>zip</type>
+            <scope>provided</scope>
+        </dependency>
         <!-- Build-time only: 234 MB shaded uber-jar copied as artifact, not imported by preinstall Java code.
              The antrun plugin declares its own perc-ant dependency for Ant task execution. -->
         <dependency>
@@ -486,6 +495,27 @@
                             <outputDirectory>${project.build.directory}/wars</outputDirectory>
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                    <!-- issue #2220: unpack perc-doctor dist zip → assembly bin/perc-doctor{.bat,.jar} -->
+                    <execution>
+                        <id>unpack-perc-doctor-dist</id>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.percussion</groupId>
+                                    <artifactId>perc-doctor</artifactId>
+                                    <version>${project.version}</version>
+                                    <classifier>dist</classifier>
+                                    <type>zip</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${assembly-directory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
                         </configuration>
                     </execution>
                     <execution>

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/install.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/install.xml
@@ -592,6 +592,11 @@
 		<include name="jetty/base/webapps/Rhythmyx.xml" />
 		<include name="**/*.bat" />
 		<include name="**/*.sh" />
+		<!-- issue #2220: Unix launcher has no extension (not matched by **/*.sh);
+			jar is not covered by bat/sh globs. Keep all three bin entries in lockstep. -->
+		<include name="bin/perc-doctor" />
+		<include name="bin/perc-doctor.bat" />
+		<include name="bin/perc-doctor.jar" />
 	</patternset>
 	<patternset id="upgrade.excludes">
 		<exclude

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/PercDoctorDistPackagingTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/PercDoctorDistPackagingTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.distribution.install;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #2220 / parent #2213 slice 5: CMS distribution must ship operator {@code perc-doctor}
+ * under {@code bin/} and refresh it on upgrade.
+ *
+ * <p>Structural packaging assertions (source POM / install.xml / sibling module scripts) — does not
+ * require a full distribution assembly when SNAPSHOT deps are missing.
+ */
+class PercDoctorDistPackagingTest {
+
+  private static final Path POM = Path.of("pom.xml");
+  private static final Path INSTALL_XML =
+      Path.of("src", "main", "resources", "distribution", "rxconfig", "Installer", "install.xml");
+  private static final Path SIBLING_UNIX =
+      Path.of("..", "perc-doctor", "src", "main", "scripts", "perc-doctor");
+  private static final Path SIBLING_WIN =
+      Path.of("..", "perc-doctor", "src", "main", "scripts", "perc-doctor.bat");
+  private static final Path SIBLING_ASSEMBLY =
+      Path.of("..", "perc-doctor", "src", "main", "assembly", "dist-bin.xml");
+
+  @Test
+  @DisplayName("pom declares perc-doctor dist zip and unpacks it into the assembly")
+  void pomUnpacksPercDoctorDist() throws Exception {
+    assertTrue(Files.isRegularFile(POM), () -> "missing " + POM.toAbsolutePath().normalize());
+    String pom = Files.readString(POM, StandardCharsets.UTF_8);
+
+    assertTrue(
+        pom.contains("<artifactId>perc-doctor</artifactId>"),
+        "pom must depend on perc-doctor (dist packaging)");
+    assertTrue(
+        pom.contains("<classifier>dist</classifier>") && pom.contains("perc-doctor"),
+        "pom must consume perc-doctor classifier dist");
+    assertTrue(
+        pom.contains("unpack-perc-doctor-dist")
+            || (pom.contains("perc-doctor")
+                && pom.contains("<type>zip</type>")
+                && pom.contains("${assembly-directory}")),
+        "pom must unpack perc-doctor dist zip into assembly-directory");
+    assertTrue(
+        pom.contains("<id>unpack-perc-doctor-dist</id>"),
+        "unpack execution id unpack-perc-doctor-dist must exist for lockstep greps");
+  }
+
+  @Test
+  @DisplayName("install.xml upgrade.overwrite refreshes bin/perc-doctor{.bat,.jar}")
+  void installXmlUpgradeOverwritesPercDoctorBin() throws Exception {
+    assertTrue(
+        Files.isRegularFile(INSTALL_XML), () -> "missing " + INSTALL_XML.toAbsolutePath().normalize());
+    String xml = Files.readString(INSTALL_XML, StandardCharsets.UTF_8);
+
+    assertTrue(xml.contains("upgrade.overwrite"), "install.xml must define upgrade.overwrite");
+    assertTrue(
+        xml.contains("bin/perc-doctor")
+            && xml.contains("bin/perc-doctor.bat")
+            && xml.contains("bin/perc-doctor.jar"),
+        "upgrade.overwrite must include Unix launcher, Windows .bat, and jar (extensionless script)");
+    assertFalse(
+        xml.contains("<exclude name=\"bin/perc-doctor")
+            || xml.contains("<exclude name=\"**/perc-doctor"),
+        "must not exclude perc-doctor from install/upgrade packaging");
+  }
+
+  @Test
+  @DisplayName("sibling perc-doctor module ships scripts + dist assembly (lockstep)")
+  void siblingModuleShipsWrappersAndAssembly() {
+    assertTrue(
+        Files.isRegularFile(SIBLING_UNIX),
+        () -> "missing sibling Unix launcher " + SIBLING_UNIX.toAbsolutePath().normalize());
+    assertTrue(
+        Files.isRegularFile(SIBLING_WIN),
+        () -> "missing sibling Windows launcher " + SIBLING_WIN.toAbsolutePath().normalize());
+    assertTrue(
+        Files.isRegularFile(SIBLING_ASSEMBLY),
+        () -> "missing sibling dist assembly " + SIBLING_ASSEMBLY.toAbsolutePath().normalize());
+  }
+}

--- a/modules/perc-doctor/README.md
+++ b/modules/perc-doctor/README.md
@@ -2,11 +2,13 @@
 
 Operator CLI for diagnosing and safely cleaning Percussion CMS install trees.
 
-**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`)  
+**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`), [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (dist packaging + install guide)  
 **Package:** `com.intsof.percussioncms.doctor`  
 **Shipped commands:** `clean-heap-dumps`, `clean-install-backups`, `clean-logs` with global `--dry-run` / `--install-root` / `-v`
 
-Later slices (tracked on #2213 / residual issues): admin HTTP API, distribution `bin` packaging.
+**Operator install guide (dry-run-first examples):** [docs/operator-install-guide.md](docs/operator-install-guide.md)
+
+Later slices (tracked on #2213 / residual issues): admin HTTP API.
 
 ## Build
 
@@ -22,19 +24,51 @@ Windows:
 ..\..\mvnw.cmd clean install
 ```
 
-## Run
+Produces:
+
+| Output | Description |
+|--------|-------------|
+| `target/perc-doctor-8.2.0-SNAPSHOT.jar` | Runnable jar (`Main-Class` = `DoctorCli`; no runtime deps) |
+| `target/perc-doctor-8.2.0-SNAPSHOT-dist.zip` | Install layout: `bin/perc-doctor`, `bin/perc-doctor.bat`, `bin/perc-doctor.jar` |
+| `target/perc-doctor-8.2.0-SNAPSHOT-dist/` | Exploded dist layout |
+
+CMS distribution (`modules/perc-distribution-tree`) unpacks the `dist` classifier zip into the install assembly so operators get the launchers under `<install-root>/bin`.
+
+## Run from a CMS install (preferred)
+
+```bash
+# Linux / macOS — dry-run first
+/opt/Percussion/bin/perc-doctor --dry-run -v clean-heap-dumps
+
+# Windows — dry-run first
+C:\Percussion\bin\perc-doctor.bat --dry-run -v clean-heap-dumps
+```
+
+Wrappers default `--install-root` to the parent of `bin/` (portable; no hardcoded user home). Override with `--install-root` when needed.
+
+## Run from a module build
 
 ```bash
 java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar [options] <command> [command-options]
 ```
 
-Or with the compiled classes on the classpath (after install).
+Or via the exploded dist:
+
+```bash
+./target/perc-doctor-8.2.0-SNAPSHOT-dist/bin/perc-doctor --help
+```
+
+Windows:
+
+```bat
+target\perc-doctor-8.2.0-SNAPSHOT-dist\bin\perc-doctor.bat --help
+```
 
 ### Global options
 
 | Flag | Meaning |
 |------|---------|
-| `--install-root <path>` | CMS install root (default: current working directory) |
+| `--install-root <path>` | CMS install root (default: current working directory for raw jar; parent of `bin/` for wrappers) |
 | `--dry-run` | Report only — **never** deletes or writes |
 | `-v` / `--verbose` | Path-level detail |
 | `-h` / `--help` | Usage |
@@ -141,5 +175,4 @@ java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
 
 ## Deferred (not in this module slice)
 
-- Admin-authenticated HTTP API mirroring CLI
-- Distribution packaging (`bin/perc-doctor` / fat jar in install tree)
+- Admin-authenticated HTTP API mirroring CLI ([#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219))

--- a/modules/perc-doctor/README.md
+++ b/modules/perc-doctor/README.md
@@ -188,7 +188,7 @@ When the CMS server is running, doctor commands are also available as an **Admin
 | Field | Type | Default | Meaning |
 |-------|------|---------|---------|
 | `dryRun` | boolean | **`true` when omitted/null** | Report only — **no deletes**. Explicit apply requires `"dryRun": false`. |
-| `installRoot` | string | Server RX install root (`rxdeploydir` / resolved install dir) | Optional override of the CMS install tree |
+| `installRoot` | string | Server RX install root (`rxdeploydir` / resolved install dir) | Optional; when set must normalize to the **same** path as the host default. Filesystem I/O always uses the host-provided root (never a client path) — arbitrary tree override is rejected (**HTTP 400**) to block path injection. |
 | `olderThan` | string | unset | `clean-logs` only — e.g. `"7d"`, `"24h"` |
 | `keepCurrent` | boolean | `true` when omitted/null | `clean-logs` only — retain active current logs |
 

--- a/modules/perc-doctor/README.md
+++ b/modules/perc-doctor/README.md
@@ -2,11 +2,11 @@
 
 Operator CLI for diagnosing and safely cleaning Percussion CMS install trees.
 
-**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`)  
+**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`)  
 **Package:** `com.intsof.percussioncms.doctor`  
-**Shipped commands:** `clean-heap-dumps`, `clean-install-backups` with global `--dry-run` / `--install-root` / `-v`
+**Shipped commands:** `clean-heap-dumps`, `clean-install-backups`, `clean-logs` with global `--dry-run` / `--install-root` / `-v`
 
-Later slices (tracked on #2213 / residual issues): `clean-logs`, admin HTTP API, distribution `bin` packaging.
+Later slices (tracked on #2213 / residual issues): admin HTTP API, distribution `bin` packaging.
 
 ## Build
 
@@ -25,7 +25,7 @@ Windows:
 ## Run
 
 ```bash
-java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar [options] <command>
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar [options] <command> [command-options]
 ```
 
 Or with the compiled classes on the classpath (after install).
@@ -88,16 +88,58 @@ java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar ^
   --install-root C:\Percussion -v clean-install-backups
 ```
 
+#### `clean-logs`
+
+Reclaim space from **known** log directories under the install root without nuking active server logs carelessly.
+
+##### Target log locations (relative to `--install-root`)
+
+| Relative path | Role |
+|---------------|------|
+| `jetty/base/logs` | Jetty / CMS logs (`install.xml` mkdirs; Log4j2 `server.log`, rotations, `audit/`) |
+| `jetty/base/modules/perc-logging/logs` | Log4j2 default relative to perc-logging module config |
+| `Deployment/Server/logs` | DTS Tomcat (`catalina.base`/logs — `catalina.log`, gzipped rotations, etc.) |
+
+Missing directories are skipped (not an error). Only files under these roots whose names end with `.log`, `.log.gz`, or `.out` are candidates. **No user-supplied globs; no walk of the entire install for arbitrary logs.**
+
+##### Options
+
+| Flag | Meaning |
+|------|---------|
+| `--older-than <duration>` | Only files with last-modified **older** than the duration. Units: `s`, `m`, `h`, `d`, `w` (e.g. `7d`, `24h`, `30m`). Omit to ignore age. |
+| `--keep-current` | **Default.** Never delete identifiable active current logs (`server.log`, `catalina.log`, `catalina.out`, … — non-dated `*.log` / `*.out`). |
+| `--no-keep-current` | Allow deleting those active basenames (still subject to `--older-than` if set). |
+
+- **Scope:** only under `--install-root` and the allowlisted log dirs
+- **Dry-run:** inventories candidates + sizes without deleting
+- Rotated / compressed names (embedded `yyyy-MM-dd`, `*.log.gz`, `name.log.N`) are not treated as current
+
+Examples:
+
+```bash
+# Preview logs older than 7 days (keep active *.log)
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
+  --install-root /opt/Percussion --dry-run -v clean-logs --older-than 7d
+
+# Apply (Windows example)
+java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar ^
+  --install-root C:\Percussion -v clean-logs --older-than 14d
+
+# Delete all non-current log candidates (no age filter)
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
+  --install-root /opt/Percussion --dry-run -v clean-logs
+```
+
 ## Safety model
 
 1. Resolve and validate install root (must exist and be a directory).
-2. Walk only under that root; skip / reject candidates that escape the root.
+2. Walk only under that root (and for `clean-logs`, only under allowlisted log dirs); skip / reject candidates that escape the root.
 3. Match allowlisted patterns only (per command; no user-supplied globs).
 4. If `--dry-run`, stop after inventory.
 5. On apply, re-check containment immediately before each delete.
+6. For `clean-logs`, apply `--keep-current` and `--older-than` before any delete.
 
 ## Deferred (not in this module slice)
 
-- `clean-logs` — age / keep-current log cleanup
 - Admin-authenticated HTTP API mirroring CLI
 - Distribution packaging (`bin/perc-doctor` / fat jar in install tree)

--- a/modules/perc-doctor/README.md
+++ b/modules/perc-doctor/README.md
@@ -2,11 +2,12 @@
 
 Operator CLI for diagnosing and safely cleaning Percussion CMS install trees.
 
-**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`)  
-**Package:** `com.intsof.percussioncms.doctor`  
-**Shipped commands:** `clean-heap-dumps`, `clean-install-backups`, `clean-logs` with global `--dry-run` / `--install-root` / `-v`
+**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`), [#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219) (admin HTTP API)  
+**Package:** `com.intsof.percussioncms.doctor` (+ `...doctor.api` for HTTP)  
+**Shipped commands:** `clean-heap-dumps`, `clean-install-backups`, `clean-logs` with global `--dry-run` / `--install-root` / `-v`  
+**HTTP:** Admin-only `POST .../maintenance/doctor/{command}` (wired in sitemanage)
 
-Later slices (tracked on #2213 / residual issues): admin HTTP API, distribution `bin` packaging.
+Later slices (tracked on #2213 / residual issues): distribution `bin` packaging.
 
 ## Build
 
@@ -139,7 +140,70 @@ java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
 5. On apply, re-check containment immediately before each delete.
 6. For `clean-logs`, apply `--keep-current` and `--older-than` before any delete.
 
+## Admin HTTP API (slice #2219)
+
+When the CMS server is running, doctor commands are also available as an **Admin-only** REST surface next to the existing maintenance manager.
+
+| | |
+|--|--|
+| **Method / path** | `POST /Rhythmyx/services/maintenance/doctor/{command}` |
+| **Commands** | `clean-heap-dumps`, `clean-install-backups`, `clean-logs` (same tokens as CLI) |
+| **Auth hard gate** | **Admin role only.** Anonymous and non-admin callers receive **HTTP 403**. |
+| **Content-Type** | `application/json` (XML also accepted/produced by the host stack) |
+
+### Request body (`DoctorRequest`)
+
+| Field | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `dryRun` | boolean | **`true` when omitted/null** | Report only — **no deletes**. Explicit apply requires `"dryRun": false`. |
+| `installRoot` | string | Server RX install root (`rxdeploydir` / resolved install dir) | Optional override of the CMS install tree |
+| `olderThan` | string | unset | `clean-logs` only — e.g. `"7d"`, `"24h"` |
+| `keepCurrent` | boolean | `true` when omitted/null | `clean-logs` only — retain active current logs |
+
+**Dry-run is the default on the API** (unlike the CLI, where `--dry-run` is opt-in). This reduces risk of accidental deletes from HTTP clients. Document this to operators: inventory is safe by default; destructive apply is opt-in via `"dryRun": false`.
+
+### Response (`DoctorReportView`)
+
+Same structured report the CLI produces (candidate paths, sizes, status `WOULD_DELETE` / `DELETED` / `SKIPPED` / `FAILED`, totals).
+
+Example (safe inventory):
+
+```http
+POST /Rhythmyx/services/maintenance/doctor/clean-heap-dumps
+Content-Type: application/json
+Authorization: (Admin session)
+
+{"dryRun": true}
+```
+
+```json
+{
+  "command": "clean-heap-dumps",
+  "installRoot": "/opt/Percussion",
+  "dryRun": true,
+  "candidateCount": 2,
+  "deletedCount": 0,
+  "failedCount": 0,
+  "totalBytes": 12345678,
+  "entries": [
+    {"path": "/opt/Percussion/java_pid1.hprof", "sizeBytes": 1000, "status": "WOULD_DELETE", "detail": null}
+  ]
+}
+```
+
+Example apply (Admin only; deletes under install root):
+
+```json
+{"dryRun": false}
+```
+
+### Host wiring
+
+- Resource class: `com.intsof.percussioncms.doctor.api.DoctorRestService` (`@Path("/doctor")`)
+- Mounted on the **maintenance** JAX-RS server in sitemanage (`address="/maintenance"`)
+- Admin gate: `com.percussion.doctor.PSDoctorAdminChecker` (`IPSUserService.isAdminUser`)
+- Default install root: `com.percussion.doctor.PSDoctorInstallRootProvider` (`PathUtils.getRxDir()`)
+
 ## Deferred (not in this module slice)
 
-- Admin-authenticated HTTP API mirroring CLI
-- Distribution packaging (`bin/perc-doctor` / fat jar in install tree)
+- Distribution packaging (`bin/perc-doctor` / fat jar in install tree) — see #2220

--- a/modules/perc-doctor/README.md
+++ b/modules/perc-doctor/README.md
@@ -1,0 +1,77 @@
+# perc-doctor
+
+Operator CLI for diagnosing and safely cleaning Percussion CMS install trees.
+
+**Issue:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213)  
+**Package:** `com.intsof.percussioncms.doctor`  
+**Slice 1:** module scaffold + `clean-heap-dumps` with global `--dry-run`
+
+Later slices (tracked on #2213 / residual issues): `clean-install-backups`, `clean-logs`, admin HTTP API, distribution `bin` packaging.
+
+## Build
+
+From this module directory:
+
+```bash
+../../mvnw clean install
+```
+
+Windows:
+
+```bat
+..\..\mvnw.cmd clean install
+```
+
+## Run
+
+```bash
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar [options] <command>
+```
+
+Or with the compiled classes on the classpath (after install).
+
+### Global options
+
+| Flag | Meaning |
+|------|---------|
+| `--install-root <path>` | CMS install root (default: current working directory) |
+| `--dry-run` | Report only — **never** deletes or writes |
+| `-v` / `--verbose` | Path-level detail |
+| `-h` / `--help` | Usage |
+
+### Commands (slice 1)
+
+#### `clean-heap-dumps`
+
+Remove Java heap dumps under the install tree.
+
+- **Allowlist:** files whose names end with `.hprof` (case-insensitive)
+- **Scope:** only under `--install-root`; paths outside the root are never deleted
+- **Dry-run:** inventories matches + sizes without deleting
+
+Examples:
+
+```bash
+# Preview reclaimable heap dumps (safe)
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
+  --install-root /opt/Percussion --dry-run -v clean-heap-dumps
+
+# Apply (Windows example)
+java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar ^
+  --install-root C:\Percussion -v clean-heap-dumps
+```
+
+## Safety model
+
+1. Resolve and validate install root (must exist and be a directory).
+2. Walk only under that root; skip / reject candidates that escape the root.
+3. Match allowlisted patterns only (`*.hprof` for this command).
+4. If `--dry-run`, stop after inventory.
+5. On apply, re-check containment immediately before each delete.
+
+## Deferred (not in this slice)
+
+- `clean-install-backups` — allowlisted installer/upgrade backup patterns
+- `clean-logs` — age / keep-current log cleanup
+- Admin-authenticated HTTP API mirroring CLI
+- Distribution packaging (`bin/perc-doctor` / fat jar in install tree)

--- a/modules/perc-doctor/README.md
+++ b/modules/perc-doctor/README.md
@@ -2,11 +2,11 @@
 
 Operator CLI for diagnosing and safely cleaning Percussion CMS install trees.
 
-**Issue:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213)  
+**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`)  
 **Package:** `com.intsof.percussioncms.doctor`  
-**Slice 1:** module scaffold + `clean-heap-dumps` with global `--dry-run`
+**Shipped commands:** `clean-heap-dumps`, `clean-install-backups` with global `--dry-run` / `--install-root` / `-v`
 
-Later slices (tracked on #2213 / residual issues): `clean-install-backups`, `clean-logs`, admin HTTP API, distribution `bin` packaging.
+Later slices (tracked on #2213 / residual issues): `clean-logs`, admin HTTP API, distribution `bin` packaging.
 
 ## Build
 
@@ -39,7 +39,7 @@ Or with the compiled classes on the classpath (after install).
 | `-v` / `--verbose` | Path-level detail |
 | `-h` / `--help` | Usage |
 
-### Commands (slice 1)
+### Commands
 
 #### `clean-heap-dumps`
 
@@ -61,17 +61,43 @@ java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar ^
   --install-root C:\Percussion -v clean-heap-dumps
 ```
 
+#### `clean-install-backups`
+
+Remove allowlisted installer / upgrade backup artifacts left in the install tree.
+
+Patterns are documented from `modules/perc-distribution-tree` (`install.xml` `zip_AppServer`, assembly/install `**/*.bak` / `**/*.backup` excludes, and known upgrade copies such as `Navigation.properties.backup`). **No arbitrary user globs.**
+
+| Pattern | Source |
+|---------|--------|
+| `AppServer_backup_<timestamp>.zip` | `install.xml` target `zip_AppServer` |
+| `**/*.bak` | assembly / install excludes (e.g. `ResourceBundle.tmx.bak`) |
+| `**/*.backup` | assembly / install excludes (includes `*.properties.backup`) |
+
+- **Scope:** only under `--install-root`; paths outside the root are never deleted
+- **Dry-run:** inventories candidates + sizes without deleting
+
+Examples:
+
+```bash
+# Preview reclaimable install backups (safe)
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
+  --install-root /opt/Percussion --dry-run -v clean-install-backups
+
+# Apply (Windows example)
+java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar ^
+  --install-root C:\Percussion -v clean-install-backups
+```
+
 ## Safety model
 
 1. Resolve and validate install root (must exist and be a directory).
 2. Walk only under that root; skip / reject candidates that escape the root.
-3. Match allowlisted patterns only (`*.hprof` for this command).
+3. Match allowlisted patterns only (per command; no user-supplied globs).
 4. If `--dry-run`, stop after inventory.
 5. On apply, re-check containment immediately before each delete.
 
-## Deferred (not in this slice)
+## Deferred (not in this module slice)
 
-- `clean-install-backups` — allowlisted installer/upgrade backup patterns
 - `clean-logs` — age / keep-current log cleanup
 - Admin-authenticated HTTP API mirroring CLI
 - Distribution packaging (`bin/perc-doctor` / fat jar in install tree)

--- a/modules/perc-doctor/docs/operator-install-guide.md
+++ b/modules/perc-doctor/docs/operator-install-guide.md
@@ -1,0 +1,173 @@
+# perc-doctor operator install guide
+
+**Module:** `modules/perc-doctor`  
+**Issues:** [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (packaging), [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent)
+
+This guide is for operators running **perc-doctor** against a CMS install on Windows or Linux. Prefer **dry-run first** for every command; only apply after you review the candidate list and sizes.
+
+## Install layout
+
+After a CMS distribution build that includes this module, the install tree ships:
+
+```text
+<install-root>/
+  bin/
+    perc-doctor          # Unix launcher (executable)
+    perc-doctor.bat      # Windows launcher
+    perc-doctor.jar      # Runnable jar (Main-Class = DoctorCli)
+```
+
+The launchers set `--install-root` to the **parent of `bin/`** (the install root) when you do not pass `--install-root` yourself. Paths are resolved from the script location — never from a hardcoded user home.
+
+### Cross-platform path rules
+
+| Do | Do not |
+|----|--------|
+| Use `<install-root>` (e.g. `/opt/Percussion` or `C:\Percussion`) | Embed a personal profile directory path |
+| Prefer `bin/perc-doctor` / `bin\perc-doctor.bat` from the install | Assume a fixed drive letter or username |
+| Pass `--install-root` only when the tree is not the parent of `bin/` | Embed machine-specific absolute paths in scripts or runbooks |
+| Use JDK 21+ via `JAVA_HOME` or `PATH` | Rely on an optional bundled JRE path that may not exist |
+
+### Alternate: module build / java -jar
+
+From a developer or support workstation after `mvnw clean install` in this module:
+
+```bash
+# Exploded dist (created by assembly)
+java -jar target/perc-doctor-*-dist/bin/perc-doctor.jar --help
+
+# Or the versioned module jar
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar --help
+```
+
+Windows:
+
+```bat
+java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar --help
+```
+
+## Global options
+
+| Flag | Meaning |
+|------|---------|
+| `--install-root <path>` | CMS install root (wrapper default: parent of `bin/`; jar default: current working directory) |
+| `--dry-run` | **Report only** — list what would change; **no deletes / writes** |
+| `-v` / `--verbose` | Path-level detail (recommended with dry-run) |
+| `-h` / `--help` | Usage |
+
+## Safety first: dry-run then apply
+
+For every command:
+
+1. Run with `--dry-run -v` and read `candidates=` / `bytes=` / path list.
+2. Confirm only intended allowlisted paths appear under the install root.
+3. Re-run **without** `--dry-run` to apply.
+4. Prefer off-hours for apply when reclaiming large log trees.
+
+## Commands
+
+### `clean-heap-dumps`
+
+Removes recursive `*.hprof` under the install root (case-insensitive). Scope is hard-limited to `--install-root`.
+
+**Dry-run first (Linux / macOS install):**
+
+```bash
+cd /opt/Percussion
+./bin/perc-doctor --dry-run -v clean-heap-dumps
+```
+
+**Dry-run first (Windows install):**
+
+```bat
+cd /d C:\Percussion
+bin\perc-doctor.bat --dry-run -v clean-heap-dumps
+```
+
+**Apply (only after review):**
+
+```bash
+./bin/perc-doctor -v clean-heap-dumps
+```
+
+```bat
+bin\perc-doctor.bat -v clean-heap-dumps
+```
+
+### `clean-install-backups`
+
+Removes **allowlisted** installer/upgrade backup artifacts only (`AppServer_backup_*.zip`, `*.bak`, `*.backup`). No user-supplied globs.
+
+**Dry-run first:**
+
+```bash
+./bin/perc-doctor --install-root /opt/Percussion --dry-run -v clean-install-backups
+```
+
+```bat
+bin\perc-doctor.bat --install-root C:\Percussion --dry-run -v clean-install-backups
+```
+
+**Apply:**
+
+```bash
+./bin/perc-doctor --install-root /opt/Percussion -v clean-install-backups
+```
+
+```bat
+bin\perc-doctor.bat --install-root C:\Percussion -v clean-install-backups
+```
+
+### `clean-logs`
+
+Reclaims space under known log directories only:
+
+| Relative path | Role |
+|---------------|------|
+| `jetty/base/logs` | Jetty / CMS logs |
+| `jetty/base/modules/perc-logging/logs` | perc-logging module logs |
+| `Deployment/Server/logs` | DTS Tomcat logs |
+
+| Flag | Meaning |
+|------|---------|
+| `--older-than <duration>` | Only files older than duration (`7d`, `24h`, `30m`, …) |
+| `--keep-current` | Default: never delete active current `*.log` / `*.out` basenames |
+| `--no-keep-current` | Allow deleting those basenames (still subject to age filter if set) |
+
+**Dry-run first (keep current logs, older than 7 days):**
+
+```bash
+./bin/perc-doctor --install-root /opt/Percussion --dry-run -v clean-logs --older-than 7d
+```
+
+```bat
+bin\perc-doctor.bat --install-root C:\Percussion --dry-run -v clean-logs --older-than 7d
+```
+
+**Apply:**
+
+```bash
+./bin/perc-doctor --install-root /opt/Percussion -v clean-logs --older-than 14d
+```
+
+```bat
+bin\perc-doctor.bat --install-root C:\Percussion -v clean-logs --older-than 14d
+```
+
+## Distribution packaging (developers)
+
+Module `mvnw clean install` attaches:
+
+| Artifact | Role |
+|----------|------|
+| `perc-doctor-<version>.jar` | Runnable Main-Class jar (no runtime deps) |
+| `perc-doctor-<version>-dist.zip` | `bin/perc-doctor`, `bin/perc-doctor.bat`, `bin/perc-doctor.jar` |
+| `target/perc-doctor-<version>-dist/` | Exploded copy of the same layout |
+
+`modules/perc-distribution-tree` unpacks the `dist` zip into the CMS assembly so operators receive the launchers under `<install-root>/bin`.
+
+## Related
+
+- Module README: [../README.md](../README.md)
+- Parent epic: [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213)
+- Admin HTTP API: deferred ([#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219))

--- a/modules/perc-doctor/pom.xml
+++ b/modules/perc-doctor/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2026 Intersoft Data Labs, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.percussion</groupId>
+        <artifactId>core</artifactId>
+        <version>8.2.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>perc-doctor</artifactId>
+    <packaging>jar</packaging>
+    <name>Percussion CMS Doctor</name>
+    <description>
+        Operator CLI for diagnosing and safely cleaning Percussion CMS install trees
+        (heap dumps, install backups, logs — slice 1: clean-heap-dumps).
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.intsof.percussioncms.doctor.DoctorCli</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/modules/perc-doctor/pom.xml
+++ b/modules/perc-doctor/pom.xml
@@ -30,7 +30,7 @@
     <name>Percussion CMS Doctor</name>
     <description>
         Operator CLI for diagnosing and safely cleaning Percussion CMS install trees
-        (heap dumps, install backups, logs — slice 1: clean-heap-dumps).
+        (heap dumps, install backups, logs).
     </description>
 
     <dependencies>

--- a/modules/perc-doctor/pom.xml
+++ b/modules/perc-doctor/pom.xml
@@ -54,6 +54,31 @@
                     </archive>
                 </configuration>
             </plugin>
+            <!--
+              Operator dist layout (issue #2220): bin/perc-doctor{.bat} + bin/perc-doctor.jar.
+              Attached as classifier "dist" (zip + exploded dir under target). Zero runtime deps,
+              so the Main-Class jar is the runnable "fat" artifact for distribution.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>perc-doctor-dist</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/dist-bin.xml</descriptor>
+                            </descriptors>
+                            <appendAssemblyId>true</appendAssemblyId>
+                            <attach>true</attach>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/modules/perc-doctor/pom.xml
+++ b/modules/perc-doctor/pom.xml
@@ -29,14 +29,29 @@
     <packaging>jar</packaging>
     <name>Percussion CMS Doctor</name>
     <description>
-        Operator CLI for diagnosing and safely cleaning Percussion CMS install trees
-        (heap dumps, install backups, logs).
+        Operator CLI and admin HTTP API for diagnosing and safely cleaning Percussion CMS
+        install trees (heap dumps, install backups, logs).
     </description>
 
     <dependencies>
+        <!-- JAX-RS annotations for DoctorRestService; provided by the CMS server (CXF).
+             Maven "provided" is on the compile and test classpaths. -->
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>${jakarta.ws.rs.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- RuntimeDelegate for jakarta.ws.rs.core.Response in unit tests -->
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>3.1.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/perc-doctor/src/main/assembly/dist-bin.xml
+++ b/modules/perc-doctor/src/main/assembly/dist-bin.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2026 Intersoft Data Labs, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!--
+  Distribution layout for CMS install / operator zip:
+
+    bin/perc-doctor
+    bin/perc-doctor.bat
+    bin/perc-doctor.jar   (stable name; versioned main jar is copied here)
+
+  Attached as classifier "dist" (zip). perc-distribution-tree unpacks this into
+  the assembly install tree.
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+    <id>dist</id>
+    <formats>
+        <format>zip</format>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/src/main/scripts</directory>
+            <outputDirectory>bin</outputDirectory>
+            <includes>
+                <include>perc-doctor</include>
+            </includes>
+            <fileMode>0755</fileMode>
+            <lineEnding>unix</lineEnding>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/src/main/scripts</directory>
+            <outputDirectory>bin</outputDirectory>
+            <includes>
+                <include>perc-doctor.bat</include>
+            </includes>
+            <lineEnding>windows</lineEnding>
+        </fileSet>
+    </fileSets>
+    <files>
+        <file>
+            <source>${project.build.directory}/${project.build.finalName}.jar</source>
+            <outputDirectory>bin</outputDirectory>
+            <destName>perc-doctor.jar</destName>
+        </file>
+    </files>
+</assembly>

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanHeapDumpsCommand.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanHeapDumpsCommand.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Remove (or inventory) Java heap dump files (recursive {@code *.hprof}) under a CMS install root.
+ *
+ * <p>Safety: only allowlisted {@code .hprof} names; every candidate is re-checked against the
+ * install root before delete. Dry-run never deletes.
+ */
+public final class CleanHeapDumpsCommand {
+
+  /** CLI command token. */
+  public static final String COMMAND_NAME = "clean-heap-dumps";
+
+  private CleanHeapDumpsCommand() {}
+
+  /**
+   * Inventory recursive {@code *.hprof} files under {@code installRoot} and optionally delete them.
+   *
+   * @param installRoot resolved install root (must exist)
+   * @param dryRun when true, only inventory (no deletes)
+   * @return report of candidates and actions
+   * @throws IOException on walk failures that cannot be recovered
+   * @throws IllegalArgumentException if install root is invalid
+   */
+  public static CleanReport execute(Path installRoot, boolean dryRun) throws IOException {
+    Path root = InstallRootGuard.requireInstallRoot(installRoot);
+    CleanReport report = new CleanReport(COMMAND_NAME, root, dryRun);
+
+    List<Path> candidates = findHeapDumps(root);
+    candidates.sort(Comparator.comparing(p -> p.toString()));
+
+    for (Path candidate : candidates) {
+      processCandidate(report, root, candidate, dryRun);
+    }
+    return report;
+  }
+
+  static List<Path> findHeapDumps(Path root) throws IOException {
+    List<Path> found = new ArrayList<>();
+    Files.walkFileTree(
+        root,
+        new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+            // Skip trees that escape the install root (e.g. unexpected symlink targets).
+            if (!InstallRootGuard.isUnderInstallRoot(root, dir)) {
+              return FileVisitResult.SKIP_SUBTREE;
+            }
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+            if (!attrs.isRegularFile()) {
+              return FileVisitResult.CONTINUE;
+            }
+            if (!InstallRootGuard.isUnderInstallRoot(root, file)) {
+              return FileVisitResult.CONTINUE;
+            }
+            Path fileName = file.getFileName();
+            if (fileName == null || !InstallRootGuard.isHeapDumpFileName(fileName.toString())) {
+              return FileVisitResult.CONTINUE;
+            }
+            found.add(file);
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult visitFileFailed(Path file, IOException exc) {
+            // Continue walk; failures on individual entries are recorded at process time if needed
+            return FileVisitResult.CONTINUE;
+          }
+        });
+    return found;
+  }
+
+  private static void processCandidate(
+      CleanReport report, Path root, Path candidate, boolean dryRun) {
+    Objects.requireNonNull(candidate, "candidate");
+    try {
+      InstallRootGuard.requireUnderInstallRoot(root, candidate);
+    } catch (IllegalArgumentException outside) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, 0L, CleanReport.EntryStatus.FAILED, outside.getMessage()));
+      return;
+    }
+
+    Path name = candidate.getFileName();
+    if (name == null || !InstallRootGuard.isHeapDumpFileName(name.toString())) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, 0L, CleanReport.EntryStatus.SKIPPED, "not an allowlisted .hprof file"));
+      return;
+    }
+
+    long size = 0L;
+    try {
+      if (Files.isRegularFile(candidate)) {
+        size = Files.size(candidate);
+      }
+    } catch (IOException e) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, 0L, CleanReport.EntryStatus.FAILED, "size: " + e.getMessage()));
+      return;
+    }
+
+    if (dryRun) {
+      report.add(
+          new CleanReport.Entry(candidate, size, CleanReport.EntryStatus.WOULD_DELETE, null));
+      return;
+    }
+
+    try {
+      // Re-check containment immediately before delete (TOCTOU-resistant enough for ops tool).
+      InstallRootGuard.requireUnderInstallRoot(root, candidate);
+      boolean deleted = Files.deleteIfExists(candidate);
+      if (deleted) {
+        report.add(new CleanReport.Entry(candidate, size, CleanReport.EntryStatus.DELETED, null));
+      } else {
+        report.add(
+            new CleanReport.Entry(
+                candidate, size, CleanReport.EntryStatus.SKIPPED, "already absent"));
+      }
+    } catch (IOException e) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, size, CleanReport.EntryStatus.FAILED, "delete: " + e.getMessage()));
+    } catch (IllegalArgumentException outside) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, size, CleanReport.EntryStatus.FAILED, outside.getMessage()));
+    }
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanHeapDumpsCommand.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanHeapDumpsCommand.java
@@ -53,7 +53,8 @@ public final class CleanHeapDumpsCommand {
     Path root = InstallRootGuard.requireInstallRoot(installRoot);
     CleanReport report = new CleanReport(COMMAND_NAME, root, dryRun);
 
-    List<Path> candidates = findHeapDumps(root);
+    List<Path> candidates = new ArrayList<>();
+    walkHeapDumps(root, candidates, report);
     candidates.sort(Comparator.comparing(p -> p.toString()));
 
     for (Path candidate : candidates) {
@@ -62,8 +63,23 @@ public final class CleanHeapDumpsCommand {
     return report;
   }
 
+  /**
+   * Inventory {@code *.hprof} under {@code root} without recording walk failures (test helper).
+   */
   static List<Path> findHeapDumps(Path root) throws IOException {
     List<Path> found = new ArrayList<>();
+    walkHeapDumps(root, found, null);
+    return found;
+  }
+
+  /**
+   * Walk install tree for allowlisted heap dumps. When {@code report} is non-null, I/O failures
+   * during the walk are appended as {@link CleanReport.EntryStatus#FAILED} so operators see skipped
+   * paths.
+   */
+  static void walkHeapDumps(Path root, List<Path> found, CleanReport report) throws IOException {
+    Objects.requireNonNull(root, "root");
+    Objects.requireNonNull(found, "found");
     Files.walkFileTree(
         root,
         new SimpleFileVisitor<Path>() {
@@ -94,11 +110,24 @@ public final class CleanHeapDumpsCommand {
 
           @Override
           public FileVisitResult visitFileFailed(Path file, IOException exc) {
-            // Continue walk; failures on individual entries are recorded at process time if needed
+            recordVisitFailure(report, file, exc);
             return FileVisitResult.CONTINUE;
           }
         });
-    return found;
+  }
+
+  /** Record a walk I/O failure on the report when one is provided (package-visible for tests). */
+  static void recordVisitFailure(CleanReport report, Path file, IOException exc) {
+    if (report == null || file == null) {
+      return;
+    }
+    String detail = exc != null ? exc.getMessage() : "unknown I/O error";
+    if (detail == null || detail.isBlank()) {
+      detail = exc != null ? exc.getClass().getSimpleName() : "unknown I/O error";
+    }
+    report.add(
+        new CleanReport.Entry(
+            file, 0L, CleanReport.EntryStatus.FAILED, "walk: " + detail));
   }
 
   private static void processCandidate(

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanInstallBackupsCommand.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanInstallBackupsCommand.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Remove (or inventory) allowlisted installer / upgrade backup artifacts under a CMS install root.
+ *
+ * <p>Allowlist (see {@link InstallRootGuard#isInstallBackupFileName(String)}):
+ *
+ * <ul>
+ *   <li>{@code AppServer_backup_&lt;timestamp&gt;.zip}
+ *   <li>any {@code .bak} file under the install tree
+ *   <li>any {@code .backup} file under the install tree (includes known {@code
+ *       *.properties.backup} such as {@code Navigation.properties.backup})
+ * </ul>
+ *
+ * <p>Safety: only allowlisted names; every candidate is re-checked against the install root before
+ * delete. Dry-run never deletes. No arbitrary user-supplied globs.
+ */
+public final class CleanInstallBackupsCommand {
+
+  /** CLI command token. */
+  public static final String COMMAND_NAME = "clean-install-backups";
+
+  private CleanInstallBackupsCommand() {}
+
+  /**
+   * Inventory allowlisted install-backup files under {@code installRoot} and optionally delete
+   * them.
+   *
+   * @param installRoot resolved install root (must exist)
+   * @param dryRun when true, only inventory (no deletes)
+   * @return report of candidates and actions
+   * @throws IOException on walk failures that cannot be recovered
+   * @throws IllegalArgumentException if install root is invalid
+   */
+  public static CleanReport execute(Path installRoot, boolean dryRun) throws IOException {
+    Path root = InstallRootGuard.requireInstallRoot(installRoot);
+    CleanReport report = new CleanReport(COMMAND_NAME, root, dryRun);
+
+    List<Path> candidates = new ArrayList<>();
+    walkInstallBackups(root, candidates, report);
+    candidates.sort(Comparator.comparing(p -> p.toString()));
+
+    for (Path candidate : candidates) {
+      processCandidate(report, root, candidate, dryRun);
+    }
+    return report;
+  }
+
+  /**
+   * Inventory allowlisted install backups under {@code root} without recording walk failures (test
+   * helper).
+   */
+  static List<Path> findInstallBackups(Path root) throws IOException {
+    List<Path> found = new ArrayList<>();
+    walkInstallBackups(root, found, null);
+    return found;
+  }
+
+  /**
+   * Walk install tree for allowlisted install backups. When {@code report} is non-null, I/O
+   * failures during the walk are appended as {@link CleanReport.EntryStatus#FAILED} so operators
+   * see skipped paths.
+   */
+  static void walkInstallBackups(Path root, List<Path> found, CleanReport report)
+      throws IOException {
+    Objects.requireNonNull(root, "root");
+    Objects.requireNonNull(found, "found");
+    Files.walkFileTree(
+        root,
+        new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+            // Skip trees that escape the install root (e.g. unexpected symlink targets).
+            if (!InstallRootGuard.isUnderInstallRoot(root, dir)) {
+              return FileVisitResult.SKIP_SUBTREE;
+            }
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+            if (!attrs.isRegularFile()) {
+              return FileVisitResult.CONTINUE;
+            }
+            if (!InstallRootGuard.isUnderInstallRoot(root, file)) {
+              return FileVisitResult.CONTINUE;
+            }
+            Path fileName = file.getFileName();
+            if (fileName == null
+                || !InstallRootGuard.isInstallBackupFileName(fileName.toString())) {
+              return FileVisitResult.CONTINUE;
+            }
+            found.add(file);
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult visitFileFailed(Path file, IOException exc) {
+            recordVisitFailure(report, file, exc);
+            return FileVisitResult.CONTINUE;
+          }
+        });
+  }
+
+  /** Record a walk I/O failure on the report when one is provided (package-visible for tests). */
+  static void recordVisitFailure(CleanReport report, Path file, IOException exc) {
+    if (report == null || file == null) {
+      return;
+    }
+    String detail = exc != null ? exc.getMessage() : "unknown I/O error";
+    if (detail == null || detail.isBlank()) {
+      detail = exc != null ? exc.getClass().getSimpleName() : "unknown I/O error";
+    }
+    report.add(
+        new CleanReport.Entry(
+            file, 0L, CleanReport.EntryStatus.FAILED, "walk: " + detail));
+  }
+
+  private static void processCandidate(
+      CleanReport report, Path root, Path candidate, boolean dryRun) {
+    Objects.requireNonNull(candidate, "candidate");
+    try {
+      InstallRootGuard.requireUnderInstallRoot(root, candidate);
+    } catch (IllegalArgumentException outside) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, 0L, CleanReport.EntryStatus.FAILED, outside.getMessage()));
+      return;
+    }
+
+    Path name = candidate.getFileName();
+    if (name == null || !InstallRootGuard.isInstallBackupFileName(name.toString())) {
+      report.add(
+          new CleanReport.Entry(
+              candidate,
+              0L,
+              CleanReport.EntryStatus.SKIPPED,
+              "not an allowlisted install-backup file"));
+      return;
+    }
+
+    long size = 0L;
+    try {
+      if (Files.isRegularFile(candidate)) {
+        size = Files.size(candidate);
+      }
+    } catch (IOException e) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, 0L, CleanReport.EntryStatus.FAILED, "size: " + e.getMessage()));
+      return;
+    }
+
+    if (dryRun) {
+      report.add(
+          new CleanReport.Entry(candidate, size, CleanReport.EntryStatus.WOULD_DELETE, null));
+      return;
+    }
+
+    try {
+      // Re-check containment immediately before delete (TOCTOU-resistant enough for ops tool).
+      InstallRootGuard.requireUnderInstallRoot(root, candidate);
+      boolean deleted = Files.deleteIfExists(candidate);
+      if (deleted) {
+        report.add(new CleanReport.Entry(candidate, size, CleanReport.EntryStatus.DELETED, null));
+      } else {
+        report.add(
+            new CleanReport.Entry(
+                candidate, size, CleanReport.EntryStatus.SKIPPED, "already absent"));
+      }
+    } catch (IOException e) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, size, CleanReport.EntryStatus.FAILED, "delete: " + e.getMessage()));
+    } catch (IllegalArgumentException outside) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, size, CleanReport.EntryStatus.FAILED, outside.getMessage()));
+    }
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanLogsCommand.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanLogsCommand.java
@@ -69,8 +69,9 @@ public final class CleanLogsCommand {
   /**
    * Options for {@link #execute(Path, boolean, Options)}.
    *
-   * <p>{@code olderThan} — when non-null, only files with last-modified before {@code now -
-   * olderThan}. {@code keepCurrent} — when true, skip identifiable current / active log files.
+   * <p>{@code olderThan} — when non-null, only files whose last-modified is older than this
+   * duration relative to the time each file is evaluated (per-candidate {@code Instant.now()}).
+   * {@code keepCurrent} — when true, skip identifiable current / active log files.
    */
   public static final class Options {
     private final Duration olderThan;
@@ -134,17 +135,17 @@ public final class CleanLogsCommand {
     Path root = InstallRootGuard.requireInstallRoot(installRoot);
     CleanReport report = new CleanReport(COMMAND_NAME, root, dryRun);
 
-    Instant cutoff =
-        options.getOlderThan() == null ? null : Instant.now().minus(options.getOlderThan());
-
     List<Path> candidates = new ArrayList<>();
     for (Path logDir : InstallRootGuard.existingLogDirs(root)) {
       walkLogDir(root, logDir, candidates, report);
     }
     candidates.sort(Comparator.comparing(p -> p.toString()));
 
+    // Age cutoff is evaluated per candidate (Instant.now() at process time), not once at
+    // walk-start, so a long walk does not leave a stale threshold for later files.
     for (Path candidate : candidates) {
-      processCandidate(report, root, candidate, dryRun, options.isKeepCurrent(), cutoff);
+      processCandidate(
+          report, root, candidate, dryRun, options.isKeepCurrent(), options.getOlderThan());
     }
     return report;
   }
@@ -231,7 +232,7 @@ public final class CleanLogsCommand {
       Path candidate,
       boolean dryRun,
       boolean keepCurrent,
-      Instant cutoff) {
+      Duration olderThan) {
     Objects.requireNonNull(candidate, "candidate");
     try {
       InstallRootGuard.requireUnderInstallRoot(root, candidate);
@@ -258,7 +259,7 @@ public final class CleanLogsCommand {
       return;
     }
 
-    if (cutoff != null) {
+    if (olderThan != null) {
       Instant mtime;
       try {
         FileTime ft = Files.getLastModifiedTime(candidate);
@@ -269,6 +270,8 @@ public final class CleanLogsCommand {
                 candidate, 0L, CleanReport.EntryStatus.FAILED, "mtime: " + e.getMessage()));
         return;
       }
+      // Per-file age reference: now is sampled when this candidate is evaluated.
+      Instant cutoff = Instant.now().minus(olderThan);
       if (!mtime.isBefore(cutoff)) {
         long size = sizeOrZero(candidate);
         report.add(

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanLogsCommand.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanLogsCommand.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Remove (or inventory) aged log files under known CMS / Jetty / DTS log directories.
+ *
+ * <p>Target roots (relative to install root; missing dirs skipped):
+ *
+ * <ul>
+ *   <li>{@code jetty/base/logs}
+ *   <li>{@code jetty/base/modules/perc-logging/logs}
+ *   <li>{@code Deployment/Server/logs}
+ * </ul>
+ *
+ * <p>Only allowlisted log file names ({@link InstallRootGuard#isLogFileName(String)}) under those
+ * roots are considered. Safety options:
+ *
+ * <ul>
+ *   <li>{@code --older-than &lt;duration&gt;} — only files with mtime older than the duration
+ *   <li>{@code --keep-current} (default true) — never delete identifiable active {@code *.log} /
+ *       {@code *.out} files
+ * </ul>
+ *
+ * <p>Dry-run never deletes. Paths outside the install root are never deleted.
+ */
+public final class CleanLogsCommand {
+
+  /** CLI command token. */
+  public static final String COMMAND_NAME = "clean-logs";
+
+  /** Duration token: one or more digits plus unit {@code w|d|h|m|s} (case-insensitive). */
+  private static final Pattern DURATION_PATTERN =
+      Pattern.compile("^(\\d+)([smhdw])$", Pattern.CASE_INSENSITIVE);
+
+  private CleanLogsCommand() {}
+
+  /**
+   * Options for {@link #execute(Path, boolean, Options)}.
+   *
+   * <p>{@code olderThan} — when non-null, only files with last-modified before {@code now -
+   * olderThan}. {@code keepCurrent} — when true, skip identifiable current / active log files.
+   */
+  public static final class Options {
+    private final Duration olderThan;
+    private final boolean keepCurrent;
+
+    /**
+     * Create clean-logs filter options.
+     *
+     * @param olderThan optional minimum age; null means no age filter
+     * @param keepCurrent retain current active logs (recommended default true)
+     */
+    public Options(Duration olderThan, boolean keepCurrent) {
+      this.olderThan = olderThan;
+      this.keepCurrent = keepCurrent;
+      if (olderThan != null && (olderThan.isNegative() || olderThan.isZero())) {
+        throw new IllegalArgumentException("--older-than must be a positive duration");
+      }
+    }
+
+    /**
+     * Age threshold, or null when unset.
+     *
+     * @return age threshold, or null when unset
+     */
+    public Duration getOlderThan() {
+      return olderThan;
+    }
+
+    /**
+     * Whether current active logs are retained.
+     *
+     * @return whether current active logs are retained
+     */
+    public boolean isKeepCurrent() {
+      return keepCurrent;
+    }
+
+    /**
+     * Default: no age filter, keep current active logs.
+     *
+     * @return default options instance
+     */
+    public static Options defaults() {
+      return new Options(null, true);
+    }
+  }
+
+  /**
+   * Inventory log candidates under known log dirs and optionally delete them.
+   *
+   * @param installRoot resolved install root (must exist)
+   * @param dryRun when true, only inventory (no deletes)
+   * @param options age / keep-current filters
+   * @return report of candidates and actions
+   * @throws IOException on walk failures that cannot be recovered
+   * @throws IllegalArgumentException if install root or options are invalid
+   */
+  public static CleanReport execute(Path installRoot, boolean dryRun, Options options)
+      throws IOException {
+    Objects.requireNonNull(options, "options");
+    Path root = InstallRootGuard.requireInstallRoot(installRoot);
+    CleanReport report = new CleanReport(COMMAND_NAME, root, dryRun);
+
+    Instant cutoff =
+        options.getOlderThan() == null ? null : Instant.now().minus(options.getOlderThan());
+
+    List<Path> candidates = new ArrayList<>();
+    for (Path logDir : InstallRootGuard.existingLogDirs(root)) {
+      walkLogDir(root, logDir, candidates, report);
+    }
+    candidates.sort(Comparator.comparing(p -> p.toString()));
+
+    for (Path candidate : candidates) {
+      processCandidate(report, root, candidate, dryRun, options.isKeepCurrent(), cutoff);
+    }
+    return report;
+  }
+
+  /**
+   * Inventory log candidates under known log dirs without recording walk failures (test helper).
+   * Does not apply age / keep-current filters — returns all allowlisted log file names found.
+   */
+  static List<Path> findLogFiles(Path root) throws IOException {
+    Path installRoot = InstallRootGuard.requireInstallRoot(root);
+    List<Path> found = new ArrayList<>();
+    for (Path logDir : InstallRootGuard.existingLogDirs(installRoot)) {
+      walkLogDir(installRoot, logDir, found, null);
+    }
+    return found;
+  }
+
+  /**
+   * Walk a single log directory tree. When {@code report} is non-null, I/O failures during the walk
+   * are appended as {@link CleanReport.EntryStatus#FAILED}.
+   */
+  static void walkLogDir(Path installRoot, Path logDir, List<Path> found, CleanReport report)
+      throws IOException {
+    Objects.requireNonNull(installRoot, "installRoot");
+    Objects.requireNonNull(logDir, "logDir");
+    Objects.requireNonNull(found, "found");
+    if (!InstallRootGuard.isUnderInstallRoot(installRoot, logDir)) {
+      return;
+    }
+    if (!Files.isDirectory(logDir)) {
+      return;
+    }
+    Files.walkFileTree(
+        logDir,
+        new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+            if (!InstallRootGuard.isUnderInstallRoot(installRoot, dir)) {
+              return FileVisitResult.SKIP_SUBTREE;
+            }
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+            if (!attrs.isRegularFile()) {
+              return FileVisitResult.CONTINUE;
+            }
+            if (!InstallRootGuard.isUnderInstallRoot(installRoot, file)) {
+              return FileVisitResult.CONTINUE;
+            }
+            Path fileName = file.getFileName();
+            if (fileName == null || !InstallRootGuard.isLogFileName(fileName.toString())) {
+              return FileVisitResult.CONTINUE;
+            }
+            found.add(file);
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult visitFileFailed(Path file, IOException exc) {
+            recordVisitFailure(report, file, exc);
+            return FileVisitResult.CONTINUE;
+          }
+        });
+  }
+
+  /** Record a walk I/O failure on the report when one is provided (package-visible for tests). */
+  static void recordVisitFailure(CleanReport report, Path file, IOException exc) {
+    if (report == null || file == null) {
+      return;
+    }
+    String detail = exc != null ? exc.getMessage() : "unknown I/O error";
+    if (detail == null || detail.isBlank()) {
+      detail = exc != null ? exc.getClass().getSimpleName() : "unknown I/O error";
+    }
+    report.add(
+        new CleanReport.Entry(file, 0L, CleanReport.EntryStatus.FAILED, "walk: " + detail));
+  }
+
+  private static void processCandidate(
+      CleanReport report,
+      Path root,
+      Path candidate,
+      boolean dryRun,
+      boolean keepCurrent,
+      Instant cutoff) {
+    Objects.requireNonNull(candidate, "candidate");
+    try {
+      InstallRootGuard.requireUnderInstallRoot(root, candidate);
+    } catch (IllegalArgumentException outside) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, 0L, CleanReport.EntryStatus.FAILED, outside.getMessage()));
+      return;
+    }
+
+    Path name = candidate.getFileName();
+    if (name == null || !InstallRootGuard.isLogFileName(name.toString())) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, 0L, CleanReport.EntryStatus.SKIPPED, "not an allowlisted log file"));
+      return;
+    }
+
+    if (keepCurrent && InstallRootGuard.isCurrentLogFileName(name.toString())) {
+      long size = sizeOrZero(candidate);
+      report.add(
+          new CleanReport.Entry(
+              candidate, size, CleanReport.EntryStatus.SKIPPED, "keep-current: active log"));
+      return;
+    }
+
+    if (cutoff != null) {
+      Instant mtime;
+      try {
+        FileTime ft = Files.getLastModifiedTime(candidate);
+        mtime = ft.toInstant();
+      } catch (IOException e) {
+        report.add(
+            new CleanReport.Entry(
+                candidate, 0L, CleanReport.EntryStatus.FAILED, "mtime: " + e.getMessage()));
+        return;
+      }
+      if (!mtime.isBefore(cutoff)) {
+        long size = sizeOrZero(candidate);
+        report.add(
+            new CleanReport.Entry(
+                candidate,
+                size,
+                CleanReport.EntryStatus.SKIPPED,
+                "newer than --older-than cutoff"));
+        return;
+      }
+    }
+
+    long size = 0L;
+    try {
+      if (Files.isRegularFile(candidate)) {
+        size = Files.size(candidate);
+      }
+    } catch (IOException e) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, 0L, CleanReport.EntryStatus.FAILED, "size: " + e.getMessage()));
+      return;
+    }
+
+    if (dryRun) {
+      report.add(
+          new CleanReport.Entry(candidate, size, CleanReport.EntryStatus.WOULD_DELETE, null));
+      return;
+    }
+
+    try {
+      // Re-check containment immediately before delete (TOCTOU-resistant enough for ops tool).
+      InstallRootGuard.requireUnderInstallRoot(root, candidate);
+      boolean deleted = Files.deleteIfExists(candidate);
+      if (deleted) {
+        report.add(new CleanReport.Entry(candidate, size, CleanReport.EntryStatus.DELETED, null));
+      } else {
+        report.add(
+            new CleanReport.Entry(
+                candidate, size, CleanReport.EntryStatus.SKIPPED, "already absent"));
+      }
+    } catch (IOException e) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, size, CleanReport.EntryStatus.FAILED, "delete: " + e.getMessage()));
+    } catch (IllegalArgumentException outside) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, size, CleanReport.EntryStatus.FAILED, outside.getMessage()));
+    }
+  }
+
+  private static long sizeOrZero(Path candidate) {
+    try {
+      if (Files.isRegularFile(candidate)) {
+        return Files.size(candidate);
+      }
+    } catch (IOException ignored) {
+      // best-effort for skip reporting
+    }
+    return 0L;
+  }
+
+  /**
+   * Parse a simple duration token for {@code --older-than}.
+   *
+   * <p>Accepted forms (case-insensitive unit): {@code &lt;digits&gt;&lt;unit&gt;} where unit is
+   * {@code s} (seconds), {@code m} (minutes), {@code h} (hours), {@code d} (days), or {@code w}
+   * (weeks). Examples: {@code 7d}, {@code 24h}, {@code 30m}, {@code 90s}, {@code 2w}.
+   *
+   * @param token duration string
+   * @return positive {@link Duration}
+   * @throws IllegalArgumentException if the token is null, empty, malformed, or non-positive
+   */
+  public static Duration parseOlderThan(String token) {
+    if (token == null || token.isBlank()) {
+      throw new IllegalArgumentException(
+          "--older-than requires a duration like 7d, 24h, 30m, 90s, or 2w");
+    }
+    String trimmed = token.trim();
+    Matcher m = DURATION_PATTERN.matcher(trimmed);
+    if (!m.matches()) {
+      throw new IllegalArgumentException(
+          "invalid --older-than duration '"
+              + token
+              + "' (expected <number><s|m|h|d|w>, e.g. 7d)");
+    }
+    long amount;
+    try {
+      amount = Long.parseLong(m.group(1));
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("invalid --older-than duration '" + token + "'", e);
+    }
+    if (amount <= 0L) {
+      throw new IllegalArgumentException("--older-than must be a positive duration");
+    }
+    char unit = m.group(2).toLowerCase(Locale.ROOT).charAt(0);
+    switch (unit) {
+      case 's':
+        return Duration.ofSeconds(amount);
+      case 'm':
+        return Duration.ofMinutes(amount);
+      case 'h':
+        return Duration.ofHours(amount);
+      case 'd':
+        return Duration.ofDays(amount);
+      case 'w':
+        return Duration.ofDays(Math.multiplyExact(amount, 7L));
+      default:
+        throw new IllegalArgumentException("invalid --older-than unit in '" + token + "'");
+    }
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanReport.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanReport.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Inventory / action report for a doctor clean command. */
+public final class CleanReport {
+
+  /** Outcome for a single inventoried path. */
+  public enum EntryStatus {
+    /** Dry-run: would delete if apply were used. */
+    WOULD_DELETE,
+    /** Apply: file was deleted. */
+    DELETED,
+    /** Intentionally not deleted (e.g. already absent). */
+    SKIPPED,
+    /** Error while sizing or deleting. */
+    FAILED
+  }
+
+  /** One file considered by a clean command. */
+  public static final class Entry {
+    private final Path path;
+    private final long sizeBytes;
+    private final EntryStatus status;
+    private final String detail;
+
+    /**
+     * @param path absolute or normalized path of the candidate
+     * @param sizeBytes size in bytes (0 if unknown / failed early)
+     * @param status outcome
+     * @param detail optional human-readable detail (may be null)
+     */
+    public Entry(Path path, long sizeBytes, EntryStatus status, String detail) {
+      this.path = Objects.requireNonNull(path, "path");
+      this.sizeBytes = sizeBytes;
+      this.status = Objects.requireNonNull(status, "status");
+      this.detail = detail;
+    }
+
+    /** @return candidate path */
+    public Path getPath() {
+      return path;
+    }
+
+    /** @return size in bytes when known */
+    public long getSizeBytes() {
+      return sizeBytes;
+    }
+
+    /** @return outcome status */
+    public EntryStatus getStatus() {
+      return status;
+    }
+
+    /** @return optional detail message, or null */
+    public String getDetail() {
+      return detail;
+    }
+  }
+
+  private final String command;
+  private final Path installRoot;
+  private final boolean dryRun;
+  private final List<Entry> entries = new ArrayList<>();
+
+  /**
+   * @param command command name (e.g. {@code clean-heap-dumps})
+   * @param installRoot resolved install root
+   * @param dryRun whether this report is from a dry-run
+   */
+  public CleanReport(String command, Path installRoot, boolean dryRun) {
+    this.command = Objects.requireNonNull(command, "command");
+    this.installRoot = Objects.requireNonNull(installRoot, "installRoot");
+    this.dryRun = dryRun;
+  }
+
+  /** Append an inventory/action entry. */
+  public void add(Entry entry) {
+    entries.add(Objects.requireNonNull(entry, "entry"));
+  }
+
+  /** @return command name */
+  public String getCommand() {
+    return command;
+  }
+
+  /** @return install root used for this run */
+  public Path getInstallRoot() {
+    return installRoot;
+  }
+
+  /** @return true if no deletes were performed */
+  public boolean isDryRun() {
+    return dryRun;
+  }
+
+  /** @return unmodifiable list of entries */
+  public List<Entry> getEntries() {
+    return Collections.unmodifiableList(entries);
+  }
+
+  /** @return number of entries (including failed/skipped) */
+  public int getCandidateCount() {
+    return entries.size();
+  }
+
+  /** @return sum of sizes for non-failed entries */
+  public long getTotalBytes() {
+    long total = 0L;
+    for (Entry e : entries) {
+      if (e.getStatus() == EntryStatus.FAILED) {
+        continue;
+      }
+      total += e.getSizeBytes();
+    }
+    return total;
+  }
+
+  /** @return count of successfully deleted entries */
+  public int getDeletedCount() {
+    int n = 0;
+    for (Entry e : entries) {
+      if (e.getStatus() == EntryStatus.DELETED) {
+        n++;
+      }
+    }
+    return n;
+  }
+
+  /** @return count of failed entries */
+  public int getFailedCount() {
+    int n = 0;
+    for (Entry e : entries) {
+      if (e.getStatus() == EntryStatus.FAILED) {
+        n++;
+      }
+    }
+    return n;
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
@@ -19,15 +19,17 @@ package com.intsof.percussioncms.doctor;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Path;
+import java.time.Duration;
 
 /**
  * CLI entry for {@code perc-doctor}.
  *
  * <pre>
- * perc-doctor [--install-root &lt;path&gt;] [--dry-run] [-v|--verbose] &lt;command&gt;
+ * perc-doctor [--install-root &lt;path&gt;] [--dry-run] [-v|--verbose]
+ *   &lt;command&gt; [command-options]
  * </pre>
  *
- * <p>Commands: {@code clean-heap-dumps}, {@code clean-install-backups}.
+ * <p>Commands: {@code clean-heap-dumps}, {@code clean-install-backups}, {@code clean-logs}.
  */
 public final class DoctorCli {
 
@@ -75,8 +77,10 @@ public final class DoctorCli {
       err.println(
           "Error: missing command. Try: "
               + CleanHeapDumpsCommand.COMMAND_NAME
-              + " or "
-              + CleanInstallBackupsCommand.COMMAND_NAME);
+              + ", "
+              + CleanInstallBackupsCommand.COMMAND_NAME
+              + ", or "
+              + CleanLogsCommand.COMMAND_NAME);
       printHelp(err);
       return EXIT_USAGE;
     }
@@ -97,12 +101,21 @@ public final class DoctorCli {
         printReport(report, parsed.verbose, out);
         return report.getFailedCount() > 0 ? EXIT_ERROR : EXIT_OK;
       }
+      if (CleanLogsCommand.COMMAND_NAME.equals(parsed.command)) {
+        CleanLogsCommand.Options options =
+            new CleanLogsCommand.Options(parsed.olderThan, parsed.keepCurrent);
+        CleanReport report = CleanLogsCommand.execute(installRoot, parsed.dryRun, options);
+        printReport(report, parsed.verbose, out);
+        return report.getFailedCount() > 0 ? EXIT_ERROR : EXIT_OK;
+      }
       err.println("Error: unknown command: " + parsed.command);
       err.println(
           "Supported commands: "
               + CleanHeapDumpsCommand.COMMAND_NAME
               + ", "
-              + CleanInstallBackupsCommand.COMMAND_NAME);
+              + CleanInstallBackupsCommand.COMMAND_NAME
+              + ", "
+              + CleanLogsCommand.COMMAND_NAME);
       printHelp(err);
       return EXIT_USAGE;
     } catch (IllegalArgumentException e) {
@@ -120,11 +133,15 @@ public final class DoctorCli {
     boolean verbose;
     boolean help;
     String command;
+    /** Optional age filter for {@code clean-logs}; null when unset. */
+    Duration olderThan;
+    /** Default true for {@code clean-logs}. */
+    boolean keepCurrent = true;
   }
 
   /**
    * Minimal argv parser (no external CLI library). Supports long options and {@code -v}/{@code
-   * -h}.
+   * -h}. Global and command-specific options may appear before or after the command token.
    */
   static ParsedArgs parseArgs(String[] args) {
     ParsedArgs parsed = new ParsedArgs();
@@ -144,6 +161,16 @@ public final class DoctorCli {
           throw new IllegalArgumentException("--install-root requires a path argument");
         }
         parsed.installRoot = args[++i];
+      } else if ("--older-than".equals(a)) {
+        if (i + 1 >= args.length) {
+          throw new IllegalArgumentException(
+              "--older-than requires a duration argument (e.g. 7d)");
+        }
+        parsed.olderThan = CleanLogsCommand.parseOlderThan(args[++i]);
+      } else if ("--keep-current".equals(a)) {
+        parsed.keepCurrent = true;
+      } else if ("--no-keep-current".equals(a)) {
+        parsed.keepCurrent = false;
       } else if (a.startsWith("-")) {
         throw new IllegalArgumentException("unknown option: " + a);
       } else if (parsed.command == null) {
@@ -156,11 +183,11 @@ public final class DoctorCli {
   }
 
   private static void printHelp(PrintStream stream) {
-    stream.println("usage: perc-doctor [options] <command>");
+    stream.println("usage: perc-doctor [options] <command> [command-options]");
     stream.println();
     stream.println(
         "CMS Doctor — safe install-tree maintenance"
-            + " (clean-heap-dumps, clean-install-backups).");
+            + " (clean-heap-dumps, clean-install-backups, clean-logs).");
     stream.println();
     stream.println("Options:");
     stream.println("  --install-root <path>  CMS install root (default: current working directory)");
@@ -173,6 +200,16 @@ public final class DoctorCli {
     stream.println(
         "  clean-install-backups  Remove allowlisted installer/upgrade backups"
             + " (*.bak, *.backup, AppServer_backup_*.zip)");
+    stream.println(
+        "  clean-logs             Remove aged logs under known Jetty/CMS/DTS log dirs");
+    stream.println();
+    stream.println("clean-logs options:");
+    stream.println(
+        "  --older-than <dur>     Only files older than duration (e.g. 7d, 24h, 30m)");
+    stream.println(
+        "  --keep-current         Never delete active current *.log/*.out (default)");
+    stream.println(
+        "  --no-keep-current      Allow deleting active current log basenames");
     stream.println();
     stream.println("Examples:");
     stream.println("  perc-doctor --install-root /opt/Percussion --dry-run clean-heap-dumps");
@@ -180,6 +217,10 @@ public final class DoctorCli {
     stream.println(
         "  perc-doctor --install-root /opt/Percussion --dry-run -v clean-install-backups");
     stream.println("  perc-doctor --install-root C:\\Percussion -v clean-install-backups");
+    stream.println(
+        "  perc-doctor --install-root /opt/Percussion --dry-run -v clean-logs --older-than 7d");
+    stream.println(
+        "  perc-doctor --install-root C:\\Percussion -v clean-logs --older-than 14d");
   }
 
   static void printReport(CleanReport report, boolean verbose, PrintStream out) {

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
@@ -90,6 +90,24 @@ public final class DoctorCli {
             ? Path.of(parsed.installRoot)
             : Path.of("").toAbsolutePath().normalize();
 
+    // clean-logs-only options: warn (do not hard-fail) when used with other commands.
+    if (parsed.olderThan != null
+        && !CleanLogsCommand.COMMAND_NAME.equals(parsed.command)) {
+      err.println(
+          "Warning: --older-than is only used by "
+              + CleanLogsCommand.COMMAND_NAME
+              + "; ignoring for "
+              + parsed.command);
+    }
+    if (parsed.keepCurrentExplicit
+        && !CleanLogsCommand.COMMAND_NAME.equals(parsed.command)) {
+      err.println(
+          "Warning: --keep-current / --no-keep-current are only used by "
+              + CleanLogsCommand.COMMAND_NAME
+              + "; ignoring for "
+              + parsed.command);
+    }
+
     try {
       if (CleanHeapDumpsCommand.COMMAND_NAME.equals(parsed.command)) {
         CleanReport report = CleanHeapDumpsCommand.execute(installRoot, parsed.dryRun);
@@ -137,6 +155,8 @@ public final class DoctorCli {
     Duration olderThan;
     /** Default true for {@code clean-logs}. */
     boolean keepCurrent = true;
+    /** True when the user passed {@code --keep-current} or {@code --no-keep-current}. */
+    boolean keepCurrentExplicit;
   }
 
   /**
@@ -169,8 +189,10 @@ public final class DoctorCli {
         parsed.olderThan = CleanLogsCommand.parseOlderThan(args[++i]);
       } else if ("--keep-current".equals(a)) {
         parsed.keepCurrent = true;
+        parsed.keepCurrentExplicit = true;
       } else if ("--no-keep-current".equals(a)) {
         parsed.keepCurrent = false;
+        parsed.keepCurrentExplicit = true;
       } else if (a.startsWith("-")) {
         throw new IllegalArgumentException("unknown option: " + a);
       } else if (parsed.command == null) {

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Path;
+
+/**
+ * CLI entry for {@code perc-doctor}.
+ *
+ * <pre>
+ * perc-doctor [--install-root &lt;path&gt;] [--dry-run] [-v|--verbose] &lt;command&gt;
+ * </pre>
+ *
+ * <p>Slice 1 command: {@code clean-heap-dumps}.
+ */
+public final class DoctorCli {
+
+  static final int EXIT_OK = 0;
+  static final int EXIT_USAGE = 2;
+  static final int EXIT_ERROR = 1;
+
+  private DoctorCli() {}
+
+  /**
+   * Process entrypoint; exits the JVM with the command result code.
+   *
+   * @param args CLI arguments
+   */
+  public static void main(String[] args) {
+    int code = run(args, System.out, System.err);
+    System.exit(code);
+  }
+
+  /**
+   * Parse args and execute; returns process exit code without calling {@link System#exit}.
+   * Exposed for tests.
+   *
+   * @param args command-line arguments (same as {@code main})
+   * @param out standard output stream
+   * @param err standard error stream
+   * @return process exit code ({@link #EXIT_OK}, {@link #EXIT_ERROR}, or {@link #EXIT_USAGE})
+   */
+  public static int run(String[] args, PrintStream out, PrintStream err) {
+    ParsedArgs parsed;
+    try {
+      parsed = parseArgs(args);
+    } catch (IllegalArgumentException e) {
+      err.println("Error: " + e.getMessage());
+      printHelp(err);
+      return EXIT_USAGE;
+    }
+
+    if (parsed.help) {
+      printHelp(out);
+      return EXIT_OK;
+    }
+
+    if (parsed.command == null || parsed.command.isEmpty()) {
+      err.println("Error: missing command. Try: clean-heap-dumps");
+      printHelp(err);
+      return EXIT_USAGE;
+    }
+
+    Path installRoot =
+        parsed.installRoot != null
+            ? Path.of(parsed.installRoot)
+            : Path.of("").toAbsolutePath().normalize();
+
+    try {
+      if (CleanHeapDumpsCommand.COMMAND_NAME.equals(parsed.command)) {
+        CleanReport report = CleanHeapDumpsCommand.execute(installRoot, parsed.dryRun);
+        printReport(report, parsed.verbose, out);
+        return report.getFailedCount() > 0 ? EXIT_ERROR : EXIT_OK;
+      }
+      err.println("Error: unknown command: " + parsed.command);
+      err.println("Supported commands (slice 1): " + CleanHeapDumpsCommand.COMMAND_NAME);
+      printHelp(err);
+      return EXIT_USAGE;
+    } catch (IllegalArgumentException e) {
+      err.println("Error: " + e.getMessage());
+      return EXIT_ERROR;
+    } catch (IOException e) {
+      err.println("Error: " + e.getMessage());
+      return EXIT_ERROR;
+    }
+  }
+
+  static final class ParsedArgs {
+    String installRoot;
+    boolean dryRun;
+    boolean verbose;
+    boolean help;
+    String command;
+  }
+
+  /**
+   * Minimal argv parser (no external CLI library). Supports long options and {@code -v}/{@code
+   * -h}.
+   */
+  static ParsedArgs parseArgs(String[] args) {
+    ParsedArgs parsed = new ParsedArgs();
+    if (args == null) {
+      return parsed;
+    }
+    for (int i = 0; i < args.length; i++) {
+      String a = args[i];
+      if ("--help".equals(a) || "-h".equals(a)) {
+        parsed.help = true;
+      } else if ("--dry-run".equals(a)) {
+        parsed.dryRun = true;
+      } else if ("--verbose".equals(a) || "-v".equals(a)) {
+        parsed.verbose = true;
+      } else if ("--install-root".equals(a)) {
+        if (i + 1 >= args.length) {
+          throw new IllegalArgumentException("--install-root requires a path argument");
+        }
+        parsed.installRoot = args[++i];
+      } else if (a.startsWith("-")) {
+        throw new IllegalArgumentException("unknown option: " + a);
+      } else if (parsed.command == null) {
+        parsed.command = a;
+      } else {
+        throw new IllegalArgumentException("unexpected argument: " + a);
+      }
+    }
+    return parsed;
+  }
+
+  private static void printHelp(PrintStream stream) {
+    stream.println("usage: perc-doctor [options] <command>");
+    stream.println();
+    stream.println("CMS Doctor — safe install-tree maintenance (slice 1: clean-heap-dumps).");
+    stream.println();
+    stream.println("Options:");
+    stream.println("  --install-root <path>  CMS install root (default: current working directory)");
+    stream.println("  --dry-run              Report only; never delete or write");
+    stream.println("  -v, --verbose          Print each candidate path and size");
+    stream.println("  -h, --help             Show usage");
+    stream.println();
+    stream.println("Commands:");
+    stream.println("  clean-heap-dumps       Remove recursive *.hprof under install root");
+    stream.println();
+    stream.println("Examples:");
+    stream.println("  perc-doctor --install-root /opt/Percussion --dry-run clean-heap-dumps");
+    stream.println("  perc-doctor --install-root C:\\Percussion -v clean-heap-dumps");
+  }
+
+  static void printReport(CleanReport report, boolean verbose, PrintStream out) {
+    out.println("command=" + report.getCommand());
+    out.println("install-root=" + report.getInstallRoot());
+    out.println("dry-run=" + report.isDryRun());
+    out.println("candidates=" + report.getCandidateCount());
+    out.println("bytes=" + report.getTotalBytes());
+    if (!report.isDryRun()) {
+      out.println("deleted=" + report.getDeletedCount());
+    }
+    out.println("failed=" + report.getFailedCount());
+    if (verbose) {
+      for (CleanReport.Entry e : report.getEntries()) {
+        String detail = e.getDetail() == null ? "" : " " + e.getDetail();
+        out.println(
+            "  " + e.getStatus() + " " + e.getSizeBytes() + " " + e.getPath() + detail);
+      }
+    } else if (report.isDryRun() && report.getCandidateCount() > 0) {
+      out.println("(use -v/--verbose for path list)");
+    }
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
@@ -27,7 +27,7 @@ import java.nio.file.Path;
  * perc-doctor [--install-root &lt;path&gt;] [--dry-run] [-v|--verbose] &lt;command&gt;
  * </pre>
  *
- * <p>Slice 1 command: {@code clean-heap-dumps}.
+ * <p>Commands: {@code clean-heap-dumps}, {@code clean-install-backups}.
  */
 public final class DoctorCli {
 
@@ -72,7 +72,11 @@ public final class DoctorCli {
     }
 
     if (parsed.command == null || parsed.command.isEmpty()) {
-      err.println("Error: missing command. Try: clean-heap-dumps");
+      err.println(
+          "Error: missing command. Try: "
+              + CleanHeapDumpsCommand.COMMAND_NAME
+              + " or "
+              + CleanInstallBackupsCommand.COMMAND_NAME);
       printHelp(err);
       return EXIT_USAGE;
     }
@@ -88,8 +92,17 @@ public final class DoctorCli {
         printReport(report, parsed.verbose, out);
         return report.getFailedCount() > 0 ? EXIT_ERROR : EXIT_OK;
       }
+      if (CleanInstallBackupsCommand.COMMAND_NAME.equals(parsed.command)) {
+        CleanReport report = CleanInstallBackupsCommand.execute(installRoot, parsed.dryRun);
+        printReport(report, parsed.verbose, out);
+        return report.getFailedCount() > 0 ? EXIT_ERROR : EXIT_OK;
+      }
       err.println("Error: unknown command: " + parsed.command);
-      err.println("Supported commands (slice 1): " + CleanHeapDumpsCommand.COMMAND_NAME);
+      err.println(
+          "Supported commands: "
+              + CleanHeapDumpsCommand.COMMAND_NAME
+              + ", "
+              + CleanInstallBackupsCommand.COMMAND_NAME);
       printHelp(err);
       return EXIT_USAGE;
     } catch (IllegalArgumentException e) {
@@ -145,7 +158,9 @@ public final class DoctorCli {
   private static void printHelp(PrintStream stream) {
     stream.println("usage: perc-doctor [options] <command>");
     stream.println();
-    stream.println("CMS Doctor — safe install-tree maintenance (slice 1: clean-heap-dumps).");
+    stream.println(
+        "CMS Doctor — safe install-tree maintenance"
+            + " (clean-heap-dumps, clean-install-backups).");
     stream.println();
     stream.println("Options:");
     stream.println("  --install-root <path>  CMS install root (default: current working directory)");
@@ -155,10 +170,16 @@ public final class DoctorCli {
     stream.println();
     stream.println("Commands:");
     stream.println("  clean-heap-dumps       Remove recursive *.hprof under install root");
+    stream.println(
+        "  clean-install-backups  Remove allowlisted installer/upgrade backups"
+            + " (*.bak, *.backup, AppServer_backup_*.zip)");
     stream.println();
     stream.println("Examples:");
     stream.println("  perc-doctor --install-root /opt/Percussion --dry-run clean-heap-dumps");
     stream.println("  perc-doctor --install-root C:\\Percussion -v clean-heap-dumps");
+    stream.println(
+        "  perc-doctor --install-root /opt/Percussion --dry-run -v clean-install-backups");
+    stream.println("  perc-doctor --install-root C:\\Percussion -v clean-install-backups");
   }
 
   static void printReport(CleanReport report, boolean verbose, PrintStream out) {

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/InstallRootGuard.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/InstallRootGuard.java
@@ -54,6 +54,9 @@ public final class InstallRootGuard {
    * absolute normalize). Does not follow the candidate as a real path (avoids requiring the file
    * to exist for the check).
    *
+   * <p>On Windows (case-insensitive FS), comparison is case-insensitive so {@code c:\percussion}
+   * matches descendants resolved as {@code C:\Percussion\...}.
+   *
    * @param installRoot install root (relative or absolute)
    * @param candidate path to test
    * @return true when {@code candidate} is under {@code installRoot}
@@ -63,7 +66,7 @@ public final class InstallRootGuard {
     Objects.requireNonNull(candidate, "candidate");
     Path root = installRoot.toAbsolutePath().normalize();
     Path path = candidate.toAbsolutePath().normalize();
-    return path.startsWith(root);
+    return pathStartsWithRoot(path, root);
   }
 
   /**
@@ -77,11 +80,35 @@ public final class InstallRootGuard {
   public static Path requireUnderInstallRoot(Path installRoot, Path candidate) {
     Path root = installRoot.toAbsolutePath().normalize();
     Path path = candidate.toAbsolutePath().normalize();
-    if (!path.startsWith(root)) {
+    if (!pathStartsWithRoot(path, root)) {
       throw new IllegalArgumentException(
           "Path is outside install root: " + path + " (root=" + root + ")");
     }
     return path;
+  }
+
+  /**
+   * Whether {@code path} is {@code root} or a descendant. Uses {@link Path#startsWith(Path)} first;
+   * on case-insensitive platforms (Windows) also compares folded path strings so mixed-case roots
+   * still match.
+   */
+  static boolean pathStartsWithRoot(Path path, Path root) {
+    if (path.startsWith(root)) {
+      return true;
+    }
+    if (!isCaseInsensitiveFileSystem()) {
+      return false;
+    }
+    // Path.startsWith is case-sensitive even on Windows; fold for containment only.
+    Path pathFolded = Path.of(path.toString().toLowerCase(Locale.ROOT));
+    Path rootFolded = Path.of(root.toString().toLowerCase(Locale.ROOT));
+    return pathFolded.startsWith(rootFolded);
+  }
+
+  /** Windows treats path comparisons as case-insensitive; other OSes stay case-sensitive. */
+  static boolean isCaseInsensitiveFileSystem() {
+    String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+    return os.contains("win");
   }
 
   /**

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/InstallRootGuard.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/InstallRootGuard.java
@@ -177,4 +177,159 @@ public final class InstallRootGuard {
     int midLen = lowerFileName.length() - prefix.length() - suffix.length();
     return midLen > 0;
   }
+
+  /**
+   * Relative log directory roots under a CMS install (portable segments joined with {@link
+   * Path#of(String, String...)}). Documented in the module README.
+   *
+   * <ul>
+   *   <li>{@code jetty/base/logs} — Jetty / CMS Log4j2 and install layout ({@code install.xml})
+   *   <li>{@code jetty/base/modules/perc-logging/logs} — Log4j2 default relative to
+   *       perc-logging module config
+   *   <li>{@code Deployment/Server/logs} — DTS / Tomcat ({@code catalina.base}/logs)
+   * </ul>
+   *
+   * <p>Missing directories are skipped at walk time (not an error).
+   */
+  public static final String[] LOG_DIR_RELATIVE = {
+    "jetty/base/logs",
+    "jetty/base/modules/perc-logging/logs",
+    "Deployment/Server/logs"
+  };
+
+  /**
+   * Resolve allowlisted log directory roots that exist under {@code installRoot}. Only existing
+   * directories that stay under the install root are returned.
+   *
+   * @param installRoot resolved install root
+   * @return list of existing log dir paths under the root (may be empty)
+   */
+  public static java.util.List<Path> existingLogDirs(Path installRoot) {
+    Objects.requireNonNull(installRoot, "installRoot");
+    Path root = installRoot.toAbsolutePath().normalize();
+    java.util.List<Path> dirs = new java.util.ArrayList<>();
+    for (String relative : LOG_DIR_RELATIVE) {
+      Path dir = resolveRelativeUnderRoot(root, relative);
+      if (dir == null) {
+        continue;
+      }
+      if (Files.isDirectory(dir) && isUnderInstallRoot(root, dir)) {
+        dirs.add(dir);
+      }
+    }
+    return dirs;
+  }
+
+  /**
+   * Join a forward-slash relative path under {@code root}. Rejects {@code ..} segments and
+   * absolute relative inputs so the result cannot escape the root via the relative string.
+   *
+   * @return resolved path under root, or null if the relative path is invalid
+   */
+  static Path resolveRelativeUnderRoot(Path root, String relativeSlashPath) {
+    if (relativeSlashPath == null || relativeSlashPath.isEmpty()) {
+      return null;
+    }
+    if (relativeSlashPath.indexOf('\\') >= 0) {
+      return null;
+    }
+    String[] parts = relativeSlashPath.split("/");
+    Path resolved = root;
+    for (String part : parts) {
+      if (part.isEmpty() || ".".equals(part)) {
+        continue;
+      }
+      if ("..".equals(part)) {
+        return null;
+      }
+      resolved = resolved.resolve(part);
+    }
+    Path normalized = resolved.toAbsolutePath().normalize();
+    if (!pathStartsWithRoot(normalized, root.toAbsolutePath().normalize())) {
+      return null;
+    }
+    return normalized;
+  }
+
+  /**
+   * Allowlisted log file name for {@code clean-logs}: ends with {@code .log}, {@code .log.gz}, or
+   * {@code .out} (e.g. {@code catalina.out}). Case-insensitive. Path separators rejected.
+   *
+   * @param fileName bare file name (not a path)
+   * @return true if the name is a log candidate
+   */
+  public static boolean isLogFileName(String fileName) {
+    if (fileName == null || fileName.isEmpty()) {
+      return false;
+    }
+    if (fileName.indexOf('/') >= 0 || fileName.indexOf('\\') >= 0) {
+      return false;
+    }
+    String lower = fileName.toLowerCase(Locale.ROOT);
+    return lower.endsWith(".log")
+        || lower.endsWith(".log.gz")
+        || lower.endsWith(".out");
+  }
+
+  /**
+   * Whether {@code fileName} is an identifiable <em>current / active</em> log that {@code
+   * --keep-current} should retain.
+   *
+   * <p>Current logs are non-compressed {@code *.log} / {@code *.out} basenames that do not embed a
+   * rolled date token ({@code yyyy-MM-dd}) and are not numbered backups like {@code name.log.1}.
+   * Examples kept: {@code server.log}, {@code catalina.log}, {@code catalina.out}. Examples not
+   * current: {@code server-2024-01-15-1.log}, {@code catalina.2024-01-15.log.gz}.
+   *
+   * @param fileName bare file name
+   * @return true if the file should be treated as the active log
+   */
+  public static boolean isCurrentLogFileName(String fileName) {
+    if (fileName == null || fileName.isEmpty()) {
+      return false;
+    }
+    if (fileName.indexOf('/') >= 0 || fileName.indexOf('\\') >= 0) {
+      return false;
+    }
+    String lower = fileName.toLowerCase(Locale.ROOT);
+    // Compressed / explicitly rolled archives are never "current active"
+    if (lower.endsWith(".gz")) {
+      return false;
+    }
+    // name.log.N style (common Tomcat / JUL rotation)
+    if (lower.matches(".*\\.log\\.\\d+$") || lower.matches(".*\\.out\\.\\d+$")) {
+      return false;
+    }
+    // Embedded ISO date token used by Log4j2 / Tomcat rolled names
+    if (containsIsoDateToken(lower)) {
+      return false;
+    }
+    return lower.endsWith(".log") || lower.endsWith(".out");
+  }
+
+  /** True when {@code lowerName} contains a {@code yyyy-MM-dd} token. */
+  static boolean containsIsoDateToken(String lowerName) {
+    if (lowerName == null || lowerName.length() < 10) {
+      return false;
+    }
+    // Lightweight scan for yyyy-mm-dd without regex overhead on every file
+    for (int i = 0; i <= lowerName.length() - 10; i++) {
+      if (isDigit(lowerName.charAt(i))
+          && isDigit(lowerName.charAt(i + 1))
+          && isDigit(lowerName.charAt(i + 2))
+          && isDigit(lowerName.charAt(i + 3))
+          && lowerName.charAt(i + 4) == '-'
+          && isDigit(lowerName.charAt(i + 5))
+          && isDigit(lowerName.charAt(i + 6))
+          && lowerName.charAt(i + 7) == '-'
+          && isDigit(lowerName.charAt(i + 8))
+          && isDigit(lowerName.charAt(i + 9))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isDigit(char c) {
+    return c >= '0' && c <= '9';
+  }
 }

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/InstallRootGuard.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/InstallRootGuard.java
@@ -129,4 +129,52 @@ public final class InstallRootGuard {
     String lower = fileName.toLowerCase(Locale.ROOT);
     return lower.endsWith(".hprof");
   }
+
+  /**
+   * Allowlisted installer / upgrade backup file name for {@code clean-install-backups}.
+   *
+   * <p>Patterns are drawn from {@code perc-distribution-tree} installer and assembly excludes —
+   * not arbitrary user globs:
+   *
+   * <ul>
+   *   <li>{@code AppServer_backup_&lt;timestamp&gt;.zip} (see {@code install.xml} {@code
+   *       zip_AppServer})
+   *   <li>any file ending with {@code .bak} (assembly / install excludes)
+   *   <li>any file ending with {@code .backup} (assembly / install excludes; includes known
+   *       {@code *.properties.backup} such as {@code Navigation.properties.backup})
+   * </ul>
+   *
+   * <p>Matching is case-insensitive. Path separators in {@code fileName} are rejected.
+   *
+   * @param fileName bare file name (not a path)
+   * @return true if the name matches an allowlisted install-backup pattern
+   */
+  public static boolean isInstallBackupFileName(String fileName) {
+    if (fileName == null || fileName.isEmpty()) {
+      return false;
+    }
+    // Reject path separators smuggled into a "name"
+    if (fileName.indexOf('/') >= 0 || fileName.indexOf('\\') >= 0) {
+      return false;
+    }
+    String lower = fileName.toLowerCase(Locale.ROOT);
+    if (lower.endsWith(".bak") || lower.endsWith(".backup")) {
+      return true;
+    }
+    // AppServer_backup_${timestamp}.zip — require non-empty timestamp segment
+    return isAppServerBackupZipName(lower);
+  }
+
+  /**
+   * {@code AppServer_backup_<timestamp>.zip} with a non-empty timestamp (case already folded).
+   */
+  static boolean isAppServerBackupZipName(String lowerFileName) {
+    final String prefix = "appserver_backup_";
+    final String suffix = ".zip";
+    if (!lowerFileName.startsWith(prefix) || !lowerFileName.endsWith(suffix)) {
+      return false;
+    }
+    int midLen = lowerFileName.length() - prefix.length() - suffix.length();
+    return midLen > 0;
+  }
 }

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/InstallRootGuard.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/InstallRootGuard.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Path-safety helpers for doctor operations. All filesystem mutations must stay under a resolved
+ * install root; paths that escape the root are rejected.
+ */
+public final class InstallRootGuard {
+
+  private InstallRootGuard() {}
+
+  /**
+   * Normalize {@code installRoot} to an absolute path and require that it exists and is a
+   * directory.
+   *
+   * @param installRoot raw install root (relative or absolute)
+   * @return absolute normalized install root
+   * @throws IllegalArgumentException if missing, not a directory, or null
+   */
+  public static Path requireInstallRoot(Path installRoot) {
+    Objects.requireNonNull(installRoot, "installRoot");
+    Path normalized = installRoot.toAbsolutePath().normalize();
+    if (!Files.exists(normalized)) {
+      throw new IllegalArgumentException("Install root does not exist: " + normalized);
+    }
+    if (!Files.isDirectory(normalized)) {
+      throw new IllegalArgumentException("Install root is not a directory: " + normalized);
+    }
+    return normalized;
+  }
+
+  /**
+   * Returns true if {@code candidate} is the install root itself or a descendant of it (after
+   * absolute normalize). Does not follow the candidate as a real path (avoids requiring the file
+   * to exist for the check).
+   *
+   * @param installRoot install root (relative or absolute)
+   * @param candidate path to test
+   * @return true when {@code candidate} is under {@code installRoot}
+   */
+  public static boolean isUnderInstallRoot(Path installRoot, Path candidate) {
+    Objects.requireNonNull(installRoot, "installRoot");
+    Objects.requireNonNull(candidate, "candidate");
+    Path root = installRoot.toAbsolutePath().normalize();
+    Path path = candidate.toAbsolutePath().normalize();
+    return path.startsWith(root);
+  }
+
+  /**
+   * Require that {@code candidate} is under {@code installRoot}.
+   *
+   * @param installRoot install root
+   * @param candidate path that must stay under the root
+   * @return absolute normalized {@code candidate}
+   * @throws IllegalArgumentException if the path escapes the install root
+   */
+  public static Path requireUnderInstallRoot(Path installRoot, Path candidate) {
+    Path root = installRoot.toAbsolutePath().normalize();
+    Path path = candidate.toAbsolutePath().normalize();
+    if (!path.startsWith(root)) {
+      throw new IllegalArgumentException(
+          "Path is outside install root: " + path + " (root=" + root + ")");
+    }
+    return path;
+  }
+
+  /**
+   * Allowlisted heap-dump file name: ends with {@code .hprof} (case-insensitive). No other
+   * extensions are accepted by {@code clean-heap-dumps}.
+   *
+   * @param fileName bare file name (not a path)
+   * @return true if the name is an allowlisted heap dump
+   */
+  public static boolean isHeapDumpFileName(String fileName) {
+    if (fileName == null || fileName.isEmpty()) {
+      return false;
+    }
+    // Reject path separators smuggled into a "name"
+    if (fileName.indexOf('/') >= 0 || fileName.indexOf('\\') >= 0) {
+      return false;
+    }
+    String lower = fileName.toLowerCase(Locale.ROOT);
+    return lower.endsWith(".hprof");
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorAdminChecker.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorAdminChecker.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+/**
+ * Host-provided admin authorization gate for the doctor HTTP API.
+ *
+ * <p>Implementations must return {@code false} for anonymous / unauthenticated callers and for
+ * authenticated non-Admin users.
+ */
+@FunctionalInterface
+public interface DoctorAdminChecker {
+
+  /**
+   * @return {@code true} only when the current request principal is an Admin user
+   */
+  boolean isCurrentUserAdmin();
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorApiService.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorApiService.java
@@ -86,12 +86,52 @@ public final class DoctorApiService {
     return DoctorReportView.from(report);
   }
 
+  /**
+   * Resolve the install root for HTTP execution.
+   *
+   * <p><strong>Security:</strong> the HTTP API never uses a client-supplied path for filesystem
+   * I/O. Optional {@link DoctorRequest#getInstallRoot()} is accepted only when it normalizes to the
+   * same absolute path as the host default; the return value is always the host-provided {@link
+   * Path} so CodeQL / runtime path-injection cannot flow from the JSON body into {@code
+   * Files.exists} / walk / delete sinks.
+   *
+   * @param body request body (non-null)
+   * @return trusted install root from {@link DoctorInstallRootProvider}
+   * @throws IllegalArgumentException if a non-blank override does not match the host root
+   */
   private Path resolveInstallRoot(DoctorRequest body) {
+    Path hostRoot =
+        Objects.requireNonNull(
+            installRootProvider.getDefaultInstallRoot(), "installRootProvider returned null");
     String explicit = body.getInstallRoot();
-    if (explicit != null && !explicit.isBlank()) {
-      return Path.of(explicit.trim());
+    if (explicit == null || explicit.isBlank()) {
+      return hostRoot;
     }
-    return installRootProvider.getDefaultInstallRoot();
+    Path requested = Path.of(explicit.trim()).toAbsolutePath().normalize();
+    Path trusted = hostRoot.toAbsolutePath().normalize();
+    if (!installRootPathsEqual(requested, trusted)) {
+      throw new IllegalArgumentException(
+          "installRoot override is not permitted for the HTTP API; omit installRoot to use the"
+              + " server install root");
+    }
+    // Always return the host Path (trusted), never Path.of(client string).
+    return hostRoot;
+  }
+
+  /**
+   * Equality of install roots after absolute normalize. On Windows, compare case-insensitively
+   * because the FS does.
+   */
+  static boolean installRootPathsEqual(Path a, Path b) {
+    if (a.equals(b)) {
+      return true;
+    }
+    // Windows path equality is case-insensitive; Path.equals is not always.
+    String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+    if (os.contains("win")) {
+      return a.toString().equalsIgnoreCase(b.toString());
+    }
+    return false;
   }
 
   /**

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorApiService.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorApiService.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+import com.intsof.percussioncms.doctor.CleanHeapDumpsCommand;
+import com.intsof.percussioncms.doctor.CleanInstallBackupsCommand;
+import com.intsof.percussioncms.doctor.CleanLogsCommand;
+import com.intsof.percussioncms.doctor.CleanReport;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Executes doctor clean commands for the HTTP API. Reuses the same command implementations as the
+ * CLI ({@link CleanHeapDumpsCommand}, {@link CleanInstallBackupsCommand}, {@link
+ * CleanLogsCommand}).
+ *
+ * <p>Authorization is enforced by the caller ({@link DoctorRestService}); this class only runs
+ * commands.
+ */
+public final class DoctorApiService {
+
+  private final DoctorInstallRootProvider installRootProvider;
+
+  /**
+   * @param installRootProvider default install root when the request omits {@code installRoot}
+   */
+  public DoctorApiService(DoctorInstallRootProvider installRootProvider) {
+    this.installRootProvider =
+        Objects.requireNonNull(installRootProvider, "installRootProvider");
+  }
+
+  /**
+   * Run a doctor command and return a JSON-friendly report.
+   *
+   * @param command CLI command token (e.g. {@code clean-heap-dumps})
+   * @param request body; null treated as empty request (dry-run default)
+   * @return structured report
+   * @throws DoctorUnknownCommandException if the command is not supported
+   * @throws IllegalArgumentException if options or install root are invalid
+   * @throws IOException on unrecoverable walk failures
+   */
+  public DoctorReportView execute(String command, DoctorRequest request)
+      throws IOException, DoctorUnknownCommandException {
+    DoctorRequest body = request != null ? request : new DoctorRequest();
+    String cmd = command == null ? "" : command.trim();
+    if (cmd.isEmpty()) {
+      throw new DoctorUnknownCommandException("(empty)");
+    }
+
+    Path installRoot = resolveInstallRoot(body);
+    boolean dryRun = body.isEffectiveDryRun();
+
+    CleanReport report;
+    if (CleanHeapDumpsCommand.COMMAND_NAME.equals(cmd)) {
+      report = CleanHeapDumpsCommand.execute(installRoot, dryRun);
+    } else if (CleanInstallBackupsCommand.COMMAND_NAME.equals(cmd)) {
+      report = CleanInstallBackupsCommand.execute(installRoot, dryRun);
+    } else if (CleanLogsCommand.COMMAND_NAME.equals(cmd)) {
+      Duration olderThan = null;
+      if (body.getOlderThan() != null && !body.getOlderThan().isBlank()) {
+        olderThan = CleanLogsCommand.parseOlderThan(body.getOlderThan().trim());
+      }
+      CleanLogsCommand.Options options =
+          new CleanLogsCommand.Options(olderThan, body.isEffectiveKeepCurrent());
+      report = CleanLogsCommand.execute(installRoot, dryRun, options);
+    } else {
+      throw new DoctorUnknownCommandException(cmd);
+    }
+    return DoctorReportView.from(report);
+  }
+
+  private Path resolveInstallRoot(DoctorRequest body) {
+    String explicit = body.getInstallRoot();
+    if (explicit != null && !explicit.isBlank()) {
+      return Path.of(explicit.trim());
+    }
+    return installRootProvider.getDefaultInstallRoot();
+  }
+
+  /**
+   * Normalize a path-style command token to the CLI form if callers use underscores or mixed case.
+   * Currently the API expects the same tokens as the CLI (lowercase with hyphens).
+   *
+   * @param command raw path segment
+   * @return trimmed command token
+   */
+  public static String normalizeCommand(String command) {
+    if (command == null) {
+      return "";
+    }
+    return command.trim().toLowerCase(Locale.ROOT);
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorInstallRootProvider.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorInstallRootProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+import java.nio.file.Path;
+
+/**
+ * Supplies the default CMS install root when a doctor request omits {@code installRoot}.
+ *
+ * <p>Server hosts typically resolve {@code rxdeploydir} / RX install directory. CLI does not use
+ * this interface.
+ */
+@FunctionalInterface
+public interface DoctorInstallRootProvider {
+
+  /**
+   * @return absolute install root path; never null
+   * @throws IllegalStateException if the host cannot resolve an install root
+   */
+  Path getDefaultInstallRoot();
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorReportView.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorReportView.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+import com.intsof.percussioncms.doctor.CleanReport;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * JSON-serializable structured report matching CLI clean command output ({@link CleanReport}).
+ *
+ * <p>Paths are absolute path strings for portable JSON (no {@link java.nio.file.Path} type).
+ */
+public class DoctorReportView {
+
+  /** One inventoried / acted-on file. */
+  public static class EntryView {
+    private String path;
+    private long sizeBytes;
+    private String status;
+    private String detail;
+
+    public EntryView() {}
+
+    public EntryView(String path, long sizeBytes, String status, String detail) {
+      this.path = path;
+      this.sizeBytes = sizeBytes;
+      this.status = status;
+      this.detail = detail;
+    }
+
+    public String getPath() {
+      return path;
+    }
+
+    public void setPath(String path) {
+      this.path = path;
+    }
+
+    public long getSizeBytes() {
+      return sizeBytes;
+    }
+
+    public void setSizeBytes(long sizeBytes) {
+      this.sizeBytes = sizeBytes;
+    }
+
+    public String getStatus() {
+      return status;
+    }
+
+    public void setStatus(String status) {
+      this.status = status;
+    }
+
+    public String getDetail() {
+      return detail;
+    }
+
+    public void setDetail(String detail) {
+      this.detail = detail;
+    }
+  }
+
+  private String command;
+  private String installRoot;
+  private boolean dryRun;
+  private int candidateCount;
+  private int deletedCount;
+  private int failedCount;
+  private long totalBytes;
+  private List<EntryView> entries = new ArrayList<>();
+
+  public DoctorReportView() {}
+
+  /**
+   * Convert a CLI {@link CleanReport} into a JSON view.
+   *
+   * @param report command report; never null
+   * @return view for REST response
+   */
+  public static DoctorReportView from(CleanReport report) {
+    Objects.requireNonNull(report, "report");
+    DoctorReportView view = new DoctorReportView();
+    view.command = report.getCommand();
+    view.installRoot = report.getInstallRoot().toString();
+    view.dryRun = report.isDryRun();
+    view.candidateCount = report.getCandidateCount();
+    view.deletedCount = report.getDeletedCount();
+    view.failedCount = report.getFailedCount();
+    view.totalBytes = report.getTotalBytes();
+    List<EntryView> list = new ArrayList<>();
+    for (CleanReport.Entry e : report.getEntries()) {
+      list.add(
+          new EntryView(
+              e.getPath().toString(),
+              e.getSizeBytes(),
+              e.getStatus().name(),
+              e.getDetail()));
+    }
+    view.entries = list;
+    return view;
+  }
+
+  public String getCommand() {
+    return command;
+  }
+
+  public void setCommand(String command) {
+    this.command = command;
+  }
+
+  public String getInstallRoot() {
+    return installRoot;
+  }
+
+  public void setInstallRoot(String installRoot) {
+    this.installRoot = installRoot;
+  }
+
+  public boolean isDryRun() {
+    return dryRun;
+  }
+
+  public void setDryRun(boolean dryRun) {
+    this.dryRun = dryRun;
+  }
+
+  public int getCandidateCount() {
+    return candidateCount;
+  }
+
+  public void setCandidateCount(int candidateCount) {
+    this.candidateCount = candidateCount;
+  }
+
+  public int getDeletedCount() {
+    return deletedCount;
+  }
+
+  public void setDeletedCount(int deletedCount) {
+    this.deletedCount = deletedCount;
+  }
+
+  public int getFailedCount() {
+    return failedCount;
+  }
+
+  public void setFailedCount(int failedCount) {
+    this.failedCount = failedCount;
+  }
+
+  public long getTotalBytes() {
+    return totalBytes;
+  }
+
+  public void setTotalBytes(long totalBytes) {
+    this.totalBytes = totalBytes;
+  }
+
+  public List<EntryView> getEntries() {
+    return entries == null ? Collections.emptyList() : entries;
+  }
+
+  public void setEntries(List<EntryView> entries) {
+    this.entries = entries;
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorRequest.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorRequest.java
@@ -32,8 +32,10 @@ public class DoctorRequest {
   private Boolean dryRun;
 
   /**
-   * Optional CMS install root. When blank/null, the host supplies the server install root
-   * ({@code rxdeploydir} / resolved RX dir).
+   * Optional CMS install root string. When blank/null, the host supplies the server install root
+   * ({@code rxdeploydir} / resolved RX dir). When non-blank, the HTTP API accepts it only if it
+   * normalizes to the same path as the host default; filesystem I/O always uses the host-provided
+   * path (never a client-constructed path) to prevent path injection.
    */
   private String installRoot;
 

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorRequest.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorRequest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+/**
+ * JSON body for {@code POST .../doctor/{command}}.
+ *
+ * <p><strong>Dry-run default:</strong> when {@link #dryRun} is {@code null} or omitted, the API
+ * treats the request as a dry-run ({@code true}). Explicit apply requires {@code "dryRun": false}.
+ * This is the safer default for an admin HTTP surface that can delete install-tree files.
+ */
+public class DoctorRequest {
+
+  /**
+   * When {@code true} or omitted/null, inventory only (no deletes). When {@code false}, perform
+   * deletes after inventory.
+   */
+  private Boolean dryRun;
+
+  /**
+   * Optional CMS install root. When blank/null, the host supplies the server install root
+   * ({@code rxdeploydir} / resolved RX dir).
+   */
+  private String installRoot;
+
+  /**
+   * Optional age filter for {@code clean-logs} only (e.g. {@code 7d}, {@code 24h}). Ignored by
+   * other commands.
+   */
+  private String olderThan;
+
+  /**
+   * Optional keep-current flag for {@code clean-logs}. When null, defaults to {@code true} (same as
+   * CLI).
+   */
+  private Boolean keepCurrent;
+
+  /** @return dry-run flag as sent by client; may be null */
+  public Boolean getDryRun() {
+    return dryRun;
+  }
+
+  /** @param dryRun dry-run flag; null means default true */
+  public void setDryRun(Boolean dryRun) {
+    this.dryRun = dryRun;
+  }
+
+  /**
+   * Effective dry-run: {@code true} when the field is null or true.
+   *
+   * @return whether this request must not delete
+   */
+  public boolean isEffectiveDryRun() {
+    return dryRun == null || Boolean.TRUE.equals(dryRun);
+  }
+
+  /** @return optional install root path string */
+  public String getInstallRoot() {
+    return installRoot;
+  }
+
+  /** @param installRoot optional install root */
+  public void setInstallRoot(String installRoot) {
+    this.installRoot = installRoot;
+  }
+
+  /** @return optional older-than duration token for clean-logs */
+  public String getOlderThan() {
+    return olderThan;
+  }
+
+  /** @param olderThan optional duration token */
+  public void setOlderThan(String olderThan) {
+    this.olderThan = olderThan;
+  }
+
+  /** @return keep-current flag; may be null */
+  public Boolean getKeepCurrent() {
+    return keepCurrent;
+  }
+
+  /** @param keepCurrent keep-current flag for clean-logs */
+  public void setKeepCurrent(Boolean keepCurrent) {
+    this.keepCurrent = keepCurrent;
+  }
+
+  /**
+   * Effective keep-current for clean-logs: defaults to {@code true} when null.
+   *
+   * @return whether active current logs are retained
+   */
+  public boolean isEffectiveKeepCurrent() {
+    return keepCurrent == null || Boolean.TRUE.equals(keepCurrent);
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorRestService.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorRestService.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Admin-only HTTP mirror of the perc-doctor CLI.
+ *
+ * <p>Mounted by the host under the maintenance JAX-RS server, e.g. {@code
+ * POST /Rhythmyx/services/maintenance/doctor/{command}} with JSON body {@link DoctorRequest}.
+ *
+ * <p><strong>Hard gate:</strong> only Admin users may invoke any command. Anonymous and non-admin
+ * callers receive HTTP 403.
+ *
+ * <p><strong>Dry-run default:</strong> omitted or null {@code dryRun} is treated as {@code true}
+ * (report only; no deletes). Apply requires explicit {@code "dryRun": false}.
+ */
+@Path("/doctor")
+public class DoctorRestService {
+
+  private final DoctorAdminChecker adminChecker;
+  private final DoctorApiService apiService;
+
+  /**
+   * @param adminChecker host admin gate; never null
+   * @param installRootProvider default install root when request omits it; never null
+   */
+  public DoctorRestService(
+      DoctorAdminChecker adminChecker, DoctorInstallRootProvider installRootProvider) {
+    this(
+        adminChecker,
+        new DoctorApiService(Objects.requireNonNull(installRootProvider, "installRootProvider")));
+  }
+
+  /**
+   * Package-visible for tests that inject a custom {@link DoctorApiService}.
+   *
+   * @param adminChecker host admin gate
+   * @param apiService command runner
+   */
+  DoctorRestService(DoctorAdminChecker adminChecker, DoctorApiService apiService) {
+    this.adminChecker = Objects.requireNonNull(adminChecker, "adminChecker");
+    this.apiService = Objects.requireNonNull(apiService, "apiService");
+  }
+
+  /**
+   * Execute a doctor command.
+   *
+   * @param command CLI command token ({@code clean-heap-dumps}, {@code clean-install-backups},
+   *     {@code clean-logs})
+   * @param request JSON body; may be null (treated as empty dry-run request)
+   * @return structured report (same fields as CLI inventory/action report)
+   */
+  @POST
+  @Path("/{command}")
+  @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+  public DoctorReportView runCommand(
+      @PathParam("command") String command, DoctorRequest request) {
+    requireAdmin();
+
+    String normalized = DoctorApiService.normalizeCommand(command);
+    try {
+      return apiService.execute(normalized, request);
+    } catch (DoctorUnknownCommandException e) {
+      throw new WebApplicationException(
+          Response.status(Response.Status.NOT_FOUND)
+              .entity("Unknown doctor command: " + safeCommand(normalized))
+              .type(MediaType.TEXT_PLAIN)
+              .build());
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(
+          Response.status(Response.Status.BAD_REQUEST)
+              .entity("Invalid doctor request: " + safeMessage(e))
+              .type(MediaType.TEXT_PLAIN)
+              .build());
+    } catch (IOException e) {
+      throw new WebApplicationException(
+          Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+              .entity("Doctor command failed.")
+              .type(MediaType.TEXT_PLAIN)
+              .build());
+    }
+  }
+
+  private void requireAdmin() {
+    boolean admin;
+    try {
+      admin = adminChecker.isCurrentUserAdmin();
+    } catch (RuntimeException e) {
+      // Treat auth resolution failures as forbidden (do not leak internals).
+      throw forbidden();
+    }
+    if (!admin) {
+      throw forbidden();
+    }
+  }
+
+  private static WebApplicationException forbidden() {
+    return new WebApplicationException(
+        Response.status(Response.Status.FORBIDDEN)
+            .entity("Only Admin users may run doctor commands.")
+            .type(MediaType.TEXT_PLAIN)
+            .build());
+  }
+
+  private static String safeCommand(String command) {
+    if (command == null || command.isBlank()) {
+      return "(empty)";
+    }
+    // Bound length so a crafted path segment cannot flood logs/responses.
+    String c = command.trim();
+    return c.length() > 64 ? c.substring(0, 64) : c;
+  }
+
+  private static String safeMessage(IllegalArgumentException e) {
+    String msg = e.getMessage();
+    if (msg == null || msg.isBlank()) {
+      return "bad request";
+    }
+    // Avoid leaking raw paths in overly long messages.
+    return msg.length() > 200 ? msg.substring(0, 200) : msg;
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorUnknownCommandException.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorUnknownCommandException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+/** Thrown when the doctor HTTP API receives an unsupported command token. */
+public class DoctorUnknownCommandException extends Exception {
+
+  private final String command;
+
+  /**
+   * @param command the unsupported command token
+   */
+  public DoctorUnknownCommandException(String command) {
+    super("Unknown doctor command: " + command);
+    this.command = command;
+  }
+
+  /** @return the unsupported command token */
+  public String getCommand() {
+    return command;
+  }
+}

--- a/modules/perc-doctor/src/main/scripts/perc-doctor
+++ b/modules/perc-doctor/src/main/scripts/perc-doctor
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Intersoft Data Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Operator launcher for perc-doctor on Unix-like hosts.
+# Layout (CMS install or dist zip):
+#   <install-root>/bin/perc-doctor
+#   <install-root>/bin/perc-doctor.jar
+#
+# Default --install-root is the parent of this script's directory (the install
+# root). Operators may still pass --install-root explicitly to override.
+# Never hardcodes a user home path.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+JAR="${SCRIPT_DIR}/perc-doctor.jar"
+
+if [[ ! -f "${JAR}" ]]; then
+  echo "perc-doctor: jar not found at ${JAR}" >&2
+  echo "Expected layout: <install-root>/bin/perc-doctor.jar next to this script." >&2
+  exit 1
+fi
+
+if [[ -n "${JAVA_HOME:-}" && -x "${JAVA_HOME}/bin/java" ]]; then
+  JAVA="${JAVA_HOME}/bin/java"
+elif command -v java >/dev/null 2>&1; then
+  JAVA="$(command -v java)"
+else
+  echo "perc-doctor: java not found. Set JAVA_HOME (JDK 21+) or put java on PATH." >&2
+  exit 1
+fi
+
+has_install_root=0
+for arg in "$@"; do
+  if [[ "${arg}" == "--install-root" ]]; then
+    has_install_root=1
+    break
+  fi
+done
+
+if [[ "${has_install_root}" -eq 0 ]]; then
+  exec "${JAVA}" -jar "${JAR}" --install-root "${INSTALL_ROOT}" "$@"
+else
+  exec "${JAVA}" -jar "${JAR}" "$@"
+fi

--- a/modules/perc-doctor/src/main/scripts/perc-doctor.bat
+++ b/modules/perc-doctor/src/main/scripts/perc-doctor.bat
@@ -1,0 +1,64 @@
+@echo off
+REM Copyright (c) 2026 Intersoft Data Labs, Inc.
+REM
+REM Licensed under the Apache License, Version 2.0 (the "License");
+REM you may not use this file except in compliance with the License.
+REM You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+REM
+REM Operator launcher for perc-doctor on Windows.
+REM Layout (CMS install or dist zip):
+REM   <install-root>\bin\perc-doctor.bat
+REM   <install-root>\bin\perc-doctor.jar
+REM
+REM Default --install-root is the parent of this script's directory (the install
+REM root). Operators may still pass --install-root explicitly to override.
+REM Never hardcodes a user home path.
+
+setlocal EnableExtensions EnableDelayedExpansion
+
+set "SCRIPT_DIR=%~dp0"
+if "%SCRIPT_DIR:~-1%"=="\" set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+for %%I in ("%SCRIPT_DIR%\..") do set "INSTALL_ROOT=%%~fI"
+set "JAR=%SCRIPT_DIR%\perc-doctor.jar"
+
+if not exist "%JAR%" (
+  echo perc-doctor: jar not found at %JAR% 1>&2
+  echo Expected layout: ^<install-root^>\bin\perc-doctor.jar next to this script. 1>&2
+  exit /b 1
+)
+
+set "JAVA_EXE="
+if defined JAVA_HOME (
+  if exist "%JAVA_HOME%\bin\java.exe" set "JAVA_EXE=%JAVA_HOME%\bin\java.exe"
+)
+if not defined JAVA_EXE (
+  where java >nul 2>&1
+  if not errorlevel 1 (
+    set "JAVA_EXE=java"
+  )
+)
+if not defined JAVA_EXE (
+  echo perc-doctor: java not found. Set JAVA_HOME ^(JDK 21+^) or put java on PATH. 1>&2
+  exit /b 1
+)
+
+set "HAS_INSTALL_ROOT=0"
+for %%A in (%*) do (
+  if /I "%%~A"=="--install-root" set "HAS_INSTALL_ROOT=1"
+)
+
+if "%HAS_INSTALL_ROOT%"=="0" (
+  "%JAVA_EXE%" -jar "%JAR%" --install-root "%INSTALL_ROOT%" %*
+) else (
+  "%JAVA_EXE%" -jar "%JAR%" %*
+)
+set "EXIT_CODE=%ERRORLEVEL%"
+endlocal & exit /b %EXIT_CODE%

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CleanHeapDumpsCommandTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CleanHeapDumpsCommandTest.java
@@ -121,4 +121,26 @@ class CleanHeapDumpsCommandTest {
     assertTrue(Files.exists(bak));
     assertTrue(Files.exists(txt));
   }
+
+  @Test
+  void visitFileFailedRecordsFailedEntryOnReport() {
+    CleanReport report = new CleanReport(CleanHeapDumpsCommand.COMMAND_NAME, installRoot, true);
+    Path failed = installRoot.resolve("unreadable.hprof");
+    CleanHeapDumpsCommand.recordVisitFailure(
+        report, failed, new java.io.IOException("Access denied"));
+
+    assertEquals(1, report.getFailedCount());
+    CleanReport.Entry e = report.getEntries().get(0);
+    assertEquals(CleanReport.EntryStatus.FAILED, e.getStatus());
+    assertEquals(failed, e.getPath());
+    assertTrue(e.getDetail().contains("walk:"));
+    assertTrue(e.getDetail().toLowerCase().contains("access denied"));
+  }
+
+  @Test
+  void recordVisitFailureNoopsWhenReportNull() {
+    // Should not throw when inventory-only walk has no report
+    CleanHeapDumpsCommand.recordVisitFailure(
+        null, installRoot.resolve("x.hprof"), new java.io.IOException("x"));
+  }
 }

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CleanHeapDumpsCommandTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CleanHeapDumpsCommandTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CleanHeapDumpsCommandTest {
+
+  @TempDir Path tempDir;
+
+  private Path installRoot;
+  private Path nestedDump;
+  private Path rootDump;
+  private Path logFile;
+  private Path outsideDump;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    installRoot = Files.createDirectories(tempDir.resolve("cms-install"));
+    Path jetty = Files.createDirectories(installRoot.resolve("jetty").resolve("base"));
+    nestedDump = jetty.resolve("java_pid4242.hprof");
+    rootDump = installRoot.resolve("crash.hprof");
+    logFile = installRoot.resolve("server.log");
+    Files.write(nestedDump, "HEAPNEST".getBytes(StandardCharsets.UTF_8));
+    Files.write(rootDump, "HEAPROOT".getBytes(StandardCharsets.UTF_8));
+    Files.writeString(logFile, "not a dump");
+
+    Path outside = Files.createDirectories(tempDir.resolve("not-install"));
+    outsideDump = outside.resolve("outside.hprof");
+    Files.write(outsideDump, "OUTSIDE".getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void dryRunInventoriesOnlyAllowlistedHprofUnderRootAndDoesNotDelete() throws Exception {
+    CleanReport report = CleanHeapDumpsCommand.execute(installRoot, true);
+
+    assertTrue(report.isDryRun());
+    assertEquals(2, report.getCandidateCount());
+    assertEquals(0, report.getDeletedCount());
+    assertTrue(Files.exists(nestedDump));
+    assertTrue(Files.exists(rootDump));
+    assertTrue(Files.exists(logFile));
+    assertTrue(Files.exists(outsideDump));
+
+    for (CleanReport.Entry e : report.getEntries()) {
+      assertEquals(CleanReport.EntryStatus.WOULD_DELETE, e.getStatus());
+      assertTrue(InstallRootGuard.isUnderInstallRoot(installRoot, e.getPath()));
+      assertTrue(InstallRootGuard.isHeapDumpFileName(e.getPath().getFileName().toString()));
+    }
+
+    long expectedBytes =
+        Files.size(nestedDump) + Files.size(rootDump);
+    assertEquals(expectedBytes, report.getTotalBytes());
+  }
+
+  @Test
+  void applyDeletesHprofUnderRootOnlyLeavesOtherFiles() throws Exception {
+    CleanReport report = CleanHeapDumpsCommand.execute(installRoot, false);
+
+    assertFalse(report.isDryRun());
+    assertEquals(2, report.getDeletedCount());
+    assertEquals(0, report.getFailedCount());
+    assertFalse(Files.exists(nestedDump));
+    assertFalse(Files.exists(rootDump));
+    assertTrue(Files.exists(logFile), "non-hprof must not be deleted");
+    assertTrue(Files.exists(outsideDump), "files outside install root must not be deleted");
+  }
+
+  @Test
+  void findHeapDumpsDoesNotIncludeOutsideInstallRoot() throws Exception {
+    List<Path> found = CleanHeapDumpsCommand.findHeapDumps(installRoot);
+    assertEquals(2, found.size());
+    for (Path p : found) {
+      assertTrue(InstallRootGuard.isUnderInstallRoot(installRoot, p));
+      assertFalse(p.equals(outsideDump));
+    }
+  }
+
+  @Test
+  void executeRejectsMissingInstallRoot() {
+    Path missing = tempDir.resolve("missing-root");
+    assertThrows(IllegalArgumentException.class, () -> CleanHeapDumpsCommand.execute(missing, true));
+  }
+
+  @Test
+  void allowlistSkipsNonHprofExtensions() throws Exception {
+    Path bak = installRoot.resolve("java_pid1.hprof.bak");
+    Path txt = installRoot.resolve("notes.txt");
+    Files.writeString(bak, "bak");
+    Files.writeString(txt, "txt");
+
+    CleanReport dry = CleanHeapDumpsCommand.execute(installRoot, true);
+    assertEquals(2, dry.getCandidateCount());
+
+    CleanHeapDumpsCommand.execute(installRoot, false);
+    assertTrue(Files.exists(bak));
+    assertTrue(Files.exists(txt));
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CleanInstallBackupsCommandTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CleanInstallBackupsCommandTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CleanInstallBackupsCommandTest {
+
+  @TempDir Path tempDir;
+
+  private Path installRoot;
+  private Path appServerZip;
+  private Path bakFile;
+  private Path backupFile;
+  private Path propertiesBackup;
+  private Path keepLog;
+  private Path outsideBak;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    installRoot = Files.createDirectories(tempDir.resolve("cms-install"));
+    Path rxconfig = Files.createDirectories(installRoot.resolve("rxconfig").resolve("Server"));
+
+    appServerZip = installRoot.resolve("AppServer_backup_20240115_120000.zip");
+    bakFile = installRoot.resolve("ResourceBundle.tmx.bak");
+    backupFile = installRoot.resolve("misc.config.backup");
+    propertiesBackup = rxconfig.resolve("Navigation.properties.backup");
+    keepLog = installRoot.resolve("server.log");
+
+    Files.write(appServerZip, "ZIP".getBytes(StandardCharsets.UTF_8));
+    Files.writeString(bakFile, "bak");
+    Files.writeString(backupFile, "backup");
+    Files.writeString(propertiesBackup, "nav-backup");
+    Files.writeString(keepLog, "active log");
+
+    Path outside = Files.createDirectories(tempDir.resolve("not-install"));
+    outsideBak = outside.resolve("escape.bak");
+    Files.writeString(outsideBak, "outside");
+  }
+
+  @Test
+  void dryRunInventoriesAllowlistedBackupsOnlyAndDoesNotDelete() throws Exception {
+    CleanReport report = CleanInstallBackupsCommand.execute(installRoot, true);
+
+    assertTrue(report.isDryRun());
+    assertEquals(4, report.getCandidateCount());
+    assertEquals(0, report.getDeletedCount());
+    assertTrue(Files.exists(appServerZip));
+    assertTrue(Files.exists(bakFile));
+    assertTrue(Files.exists(backupFile));
+    assertTrue(Files.exists(propertiesBackup));
+    assertTrue(Files.exists(keepLog));
+    assertTrue(Files.exists(outsideBak));
+
+    for (CleanReport.Entry e : report.getEntries()) {
+      assertEquals(CleanReport.EntryStatus.WOULD_DELETE, e.getStatus());
+      assertTrue(InstallRootGuard.isUnderInstallRoot(installRoot, e.getPath()));
+      assertTrue(
+          InstallRootGuard.isInstallBackupFileName(e.getPath().getFileName().toString()));
+    }
+
+    long expectedBytes =
+        Files.size(appServerZip)
+            + Files.size(bakFile)
+            + Files.size(backupFile)
+            + Files.size(propertiesBackup);
+    assertEquals(expectedBytes, report.getTotalBytes());
+  }
+
+  @Test
+  void applyDeletesAllowlistedBackupsUnderRootOnlyLeavesOtherFiles() throws Exception {
+    CleanReport report = CleanInstallBackupsCommand.execute(installRoot, false);
+
+    assertFalse(report.isDryRun());
+    assertEquals(4, report.getDeletedCount());
+    assertEquals(0, report.getFailedCount());
+    assertFalse(Files.exists(appServerZip));
+    assertFalse(Files.exists(bakFile));
+    assertFalse(Files.exists(backupFile));
+    assertFalse(Files.exists(propertiesBackup));
+    assertTrue(Files.exists(keepLog), "non-backup files must not be deleted");
+    assertTrue(Files.exists(outsideBak), "files outside install root must not be deleted");
+  }
+
+  @Test
+  void findInstallBackupsDoesNotIncludeOutsideInstallRoot() throws Exception {
+    List<Path> found = CleanInstallBackupsCommand.findInstallBackups(installRoot);
+    assertEquals(4, found.size());
+    for (Path p : found) {
+      assertTrue(InstallRootGuard.isUnderInstallRoot(installRoot, p));
+      assertFalse(p.equals(outsideBak));
+    }
+  }
+
+  @Test
+  void executeRejectsMissingInstallRoot() {
+    Path missing = tempDir.resolve("missing-root");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> CleanInstallBackupsCommand.execute(missing, true));
+  }
+
+  @Test
+  void allowlistRejectsNonBackupNamesAndHeapDumps() throws Exception {
+    Path hprof = installRoot.resolve("java_pid1.hprof");
+    Path txt = installRoot.resolve("notes.txt");
+    Path emptyZip = installRoot.resolve("AppServer_backup_.zip");
+    Path wrongPrefix = installRoot.resolve("OtherServer_backup_1.zip");
+    Files.writeString(hprof, "heap");
+    Files.writeString(txt, "txt");
+    Files.writeString(emptyZip, "bad");
+    Files.writeString(wrongPrefix, "bad");
+
+    CleanReport dry = CleanInstallBackupsCommand.execute(installRoot, true);
+    // still only the 4 allowlisted fixtures from setUp
+    assertEquals(4, dry.getCandidateCount());
+
+    CleanInstallBackupsCommand.execute(installRoot, false);
+    assertTrue(Files.exists(hprof));
+    assertTrue(Files.exists(txt));
+    assertTrue(Files.exists(emptyZip));
+    assertTrue(Files.exists(wrongPrefix));
+  }
+
+  @Test
+  void visitFileFailedRecordsFailedEntryOnReport() {
+    CleanReport report =
+        new CleanReport(CleanInstallBackupsCommand.COMMAND_NAME, installRoot, true);
+    Path failed = installRoot.resolve("unreadable.bak");
+    CleanInstallBackupsCommand.recordVisitFailure(
+        report, failed, new java.io.IOException("Access denied"));
+
+    assertEquals(1, report.getFailedCount());
+    CleanReport.Entry e = report.getEntries().get(0);
+    assertEquals(CleanReport.EntryStatus.FAILED, e.getStatus());
+    assertEquals(failed, e.getPath());
+    assertTrue(e.getDetail().contains("walk:"));
+    assertTrue(e.getDetail().toLowerCase().contains("access denied"));
+  }
+
+  @Test
+  void recordVisitFailureNoopsWhenReportNull() {
+    CleanInstallBackupsCommand.recordVisitFailure(
+        null, installRoot.resolve("x.bak"), new java.io.IOException("x"));
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CleanLogsCommandTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CleanLogsCommandTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CleanLogsCommandTest {
+
+  @TempDir Path tempDir;
+
+  private Path installRoot;
+  private Path jettyLogs;
+  private Path dtsLogs;
+  private Path serverLog;
+  private Path rolledServerLog;
+  private Path oldRolledLog;
+  private Path catalinaGz;
+  private Path outsideLog;
+  private Path nonLogInLogDir;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    installRoot = Files.createDirectories(tempDir.resolve("cms-install"));
+    jettyLogs =
+        Files.createDirectories(
+            installRoot.resolve("jetty").resolve("base").resolve("logs"));
+    dtsLogs =
+        Files.createDirectories(
+            installRoot.resolve("Deployment").resolve("Server").resolve("logs"));
+
+    serverLog = jettyLogs.resolve("server.log");
+    rolledServerLog = jettyLogs.resolve("server-2024-01-15-1.log");
+    oldRolledLog = jettyLogs.resolve("server-2023-06-01-1.log");
+    catalinaGz = dtsLogs.resolve("catalina.2024-01-10.log.gz");
+    nonLogInLogDir = jettyLogs.resolve("readme.txt");
+
+    Files.writeString(serverLog, "active-server");
+    Files.writeString(rolledServerLog, "rolled-recent");
+    Files.writeString(oldRolledLog, "rolled-old");
+    Files.write(catalinaGz, new byte[] {(byte) 0x1f, (byte) 0x8b});
+    Files.writeString(nonLogInLogDir, "not-a-log");
+
+    // Make old rolled file aged beyond 7d; leave rolledServerLog "recent"
+    Instant now = Instant.now();
+    Files.setLastModifiedTime(oldRolledLog, FileTime.from(now.minus(Duration.ofDays(30))));
+    Files.setLastModifiedTime(rolledServerLog, FileTime.from(now.minus(Duration.ofHours(2))));
+    Files.setLastModifiedTime(catalinaGz, FileTime.from(now.minus(Duration.ofDays(20))));
+    Files.setLastModifiedTime(serverLog, FileTime.from(now.minus(Duration.ofDays(40))));
+
+    Path outside = Files.createDirectories(tempDir.resolve("not-install").resolve("logs"));
+    outsideLog = outside.resolve("escape.log");
+    Files.writeString(outsideLog, "outside");
+    Files.setLastModifiedTime(outsideLog, FileTime.from(now.minus(Duration.ofDays(40))));
+  }
+
+  @Test
+  void dryRunNeverDeletesWithAgeAndKeepCurrent() throws Exception {
+    CleanLogsCommand.Options opts =
+        new CleanLogsCommand.Options(Duration.ofDays(7), true);
+    CleanReport report = CleanLogsCommand.execute(installRoot, true, opts);
+
+    assertTrue(report.isDryRun());
+    assertEquals(0, report.getDeletedCount());
+    assertTrue(Files.exists(serverLog));
+    assertTrue(Files.exists(rolledServerLog));
+    assertTrue(Files.exists(oldRolledLog));
+    assertTrue(Files.exists(catalinaGz));
+    assertTrue(Files.exists(outsideLog));
+    assertTrue(Files.exists(nonLogInLogDir));
+
+    // keep-current skips server.log; age skips recent rolled; old rolled + catalina gz would delete
+    int wouldDelete = 0;
+    int skipped = 0;
+    for (CleanReport.Entry e : report.getEntries()) {
+      assertTrue(InstallRootGuard.isUnderInstallRoot(installRoot, e.getPath()));
+      if (e.getStatus() == CleanReport.EntryStatus.WOULD_DELETE) {
+        wouldDelete++;
+      } else if (e.getStatus() == CleanReport.EntryStatus.SKIPPED) {
+        skipped++;
+      }
+    }
+    assertEquals(2, wouldDelete, "old rolled + catalina.gz");
+    assertTrue(skipped >= 2, "keep-current + age skip at least current + recent rolled");
+  }
+
+  @Test
+  void applyDeletesOnlyAgedNonCurrentUnderRoot() throws Exception {
+    CleanLogsCommand.Options opts =
+        new CleanLogsCommand.Options(Duration.ofDays(7), true);
+    CleanReport report = CleanLogsCommand.execute(installRoot, false, opts);
+
+    assertFalse(report.isDryRun());
+    assertEquals(2, report.getDeletedCount());
+    assertEquals(0, report.getFailedCount());
+    assertTrue(Files.exists(serverLog), "keep-current must retain active server.log");
+    assertTrue(Files.exists(rolledServerLog), "recent rolled must be retained by age filter");
+    assertFalse(Files.exists(oldRolledLog), "old rolled log should be deleted");
+    assertFalse(Files.exists(catalinaGz), "old catalina.gz should be deleted");
+    assertTrue(Files.exists(outsideLog), "outside install root must not be deleted");
+    assertTrue(Files.exists(nonLogInLogDir), "non-log files in log dir must not be deleted");
+  }
+
+  @Test
+  void keepCurrentFalseAllowsDeletingActiveLogWhenAged() throws Exception {
+    CleanLogsCommand.Options opts =
+        new CleanLogsCommand.Options(Duration.ofDays(7), false);
+    CleanReport report = CleanLogsCommand.execute(installRoot, false, opts);
+
+    assertFalse(Files.exists(serverLog), "active log deletable when keep-current off and aged");
+    assertFalse(Files.exists(oldRolledLog));
+    assertFalse(Files.exists(catalinaGz));
+    assertTrue(Files.exists(rolledServerLog), "recent rolled still protected by age");
+    assertTrue(report.getDeletedCount() >= 3);
+  }
+
+  @Test
+  void noAgeFilterWithKeepCurrentDeletesRolledOnly() throws Exception {
+    CleanLogsCommand.Options opts = CleanLogsCommand.Options.defaults();
+    CleanReport report = CleanLogsCommand.execute(installRoot, false, opts);
+
+    assertTrue(Files.exists(serverLog), "current retained");
+    assertFalse(Files.exists(rolledServerLog));
+    assertFalse(Files.exists(oldRolledLog));
+    assertFalse(Files.exists(catalinaGz));
+    assertEquals(3, report.getDeletedCount());
+  }
+
+  @Test
+  void findLogFilesOnlyUnderKnownDirsAndRoot() throws Exception {
+    List<Path> found = CleanLogsCommand.findLogFiles(installRoot);
+    assertEquals(4, found.size()); // server + 2 rolled + catalina.gz; not readme.txt
+    for (Path p : found) {
+      assertTrue(InstallRootGuard.isUnderInstallRoot(installRoot, p));
+      assertFalse(p.equals(outsideLog));
+      assertTrue(InstallRootGuard.isLogFileName(p.getFileName().toString()));
+    }
+  }
+
+  @Test
+  void executeRejectsMissingInstallRoot() {
+    Path missing = tempDir.resolve("missing-root");
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            CleanLogsCommand.execute(
+                missing, true, new CleanLogsCommand.Options(Duration.ofDays(1), true)));
+  }
+
+  @Test
+  void missingLogDirsIsEmptyReportNotError() throws Exception {
+    Path emptyRoot = Files.createDirectories(tempDir.resolve("empty-install"));
+    CleanReport report =
+        CleanLogsCommand.execute(emptyRoot, true, CleanLogsCommand.Options.defaults());
+    assertEquals(0, report.getCandidateCount());
+    assertEquals(0, report.getFailedCount());
+  }
+
+  @Test
+  void parseOlderThanAcceptsUnits() {
+    assertEquals(Duration.ofDays(7), CleanLogsCommand.parseOlderThan("7d"));
+    assertEquals(Duration.ofHours(24), CleanLogsCommand.parseOlderThan("24h"));
+    assertEquals(Duration.ofMinutes(30), CleanLogsCommand.parseOlderThan("30m"));
+    assertEquals(Duration.ofSeconds(90), CleanLogsCommand.parseOlderThan("90s"));
+    assertEquals(Duration.ofDays(14), CleanLogsCommand.parseOlderThan("2w"));
+    assertEquals(Duration.ofDays(7), CleanLogsCommand.parseOlderThan("7D"));
+  }
+
+  @Test
+  void parseOlderThanRejectsInvalid() {
+    assertThrows(IllegalArgumentException.class, () -> CleanLogsCommand.parseOlderThan(""));
+    assertThrows(IllegalArgumentException.class, () -> CleanLogsCommand.parseOlderThan("7"));
+    assertThrows(IllegalArgumentException.class, () -> CleanLogsCommand.parseOlderThan("d7"));
+    assertThrows(IllegalArgumentException.class, () -> CleanLogsCommand.parseOlderThan("0d"));
+    assertThrows(IllegalArgumentException.class, () -> CleanLogsCommand.parseOlderThan("-1d"));
+    assertThrows(IllegalArgumentException.class, () -> CleanLogsCommand.parseOlderThan("1x"));
+  }
+
+  @Test
+  void logFileNameAndCurrentHelpers() {
+    assertTrue(InstallRootGuard.isLogFileName("server.log"));
+    assertTrue(InstallRootGuard.isLogFileName("catalina.2024-01-01.log.gz"));
+    assertTrue(InstallRootGuard.isLogFileName("catalina.out"));
+    assertFalse(InstallRootGuard.isLogFileName("readme.txt"));
+    assertFalse(InstallRootGuard.isLogFileName("a/b.log"));
+
+    assertTrue(InstallRootGuard.isCurrentLogFileName("server.log"));
+    assertTrue(InstallRootGuard.isCurrentLogFileName("catalina.out"));
+    assertFalse(InstallRootGuard.isCurrentLogFileName("server-2024-01-15-1.log"));
+    assertFalse(InstallRootGuard.isCurrentLogFileName("catalina.2024-01-15.log.gz"));
+    assertFalse(InstallRootGuard.isCurrentLogFileName("server.log.1"));
+  }
+
+  @Test
+  void visitFileFailedRecordsFailedEntryOnReport() {
+    CleanReport report = new CleanReport(CleanLogsCommand.COMMAND_NAME, installRoot, true);
+    Path failed = jettyLogs.resolve("unreadable.log");
+    CleanLogsCommand.recordVisitFailure(report, failed, new java.io.IOException("Access denied"));
+
+    assertEquals(1, report.getFailedCount());
+    CleanReport.Entry e = report.getEntries().get(0);
+    assertEquals(CleanReport.EntryStatus.FAILED, e.getStatus());
+    assertTrue(e.getDetail().contains("walk:"));
+  }
+
+  @Test
+  void optionsRejectNonPositiveOlderThan() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new CleanLogsCommand.Options(Duration.ZERO, true));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new CleanLogsCommand.Options(Duration.ofSeconds(-1), true));
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
@@ -258,4 +258,34 @@ class DoctorCliTest {
             new PrintStream(errBuf, true, StandardCharsets.UTF_8));
     assertEquals(DoctorCli.EXIT_USAGE, code);
   }
+
+  @Test
+  void olderThanOnNonCleanLogsCommandWarnsAndContinues() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-older-warn"));
+    Path dump = root.resolve("warn.hprof");
+    Files.write(dump, "abc".getBytes(StandardCharsets.UTF_8));
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root",
+              root.toString(),
+              "--dry-run",
+              "--older-than",
+              "7d",
+              "clean-heap-dumps"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    String err = errBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(
+        err.contains("--older-than") && err.toLowerCase().contains("ignoring"),
+        "expected ignore warning for --older-than on non-clean-logs: " + err);
+    assertTrue(Files.exists(dump));
+    assertTrue(outBuf.toString(StandardCharsets.UTF_8).contains("candidates=1"));
+  }
 }

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
@@ -127,4 +127,55 @@ class DoctorCliTest {
     assertEquals(DoctorCli.EXIT_ERROR, code);
     assertTrue(errBuf.toString(StandardCharsets.UTF_8).toLowerCase().contains("install root"));
   }
+
+  @Test
+  void cleanInstallBackupsDryRunViaCliDoesNotDelete() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-bak"));
+    Path bak = root.resolve("config.properties.backup");
+    Path zip = root.resolve("AppServer_backup_20260101.zip");
+    Files.writeString(bak, "bak");
+    Files.write(zip, "zip".getBytes(StandardCharsets.UTF_8));
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root", root.toString(), "--dry-run", "-v", "clean-install-backups"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    assertTrue(Files.exists(bak));
+    assertTrue(Files.exists(zip));
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("command=clean-install-backups"));
+    assertTrue(out.contains("dry-run=true"));
+    assertTrue(out.contains("candidates=2"));
+    assertTrue(out.contains("WOULD_DELETE"));
+  }
+
+  @Test
+  void cleanInstallBackupsApplyViaCliDeletesAllowlistedOnly() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-bak-apply"));
+    Path bak = root.resolve("x.bak");
+    Path keep = root.resolve("server.log");
+    Files.writeString(bak, "bak");
+    Files.writeString(keep, "log");
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"--install-root", root.toString(), "clean-install-backups"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    assertFalse(Files.exists(bak));
+    assertTrue(Files.exists(keep));
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("deleted=1"));
+  }
 }

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
@@ -178,4 +178,84 @@ class DoctorCliTest {
     String out = outBuf.toString(StandardCharsets.UTF_8);
     assertTrue(out.contains("deleted=1"));
   }
+
+  @Test
+  void cleanLogsDryRunViaCliDoesNotDelete() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-logs"));
+    Path logs =
+        Files.createDirectories(root.resolve("jetty").resolve("base").resolve("logs"));
+    Path current = logs.resolve("server.log");
+    Path rolled = logs.resolve("server-2020-01-01-1.log");
+    Files.writeString(current, "cur");
+    Files.writeString(rolled, "old");
+    Files.setLastModifiedTime(
+        rolled, java.nio.file.attribute.FileTime.from(java.time.Instant.now().minusSeconds(86400L * 30)));
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root",
+              root.toString(),
+              "--dry-run",
+              "-v",
+              "clean-logs",
+              "--older-than",
+              "7d"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    assertTrue(Files.exists(current));
+    assertTrue(Files.exists(rolled));
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("command=clean-logs"));
+    assertTrue(out.contains("dry-run=true"));
+    assertTrue(out.contains("WOULD_DELETE"));
+  }
+
+  @Test
+  void cleanLogsApplyViaCliKeepsCurrentDeletesAgedRolled() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-logs-apply"));
+    Path logs =
+        Files.createDirectories(root.resolve("jetty").resolve("base").resolve("logs"));
+    Path current = logs.resolve("server.log");
+    Path rolled = logs.resolve("server-2020-02-02-1.log");
+    Files.writeString(current, "cur");
+    Files.writeString(rolled, "old");
+    Files.setLastModifiedTime(
+        rolled, java.nio.file.attribute.FileTime.from(java.time.Instant.now().minusSeconds(86400L * 30)));
+    Files.setLastModifiedTime(
+        current, java.nio.file.attribute.FileTime.from(java.time.Instant.now().minusSeconds(86400L * 30)));
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root", root.toString(), "clean-logs", "--older-than", "7d"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    assertTrue(Files.exists(current), "keep-current default retains server.log");
+    assertFalse(Files.exists(rolled));
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("deleted=1"));
+  }
+
+  @Test
+  void cleanLogsInvalidOlderThanIsUsageError() {
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"clean-logs", "--older-than", "not-a-duration"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+    assertEquals(DoctorCli.EXIT_USAGE, code);
+  }
 }

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DoctorCliTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void dryRunViaCliDoesNotDelete() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install"));
+    Path dump = root.resolve("a.hprof");
+    Files.write(dump, "abc".getBytes(StandardCharsets.UTF_8));
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root", root.toString(), "--dry-run", "-v", "clean-heap-dumps"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    assertTrue(Files.exists(dump));
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("dry-run=true"));
+    assertTrue(out.contains("candidates=1"));
+    assertTrue(out.contains("WOULD_DELETE"));
+  }
+
+  @Test
+  void applyViaCliDeletesHeapDumps() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install2"));
+    Path dump = root.resolve("b.hprof");
+    Files.write(dump, "xyz".getBytes(StandardCharsets.UTF_8));
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"--install-root", root.toString(), "clean-heap-dumps"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    assertFalse(Files.exists(dump));
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("deleted=1"));
+  }
+
+  @Test
+  void missingCommandIsUsageError() {
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"--dry-run"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+    assertEquals(DoctorCli.EXIT_USAGE, code);
+  }
+
+  @Test
+  void unknownOptionIsUsageError() {
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"--not-a-real-flag", "clean-heap-dumps"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+    assertEquals(DoctorCli.EXIT_USAGE, code);
+  }
+
+  @Test
+  void unknownCommandIsUsageError() {
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"clean-everything"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+    assertEquals(DoctorCli.EXIT_USAGE, code);
+  }
+
+  @Test
+  void missingInstallRootIsError() {
+    Path missing = tempDir.resolve("gone");
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root", missing.toString(), "--dry-run", "clean-heap-dumps"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+    assertEquals(DoctorCli.EXIT_ERROR, code);
+    assertTrue(errBuf.toString(StandardCharsets.UTF_8).toLowerCase().contains("install root"));
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/InstallRootGuardTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/InstallRootGuardTest.java
@@ -125,4 +125,42 @@ class InstallRootGuardTest {
         InstallRootGuard.isUnderInstallRoot(root, siblingPrefix),
         "must not treat InstallExtra as under Install");
   }
+
+  @Test
+  void logFileNameAllowlistAndCurrentDetection() {
+    assertTrue(InstallRootGuard.isLogFileName("server.log"));
+    assertTrue(InstallRootGuard.isLogFileName("SERVER.LOG"));
+    assertTrue(InstallRootGuard.isLogFileName("catalina.out"));
+    assertTrue(InstallRootGuard.isLogFileName("catalina.2024-01-15.log.gz"));
+    assertFalse(InstallRootGuard.isLogFileName("notes.txt"));
+    assertFalse(InstallRootGuard.isLogFileName("../evil.log"));
+    assertFalse(InstallRootGuard.isLogFileName(null));
+
+    assertTrue(InstallRootGuard.isCurrentLogFileName("server.log"));
+    assertTrue(InstallRootGuard.isCurrentLogFileName("globaltemplate.log"));
+    assertTrue(InstallRootGuard.isCurrentLogFileName("catalina.out"));
+    assertFalse(InstallRootGuard.isCurrentLogFileName("server-2024-01-15-1.log"));
+    assertFalse(InstallRootGuard.isCurrentLogFileName("catalina.2024-01-15.log.gz"));
+    assertFalse(InstallRootGuard.isCurrentLogFileName("server.log.1"));
+  }
+
+  @Test
+  void existingLogDirsOnlyReturnsPresentDirsUnderRoot() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("cms-logs"));
+    Path jettyLogs =
+        Files.createDirectories(root.resolve("jetty").resolve("base").resolve("logs"));
+    // DTS dir intentionally missing
+    java.util.List<Path> dirs = InstallRootGuard.existingLogDirs(root);
+    assertEquals(1, dirs.size());
+    assertEquals(jettyLogs.toAbsolutePath().normalize(), dirs.get(0));
+  }
+
+  @Test
+  void resolveRelativeUnderRootRejectsDotDot() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("cms-rel")).toAbsolutePath().normalize();
+    Path resolved = InstallRootGuard.resolveRelativeUnderRoot(root, "jetty/base/logs");
+    assertTrue(resolved.startsWith(root));
+    assertEquals(null, InstallRootGuard.resolveRelativeUnderRoot(root, "../escape"));
+    assertEquals(null, InstallRootGuard.resolveRelativeUnderRoot(root, "a\\b"));
+  }
 }

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/InstallRootGuardTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/InstallRootGuardTest.java
@@ -24,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 class InstallRootGuardTest {
@@ -86,5 +88,19 @@ class InstallRootGuardTest {
     assertFalse(InstallRootGuard.isHeapDumpFileName(""));
     assertFalse(InstallRootGuard.isHeapDumpFileName(null));
     assertFalse(InstallRootGuard.isHeapDumpFileName("../evil.hprof"));
+  }
+
+  @Test
+  @EnabledOnOs(OS.WINDOWS)
+  void isUnderInstallRootIsCaseInsensitiveOnWindows() {
+    // Path.startsWith is case-sensitive; Windows FS is not — guard must fold.
+    Path root = Path.of("C:\\Percussion\\Install");
+    Path child = Path.of("c:\\percussion\\install\\jetty\\base\\java_pid1.hprof");
+    Path siblingPrefix = Path.of("C:\\Percussion\\InstallExtra\\x.hprof");
+    assertTrue(InstallRootGuard.isUnderInstallRoot(root, child));
+    assertTrue(InstallRootGuard.isUnderInstallRoot(root, Path.of("C:\\PERCUSSION\\INSTALL")));
+    assertFalse(
+        InstallRootGuard.isUnderInstallRoot(root, siblingPrefix),
+        "must not treat InstallExtra as under Install");
   }
 }

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/InstallRootGuardTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/InstallRootGuardTest.java
@@ -91,6 +91,28 @@ class InstallRootGuardTest {
   }
 
   @Test
+  void installBackupAllowlistAcceptsDocumentedPatternsOnly() {
+    assertTrue(InstallRootGuard.isInstallBackupFileName("AppServer_backup_20240115_120000.zip"));
+    assertTrue(InstallRootGuard.isInstallBackupFileName("appserver_backup_1.zip"));
+    assertTrue(InstallRootGuard.isInstallBackupFileName("ResourceBundle.tmx.bak"));
+    assertTrue(InstallRootGuard.isInstallBackupFileName("file.BAK"));
+    assertTrue(InstallRootGuard.isInstallBackupFileName("misc.config.backup"));
+    assertTrue(InstallRootGuard.isInstallBackupFileName("Navigation.properties.backup"));
+    assertTrue(InstallRootGuard.isInstallBackupFileName("FOO.PROPERTIES.BACKUP"));
+
+    assertFalse(InstallRootGuard.isInstallBackupFileName("AppServer_backup_.zip"));
+    assertFalse(InstallRootGuard.isInstallBackupFileName("AppServer_backup.zip"));
+    assertFalse(InstallRootGuard.isInstallBackupFileName("OtherServer_backup_1.zip"));
+    assertFalse(InstallRootGuard.isInstallBackupFileName("java_pid123.hprof"));
+    assertFalse(InstallRootGuard.isInstallBackupFileName("server.log"));
+    assertFalse(InstallRootGuard.isInstallBackupFileName("notes.txt"));
+    assertFalse(InstallRootGuard.isInstallBackupFileName(""));
+    assertFalse(InstallRootGuard.isInstallBackupFileName(null));
+    assertFalse(InstallRootGuard.isInstallBackupFileName("../evil.bak"));
+    assertFalse(InstallRootGuard.isInstallBackupFileName("dir/file.bak"));
+  }
+
+  @Test
   @EnabledOnOs(OS.WINDOWS)
   void isUnderInstallRootIsCaseInsensitiveOnWindows() {
     // Path.startsWith is case-sensitive; Windows FS is not — guard must fold.

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/InstallRootGuardTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/InstallRootGuardTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class InstallRootGuardTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void requireInstallRootAcceptsExistingDirectory() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install"));
+    Path resolved = InstallRootGuard.requireInstallRoot(root);
+    assertEquals(root.toAbsolutePath().normalize(), resolved);
+  }
+
+  @Test
+  void requireInstallRootRejectsMissing() {
+    Path missing = tempDir.resolve("no-such-dir");
+    assertThrows(IllegalArgumentException.class, () -> InstallRootGuard.requireInstallRoot(missing));
+  }
+
+  @Test
+  void isUnderInstallRootAllowsDescendantAndRoot() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("cms"));
+    Path child = Files.createDirectories(root.resolve("logs"));
+    assertTrue(InstallRootGuard.isUnderInstallRoot(root, root));
+    assertTrue(InstallRootGuard.isUnderInstallRoot(root, child));
+    assertTrue(InstallRootGuard.isUnderInstallRoot(root, child.resolve("java_pid1.hprof")));
+  }
+
+  @Test
+  void requireUnderInstallRootRejectsSiblingOutsideRoot() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("cms"));
+    Path outside = Files.createDirectories(tempDir.resolve("outside"));
+    Path dump = outside.resolve("escape.hprof");
+    Files.writeString(dump, "x");
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> InstallRootGuard.requireUnderInstallRoot(root, dump));
+    assertTrue(ex.getMessage().toLowerCase().contains("outside"));
+    assertFalse(InstallRootGuard.isUnderInstallRoot(root, dump));
+  }
+
+  @Test
+  void requireUnderInstallRootRejectsParentEscapeViaDotDot() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("cms"));
+    Path escape = root.resolve("..").resolve("escape.hprof").normalize();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> InstallRootGuard.requireUnderInstallRoot(root, escape));
+  }
+
+  @Test
+  void heapDumpAllowlistAcceptsHprofOnly() {
+    assertTrue(InstallRootGuard.isHeapDumpFileName("java_pid123.hprof"));
+    assertTrue(InstallRootGuard.isHeapDumpFileName("HEAP.HPROF"));
+    assertFalse(InstallRootGuard.isHeapDumpFileName("app.log"));
+    assertFalse(InstallRootGuard.isHeapDumpFileName("java_pid123.hprof.bak"));
+    assertFalse(InstallRootGuard.isHeapDumpFileName("hprof"));
+    assertFalse(InstallRootGuard.isHeapDumpFileName(""));
+    assertFalse(InstallRootGuard.isHeapDumpFileName(null));
+    assertFalse(InstallRootGuard.isHeapDumpFileName("../evil.hprof"));
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/PercDoctorPackagingTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/PercDoctorPackagingTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Structural packaging contracts for operator {@code bin/perc-doctor} launchers and the dist
+ * assembly (issue #2220 / parent #2213 slice 5).
+ *
+ * <p>Does not require a built jar; asserts source scripts and Maven assembly wiring stay portable
+ * (no hardcoded user homes) and resolve install root relative to the script location.
+ */
+class PercDoctorPackagingTest {
+
+  private static final Path UNIX_SCRIPT = Path.of("src", "main", "scripts", "perc-doctor");
+  private static final Path WINDOWS_SCRIPT = Path.of("src", "main", "scripts", "perc-doctor.bat");
+  private static final Path ASSEMBLY = Path.of("src", "main", "assembly", "dist-bin.xml");
+  private static final Path POM = Path.of("pom.xml");
+
+  /**
+   * Hardcoded user-home shapes that must never appear in operator launchers or docs. Avoid matching
+   * instructional prose; focus on absolute personal profile paths and this developer's home.
+   */
+  private static final Pattern HARDCODED_USER_HOME =
+      Pattern.compile("(?i)(C:\\\\Users\\\\[A-Za-z]|/home/[a-zA-Z0-9._-]+|/Users/[A-Za-z]|\\\\Users\\\\Nate)");
+
+  @Test
+  @DisplayName("Unix and Windows bin wrappers exist")
+  void wrappersExist() {
+    assertTrue(Files.isRegularFile(UNIX_SCRIPT), () -> "missing " + UNIX_SCRIPT.toAbsolutePath());
+    assertTrue(
+        Files.isRegularFile(WINDOWS_SCRIPT), () -> "missing " + WINDOWS_SCRIPT.toAbsolutePath());
+  }
+
+  @Test
+  @DisplayName("wrappers resolve install root from script directory, not hardcoded homes")
+  void wrappersResolveInstallRootPortably() throws Exception {
+    String unix = Files.readString(UNIX_SCRIPT, StandardCharsets.UTF_8);
+    String win = Files.readString(WINDOWS_SCRIPT, StandardCharsets.UTF_8);
+
+    assertTrue(unix.startsWith("#!/"), "Unix wrapper must be a shell script with shebang");
+    assertTrue(
+        unix.contains("SCRIPT_DIR") && unix.contains("INSTALL_ROOT"),
+        "Unix wrapper must derive SCRIPT_DIR / INSTALL_ROOT");
+    assertTrue(
+        unix.contains("perc-doctor.jar"),
+        "Unix wrapper must invoke stable bin/perc-doctor.jar name");
+    assertTrue(
+        unix.contains("--install-root"),
+        "Unix wrapper must pass --install-root when operator omits it");
+    assertFalse(
+        HARDCODED_USER_HOME.matcher(unix).find(),
+        "Unix wrapper must not hardcode a user home path");
+
+    assertTrue(win.toLowerCase().contains("@echo off"), "Windows wrapper must be a .bat");
+    assertTrue(
+        win.contains("SCRIPT_DIR") && win.contains("INSTALL_ROOT"),
+        "Windows wrapper must derive SCRIPT_DIR / INSTALL_ROOT");
+    assertTrue(
+        win.contains("perc-doctor.jar"),
+        "Windows wrapper must invoke stable bin/perc-doctor.jar name");
+    assertTrue(
+        win.contains("--install-root"),
+        "Windows wrapper must pass --install-root when operator omits it");
+    assertFalse(
+        HARDCODED_USER_HOME.matcher(win).find(),
+        "Windows wrapper must not hardcode a user home path");
+  }
+
+  @Test
+  @DisplayName("dist assembly packs bin wrappers + versionless perc-doctor.jar")
+  void distAssemblyLayout() throws Exception {
+    assertTrue(Files.isRegularFile(ASSEMBLY), () -> "missing " + ASSEMBLY.toAbsolutePath());
+    String xml = Files.readString(ASSEMBLY, StandardCharsets.UTF_8);
+    assertTrue(xml.contains("<id>dist</id>"), "assembly id must be dist");
+    assertTrue(xml.contains("perc-doctor.jar"), "assembly must ship perc-doctor.jar");
+    assertTrue(xml.contains("destName>perc-doctor.jar"), "stable dest name for operators");
+    assertTrue(
+        xml.contains("perc-doctor.bat") && xml.contains("<include>perc-doctor</include>"),
+        "assembly must include both platform wrappers");
+    assertTrue(xml.contains("<outputDirectory>bin</outputDirectory>"), "layout under bin/");
+  }
+
+  @Test
+  @DisplayName("module pom attaches dist assembly and Main-Class on jar")
+  void pomWiresAssemblyAndMainClass() throws Exception {
+    assertTrue(Files.isRegularFile(POM), () -> "missing " + POM.toAbsolutePath());
+    String pom = Files.readString(POM, StandardCharsets.UTF_8);
+    assertTrue(
+        pom.contains("com.intsof.percussioncms.doctor.DoctorCli"),
+        "jar Main-Class must be DoctorCli");
+    assertTrue(
+        pom.contains("maven-assembly-plugin") && pom.contains("dist-bin.xml"),
+        "pom must run assembly descriptor dist-bin.xml");
+    assertTrue(
+        pom.contains("<classifier>dist</classifier>")
+            || pom.contains("descriptor>src/main/assembly/dist-bin.xml"),
+        "dist packaging must be wired for consumers (perc-distribution-tree)");
+  }
+
+  @Test
+  @DisplayName("operator docs emphasize dry-run-first and portable install-root examples")
+  void installGuideDryRunFirst() throws Exception {
+    Path guide = Path.of("docs", "operator-install-guide.md");
+    Path readme = Path.of("README.md");
+    assertTrue(Files.isRegularFile(guide), () -> "missing " + guide.toAbsolutePath());
+    assertTrue(Files.isRegularFile(readme), () -> "missing " + readme.toAbsolutePath());
+
+    String guideText = Files.readString(guide, StandardCharsets.UTF_8);
+    String readmeText = Files.readString(readme, StandardCharsets.UTF_8);
+
+    for (String text : List.of(guideText, readmeText)) {
+      assertFalse(
+          HARDCODED_USER_HOME.matcher(text).find(),
+          "docs must not hardcode a developer user home path");
+    }
+
+    assertTrue(guideText.contains("--dry-run"), "install guide must show --dry-run");
+    assertTrue(
+        guideText.contains("clean-heap-dumps")
+            && guideText.contains("clean-install-backups")
+            && guideText.contains("clean-logs"),
+        "install guide must cover all shipped commands");
+    assertTrue(
+        guideText.contains("bin/perc-doctor") || guideText.contains("bin\\perc-doctor"),
+        "install guide must document install-tree bin wrappers");
+    assertTrue(
+        guideText.contains("/opt/") || guideText.contains("C:\\Percussion"),
+        "install guide should use generic install-root examples (not a user home)");
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/api/DoctorApiServiceTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/api/DoctorApiServiceTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.doctor.CleanHeapDumpsCommand;
+import com.intsof.percussioncms.doctor.CleanReport;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Behavioral tests for doctor HTTP command runner (dry-run default + inventory). */
+class DoctorApiServiceTest {
+
+  @TempDir Path tempDir;
+
+  private Path installRoot;
+  private Path heapDump;
+  private DoctorApiService service;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    installRoot = Files.createDirectories(tempDir.resolve("cms-install"));
+    heapDump = installRoot.resolve("java_pid9.hprof");
+    Files.write(heapDump, "HEAP".getBytes(StandardCharsets.UTF_8));
+    service = new DoctorApiService(() -> installRoot);
+  }
+
+  @Test
+  void dryRunDefaultWhenBodyNullInventoriesAndDoesNotDelete() throws Exception {
+    DoctorReportView view =
+        service.execute(CleanHeapDumpsCommand.COMMAND_NAME, null);
+
+    assertTrue(view.isDryRun());
+    assertEquals(1, view.getCandidateCount());
+    assertEquals(0, view.getDeletedCount());
+    assertEquals(CleanReport.EntryStatus.WOULD_DELETE.name(), view.getEntries().get(0).getStatus());
+    assertTrue(Files.exists(heapDump), "dry-run must not delete");
+  }
+
+  @Test
+  void dryRunDefaultWhenDryRunFieldOmitted() throws Exception {
+    DoctorRequest req = new DoctorRequest();
+    // dryRun left null → effective dry-run
+    DoctorReportView view = service.execute(CleanHeapDumpsCommand.COMMAND_NAME, req);
+
+    assertTrue(view.isDryRun());
+    assertTrue(Files.exists(heapDump));
+    assertEquals(0, view.getDeletedCount());
+  }
+
+  @Test
+  void explicitDryRunTrueDoesNotDelete() throws Exception {
+    DoctorRequest req = new DoctorRequest();
+    req.setDryRun(true);
+    DoctorReportView view = service.execute(CleanHeapDumpsCommand.COMMAND_NAME, req);
+
+    assertTrue(view.isDryRun());
+    assertTrue(Files.exists(heapDump));
+    assertEquals(Files.size(heapDump), view.getTotalBytes());
+  }
+
+  @Test
+  void dryRunFalseAppliesDeletes() throws Exception {
+    DoctorRequest req = new DoctorRequest();
+    req.setDryRun(false);
+    DoctorReportView view = service.execute(CleanHeapDumpsCommand.COMMAND_NAME, req);
+
+    assertFalse(view.isDryRun());
+    assertEquals(1, view.getDeletedCount());
+    assertFalse(Files.exists(heapDump));
+  }
+
+  @Test
+  void explicitInstallRootOverridesProvider() throws Exception {
+    Path otherRoot = Files.createDirectories(tempDir.resolve("other-install"));
+    Path otherDump = otherRoot.resolve("x.hprof");
+    Files.write(otherDump, "X".getBytes(StandardCharsets.UTF_8));
+
+    DoctorRequest req = new DoctorRequest();
+    req.setDryRun(true);
+    req.setInstallRoot(otherRoot.toString());
+
+    DoctorReportView view = service.execute(CleanHeapDumpsCommand.COMMAND_NAME, req);
+    assertEquals(1, view.getCandidateCount());
+    assertTrue(view.getInstallRoot().contains("other-install") || view.getInstallRoot().equals(otherRoot.toString()));
+    assertTrue(Files.exists(heapDump), "default install root dump untouched");
+    assertTrue(Files.exists(otherDump), "dry-run");
+  }
+
+  @Test
+  void unknownCommandThrows() {
+    assertThrows(
+        DoctorUnknownCommandException.class,
+        () -> service.execute("not-a-real-command", new DoctorRequest()));
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/api/DoctorApiServiceTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/api/DoctorApiServiceTest.java
@@ -93,7 +93,22 @@ class DoctorApiServiceTest {
   }
 
   @Test
-  void explicitInstallRootOverridesProvider() throws Exception {
+  void explicitInstallRootMatchingHostIsAcceptedAndUsesHostPath() throws Exception {
+    DoctorRequest req = new DoctorRequest();
+    req.setDryRun(true);
+    // Same tree as provider — allowed, but I/O still uses host Path.
+    req.setInstallRoot(installRoot.toAbsolutePath().normalize().toString());
+
+    DoctorReportView view = service.execute(CleanHeapDumpsCommand.COMMAND_NAME, req);
+    assertEquals(1, view.getCandidateCount());
+    assertTrue(Files.exists(heapDump), "dry-run");
+    assertEquals(
+        installRoot.toAbsolutePath().normalize().toString(),
+        Path.of(view.getInstallRoot()).toAbsolutePath().normalize().toString());
+  }
+
+  @Test
+  void explicitInstallRootOutsideHostIsRejected() throws Exception {
     Path otherRoot = Files.createDirectories(tempDir.resolve("other-install"));
     Path otherDump = otherRoot.resolve("x.hprof");
     Files.write(otherDump, "X".getBytes(StandardCharsets.UTF_8));
@@ -102,11 +117,13 @@ class DoctorApiServiceTest {
     req.setDryRun(true);
     req.setInstallRoot(otherRoot.toString());
 
-    DoctorReportView view = service.execute(CleanHeapDumpsCommand.COMMAND_NAME, req);
-    assertEquals(1, view.getCandidateCount());
-    assertTrue(view.getInstallRoot().contains("other-install") || view.getInstallRoot().equals(otherRoot.toString()));
-    assertTrue(Files.exists(heapDump), "default install root dump untouched");
-    assertTrue(Files.exists(otherDump), "dry-run");
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> service.execute(CleanHeapDumpsCommand.COMMAND_NAME, req));
+    assertTrue(ex.getMessage().toLowerCase().contains("installroot"));
+    assertTrue(Files.exists(heapDump), "rejected override must not touch host root");
+    assertTrue(Files.exists(otherDump), "rejected override must not walk outside root");
   }
 
   @Test

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/api/DoctorRequestTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/api/DoctorRequestTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class DoctorRequestTest {
+
+  @Test
+  void effectiveDryRunDefaultsTrue() {
+    DoctorRequest r = new DoctorRequest();
+    assertTrue(r.isEffectiveDryRun());
+    r.setDryRun(true);
+    assertTrue(r.isEffectiveDryRun());
+    r.setDryRun(false);
+    assertFalse(r.isEffectiveDryRun());
+  }
+
+  @Test
+  void effectiveKeepCurrentDefaultsTrue() {
+    DoctorRequest r = new DoctorRequest();
+    assertTrue(r.isEffectiveKeepCurrent());
+    r.setKeepCurrent(false);
+    assertFalse(r.isEffectiveKeepCurrent());
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/api/DoctorRestServiceTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/api/DoctorRestServiceTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.doctor.CleanHeapDumpsCommand;
+import jakarta.ws.rs.WebApplicationException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Auth rejection + happy-path dry-run inventory for doctor REST resource. */
+class DoctorRestServiceTest {
+
+  @TempDir Path tempDir;
+
+  private Path installRoot;
+  private Path heapDump;
+  private AtomicBoolean admin;
+  private DoctorRestService rest;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    installRoot = Files.createDirectories(tempDir.resolve("cms-install"));
+    heapDump = installRoot.resolve("crash.hprof");
+    Files.write(heapDump, "HEAP".getBytes(StandardCharsets.UTF_8));
+    admin = new AtomicBoolean(true);
+    rest = new DoctorRestService(admin::get, () -> installRoot);
+  }
+
+  @Test
+  void adminDryRunInventoryHappyPath() {
+    DoctorRequest req = new DoctorRequest();
+    req.setDryRun(true);
+
+    DoctorReportView view = rest.runCommand(CleanHeapDumpsCommand.COMMAND_NAME, req);
+
+    assertTrue(view.isDryRun());
+    assertEquals(1, view.getCandidateCount());
+    assertEquals(0, view.getDeletedCount());
+    assertTrue(Files.exists(heapDump));
+    assertEquals(CleanHeapDumpsCommand.COMMAND_NAME, view.getCommand());
+  }
+
+  @Test
+  void omittedBodyDefaultsToDryRun() {
+    DoctorReportView view = rest.runCommand(CleanHeapDumpsCommand.COMMAND_NAME, null);
+    assertTrue(view.isDryRun());
+    assertTrue(Files.exists(heapDump));
+  }
+
+  @Test
+  void nonAdminRejectedWith403() {
+    admin.set(false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> rest.runCommand(CleanHeapDumpsCommand.COMMAND_NAME, new DoctorRequest()));
+    assertEquals(403, ex.getResponse().getStatus());
+    String body = String.valueOf(ex.getResponse().getEntity());
+    assertTrue(body.contains("Admin"));
+    assertTrue(Files.exists(heapDump), "rejected request must not delete");
+  }
+
+  @Test
+  void anonymousStyleGateFalseIs403() {
+    // Admin checker returns false when no current user / anonymous.
+    rest = new DoctorRestService(() -> false, () -> installRoot);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> rest.runCommand(CleanHeapDumpsCommand.COMMAND_NAME, null));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void unknownCommandIs404() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> rest.runCommand("wipe-everything", new DoctorRequest()));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void adminCheckerExceptionIs403WithoutLeak() {
+    rest =
+        new DoctorRestService(
+            () -> {
+              throw new IllegalStateException("secret-db-host=internal");
+            },
+            () -> installRoot);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> rest.runCommand(CleanHeapDumpsCommand.COMMAND_NAME, null));
+    assertEquals(403, ex.getResponse().getStatus());
+    String body = String.valueOf(ex.getResponse().getEntity());
+    assertTrue(!body.contains("secret-db-host"));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     </licenses>
     <modules>
         <module>modules/intsof-common-utilities</module>
+        <module>modules/perc-doctor</module>
         <module>modules/perc-security-utils</module>
         <module>modules/perc-security-acl-shim</module>
         <module>modules/perc-xml-security</module>

--- a/projects/sitemanage/pom.xml
+++ b/projects/sitemanage/pom.xml
@@ -49,6 +49,12 @@
             <artifactId>rest</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <!-- CMS Doctor admin HTTP API (issue #2219): reuses CLI command implementations -->
+        <dependency>
+            <groupId>com.percussion</groupId>
+            <artifactId>perc-doctor</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
         <!-- TEMP DISABLED until mkd-gcm-sdk / mkd-gcm-natives are on Maven Central.
              GCM language corrections: thin JNA SDK. Native mkd_gcm_ffi is packaged into
              <installdir>/bin by perc-distribution-tree (StartJetty -Djna.library.path);

--- a/projects/sitemanage/src/main/java/com/percussion/doctor/PSDoctorAdminChecker.java
+++ b/projects/sitemanage/src/main/java/com/percussion/doctor/PSDoctorAdminChecker.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.doctor;
+
+import com.intsof.percussioncms.doctor.api.DoctorAdminChecker;
+import com.percussion.share.service.exception.PSDataServiceException;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
+import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Admin gate for perc-doctor HTTP API using the CMS user service.
+ *
+ * <p>Returns {@code false} for anonymous callers, missing principals, and non-Admin users.
+ */
+public class PSDoctorAdminChecker implements DoctorAdminChecker {
+
+  private final IPSUserService userService;
+
+  /**
+   * @param userService CMS user service; never null
+   */
+  public PSDoctorAdminChecker(IPSUserService userService) {
+    this.userService = Objects.requireNonNull(userService, "userService");
+  }
+
+  @Override
+  public boolean isCurrentUserAdmin() {
+    try {
+      PSCurrentUser current = userService.getCurrentUser();
+      if (current == null) {
+        return false;
+      }
+      String name = current.getName();
+      if (StringUtils.isBlank(name)) {
+        return false;
+      }
+      return userService.isAdminUser(name);
+    } catch (PSDataServiceException e) {
+      log.warn("Doctor admin check failed: {}", e.getMessage());
+      return false;
+    } catch (RuntimeException e) {
+      // Includes PSNoCurrentUserException when no authenticated principal.
+      log.debug("Doctor admin check: no current admin user ({})", e.toString());
+      return false;
+    }
+  }
+
+  private static final Logger log = LogManager.getLogger(PSDoctorAdminChecker.class);
+}

--- a/projects/sitemanage/src/main/java/com/percussion/doctor/PSDoctorInstallRootProvider.java
+++ b/projects/sitemanage/src/main/java/com/percussion/doctor/PSDoctorInstallRootProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.doctor;
+
+import com.intsof.percussioncms.doctor.api.DoctorInstallRootProvider;
+import com.percussion.utils.io.PathUtils;
+import java.io.File;
+import java.nio.file.Path;
+
+/**
+ * Resolves the default CMS install root for doctor HTTP requests via {@link PathUtils#getRxDir()}.
+ *
+ * <p>Uses portable {@link File}/{@link Path} APIs (no hardcoded drive letters or user home paths).
+ */
+public class PSDoctorInstallRootProvider implements DoctorInstallRootProvider {
+
+  @Override
+  public Path getDefaultInstallRoot() {
+    File rxDir = PathUtils.getRxDir();
+    if (rxDir == null) {
+      throw new IllegalStateException("CMS install root is not available");
+    }
+    return rxDir.toPath().toAbsolutePath().normalize();
+  }
+}

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -1008,9 +1008,21 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
     </jaxrs:server>
 
 
+    <!-- perc-doctor admin HTTP API (issue #2219 / parent #2213 slice 4):
+         POST /maintenance/doctor/{command} — Admin only; dryRun defaults to true. -->
+    <bean id="doctorAdminChecker" class="com.percussion.doctor.PSDoctorAdminChecker">
+        <constructor-arg ref="userService"/>
+    </bean>
+    <bean id="doctorInstallRootProvider" class="com.percussion.doctor.PSDoctorInstallRootProvider"/>
+    <bean id="doctorRestService" class="com.intsof.percussioncms.doctor.api.DoctorRestService">
+        <constructor-arg ref="doctorAdminChecker"/>
+        <constructor-arg ref="doctorInstallRootProvider"/>
+    </bean>
+
     <jaxrs:server id="maintenance-jax-rs" address="/maintenance">
         <jaxrs:serviceBeans>
             <ref bean="maintenanceManagerRestService"/>
+            <ref bean="doctorRestService"/>
         </jaxrs:serviceBeans>
         <jaxrs:extensionMappings>
             <entry key="json" value="application/json"/>

--- a/projects/sitemanage/src/test/java/com/percussion/doctor/PSDoctorAdminCheckerTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/doctor/PSDoctorAdminCheckerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.percussion.share.service.exception.PSDataServiceException;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
+import com.percussion.user.service.IPSUserService.PSNoCurrentUserException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PSDoctorAdminCheckerTest {
+
+  @Mock private IPSUserService userService;
+
+  private PSDoctorAdminChecker checker;
+
+  @BeforeEach
+  void setUp() {
+    checker = new PSDoctorAdminChecker(userService);
+  }
+
+  @Test
+  void adminUserAllowed() throws Exception {
+    PSCurrentUser user = new PSCurrentUser();
+    user.setName("admin1");
+    when(userService.getCurrentUser()).thenReturn(user);
+    when(userService.isAdminUser("admin1")).thenReturn(true);
+
+    assertTrue(checker.isCurrentUserAdmin());
+  }
+
+  @Test
+  void nonAdminRejected() throws Exception {
+    PSCurrentUser user = new PSCurrentUser();
+    user.setName("editor");
+    when(userService.getCurrentUser()).thenReturn(user);
+    when(userService.isAdminUser("editor")).thenReturn(false);
+
+    assertFalse(checker.isCurrentUserAdmin());
+  }
+
+  @Test
+  void anonymousNoCurrentUserRejected() throws Exception {
+    when(userService.getCurrentUser()).thenThrow(new PSNoCurrentUserException("none"));
+
+    assertFalse(checker.isCurrentUserAdmin());
+  }
+
+  @Test
+  void blankUserNameRejected() throws Exception {
+    PSCurrentUser user = new PSCurrentUser();
+    user.setName("  ");
+    when(userService.getCurrentUser()).thenReturn(user);
+
+    assertFalse(checker.isCurrentUserAdmin());
+  }
+
+  @Test
+  void dataServiceFailureRejected() throws Exception {
+    when(userService.getCurrentUser()).thenThrow(new PSDataServiceException("boom"));
+
+    assertFalse(checker.isCurrentUserAdmin());
+  }
+}


### PR DESCRIPTION
## Summary

Overnight **same-file thrash absorption** for the perc-doctor stack (#2213 slices). Five stacked/sibling PRs all mutated shared paths (`modules/perc-doctor/README.md`, `DoctorCli.java`, `InstallRootGuard.java`, `pom.xml`, related tests). #2228 and #2229 were **sibling tips** on #2227 and conflicted on README when merged together.

This cluster PR unions all five against `main` so humans review **one** PR instead of a thrashing stack.

### Thrash files
- `modules/perc-doctor/README.md` (5 PRs)
- `modules/perc-doctor/pom.xml` (4 PRs)
- `modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java` (3 PRs)
- `modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/InstallRootGuard.java` (3 PRs)
- `modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java` (3 PRs)
- `modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/InstallRootGuardTest.java` (3 PRs)

### Content absorbed
1. **#2221** — perc-doctor scaffold + `clean-heap-dumps`
2. **#2226** — `clean-install-backups` CLI
3. **#2227** — `clean-logs` (`--older-than` / `--keep-current`)
4. **#2228** — dist bin packaging + operator install guide + distribution-tree unpack
5. **#2229** — admin HTTP API `POST /maintenance/doctor/{command}` + sitemanage beans wiring

README conflict between #2228 and #2229 resolved with **union** semantics (both packaging + HTTP docs; deferred section cleared for delivered slices).

## Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
|------------|-------------|------|----------|-------|
| yes | #2221 | `feat/issue-2213-perc-doctor-scaffold` | yes | scaffold + heap dumps |
| yes | #2226 | `feat/issue-2217-clean-install-backups` | yes | stacked on #2221 |
| yes | #2227 | `feat/issue-2218-clean-logs` | yes | stacked on #2226; follow-up fix included |
| yes | #2228 | `feat/issue-2220-perc-doctor-dist-packaging` | yes | sibling of #2229 on #2227 |
| yes | #2229 | `feat/issue-2219-admin-http-api` | yes | sibling of #2228; README union |

## Test plan / gates
- [x] `./mvnw -pl modules/perc-doctor -am test` green after full absorb
- [ ] Human review of unioned README + sitemanage bean wiring
- [ ] CI on this cluster PR
- Fixes #2217 #2218 #2219 #2220; Partial #2213 (scaffold #2221 content included)

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok using grok-4.5 with agent night-issue-prs cluster.