### PR TITLE
feat(siteimpact): page Site Impact parity with assets (Fixes #948)

### DIFF
--- a/WebUI/src/main/webapp/cm/app/js/legacy/plugins/perc_path_constants.js
+++ b/WebUI/src/main/webapp/cm/app/js/legacy/plugins/perc_path_constants.js
@@ -338,6 +338,7 @@
     ITEM_GETDATES: SERVICES.ITEMMGT + "/item/getitemdates",
     ITEM_LAST_COMMENT: SERVICES.ITEMMGT + "/item/lastComment",
     ASSET_SITE_IMPACT: SERVICES.ITEMMGT + "/item/siteimpact/asset",
+    PAGE_SITE_IMPACT: SERVICES.ITEMMGT + "/item/siteimpact/page",
     ADD_TO_MYPAGES: SERVICES.ITEMMGT + "/item/addtomypages",
     REMOVE_FROM_MYPAGES: SERVICES.ITEMMGT + "/item/removefrommypages",
     IS_MY_PAGE: SERVICES.ITEMMGT + "/item/ismypage",

--- a/WebUI/src/main/webapp/cm/app/js/legacy/services/PercSiteImpactService.js
+++ b/WebUI/src/main/webapp/cm/app/js/legacy/services/PercSiteImpactService.js
@@ -28,9 +28,22 @@
   /**
    * Makes a call to the server and calls the supplied callback with status and result. See $.PercServiceUtils.makeJsonRequest
    * for more details.
+   * @param itemId (String) guid of the page or asset
+   * @param itemType (String) optional; use PercSiteImpactView.ITEM_TYPE_PAGE or ITEM_TYPE_ASSET.
+   *        Defaults to asset for backward compatibility.
+   * @param callback function(status, result)
    */
-  function getSiteImpactDetails(itemId, callback) {
-    var url = $.perc_paths.ASSET_SITE_IMPACT + "/" + itemId;
+  function getSiteImpactDetails(itemId, itemType, callback) {
+    // Back-compat: older callers pass (itemId, callback)
+    if (typeof itemType === "function") {
+      callback = itemType;
+      itemType = null;
+    }
+    var baseUrl =
+      itemType === "page"
+        ? $.perc_paths.PAGE_SITE_IMPACT
+        : $.perc_paths.ASSET_SITE_IMPACT;
+    var url = baseUrl + "/" + itemId;
     $.PercServiceUtils.makeJsonRequest(
       url,
       $.PercServiceUtils.TYPE_GET,

--- a/WebUI/src/main/webapp/cm/app/js/legacy/views/PercSiteImpactView.js
+++ b/WebUI/src/main/webapp/cm/app/js/legacy/views/PercSiteImpactView.js
@@ -36,7 +36,11 @@
     var dialog;
     var rootElem = rootElement;
     //Makes a service call and gets the site impact data, passes the _renderResults as the callback
-    $.PercSiteImpactService.getSiteImpactDetails(itemId, _renderResults);
+    $.PercSiteImpactService.getSiteImpactDetails(
+      itemId,
+      itemType,
+      _renderResults,
+    );
     /**
      * Creates the dialog and sets the field values from the supplied result.data object.
      * On dialog open calls the addRevisionRows to add the revision rows.

--- a/WebUI/src/main/webapp/cm/plugins/perc_path_constants.js
+++ b/WebUI/src/main/webapp/cm/plugins/perc_path_constants.js
@@ -338,6 +338,7 @@
     ITEM_GETDATES: SERVICES.ITEMMGT + "/item/getitemdates",
     ITEM_LAST_COMMENT: SERVICES.ITEMMGT + "/item/lastComment",
     ASSET_SITE_IMPACT: SERVICES.ITEMMGT + "/item/siteimpact/asset",
+    PAGE_SITE_IMPACT: SERVICES.ITEMMGT + "/item/siteimpact/page",
     ADD_TO_MYPAGES: SERVICES.ITEMMGT + "/item/addtomypages",
     REMOVE_FROM_MYPAGES: SERVICES.ITEMMGT + "/item/removefrommypages",
     IS_MY_PAGE: SERVICES.ITEMMGT + "/item/ismypage",

--- a/WebUI/src/main/webapp/cm/services/PercSiteImpactService.js
+++ b/WebUI/src/main/webapp/cm/services/PercSiteImpactService.js
@@ -28,9 +28,22 @@
   /**
    * Makes a call to the server and calls the supplied callback with status and result. See $.PercServiceUtils.makeJsonRequest
    * for more details.
+   * @param itemId (String) guid of the page or asset
+   * @param itemType (String) optional; use PercSiteImpactView.ITEM_TYPE_PAGE or ITEM_TYPE_ASSET.
+   *        Defaults to asset for backward compatibility.
+   * @param callback function(status, result)
    */
-  function getSiteImpactDetails(itemId, callback) {
-    var url = $.perc_paths.ASSET_SITE_IMPACT + "/" + itemId;
+  function getSiteImpactDetails(itemId, itemType, callback) {
+    // Back-compat: older callers pass (itemId, callback)
+    if (typeof itemType === "function") {
+      callback = itemType;
+      itemType = null;
+    }
+    var baseUrl =
+      itemType === "page"
+        ? $.perc_paths.PAGE_SITE_IMPACT
+        : $.perc_paths.ASSET_SITE_IMPACT;
+    var url = baseUrl + "/" + itemId;
     $.PercServiceUtils.makeJsonRequest(
       url,
       $.PercServiceUtils.TYPE_GET,

--- a/WebUI/src/main/webapp/cm/views/PercSiteImpactView.js
+++ b/WebUI/src/main/webapp/cm/views/PercSiteImpactView.js
@@ -36,7 +36,11 @@
     var dialog;
     var rootElem = rootElement;
     //Makes a service call and gets the site impact data, passes the _renderResults as the callback
-    $.PercSiteImpactService.getSiteImpactDetails(itemId, _renderResults);
+    $.PercSiteImpactService.getSiteImpactDetails(
+      itemId,
+      itemType,
+      _renderResults,
+    );
     /**
      * Creates the dialog and sets the field values from the supplied result.data object.
      * On dialog open calls the addRevisionRows to add the revision rows.

--- a/WebUI/src/main/webapp/cm/widgets/perc_page_edit_dialog.js
+++ b/WebUI/src/main/webapp/cm/widgets/perc_page_edit_dialog.js
@@ -184,6 +184,24 @@
         .contents()
         .find("#perc-content-edit-metadata-link")
         .show();
+
+      // Site impact for pages (parity with asset edit): reverse links / relationships.
+      var $siteImpactPanel = $("#edit-page-metadata-frame")
+        .contents()
+        .find("#perc-site-impact-panel");
+      if ($siteImpactPanel.length && pageid) {
+        $siteImpactPanel.show();
+        if (
+          $.PercSiteImpactView &&
+          typeof $.PercSiteImpactView.renderSiteImpact === "function"
+        ) {
+          $.PercSiteImpactView.renderSiteImpact(
+            pageid,
+            $.PercSiteImpactView.ITEM_TYPE_PAGE,
+            $siteImpactPanel,
+          );
+        }
+      }
     }
 
     // A private helper method to group the fields and create collapsible sections

--- a/WebUI/war/plugins/perc_path_constants.js
+++ b/WebUI/war/plugins/perc_path_constants.js
@@ -312,6 +312,7 @@
         ITEM_GETDATES         : SERVICES.ITEMMGT + "/item/getitemdates",
         ITEM_LAST_COMMENT     : SERVICES.ITEMMGT + "/item/lastComment",
         ASSET_SITE_IMPACT     : SERVICES.ITEMMGT + "/item/siteimpact/asset",
+        PAGE_SITE_IMPACT      : SERVICES.ITEMMGT + "/item/siteimpact/page",
         ADD_TO_MYPAGES        : SERVICES.ITEMMGT + "/item/addtomypages",
         REMOVE_FROM_MYPAGES   : SERVICES.ITEMMGT + "/item/removefrommypages",
         IS_MY_PAGE            : SERVICES.ITEMMGT + "/item/ismypage",

--- a/WebUI/war/services/PercSiteImpactService.js
+++ b/WebUI/war/services/PercSiteImpactService.js
@@ -30,10 +30,18 @@
     /**
      * Makes a call to the server and calls the supplied callback with status and result. See $.PercServiceUtils.makeJsonRequest
      * for more details.
+     * @param itemId (String) guid of the page or asset
+     * @param itemType (String) optional; "page" or "asset". Defaults to asset.
+     * @param callback function(status, result)
      */
-    function getSiteImpactDetails(itemId, callback)
+    function getSiteImpactDetails(itemId, itemType, callback)
     {
-        var url = $.perc_paths.ASSET_SITE_IMPACT + "/" + itemId;
+        if (typeof itemType === "function") {
+            callback = itemType;
+            itemType = null;
+        }
+        var baseUrl = itemType === "page" ? $.perc_paths.PAGE_SITE_IMPACT : $.perc_paths.ASSET_SITE_IMPACT;
+        var url = baseUrl + "/" + itemId;
         $.PercServiceUtils.makeJsonRequest(url,$.PercServiceUtils.TYPE_GET,false,callback);
     }
 })(jQuery);

--- a/WebUI/war/views/PercSiteImpactView.js
+++ b/WebUI/war/views/PercSiteImpactView.js
@@ -36,7 +36,7 @@
         var dialog;
         var rootElem = rootElement;
         //Makes a service call and gets the site impact data, passes the _renderResults as the callback
-        $.PercSiteImpactService.getSiteImpactDetails(itemId, _renderResults);
+        $.PercSiteImpactService.getSiteImpactDetails(itemId, itemType, _renderResults);
         /**
          * Creates the dialog and sets the field values from the supplied result.data object.
          * On dialog open calls the addRevisionRows to add the revision rows.

--- a/WebUI/war/widgets/perc_page_edit_dialog.js
+++ b/WebUI/war/widgets/perc_page_edit_dialog.js
@@ -146,6 +146,15 @@
             setTimeout(function () { _handleAutoSummary();}, 4000);
 
             $("#edit-page-metadata-frame").contents().find("#perc-content-edit-metadata-link").show();
+
+            // Site impact for pages (parity with asset edit): reverse links / relationships.
+            var $siteImpactPanel = $("#edit-page-metadata-frame").contents().find("#perc-site-impact-panel");
+            if ($siteImpactPanel.length && pageid) {
+                $siteImpactPanel.show();
+                if ($.PercSiteImpactView && typeof $.PercSiteImpactView.renderSiteImpact === "function") {
+                    $.PercSiteImpactView.renderSiteImpact(pageid, $.PercSiteImpactView.ITEM_TYPE_PAGE, $siteImpactPanel);
+                }
+            }
         }
 
         // A private helper method to group the fields and create collapsible sections

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/IPSItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/IPSItemService.java
@@ -143,6 +143,16 @@ public interface IPSItemService {
   String getAssetSiteImpact(String assetId);
 
   /**
+   * Calculates the site impact of a page: pages and templates that reverse-relate to or hold
+   * managed links targeting the given page. Response JSON shape matches {@link
+   * #getAssetSiteImpact(String)}.
+   *
+   * @param pageId The id of the page in the string format of the guid, must not be blank
+   * @return String representation of the JSON object, never null
+   */
+  String getPageSiteImpact(String pageId);
+
+  /**
    * Adds a page to logged in user's my pages.
    *
    * @param pageId guid of the page id, must not be blank

--- a/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/itemmanagement/service/impl/PSItemService.java
@@ -486,17 +486,38 @@ public class PSItemService implements IPSItemService {
 
   // FIXME: This really needs to be re-factored so that it is working with Jackson or Jaxb or
   // something.
+  @Override
   @GET
   @Path("siteimpact/asset/{assetId}")
   @Produces(MediaType.TEXT_PLAIN)
   public String getAssetSiteImpact(@PathParam("assetId") String assetId) {
+    return buildSiteImpactJson(assetId, "asset");
+  }
+
+  @Override
+  @GET
+  @Path("siteimpact/page/{pageId}")
+  @Produces(MediaType.TEXT_PLAIN)
+  public String getPageSiteImpact(@PathParam("pageId") String pageId) {
+    return buildSiteImpactJson(pageId, "page");
+  }
+
+  /**
+   * Shared site-impact JSON builder for assets and pages. Finds relationship owners (walks nested
+   * assets) and managed-link parents that reference the item, then resolves page/template details.
+   *
+   * @param itemId guid string of the asset or page, assumed not blank
+   * @param itemKind label for logs ("asset" or "page")
+   * @return JSON string with pages and templates arrays; never null
+   */
+  private String buildSiteImpactJson(String itemId, String itemKind) {
     Map<String, Object> result = new LinkedHashMap<>();
     Set<String> ownerPages = new HashSet<>();
     Set<String> ownerTemplates = new HashSet<>();
     try {
-      fillOwners(assetId, ownerPages, ownerTemplates);
+      fillOwners(itemId, ownerPages, ownerTemplates);
 
-      getManagedLinkOwners(assetId, ownerPages, ownerTemplates, MAX_PAGES_SITEIMPACT);
+      getManagedLinkOwners(itemId, ownerPages, ownerTemplates, MAX_PAGES_SITEIMPACT);
       List<Object> pageArray = new ArrayList<>();
       for (String page : ownerPages) {
         PSItemProperties itemProps = null;
@@ -504,9 +525,11 @@ public class PSItemService implements IPSItemService {
           itemProps = folderHelper.findItemPropertiesById(page);
         } catch (Exception e) {
           log.error(
-              "An error occurred while processing Asset Impact checking item properties for Page:"
-                  + " {} Error: {}",
+              "An error occurred while processing Site Impact checking item properties for Page:"
+                  + " {} (target {} id: {}) Error: {}",
               page,
+              itemKind,
+              itemId,
               PSExceptionUtils.getMessageForLog(e));
           log.debug(PSExceptionUtils.getDebugMessageForLog(e));
         }
@@ -521,8 +544,11 @@ public class PSItemService implements IPSItemService {
           template = templateService.find(templateId);
         } catch (Exception e) {
           log.error(
-              "An error occurred while processing Asset Impact with Template {} Error: {}",
+              "An error occurred while processing Site Impact with Template {} (target {} id: {})"
+                  + " Error: {}",
               templateId,
+              itemKind,
+              itemId,
               PSExceptionUtils.getMessageForLog(e));
           log.debug(PSExceptionUtils.getDebugMessageForLog(e));
         }
@@ -559,9 +585,14 @@ public class PSItemService implements IPSItemService {
       result.put("templates", templateArray);
     } catch (Exception e) {
       log.error(
-          "An unexpected error occurred while fetching the site impact details for the asset.", e);
+          "An unexpected error occurred while fetching the site impact details for the {}.",
+          itemKind,
+          e);
       throw new WebApplicationException(
-          "An unexpected error occurred while fetching the site impact details for the asset.", e);
+          "An unexpected error occurred while fetching the site impact details for the "
+              + itemKind
+              + ".",
+          e);
     }
     try {
       ObjectMapper mapper = JsonMapper.builder().build();
@@ -574,17 +605,17 @@ public class PSItemService implements IPSItemService {
 
   /**
    * Helper function that fills the supplied set of owner pages and templates with the owners of the
-   * of the given asset, calls it self if the owner of the given asset is an asset.
+   * of the given item, calls itself if the owner is an asset (nested local content).
    *
-   * @param assetId assumed not blank.
+   * @param itemId assumed not blank (asset or page guid string).
    * @param ownerPages assumed not <code>null</code>, may be empty.
    * @param ownerTemplates assumed not <code>null</code>, may be empty.
    */
-  private void fillOwners(String assetId, Set<String> ownerPages, Set<String> ownerTemplates)
+  private void fillOwners(String itemId, Set<String> ownerPages, Set<String> ownerTemplates)
       throws PSValidationException {
     Set<String> owners = null;
 
-    owners = waRelService.getRelationshipOwners(assetId, true);
+    owners = waRelService.getRelationshipOwners(itemId, true);
 
     if (owners != null) {
       for (String owner : owners) {
@@ -600,10 +631,10 @@ public class PSItemService implements IPSItemService {
   }
 
   private void getManagedLinkOwners(
-      String assetId, Set<String> ownerPages, Set<String> ownerTemplates, int limit) {
+      String itemId, Set<String> ownerPages, Set<String> ownerTemplates, int limit) {
 
-    IPSGuid assetGuid = idMapper.getGuid(assetId);
-    List<PSManagedLink> links = linkService.findLinksByChildId(idMapper.getContentId(assetGuid));
+    IPSGuid itemGuid = idMapper.getGuid(itemId);
+    List<PSManagedLink> links = linkService.findLinksByChildId(idMapper.getContentId(itemGuid));
 
     for (PSManagedLink link : links) {
 

--- a/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSItemServicePageSiteImpactTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/itemmanagement/service/impl/PSItemServicePageSiteImpactTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.itemmanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.percussion.assetmanagement.dao.IPSAssetDao;
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.itemmanagement.service.IPSItemWorkflowService;
+import com.percussion.itemmanagement.service.IPSWorkflowHelper;
+import com.percussion.itemmanagement.service.IPSWorkflowHelper.PSItemTypeEnum;
+import com.percussion.pagemanagement.data.PSTemplateSummary;
+import com.percussion.pagemanagement.service.IPSTemplateService;
+import com.percussion.services.linkmanagement.IPSManagedLinkDao;
+import com.percussion.services.linkmanagement.data.PSManagedLink;
+import com.percussion.services.notification.IPSNotificationService;
+import com.percussion.services.publisher.IPSPublisherService;
+import com.percussion.services.system.IPSSystemService;
+import com.percussion.services.useritems.IPSUserItemsDao;
+import com.percussion.share.dao.IPSContentItemDao;
+import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.dao.impl.PSContentItem;
+import com.percussion.share.data.PSItemProperties;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.webservices.content.IPSContentWs;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Unit tests for page site-impact REST path ({@code siteimpact/page/{pageId}}). Verifies reverse
+ * relationship owners and managed-link parents without a full CMS.
+ */
+@ExtendWith(MockitoExtension.class)
+class PSItemServicePageSiteImpactTest {
+
+  private static final String PAGE_ID = "0-123-456";
+  private static final String OWNER_PAGE_ID = "0-123-789";
+  private static final String OWNER_TEMPLATE_ID = "0-123-999";
+  private static final String PARENT_PAGE_ID = "0-123-555";
+
+  @Mock private IPSIdMapper idMapper;
+  @Mock private IPSSystemService systemService;
+  @Mock private IPSWorkflowHelper workflowHelper;
+  @Mock private IPSContentWs contentWs;
+  @Mock private IPSWidgetAssetRelationshipService waRelService;
+  @Mock private IPSItemWorkflowService itemWfService;
+  @Mock private IPSFolderHelper folderHelper;
+  @Mock private IPSContentItemDao contentItemDao;
+  @Mock private IPSAssetDao assetDao;
+  @Mock private IPSTemplateService templateService;
+  @Mock private IPSUserItemsDao userItemDao;
+  @Mock private IPSNotificationService notificationService;
+  @Mock private IPSPublisherService pubService;
+  @Mock private IPSManagedLinkDao linkService;
+
+  private PSItemService service;
+  private final ObjectMapper mapper = JsonMapper.builder().build();
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new PSItemService(
+            idMapper,
+            systemService,
+            workflowHelper,
+            contentWs,
+            waRelService,
+            itemWfService,
+            folderHelper,
+            contentItemDao,
+            assetDao,
+            templateService,
+            userItemDao,
+            notificationService,
+            pubService,
+            linkService);
+  }
+
+  @Test
+  void getPageSiteImpactIncludesRelationshipOwnersAndManagedLinkPages() throws Exception {
+    Set<String> owners = new HashSet<>();
+    owners.add(OWNER_PAGE_ID);
+    owners.add(OWNER_TEMPLATE_ID);
+    when(waRelService.getRelationshipOwners(eq(PAGE_ID), anyBoolean())).thenReturn(owners);
+    when(workflowHelper.getItemType(OWNER_PAGE_ID)).thenReturn(PSItemTypeEnum.PAGE);
+    when(workflowHelper.getItemType(OWNER_TEMPLATE_ID)).thenReturn(PSItemTypeEnum.TEMPLATE);
+
+    IPSGuid pageGuid = mock(IPSGuid.class);
+    when(idMapper.getGuid(PAGE_ID)).thenReturn(pageGuid);
+    when(idMapper.getContentId(pageGuid)).thenReturn(456);
+
+    PSManagedLink link = new PSManagedLink();
+    link.setLinkId(10L);
+    link.setParentId(100);
+    link.setChildId(456);
+    when(linkService.findLinksByChildId(456)).thenReturn(List.of(link));
+
+    IPSGuid parentGuid = mock(IPSGuid.class);
+    when(idMapper.getGuidFromContentId(100)).thenReturn(parentGuid);
+    when(parentGuid.toString()).thenReturn(PARENT_PAGE_ID);
+
+    PSContentItem parentPage = new PSContentItem();
+    parentPage.setId(PARENT_PAGE_ID);
+    parentPage.setType("percPage");
+    when(contentItemDao.find(PARENT_PAGE_ID)).thenReturn(parentPage);
+
+    PSItemProperties ownerPageProps = new PSItemProperties();
+    ownerPageProps.setId(OWNER_PAGE_ID);
+    ownerPageProps.setName("Owner Page");
+    ownerPageProps.setPath("/Sites/Demo/owner-page");
+    ownerPageProps.setStatus("Live");
+    ownerPageProps.setSummary("owner");
+
+    PSItemProperties parentPageProps = new PSItemProperties();
+    parentPageProps.setId(PARENT_PAGE_ID);
+    parentPageProps.setName("Linker Page");
+    parentPageProps.setPath("/Sites/Demo/linker-page");
+    parentPageProps.setStatus("Draft");
+    parentPageProps.setSummary("linker");
+
+    when(folderHelper.findItemPropertiesById(OWNER_PAGE_ID)).thenReturn(ownerPageProps);
+    when(folderHelper.findItemPropertiesById(PARENT_PAGE_ID)).thenReturn(parentPageProps);
+
+    PSTemplateSummary template = new PSTemplateSummary();
+    template.setId(OWNER_TEMPLATE_ID);
+    template.setName("Base Template");
+    when(templateService.find(OWNER_TEMPLATE_ID)).thenReturn(template);
+    when(folderHelper.getItemSites(OWNER_TEMPLATE_ID)).thenReturn(Collections.emptyList());
+
+    String json = service.getPageSiteImpact(PAGE_ID);
+    JsonNode root = mapper.readTree(json);
+
+    assertTrue(root.has("pages"));
+    assertTrue(root.has("templates"));
+    assertEquals(2, root.get("pages").size());
+    assertEquals(1, root.get("templates").size());
+    assertEquals("Base Template", root.get("templates").get(0).get("template").get("name").asString());
+
+    Set<String> pageNames = new HashSet<>();
+    for (JsonNode page : root.get("pages")) {
+      pageNames.add(page.get("name").asString());
+    }
+    assertTrue(pageNames.contains("Owner Page"));
+    assertTrue(pageNames.contains("Linker Page"));
+  }
+
+  @Test
+  void getPageSiteImpactReturnsEmptyArraysWhenNoOwners() throws Exception {
+    when(waRelService.getRelationshipOwners(eq(PAGE_ID), anyBoolean()))
+        .thenReturn(Collections.emptySet());
+
+    IPSGuid pageGuid = mock(IPSGuid.class);
+    when(idMapper.getGuid(PAGE_ID)).thenReturn(pageGuid);
+    when(idMapper.getContentId(pageGuid)).thenReturn(456);
+    when(linkService.findLinksByChildId(456)).thenReturn(Collections.emptyList());
+
+    String json = service.getPageSiteImpact(PAGE_ID);
+    JsonNode root = mapper.readTree(json);
+
+    assertTrue(root.get("pages").isArray());
+    assertTrue(root.get("templates").isArray());
+    assertEquals(0, root.get("pages").size());
+    assertEquals(0, root.get("templates").size());
+  }
+
+  @Test
+  void getAssetSiteImpactSharesBuilderPathWithEmptyResult() throws Exception {
+    when(waRelService.getRelationshipOwners(anyString(), anyBoolean()))
+        .thenReturn(Collections.emptySet());
+    IPSGuid assetGuid = mock(IPSGuid.class);
+    when(idMapper.getGuid("asset-1")).thenReturn(assetGuid);
+    when(idMapper.getContentId(assetGuid)).thenReturn(1);
+    when(linkService.findLinksByChildId(1)).thenReturn(Collections.emptyList());
+
+    String json = service.getAssetSiteImpact("asset-1");
+    JsonNode root = mapper.readTree(json);
+    assertEquals(0, root.get("pages").size());
+    assertEquals(0, root.get("templates").size());
+  }
+}

--- a/system/cms/content/applications/sys_resources/ApplicationFiles/stylesheets/contentEdit.xsl
+++ b/system/cms/content/applications/sys_resources/ApplicationFiles/stylesheets/contentEdit.xsl
@@ -168,14 +168,26 @@
 			</div>
 		</div>
 		<div id="perc-content-edit-metadata-sep"/>
+		<!-- Page editors expose page_title; assets do not. Labels differ for page vs asset site impact. -->
+		<xsl:variable name="isPageEditor" select="boolean(//Control[@paramName='page_title'])"/>
 		<div id="perc-site-impact-panel" style = "display:none">
 			<div id="perc-content-edit-site-link" class = "perc-spacer">
 				<span id="perc-content-edit-site-icon" />Site Impact</div>
 			<div class="perc-content-edit-data">
-				<span class = "font_normal_07em_black">Pages using this asset</span>
+				<span class="font_normal_07em_black perc-site-impact-pages-label">
+					<xsl:choose>
+						<xsl:when test="$isPageEditor">Pages linking to this page</xsl:when>
+						<xsl:otherwise>Pages using this asset</xsl:otherwise>
+					</xsl:choose>
+				</span>
 				<div class = "perc-site-impact-pages">
 				</div>
-				<span class = "font_normal_07em_black">Templates using this asset</span>
+				<span class="font_normal_07em_black perc-site-impact-templates-label">
+					<xsl:choose>
+						<xsl:when test="$isPageEditor">Templates linking to this page</xsl:when>
+						<xsl:otherwise>Templates using this asset</xsl:otherwise>
+					</xsl:choose>
+				</span>
 				<div class = "perc-site-impact-templates">
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
Implements **page Site Impact** parity with the existing asset feature (Fixes #948 / migrated from percussion#657).

Users editing page metadata can now see which other pages/templates reverse-relate to or hold managed links targeting that page.

### Backend (projects/sitemanage)
- New REST: `GET /itemmanagement/item/siteimpact/page/{pageId}`
- Shared `buildSiteImpactJson` used by both asset and page paths (relationship owners + managed-link parents)
- Interface: `IPSItemService.getPageSiteImpact`
- Unit tests: `PSItemServicePageSiteImpactTest` (mock-based, no full CMS)

### WebUI
- `PAGE_SITE_IMPACT` path constant
- `PercSiteImpactService.getSiteImpactDetails(itemId, itemType, callback)` routes page vs asset (back-compat for 2-arg callers)
- `perc_page_edit_dialog` shows `#perc-site-impact-panel` and renders with `ITEM_TYPE_PAGE`
- Dual trees: `cm/` + `app/js/legacy/` + tracked `war/` lockstep

### system
- `contentEdit.xsl`: page vs asset labels when `page_title` control present
  - Pages: "Pages linking to this page" / "Templates linking to this page"
  - Assets: existing "Pages/Templates using this asset"

## Test plan
- [x] `cd projects/sitemanage && ../../mvnw clean install` — BUILD SUCCESS
- [x] `cd system && ../mvnw clean install` — BUILD SUCCESS  
- [x] `cd WebUI && ../mvnw clean install` — BUILD SUCCESS
- [x] `PSItemServicePageSiteImpactTest` — relationship owners, managed-link parents, empty arrays
- [ ] Manual: open page metadata (edit/view) → Site Impact panel lists linking pages; asset site impact unchanged

## Gates evidence
| Gate | Result |
|------|--------|
| sitemanage clean install | SUCCESS |
| system clean install | SUCCESS |
| WebUI clean install | SUCCESS |
| Behavioral unit tests | PSItemServicePageSiteImpactTest green |
| Erlang self-review | No bugs found; portable paths (no new path I/O); companions (interface + dual WebUI trees + XSL labels + tests) present |
| In-scope commit only | Yes |

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #948

Fixes #948

> Co-Authored by Grok Build using grok-4.5 with agent main.