### PR TITLE
feat(perc-doctor): clean-temp for allowlisted install temp/work dirs (#2232)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2232-clean-temp-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2232-clean-temp-erlang.md
@@ -1,0 +1,52 @@
+# Erlang review — issue #2232 perc-doctor clean-temp
+
+**Date:** 2026-08-07  
+**Branch:** `feat/issue-2232-clean-temp`  
+**Scope:** uncommitted / pre-PR changes for `clean-temp` under `modules/perc-doctor`  
+**Parent:** #2213  
+
+## Summary
+
+Adds CLI/API command `clean-temp` that inventories and optionally deletes regular files under allowlisted install temp/work directories (`temp`, `jetty/base/work`, `Deployment/Server/temp`, `Deployment/Server/work`). Mirrors `CleanLogsCommand` scoped-walk pattern with `InstallRootGuard` containment, dry-run-first, TOCTOU re-check before delete, and retention of allowlisted root directories. Unit tests cover dry-run, apply, outside-root exclusion, missing dirs, CLI wiring, and API dry-run default. README + operator guide document the allowlist.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs | none found |
+| Behavioral unit tests for new logic | yes (`CleanTempCommandTest` 9, CLI + API + InstallRootGuard coverage) |
+| Portable path / file I/O | pass — `java.nio.file.Path` / `Files` only; forward-slash relative allowlist; `resolveRelativeUnderRoot` + case-insensitive Windows containment via existing guard |
+| Change-class companions | CLI + command class + guard allowlist + API dispatch + docs + tests (same class as clean-logs) |
+| May commit/push | **yes** |
+
+## Cross-platform path checklist
+
+- [x] No hardcoded user homes / drive letters in product code
+- [x] Relative allowlist uses `/` segments resolved via `resolveRelativeUnderRoot`
+- [x] Containment uses `InstallRootGuard` (Windows case fold already present)
+- [x] Tests use `@TempDir` and `Path.resolve` (portable)
+
+## Issues
+
+None (approve).
+
+## Memory patterns hit
+
+- Scoped clean commands: allowlisted dirs only, no user globs
+- Dry-run never mutates; re-check containment before delete
+- Document allowlist in README / operator guide
+
+## Verification
+
+```text
+cd modules/perc-doctor && ../../mvnw clean install
+CleanTempCommandTest: 9 tests, 0 failures
+DoctorCliTest: 14 tests, 0 failures
+InstallRootGuardTest: 13 tests, 0 failures
+DoctorApiServiceTest: 9 tests, 0 failures
+Module suite green
+```

--- a/modules/perc-doctor/README.md
+++ b/modules/perc-doctor/README.md
@@ -2,9 +2,9 @@
 
 Operator CLI for diagnosing and safely cleaning Percussion CMS install trees.
 
-**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`), [#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219) (admin HTTP API), [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (dist packaging + install guide)  
+**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`), [#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219) (admin HTTP API), [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (dist packaging + install guide), [#2232](https://github.com/intersoftdatalabs-in/percussioncms/issues/2232) (`clean-temp`)  
 **Package:** `com.intsof.percussioncms.doctor` (+ `...doctor.api` for HTTP)  
-**Shipped commands:** `clean-heap-dumps`, `clean-install-backups`, `clean-logs` with global `--dry-run` / `--install-root` / `-v`  
+**Shipped commands:** `clean-heap-dumps`, `clean-install-backups`, `clean-logs`, `clean-temp` with global `--dry-run` / `--install-root` / `-v`  
 **HTTP:** Admin-only `POST .../maintenance/doctor/{command}` (wired in sitemanage)
 
 **Operator install guide (dry-run-first examples):** [docs/operator-install-guide.md](docs/operator-install-guide.md)
@@ -163,14 +163,45 @@ java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
   --install-root /opt/Percussion --dry-run -v clean-logs
 ```
 
+#### `clean-temp`
+
+Reclaim space from **known** install temp / work directories under the install root. Prefer stopping CMS / DTS processes before apply so temp files are not locked.
+
+##### Target temp / work locations (relative to `--install-root`)
+
+| Relative path | Role |
+|---------------|------|
+| `temp` | CMS install temp (`install.xml` creates `${install.dir}/temp`) |
+| `jetty/base/work` | Jetty work directory (assembly / install layout) |
+| `Deployment/Server/temp` | DTS Tomcat `catalina.base`/temp |
+| `Deployment/Server/work` | DTS Tomcat `catalina.base`/work |
+
+Missing directories are skipped (not an error). **Only files under these roots** are candidates. The allowlisted root directories themselves are **never** deleted (empty nested subdirs may be removed best-effort after apply). **No user-supplied globs; no walk of the entire install for arbitrary temp files.**
+
+- **Scope:** only under `--install-root` and the allowlisted temp/work dirs
+- **Dry-run:** inventories candidates + sizes without deleting
+
+Examples:
+
+```bash
+# Preview reclaimable temp/work files (safe)
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
+  --install-root /opt/Percussion --dry-run -v clean-temp
+
+# Apply (Windows example)
+java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar ^
+  --install-root C:\Percussion -v clean-temp
+```
+
 ## Safety model
 
 1. Resolve and validate install root (must exist and be a directory).
-2. Walk only under that root (and for `clean-logs`, only under allowlisted log dirs); skip / reject candidates that escape the root.
+2. Walk only under that root (and for `clean-logs` / `clean-temp`, only under allowlisted dirs); skip / reject candidates that escape the root.
 3. Match allowlisted patterns only (per command; no user-supplied globs).
 4. If `--dry-run`, stop after inventory.
 5. On apply, re-check containment immediately before each delete.
 6. For `clean-logs`, apply `--keep-current` and `--older-than` before any delete.
+7. For `clean-temp`, never remove the allowlisted temp/work root directories themselves.
 
 ## Admin HTTP API (slice #2219)
 
@@ -179,7 +210,7 @@ When the CMS server is running, doctor commands are also available as an **Admin
 | | |
 |--|--|
 | **Method / path** | `POST /Rhythmyx/services/maintenance/doctor/{command}` |
-| **Commands** | `clean-heap-dumps`, `clean-install-backups`, `clean-logs` (same tokens as CLI) |
+| **Commands** | `clean-heap-dumps`, `clean-install-backups`, `clean-logs`, `clean-temp` (same tokens as CLI) |
 | **Auth hard gate** | **Admin role only.** Anonymous and non-admin callers receive **HTTP 403**. |
 | **Content-Type** | `application/json` (XML also accepted/produced by the host stack) |
 
@@ -238,4 +269,4 @@ Example apply (Admin only; deletes under install root):
 
 ## Deferred (not in this module slice)
 
-None for the #2213 slices absorbed here (`clean-*` CLI, dist packaging #2220, admin HTTP #2219). Further residuals stay on the parent epic if any.
+`clean-temp` is delivered under [#2232](https://github.com/intersoftdatalabs-in/percussioncms/issues/2232). Further residuals (e.g. `fix-permissions` / deeper `check-config`) stay on the parent epic [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213).

--- a/modules/perc-doctor/docs/operator-install-guide.md
+++ b/modules/perc-doctor/docs/operator-install-guide.md
@@ -1,7 +1,7 @@
 # perc-doctor operator install guide
 
 **Module:** `modules/perc-doctor`  
-**Issues:** [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (packaging), [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent)
+**Issues:** [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (packaging), [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2232](https://github.com/intersoftdatalabs-in/percussioncms/issues/2232) (`clean-temp`)
 
 This guide is for operators running **perc-doctor** against a CMS install on Windows or Linux. Prefer **dry-run first** for every command; only apply after you review the candidate list and sizes.
 
@@ -154,6 +154,37 @@ bin\perc-doctor.bat --install-root C:\Percussion --dry-run -v clean-logs --older
 bin\perc-doctor.bat --install-root C:\Percussion -v clean-logs --older-than 14d
 ```
 
+### `clean-temp`
+
+Removes **files** under known install temp / work directories only. Prefer stopping CMS / DTS first so files are not locked. Allowlisted roots themselves are retained.
+
+| Relative path | Role |
+|---------------|------|
+| `temp` | CMS install temp |
+| `jetty/base/work` | Jetty work directory |
+| `Deployment/Server/temp` | DTS Tomcat temp |
+| `Deployment/Server/work` | DTS Tomcat work |
+
+**Dry-run first:**
+
+```bash
+./bin/perc-doctor --install-root /opt/Percussion --dry-run -v clean-temp
+```
+
+```bat
+bin\perc-doctor.bat --install-root C:\Percussion --dry-run -v clean-temp
+```
+
+**Apply (only after review; prefer CMS/DTS stopped):**
+
+```bash
+./bin/perc-doctor --install-root /opt/Percussion -v clean-temp
+```
+
+```bat
+bin\perc-doctor.bat --install-root C:\Percussion -v clean-temp
+```
+
 ## Distribution packaging (developers)
 
 Module `mvnw clean install` attaches:
@@ -170,4 +201,5 @@ Module `mvnw clean install` attaches:
 
 - Module README: [../README.md](../README.md)
 - Parent epic: [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213)
-- Admin HTTP API: deferred ([#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219))
+- `clean-temp` slice: [#2232](https://github.com/intersoftdatalabs-in/percussioncms/issues/2232)
+- Admin HTTP API: shipped with MVP cluster ([#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219) / [#2230](https://github.com/intersoftdatalabs-in/percussioncms/pull/2230))

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanTempCommand.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanTempCommand.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Remove (or inventory) files under known CMS install temp / work directories.
+ *
+ * <p>Target roots (relative to install root; missing dirs skipped):
+ *
+ * <ul>
+ *   <li>{@code temp}
+ *   <li>{@code jetty/base/work}
+ *   <li>{@code Deployment/Server/temp}
+ *   <li>{@code Deployment/Server/work}
+ * </ul>
+ *
+ * <p>Only files under those allowlisted roots are considered. The allowlisted root directories
+ * themselves are never deleted. Dry-run never deletes. Paths outside the install root are never
+ * deleted. Prefer stopping the CMS / DTS processes before apply so files are not locked.
+ */
+public final class CleanTempCommand {
+
+  /** CLI command token. */
+  public static final String COMMAND_NAME = "clean-temp";
+
+  private CleanTempCommand() {}
+
+  /**
+   * Inventory files under known temp/work dirs and optionally delete them.
+   *
+   * @param installRoot resolved install root (must exist)
+   * @param dryRun when true, only inventory (no deletes)
+   * @return report of candidates and actions
+   * @throws IOException on walk failures that cannot be recovered
+   * @throws IllegalArgumentException if install root is invalid
+   */
+  public static CleanReport execute(Path installRoot, boolean dryRun) throws IOException {
+    Path root = InstallRootGuard.requireInstallRoot(installRoot);
+    CleanReport report = new CleanReport(COMMAND_NAME, root, dryRun);
+
+    List<Path> tempRoots = InstallRootGuard.existingTempDirs(root);
+    List<Path> candidates = new ArrayList<>();
+    for (Path tempDir : tempRoots) {
+      walkTempDir(root, tempDir, candidates, report);
+    }
+    candidates.sort(Comparator.comparing(p -> p.toString()));
+
+    Set<Path> parentDirs = new HashSet<>();
+    for (Path candidate : candidates) {
+      processCandidate(report, root, tempRoots, candidate, dryRun);
+      Path parent = candidate.getParent();
+      if (parent != null) {
+        parentDirs.add(parent);
+      }
+    }
+
+    // Best-effort: remove empty nested dirs after apply (never the allowlisted roots).
+    if (!dryRun) {
+      removeEmptyNestedDirs(root, tempRoots, parentDirs);
+    }
+    return report;
+  }
+
+  /**
+   * Inventory temp files under known temp dirs without recording walk failures (test helper).
+   * Returns all regular files found under allowlisted roots.
+   */
+  static List<Path> findTempFiles(Path root) throws IOException {
+    Path installRoot = InstallRootGuard.requireInstallRoot(root);
+    List<Path> found = new ArrayList<>();
+    for (Path tempDir : InstallRootGuard.existingTempDirs(installRoot)) {
+      walkTempDir(installRoot, tempDir, found, null);
+    }
+    return found;
+  }
+
+  /**
+   * Walk a single temp/work directory tree. When {@code report} is non-null, I/O failures during
+   * the walk are appended as {@link CleanReport.EntryStatus#FAILED}.
+   */
+  static void walkTempDir(Path installRoot, Path tempDir, List<Path> found, CleanReport report)
+      throws IOException {
+    Objects.requireNonNull(installRoot, "installRoot");
+    Objects.requireNonNull(tempDir, "tempDir");
+    Objects.requireNonNull(found, "found");
+    if (!InstallRootGuard.isUnderInstallRoot(installRoot, tempDir)) {
+      return;
+    }
+    if (!Files.isDirectory(tempDir)) {
+      return;
+    }
+    Files.walkFileTree(
+        tempDir,
+        new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+            if (!InstallRootGuard.isUnderInstallRoot(installRoot, dir)) {
+              return FileVisitResult.SKIP_SUBTREE;
+            }
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+            if (!attrs.isRegularFile()) {
+              return FileVisitResult.CONTINUE;
+            }
+            if (!InstallRootGuard.isUnderInstallRoot(installRoot, file)) {
+              return FileVisitResult.CONTINUE;
+            }
+            // Never treat the allowlisted root itself as a file candidate.
+            if (tempDir.equals(file.toAbsolutePath().normalize())) {
+              return FileVisitResult.CONTINUE;
+            }
+            found.add(file);
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult visitFileFailed(Path file, IOException exc) {
+            recordVisitFailure(report, file, exc);
+            return FileVisitResult.CONTINUE;
+          }
+        });
+  }
+
+  /** Record a walk I/O failure on the report when one is provided (package-visible for tests). */
+  static void recordVisitFailure(CleanReport report, Path file, IOException exc) {
+    if (report == null || file == null) {
+      return;
+    }
+    String detail = exc != null ? exc.getMessage() : "unknown I/O error";
+    if (detail == null || detail.isBlank()) {
+      detail = exc != null ? exc.getClass().getSimpleName() : "unknown I/O error";
+    }
+    report.add(
+        new CleanReport.Entry(file, 0L, CleanReport.EntryStatus.FAILED, "walk: " + detail));
+  }
+
+  private static void processCandidate(
+      CleanReport report,
+      Path root,
+      List<Path> tempRoots,
+      Path candidate,
+      boolean dryRun) {
+    Objects.requireNonNull(candidate, "candidate");
+    try {
+      InstallRootGuard.requireUnderInstallRoot(root, candidate);
+    } catch (IllegalArgumentException outside) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, 0L, CleanReport.EntryStatus.FAILED, outside.getMessage()));
+      return;
+    }
+
+    if (!isUnderAnyTempRoot(tempRoots, candidate)) {
+      report.add(
+          new CleanReport.Entry(
+              candidate,
+              0L,
+              CleanReport.EntryStatus.SKIPPED,
+              "not under an allowlisted temp/work directory"));
+      return;
+    }
+
+    // Never delete the allowlisted root directories themselves.
+    Path normalizedCandidate = candidate.toAbsolutePath().normalize();
+    for (Path tempRoot : tempRoots) {
+      if (tempRoot.toAbsolutePath().normalize().equals(normalizedCandidate)) {
+        report.add(
+            new CleanReport.Entry(
+                candidate,
+                0L,
+                CleanReport.EntryStatus.SKIPPED,
+                "allowlisted temp/work root is retained"));
+        return;
+      }
+    }
+
+    long size = 0L;
+    try {
+      if (Files.isRegularFile(candidate)) {
+        size = Files.size(candidate);
+      }
+    } catch (IOException e) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, 0L, CleanReport.EntryStatus.FAILED, "size: " + e.getMessage()));
+      return;
+    }
+
+    if (dryRun) {
+      report.add(
+          new CleanReport.Entry(candidate, size, CleanReport.EntryStatus.WOULD_DELETE, null));
+      return;
+    }
+
+    try {
+      // Re-check containment immediately before delete (TOCTOU-resistant enough for ops tool).
+      InstallRootGuard.requireUnderInstallRoot(root, candidate);
+      if (!isUnderAnyTempRoot(tempRoots, candidate)) {
+        report.add(
+            new CleanReport.Entry(
+                candidate,
+                size,
+                CleanReport.EntryStatus.FAILED,
+                "path escaped allowlisted temp/work roots before delete"));
+        return;
+      }
+      boolean deleted = Files.deleteIfExists(candidate);
+      if (deleted) {
+        report.add(new CleanReport.Entry(candidate, size, CleanReport.EntryStatus.DELETED, null));
+      } else {
+        report.add(
+            new CleanReport.Entry(
+                candidate, size, CleanReport.EntryStatus.SKIPPED, "already absent"));
+      }
+    } catch (IOException e) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, size, CleanReport.EntryStatus.FAILED, "delete: " + e.getMessage()));
+    } catch (IllegalArgumentException outside) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, size, CleanReport.EntryStatus.FAILED, outside.getMessage()));
+    }
+  }
+
+  /**
+   * True when {@code candidate} is under (or equal to) one of the allowlisted temp roots, all
+   * relative to install-root containment already verified by the caller.
+   */
+  static boolean isUnderAnyTempRoot(List<Path> tempRoots, Path candidate) {
+    if (tempRoots == null || candidate == null) {
+      return false;
+    }
+    Path path = candidate.toAbsolutePath().normalize();
+    for (Path tempRoot : tempRoots) {
+      if (tempRoot == null) {
+        continue;
+      }
+      Path root = tempRoot.toAbsolutePath().normalize();
+      if (InstallRootGuard.pathStartsWithRoot(path, root)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Best-effort empty directory cleanup under allowlisted roots. Never removes the allowlisted
+   * roots themselves. Failures are ignored (files are what reclaim space).
+   */
+  static void removeEmptyNestedDirs(
+      Path installRoot, List<Path> tempRoots, Set<Path> seedParents) {
+    if (tempRoots == null || tempRoots.isEmpty()) {
+      return;
+    }
+    Set<Path> rootsNormalized = new HashSet<>();
+    for (Path r : tempRoots) {
+      rootsNormalized.add(r.toAbsolutePath().normalize());
+    }
+
+    // Walk deepest first so children empty before parents.
+    List<Path> toTry = new ArrayList<>();
+    if (seedParents != null) {
+      toTry.addAll(seedParents);
+    }
+    // Also re-scan each temp root for empty nested dirs that had no files.
+    for (Path tempRoot : tempRoots) {
+      try {
+        collectNestedDirs(installRoot, tempRoot, toTry);
+      } catch (IOException ignored) {
+        // best-effort
+      }
+    }
+
+    toTry.sort(
+        Comparator.comparingInt((Path p) -> p.toAbsolutePath().normalize().getNameCount())
+            .reversed()
+            .thenComparing(p -> p.toString()));
+
+    for (Path dir : toTry) {
+      Path normalized = dir.toAbsolutePath().normalize();
+      if (rootsNormalized.contains(normalized)) {
+        continue;
+      }
+      if (!InstallRootGuard.isUnderInstallRoot(installRoot, normalized)) {
+        continue;
+      }
+      if (!isUnderAnyTempRoot(tempRoots, normalized)) {
+        continue;
+      }
+      try {
+        if (Files.isDirectory(normalized)) {
+          // delete only if empty
+          try (var stream = Files.list(normalized)) {
+            if (stream.findAny().isEmpty()) {
+              Files.deleteIfExists(normalized);
+            }
+          }
+        }
+      } catch (IOException ignored) {
+        // best-effort
+      }
+    }
+  }
+
+  private static void collectNestedDirs(Path installRoot, Path tempRoot, List<Path> out)
+      throws IOException {
+    if (!Files.isDirectory(tempRoot)) {
+      return;
+    }
+    Files.walkFileTree(
+        tempRoot,
+        new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+            if (!InstallRootGuard.isUnderInstallRoot(installRoot, dir)) {
+              return FileVisitResult.SKIP_SUBTREE;
+            }
+            Path normalized = dir.toAbsolutePath().normalize();
+            Path rootNorm = tempRoot.toAbsolutePath().normalize();
+            if (!normalized.equals(rootNorm)) {
+              out.add(normalized);
+            }
+            return FileVisitResult.CONTINUE;
+          }
+        });
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
@@ -29,7 +29,8 @@ import java.time.Duration;
  *   &lt;command&gt; [command-options]
  * </pre>
  *
- * <p>Commands: {@code clean-heap-dumps}, {@code clean-install-backups}, {@code clean-logs}.
+ * <p>Commands: {@code clean-heap-dumps}, {@code clean-install-backups}, {@code clean-logs},
+ * {@code clean-temp}.
  */
 public final class DoctorCli {
 
@@ -79,8 +80,10 @@ public final class DoctorCli {
               + CleanHeapDumpsCommand.COMMAND_NAME
               + ", "
               + CleanInstallBackupsCommand.COMMAND_NAME
+              + ", "
+              + CleanLogsCommand.COMMAND_NAME
               + ", or "
-              + CleanLogsCommand.COMMAND_NAME);
+              + CleanTempCommand.COMMAND_NAME);
       printHelp(err);
       return EXIT_USAGE;
     }
@@ -126,6 +129,11 @@ public final class DoctorCli {
         printReport(report, parsed.verbose, out);
         return report.getFailedCount() > 0 ? EXIT_ERROR : EXIT_OK;
       }
+      if (CleanTempCommand.COMMAND_NAME.equals(parsed.command)) {
+        CleanReport report = CleanTempCommand.execute(installRoot, parsed.dryRun);
+        printReport(report, parsed.verbose, out);
+        return report.getFailedCount() > 0 ? EXIT_ERROR : EXIT_OK;
+      }
       err.println("Error: unknown command: " + parsed.command);
       err.println(
           "Supported commands: "
@@ -133,7 +141,9 @@ public final class DoctorCli {
               + ", "
               + CleanInstallBackupsCommand.COMMAND_NAME
               + ", "
-              + CleanLogsCommand.COMMAND_NAME);
+              + CleanLogsCommand.COMMAND_NAME
+              + ", "
+              + CleanTempCommand.COMMAND_NAME);
       printHelp(err);
       return EXIT_USAGE;
     } catch (IllegalArgumentException e) {
@@ -209,7 +219,7 @@ public final class DoctorCli {
     stream.println();
     stream.println(
         "CMS Doctor — safe install-tree maintenance"
-            + " (clean-heap-dumps, clean-install-backups, clean-logs).");
+            + " (clean-heap-dumps, clean-install-backups, clean-logs, clean-temp).");
     stream.println();
     stream.println("Options:");
     stream.println("  --install-root <path>  CMS install root (default: current working directory)");
@@ -224,6 +234,8 @@ public final class DoctorCli {
             + " (*.bak, *.backup, AppServer_backup_*.zip)");
     stream.println(
         "  clean-logs             Remove aged logs under known Jetty/CMS/DTS log dirs");
+    stream.println(
+        "  clean-temp             Remove files under known install temp/work dirs");
     stream.println();
     stream.println("clean-logs options:");
     stream.println(
@@ -243,6 +255,9 @@ public final class DoctorCli {
         "  perc-doctor --install-root /opt/Percussion --dry-run -v clean-logs --older-than 7d");
     stream.println(
         "  perc-doctor --install-root C:\\Percussion -v clean-logs --older-than 14d");
+    stream.println(
+        "  perc-doctor --install-root /opt/Percussion --dry-run -v clean-temp");
+    stream.println("  perc-doctor --install-root C:\\Percussion -v clean-temp");
   }
 
   static void printReport(CleanReport report, boolean verbose, PrintStream out) {

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/InstallRootGuard.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/InstallRootGuard.java
@@ -198,6 +198,27 @@ public final class InstallRootGuard {
   };
 
   /**
+   * Relative install temp / work directory roots for {@code clean-temp}. Documented in the module
+   * README and operator guide.
+   *
+   * <ul>
+   *   <li>{@code temp} — CMS install temp ({@code install.xml} {@code mkdir ${install.dir}/temp})
+   *   <li>{@code jetty/base/work} — Jetty work directory (assembly / install layout)
+   *   <li>{@code Deployment/Server/temp} — DTS Tomcat {@code catalina.base}/temp
+   *   <li>{@code Deployment/Server/work} — DTS Tomcat {@code catalina.base}/work
+   * </ul>
+   *
+   * <p>Missing directories are skipped at walk time (not an error). Only contents under these
+   * roots are candidates; the allowlisted root directories themselves are never removed.
+   */
+  public static final String[] TEMP_DIR_RELATIVE = {
+    "temp",
+    "jetty/base/work",
+    "Deployment/Server/temp",
+    "Deployment/Server/work"
+  };
+
+  /**
    * Resolve allowlisted log directory roots that exist under {@code installRoot}. Only existing
    * directories that stay under the install root are returned.
    *
@@ -205,10 +226,33 @@ public final class InstallRootGuard {
    * @return list of existing log dir paths under the root (may be empty)
    */
   public static java.util.List<Path> existingLogDirs(Path installRoot) {
+    return existingAllowlistedDirs(installRoot, LOG_DIR_RELATIVE);
+  }
+
+  /**
+   * Resolve allowlisted temp / work directory roots that exist under {@code installRoot}. Only
+   * existing directories that stay under the install root are returned.
+   *
+   * @param installRoot resolved install root
+   * @return list of existing temp/work dir paths under the root (may be empty)
+   */
+  public static java.util.List<Path> existingTempDirs(Path installRoot) {
+    return existingAllowlistedDirs(installRoot, TEMP_DIR_RELATIVE);
+  }
+
+  /**
+   * Resolve relative directory roots that exist under {@code installRoot} and remain contained.
+   *
+   * @param installRoot resolved install root
+   * @param relativeRoots forward-slash relative paths under the install root
+   * @return list of existing directory paths under the root (may be empty)
+   */
+  static java.util.List<Path> existingAllowlistedDirs(Path installRoot, String[] relativeRoots) {
     Objects.requireNonNull(installRoot, "installRoot");
+    Objects.requireNonNull(relativeRoots, "relativeRoots");
     Path root = installRoot.toAbsolutePath().normalize();
     java.util.List<Path> dirs = new java.util.ArrayList<>();
-    for (String relative : LOG_DIR_RELATIVE) {
+    for (String relative : relativeRoots) {
       Path dir = resolveRelativeUnderRoot(root, relative);
       if (dir == null) {
         continue;

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorApiService.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorApiService.java
@@ -20,6 +20,7 @@ import com.intsof.percussioncms.doctor.CleanHeapDumpsCommand;
 import com.intsof.percussioncms.doctor.CleanInstallBackupsCommand;
 import com.intsof.percussioncms.doctor.CleanLogsCommand;
 import com.intsof.percussioncms.doctor.CleanReport;
+import com.intsof.percussioncms.doctor.CleanTempCommand;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -29,7 +30,7 @@ import java.util.Objects;
 /**
  * Executes doctor clean commands for the HTTP API. Reuses the same command implementations as the
  * CLI ({@link CleanHeapDumpsCommand}, {@link CleanInstallBackupsCommand}, {@link
- * CleanLogsCommand}).
+ * CleanLogsCommand}, {@link CleanTempCommand}).
  *
  * <p>Authorization is enforced by the caller ({@link DoctorRestService}); this class only runs
  * commands.
@@ -80,6 +81,8 @@ public final class DoctorApiService {
       CleanLogsCommand.Options options =
           new CleanLogsCommand.Options(olderThan, body.isEffectiveKeepCurrent());
       report = CleanLogsCommand.execute(installRoot, dryRun, options);
+    } else if (CleanTempCommand.COMMAND_NAME.equals(cmd)) {
+      report = CleanTempCommand.execute(installRoot, dryRun);
     } else {
       throw new DoctorUnknownCommandException(cmd);
     }

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorRestService.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorRestService.java
@@ -71,7 +71,7 @@ public class DoctorRestService {
    * Execute a doctor command.
    *
    * @param command CLI command token ({@code clean-heap-dumps}, {@code clean-install-backups},
-   *     {@code clean-logs})
+   *     {@code clean-logs}, {@code clean-temp})
    * @param request JSON body; may be null (treated as empty dry-run request)
    * @return structured report (same fields as CLI inventory/action report)
    */

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CleanTempCommandTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CleanTempCommandTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CleanTempCommandTest {
+
+  @TempDir Path tempDir;
+
+  private Path installRoot;
+  private Path cmsTemp;
+  private Path jettyWork;
+  private Path dtsTemp;
+  private Path nestedTempFile;
+  private Path jettyWorkFile;
+  private Path dtsTempFile;
+  private Path outsideTempFile;
+  private Path nonTempFile;
+  private Path logsDirFile;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    installRoot = Files.createDirectories(tempDir.resolve("cms-install"));
+    cmsTemp = Files.createDirectories(installRoot.resolve("temp"));
+    jettyWork =
+        Files.createDirectories(installRoot.resolve("jetty").resolve("base").resolve("work"));
+    dtsTemp =
+        Files.createDirectories(
+            installRoot.resolve("Deployment").resolve("Server").resolve("temp"));
+
+    Path nested = Files.createDirectories(cmsTemp.resolve("session").resolve("abc"));
+    nestedTempFile = nested.resolve("upload.tmp");
+    jettyWorkFile = jettyWork.resolve("jstl_1");
+    dtsTempFile = dtsTemp.resolve("safeToDelete.tmp");
+    nonTempFile = installRoot.resolve("rxconfig").resolve("Server").resolve("server.properties");
+    Files.createDirectories(nonTempFile.getParent());
+    Files.writeString(nestedTempFile, "nested-temp");
+    Files.write(jettyWorkFile, "work-bytes".getBytes(StandardCharsets.UTF_8));
+    Files.writeString(dtsTempFile, "dts-temp");
+    Files.writeString(nonTempFile, "keep-me");
+
+    Path logs =
+        Files.createDirectories(installRoot.resolve("jetty").resolve("base").resolve("logs"));
+    logsDirFile = logs.resolve("server.log");
+    Files.writeString(logsDirFile, "not-temp");
+
+    Path outside = Files.createDirectories(tempDir.resolve("not-install").resolve("temp"));
+    outsideTempFile = outside.resolve("escape.tmp");
+    Files.writeString(outsideTempFile, "outside");
+  }
+
+  @Test
+  void dryRunInventoriesOnlyAllowlistedTempDirsAndDoesNotDelete() throws Exception {
+    CleanReport report = CleanTempCommand.execute(installRoot, true);
+
+    assertTrue(report.isDryRun());
+    assertEquals(0, report.getDeletedCount());
+    assertEquals(3, report.getCandidateCount());
+    assertTrue(Files.exists(nestedTempFile));
+    assertTrue(Files.exists(jettyWorkFile));
+    assertTrue(Files.exists(dtsTempFile));
+    assertTrue(Files.exists(outsideTempFile));
+    assertTrue(Files.exists(nonTempFile));
+    assertTrue(Files.exists(logsDirFile));
+    assertTrue(Files.isDirectory(cmsTemp), "allowlisted root dirs must remain");
+    assertTrue(Files.isDirectory(jettyWork));
+    assertTrue(Files.isDirectory(dtsTemp));
+
+    for (CleanReport.Entry e : report.getEntries()) {
+      assertEquals(CleanReport.EntryStatus.WOULD_DELETE, e.getStatus());
+      assertTrue(InstallRootGuard.isUnderInstallRoot(installRoot, e.getPath()));
+      assertTrue(
+          CleanTempCommand.isUnderAnyTempRoot(
+              InstallRootGuard.existingTempDirs(installRoot), e.getPath()));
+    }
+
+    long expectedBytes =
+        Files.size(nestedTempFile) + Files.size(jettyWorkFile) + Files.size(dtsTempFile);
+    assertEquals(expectedBytes, report.getTotalBytes());
+  }
+
+  @Test
+  void applyDeletesFilesUnderTempRootsOnlyLeavesRootsAndOtherTrees() throws Exception {
+    CleanReport report = CleanTempCommand.execute(installRoot, false);
+
+    assertFalse(report.isDryRun());
+    assertEquals(3, report.getDeletedCount());
+    assertEquals(0, report.getFailedCount());
+    assertFalse(Files.exists(nestedTempFile));
+    assertFalse(Files.exists(jettyWorkFile));
+    assertFalse(Files.exists(dtsTempFile));
+    assertTrue(Files.exists(outsideTempFile), "outside install root must not be deleted");
+    assertTrue(Files.exists(nonTempFile), "files outside allowlisted temp dirs must remain");
+    assertTrue(Files.exists(logsDirFile), "log tree is not a clean-temp target");
+    assertTrue(Files.isDirectory(cmsTemp), "allowlisted temp root must be retained");
+    assertTrue(Files.isDirectory(jettyWork), "allowlisted work root must be retained");
+    assertTrue(Files.isDirectory(dtsTemp), "allowlisted DTS temp root must be retained");
+    // Nested empty dirs under temp may be removed best-effort
+    assertFalse(Files.exists(nestedTempFile.getParent().resolve("upload.tmp")));
+  }
+
+  @Test
+  void findTempFilesDoesNotIncludeOutsideInstallRootOrNonTempTrees() throws Exception {
+    List<Path> found = CleanTempCommand.findTempFiles(installRoot);
+    assertEquals(3, found.size());
+    for (Path p : found) {
+      assertTrue(InstallRootGuard.isUnderInstallRoot(installRoot, p));
+      assertFalse(p.equals(outsideTempFile));
+      assertFalse(p.equals(nonTempFile));
+      assertFalse(p.equals(logsDirFile));
+    }
+  }
+
+  @Test
+  void executeRejectsMissingInstallRoot() {
+    Path missing = tempDir.resolve("missing-root");
+    assertThrows(IllegalArgumentException.class, () -> CleanTempCommand.execute(missing, true));
+  }
+
+  @Test
+  void missingTempDirsAreSkippedNotError() throws Exception {
+    Path emptyRoot = Files.createDirectories(tempDir.resolve("empty-install"));
+    CleanReport report = CleanTempCommand.execute(emptyRoot, true);
+    assertEquals(0, report.getCandidateCount());
+    assertEquals(0, report.getFailedCount());
+    assertTrue(report.isDryRun());
+  }
+
+  @Test
+  void onlyExistingTempDirsAreWalked() throws Exception {
+    // Remove jetty work; keep cms temp + dts temp
+    Files.deleteIfExists(jettyWorkFile);
+    Files.delete(jettyWork);
+
+    CleanReport report = CleanTempCommand.execute(installRoot, true);
+    assertEquals(2, report.getCandidateCount());
+    for (CleanReport.Entry e : report.getEntries()) {
+      assertFalse(e.getPath().startsWith(jettyWork));
+    }
+  }
+
+  @Test
+  void visitFileFailedRecordsFailedEntryOnReport() {
+    CleanReport report = new CleanReport(CleanTempCommand.COMMAND_NAME, installRoot, true);
+    Path failed = cmsTemp.resolve("locked.tmp");
+    CleanTempCommand.recordVisitFailure(
+        report, failed, new java.io.IOException("Access denied"));
+
+    assertEquals(1, report.getFailedCount());
+    CleanReport.Entry e = report.getEntries().get(0);
+    assertEquals(CleanReport.EntryStatus.FAILED, e.getStatus());
+    assertEquals(failed, e.getPath());
+    assertTrue(e.getDetail().contains("walk:"));
+    assertTrue(e.getDetail().toLowerCase().contains("access denied"));
+  }
+
+  @Test
+  void recordVisitFailureNoopsWhenReportNull() {
+    CleanTempCommand.recordVisitFailure(
+        null, installRoot.resolve("temp").resolve("x.tmp"), new java.io.IOException("x"));
+  }
+
+  @Test
+  void isUnderAnyTempRootRejectsNullsAndOutside() throws Exception {
+    List<Path> roots = InstallRootGuard.existingTempDirs(installRoot);
+    assertTrue(CleanTempCommand.isUnderAnyTempRoot(roots, nestedTempFile));
+    assertFalse(CleanTempCommand.isUnderAnyTempRoot(roots, outsideTempFile));
+    assertFalse(CleanTempCommand.isUnderAnyTempRoot(roots, nonTempFile));
+    assertFalse(CleanTempCommand.isUnderAnyTempRoot(null, nestedTempFile));
+    assertFalse(CleanTempCommand.isUnderAnyTempRoot(roots, null));
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
@@ -288,4 +288,56 @@ class DoctorCliTest {
     assertTrue(Files.exists(dump));
     assertTrue(outBuf.toString(StandardCharsets.UTF_8).contains("candidates=1"));
   }
+
+  @Test
+  void cleanTempDryRunViaCliDoesNotDelete() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-temp"));
+    Path cmsTemp = Files.createDirectories(root.resolve("temp"));
+    Path junk = cmsTemp.resolve("scratch.tmp");
+    Files.writeString(junk, "temp-data");
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root", root.toString(), "--dry-run", "-v", "clean-temp"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    assertTrue(Files.exists(junk));
+    assertTrue(Files.isDirectory(cmsTemp));
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("command=clean-temp"));
+    assertTrue(out.contains("dry-run=true"));
+    assertTrue(out.contains("candidates=1"));
+    assertTrue(out.contains("WOULD_DELETE"));
+  }
+
+  @Test
+  void cleanTempApplyViaCliDeletesUnderAllowlistedTempDirs() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-temp-apply"));
+    Path cmsTemp = Files.createDirectories(root.resolve("temp"));
+    Path junk = cmsTemp.resolve("scratch.tmp");
+    Path keep = root.resolve("important.cfg");
+    Files.writeString(junk, "temp-data");
+    Files.writeString(keep, "keep");
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"--install-root", root.toString(), "clean-temp"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    assertFalse(Files.exists(junk));
+    assertTrue(Files.exists(keep));
+    assertTrue(Files.isDirectory(cmsTemp), "temp root retained");
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("deleted=1"));
+  }
 }

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/InstallRootGuardTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/InstallRootGuardTest.java
@@ -156,6 +156,29 @@ class InstallRootGuardTest {
   }
 
   @Test
+  void existingTempDirsOnlyReturnsPresentDirsUnderRoot() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("cms-temp"));
+    Path cmsTemp = Files.createDirectories(root.resolve("temp"));
+    Path jettyWork =
+        Files.createDirectories(root.resolve("jetty").resolve("base").resolve("work"));
+    // DTS temp/work intentionally missing
+    java.util.List<Path> dirs = InstallRootGuard.existingTempDirs(root);
+    assertEquals(2, dirs.size());
+    assertTrue(dirs.contains(cmsTemp.toAbsolutePath().normalize()));
+    assertTrue(dirs.contains(jettyWork.toAbsolutePath().normalize()));
+  }
+
+  @Test
+  void tempDirRelativeAllowlistIsDocumentedAndStable() {
+    // Guard against accidental allowlist expansion without docs/tests.
+    assertEquals(4, InstallRootGuard.TEMP_DIR_RELATIVE.length);
+    assertEquals("temp", InstallRootGuard.TEMP_DIR_RELATIVE[0]);
+    assertEquals("jetty/base/work", InstallRootGuard.TEMP_DIR_RELATIVE[1]);
+    assertEquals("Deployment/Server/temp", InstallRootGuard.TEMP_DIR_RELATIVE[2]);
+    assertEquals("Deployment/Server/work", InstallRootGuard.TEMP_DIR_RELATIVE[3]);
+  }
+
+  @Test
   void resolveRelativeUnderRootRejectsDotDot() throws Exception {
     Path root = Files.createDirectories(tempDir.resolve("cms-rel")).toAbsolutePath().normalize();
     Path resolved = InstallRootGuard.resolveRelativeUnderRoot(root, "jetty/base/logs");

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/api/DoctorApiServiceTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/api/DoctorApiServiceTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.intsof.percussioncms.doctor.CleanHeapDumpsCommand;
 import com.intsof.percussioncms.doctor.CleanReport;
+import com.intsof.percussioncms.doctor.CleanTempCommand;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -131,5 +132,37 @@ class DoctorApiServiceTest {
     assertThrows(
         DoctorUnknownCommandException.class,
         () -> service.execute("not-a-real-command", new DoctorRequest()));
+  }
+
+  @Test
+  void cleanTempDryRunDefaultDoesNotDelete() throws Exception {
+    Path cmsTemp = Files.createDirectories(installRoot.resolve("temp"));
+    Path junk = cmsTemp.resolve("api-scratch.tmp");
+    Files.writeString(junk, "tmp");
+
+    DoctorReportView view = service.execute(CleanTempCommand.COMMAND_NAME, null);
+
+    assertTrue(view.isDryRun());
+    assertEquals(1, view.getCandidateCount());
+    assertEquals(0, view.getDeletedCount());
+    assertEquals(CleanReport.EntryStatus.WOULD_DELETE.name(), view.getEntries().get(0).getStatus());
+    assertTrue(Files.exists(junk), "dry-run must not delete temp files");
+    assertTrue(Files.isDirectory(cmsTemp));
+  }
+
+  @Test
+  void cleanTempApplyDeletesUnderAllowlistedDirs() throws Exception {
+    Path cmsTemp = Files.createDirectories(installRoot.resolve("temp"));
+    Path junk = cmsTemp.resolve("api-apply.tmp");
+    Files.writeString(junk, "tmp");
+
+    DoctorRequest req = new DoctorRequest();
+    req.setDryRun(false);
+    DoctorReportView view = service.execute(CleanTempCommand.COMMAND_NAME, req);
+
+    assertFalse(view.isDryRun());
+    assertEquals(1, view.getDeletedCount());
+    assertFalse(Files.exists(junk));
+    assertTrue(Files.isDirectory(cmsTemp));
   }
 }


