### PR TITLE
feat(perc-doctor): diagnose/health read-only install checklist (#2213)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2213-diagnose-health-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2213-diagnose-health-erlang.md
@@ -1,0 +1,29 @@
+# Erlang review: feat(perc-doctor) diagnose/health (#2213)
+
+**Branch:** `feat/issue-2213-diagnose-health`  
+**Date:** 2026-08-06  
+**Recommendation:** approve  
+**Gate:** May commit/push: **yes**
+
+## Summary
+
+Adds read-only `diagnose` / `health` checklist to `modules/perc-doctor` with unit tests, CLI help, and operator docs. Does not re-touch clean-* commands or HTTP API apply paths.
+
+## Scope
+
+- `DiagnoseReport`, `DiagnoseCommand` (new)
+- `DoctorCli` dispatch/help/print
+- `DiagnoseCommandTest`, `DoctorCliTest`, packaging doc assertion
+- README + operator-install-guide
+
+Cross-platform path review: all layout/config/log probes use `InstallRootGuard.resolveRelativeUnderRoot` (forward-slash relative segments + `Path.resolve`) and re-check `isUnderInstallRoot`. No hardcoded user homes, no string path joins with `\` or `/` for filesystem ops. Free disk via `Files.getFileStore`. Java version from system properties only.
+
+## Issues
+
+None at `bug` severity.
+
+- **nit:** `DiagnoseCommand.execute` declares `throws IOException` though current body does not throw it (consistent with clean commands; acceptable).
+
+## Tests
+
+Module `mvnw clean install`: all Surefire green including new `DiagnoseCommandTest` (9) and expanded `DoctorCliTest` (16). Behavioral coverage: report shape, path containment, no mutations, bare vs full tree, CLI alias/exit codes, help text.

--- a/modules/perc-doctor/README.md
+++ b/modules/perc-doctor/README.md
@@ -4,8 +4,8 @@ Operator CLI for diagnosing and safely cleaning Percussion CMS install trees.
 
 **Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`), [#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219) (admin HTTP API), [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (dist packaging + install guide)  
 **Package:** `com.intsof.percussioncms.doctor` (+ `...doctor.api` for HTTP)  
-**Shipped commands:** `clean-heap-dumps`, `clean-install-backups`, `clean-logs` with global `--dry-run` / `--install-root` / `-v`  
-**HTTP:** Admin-only `POST .../maintenance/doctor/{command}` (wired in sitemanage)
+**Shipped commands:** `diagnose`/`health` (read-only), `clean-heap-dumps`, `clean-install-backups`, `clean-logs` with global `--dry-run` / `--install-root` / `-v`  
+**HTTP:** Admin-only `POST .../maintenance/doctor/{command}` for clean-* commands (wired in sitemanage); diagnose is CLI-first
 
 **Operator install guide (dry-run-first examples):** [docs/operator-install-guide.md](docs/operator-install-guide.md)
 
@@ -73,6 +73,50 @@ target\perc-doctor-8.2.0-SNAPSHOT-dist\bin\perc-doctor.bat --help
 | `-h` / `--help` | Usage |
 
 ### Commands
+
+#### `diagnose` / `health`
+
+Read-only install checklist. **Never deletes or writes.** Alias: `health` is identical to `diagnose`.
+
+Checks (all path probes stay under `--install-root`):
+
+| Area | What |
+|------|------|
+| Install root | Exists and is a directory |
+| Layout | Critical dirs: `jetty`, `jetty/base`, `rxconfig` (missing → fail). Optional: `bin`, `rxconfig/Server`, `Deployment` (missing → warn) |
+| Key config | Presence of `rxconfig/Server/server.properties`, `rxconfig/Installer/rxrepository.properties` (missing → warn) |
+| Log dirs | Known Jetty/CMS/DTS log dir existence (same roots as `clean-logs`) |
+| Free disk | Usable space on the install root volume (warn below 1 GiB) |
+| Java | Running doctor JVM version/major (info + warn if major &lt; 21) |
+
+Global `--dry-run` is accepted for flag parity and echoed on the report; diagnose is always non-mutating. Exit code is non-zero when any check is `FAIL`.
+
+Examples:
+
+```bash
+# Checklist with detail (Linux / macOS)
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
+  --install-root /opt/Percussion -v diagnose
+
+# Alias + dry-run flag echo (Windows)
+java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar ^
+  --install-root C:\Percussion --dry-run -v health
+```
+
+Sample summary lines:
+
+```text
+command=diagnose
+install-root=/opt/Percussion
+dry-run=false
+read-only=true
+checks=16
+pass=10
+warn=4
+fail=0
+info=1
+healthy=true
+```
 
 #### `clean-heap-dumps`
 
@@ -166,11 +210,12 @@ java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
 ## Safety model
 
 1. Resolve and validate install root (must exist and be a directory).
-2. Walk only under that root (and for `clean-logs`, only under allowlisted log dirs); skip / reject candidates that escape the root.
-3. Match allowlisted patterns only (per command; no user-supplied globs).
-4. If `--dry-run`, stop after inventory.
-5. On apply, re-check containment immediately before each delete.
-6. For `clean-logs`, apply `--keep-current` and `--older-than` before any delete.
+2. For `diagnose`/`health`: only read path existence, sizes, and JVM/disk properties; never delete or write.
+3. Walk only under that root (and for `clean-logs`, only under allowlisted log dirs); skip / reject candidates that escape the root.
+4. Match allowlisted patterns only (per clean command; no user-supplied globs).
+5. If `--dry-run`, stop after inventory (clean commands).
+6. On apply, re-check containment immediately before each delete.
+7. For `clean-logs`, apply `--keep-current` and `--older-than` before any delete.
 
 ## Admin HTTP API (slice #2219)
 
@@ -236,6 +281,6 @@ Example apply (Admin only; deletes under install root):
 - Admin gate: `com.percussion.doctor.PSDoctorAdminChecker` (`IPSUserService.isAdminUser`)
 - Default install root: `com.percussion.doctor.PSDoctorInstallRootProvider` (`PathUtils.getRxDir()`)
 
-## Deferred (not in this module slice)
+## Deferred (stretch after diagnose)
 
-None for the #2213 slices absorbed here (`clean-*` CLI, dist packaging #2220, admin HTTP #2219). Further residuals stay on the parent epic if any.
+Further stretch commands under parent [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213): `clean-temp`, `fix-permissions`, deeper `check-config` (beyond presence), and optional diagnose on the admin HTTP surface.

--- a/modules/perc-doctor/docs/operator-install-guide.md
+++ b/modules/perc-doctor/docs/operator-install-guide.md
@@ -66,6 +66,28 @@ For every command:
 
 ## Commands
 
+### `diagnose` / `health` (read-only)
+
+Run a non-mutating install checklist (layout dirs, free disk, key config presence, Java version, known log dirs). **Never deletes.** Alias: `health` is the same command. Safe to run anytime; prefer `-v` for checklist detail.
+
+**Linux / macOS:**
+
+```bash
+cd /opt/Percussion
+./bin/perc-doctor -v diagnose
+# or
+./bin/perc-doctor --dry-run -v health
+```
+
+**Windows:**
+
+```bat
+cd /d C:\Percussion
+bin\perc-doctor.bat -v diagnose
+```
+
+Exit code is non-zero when any check is `FAIL` (e.g. missing `jetty/base` or `rxconfig`). WARN-only outcomes still exit 0.
+
 ### `clean-heap-dumps`
 
 Removes recursive `*.hprof` under the install root (case-insensitive). Scope is hard-limited to `--install-root`.

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DiagnoseCommand.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DiagnoseCommand.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Read-only install health checklist for operators ({@code diagnose} / {@code health}).
+ *
+ * <p>Never deletes or writes. Checks install-root layout markers, free disk space, key config file
+ * presence, the running Java version, and known log directory existence. Every resolved path is
+ * constrained under the install root via {@link InstallRootGuard}.
+ *
+ * <p>Global {@code --dry-run} is accepted for CLI parity and echoed on the report; it has no effect
+ * because this command is always non-mutating.
+ */
+public final class DiagnoseCommand {
+
+  /** Primary CLI command token. */
+  public static final String COMMAND_NAME = "diagnose";
+
+  /** Alias accepted by the CLI (same behavior as {@link #COMMAND_NAME}). */
+  public static final String COMMAND_ALIAS = "health";
+
+  /**
+   * Expected layout directories relative to install root (forward-slash segments). Critical when
+   * missing → {@link DiagnoseReport.CheckStatus#FAIL}; optional → WARN.
+   */
+  static final String[] LAYOUT_DIRS_CRITICAL = {
+    "jetty",
+    "jetty/base",
+    "rxconfig"
+  };
+
+  /** Optional but common layout dirs (missing → WARN). */
+  static final String[] LAYOUT_DIRS_OPTIONAL = {
+    "bin",
+    "rxconfig/Server",
+    "Deployment"
+  };
+
+  /**
+   * Key config files relative to install root. Missing → WARN (install may be partial or mid-upgrade).
+   */
+  static final String[] KEY_CONFIG_FILES = {
+    "rxconfig/Server/server.properties",
+    "rxconfig/Installer/rxrepository.properties"
+  };
+
+  /** Free space below this many bytes is reported as WARN (1 GiB). */
+  static final long LOW_DISK_BYTES = 1L * 1024 * 1024 * 1024;
+
+  /** CMS product baseline Java major version (informational WARN when lower). */
+  static final int EXPECTED_JAVA_MAJOR = 21;
+
+  private DiagnoseCommand() {}
+
+  /**
+   * Whether {@code command} is {@code diagnose} or {@code health} (case-sensitive CLI tokens).
+   *
+   * @param command raw command token
+   * @return true when this command should run
+   */
+  public static boolean isDiagnoseCommand(String command) {
+    return COMMAND_NAME.equals(command) || COMMAND_ALIAS.equals(command);
+  }
+
+  /**
+   * Run the read-only checklist under {@code installRoot}.
+   *
+   * @param installRoot CMS install root (must exist and be a directory)
+   * @param dryRun echoed global flag only; never enables writes
+   * @param commandToken token to record on the report ({@code diagnose} or {@code health})
+   * @return checklist report
+   * @throws IllegalArgumentException if install root is invalid
+   * @throws IOException if free-space probe fails in an unrecoverable way (individual checks still
+   *     prefer WARN/FAIL rows over throwing when possible)
+   */
+  public static DiagnoseReport execute(Path installRoot, boolean dryRun, String commandToken)
+      throws IOException {
+    Path root = InstallRootGuard.requireInstallRoot(installRoot);
+    String token =
+        commandToken != null && !commandToken.isEmpty() ? commandToken : COMMAND_NAME;
+    DiagnoseReport report = new DiagnoseReport(token, root, dryRun);
+
+    // Always-true once requireInstallRoot succeeds — documents the root for operators.
+    report.add(
+        new DiagnoseReport.Check(
+            "install-root",
+            DiagnoseReport.CheckStatus.PASS,
+            "Install root exists and is a directory",
+            root));
+
+    checkLayoutDirs(report, root);
+    checkKeyConfigs(report, root);
+    checkLogDirs(report, root);
+    checkFreeDisk(report, root);
+    checkJavaVersion(report);
+
+    return report;
+  }
+
+  /**
+   * Convenience overload that records {@link #COMMAND_NAME} on the report.
+   *
+   * @param installRoot CMS install root
+   * @param dryRun echoed global flag
+   * @return checklist report
+   * @throws IOException on unrecoverable I/O
+   */
+  public static DiagnoseReport execute(Path installRoot, boolean dryRun) throws IOException {
+    return execute(installRoot, dryRun, COMMAND_NAME);
+  }
+
+  static void checkLayoutDirs(DiagnoseReport report, Path root) {
+    for (String relative : LAYOUT_DIRS_CRITICAL) {
+      addDirCheck(report, root, relative, true);
+    }
+    for (String relative : LAYOUT_DIRS_OPTIONAL) {
+      addDirCheck(report, root, relative, false);
+    }
+  }
+
+  static void addDirCheck(
+      DiagnoseReport report, Path root, String relativeSlashPath, boolean critical) {
+    Path resolved = InstallRootGuard.resolveRelativeUnderRoot(root, relativeSlashPath);
+    String id = "layout." + relativeSlashPath.replace('/', '.');
+    if (resolved == null) {
+      report.add(
+          new DiagnoseReport.Check(
+              id,
+              DiagnoseReport.CheckStatus.FAIL,
+              "Invalid relative layout path (path guard rejected): " + relativeSlashPath,
+              null));
+      return;
+    }
+    // Containment re-check (defense in depth).
+    if (!InstallRootGuard.isUnderInstallRoot(root, resolved)) {
+      report.add(
+          new DiagnoseReport.Check(
+              id,
+              DiagnoseReport.CheckStatus.FAIL,
+              "Resolved path is outside install root: " + resolved,
+              resolved));
+      return;
+    }
+    if (Files.isDirectory(resolved)) {
+      report.add(
+          new DiagnoseReport.Check(
+              id, DiagnoseReport.CheckStatus.PASS, "Directory present: " + relativeSlashPath, resolved));
+    } else if (Files.exists(resolved)) {
+      report.add(
+          new DiagnoseReport.Check(
+              id,
+              DiagnoseReport.CheckStatus.FAIL,
+              "Expected a directory but found a non-directory: " + relativeSlashPath,
+              resolved));
+    } else {
+      report.add(
+          new DiagnoseReport.Check(
+              id,
+              critical ? DiagnoseReport.CheckStatus.FAIL : DiagnoseReport.CheckStatus.WARN,
+              "Missing directory: " + relativeSlashPath,
+              resolved));
+    }
+  }
+
+  static void checkKeyConfigs(DiagnoseReport report, Path root) {
+    for (String relative : KEY_CONFIG_FILES) {
+      Path resolved = InstallRootGuard.resolveRelativeUnderRoot(root, relative);
+      String id = "config." + relative.replace('/', '.');
+      if (resolved == null) {
+        report.add(
+            new DiagnoseReport.Check(
+                id,
+                DiagnoseReport.CheckStatus.FAIL,
+                "Invalid relative config path (path guard rejected): " + relative,
+                null));
+        continue;
+      }
+      if (!InstallRootGuard.isUnderInstallRoot(root, resolved)) {
+        report.add(
+            new DiagnoseReport.Check(
+                id,
+                DiagnoseReport.CheckStatus.FAIL,
+                "Resolved config path is outside install root: " + resolved,
+                resolved));
+        continue;
+      }
+      if (Files.isRegularFile(resolved)) {
+        report.add(
+            new DiagnoseReport.Check(
+                id, DiagnoseReport.CheckStatus.PASS, "Config file present: " + relative, resolved));
+      } else {
+        report.add(
+            new DiagnoseReport.Check(
+                id,
+                DiagnoseReport.CheckStatus.WARN,
+                "Key config file missing: " + relative,
+                resolved));
+      }
+    }
+  }
+
+  static void checkLogDirs(DiagnoseReport report, Path root) {
+    for (String relative : InstallRootGuard.LOG_DIR_RELATIVE) {
+      Path resolved = InstallRootGuard.resolveRelativeUnderRoot(root, relative);
+      String id = "logs." + relative.replace('/', '.');
+      if (resolved == null) {
+        report.add(
+            new DiagnoseReport.Check(
+                id,
+                DiagnoseReport.CheckStatus.FAIL,
+                "Invalid relative log path (path guard rejected): " + relative,
+                null));
+        continue;
+      }
+      if (!InstallRootGuard.isUnderInstallRoot(root, resolved)) {
+        report.add(
+            new DiagnoseReport.Check(
+                id,
+                DiagnoseReport.CheckStatus.FAIL,
+                "Resolved log path is outside install root: " + resolved,
+                resolved));
+        continue;
+      }
+      if (Files.isDirectory(resolved)) {
+        report.add(
+            new DiagnoseReport.Check(
+                id, DiagnoseReport.CheckStatus.PASS, "Log directory present: " + relative, resolved));
+      } else {
+        // Missing log dirs are common on fresh or partial trees — warn, do not fail.
+        report.add(
+            new DiagnoseReport.Check(
+                id,
+                DiagnoseReport.CheckStatus.WARN,
+                "Known log directory missing: " + relative,
+                resolved));
+      }
+    }
+  }
+
+  static void checkFreeDisk(DiagnoseReport report, Path root) {
+    try {
+      FileStore store = Files.getFileStore(root);
+      long usable = store.getUsableSpace();
+      long total = store.getTotalSpace();
+      String human =
+          "usable="
+              + formatBytes(usable)
+              + " total="
+              + formatBytes(total)
+              + " store="
+              + store.name();
+      if (usable < LOW_DISK_BYTES) {
+        report.add(
+            new DiagnoseReport.Check(
+                "disk.free",
+                DiagnoseReport.CheckStatus.WARN,
+                "Low free disk space (" + human + ")",
+                root));
+      } else {
+        report.add(
+            new DiagnoseReport.Check(
+                "disk.free",
+                DiagnoseReport.CheckStatus.PASS,
+                "Adequate free disk space (" + human + ")",
+                root));
+      }
+    } catch (IOException e) {
+      String detail = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+      report.add(
+          new DiagnoseReport.Check(
+              "disk.free",
+              DiagnoseReport.CheckStatus.WARN,
+              "Could not probe free disk space: " + detail,
+              root));
+    }
+  }
+
+  static void checkJavaVersion(DiagnoseReport report) {
+    String version = System.getProperty("java.version", "unknown");
+    String home = System.getProperty("java.home", "");
+    int major = parseJavaMajor(version);
+    String detail =
+        "java.version="
+            + version
+            + (home.isEmpty() ? "" : " java.home=" + home)
+            + (major > 0 ? " major=" + major : "");
+    report.add(
+        new DiagnoseReport.Check(
+            "java.version", DiagnoseReport.CheckStatus.INFO, detail, null));
+    if (major > 0 && major < EXPECTED_JAVA_MAJOR) {
+      report.add(
+          new DiagnoseReport.Check(
+              "java.major",
+              DiagnoseReport.CheckStatus.WARN,
+              "Running Java major "
+                  + major
+                  + " is below CMS baseline "
+                  + EXPECTED_JAVA_MAJOR
+                  + " (doctor process JVM)",
+              null));
+    } else if (major >= EXPECTED_JAVA_MAJOR) {
+      report.add(
+          new DiagnoseReport.Check(
+              "java.major",
+              DiagnoseReport.CheckStatus.PASS,
+              "Running Java major " + major + " meets CMS baseline " + EXPECTED_JAVA_MAJOR,
+              null));
+    } else {
+      report.add(
+          new DiagnoseReport.Check(
+              "java.major",
+              DiagnoseReport.CheckStatus.WARN,
+              "Could not parse Java major from version string: " + version,
+              null));
+    }
+  }
+
+  /**
+   * Parse the major version from a {@code java.version} string ({@code 1.8.0_xxx} → 8, {@code
+   * 21.0.2} → 21). Returns 0 when unparseable.
+   *
+   * @param version {@code java.version} property value
+   * @return major version or 0
+   */
+  static int parseJavaMajor(String version) {
+    if (version == null || version.isEmpty()) {
+      return 0;
+    }
+    String v = version.trim().toLowerCase(Locale.ROOT);
+    // Strip common prefixes
+    if (v.startsWith("java")) {
+      int sp = v.indexOf(' ');
+      if (sp > 0) {
+        v = v.substring(sp + 1).trim();
+      }
+    }
+    // Legacy 1.x
+    if (v.startsWith("1.")) {
+      int secondDot = v.indexOf('.', 2);
+      String mid = secondDot > 2 ? v.substring(2, secondDot) : v.substring(2);
+      return parsePositiveIntPrefix(mid);
+    }
+    // Modern: 9, 11.0.2, 21.0.1+12
+    int end = 0;
+    while (end < v.length() && Character.isDigit(v.charAt(end))) {
+      end++;
+    }
+    if (end == 0) {
+      return 0;
+    }
+    return parsePositiveIntPrefix(v.substring(0, end));
+  }
+
+  private static int parsePositiveIntPrefix(String s) {
+    if (s == null || s.isEmpty()) {
+      return 0;
+    }
+    try {
+      int n = Integer.parseInt(s);
+      return n > 0 ? n : 0;
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
+  /** Human-readable byte size for operator output (binary units). */
+  static String formatBytes(long bytes) {
+    if (bytes < 0) {
+      return Long.toString(bytes);
+    }
+    final String[] units = {"B", "KiB", "MiB", "GiB", "TiB"};
+    double v = (double) bytes;
+    int u = 0;
+    while (v >= 1024.0 && u < units.length - 1) {
+      v /= 1024.0;
+      u++;
+    }
+    if (u == 0) {
+      return bytes + " B";
+    }
+    return String.format(Locale.ROOT, "%.1f %s", v, units[u]);
+  }
+
+  /**
+   * Resolve a relative path under root for tests / callers; package-visible path-guard helper.
+   *
+   * @param root install root
+   * @param relativeSlashPath forward-slash relative path
+   * @return resolved path or null if rejected by the path guard
+   */
+  static Path resolveChecked(Path root, String relativeSlashPath) {
+    Objects.requireNonNull(root, "root");
+    return InstallRootGuard.resolveRelativeUnderRoot(root, relativeSlashPath);
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DiagnoseReport.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DiagnoseReport.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Read-only checklist report for {@code diagnose} / {@code health}. Never implies filesystem
+ * mutations — all checks are informational.
+ */
+public final class DiagnoseReport {
+
+  /** Outcome severity for a single checklist item. */
+  public enum CheckStatus {
+    /** Expected condition met. */
+    PASS,
+    /** Non-fatal concern (missing optional path, low disk, older Java). */
+    WARN,
+    /** Critical missing layout / unreadable root. */
+    FAIL,
+    /** Pure information (e.g. reported Java version string). */
+    INFO
+  }
+
+  /** One checklist row. */
+  public static final class Check {
+    private final String id;
+    private final CheckStatus status;
+    private final String message;
+    private final Path path;
+
+    /**
+     * @param id stable machine-oriented check id (e.g. {@code layout.jetty-base})
+     * @param status outcome severity
+     * @param message human-readable detail
+     * @param path optional related path under install root (may be null)
+     */
+    public Check(String id, CheckStatus status, String message, Path path) {
+      this.id = Objects.requireNonNull(id, "id");
+      this.status = Objects.requireNonNull(status, "status");
+      this.message = Objects.requireNonNull(message, "message");
+      this.path = path;
+    }
+
+    /** @return stable check id */
+    public String getId() {
+      return id;
+    }
+
+    /** @return outcome severity */
+    public CheckStatus getStatus() {
+      return status;
+    }
+
+    /** @return human-readable detail */
+    public String getMessage() {
+      return message;
+    }
+
+    /** @return related path, or null */
+    public Path getPath() {
+      return path;
+    }
+  }
+
+  private final String command;
+  private final Path installRoot;
+  private final boolean dryRun;
+  private final List<Check> checks = new ArrayList<>();
+
+  /**
+   * @param command command token used for this run ({@code diagnose} or {@code health})
+   * @param installRoot resolved install root
+   * @param dryRun echoed global flag (diagnose never mutates regardless)
+   */
+  public DiagnoseReport(String command, Path installRoot, boolean dryRun) {
+    this.command = Objects.requireNonNull(command, "command");
+    this.installRoot = Objects.requireNonNull(installRoot, "installRoot");
+    this.dryRun = dryRun;
+  }
+
+  /** Append a checklist entry. */
+  public void add(Check check) {
+    checks.add(Objects.requireNonNull(check, "check"));
+  }
+
+  /** @return command token */
+  public String getCommand() {
+    return command;
+  }
+
+  /** @return install root used for this run */
+  public Path getInstallRoot() {
+    return installRoot;
+  }
+
+  /**
+   * Echo of the global {@code --dry-run} flag. Diagnose is always read-only; this value is reported
+   * for flag parity with other commands and never gates deletes (there are none).
+   *
+   * @return whether {@code --dry-run} was set on the CLI
+   */
+  public boolean isDryRun() {
+    return dryRun;
+  }
+
+  /** @return unmodifiable checklist */
+  public List<Check> getChecks() {
+    return Collections.unmodifiableList(checks);
+  }
+
+  /** @return number of checks */
+  public int getCheckCount() {
+    return checks.size();
+  }
+
+  /** @return count of {@link CheckStatus#PASS} */
+  public int getPassCount() {
+    return count(CheckStatus.PASS);
+  }
+
+  /** @return count of {@link CheckStatus#WARN} */
+  public int getWarnCount() {
+    return count(CheckStatus.WARN);
+  }
+
+  /** @return count of {@link CheckStatus#FAIL} */
+  public int getFailCount() {
+    return count(CheckStatus.FAIL);
+  }
+
+  /** @return count of {@link CheckStatus#INFO} */
+  public int getInfoCount() {
+    return count(CheckStatus.INFO);
+  }
+
+  /**
+   * @return true when no {@link CheckStatus#FAIL} entries (WARN/INFO allowed)
+   */
+  public boolean isHealthy() {
+    return getFailCount() == 0;
+  }
+
+  private int count(CheckStatus status) {
+    int n = 0;
+    for (Check c : checks) {
+      if (c.getStatus() == status) {
+        n++;
+      }
+    }
+    return n;
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
@@ -29,7 +29,8 @@ import java.time.Duration;
  *   &lt;command&gt; [command-options]
  * </pre>
  *
- * <p>Commands: {@code clean-heap-dumps}, {@code clean-install-backups}, {@code clean-logs}.
+ * <p>Commands: {@code diagnose}/{@code health}, {@code clean-heap-dumps}, {@code
+ * clean-install-backups}, {@code clean-logs}.
  */
 public final class DoctorCli {
 
@@ -76,6 +77,10 @@ public final class DoctorCli {
     if (parsed.command == null || parsed.command.isEmpty()) {
       err.println(
           "Error: missing command. Try: "
+              + DiagnoseCommand.COMMAND_NAME
+              + "/"
+              + DiagnoseCommand.COMMAND_ALIAS
+              + ", "
               + CleanHeapDumpsCommand.COMMAND_NAME
               + ", "
               + CleanInstallBackupsCommand.COMMAND_NAME
@@ -109,6 +114,12 @@ public final class DoctorCli {
     }
 
     try {
+      if (DiagnoseCommand.isDiagnoseCommand(parsed.command)) {
+        DiagnoseReport report =
+            DiagnoseCommand.execute(installRoot, parsed.dryRun, parsed.command);
+        printDiagnoseReport(report, parsed.verbose, out);
+        return report.isHealthy() ? EXIT_OK : EXIT_ERROR;
+      }
       if (CleanHeapDumpsCommand.COMMAND_NAME.equals(parsed.command)) {
         CleanReport report = CleanHeapDumpsCommand.execute(installRoot, parsed.dryRun);
         printReport(report, parsed.verbose, out);
@@ -129,6 +140,10 @@ public final class DoctorCli {
       err.println("Error: unknown command: " + parsed.command);
       err.println(
           "Supported commands: "
+              + DiagnoseCommand.COMMAND_NAME
+              + "/"
+              + DiagnoseCommand.COMMAND_ALIAS
+              + ", "
               + CleanHeapDumpsCommand.COMMAND_NAME
               + ", "
               + CleanInstallBackupsCommand.COMMAND_NAME
@@ -208,16 +223,19 @@ public final class DoctorCli {
     stream.println("usage: perc-doctor [options] <command> [command-options]");
     stream.println();
     stream.println(
-        "CMS Doctor — safe install-tree maintenance"
-            + " (clean-heap-dumps, clean-install-backups, clean-logs).");
+        "CMS Doctor — install diagnose + safe install-tree maintenance"
+            + " (diagnose/health, clean-heap-dumps, clean-install-backups, clean-logs).");
     stream.println();
     stream.println("Options:");
     stream.println("  --install-root <path>  CMS install root (default: current working directory)");
     stream.println("  --dry-run              Report only; never delete or write");
-    stream.println("  -v, --verbose          Print each candidate path and size");
+    stream.println("  -v, --verbose          Print each candidate path / check detail");
     stream.println("  -h, --help             Show usage");
     stream.println();
     stream.println("Commands:");
+    stream.println(
+        "  diagnose, health       Read-only install checklist (layout, disk, config, Java,"
+            + " log dirs); never deletes");
     stream.println("  clean-heap-dumps       Remove recursive *.hprof under install root");
     stream.println(
         "  clean-install-backups  Remove allowlisted installer/upgrade backups"
@@ -234,6 +252,8 @@ public final class DoctorCli {
         "  --no-keep-current      Allow deleting active current log basenames");
     stream.println();
     stream.println("Examples:");
+    stream.println("  perc-doctor --install-root /opt/Percussion -v diagnose");
+    stream.println("  perc-doctor --install-root C:\\Percussion --dry-run health");
     stream.println("  perc-doctor --install-root /opt/Percussion --dry-run clean-heap-dumps");
     stream.println("  perc-doctor --install-root C:\\Percussion -v clean-heap-dumps");
     stream.println(
@@ -243,6 +263,27 @@ public final class DoctorCli {
         "  perc-doctor --install-root /opt/Percussion --dry-run -v clean-logs --older-than 7d");
     stream.println(
         "  perc-doctor --install-root C:\\Percussion -v clean-logs --older-than 14d");
+  }
+
+  static void printDiagnoseReport(DiagnoseReport report, boolean verbose, PrintStream out) {
+    out.println("command=" + report.getCommand());
+    out.println("install-root=" + report.getInstallRoot());
+    out.println("dry-run=" + report.isDryRun());
+    out.println("read-only=true");
+    out.println("checks=" + report.getCheckCount());
+    out.println("pass=" + report.getPassCount());
+    out.println("warn=" + report.getWarnCount());
+    out.println("fail=" + report.getFailCount());
+    out.println("info=" + report.getInfoCount());
+    out.println("healthy=" + report.isHealthy());
+    if (verbose) {
+      for (DiagnoseReport.Check c : report.getChecks()) {
+        String pathPart = c.getPath() == null ? "" : " " + c.getPath();
+        out.println("  " + c.getStatus() + " " + c.getId() + " " + c.getMessage() + pathPart);
+      }
+    } else if (report.getCheckCount() > 0) {
+      out.println("(use -v/--verbose for checklist detail)");
+    }
   }
 
   static void printReport(CleanReport report, boolean verbose, PrintStream out) {

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DiagnoseCommandTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DiagnoseCommandTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DiagnoseCommandTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void isDiagnoseCommandRecognizesTokens() {
+    assertTrue(DiagnoseCommand.isDiagnoseCommand("diagnose"));
+    assertTrue(DiagnoseCommand.isDiagnoseCommand("health"));
+    assertFalse(DiagnoseCommand.isDiagnoseCommand("clean-logs"));
+    assertFalse(DiagnoseCommand.isDiagnoseCommand("Diagnose"));
+    assertFalse(DiagnoseCommand.isDiagnoseCommand(null));
+  }
+
+  @Test
+  void reportShapeHasStableIdsAndNoMutations() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("empty-install"));
+    Path marker = root.resolve("sentinel.txt");
+    Files.writeString(marker, "keep-me", StandardCharsets.UTF_8);
+
+    DiagnoseReport report = DiagnoseCommand.execute(root, true);
+
+    assertEquals(DiagnoseCommand.COMMAND_NAME, report.getCommand());
+    assertEquals(root.toAbsolutePath().normalize(), report.getInstallRoot());
+    assertTrue(report.isDryRun());
+    assertTrue(report.getCheckCount() >= 5, "expected multiple checklist rows");
+    assertTrue(Files.exists(marker), "diagnose must never delete files");
+    assertTrue(Files.readString(marker).equals("keep-me"));
+
+    Set<String> ids = new HashSet<>();
+    for (DiagnoseReport.Check c : report.getChecks()) {
+      assertNotNull(c.getId());
+      assertFalse(c.getId().isEmpty());
+      assertNotNull(c.getStatus());
+      assertNotNull(c.getMessage());
+      assertFalse(c.getMessage().isEmpty());
+      ids.add(c.getId());
+    }
+    assertTrue(ids.contains("install-root"));
+    assertTrue(ids.contains("disk.free"));
+    assertTrue(ids.contains("java.version"));
+    assertTrue(ids.contains("java.major"));
+    assertTrue(ids.contains("layout.jetty.base") || ids.contains("layout.jetty"));
+    assertTrue(ids.stream().anyMatch(id -> id.startsWith("config.")));
+    assertTrue(ids.stream().anyMatch(id -> id.startsWith("logs.")));
+  }
+
+  @Test
+  void emptyTreeFailsCriticalLayoutAndWarnsConfigs() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("bare"));
+    DiagnoseReport report = DiagnoseCommand.execute(root, false, "health");
+
+    assertEquals("health", report.getCommand());
+    assertFalse(report.isDryRun());
+    assertFalse(report.isHealthy(), "missing jetty/rxconfig should fail health");
+    assertTrue(report.getFailCount() >= 1);
+
+    DiagnoseReport.Check jettyBase =
+        findCheck(report, "layout.jetty.base");
+    assertNotNull(jettyBase);
+    assertEquals(DiagnoseReport.CheckStatus.FAIL, jettyBase.getStatus());
+
+    DiagnoseReport.Check serverProps =
+        findCheck(report, "config.rxconfig.Server.server.properties");
+    assertNotNull(serverProps);
+    assertEquals(DiagnoseReport.CheckStatus.WARN, serverProps.getStatus());
+  }
+
+  @Test
+  void fullLayoutPassesCriticalChecks() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("full"));
+    Files.createDirectories(root.resolve("jetty").resolve("base").resolve("logs"));
+    Files.createDirectories(
+        root.resolve("jetty")
+            .resolve("base")
+            .resolve("modules")
+            .resolve("perc-logging")
+            .resolve("logs"));
+    Files.createDirectories(root.resolve("Deployment").resolve("Server").resolve("logs"));
+    Files.createDirectories(root.resolve("bin"));
+    Files.createDirectories(root.resolve("rxconfig").resolve("Server"));
+    Files.createDirectories(root.resolve("rxconfig").resolve("Installer"));
+    Files.writeString(
+        root.resolve("rxconfig").resolve("Server").resolve("server.properties"), "x=1");
+    Files.writeString(
+        root.resolve("rxconfig").resolve("Installer").resolve("rxrepository.properties"), "y=2");
+
+    DiagnoseReport report = DiagnoseCommand.execute(root, true);
+
+    assertTrue(report.isHealthy(), "full synthetic tree should have zero FAIL: " + summarize(report));
+    assertEquals(DiagnoseReport.CheckStatus.PASS, findCheck(report, "layout.jetty.base").getStatus());
+    assertEquals(DiagnoseReport.CheckStatus.PASS, findCheck(report, "layout.rxconfig").getStatus());
+    assertEquals(
+        DiagnoseReport.CheckStatus.PASS,
+        findCheck(report, "config.rxconfig.Server.server.properties").getStatus());
+    assertEquals(
+        DiagnoseReport.CheckStatus.PASS, findCheck(report, "logs.jetty.base.logs").getStatus());
+    // Never delete configs either
+    assertTrue(
+        Files.exists(root.resolve("rxconfig").resolve("Server").resolve("server.properties")));
+  }
+
+  @Test
+  void pathGuardsRejectDotDotRelative() {
+    Path root = tempDir.resolve("guard-root");
+    // resolveRelativeUnderRoot must reject ".."
+    assertEquals(null, DiagnoseCommand.resolveChecked(root, "../escape"));
+    assertEquals(null, InstallRootGuard.resolveRelativeUnderRoot(root, "jetty/../../etc"));
+  }
+
+  @Test
+  void checkPathsStayUnderInstallRoot() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("contained"));
+    Files.createDirectories(root.resolve("jetty").resolve("base"));
+    Files.createDirectories(root.resolve("rxconfig"));
+
+    DiagnoseReport report = DiagnoseCommand.execute(root, true);
+    for (DiagnoseReport.Check c : report.getChecks()) {
+      if (c.getPath() == null) {
+        continue;
+      }
+      assertTrue(
+          InstallRootGuard.isUnderInstallRoot(root, c.getPath()),
+          "check path must stay under install root: " + c.getId() + " -> " + c.getPath());
+    }
+  }
+
+  @Test
+  void missingInstallRootThrows() {
+    Path missing = tempDir.resolve("nope");
+    assertThrows(IllegalArgumentException.class, () -> DiagnoseCommand.execute(missing, true));
+  }
+
+  @Test
+  void parseJavaMajorHandlesLegacyAndModern() {
+    assertEquals(8, DiagnoseCommand.parseJavaMajor("1.8.0_402"));
+    assertEquals(11, DiagnoseCommand.parseJavaMajor("11.0.22"));
+    assertEquals(21, DiagnoseCommand.parseJavaMajor("21.0.2"));
+    assertEquals(21, DiagnoseCommand.parseJavaMajor("21"));
+    assertEquals(0, DiagnoseCommand.parseJavaMajor(""));
+    assertEquals(0, DiagnoseCommand.parseJavaMajor(null));
+  }
+
+  @Test
+  void formatBytesUsesBinaryUnits() {
+    assertEquals("0 B", DiagnoseCommand.formatBytes(0));
+    assertTrue(DiagnoseCommand.formatBytes(1536).contains("KiB"));
+    assertTrue(DiagnoseCommand.formatBytes(2L * 1024 * 1024 * 1024).contains("GiB"));
+  }
+
+  private static DiagnoseReport.Check findCheck(DiagnoseReport report, String id) {
+    for (DiagnoseReport.Check c : report.getChecks()) {
+      if (id.equals(c.getId())) {
+        return c;
+      }
+    }
+    return null;
+  }
+
+  private static String summarize(DiagnoseReport report) {
+    StringBuilder sb = new StringBuilder();
+    for (DiagnoseReport.Check c : report.getChecks()) {
+      sb.append(c.getStatus()).append(' ').append(c.getId()).append(' ').append(c.getMessage())
+          .append("; ");
+    }
+    return sb.toString();
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
@@ -260,6 +260,88 @@ class DoctorCliTest {
   }
 
   @Test
+  void diagnoseViaCliIsReadOnlyAndPrintsReportShape() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-diagnose"));
+    Files.createDirectories(root.resolve("jetty").resolve("base"));
+    Files.createDirectories(root.resolve("rxconfig").resolve("Server"));
+    Path keep = root.resolve("keep.me");
+    Files.writeString(keep, "safe");
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root", root.toString(), "--dry-run", "-v", "diagnose"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    assertTrue(Files.exists(keep));
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("command=diagnose"));
+    assertTrue(out.contains("dry-run=true"));
+    assertTrue(out.contains("read-only=true"));
+    assertTrue(out.contains("healthy=true"));
+    assertTrue(out.contains("checks="));
+    assertTrue(out.contains("PASS install-root") || out.contains("install-root"));
+  }
+
+  @Test
+  void healthAliasViaCliWorks() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-health"));
+    Files.createDirectories(root.resolve("jetty").resolve("base"));
+    Files.createDirectories(root.resolve("rxconfig"));
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"--install-root", root.toString(), "-v", "health"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("command=health"));
+    assertTrue(out.contains("read-only=true"));
+  }
+
+  @Test
+  void diagnoseBareTreeExitsErrorOnFailChecks() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-bare-diag"));
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"--install-root", root.toString(), "diagnose"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_ERROR, code);
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("healthy=false"));
+    assertTrue(out.contains("fail="));
+  }
+
+  @Test
+  void helpMentionsDiagnose() {
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"--help"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+    assertEquals(DoctorCli.EXIT_OK, code);
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("diagnose"));
+    assertTrue(out.contains("health"));
+  }
+
+  @Test
   void olderThanOnNonCleanLogsCommandWarnsAndContinues() throws Exception {
     Path root = Files.createDirectories(tempDir.resolve("install-older-warn"));
     Path dump = root.resolve("warn.hprof");

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/PercDoctorPackagingTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/PercDoctorPackagingTest.java
@@ -143,8 +143,9 @@ class PercDoctorPackagingTest {
     assertTrue(
         guideText.contains("clean-heap-dumps")
             && guideText.contains("clean-install-backups")
-            && guideText.contains("clean-logs"),
-        "install guide must cover all shipped commands");
+            && guideText.contains("clean-logs")
+            && (guideText.contains("diagnose") || guideText.contains("health")),
+        "install guide must cover all shipped commands including diagnose/health");
     assertTrue(
         guideText.contains("bin/perc-doctor") || guideText.contains("bin\\perc-doctor"),
         "install guide must document install-tree bin wrappers");


### PR DESCRIPTION
## Summary

**Parent tracker:** #2213  
**Slice:** stretch after MVP — read-only `diagnose` / `health` checklist (not a re-do of clean-* / API from #2230).

Adds CLI `diagnose` (alias `health`) to `modules/perc-doctor`:

- Install-root validation and layout markers (`jetty`, `jetty/base`, `rxconfig` critical; `bin`, `rxconfig/Server`, `Deployment` optional)
- Free disk space on the install volume (WARN under 1 GiB)
- Key config presence (`server.properties`, `rxrepository.properties`)
- Running JVM Java version / major (INFO + WARN if major < 21)
- Known log directory existence (same roots as `clean-logs`)
- **Never deletes or writes**; honors `--install-root` / `--dry-run` / `-v`; path containment via `InstallRootGuard`
- Unit tests for report shape, path guards, CLI wiring; README + operator guide examples

Does **not** re-implement clean-logs/backups/API (already on main via #2230). `#2218` (clean-logs) is already satisfied by #2230.

### Residual (filed as follow-ups)

Further stretch under #2213: `clean-temp`, `fix-permissions`, deeper `check-config` (beyond presence), optional diagnose on admin HTTP.

## Test plan

- [x] `cd modules/perc-doctor && ../../mvnw clean install` (all Surefire green; `DiagnoseCommandTest` 9, `DoctorCliTest` 16)
- [x] Behavioral tests: no mutations, containment, bare vs full tree, CLI `health` alias, non-zero exit on FAIL
- [x] Erlang self-review: `docs/ai-generated/code-reviews/issue-2213-diagnose-health-erlang.md` (approve)

## Gates evidence

| Gate | Result |
|------|--------|
| A Implement + unit tests | yes |
| B Erlang / portable paths | yes (Path + InstallRootGuard only) |
| C Module `mvnw clean install` | pass |
| D In-scope files only | perc-doctor + erlang report |
| E Commit refs #2213 | yes |
| F Operator labels | operator:grok, operator:night-issue-prs, model:grok-4.5 |
| G Base main, no merge | this PR |

**Operator:** Grok: night-issue-prs (model grok-4.5)

Partial for #2213.

> Co-Authored by Grok Build using grok-4.5 with agent main.