### PR TITLE
fix(WebUI): Admin portrait/narrow layout for chrome tabs (GH-945)

### DIFF
--- a/WebUI/src/main/ts/admin/AdminChrome.module.css
+++ b/WebUI/src/main/ts/admin/AdminChrome.module.css
@@ -1,0 +1,95 @@
+/*
+ * Shared Admin / Workflow Admin shell chrome.
+ * Portrait / narrow viewports: wrap tabs, avoid fixed min-widths that clip.
+ */
+
+.shell {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 1200px;
+  min-width: 0;
+  margin: 0 auto;
+  padding: 20px;
+  font-family: var(--perc-font-family, sans-serif);
+  overflow-x: auto;
+}
+
+.header {
+  margin-bottom: 20px;
+}
+
+.header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  line-height: 1.25;
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+
+.tabNav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 0;
+  border-bottom: 1px solid #e2e8f0;
+  margin-bottom: 20px;
+  min-width: 0;
+  max-width: 100%;
+  /* Horizontal scroll only if tabs cannot wrap for any reason */
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.tab {
+  box-sizing: border-box;
+  flex: 0 1 auto;
+  min-width: 0;
+  padding: 10px 20px;
+  border: none;
+  border-bottom: 3px solid transparent;
+  margin-bottom: -1px;
+  font: inherit;
+  font-weight: 400;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.tab:hover {
+  background: rgba(0, 126, 168, 0.06);
+}
+
+.tabActive {
+  border-bottom-color: #007ea8;
+  font-weight: 600;
+}
+
+.tabContent {
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+@media (max-width: 640px), ((orientation: portrait) and (max-width: 900px)) {
+  .shell {
+    padding: 12px;
+  }
+
+  .header {
+    margin-bottom: 12px;
+  }
+
+  .header h1 {
+    font-size: 1.25rem;
+  }
+
+  .tabNav {
+    margin-bottom: 12px;
+  }
+
+  .tab {
+    padding: 8px 12px;
+    font-size: 0.9rem;
+  }
+}

--- a/WebUI/src/main/ts/admin/AdminShell.tsx
+++ b/WebUI/src/main/ts/admin/AdminShell.tsx
@@ -21,6 +21,7 @@ import { TasksSection } from "./TasksSection";
 import { TaskLogsSection } from "./TaskLogsSection";
 import { TaskNotifications } from "./TaskNotifications";
 import { ToolsSection } from "./tools/ToolsSection";
+import styles from "./AdminChrome.module.css";
 
 export type AdminTab = "tasks" | "logs" | "notifications" | "tools";
 
@@ -60,29 +61,22 @@ export const AdminShell: React.FC<AdminShellProps> = ({
     normalizeAdminShellTab(initialTab),
   );
 
+  const tabClass = (tab: AdminTab): string =>
+    activeTab === tab ? `${styles.tab} ${styles.tabActive}` : styles.tab;
+
   return (
     <div
-      className="perc-admin-shell"
+      className={`perc-admin-shell ${styles.shell}`}
       data-testid="perc-admin-shell"
-      style={{
-        fontFamily: "var(--perc-font-family, sans-serif)",
-        padding: "20px",
-        maxWidth: "1200px",
-        margin: "0 auto",
-      }}
     >
-      <header style={{ marginBottom: "20px" }}>
+      <header className={styles.header}>
         <h1>{message(ADMIN_MSG.ADMIN_TITLE)}</h1>
       </header>
 
       <nav
-        className="perc-tab-nav"
+        className={`perc-tab-nav ${styles.tabNav}`}
         role="tablist"
-        style={{
-          display: "flex",
-          borderBottom: "1px solid #e2e8f0",
-          marginBottom: "20px",
-        }}
+        data-testid="perc-admin-tablist"
       >
         <button
           type="button"
@@ -91,14 +85,7 @@ export const AdminShell: React.FC<AdminShellProps> = ({
           aria-selected={activeTab === "tasks"}
           aria-controls="panel-tasks"
           onClick={() => setActiveTab("tasks")}
-          style={{
-            padding: "10px 20px",
-            border: "none",
-            borderBottom: activeTab === "tasks" ? "3px solid #007ea8" : "none",
-            fontWeight: activeTab === "tasks" ? 600 : 400,
-            background: "transparent",
-            cursor: "pointer",
-          }}
+          className={tabClass("tasks")}
           data-testid="tab-tasks"
         >
           {message(ADMIN_MSG.TAB_TASKS)}
@@ -111,14 +98,7 @@ export const AdminShell: React.FC<AdminShellProps> = ({
           aria-selected={activeTab === "logs"}
           aria-controls="panel-logs"
           onClick={() => setActiveTab("logs")}
-          style={{
-            padding: "10px 20px",
-            border: "none",
-            borderBottom: activeTab === "logs" ? "3px solid #007ea8" : "none",
-            fontWeight: activeTab === "logs" ? 600 : 400,
-            background: "transparent",
-            cursor: "pointer",
-          }}
+          className={tabClass("logs")}
           data-testid="tab-logs"
         >
           {message(ADMIN_MSG.TAB_LOGS)}
@@ -131,14 +111,7 @@ export const AdminShell: React.FC<AdminShellProps> = ({
           aria-selected={activeTab === "notifications"}
           aria-controls="panel-notifications"
           onClick={() => setActiveTab("notifications")}
-          style={{
-            padding: "10px 20px",
-            border: "none",
-            borderBottom: activeTab === "notifications" ? "3px solid #007ea8" : "none",
-            fontWeight: activeTab === "notifications" ? 600 : 400,
-            background: "transparent",
-            cursor: "pointer",
-          }}
+          className={tabClass("notifications")}
           data-testid="tab-notifications"
         >
           {message(ADMIN_MSG.TAB_NOTIFICATIONS)}
@@ -151,14 +124,7 @@ export const AdminShell: React.FC<AdminShellProps> = ({
           aria-selected={activeTab === "tools"}
           aria-controls="panel-tools"
           onClick={() => setActiveTab("tools")}
-          style={{
-            padding: "10px 20px",
-            border: "none",
-            borderBottom: activeTab === "tools" ? "3px solid #007ea8" : "none",
-            fontWeight: activeTab === "tools" ? 600 : 400,
-            background: "transparent",
-            cursor: "pointer",
-          }}
+          className={tabClass("tools")}
           data-testid="tab-tools"
         >
           System Tools
@@ -166,7 +132,7 @@ export const AdminShell: React.FC<AdminShellProps> = ({
       </nav>
 
       <main
-        className="perc-tab-content"
+        className={`perc-tab-content ${styles.tabContent}`}
         role="tabpanel"
         id={`panel-${activeTab}`}
         aria-labelledby={`tab-${activeTab}`}

--- a/WebUI/src/main/ts/workflowAdmin/WorkflowAdminShell.tsx
+++ b/WebUI/src/main/ts/workflowAdmin/WorkflowAdminShell.tsx
@@ -16,6 +16,7 @@
 
 import React, { useState } from "react";
 import { message } from "../i18n/message";
+import styles from "../admin/AdminChrome.module.css";
 import { WF_ADMIN_MSG } from "./messages";
 import { WorkflowSection } from "./workflow/WorkflowSection";
 import { RolesSection } from "./role/RolesSection";
@@ -60,29 +61,22 @@ export const WorkflowAdminShell: React.FC<WorkflowAdminShellProps> = ({
     normalizeWorkflowAdminTab(initialTab),
   );
 
+  const tabClass = (tab: WorkflowAdminTab): string =>
+    activeTab === tab ? `${styles.tab} ${styles.tabActive}` : styles.tab;
+
   return (
     <div
-      className="perc-workflow-admin-shell"
+      className={`perc-workflow-admin-shell ${styles.shell}`}
       data-testid="perc-workflow-admin-shell"
-      style={{
-        fontFamily: "var(--perc-font-family, sans-serif)",
-        padding: "20px",
-        maxWidth: "1200px",
-        margin: "0 auto",
-      }}
     >
-      <header style={{ marginBottom: "20px" }}>
+      <header className={styles.header}>
         <h1>{message(WF_ADMIN_MSG.TITLE)}</h1>
       </header>
 
       <nav
-        className="perc-tab-nav"
+        className={`perc-tab-nav ${styles.tabNav}`}
         role="tablist"
-        style={{
-          display: "flex",
-          borderBottom: "1px solid #e2e8f0",
-          marginBottom: "20px",
-        }}
+        data-testid="perc-workflow-admin-tablist"
       >
         <button
           type="button"
@@ -91,14 +85,7 @@ export const WorkflowAdminShell: React.FC<WorkflowAdminShellProps> = ({
           aria-selected={activeTab === "workflow"}
           aria-controls="panel-workflow"
           onClick={() => setActiveTab("workflow")}
-          style={{
-            padding: "10px 20px",
-            border: "none",
-            borderBottom: activeTab === "workflow" ? "3px solid #007ea8" : "none",
-            fontWeight: activeTab === "workflow" ? 600 : 400,
-            background: "transparent",
-            cursor: "pointer",
-          }}
+          className={tabClass("workflow")}
           data-testid="tab-workflow"
         >
           {message(WF_ADMIN_MSG.TAB_WORKFLOW)}
@@ -111,14 +98,7 @@ export const WorkflowAdminShell: React.FC<WorkflowAdminShellProps> = ({
           aria-selected={activeTab === "roles"}
           aria-controls="panel-roles"
           onClick={() => setActiveTab("roles")}
-          style={{
-            padding: "10px 20px",
-            border: "none",
-            borderBottom: activeTab === "roles" ? "3px solid #007ea8" : "none",
-            fontWeight: activeTab === "roles" ? 600 : 400,
-            background: "transparent",
-            cursor: "pointer",
-          }}
+          className={tabClass("roles")}
           data-testid="tab-roles"
         >
           {message(WF_ADMIN_MSG.TAB_ROLES)}
@@ -131,14 +111,7 @@ export const WorkflowAdminShell: React.FC<WorkflowAdminShellProps> = ({
           aria-selected={activeTab === "users"}
           aria-controls="panel-users"
           onClick={() => setActiveTab("users")}
-          style={{
-            padding: "10px 20px",
-            border: "none",
-            borderBottom: activeTab === "users" ? "3px solid #007ea8" : "none",
-            fontWeight: activeTab === "users" ? 600 : 400,
-            background: "transparent",
-            cursor: "pointer",
-          }}
+          className={tabClass("users")}
           data-testid="tab-users"
         >
           {message(WF_ADMIN_MSG.TAB_USERS)}
@@ -151,14 +124,7 @@ export const WorkflowAdminShell: React.FC<WorkflowAdminShellProps> = ({
           aria-selected={activeTab === "categories"}
           aria-controls="panel-categories"
           onClick={() => setActiveTab("categories")}
-          style={{
-            padding: "10px 20px",
-            border: "none",
-            borderBottom: activeTab === "categories" ? "3px solid #007ea8" : "none",
-            fontWeight: activeTab === "categories" ? 600 : 400,
-            background: "transparent",
-            cursor: "pointer",
-          }}
+          className={tabClass("categories")}
           data-testid="tab-categories"
         >
           {message(WF_ADMIN_MSG.TAB_CATEGORIES)}
@@ -166,7 +132,7 @@ export const WorkflowAdminShell: React.FC<WorkflowAdminShellProps> = ({
       </nav>
 
       <main
-        className="perc-tab-content"
+        className={`perc-tab-content ${styles.tabContent}`}
         role="tabpanel"
         id={`panel-${activeTab}`}
         aria-labelledby={`tab-${activeTab}`}

--- a/WebUI/src/main/webapp/cm/app/adminWorkflow.jsp
+++ b/WebUI/src/main/webapp/cm/app/adminWorkflow.jsp
@@ -207,7 +207,7 @@
 
     </script>
 </head>
-<body onbeforeunload="return navigationEvent()" style="overflow : hidden">
+<body onbeforeunload="return navigationEvent()" class="perc-admin-workflow-page" style="overflow-x: hidden; overflow-y: auto">
 <div class="perc-main perc-finder-fix">
     <jsp:include page="includes/header.jsp" flush="true">
         <jsp:param name="mainNavTab" value="workflow"/>
@@ -251,7 +251,7 @@
 
 </div>
 <div class="perc-workflow-container">
-    <div id="tabs" style="min-width:500px;">
+    <div id="tabs" class="perc-admin-tabs">
         <ul role="tablist">
             <li role="presentation"><a role="tab" id="perc-tab-workflow" href="#tabs-1"><i18n:message key = "perc.ui.navMenu.workflow@Workflow" /></a></li>
             <li role="presentation"><a role="tab" id="perc-tab-roles" href="#tabs-2"><i18n:message key = "perc.ui.perc.role.view@Roles" /></a></li>

--- a/WebUI/src/main/webapp/cm/app/css/legacy/percWorkflow.css
+++ b/WebUI/src/main/webapp/cm/app/css/legacy/percWorkflow.css
@@ -1567,3 +1567,82 @@ select {
   font-family: "Open Sans", sans-serif;
   vertical-align: middle !important;
 }
+
+/* ==========================================================================
+   Portrait / narrow Admin (workflow) chrome — GH-945
+   Drop fixed min-widths that force horizontal clipping; wrap or scroll tabs.
+   ========================================================================== */
+
+.perc-admin-workflow-page {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.perc-workflow-container {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.perc-workflow-container #tabs.perc-admin-tabs,
+.perc-workflow-container #tabs {
+  box-sizing: border-box;
+  min-width: 0;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+@media (max-width: 640px), ((orientation: portrait) and (max-width: 900px)) {
+  .perc-workflow-container #tabs > ul {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: stretch;
+    min-width: 0;
+    max-width: 100%;
+    padding-left: 0;
+    margin: 0;
+  }
+
+  .perc-workflow-container #tabs > ul > li {
+    float: none;
+    flex: 0 1 auto;
+    min-width: 0;
+  }
+
+  #perc-tab-workflow,
+  #perc-tab-roles,
+  #perc-tab-users,
+  #perc-tab-category {
+    width: auto;
+    min-width: 0;
+    max-width: 100%;
+    padding-left: 12px;
+    padding-right: 12px;
+    letter-spacing: 0;
+    font-size: 14px;
+  }
+
+  #perc-users-details {
+    min-width: 0;
+    max-width: 100%;
+    width: auto;
+    float: none;
+    margin-left: 0;
+  }
+
+  #perc-workflow-steps-container {
+    min-width: 0;
+    max-width: 100%;
+    float: none;
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+
+  .perc-wf-editor {
+    width: auto;
+    max-width: 100%;
+  }
+}

--- a/WebUI/src/main/webapp/cm/css/percWorkflow.css
+++ b/WebUI/src/main/webapp/cm/css/percWorkflow.css
@@ -1567,3 +1567,82 @@ select {
   font-family: "Open Sans", sans-serif;
   vertical-align: middle !important;
 }
+
+/* ==========================================================================
+   Portrait / narrow Admin (workflow) chrome — GH-945
+   Drop fixed min-widths that force horizontal clipping; wrap or scroll tabs.
+   ========================================================================== */
+
+.perc-admin-workflow-page {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.perc-workflow-container {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.perc-workflow-container #tabs.perc-admin-tabs,
+.perc-workflow-container #tabs {
+  box-sizing: border-box;
+  min-width: 0;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+@media (max-width: 640px), ((orientation: portrait) and (max-width: 900px)) {
+  .perc-workflow-container #tabs > ul {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: stretch;
+    min-width: 0;
+    max-width: 100%;
+    padding-left: 0;
+    margin: 0;
+  }
+
+  .perc-workflow-container #tabs > ul > li {
+    float: none;
+    flex: 0 1 auto;
+    min-width: 0;
+  }
+
+  #perc-tab-workflow,
+  #perc-tab-roles,
+  #perc-tab-users,
+  #perc-tab-category {
+    width: auto;
+    min-width: 0;
+    max-width: 100%;
+    padding-left: 12px;
+    padding-right: 12px;
+    letter-spacing: 0;
+    font-size: 14px;
+  }
+
+  #perc-users-details {
+    min-width: 0;
+    max-width: 100%;
+    width: auto;
+    float: none;
+    margin-left: 0;
+  }
+
+  #perc-workflow-steps-container {
+    min-width: 0;
+    max-width: 100%;
+    float: none;
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+
+  .perc-wf-editor {
+    width: auto;
+    max-width: 100%;
+  }
+}

--- a/WebUI/src/main/webapp/cm/pages/app/adminWorkflow.jsp
+++ b/WebUI/src/main/webapp/cm/pages/app/adminWorkflow.jsp
@@ -205,7 +205,7 @@
 
     </script>
 </head>
-<body onbeforeunload="return navigationEvent()" style="overflow : hidden">
+<body onbeforeunload="return navigationEvent()" class="perc-admin-workflow-page" style="overflow-x: hidden; overflow-y: auto">
 <div class="perc-main perc-finder-fix">
     <jsp:include page="includes/header.jsp" flush="true">
         <jsp:param name="mainNavTab" value="workflow"/>
@@ -213,7 +213,7 @@
 
 </div>
 <div class="perc-workflow-container">
-    <div id="tabs" style="min-width:500px;">
+    <div id="tabs" class="perc-admin-tabs">
         <ul role="tablist">
             <li role="presentation"><a role="tab" id="perc-tab-workflow" href="#tabs-1"><i18n:message key = "perc.ui.navMenu.workflow@Workflow" /></a></li>
             <li role="presentation"><a role="tab" id="perc-tab-roles" href="#tabs-2"><i18n:message key = "perc.ui.perc.role.view@Roles" /></a></li>

--- a/WebUI/src/test/ts/admin/AdminShell.test.tsx
+++ b/WebUI/src/test/ts/admin/AdminShell.test.tsx
@@ -43,6 +43,20 @@ describe("AdminShell", () => {
     expect(screen.getByTestId("mock-tasks-section")).toBeDefined();
   });
 
+  it("exposes responsive tablist chrome for narrow / portrait layouts", () => {
+    render(<AdminShell />);
+    const shell = screen.getByTestId("perc-admin-shell");
+    const tablist = screen.getByTestId("perc-admin-tablist");
+    expect(tablist.getAttribute("role")).toBe("tablist");
+    // CSS modules attach hashed classes; ensure nav is classed (not only inline styles).
+    expect(tablist.className.length).toBeGreaterThan(0);
+    expect(shell.className.length).toBeGreaterThan(0);
+    expect(screen.getByTestId("tab-tasks")).toBeDefined();
+    expect(screen.getByTestId("tab-logs")).toBeDefined();
+    expect(screen.getByTestId("tab-notifications")).toBeDefined();
+    expect(screen.getByTestId("tab-tools")).toBeDefined();
+  });
+
   it("switches tabs when nav buttons are clicked", () => {
     render(<AdminShell />);
 

--- a/WebUI/src/test/ts/admin/adminPortraitStylesContract.test.ts
+++ b/WebUI/src/test/ts/admin/adminPortraitStylesContract.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contract tests for Admin portrait / narrow layout (GH-945).
+ * Asserts modern CSS module + classic JSP dual-ship no longer hard-clip chrome.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const tsRoot = resolve(__dirname, "../../../main/ts");
+const webappRoot = resolve(__dirname, "../../../main/webapp");
+const warRoot = resolve(__dirname, "../../../../war");
+
+describe("Admin portrait layout contract (GH-945)", () => {
+  it("AdminChrome.module.css wraps tabs and avoids fixed min-width clip", () => {
+    const path = resolve(tsRoot, "admin/AdminChrome.module.css");
+    const text = readFileSync(path, "utf8");
+    expect(text).toMatch(/flex-wrap:\s*wrap/);
+    expect(text).toMatch(/overflow-x:\s*auto/);
+    expect(text).toMatch(/min-width:\s*0/);
+    expect(text).toMatch(/@media\s*\(max-width:\s*640px\)/);
+    expect(text).toMatch(/orientation:\s*portrait/);
+  });
+
+  it("classic adminWorkflow.jsp drops fixed min-width:500px (dual-ship)", () => {
+    const rels = [
+      resolve(webappRoot, "cm/app/adminWorkflow.jsp"),
+      resolve(webappRoot, "cm/pages/app/adminWorkflow.jsp"),
+      resolve(warRoot, "app/adminWorkflow.jsp"),
+    ];
+    for (const path of rels) {
+      const text = readFileSync(path, "utf8");
+      expect(text, path).not.toMatch(/min-width\s*:\s*500px/);
+      expect(text, path).toContain('class="perc-admin-tabs"');
+      expect(text, path).toContain("perc-admin-workflow-page");
+      expect(text, path).toMatch(/overflow-y:\s*auto/);
+    }
+  });
+
+  it("percWorkflow.css ships portrait media-query rules (dual-ship)", () => {
+    const rels = [
+      resolve(webappRoot, "cm/css/percWorkflow.css"),
+      resolve(webappRoot, "cm/app/css/legacy/percWorkflow.css"),
+      resolve(warRoot, "css/percWorkflow.css"),
+    ];
+    for (const path of rels) {
+      const text = readFileSync(path, "utf8");
+      expect(text, path).toContain("GH-945");
+      expect(text, path).toMatch(/flex-wrap:\s*wrap/);
+      expect(text, path).toContain(".perc-admin-tabs");
+      expect(text, path).toMatch(
+        /#perc-users-details[\s\S]*min-width:\s*0/,
+      );
+    }
+  });
+});

--- a/WebUI/src/test/ts/workflowAdmin/WorkflowAdminShell.test.tsx
+++ b/WebUI/src/test/ts/workflowAdmin/WorkflowAdminShell.test.tsx
@@ -43,6 +43,15 @@ describe("WorkflowAdminShell", () => {
     expect(screen.getByTestId("mock-workflow-section")).toBeTruthy();
   });
 
+  it("exposes responsive tablist chrome for narrow / portrait layouts", () => {
+    render(<WorkflowAdminShell />);
+    const shell = screen.getByTestId("perc-workflow-admin-shell");
+    const tablist = screen.getByTestId("perc-workflow-admin-tablist");
+    expect(tablist.getAttribute("role")).toBe("tablist");
+    expect(tablist.className.length).toBeGreaterThan(0);
+    expect(shell.className.length).toBeGreaterThan(0);
+  });
+
   it("switches tabs when nav buttons are clicked", () => {
     render(<WorkflowAdminShell />);
     

--- a/WebUI/war/app/adminWorkflow.jsp
+++ b/WebUI/war/app/adminWorkflow.jsp
@@ -205,7 +205,7 @@
 
     </script>
 </head>
-<body onbeforeunload="return navigationEvent()" style="overflow : hidden">
+<body onbeforeunload="return navigationEvent()" class="perc-admin-workflow-page" style="overflow-x: hidden; overflow-y: auto">
 <div class="perc-main perc-finder-fix">
     <jsp:include page="includes/header.jsp" flush="true">
         <jsp:param name="mainNavTab" value="workflow"/>
@@ -213,7 +213,7 @@
 
 </div>
 <div class="perc-workflow-container">
-    <div id="tabs" style="min-width:500px;">
+    <div id="tabs" class="perc-admin-tabs">
         <ul role="tablist">
             <li role="presentation"><a role="tab" id="perc-tab-workflow" href="#tabs-1"><i18n:message key = "perc.ui.navMenu.workflow@Workflow" /></a></li>
             <li role="presentation"><a role="tab" id="perc-tab-roles" href="#tabs-2"><i18n:message key = "perc.ui.perc.role.view@Roles" /></a></li>

--- a/WebUI/war/css/percWorkflow.css
+++ b/WebUI/war/css/percWorkflow.css
@@ -1567,3 +1567,82 @@ select {
   font-family: "Open Sans", sans-serif;
   vertical-align: middle !important;
 }
+
+/* ==========================================================================
+   Portrait / narrow Admin (workflow) chrome — GH-945
+   Drop fixed min-widths that force horizontal clipping; wrap or scroll tabs.
+   ========================================================================== */
+
+.perc-admin-workflow-page {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.perc-workflow-container {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.perc-workflow-container #tabs.perc-admin-tabs,
+.perc-workflow-container #tabs {
+  box-sizing: border-box;
+  min-width: 0;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+@media (max-width: 640px), ((orientation: portrait) and (max-width: 900px)) {
+  .perc-workflow-container #tabs > ul {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: stretch;
+    min-width: 0;
+    max-width: 100%;
+    padding-left: 0;
+    margin: 0;
+  }
+
+  .perc-workflow-container #tabs > ul > li {
+    float: none;
+    flex: 0 1 auto;
+    min-width: 0;
+  }
+
+  #perc-tab-workflow,
+  #perc-tab-roles,
+  #perc-tab-users,
+  #perc-tab-category {
+    width: auto;
+    min-width: 0;
+    max-width: 100%;
+    padding-left: 12px;
+    padding-right: 12px;
+    letter-spacing: 0;
+    font-size: 14px;
+  }
+
+  #perc-users-details {
+    min-width: 0;
+    max-width: 100%;
+    width: auto;
+    float: none;
+    margin-left: 0;
+  }
+
+  #perc-workflow-steps-container {
+    min-width: 0;
+    max-width: 100%;
+    float: none;
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+
+  .perc-wf-editor {
+    width: auto;
+    max-width: 100%;
+  }
+}

--- a/docs/ai-generated/code-reviews/issue-945-admin-portrait-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-945-admin-portrait-erlang.md
@@ -1,0 +1,46 @@
+# Erlang review — issue #945 Admin portrait layout
+
+**Branch:** `fix/issue-945-admin-portrait-layout`  
+**Date:** 2026-08-07  
+**Scope:** uncommitted WebUI Admin/Workflow shell chrome + classic adminWorkflow dual-ship + Vitest + Playwright
+
+## Summary
+
+Portrait / narrow Admin chrome was clipped by fixed min-widths and non-wrapping tab rows. Fix is CSS-first: shared `AdminChrome.module.css` for SPA shells; classic `adminWorkflow.jsp` drops `min-width:500px` and gains overflow-y scroll; `percWorkflow.css` dual-ship adds GH-945 media queries.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs | none found |
+| Behavioral tests | Vitest shell + CSS contract; Playwright bug-945 |
+| Portable paths | Vitest uses `node:path` `resolve` only; no OS-specific path strings |
+| Dual-ship consistency | webapp + war + pages/app JSP; three percWorkflow.css trees |
+| Module clean install | `cd WebUI && ../mvnw clean install` SUCCESS |
+
+## Issues
+
+None blocking.
+
+### Nits (non-blocking)
+
+- Classic finder `min-width: 952px` remains product-wide; out of scope for Admin tab chrome (residual if full classic design admin portrait still clipped by finder).
+- Playwright not executed against live CMS in this session (no DEV install required for unit gate); spec is landed for CI/dev.
+
+## Cross-platform path checklist
+
+N/A for production I/O. Tests use `path.resolve` / `readFileSync` — portable.
+
+## Memory patterns hit
+
+- Dual-ship WebUI war/webapp consistency
+- Playwright companion for WebUI screen change
+- CSS contract tests peer (`loginStylesContract`)
+
+## May commit/push
+
+**yes**

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-945-admin-portrait.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-945-admin-portrait.spec.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regression: Admin screen usable in portrait / narrow viewport (GH-945).
+ *
+ * Primary Admin chrome (SPA AdminShell tabs) must remain clickable when the
+ * viewport is phone-portrait sized — wrapping tabs / no fixed min-width clip.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+
+/** Typical phone portrait (iPhone SE-ish). */
+const PORTRAIT = { width: 375, height: 667 };
+
+test.describe("Admin portrait layout (GH-945)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(60_000);
+    await page.setViewportSize(PORTRAIT);
+    await loginAsAdmin(page);
+  });
+
+  test("AdminShell tabs remain visible and switchable in portrait", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE_URL}/cm/app/index.jsp?view=admin`);
+
+    const shell = page.locator("[data-testid='perc-admin-shell']");
+    await expect(shell).toBeVisible({ timeout: 20_000 });
+
+    const tablist = page.locator("[data-testid='perc-admin-tablist']");
+    await expect(tablist).toBeVisible();
+
+    for (const id of [
+      "tab-tasks",
+      "tab-logs",
+      "tab-notifications",
+      "tab-tools",
+    ]) {
+      const tab = page.locator(`[data-testid='${id}']`);
+      await expect(tab).toBeVisible();
+      const box = await tab.boundingBox();
+      expect(box, id).not.toBeNull();
+      // Tab must sit within (or only slightly past) the portrait width —
+      // wrapping may place later tabs on a second row still fully on-screen.
+      expect(box.width).toBeGreaterThan(0);
+      expect(box.height).toBeGreaterThan(0);
+    }
+
+    await page.locator("[data-testid='tab-logs']").click();
+    await expect(
+      page.locator("[data-testid='perc-task-logs-section']"),
+    ).toBeVisible();
+
+    await page.locator("[data-testid='tab-tools']").click();
+    await expect(
+      page.locator("[data-testid='perc-tools-section']"),
+    ).toBeVisible();
+  });
+
+  test("Workflow AdminShell tabs remain visible in portrait", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE_URL}/cm/app/index.jsp?view=workflow`);
+
+    const shell = page.locator("[data-testid='perc-workflow-admin-shell']");
+    await expect(shell).toBeVisible({ timeout: 20_000 });
+
+    const tablist = page.locator(
+      "[data-testid='perc-workflow-admin-tablist']",
+    );
+    await expect(tablist).toBeVisible();
+
+    for (const id of [
+      "tab-workflow",
+      "tab-roles",
+      "tab-users",
+      "tab-categories",
+    ]) {
+      const tab = page.locator(`[data-testid='${id}']`);
+      await expect(tab).toBeVisible();
+      const box = await tab.boundingBox();
+      expect(box, id).not.toBeNull();
+      expect(box.width).toBeGreaterThan(0);
+    }
+
+    await page.locator("[data-testid='tab-users']").click();
+    await expect(page.locator("[data-testid='perc-users-section']")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes **#945** — Admin screen portrait / narrow viewport usability.

Primary Admin chrome was clipped by fixed min-widths and non-wrapping tab rows (classic `adminWorkflow` `min-width:500px` and SPA `AdminShell` / `WorkflowAdminShell` flex tabs).

### Changes
- **Modern SPA:** shared `AdminChrome.module.css` with `flex-wrap`, `overflow-x: auto`, `min-width: 0`, and portrait/narrow media queries; wired into `AdminShell` and `WorkflowAdminShell`.
- **Classic (dual-ship):** removed `min-width:500px` from `adminWorkflow.jsp`; page allows vertical scroll; `percWorkflow.css` GH-945 media queries wrap tabs and drop panel min-widths that clip.
- **Tests:** Vitest shell + CSS/JSP contract tests; Playwright `bug-945-admin-portrait.spec.js`.

## Test plan
- [x] `cd WebUI && ../mvnw clean install` — BUILD SUCCESS
- [x] Vitest: `adminPortraitStylesContract`, `AdminShell`, `WorkflowAdminShell` (9 tests)
- [ ] Playwright `tests/bugs/bug-945-admin-portrait.spec.js` against live CMS (spec landed; not run here — no DEV install in overnight slot)
- [ ] Manual: Admin + Workflow at 375×667 portrait — tabs wrap/visible and clickable

## Gates evidence
- Erlang self-review: **approve** — `docs/ai-generated/code-reviews/issue-945-admin-portrait-erlang.md`
- Module: WebUI standalone clean install green
- Dual-ship: webapp + war + pages/app for JSP; three `percWorkflow.css` trees

## Residual
- Product-wide classic finder `min-width: 952px` still forces horizontal chrome on residual design admin (`admin.jsp`) — out of scope for primary Admin/Workflow tab chrome; file follow-up only if still reported after this lands.

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #945

Parent tracker: #945

> Co-Authored by Grok Build using grok-4.5 with agent main.