### PR TITLE
fix(publishing): Oracle schema vs UID for TableFactory origin (#2245)

### DIFF
--- a/docs/ai-generated/code-reviews/2245-oracle-schema-vs-uid-erlang.md
+++ b/docs/ai-generated/code-reviews/2245-oracle-schema-vs-uid-erlang.md
@@ -1,0 +1,42 @@
+# Erlang review: #2245 Oracle schema vs UID in TableFactory/publishing
+
+**Branch:** `fix/issue-2245-oracle-schema-vs-uid`  
+**Date:** 2026-08-07  
+**Reviewer persona:** Erlang (strict independent pre-commit)  
+**Gate:** **approve** — May commit/push: **yes**
+
+## Summary
+
+Minimal fix at the inventory choke point `PSDatabaseDeliveryHandler.getDbmsInfoFromPubServer`: Oracle TableFactory origin now prefers the **connect user** when non-blank, so configs with `schema=ORAPROD` / `userid=SYSTEM` no longer qualify DDL as `ORAPROD.PERC_EXPORT_PAGE` (ORA-01918 when that Oracle user is absent). MSSQL `owner` path unchanged. Pure helper + 10 behavioral unit tests without live Oracle.
+
+## Scope
+
+| Path | Change |
+|------|--------|
+| `system/business/.../PSDatabaseDeliveryHandler.java` | `resolveDbmsOrigin` + wire into `getDbmsInfoFromPubServer` |
+| `system/src/test/.../PSDatabaseDeliveryHandlerOracleOriginTest.java` | New JUnit 5 tests (Oracle ≠ UID, default schema, MSSQL owner, qualifyTableName) |
+
+Cross-platform path review: N/A (no path/file I/O).  
+Prior memory: inventory #2244 / PR #2253 recommended this surface.
+
+## Recommendation
+
+Approve. Residual live Oracle matrix remains #2246 (intentional cross-schema when schema user exists is a documented trade-off of this fix).
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs | None found |
+| Behavioral unit tests for new logic | Present (`resolveDbmsOrigin` + property-bag + qualify) |
+| Non-portable paths | None |
+| Module `mvnw clean install` | `system` BUILD SUCCESS |
+| Change-class companions | Tests only; no Spring bean / REST surface |
+
+## Issues
+
+None (severity bug/suggestion/nit empty).
+
+## Notes for residual #2246
+
+When operators intentionally connect as DBA (`SYSTEM`) and create objects in an existing Oracle schema user (`ORAPROD`), this fix creates objects under the connect user schema instead. Live smoke should confirm whether that matches customer intent or needs a follow-up policy (e.g. optional “force schema origin” flag).

--- a/system/business/src/com/percussion/rx/delivery/impl/PSDatabaseDeliveryHandler.java
+++ b/system/business/src/com/percussion/rx/delivery/impl/PSDatabaseDeliveryHandler.java
@@ -738,9 +738,67 @@ public class PSDatabaseDeliveryHandler extends PSBaseDeliveryHandler
       var dbmsInfo = new DbmsInfo();
       dbmsInfo.m_dbName = dbServer.getDatabase();
       dbmsInfo.m_driverType = dbServer.getDriverType().getDriverName();
-      dbmsInfo.m_origin = dbServer.getOwner();
+      // Oracle: schema property is not always a safe TableFactory origin (see resolveDbmsOrigin).
+      dbmsInfo.m_origin = resolveDbmsOrigin(dbServer);
       dbmsInfo.m_resourceName = datasource;
       return dbmsInfo;
+   }
+
+   /**
+    * Resolves the TableFactory origin ({@code DB_SCHEMA} / object owner) for a
+    * database publish server without requiring a live JDBC connection.
+    *
+    * <p>Driver rules:
+    * <ul>
+    *   <li><b>MSSQL</b> — use {@link PSDatabasePubServer#getOwner()} (the
+    *       {@code owner} property, e.g. {@code dbo}). Connect {@code userid}
+    *       is never used as origin.</li>
+    *   <li><b>Oracle</b> — Oracle treats a qualified schema name as a
+    *       <em>user</em> for object ownership. Configurations with
+    *       {@code schema} ≠ connect {@code userid} (e.g. schema={@code ORAPROD},
+    *       userid={@code SYSTEM}) previously set origin to the schema and
+    *       produced {@code CREATE TABLE ORAPROD.PERC_EXPORT_PAGE}, which raises
+    *       {@code ORA-01918} when that Oracle user does not exist (#953 / #2245).
+    *       For Oracle, TableFactory origin is therefore the <b>connect user</b>
+    *       when it is non-blank; schema remains on {@link PSDatabasePubServer}
+    *       for configuration / datasource registration and is only used as
+    *       origin when the connect user is blank (legacy fallback).</li>
+    *   <li><b>MySQL</b> — owner/schema is typically unused; return owner as-is.</li>
+    * </ul>
+    *
+    * <p>Pure function for unit tests — no JNDI, Spring, or live DB.
+    *
+    * @param dbServer database publish server view, never {@code null}
+    * @return origin/schema for {@link PSJdbcDbmsDef}, may be {@code null} or empty
+    */
+   public static String resolveDbmsOrigin(PSDatabasePubServer dbServer)
+   {
+      notNull(dbServer);
+      var owner = dbServer.getOwner();
+      var userName = dbServer.getUserName();
+      if (dbServer.getDriverType() == PSDatabasePubServer.DriverType.ORACLE)
+      {
+         if (StringUtils.isNotBlank(userName))
+         {
+            if (StringUtils.isNotBlank(owner)
+                  && !owner.trim().equalsIgnoreCase(userName.trim())
+                  && ms_log.isInfoEnabled())
+            {
+               ms_log.info(
+                     "Oracle database publish server schema '{}' differs from connect user '{}'; "
+                           + "using connect user as TableFactory origin to avoid treating schema as "
+                           + "Oracle user (ORA-01918). Intentional cross-schema publish requires the "
+                           + "schema Oracle user to exist; residual validation is tracked separately.",
+                     owner.trim(),
+                     userName.trim());
+            }
+            return userName.trim();
+         }
+         // Connect user missing — fall back to configured schema/owner (may still be empty).
+         return owner;
+      }
+      // MSSQL owner (dbo) / MySQL unused: never substitute connect user for owner.
+      return owner;
    }
    /**
     * Gets the publish server from the supplied item or job.

--- a/system/src/test/java/com/percussion/rx/delivery/impl/PSDatabaseDeliveryHandlerOracleOriginTest.java
+++ b/system/src/test/java/com/percussion/rx/delivery/impl/PSDatabaseDeliveryHandlerOracleOriginTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rx.delivery.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.percussion.services.pubserver.IPSPubServerDao;
+import com.percussion.services.pubserver.data.PSDatabasePubServer;
+import com.percussion.services.pubserver.data.PSDatabasePubServer.DriverType;
+import com.percussion.services.pubserver.data.PSPubServer;
+import com.percussion.util.PSSqlHelper;
+import com.percussion.utils.jdbc.PSJdbcUtils;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for Oracle schema vs connect-UID origin resolution used by
+ * database / page-database publishing (#953 / #2245).
+ *
+ * <p>No live Oracle — pure mapping and SQL qualification assertions only.
+ */
+public class PSDatabaseDeliveryHandlerOracleOriginTest {
+
+  @Test
+  void oracleSchemaDifferingFromUid_usesConnectUserAsOrigin() {
+    var db = new PSDatabasePubServer();
+    db.setDriverType(DriverType.ORACLE);
+    db.setUserName("SYSTEM");
+    db.setOwner("ORAPROD"); // configured schema property value
+
+    assertEquals(
+        "SYSTEM",
+        PSDatabaseDeliveryHandler.resolveDbmsOrigin(db),
+        "Oracle TableFactory origin must be connect UID when schema ≠ UID (ORA-01918)");
+    // Configured schema remains on the pub-server view for display / datasource config.
+    assertEquals("ORAPROD", db.getOwner());
+    assertEquals("SYSTEM", db.getUserName());
+  }
+
+  @Test
+  void oracleSchemaMatchingUid_usesConnectUserAsOrigin() {
+    var db = new PSDatabasePubServer();
+    db.setDriverType(DriverType.ORACLE);
+    db.setUserName("ORAPROD");
+    db.setOwner("ORAPROD");
+
+    assertEquals("ORAPROD", PSDatabaseDeliveryHandler.resolveDbmsOrigin(db));
+  }
+
+  @Test
+  void oracleEmptyUser_fallsBackToSchemaOwner() {
+    var db = new PSDatabasePubServer();
+    db.setDriverType(DriverType.ORACLE);
+    db.setUserName("");
+    db.setOwner("ORAPROD");
+
+    assertEquals("ORAPROD", PSDatabaseDeliveryHandler.resolveDbmsOrigin(db));
+  }
+
+  @Test
+  void oracleNullUser_fallsBackToSchemaOwner() {
+    var db = new PSDatabasePubServer();
+    db.setDriverType(DriverType.ORACLE);
+    db.setUserName(null);
+    db.setOwner("ORAPROD");
+
+    assertEquals("ORAPROD", PSDatabaseDeliveryHandler.resolveDbmsOrigin(db));
+  }
+
+  @Test
+  void oracleFromPubServerProperties_schemaDefaultsToUserWhenMissing() {
+    var pub = new PSPubServer();
+    pub.addProperty(IPSPubServerDao.PUBLISH_DRIVER_PROPERTY, "ORACLE");
+    pub.addProperty(IPSPubServerDao.PUBLISH_USER_ID_PROPERTY, "SYSTEM");
+    pub.addProperty(IPSPubServerDao.PUBLISH_PASSWORD_PROPERTY, "secret");
+    pub.addProperty(IPSPubServerDao.PUBLISH_SID_PROPERTY, "ORCL");
+    pub.addProperty(IPSPubServerDao.PUBLISH_DATABASE_SERVER_NAME, "dbhost");
+    pub.addProperty(IPSPubServerDao.PUBLISH_PORT_PROPERTY, "1521");
+    // no schema property → PSDatabasePubServer defaults owner to userName
+
+    var db = new PSDatabasePubServer(pub);
+    assertEquals("SYSTEM", db.getUserName());
+    assertEquals("SYSTEM", db.getOwner());
+    assertEquals("SYSTEM", PSDatabaseDeliveryHandler.resolveDbmsOrigin(db));
+  }
+
+  @Test
+  void oracleFromPubServerProperties_schemaOraprodUidSystem_originIsSystem() {
+    var pub = new PSPubServer();
+    pub.addProperty(IPSPubServerDao.PUBLISH_DRIVER_PROPERTY, "ORACLE");
+    pub.addProperty(IPSPubServerDao.PUBLISH_USER_ID_PROPERTY, "SYSTEM");
+    pub.addProperty(IPSPubServerDao.PUBLISH_PASSWORD_PROPERTY, "secret");
+    pub.addProperty(IPSPubServerDao.PUBLISH_SCHEMA_PROPERTY, "ORAPROD");
+    pub.addProperty(IPSPubServerDao.PUBLISH_SID_PROPERTY, "ORCL");
+    pub.addProperty(IPSPubServerDao.PUBLISH_DATABASE_SERVER_NAME, "PERCHCLDOMINO");
+    pub.addProperty(IPSPubServerDao.PUBLISH_PORT_PROPERTY, "1521");
+
+    var db = new PSDatabasePubServer(pub);
+    assertEquals("SYSTEM", db.getUserName());
+    assertEquals("ORAPROD", db.getOwner(), "schema property still stored on owner field");
+    assertEquals(
+        "SYSTEM",
+        PSDatabaseDeliveryHandler.resolveDbmsOrigin(db),
+        "TableFactory origin must not treat schema ORAPROD as Oracle user");
+  }
+
+  @Test
+  void mssqlOwnerPreserved_connectUserNotUsedAsOrigin() {
+    var db = new PSDatabasePubServer();
+    db.setDriverType(DriverType.MSSQL);
+    db.setUserName("sa");
+    db.setOwner("dbo");
+
+    assertEquals(
+        "dbo",
+        PSDatabaseDeliveryHandler.resolveDbmsOrigin(db),
+        "MSSQL owner semantics must be preserved");
+  }
+
+  @Test
+  void mssqlFromPubServerProperties_ownerAndUserSeparate() {
+    var pub = new PSPubServer();
+    pub.addProperty(IPSPubServerDao.PUBLISH_DRIVER_PROPERTY, "MSSQL");
+    pub.addProperty(IPSPubServerDao.PUBLISH_USER_ID_PROPERTY, "sa");
+    pub.addProperty(IPSPubServerDao.PUBLISH_PASSWORD_PROPERTY, "secret");
+    pub.addProperty(IPSPubServerDao.PUBLISH_OWNER_PROPERTY, "dbo");
+    pub.addProperty(IPSPubServerDao.PUBLISH_DATABASE_NAME_PROPERTY, "cmlite_db");
+    pub.addProperty(IPSPubServerDao.PUBLISH_DATABASE_SERVER_NAME, "sqlhost");
+    pub.addProperty(IPSPubServerDao.PUBLISH_PORT_PROPERTY, "1433");
+
+    var db = new PSDatabasePubServer(pub);
+    assertEquals("sa", db.getUserName());
+    assertEquals("dbo", db.getOwner());
+    assertEquals("dbo", PSDatabaseDeliveryHandler.resolveDbmsOrigin(db));
+  }
+
+  @Test
+  void mysqlOriginIsOwnerUnchanged() {
+    var db = new PSDatabasePubServer();
+    db.setDriverType(DriverType.MYSQL);
+    db.setUserName("root");
+    db.setOwner(null);
+
+    assertNull(PSDatabaseDeliveryHandler.resolveDbmsOrigin(db));
+  }
+
+  @Test
+  void oracleQualifiedTableUsesResolvedOriginNotSchema() {
+    var db = new PSDatabasePubServer();
+    db.setDriverType(DriverType.ORACLE);
+    db.setUserName("SYSTEM");
+    db.setOwner("ORAPROD");
+
+    String origin = PSDatabaseDeliveryHandler.resolveDbmsOrigin(db);
+    String qualified =
+        PSSqlHelper.qualifyTableName(
+            "PERC_EXPORT_PAGE", null, origin, PSJdbcUtils.ORACLE_DRIVER);
+
+    assertEquals("SYSTEM.PERC_EXPORT_PAGE", qualified);
+    // Unfixed path would have been ORAPROD.PERC_EXPORT_PAGE → ORA-01918 if user missing.
+    assertEquals(
+        "ORAPROD.PERC_EXPORT_PAGE",
+        PSSqlHelper.qualifyTableName(
+            "PERC_EXPORT_PAGE", null, "ORAPROD", PSJdbcUtils.ORACLE_DRIVER));
+  }
+}