### PR DESCRIPTION
## Summary

**Parent tracker:** #2213  
**Slice:** residual stretch — `clean-temp` for install temp/work dirs (after MVP clean-* in #2230; does not re-do diagnose #2231).

Adds CLI (and admin HTTP) command `clean-temp` to `modules/perc-doctor`:

- Allowlisted temp/work locations only (documented in README + operator guide):
  - `temp` — CMS install temp (`install.xml`)
  - `jetty/base/work` — Jetty work
  - `Deployment/Server/temp` — DTS Tomcat temp
  - `Deployment/Server/work` — DTS Tomcat work
- Dry-run never deletes; apply re-checks `InstallRootGuard` containment before each delete
- Allowlisted root directories are retained (contents + best-effort empty nested dirs)
- Honors global `--dry-run` / `--install-root` / `-v`
- Unit tests: filters, outside-root exclusion, dry-run vs apply, CLI + API wiring
- Mirrors `CleanLogsCommand` / `CleanHeapDumpsCommand` patterns

## Test plan

- [x] `cd modules/perc-doctor && ../../mvnw clean install` (module Surefire green)
- [x] `CleanTempCommandTest` 9 — dry-run, apply, containment, missing dirs
- [x] `DoctorCliTest` clean-temp dry-run + apply
- [x] `InstallRootGuardTest` existingTempDirs + TEMP_DIR_RELATIVE stability
- [x] `DoctorApiServiceTest` clean-temp dry-run default + apply
- [x] Erlang self-review: `docs/ai-generated/code-reviews/issue-2232-clean-temp-erlang.md` (approve)

## Gates evidence

| Gate | Result |
|------|--------|
| A Implement + unit tests | yes |
| B Erlang / portable paths | yes (Path + InstallRootGuard only) |
| C Module `mvnw clean install` | pass |
| D In-scope files only | perc-doctor + erlang report |
| E Commit refs #2232 | yes |
| F Operator labels | operator:grok, operator:night-issue-prs, model:grok-4.5 |
| G Base main, no merge | this PR |

**Operator:** Grok: night-issue-prs (model grok-4.5)

Fixes #2232  
Refs #2213

> Co-Authored by Grok Build using grok-4.5 with agent main.