### PR TITLE
feat(sys_tinymce): InlineLinkTitleField control setting (#2241)

### DIFF
--- a/docs/ai-generated/code-reviews/2241-inline-link-title-field-setting-erlang.md
+++ b/docs/ai-generated/code-reviews/2241-inline-link-title-field-setting-erlang.md
@@ -1,0 +1,56 @@
+# Erlang review — #2241 Control setting: inline link title field name
+
+**Date:** 2026-08-07  
+**Branch:** `fix/issue-2241-inline-link-title-field-setting`  
+**Parent:** #946  
+**Reviewer persona:** Erlang (pre-commit gate)
+
+## Summary
+
+Adds `InlineLinkTitleField` control parameter to `sys_tinymce` (ControlMeta + CE XSL init), registers TinyMCE option `inlineLinkTitleField` (empty default = product field defaults), and unit tests for control-meta parse + `PSControlRef` XML round-trip of the param.
+
+## Scope
+
+| Path | Change |
+|------|--------|
+| `system/cms/.../sys_Templates.xsl` | ControlMeta param + XSL variable + `perc_tinymce_init` wire |
+| `modules/perc-tinymce/.../rxinline/plugin.js` | `editor.options.register("inlineLinkTitleField")` |
+| `modules/perc-tinymce/.../percadvlink/plugin.js` | same registration (CMS insert plugin) |
+| `modules/perc-tinymce/.../percadvimage/plugin.js` | same registration |
+| `system/src/test/.../controlmeta.xml` | fixture peer param |
+| `system/src/test/.../PSInlineLinkTitleFieldControlParamTest.java` | meta + persist round-trip |
+
+**Out of scope (by design, residual slices):** runtime title resolve (#2242), Playwright (#2243).
+
+**Memory patterns:** none hit (no path I/O, no Spring beans, no new REST surface).
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+## Cross-platform path review
+
+N/A — no new file I/O, path joins, or path assertions. XSL/JS only use existing relative web paths.
+
+## Issues
+
+None (bug/suggestion/nit empty).
+
+### Notes (non-blocking)
+
+- Duplicate `options.register` for `inlineLinkTitleField` in three plugins is intentional peer style so TinyMCE 6 does not strip the option depending on which plugins load; #2242 can `editor.options.get("inlineLinkTitleField")` from percadvlink/image without extra wiring.
+- Empty string default (not `displaytitle` string) matches product acceptance: empty/absent → displaytitle/resource_link_title at resolve time (#2242).
+
+## Gates evidence
+
+- `modules/perc-tinymce`: `mvnw clean install` — BUILD SUCCESS  
+- `system`: `mvnw clean install -DskipITs` — BUILD SUCCESS (1144 tests, 0 failures; includes `PSInlineLinkTitleFieldControlParamTest` 4/4)  
+- Focused: `-Dtest=PSInlineLinkTitleFieldControlParamTest` — 4 tests green  
+
+---
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/modules/perc-tinymce/src/main/resources/META-INF/resources/sys_resources/tinymce/plugins/percadvimage/plugin.js
+++ b/modules/perc-tinymce/src/main/resources/META-INF/resources/sys_resources/tinymce/plugins/percadvimage/plugin.js
@@ -1,6 +1,14 @@
 /*global tinymce:true */
 
 tinymce.PluginManager.add("percadvimage", function (editor, url) {
+  // Register so CE/control-settings value from perc_tinymce_init is retained
+  // (TinyMCE 6 strips unknown options). Empty = product default field names.
+  // Runtime pass-through to getInlineRenderLink is #2242.
+  editor.options.register("inlineLinkTitleField", {
+    processor: "string",
+    default: "",
+  });
+
   var formData = {};
 
   function showDialog(buttonAPI) {

--- a/modules/perc-tinymce/src/main/resources/META-INF/resources/sys_resources/tinymce/plugins/percadvlink/plugin.js
+++ b/modules/perc-tinymce/src/main/resources/META-INF/resources/sys_resources/tinymce/plugins/percadvlink/plugin.js
@@ -16,6 +16,14 @@
  */
 
 tinymce.PluginManager.add("percadvlink", function (editor) {
+  // Register so CE/control-settings value from perc_tinymce_init is retained
+  // (TinyMCE 6 strips unknown options). Empty = product default field names.
+  // Runtime pass-through to getInlineRenderLink is #2242.
+  editor.options.register("inlineLinkTitleField", {
+    processor: "string",
+    default: "",
+  });
+
   function createLinkList(callback) {
     return function () {
       // editor.options.get() replaces the deprecated editor.settings in TinyMCE 6+.

--- a/modules/perc-tinymce/src/main/resources/META-INF/resources/sys_resources/tinymce/plugins/rxinline/plugin.js
+++ b/modules/perc-tinymce/src/main/resources/META-INF/resources/sys_resources/tinymce/plugins/rxinline/plugin.js
@@ -13,6 +13,12 @@ tinymce.PluginManager.add("rxinline", function (editor) {
     processor: "string",
     default: "104",
   });
+  // Content field name for inline link/image title attrs; empty = product default
+  // (displaytitle / resource_link_title). Consumed by insert/resolve paths (#2242).
+  editor.options.register("inlineLinkTitleField", {
+    processor: "string",
+    default: "",
+  });
 
   // Use editor.options.get() instead of the deprecated editor.getParam().
   var tinyMCEinlineLinkSlot = (
@@ -24,6 +30,8 @@ tinymce.PluginManager.add("rxinline", function (editor) {
   var tinyMCEinlineImageSlot = (
     editor.options.get("inlineImageSlot") || "104"
   ).trim();
+  // inlineLinkTitleField is registered above for CE/init and for #2242
+  // insert/resolve paths (editor.options.get("inlineLinkTitleField")).
 
   var ctypeid;
   if (typeof document.forms.EditForm !== "undefined") {

--- a/system/cms/content/applications/sys_resources/ApplicationFiles/stylesheets/sys_Templates.xsl
+++ b/system/cms/content/applications/sys_resources/ApplicationFiles/stylesheets/sys_Templates.xsl
@@ -3855,6 +3855,10 @@ onchange    %Script;       #IMPLIED
             <psxctl:Description>This parameter specifies the id of inline variant slot. The inline search dialog box shows the content types that have at least one variant added to the inline variant slot. The default value is system inline variant slotid 105.</psxctl:Description>
             <psxctl:DefaultValue>105</psxctl:DefaultValue>
          </psxctl:Param>
+         <psxctl:Param name="InlineLinkTitleField" datatype="String" paramtype="generic">
+            <psxctl:Description>This parameter specifies the content field name used for the title attribute of inline links and images inserted from this rich-text control (for example, pagetitle or page_title). When empty or absent, the product default is used (displaytitle for assets; resource_link_title / page link title for pages).</psxctl:Description>
+            <psxctl:DefaultValue></psxctl:DefaultValue>
+         </psxctl:Param>
          <psxctl:Param name="dlg_width" datatype="Number" paramtype="generic">
             <psxctl:Description>This parameter specifies the width of the dialog box that is opened during field editing in Active Assembly.</psxctl:Description>
             <psxctl:DefaultValue>90%</psxctl:DefaultValue>
@@ -4047,6 +4051,16 @@ onchange    %Script;       #IMPLIED
             </xsl:otherwise>
          </xsl:choose>
       </xsl:variable>
+      <xsl:variable name="InlineLinkTitleField">
+         <xsl:choose>
+            <xsl:when test="ParamList/Param[@name='InlineLinkTitleField']">
+               <xsl:value-of select="ParamList/Param[@name='InlineLinkTitleField']"/>
+            </xsl:when>
+            <xsl:otherwise>
+               <xsl:value-of select="document('')/*/psxctl:ControlMeta[@name='sys_tinymce']/psxctl:ParamList/psxctl:Param[@name='InlineLinkTitleField']/psxctl:DefaultValue"/>
+            </xsl:otherwise>
+         </xsl:choose>
+      </xsl:variable>
       <xsl:variable name="validItemLocale">
          <xsl:choose>
             <xsl:when test="not($itemLocale = '')">
@@ -4109,6 +4123,7 @@ onchange    %Script;       #IMPLIED
        inlineLinkSlot : "]]><xsl:value-of select="$InlineLinkSlot"/><![CDATA[",
        inlineImageSlot : "]]><xsl:value-of select="$InlineImageSlot"/><![CDATA[",
        inlineVariantSlot : "]]><xsl:value-of select="$InlineVariantSlot"/><![CDATA[",
+       inlineLinkTitleField : "]]><xsl:value-of select="$InlineLinkTitleField"/><![CDATA[",
        editor_selector : "tinymce_]]><xsl:value-of select="$uniqueName"/><![CDATA[",
        perc_locale  : "]]><xsl:value-of select="$validItemLocale"/><![CDATA[",
        community  : "]]><xsl:value-of select="$communityName"/><![CDATA[",

--- a/system/src/test/java/com/percussion/design/objectstore/PSInlineLinkTitleFieldControlParamTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSInlineLinkTitleFieldControlParamTest.java
@@ -17,6 +17,7 @@
 package com.percussion.design.objectstore;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -129,7 +130,7 @@ public class PSInlineLinkTitleFieldControlParamTest {
         foundTitleField = true;
       }
     }
-    assertTrue(!foundTitleField, "absent InlineLinkTitleField must not be invented on round-trip");
+    assertFalse(foundTitleField, "absent InlineLinkTitleField must not be invented on round-trip");
   }
 
   @Test

--- a/system/src/test/java/com/percussion/design/objectstore/PSInlineLinkTitleFieldControlParamTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSInlineLinkTitleFieldControlParamTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.design.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.util.PSCollection;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Minimal persist/meta coverage for the {@code InlineLinkTitleField} sys_tinymce control parameter
+ * (issue #2241 / parent #946). Empty/absent remains backward compatible with product defaults
+ * ({@code displaytitle} for assets; page link title for pages — resolved in #2242).
+ */
+@Tag("UnitTest")
+public class PSInlineLinkTitleFieldControlParamTest {
+
+  /** Control-settings param name (PascalCase peers: InlineLinkSlot). */
+  public static final String PARAM_NAME = "InlineLinkTitleField";
+
+  /** Control that hosts the setting. */
+  public static final String CONTROL_NAME = "sys_tinymce";
+
+  @Test
+  public void controlMeta_parsesEmptyDefaultForInlineLinkTitleField() throws Exception {
+    String xml =
+        """
+        <controls xmlns:psxctl="urn:percussion.com/control">
+          <psxctl:ControlMeta name="sys_tinymce" dimension="single" choiceset="none">
+            <psxctl:Description>TinyMCE</psxctl:Description>
+            <psxctl:ParamList>
+              <psxctl:Param name="InlineLinkTitleField" datatype="String" paramtype="generic">
+                <psxctl:Description>inline link title field name</psxctl:Description>
+                <psxctl:DefaultValue></psxctl:DefaultValue>
+              </psxctl:Param>
+            </psxctl:ParamList>
+          </psxctl:ControlMeta>
+        </controls>
+        """;
+    Document doc =
+        PSXmlDocumentBuilder.createXmlDocument(
+            new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)), false);
+    Element metaEl =
+        (Element) doc.getElementsByTagName(PSControlMeta.XML_NODE_NAME).item(0);
+    PSControlMeta meta = new PSControlMeta(metaEl);
+
+    assertEquals(CONTROL_NAME, meta.getName());
+    @SuppressWarnings("unchecked")
+    List<PSControlParameter> params = meta.getParams();
+    assertNotNull(params);
+    assertEquals(1, params.size());
+
+    PSControlParameter param = params.get(0);
+    assertEquals(PARAM_NAME, param.getName());
+    assertEquals("String", param.getDataType());
+    assertEquals("generic", param.getParamType());
+    // Empty default = use product displaytitle / resource_link_title defaults at resolve time
+    assertEquals("", param.getDefaultValue());
+  }
+
+  @Test
+  public void controlRef_roundTripsConfiguredTitleFieldParam() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSCollection parameters = new PSCollection(PSParam.class);
+    parameters.add(new PSParam(PARAM_NAME, new PSTextLiteral("pagetitle")));
+    parameters.add(new PSParam("InlineLinkSlot", new PSTextLiteral("103")));
+
+    PSControlRef original = new PSControlRef(CONTROL_NAME, parameters);
+    Element elem = original.toXml(doc);
+
+    PSControlRef restored = new PSControlRef(elem, null, null);
+    assertEquals(original, restored);
+    assertEquals(CONTROL_NAME, restored.getName());
+
+    String titleField = null;
+    String linkSlot = null;
+    Iterator<?> it = restored.getParameters();
+    while (it.hasNext()) {
+      PSParam p = (PSParam) it.next();
+      if (PARAM_NAME.equals(p.getName())) {
+        titleField = p.getValue().getValueText();
+      } else if ("InlineLinkSlot".equals(p.getName())) {
+        linkSlot = p.getValue().getValueText();
+      }
+    }
+    assertEquals("pagetitle", titleField);
+    assertEquals("103", linkSlot);
+  }
+
+  @Test
+  public void controlRef_roundTripsAbsentTitleFieldAsNoParam() throws Exception {
+    // Content types that never set the param stay empty — no new required param on the control.
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSCollection parameters = new PSCollection(PSParam.class);
+    parameters.add(new PSParam("height", new PSTextLiteral("350")));
+
+    PSControlRef original = new PSControlRef(CONTROL_NAME, parameters);
+    PSControlRef restored = new PSControlRef(original.toXml(doc), null, null);
+
+    boolean foundTitleField = false;
+    Iterator<?> it = restored.getParameters();
+    while (it.hasNext()) {
+      PSParam p = (PSParam) it.next();
+      if (PARAM_NAME.equals(p.getName())) {
+        foundTitleField = true;
+      }
+    }
+    assertTrue(!foundTitleField, "absent InlineLinkTitleField must not be invented on round-trip");
+  }
+
+  @Test
+  public void controlRef_roundTripsExplicitEmptyTitleField() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    PSCollection parameters = new PSCollection(PSParam.class);
+    parameters.add(new PSParam(PARAM_NAME, new PSTextLiteral("")));
+
+    PSControlRef original = new PSControlRef(CONTROL_NAME, parameters);
+    PSControlRef restored = new PSControlRef(original.toXml(doc), null, null);
+    assertEquals(original, restored);
+
+    Iterator<?> it = restored.getParameters();
+    assertTrue(it.hasNext());
+    PSParam p = (PSParam) it.next();
+    assertEquals(PARAM_NAME, p.getName());
+    assertEquals("", p.getValue().getValueText());
+  }
+}

--- a/system/src/test/resources/com/percussion/design/objectstore/controlmeta.xml
+++ b/system/src/test/resources/com/percussion/design/objectstore/controlmeta.xml
@@ -379,6 +379,11 @@
 				<psxctl:Description>tinymce config file</psxctl:Description>
 				<psxctl:DefaultValue>../sys_resources/tinymce/config/default_config.json</psxctl:DefaultValue>
 			</psxctl:Param>
+			<psxctl:Param name="InlineLinkTitleField" datatype="String"
+				paramtype="generic">
+				<psxctl:Description>Content field name used for inline link titles. Empty uses product default (displaytitle / resource_link_title).</psxctl:Description>
+				<psxctl:DefaultValue></psxctl:DefaultValue>
+			</psxctl:Param>
 		</psxctl:ParamList>
 		<psxctl:Dependencies>
 			<psxctl:Dependency status="setupOptional"


### PR DESCRIPTION
## Summary

Parent tracker: #946 (Configure custom title field for inline links).  
This PR is **slice 2 of 4** (#2241): control-settings text field for the content field name used as inline link/image `title`, with persist via existing control-parameter machinery.

### What changed
- **`sys_tinymce` ControlMeta** (`sys_Templates.xsl`): new param `InlineLinkTitleField` (String, empty default).
- **CE init wire**: XSL reads field control `ParamList` and passes `inlineLinkTitleField` into `perc_tinymce_init({...})` next to slot peers.
- **TinyMCE option registration** on `rxinline`, `percadvlink`, and `percadvimage` so TinyMCE 6 retains the option for #2242 (`editor.options.get("inlineLinkTitleField")`).
- **Tests**: `PSInlineLinkTitleFieldControlParamTest` — ControlMeta empty default, configured `PSControlRef` round-trip, absent param not invented, explicit empty string round-trip.
- Fixture `controlmeta.xml` updated for peer visibility.

### Backward compatibility
Empty or absent `InlineLinkTitleField` leaves product defaults (assets: `displaytitle`; pages: `resource_link_title` / page link title). Runtime resolve of the configured name is **#2242**.

### Out of scope
- Insert/runtime title resolution (#2242)
- Full Vitest/Playwright (#2243)

## Test plan
- [x] `modules/perc-tinymce`: `mvnw clean install` — BUILD SUCCESS
- [x] `system`: `mvnw clean install -DskipITs` — BUILD SUCCESS (1144 tests, 0 failures)
- [x] Focused: `-Dtest=PSInlineLinkTitleFieldControlParamTest` — 4/4 green
- [x] Erlang pre-commit review: approve (`docs/ai-generated/code-reviews/2241-inline-link-title-field-setting-erlang.md`)
- [ ] Manual (optional, residual E2E #2243): set control param on a body field, save/reload content type, confirm value persists and editor init includes option

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2241  
Refs #946

> Co-Authored by Grok Build using grok-4.5 with agent main.