### PR DESCRIPTION
## Summary

Slice **2 of 3** for parent epic **#953** (pre-built / page-database publishing fails with `ORA-01918: user 'ORAPROD' does not exist` when schema is ORAPROD and connect user is SYSTEM).

**Root cause (from #2244 inventory):** `PSDatabaseDeliveryHandler.getDbmsInfoFromPubServer` set `DbmsInfo.m_origin = getOwner()` (Oracle `schema` property). TableFactory then qualifies DDL as `ORAPROD.PERC_EXPORT_PAGE`. Oracle treats that schema component as a user; if it does not exist → ORA-01918.

**Fix:** Pure helper `resolveDbmsOrigin(PSDatabasePubServer)`:
- **Oracle:** TableFactory origin = connect **userid** when non-blank (schema stays on `PSDatabasePubServer` for config/display/datasource registration).
- **MSSQL:** origin remains **owner** (e.g. `dbo`) — connect user is never substituted.
- **MySQL:** owner unchanged (typically unused).

Wired into `getDbmsInfoFromPubServer` so both pre-edition `PSUpdateTablesEditionTask` and item delivery use the same mapping.

### Trade-off / residual
Intentional DBA-style cross-schema publish (connect as SYSTEM, objects in existing ORAPROD user) now creates objects under the connect user schema. Live matrix validation: **#2246**.

### Siblings
| Slice | Issue | Role |
|-------|-------|------|
| 1 Inventory | #2244 | PR #2253 |
| 2 Unit-testable fix | #2245 | **This PR** |
| 3 Live Oracle smoke | #2246 | Residual |

Parent tracker: **#953**

## Test plan
- [x] `PSDatabaseDeliveryHandlerOracleOriginTest` (10 tests): schema=ORAPROD/uid=SYSTEM → origin SYSTEM; empty schema default; MSSQL owner=dbo; `qualifyTableName` → `SYSTEM.PERC_EXPORT_PAGE`
- [x] `cd system && mvnw clean install` — BUILD SUCCESS
- [ ] Live Oracle (#2246)

## Gates evidence
- **Change class:** publishing dbms origin mapping (pure helper + unit tests)
- **Erlang:** approve — `docs/ai-generated/code-reviews/2245-oracle-schema-vs-uid-erlang.md`
- **Maven:** `system` standalone `mvnw clean install` green
- **Operator:** Grok: night-issue-prs (model grok-4.5)

Fixes #2245  
Refs #953  
Related #2244 #2246

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.