### PR TITLE
feat(perc-doctor): check-config + fix-permissions (#2233)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2233-check-config-fix-permissions-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2233-check-config-fix-permissions-erlang.md
@@ -1,0 +1,52 @@
+# Erlang review — issue #2233 perc-doctor check-config / fix-permissions
+
+**Branch:** `feat/issue-2233-check-config-fix-permissions`  
+**Scope:** `modules/perc-doctor` CLI commands + tests + operator docs  
+**Date:** 2026-08-07  
+**Reviewer persona:** Erlang (independent pre-commit)
+
+## Summary
+
+Adds two peer CLI commands to `perc-doctor`:
+
+1. **`check-config`** — read-only value/misconfig checklist for documented `server.properties` and `rxrepository.properties` (beyond presence-only checks used by open diagnose PR #2231).
+2. **`fix-permissions`** — dry-run-first allowlisted mode/access report; POSIX owner-execute on `bin/perc-doctor`, owner rwx on known log dirs, owner-read on key configs. Windows reports access only (no ACL rewrite, no shell).
+
+Wiring mirrors `clean-logs`: global `--install-root` / `--dry-run` / `-v`, `DoctorCli` dispatch, help/examples, packaging doc coverage. Unit tests cover containment, non-mutation, misconfig FAIL/WARN paths, CLI exit codes, and OS-conditioned POSIX fixes.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Gate | Result |
+|------|--------|
+| Bugs | none found |
+| Behavioral unit tests for new logic | yes (`CheckConfigCommandTest` 11, `FixPermissionsCommandTest` 8/2 skipped on Windows, CLI coverage) |
+| Portable path / file I/O | pass — `java.nio.file.Path` / `Files` only; relative segments via `InstallRootGuard.resolveRelativeUnderRoot`; no hardcoded user homes; Windows vs POSIX branched with attribute-view probe |
+| May commit/push | **yes** |
+
+## Cross-platform path checklist
+
+- [x] No `C:\Users\...` / `/home/...` hardcoding in code or docs (generic `/opt/Percussion`, `C:\Percussion`)
+- [x] Relative config/log/bin paths use forward-slash segment lists resolved with `Path` APIs
+- [x] Containment re-checked before any mode mutation
+- [x] POSIX-only APIs guarded (`supportedFileAttributeViews().contains("posix")` + try/catch `UnsupportedOperationException`)
+- [x] Tests use `@TempDir` and `Path.resolve` (no separator literals that break OS)
+
+## Issues
+
+None (blocking).
+
+### Notes (non-blocking)
+
+- Admin HTTP API not wired for these two commands (CLI-first slice; clean-* API remains). Follow-up if product wants parity.
+- Weak-password token list is intentionally conservative (WARN only; never prints secrets).
+- Does not share types with open #2231 `DiagnoseReport` (independent checklist report) to avoid thrash.
+
+## Memory patterns hit
+
+- Install-root containment for doctor I/O
+- Dry-run / report-first ops commands
+- Prefer `Files` / `Path` over `File` and shell

--- a/modules/perc-doctor/README.md
+++ b/modules/perc-doctor/README.md
@@ -2,10 +2,10 @@
 
 Operator CLI for diagnosing and safely cleaning Percussion CMS install trees.
 
-**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`), [#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219) (admin HTTP API), [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (dist packaging + install guide)  
+**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2233](https://github.com/intersoftdatalabs-in/percussioncms/issues/2233) (`check-config` / `fix-permissions`), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`), [#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219) (admin HTTP API), [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (dist packaging + install guide)  
 **Package:** `com.intsof.percussioncms.doctor` (+ `...doctor.api` for HTTP)  
-**Shipped commands:** `clean-heap-dumps`, `clean-install-backups`, `clean-logs` with global `--dry-run` / `--install-root` / `-v`  
-**HTTP:** Admin-only `POST .../maintenance/doctor/{command}` (wired in sitemanage)
+**Shipped commands:** `clean-heap-dumps`, `clean-install-backups`, `clean-logs`, `check-config`, `fix-permissions` with global `--dry-run` / `--install-root` / `-v`  
+**HTTP:** Admin-only `POST .../maintenance/doctor/{command}` for clean-* (wired in sitemanage); `check-config` / `fix-permissions` are CLI-first in this slice
 
 **Operator install guide (dry-run-first examples):** [docs/operator-install-guide.md](docs/operator-install-guide.md)
 
@@ -163,14 +163,80 @@ java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
   --install-root /opt/Percussion --dry-run -v clean-logs
 ```
 
+#### `check-config`
+
+Read-only **value / misconfig** checks on documented CMS config files (deeper than presence-only layout checks). Never deletes or writes. Honors `--install-root`, `--dry-run` (echoed only), and `-v`.
+
+| Relative path | Role |
+|---------------|------|
+| `rxconfig/Server/server.properties` | Server flags / bind port |
+| `rxconfig/Installer/rxrepository.properties` | Repository JDBC settings |
+
+Scoped checks (documented; no arbitrary property scans beyond placeholder scan):
+
+| Area | Examples |
+|------|----------|
+| Presence + readable | Missing file → **WARN** (partial install); unreadable → **FAIL** |
+| `enableDebugTools=true` | **WARN** (unsafe for production) |
+| `disableCrossSiteRequestForgeryCheck=true` | **WARN** |
+| `bindPort` | Missing/invalid/out-of-range/unresolved `${...}` → **WARN**/**FAIL** |
+| `requireHTTPS` | **INFO** when false/unset (lab ok); **PASS** when true |
+| Required repo keys | `DB_BACKEND`, `DB_DRIVER_NAME`, `DB_DRIVER_CLASS_NAME`, `DB_SERVER`, `UID` blank/placeholder → **FAIL** |
+| Driver vs backend | H2 vs non-H2 mismatch → **WARN** |
+| `PWD` / `PWD_ENCRYPTED` | Weak/default tokens, empty non-H2 PWD, plaintext storage → **WARN**/**INFO** |
+| Unresolved `${...}` | Other property values → **WARN** (truncated after 5) |
+
+Exit code is non-zero when any check is **FAIL** (`healthy=false`). Password values are never printed.
+
+Examples:
+
+```bash
+# Value / misconfig checklist (safe; always read-only)
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
+  --install-root /opt/Percussion --dry-run -v check-config
+
+# Windows
+java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar ^
+  --install-root C:\Percussion -v check-config
+```
+
+#### `fix-permissions`
+
+Report (and optionally fix) **allowlisted** install mode / access issues. Prefer `--dry-run` first. **Never** runs a shell and never accepts user path globs.
+
+| Target | Behavior |
+|--------|----------|
+| `bin/perc-doctor`, `bin/perc-doctor.bat`, `bin/perc-doctor.jar` | Report readable; on POSIX add **owner-execute** to the Unix `perc-doctor` script when missing |
+| Known log dirs (`jetty/base/logs`, `jetty/base/modules/perc-logging/logs`, `Deployment/Server/logs`) | Report access; on POSIX ensure **owner rwx** when the directory exists |
+| `rxconfig/Server/server.properties`, `rxconfig/Installer/rxrepository.properties` | Report owner-read; on POSIX add **owner-read** when missing |
+
+On Windows (non-POSIX file stores): reports readability/writability and skips mode mutation (Windows ACL repair is out of scope). Dry-run never writes; apply re-checks install-root containment before each mode change.
+
+Examples:
+
+```bash
+# Preview mode fixes (safe)
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
+  --install-root /opt/Percussion --dry-run -v fix-permissions
+
+# Apply (POSIX only for actual mode writes)
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
+  --install-root /opt/Percussion -v fix-permissions
+
+# Windows — report access; no ACL rewrite
+java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar ^
+  --install-root C:\Percussion --dry-run -v fix-permissions
+```
+
 ## Safety model
 
 1. Resolve and validate install root (must exist and be a directory).
 2. Walk only under that root (and for `clean-logs`, only under allowlisted log dirs); skip / reject candidates that escape the root.
 3. Match allowlisted patterns only (per command; no user-supplied globs).
-4. If `--dry-run`, stop after inventory.
-5. On apply, re-check containment immediately before each delete.
+4. If `--dry-run`, stop after inventory (check-config is always non-mutating regardless).
+5. On apply, re-check containment immediately before each delete or mode change.
 6. For `clean-logs`, apply `--keep-current` and `--older-than` before any delete.
+7. For `fix-permissions`, mutate only POSIX mode bits on allowlisted paths; no shell.
 
 ## Admin HTTP API (slice #2219)
 

--- a/modules/perc-doctor/docs/operator-install-guide.md
+++ b/modules/perc-doctor/docs/operator-install-guide.md
@@ -154,6 +154,57 @@ bin\perc-doctor.bat --install-root C:\Percussion --dry-run -v clean-logs --older
 bin\perc-doctor.bat --install-root C:\Percussion -v clean-logs --older-than 14d
 ```
 
+### `check-config`
+
+Read-only **value / misconfig** checklist on documented config files (beyond presence-only checks). Always non-mutating; `--dry-run` is accepted for flag parity.
+
+Scoped files:
+
+- `rxconfig/Server/server.properties` — e.g. `enableDebugTools`, CSRF disable, `bindPort`, `requireHTTPS`
+- `rxconfig/Installer/rxrepository.properties` — required JDBC keys, driver/backend consistency, weak `PWD`, plaintext `PWD_ENCRYPTED`
+
+Exit code is non-zero when any check is **FAIL**. Password values are never printed.
+
+**Safe inventory (Linux / macOS):**
+
+```bash
+./bin/perc-doctor --install-root /opt/Percussion --dry-run -v check-config
+```
+
+**Safe inventory (Windows):**
+
+```bat
+bin\perc-doctor.bat --install-root C:\Percussion -v check-config
+```
+
+### `fix-permissions`
+
+Reports (and on POSIX can fix) **allowlisted** mode / access issues only — no shell, no user globs. Prefer dry-run first.
+
+| Target | Fix behavior |
+|--------|----------------|
+| `bin/perc-doctor` (+ `.bat` / `.jar` report) | POSIX: add owner-execute on the Unix script when missing |
+| Known log directories | POSIX: ensure owner rwx when the directory exists |
+| Key `rxconfig` property files | POSIX: ensure owner-read when present |
+
+On Windows the command reports readable/writable and does **not** rewrite ACLs.
+
+**Dry-run first:**
+
+```bash
+./bin/perc-doctor --install-root /opt/Percussion --dry-run -v fix-permissions
+```
+
+```bat
+bin\perc-doctor.bat --install-root C:\Percussion --dry-run -v fix-permissions
+```
+
+**Apply (POSIX mode bits only):**
+
+```bash
+./bin/perc-doctor --install-root /opt/Percussion -v fix-permissions
+```
+
 ## Distribution packaging (developers)
 
 Module `mvnw clean install` attaches:

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CheckConfigCommand.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CheckConfigCommand.java
@@ -1,0 +1,556 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Read-only deeper config value / misconfig checks for a CMS install ({@code check-config}).
+ *
+ * <p>Goes beyond file presence (covered by {@code diagnose} / {@code health}) into documented,
+ * scoped property value checks. Never deletes or writes. All resolved paths are constrained under
+ * the install root via {@link InstallRootGuard}.
+ *
+ * <p>Scoped files (relative to install root):
+ *
+ * <ul>
+ *   <li>{@code rxconfig/Server/server.properties}
+ *   <li>{@code rxconfig/Installer/rxrepository.properties}
+ * </ul>
+ *
+ * <p>Global {@code --dry-run} is accepted for CLI parity and echoed on the report; it has no effect
+ * because this command is always non-mutating.
+ */
+public final class CheckConfigCommand {
+
+  /** CLI command token. */
+  public static final String COMMAND_NAME = "check-config";
+
+  /** Relative path of CMS server.properties under the install root. */
+  public static final String SERVER_PROPERTIES_REL = "rxconfig/Server/server.properties";
+
+  /** Relative path of repository installer properties under the install root. */
+  public static final String RXREPOSITORY_PROPERTIES_REL =
+      "rxconfig/Installer/rxrepository.properties";
+
+  /**
+   * Required non-blank keys in {@code rxrepository.properties} for a usable CMS repository
+   * connection (H2 embedded still needs these keys set).
+   */
+  static final String[] REQUIRED_REPO_KEYS = {
+    "DB_BACKEND", "DB_DRIVER_NAME", "DB_DRIVER_CLASS_NAME", "DB_SERVER", "UID"
+  };
+
+  /** Weak / default password tokens that should not ship in production (case-insensitive). */
+  static final Set<String> WEAK_PASSWORD_TOKENS =
+      new HashSet<>(
+          Arrays.asList(
+              "password",
+              "changeme",
+              "demo",
+              "admin",
+              "root",
+              "sa",
+              "secret",
+              "percussion",
+              "cms",
+              "123456",
+              "password1"));
+
+  /** Unresolved Ant / installer style placeholders in property values. */
+  private static final Pattern UNRESOLVED_PLACEHOLDER =
+      Pattern.compile("\\$\\{[^}]+\\}");
+
+  private CheckConfigCommand() {}
+
+  /**
+   * Run value / misconfig checks under {@code installRoot}.
+   *
+   * @param installRoot CMS install root (must exist and be a directory)
+   * @param dryRun echoed global flag only; never enables writes
+   * @return checklist report
+   * @throws IllegalArgumentException if install root is invalid
+   * @throws IOException if a config file cannot be read after existence was confirmed (individual
+   *     checks prefer FAIL rows when possible)
+   */
+  public static CheckConfigReport execute(Path installRoot, boolean dryRun) throws IOException {
+    Path root = InstallRootGuard.requireInstallRoot(installRoot);
+    CheckConfigReport report = new CheckConfigReport(COMMAND_NAME, root, dryRun);
+
+    report.add(
+        new CheckConfigReport.Check(
+            "install-root",
+            CheckConfigReport.CheckStatus.PASS,
+            "Install root exists and is a directory",
+            root));
+
+    checkServerProperties(report, root);
+    checkRxRepositoryProperties(report, root);
+
+    return report;
+  }
+
+  static void checkServerProperties(CheckConfigReport report, Path root) {
+    Path path = resolveScopedFile(report, root, SERVER_PROPERTIES_REL, "server.properties");
+    if (path == null) {
+      return;
+    }
+    if (!Files.isRegularFile(path)) {
+      report.add(
+          new CheckConfigReport.Check(
+              "server.properties.present",
+              CheckConfigReport.CheckStatus.WARN,
+              "server.properties missing (cannot validate values): " + SERVER_PROPERTIES_REL,
+              path));
+      return;
+    }
+    report.add(
+        new CheckConfigReport.Check(
+            "server.properties.present",
+            CheckConfigReport.CheckStatus.PASS,
+            "server.properties present",
+            path));
+
+    Properties props = loadProperties(report, path, "server.properties");
+    if (props == null) {
+      return;
+    }
+
+    checkBooleanFlag(
+        report,
+        path,
+        props,
+        "enableDebugTools",
+        true,
+        CheckConfigReport.CheckStatus.WARN,
+        "enableDebugTools=true is unsafe for production (debug tooling exposed)");
+    checkBooleanFlag(
+        report,
+        path,
+        props,
+        "disableCrossSiteRequestForgeryCheck",
+        true,
+        CheckConfigReport.CheckStatus.WARN,
+        "disableCrossSiteRequestForgeryCheck=true disables CSRF protection");
+
+    String requireHttps = trimToEmpty(props.getProperty("requireHTTPS"));
+    if (requireHttps.isEmpty()) {
+      report.add(
+          new CheckConfigReport.Check(
+              "server.requireHTTPS",
+              CheckConfigReport.CheckStatus.INFO,
+              "requireHTTPS not set (product default may apply)",
+              path));
+    } else if (isTruthy(requireHttps)) {
+      report.add(
+          new CheckConfigReport.Check(
+              "server.requireHTTPS",
+              CheckConfigReport.CheckStatus.PASS,
+              "requireHTTPS=true",
+              path));
+    } else {
+      report.add(
+          new CheckConfigReport.Check(
+              "server.requireHTTPS",
+              CheckConfigReport.CheckStatus.INFO,
+              "requireHTTPS=false (acceptable for lab/dev; prefer true behind TLS termination"
+                  + " when not terminated elsewhere)",
+              path));
+    }
+
+    String bindPort = trimToEmpty(props.getProperty("bindPort"));
+    if (bindPort.isEmpty()) {
+      report.add(
+          new CheckConfigReport.Check(
+              "server.bindPort",
+              CheckConfigReport.CheckStatus.WARN,
+              "bindPort is empty or missing",
+              path));
+    } else if (containsUnresolvedPlaceholder(bindPort)) {
+      report.add(
+          new CheckConfigReport.Check(
+              "server.bindPort",
+              CheckConfigReport.CheckStatus.FAIL,
+              "bindPort contains unresolved placeholder: " + bindPort,
+              path));
+    } else {
+      try {
+        int port = Integer.parseInt(bindPort);
+        if (port <= 0 || port > 65535) {
+          report.add(
+              new CheckConfigReport.Check(
+                  "server.bindPort",
+                  CheckConfigReport.CheckStatus.FAIL,
+                  "bindPort out of range (1-65535): " + bindPort,
+                  path));
+        } else {
+          report.add(
+              new CheckConfigReport.Check(
+                  "server.bindPort",
+                  CheckConfigReport.CheckStatus.PASS,
+                  "bindPort is a valid TCP port: " + port,
+                  path));
+        }
+      } catch (NumberFormatException e) {
+        report.add(
+            new CheckConfigReport.Check(
+                "server.bindPort",
+                CheckConfigReport.CheckStatus.FAIL,
+                "bindPort is not an integer: " + bindPort,
+                path));
+      }
+    }
+
+    checkUnresolvedPlaceholders(report, path, props, "server");
+  }
+
+  static void checkRxRepositoryProperties(CheckConfigReport report, Path root) {
+    Path path =
+        resolveScopedFile(report, root, RXREPOSITORY_PROPERTIES_REL, "rxrepository.properties");
+    if (path == null) {
+      return;
+    }
+    if (!Files.isRegularFile(path)) {
+      report.add(
+          new CheckConfigReport.Check(
+              "rxrepository.properties.present",
+              CheckConfigReport.CheckStatus.WARN,
+              "rxrepository.properties missing (cannot validate values): "
+                  + RXREPOSITORY_PROPERTIES_REL,
+              path));
+      return;
+    }
+    report.add(
+        new CheckConfigReport.Check(
+            "rxrepository.properties.present",
+            CheckConfigReport.CheckStatus.PASS,
+            "rxrepository.properties present",
+            path));
+
+    Properties props = loadProperties(report, path, "rxrepository.properties");
+    if (props == null) {
+      return;
+    }
+
+    for (String key : REQUIRED_REPO_KEYS) {
+      String value = trimToEmpty(props.getProperty(key));
+      if (value.isEmpty()) {
+        report.add(
+            new CheckConfigReport.Check(
+                "repo." + key,
+                CheckConfigReport.CheckStatus.FAIL,
+                "Required repository key missing or blank: " + key,
+                path));
+      } else if (containsUnresolvedPlaceholder(value)) {
+        report.add(
+            new CheckConfigReport.Check(
+                "repo." + key,
+                CheckConfigReport.CheckStatus.FAIL,
+                "Required repository key has unresolved placeholder: " + key + "=" + value,
+                path));
+      } else {
+        report.add(
+            new CheckConfigReport.Check(
+                "repo." + key,
+                CheckConfigReport.CheckStatus.PASS,
+                "Required repository key set: " + key,
+                path));
+      }
+    }
+
+    String backend = trimToEmpty(props.getProperty("DB_BACKEND")).toUpperCase(Locale.ROOT);
+    String driverName = trimToEmpty(props.getProperty("DB_DRIVER_NAME")).toLowerCase(Locale.ROOT);
+    String driverClass =
+        trimToEmpty(props.getProperty("DB_DRIVER_CLASS_NAME")).toLowerCase(Locale.ROOT);
+    if (!backend.isEmpty() && !driverName.isEmpty() && !driverClass.isEmpty()) {
+      if (isH2Backend(backend)) {
+        if (!driverName.contains("h2") && !driverClass.contains("h2")) {
+          report.add(
+              new CheckConfigReport.Check(
+                  "repo.driver-backend-consistency",
+                  CheckConfigReport.CheckStatus.WARN,
+                  "DB_BACKEND looks like H2 but driver name/class do not mention h2 (driverName="
+                      + props.getProperty("DB_DRIVER_NAME")
+                      + ")",
+                  path));
+        } else {
+          report.add(
+              new CheckConfigReport.Check(
+                  "repo.driver-backend-consistency",
+                  CheckConfigReport.CheckStatus.PASS,
+                  "H2 backend matches H2 driver settings",
+                  path));
+        }
+      } else {
+        // Non-H2: driver should not be the embedded H2 class.
+        if (driverClass.contains("org.h2.") || "h2".equals(driverName)) {
+          report.add(
+              new CheckConfigReport.Check(
+                  "repo.driver-backend-consistency",
+                  CheckConfigReport.CheckStatus.WARN,
+                  "DB_BACKEND="
+                      + props.getProperty("DB_BACKEND")
+                      + " but driver settings look like H2",
+                  path));
+        } else {
+          report.add(
+              new CheckConfigReport.Check(
+                  "repo.driver-backend-consistency",
+                  CheckConfigReport.CheckStatus.PASS,
+                  "Non-H2 backend has non-H2 driver settings",
+                  path));
+        }
+      }
+    }
+
+    String pwd = props.getProperty("PWD");
+    String pwdTrimmed = pwd == null ? "" : pwd.trim();
+    String pwdEncrypted = trimToEmpty(props.getProperty("PWD_ENCRYPTED")).toUpperCase(Locale.ROOT);
+
+    if (pwdTrimmed.isEmpty()) {
+      if (isH2Backend(backend)) {
+        report.add(
+            new CheckConfigReport.Check(
+                "repo.PWD",
+                CheckConfigReport.CheckStatus.INFO,
+                "PWD empty (common for embedded H2 lab installs)",
+                path));
+      } else if (!backend.isEmpty()) {
+        report.add(
+            new CheckConfigReport.Check(
+                "repo.PWD",
+                CheckConfigReport.CheckStatus.WARN,
+                "PWD is empty for non-H2 backend " + props.getProperty("DB_BACKEND"),
+                path));
+      }
+    } else if (isWeakPassword(pwdTrimmed)) {
+      report.add(
+          new CheckConfigReport.Check(
+              "repo.PWD",
+              CheckConfigReport.CheckStatus.WARN,
+              "PWD looks like a well-known weak/default password token",
+              path));
+    } else {
+      report.add(
+          new CheckConfigReport.Check(
+              "repo.PWD",
+              CheckConfigReport.CheckStatus.PASS,
+              "PWD is set (value not printed)",
+              path));
+    }
+
+    if (!pwdTrimmed.isEmpty() && ("N".equals(pwdEncrypted) || pwdEncrypted.isEmpty())) {
+      report.add(
+          new CheckConfigReport.Check(
+              "repo.PWD_ENCRYPTED",
+              CheckConfigReport.CheckStatus.WARN,
+              "PWD is stored in plaintext (PWD_ENCRYPTED is not Y); prefer encrypted storage in"
+                  + " production",
+              path));
+    } else if ("Y".equals(pwdEncrypted)) {
+      report.add(
+          new CheckConfigReport.Check(
+              "repo.PWD_ENCRYPTED",
+              CheckConfigReport.CheckStatus.PASS,
+              "PWD_ENCRYPTED=Y",
+              path));
+    } else if (!pwdEncrypted.isEmpty()) {
+      report.add(
+          new CheckConfigReport.Check(
+              "repo.PWD_ENCRYPTED",
+              CheckConfigReport.CheckStatus.INFO,
+              "PWD_ENCRYPTED=" + props.getProperty("PWD_ENCRYPTED"),
+              path));
+    }
+
+    checkUnresolvedPlaceholders(report, path, props, "repo");
+  }
+
+  /**
+   * Resolve a documented relative config path under root with containment. On path-guard failure
+   * records FAIL and returns null.
+   */
+  static Path resolveScopedFile(
+      CheckConfigReport report, Path root, String relativeSlashPath, String label) {
+    Path resolved = InstallRootGuard.resolveRelativeUnderRoot(root, relativeSlashPath);
+    if (resolved == null) {
+      report.add(
+          new CheckConfigReport.Check(
+              label + ".path",
+              CheckConfigReport.CheckStatus.FAIL,
+              "Invalid relative config path (path guard rejected): " + relativeSlashPath,
+              null));
+      return null;
+    }
+    if (!InstallRootGuard.isUnderInstallRoot(root, resolved)) {
+      report.add(
+          new CheckConfigReport.Check(
+              label + ".path",
+              CheckConfigReport.CheckStatus.FAIL,
+              "Resolved config path is outside install root: " + resolved,
+              resolved));
+      return null;
+    }
+    return resolved;
+  }
+
+  static Properties loadProperties(CheckConfigReport report, Path path, String label) {
+    Properties props = new Properties();
+    try (InputStream in = Files.newInputStream(path)) {
+      props.load(in);
+      return props;
+    } catch (IOException e) {
+      report.add(
+          new CheckConfigReport.Check(
+              label + ".readable",
+              CheckConfigReport.CheckStatus.FAIL,
+              "Failed to read " + label + ": " + e.getMessage(),
+              path));
+      return null;
+    }
+  }
+
+  static void checkBooleanFlag(
+      CheckConfigReport report,
+      Path path,
+      Properties props,
+      String key,
+      boolean badWhenTrue,
+      CheckConfigReport.CheckStatus badStatus,
+      String badMessage) {
+    String raw = trimToEmpty(props.getProperty(key));
+    String id = "server." + key;
+    if (raw.isEmpty()) {
+      report.add(
+          new CheckConfigReport.Check(
+              id,
+              CheckConfigReport.CheckStatus.INFO,
+              key + " not set (product default may apply)",
+              path));
+      return;
+    }
+    if (containsUnresolvedPlaceholder(raw)) {
+      report.add(
+          new CheckConfigReport.Check(
+              id,
+              CheckConfigReport.CheckStatus.FAIL,
+              key + " contains unresolved placeholder: " + raw,
+              path));
+      return;
+    }
+    boolean truthy = isTruthy(raw);
+    if (badWhenTrue && truthy) {
+      report.add(new CheckConfigReport.Check(id, badStatus, badMessage, path));
+    } else {
+      report.add(
+          new CheckConfigReport.Check(
+              id, CheckConfigReport.CheckStatus.PASS, key + "=" + raw, path));
+    }
+  }
+
+  /**
+   * Scan property values for unresolved {@code ${...}} placeholders. Skips keys already checked
+   * with dedicated FAIL rows for required repo keys / bindPort.
+   */
+  static void checkUnresolvedPlaceholders(
+      CheckConfigReport report, Path path, Properties props, String idPrefix) {
+    int found = 0;
+    for (String name : props.stringPropertyNames()) {
+      String value = props.getProperty(name);
+      if (value == null || !containsUnresolvedPlaceholder(value)) {
+        continue;
+      }
+      // Avoid double-reporting dedicated keys.
+      if ("bindPort".equals(name) || isRequiredRepoKey(name)) {
+        continue;
+      }
+      found++;
+      if (found <= 5) {
+        report.add(
+            new CheckConfigReport.Check(
+                idPrefix + ".placeholder." + name,
+                CheckConfigReport.CheckStatus.WARN,
+                "Unresolved placeholder in " + name + "=" + value,
+                path));
+      }
+    }
+    if (found == 0) {
+      report.add(
+          new CheckConfigReport.Check(
+              idPrefix + ".placeholders",
+              CheckConfigReport.CheckStatus.PASS,
+              "No unresolved ${...} placeholders in scanned values",
+              path));
+    } else if (found > 5) {
+      report.add(
+          new CheckConfigReport.Check(
+              idPrefix + ".placeholders.truncated",
+              CheckConfigReport.CheckStatus.WARN,
+              "Additional unresolved placeholders not listed (total=" + found + ")",
+              path));
+    }
+  }
+
+  static boolean isRequiredRepoKey(String name) {
+    for (String key : REQUIRED_REPO_KEYS) {
+      if (key.equals(name)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static boolean isH2Backend(String backendUpperOrEmpty) {
+    if (backendUpperOrEmpty == null || backendUpperOrEmpty.isEmpty()) {
+      return false;
+    }
+    String b = backendUpperOrEmpty.toUpperCase(Locale.ROOT);
+    return "H2".equals(b) || b.contains("H2");
+  }
+
+  static boolean isWeakPassword(String password) {
+    Objects.requireNonNull(password, "password");
+    String lower = password.toLowerCase(Locale.ROOT);
+    return WEAK_PASSWORD_TOKENS.contains(lower);
+  }
+
+  static boolean containsUnresolvedPlaceholder(String value) {
+    return value != null && UNRESOLVED_PLACEHOLDER.matcher(value).find();
+  }
+
+  static boolean isTruthy(String raw) {
+    if (raw == null) {
+      return false;
+    }
+    String v = raw.trim().toLowerCase(Locale.ROOT);
+    return "true".equals(v) || "yes".equals(v) || "y".equals(v) || "1".equals(v);
+  }
+
+  static String trimToEmpty(String value) {
+    return value == null ? "" : value.trim();
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CheckConfigReport.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CheckConfigReport.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Read-only value / misconfig checklist report for {@code check-config}. Never implies filesystem
+ * mutations.
+ */
+public final class CheckConfigReport {
+
+  /** Outcome severity for a single config check. */
+  public enum CheckStatus {
+    /** Expected condition met. */
+    PASS,
+    /** Non-fatal concern (weak defaults, production hygiene). */
+    WARN,
+    /** Critical misconfig or unreadable required config. */
+    FAIL,
+    /** Pure information (documented default, not necessarily wrong). */
+    INFO
+  }
+
+  /** One checklist row. */
+  public static final class Check {
+    private final String id;
+    private final CheckStatus status;
+    private final String message;
+    private final Path path;
+
+    /**
+     * @param id stable machine-oriented check id (e.g. {@code server.enableDebugTools})
+     * @param status outcome severity
+     * @param message human-readable detail
+     * @param path optional related path under install root (may be null)
+     */
+    public Check(String id, CheckStatus status, String message, Path path) {
+      this.id = Objects.requireNonNull(id, "id");
+      this.status = Objects.requireNonNull(status, "status");
+      this.message = Objects.requireNonNull(message, "message");
+      this.path = path;
+    }
+
+    /** @return stable check id */
+    public String getId() {
+      return id;
+    }
+
+    /** @return outcome severity */
+    public CheckStatus getStatus() {
+      return status;
+    }
+
+    /** @return human-readable detail */
+    public String getMessage() {
+      return message;
+    }
+
+    /** @return related path, or null */
+    public Path getPath() {
+      return path;
+    }
+  }
+
+  private final String command;
+  private final Path installRoot;
+  private final boolean dryRun;
+  private final List<Check> checks = new ArrayList<>();
+
+  /**
+   * @param command command token ({@code check-config})
+   * @param installRoot resolved install root
+   * @param dryRun echoed global flag (check-config never mutates regardless)
+   */
+  public CheckConfigReport(String command, Path installRoot, boolean dryRun) {
+    this.command = Objects.requireNonNull(command, "command");
+    this.installRoot = Objects.requireNonNull(installRoot, "installRoot");
+    this.dryRun = dryRun;
+  }
+
+  /** Append a checklist entry. */
+  public void add(Check check) {
+    checks.add(Objects.requireNonNull(check, "check"));
+  }
+
+  /** @return command token */
+  public String getCommand() {
+    return command;
+  }
+
+  /** @return install root used for this run */
+  public Path getInstallRoot() {
+    return installRoot;
+  }
+
+  /**
+   * Echo of the global {@code --dry-run} flag. check-config is always read-only; this value is
+   * reported for flag parity and never gates writes (there are none).
+   *
+   * @return whether {@code --dry-run} was set on the CLI
+   */
+  public boolean isDryRun() {
+    return dryRun;
+  }
+
+  /** @return unmodifiable checklist */
+  public List<Check> getChecks() {
+    return Collections.unmodifiableList(checks);
+  }
+
+  /** @return number of checks */
+  public int getCheckCount() {
+    return checks.size();
+  }
+
+  /** @return count of {@link CheckStatus#PASS} */
+  public int getPassCount() {
+    return count(CheckStatus.PASS);
+  }
+
+  /** @return count of {@link CheckStatus#WARN} */
+  public int getWarnCount() {
+    return count(CheckStatus.WARN);
+  }
+
+  /** @return count of {@link CheckStatus#FAIL} */
+  public int getFailCount() {
+    return count(CheckStatus.FAIL);
+  }
+
+  /** @return count of {@link CheckStatus#INFO} */
+  public int getInfoCount() {
+    return count(CheckStatus.INFO);
+  }
+
+  /**
+   * @return true when no {@link CheckStatus#FAIL} entries (WARN/INFO allowed)
+   */
+  public boolean isHealthy() {
+    return getFailCount() == 0;
+  }
+
+  private int count(CheckStatus status) {
+    int n = 0;
+    for (Check c : checks) {
+      if (c.getStatus() == status) {
+        n++;
+      }
+    }
+    return n;
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
@@ -29,7 +29,8 @@ import java.time.Duration;
  *   &lt;command&gt; [command-options]
  * </pre>
  *
- * <p>Commands: {@code clean-heap-dumps}, {@code clean-install-backups}, {@code clean-logs}.
+ * <p>Commands: {@code clean-heap-dumps}, {@code clean-install-backups}, {@code clean-logs}, {@code
+ * check-config}, {@code fix-permissions}.
  */
 public final class DoctorCli {
 
@@ -79,8 +80,12 @@ public final class DoctorCli {
               + CleanHeapDumpsCommand.COMMAND_NAME
               + ", "
               + CleanInstallBackupsCommand.COMMAND_NAME
+              + ", "
+              + CleanLogsCommand.COMMAND_NAME
+              + ", "
+              + CheckConfigCommand.COMMAND_NAME
               + ", or "
-              + CleanLogsCommand.COMMAND_NAME);
+              + FixPermissionsCommand.COMMAND_NAME);
       printHelp(err);
       return EXIT_USAGE;
     }
@@ -126,6 +131,16 @@ public final class DoctorCli {
         printReport(report, parsed.verbose, out);
         return report.getFailedCount() > 0 ? EXIT_ERROR : EXIT_OK;
       }
+      if (CheckConfigCommand.COMMAND_NAME.equals(parsed.command)) {
+        CheckConfigReport report = CheckConfigCommand.execute(installRoot, parsed.dryRun);
+        printCheckConfigReport(report, parsed.verbose, out);
+        return report.isHealthy() ? EXIT_OK : EXIT_ERROR;
+      }
+      if (FixPermissionsCommand.COMMAND_NAME.equals(parsed.command)) {
+        FixPermissionsReport report = FixPermissionsCommand.execute(installRoot, parsed.dryRun);
+        printFixPermissionsReport(report, parsed.verbose, out);
+        return report.getFailedCount() > 0 ? EXIT_ERROR : EXIT_OK;
+      }
       err.println("Error: unknown command: " + parsed.command);
       err.println(
           "Supported commands: "
@@ -133,7 +148,11 @@ public final class DoctorCli {
               + ", "
               + CleanInstallBackupsCommand.COMMAND_NAME
               + ", "
-              + CleanLogsCommand.COMMAND_NAME);
+              + CleanLogsCommand.COMMAND_NAME
+              + ", "
+              + CheckConfigCommand.COMMAND_NAME
+              + ", "
+              + FixPermissionsCommand.COMMAND_NAME);
       printHelp(err);
       return EXIT_USAGE;
     } catch (IllegalArgumentException e) {
@@ -209,7 +228,7 @@ public final class DoctorCli {
     stream.println();
     stream.println(
         "CMS Doctor — safe install-tree maintenance"
-            + " (clean-heap-dumps, clean-install-backups, clean-logs).");
+            + " (clean-*, check-config, fix-permissions).");
     stream.println();
     stream.println("Options:");
     stream.println("  --install-root <path>  CMS install root (default: current working directory)");
@@ -224,6 +243,10 @@ public final class DoctorCli {
             + " (*.bak, *.backup, AppServer_backup_*.zip)");
     stream.println(
         "  clean-logs             Remove aged logs under known Jetty/CMS/DTS log dirs");
+    stream.println(
+        "  check-config           Read-only value/misconfig checks (server + repository props)");
+    stream.println(
+        "  fix-permissions        Report/fix allowlisted launcher + log-dir modes (POSIX)");
     stream.println();
     stream.println("clean-logs options:");
     stream.println(
@@ -243,6 +266,12 @@ public final class DoctorCli {
         "  perc-doctor --install-root /opt/Percussion --dry-run -v clean-logs --older-than 7d");
     stream.println(
         "  perc-doctor --install-root C:\\Percussion -v clean-logs --older-than 14d");
+    stream.println(
+        "  perc-doctor --install-root /opt/Percussion --dry-run -v check-config");
+    stream.println("  perc-doctor --install-root C:\\Percussion -v check-config");
+    stream.println(
+        "  perc-doctor --install-root /opt/Percussion --dry-run -v fix-permissions");
+    stream.println("  perc-doctor --install-root C:\\Percussion -v fix-permissions");
   }
 
   static void printReport(CleanReport report, boolean verbose, PrintStream out) {
@@ -262,6 +291,48 @@ public final class DoctorCli {
             "  " + e.getStatus() + " " + e.getSizeBytes() + " " + e.getPath() + detail);
       }
     } else if (report.isDryRun() && report.getCandidateCount() > 0) {
+      out.println("(use -v/--verbose for path list)");
+    }
+  }
+
+  static void printCheckConfigReport(CheckConfigReport report, boolean verbose, PrintStream out) {
+    out.println("command=" + report.getCommand());
+    out.println("install-root=" + report.getInstallRoot());
+    out.println("dry-run=" + report.isDryRun());
+    out.println("checks=" + report.getCheckCount());
+    out.println("pass=" + report.getPassCount());
+    out.println("warn=" + report.getWarnCount());
+    out.println("fail=" + report.getFailCount());
+    out.println("info=" + report.getInfoCount());
+    out.println("healthy=" + report.isHealthy());
+    if (verbose) {
+      for (CheckConfigReport.Check c : report.getChecks()) {
+        String pathPart = c.getPath() == null ? "" : " path=" + c.getPath();
+        out.println("  " + c.getStatus() + " " + c.getId() + " " + c.getMessage() + pathPart);
+      }
+    } else if (report.getCheckCount() > 0) {
+      out.println("(use -v/--verbose for check list)");
+    }
+  }
+
+  static void printFixPermissionsReport(
+      FixPermissionsReport report, boolean verbose, PrintStream out) {
+    out.println("command=" + report.getCommand());
+    out.println("install-root=" + report.getInstallRoot());
+    out.println("dry-run=" + report.isDryRun());
+    out.println("candidates=" + report.getCandidateCount());
+    if (report.isDryRun()) {
+      out.println("would-fix=" + report.getWouldFixCount());
+    } else {
+      out.println("fixed=" + report.getFixedCount());
+    }
+    out.println("failed=" + report.getFailedCount());
+    if (verbose) {
+      for (FixPermissionsReport.Entry e : report.getEntries()) {
+        String detail = e.getDetail() == null ? "" : " " + e.getDetail();
+        out.println("  " + e.getStatus() + " " + e.getPath() + detail);
+      }
+    } else if (report.getCandidateCount() > 0) {
       out.println("(use -v/--verbose for path list)");
     }
   }

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/FixPermissionsCommand.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/FixPermissionsCommand.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Report (and optionally fix) common install permission / mode issues under the CMS install root
+ * ({@code fix-permissions}).
+ *
+ * <p><strong>Scoped, documented targets only</strong> — no arbitrary paths, no shell, no user
+ * globs. Mutations are limited to POSIX mode bits on allowlisted paths when the filesystem supports
+ * {@link PosixFilePermission}. On Windows (and other non-POSIX stores) the command reports
+ * readability / writability and skips mode changes.
+ *
+ * <p>Allowlisted relative targets:
+ *
+ * <ul>
+ *   <li>Launchers under {@code bin/}: {@code perc-doctor}, {@code perc-doctor.bat}, {@code
+ *       perc-doctor.jar} — ensure owner read (+ execute for non-{@code .bat}/non-{@code .jar} Unix
+ *       scripts when present)
+ *   <li>Known log directories from {@link InstallRootGuard#LOG_DIR_RELATIVE} — ensure owner
+ *       read/write/execute on the directory when present (so the service can write logs)
+ *   <li>Key config files ({@link CheckConfigCommand#SERVER_PROPERTIES_REL}, {@link
+ *       CheckConfigCommand#RXREPOSITORY_PROPERTIES_REL}) — report owner-read; set owner-read on
+ *       POSIX when missing
+ * </ul>
+ *
+ * <p>Dry-run never writes. Apply re-checks containment immediately before each mode change.
+ */
+public final class FixPermissionsCommand {
+
+  /** CLI command token. */
+  public static final String COMMAND_NAME = "fix-permissions";
+
+  /**
+   * Allowlisted launcher file names under {@code bin/} (not full paths). Bare names only; no path
+   * separators.
+   */
+  public static final String[] BIN_LAUNCHER_NAMES = {
+    "perc-doctor", "perc-doctor.bat", "perc-doctor.jar"
+  };
+
+  private FixPermissionsCommand() {}
+
+  /**
+   * Inventory and optionally fix permissions under {@code installRoot}.
+   *
+   * @param installRoot CMS install root (must exist and be a directory)
+   * @param dryRun when true, report only (no mode writes)
+   * @return report of inspected / fixed paths
+   * @throws IllegalArgumentException if install root is invalid
+   * @throws IOException on unrecoverable I/O (individual entries prefer FAILED rows)
+   */
+  public static FixPermissionsReport execute(Path installRoot, boolean dryRun) throws IOException {
+    Path root = InstallRootGuard.requireInstallRoot(installRoot);
+    FixPermissionsReport report = new FixPermissionsReport(COMMAND_NAME, root, dryRun);
+    boolean posix = supportsPosix(root);
+
+    if (!posix) {
+      report.add(
+          new FixPermissionsReport.Entry(
+              root,
+              FixPermissionsReport.EntryStatus.SKIPPED,
+              "POSIX mode bits not supported on this filesystem; reporting access only"
+                  + " (Windows ACL repair is out of scope for this command)"));
+    }
+
+    fixBinLaunchers(report, root, dryRun, posix);
+    fixLogDirs(report, root, dryRun, posix);
+    fixKeyConfigFiles(report, root, dryRun, posix);
+
+    return report;
+  }
+
+  static void fixBinLaunchers(
+      FixPermissionsReport report, Path root, boolean dryRun, boolean posix) {
+    Path binDir = InstallRootGuard.resolveRelativeUnderRoot(root, "bin");
+    if (binDir == null || !InstallRootGuard.isUnderInstallRoot(root, binDir)) {
+      report.add(
+          new FixPermissionsReport.Entry(
+              root,
+              FixPermissionsReport.EntryStatus.FAILED,
+              "bin/ path rejected by install-root guard"));
+      return;
+    }
+    if (!Files.isDirectory(binDir)) {
+      report.add(
+          new FixPermissionsReport.Entry(
+              binDir,
+              FixPermissionsReport.EntryStatus.SKIPPED,
+              "bin/ directory missing; launcher mode checks skipped"));
+      return;
+    }
+
+    for (String name : BIN_LAUNCHER_NAMES) {
+      if (name.indexOf('/') >= 0 || name.indexOf('\\') >= 0) {
+        continue;
+      }
+      Path file = binDir.resolve(name).toAbsolutePath().normalize();
+      if (!InstallRootGuard.isUnderInstallRoot(root, file)) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.FAILED,
+                "Launcher path escaped install root"));
+        continue;
+      }
+      if (!Files.isRegularFile(file)) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.SKIPPED,
+                "Launcher not present: bin/" + name));
+        continue;
+      }
+
+      // Report basic accessibility always.
+      boolean readable = Files.isReadable(file);
+      if (!readable) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.FAILED,
+                "Launcher not readable by current user: bin/" + name));
+        continue;
+      }
+
+      boolean needOwnerExec = posix && isUnixScriptLauncher(name);
+      if (!needOwnerExec) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.OK,
+                "Launcher present and readable: bin/" + name));
+        continue;
+      }
+
+      try {
+        Set<PosixFilePermission> perms = Files.getPosixFilePermissions(file);
+        if (perms.contains(PosixFilePermission.OWNER_EXECUTE)) {
+          report.add(
+              new FixPermissionsReport.Entry(
+                  file,
+                  FixPermissionsReport.EntryStatus.OK,
+                  "Unix launcher already owner-executable: bin/" + name));
+          continue;
+        }
+        if (dryRun) {
+          report.add(
+              new FixPermissionsReport.Entry(
+                  file,
+                  FixPermissionsReport.EntryStatus.WOULD_FIX,
+                  "Would add owner-execute on bin/" + name));
+          continue;
+        }
+        // Re-check containment immediately before mutation.
+        InstallRootGuard.requireUnderInstallRoot(root, file);
+        EnumSet<PosixFilePermission> updated = EnumSet.copyOf(perms);
+        updated.add(PosixFilePermission.OWNER_READ);
+        updated.add(PosixFilePermission.OWNER_EXECUTE);
+        Files.setPosixFilePermissions(file, updated);
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.FIXED,
+                "Added owner-execute on bin/" + name));
+      } catch (UnsupportedOperationException e) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.SKIPPED,
+                "POSIX permissions unsupported for bin/" + name));
+      } catch (IOException | SecurityException e) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.FAILED,
+                "Failed to inspect/fix launcher mode: " + e.getMessage()));
+      }
+    }
+  }
+
+  static void fixLogDirs(FixPermissionsReport report, Path root, boolean dryRun, boolean posix) {
+    for (String relative : InstallRootGuard.LOG_DIR_RELATIVE) {
+      Path dir = InstallRootGuard.resolveRelativeUnderRoot(root, relative);
+      if (dir == null) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                root,
+                FixPermissionsReport.EntryStatus.FAILED,
+                "Invalid log dir relative path: " + relative));
+        continue;
+      }
+      if (!InstallRootGuard.isUnderInstallRoot(root, dir)) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                dir,
+                FixPermissionsReport.EntryStatus.FAILED,
+                "Log dir path escaped install root: " + relative));
+        continue;
+      }
+      if (!Files.isDirectory(dir)) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                dir,
+                FixPermissionsReport.EntryStatus.SKIPPED,
+                "Log directory missing: " + relative));
+        continue;
+      }
+
+      boolean writable = Files.isWritable(dir);
+      boolean readable = Files.isReadable(dir);
+      if (!posix) {
+        FixPermissionsReport.EntryStatus st =
+            writable && readable
+                ? FixPermissionsReport.EntryStatus.OK
+                : FixPermissionsReport.EntryStatus.FAILED;
+        report.add(
+            new FixPermissionsReport.Entry(
+                dir,
+                st,
+                "Log dir access readable="
+                    + readable
+                    + " writable="
+                    + writable
+                    + " (no POSIX mode fix on this platform): "
+                    + relative));
+        continue;
+      }
+
+      try {
+        Set<PosixFilePermission> perms = Files.getPosixFilePermissions(dir);
+        boolean hasOwnerRwx =
+            perms.contains(PosixFilePermission.OWNER_READ)
+                && perms.contains(PosixFilePermission.OWNER_WRITE)
+                && perms.contains(PosixFilePermission.OWNER_EXECUTE);
+        if (hasOwnerRwx && writable) {
+          report.add(
+              new FixPermissionsReport.Entry(
+                  dir,
+                  FixPermissionsReport.EntryStatus.OK,
+                  "Log dir has owner rwx: " + relative));
+          continue;
+        }
+        if (dryRun) {
+          report.add(
+              new FixPermissionsReport.Entry(
+                  dir,
+                  FixPermissionsReport.EntryStatus.WOULD_FIX,
+                  "Would ensure owner rwx on log dir: " + relative));
+          continue;
+        }
+        InstallRootGuard.requireUnderInstallRoot(root, dir);
+        EnumSet<PosixFilePermission> updated = EnumSet.copyOf(perms);
+        updated.add(PosixFilePermission.OWNER_READ);
+        updated.add(PosixFilePermission.OWNER_WRITE);
+        updated.add(PosixFilePermission.OWNER_EXECUTE);
+        Files.setPosixFilePermissions(dir, updated);
+        report.add(
+            new FixPermissionsReport.Entry(
+                dir,
+                FixPermissionsReport.EntryStatus.FIXED,
+                "Ensured owner rwx on log dir: " + relative));
+      } catch (UnsupportedOperationException e) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                dir,
+                FixPermissionsReport.EntryStatus.SKIPPED,
+                "POSIX permissions unsupported for log dir: " + relative));
+      } catch (IOException | SecurityException e) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                dir,
+                FixPermissionsReport.EntryStatus.FAILED,
+                "Failed to inspect/fix log dir mode (" + relative + "): " + e.getMessage()));
+      }
+    }
+  }
+
+  static void fixKeyConfigFiles(
+      FixPermissionsReport report, Path root, boolean dryRun, boolean posix) {
+    String[] relatives = {
+      CheckConfigCommand.SERVER_PROPERTIES_REL, CheckConfigCommand.RXREPOSITORY_PROPERTIES_REL
+    };
+    for (String relative : relatives) {
+      Path file = InstallRootGuard.resolveRelativeUnderRoot(root, relative);
+      if (file == null || !InstallRootGuard.isUnderInstallRoot(root, file)) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                root,
+                FixPermissionsReport.EntryStatus.FAILED,
+                "Config path rejected by guard: " + relative));
+        continue;
+      }
+      if (!Files.isRegularFile(file)) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.SKIPPED,
+                "Config file missing: " + relative));
+        continue;
+      }
+      boolean readable = Files.isReadable(file);
+      if (!posix) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                readable
+                    ? FixPermissionsReport.EntryStatus.OK
+                    : FixPermissionsReport.EntryStatus.FAILED,
+                "Config readable=" + readable + " (no POSIX mode fix): " + relative));
+        continue;
+      }
+      try {
+        Set<PosixFilePermission> perms = Files.getPosixFilePermissions(file);
+        if (perms.contains(PosixFilePermission.OWNER_READ) && readable) {
+          report.add(
+              new FixPermissionsReport.Entry(
+                  file,
+                  FixPermissionsReport.EntryStatus.OK,
+                  "Config owner-readable: " + relative));
+          continue;
+        }
+        if (dryRun) {
+          report.add(
+              new FixPermissionsReport.Entry(
+                  file,
+                  FixPermissionsReport.EntryStatus.WOULD_FIX,
+                  "Would add owner-read on config: " + relative));
+          continue;
+        }
+        InstallRootGuard.requireUnderInstallRoot(root, file);
+        EnumSet<PosixFilePermission> updated = EnumSet.copyOf(perms);
+        updated.add(PosixFilePermission.OWNER_READ);
+        Files.setPosixFilePermissions(file, updated);
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.FIXED,
+                "Added owner-read on config: " + relative));
+      } catch (UnsupportedOperationException e) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.SKIPPED,
+                "POSIX permissions unsupported for config: " + relative));
+      } catch (IOException | SecurityException e) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.FAILED,
+                "Failed to inspect/fix config mode (" + relative + "): " + e.getMessage()));
+      }
+    }
+  }
+
+  /**
+   * Unix shell launcher (no extension / not Windows batch / not jar) needs owner-execute.
+   *
+   * @param fileName bare name under bin/
+   * @return true when owner-execute should be ensured on POSIX
+   */
+  static boolean isUnixScriptLauncher(String fileName) {
+    Objects.requireNonNull(fileName, "fileName");
+    String lower = fileName.toLowerCase(Locale.ROOT);
+    if (lower.endsWith(".bat") || lower.endsWith(".cmd") || lower.endsWith(".jar")) {
+      return false;
+    }
+    // perc-doctor (no extension) is the Unix wrapper
+    return "perc-doctor".equals(lower) || !lower.contains(".");
+  }
+
+  /**
+   * Whether {@code path}'s file store supports POSIX permissions (probe via store or attribute
+   * view).
+   */
+  static boolean supportsPosix(Path path) {
+    try {
+      return path.getFileSystem().supportedFileAttributeViews().contains("posix");
+    } catch (RuntimeException e) {
+      return false;
+    }
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/FixPermissionsReport.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/FixPermissionsReport.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Inventory / action report for {@code fix-permissions}. */
+public final class FixPermissionsReport {
+
+  /** Outcome for a single path / permission item. */
+  public enum EntryStatus {
+    /** Already correct; no change needed. */
+    OK,
+    /** Dry-run: would apply a documented mode fix. */
+    WOULD_FIX,
+    /** Apply: mode fix was applied. */
+    FIXED,
+    /** Intentionally not changed (unsupported platform, missing path, etc.). */
+    SKIPPED,
+    /** Error while inspecting or applying. */
+    FAILED
+  }
+
+  /** One path considered by fix-permissions. */
+  public static final class Entry {
+    private final Path path;
+    private final EntryStatus status;
+    private final String detail;
+
+    /**
+     * @param path absolute or normalized path of the candidate
+     * @param status outcome
+     * @param detail human-readable detail (may be null)
+     */
+    public Entry(Path path, EntryStatus status, String detail) {
+      this.path = Objects.requireNonNull(path, "path");
+      this.status = Objects.requireNonNull(status, "status");
+      this.detail = detail;
+    }
+
+    /** @return candidate path */
+    public Path getPath() {
+      return path;
+    }
+
+    /** @return outcome status */
+    public EntryStatus getStatus() {
+      return status;
+    }
+
+    /** @return optional detail message, or null */
+    public String getDetail() {
+      return detail;
+    }
+  }
+
+  private final String command;
+  private final Path installRoot;
+  private final boolean dryRun;
+  private final List<Entry> entries = new ArrayList<>();
+
+  /**
+   * @param command command name ({@code fix-permissions})
+   * @param installRoot resolved install root
+   * @param dryRun whether this report is from a dry-run
+   */
+  public FixPermissionsReport(String command, Path installRoot, boolean dryRun) {
+    this.command = Objects.requireNonNull(command, "command");
+    this.installRoot = Objects.requireNonNull(installRoot, "installRoot");
+    this.dryRun = dryRun;
+  }
+
+  /** Append an inventory/action entry. */
+  public void add(Entry entry) {
+    entries.add(Objects.requireNonNull(entry, "entry"));
+  }
+
+  /** @return command name */
+  public String getCommand() {
+    return command;
+  }
+
+  /** @return install root used for this run */
+  public Path getInstallRoot() {
+    return installRoot;
+  }
+
+  /** @return true if no mode fixes were applied */
+  public boolean isDryRun() {
+    return dryRun;
+  }
+
+  /** @return unmodifiable list of entries */
+  public List<Entry> getEntries() {
+    return Collections.unmodifiableList(entries);
+  }
+
+  /** @return number of entries */
+  public int getCandidateCount() {
+    return entries.size();
+  }
+
+  /** @return count of successfully fixed entries */
+  public int getFixedCount() {
+    int n = 0;
+    for (Entry e : entries) {
+      if (e.getStatus() == EntryStatus.FIXED) {
+        n++;
+      }
+    }
+    return n;
+  }
+
+  /** @return count of dry-run would-fix entries */
+  public int getWouldFixCount() {
+    int n = 0;
+    for (Entry e : entries) {
+      if (e.getStatus() == EntryStatus.WOULD_FIX) {
+        n++;
+      }
+    }
+    return n;
+  }
+
+  /** @return count of failed entries */
+  public int getFailedCount() {
+    int n = 0;
+    for (Entry e : entries) {
+      if (e.getStatus() == EntryStatus.FAILED) {
+        n++;
+      }
+    }
+    return n;
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CheckConfigCommandTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CheckConfigCommandTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CheckConfigCommandTest {
+
+  @TempDir Path tempDir;
+
+  private Path installRoot;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    installRoot = Files.createDirectories(tempDir.resolve("cms-install"));
+  }
+
+  @Test
+  void bareInstallWarnsOnMissingConfigsAndStaysHealthyWithoutFail() throws Exception {
+    CheckConfigReport report = CheckConfigCommand.execute(installRoot, true);
+    assertEquals(CheckConfigCommand.COMMAND_NAME, report.getCommand());
+    assertTrue(report.isDryRun());
+    assertTrue(report.getCheckCount() >= 2);
+    // Missing configs are WARN, not FAIL — install may be partial.
+    assertTrue(report.isHealthy(), "missing optional configs should be WARN not FAIL");
+    assertTrue(report.getWarnCount() >= 2);
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.WARN, "server.properties.present"));
+    assertTrue(
+        hasStatusId(report, CheckConfigReport.CheckStatus.WARN, "rxrepository.properties.present"));
+  }
+
+  @Test
+  void healthyServerAndH2RepoProducesPassAndInfo() throws Exception {
+    writeServerProps(
+        "enableDebugTools=false\n"
+            + "disableCrossSiteRequestForgeryCheck=false\n"
+            + "requireHTTPS=true\n"
+            + "bindPort=9992\n");
+    writeRepoProps(
+        "DB_BACKEND=H2\n"
+            + "DB_DRIVER_NAME=h2\n"
+            + "DB_DRIVER_CLASS_NAME=org.h2.Driver\n"
+            + "DB_SERVER=file:../../Repository/CMDB\n"
+            + "UID=sa\n"
+            + "PWD=\n");
+
+    CheckConfigReport report = CheckConfigCommand.execute(installRoot, false);
+    assertFalse(report.isDryRun());
+    assertTrue(report.isHealthy());
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.PASS, "server.enableDebugTools"));
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.PASS, "server.bindPort"));
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.PASS, "repo.DB_BACKEND"));
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.INFO, "repo.PWD"));
+  }
+
+  @Test
+  void debugToolsAndCsrfDisableWarn() throws Exception {
+    writeServerProps(
+        "enableDebugTools=true\n"
+            + "disableCrossSiteRequestForgeryCheck=true\n"
+            + "bindPort=9992\n");
+    writeRepoProps(h2RepoBody());
+
+    CheckConfigReport report = CheckConfigCommand.execute(installRoot, true);
+    assertTrue(report.isHealthy());
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.WARN, "server.enableDebugTools"));
+    assertTrue(
+        hasStatusId(
+            report,
+            CheckConfigReport.CheckStatus.WARN,
+            "server.disableCrossSiteRequestForgeryCheck"));
+  }
+
+  @Test
+  void invalidBindPortFails() throws Exception {
+    writeServerProps("bindPort=not-a-port\n");
+    writeRepoProps(h2RepoBody());
+
+    CheckConfigReport report = CheckConfigCommand.execute(installRoot, true);
+    assertFalse(report.isHealthy());
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.FAIL, "server.bindPort"));
+  }
+
+  @Test
+  void unresolvedPlaceholderInBindPortFails() throws Exception {
+    writeServerProps("bindPort=${cms.port}\n");
+    writeRepoProps(h2RepoBody());
+
+    CheckConfigReport report = CheckConfigCommand.execute(installRoot, true);
+    assertFalse(report.isHealthy());
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.FAIL, "server.bindPort"));
+  }
+
+  @Test
+  void missingRequiredRepoKeyFails() throws Exception {
+    writeServerProps("bindPort=9992\nenableDebugTools=false\n");
+    writeRepoProps(
+        "DB_BACKEND=MSSQL\n"
+            + "DB_DRIVER_NAME=sqlserver\n"
+            + "DB_DRIVER_CLASS_NAME=com.microsoft.sqlserver.jdbc.SQLServerDriver\n"
+            + "DB_SERVER=\n"
+            + "UID=cms\n"
+            + "PWD=demo\n"
+            + "PWD_ENCRYPTED=N\n");
+
+    CheckConfigReport report = CheckConfigCommand.execute(installRoot, true);
+    assertFalse(report.isHealthy());
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.FAIL, "repo.DB_SERVER"));
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.WARN, "repo.PWD"));
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.WARN, "repo.PWD_ENCRYPTED"));
+  }
+
+  @Test
+  void driverBackendMismatchWarns() throws Exception {
+    writeServerProps("bindPort=9992\n");
+    writeRepoProps(
+        "DB_BACKEND=MSSQL\n"
+            + "DB_DRIVER_NAME=h2\n"
+            + "DB_DRIVER_CLASS_NAME=org.h2.Driver\n"
+            + "DB_SERVER=//sql.example.com:1433\n"
+            + "UID=cms\n"
+            + "PWD=s3cureValue\n"
+            + "PWD_ENCRYPTED=Y\n");
+
+    CheckConfigReport report = CheckConfigCommand.execute(installRoot, true);
+    assertTrue(report.isHealthy());
+    assertTrue(
+        hasStatusId(report, CheckConfigReport.CheckStatus.WARN, "repo.driver-backend-consistency"));
+  }
+
+  @Test
+  void neverWritesUnderInstallRoot() throws Exception {
+    writeServerProps("bindPort=9992\nenableDebugTools=true\n");
+    writeRepoProps(h2RepoBody());
+    Path marker = installRoot.resolve("marker.txt");
+    Files.writeString(marker, "keep");
+    long before = Files.walk(installRoot).count();
+
+    CheckConfigCommand.execute(installRoot, false);
+
+    assertTrue(Files.exists(marker));
+    assertEquals(before, Files.walk(installRoot).count());
+    assertEquals(
+        "keep", Files.readString(marker, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void missingInstallRootRejected() {
+    Path missing = tempDir.resolve("gone");
+    assertThrows(IllegalArgumentException.class, () -> CheckConfigCommand.execute(missing, true));
+  }
+
+  @Test
+  void allResolvedPathsStayUnderInstallRoot() throws Exception {
+    writeServerProps("bindPort=9992\n");
+    writeRepoProps(h2RepoBody());
+    CheckConfigReport report = CheckConfigCommand.execute(installRoot, true);
+    for (CheckConfigReport.Check c : report.getChecks()) {
+      if (c.getPath() == null) {
+        continue;
+      }
+      assertTrue(
+          InstallRootGuard.isUnderInstallRoot(installRoot, c.getPath()),
+          "path escaped root: " + c.getPath());
+    }
+  }
+
+  @Test
+  void weakPasswordHelperRecognizesKnownTokens() {
+    assertTrue(CheckConfigCommand.isWeakPassword("demo"));
+    assertTrue(CheckConfigCommand.isWeakPassword("Password"));
+    assertFalse(CheckConfigCommand.isWeakPassword("s3cureValue!"));
+  }
+
+  private void writeServerProps(String body) throws Exception {
+    Path dir = Files.createDirectories(installRoot.resolve("rxconfig").resolve("Server"));
+    Files.writeString(dir.resolve("server.properties"), body, StandardCharsets.UTF_8);
+  }
+
+  private void writeRepoProps(String body) throws Exception {
+    Path dir = Files.createDirectories(installRoot.resolve("rxconfig").resolve("Installer"));
+    Files.writeString(dir.resolve("rxrepository.properties"), body, StandardCharsets.UTF_8);
+  }
+
+  private static String h2RepoBody() {
+    return "DB_BACKEND=H2\n"
+        + "DB_DRIVER_NAME=h2\n"
+        + "DB_DRIVER_CLASS_NAME=org.h2.Driver\n"
+        + "DB_SERVER=file:../../Repository/CMDB\n"
+        + "UID=sa\n"
+        + "PWD=\n";
+  }
+
+  private static boolean hasStatusId(
+      CheckConfigReport report, CheckConfigReport.CheckStatus status, String id) {
+    List<String> matches =
+        report.getChecks().stream()
+            .filter(c -> c.getStatus() == status && id.equals(c.getId()))
+            .map(CheckConfigReport.Check::getId)
+            .collect(Collectors.toList());
+    return !matches.isEmpty();
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
@@ -288,4 +288,89 @@ class DoctorCliTest {
     assertTrue(Files.exists(dump));
     assertTrue(outBuf.toString(StandardCharsets.UTF_8).contains("candidates=1"));
   }
+
+  @Test
+  void checkConfigViaCliReportsHealthyOnBareTree() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-check-config"));
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root", root.toString(), "--dry-run", "-v", "check-config"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("command=check-config"));
+    assertTrue(out.contains("dry-run=true"));
+    assertTrue(out.contains("healthy=true"));
+    assertTrue(out.contains("WARN"));
+  }
+
+  @Test
+  void checkConfigViaCliFailsOnInvalidBindPort() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-check-config-fail"));
+    Path serverDir = Files.createDirectories(root.resolve("rxconfig").resolve("Server"));
+    Files.writeString(serverDir.resolve("server.properties"), "bindPort=xyz\n");
+    Path installerDir = Files.createDirectories(root.resolve("rxconfig").resolve("Installer"));
+    Files.writeString(
+        installerDir.resolve("rxrepository.properties"),
+        "DB_BACKEND=H2\nDB_DRIVER_NAME=h2\nDB_DRIVER_CLASS_NAME=org.h2.Driver\n"
+            + "DB_SERVER=file:x\nUID=sa\n");
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"--install-root", root.toString(), "-v", "check-config"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_ERROR, code);
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("healthy=false"));
+    assertTrue(out.contains("server.bindPort"));
+  }
+
+  @Test
+  void fixPermissionsViaCliDryRunDoesNotFailOnWindowsLayout() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-fix-perms"));
+    Path bin = Files.createDirectories(root.resolve("bin"));
+    Files.writeString(bin.resolve("perc-doctor"), "#!/bin/sh\n");
+    Files.writeString(bin.resolve("perc-doctor.bat"), "@echo off\r\n");
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root", root.toString(), "--dry-run", "-v", "fix-permissions"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("command=fix-permissions"));
+    assertTrue(out.contains("dry-run=true"));
+    assertTrue(out.contains("candidates="));
+  }
+
+  @Test
+  void helpListsCheckConfigAndFixPermissions() {
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"--help"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+    assertEquals(DoctorCli.EXIT_OK, code);
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("check-config"));
+    assertTrue(out.contains("fix-permissions"));
+  }
 }

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/FixPermissionsCommandTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/FixPermissionsCommandTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+class FixPermissionsCommandTest {
+
+  @TempDir Path tempDir;
+
+  private Path installRoot;
+  private Path binDir;
+  private Path unixLauncher;
+  private Path jettyLogs;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    installRoot = Files.createDirectories(tempDir.resolve("cms-install"));
+    binDir = Files.createDirectories(installRoot.resolve("bin"));
+    unixLauncher = binDir.resolve("perc-doctor");
+    Files.writeString(unixLauncher, "#!/bin/sh\necho doctor\n", StandardCharsets.UTF_8);
+    Files.writeString(binDir.resolve("perc-doctor.bat"), "@echo off\r\n", StandardCharsets.UTF_8);
+    Files.write(binDir.resolve("perc-doctor.jar"), new byte[] {0x50, 0x4b});
+    jettyLogs =
+        Files.createDirectories(
+            installRoot.resolve("jetty").resolve("base").resolve("logs"));
+    Path serverDir = Files.createDirectories(installRoot.resolve("rxconfig").resolve("Server"));
+    Files.writeString(serverDir.resolve("server.properties"), "bindPort=9992\n");
+    Path installerDir =
+        Files.createDirectories(installRoot.resolve("rxconfig").resolve("Installer"));
+    Files.writeString(
+        installerDir.resolve("rxrepository.properties"),
+        "DB_BACKEND=H2\nDB_DRIVER_NAME=h2\nDB_DRIVER_CLASS_NAME=org.h2.Driver\n"
+            + "DB_SERVER=file:x\nUID=sa\n");
+  }
+
+  @Test
+  void dryRunNeverMutatesAndReportsCandidates() throws Exception {
+    FixPermissionsReport report = FixPermissionsCommand.execute(installRoot, true);
+    assertEquals(FixPermissionsCommand.COMMAND_NAME, report.getCommand());
+    assertTrue(report.isDryRun());
+    assertTrue(report.getCandidateCount() > 0);
+    assertEquals(0, report.getFixedCount());
+    // Launcher file content unchanged
+    assertTrue(Files.readString(unixLauncher, StandardCharsets.UTF_8).contains("#!/bin/sh"));
+  }
+
+  @Test
+  void missingPathsAreSkippedNotFailed() throws Exception {
+    Path emptyRoot = Files.createDirectories(tempDir.resolve("empty-install"));
+    FixPermissionsReport report = FixPermissionsCommand.execute(emptyRoot, true);
+    assertEquals(0, report.getFailedCount());
+    assertTrue(
+        report.getEntries().stream()
+            .anyMatch(e -> e.getStatus() == FixPermissionsReport.EntryStatus.SKIPPED));
+  }
+
+  @Test
+  void missingInstallRootRejected() {
+    Path missing = tempDir.resolve("gone");
+    assertThrows(
+        IllegalArgumentException.class, () -> FixPermissionsCommand.execute(missing, true));
+  }
+
+  @Test
+  void allEntryPathsStayUnderInstallRoot() throws Exception {
+    FixPermissionsReport report = FixPermissionsCommand.execute(installRoot, true);
+    for (FixPermissionsReport.Entry e : report.getEntries()) {
+      assertTrue(
+          InstallRootGuard.isUnderInstallRoot(installRoot, e.getPath()),
+          "path escaped root: " + e.getPath());
+    }
+  }
+
+  @Test
+  void isUnixScriptLauncherHeuristic() {
+    assertTrue(FixPermissionsCommand.isUnixScriptLauncher("perc-doctor"));
+    assertFalse(FixPermissionsCommand.isUnixScriptLauncher("perc-doctor.bat"));
+    assertFalse(FixPermissionsCommand.isUnixScriptLauncher("perc-doctor.jar"));
+    assertFalse(FixPermissionsCommand.isUnixScriptLauncher("perc-doctor.cmd"));
+  }
+
+  @Test
+  @EnabledOnOs({OS.LINUX, OS.MAC})
+  void posixDryRunWouldFixMissingOwnerExecute() throws Exception {
+    // Strip owner execute if present
+    Set<PosixFilePermission> perms = Files.getPosixFilePermissions(unixLauncher);
+    EnumSet<PosixFilePermission> stripped = EnumSet.copyOf(perms);
+    stripped.remove(PosixFilePermission.OWNER_EXECUTE);
+    stripped.remove(PosixFilePermission.GROUP_EXECUTE);
+    stripped.remove(PosixFilePermission.OTHERS_EXECUTE);
+    Files.setPosixFilePermissions(unixLauncher, stripped);
+
+    FixPermissionsReport dry = FixPermissionsCommand.execute(installRoot, true);
+    assertTrue(dry.getWouldFixCount() >= 1);
+    assertFalse(Files.getPosixFilePermissions(unixLauncher).contains(PosixFilePermission.OWNER_EXECUTE));
+
+    FixPermissionsReport apply = FixPermissionsCommand.execute(installRoot, false);
+    assertTrue(apply.getFixedCount() >= 1);
+    assertTrue(
+        Files.getPosixFilePermissions(unixLauncher).contains(PosixFilePermission.OWNER_EXECUTE));
+  }
+
+  @Test
+  @EnabledOnOs({OS.LINUX, OS.MAC})
+  void posixLogDirOwnerRwxFix() throws Exception {
+    Set<PosixFilePermission> perms = Files.getPosixFilePermissions(jettyLogs);
+    EnumSet<PosixFilePermission> stripped = EnumSet.copyOf(perms);
+    stripped.remove(PosixFilePermission.OWNER_WRITE);
+    Files.setPosixFilePermissions(jettyLogs, stripped);
+
+    FixPermissionsReport dry = FixPermissionsCommand.execute(installRoot, true);
+    assertTrue(
+        dry.getEntries().stream()
+            .anyMatch(
+                e ->
+                    e.getStatus() == FixPermissionsReport.EntryStatus.WOULD_FIX
+                        && e.getPath().equals(jettyLogs.toAbsolutePath().normalize())));
+
+    FixPermissionsReport apply = FixPermissionsCommand.execute(installRoot, false);
+    assertTrue(
+        Files.getPosixFilePermissions(jettyLogs).contains(PosixFilePermission.OWNER_WRITE));
+    assertTrue(apply.getFixedCount() >= 1);
+  }
+
+  @Test
+  @EnabledOnOs(OS.WINDOWS)
+  void windowsReportsAccessWithoutModeMutation() throws Exception {
+    FixPermissionsReport report = FixPermissionsCommand.execute(installRoot, false);
+    assertEquals(0, report.getFixedCount());
+    assertTrue(
+        report.getEntries().stream()
+            .anyMatch(
+                e ->
+                    e.getStatus() == FixPermissionsReport.EntryStatus.SKIPPED
+                        && e.getDetail() != null
+                        && e.getDetail().toLowerCase().contains("posix")));
+    // Launchers still OK/readable
+    assertTrue(
+        report.getEntries().stream()
+            .anyMatch(
+                e ->
+                    e.getPath().getFileName().toString().equals("perc-doctor.bat")
+                        && (e.getStatus() == FixPermissionsReport.EntryStatus.OK
+                            || e.getStatus() == FixPermissionsReport.EntryStatus.SKIPPED)));
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/PercDoctorPackagingTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/PercDoctorPackagingTest.java
@@ -143,7 +143,9 @@ class PercDoctorPackagingTest {
     assertTrue(
         guideText.contains("clean-heap-dumps")
             && guideText.contains("clean-install-backups")
-            && guideText.contains("clean-logs"),
+            && guideText.contains("clean-logs")
+            && guideText.contains("check-config")
+            && guideText.contains("fix-permissions"),
         "install guide must cover all shipped commands");
     assertTrue(
         guideText.contains("bin/perc-doctor") || guideText.contains("bin\\perc-doctor"),


### PR DESCRIPTION
## Summary

**Parent tracker:** #2213  
**Slice:** #2233 — deeper `check-config` (value/misconfig beyond presence) + `fix-permissions` for common install mode/access issues.

Adds CLI commands to `modules/perc-doctor` (peer wiring like `clean-logs`):

### `check-config` (always read-only)
- Scoped files: `rxconfig/Server/server.properties`, `rxconfig/Installer/rxrepository.properties`
- Value checks: `enableDebugTools`, CSRF disable, `bindPort`, `requireHTTPS`, required repo JDBC keys, driver/backend consistency, weak/plaintext `PWD`, unresolved `${...}` placeholders
- Never mutates; never prints secrets; exit non-zero on any **FAIL**
- Independent of open diagnose/health PR #2231 (different command name + value depth)

### `fix-permissions` (dry-run first)
- Allowlisted only: `bin/perc-doctor{,.bat,.jar}`, known log dirs, key config files
- POSIX: owner-execute on Unix launcher, owner rwx on log dirs, owner-read on configs
- Windows: report readable/writable; no ACL rewrite; **no shell**
- Containment re-check via `InstallRootGuard` before each mode change

### Docs / tests
- README + operator-install-guide examples (portable `/opt/Percussion`, `C:\Percussion`)
- Unit tests: containment, non-mutation, misconfig FAIL/WARN, CLI exit codes, OS-conditioned POSIX apply
- Erlang self-review: `docs/ai-generated/code-reviews/issue-2233-check-config-fix-permissions-erlang.md`

**Not in this PR:** admin HTTP API parity for these two commands (clean-* API unchanged). Optional residual if desired.

## Test plan

- [x] `cd modules/perc-doctor && ../../mvnw clean install` (all Surefire green)
- [x] `CheckConfigCommandTest` 11, `FixPermissionsCommandTest` 8 (2 POSIX skipped on Windows), `DoctorCliTest` 16
- [x] Behavioral: dry-run never writes; paths under install root; invalid bindPort → CLI exit error

## Gates evidence

| Gate | Result |
|------|--------|
| A Implement + unit tests | yes |
| B Erlang / portable paths | approve |
| C Module `mvnw clean install` | pass |
| D In-scope files only | perc-doctor + erlang report |
| E Commit refs #2233 | yes |
| F Operator labels | operator:grok, operator:night-issue-prs, model:grok-4.5 |
| G Base main, no merge | this PR |

**Operator:** Grok: night-issue-prs (model grok-4.5)

Fixes #2233  
Refs #2213

> Co-Authored by Grok Build using grok-4.5 with agent main.