### PR TITLE
fix(sitemanage): runtime resolve custom inline link title field + fallback (#2242)

### DIFF
--- a/WebUI/src/main/webapp/cm/app/js/legacy/services/PercPathService.js
+++ b/WebUI/src/main/webapp/cm/app/js/legacy/services/PercPathService.js
@@ -759,8 +759,20 @@
    *     data (second arg) -- this will be String error message if status is false, otherwise the data object returned by service call.
    *
    */
-  function getInlineRenderLink(itemId, callback) {
+  /**
+   * Gets item render link details for inline link/image insert.
+   * @param {string} itemId target content id
+   * @param {function} callback (status, data|error)
+   * @param {string} [titleField] optional configured title field name from the
+   *   rich-text control (InlineLinkTitleField / editor.options.inlineLinkTitleField).
+   *   Passed as query param titleField for server resolve (#2242 / #946).
+   */
+  function getInlineRenderLink(itemId, callback, titleField) {
     var svcUrl = $.perc_paths.RENDER_LINK_PREVIEW + "/" + itemId + "/default";
+    if (titleField != null && String(titleField).trim() !== "") {
+      svcUrl +=
+        "?titleField=" + encodeURIComponent(String(titleField).trim());
+    }
 
     $.PercServiceUtils.makeJsonRequest(
       svcUrl,

--- a/WebUI/src/main/webapp/cm/services/PercPathService.js
+++ b/WebUI/src/main/webapp/cm/services/PercPathService.js
@@ -759,8 +759,20 @@
    *     data (second arg) -- this will be String error message if status is false, otherwise the data object returned by service call.
    *
    */
-  function getInlineRenderLink(itemId, callback) {
+  /**
+   * Gets item render link details for inline link/image insert.
+   * @param {string} itemId target content id
+   * @param {function} callback (status, data|error)
+   * @param {string} [titleField] optional configured title field name from the
+   *   rich-text control (InlineLinkTitleField / editor.options.inlineLinkTitleField).
+   *   Passed as query param titleField for server resolve (#2242 / #946).
+   */
+  function getInlineRenderLink(itemId, callback, titleField) {
     var svcUrl = $.perc_paths.RENDER_LINK_PREVIEW + "/" + itemId + "/default";
+    if (titleField != null && String(titleField).trim() !== "") {
+      svcUrl +=
+        "?titleField=" + encodeURIComponent(String(titleField).trim());
+    }
 
     $.PercServiceUtils.makeJsonRequest(
       svcUrl,

--- a/WebUI/war/services/PercPathService.js
+++ b/WebUI/war/services/PercPathService.js
@@ -731,11 +731,17 @@
      * @param {Object} callback The function that will be called with two arguments,
      *     status (first arg) -- boolean true if service call succeeds otherwise false
      *     data (second arg) -- this will be String error message if status is false, otherwise the data object returned by service call.
-     *
+     * @param {string} [titleField] optional configured title field name from the
+     *     rich-text control (InlineLinkTitleField / editor.options.inlineLinkTitleField).
+     *     Passed as query param titleField for server resolve (#2242 / #946).
      */
-    function getInlineRenderLink(itemId, callback)
+    function getInlineRenderLink(itemId, callback, titleField)
     {
         var svcUrl = $.perc_paths.RENDER_LINK_PREVIEW + "/" + itemId + "/default";
+        if (titleField != null && String(titleField).trim() !== "")
+        {
+            svcUrl += "?titleField=" + encodeURIComponent(String(titleField).trim());
+        }
 
         $.PercServiceUtils.makeJsonRequest(
             svcUrl,

--- a/docs/ai-generated/code-reviews/2242-inline-link-title-resolve-erlang.md
+++ b/docs/ai-generated/code-reviews/2242-inline-link-title-resolve-erlang.md
@@ -1,0 +1,47 @@
+# Erlang self-review — #2242 runtime inline link title resolve
+
+**Date**: 2026-08-07  
+**Branch**: `fix/issue-2242-runtime-inline-link-title-field`  
+**Verdict**: **approve** (pre-commit)
+
+## Change class
+
+Insert-time title resolve for inline links/images: pure resolver helper + wire into `PSRenderLinkService` preview paths + optional `titleField` query/body + client pass-through from TinyMCE control option.
+
+## Companions checked
+
+| Companion | Status |
+|-----------|--------|
+| Pure resolver with documented fallback | `PSInlineLinkTitleResolver` |
+| Behavioral unit tests for resolve + fallback | `PSInlineLinkTitleResolverTest` (11 cases) |
+| Asset path uses resolver | `renderPreviewResourceLink` |
+| Page path uses resolver + type default BC | `renderPreviewPageLink(..., titleField)` |
+| API accepts per-control field | `@QueryParam("titleField")` + `PSInlineLinkRequest.titleField` |
+| Client pass-through | `PercPathService.getInlineRenderLink` (3 trees) + percadvlink/percadvimage |
+| Playwright residual | deferred #2243 (out of slice) |
+| Image runtime assembly (R1/R3) | deferred — insert-time is P0; runtime image refresh remains displaytitle (inventory P1) |
+
+## Fallback chain (documented)
+
+1. Configured field (non-blank value on target)  
+2. `displaytitle` (if custom missing/empty and not already displaytitle)  
+3. Type default: page `resource_link_title` / `page.getLinkTitle()`; asset `displaytitle`  
+4. Empty string  
+
+Unset/blank config → type default only (pre-feature BC).
+
+## Bug / path / test gates
+
+- No portable path I/O introduced.  
+- No NPE on null field maps.  
+- JAX-RS method names distinct from interface overloads (signature clash avoided).  
+- `sitemanage` `mvnw clean install -DskipITs` BUILD SUCCESS.  
+- `perc-tinymce` `mvnw clean install` BUILD SUCCESS.  
+- Focused tests: 11/11 green.
+
+## Residual
+
+- Vitest/Playwright E2E matrix → #2243  
+- Assembly-time image title refresh (optional P1) — not this PR  
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/modules/perc-tinymce/src/main/resources/META-INF/resources/sys_resources/tinymce/plugins/percadvimage/plugin.js
+++ b/modules/perc-tinymce/src/main/resources/META-INF/resources/sys_resources/tinymce/plugins/percadvimage/plugin.js
@@ -1,13 +1,30 @@
 /*global tinymce:true */
 
 tinymce.PluginManager.add("percadvimage", function (editor, url) {
-  // Register so CE/control-settings value from perc_tinymce_init is retained
-  // (TinyMCE 6 strips unknown options). Empty = product default field names.
-  // Runtime pass-through to getInlineRenderLink is #2242.
-  editor.options.register("inlineLinkTitleField", {
-    processor: "string",
-    default: "",
-  });
+  // Retain CE control setting (InlineLinkTitleField → inlineLinkTitleField). Safe if
+  // already registered by rxinline / #2241. Consumed when resolving insert titles (#2242).
+  if (
+    !editor.options.isRegistered ||
+    !editor.options.isRegistered("inlineLinkTitleField")
+  ) {
+    try {
+      editor.options.register("inlineLinkTitleField", {
+        processor: "string",
+        default: "",
+      });
+    } catch (ignore) {
+      // already registered
+    }
+  }
+
+  function getInlineLinkTitleField() {
+    try {
+      var v = editor.options.get("inlineLinkTitleField");
+      return v == null ? "" : String(v).trim();
+    } catch (e) {
+      return "";
+    }
+  }
 
   var formData = {};
 
@@ -334,6 +351,7 @@ tinymce.PluginManager.add("percadvimage", function (editor, url) {
             return;
           }
 
+          // Pass control-configured title field so server resolve can prefer it (#2242)
           topFrJQ.PercPathService.getInlineRenderLink(
             itemId,
             function (status, data) {
@@ -498,6 +516,7 @@ tinymce.PluginManager.add("percadvimage", function (editor, url) {
                 callback(renderLink.url, renderLink.thumbUrl, renderLink.title);
               }
             },
+            getInlineLinkTitleField(),
           );
         },
       );

--- a/modules/perc-tinymce/src/main/resources/META-INF/resources/sys_resources/tinymce/plugins/percadvlink/plugin.js
+++ b/modules/perc-tinymce/src/main/resources/META-INF/resources/sys_resources/tinymce/plugins/percadvlink/plugin.js
@@ -16,13 +16,30 @@
  */
 
 tinymce.PluginManager.add("percadvlink", function (editor) {
-  // Register so CE/control-settings value from perc_tinymce_init is retained
-  // (TinyMCE 6 strips unknown options). Empty = product default field names.
-  // Runtime pass-through to getInlineRenderLink is #2242.
-  editor.options.register("inlineLinkTitleField", {
-    processor: "string",
-    default: "",
-  });
+  // Retain CE control setting (InlineLinkTitleField → inlineLinkTitleField). Safe if
+  // already registered by rxinline / #2241. Consumed when resolving insert titles (#2242).
+  if (
+    !editor.options.isRegistered ||
+    !editor.options.isRegistered("inlineLinkTitleField")
+  ) {
+    try {
+      editor.options.register("inlineLinkTitleField", {
+        processor: "string",
+        default: "",
+      });
+    } catch (ignore) {
+      // already registered
+    }
+  }
+
+  function getInlineLinkTitleField() {
+    try {
+      var v = editor.options.get("inlineLinkTitleField");
+      return v == null ? "" : String(v).trim();
+    } catch (e) {
+      return "";
+    }
+  }
 
   function createLinkList(callback) {
     return function () {
@@ -197,6 +214,7 @@ tinymce.PluginManager.add("percadvlink", function (editor) {
     function updateLinkData(pathItem) {
       //Save the path to cookie
       topFrJQ.cookie("perc-inlinelink-path", pathItem.path);
+      // Pass control-configured title field so server resolve can prefer it (#2242)
       topFrJQ.PercPathService.getInlineRenderLink(
         pathItem.id,
         function (status, retData) {
@@ -224,6 +242,7 @@ tinymce.PluginManager.add("percadvlink", function (editor) {
           addLink("no");
           win.setData(data);
         },
+        getInlineLinkTitleField(),
       );
     }
 

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSInlineLinkRequest.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/data/PSInlineLinkRequest.java
@@ -38,6 +38,12 @@ public class PSInlineLinkRequest extends PSAbstractDataObject {
   @NotNull @NotBlank private String targetId;
   private String resourceDefinitionId;
   private String thumbResourceDefinitionId;
+  /**
+   * Optional content field name for the inline link/image {@code title} attribute (control setting
+   * {@code InlineLinkTitleField} / query param {@code titleField}). Empty or null = product default
+   * (assets: {@code displaytitle}; pages: link title). See #2242 / #946.
+   */
+  private String titleField;
 
   /**
    * Gets the ID of the asset resource that we are linking to.
@@ -71,5 +77,18 @@ public class PSInlineLinkRequest extends PSAbstractDataObject {
 
   public void setResourceDefinitionId(String resourceDefinitionId) {
     this.resourceDefinitionId = resourceDefinitionId;
+  }
+
+  /**
+   * Optional field name used to resolve {@link PSInlineRenderLink#getTitle()}.
+   *
+   * @return may be {@code null} or blank for product defaults
+   */
+  public String getTitleField() {
+    return titleField;
+  }
+
+  public void setTitleField(String titleField) {
+    this.titleField = titleField;
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSInlineLinkTitleResolver.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSInlineLinkTitleResolver.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.service.impl;
+
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Resolves the HTML {@code title} attribute value for inline links/images inserted from a rich-text
+ * control (parent epic #946 / slice #2242).
+ *
+ * <p><b>Fallback chain</b> (when a control setting names a field):
+ *
+ * <ol>
+ *   <li>Configured field on the <em>target</em> item, if present and non-blank
+ *   <li>{@value #DISPLAYTITLE_FIELD} on the target, if present and non-blank
+ *   <li>Type default (pre-feature behavior): page {@code resource_link_title} / {@code
+ *       page.getLinkTitle()}, or asset {@code displaytitle}
+ *   <li>Empty string when nothing above yields a value
+ * </ol>
+ *
+ * <p>When the configured field name is blank or absent, the type default is used immediately
+ * (backward compatible with pre-feature insert behavior).
+ */
+public final class PSInlineLinkTitleResolver {
+
+  /** Shared/system field used as the first fallback after a missing custom field. */
+  public static final String DISPLAYTITLE_FIELD = "displaytitle";
+
+  /** Default title field for assets / files / images when no control setting is configured. */
+  public static final String ASSET_DEFAULT_TITLE_FIELD = DISPLAYTITLE_FIELD;
+
+  /**
+   * Default title field name for pages when no control setting is configured ({@code
+   * resource_link_title} / page link title).
+   */
+  public static final String PAGE_DEFAULT_TITLE_FIELD = "resource_link_title";
+
+  private PSInlineLinkTitleResolver() {
+    // utility
+  }
+
+  /**
+   * Resolves the inline link title for a target item.
+   *
+   * @param configuredFieldName field name from the source rich-text control setting ({@code
+   *     InlineLinkTitleField} / TinyMCE {@code inlineLinkTitleField}); may be {@code null} or blank
+   * @param fields target item field map; may be {@code null} (treated as empty)
+   * @param typeDefault pre-feature default title for this target type (e.g. page link title or
+   *     asset displaytitle value); may be {@code null}
+   * @return never {@code null}; may be empty
+   */
+  public static String resolve(
+      String configuredFieldName, Map<String, ?> fields, String typeDefault) {
+    if (StringUtils.isNotBlank(configuredFieldName)) {
+      String configured = fieldAsString(fields, configuredFieldName.trim());
+      if (StringUtils.isNotBlank(configured)) {
+        return configured;
+      }
+      // Custom field missing/empty → displaytitle (issue #2242 fallback)
+      if (!DISPLAYTITLE_FIELD.equalsIgnoreCase(configuredFieldName.trim())) {
+        String displayTitle = fieldAsString(fields, DISPLAYTITLE_FIELD);
+        if (StringUtils.isNotBlank(displayTitle)) {
+          return displayTitle;
+        }
+      }
+    }
+    return StringUtils.defaultString(typeDefault);
+  }
+
+  /**
+   * Reads a single field value as a trimmed string. Non-string values use {@link
+   * Object#toString()}. Blank or missing values yield {@code null}.
+   *
+   * @param fields may be {@code null}
+   * @param fieldName may be {@code null} or blank
+   * @return trimmed non-blank string, or {@code null}
+   */
+  public static String fieldAsString(Map<String, ?> fields, String fieldName) {
+    if (fields == null || StringUtils.isBlank(fieldName)) {
+      return null;
+    }
+    Object raw = fields.get(fieldName);
+    if (raw == null) {
+      // Case-insensitive key match for content-type field names that differ only by case
+      for (Map.Entry<String, ?> e : fields.entrySet()) {
+        if (e.getKey() != null && e.getKey().equalsIgnoreCase(fieldName)) {
+          raw = e.getValue();
+          break;
+        }
+      }
+    }
+    if (raw == null) {
+      return null;
+    }
+    String text = raw instanceof String ? (String) raw : String.valueOf(raw);
+    return StringUtils.isBlank(text) ? null : text.trim();
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSInlineLinkTitleResolver.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSInlineLinkTitleResolver.java
@@ -46,9 +46,27 @@ public final class PSInlineLinkTitleResolver {
 
   /**
    * Default title field name for pages when no control setting is configured ({@code
-   * resource_link_title} / page link title).
+   * resource_link_title} / page link title). Matches {@code PSPageDao} field mapping.
    */
   public static final String PAGE_DEFAULT_TITLE_FIELD = "resource_link_title";
+
+  /**
+   * Browser title field on page content type ({@code page_title}). Matches {@code PSPageDao}
+   * mapping of {@code PSPage#getTitle()}.
+   */
+  public static final String PAGE_TITLE_FIELD = "page_title";
+
+  /** System item name field ({@code sys_title}). Matches {@code PSPageDao} / item summary name. */
+  public static final String SYS_TITLE_FIELD = "sys_title";
+
+  /** Page description field name (DTO / content). */
+  public static final String PAGE_DESCRIPTION_FIELD = "page_description";
+
+  /** Page summary field name (DTO / content). */
+  public static final String PAGE_SUMMARY_FIELD = "page_summary";
+
+  /** Page author field name (DTO / content). */
+  public static final String PAGE_AUTHOR_FIELD = "page_authorname";
 
   private PSInlineLinkTitleResolver() {
     // utility
@@ -96,12 +114,19 @@ public final class PSInlineLinkTitleResolver {
     }
     Object raw = fields.get(fieldName);
     if (raw == null) {
-      // Case-insensitive key match for content-type field names that differ only by case
-      for (Map.Entry<String, ?> e : fields.entrySet()) {
-        if (e.getKey() != null && e.getKey().equalsIgnoreCase(fieldName)) {
-          raw = e.getValue();
-          break;
+      // Case-insensitive key match. Exact key preferred above. If multiple keys differ only by
+      // case (pathological HashMap content), pick the lexicographically first key so the result
+      // is deterministic regardless of HashMap iteration order.
+      String matchedKey = null;
+      for (String key : fields.keySet()) {
+        if (key != null && key.equalsIgnoreCase(fieldName)) {
+          if (matchedKey == null || key.compareTo(matchedKey) < 0) {
+            matchedKey = key;
+          }
         }
+      }
+      if (matchedKey != null) {
+        raw = fields.get(matchedKey);
       }
     }
     if (raw == null) {

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSInlineLinkTitleResolver.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSInlineLinkTitleResolver.java
@@ -59,13 +59,22 @@ public final class PSInlineLinkTitleResolver {
   /** System item name field ({@code sys_title}). Matches {@code PSPageDao} / item summary name. */
   public static final String SYS_TITLE_FIELD = "sys_title";
 
-  /** Page description field name (DTO / content). */
+  /**
+   * Page description field name ({@code page_description}). Matches {@code PSPageDao} mapping of
+   * {@code PSPage#getDescription()}.
+   */
   public static final String PAGE_DESCRIPTION_FIELD = "page_description";
 
-  /** Page summary field name (DTO / content). */
+  /**
+   * Page summary field name ({@code page_summary}). Matches {@code PSPageDao} mapping of {@code
+   * PSPage#getSummary()}.
+   */
   public static final String PAGE_SUMMARY_FIELD = "page_summary";
 
-  /** Page author field name (DTO / content). */
+  /**
+   * Page author field name ({@code page_authorname}). Matches {@code PSPageDao} mapping of {@code
+   * PSPage#getAuthor()}.
+   */
   public static final String PAGE_AUTHOR_FIELD = "page_authorname";
 
   private PSInlineLinkTitleResolver() {

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSRenderLinkService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSRenderLinkService.java
@@ -83,14 +83,17 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -285,12 +288,18 @@ public class PSRenderLinkService
     return resources;
   }
 
+  /**
+   * REST: preview page link. Optional {@code titleField} query param selects the target content
+   * field for the HTML title attribute (#2242). Method name is distinct from {@link
+   * #renderPreviewPageLink(String, String)} (renderType) to avoid Java signature clash.
+   */
   @GET
   @Path("/preview/{id}/page")
   @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-  public PSInlineRenderLink renderPreviewPageLink(@PathParam(ID_PATH_PARAM) String pageId) {
+  public PSInlineRenderLink restRenderPreviewPageLink(
+      @PathParam(ID_PATH_PARAM) String pageId, @QueryParam("titleField") String titleField) {
     try {
-      return renderPreviewPageLink(pageId, "html");
+      return renderPreviewPageLink(pageId, "html", titleField);
     } catch (PSDataServiceException e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
@@ -298,8 +307,34 @@ public class PSRenderLinkService
     }
   }
 
+  /** {@inheritDoc} */
+  public PSInlineRenderLink renderPreviewPageLink(String pageId) {
+    try {
+      return renderPreviewPageLink(pageId, "html", null);
+    } catch (PSDataServiceException e) {
+      log.error(PSExceptionUtils.getMessageForLog(e));
+      log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+      throw new WebApplicationException(e.getMessage());
+    }
+  }
+
+  /** {@inheritDoc} */
   public PSInlineRenderLink renderPreviewPageLink(String pageId, String renderType)
       throws PSDataServiceException {
+    return renderPreviewPageLink(pageId, renderType, null);
+  }
+
+  /**
+   * Renders a preview page link, optionally resolving {@code title} from a configured content field
+   * (control setting / {@code titleField} query param). See {@link PSInlineLinkTitleResolver}.
+   *
+   * @param pageId page id, never blank
+   * @param renderType html/xml/database
+   * @param titleField optional target field name for the link title attribute
+   * @return preview link or {@code null} if page missing
+   */
+  public PSInlineRenderLink renderPreviewPageLink(
+      String pageId, String renderType, String titleField) throws PSDataServiceException {
     notNull(pageId, "pageId");
     PSPage page = null;
     try {
@@ -328,18 +363,20 @@ public class PSRenderLinkService
     PSAssetResource r = resolveResourceDefinition(resourceId, null, null);
     renderLinkHelper(renLink, context, r, page);
     renLink.setStateClass(getStateClass(pageId));
-    renLink.setTitle(page.getLinkTitle());
+    renLink.setTitle(resolvePageInlineLinkTitle(page, pageId, titleField));
     legacyLinkGenerator.addLegacyDataToInlineLink(renLink, page);
     return renLink;
   }
 
+  /** REST: default preview link (page or asset). Optional {@code titleField} query param. */
   @GET
   @Path("/preview/{id}/default")
   @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-  public PSInlineRenderLink renderPreviewLink(@PathParam(ID_PATH_PARAM) String targetId) {
+  public PSInlineRenderLink restRenderPreviewLinkDefault(
+      @PathParam(ID_PATH_PARAM) String targetId, @QueryParam("titleField") String titleField) {
 
     try {
-      return renderPreviewLink(targetId, null, null);
+      return renderPreviewLink(targetId, null, null, titleField);
     } catch (DataServiceLoadException | DataServiceNotFoundException e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
@@ -347,14 +384,16 @@ public class PSRenderLinkService
     }
   }
 
+  /** REST: preview with resource definition id. Optional {@code titleField} query param. */
   @GET
   @Path("/preview/{id}/{resourceDef}")
   @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-  public PSInlineRenderLink renderPreviewLink(
+  public PSInlineRenderLink restRenderPreviewLinkWithResource(
       @PathParam(ID_PATH_PARAM) String targetId,
-      @PathParam("resourceDef") String resourceDefinitionId) {
+      @PathParam("resourceDef") String resourceDefinitionId,
+      @QueryParam("titleField") String titleField) {
     try {
-      return renderPreviewLink(targetId, resourceDefinitionId, null);
+      return renderPreviewLink(targetId, resourceDefinitionId, null, titleField);
     } catch (DataServiceLoadException | DataServiceNotFoundException e) {
       log.error(PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
@@ -362,25 +401,31 @@ public class PSRenderLinkService
     }
   }
 
+  /**
+   * REST + internal: preview with resource + thumbnail resource definition ids. Optional {@code
+   * titleField} query param for title resolve (#2242).
+   */
   @GET
   @Path("/preview/{id}/{resourceDef}/{thumbResourceDef}")
   @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
   public PSInlineRenderLink renderPreviewLink(
       @PathParam(ID_PATH_PARAM) String targetId,
       @PathParam("resourceDef") String resourceDefinitionId,
-      @PathParam("thumbResourceDef") String thumbResourceDefinitionId)
+      @PathParam("thumbResourceDef") String thumbResourceDefinitionId,
+      @QueryParam("titleField") String titleField)
       throws DataServiceLoadException, DataServiceNotFoundException {
 
     try {
       IPSItemSummary itemSummary = resourceInstanceHelper.findResourceAsset(targetId);
       if (itemSummary.isPage()) {
-        return renderPreviewPageLink(targetId);
+        return renderPreviewPageLink(targetId, "html", titleField);
       }
 
       PSInlineLinkRequest lr = new PSInlineLinkRequest();
       lr.setTargetId(targetId);
       lr.setResourceDefinitionId(resourceDefinitionId);
       lr.setThumbResourceDefinitionId(thumbResourceDefinitionId);
+      lr.setTitleField(titleField);
 
       return renderPreviewResourceLink(lr);
     } catch (PSDataServiceException e) {
@@ -388,6 +433,15 @@ public class PSRenderLinkService
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
       throw new WebApplicationException(e.getMessage());
     }
+  }
+
+  /**
+   * Backward-compatible overload without title field (internal callers / BC).
+   */
+  public PSInlineRenderLink renderPreviewLink(
+      String targetId, String resourceDefinitionId, String thumbResourceDefinitionId)
+      throws DataServiceLoadException, DataServiceNotFoundException {
+    return renderPreviewLink(targetId, resourceDefinitionId, thumbResourceDefinitionId, null);
   }
 
   /** {@inheritDoc} */
@@ -486,7 +540,7 @@ public class PSRenderLinkService
 
     renLink.setStateClass(getStateClass(request.getTargetId()));
     renLink.setAltText((String) asset.getFields().get("alttext"));
-    renLink.setTitle((String) asset.getFields().get("displaytitle"));
+    renLink.setTitle(resolveAssetInlineLinkTitle(asset, request.getTitleField()));
 
     /*
      * Fill in legacy data.
@@ -494,6 +548,63 @@ public class PSRenderLinkService
     legacyLinkGenerator.addLegacyDataToInlineLink(renLink, request, asset);
 
     return renLink;
+  }
+
+  /**
+   * Resolves page inline link title: configured field → displaytitle → page link title (BC).
+   *
+   * @param page loaded page, never null
+   * @param pageId page id for optional field load
+   * @param titleField optional configured field name
+   * @return never null (may be empty)
+   */
+  private String resolvePageInlineLinkTitle(PSPage page, String pageId, String titleField) {
+    String typeDefault = page.getLinkTitle();
+    if (StringUtils.isBlank(titleField)) {
+      return StringUtils.defaultString(typeDefault);
+    }
+    // Start with known DTO fields; overlay content fields so custom + displaytitle are visible.
+    Map<String, Object> fields = buildPageTitleFieldMap(page);
+    try {
+      PSAsset partial = resourceInstanceHelper.loadPartialAsset(pageId);
+      if (partial != null && partial.getFields() != null) {
+        fields.putAll(partial.getFields());
+      }
+    } catch (Exception e) {
+      log.debug(
+          "Could not load page fields for titleField={}: {}",
+          titleField,
+          PSExceptionUtils.getMessageForLog(e));
+    }
+    return PSInlineLinkTitleResolver.resolve(titleField, fields, typeDefault);
+  }
+
+  /**
+   * Known page title-related fields from the page DTO (matches {@code PSPageDao} mapping). Used so
+   * common configs like {@code page_title} / {@code resource_link_title} do not require an extra
+   * content load. Shared {@code displaytitle} is not invented here — if absent, the resolver falls
+   * through to the page link-title type default.
+   */
+  private static Map<String, Object> buildPageTitleFieldMap(PSPage page) {
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("resource_link_title", page.getLinkTitle());
+    fields.put("page_title", page.getTitle());
+    fields.put("sys_title", page.getName());
+    fields.put("page_description", page.getDescription());
+    fields.put("page_summary", page.getSummary());
+    fields.put("page_authorname", page.getAuthor());
+    return fields;
+  }
+
+  /**
+   * Resolves asset/file/image inline link title: configured field → displaytitle → type default.
+   */
+  private static String resolveAssetInlineLinkTitle(PSAsset asset, String titleField) {
+    Map<String, Object> fields = asset.getFields() != null ? asset.getFields() : Collections.emptyMap();
+    String typeDefault =
+        PSInlineLinkTitleResolver.fieldAsString(
+            fields, PSInlineLinkTitleResolver.ASSET_DEFAULT_TITLE_FIELD);
+    return PSInlineLinkTitleResolver.resolve(titleField, fields, typeDefault);
   }
 
   private String getStateClass(String id) {

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSRenderLinkService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSRenderLinkService.java
@@ -363,7 +363,7 @@ public class PSRenderLinkService
     PSAssetResource r = resolveResourceDefinition(resourceId, null, null);
     renderLinkHelper(renLink, context, r, page);
     renLink.setStateClass(getStateClass(pageId));
-    renLink.setTitle(resolvePageInlineLinkTitle(page, pageId, titleField));
+    renLink.setTitle(resolvePageInlineLinkTitle(page, titleField));
     legacyLinkGenerator.addLegacyDataToInlineLink(renLink, page);
     return renLink;
   }
@@ -556,13 +556,15 @@ public class PSRenderLinkService
    * {@code page_title} / {@code resource_link_title}). Custom / shared fields such as {@code
    * displaytitle} still trigger the partial load when needed.
    *
-   * @param page loaded page, never null
-   * @param pageId page id for optional field load
+   * <p>Callers must set {@link PSPage#setId(String)} before invoking this method; the page id is
+   * used for the optional partial-asset load.
+   *
+   * @param page loaded page with id set, never null
    * @param titleField optional configured field name
    * @return never null (may be empty)
    */
   // package-private for unit tests (#2242 review)
-  String resolvePageInlineLinkTitle(PSPage page, String pageId, String titleField) {
+  String resolvePageInlineLinkTitle(PSPage page, String titleField) {
     String typeDefault = page.getLinkTitle();
     if (StringUtils.isBlank(titleField)) {
       return StringUtils.defaultString(typeDefault);
@@ -571,7 +573,7 @@ public class PSRenderLinkService
     // Skip partial load when DTO already has a non-blank value for the configured field.
     if (StringUtils.isBlank(PSInlineLinkTitleResolver.fieldAsString(fields, titleField))) {
       try {
-        PSAsset partial = resourceInstanceHelper.loadPartialAsset(pageId);
+        PSAsset partial = resourceInstanceHelper.loadPartialAsset(page.getId());
         if (partial != null && partial.getFields() != null) {
           fields.putAll(partial.getFields());
         }

--- a/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSRenderLinkService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pagemanagement/service/impl/PSRenderLinkService.java
@@ -368,23 +368,26 @@ public class PSRenderLinkService
     return renLink;
   }
 
-  /** REST: default preview link (page or asset). Optional {@code titleField} query param. */
+  /**
+   * REST: default preview link (page or asset). Optional {@code titleField} query param.
+   *
+   * <p>Exceptions surface as {@link WebApplicationException} from {@link
+   * #renderPreviewLink(String, String, String, String)} (no outer DataService* catch — those
+   * checked types no longer escape the 4-arg method).
+   */
   @GET
   @Path("/preview/{id}/default")
   @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
   public PSInlineRenderLink restRenderPreviewLinkDefault(
       @PathParam(ID_PATH_PARAM) String targetId, @QueryParam("titleField") String titleField) {
-
-    try {
-      return renderPreviewLink(targetId, null, null, titleField);
-    } catch (DataServiceLoadException | DataServiceNotFoundException e) {
-      log.error(PSExceptionUtils.getMessageForLog(e));
-      log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-      throw new WebApplicationException(e.getMessage());
-    }
+    return renderPreviewLink(targetId, null, null, titleField);
   }
 
-  /** REST: preview with resource definition id. Optional {@code titleField} query param. */
+  /**
+   * REST: preview with resource definition id. Optional {@code titleField} query param.
+   *
+   * <p>See {@link #restRenderPreviewLinkDefault} for exception handling notes.
+   */
   @GET
   @Path("/preview/{id}/{resourceDef}")
   @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
@@ -392,18 +395,15 @@ public class PSRenderLinkService
       @PathParam(ID_PATH_PARAM) String targetId,
       @PathParam("resourceDef") String resourceDefinitionId,
       @QueryParam("titleField") String titleField) {
-    try {
-      return renderPreviewLink(targetId, resourceDefinitionId, null, titleField);
-    } catch (DataServiceLoadException | DataServiceNotFoundException e) {
-      log.error(PSExceptionUtils.getMessageForLog(e));
-      log.debug(PSExceptionUtils.getDebugMessageForLog(e));
-      throw new WebApplicationException(e.getMessage());
-    }
+    return renderPreviewLink(targetId, resourceDefinitionId, null, titleField);
   }
 
   /**
    * REST + internal: preview with resource + thumbnail resource definition ids. Optional {@code
    * titleField} query param for title resolve (#2242).
+   *
+   * <p>All {@link PSDataServiceException} paths are converted to {@link WebApplicationException}.
+   * Checked DataService* types do not escape (dead outer catches on REST wrappers removed).
    */
   @GET
   @Path("/preview/{id}/{resourceDef}/{thumbResourceDef}")
@@ -412,8 +412,7 @@ public class PSRenderLinkService
       @PathParam(ID_PATH_PARAM) String targetId,
       @PathParam("resourceDef") String resourceDefinitionId,
       @PathParam("thumbResourceDef") String thumbResourceDefinitionId,
-      @QueryParam("titleField") String titleField)
-      throws DataServiceLoadException, DataServiceNotFoundException {
+      @QueryParam("titleField") String titleField) {
 
     try {
       IPSItemSummary itemSummary = resourceInstanceHelper.findResourceAsset(targetId);
@@ -439,8 +438,7 @@ public class PSRenderLinkService
    * Backward-compatible overload without title field (internal callers / BC).
    */
   public PSInlineRenderLink renderPreviewLink(
-      String targetId, String resourceDefinitionId, String thumbResourceDefinitionId)
-      throws DataServiceLoadException, DataServiceNotFoundException {
+      String targetId, String resourceDefinitionId, String thumbResourceDefinitionId) {
     return renderPreviewLink(targetId, resourceDefinitionId, thumbResourceDefinitionId, null);
   }
 
@@ -553,54 +551,65 @@ public class PSRenderLinkService
   /**
    * Resolves page inline link title: configured field → displaytitle → page link title (BC).
    *
+   * <p>Uses the page DTO field map first. Loads a partial asset only when the configured field is
+   * not already satisfied from the DTO (avoids a data-service round-trip for common configs like
+   * {@code page_title} / {@code resource_link_title}). Custom / shared fields such as {@code
+   * displaytitle} still trigger the partial load when needed.
+   *
    * @param page loaded page, never null
    * @param pageId page id for optional field load
    * @param titleField optional configured field name
    * @return never null (may be empty)
    */
-  private String resolvePageInlineLinkTitle(PSPage page, String pageId, String titleField) {
+  // package-private for unit tests (#2242 review)
+  String resolvePageInlineLinkTitle(PSPage page, String pageId, String titleField) {
     String typeDefault = page.getLinkTitle();
     if (StringUtils.isBlank(titleField)) {
       return StringUtils.defaultString(typeDefault);
     }
-    // Start with known DTO fields; overlay content fields so custom + displaytitle are visible.
     Map<String, Object> fields = buildPageTitleFieldMap(page);
-    try {
-      PSAsset partial = resourceInstanceHelper.loadPartialAsset(pageId);
-      if (partial != null && partial.getFields() != null) {
-        fields.putAll(partial.getFields());
+    // Skip partial load when DTO already has a non-blank value for the configured field.
+    if (StringUtils.isBlank(PSInlineLinkTitleResolver.fieldAsString(fields, titleField))) {
+      try {
+        PSAsset partial = resourceInstanceHelper.loadPartialAsset(pageId);
+        if (partial != null && partial.getFields() != null) {
+          fields.putAll(partial.getFields());
+        }
+      } catch (Exception e) {
+        log.debug(
+            "Could not load page fields for titleField={}: {}",
+            titleField,
+            PSExceptionUtils.getMessageForLog(e));
       }
-    } catch (Exception e) {
-      log.debug(
-          "Could not load page fields for titleField={}: {}",
-          titleField,
-          PSExceptionUtils.getMessageForLog(e));
     }
     return PSInlineLinkTitleResolver.resolve(titleField, fields, typeDefault);
   }
 
   /**
-   * Known page title-related fields from the page DTO (matches {@code PSPageDao} mapping). Used so
-   * common configs like {@code page_title} / {@code resource_link_title} do not require an extra
-   * content load. Shared {@code displaytitle} is not invented here — if absent, the resolver falls
-   * through to the page link-title type default.
+   * Known page title-related fields from the page DTO. Keys use {@link PSInlineLinkTitleResolver}
+   * constants and must stay aligned with {@code PSPageDao} field mapping ({@code page_title},
+   * {@code resource_link_title}, etc.). Shared {@code displaytitle} is not invented here — if
+   * absent, the resolver falls through to the page link-title type default.
    */
-  private static Map<String, Object> buildPageTitleFieldMap(PSPage page) {
+  // package-private for unit tests (#2242 review)
+  static Map<String, Object> buildPageTitleFieldMap(PSPage page) {
     Map<String, Object> fields = new HashMap<>();
-    fields.put("resource_link_title", page.getLinkTitle());
-    fields.put("page_title", page.getTitle());
-    fields.put("sys_title", page.getName());
-    fields.put("page_description", page.getDescription());
-    fields.put("page_summary", page.getSummary());
-    fields.put("page_authorname", page.getAuthor());
+    fields.put(PSInlineLinkTitleResolver.PAGE_DEFAULT_TITLE_FIELD, page.getLinkTitle());
+    fields.put(PSInlineLinkTitleResolver.PAGE_TITLE_FIELD, page.getTitle());
+    fields.put(PSInlineLinkTitleResolver.SYS_TITLE_FIELD, page.getName());
+    fields.put(PSInlineLinkTitleResolver.PAGE_DESCRIPTION_FIELD, page.getDescription());
+    fields.put(PSInlineLinkTitleResolver.PAGE_SUMMARY_FIELD, page.getSummary());
+    fields.put(PSInlineLinkTitleResolver.PAGE_AUTHOR_FIELD, page.getAuthor());
     return fields;
   }
 
   /**
    * Resolves asset/file/image inline link title: configured field → displaytitle → type default.
    */
-  private static String resolveAssetInlineLinkTitle(PSAsset asset, String titleField) {
-    Map<String, Object> fields = asset.getFields() != null ? asset.getFields() : Collections.emptyMap();
+  // package-private for unit tests (#2242 review)
+  static String resolveAssetInlineLinkTitle(PSAsset asset, String titleField) {
+    Map<String, Object> fields =
+        asset.getFields() != null ? asset.getFields() : Collections.emptyMap();
     String typeDefault =
         PSInlineLinkTitleResolver.fieldAsString(
             fields, PSInlineLinkTitleResolver.ASSET_DEFAULT_TITLE_FIELD);

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSInlineLinkTitleResolverTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSInlineLinkTitleResolverTest.java
@@ -160,4 +160,24 @@ class PSInlineLinkTitleResolverTest {
     fields.put("PageTitle", "Mixed Case Key");
     assertEquals("Mixed Case Key", PSInlineLinkTitleResolver.fieldAsString(fields, "pagetitle"));
   }
+
+  @Test
+  @DisplayName("fieldAsString prefers exact key over case-insensitive siblings")
+  void fieldAsString_exactKeyPreferred() {
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("PageTitle", "Mixed");
+    fields.put("pagetitle", "Exact Lower");
+    assertEquals("Exact Lower", PSInlineLinkTitleResolver.fieldAsString(fields, "pagetitle"));
+  }
+
+  @Test
+  @DisplayName("fieldAsString case-conflict without exact key picks lexicographically first key")
+  void fieldAsString_caseConflict_deterministicLexFirst() {
+    Map<String, Object> fields = new HashMap<>();
+    // Pathological: two keys differ only by case; no exact "pagetitle" entry.
+    fields.put("PageTitle", "From Pascal");
+    fields.put("PAGETITLE", "From Upper");
+    // Lexicographically first among case-insensitive matches: "PAGETITLE" < "PageTitle"
+    assertEquals("From Upper", PSInlineLinkTitleResolver.fieldAsString(fields, "pagetitle"));
+  }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSInlineLinkTitleResolverTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSInlineLinkTitleResolverTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Focused unit tests for inline link title resolve + fallback (#2242 / parent #946). Broad
+ * Playwright / Vitest residual is #2243.
+ */
+@Tag("UnitTest")
+class PSInlineLinkTitleResolverTest {
+
+  @Test
+  @DisplayName("unset config uses type default (asset BC = displaytitle value)")
+  void unsetConfig_usesTypeDefault() {
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("displaytitle", "Asset Display Title");
+    fields.put("pagetitle", "Should Not Win");
+
+    assertEquals(
+        "Asset Display Title",
+        PSInlineLinkTitleResolver.resolve(null, fields, "Asset Display Title"));
+    assertEquals(
+        "Asset Display Title", PSInlineLinkTitleResolver.resolve("", fields, "Asset Display Title"));
+    assertEquals(
+        "Asset Display Title",
+        PSInlineLinkTitleResolver.resolve("   ", fields, "Asset Display Title"));
+  }
+
+  @Test
+  @DisplayName("configured field wins when present and non-empty")
+  void configuredField_winsWhenPresent() {
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("displaytitle", "Display");
+    fields.put("pagetitle", "Page Title Custom");
+    fields.put("resource_link_title", "Link Title");
+
+    assertEquals(
+        "Page Title Custom",
+        PSInlineLinkTitleResolver.resolve("pagetitle", fields, "Link Title"));
+  }
+
+  @Test
+  @DisplayName("empty configured field falls back to displaytitle")
+  void emptyConfigured_fallsBackToDisplaytitle() {
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("pagetitle", "   ");
+    fields.put("displaytitle", "From Displaytitle");
+    fields.put("resource_link_title", "Link Default");
+
+    assertEquals(
+        "From Displaytitle",
+        PSInlineLinkTitleResolver.resolve("pagetitle", fields, "Link Default"));
+  }
+
+  @Test
+  @DisplayName("missing configured field falls back to displaytitle")
+  void missingConfigured_fallsBackToDisplaytitle() {
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("displaytitle", "Asset Title");
+
+    assertEquals(
+        "Asset Title",
+        PSInlineLinkTitleResolver.resolve("nonexistent_field", fields, "type-default"));
+  }
+
+  @Test
+  @DisplayName("displaytitle empty after failed custom falls through to type default")
+  void displaytitleEmpty_usesTypeDefault() {
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("pagetitle", "");
+    fields.put("displaytitle", null);
+
+    assertEquals(
+        "Page Link Title",
+        PSInlineLinkTitleResolver.resolve("pagetitle", fields, "Page Link Title"));
+  }
+
+  @Test
+  @DisplayName("configured displaytitle that is empty uses type default (no double-lookup loop)")
+  void configuredDisplaytitleEmpty_usesTypeDefault() {
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("displaytitle", "");
+
+    assertEquals(
+        "type-default",
+        PSInlineLinkTitleResolver.resolve("displaytitle", fields, "type-default"));
+  }
+
+  @Test
+  @DisplayName("page type default (resource_link_title) preserved when no config")
+  void pageTypeDefault_resourceLinkTitle() {
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("resource_link_title", "Nav Title");
+    fields.put("page_title", "Browser Title");
+    fields.put("displaytitle", "Would Be Wrong For Page BC");
+
+    // Unset config must match pre-feature: page.getLinkTitle() passed as typeDefault
+    assertEquals(
+        "Nav Title",
+        PSInlineLinkTitleResolver.resolve(null, fields, "Nav Title"));
+  }
+
+  @Test
+  @DisplayName("page custom page_title with displaytitle missing uses type default")
+  void pageCustomMissingDisplaytitle_usesTypeDefault() {
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("page_title", "");
+    // pages often have no shared displaytitle
+
+    assertEquals(
+        "Nav Title",
+        PSInlineLinkTitleResolver.resolve("page_title", fields, "Nav Title"));
+  }
+
+  @Test
+  @DisplayName("null fields map is safe")
+  void nullFields_safe() {
+    assertEquals("default", PSInlineLinkTitleResolver.resolve("pagetitle", null, "default"));
+    assertEquals("", PSInlineLinkTitleResolver.resolve(null, null, null));
+  }
+
+  @Test
+  @DisplayName("fieldAsString trims and ignores blank")
+  void fieldAsString_trims() {
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("a", "  hi  ");
+    fields.put("b", "   ");
+    assertEquals("hi", PSInlineLinkTitleResolver.fieldAsString(fields, "a"));
+    assertNull(PSInlineLinkTitleResolver.fieldAsString(fields, "b"));
+    assertNull(PSInlineLinkTitleResolver.fieldAsString(fields, "missing"));
+  }
+
+  @Test
+  @DisplayName("fieldAsString matches field name case-insensitively")
+  void fieldAsString_caseInsensitiveKey() {
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("PageTitle", "Mixed Case Key");
+    assertEquals("Mixed Case Key", PSInlineLinkTitleResolver.fieldAsString(fields, "pagetitle"));
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSRenderLinkServiceInlineTitleTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSRenderLinkServiceInlineTitleTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pagemanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.assetmanagement.data.PSAsset;
+import com.percussion.pagemanagement.assembler.IPSRenderLinkContextFactory;
+import com.percussion.pagemanagement.assembler.impl.PSLegacyLinkGenerator;
+import com.percussion.pagemanagement.assembler.impl.PSResourceInstanceHelper;
+import com.percussion.pagemanagement.data.PSPage;
+import com.percussion.pagemanagement.service.IPSPageService;
+import com.percussion.pagemanagement.service.IPSResourceDefinitionService;
+import com.percussion.services.linkmanagement.IPSManagedLinkDao;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.theme.service.impl.PSThemeService;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Behavioral unit coverage for page/asset inline link title resolve wiring on {@link
+ * PSRenderLinkService} (#2242 / parent #946). Pure resolver chain is covered by {@link
+ * PSInlineLinkTitleResolverTest}; Playwright residual is #2243.
+ */
+@Tag("UnitTest")
+@ExtendWith(MockitoExtension.class)
+class PSRenderLinkServiceInlineTitleTest {
+
+  @Mock private IPSIdMapper idMapper;
+  @Mock private PSLegacyLinkGenerator legacyLinkGenerator;
+  @Mock private IPSPageService pageService;
+  @Mock private IPSRenderLinkContextFactory renderLinkContextFactory;
+  @Mock private IPSResourceDefinitionService resourceDefinitionService;
+  @Mock private PSResourceInstanceHelper resourceInstanceHelper;
+  @Mock private PSThemeService themeService;
+  @Mock private IPSManagedLinkDao managedLinkDao;
+
+  private PSRenderLinkService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new PSRenderLinkService(
+            idMapper,
+            legacyLinkGenerator,
+            pageService,
+            renderLinkContextFactory,
+            resourceDefinitionService,
+            resourceInstanceHelper,
+            themeService,
+            managedLinkDao);
+  }
+
+  @Test
+  @DisplayName("buildPageTitleFieldMap maps DTO getters to PSPageDao field names")
+  void buildPageTitleFieldMap_usesSharedFieldNameConstants() {
+    PSPage page = new PSPage();
+    page.setLinkTitle("Nav Title");
+    page.setTitle("Browser Title");
+    page.setName("sys-name");
+    page.setDescription("desc");
+    page.setSummary("sum");
+    page.setAuthor("author");
+
+    Map<String, Object> fields = PSRenderLinkService.buildPageTitleFieldMap(page);
+
+    assertEquals("Nav Title", fields.get(PSInlineLinkTitleResolver.PAGE_DEFAULT_TITLE_FIELD));
+    assertEquals("Browser Title", fields.get(PSInlineLinkTitleResolver.PAGE_TITLE_FIELD));
+    assertEquals("sys-name", fields.get(PSInlineLinkTitleResolver.SYS_TITLE_FIELD));
+    assertEquals("desc", fields.get(PSInlineLinkTitleResolver.PAGE_DESCRIPTION_FIELD));
+    assertEquals("sum", fields.get(PSInlineLinkTitleResolver.PAGE_SUMMARY_FIELD));
+    assertEquals("author", fields.get(PSInlineLinkTitleResolver.PAGE_AUTHOR_FIELD));
+    assertFalse(fields.containsKey(PSInlineLinkTitleResolver.DISPLAYTITLE_FIELD));
+  }
+
+  @Test
+  @DisplayName("resolveAssetInlineLinkTitle uses configured field then displaytitle")
+  void resolveAssetInlineLinkTitle_configuredThenDisplaytitle() {
+    PSAsset asset = new PSAsset();
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("displaytitle", "Asset Display");
+    fields.put("pagetitle", "Custom Page Title");
+    asset.setFields(fields);
+
+    assertEquals(
+        "Custom Page Title",
+        PSRenderLinkService.resolveAssetInlineLinkTitle(asset, "pagetitle"));
+    assertEquals(
+        "Asset Display",
+        PSRenderLinkService.resolveAssetInlineLinkTitle(asset, "missing"));
+    assertEquals(
+        "Asset Display",
+        PSRenderLinkService.resolveAssetInlineLinkTitle(asset, null));
+  }
+
+  @Test
+  @DisplayName("page titleField from DTO skips partial asset load")
+  void resolvePageInlineLinkTitle_dtoHit_skipsPartialLoad() throws Exception {
+    PSPage page = new PSPage();
+    page.setLinkTitle("Link Default");
+    page.setTitle("From DTO page_title");
+
+    String title =
+        service.resolvePageInlineLinkTitle(page, "page-1", PSInlineLinkTitleResolver.PAGE_TITLE_FIELD);
+
+    assertEquals("From DTO page_title", title);
+    verify(resourceInstanceHelper, never()).loadPartialAsset(anyString());
+  }
+
+  @Test
+  @DisplayName("page custom titleField loads partial and uses content field")
+  void resolvePageInlineLinkTitle_customField_loadsPartial() throws Exception {
+    PSPage page = new PSPage();
+    page.setLinkTitle("Link Default");
+    page.setTitle("Browser");
+
+    PSAsset partial = new PSAsset();
+    Map<String, Object> contentFields = new HashMap<>();
+    contentFields.put("my_custom_title", "From Content");
+    partial.setFields(contentFields);
+    when(resourceInstanceHelper.loadPartialAsset("page-2")).thenReturn(partial);
+
+    String title = service.resolvePageInlineLinkTitle(page, "page-2", "my_custom_title");
+
+    assertEquals("From Content", title);
+    verify(resourceInstanceHelper).loadPartialAsset("page-2");
+  }
+
+  @Test
+  @DisplayName("page blank titleField returns link title without load")
+  void resolvePageInlineLinkTitle_blankConfig_usesTypeDefault() throws Exception {
+    PSPage page = new PSPage();
+    page.setLinkTitle("BC Link Title");
+
+    assertEquals("BC Link Title", service.resolvePageInlineLinkTitle(page, "page-3", null));
+    assertEquals("BC Link Title", service.resolvePageInlineLinkTitle(page, "page-3", "  "));
+    verify(resourceInstanceHelper, never()).loadPartialAsset(anyString());
+  }
+
+  @Test
+  @DisplayName("page custom missing falls back to type default when displaytitle absent")
+  void resolvePageInlineLinkTitle_missingCustom_usesTypeDefault() throws Exception {
+    PSPage page = new PSPage();
+    page.setLinkTitle("Link Default");
+
+    PSAsset partial = new PSAsset();
+    partial.setFields(new HashMap<>());
+    when(resourceInstanceHelper.loadPartialAsset("page-4")).thenReturn(partial);
+
+    String title = service.resolvePageInlineLinkTitle(page, "page-4", "nonexistent");
+    assertEquals("Link Default", title);
+  }
+
+  @Test
+  @DisplayName("page constants stay aligned with literal PSPageDao field names")
+  void pageFieldConstants_matchDaoLiterals() {
+    // Guard against silent drift from PSPageDao field put/get strings.
+    assertEquals("resource_link_title", PSInlineLinkTitleResolver.PAGE_DEFAULT_TITLE_FIELD);
+    assertEquals("page_title", PSInlineLinkTitleResolver.PAGE_TITLE_FIELD);
+    assertEquals("sys_title", PSInlineLinkTitleResolver.SYS_TITLE_FIELD);
+    assertTrue(PSRenderLinkService.buildPageTitleFieldMap(new PSPage()).keySet()
+        .containsAll(
+            java.util.Set.of(
+                PSInlineLinkTitleResolver.PAGE_DEFAULT_TITLE_FIELD,
+                PSInlineLinkTitleResolver.PAGE_TITLE_FIELD,
+                PSInlineLinkTitleResolver.SYS_TITLE_FIELD)));
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSRenderLinkServiceInlineTitleTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/PSRenderLinkServiceInlineTitleTest.java
@@ -122,22 +122,24 @@ class PSRenderLinkServiceInlineTitleTest {
 
   @Test
   @DisplayName("page titleField from DTO skips partial asset load")
-  void resolvePageInlineLinkTitle_dtoHit_skipsPartialLoad() throws Exception {
+  void resolvePageInlineLinkTitle_dtoHit_skipsPartialLoad() {
     PSPage page = new PSPage();
+    page.setId("page-1");
     page.setLinkTitle("Link Default");
     page.setTitle("From DTO page_title");
 
     String title =
-        service.resolvePageInlineLinkTitle(page, "page-1", PSInlineLinkTitleResolver.PAGE_TITLE_FIELD);
+        service.resolvePageInlineLinkTitle(page, PSInlineLinkTitleResolver.PAGE_TITLE_FIELD);
 
     assertEquals("From DTO page_title", title);
-    verify(resourceInstanceHelper, never()).loadPartialAsset(anyString());
+    verifyNeverLoadPartialAsset();
   }
 
   @Test
   @DisplayName("page custom titleField loads partial and uses content field")
-  void resolvePageInlineLinkTitle_customField_loadsPartial() throws Exception {
+  void resolvePageInlineLinkTitle_customField_loadsPartial() {
     PSPage page = new PSPage();
+    page.setId("page-2");
     page.setLinkTitle("Link Default");
     page.setTitle("Browser");
 
@@ -145,51 +147,90 @@ class PSRenderLinkServiceInlineTitleTest {
     Map<String, Object> contentFields = new HashMap<>();
     contentFields.put("my_custom_title", "From Content");
     partial.setFields(contentFields);
-    when(resourceInstanceHelper.loadPartialAsset("page-2")).thenReturn(partial);
+    stubLoadPartialAsset("page-2", partial);
 
-    String title = service.resolvePageInlineLinkTitle(page, "page-2", "my_custom_title");
+    String title = service.resolvePageInlineLinkTitle(page, "my_custom_title");
 
     assertEquals("From Content", title);
-    verify(resourceInstanceHelper).loadPartialAsset("page-2");
+    verifyLoadPartialAsset("page-2");
   }
 
   @Test
   @DisplayName("page blank titleField returns link title without load")
-  void resolvePageInlineLinkTitle_blankConfig_usesTypeDefault() throws Exception {
+  void resolvePageInlineLinkTitle_blankConfig_usesTypeDefault() {
     PSPage page = new PSPage();
+    page.setId("page-3");
     page.setLinkTitle("BC Link Title");
 
-    assertEquals("BC Link Title", service.resolvePageInlineLinkTitle(page, "page-3", null));
-    assertEquals("BC Link Title", service.resolvePageInlineLinkTitle(page, "page-3", "  "));
-    verify(resourceInstanceHelper, never()).loadPartialAsset(anyString());
+    assertEquals("BC Link Title", service.resolvePageInlineLinkTitle(page, null));
+    assertEquals("BC Link Title", service.resolvePageInlineLinkTitle(page, "  "));
+    verifyNeverLoadPartialAsset();
   }
 
   @Test
   @DisplayName("page custom missing falls back to type default when displaytitle absent")
-  void resolvePageInlineLinkTitle_missingCustom_usesTypeDefault() throws Exception {
+  void resolvePageInlineLinkTitle_missingCustom_usesTypeDefault() {
     PSPage page = new PSPage();
+    page.setId("page-4");
     page.setLinkTitle("Link Default");
 
     PSAsset partial = new PSAsset();
     partial.setFields(new HashMap<>());
-    when(resourceInstanceHelper.loadPartialAsset("page-4")).thenReturn(partial);
+    stubLoadPartialAsset("page-4", partial);
 
-    String title = service.resolvePageInlineLinkTitle(page, "page-4", "nonexistent");
+    String title = service.resolvePageInlineLinkTitle(page, "nonexistent");
     assertEquals("Link Default", title);
   }
 
   @Test
   @DisplayName("page constants stay aligned with literal PSPageDao field names")
   void pageFieldConstants_matchDaoLiterals() {
-    // Guard against silent drift from PSPageDao field put/get strings.
+    // Guard against silent drift from PSPageDao field put/get strings (all 6 page-field constants).
     assertEquals("resource_link_title", PSInlineLinkTitleResolver.PAGE_DEFAULT_TITLE_FIELD);
     assertEquals("page_title", PSInlineLinkTitleResolver.PAGE_TITLE_FIELD);
     assertEquals("sys_title", PSInlineLinkTitleResolver.SYS_TITLE_FIELD);
-    assertTrue(PSRenderLinkService.buildPageTitleFieldMap(new PSPage()).keySet()
-        .containsAll(
-            java.util.Set.of(
-                PSInlineLinkTitleResolver.PAGE_DEFAULT_TITLE_FIELD,
-                PSInlineLinkTitleResolver.PAGE_TITLE_FIELD,
-                PSInlineLinkTitleResolver.SYS_TITLE_FIELD)));
+    assertEquals("page_description", PSInlineLinkTitleResolver.PAGE_DESCRIPTION_FIELD);
+    assertEquals("page_summary", PSInlineLinkTitleResolver.PAGE_SUMMARY_FIELD);
+    assertEquals("page_authorname", PSInlineLinkTitleResolver.PAGE_AUTHOR_FIELD);
+    assertTrue(
+        PSRenderLinkService.buildPageTitleFieldMap(new PSPage())
+            .keySet()
+            .containsAll(
+                java.util.Set.of(
+                    PSInlineLinkTitleResolver.PAGE_DEFAULT_TITLE_FIELD,
+                    PSInlineLinkTitleResolver.PAGE_TITLE_FIELD,
+                    PSInlineLinkTitleResolver.SYS_TITLE_FIELD,
+                    PSInlineLinkTitleResolver.PAGE_DESCRIPTION_FIELD,
+                    PSInlineLinkTitleResolver.PAGE_SUMMARY_FIELD,
+                    PSInlineLinkTitleResolver.PAGE_AUTHOR_FIELD)));
+  }
+
+  /**
+   * Helpers isolate checked {@code PSAssetServiceException} from mock stubbing/verification so test
+   * methods need not declare {@code throws Exception} (production {@code
+   * resolvePageInlineLinkTitle} does not throw checked exceptions).
+   */
+  private void stubLoadPartialAsset(String pageId, PSAsset partial) {
+    try {
+      when(resourceInstanceHelper.loadPartialAsset(pageId)).thenReturn(partial);
+    } catch (Exception e) {
+      throw new AssertionError("stub loadPartialAsset failed", e);
+    }
+  }
+
+  private void verifyLoadPartialAsset(String pageId) {
+    try {
+      verify(resourceInstanceHelper).loadPartialAsset(pageId);
+    } catch (Exception e) {
+      throw new AssertionError("verify loadPartialAsset failed", e);
+    }
+  }
+
+  private void verifyNeverLoadPartialAsset() {
+    try {
+      verify(resourceInstanceHelper, never()).loadPartialAsset(anyString());
+    } catch (Exception e) {
+      throw new AssertionError("verify never loadPartialAsset failed", e);
+    }
   }
 }


### PR DESCRIPTION
## Summary

Parent tracker: #946 (Configure custom title field for inline links).  
This PR is **slice 3 of 4** (#2242): runtime/insert resolve of the configured title field with fallback.

### What changed
- **`PSInlineLinkTitleResolver`**: pure fallback chain  
  `configured field` → `displaytitle` → type default (page `resource_link_title` / asset `displaytitle`) → empty  
  Unset/blank config = pre-feature defaults (BC).
- **`PSRenderLinkService`**: page and asset preview paths use the resolver; optional query param `titleField` on GET preview endpoints; `PSInlineLinkRequest.titleField` for POST.
- **Client pass-through**: `PercPathService.getInlineRenderLink(itemId, cb, titleField)` (war + webapp dual trees) and TinyMCE `percadvlink` / `percadvimage` read `editor.options.get("inlineLinkTitleField")`.
- **Tests**: `PSInlineLinkTitleResolverTest` — 11 focused unit cases for resolve + fallback.

### Depends on / peers
- Control setting persist is #2241 (PR #2256) — option name `inlineLinkTitleField`. This PR registers the option defensively if missing and fully implements server resolve.
- Inventory: #2240.

### Out of scope
- Exhaustive Playwright/Vitest (#2243)
- Assembly-time image title refresh (inventory P1) — insert-time is P0

## Test plan
- [x] `projects/sitemanage`: `mvnw clean install -DskipITs` — BUILD SUCCESS (746 tests, 0 failures)
- [x] `modules/perc-tinymce`: `mvnw clean install` — BUILD SUCCESS
- [x] Focused: `-Dtest=PSInlineLinkTitleResolverTest` — 11/11 green
- [x] Erlang pre-commit review: approve (`docs/ai-generated/code-reviews/2242-inline-link-title-resolve-erlang.md`)
- [ ] Manual residual (#2243): set InlineLinkTitleField on body control, insert link to page/asset, confirm title attribute

## Gates evidence
- Change class: insert-time title resolve + REST query param + client pass-through
- Module clean install: sitemanage + perc-tinymce green
- No rule-file changes
- Portable paths: N/A (no new file I/O)

## Links
- Fixes #2242
- Refs #946 (parent tracker)
- Related: #2240 inventory, #2241 control setting, #2243 residual tests

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.