### PR TITLE
feat(system): pipeline IR v1 + classic import + load/save (#2247)

### DIFF
--- a/docs/developer-module/README.md
+++ b/docs/developer-module/README.md
@@ -13,6 +13,8 @@ Tool-agnostic reverse engineering of the Rhythmyx 7.3.2 **Workbench** (Eclipse D
 | [workbench-functional-inventory.md](./workbench-functional-inventory.md)     | Primary inventory + functional requirements: IA, object catalog, module FR, cross-cutting platform needs, prioritization, appendices                                                           |
 | [data-pipeline-engine-inventory.md](./data-pipeline-engine-inventory.md)     | **XML Application / E2Designer data pipeline engine** — full stage inventory (tanks, mapper, selector, updater, txn, hooks, value system) + modernization brief (JSON, datasources, hooks, IR) |
 | [data-pipeline-server-runtime-map.md](./data-pipeline-server-runtime-map.md) | **Server runtime map** in this repo — `PSApplicationHandler` → `PSQueryHandler` / `PSUpdateHandler` (+ reuse vs reimplement notes for Slice A)                                                 |
+| [pipeline-ir-v1.md](./pipeline-ir-v1.md) | **Pipeline IR v1.0** schema — versioned app→resource→stages JSON; classic import + native load/save (Slice A part 1 / #2247) |
+
 
 ## Source system (sibling: `rx732patchdev`)
 

--- a/docs/developer-module/pipeline-ir-v1.md
+++ b/docs/developer-module/pipeline-ir-v1.md
@@ -1,0 +1,139 @@
+# Pipeline IR v1.0
+
+| Field | Value |
+|-------|-------|
+| **IR version** | `1.0` (`PipelineIrDocument.CURRENT_IR_VERSION`) |
+| **Issue** | [#2247](https://github.com/intersoftdatalabs-in/percussioncms/issues/2247) (parent [#1690](https://github.com/intersoftdatalabs-in/percussioncms/issues/1690)) |
+| **Code** | `com.percussion.services.pipeline` (`system/services`) |
+| **Companions** | [data-pipeline-engine-inventory.md](./data-pipeline-engine-inventory.md) §16 Slice A; [data-pipeline-server-runtime-map.md](./data-pipeline-server-runtime-map.md) |
+
+## Purpose
+
+Versioned, JSON-friendly **intermediate representation** for classic XML Applications / data pipelines:
+
+```
+application (meta)
+  └── resources[]  (classic PSDataSet)
+        └── stages (pageTank | backendTank | mapper | selector | pager | updater)
+```
+
+Slice A part 1 delivers **IR model + load/save + classic import**. Execution, SQL runtime, JSON request I/O, hooks, and the graph editor are later slices.
+
+## Document shape (normative sketch)
+
+```json
+{
+  "irVersion": "1.0",
+  "source": "CLASSIC_IMPORT | NATIVE",
+  "app": {
+    "id": 390,
+    "name": "sys_adminCataloger",
+    "description": "",
+    "requestRoot": "sys_adminCataloger",
+    "enabled": true,
+    "hidden": false,
+    "appType": null,
+    "version": "2.0"
+  },
+  "resources": [
+    {
+      "name": "Dataset34",
+      "description": "",
+      "kind": "QUERY | UPDATE | CONTENT_EDITOR | UNKNOWN",
+      "requestPage": "sys_rxlookup",
+      "transactionMode": "none | row | all",
+      "pipeName": "QueryPipe",
+      "stages": {
+        "pageTank": {
+          "present": true,
+          "schemaSource": "file:Properties.dtd",
+          "actionTypeXmlField": null
+        },
+        "backendTank": {
+          "present": true,
+          "tables": [
+            { "alias": "PSX_ADMINLOOKUP", "table": "PSX_ADMINLOOKUP", "datasource": "" }
+          ],
+          "joinCount": 0
+        },
+        "mapper": {
+          "present": true,
+          "allowEmptyDocReturn": false,
+          "mappings": [
+            {
+              "documentField": "Properties/@Type",
+              "backend": "PSX_ADMINLOOKUP.TYPE",
+              "backendKind": "COLUMN | EXTENSION | OTHER"
+            }
+          ]
+        },
+        "selector": {
+          "present": true,
+          "unique": false,
+          "method": "whereClause | nativeStatement | unknown",
+          "whereClauseCount": 1,
+          "sortedColumnCount": 0,
+          "nativeStatement": null
+        },
+        "pager": { "present": false, "maxRowsPerPage": 0, "maxPages": 0, "maxPageLinks": 0 },
+        "updater": {
+          "present": false,
+          "allowInsert": false,
+          "allowUpdate": false,
+          "allowDelete": false,
+          "updateColumnCount": 0
+        }
+      }
+    }
+  ]
+}
+```
+
+## Storage
+
+| Mode | Location | Notes |
+|------|----------|-------|
+| Classic objectstore XML | Existing `PSServerXmlObjectStore` / application directories | Source for **import** only in this slice |
+| Native IR JSON | `<rxRoot>/ObjectStore/pipeline-ir/<appName>.pipeline.json` | File store via `PSPipelineIrFileStore`; injectable base dir for tests |
+
+App names are single path components only (no `/`, `\`, `..`) to prevent path injection — same rule as the Pipelines catalog adaptor.
+
+## Import subset (v1)
+
+From classic `PSApplication` / `PSDataSet` / pipes:
+
+| Classic | IR |
+|---------|-----|
+| App name/id/enabled/hidden/requestRoot/version | `app.*` |
+| `PSQueryPipe` | resource `kind=QUERY` + selector |
+| `PSUpdatePipe` | resource `kind=UPDATE` + updater |
+| `PSContentEditor` | resource `kind=CONTENT_EDITOR` (no deep CE pipe expand) |
+| `PSPageDataTank` | `stages.pageTank` |
+| `PSBackEndDataTank` | `stages.backendTank` (tables + join count) |
+| `PSDataMapper` | `stages.mapper` (field inventory) |
+| `PSDataSelector` | `stages.selector` (method + clause counts) |
+| `PSResultPager` | `stages.pager` |
+| `PSDataSynchronizer` | `stages.updater` |
+
+Not imported in v1 (deferred): full where-clause trees, join graphs, exits/hooks, result pages/XSL, ACLs, CE field maps.
+
+## Service API
+
+`IPSPipelineIrService` / `PSPipelineIrService` / `PSPipelineIrServiceLocator`:
+
+- `importClassicXml` / `importClassicApplication`
+- `toJson` / `fromJson`
+- `save` / `load` / `exists`
+
+No REST surface in this slice (catalog list remains `GET /services/pipelines`).
+
+## Tests
+
+- IR JSON round-trip + file load/save
+- Golden classic fixture `sys_adminCataloger` → IR stage inventory (backend tank, mapper, selector, page tank)
+
+## Evolution
+
+- **1.x** additive fields preferred; bump `irVersion` only for breaking shape changes.
+- Slice A2 (#2248): SQL execute + JSON I/O + hooks consume this IR.
+- Slice B: designer writes native IR (`source=NATIVE`).

--- a/system/services/src/com/percussion/services/pipeline/IPSPipelineIrService.java
+++ b/system/services/src/com/percussion/services/pipeline/IPSPipelineIrService.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline;
+
+import com.percussion.design.objectstore.PSApplication;
+import com.percussion.services.pipeline.model.PipelineIrDocument;
+import java.io.InputStream;
+import java.util.Optional;
+
+/**
+ * Pipeline intermediate representation (IR) service: classic import, JSON codec, native load/save.
+ *
+ * <p>Slice A foundation only — no execute / SQL runtime / hooks.
+ */
+public interface IPSPipelineIrService {
+
+  /**
+   * Import classic application XML stream into IR.
+   *
+   * @param classicXml not closed by the service
+   */
+  PipelineIrDocument importClassicXml(InputStream classicXml) throws PSPipelineIrException;
+
+  /** Import an already-materialized objectstore application into IR. */
+  PipelineIrDocument importClassicApplication(PSApplication application)
+      throws PSPipelineIrException;
+
+  /** Encode IR as JSON text. */
+  String toJson(PipelineIrDocument document) throws PSPipelineIrException;
+
+  /** Decode IR from JSON text. */
+  PipelineIrDocument fromJson(String json) throws PSPipelineIrException;
+
+  /**
+   * Persist native IR by {@code document.app.name}.
+   *
+   * <p>Storage is the file-backed store configured for this service instance (design-time IR
+   * documents, separate from classic objectstore XML apps).
+   */
+  void save(PipelineIrDocument document) throws PSPipelineIrException;
+
+  /**
+   * Load native IR by application name.
+   *
+   * @return empty when not found
+   */
+  Optional<PipelineIrDocument> load(String appName) throws PSPipelineIrException;
+
+  /** @return true when native IR exists for the name */
+  boolean exists(String appName) throws PSPipelineIrException;
+}

--- a/system/services/src/com/percussion/services/pipeline/PSClassicPipelineImporter.java
+++ b/system/services/src/com/percussion/services/pipeline/PSClassicPipelineImporter.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline;
+
+import com.percussion.design.objectstore.PSApplication;
+import com.percussion.design.objectstore.PSBackEndColumn;
+import com.percussion.design.objectstore.PSBackEndDataTank;
+import com.percussion.design.objectstore.PSBackEndTable;
+import com.percussion.design.objectstore.PSContentEditor;
+import com.percussion.design.objectstore.PSDataMapper;
+import com.percussion.design.objectstore.PSDataMapping;
+import com.percussion.design.objectstore.PSDataSelector;
+import com.percussion.design.objectstore.PSDataSet;
+import com.percussion.design.objectstore.PSDataSynchronizer;
+import com.percussion.design.objectstore.PSExtensionCall;
+import com.percussion.design.objectstore.PSPageDataTank;
+import com.percussion.design.objectstore.PSPipe;
+import com.percussion.design.objectstore.PSQueryPipe;
+import com.percussion.design.objectstore.PSRequestor;
+import com.percussion.design.objectstore.PSResultPager;
+import com.percussion.design.objectstore.PSUpdatePipe;
+import com.percussion.design.objectstore.PSUnknownDocTypeException;
+import com.percussion.design.objectstore.PSUnknownNodeTypeException;
+import com.percussion.services.pipeline.model.BackendTableRefIr;
+import com.percussion.services.pipeline.model.BackendTankStageIr;
+import com.percussion.services.pipeline.model.MapperStageIr;
+import com.percussion.services.pipeline.model.MappingEntryIr;
+import com.percussion.services.pipeline.model.PageTankStageIr;
+import com.percussion.services.pipeline.model.PagerStageIr;
+import com.percussion.services.pipeline.model.PipelineAppMeta;
+import com.percussion.services.pipeline.model.PipelineIrDocument;
+import com.percussion.services.pipeline.model.PipelineResourceIr;
+import com.percussion.services.pipeline.model.PipelineStagesIr;
+import com.percussion.services.pipeline.model.SelectorStageIr;
+import com.percussion.services.pipeline.model.UpdaterStageIr;
+import com.percussion.util.PSCollection;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+/**
+ * Imports a classic XML Application ({@link PSApplication} / objectstore) into pipeline IR.
+ *
+ * <p>Subset only: app meta + datasets with query/update pipe stage inventory (tanks, mapper,
+ * selector, pager, updater flags). Content Editor pipes are labeled but not deeply expanded (Slice
+ * A scope).
+ */
+public final class PSClassicPipelineImporter {
+
+  private PSClassicPipelineImporter() {}
+
+  /**
+   * Parse classic application XML and convert to IR.
+   *
+   * @param xml classic {@code PSXApplication} document stream (not closed by this method)
+   * @return IR document, never {@code null}
+   */
+  public static PipelineIrDocument importFromXml(InputStream xml) throws PSPipelineIrException {
+    Objects.requireNonNull(xml, "xml");
+    try {
+      Document doc = PSXmlDocumentBuilder.createXmlDocument(xml, false);
+      PSApplication app = new PSApplication(doc);
+      return importFromApplication(app);
+    } catch (PSUnknownDocTypeException | PSUnknownNodeTypeException | SAXException | IOException e) {
+      throw new PSPipelineIrException("Failed to parse classic application XML", e);
+    } catch (RuntimeException e) {
+      throw new PSPipelineIrException("Failed to import classic application XML", e);
+    }
+  }
+
+  /**
+   * Convert an already-loaded objectstore application to IR.
+   *
+   * @param app classic application, never {@code null}
+   * @return IR document, never {@code null}
+   */
+  public static PipelineIrDocument importFromApplication(PSApplication app) {
+    Objects.requireNonNull(app, "app");
+    PipelineIrDocument ir = new PipelineIrDocument();
+    ir.setIrVersion(PipelineIrDocument.CURRENT_IR_VERSION);
+    ir.setSource(PipelineIrDocument.SOURCE_CLASSIC_IMPORT);
+    ir.setApp(mapAppMeta(app));
+    List<PipelineResourceIr> resources = new ArrayList<>();
+    PSCollection dataSets = app.getDataSets();
+    if (dataSets != null) {
+      for (Object o : dataSets) {
+        if (o instanceof PSDataSet ds) {
+          resources.add(mapDataSet(ds));
+        }
+      }
+    }
+    ir.setResources(resources);
+    return ir;
+  }
+
+  private static PipelineAppMeta mapAppMeta(PSApplication app) {
+    PipelineAppMeta meta = new PipelineAppMeta();
+    meta.setId(app.getId());
+    meta.setName(app.getName());
+    meta.setDescription(app.getDescription());
+    meta.setRequestRoot(app.getRequestRoot());
+    meta.setEnabled(app.isEnabled());
+    meta.setHidden(app.isHidden());
+    if (app.getApplicationType() != null) {
+      meta.setAppType(app.getApplicationType().name());
+    }
+    meta.setVersion(app.getVersion());
+    return meta;
+  }
+
+  private static PipelineResourceIr mapDataSet(PSDataSet ds) {
+    PipelineResourceIr res = new PipelineResourceIr();
+    res.setName(ds.getName());
+    res.setDescription(ds.getDescription());
+    res.setTransactionMode(transactionMode(ds));
+    PSRequestor req = ds.getRequestor();
+    if (req != null) {
+      res.setRequestPage(req.getRequestPage());
+    }
+
+    if (ds instanceof PSContentEditor) {
+      res.setKind(PipelineResourceIr.KIND_CONTENT_EDITOR);
+      // CE pipe DNA is out of Slice A import depth; leave stages empty/not present.
+      res.setStages(new PipelineStagesIr());
+      return res;
+    }
+
+    PSPipe pipe = ds.getPipe();
+    PipelineStagesIr stages = new PipelineStagesIr();
+    if (pipe != null) {
+      res.setPipeName(pipe.getName());
+      stages.setBackendTank(mapBackendTank(pipe.getBackEndDataTank()));
+      stages.setMapper(mapMapper(pipe.getDataMapper()));
+      if (pipe instanceof PSQueryPipe queryPipe) {
+        res.setKind(PipelineResourceIr.KIND_QUERY);
+        stages.setSelector(mapSelector(queryPipe.getDataSelector()));
+      } else if (pipe instanceof PSUpdatePipe updatePipe) {
+        res.setKind(PipelineResourceIr.KIND_UPDATE);
+        stages.setUpdater(mapUpdater(updatePipe.getDataSynchronizer()));
+      } else {
+        res.setKind(PipelineResourceIr.KIND_UNKNOWN);
+      }
+    } else {
+      res.setKind(PipelineResourceIr.KIND_UNKNOWN);
+    }
+
+    stages.setPageTank(mapPageTank(ds.getPageDataTank()));
+    stages.setPager(mapPager(ds.getResultPager()));
+    res.setStages(stages);
+    return res;
+  }
+
+  private static String transactionMode(PSDataSet ds) {
+    if (ds.isTransactionForAllRows()) {
+      return "all";
+    }
+    if (ds.isTransactionForRow()) {
+      return "row";
+    }
+    return "none";
+  }
+
+  private static PageTankStageIr mapPageTank(PSPageDataTank tank) {
+    PageTankStageIr stage = new PageTankStageIr();
+    if (tank == null) {
+      return stage;
+    }
+    stage.setPresent(true);
+    URL schema = tank.getSchemaSource();
+    if (schema != null) {
+      stage.setSchemaSource(schema.toExternalForm());
+    }
+    stage.setActionTypeXmlField(emptyToNull(tank.getActionTypeXmlField()));
+    return stage;
+  }
+
+  private static BackendTankStageIr mapBackendTank(PSBackEndDataTank tank) {
+    BackendTankStageIr stage = new BackendTankStageIr();
+    if (tank == null) {
+      return stage;
+    }
+    stage.setPresent(true);
+    List<BackendTableRefIr> tables = new ArrayList<>();
+    PSCollection tcol = tank.getTables();
+    if (tcol != null) {
+      for (Object o : tcol) {
+        if (o instanceof PSBackEndTable t) {
+          BackendTableRefIr ref = new BackendTableRefIr();
+          ref.setAlias(t.getAlias());
+          ref.setTable(t.getTable());
+          ref.setDatasource(StringUtils.defaultString(t.getDataSource()));
+          tables.add(ref);
+        }
+      }
+    }
+    stage.setTables(tables);
+    PSCollection joins = tank.getJoins();
+    stage.setJoinCount(joins != null ? joins.size() : 0);
+    return stage;
+  }
+
+  private static MapperStageIr mapMapper(PSDataMapper mapper) {
+    MapperStageIr stage = new MapperStageIr();
+    if (mapper == null) {
+      return stage;
+    }
+    stage.setPresent(true);
+    stage.setAllowEmptyDocReturn(mapper.allowsEmptyDocReturn());
+    List<MappingEntryIr> mappings = new ArrayList<>();
+    for (int i = 0; i < mapper.size(); i++) {
+      Object o = mapper.get(i);
+      if (o instanceof PSDataMapping mapping) {
+        mappings.add(mapMapping(mapping));
+      }
+    }
+    stage.setMappings(mappings);
+    return stage;
+  }
+
+  private static MappingEntryIr mapMapping(PSDataMapping mapping) {
+    MappingEntryIr entry = new MappingEntryIr();
+    entry.setDocumentField(mapping.getXmlField());
+    Object be = mapping.getBackEndMapping();
+    if (be instanceof PSBackEndColumn col) {
+      entry.setBackendKind(MappingEntryIr.BACKEND_KIND_COLUMN);
+      String alias = col.getTable() != null ? col.getTable().getAlias() : null;
+      String column = col.getColumn();
+      if (StringUtils.isNotBlank(alias) && StringUtils.isNotBlank(column)) {
+        entry.setBackend(alias + "." + column);
+      } else {
+        entry.setBackend(column);
+      }
+    } else if (be instanceof PSExtensionCall call) {
+      entry.setBackendKind(MappingEntryIr.BACKEND_KIND_EXTENSION);
+      entry.setBackend(call.getValueDisplayText());
+    } else if (be != null) {
+      entry.setBackendKind(MappingEntryIr.BACKEND_KIND_OTHER);
+      entry.setBackend(String.valueOf(be));
+    }
+    return entry;
+  }
+
+  private static SelectorStageIr mapSelector(PSDataSelector selector) {
+    SelectorStageIr stage = new SelectorStageIr();
+    if (selector == null) {
+      return stage;
+    }
+    stage.setPresent(true);
+    stage.setUnique(selector.isSelectUnique());
+    if (selector.isSelectByNativeStatement()) {
+      stage.setMethod(SelectorStageIr.METHOD_NATIVE);
+      stage.setNativeStatement(selector.getNativeStatement());
+    } else if (selector.isSelectByWhereClause()) {
+      stage.setMethod(SelectorStageIr.METHOD_WHERE);
+    } else {
+      stage.setMethod(SelectorStageIr.METHOD_UNKNOWN);
+    }
+    PSCollection wheres = selector.getWhereClauses();
+    stage.setWhereClauseCount(wheres != null ? wheres.size() : 0);
+    PSCollection sorts = selector.getSortedColumns();
+    stage.setSortedColumnCount(sorts != null ? sorts.size() : 0);
+    return stage;
+  }
+
+  private static PagerStageIr mapPager(PSResultPager pager) {
+    PagerStageIr stage = new PagerStageIr();
+    if (pager == null) {
+      return stage;
+    }
+    stage.setPresent(true);
+    stage.setMaxRowsPerPage(pager.getMaxRowsPerPage());
+    stage.setMaxPages(pager.getMaxPages());
+    stage.setMaxPageLinks(pager.getMaxPageLinks());
+    return stage;
+  }
+
+  private static UpdaterStageIr mapUpdater(PSDataSynchronizer sync) {
+    UpdaterStageIr stage = new UpdaterStageIr();
+    if (sync == null) {
+      return stage;
+    }
+    stage.setPresent(true);
+    stage.setAllowInsert(sync.isInsertingAllowed());
+    stage.setAllowUpdate(sync.isUpdatingAllowed());
+    stage.setAllowDelete(sync.isDeletingAllowed());
+    PSCollection cols = sync.getUpdateColumns();
+    stage.setUpdateColumnCount(cols != null ? cols.size() : 0);
+    return stage;
+  }
+
+  private static String emptyToNull(String s) {
+    return StringUtils.isBlank(s) ? null : s;
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/PSPipelineIrException.java
+++ b/system/services/src/com/percussion/services/pipeline/PSPipelineIrException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline;
+
+/**
+ * Checked failure for pipeline IR load/save/import operations.
+ */
+public class PSPipelineIrException extends Exception {
+
+  private static final long serialVersionUID = 1L;
+
+  public PSPipelineIrException(String message) {
+    super(message);
+  }
+
+  public PSPipelineIrException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/PSPipelineIrFileStore.java
+++ b/system/services/src/com/percussion/services/pipeline/PSPipelineIrFileStore.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline;
+
+import com.percussion.services.pipeline.model.PipelineIrDocument;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * File-backed native pipeline IR store under a configurable base directory.
+ *
+ * <p>Mirrors the classic design objectstore pattern of one document per application name, but
+ * stores versioned JSON IR ({@code &lt;safeName&gt;.pipeline.json}) instead of {@code
+ * PSXApplication} XML. Paths are resolved with {@link Path} only (portable Windows/Unix); names are
+ * sanitized against traversal.
+ */
+public class PSPipelineIrFileStore {
+
+  /** Filename suffix for native IR documents. */
+  public static final String FILE_SUFFIX = ".pipeline.json";
+
+  private final Path baseDir;
+
+  /**
+   * @param baseDir directory that will hold {@code *.pipeline.json} files (created on first save)
+   */
+  public PSPipelineIrFileStore(Path baseDir) {
+    this.baseDir = Objects.requireNonNull(baseDir, "baseDir").toAbsolutePath().normalize();
+  }
+
+  /** Absolute normalized store root. */
+  public Path getBaseDir() {
+    return baseDir;
+  }
+
+  /**
+   * Persist IR under {@code baseDir/&lt;appName&gt;.pipeline.json}.
+   *
+   * @param document must include a safe non-blank {@code app.name}
+   */
+  public void save(PipelineIrDocument document) throws PSPipelineIrException {
+    Objects.requireNonNull(document, "document");
+    if (document.getApp() == null || StringUtils.isBlank(document.getApp().getName())) {
+      throw new PSPipelineIrException("Pipeline IR app.name is required to save");
+    }
+    String name = document.getApp().getName().trim();
+    if (!isSafeApplicationName(name)) {
+      throw new PSPipelineIrException("Unsafe pipeline application name for store: " + name);
+    }
+    Path target = resolveExistingOrNew(name);
+    try {
+      Files.createDirectories(baseDir);
+      String json = PSPipelineIrJsonCodec.toJson(document);
+      // Write via temp + move for atomicity on the same filesystem when supported
+      Path tmp = target.resolveSibling(target.getFileName().toString() + ".tmp");
+      Files.writeString(tmp, json, StandardCharsets.UTF_8);
+      try {
+        Files.move(tmp, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+            java.nio.file.StandardCopyOption.ATOMIC_MOVE);
+      } catch (IOException atomicFailed) {
+        Files.move(tmp, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+      }
+    } catch (IOException e) {
+      throw new PSPipelineIrException("Failed to save pipeline IR for " + name, e);
+    }
+  }
+
+  /**
+   * Load IR by application name.
+   *
+   * @return empty when file is missing
+   */
+  public Optional<PipelineIrDocument> load(String appName) throws PSPipelineIrException {
+    if (!isSafeApplicationName(appName)) {
+      throw new PSPipelineIrException("Unsafe pipeline application name for store: " + appName);
+    }
+    Path target = resolveExistingOrNew(appName.trim());
+    if (!Files.isRegularFile(target)) {
+      return Optional.empty();
+    }
+    try {
+      String json = Files.readString(target, StandardCharsets.UTF_8);
+      return Optional.of(PSPipelineIrJsonCodec.fromJson(json));
+    } catch (IOException e) {
+      throw new PSPipelineIrException("Failed to load pipeline IR for " + appName, e);
+    }
+  }
+
+  /** @return true when a native IR file exists for the name */
+  public boolean exists(String appName) throws PSPipelineIrException {
+    if (!isSafeApplicationName(appName)) {
+      throw new PSPipelineIrException("Unsafe pipeline application name for store: " + appName);
+    }
+    return Files.isRegularFile(resolveExistingOrNew(appName.trim()));
+  }
+
+  /**
+   * Delete native IR file if present.
+   *
+   * @return true when a file was removed
+   */
+  public boolean delete(String appName) throws PSPipelineIrException {
+    if (!isSafeApplicationName(appName)) {
+      throw new PSPipelineIrException("Unsafe pipeline application name for store: " + appName);
+    }
+    Path target = resolveExistingOrNew(appName.trim());
+    try {
+      return Files.deleteIfExists(target);
+    } catch (IOException e) {
+      throw new PSPipelineIrException("Failed to delete pipeline IR for " + appName, e);
+    }
+  }
+
+  /**
+   * Single path component only — matches catalog path-injection sanitizer patterns used by
+   * {@code PipelinesAdaptor}.
+   */
+  public static boolean isSafeApplicationName(String name) {
+    if (StringUtils.isBlank(name)) {
+      return false;
+    }
+    return !name.contains("..")
+        && name.indexOf('/') < 0
+        && name.indexOf('\\') < 0
+        && name.indexOf('\0') < 0;
+  }
+
+  /**
+   * Resolve storage path and ensure it remains under {@link #baseDir}.
+   */
+  Path resolveExistingOrNew(String safeName) throws PSPipelineIrException {
+    Path candidate = baseDir.resolve(safeName + FILE_SUFFIX).normalize();
+    if (!candidate.startsWith(baseDir)) {
+      throw new PSPipelineIrException("Resolved path escapes pipeline IR store root");
+    }
+    return candidate;
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/PSPipelineIrJsonCodec.java
+++ b/system/services/src/com/percussion/services/pipeline/PSPipelineIrJsonCodec.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline;
+
+import com.percussion.services.pipeline.model.PipelineIrDocument;
+import java.util.Objects;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * JSON encode/decode for {@link PipelineIrDocument} (Jackson tools API used elsewhere in system).
+ */
+public final class PSPipelineIrJsonCodec {
+
+  private static final ObjectMapper MAPPER =
+      JsonMapper.builder()
+          .configure(SerializationFeature.INDENT_OUTPUT, true)
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+          .build();
+
+  private PSPipelineIrJsonCodec() {}
+
+  /**
+   * Serialize IR to pretty-printed JSON UTF-8 text.
+   *
+   * @param document never {@code null}
+   * @return JSON string, never {@code null}
+   */
+  public static String toJson(PipelineIrDocument document) throws PSPipelineIrException {
+    Objects.requireNonNull(document, "document");
+    try {
+      return MAPPER.writeValueAsString(document);
+    } catch (JacksonException e) {
+      throw new PSPipelineIrException("Failed to encode pipeline IR as JSON", e);
+    }
+  }
+
+  /**
+   * Parse IR from JSON text.
+   *
+   * @param json never {@code null}
+   * @return document, never {@code null}
+   */
+  public static PipelineIrDocument fromJson(String json) throws PSPipelineIrException {
+    Objects.requireNonNull(json, "json");
+    try {
+      PipelineIrDocument doc = MAPPER.readValue(json, PipelineIrDocument.class);
+      if (doc == null) {
+        throw new PSPipelineIrException("JSON decoded to null pipeline IR document");
+      }
+      return doc;
+    } catch (JacksonException e) {
+      throw new PSPipelineIrException("Failed to decode pipeline IR JSON", e);
+    }
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/PSPipelineIrService.java
+++ b/system/services/src/com/percussion/services/pipeline/PSPipelineIrService.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline;
+
+import com.percussion.design.objectstore.PSApplication;
+import com.percussion.services.pipeline.model.PipelineIrDocument;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Default {@link IPSPipelineIrService}: classic objectstore import + JSON IR + file store.
+ *
+ * <p>Does not depend on a running server or {@code PSServerXmlObjectStore} singleton so unit tests
+ * and design tooling can use the service with an injected base directory.
+ */
+public class PSPipelineIrService implements IPSPipelineIrService {
+
+  private final PSPipelineIrFileStore store;
+
+  /**
+   * @param storeDir directory for {@code *.pipeline.json} native IR documents
+   */
+  public PSPipelineIrService(Path storeDir) {
+    this(new PSPipelineIrFileStore(storeDir));
+  }
+
+  /** Package-visible for tests that inject a store. */
+  PSPipelineIrService(PSPipelineIrFileStore store) {
+    this.store = Objects.requireNonNull(store, "store");
+  }
+
+  @Override
+  public PipelineIrDocument importClassicXml(InputStream classicXml) throws PSPipelineIrException {
+    return PSClassicPipelineImporter.importFromXml(classicXml);
+  }
+
+  @Override
+  public PipelineIrDocument importClassicApplication(PSApplication application)
+      throws PSPipelineIrException {
+    Objects.requireNonNull(application, "application");
+    return PSClassicPipelineImporter.importFromApplication(application);
+  }
+
+  @Override
+  public String toJson(PipelineIrDocument document) throws PSPipelineIrException {
+    return PSPipelineIrJsonCodec.toJson(document);
+  }
+
+  @Override
+  public PipelineIrDocument fromJson(String json) throws PSPipelineIrException {
+    return PSPipelineIrJsonCodec.fromJson(json);
+  }
+
+  @Override
+  public void save(PipelineIrDocument document) throws PSPipelineIrException {
+    store.save(document);
+  }
+
+  @Override
+  public Optional<PipelineIrDocument> load(String appName) throws PSPipelineIrException {
+    return store.load(appName);
+  }
+
+  @Override
+  public boolean exists(String appName) throws PSPipelineIrException {
+    return store.exists(appName);
+  }
+
+  /** Exposed for diagnostics / tests. */
+  public Path getStoreBaseDir() {
+    return store.getBaseDir();
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/PSPipelineIrServiceLocator.java
+++ b/system/services/src/com/percussion/services/pipeline/PSPipelineIrServiceLocator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline;
+
+import com.percussion.server.PSServer;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Thread-safe locator for {@link IPSPipelineIrService}.
+ *
+ * <p>Default store root: {@code <rxRoot>/ObjectStore/pipeline-ir} when the server root is known;
+ * otherwise {@code ./ObjectStore/pipeline-ir} relative to the process working directory (tests
+ * should construct {@link PSPipelineIrService} with an explicit temp path instead).
+ */
+public final class PSPipelineIrServiceLocator {
+
+  private static final AtomicReference<IPSPipelineIrService> SERVICE = new AtomicReference<>();
+
+  private PSPipelineIrServiceLocator() {}
+
+  /** Lazy default instance. */
+  public static IPSPipelineIrService getPipelineIrService() {
+    IPSPipelineIrService svc = SERVICE.get();
+    if (svc == null) {
+      synchronized (PSPipelineIrServiceLocator.class) {
+        svc = SERVICE.get();
+        if (svc == null) {
+          svc = new PSPipelineIrService(defaultStoreDir());
+          SERVICE.set(svc);
+        }
+      }
+    }
+    return svc;
+  }
+
+  /**
+   * Override for tests. Pass {@code null} to clear.
+   *
+   * @param service replacement or {@code null}
+   */
+  public static void setPipelineIrService(IPSPipelineIrService service) {
+    SERVICE.set(service);
+  }
+
+  static Path defaultStoreDir() {
+    String rxRoot = null;
+    try {
+      rxRoot = PSServer.getRxDir() != null ? PSServer.getRxDir().getAbsolutePath() : null;
+    } catch (Throwable t) {
+      // Server not initialized — fall through to relative default
+      rxRoot = null;
+    }
+    if (rxRoot == null || rxRoot.isBlank()) {
+      return Paths.get("ObjectStore", "pipeline-ir").toAbsolutePath().normalize();
+    }
+    return Paths.get(rxRoot, "ObjectStore", "pipeline-ir").toAbsolutePath().normalize();
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/model/BackendTableRefIr.java
+++ b/system/services/src/com/percussion/services/pipeline/model/BackendTableRefIr.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.model;
+
+import java.util.Objects;
+
+/** Backend table reference inside a backend tank stage. */
+public class BackendTableRefIr {
+
+  private String alias;
+  private String table;
+  private String datasource;
+
+  public String getAlias() {
+    return alias;
+  }
+
+  public void setAlias(String alias) {
+    this.alias = alias;
+  }
+
+  public String getTable() {
+    return table;
+  }
+
+  public void setTable(String table) {
+    this.table = table;
+  }
+
+  public String getDatasource() {
+    return datasource;
+  }
+
+  public void setDatasource(String datasource) {
+    this.datasource = datasource;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof BackendTableRefIr that)) {
+      return false;
+    }
+    return Objects.equals(alias, that.alias)
+        && Objects.equals(table, that.table)
+        && Objects.equals(datasource, that.datasource);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(alias, table, datasource);
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/model/BackendTankStageIr.java
+++ b/system/services/src/com/percussion/services/pipeline/model/BackendTankStageIr.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** Backend data tank stage (classic {@code PSBackEndDataTank}). */
+public class BackendTankStageIr {
+
+  private boolean present;
+  private List<BackendTableRefIr> tables = new ArrayList<>();
+  private int joinCount;
+
+  public boolean isPresent() {
+    return present;
+  }
+
+  public void setPresent(boolean present) {
+    this.present = present;
+  }
+
+  public List<BackendTableRefIr> getTables() {
+    return tables;
+  }
+
+  public void setTables(List<BackendTableRefIr> tables) {
+    this.tables = tables != null ? tables : new ArrayList<>();
+  }
+
+  public int getJoinCount() {
+    return joinCount;
+  }
+
+  public void setJoinCount(int joinCount) {
+    this.joinCount = joinCount;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof BackendTankStageIr that)) {
+      return false;
+    }
+    return present == that.present
+        && joinCount == that.joinCount
+        && Objects.equals(tables, that.tables);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(present, tables, joinCount);
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/model/MapperStageIr.java
+++ b/system/services/src/com/percussion/services/pipeline/model/MapperStageIr.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** Data mapper stage (classic {@code PSDataMapper}). */
+public class MapperStageIr {
+
+  private boolean present;
+  private boolean allowEmptyDocReturn;
+  private List<MappingEntryIr> mappings = new ArrayList<>();
+
+  public boolean isPresent() {
+    return present;
+  }
+
+  public void setPresent(boolean present) {
+    this.present = present;
+  }
+
+  public boolean isAllowEmptyDocReturn() {
+    return allowEmptyDocReturn;
+  }
+
+  public void setAllowEmptyDocReturn(boolean allowEmptyDocReturn) {
+    this.allowEmptyDocReturn = allowEmptyDocReturn;
+  }
+
+  public List<MappingEntryIr> getMappings() {
+    return mappings;
+  }
+
+  public void setMappings(List<MappingEntryIr> mappings) {
+    this.mappings = mappings != null ? mappings : new ArrayList<>();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof MapperStageIr that)) {
+      return false;
+    }
+    return present == that.present
+        && allowEmptyDocReturn == that.allowEmptyDocReturn
+        && Objects.equals(mappings, that.mappings);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(present, allowEmptyDocReturn, mappings);
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/model/MappingEntryIr.java
+++ b/system/services/src/com/percussion/services/pipeline/model/MappingEntryIr.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.model;
+
+import java.util.Objects;
+
+/** One document ↔ backend mapping row. */
+public class MappingEntryIr {
+
+  public static final String BACKEND_KIND_COLUMN = "COLUMN";
+  public static final String BACKEND_KIND_EXTENSION = "EXTENSION";
+  public static final String BACKEND_KIND_OTHER = "OTHER";
+
+  private String documentField;
+  private String backend;
+  private String backendKind = BACKEND_KIND_OTHER;
+
+  public String getDocumentField() {
+    return documentField;
+  }
+
+  public void setDocumentField(String documentField) {
+    this.documentField = documentField;
+  }
+
+  public String getBackend() {
+    return backend;
+  }
+
+  public void setBackend(String backend) {
+    this.backend = backend;
+  }
+
+  public String getBackendKind() {
+    return backendKind;
+  }
+
+  public void setBackendKind(String backendKind) {
+    this.backendKind = backendKind != null ? backendKind : BACKEND_KIND_OTHER;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof MappingEntryIr that)) {
+      return false;
+    }
+    return Objects.equals(documentField, that.documentField)
+        && Objects.equals(backend, that.backend)
+        && Objects.equals(backendKind, that.backendKind);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(documentField, backend, backendKind);
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/model/PageTankStageIr.java
+++ b/system/services/src/com/percussion/services/pipeline/model/PageTankStageIr.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.model;
+
+import java.util.Objects;
+
+/** Page / document tank stage (classic {@code PSPageDataTank}). */
+public class PageTankStageIr {
+
+  private boolean present;
+  private String schemaSource;
+  private String actionTypeXmlField;
+
+  public boolean isPresent() {
+    return present;
+  }
+
+  public void setPresent(boolean present) {
+    this.present = present;
+  }
+
+  public String getSchemaSource() {
+    return schemaSource;
+  }
+
+  public void setSchemaSource(String schemaSource) {
+    this.schemaSource = schemaSource;
+  }
+
+  public String getActionTypeXmlField() {
+    return actionTypeXmlField;
+  }
+
+  public void setActionTypeXmlField(String actionTypeXmlField) {
+    this.actionTypeXmlField = actionTypeXmlField;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PageTankStageIr that)) {
+      return false;
+    }
+    return present == that.present
+        && Objects.equals(schemaSource, that.schemaSource)
+        && Objects.equals(actionTypeXmlField, that.actionTypeXmlField);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(present, schemaSource, actionTypeXmlField);
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/model/PagerStageIr.java
+++ b/system/services/src/com/percussion/services/pipeline/model/PagerStageIr.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.model;
+
+import java.util.Objects;
+
+/** Result pager stage (classic {@code PSResultPager}). */
+public class PagerStageIr {
+
+  private boolean present;
+  private int maxRowsPerPage;
+  private int maxPages;
+  private int maxPageLinks;
+
+  public boolean isPresent() {
+    return present;
+  }
+
+  public void setPresent(boolean present) {
+    this.present = present;
+  }
+
+  public int getMaxRowsPerPage() {
+    return maxRowsPerPage;
+  }
+
+  public void setMaxRowsPerPage(int maxRowsPerPage) {
+    this.maxRowsPerPage = maxRowsPerPage;
+  }
+
+  public int getMaxPages() {
+    return maxPages;
+  }
+
+  public void setMaxPages(int maxPages) {
+    this.maxPages = maxPages;
+  }
+
+  public int getMaxPageLinks() {
+    return maxPageLinks;
+  }
+
+  public void setMaxPageLinks(int maxPageLinks) {
+    this.maxPageLinks = maxPageLinks;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PagerStageIr that)) {
+      return false;
+    }
+    return present == that.present
+        && maxRowsPerPage == that.maxRowsPerPage
+        && maxPages == that.maxPages
+        && maxPageLinks == that.maxPageLinks;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(present, maxRowsPerPage, maxPages, maxPageLinks);
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/model/PipelineAppMeta.java
+++ b/system/services/src/com/percussion/services/pipeline/model/PipelineAppMeta.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.model;
+
+import java.util.Objects;
+
+/** Application-level metadata on a pipeline IR document. */
+public class PipelineAppMeta {
+
+  private int id;
+  private String name;
+  private String description;
+  private String requestRoot;
+  private boolean enabled;
+  private boolean hidden;
+  private String appType;
+  private String version;
+
+  public int getId() {
+    return id;
+  }
+
+  public void setId(int id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public String getRequestRoot() {
+    return requestRoot;
+  }
+
+  public void setRequestRoot(String requestRoot) {
+    this.requestRoot = requestRoot;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public boolean isHidden() {
+    return hidden;
+  }
+
+  public void setHidden(boolean hidden) {
+    this.hidden = hidden;
+  }
+
+  public String getAppType() {
+    return appType;
+  }
+
+  public void setAppType(String appType) {
+    this.appType = appType;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PipelineAppMeta that)) {
+      return false;
+    }
+    return id == that.id
+        && enabled == that.enabled
+        && hidden == that.hidden
+        && Objects.equals(name, that.name)
+        && Objects.equals(description, that.description)
+        && Objects.equals(requestRoot, that.requestRoot)
+        && Objects.equals(appType, that.appType)
+        && Objects.equals(version, that.version);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, description, requestRoot, enabled, hidden, appType, version);
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/model/PipelineIrDocument.java
+++ b/system/services/src/com/percussion/services/pipeline/model/PipelineIrDocument.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Versioned pipeline intermediate representation (IR) root document.
+ *
+ * <p>JSON-friendly tree: application → resources → pipe stages. See {@code
+ * docs/developer-module/pipeline-ir-v1.md}.
+ */
+public class PipelineIrDocument {
+
+  /** Current IR schema version written by this codebase. */
+  public static final String CURRENT_IR_VERSION = "1.0";
+
+  public static final String SOURCE_CLASSIC_IMPORT = "CLASSIC_IMPORT";
+  public static final String SOURCE_NATIVE = "NATIVE";
+
+  private String irVersion = CURRENT_IR_VERSION;
+  private String source = SOURCE_NATIVE;
+  private PipelineAppMeta app = new PipelineAppMeta();
+  private List<PipelineResourceIr> resources = new ArrayList<>();
+
+  public String getIrVersion() {
+    return irVersion;
+  }
+
+  public void setIrVersion(String irVersion) {
+    this.irVersion = irVersion;
+  }
+
+  public String getSource() {
+    return source;
+  }
+
+  public void setSource(String source) {
+    this.source = source;
+  }
+
+  public PipelineAppMeta getApp() {
+    return app;
+  }
+
+  public void setApp(PipelineAppMeta app) {
+    this.app = app != null ? app : new PipelineAppMeta();
+  }
+
+  public List<PipelineResourceIr> getResources() {
+    return resources;
+  }
+
+  public void setResources(List<PipelineResourceIr> resources) {
+    this.resources = resources != null ? resources : new ArrayList<>();
+  }
+
+  /**
+   * Find a resource by name (case-sensitive).
+   *
+   * @return matching resource or {@code null}
+   */
+  public PipelineResourceIr findResource(String name) {
+    if (name == null || resources == null) {
+      return null;
+    }
+    for (PipelineResourceIr r : resources) {
+      if (r != null && name.equals(r.getName())) {
+        return r;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PipelineIrDocument that)) {
+      return false;
+    }
+    return Objects.equals(irVersion, that.irVersion)
+        && Objects.equals(source, that.source)
+        && Objects.equals(app, that.app)
+        && Objects.equals(resources, that.resources);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(irVersion, source, app, resources);
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/model/PipelineResourceIr.java
+++ b/system/services/src/com/percussion/services/pipeline/model/PipelineResourceIr.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * One request resource (classic {@code PSDataSet}) in pipeline IR form.
+ *
+ * <p>Kind values: {@link #KIND_QUERY}, {@link #KIND_UPDATE}, {@link #KIND_CONTENT_EDITOR}, {@link
+ * #KIND_UNKNOWN}.
+ */
+public class PipelineResourceIr {
+
+  public static final String KIND_QUERY = "QUERY";
+  public static final String KIND_UPDATE = "UPDATE";
+  public static final String KIND_CONTENT_EDITOR = "CONTENT_EDITOR";
+  public static final String KIND_UNKNOWN = "UNKNOWN";
+
+  private String name;
+  private String description;
+  private String kind = KIND_UNKNOWN;
+  private String requestPage;
+  private String transactionMode;
+  private String pipeName;
+  private PipelineStagesIr stages = new PipelineStagesIr();
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public String getKind() {
+    return kind;
+  }
+
+  public void setKind(String kind) {
+    this.kind = kind != null ? kind : KIND_UNKNOWN;
+  }
+
+  public String getRequestPage() {
+    return requestPage;
+  }
+
+  public void setRequestPage(String requestPage) {
+    this.requestPage = requestPage;
+  }
+
+  public String getTransactionMode() {
+    return transactionMode;
+  }
+
+  public void setTransactionMode(String transactionMode) {
+    this.transactionMode = transactionMode;
+  }
+
+  public String getPipeName() {
+    return pipeName;
+  }
+
+  public void setPipeName(String pipeName) {
+    this.pipeName = pipeName;
+  }
+
+  public PipelineStagesIr getStages() {
+    return stages;
+  }
+
+  public void setStages(PipelineStagesIr stages) {
+    this.stages = stages != null ? stages : new PipelineStagesIr();
+  }
+
+  /**
+   * Ordered inventory of present stage kinds for assertions and catalog UIs.
+   *
+   * @return non-null list of stage keys (e.g. {@code pageTank}, {@code mapper})
+   */
+  public List<String> presentStageInventory() {
+    List<String> out = new ArrayList<>();
+    PipelineStagesIr s = stages != null ? stages : new PipelineStagesIr();
+    if (s.getPageTank() != null && s.getPageTank().isPresent()) {
+      out.add("pageTank");
+    }
+    if (s.getBackendTank() != null && s.getBackendTank().isPresent()) {
+      out.add("backendTank");
+    }
+    if (s.getMapper() != null && s.getMapper().isPresent()) {
+      out.add("mapper");
+    }
+    if (s.getSelector() != null && s.getSelector().isPresent()) {
+      out.add("selector");
+    }
+    if (s.getPager() != null && s.getPager().isPresent()) {
+      out.add("pager");
+    }
+    if (s.getUpdater() != null && s.getUpdater().isPresent()) {
+      out.add("updater");
+    }
+    return out;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PipelineResourceIr that)) {
+      return false;
+    }
+    return Objects.equals(name, that.name)
+        && Objects.equals(description, that.description)
+        && Objects.equals(kind, that.kind)
+        && Objects.equals(requestPage, that.requestPage)
+        && Objects.equals(transactionMode, that.transactionMode)
+        && Objects.equals(pipeName, that.pipeName)
+        && Objects.equals(stages, that.stages);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, description, kind, requestPage, transactionMode, pipeName, stages);
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/model/PipelineStagesIr.java
+++ b/system/services/src/com/percussion/services/pipeline/model/PipelineStagesIr.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.model;
+
+import java.util.Objects;
+
+/** Pipe stage skeleton for one resource (subset of classic query/update pipe). */
+public class PipelineStagesIr {
+
+  private PageTankStageIr pageTank = new PageTankStageIr();
+  private BackendTankStageIr backendTank = new BackendTankStageIr();
+  private MapperStageIr mapper = new MapperStageIr();
+  private SelectorStageIr selector = new SelectorStageIr();
+  private PagerStageIr pager = new PagerStageIr();
+  private UpdaterStageIr updater = new UpdaterStageIr();
+
+  public PageTankStageIr getPageTank() {
+    return pageTank;
+  }
+
+  public void setPageTank(PageTankStageIr pageTank) {
+    this.pageTank = pageTank != null ? pageTank : new PageTankStageIr();
+  }
+
+  public BackendTankStageIr getBackendTank() {
+    return backendTank;
+  }
+
+  public void setBackendTank(BackendTankStageIr backendTank) {
+    this.backendTank = backendTank != null ? backendTank : new BackendTankStageIr();
+  }
+
+  public MapperStageIr getMapper() {
+    return mapper;
+  }
+
+  public void setMapper(MapperStageIr mapper) {
+    this.mapper = mapper != null ? mapper : new MapperStageIr();
+  }
+
+  public SelectorStageIr getSelector() {
+    return selector;
+  }
+
+  public void setSelector(SelectorStageIr selector) {
+    this.selector = selector != null ? selector : new SelectorStageIr();
+  }
+
+  public PagerStageIr getPager() {
+    return pager;
+  }
+
+  public void setPager(PagerStageIr pager) {
+    this.pager = pager != null ? pager : new PagerStageIr();
+  }
+
+  public UpdaterStageIr getUpdater() {
+    return updater;
+  }
+
+  public void setUpdater(UpdaterStageIr updater) {
+    this.updater = updater != null ? updater : new UpdaterStageIr();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PipelineStagesIr that)) {
+      return false;
+    }
+    return Objects.equals(pageTank, that.pageTank)
+        && Objects.equals(backendTank, that.backendTank)
+        && Objects.equals(mapper, that.mapper)
+        && Objects.equals(selector, that.selector)
+        && Objects.equals(pager, that.pager)
+        && Objects.equals(updater, that.updater);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(pageTank, backendTank, mapper, selector, pager, updater);
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/model/SelectorStageIr.java
+++ b/system/services/src/com/percussion/services/pipeline/model/SelectorStageIr.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.model;
+
+import java.util.Objects;
+
+/** Query selector stage (classic {@code PSDataSelector}). */
+public class SelectorStageIr {
+
+  public static final String METHOD_WHERE = "whereClause";
+  public static final String METHOD_NATIVE = "nativeStatement";
+  public static final String METHOD_UNKNOWN = "unknown";
+
+  private boolean present;
+  private boolean unique;
+  private String method = METHOD_UNKNOWN;
+  private int whereClauseCount;
+  private int sortedColumnCount;
+  private String nativeStatement;
+
+  public boolean isPresent() {
+    return present;
+  }
+
+  public void setPresent(boolean present) {
+    this.present = present;
+  }
+
+  public boolean isUnique() {
+    return unique;
+  }
+
+  public void setUnique(boolean unique) {
+    this.unique = unique;
+  }
+
+  public String getMethod() {
+    return method;
+  }
+
+  public void setMethod(String method) {
+    this.method = method != null ? method : METHOD_UNKNOWN;
+  }
+
+  public int getWhereClauseCount() {
+    return whereClauseCount;
+  }
+
+  public void setWhereClauseCount(int whereClauseCount) {
+    this.whereClauseCount = whereClauseCount;
+  }
+
+  public int getSortedColumnCount() {
+    return sortedColumnCount;
+  }
+
+  public void setSortedColumnCount(int sortedColumnCount) {
+    this.sortedColumnCount = sortedColumnCount;
+  }
+
+  public String getNativeStatement() {
+    return nativeStatement;
+  }
+
+  public void setNativeStatement(String nativeStatement) {
+    this.nativeStatement = nativeStatement;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SelectorStageIr that)) {
+      return false;
+    }
+    return present == that.present
+        && unique == that.unique
+        && whereClauseCount == that.whereClauseCount
+        && sortedColumnCount == that.sortedColumnCount
+        && Objects.equals(method, that.method)
+        && Objects.equals(nativeStatement, that.nativeStatement);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        present, unique, method, whereClauseCount, sortedColumnCount, nativeStatement);
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/model/UpdaterStageIr.java
+++ b/system/services/src/com/percussion/services/pipeline/model/UpdaterStageIr.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.model;
+
+import java.util.Objects;
+
+/** Update synchronizer stage (classic {@code PSDataSynchronizer} on update pipes). */
+public class UpdaterStageIr {
+
+  private boolean present;
+  private boolean allowInsert;
+  private boolean allowUpdate;
+  private boolean allowDelete;
+  private int updateColumnCount;
+
+  public boolean isPresent() {
+    return present;
+  }
+
+  public void setPresent(boolean present) {
+    this.present = present;
+  }
+
+  public boolean isAllowInsert() {
+    return allowInsert;
+  }
+
+  public void setAllowInsert(boolean allowInsert) {
+    this.allowInsert = allowInsert;
+  }
+
+  public boolean isAllowUpdate() {
+    return allowUpdate;
+  }
+
+  public void setAllowUpdate(boolean allowUpdate) {
+    this.allowUpdate = allowUpdate;
+  }
+
+  public boolean isAllowDelete() {
+    return allowDelete;
+  }
+
+  public void setAllowDelete(boolean allowDelete) {
+    this.allowDelete = allowDelete;
+  }
+
+  public int getUpdateColumnCount() {
+    return updateColumnCount;
+  }
+
+  public void setUpdateColumnCount(int updateColumnCount) {
+    this.updateColumnCount = updateColumnCount;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof UpdaterStageIr that)) {
+      return false;
+    }
+    return present == that.present
+        && allowInsert == that.allowInsert
+        && allowUpdate == that.allowUpdate
+        && allowDelete == that.allowDelete
+        && updateColumnCount == that.updateColumnCount;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(present, allowInsert, allowUpdate, allowDelete, updateColumnCount);
+  }
+}

--- a/system/src/test/java/com/percussion/services/pipeline/PSPipelineIrServiceTest.java
+++ b/system/src/test/java/com/percussion/services/pipeline/PSPipelineIrServiceTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.percussion.services.pipeline.model.BackendTableRefIr;
+import com.percussion.services.pipeline.model.MapperStageIr;
+import com.percussion.services.pipeline.model.PipelineIrDocument;
+import com.percussion.services.pipeline.model.PipelineResourceIr;
+import com.percussion.services.pipeline.model.SelectorStageIr;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit tests for pipeline IR: classic import stage inventory, JSON round-trip, and file load/save.
+ */
+@DisplayName("Pipeline IR service (Slice A foundation)")
+class PSPipelineIrServiceTest {
+
+  private static final String FIXTURE =
+      "/com/percussion/services/pipeline/fixtures/sys_adminCataloger.xml";
+
+  @TempDir Path tempDir;
+
+  private IPSPipelineIrService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new PSPipelineIrService(tempDir);
+  }
+
+  @Test
+  @DisplayName("classic import: sys_adminCataloger yields query resource with tanks/mapper/selector")
+  void importClassicAdminCataloger_stageInventory() throws Exception {
+    PipelineIrDocument ir;
+    try (InputStream in = openFixture()) {
+      ir = service.importClassicXml(in);
+    }
+
+    assertEquals(PipelineIrDocument.CURRENT_IR_VERSION, ir.getIrVersion());
+    assertEquals(PipelineIrDocument.SOURCE_CLASSIC_IMPORT, ir.getSource());
+    assertEquals("sys_adminCataloger", ir.getApp().getName());
+    assertEquals("sys_adminCataloger", ir.getApp().getRequestRoot());
+    assertTrue(ir.getApp().isEnabled());
+    assertFalse(ir.getApp().isHidden());
+    assertEquals(1, ir.getResources().size());
+
+    PipelineResourceIr res = ir.findResource("Dataset34");
+    assertNotNull(res, "expected Dataset34 resource");
+    assertEquals(PipelineResourceIr.KIND_QUERY, res.getKind());
+    assertEquals("sys_rxlookup", res.getRequestPage());
+    assertEquals("QueryPipe", res.getPipeName());
+    assertEquals("none", res.getTransactionMode());
+
+    List<String> inventory = res.presentStageInventory();
+    assertTrue(inventory.contains("pageTank"), "page tank present: " + inventory);
+    assertTrue(inventory.contains("backendTank"), "backend tank present: " + inventory);
+    assertTrue(inventory.contains("mapper"), "mapper present: " + inventory);
+    assertTrue(inventory.contains("selector"), "selector present: " + inventory);
+    assertFalse(inventory.contains("updater"), "query pipe must not expose updater: " + inventory);
+
+    assertTrue(res.getStages().getPageTank().getSchemaSource().contains("Properties.dtd"));
+
+    List<BackendTableRefIr> tables = res.getStages().getBackendTank().getTables();
+    assertEquals(1, tables.size());
+    assertEquals("PSX_ADMINLOOKUP", tables.get(0).getAlias());
+    assertEquals("PSX_ADMINLOOKUP", tables.get(0).getTable());
+    assertEquals(0, res.getStages().getBackendTank().getJoinCount());
+
+    MapperStageIr mapper = res.getStages().getMapper();
+    assertEquals(5, mapper.getMappings().size(), "five column mappings in golden fixture");
+    assertEquals("Properties/@Type", mapper.getMappings().get(0).getDocumentField());
+    assertEquals("PSX_ADMINLOOKUP.TYPE", mapper.getMappings().get(0).getBackend());
+
+    SelectorStageIr selector = res.getStages().getSelector();
+    assertEquals(SelectorStageIr.METHOD_WHERE, selector.getMethod());
+    assertEquals(1, selector.getWhereClauseCount());
+    assertFalse(selector.isUnique());
+  }
+
+  @Test
+  @DisplayName("IR JSON encode/decode round-trips golden import")
+  void jsonRoundTrip_preservesDocument() throws Exception {
+    PipelineIrDocument original;
+    try (InputStream in = openFixture()) {
+      original = service.importClassicXml(in);
+    }
+
+    String json = service.toJson(original);
+    assertTrue(json.contains("\"irVersion\""));
+    assertTrue(json.contains("sys_adminCataloger"));
+    assertTrue(json.contains("Dataset34"));
+
+    PipelineIrDocument decoded = service.fromJson(json);
+    assertEquals(original, decoded);
+    assertEquals(
+        original.findResource("Dataset34").presentStageInventory(),
+        decoded.findResource("Dataset34").presentStageInventory());
+  }
+
+  @Test
+  @DisplayName("native IR save then load round-trips under portable Path store")
+  void saveLoad_roundTrip() throws Exception {
+    PipelineIrDocument original;
+    try (InputStream in = openFixture()) {
+      original = service.importClassicXml(in);
+    }
+    // Mark as native after import for storage
+    original.setSource(PipelineIrDocument.SOURCE_NATIVE);
+
+    assertFalse(service.exists("sys_adminCataloger"));
+    service.save(original);
+    assertTrue(service.exists("sys_adminCataloger"));
+
+    Path stored =
+        tempDir.resolve("sys_adminCataloger" + PSPipelineIrFileStore.FILE_SUFFIX);
+    assertTrue(Files.isRegularFile(stored), "expected file at " + stored);
+
+    Optional<PipelineIrDocument> loaded = service.load("sys_adminCataloger");
+    assertTrue(loaded.isPresent());
+    assertEquals(original, loaded.get());
+    assertEquals(PipelineIrDocument.SOURCE_NATIVE, loaded.get().getSource());
+  }
+
+  @Test
+  @DisplayName("load missing name returns empty; unsafe names rejected")
+  void load_missingAndUnsafe() throws Exception {
+    assertTrue(service.load("no-such-app").isEmpty());
+    assertThrows(PSPipelineIrException.class, () -> service.load("../escape"));
+    assertThrows(PSPipelineIrException.class, () -> service.load("a/b"));
+    assertThrows(PSPipelineIrException.class, () -> service.exists("x\\y"));
+  }
+
+  @Test
+  @DisplayName("safe application name helper rejects traversal")
+  void safeNameHelper() {
+    assertTrue(PSPipelineIrFileStore.isSafeApplicationName("sys_adminCataloger"));
+    assertFalse(PSPipelineIrFileStore.isSafeApplicationName(""));
+    assertFalse(PSPipelineIrFileStore.isSafeApplicationName(null));
+    assertFalse(PSPipelineIrFileStore.isSafeApplicationName(".."));
+    assertFalse(PSPipelineIrFileStore.isSafeApplicationName("foo/bar"));
+    assertFalse(PSPipelineIrFileStore.isSafeApplicationName("foo\\bar"));
+  }
+
+  private static InputStream openFixture() {
+    InputStream in = PSPipelineIrServiceTest.class.getResourceAsStream(FIXTURE);
+    assertNotNull(in, "missing classpath fixture " + FIXTURE);
+    return in;
+  }
+}

--- a/system/src/test/resources/com/percussion/services/pipeline/fixtures/sys_adminCataloger.xml
+++ b/system/src/test/resources/com/percussion/services/pipeline/fixtures/sys_adminCataloger.xml
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PSXApplication active="no" enabled="yes" hidden="no"
+	id="390" startPriority="0" version="2.0">
+	<name>sys_adminCataloger</name>
+	<description />
+	<requestRoot>sys_adminCataloger</requestRoot>
+	<defaultRequestPage />
+	<appExtensionContext>application/_SYAMALA_999715055750/</appExtensionContext>
+	<PSXRevisionHistory>
+		<PSXRevisionEntry majorVersion="1" minorVersion="0">
+			<agent>BackEndTable:admin1</agent>
+			<description>Saved</description>
+			<time>20010905T144148250</time>
+		</PSXRevisionEntry>
+		<PSXRevisionEntry majorVersion="1" minorVersion="15">
+			<agent>BackEndTable:admin1</agent>
+			<description>Saved</description>
+			<time>20030606T214731578</time>
+		</PSXRevisionEntry>
+	</PSXRevisionHistory>
+	<PSXAcl id="0">
+		<PSXAclEntry id="0" type="user">
+			<name>Default</name>
+			<securityProviderType>Any</securityProviderType>
+			<securityProviderInstance />
+			<applicationAccessLevel dataCreate="no"
+				dataDelete="no" dataQuery="yes" dataUpdate="no" designDelete="no"
+				designRead="no" designUpdate="no" modifyAcl="no" />
+		</PSXAclEntry>
+		<PSXAclEntry id="0" type="role">
+			<name>Admin</name>
+			<securityProviderType>Any</securityProviderType>
+			<securityProviderInstance />
+			<applicationAccessLevel dataCreate="yes"
+				dataDelete="yes" dataQuery="yes" dataUpdate="yes" designDelete="yes"
+				designRead="yes" designUpdate="yes" modifyAcl="yes" />
+		</PSXAclEntry>
+		<multiMembershipBehavior>mergeMaximumAccess</multiMembershipBehavior>
+	</PSXAcl>
+	<maxThreads>0</maxThreads>
+	<maxRequestTime>0</maxRequestTime>
+	<maxRequestsInQueue>0</maxRequestsInQueue>
+	<userSessionEnabled>no</userSessionEnabled>
+	<userSessionTimeout>0</userSessionTimeout>
+	<requestTypeHtmlParamName>DBActionType</requestTypeHtmlParamName>
+	<requestTypeValueQuery>QUERY</requestTypeValueQuery>
+	<requestTypeValueInsert>INSERT</requestTypeValueInsert>
+	<requestTypeValueUpdate>UPDATE</requestTypeValueUpdate>
+	<requestTypeValueDelete>DELETE</requestTypeValueDelete>
+	<PSXDataSet id="12">
+		<name>Dataset34</name>
+		<description />
+		<transactionType>none</transactionType>
+		<PSXQueryPipe id="5295">
+			<name>QueryPipe</name>
+			<description />
+			<PSXBackEndDataTank id="5291">
+				<PSXBackEndTable id="5290">
+					<alias>PSX_ADMINLOOKUP</alias>
+					<table>PSX_ADMINLOOKUP</table>
+					<datasource />
+				</PSXBackEndTable>
+			</PSXBackEndDataTank>
+			<PSXDataMapper id="5293" returnEmptyXml="no">
+				<PSXDataMapping groupId="1" id="0">
+					<PSXXmlField id="0">
+						<name>Properties/@Type</name>
+					</PSXXmlField>
+					<PSXBackEndColumn id="0">
+						<tableAlias>PSX_ADMINLOOKUP</tableAlias>
+						<column>TYPE</column>
+						<columnAlias />
+					</PSXBackEndColumn>
+					<Conditionals />
+				</PSXDataMapping>
+				<PSXDataMapping groupId="1" id="0">
+					<PSXXmlField id="0">
+						<name>Properties/Property</name>
+					</PSXXmlField>
+					<PSXBackEndColumn id="0">
+						<tableAlias>PSX_ADMINLOOKUP</tableAlias>
+						<column>NAME</column>
+						<columnAlias />
+					</PSXBackEndColumn>
+					<Conditionals />
+				</PSXDataMapping>
+				<PSXDataMapping groupId="1" id="0">
+					<PSXXmlField id="0">
+						<name>Properties/Property/@Category</name>
+					</PSXXmlField>
+					<PSXBackEndColumn id="0">
+						<tableAlias>PSX_ADMINLOOKUP</tableAlias>
+						<column>CATEGORY</column>
+						<columnAlias />
+					</PSXBackEndColumn>
+					<Conditionals />
+				</PSXDataMapping>
+				<PSXDataMapping groupId="1" id="0">
+					<PSXXmlField id="0">
+						<name>Properties/Property/@LimitToList</name>
+					</PSXXmlField>
+					<PSXBackEndColumn id="0">
+						<tableAlias>PSX_ADMINLOOKUP</tableAlias>
+						<column>LIMITTOLIST</column>
+						<columnAlias />
+					</PSXBackEndColumn>
+					<Conditionals />
+				</PSXDataMapping>
+				<PSXDataMapping groupId="1" id="0">
+					<PSXXmlField id="0">
+						<name>Properties/Property/@CatalogUrl</name>
+					</PSXXmlField>
+					<PSXBackEndColumn id="0">
+						<tableAlias>PSX_ADMINLOOKUP</tableAlias>
+						<column>CATALOGURL</column>
+						<columnAlias />
+					</PSXBackEndColumn>
+					<Conditionals />
+				</PSXDataMapping>
+			</PSXDataMapper>
+			<PSXDataSelector id="5292" method="whereClause"
+				unique="no">
+				<WhereClauses>
+					<PSXWhereClause id="0" omitWhenNull="no">
+						<PSXConditional id="0">
+							<variable>
+								<PSXBackEndColumn id="0">
+									<tableAlias>PSX_ADMINLOOKUP</tableAlias>
+									<column>TYPE</column>
+									<columnAlias />
+								</PSXBackEndColumn>
+							</variable>
+							<operator>=</operator>
+							<value>
+								<PSXHtmlParameter id="0">
+									<name>sys_key</name>
+								</PSXHtmlParameter>
+							</value>
+							<boolean>AND</boolean>
+						</PSXConditional>
+					</PSXWhereClause>
+				</WhereClauses>
+				<Sorting />
+				<nativeStatement />
+				<Caching enabled="no" type="interval">
+					<ageInterval>15</ageInterval>
+				</Caching>
+			</PSXDataSelector>
+			<PSXResourceCacheSettings enabled="no"
+				id="0">
+				<Keys />
+				<Dependencies />
+			</PSXResourceCacheSettings>
+		</PSXQueryPipe>
+		<PSXPageDataTank id="11">
+			<schemaSource>file:Properties.dtd</schemaSource>
+			<actionTypeXmlField />
+		</PSXPageDataTank>
+		<PSXRequestor directDataStream="no" id="0">
+			<requestPage>sys_rxlookup</requestPage>
+			<SelectionParams />
+			<ValidationRules />
+			<characterEncoding>UTF-8</characterEncoding>
+			<MimeProperties>
+				<htm>
+					<PSXTextLiteral id="0">
+						<text>text/html</text>
+					</PSXTextLiteral>
+				</htm>
+				<html>
+					<PSXTextLiteral id="0">
+						<text>text/html</text>
+					</PSXTextLiteral>
+				</html>
+			</MimeProperties>
+		</PSXRequestor>
+		<PSXResultPageSet id="0">
+			<PSXResultPage id="13">
+				<extensionsSupported />
+			</PSXResultPage>
+		</PSXResultPageSet>
+	</PSXDataSet>
+	<PSXLogger id="0" logAppStartStop="no" logAppStatistics="no"
+		logBasicUserActivity="no" logDetailedUserActivity="no" logErrors="no"
+		logExecutionPlan="no" logFullUserActivity="no"
+		logMultipleHandlers="no" logServerStartStop="no" />
+	<PSXTraceInfo id="0" traceAppHandlerProc="yes"
+		traceAppSecurity="yes" traceBasicRequestInfo="yes"
+		traceConditionalEval="no" traceDbPool="no" traceEnabled="no"
+		traceExitExec="no" traceExitProc="no" traceFileInfo="no"
+		traceInitHttpVar="no" traceMapper="no" traceOutputColumnWidth="80"
+		traceOutputConv="no" tracePostExitCgi="no" tracePostExitXml="no"
+		tracePostPreProcHttpVar="no" traceResourceHandler="yes"
+		traceResultSet="no" traceSessionInfo="no"
+		traceTimestampOnlyEnabled="no" />
+	<PSXErrorWebPages id="9" returnHtml="yes" />
+	<backEndLoginPassthru>no</backEndLoginPassthru>
+	<PSXNotifier id="10">
+		<providerType>SMTP</providerType>
+		<server>localhost</server>
+		<from />
+	</PSXNotifier>
+	<userProperty name="savedFromWorkbench">Yes</userProperty>
+	<userProperty name="locationY9">55</userProperty>
+	<userProperty name="locationY8">10</userProperty>
+	<userProperty name="schemaSourceReadOnly11">true</userProperty>
+	<userProperty name="resultPageFilePath13">C:\E2\property.dtd</userProperty>
+	<userProperty name="locationX13">218</userProperty>
+	<userProperty name="locationX12">109</userProperty>
+	<userProperty name="locationX9">16</userProperty>
+	<userProperty name="locationX8">16</userProperty>
+	<userProperty name="locationX10">16</userProperty>
+	<userProperty name="locationY13">115</userProperty>
+	<userProperty name="locationY12">114</userProperty>
+	<userProperty name="pageDatatankFilePath11">C:\Rhythmyx\sys_adminCataloger\Properties.dtd</userProperty>
+	<userProperty name="locationY10">100</userProperty>
+	<userProperty name="pageDatatankSrcType11">2</userProperty>
+</PSXApplication>


### PR DESCRIPTION
## Summary

Implements **Pipelines Slice A part 1** (#2247) under parent epic [#1690](https://github.com/intersoftdatalabs-in/percussioncms/issues/1690): versioned pipeline IR, classic XML application import subset, and native IR load/save.

### Delivered
- **IR v1.0** model (`com.percussion.services.pipeline.model`) — app → resources → stages (pageTank, backendTank, mapper, selector, pager, updater)
- **`IPSPipelineIrService` / `PSPipelineIrService`** — import, JSON codec, file store
- **Classic import** via objectstore `PSApplication` (`PSClassicPipelineImporter`) — query/update stage inventory; CE labeled without deep expand
- **Native store** — `<rxRoot>/ObjectStore/pipeline-ir/<app>.pipeline.json` with path-safe names (portable `Path` API)
- **Schema doc** — `docs/developer-module/pipeline-ir-v1.md`
- **Tests** — golden `sys_adminCataloger` import stage inventory + JSON/file round-trip

### Out of scope (this PR)
- SQL execute / invoke → [#2248](https://github.com/intersoftdatalabs-in/percussioncms/issues/2248)
- JSON request/response runtime I/O → #2248
- Pre/post hooks → #2248
- Designer WebUI (Slice B)
- Thin REST (catalog list already exists; load/save covered by service + unit tests)

Fixes #2247  
Refs #1690

## Test plan
- [x] `cd system && ../mvnw clean install` (module suite green; includes `PSPipelineIrServiceTest` 5 tests)
- [x] Focused: `-Dtest=PSPipelineIrServiceTest`
- [x] Assert classic fixture stage inventory (pageTank, backendTank, mapper, selector; 5 mappings)
- [x] Assert JSON encode/decode equality
- [x] Assert Path-based save/load under `@TempDir`
- [x] Unsafe app names (`..`, `/`, `\`) rejected

## Gates evidence
| Gate | Result |
|------|--------|
| Behavioral unit tests | Pass (5/5) |
| Erlang self-review | Pass — portable Path I/O, name sanitization, no execute surface |
| Module `mvnw clean install` | `system` BUILD SUCCESS |
| Change-class companions | Service interface + impl + locator + model + import + store + fixture + docs |
| Spotless | Not required (AGENTS) |

**Operator:** Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.