### PR TITLE
fix(dts): catalina.log when DTS runs as Windows service (#938)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/README.md
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/README.md
@@ -38,6 +38,20 @@ See `InstallerUserSettings` and `com.intsof.common:utilities`.
 | Embedded DB (new install)   | **H2** under `Deployment/Server/h2data/` (`-Dperc.h2.data.home`)                      |
 | Shared JDBC on `common/lib` | H2 + external drivers (jTDS, MariaDB, MSSQL, Oracle, HikariCP) — **not** Apache Derby |
 
+### Windows service logging (issue #938)
+
+When DTS runs as a **Windows service**, Procrun redirects JVM stdout/stderr to:
+
+```text
+Deployment/Server/logs/catalina.log
+```
+
+This matches Linux `CATALINA_OUT=${CATALINA_HOME}/logs/catalina.log` in
+`DTSProductionService.sh` / `DTSStagingService.sh`. Installers also set the Log4j
+JUL bridge and `log4j.configurationFile` to `log4j2/conf/log4j2-tomcat.xml`
+(service mode does not run `setenv.bat`). Operator details:
+`src/main/rootFiles/README-windows-service.md`.
+
 **HTTPS (Tomcat 11):** `conf/server.xml` uses nested `<SSLHostConfig>` / `<Certificate>` (legacy Connector `keystoreFile` attributes no longer create a default SSL host config). Keystore defaults: `conf/.keystore`, type **PKCS12**, password from `conf/perc/perc-catalina.properties`.
 
 **Derby:** Not packaged into the shipping Tomcat `common/lib`. Upgrade-time Derby→H2 migration still runs offline from `installDts.xml` (`PSMigrateDtsEmbeddedRepository` / `PSUpgradeDerby` via perc-ant). Do not re-add `org.apache.derby` cargo container dependencies without an explicit migration-window reason.

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/DTSProductionService.bat
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/DTSProductionService.bat
@@ -105,12 +105,17 @@ rem Each command line option is prefixed with PR_
 set PR_DESCRIPTION=Percussion Delivery Tier Services For Production - Apache Tomcat Server
 set PR_INSTALL=%EXECUTABLE%
 set PR_LOGPATH=%CATALINA_BASE%\logs
-Set PR_JAVA_OPTS=%JAVA_OPTS% -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Addresses=true -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
+rem Issue #938: match Linux CATALINA_OUT — procrun "auto" writes service-stdout.YYYY-MM-DD.log,
+rem not catalina.log. Point StdOutput/StdError at Deployment/Server/logs/catalina.log.
+set PR_STDOUTPUT=%CATALINA_BASE%\logs\catalina.log
+set PR_STDERROR=%CATALINA_BASE%\logs\catalina.log
 set PR_CLASSPATH=%CATALINA_HOME%/bin/bootstrap.jar;%CATALINA_HOME%/bin/tomcat-juli.jar;%CATALINA_BASE%/log4j2/lib/*;%CATALINA_BASE%/log4j2/conf
 set PR_JVM=%JRE_HOME%\bin\server\jvm.dll
 
 echo Using JVM:              %PR_JVM%
-"%EXECUTABLE%" //IS//%SERVICE_NAME% --LogJniMessages=%LOG_JNI% --LogLevel=%LOG_LEVEL% --StopPath=%CATALINA_HOME%\bin --StartPath=%CATALINA_HOME%\bin --Startup=auto --JavaHome=%JRE_HOME% --StartClass org.apache.catalina.startup.Bootstrap --StartMethod=main --StartParams=start --StopParams=stop --StartMethod=main --StopMethod=main --StopClass org.apache.catalina.startup.Bootstrap 
+echo Using LogPath:          %PR_LOGPATH%
+echo Using StdOutput/Error:  %PR_STDOUTPUT%
+"%EXECUTABLE%" //IS//%SERVICE_NAME% --LogJniMessages=%LOG_JNI% --LogLevel=%LOG_LEVEL% --LogPath="%PR_LOGPATH%" --StdOutput="%PR_STDOUTPUT%" --StdError="%PR_STDERROR%" --StopPath=%CATALINA_HOME%\bin --StartPath=%CATALINA_HOME%\bin --Startup=auto --JavaHome=%JRE_HOME% --StartClass org.apache.catalina.startup.Bootstrap --StartMethod=main --StartParams=start --StopParams=stop --StartMethod=main --StopMethod=main --StopClass org.apache.catalina.startup.Bootstrap 
 if not errorlevel 1 goto installed
 echo Failed installing '%SERVICE_NAME%' service
 goto end
@@ -120,17 +125,19 @@ set PR_DISPLAYNAME=
 set PR_DESCRIPTION=
 set PR_INSTALL=
 set PR_LOGPATH=
+set PR_STDOUTPUT=
+set PR_STDERROR=
 set PR_CLASSPATH=
 set PR_JVM=
 rem Set extra parameters
 REM Note: java.endorsed.dirs property is not supported on Java 9+ (fatal on 21); do not add it back.
 "%EXECUTABLE%" //US//%SERVICE_NAME% --JvmOptions "-Dcatalina.base=%CATALINA_BASE%;-Dcatalina.home=%CATALINA_HOME%" --StartMode jvm --StopMode jvm
-rem More extra parameters
-set PR_LOGPATH=%CATALINA_BASE%\logs
-set PR_STDOUTPUT=auto
-set PR_STDERROR=auto
-"%EXECUTABLE%" //US//%SERVICE_NAME% ++JvmOptions "-Djava.net.preferIPv4Stack=true;-Djava.net.preferIPv4Addresses=true;-Djava.io.tmpdir=%CATALINA_BASE%\temp;-Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager;-Djava.util.logging.config.file=%CATALINA_BASE%\log4j2\conf\log4j2-tomcat.xml;-Dfile.encoding=UTF-8;-Dperc.h2.data.home=%CATALINA_HOME%\h2data" --JvmMs 128 --JvmMx 1024
+rem Issue #938: align with setenv.bat / Linux Log4j JUL bridge. Do not use ClassLoaderLogManager
+rem with java.util.logging.config.file against log4j2-tomcat.xml (that is Log4j2 XML, not JUL).
+rem Re-apply catalina.log stdout/stderr so a re-run of install stays consistent.
+"%EXECUTABLE%" //US//%SERVICE_NAME% --LogPath="%CATALINA_BASE%\logs" --StdOutput="%CATALINA_BASE%\logs\catalina.log" --StdError="%CATALINA_BASE%\logs\catalina.log" ++JvmOptions "-Djava.net.preferIPv4Stack=true;-Djava.net.preferIPv4Addresses=true;-Djava.io.tmpdir=%CATALINA_BASE%\temp;-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager;-Dlog4j.configurationFile=%CATALINA_BASE%\log4j2\conf\log4j2-tomcat.xml;-Dorg.apache.logging.log4j.jul.Log4jLogger.level=OFF;-Dfile.encoding=UTF-8;-Dperc.h2.data.home=%CATALINA_HOME%\h2data" --JvmMs 128 --JvmMx 1024
 echo The service '%SERVICE_NAME%' has been installed.
+echo Application/console log: %CATALINA_BASE%\logs\catalina.log
 
 :end
 cd %CURRENT_DIR%

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/DTSStagingService.bat
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/DTSStagingService.bat
@@ -105,12 +105,17 @@ rem Each command line option is prefixed with PR_
 set PR_DESCRIPTION=Percussion Delivery Tier Services For Staging - Apache Tomcat Server
 set PR_INSTALL=%EXECUTABLE%
 set PR_LOGPATH=%CATALINA_BASE%\logs
-Set PR_JAVA_OPTS=%JAVA_OPTS% -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Addresses=true -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
+rem Issue #938: match Linux CATALINA_OUT — procrun "auto" writes service-stdout.YYYY-MM-DD.log,
+rem not catalina.log. Point StdOutput/StdError at Deployment/Server/logs/catalina.log.
+set PR_STDOUTPUT=%CATALINA_BASE%\logs\catalina.log
+set PR_STDERROR=%CATALINA_BASE%\logs\catalina.log
 set PR_CLASSPATH=%CATALINA_HOME%/bin/bootstrap.jar;%CATALINA_HOME%/bin/tomcat-juli.jar;%CATALINA_BASE%/log4j2/lib/*;%CATALINA_BASE%/log4j2/conf
 set PR_JVM=%JRE_HOME%\bin\server\jvm.dll
 
 echo Using JVM:              %PR_JVM%
-"%EXECUTABLE%" //IS//%SERVICE_NAME% --LogJniMessages=%LOG_JNI% --LogLevel=%LOG_LEVEL% --StopPath=%CATALINA_HOME%\bin --StartPath=%CATALINA_HOME%\bin --Startup=auto --JavaHome=%JRE_HOME% --StartClass org.apache.catalina.startup.Bootstrap --StartMethod=main --StartParams=start --StopParams=stop --StartMethod=main --StopMethod=main --StopClass org.apache.catalina.startup.Bootstrap 
+echo Using LogPath:          %PR_LOGPATH%
+echo Using StdOutput/Error:  %PR_STDOUTPUT%
+"%EXECUTABLE%" //IS//%SERVICE_NAME% --LogJniMessages=%LOG_JNI% --LogLevel=%LOG_LEVEL% --LogPath="%PR_LOGPATH%" --StdOutput="%PR_STDOUTPUT%" --StdError="%PR_STDERROR%" --StopPath=%CATALINA_HOME%\bin --StartPath=%CATALINA_HOME%\bin --Startup=auto --JavaHome=%JRE_HOME% --StartClass org.apache.catalina.startup.Bootstrap --StartMethod=main --StartParams=start --StopParams=stop --StartMethod=main --StopMethod=main --StopClass org.apache.catalina.startup.Bootstrap 
 if not errorlevel 1 goto installed
 echo Failed installing '%SERVICE_NAME%' service
 goto end
@@ -120,17 +125,19 @@ set PR_DISPLAYNAME=
 set PR_DESCRIPTION=
 set PR_INSTALL=
 set PR_LOGPATH=
+set PR_STDOUTPUT=
+set PR_STDERROR=
 set PR_CLASSPATH=
 set PR_JVM=
 rem Set extra parameters
 REM Note: java.endorsed.dirs property is not supported on Java 9+ (fatal on 21); do not add it back.
 "%EXECUTABLE%" //US//%SERVICE_NAME% --JvmOptions "-Dcatalina.base=%CATALINA_BASE%;-Dcatalina.home=%CATALINA_HOME%" --StartMode jvm --StopMode jvm
-rem More extra parameters
-set PR_LOGPATH=%CATALINA_BASE%\logs
-set PR_STDOUTPUT=auto
-set PR_STDERROR=auto
-"%EXECUTABLE%" //US//%SERVICE_NAME% ++JvmOptions "-Djava.net.preferIPv4Stack=true;-Djava.net.preferIPv4Addresses=true;-Djava.io.tmpdir=%CATALINA_BASE%\temp;-Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager;-Djava.util.logging.config.file=%CATALINA_BASE%\log4j2\conf\log4j2-tomcat.xml;-Dfile.encoding=UTF-8;-Dperc.h2.data.home=%CATALINA_HOME%\h2data" --JvmMs 128 --JvmMx 1024
+rem Issue #938: align with setenv.bat / Linux Log4j JUL bridge. Do not use ClassLoaderLogManager
+rem with java.util.logging.config.file against log4j2-tomcat.xml (that is Log4j2 XML, not JUL).
+rem Re-apply catalina.log stdout/stderr so a re-run of install stays consistent.
+"%EXECUTABLE%" //US//%SERVICE_NAME% --LogPath="%CATALINA_BASE%\logs" --StdOutput="%CATALINA_BASE%\logs\catalina.log" --StdError="%CATALINA_BASE%\logs\catalina.log" ++JvmOptions "-Djava.net.preferIPv4Stack=true;-Djava.net.preferIPv4Addresses=true;-Djava.io.tmpdir=%CATALINA_BASE%\temp;-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager;-Dlog4j.configurationFile=%CATALINA_BASE%\log4j2\conf\log4j2-tomcat.xml;-Dorg.apache.logging.log4j.jul.Log4jLogger.level=OFF;-Dfile.encoding=UTF-8;-Dperc.h2.data.home=%CATALINA_HOME%\h2data" --JvmMs 128 --JvmMx 1024
 echo The service '%SERVICE_NAME%' has been installed.
+echo Application/console log: %CATALINA_BASE%\logs\catalina.log
 
 :end
 cd %CURRENT_DIR%

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/README-windows-service.md
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/main/rootFiles/README-windows-service.md
@@ -1,0 +1,81 @@
+# Percussion DTS Windows services (Procrun / tomcat11)
+
+Production and Staging DTS install as native Windows services via Apache Commons
+Daemon **Procrun** (`tomcat11.exe` / `tomcat11w.exe`).
+
+| Installer                  | Default service name      |
+|----------------------------|---------------------------|
+| `DTSProductionService.bat` | `PercussionProductionDTS` |
+| `DTSStagingService.bat`    | `PercussionStagingDTS`    |
+
+Scripts live under `Deployment/Server/` after install (same tree as Tomcat).
+
+## Install / remove
+
+Run from an elevated command prompt with the current directory set to
+`Deployment\Server` (or rely on the script’s `CATALINA_HOME` discovery):
+
+```bat
+cd /d C:\path\to\DTS\Deployment\Server
+DTSProductionService.bat install
+DTSStagingService.bat install
+
+DTSProductionService.bat remove
+```
+
+Optional second argument overrides the Windows service name.
+
+Java home is resolved via `resolve-java-home.bat` at the DTS install root
+(`java.properties` written at install time — GH-991). A JRE under
+`<InstallRoot>\JRE` is **not** required.
+
+## Where logs go (issue #938)
+
+| Stream | Path |
+|--------|------|
+| Application / console (stdout + stderr) | `Deployment\Server\logs\catalina.log` |
+| Procrun / commons-daemon service log | `Deployment\Server\logs\` (LogPath; prefix defaults to service tooling) |
+| Log4j2 Tomcat + DTS app logs | `Deployment\Server\logs\` (`catalina.log`, `localhost.log`, per-app `*.log`) |
+
+This matches Linux service installers, which set:
+
+```text
+CATALINA_OUT=${CATALINA_HOME}/logs/catalina.log
+```
+
+Procrun’s `StdOutput=auto` / `StdError=auto` mode would instead create dated
+`service-stdout.YYYY-MM-DD.log` files and is **not** used. After reinstalling the
+service with a fixed script, restart the service and confirm
+`Deployment\Server\logs\catalina.log` updates.
+
+### Existing installs
+
+If the service was installed with an older script:
+
+1. Stop the service.
+2. `DTSProductionService.bat remove` (or Staging equivalent).
+3. Re-run `… install` from the updated tree.
+4. Start the service.
+
+GUI tweaks: `tomcat11w.exe //ES//PercussionProductionDTS` → Logging tab
+(StdOutput / StdError / Log path).
+
+## Log4j wiring under the service
+
+Console start (`TomcatStartup.bat` → `catalina.bat` + `setenv.bat`) puts Log4j on
+the classpath and sets the JUL bridge. The Windows **service** does not run
+`setenv.bat`; Procrun starts `org.apache.catalina.startup.Bootstrap` directly.
+The installers therefore set:
+
+* classpath: `bootstrap.jar`, `tomcat-juli.jar`, `log4j2/lib/*`, `log4j2/conf`
+* `-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager`
+* `-Dlog4j.configurationFile=<CATALINA_BASE>\log4j2\conf\log4j2-tomcat.xml`
+
+Do not point `java.util.logging.config.file` at the Log4j2 XML (that property is
+for JUL properties files only).
+
+## Related
+
+* Linux: `README-systemd.md`, `DTSProductionService.sh` / `DTSStagingService.sh`
+* CMS Jetty Windows service is separate (`modules/perc-jetty`); do not conflate
+  with DTS Tomcat logging.

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsWindowsServiceCatalinaLogTest.java
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/src/test/java/com/percussion/delivery/distribution/DtsWindowsServiceCatalinaLogTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.delivery.distribution;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards issue #938: Windows DTS Procrun service install must write console output to {@code
+ * logs/catalina.log} (parity with Linux {@code CATALINA_OUT}) and wire Log4j JUL correctly.
+ *
+ * <p>Historically installers used {@code PR_STDOUTPUT=auto} (creates {@code
+ * service-stdout.YYYY-MM-DD.log}) and pointed JUL {@code ClassLoaderLogManager} at Log4j2 XML via
+ * {@code java.util.logging.config.file}, so {@code catalina.log} never updated under the Windows
+ * service.
+ */
+class DtsWindowsServiceCatalinaLogTest {
+
+  private static final Path ROOT_FILES = Path.of("src", "main", "rootFiles");
+
+  private static final List<String> SERVICE_BATS =
+      List.of("DTSProductionService.bat", "DTSStagingService.bat");
+
+  private static String production;
+  private static String staging;
+
+  @BeforeAll
+  static void load() throws IOException {
+    production = read(ROOT_FILES.resolve("DTSProductionService.bat"));
+    staging = read(ROOT_FILES.resolve("DTSStagingService.bat"));
+  }
+
+  @Test
+  void bothBats_redirectStdoutStderrToCatalinaLog() {
+    for (String bat : List.of(production, staging)) {
+      assertTrue(
+          bat.contains("logs\\catalina.log") || bat.contains("logs/catalina.log"),
+          "service bat must reference logs\\catalina.log for Procrun StdOutput/StdError");
+      assertTrue(
+          bat.contains("--StdOutput=") || bat.contains("PR_STDOUTPUT="),
+          "must set Procrun StdOutput");
+      assertTrue(
+          bat.contains("--StdError=") || bat.contains("PR_STDERROR="),
+          "must set Procrun StdError");
+      assertTrue(
+          bat.contains("PR_STDOUTPUT=%CATALINA_BASE%\\logs\\catalina.log")
+              || bat.contains("--StdOutput=\"%CATALINA_BASE%\\logs\\catalina.log\""),
+          "StdOutput must be catalina.log under CATALINA_BASE\\logs (not procrun auto)");
+      assertFalse(
+          bat.matches("(?s).*PR_STDOUTPUT\\s*=\\s*auto.*")
+              || bat.contains("--StdOutput=auto")
+              || bat.contains("--StdOutput auto"),
+          "must not use Procrun StdOutput=auto (that creates dated service-stdout logs)");
+      assertFalse(
+          bat.matches("(?s).*PR_STDERROR\\s*=\\s*auto.*")
+              || bat.contains("--StdError=auto")
+              || bat.contains("--StdError auto"),
+          "must not use Procrun StdError=auto");
+    }
+  }
+
+  @Test
+  void bothBats_useLog4jJulManagerAndConfigurationFile() {
+    for (String bat : List.of(production, staging)) {
+      assertTrue(
+          bat.contains(
+              "java.util.logging.manager=org.apache.logging.log4j.jul.LogManager"),
+          "service JVM options must use Log4j JUL bridge (matches setenv.bat)");
+      assertTrue(
+          bat.contains("log4j.configurationFile=")
+              && bat.contains("log4j2-tomcat.xml"),
+          "must set log4j.configurationFile to log4j2-tomcat.xml");
+      assertFalse(
+          bat.contains("org.apache.juli.ClassLoaderLogManager"),
+          "must not use ClassLoaderLogManager against Log4j2 XML");
+      assertFalse(
+          bat.contains("java.util.logging.config.file=")
+              && bat.contains("log4j2-tomcat.xml"),
+          "must not pass log4j2-tomcat.xml as java.util.logging.config.file");
+    }
+  }
+
+  @Test
+  void bothBats_keepLog4jOnProcrunClasspath() {
+    for (String bat : List.of(production, staging)) {
+      assertTrue(
+          bat.contains("log4j2/lib/*") && bat.contains("log4j2/conf"),
+          "Procrun classpath must include log4j2/lib and log4j2/conf");
+    }
+  }
+
+  @Test
+  void linuxServiceScripts_setCatalinaOutToCatalinaLog() throws IOException {
+    for (String sh : new String[] {"DTSProductionService.sh", "DTSStagingService.sh"}) {
+      String text = read(ROOT_FILES.resolve(sh));
+      assertTrue(
+          text.contains("CATALINA_OUT=${CATALINA_HOME}/logs/catalina.log"),
+          sh + " must set CATALINA_OUT to logs/catalina.log (Linux parity baseline)");
+    }
+  }
+
+  @Test
+  void log4j2TomcatConfig_writesCatalinaLogUnderCatalinaBase() throws IOException {
+    String xml =
+        read(Path.of("src", "main", "tomcat11", "conf", "log4j2-tomcat.xml"));
+    assertTrue(xml.contains("${logdir}/catalina.log") || xml.contains("catalina.log"));
+    assertTrue(xml.contains("${sys:catalina.base}/logs") || xml.contains("logdir"));
+  }
+
+  private static String read(Path path) throws IOException {
+    assertTrue(Files.isRegularFile(path), () -> "missing " + path.toAbsolutePath());
+    return Files.readString(path, StandardCharsets.UTF_8);
+  }
+}

--- a/docs/ai-generated/code-reviews/issue-938-dts-windows-service-catalina-log-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-938-dts-windows-service-catalina-log-erlang.md
@@ -1,0 +1,64 @@
+# Erlang review: issue #938 DTS Windows service catalina.log
+
+**Date:** 2026-08-07  
+**Branch:** `fix/issue-938-dts-windows-service-catalina-log`  
+**Reviewer persona:** Erlang (pre-commit gate)  
+**Recommendation:** approve  
+**Gate:** May commit/push: **yes**
+
+## Summary
+
+Windows DTS Procrun installers (`DTSProductionService.bat`, `DTSStagingService.bat`)
+now redirect StdOutput/StdError to `Deployment/Server/logs/catalina.log` (parity with
+Linux `CATALINA_OUT`) and wire Log4j JUL + `log4j.configurationFile` correctly for
+service mode (no `setenv.bat`). Packaging/script tests and operator docs added.
+CMS Jetty logging untouched.
+
+## Scope
+
+| Path | Change class |
+|------|----------------|
+| `delivery-tier-distribution/.../DTSProductionService.bat` | Windows service installer |
+| `delivery-tier-distribution/.../DTSStagingService.bat` | Windows service installer |
+| `.../DtsWindowsServiceCatalinaLogTest.java` | Packaging/script assertion peer |
+| `.../README-windows-service.md` | Operator note |
+| `.../README.md` | Module operator note |
+| `docs/ai-generated/code-reviews/...-erlang.md` | This report |
+
+Cross-platform path review: bat scripts intentionally use Windows `\` and Procrun
+flags (Windows-only entrypoints). Java tests use `Path.of` / UTF-8 reads only. Linux
+`.sh` CATALINA_OUT assertion remains forward-slash as on disk. No hardcoded
+`C:\…` install roots. No CMS Jetty (`perc-jetty`) changes.
+
+Prior report / memory patterns: installer/packaging peers
+(`DtsTomcat11WindowsServiceAlignmentTest`, `DtsServiceInstallScriptTest`); change-class
+companions include script + test + operator doc.
+
+## Issues
+
+None at **bug** severity.
+
+### suggestion
+
+1. **Dual writers to `catalina.log`** — Log4j RollingFile CATALINA appender and Procrun
+   stdout both target `catalina.log` (same as Linux CATALINA_OUT + Log4j). Acceptable for
+   parity; operators may later drop CONSOLE appender if noise is high. No change required
+   for #938.
+
+### nit
+
+1. README-windows-service.md ships via rootFiles; installDts does not specially co-locate
+   it under Deployment/Server only — it follows existing rootFiles copy policy (acceptable;
+   module README also documents the path).
+
+## Gate checklist
+
+- [x] Behavioral packaging tests for changed installer contract
+- [x] No non-portable Java path I/O
+- [x] Module `mvnw clean install` green (delivery-tier-distribution)
+- [x] Scope limited to DTS Windows service logging (no Jetty)
+
+## Recommendation detail
+
+**approve** — root cause (stdout=auto + wrong JUL manager/config.file) fixed with
+symmetric Production/Staging bats, regression tests, and operator docs.


### PR DESCRIPTION
## Summary

Fixes **#938** (migrated from percussion/percussioncms#1284): when DTS runs as a **Windows service**, `Deployment/Server/logs/catalina.log` was not updated.

### Root cause
1. Procrun used `StdOutput/StdError=auto`, which creates dated `service-stdout.YYYY-MM-DD.log` files instead of `catalina.log` (Linux sets `CATALINA_OUT=.../logs/catalina.log`).
2. Service JVM options used `org.apache.juli.ClassLoaderLogManager` with `java.util.logging.config.file` pointing at **Log4j2 XML** (`log4j2-tomcat.xml`). Service mode does not run `setenv.bat`, so the Log4j JUL bridge never applied.

### Fix
- `DTSProductionService.bat` / `DTSStagingService.bat`: redirect StdOutput/StdError to `%CATALINA_BASE%\logs\catalina.log`; set Log4j JUL manager + `log4j.configurationFile` (aligned with `setenv.bat`).
- Packaging tests: `DtsWindowsServiceCatalinaLogTest`.
- Operator docs: `README-windows-service.md` + module README note.
- **Out of scope:** CMS Jetty Windows service logging (`perc-jetty`) — unchanged.

## Test plan
- [x] `cd deliverytiersuite/delivery-tier-suite/delivery-tier-distribution && mvnw clean install` (standalone module)
- [x] `DtsWindowsServiceCatalinaLogTest` (5 tests) green
- [x] Erlang pre-commit review: approve (`docs/ai-generated/code-reviews/issue-938-dts-windows-service-catalina-log-erlang.md`)
- [ ] Operator: remove/reinstall Windows service from updated tree; confirm `Deployment\Server\logs\catalina.log` updates after start

## Gates evidence
| Gate | Result |
|------|--------|
| Implement + behavioral tests | Yes |
| Erlang self-review | approve |
| Module clean install | delivery-tier-distribution OK |
| In-scope commit only | Yes |
| Operator labels | operator:grok, operator:night-issue-prs, model:grok-4.5 |

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #938

> Co-Authored by Grok Build using grok-4.5 with agent main.