### PR TITLE
cluster(perc-doctor): absorb #2231/#2251/#2252 thrash (diagnose, clean-temp, check-config, fix-permissions)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2213-diagnose-health-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2213-diagnose-health-erlang.md
@@ -1,0 +1,29 @@
+# Erlang review: feat(perc-doctor) diagnose/health (#2213)
+
+**Branch:** `feat/issue-2213-diagnose-health`  
+**Date:** 2026-08-06  
+**Recommendation:** approve  
+**Gate:** May commit/push: **yes**
+
+## Summary
+
+Adds read-only `diagnose` / `health` checklist to `modules/perc-doctor` with unit tests, CLI help, and operator docs. Does not re-touch clean-* commands or HTTP API apply paths.
+
+## Scope
+
+- `DiagnoseReport`, `DiagnoseCommand` (new)
+- `DoctorCli` dispatch/help/print
+- `DiagnoseCommandTest`, `DoctorCliTest`, packaging doc assertion
+- README + operator-install-guide
+
+Cross-platform path review: all layout/config/log probes use `InstallRootGuard.resolveRelativeUnderRoot` (forward-slash relative segments + `Path.resolve`) and re-check `isUnderInstallRoot`. No hardcoded user homes, no string path joins with `\` or `/` for filesystem ops. Free disk via `Files.getFileStore`. Java version from system properties only.
+
+## Issues
+
+None at `bug` severity.
+
+- **nit:** `DiagnoseCommand.execute` declares `throws IOException` though current body does not throw it (consistent with clean commands; acceptable).
+
+## Tests
+
+Module `mvnw clean install`: all Surefire green including new `DiagnoseCommandTest` (9) and expanded `DoctorCliTest` (16). Behavioral coverage: report shape, path containment, no mutations, bare vs full tree, CLI alias/exit codes, help text.

--- a/docs/ai-generated/code-reviews/issue-2232-clean-temp-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2232-clean-temp-erlang.md
@@ -1,0 +1,52 @@
+# Erlang review — issue #2232 perc-doctor clean-temp
+
+**Date:** 2026-08-07  
+**Branch:** `feat/issue-2232-clean-temp`  
+**Scope:** uncommitted / pre-PR changes for `clean-temp` under `modules/perc-doctor`  
+**Parent:** #2213  
+
+## Summary
+
+Adds CLI/API command `clean-temp` that inventories and optionally deletes regular files under allowlisted install temp/work directories (`temp`, `jetty/base/work`, `Deployment/Server/temp`, `Deployment/Server/work`). Mirrors `CleanLogsCommand` scoped-walk pattern with `InstallRootGuard` containment, dry-run-first, TOCTOU re-check before delete, and retention of allowlisted root directories. Unit tests cover dry-run, apply, outside-root exclusion, missing dirs, CLI wiring, and API dry-run default. README + operator guide document the allowlist.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs | none found |
+| Behavioral unit tests for new logic | yes (`CleanTempCommandTest` 9, CLI + API + InstallRootGuard coverage) |
+| Portable path / file I/O | pass — `java.nio.file.Path` / `Files` only; forward-slash relative allowlist; `resolveRelativeUnderRoot` + case-insensitive Windows containment via existing guard |
+| Change-class companions | CLI + command class + guard allowlist + API dispatch + docs + tests (same class as clean-logs) |
+| May commit/push | **yes** |
+
+## Cross-platform path checklist
+
+- [x] No hardcoded user homes / drive letters in product code
+- [x] Relative allowlist uses `/` segments resolved via `resolveRelativeUnderRoot`
+- [x] Containment uses `InstallRootGuard` (Windows case fold already present)
+- [x] Tests use `@TempDir` and `Path.resolve` (portable)
+
+## Issues
+
+None (approve).
+
+## Memory patterns hit
+
+- Scoped clean commands: allowlisted dirs only, no user globs
+- Dry-run never mutates; re-check containment before delete
+- Document allowlist in README / operator guide
+
+## Verification
+
+```text
+cd modules/perc-doctor && ../../mvnw clean install
+CleanTempCommandTest: 9 tests, 0 failures
+DoctorCliTest: 14 tests, 0 failures
+InstallRootGuardTest: 13 tests, 0 failures
+DoctorApiServiceTest: 9 tests, 0 failures
+Module suite green
+```

--- a/docs/ai-generated/code-reviews/issue-2233-check-config-fix-permissions-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2233-check-config-fix-permissions-erlang.md
@@ -1,0 +1,52 @@
+# Erlang review — issue #2233 perc-doctor check-config / fix-permissions
+
+**Branch:** `feat/issue-2233-check-config-fix-permissions`  
+**Scope:** `modules/perc-doctor` CLI commands + tests + operator docs  
+**Date:** 2026-08-07  
+**Reviewer persona:** Erlang (independent pre-commit)
+
+## Summary
+
+Adds two peer CLI commands to `perc-doctor`:
+
+1. **`check-config`** — read-only value/misconfig checklist for documented `server.properties` and `rxrepository.properties` (beyond presence-only checks used by open diagnose PR #2231).
+2. **`fix-permissions`** — dry-run-first allowlisted mode/access report; POSIX owner-execute on `bin/perc-doctor`, owner rwx on known log dirs, owner-read on key configs. Windows reports access only (no ACL rewrite, no shell).
+
+Wiring mirrors `clean-logs`: global `--install-root` / `--dry-run` / `-v`, `DoctorCli` dispatch, help/examples, packaging doc coverage. Unit tests cover containment, non-mutation, misconfig FAIL/WARN paths, CLI exit codes, and OS-conditioned POSIX fixes.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Gate | Result |
+|------|--------|
+| Bugs | none found |
+| Behavioral unit tests for new logic | yes (`CheckConfigCommandTest` 11, `FixPermissionsCommandTest` 8/2 skipped on Windows, CLI coverage) |
+| Portable path / file I/O | pass — `java.nio.file.Path` / `Files` only; relative segments via `InstallRootGuard.resolveRelativeUnderRoot`; no hardcoded user homes; Windows vs POSIX branched with attribute-view probe |
+| May commit/push | **yes** |
+
+## Cross-platform path checklist
+
+- [x] No `C:\Users\...` / `/home/...` hardcoding in code or docs (generic `/opt/Percussion`, `C:\Percussion`)
+- [x] Relative config/log/bin paths use forward-slash segment lists resolved with `Path` APIs
+- [x] Containment re-checked before any mode mutation
+- [x] POSIX-only APIs guarded (`supportedFileAttributeViews().contains("posix")` + try/catch `UnsupportedOperationException`)
+- [x] Tests use `@TempDir` and `Path.resolve` (no separator literals that break OS)
+
+## Issues
+
+None (blocking).
+
+### Notes (non-blocking)
+
+- Admin HTTP API not wired for these two commands (CLI-first slice; clean-* API remains). Follow-up if product wants parity.
+- Weak-password token list is intentionally conservative (WARN only; never prints secrets).
+- Does not share types with open #2231 `DiagnoseReport` (independent checklist report) to avoid thrash.
+
+## Memory patterns hit
+
+- Install-root containment for doctor I/O
+- Dry-run / report-first ops commands
+- Prefer `Files` / `Path` over `File` and shell

--- a/modules/perc-doctor/README.md
+++ b/modules/perc-doctor/README.md
@@ -2,10 +2,10 @@
 
 Operator CLI for diagnosing and safely cleaning Percussion CMS install trees.
 
-**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`), [#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219) (admin HTTP API), [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (dist packaging + install guide)  
+**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2233](https://github.com/intersoftdatalabs-in/percussioncms/issues/2233) (`check-config` / `fix-permissions`), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`), [#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219) (admin HTTP API), [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (dist packaging + install guide)  
 **Package:** `com.intsof.percussioncms.doctor` (+ `...doctor.api` for HTTP)  
-**Shipped commands:** `clean-heap-dumps`, `clean-install-backups`, `clean-logs` with global `--dry-run` / `--install-root` / `-v`  
-**HTTP:** Admin-only `POST .../maintenance/doctor/{command}` (wired in sitemanage)
+**Shipped commands:** `clean-heap-dumps`, `clean-install-backups`, `clean-logs`, `check-config`, `fix-permissions` with global `--dry-run` / `--install-root` / `-v`  
+**HTTP:** Admin-only `POST .../maintenance/doctor/{command}` for clean-* (wired in sitemanage); `check-config` / `fix-permissions` are CLI-first in this slice
 
 **Operator install guide (dry-run-first examples):** [docs/operator-install-guide.md](docs/operator-install-guide.md)
 
@@ -163,14 +163,80 @@ java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
   --install-root /opt/Percussion --dry-run -v clean-logs
 ```
 
+#### `check-config`
+
+Read-only **value / misconfig** checks on documented CMS config files (deeper than presence-only layout checks). Never deletes or writes. Honors `--install-root`, `--dry-run` (echoed only), and `-v`.
+
+| Relative path | Role |
+|---------------|------|
+| `rxconfig/Server/server.properties` | Server flags / bind port |
+| `rxconfig/Installer/rxrepository.properties` | Repository JDBC settings |
+
+Scoped checks (documented; no arbitrary property scans beyond placeholder scan):
+
+| Area | Examples |
+|------|----------|
+| Presence + readable | Missing file → **WARN** (partial install); unreadable → **FAIL** |
+| `enableDebugTools=true` | **WARN** (unsafe for production) |
+| `disableCrossSiteRequestForgeryCheck=true` | **WARN** |
+| `bindPort` | Missing/invalid/out-of-range/unresolved `${...}` → **WARN**/**FAIL** |
+| `requireHTTPS` | **INFO** when false/unset (lab ok); **PASS** when true |
+| Required repo keys | `DB_BACKEND`, `DB_DRIVER_NAME`, `DB_DRIVER_CLASS_NAME`, `DB_SERVER`, `UID` blank/placeholder → **FAIL** |
+| Driver vs backend | H2 vs non-H2 mismatch → **WARN** |
+| `PWD` / `PWD_ENCRYPTED` | Weak/default tokens, empty non-H2 PWD, plaintext storage → **WARN**/**INFO** |
+| Unresolved `${...}` | Other property values → **WARN** (truncated after 5) |
+
+Exit code is non-zero when any check is **FAIL** (`healthy=false`). Password values are never printed.
+
+Examples:
+
+```bash
+# Value / misconfig checklist (safe; always read-only)
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
+  --install-root /opt/Percussion --dry-run -v check-config
+
+# Windows
+java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar ^
+  --install-root C:\Percussion -v check-config
+```
+
+#### `fix-permissions`
+
+Report (and optionally fix) **allowlisted** install mode / access issues. Prefer `--dry-run` first. **Never** runs a shell and never accepts user path globs.
+
+| Target | Behavior |
+|--------|----------|
+| `bin/perc-doctor`, `bin/perc-doctor.bat`, `bin/perc-doctor.jar` | Report readable; on POSIX add **owner-execute** to the Unix `perc-doctor` script when missing |
+| Known log dirs (`jetty/base/logs`, `jetty/base/modules/perc-logging/logs`, `Deployment/Server/logs`) | Report access; on POSIX ensure **owner rwx** when the directory exists |
+| `rxconfig/Server/server.properties`, `rxconfig/Installer/rxrepository.properties` | Report owner-read; on POSIX add **owner-read** when missing |
+
+On Windows (non-POSIX file stores): reports readability/writability and skips mode mutation (Windows ACL repair is out of scope). Dry-run never writes; apply re-checks install-root containment before each mode change.
+
+Examples:
+
+```bash
+# Preview mode fixes (safe)
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
+  --install-root /opt/Percussion --dry-run -v fix-permissions
+
+# Apply (POSIX only for actual mode writes)
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
+  --install-root /opt/Percussion -v fix-permissions
+
+# Windows — report access; no ACL rewrite
+java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar ^
+  --install-root C:\Percussion --dry-run -v fix-permissions
+```
+
 ## Safety model
 
 1. Resolve and validate install root (must exist and be a directory).
 2. Walk only under that root (and for `clean-logs`, only under allowlisted log dirs); skip / reject candidates that escape the root.
 3. Match allowlisted patterns only (per command; no user-supplied globs).
-4. If `--dry-run`, stop after inventory.
-5. On apply, re-check containment immediately before each delete.
+4. If `--dry-run`, stop after inventory (check-config is always non-mutating regardless).
+5. On apply, re-check containment immediately before each delete or mode change.
 6. For `clean-logs`, apply `--keep-current` and `--older-than` before any delete.
+7. For `fix-permissions`, mutate only POSIX mode bits on allowlisted paths; no shell.
 
 ## Admin HTTP API (slice #2219)
 

--- a/modules/perc-doctor/README.md
+++ b/modules/perc-doctor/README.md
@@ -4,8 +4,8 @@ Operator CLI for diagnosing and safely cleaning Percussion CMS install trees.
 
 **Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`), [#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219) (admin HTTP API), [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (dist packaging + install guide)  
 **Package:** `com.intsof.percussioncms.doctor` (+ `...doctor.api` for HTTP)  
-**Shipped commands:** `clean-heap-dumps`, `clean-install-backups`, `clean-logs` with global `--dry-run` / `--install-root` / `-v`  
-**HTTP:** Admin-only `POST .../maintenance/doctor/{command}` (wired in sitemanage)
+**Shipped commands:** `diagnose`/`health` (read-only), `clean-heap-dumps`, `clean-install-backups`, `clean-logs` with global `--dry-run` / `--install-root` / `-v`  
+**HTTP:** Admin-only `POST .../maintenance/doctor/{command}` for clean-* commands (wired in sitemanage); diagnose is CLI-first
 
 **Operator install guide (dry-run-first examples):** [docs/operator-install-guide.md](docs/operator-install-guide.md)
 
@@ -73,6 +73,50 @@ target\perc-doctor-8.2.0-SNAPSHOT-dist\bin\perc-doctor.bat --help
 | `-h` / `--help` | Usage |
 
 ### Commands
+
+#### `diagnose` / `health`
+
+Read-only install checklist. **Never deletes or writes.** Alias: `health` is identical to `diagnose`.
+
+Checks (all path probes stay under `--install-root`):
+
+| Area | What |
+|------|------|
+| Install root | Exists and is a directory |
+| Layout | Critical dirs: `jetty`, `jetty/base`, `rxconfig` (missing → fail). Optional: `bin`, `rxconfig/Server`, `Deployment` (missing → warn) |
+| Key config | Presence of `rxconfig/Server/server.properties`, `rxconfig/Installer/rxrepository.properties` (missing → warn) |
+| Log dirs | Known Jetty/CMS/DTS log dir existence (same roots as `clean-logs`) |
+| Free disk | Usable space on the install root volume (warn below 1 GiB) |
+| Java | Running doctor JVM version/major (info + warn if major &lt; 21) |
+
+Global `--dry-run` is accepted for flag parity and echoed on the report; diagnose is always non-mutating. Exit code is non-zero when any check is `FAIL`.
+
+Examples:
+
+```bash
+# Checklist with detail (Linux / macOS)
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
+  --install-root /opt/Percussion -v diagnose
+
+# Alias + dry-run flag echo (Windows)
+java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar ^
+  --install-root C:\Percussion --dry-run -v health
+```
+
+Sample summary lines:
+
+```text
+command=diagnose
+install-root=/opt/Percussion
+dry-run=false
+read-only=true
+checks=16
+pass=10
+warn=4
+fail=0
+info=1
+healthy=true
+```
 
 #### `clean-heap-dumps`
 
@@ -166,11 +210,12 @@ java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
 ## Safety model
 
 1. Resolve and validate install root (must exist and be a directory).
-2. Walk only under that root (and for `clean-logs`, only under allowlisted log dirs); skip / reject candidates that escape the root.
-3. Match allowlisted patterns only (per command; no user-supplied globs).
-4. If `--dry-run`, stop after inventory.
-5. On apply, re-check containment immediately before each delete.
-6. For `clean-logs`, apply `--keep-current` and `--older-than` before any delete.
+2. For `diagnose`/`health`: only read path existence, sizes, and JVM/disk properties; never delete or write.
+3. Walk only under that root (and for `clean-logs`, only under allowlisted log dirs); skip / reject candidates that escape the root.
+4. Match allowlisted patterns only (per clean command; no user-supplied globs).
+5. If `--dry-run`, stop after inventory (clean commands).
+6. On apply, re-check containment immediately before each delete.
+7. For `clean-logs`, apply `--keep-current` and `--older-than` before any delete.
 
 ## Admin HTTP API (slice #2219)
 
@@ -236,6 +281,6 @@ Example apply (Admin only; deletes under install root):
 - Admin gate: `com.percussion.doctor.PSDoctorAdminChecker` (`IPSUserService.isAdminUser`)
 - Default install root: `com.percussion.doctor.PSDoctorInstallRootProvider` (`PathUtils.getRxDir()`)
 
-## Deferred (not in this module slice)
+## Deferred (stretch after diagnose)
 
-None for the #2213 slices absorbed here (`clean-*` CLI, dist packaging #2220, admin HTTP #2219). Further residuals stay on the parent epic if any.
+Further stretch commands under parent [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213): `clean-temp`, `fix-permissions`, deeper `check-config` (beyond presence), and optional diagnose on the admin HTTP surface.

--- a/modules/perc-doctor/README.md
+++ b/modules/perc-doctor/README.md
@@ -2,9 +2,9 @@
 
 Operator CLI for diagnosing and safely cleaning Percussion CMS install trees.
 
-**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`), [#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219) (admin HTTP API), [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (dist packaging + install guide)  
+**Issues:** [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2217](https://github.com/intersoftdatalabs-in/percussioncms/issues/2217) (`clean-install-backups`), [#2218](https://github.com/intersoftdatalabs-in/percussioncms/issues/2218) (`clean-logs`), [#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219) (admin HTTP API), [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (dist packaging + install guide), [#2232](https://github.com/intersoftdatalabs-in/percussioncms/issues/2232) (`clean-temp`)  
 **Package:** `com.intsof.percussioncms.doctor` (+ `...doctor.api` for HTTP)  
-**Shipped commands:** `clean-heap-dumps`, `clean-install-backups`, `clean-logs` with global `--dry-run` / `--install-root` / `-v`  
+**Shipped commands:** `clean-heap-dumps`, `clean-install-backups`, `clean-logs`, `clean-temp` with global `--dry-run` / `--install-root` / `-v`  
 **HTTP:** Admin-only `POST .../maintenance/doctor/{command}` (wired in sitemanage)
 
 **Operator install guide (dry-run-first examples):** [docs/operator-install-guide.md](docs/operator-install-guide.md)
@@ -163,14 +163,45 @@ java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
   --install-root /opt/Percussion --dry-run -v clean-logs
 ```
 
+#### `clean-temp`
+
+Reclaim space from **known** install temp / work directories under the install root. Prefer stopping CMS / DTS processes before apply so temp files are not locked.
+
+##### Target temp / work locations (relative to `--install-root`)
+
+| Relative path | Role |
+|---------------|------|
+| `temp` | CMS install temp (`install.xml` creates `${install.dir}/temp`) |
+| `jetty/base/work` | Jetty work directory (assembly / install layout) |
+| `Deployment/Server/temp` | DTS Tomcat `catalina.base`/temp |
+| `Deployment/Server/work` | DTS Tomcat `catalina.base`/work |
+
+Missing directories are skipped (not an error). **Only files under these roots** are candidates. The allowlisted root directories themselves are **never** deleted (empty nested subdirs may be removed best-effort after apply). **No user-supplied globs; no walk of the entire install for arbitrary temp files.**
+
+- **Scope:** only under `--install-root` and the allowlisted temp/work dirs
+- **Dry-run:** inventories candidates + sizes without deleting
+
+Examples:
+
+```bash
+# Preview reclaimable temp/work files (safe)
+java -jar target/perc-doctor-8.2.0-SNAPSHOT.jar \
+  --install-root /opt/Percussion --dry-run -v clean-temp
+
+# Apply (Windows example)
+java -jar target\perc-doctor-8.2.0-SNAPSHOT.jar ^
+  --install-root C:\Percussion -v clean-temp
+```
+
 ## Safety model
 
 1. Resolve and validate install root (must exist and be a directory).
-2. Walk only under that root (and for `clean-logs`, only under allowlisted log dirs); skip / reject candidates that escape the root.
+2. Walk only under that root (and for `clean-logs` / `clean-temp`, only under allowlisted dirs); skip / reject candidates that escape the root.
 3. Match allowlisted patterns only (per command; no user-supplied globs).
 4. If `--dry-run`, stop after inventory.
 5. On apply, re-check containment immediately before each delete.
 6. For `clean-logs`, apply `--keep-current` and `--older-than` before any delete.
+7. For `clean-temp`, never remove the allowlisted temp/work root directories themselves.
 
 ## Admin HTTP API (slice #2219)
 
@@ -179,7 +210,7 @@ When the CMS server is running, doctor commands are also available as an **Admin
 | | |
 |--|--|
 | **Method / path** | `POST /Rhythmyx/services/maintenance/doctor/{command}` |
-| **Commands** | `clean-heap-dumps`, `clean-install-backups`, `clean-logs` (same tokens as CLI) |
+| **Commands** | `clean-heap-dumps`, `clean-install-backups`, `clean-logs`, `clean-temp` (same tokens as CLI) |
 | **Auth hard gate** | **Admin role only.** Anonymous and non-admin callers receive **HTTP 403**. |
 | **Content-Type** | `application/json` (XML also accepted/produced by the host stack) |
 
@@ -238,4 +269,4 @@ Example apply (Admin only; deletes under install root):
 
 ## Deferred (not in this module slice)
 
-None for the #2213 slices absorbed here (`clean-*` CLI, dist packaging #2220, admin HTTP #2219). Further residuals stay on the parent epic if any.
+`clean-temp` is delivered under [#2232](https://github.com/intersoftdatalabs-in/percussioncms/issues/2232). Further residuals (e.g. `fix-permissions` / deeper `check-config`) stay on the parent epic [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213).

--- a/modules/perc-doctor/docs/operator-install-guide.md
+++ b/modules/perc-doctor/docs/operator-install-guide.md
@@ -154,6 +154,57 @@ bin\perc-doctor.bat --install-root C:\Percussion --dry-run -v clean-logs --older
 bin\perc-doctor.bat --install-root C:\Percussion -v clean-logs --older-than 14d
 ```
 
+### `check-config`
+
+Read-only **value / misconfig** checklist on documented config files (beyond presence-only checks). Always non-mutating; `--dry-run` is accepted for flag parity.
+
+Scoped files:
+
+- `rxconfig/Server/server.properties` — e.g. `enableDebugTools`, CSRF disable, `bindPort`, `requireHTTPS`
+- `rxconfig/Installer/rxrepository.properties` — required JDBC keys, driver/backend consistency, weak `PWD`, plaintext `PWD_ENCRYPTED`
+
+Exit code is non-zero when any check is **FAIL**. Password values are never printed.
+
+**Safe inventory (Linux / macOS):**
+
+```bash
+./bin/perc-doctor --install-root /opt/Percussion --dry-run -v check-config
+```
+
+**Safe inventory (Windows):**
+
+```bat
+bin\perc-doctor.bat --install-root C:\Percussion -v check-config
+```
+
+### `fix-permissions`
+
+Reports (and on POSIX can fix) **allowlisted** mode / access issues only — no shell, no user globs. Prefer dry-run first.
+
+| Target | Fix behavior |
+|--------|----------------|
+| `bin/perc-doctor` (+ `.bat` / `.jar` report) | POSIX: add owner-execute on the Unix script when missing |
+| Known log directories | POSIX: ensure owner rwx when the directory exists |
+| Key `rxconfig` property files | POSIX: ensure owner-read when present |
+
+On Windows the command reports readable/writable and does **not** rewrite ACLs.
+
+**Dry-run first:**
+
+```bash
+./bin/perc-doctor --install-root /opt/Percussion --dry-run -v fix-permissions
+```
+
+```bat
+bin\perc-doctor.bat --install-root C:\Percussion --dry-run -v fix-permissions
+```
+
+**Apply (POSIX mode bits only):**
+
+```bash
+./bin/perc-doctor --install-root /opt/Percussion -v fix-permissions
+```
+
 ## Distribution packaging (developers)
 
 Module `mvnw clean install` attaches:

--- a/modules/perc-doctor/docs/operator-install-guide.md
+++ b/modules/perc-doctor/docs/operator-install-guide.md
@@ -66,6 +66,28 @@ For every command:
 
 ## Commands
 
+### `diagnose` / `health` (read-only)
+
+Run a non-mutating install checklist (layout dirs, free disk, key config presence, Java version, known log dirs). **Never deletes.** Alias: `health` is the same command. Safe to run anytime; prefer `-v` for checklist detail.
+
+**Linux / macOS:**
+
+```bash
+cd /opt/Percussion
+./bin/perc-doctor -v diagnose
+# or
+./bin/perc-doctor --dry-run -v health
+```
+
+**Windows:**
+
+```bat
+cd /d C:\Percussion
+bin\perc-doctor.bat -v diagnose
+```
+
+Exit code is non-zero when any check is `FAIL` (e.g. missing `jetty/base` or `rxconfig`). WARN-only outcomes still exit 0.
+
 ### `clean-heap-dumps`
 
 Removes recursive `*.hprof` under the install root (case-insensitive). Scope is hard-limited to `--install-root`.

--- a/modules/perc-doctor/docs/operator-install-guide.md
+++ b/modules/perc-doctor/docs/operator-install-guide.md
@@ -1,7 +1,7 @@
 # perc-doctor operator install guide
 
 **Module:** `modules/perc-doctor`  
-**Issues:** [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (packaging), [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent)
+**Issues:** [#2220](https://github.com/intersoftdatalabs-in/percussioncms/issues/2220) (packaging), [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213) (parent), [#2232](https://github.com/intersoftdatalabs-in/percussioncms/issues/2232) (`clean-temp`)
 
 This guide is for operators running **perc-doctor** against a CMS install on Windows or Linux. Prefer **dry-run first** for every command; only apply after you review the candidate list and sizes.
 
@@ -154,6 +154,37 @@ bin\perc-doctor.bat --install-root C:\Percussion --dry-run -v clean-logs --older
 bin\perc-doctor.bat --install-root C:\Percussion -v clean-logs --older-than 14d
 ```
 
+### `clean-temp`
+
+Removes **files** under known install temp / work directories only. Prefer stopping CMS / DTS first so files are not locked. Allowlisted roots themselves are retained.
+
+| Relative path | Role |
+|---------------|------|
+| `temp` | CMS install temp |
+| `jetty/base/work` | Jetty work directory |
+| `Deployment/Server/temp` | DTS Tomcat temp |
+| `Deployment/Server/work` | DTS Tomcat work |
+
+**Dry-run first:**
+
+```bash
+./bin/perc-doctor --install-root /opt/Percussion --dry-run -v clean-temp
+```
+
+```bat
+bin\perc-doctor.bat --install-root C:\Percussion --dry-run -v clean-temp
+```
+
+**Apply (only after review; prefer CMS/DTS stopped):**
+
+```bash
+./bin/perc-doctor --install-root /opt/Percussion -v clean-temp
+```
+
+```bat
+bin\perc-doctor.bat --install-root C:\Percussion -v clean-temp
+```
+
 ## Distribution packaging (developers)
 
 Module `mvnw clean install` attaches:
@@ -170,4 +201,5 @@ Module `mvnw clean install` attaches:
 
 - Module README: [../README.md](../README.md)
 - Parent epic: [#2213](https://github.com/intersoftdatalabs-in/percussioncms/issues/2213)
-- Admin HTTP API: deferred ([#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219))
+- `clean-temp` slice: [#2232](https://github.com/intersoftdatalabs-in/percussioncms/issues/2232)
+- Admin HTTP API: shipped with MVP cluster ([#2219](https://github.com/intersoftdatalabs-in/percussioncms/issues/2219) / [#2230](https://github.com/intersoftdatalabs-in/percussioncms/pull/2230))

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CheckConfigCommand.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CheckConfigCommand.java
@@ -1,0 +1,556 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Read-only deeper config value / misconfig checks for a CMS install ({@code check-config}).
+ *
+ * <p>Goes beyond file presence (covered by {@code diagnose} / {@code health}) into documented,
+ * scoped property value checks. Never deletes or writes. All resolved paths are constrained under
+ * the install root via {@link InstallRootGuard}.
+ *
+ * <p>Scoped files (relative to install root):
+ *
+ * <ul>
+ *   <li>{@code rxconfig/Server/server.properties}
+ *   <li>{@code rxconfig/Installer/rxrepository.properties}
+ * </ul>
+ *
+ * <p>Global {@code --dry-run} is accepted for CLI parity and echoed on the report; it has no effect
+ * because this command is always non-mutating.
+ */
+public final class CheckConfigCommand {
+
+  /** CLI command token. */
+  public static final String COMMAND_NAME = "check-config";
+
+  /** Relative path of CMS server.properties under the install root. */
+  public static final String SERVER_PROPERTIES_REL = "rxconfig/Server/server.properties";
+
+  /** Relative path of repository installer properties under the install root. */
+  public static final String RXREPOSITORY_PROPERTIES_REL =
+      "rxconfig/Installer/rxrepository.properties";
+
+  /**
+   * Required non-blank keys in {@code rxrepository.properties} for a usable CMS repository
+   * connection (H2 embedded still needs these keys set).
+   */
+  static final String[] REQUIRED_REPO_KEYS = {
+    "DB_BACKEND", "DB_DRIVER_NAME", "DB_DRIVER_CLASS_NAME", "DB_SERVER", "UID"
+  };
+
+  /** Weak / default password tokens that should not ship in production (case-insensitive). */
+  static final Set<String> WEAK_PASSWORD_TOKENS =
+      new HashSet<>(
+          Arrays.asList(
+              "password",
+              "changeme",
+              "demo",
+              "admin",
+              "root",
+              "sa",
+              "secret",
+              "percussion",
+              "cms",
+              "123456",
+              "password1"));
+
+  /** Unresolved Ant / installer style placeholders in property values. */
+  private static final Pattern UNRESOLVED_PLACEHOLDER =
+      Pattern.compile("\\$\\{[^}]+\\}");
+
+  private CheckConfigCommand() {}
+
+  /**
+   * Run value / misconfig checks under {@code installRoot}.
+   *
+   * @param installRoot CMS install root (must exist and be a directory)
+   * @param dryRun echoed global flag only; never enables writes
+   * @return checklist report
+   * @throws IllegalArgumentException if install root is invalid
+   * @throws IOException if a config file cannot be read after existence was confirmed (individual
+   *     checks prefer FAIL rows when possible)
+   */
+  public static CheckConfigReport execute(Path installRoot, boolean dryRun) throws IOException {
+    Path root = InstallRootGuard.requireInstallRoot(installRoot);
+    CheckConfigReport report = new CheckConfigReport(COMMAND_NAME, root, dryRun);
+
+    report.add(
+        new CheckConfigReport.Check(
+            "install-root",
+            CheckConfigReport.CheckStatus.PASS,
+            "Install root exists and is a directory",
+            root));
+
+    checkServerProperties(report, root);
+    checkRxRepositoryProperties(report, root);
+
+    return report;
+  }
+
+  static void checkServerProperties(CheckConfigReport report, Path root) {
+    Path path = resolveScopedFile(report, root, SERVER_PROPERTIES_REL, "server.properties");
+    if (path == null) {
+      return;
+    }
+    if (!Files.isRegularFile(path)) {
+      report.add(
+          new CheckConfigReport.Check(
+              "server.properties.present",
+              CheckConfigReport.CheckStatus.WARN,
+              "server.properties missing (cannot validate values): " + SERVER_PROPERTIES_REL,
+              path));
+      return;
+    }
+    report.add(
+        new CheckConfigReport.Check(
+            "server.properties.present",
+            CheckConfigReport.CheckStatus.PASS,
+            "server.properties present",
+            path));
+
+    Properties props = loadProperties(report, path, "server.properties");
+    if (props == null) {
+      return;
+    }
+
+    checkBooleanFlag(
+        report,
+        path,
+        props,
+        "enableDebugTools",
+        true,
+        CheckConfigReport.CheckStatus.WARN,
+        "enableDebugTools=true is unsafe for production (debug tooling exposed)");
+    checkBooleanFlag(
+        report,
+        path,
+        props,
+        "disableCrossSiteRequestForgeryCheck",
+        true,
+        CheckConfigReport.CheckStatus.WARN,
+        "disableCrossSiteRequestForgeryCheck=true disables CSRF protection");
+
+    String requireHttps = trimToEmpty(props.getProperty("requireHTTPS"));
+    if (requireHttps.isEmpty()) {
+      report.add(
+          new CheckConfigReport.Check(
+              "server.requireHTTPS",
+              CheckConfigReport.CheckStatus.INFO,
+              "requireHTTPS not set (product default may apply)",
+              path));
+    } else if (isTruthy(requireHttps)) {
+      report.add(
+          new CheckConfigReport.Check(
+              "server.requireHTTPS",
+              CheckConfigReport.CheckStatus.PASS,
+              "requireHTTPS=true",
+              path));
+    } else {
+      report.add(
+          new CheckConfigReport.Check(
+              "server.requireHTTPS",
+              CheckConfigReport.CheckStatus.INFO,
+              "requireHTTPS=false (acceptable for lab/dev; prefer true behind TLS termination"
+                  + " when not terminated elsewhere)",
+              path));
+    }
+
+    String bindPort = trimToEmpty(props.getProperty("bindPort"));
+    if (bindPort.isEmpty()) {
+      report.add(
+          new CheckConfigReport.Check(
+              "server.bindPort",
+              CheckConfigReport.CheckStatus.WARN,
+              "bindPort is empty or missing",
+              path));
+    } else if (containsUnresolvedPlaceholder(bindPort)) {
+      report.add(
+          new CheckConfigReport.Check(
+              "server.bindPort",
+              CheckConfigReport.CheckStatus.FAIL,
+              "bindPort contains unresolved placeholder: " + bindPort,
+              path));
+    } else {
+      try {
+        int port = Integer.parseInt(bindPort);
+        if (port <= 0 || port > 65535) {
+          report.add(
+              new CheckConfigReport.Check(
+                  "server.bindPort",
+                  CheckConfigReport.CheckStatus.FAIL,
+                  "bindPort out of range (1-65535): " + bindPort,
+                  path));
+        } else {
+          report.add(
+              new CheckConfigReport.Check(
+                  "server.bindPort",
+                  CheckConfigReport.CheckStatus.PASS,
+                  "bindPort is a valid TCP port: " + port,
+                  path));
+        }
+      } catch (NumberFormatException e) {
+        report.add(
+            new CheckConfigReport.Check(
+                "server.bindPort",
+                CheckConfigReport.CheckStatus.FAIL,
+                "bindPort is not an integer: " + bindPort,
+                path));
+      }
+    }
+
+    checkUnresolvedPlaceholders(report, path, props, "server");
+  }
+
+  static void checkRxRepositoryProperties(CheckConfigReport report, Path root) {
+    Path path =
+        resolveScopedFile(report, root, RXREPOSITORY_PROPERTIES_REL, "rxrepository.properties");
+    if (path == null) {
+      return;
+    }
+    if (!Files.isRegularFile(path)) {
+      report.add(
+          new CheckConfigReport.Check(
+              "rxrepository.properties.present",
+              CheckConfigReport.CheckStatus.WARN,
+              "rxrepository.properties missing (cannot validate values): "
+                  + RXREPOSITORY_PROPERTIES_REL,
+              path));
+      return;
+    }
+    report.add(
+        new CheckConfigReport.Check(
+            "rxrepository.properties.present",
+            CheckConfigReport.CheckStatus.PASS,
+            "rxrepository.properties present",
+            path));
+
+    Properties props = loadProperties(report, path, "rxrepository.properties");
+    if (props == null) {
+      return;
+    }
+
+    for (String key : REQUIRED_REPO_KEYS) {
+      String value = trimToEmpty(props.getProperty(key));
+      if (value.isEmpty()) {
+        report.add(
+            new CheckConfigReport.Check(
+                "repo." + key,
+                CheckConfigReport.CheckStatus.FAIL,
+                "Required repository key missing or blank: " + key,
+                path));
+      } else if (containsUnresolvedPlaceholder(value)) {
+        report.add(
+            new CheckConfigReport.Check(
+                "repo." + key,
+                CheckConfigReport.CheckStatus.FAIL,
+                "Required repository key has unresolved placeholder: " + key + "=" + value,
+                path));
+      } else {
+        report.add(
+            new CheckConfigReport.Check(
+                "repo." + key,
+                CheckConfigReport.CheckStatus.PASS,
+                "Required repository key set: " + key,
+                path));
+      }
+    }
+
+    String backend = trimToEmpty(props.getProperty("DB_BACKEND")).toUpperCase(Locale.ROOT);
+    String driverName = trimToEmpty(props.getProperty("DB_DRIVER_NAME")).toLowerCase(Locale.ROOT);
+    String driverClass =
+        trimToEmpty(props.getProperty("DB_DRIVER_CLASS_NAME")).toLowerCase(Locale.ROOT);
+    if (!backend.isEmpty() && !driverName.isEmpty() && !driverClass.isEmpty()) {
+      if (isH2Backend(backend)) {
+        if (!driverName.contains("h2") && !driverClass.contains("h2")) {
+          report.add(
+              new CheckConfigReport.Check(
+                  "repo.driver-backend-consistency",
+                  CheckConfigReport.CheckStatus.WARN,
+                  "DB_BACKEND looks like H2 but driver name/class do not mention h2 (driverName="
+                      + props.getProperty("DB_DRIVER_NAME")
+                      + ")",
+                  path));
+        } else {
+          report.add(
+              new CheckConfigReport.Check(
+                  "repo.driver-backend-consistency",
+                  CheckConfigReport.CheckStatus.PASS,
+                  "H2 backend matches H2 driver settings",
+                  path));
+        }
+      } else {
+        // Non-H2: driver should not be the embedded H2 class.
+        if (driverClass.contains("org.h2.") || "h2".equals(driverName)) {
+          report.add(
+              new CheckConfigReport.Check(
+                  "repo.driver-backend-consistency",
+                  CheckConfigReport.CheckStatus.WARN,
+                  "DB_BACKEND="
+                      + props.getProperty("DB_BACKEND")
+                      + " but driver settings look like H2",
+                  path));
+        } else {
+          report.add(
+              new CheckConfigReport.Check(
+                  "repo.driver-backend-consistency",
+                  CheckConfigReport.CheckStatus.PASS,
+                  "Non-H2 backend has non-H2 driver settings",
+                  path));
+        }
+      }
+    }
+
+    String pwd = props.getProperty("PWD");
+    String pwdTrimmed = pwd == null ? "" : pwd.trim();
+    String pwdEncrypted = trimToEmpty(props.getProperty("PWD_ENCRYPTED")).toUpperCase(Locale.ROOT);
+
+    if (pwdTrimmed.isEmpty()) {
+      if (isH2Backend(backend)) {
+        report.add(
+            new CheckConfigReport.Check(
+                "repo.PWD",
+                CheckConfigReport.CheckStatus.INFO,
+                "PWD empty (common for embedded H2 lab installs)",
+                path));
+      } else if (!backend.isEmpty()) {
+        report.add(
+            new CheckConfigReport.Check(
+                "repo.PWD",
+                CheckConfigReport.CheckStatus.WARN,
+                "PWD is empty for non-H2 backend " + props.getProperty("DB_BACKEND"),
+                path));
+      }
+    } else if (isWeakPassword(pwdTrimmed)) {
+      report.add(
+          new CheckConfigReport.Check(
+              "repo.PWD",
+              CheckConfigReport.CheckStatus.WARN,
+              "PWD looks like a well-known weak/default password token",
+              path));
+    } else {
+      report.add(
+          new CheckConfigReport.Check(
+              "repo.PWD",
+              CheckConfigReport.CheckStatus.PASS,
+              "PWD is set (value not printed)",
+              path));
+    }
+
+    if (!pwdTrimmed.isEmpty() && ("N".equals(pwdEncrypted) || pwdEncrypted.isEmpty())) {
+      report.add(
+          new CheckConfigReport.Check(
+              "repo.PWD_ENCRYPTED",
+              CheckConfigReport.CheckStatus.WARN,
+              "PWD is stored in plaintext (PWD_ENCRYPTED is not Y); prefer encrypted storage in"
+                  + " production",
+              path));
+    } else if ("Y".equals(pwdEncrypted)) {
+      report.add(
+          new CheckConfigReport.Check(
+              "repo.PWD_ENCRYPTED",
+              CheckConfigReport.CheckStatus.PASS,
+              "PWD_ENCRYPTED=Y",
+              path));
+    } else if (!pwdEncrypted.isEmpty()) {
+      report.add(
+          new CheckConfigReport.Check(
+              "repo.PWD_ENCRYPTED",
+              CheckConfigReport.CheckStatus.INFO,
+              "PWD_ENCRYPTED=" + props.getProperty("PWD_ENCRYPTED"),
+              path));
+    }
+
+    checkUnresolvedPlaceholders(report, path, props, "repo");
+  }
+
+  /**
+   * Resolve a documented relative config path under root with containment. On path-guard failure
+   * records FAIL and returns null.
+   */
+  static Path resolveScopedFile(
+      CheckConfigReport report, Path root, String relativeSlashPath, String label) {
+    Path resolved = InstallRootGuard.resolveRelativeUnderRoot(root, relativeSlashPath);
+    if (resolved == null) {
+      report.add(
+          new CheckConfigReport.Check(
+              label + ".path",
+              CheckConfigReport.CheckStatus.FAIL,
+              "Invalid relative config path (path guard rejected): " + relativeSlashPath,
+              null));
+      return null;
+    }
+    if (!InstallRootGuard.isUnderInstallRoot(root, resolved)) {
+      report.add(
+          new CheckConfigReport.Check(
+              label + ".path",
+              CheckConfigReport.CheckStatus.FAIL,
+              "Resolved config path is outside install root: " + resolved,
+              resolved));
+      return null;
+    }
+    return resolved;
+  }
+
+  static Properties loadProperties(CheckConfigReport report, Path path, String label) {
+    Properties props = new Properties();
+    try (InputStream in = Files.newInputStream(path)) {
+      props.load(in);
+      return props;
+    } catch (IOException e) {
+      report.add(
+          new CheckConfigReport.Check(
+              label + ".readable",
+              CheckConfigReport.CheckStatus.FAIL,
+              "Failed to read " + label + ": " + e.getMessage(),
+              path));
+      return null;
+    }
+  }
+
+  static void checkBooleanFlag(
+      CheckConfigReport report,
+      Path path,
+      Properties props,
+      String key,
+      boolean badWhenTrue,
+      CheckConfigReport.CheckStatus badStatus,
+      String badMessage) {
+    String raw = trimToEmpty(props.getProperty(key));
+    String id = "server." + key;
+    if (raw.isEmpty()) {
+      report.add(
+          new CheckConfigReport.Check(
+              id,
+              CheckConfigReport.CheckStatus.INFO,
+              key + " not set (product default may apply)",
+              path));
+      return;
+    }
+    if (containsUnresolvedPlaceholder(raw)) {
+      report.add(
+          new CheckConfigReport.Check(
+              id,
+              CheckConfigReport.CheckStatus.FAIL,
+              key + " contains unresolved placeholder: " + raw,
+              path));
+      return;
+    }
+    boolean truthy = isTruthy(raw);
+    if (badWhenTrue && truthy) {
+      report.add(new CheckConfigReport.Check(id, badStatus, badMessage, path));
+    } else {
+      report.add(
+          new CheckConfigReport.Check(
+              id, CheckConfigReport.CheckStatus.PASS, key + "=" + raw, path));
+    }
+  }
+
+  /**
+   * Scan property values for unresolved {@code ${...}} placeholders. Skips keys already checked
+   * with dedicated FAIL rows for required repo keys / bindPort.
+   */
+  static void checkUnresolvedPlaceholders(
+      CheckConfigReport report, Path path, Properties props, String idPrefix) {
+    int found = 0;
+    for (String name : props.stringPropertyNames()) {
+      String value = props.getProperty(name);
+      if (value == null || !containsUnresolvedPlaceholder(value)) {
+        continue;
+      }
+      // Avoid double-reporting dedicated keys.
+      if ("bindPort".equals(name) || isRequiredRepoKey(name)) {
+        continue;
+      }
+      found++;
+      if (found <= 5) {
+        report.add(
+            new CheckConfigReport.Check(
+                idPrefix + ".placeholder." + name,
+                CheckConfigReport.CheckStatus.WARN,
+                "Unresolved placeholder in " + name + "=" + value,
+                path));
+      }
+    }
+    if (found == 0) {
+      report.add(
+          new CheckConfigReport.Check(
+              idPrefix + ".placeholders",
+              CheckConfigReport.CheckStatus.PASS,
+              "No unresolved ${...} placeholders in scanned values",
+              path));
+    } else if (found > 5) {
+      report.add(
+          new CheckConfigReport.Check(
+              idPrefix + ".placeholders.truncated",
+              CheckConfigReport.CheckStatus.WARN,
+              "Additional unresolved placeholders not listed (total=" + found + ")",
+              path));
+    }
+  }
+
+  static boolean isRequiredRepoKey(String name) {
+    for (String key : REQUIRED_REPO_KEYS) {
+      if (key.equals(name)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static boolean isH2Backend(String backendUpperOrEmpty) {
+    if (backendUpperOrEmpty == null || backendUpperOrEmpty.isEmpty()) {
+      return false;
+    }
+    String b = backendUpperOrEmpty.toUpperCase(Locale.ROOT);
+    return "H2".equals(b) || b.contains("H2");
+  }
+
+  static boolean isWeakPassword(String password) {
+    Objects.requireNonNull(password, "password");
+    String lower = password.toLowerCase(Locale.ROOT);
+    return WEAK_PASSWORD_TOKENS.contains(lower);
+  }
+
+  static boolean containsUnresolvedPlaceholder(String value) {
+    return value != null && UNRESOLVED_PLACEHOLDER.matcher(value).find();
+  }
+
+  static boolean isTruthy(String raw) {
+    if (raw == null) {
+      return false;
+    }
+    String v = raw.trim().toLowerCase(Locale.ROOT);
+    return "true".equals(v) || "yes".equals(v) || "y".equals(v) || "1".equals(v);
+  }
+
+  static String trimToEmpty(String value) {
+    return value == null ? "" : value.trim();
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CheckConfigReport.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CheckConfigReport.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Read-only value / misconfig checklist report for {@code check-config}. Never implies filesystem
+ * mutations.
+ */
+public final class CheckConfigReport {
+
+  /** Outcome severity for a single config check. */
+  public enum CheckStatus {
+    /** Expected condition met. */
+    PASS,
+    /** Non-fatal concern (weak defaults, production hygiene). */
+    WARN,
+    /** Critical misconfig or unreadable required config. */
+    FAIL,
+    /** Pure information (documented default, not necessarily wrong). */
+    INFO
+  }
+
+  /** One checklist row. */
+  public static final class Check {
+    private final String id;
+    private final CheckStatus status;
+    private final String message;
+    private final Path path;
+
+    /**
+     * @param id stable machine-oriented check id (e.g. {@code server.enableDebugTools})
+     * @param status outcome severity
+     * @param message human-readable detail
+     * @param path optional related path under install root (may be null)
+     */
+    public Check(String id, CheckStatus status, String message, Path path) {
+      this.id = Objects.requireNonNull(id, "id");
+      this.status = Objects.requireNonNull(status, "status");
+      this.message = Objects.requireNonNull(message, "message");
+      this.path = path;
+    }
+
+    /** @return stable check id */
+    public String getId() {
+      return id;
+    }
+
+    /** @return outcome severity */
+    public CheckStatus getStatus() {
+      return status;
+    }
+
+    /** @return human-readable detail */
+    public String getMessage() {
+      return message;
+    }
+
+    /** @return related path, or null */
+    public Path getPath() {
+      return path;
+    }
+  }
+
+  private final String command;
+  private final Path installRoot;
+  private final boolean dryRun;
+  private final List<Check> checks = new ArrayList<>();
+
+  /**
+   * @param command command token ({@code check-config})
+   * @param installRoot resolved install root
+   * @param dryRun echoed global flag (check-config never mutates regardless)
+   */
+  public CheckConfigReport(String command, Path installRoot, boolean dryRun) {
+    this.command = Objects.requireNonNull(command, "command");
+    this.installRoot = Objects.requireNonNull(installRoot, "installRoot");
+    this.dryRun = dryRun;
+  }
+
+  /** Append a checklist entry. */
+  public void add(Check check) {
+    checks.add(Objects.requireNonNull(check, "check"));
+  }
+
+  /** @return command token */
+  public String getCommand() {
+    return command;
+  }
+
+  /** @return install root used for this run */
+  public Path getInstallRoot() {
+    return installRoot;
+  }
+
+  /**
+   * Echo of the global {@code --dry-run} flag. check-config is always read-only; this value is
+   * reported for flag parity and never gates writes (there are none).
+   *
+   * @return whether {@code --dry-run} was set on the CLI
+   */
+  public boolean isDryRun() {
+    return dryRun;
+  }
+
+  /** @return unmodifiable checklist */
+  public List<Check> getChecks() {
+    return Collections.unmodifiableList(checks);
+  }
+
+  /** @return number of checks */
+  public int getCheckCount() {
+    return checks.size();
+  }
+
+  /** @return count of {@link CheckStatus#PASS} */
+  public int getPassCount() {
+    return count(CheckStatus.PASS);
+  }
+
+  /** @return count of {@link CheckStatus#WARN} */
+  public int getWarnCount() {
+    return count(CheckStatus.WARN);
+  }
+
+  /** @return count of {@link CheckStatus#FAIL} */
+  public int getFailCount() {
+    return count(CheckStatus.FAIL);
+  }
+
+  /** @return count of {@link CheckStatus#INFO} */
+  public int getInfoCount() {
+    return count(CheckStatus.INFO);
+  }
+
+  /**
+   * @return true when no {@link CheckStatus#FAIL} entries (WARN/INFO allowed)
+   */
+  public boolean isHealthy() {
+    return getFailCount() == 0;
+  }
+
+  private int count(CheckStatus status) {
+    int n = 0;
+    for (Check c : checks) {
+      if (c.getStatus() == status) {
+        n++;
+      }
+    }
+    return n;
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanTempCommand.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/CleanTempCommand.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Remove (or inventory) files under known CMS install temp / work directories.
+ *
+ * <p>Target roots (relative to install root; missing dirs skipped):
+ *
+ * <ul>
+ *   <li>{@code temp}
+ *   <li>{@code jetty/base/work}
+ *   <li>{@code Deployment/Server/temp}
+ *   <li>{@code Deployment/Server/work}
+ * </ul>
+ *
+ * <p>Only files under those allowlisted roots are considered. The allowlisted root directories
+ * themselves are never deleted. Dry-run never deletes. Paths outside the install root are never
+ * deleted. Prefer stopping the CMS / DTS processes before apply so files are not locked.
+ */
+public final class CleanTempCommand {
+
+  /** CLI command token. */
+  public static final String COMMAND_NAME = "clean-temp";
+
+  private CleanTempCommand() {}
+
+  /**
+   * Inventory files under known temp/work dirs and optionally delete them.
+   *
+   * @param installRoot resolved install root (must exist)
+   * @param dryRun when true, only inventory (no deletes)
+   * @return report of candidates and actions
+   * @throws IOException on walk failures that cannot be recovered
+   * @throws IllegalArgumentException if install root is invalid
+   */
+  public static CleanReport execute(Path installRoot, boolean dryRun) throws IOException {
+    Path root = InstallRootGuard.requireInstallRoot(installRoot);
+    CleanReport report = new CleanReport(COMMAND_NAME, root, dryRun);
+
+    List<Path> tempRoots = InstallRootGuard.existingTempDirs(root);
+    List<Path> candidates = new ArrayList<>();
+    for (Path tempDir : tempRoots) {
+      walkTempDir(root, tempDir, candidates, report);
+    }
+    candidates.sort(Comparator.comparing(p -> p.toString()));
+
+    Set<Path> parentDirs = new HashSet<>();
+    for (Path candidate : candidates) {
+      processCandidate(report, root, tempRoots, candidate, dryRun);
+      Path parent = candidate.getParent();
+      if (parent != null) {
+        parentDirs.add(parent);
+      }
+    }
+
+    // Best-effort: remove empty nested dirs after apply (never the allowlisted roots).
+    if (!dryRun) {
+      removeEmptyNestedDirs(root, tempRoots, parentDirs);
+    }
+    return report;
+  }
+
+  /**
+   * Inventory temp files under known temp dirs without recording walk failures (test helper).
+   * Returns all regular files found under allowlisted roots.
+   */
+  static List<Path> findTempFiles(Path root) throws IOException {
+    Path installRoot = InstallRootGuard.requireInstallRoot(root);
+    List<Path> found = new ArrayList<>();
+    for (Path tempDir : InstallRootGuard.existingTempDirs(installRoot)) {
+      walkTempDir(installRoot, tempDir, found, null);
+    }
+    return found;
+  }
+
+  /**
+   * Walk a single temp/work directory tree. When {@code report} is non-null, I/O failures during
+   * the walk are appended as {@link CleanReport.EntryStatus#FAILED}.
+   */
+  static void walkTempDir(Path installRoot, Path tempDir, List<Path> found, CleanReport report)
+      throws IOException {
+    Objects.requireNonNull(installRoot, "installRoot");
+    Objects.requireNonNull(tempDir, "tempDir");
+    Objects.requireNonNull(found, "found");
+    if (!InstallRootGuard.isUnderInstallRoot(installRoot, tempDir)) {
+      return;
+    }
+    if (!Files.isDirectory(tempDir)) {
+      return;
+    }
+    Files.walkFileTree(
+        tempDir,
+        new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+            if (!InstallRootGuard.isUnderInstallRoot(installRoot, dir)) {
+              return FileVisitResult.SKIP_SUBTREE;
+            }
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+            if (!attrs.isRegularFile()) {
+              return FileVisitResult.CONTINUE;
+            }
+            if (!InstallRootGuard.isUnderInstallRoot(installRoot, file)) {
+              return FileVisitResult.CONTINUE;
+            }
+            // Never treat the allowlisted root itself as a file candidate.
+            if (tempDir.equals(file.toAbsolutePath().normalize())) {
+              return FileVisitResult.CONTINUE;
+            }
+            found.add(file);
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult visitFileFailed(Path file, IOException exc) {
+            recordVisitFailure(report, file, exc);
+            return FileVisitResult.CONTINUE;
+          }
+        });
+  }
+
+  /** Record a walk I/O failure on the report when one is provided (package-visible for tests). */
+  static void recordVisitFailure(CleanReport report, Path file, IOException exc) {
+    if (report == null || file == null) {
+      return;
+    }
+    String detail = exc != null ? exc.getMessage() : "unknown I/O error";
+    if (detail == null || detail.isBlank()) {
+      detail = exc != null ? exc.getClass().getSimpleName() : "unknown I/O error";
+    }
+    report.add(
+        new CleanReport.Entry(file, 0L, CleanReport.EntryStatus.FAILED, "walk: " + detail));
+  }
+
+  private static void processCandidate(
+      CleanReport report,
+      Path root,
+      List<Path> tempRoots,
+      Path candidate,
+      boolean dryRun) {
+    Objects.requireNonNull(candidate, "candidate");
+    try {
+      InstallRootGuard.requireUnderInstallRoot(root, candidate);
+    } catch (IllegalArgumentException outside) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, 0L, CleanReport.EntryStatus.FAILED, outside.getMessage()));
+      return;
+    }
+
+    if (!isUnderAnyTempRoot(tempRoots, candidate)) {
+      report.add(
+          new CleanReport.Entry(
+              candidate,
+              0L,
+              CleanReport.EntryStatus.SKIPPED,
+              "not under an allowlisted temp/work directory"));
+      return;
+    }
+
+    // Never delete the allowlisted root directories themselves.
+    Path normalizedCandidate = candidate.toAbsolutePath().normalize();
+    for (Path tempRoot : tempRoots) {
+      if (tempRoot.toAbsolutePath().normalize().equals(normalizedCandidate)) {
+        report.add(
+            new CleanReport.Entry(
+                candidate,
+                0L,
+                CleanReport.EntryStatus.SKIPPED,
+                "allowlisted temp/work root is retained"));
+        return;
+      }
+    }
+
+    long size = 0L;
+    try {
+      if (Files.isRegularFile(candidate)) {
+        size = Files.size(candidate);
+      }
+    } catch (IOException e) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, 0L, CleanReport.EntryStatus.FAILED, "size: " + e.getMessage()));
+      return;
+    }
+
+    if (dryRun) {
+      report.add(
+          new CleanReport.Entry(candidate, size, CleanReport.EntryStatus.WOULD_DELETE, null));
+      return;
+    }
+
+    try {
+      // Re-check containment immediately before delete (TOCTOU-resistant enough for ops tool).
+      InstallRootGuard.requireUnderInstallRoot(root, candidate);
+      if (!isUnderAnyTempRoot(tempRoots, candidate)) {
+        report.add(
+            new CleanReport.Entry(
+                candidate,
+                size,
+                CleanReport.EntryStatus.FAILED,
+                "path escaped allowlisted temp/work roots before delete"));
+        return;
+      }
+      boolean deleted = Files.deleteIfExists(candidate);
+      if (deleted) {
+        report.add(new CleanReport.Entry(candidate, size, CleanReport.EntryStatus.DELETED, null));
+      } else {
+        report.add(
+            new CleanReport.Entry(
+                candidate, size, CleanReport.EntryStatus.SKIPPED, "already absent"));
+      }
+    } catch (IOException e) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, size, CleanReport.EntryStatus.FAILED, "delete: " + e.getMessage()));
+    } catch (IllegalArgumentException outside) {
+      report.add(
+          new CleanReport.Entry(
+              candidate, size, CleanReport.EntryStatus.FAILED, outside.getMessage()));
+    }
+  }
+
+  /**
+   * True when {@code candidate} is under (or equal to) one of the allowlisted temp roots, all
+   * relative to install-root containment already verified by the caller.
+   */
+  static boolean isUnderAnyTempRoot(List<Path> tempRoots, Path candidate) {
+    if (tempRoots == null || candidate == null) {
+      return false;
+    }
+    Path path = candidate.toAbsolutePath().normalize();
+    for (Path tempRoot : tempRoots) {
+      if (tempRoot == null) {
+        continue;
+      }
+      Path root = tempRoot.toAbsolutePath().normalize();
+      if (InstallRootGuard.pathStartsWithRoot(path, root)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Best-effort empty directory cleanup under allowlisted roots. Never removes the allowlisted
+   * roots themselves. Failures are ignored (files are what reclaim space).
+   */
+  static void removeEmptyNestedDirs(
+      Path installRoot, List<Path> tempRoots, Set<Path> seedParents) {
+    if (tempRoots == null || tempRoots.isEmpty()) {
+      return;
+    }
+    Set<Path> rootsNormalized = new HashSet<>();
+    for (Path r : tempRoots) {
+      rootsNormalized.add(r.toAbsolutePath().normalize());
+    }
+
+    // Walk deepest first so children empty before parents.
+    List<Path> toTry = new ArrayList<>();
+    if (seedParents != null) {
+      toTry.addAll(seedParents);
+    }
+    // Also re-scan each temp root for empty nested dirs that had no files.
+    for (Path tempRoot : tempRoots) {
+      try {
+        collectNestedDirs(installRoot, tempRoot, toTry);
+      } catch (IOException ignored) {
+        // best-effort
+      }
+    }
+
+    toTry.sort(
+        Comparator.comparingInt((Path p) -> p.toAbsolutePath().normalize().getNameCount())
+            .reversed()
+            .thenComparing(p -> p.toString()));
+
+    for (Path dir : toTry) {
+      Path normalized = dir.toAbsolutePath().normalize();
+      if (rootsNormalized.contains(normalized)) {
+        continue;
+      }
+      if (!InstallRootGuard.isUnderInstallRoot(installRoot, normalized)) {
+        continue;
+      }
+      if (!isUnderAnyTempRoot(tempRoots, normalized)) {
+        continue;
+      }
+      try {
+        if (Files.isDirectory(normalized)) {
+          // delete only if empty
+          try (var stream = Files.list(normalized)) {
+            if (stream.findAny().isEmpty()) {
+              Files.deleteIfExists(normalized);
+            }
+          }
+        }
+      } catch (IOException ignored) {
+        // best-effort
+      }
+    }
+  }
+
+  private static void collectNestedDirs(Path installRoot, Path tempRoot, List<Path> out)
+      throws IOException {
+    if (!Files.isDirectory(tempRoot)) {
+      return;
+    }
+    Files.walkFileTree(
+        tempRoot,
+        new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+            if (!InstallRootGuard.isUnderInstallRoot(installRoot, dir)) {
+              return FileVisitResult.SKIP_SUBTREE;
+            }
+            Path normalized = dir.toAbsolutePath().normalize();
+            Path rootNorm = tempRoot.toAbsolutePath().normalize();
+            if (!normalized.equals(rootNorm)) {
+              out.add(normalized);
+            }
+            return FileVisitResult.CONTINUE;
+          }
+        });
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DiagnoseCommand.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DiagnoseCommand.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Read-only install health checklist for operators ({@code diagnose} / {@code health}).
+ *
+ * <p>Never deletes or writes. Checks install-root layout markers, free disk space, key config file
+ * presence, the running Java version, and known log directory existence. Every resolved path is
+ * constrained under the install root via {@link InstallRootGuard}.
+ *
+ * <p>Global {@code --dry-run} is accepted for CLI parity and echoed on the report; it has no effect
+ * because this command is always non-mutating.
+ */
+public final class DiagnoseCommand {
+
+  /** Primary CLI command token. */
+  public static final String COMMAND_NAME = "diagnose";
+
+  /** Alias accepted by the CLI (same behavior as {@link #COMMAND_NAME}). */
+  public static final String COMMAND_ALIAS = "health";
+
+  /**
+   * Expected layout directories relative to install root (forward-slash segments). Critical when
+   * missing → {@link DiagnoseReport.CheckStatus#FAIL}; optional → WARN.
+   */
+  static final String[] LAYOUT_DIRS_CRITICAL = {
+    "jetty",
+    "jetty/base",
+    "rxconfig"
+  };
+
+  /** Optional but common layout dirs (missing → WARN). */
+  static final String[] LAYOUT_DIRS_OPTIONAL = {
+    "bin",
+    "rxconfig/Server",
+    "Deployment"
+  };
+
+  /**
+   * Key config files relative to install root. Missing → WARN (install may be partial or mid-upgrade).
+   */
+  static final String[] KEY_CONFIG_FILES = {
+    "rxconfig/Server/server.properties",
+    "rxconfig/Installer/rxrepository.properties"
+  };
+
+  /** Free space below this many bytes is reported as WARN (1 GiB). */
+  static final long LOW_DISK_BYTES = 1L * 1024 * 1024 * 1024;
+
+  /** CMS product baseline Java major version (informational WARN when lower). */
+  static final int EXPECTED_JAVA_MAJOR = 21;
+
+  private DiagnoseCommand() {}
+
+  /**
+   * Whether {@code command} is {@code diagnose} or {@code health} (case-sensitive CLI tokens).
+   *
+   * @param command raw command token
+   * @return true when this command should run
+   */
+  public static boolean isDiagnoseCommand(String command) {
+    return COMMAND_NAME.equals(command) || COMMAND_ALIAS.equals(command);
+  }
+
+  /**
+   * Run the read-only checklist under {@code installRoot}.
+   *
+   * @param installRoot CMS install root (must exist and be a directory)
+   * @param dryRun echoed global flag only; never enables writes
+   * @param commandToken token to record on the report ({@code diagnose} or {@code health})
+   * @return checklist report
+   * @throws IllegalArgumentException if install root is invalid
+   * @throws IOException if free-space probe fails in an unrecoverable way (individual checks still
+   *     prefer WARN/FAIL rows over throwing when possible)
+   */
+  public static DiagnoseReport execute(Path installRoot, boolean dryRun, String commandToken)
+      throws IOException {
+    Path root = InstallRootGuard.requireInstallRoot(installRoot);
+    String token =
+        commandToken != null && !commandToken.isEmpty() ? commandToken : COMMAND_NAME;
+    DiagnoseReport report = new DiagnoseReport(token, root, dryRun);
+
+    // Always-true once requireInstallRoot succeeds — documents the root for operators.
+    report.add(
+        new DiagnoseReport.Check(
+            "install-root",
+            DiagnoseReport.CheckStatus.PASS,
+            "Install root exists and is a directory",
+            root));
+
+    checkLayoutDirs(report, root);
+    checkKeyConfigs(report, root);
+    checkLogDirs(report, root);
+    checkFreeDisk(report, root);
+    checkJavaVersion(report);
+
+    return report;
+  }
+
+  /**
+   * Convenience overload that records {@link #COMMAND_NAME} on the report.
+   *
+   * @param installRoot CMS install root
+   * @param dryRun echoed global flag
+   * @return checklist report
+   * @throws IOException on unrecoverable I/O
+   */
+  public static DiagnoseReport execute(Path installRoot, boolean dryRun) throws IOException {
+    return execute(installRoot, dryRun, COMMAND_NAME);
+  }
+
+  static void checkLayoutDirs(DiagnoseReport report, Path root) {
+    for (String relative : LAYOUT_DIRS_CRITICAL) {
+      addDirCheck(report, root, relative, true);
+    }
+    for (String relative : LAYOUT_DIRS_OPTIONAL) {
+      addDirCheck(report, root, relative, false);
+    }
+  }
+
+  static void addDirCheck(
+      DiagnoseReport report, Path root, String relativeSlashPath, boolean critical) {
+    Path resolved = InstallRootGuard.resolveRelativeUnderRoot(root, relativeSlashPath);
+    String id = "layout." + relativeSlashPath.replace('/', '.');
+    if (resolved == null) {
+      report.add(
+          new DiagnoseReport.Check(
+              id,
+              DiagnoseReport.CheckStatus.FAIL,
+              "Invalid relative layout path (path guard rejected): " + relativeSlashPath,
+              null));
+      return;
+    }
+    // Containment re-check (defense in depth).
+    if (!InstallRootGuard.isUnderInstallRoot(root, resolved)) {
+      report.add(
+          new DiagnoseReport.Check(
+              id,
+              DiagnoseReport.CheckStatus.FAIL,
+              "Resolved path is outside install root: " + resolved,
+              resolved));
+      return;
+    }
+    if (Files.isDirectory(resolved)) {
+      report.add(
+          new DiagnoseReport.Check(
+              id, DiagnoseReport.CheckStatus.PASS, "Directory present: " + relativeSlashPath, resolved));
+    } else if (Files.exists(resolved)) {
+      report.add(
+          new DiagnoseReport.Check(
+              id,
+              DiagnoseReport.CheckStatus.FAIL,
+              "Expected a directory but found a non-directory: " + relativeSlashPath,
+              resolved));
+    } else {
+      report.add(
+          new DiagnoseReport.Check(
+              id,
+              critical ? DiagnoseReport.CheckStatus.FAIL : DiagnoseReport.CheckStatus.WARN,
+              "Missing directory: " + relativeSlashPath,
+              resolved));
+    }
+  }
+
+  static void checkKeyConfigs(DiagnoseReport report, Path root) {
+    for (String relative : KEY_CONFIG_FILES) {
+      Path resolved = InstallRootGuard.resolveRelativeUnderRoot(root, relative);
+      String id = "config." + relative.replace('/', '.');
+      if (resolved == null) {
+        report.add(
+            new DiagnoseReport.Check(
+                id,
+                DiagnoseReport.CheckStatus.FAIL,
+                "Invalid relative config path (path guard rejected): " + relative,
+                null));
+        continue;
+      }
+      if (!InstallRootGuard.isUnderInstallRoot(root, resolved)) {
+        report.add(
+            new DiagnoseReport.Check(
+                id,
+                DiagnoseReport.CheckStatus.FAIL,
+                "Resolved config path is outside install root: " + resolved,
+                resolved));
+        continue;
+      }
+      if (Files.isRegularFile(resolved)) {
+        report.add(
+            new DiagnoseReport.Check(
+                id, DiagnoseReport.CheckStatus.PASS, "Config file present: " + relative, resolved));
+      } else {
+        report.add(
+            new DiagnoseReport.Check(
+                id,
+                DiagnoseReport.CheckStatus.WARN,
+                "Key config file missing: " + relative,
+                resolved));
+      }
+    }
+  }
+
+  static void checkLogDirs(DiagnoseReport report, Path root) {
+    for (String relative : InstallRootGuard.LOG_DIR_RELATIVE) {
+      Path resolved = InstallRootGuard.resolveRelativeUnderRoot(root, relative);
+      String id = "logs." + relative.replace('/', '.');
+      if (resolved == null) {
+        report.add(
+            new DiagnoseReport.Check(
+                id,
+                DiagnoseReport.CheckStatus.FAIL,
+                "Invalid relative log path (path guard rejected): " + relative,
+                null));
+        continue;
+      }
+      if (!InstallRootGuard.isUnderInstallRoot(root, resolved)) {
+        report.add(
+            new DiagnoseReport.Check(
+                id,
+                DiagnoseReport.CheckStatus.FAIL,
+                "Resolved log path is outside install root: " + resolved,
+                resolved));
+        continue;
+      }
+      if (Files.isDirectory(resolved)) {
+        report.add(
+            new DiagnoseReport.Check(
+                id, DiagnoseReport.CheckStatus.PASS, "Log directory present: " + relative, resolved));
+      } else {
+        // Missing log dirs are common on fresh or partial trees — warn, do not fail.
+        report.add(
+            new DiagnoseReport.Check(
+                id,
+                DiagnoseReport.CheckStatus.WARN,
+                "Known log directory missing: " + relative,
+                resolved));
+      }
+    }
+  }
+
+  static void checkFreeDisk(DiagnoseReport report, Path root) {
+    try {
+      FileStore store = Files.getFileStore(root);
+      long usable = store.getUsableSpace();
+      long total = store.getTotalSpace();
+      String human =
+          "usable="
+              + formatBytes(usable)
+              + " total="
+              + formatBytes(total)
+              + " store="
+              + store.name();
+      if (usable < LOW_DISK_BYTES) {
+        report.add(
+            new DiagnoseReport.Check(
+                "disk.free",
+                DiagnoseReport.CheckStatus.WARN,
+                "Low free disk space (" + human + ")",
+                root));
+      } else {
+        report.add(
+            new DiagnoseReport.Check(
+                "disk.free",
+                DiagnoseReport.CheckStatus.PASS,
+                "Adequate free disk space (" + human + ")",
+                root));
+      }
+    } catch (IOException e) {
+      String detail = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+      report.add(
+          new DiagnoseReport.Check(
+              "disk.free",
+              DiagnoseReport.CheckStatus.WARN,
+              "Could not probe free disk space: " + detail,
+              root));
+    }
+  }
+
+  static void checkJavaVersion(DiagnoseReport report) {
+    String version = System.getProperty("java.version", "unknown");
+    String home = System.getProperty("java.home", "");
+    int major = parseJavaMajor(version);
+    String detail =
+        "java.version="
+            + version
+            + (home.isEmpty() ? "" : " java.home=" + home)
+            + (major > 0 ? " major=" + major : "");
+    report.add(
+        new DiagnoseReport.Check(
+            "java.version", DiagnoseReport.CheckStatus.INFO, detail, null));
+    if (major > 0 && major < EXPECTED_JAVA_MAJOR) {
+      report.add(
+          new DiagnoseReport.Check(
+              "java.major",
+              DiagnoseReport.CheckStatus.WARN,
+              "Running Java major "
+                  + major
+                  + " is below CMS baseline "
+                  + EXPECTED_JAVA_MAJOR
+                  + " (doctor process JVM)",
+              null));
+    } else if (major >= EXPECTED_JAVA_MAJOR) {
+      report.add(
+          new DiagnoseReport.Check(
+              "java.major",
+              DiagnoseReport.CheckStatus.PASS,
+              "Running Java major " + major + " meets CMS baseline " + EXPECTED_JAVA_MAJOR,
+              null));
+    } else {
+      report.add(
+          new DiagnoseReport.Check(
+              "java.major",
+              DiagnoseReport.CheckStatus.WARN,
+              "Could not parse Java major from version string: " + version,
+              null));
+    }
+  }
+
+  /**
+   * Parse the major version from a {@code java.version} string ({@code 1.8.0_xxx} → 8, {@code
+   * 21.0.2} → 21). Returns 0 when unparseable.
+   *
+   * @param version {@code java.version} property value
+   * @return major version or 0
+   */
+  static int parseJavaMajor(String version) {
+    if (version == null || version.isEmpty()) {
+      return 0;
+    }
+    String v = version.trim().toLowerCase(Locale.ROOT);
+    // Strip common prefixes
+    if (v.startsWith("java")) {
+      int sp = v.indexOf(' ');
+      if (sp > 0) {
+        v = v.substring(sp + 1).trim();
+      }
+    }
+    // Legacy 1.x
+    if (v.startsWith("1.")) {
+      int secondDot = v.indexOf('.', 2);
+      String mid = secondDot > 2 ? v.substring(2, secondDot) : v.substring(2);
+      return parsePositiveIntPrefix(mid);
+    }
+    // Modern: 9, 11.0.2, 21.0.1+12
+    int end = 0;
+    while (end < v.length() && Character.isDigit(v.charAt(end))) {
+      end++;
+    }
+    if (end == 0) {
+      return 0;
+    }
+    return parsePositiveIntPrefix(v.substring(0, end));
+  }
+
+  private static int parsePositiveIntPrefix(String s) {
+    if (s == null || s.isEmpty()) {
+      return 0;
+    }
+    try {
+      int n = Integer.parseInt(s);
+      return n > 0 ? n : 0;
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
+  /** Human-readable byte size for operator output (binary units). */
+  static String formatBytes(long bytes) {
+    if (bytes < 0) {
+      return Long.toString(bytes);
+    }
+    final String[] units = {"B", "KiB", "MiB", "GiB", "TiB"};
+    double v = (double) bytes;
+    int u = 0;
+    while (v >= 1024.0 && u < units.length - 1) {
+      v /= 1024.0;
+      u++;
+    }
+    if (u == 0) {
+      return bytes + " B";
+    }
+    return String.format(Locale.ROOT, "%.1f %s", v, units[u]);
+  }
+
+  /**
+   * Resolve a relative path under root for tests / callers; package-visible path-guard helper.
+   *
+   * @param root install root
+   * @param relativeSlashPath forward-slash relative path
+   * @return resolved path or null if rejected by the path guard
+   */
+  static Path resolveChecked(Path root, String relativeSlashPath) {
+    Objects.requireNonNull(root, "root");
+    return InstallRootGuard.resolveRelativeUnderRoot(root, relativeSlashPath);
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DiagnoseReport.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DiagnoseReport.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Read-only checklist report for {@code diagnose} / {@code health}. Never implies filesystem
+ * mutations — all checks are informational.
+ */
+public final class DiagnoseReport {
+
+  /** Outcome severity for a single checklist item. */
+  public enum CheckStatus {
+    /** Expected condition met. */
+    PASS,
+    /** Non-fatal concern (missing optional path, low disk, older Java). */
+    WARN,
+    /** Critical missing layout / unreadable root. */
+    FAIL,
+    /** Pure information (e.g. reported Java version string). */
+    INFO
+  }
+
+  /** One checklist row. */
+  public static final class Check {
+    private final String id;
+    private final CheckStatus status;
+    private final String message;
+    private final Path path;
+
+    /**
+     * @param id stable machine-oriented check id (e.g. {@code layout.jetty-base})
+     * @param status outcome severity
+     * @param message human-readable detail
+     * @param path optional related path under install root (may be null)
+     */
+    public Check(String id, CheckStatus status, String message, Path path) {
+      this.id = Objects.requireNonNull(id, "id");
+      this.status = Objects.requireNonNull(status, "status");
+      this.message = Objects.requireNonNull(message, "message");
+      this.path = path;
+    }
+
+    /** @return stable check id */
+    public String getId() {
+      return id;
+    }
+
+    /** @return outcome severity */
+    public CheckStatus getStatus() {
+      return status;
+    }
+
+    /** @return human-readable detail */
+    public String getMessage() {
+      return message;
+    }
+
+    /** @return related path, or null */
+    public Path getPath() {
+      return path;
+    }
+  }
+
+  private final String command;
+  private final Path installRoot;
+  private final boolean dryRun;
+  private final List<Check> checks = new ArrayList<>();
+
+  /**
+   * @param command command token used for this run ({@code diagnose} or {@code health})
+   * @param installRoot resolved install root
+   * @param dryRun echoed global flag (diagnose never mutates regardless)
+   */
+  public DiagnoseReport(String command, Path installRoot, boolean dryRun) {
+    this.command = Objects.requireNonNull(command, "command");
+    this.installRoot = Objects.requireNonNull(installRoot, "installRoot");
+    this.dryRun = dryRun;
+  }
+
+  /** Append a checklist entry. */
+  public void add(Check check) {
+    checks.add(Objects.requireNonNull(check, "check"));
+  }
+
+  /** @return command token */
+  public String getCommand() {
+    return command;
+  }
+
+  /** @return install root used for this run */
+  public Path getInstallRoot() {
+    return installRoot;
+  }
+
+  /**
+   * Echo of the global {@code --dry-run} flag. Diagnose is always read-only; this value is reported
+   * for flag parity with other commands and never gates deletes (there are none).
+   *
+   * @return whether {@code --dry-run} was set on the CLI
+   */
+  public boolean isDryRun() {
+    return dryRun;
+  }
+
+  /** @return unmodifiable checklist */
+  public List<Check> getChecks() {
+    return Collections.unmodifiableList(checks);
+  }
+
+  /** @return number of checks */
+  public int getCheckCount() {
+    return checks.size();
+  }
+
+  /** @return count of {@link CheckStatus#PASS} */
+  public int getPassCount() {
+    return count(CheckStatus.PASS);
+  }
+
+  /** @return count of {@link CheckStatus#WARN} */
+  public int getWarnCount() {
+    return count(CheckStatus.WARN);
+  }
+
+  /** @return count of {@link CheckStatus#FAIL} */
+  public int getFailCount() {
+    return count(CheckStatus.FAIL);
+  }
+
+  /** @return count of {@link CheckStatus#INFO} */
+  public int getInfoCount() {
+    return count(CheckStatus.INFO);
+  }
+
+  /**
+   * @return true when no {@link CheckStatus#FAIL} entries (WARN/INFO allowed)
+   */
+  public boolean isHealthy() {
+    return getFailCount() == 0;
+  }
+
+  private int count(CheckStatus status) {
+    int n = 0;
+    for (Check c : checks) {
+      if (c.getStatus() == status) {
+        n++;
+      }
+    }
+    return n;
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
@@ -29,7 +29,8 @@ import java.time.Duration;
  *   &lt;command&gt; [command-options]
  * </pre>
  *
- * <p>Commands: {@code clean-heap-dumps}, {@code clean-install-backups}, {@code clean-logs}.
+ * <p>Commands: {@code clean-heap-dumps}, {@code clean-install-backups}, {@code clean-logs}, {@code
+ * check-config}, {@code fix-permissions}.
  */
 public final class DoctorCli {
 
@@ -79,8 +80,12 @@ public final class DoctorCli {
               + CleanHeapDumpsCommand.COMMAND_NAME
               + ", "
               + CleanInstallBackupsCommand.COMMAND_NAME
+              + ", "
+              + CleanLogsCommand.COMMAND_NAME
+              + ", "
+              + CheckConfigCommand.COMMAND_NAME
               + ", or "
-              + CleanLogsCommand.COMMAND_NAME);
+              + FixPermissionsCommand.COMMAND_NAME);
       printHelp(err);
       return EXIT_USAGE;
     }
@@ -126,6 +131,16 @@ public final class DoctorCli {
         printReport(report, parsed.verbose, out);
         return report.getFailedCount() > 0 ? EXIT_ERROR : EXIT_OK;
       }
+      if (CheckConfigCommand.COMMAND_NAME.equals(parsed.command)) {
+        CheckConfigReport report = CheckConfigCommand.execute(installRoot, parsed.dryRun);
+        printCheckConfigReport(report, parsed.verbose, out);
+        return report.isHealthy() ? EXIT_OK : EXIT_ERROR;
+      }
+      if (FixPermissionsCommand.COMMAND_NAME.equals(parsed.command)) {
+        FixPermissionsReport report = FixPermissionsCommand.execute(installRoot, parsed.dryRun);
+        printFixPermissionsReport(report, parsed.verbose, out);
+        return report.getFailedCount() > 0 ? EXIT_ERROR : EXIT_OK;
+      }
       err.println("Error: unknown command: " + parsed.command);
       err.println(
           "Supported commands: "
@@ -133,7 +148,11 @@ public final class DoctorCli {
               + ", "
               + CleanInstallBackupsCommand.COMMAND_NAME
               + ", "
-              + CleanLogsCommand.COMMAND_NAME);
+              + CleanLogsCommand.COMMAND_NAME
+              + ", "
+              + CheckConfigCommand.COMMAND_NAME
+              + ", "
+              + FixPermissionsCommand.COMMAND_NAME);
       printHelp(err);
       return EXIT_USAGE;
     } catch (IllegalArgumentException e) {
@@ -209,7 +228,7 @@ public final class DoctorCli {
     stream.println();
     stream.println(
         "CMS Doctor — safe install-tree maintenance"
-            + " (clean-heap-dumps, clean-install-backups, clean-logs).");
+            + " (clean-*, check-config, fix-permissions).");
     stream.println();
     stream.println("Options:");
     stream.println("  --install-root <path>  CMS install root (default: current working directory)");
@@ -224,6 +243,10 @@ public final class DoctorCli {
             + " (*.bak, *.backup, AppServer_backup_*.zip)");
     stream.println(
         "  clean-logs             Remove aged logs under known Jetty/CMS/DTS log dirs");
+    stream.println(
+        "  check-config           Read-only value/misconfig checks (server + repository props)");
+    stream.println(
+        "  fix-permissions        Report/fix allowlisted launcher + log-dir modes (POSIX)");
     stream.println();
     stream.println("clean-logs options:");
     stream.println(
@@ -243,6 +266,12 @@ public final class DoctorCli {
         "  perc-doctor --install-root /opt/Percussion --dry-run -v clean-logs --older-than 7d");
     stream.println(
         "  perc-doctor --install-root C:\\Percussion -v clean-logs --older-than 14d");
+    stream.println(
+        "  perc-doctor --install-root /opt/Percussion --dry-run -v check-config");
+    stream.println("  perc-doctor --install-root C:\\Percussion -v check-config");
+    stream.println(
+        "  perc-doctor --install-root /opt/Percussion --dry-run -v fix-permissions");
+    stream.println("  perc-doctor --install-root C:\\Percussion -v fix-permissions");
   }
 
   static void printReport(CleanReport report, boolean verbose, PrintStream out) {
@@ -262,6 +291,48 @@ public final class DoctorCli {
             "  " + e.getStatus() + " " + e.getSizeBytes() + " " + e.getPath() + detail);
       }
     } else if (report.isDryRun() && report.getCandidateCount() > 0) {
+      out.println("(use -v/--verbose for path list)");
+    }
+  }
+
+  static void printCheckConfigReport(CheckConfigReport report, boolean verbose, PrintStream out) {
+    out.println("command=" + report.getCommand());
+    out.println("install-root=" + report.getInstallRoot());
+    out.println("dry-run=" + report.isDryRun());
+    out.println("checks=" + report.getCheckCount());
+    out.println("pass=" + report.getPassCount());
+    out.println("warn=" + report.getWarnCount());
+    out.println("fail=" + report.getFailCount());
+    out.println("info=" + report.getInfoCount());
+    out.println("healthy=" + report.isHealthy());
+    if (verbose) {
+      for (CheckConfigReport.Check c : report.getChecks()) {
+        String pathPart = c.getPath() == null ? "" : " path=" + c.getPath();
+        out.println("  " + c.getStatus() + " " + c.getId() + " " + c.getMessage() + pathPart);
+      }
+    } else if (report.getCheckCount() > 0) {
+      out.println("(use -v/--verbose for check list)");
+    }
+  }
+
+  static void printFixPermissionsReport(
+      FixPermissionsReport report, boolean verbose, PrintStream out) {
+    out.println("command=" + report.getCommand());
+    out.println("install-root=" + report.getInstallRoot());
+    out.println("dry-run=" + report.isDryRun());
+    out.println("candidates=" + report.getCandidateCount());
+    if (report.isDryRun()) {
+      out.println("would-fix=" + report.getWouldFixCount());
+    } else {
+      out.println("fixed=" + report.getFixedCount());
+    }
+    out.println("failed=" + report.getFailedCount());
+    if (verbose) {
+      for (FixPermissionsReport.Entry e : report.getEntries()) {
+        String detail = e.getDetail() == null ? "" : " " + e.getDetail();
+        out.println("  " + e.getStatus() + " " + e.getPath() + detail);
+      }
+    } else if (report.getCandidateCount() > 0) {
       out.println("(use -v/--verbose for path list)");
     }
   }

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
@@ -29,7 +29,8 @@ import java.time.Duration;
  *   &lt;command&gt; [command-options]
  * </pre>
  *
- * <p>Commands: {@code clean-heap-dumps}, {@code clean-install-backups}, {@code clean-logs}.
+ * <p>Commands: {@code clean-heap-dumps}, {@code clean-install-backups}, {@code clean-logs},
+ * {@code clean-temp}.
  */
 public final class DoctorCli {
 
@@ -79,8 +80,10 @@ public final class DoctorCli {
               + CleanHeapDumpsCommand.COMMAND_NAME
               + ", "
               + CleanInstallBackupsCommand.COMMAND_NAME
+              + ", "
+              + CleanLogsCommand.COMMAND_NAME
               + ", or "
-              + CleanLogsCommand.COMMAND_NAME);
+              + CleanTempCommand.COMMAND_NAME);
       printHelp(err);
       return EXIT_USAGE;
     }
@@ -126,6 +129,11 @@ public final class DoctorCli {
         printReport(report, parsed.verbose, out);
         return report.getFailedCount() > 0 ? EXIT_ERROR : EXIT_OK;
       }
+      if (CleanTempCommand.COMMAND_NAME.equals(parsed.command)) {
+        CleanReport report = CleanTempCommand.execute(installRoot, parsed.dryRun);
+        printReport(report, parsed.verbose, out);
+        return report.getFailedCount() > 0 ? EXIT_ERROR : EXIT_OK;
+      }
       err.println("Error: unknown command: " + parsed.command);
       err.println(
           "Supported commands: "
@@ -133,7 +141,9 @@ public final class DoctorCli {
               + ", "
               + CleanInstallBackupsCommand.COMMAND_NAME
               + ", "
-              + CleanLogsCommand.COMMAND_NAME);
+              + CleanLogsCommand.COMMAND_NAME
+              + ", "
+              + CleanTempCommand.COMMAND_NAME);
       printHelp(err);
       return EXIT_USAGE;
     } catch (IllegalArgumentException e) {
@@ -209,7 +219,7 @@ public final class DoctorCli {
     stream.println();
     stream.println(
         "CMS Doctor — safe install-tree maintenance"
-            + " (clean-heap-dumps, clean-install-backups, clean-logs).");
+            + " (clean-heap-dumps, clean-install-backups, clean-logs, clean-temp).");
     stream.println();
     stream.println("Options:");
     stream.println("  --install-root <path>  CMS install root (default: current working directory)");
@@ -224,6 +234,8 @@ public final class DoctorCli {
             + " (*.bak, *.backup, AppServer_backup_*.zip)");
     stream.println(
         "  clean-logs             Remove aged logs under known Jetty/CMS/DTS log dirs");
+    stream.println(
+        "  clean-temp             Remove files under known install temp/work dirs");
     stream.println();
     stream.println("clean-logs options:");
     stream.println(
@@ -243,6 +255,9 @@ public final class DoctorCli {
         "  perc-doctor --install-root /opt/Percussion --dry-run -v clean-logs --older-than 7d");
     stream.println(
         "  perc-doctor --install-root C:\\Percussion -v clean-logs --older-than 14d");
+    stream.println(
+        "  perc-doctor --install-root /opt/Percussion --dry-run -v clean-temp");
+    stream.println("  perc-doctor --install-root C:\\Percussion -v clean-temp");
   }
 
   static void printReport(CleanReport report, boolean verbose, PrintStream out) {

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java
@@ -29,7 +29,8 @@ import java.time.Duration;
  *   &lt;command&gt; [command-options]
  * </pre>
  *
- * <p>Commands: {@code clean-heap-dumps}, {@code clean-install-backups}, {@code clean-logs}.
+ * <p>Commands: {@code diagnose}/{@code health}, {@code clean-heap-dumps}, {@code
+ * clean-install-backups}, {@code clean-logs}.
  */
 public final class DoctorCli {
 
@@ -76,6 +77,10 @@ public final class DoctorCli {
     if (parsed.command == null || parsed.command.isEmpty()) {
       err.println(
           "Error: missing command. Try: "
+              + DiagnoseCommand.COMMAND_NAME
+              + "/"
+              + DiagnoseCommand.COMMAND_ALIAS
+              + ", "
               + CleanHeapDumpsCommand.COMMAND_NAME
               + ", "
               + CleanInstallBackupsCommand.COMMAND_NAME
@@ -109,6 +114,12 @@ public final class DoctorCli {
     }
 
     try {
+      if (DiagnoseCommand.isDiagnoseCommand(parsed.command)) {
+        DiagnoseReport report =
+            DiagnoseCommand.execute(installRoot, parsed.dryRun, parsed.command);
+        printDiagnoseReport(report, parsed.verbose, out);
+        return report.isHealthy() ? EXIT_OK : EXIT_ERROR;
+      }
       if (CleanHeapDumpsCommand.COMMAND_NAME.equals(parsed.command)) {
         CleanReport report = CleanHeapDumpsCommand.execute(installRoot, parsed.dryRun);
         printReport(report, parsed.verbose, out);
@@ -129,6 +140,10 @@ public final class DoctorCli {
       err.println("Error: unknown command: " + parsed.command);
       err.println(
           "Supported commands: "
+              + DiagnoseCommand.COMMAND_NAME
+              + "/"
+              + DiagnoseCommand.COMMAND_ALIAS
+              + ", "
               + CleanHeapDumpsCommand.COMMAND_NAME
               + ", "
               + CleanInstallBackupsCommand.COMMAND_NAME
@@ -208,16 +223,19 @@ public final class DoctorCli {
     stream.println("usage: perc-doctor [options] <command> [command-options]");
     stream.println();
     stream.println(
-        "CMS Doctor — safe install-tree maintenance"
-            + " (clean-heap-dumps, clean-install-backups, clean-logs).");
+        "CMS Doctor — install diagnose + safe install-tree maintenance"
+            + " (diagnose/health, clean-heap-dumps, clean-install-backups, clean-logs).");
     stream.println();
     stream.println("Options:");
     stream.println("  --install-root <path>  CMS install root (default: current working directory)");
     stream.println("  --dry-run              Report only; never delete or write");
-    stream.println("  -v, --verbose          Print each candidate path and size");
+    stream.println("  -v, --verbose          Print each candidate path / check detail");
     stream.println("  -h, --help             Show usage");
     stream.println();
     stream.println("Commands:");
+    stream.println(
+        "  diagnose, health       Read-only install checklist (layout, disk, config, Java,"
+            + " log dirs); never deletes");
     stream.println("  clean-heap-dumps       Remove recursive *.hprof under install root");
     stream.println(
         "  clean-install-backups  Remove allowlisted installer/upgrade backups"
@@ -234,6 +252,8 @@ public final class DoctorCli {
         "  --no-keep-current      Allow deleting active current log basenames");
     stream.println();
     stream.println("Examples:");
+    stream.println("  perc-doctor --install-root /opt/Percussion -v diagnose");
+    stream.println("  perc-doctor --install-root C:\\Percussion --dry-run health");
     stream.println("  perc-doctor --install-root /opt/Percussion --dry-run clean-heap-dumps");
     stream.println("  perc-doctor --install-root C:\\Percussion -v clean-heap-dumps");
     stream.println(
@@ -243,6 +263,27 @@ public final class DoctorCli {
         "  perc-doctor --install-root /opt/Percussion --dry-run -v clean-logs --older-than 7d");
     stream.println(
         "  perc-doctor --install-root C:\\Percussion -v clean-logs --older-than 14d");
+  }
+
+  static void printDiagnoseReport(DiagnoseReport report, boolean verbose, PrintStream out) {
+    out.println("command=" + report.getCommand());
+    out.println("install-root=" + report.getInstallRoot());
+    out.println("dry-run=" + report.isDryRun());
+    out.println("read-only=true");
+    out.println("checks=" + report.getCheckCount());
+    out.println("pass=" + report.getPassCount());
+    out.println("warn=" + report.getWarnCount());
+    out.println("fail=" + report.getFailCount());
+    out.println("info=" + report.getInfoCount());
+    out.println("healthy=" + report.isHealthy());
+    if (verbose) {
+      for (DiagnoseReport.Check c : report.getChecks()) {
+        String pathPart = c.getPath() == null ? "" : " " + c.getPath();
+        out.println("  " + c.getStatus() + " " + c.getId() + " " + c.getMessage() + pathPart);
+      }
+    } else if (report.getCheckCount() > 0) {
+      out.println("(use -v/--verbose for checklist detail)");
+    }
   }
 
   static void printReport(CleanReport report, boolean verbose, PrintStream out) {

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/FixPermissionsCommand.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/FixPermissionsCommand.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Report (and optionally fix) common install permission / mode issues under the CMS install root
+ * ({@code fix-permissions}).
+ *
+ * <p><strong>Scoped, documented targets only</strong> — no arbitrary paths, no shell, no user
+ * globs. Mutations are limited to POSIX mode bits on allowlisted paths when the filesystem supports
+ * {@link PosixFilePermission}. On Windows (and other non-POSIX stores) the command reports
+ * readability / writability and skips mode changes.
+ *
+ * <p>Allowlisted relative targets:
+ *
+ * <ul>
+ *   <li>Launchers under {@code bin/}: {@code perc-doctor}, {@code perc-doctor.bat}, {@code
+ *       perc-doctor.jar} — ensure owner read (+ execute for non-{@code .bat}/non-{@code .jar} Unix
+ *       scripts when present)
+ *   <li>Known log directories from {@link InstallRootGuard#LOG_DIR_RELATIVE} — ensure owner
+ *       read/write/execute on the directory when present (so the service can write logs)
+ *   <li>Key config files ({@link CheckConfigCommand#SERVER_PROPERTIES_REL}, {@link
+ *       CheckConfigCommand#RXREPOSITORY_PROPERTIES_REL}) — report owner-read; set owner-read on
+ *       POSIX when missing
+ * </ul>
+ *
+ * <p>Dry-run never writes. Apply re-checks containment immediately before each mode change.
+ */
+public final class FixPermissionsCommand {
+
+  /** CLI command token. */
+  public static final String COMMAND_NAME = "fix-permissions";
+
+  /**
+   * Allowlisted launcher file names under {@code bin/} (not full paths). Bare names only; no path
+   * separators.
+   */
+  public static final String[] BIN_LAUNCHER_NAMES = {
+    "perc-doctor", "perc-doctor.bat", "perc-doctor.jar"
+  };
+
+  private FixPermissionsCommand() {}
+
+  /**
+   * Inventory and optionally fix permissions under {@code installRoot}.
+   *
+   * @param installRoot CMS install root (must exist and be a directory)
+   * @param dryRun when true, report only (no mode writes)
+   * @return report of inspected / fixed paths
+   * @throws IllegalArgumentException if install root is invalid
+   * @throws IOException on unrecoverable I/O (individual entries prefer FAILED rows)
+   */
+  public static FixPermissionsReport execute(Path installRoot, boolean dryRun) throws IOException {
+    Path root = InstallRootGuard.requireInstallRoot(installRoot);
+    FixPermissionsReport report = new FixPermissionsReport(COMMAND_NAME, root, dryRun);
+    boolean posix = supportsPosix(root);
+
+    if (!posix) {
+      report.add(
+          new FixPermissionsReport.Entry(
+              root,
+              FixPermissionsReport.EntryStatus.SKIPPED,
+              "POSIX mode bits not supported on this filesystem; reporting access only"
+                  + " (Windows ACL repair is out of scope for this command)"));
+    }
+
+    fixBinLaunchers(report, root, dryRun, posix);
+    fixLogDirs(report, root, dryRun, posix);
+    fixKeyConfigFiles(report, root, dryRun, posix);
+
+    return report;
+  }
+
+  static void fixBinLaunchers(
+      FixPermissionsReport report, Path root, boolean dryRun, boolean posix) {
+    Path binDir = InstallRootGuard.resolveRelativeUnderRoot(root, "bin");
+    if (binDir == null || !InstallRootGuard.isUnderInstallRoot(root, binDir)) {
+      report.add(
+          new FixPermissionsReport.Entry(
+              root,
+              FixPermissionsReport.EntryStatus.FAILED,
+              "bin/ path rejected by install-root guard"));
+      return;
+    }
+    if (!Files.isDirectory(binDir)) {
+      report.add(
+          new FixPermissionsReport.Entry(
+              binDir,
+              FixPermissionsReport.EntryStatus.SKIPPED,
+              "bin/ directory missing; launcher mode checks skipped"));
+      return;
+    }
+
+    for (String name : BIN_LAUNCHER_NAMES) {
+      if (name.indexOf('/') >= 0 || name.indexOf('\\') >= 0) {
+        continue;
+      }
+      Path file = binDir.resolve(name).toAbsolutePath().normalize();
+      if (!InstallRootGuard.isUnderInstallRoot(root, file)) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.FAILED,
+                "Launcher path escaped install root"));
+        continue;
+      }
+      if (!Files.isRegularFile(file)) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.SKIPPED,
+                "Launcher not present: bin/" + name));
+        continue;
+      }
+
+      // Report basic accessibility always.
+      boolean readable = Files.isReadable(file);
+      if (!readable) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.FAILED,
+                "Launcher not readable by current user: bin/" + name));
+        continue;
+      }
+
+      boolean needOwnerExec = posix && isUnixScriptLauncher(name);
+      if (!needOwnerExec) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.OK,
+                "Launcher present and readable: bin/" + name));
+        continue;
+      }
+
+      try {
+        Set<PosixFilePermission> perms = Files.getPosixFilePermissions(file);
+        if (perms.contains(PosixFilePermission.OWNER_EXECUTE)) {
+          report.add(
+              new FixPermissionsReport.Entry(
+                  file,
+                  FixPermissionsReport.EntryStatus.OK,
+                  "Unix launcher already owner-executable: bin/" + name));
+          continue;
+        }
+        if (dryRun) {
+          report.add(
+              new FixPermissionsReport.Entry(
+                  file,
+                  FixPermissionsReport.EntryStatus.WOULD_FIX,
+                  "Would add owner-execute on bin/" + name));
+          continue;
+        }
+        // Re-check containment immediately before mutation.
+        InstallRootGuard.requireUnderInstallRoot(root, file);
+        EnumSet<PosixFilePermission> updated = EnumSet.copyOf(perms);
+        updated.add(PosixFilePermission.OWNER_READ);
+        updated.add(PosixFilePermission.OWNER_EXECUTE);
+        Files.setPosixFilePermissions(file, updated);
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.FIXED,
+                "Added owner-execute on bin/" + name));
+      } catch (UnsupportedOperationException e) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.SKIPPED,
+                "POSIX permissions unsupported for bin/" + name));
+      } catch (IOException | SecurityException e) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.FAILED,
+                "Failed to inspect/fix launcher mode: " + e.getMessage()));
+      }
+    }
+  }
+
+  static void fixLogDirs(FixPermissionsReport report, Path root, boolean dryRun, boolean posix) {
+    for (String relative : InstallRootGuard.LOG_DIR_RELATIVE) {
+      Path dir = InstallRootGuard.resolveRelativeUnderRoot(root, relative);
+      if (dir == null) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                root,
+                FixPermissionsReport.EntryStatus.FAILED,
+                "Invalid log dir relative path: " + relative));
+        continue;
+      }
+      if (!InstallRootGuard.isUnderInstallRoot(root, dir)) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                dir,
+                FixPermissionsReport.EntryStatus.FAILED,
+                "Log dir path escaped install root: " + relative));
+        continue;
+      }
+      if (!Files.isDirectory(dir)) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                dir,
+                FixPermissionsReport.EntryStatus.SKIPPED,
+                "Log directory missing: " + relative));
+        continue;
+      }
+
+      boolean writable = Files.isWritable(dir);
+      boolean readable = Files.isReadable(dir);
+      if (!posix) {
+        FixPermissionsReport.EntryStatus st =
+            writable && readable
+                ? FixPermissionsReport.EntryStatus.OK
+                : FixPermissionsReport.EntryStatus.FAILED;
+        report.add(
+            new FixPermissionsReport.Entry(
+                dir,
+                st,
+                "Log dir access readable="
+                    + readable
+                    + " writable="
+                    + writable
+                    + " (no POSIX mode fix on this platform): "
+                    + relative));
+        continue;
+      }
+
+      try {
+        Set<PosixFilePermission> perms = Files.getPosixFilePermissions(dir);
+        boolean hasOwnerRwx =
+            perms.contains(PosixFilePermission.OWNER_READ)
+                && perms.contains(PosixFilePermission.OWNER_WRITE)
+                && perms.contains(PosixFilePermission.OWNER_EXECUTE);
+        if (hasOwnerRwx && writable) {
+          report.add(
+              new FixPermissionsReport.Entry(
+                  dir,
+                  FixPermissionsReport.EntryStatus.OK,
+                  "Log dir has owner rwx: " + relative));
+          continue;
+        }
+        if (dryRun) {
+          report.add(
+              new FixPermissionsReport.Entry(
+                  dir,
+                  FixPermissionsReport.EntryStatus.WOULD_FIX,
+                  "Would ensure owner rwx on log dir: " + relative));
+          continue;
+        }
+        InstallRootGuard.requireUnderInstallRoot(root, dir);
+        EnumSet<PosixFilePermission> updated = EnumSet.copyOf(perms);
+        updated.add(PosixFilePermission.OWNER_READ);
+        updated.add(PosixFilePermission.OWNER_WRITE);
+        updated.add(PosixFilePermission.OWNER_EXECUTE);
+        Files.setPosixFilePermissions(dir, updated);
+        report.add(
+            new FixPermissionsReport.Entry(
+                dir,
+                FixPermissionsReport.EntryStatus.FIXED,
+                "Ensured owner rwx on log dir: " + relative));
+      } catch (UnsupportedOperationException e) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                dir,
+                FixPermissionsReport.EntryStatus.SKIPPED,
+                "POSIX permissions unsupported for log dir: " + relative));
+      } catch (IOException | SecurityException e) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                dir,
+                FixPermissionsReport.EntryStatus.FAILED,
+                "Failed to inspect/fix log dir mode (" + relative + "): " + e.getMessage()));
+      }
+    }
+  }
+
+  static void fixKeyConfigFiles(
+      FixPermissionsReport report, Path root, boolean dryRun, boolean posix) {
+    String[] relatives = {
+      CheckConfigCommand.SERVER_PROPERTIES_REL, CheckConfigCommand.RXREPOSITORY_PROPERTIES_REL
+    };
+    for (String relative : relatives) {
+      Path file = InstallRootGuard.resolveRelativeUnderRoot(root, relative);
+      if (file == null || !InstallRootGuard.isUnderInstallRoot(root, file)) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                root,
+                FixPermissionsReport.EntryStatus.FAILED,
+                "Config path rejected by guard: " + relative));
+        continue;
+      }
+      if (!Files.isRegularFile(file)) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.SKIPPED,
+                "Config file missing: " + relative));
+        continue;
+      }
+      boolean readable = Files.isReadable(file);
+      if (!posix) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                readable
+                    ? FixPermissionsReport.EntryStatus.OK
+                    : FixPermissionsReport.EntryStatus.FAILED,
+                "Config readable=" + readable + " (no POSIX mode fix): " + relative));
+        continue;
+      }
+      try {
+        Set<PosixFilePermission> perms = Files.getPosixFilePermissions(file);
+        if (perms.contains(PosixFilePermission.OWNER_READ) && readable) {
+          report.add(
+              new FixPermissionsReport.Entry(
+                  file,
+                  FixPermissionsReport.EntryStatus.OK,
+                  "Config owner-readable: " + relative));
+          continue;
+        }
+        if (dryRun) {
+          report.add(
+              new FixPermissionsReport.Entry(
+                  file,
+                  FixPermissionsReport.EntryStatus.WOULD_FIX,
+                  "Would add owner-read on config: " + relative));
+          continue;
+        }
+        InstallRootGuard.requireUnderInstallRoot(root, file);
+        EnumSet<PosixFilePermission> updated = EnumSet.copyOf(perms);
+        updated.add(PosixFilePermission.OWNER_READ);
+        Files.setPosixFilePermissions(file, updated);
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.FIXED,
+                "Added owner-read on config: " + relative));
+      } catch (UnsupportedOperationException e) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.SKIPPED,
+                "POSIX permissions unsupported for config: " + relative));
+      } catch (IOException | SecurityException e) {
+        report.add(
+            new FixPermissionsReport.Entry(
+                file,
+                FixPermissionsReport.EntryStatus.FAILED,
+                "Failed to inspect/fix config mode (" + relative + "): " + e.getMessage()));
+      }
+    }
+  }
+
+  /**
+   * Unix shell launcher (no extension / not Windows batch / not jar) needs owner-execute.
+   *
+   * @param fileName bare name under bin/
+   * @return true when owner-execute should be ensured on POSIX
+   */
+  static boolean isUnixScriptLauncher(String fileName) {
+    Objects.requireNonNull(fileName, "fileName");
+    String lower = fileName.toLowerCase(Locale.ROOT);
+    if (lower.endsWith(".bat") || lower.endsWith(".cmd") || lower.endsWith(".jar")) {
+      return false;
+    }
+    // perc-doctor (no extension) is the Unix wrapper
+    return "perc-doctor".equals(lower) || !lower.contains(".");
+  }
+
+  /**
+   * Whether {@code path}'s file store supports POSIX permissions (probe via store or attribute
+   * view).
+   */
+  static boolean supportsPosix(Path path) {
+    try {
+      return path.getFileSystem().supportedFileAttributeViews().contains("posix");
+    } catch (RuntimeException e) {
+      return false;
+    }
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/FixPermissionsReport.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/FixPermissionsReport.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Inventory / action report for {@code fix-permissions}. */
+public final class FixPermissionsReport {
+
+  /** Outcome for a single path / permission item. */
+  public enum EntryStatus {
+    /** Already correct; no change needed. */
+    OK,
+    /** Dry-run: would apply a documented mode fix. */
+    WOULD_FIX,
+    /** Apply: mode fix was applied. */
+    FIXED,
+    /** Intentionally not changed (unsupported platform, missing path, etc.). */
+    SKIPPED,
+    /** Error while inspecting or applying. */
+    FAILED
+  }
+
+  /** One path considered by fix-permissions. */
+  public static final class Entry {
+    private final Path path;
+    private final EntryStatus status;
+    private final String detail;
+
+    /**
+     * @param path absolute or normalized path of the candidate
+     * @param status outcome
+     * @param detail human-readable detail (may be null)
+     */
+    public Entry(Path path, EntryStatus status, String detail) {
+      this.path = Objects.requireNonNull(path, "path");
+      this.status = Objects.requireNonNull(status, "status");
+      this.detail = detail;
+    }
+
+    /** @return candidate path */
+    public Path getPath() {
+      return path;
+    }
+
+    /** @return outcome status */
+    public EntryStatus getStatus() {
+      return status;
+    }
+
+    /** @return optional detail message, or null */
+    public String getDetail() {
+      return detail;
+    }
+  }
+
+  private final String command;
+  private final Path installRoot;
+  private final boolean dryRun;
+  private final List<Entry> entries = new ArrayList<>();
+
+  /**
+   * @param command command name ({@code fix-permissions})
+   * @param installRoot resolved install root
+   * @param dryRun whether this report is from a dry-run
+   */
+  public FixPermissionsReport(String command, Path installRoot, boolean dryRun) {
+    this.command = Objects.requireNonNull(command, "command");
+    this.installRoot = Objects.requireNonNull(installRoot, "installRoot");
+    this.dryRun = dryRun;
+  }
+
+  /** Append an inventory/action entry. */
+  public void add(Entry entry) {
+    entries.add(Objects.requireNonNull(entry, "entry"));
+  }
+
+  /** @return command name */
+  public String getCommand() {
+    return command;
+  }
+
+  /** @return install root used for this run */
+  public Path getInstallRoot() {
+    return installRoot;
+  }
+
+  /** @return true if no mode fixes were applied */
+  public boolean isDryRun() {
+    return dryRun;
+  }
+
+  /** @return unmodifiable list of entries */
+  public List<Entry> getEntries() {
+    return Collections.unmodifiableList(entries);
+  }
+
+  /** @return number of entries */
+  public int getCandidateCount() {
+    return entries.size();
+  }
+
+  /** @return count of successfully fixed entries */
+  public int getFixedCount() {
+    int n = 0;
+    for (Entry e : entries) {
+      if (e.getStatus() == EntryStatus.FIXED) {
+        n++;
+      }
+    }
+    return n;
+  }
+
+  /** @return count of dry-run would-fix entries */
+  public int getWouldFixCount() {
+    int n = 0;
+    for (Entry e : entries) {
+      if (e.getStatus() == EntryStatus.WOULD_FIX) {
+        n++;
+      }
+    }
+    return n;
+  }
+
+  /** @return count of failed entries */
+  public int getFailedCount() {
+    int n = 0;
+    for (Entry e : entries) {
+      if (e.getStatus() == EntryStatus.FAILED) {
+        n++;
+      }
+    }
+    return n;
+  }
+}

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/InstallRootGuard.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/InstallRootGuard.java
@@ -198,6 +198,27 @@ public final class InstallRootGuard {
   };
 
   /**
+   * Relative install temp / work directory roots for {@code clean-temp}. Documented in the module
+   * README and operator guide.
+   *
+   * <ul>
+   *   <li>{@code temp} — CMS install temp ({@code install.xml} {@code mkdir ${install.dir}/temp})
+   *   <li>{@code jetty/base/work} — Jetty work directory (assembly / install layout)
+   *   <li>{@code Deployment/Server/temp} — DTS Tomcat {@code catalina.base}/temp
+   *   <li>{@code Deployment/Server/work} — DTS Tomcat {@code catalina.base}/work
+   * </ul>
+   *
+   * <p>Missing directories are skipped at walk time (not an error). Only contents under these
+   * roots are candidates; the allowlisted root directories themselves are never removed.
+   */
+  public static final String[] TEMP_DIR_RELATIVE = {
+    "temp",
+    "jetty/base/work",
+    "Deployment/Server/temp",
+    "Deployment/Server/work"
+  };
+
+  /**
    * Resolve allowlisted log directory roots that exist under {@code installRoot}. Only existing
    * directories that stay under the install root are returned.
    *
@@ -205,10 +226,33 @@ public final class InstallRootGuard {
    * @return list of existing log dir paths under the root (may be empty)
    */
   public static java.util.List<Path> existingLogDirs(Path installRoot) {
+    return existingAllowlistedDirs(installRoot, LOG_DIR_RELATIVE);
+  }
+
+  /**
+   * Resolve allowlisted temp / work directory roots that exist under {@code installRoot}. Only
+   * existing directories that stay under the install root are returned.
+   *
+   * @param installRoot resolved install root
+   * @return list of existing temp/work dir paths under the root (may be empty)
+   */
+  public static java.util.List<Path> existingTempDirs(Path installRoot) {
+    return existingAllowlistedDirs(installRoot, TEMP_DIR_RELATIVE);
+  }
+
+  /**
+   * Resolve relative directory roots that exist under {@code installRoot} and remain contained.
+   *
+   * @param installRoot resolved install root
+   * @param relativeRoots forward-slash relative paths under the install root
+   * @return list of existing directory paths under the root (may be empty)
+   */
+  static java.util.List<Path> existingAllowlistedDirs(Path installRoot, String[] relativeRoots) {
     Objects.requireNonNull(installRoot, "installRoot");
+    Objects.requireNonNull(relativeRoots, "relativeRoots");
     Path root = installRoot.toAbsolutePath().normalize();
     java.util.List<Path> dirs = new java.util.ArrayList<>();
-    for (String relative : LOG_DIR_RELATIVE) {
+    for (String relative : relativeRoots) {
       Path dir = resolveRelativeUnderRoot(root, relative);
       if (dir == null) {
         continue;

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorApiService.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorApiService.java
@@ -20,6 +20,7 @@ import com.intsof.percussioncms.doctor.CleanHeapDumpsCommand;
 import com.intsof.percussioncms.doctor.CleanInstallBackupsCommand;
 import com.intsof.percussioncms.doctor.CleanLogsCommand;
 import com.intsof.percussioncms.doctor.CleanReport;
+import com.intsof.percussioncms.doctor.CleanTempCommand;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -29,7 +30,7 @@ import java.util.Objects;
 /**
  * Executes doctor clean commands for the HTTP API. Reuses the same command implementations as the
  * CLI ({@link CleanHeapDumpsCommand}, {@link CleanInstallBackupsCommand}, {@link
- * CleanLogsCommand}).
+ * CleanLogsCommand}, {@link CleanTempCommand}).
  *
  * <p>Authorization is enforced by the caller ({@link DoctorRestService}); this class only runs
  * commands.
@@ -80,6 +81,8 @@ public final class DoctorApiService {
       CleanLogsCommand.Options options =
           new CleanLogsCommand.Options(olderThan, body.isEffectiveKeepCurrent());
       report = CleanLogsCommand.execute(installRoot, dryRun, options);
+    } else if (CleanTempCommand.COMMAND_NAME.equals(cmd)) {
+      report = CleanTempCommand.execute(installRoot, dryRun);
     } else {
       throw new DoctorUnknownCommandException(cmd);
     }

--- a/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorRestService.java
+++ b/modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/api/DoctorRestService.java
@@ -71,7 +71,7 @@ public class DoctorRestService {
    * Execute a doctor command.
    *
    * @param command CLI command token ({@code clean-heap-dumps}, {@code clean-install-backups},
-   *     {@code clean-logs})
+   *     {@code clean-logs}, {@code clean-temp})
    * @param request JSON body; may be null (treated as empty dry-run request)
    * @return structured report (same fields as CLI inventory/action report)
    */

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CheckConfigCommandTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CheckConfigCommandTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CheckConfigCommandTest {
+
+  @TempDir Path tempDir;
+
+  private Path installRoot;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    installRoot = Files.createDirectories(tempDir.resolve("cms-install"));
+  }
+
+  @Test
+  void bareInstallWarnsOnMissingConfigsAndStaysHealthyWithoutFail() throws Exception {
+    CheckConfigReport report = CheckConfigCommand.execute(installRoot, true);
+    assertEquals(CheckConfigCommand.COMMAND_NAME, report.getCommand());
+    assertTrue(report.isDryRun());
+    assertTrue(report.getCheckCount() >= 2);
+    // Missing configs are WARN, not FAIL — install may be partial.
+    assertTrue(report.isHealthy(), "missing optional configs should be WARN not FAIL");
+    assertTrue(report.getWarnCount() >= 2);
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.WARN, "server.properties.present"));
+    assertTrue(
+        hasStatusId(report, CheckConfigReport.CheckStatus.WARN, "rxrepository.properties.present"));
+  }
+
+  @Test
+  void healthyServerAndH2RepoProducesPassAndInfo() throws Exception {
+    writeServerProps(
+        "enableDebugTools=false\n"
+            + "disableCrossSiteRequestForgeryCheck=false\n"
+            + "requireHTTPS=true\n"
+            + "bindPort=9992\n");
+    writeRepoProps(
+        "DB_BACKEND=H2\n"
+            + "DB_DRIVER_NAME=h2\n"
+            + "DB_DRIVER_CLASS_NAME=org.h2.Driver\n"
+            + "DB_SERVER=file:../../Repository/CMDB\n"
+            + "UID=sa\n"
+            + "PWD=\n");
+
+    CheckConfigReport report = CheckConfigCommand.execute(installRoot, false);
+    assertFalse(report.isDryRun());
+    assertTrue(report.isHealthy());
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.PASS, "server.enableDebugTools"));
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.PASS, "server.bindPort"));
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.PASS, "repo.DB_BACKEND"));
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.INFO, "repo.PWD"));
+  }
+
+  @Test
+  void debugToolsAndCsrfDisableWarn() throws Exception {
+    writeServerProps(
+        "enableDebugTools=true\n"
+            + "disableCrossSiteRequestForgeryCheck=true\n"
+            + "bindPort=9992\n");
+    writeRepoProps(h2RepoBody());
+
+    CheckConfigReport report = CheckConfigCommand.execute(installRoot, true);
+    assertTrue(report.isHealthy());
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.WARN, "server.enableDebugTools"));
+    assertTrue(
+        hasStatusId(
+            report,
+            CheckConfigReport.CheckStatus.WARN,
+            "server.disableCrossSiteRequestForgeryCheck"));
+  }
+
+  @Test
+  void invalidBindPortFails() throws Exception {
+    writeServerProps("bindPort=not-a-port\n");
+    writeRepoProps(h2RepoBody());
+
+    CheckConfigReport report = CheckConfigCommand.execute(installRoot, true);
+    assertFalse(report.isHealthy());
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.FAIL, "server.bindPort"));
+  }
+
+  @Test
+  void unresolvedPlaceholderInBindPortFails() throws Exception {
+    writeServerProps("bindPort=${cms.port}\n");
+    writeRepoProps(h2RepoBody());
+
+    CheckConfigReport report = CheckConfigCommand.execute(installRoot, true);
+    assertFalse(report.isHealthy());
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.FAIL, "server.bindPort"));
+  }
+
+  @Test
+  void missingRequiredRepoKeyFails() throws Exception {
+    writeServerProps("bindPort=9992\nenableDebugTools=false\n");
+    writeRepoProps(
+        "DB_BACKEND=MSSQL\n"
+            + "DB_DRIVER_NAME=sqlserver\n"
+            + "DB_DRIVER_CLASS_NAME=com.microsoft.sqlserver.jdbc.SQLServerDriver\n"
+            + "DB_SERVER=\n"
+            + "UID=cms\n"
+            + "PWD=demo\n"
+            + "PWD_ENCRYPTED=N\n");
+
+    CheckConfigReport report = CheckConfigCommand.execute(installRoot, true);
+    assertFalse(report.isHealthy());
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.FAIL, "repo.DB_SERVER"));
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.WARN, "repo.PWD"));
+    assertTrue(hasStatusId(report, CheckConfigReport.CheckStatus.WARN, "repo.PWD_ENCRYPTED"));
+  }
+
+  @Test
+  void driverBackendMismatchWarns() throws Exception {
+    writeServerProps("bindPort=9992\n");
+    writeRepoProps(
+        "DB_BACKEND=MSSQL\n"
+            + "DB_DRIVER_NAME=h2\n"
+            + "DB_DRIVER_CLASS_NAME=org.h2.Driver\n"
+            + "DB_SERVER=//sql.example.com:1433\n"
+            + "UID=cms\n"
+            + "PWD=s3cureValue\n"
+            + "PWD_ENCRYPTED=Y\n");
+
+    CheckConfigReport report = CheckConfigCommand.execute(installRoot, true);
+    assertTrue(report.isHealthy());
+    assertTrue(
+        hasStatusId(report, CheckConfigReport.CheckStatus.WARN, "repo.driver-backend-consistency"));
+  }
+
+  @Test
+  void neverWritesUnderInstallRoot() throws Exception {
+    writeServerProps("bindPort=9992\nenableDebugTools=true\n");
+    writeRepoProps(h2RepoBody());
+    Path marker = installRoot.resolve("marker.txt");
+    Files.writeString(marker, "keep");
+    long before = Files.walk(installRoot).count();
+
+    CheckConfigCommand.execute(installRoot, false);
+
+    assertTrue(Files.exists(marker));
+    assertEquals(before, Files.walk(installRoot).count());
+    assertEquals(
+        "keep", Files.readString(marker, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void missingInstallRootRejected() {
+    Path missing = tempDir.resolve("gone");
+    assertThrows(IllegalArgumentException.class, () -> CheckConfigCommand.execute(missing, true));
+  }
+
+  @Test
+  void allResolvedPathsStayUnderInstallRoot() throws Exception {
+    writeServerProps("bindPort=9992\n");
+    writeRepoProps(h2RepoBody());
+    CheckConfigReport report = CheckConfigCommand.execute(installRoot, true);
+    for (CheckConfigReport.Check c : report.getChecks()) {
+      if (c.getPath() == null) {
+        continue;
+      }
+      assertTrue(
+          InstallRootGuard.isUnderInstallRoot(installRoot, c.getPath()),
+          "path escaped root: " + c.getPath());
+    }
+  }
+
+  @Test
+  void weakPasswordHelperRecognizesKnownTokens() {
+    assertTrue(CheckConfigCommand.isWeakPassword("demo"));
+    assertTrue(CheckConfigCommand.isWeakPassword("Password"));
+    assertFalse(CheckConfigCommand.isWeakPassword("s3cureValue!"));
+  }
+
+  private void writeServerProps(String body) throws Exception {
+    Path dir = Files.createDirectories(installRoot.resolve("rxconfig").resolve("Server"));
+    Files.writeString(dir.resolve("server.properties"), body, StandardCharsets.UTF_8);
+  }
+
+  private void writeRepoProps(String body) throws Exception {
+    Path dir = Files.createDirectories(installRoot.resolve("rxconfig").resolve("Installer"));
+    Files.writeString(dir.resolve("rxrepository.properties"), body, StandardCharsets.UTF_8);
+  }
+
+  private static String h2RepoBody() {
+    return "DB_BACKEND=H2\n"
+        + "DB_DRIVER_NAME=h2\n"
+        + "DB_DRIVER_CLASS_NAME=org.h2.Driver\n"
+        + "DB_SERVER=file:../../Repository/CMDB\n"
+        + "UID=sa\n"
+        + "PWD=\n";
+  }
+
+  private static boolean hasStatusId(
+      CheckConfigReport report, CheckConfigReport.CheckStatus status, String id) {
+    List<String> matches =
+        report.getChecks().stream()
+            .filter(c -> c.getStatus() == status && id.equals(c.getId()))
+            .map(CheckConfigReport.Check::getId)
+            .collect(Collectors.toList());
+    return !matches.isEmpty();
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CleanTempCommandTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/CleanTempCommandTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CleanTempCommandTest {
+
+  @TempDir Path tempDir;
+
+  private Path installRoot;
+  private Path cmsTemp;
+  private Path jettyWork;
+  private Path dtsTemp;
+  private Path nestedTempFile;
+  private Path jettyWorkFile;
+  private Path dtsTempFile;
+  private Path outsideTempFile;
+  private Path nonTempFile;
+  private Path logsDirFile;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    installRoot = Files.createDirectories(tempDir.resolve("cms-install"));
+    cmsTemp = Files.createDirectories(installRoot.resolve("temp"));
+    jettyWork =
+        Files.createDirectories(installRoot.resolve("jetty").resolve("base").resolve("work"));
+    dtsTemp =
+        Files.createDirectories(
+            installRoot.resolve("Deployment").resolve("Server").resolve("temp"));
+
+    Path nested = Files.createDirectories(cmsTemp.resolve("session").resolve("abc"));
+    nestedTempFile = nested.resolve("upload.tmp");
+    jettyWorkFile = jettyWork.resolve("jstl_1");
+    dtsTempFile = dtsTemp.resolve("safeToDelete.tmp");
+    nonTempFile = installRoot.resolve("rxconfig").resolve("Server").resolve("server.properties");
+    Files.createDirectories(nonTempFile.getParent());
+    Files.writeString(nestedTempFile, "nested-temp");
+    Files.write(jettyWorkFile, "work-bytes".getBytes(StandardCharsets.UTF_8));
+    Files.writeString(dtsTempFile, "dts-temp");
+    Files.writeString(nonTempFile, "keep-me");
+
+    Path logs =
+        Files.createDirectories(installRoot.resolve("jetty").resolve("base").resolve("logs"));
+    logsDirFile = logs.resolve("server.log");
+    Files.writeString(logsDirFile, "not-temp");
+
+    Path outside = Files.createDirectories(tempDir.resolve("not-install").resolve("temp"));
+    outsideTempFile = outside.resolve("escape.tmp");
+    Files.writeString(outsideTempFile, "outside");
+  }
+
+  @Test
+  void dryRunInventoriesOnlyAllowlistedTempDirsAndDoesNotDelete() throws Exception {
+    CleanReport report = CleanTempCommand.execute(installRoot, true);
+
+    assertTrue(report.isDryRun());
+    assertEquals(0, report.getDeletedCount());
+    assertEquals(3, report.getCandidateCount());
+    assertTrue(Files.exists(nestedTempFile));
+    assertTrue(Files.exists(jettyWorkFile));
+    assertTrue(Files.exists(dtsTempFile));
+    assertTrue(Files.exists(outsideTempFile));
+    assertTrue(Files.exists(nonTempFile));
+    assertTrue(Files.exists(logsDirFile));
+    assertTrue(Files.isDirectory(cmsTemp), "allowlisted root dirs must remain");
+    assertTrue(Files.isDirectory(jettyWork));
+    assertTrue(Files.isDirectory(dtsTemp));
+
+    for (CleanReport.Entry e : report.getEntries()) {
+      assertEquals(CleanReport.EntryStatus.WOULD_DELETE, e.getStatus());
+      assertTrue(InstallRootGuard.isUnderInstallRoot(installRoot, e.getPath()));
+      assertTrue(
+          CleanTempCommand.isUnderAnyTempRoot(
+              InstallRootGuard.existingTempDirs(installRoot), e.getPath()));
+    }
+
+    long expectedBytes =
+        Files.size(nestedTempFile) + Files.size(jettyWorkFile) + Files.size(dtsTempFile);
+    assertEquals(expectedBytes, report.getTotalBytes());
+  }
+
+  @Test
+  void applyDeletesFilesUnderTempRootsOnlyLeavesRootsAndOtherTrees() throws Exception {
+    CleanReport report = CleanTempCommand.execute(installRoot, false);
+
+    assertFalse(report.isDryRun());
+    assertEquals(3, report.getDeletedCount());
+    assertEquals(0, report.getFailedCount());
+    assertFalse(Files.exists(nestedTempFile));
+    assertFalse(Files.exists(jettyWorkFile));
+    assertFalse(Files.exists(dtsTempFile));
+    assertTrue(Files.exists(outsideTempFile), "outside install root must not be deleted");
+    assertTrue(Files.exists(nonTempFile), "files outside allowlisted temp dirs must remain");
+    assertTrue(Files.exists(logsDirFile), "log tree is not a clean-temp target");
+    assertTrue(Files.isDirectory(cmsTemp), "allowlisted temp root must be retained");
+    assertTrue(Files.isDirectory(jettyWork), "allowlisted work root must be retained");
+    assertTrue(Files.isDirectory(dtsTemp), "allowlisted DTS temp root must be retained");
+    // Nested empty dirs under temp may be removed best-effort
+    assertFalse(Files.exists(nestedTempFile.getParent().resolve("upload.tmp")));
+  }
+
+  @Test
+  void findTempFilesDoesNotIncludeOutsideInstallRootOrNonTempTrees() throws Exception {
+    List<Path> found = CleanTempCommand.findTempFiles(installRoot);
+    assertEquals(3, found.size());
+    for (Path p : found) {
+      assertTrue(InstallRootGuard.isUnderInstallRoot(installRoot, p));
+      assertFalse(p.equals(outsideTempFile));
+      assertFalse(p.equals(nonTempFile));
+      assertFalse(p.equals(logsDirFile));
+    }
+  }
+
+  @Test
+  void executeRejectsMissingInstallRoot() {
+    Path missing = tempDir.resolve("missing-root");
+    assertThrows(IllegalArgumentException.class, () -> CleanTempCommand.execute(missing, true));
+  }
+
+  @Test
+  void missingTempDirsAreSkippedNotError() throws Exception {
+    Path emptyRoot = Files.createDirectories(tempDir.resolve("empty-install"));
+    CleanReport report = CleanTempCommand.execute(emptyRoot, true);
+    assertEquals(0, report.getCandidateCount());
+    assertEquals(0, report.getFailedCount());
+    assertTrue(report.isDryRun());
+  }
+
+  @Test
+  void onlyExistingTempDirsAreWalked() throws Exception {
+    // Remove jetty work; keep cms temp + dts temp
+    Files.deleteIfExists(jettyWorkFile);
+    Files.delete(jettyWork);
+
+    CleanReport report = CleanTempCommand.execute(installRoot, true);
+    assertEquals(2, report.getCandidateCount());
+    for (CleanReport.Entry e : report.getEntries()) {
+      assertFalse(e.getPath().startsWith(jettyWork));
+    }
+  }
+
+  @Test
+  void visitFileFailedRecordsFailedEntryOnReport() {
+    CleanReport report = new CleanReport(CleanTempCommand.COMMAND_NAME, installRoot, true);
+    Path failed = cmsTemp.resolve("locked.tmp");
+    CleanTempCommand.recordVisitFailure(
+        report, failed, new java.io.IOException("Access denied"));
+
+    assertEquals(1, report.getFailedCount());
+    CleanReport.Entry e = report.getEntries().get(0);
+    assertEquals(CleanReport.EntryStatus.FAILED, e.getStatus());
+    assertEquals(failed, e.getPath());
+    assertTrue(e.getDetail().contains("walk:"));
+    assertTrue(e.getDetail().toLowerCase().contains("access denied"));
+  }
+
+  @Test
+  void recordVisitFailureNoopsWhenReportNull() {
+    CleanTempCommand.recordVisitFailure(
+        null, installRoot.resolve("temp").resolve("x.tmp"), new java.io.IOException("x"));
+  }
+
+  @Test
+  void isUnderAnyTempRootRejectsNullsAndOutside() throws Exception {
+    List<Path> roots = InstallRootGuard.existingTempDirs(installRoot);
+    assertTrue(CleanTempCommand.isUnderAnyTempRoot(roots, nestedTempFile));
+    assertFalse(CleanTempCommand.isUnderAnyTempRoot(roots, outsideTempFile));
+    assertFalse(CleanTempCommand.isUnderAnyTempRoot(roots, nonTempFile));
+    assertFalse(CleanTempCommand.isUnderAnyTempRoot(null, nestedTempFile));
+    assertFalse(CleanTempCommand.isUnderAnyTempRoot(roots, null));
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DiagnoseCommandTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DiagnoseCommandTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DiagnoseCommandTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void isDiagnoseCommandRecognizesTokens() {
+    assertTrue(DiagnoseCommand.isDiagnoseCommand("diagnose"));
+    assertTrue(DiagnoseCommand.isDiagnoseCommand("health"));
+    assertFalse(DiagnoseCommand.isDiagnoseCommand("clean-logs"));
+    assertFalse(DiagnoseCommand.isDiagnoseCommand("Diagnose"));
+    assertFalse(DiagnoseCommand.isDiagnoseCommand(null));
+  }
+
+  @Test
+  void reportShapeHasStableIdsAndNoMutations() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("empty-install"));
+    Path marker = root.resolve("sentinel.txt");
+    Files.writeString(marker, "keep-me", StandardCharsets.UTF_8);
+
+    DiagnoseReport report = DiagnoseCommand.execute(root, true);
+
+    assertEquals(DiagnoseCommand.COMMAND_NAME, report.getCommand());
+    assertEquals(root.toAbsolutePath().normalize(), report.getInstallRoot());
+    assertTrue(report.isDryRun());
+    assertTrue(report.getCheckCount() >= 5, "expected multiple checklist rows");
+    assertTrue(Files.exists(marker), "diagnose must never delete files");
+    assertTrue(Files.readString(marker).equals("keep-me"));
+
+    Set<String> ids = new HashSet<>();
+    for (DiagnoseReport.Check c : report.getChecks()) {
+      assertNotNull(c.getId());
+      assertFalse(c.getId().isEmpty());
+      assertNotNull(c.getStatus());
+      assertNotNull(c.getMessage());
+      assertFalse(c.getMessage().isEmpty());
+      ids.add(c.getId());
+    }
+    assertTrue(ids.contains("install-root"));
+    assertTrue(ids.contains("disk.free"));
+    assertTrue(ids.contains("java.version"));
+    assertTrue(ids.contains("java.major"));
+    assertTrue(ids.contains("layout.jetty.base") || ids.contains("layout.jetty"));
+    assertTrue(ids.stream().anyMatch(id -> id.startsWith("config.")));
+    assertTrue(ids.stream().anyMatch(id -> id.startsWith("logs.")));
+  }
+
+  @Test
+  void emptyTreeFailsCriticalLayoutAndWarnsConfigs() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("bare"));
+    DiagnoseReport report = DiagnoseCommand.execute(root, false, "health");
+
+    assertEquals("health", report.getCommand());
+    assertFalse(report.isDryRun());
+    assertFalse(report.isHealthy(), "missing jetty/rxconfig should fail health");
+    assertTrue(report.getFailCount() >= 1);
+
+    DiagnoseReport.Check jettyBase =
+        findCheck(report, "layout.jetty.base");
+    assertNotNull(jettyBase);
+    assertEquals(DiagnoseReport.CheckStatus.FAIL, jettyBase.getStatus());
+
+    DiagnoseReport.Check serverProps =
+        findCheck(report, "config.rxconfig.Server.server.properties");
+    assertNotNull(serverProps);
+    assertEquals(DiagnoseReport.CheckStatus.WARN, serverProps.getStatus());
+  }
+
+  @Test
+  void fullLayoutPassesCriticalChecks() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("full"));
+    Files.createDirectories(root.resolve("jetty").resolve("base").resolve("logs"));
+    Files.createDirectories(
+        root.resolve("jetty")
+            .resolve("base")
+            .resolve("modules")
+            .resolve("perc-logging")
+            .resolve("logs"));
+    Files.createDirectories(root.resolve("Deployment").resolve("Server").resolve("logs"));
+    Files.createDirectories(root.resolve("bin"));
+    Files.createDirectories(root.resolve("rxconfig").resolve("Server"));
+    Files.createDirectories(root.resolve("rxconfig").resolve("Installer"));
+    Files.writeString(
+        root.resolve("rxconfig").resolve("Server").resolve("server.properties"), "x=1");
+    Files.writeString(
+        root.resolve("rxconfig").resolve("Installer").resolve("rxrepository.properties"), "y=2");
+
+    DiagnoseReport report = DiagnoseCommand.execute(root, true);
+
+    assertTrue(report.isHealthy(), "full synthetic tree should have zero FAIL: " + summarize(report));
+    assertEquals(DiagnoseReport.CheckStatus.PASS, findCheck(report, "layout.jetty.base").getStatus());
+    assertEquals(DiagnoseReport.CheckStatus.PASS, findCheck(report, "layout.rxconfig").getStatus());
+    assertEquals(
+        DiagnoseReport.CheckStatus.PASS,
+        findCheck(report, "config.rxconfig.Server.server.properties").getStatus());
+    assertEquals(
+        DiagnoseReport.CheckStatus.PASS, findCheck(report, "logs.jetty.base.logs").getStatus());
+    // Never delete configs either
+    assertTrue(
+        Files.exists(root.resolve("rxconfig").resolve("Server").resolve("server.properties")));
+  }
+
+  @Test
+  void pathGuardsRejectDotDotRelative() {
+    Path root = tempDir.resolve("guard-root");
+    // resolveRelativeUnderRoot must reject ".."
+    assertEquals(null, DiagnoseCommand.resolveChecked(root, "../escape"));
+    assertEquals(null, InstallRootGuard.resolveRelativeUnderRoot(root, "jetty/../../etc"));
+  }
+
+  @Test
+  void checkPathsStayUnderInstallRoot() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("contained"));
+    Files.createDirectories(root.resolve("jetty").resolve("base"));
+    Files.createDirectories(root.resolve("rxconfig"));
+
+    DiagnoseReport report = DiagnoseCommand.execute(root, true);
+    for (DiagnoseReport.Check c : report.getChecks()) {
+      if (c.getPath() == null) {
+        continue;
+      }
+      assertTrue(
+          InstallRootGuard.isUnderInstallRoot(root, c.getPath()),
+          "check path must stay under install root: " + c.getId() + " -> " + c.getPath());
+    }
+  }
+
+  @Test
+  void missingInstallRootThrows() {
+    Path missing = tempDir.resolve("nope");
+    assertThrows(IllegalArgumentException.class, () -> DiagnoseCommand.execute(missing, true));
+  }
+
+  @Test
+  void parseJavaMajorHandlesLegacyAndModern() {
+    assertEquals(8, DiagnoseCommand.parseJavaMajor("1.8.0_402"));
+    assertEquals(11, DiagnoseCommand.parseJavaMajor("11.0.22"));
+    assertEquals(21, DiagnoseCommand.parseJavaMajor("21.0.2"));
+    assertEquals(21, DiagnoseCommand.parseJavaMajor("21"));
+    assertEquals(0, DiagnoseCommand.parseJavaMajor(""));
+    assertEquals(0, DiagnoseCommand.parseJavaMajor(null));
+  }
+
+  @Test
+  void formatBytesUsesBinaryUnits() {
+    assertEquals("0 B", DiagnoseCommand.formatBytes(0));
+    assertTrue(DiagnoseCommand.formatBytes(1536).contains("KiB"));
+    assertTrue(DiagnoseCommand.formatBytes(2L * 1024 * 1024 * 1024).contains("GiB"));
+  }
+
+  private static DiagnoseReport.Check findCheck(DiagnoseReport report, String id) {
+    for (DiagnoseReport.Check c : report.getChecks()) {
+      if (id.equals(c.getId())) {
+        return c;
+      }
+    }
+    return null;
+  }
+
+  private static String summarize(DiagnoseReport report) {
+    StringBuilder sb = new StringBuilder();
+    for (DiagnoseReport.Check c : report.getChecks()) {
+      sb.append(c.getStatus()).append(' ').append(c.getId()).append(' ').append(c.getMessage())
+          .append("; ");
+    }
+    return sb.toString();
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
@@ -260,6 +260,88 @@ class DoctorCliTest {
   }
 
   @Test
+  void diagnoseViaCliIsReadOnlyAndPrintsReportShape() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-diagnose"));
+    Files.createDirectories(root.resolve("jetty").resolve("base"));
+    Files.createDirectories(root.resolve("rxconfig").resolve("Server"));
+    Path keep = root.resolve("keep.me");
+    Files.writeString(keep, "safe");
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root", root.toString(), "--dry-run", "-v", "diagnose"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    assertTrue(Files.exists(keep));
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("command=diagnose"));
+    assertTrue(out.contains("dry-run=true"));
+    assertTrue(out.contains("read-only=true"));
+    assertTrue(out.contains("healthy=true"));
+    assertTrue(out.contains("checks="));
+    assertTrue(out.contains("PASS install-root") || out.contains("install-root"));
+  }
+
+  @Test
+  void healthAliasViaCliWorks() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-health"));
+    Files.createDirectories(root.resolve("jetty").resolve("base"));
+    Files.createDirectories(root.resolve("rxconfig"));
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"--install-root", root.toString(), "-v", "health"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("command=health"));
+    assertTrue(out.contains("read-only=true"));
+  }
+
+  @Test
+  void diagnoseBareTreeExitsErrorOnFailChecks() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-bare-diag"));
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"--install-root", root.toString(), "diagnose"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_ERROR, code);
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("healthy=false"));
+    assertTrue(out.contains("fail="));
+  }
+
+  @Test
+  void helpMentionsDiagnose() {
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"--help"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+    assertEquals(DoctorCli.EXIT_OK, code);
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("diagnose"));
+    assertTrue(out.contains("health"));
+  }
+
+  @Test
   void olderThanOnNonCleanLogsCommandWarnsAndContinues() throws Exception {
     Path root = Files.createDirectories(tempDir.resolve("install-older-warn"));
     Path dump = root.resolve("warn.hprof");

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
@@ -288,4 +288,56 @@ class DoctorCliTest {
     assertTrue(Files.exists(dump));
     assertTrue(outBuf.toString(StandardCharsets.UTF_8).contains("candidates=1"));
   }
+
+  @Test
+  void cleanTempDryRunViaCliDoesNotDelete() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-temp"));
+    Path cmsTemp = Files.createDirectories(root.resolve("temp"));
+    Path junk = cmsTemp.resolve("scratch.tmp");
+    Files.writeString(junk, "temp-data");
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root", root.toString(), "--dry-run", "-v", "clean-temp"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    assertTrue(Files.exists(junk));
+    assertTrue(Files.isDirectory(cmsTemp));
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("command=clean-temp"));
+    assertTrue(out.contains("dry-run=true"));
+    assertTrue(out.contains("candidates=1"));
+    assertTrue(out.contains("WOULD_DELETE"));
+  }
+
+  @Test
+  void cleanTempApplyViaCliDeletesUnderAllowlistedTempDirs() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-temp-apply"));
+    Path cmsTemp = Files.createDirectories(root.resolve("temp"));
+    Path junk = cmsTemp.resolve("scratch.tmp");
+    Path keep = root.resolve("important.cfg");
+    Files.writeString(junk, "temp-data");
+    Files.writeString(keep, "keep");
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"--install-root", root.toString(), "clean-temp"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    assertFalse(Files.exists(junk));
+    assertTrue(Files.exists(keep));
+    assertTrue(Files.isDirectory(cmsTemp), "temp root retained");
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("deleted=1"));
+  }
 }

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java
@@ -288,4 +288,89 @@ class DoctorCliTest {
     assertTrue(Files.exists(dump));
     assertTrue(outBuf.toString(StandardCharsets.UTF_8).contains("candidates=1"));
   }
+
+  @Test
+  void checkConfigViaCliReportsHealthyOnBareTree() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-check-config"));
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root", root.toString(), "--dry-run", "-v", "check-config"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("command=check-config"));
+    assertTrue(out.contains("dry-run=true"));
+    assertTrue(out.contains("healthy=true"));
+    assertTrue(out.contains("WARN"));
+  }
+
+  @Test
+  void checkConfigViaCliFailsOnInvalidBindPort() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-check-config-fail"));
+    Path serverDir = Files.createDirectories(root.resolve("rxconfig").resolve("Server"));
+    Files.writeString(serverDir.resolve("server.properties"), "bindPort=xyz\n");
+    Path installerDir = Files.createDirectories(root.resolve("rxconfig").resolve("Installer"));
+    Files.writeString(
+        installerDir.resolve("rxrepository.properties"),
+        "DB_BACKEND=H2\nDB_DRIVER_NAME=h2\nDB_DRIVER_CLASS_NAME=org.h2.Driver\n"
+            + "DB_SERVER=file:x\nUID=sa\n");
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"--install-root", root.toString(), "-v", "check-config"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_ERROR, code);
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("healthy=false"));
+    assertTrue(out.contains("server.bindPort"));
+  }
+
+  @Test
+  void fixPermissionsViaCliDryRunDoesNotFailOnWindowsLayout() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("install-fix-perms"));
+    Path bin = Files.createDirectories(root.resolve("bin"));
+    Files.writeString(bin.resolve("perc-doctor"), "#!/bin/sh\n");
+    Files.writeString(bin.resolve("perc-doctor.bat"), "@echo off\r\n");
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {
+              "--install-root", root.toString(), "--dry-run", "-v", "fix-permissions"
+            },
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+
+    assertEquals(DoctorCli.EXIT_OK, code);
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("command=fix-permissions"));
+    assertTrue(out.contains("dry-run=true"));
+    assertTrue(out.contains("candidates="));
+  }
+
+  @Test
+  void helpListsCheckConfigAndFixPermissions() {
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    int code =
+        DoctorCli.run(
+            new String[] {"--help"},
+            new PrintStream(outBuf, true, StandardCharsets.UTF_8),
+            new PrintStream(errBuf, true, StandardCharsets.UTF_8));
+    assertEquals(DoctorCli.EXIT_OK, code);
+    String out = outBuf.toString(StandardCharsets.UTF_8);
+    assertTrue(out.contains("check-config"));
+    assertTrue(out.contains("fix-permissions"));
+  }
 }

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/FixPermissionsCommandTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/FixPermissionsCommandTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.doctor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+class FixPermissionsCommandTest {
+
+  @TempDir Path tempDir;
+
+  private Path installRoot;
+  private Path binDir;
+  private Path unixLauncher;
+  private Path jettyLogs;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    installRoot = Files.createDirectories(tempDir.resolve("cms-install"));
+    binDir = Files.createDirectories(installRoot.resolve("bin"));
+    unixLauncher = binDir.resolve("perc-doctor");
+    Files.writeString(unixLauncher, "#!/bin/sh\necho doctor\n", StandardCharsets.UTF_8);
+    Files.writeString(binDir.resolve("perc-doctor.bat"), "@echo off\r\n", StandardCharsets.UTF_8);
+    Files.write(binDir.resolve("perc-doctor.jar"), new byte[] {0x50, 0x4b});
+    jettyLogs =
+        Files.createDirectories(
+            installRoot.resolve("jetty").resolve("base").resolve("logs"));
+    Path serverDir = Files.createDirectories(installRoot.resolve("rxconfig").resolve("Server"));
+    Files.writeString(serverDir.resolve("server.properties"), "bindPort=9992\n");
+    Path installerDir =
+        Files.createDirectories(installRoot.resolve("rxconfig").resolve("Installer"));
+    Files.writeString(
+        installerDir.resolve("rxrepository.properties"),
+        "DB_BACKEND=H2\nDB_DRIVER_NAME=h2\nDB_DRIVER_CLASS_NAME=org.h2.Driver\n"
+            + "DB_SERVER=file:x\nUID=sa\n");
+  }
+
+  @Test
+  void dryRunNeverMutatesAndReportsCandidates() throws Exception {
+    FixPermissionsReport report = FixPermissionsCommand.execute(installRoot, true);
+    assertEquals(FixPermissionsCommand.COMMAND_NAME, report.getCommand());
+    assertTrue(report.isDryRun());
+    assertTrue(report.getCandidateCount() > 0);
+    assertEquals(0, report.getFixedCount());
+    // Launcher file content unchanged
+    assertTrue(Files.readString(unixLauncher, StandardCharsets.UTF_8).contains("#!/bin/sh"));
+  }
+
+  @Test
+  void missingPathsAreSkippedNotFailed() throws Exception {
+    Path emptyRoot = Files.createDirectories(tempDir.resolve("empty-install"));
+    FixPermissionsReport report = FixPermissionsCommand.execute(emptyRoot, true);
+    assertEquals(0, report.getFailedCount());
+    assertTrue(
+        report.getEntries().stream()
+            .anyMatch(e -> e.getStatus() == FixPermissionsReport.EntryStatus.SKIPPED));
+  }
+
+  @Test
+  void missingInstallRootRejected() {
+    Path missing = tempDir.resolve("gone");
+    assertThrows(
+        IllegalArgumentException.class, () -> FixPermissionsCommand.execute(missing, true));
+  }
+
+  @Test
+  void allEntryPathsStayUnderInstallRoot() throws Exception {
+    FixPermissionsReport report = FixPermissionsCommand.execute(installRoot, true);
+    for (FixPermissionsReport.Entry e : report.getEntries()) {
+      assertTrue(
+          InstallRootGuard.isUnderInstallRoot(installRoot, e.getPath()),
+          "path escaped root: " + e.getPath());
+    }
+  }
+
+  @Test
+  void isUnixScriptLauncherHeuristic() {
+    assertTrue(FixPermissionsCommand.isUnixScriptLauncher("perc-doctor"));
+    assertFalse(FixPermissionsCommand.isUnixScriptLauncher("perc-doctor.bat"));
+    assertFalse(FixPermissionsCommand.isUnixScriptLauncher("perc-doctor.jar"));
+    assertFalse(FixPermissionsCommand.isUnixScriptLauncher("perc-doctor.cmd"));
+  }
+
+  @Test
+  @EnabledOnOs({OS.LINUX, OS.MAC})
+  void posixDryRunWouldFixMissingOwnerExecute() throws Exception {
+    // Strip owner execute if present
+    Set<PosixFilePermission> perms = Files.getPosixFilePermissions(unixLauncher);
+    EnumSet<PosixFilePermission> stripped = EnumSet.copyOf(perms);
+    stripped.remove(PosixFilePermission.OWNER_EXECUTE);
+    stripped.remove(PosixFilePermission.GROUP_EXECUTE);
+    stripped.remove(PosixFilePermission.OTHERS_EXECUTE);
+    Files.setPosixFilePermissions(unixLauncher, stripped);
+
+    FixPermissionsReport dry = FixPermissionsCommand.execute(installRoot, true);
+    assertTrue(dry.getWouldFixCount() >= 1);
+    assertFalse(Files.getPosixFilePermissions(unixLauncher).contains(PosixFilePermission.OWNER_EXECUTE));
+
+    FixPermissionsReport apply = FixPermissionsCommand.execute(installRoot, false);
+    assertTrue(apply.getFixedCount() >= 1);
+    assertTrue(
+        Files.getPosixFilePermissions(unixLauncher).contains(PosixFilePermission.OWNER_EXECUTE));
+  }
+
+  @Test
+  @EnabledOnOs({OS.LINUX, OS.MAC})
+  void posixLogDirOwnerRwxFix() throws Exception {
+    Set<PosixFilePermission> perms = Files.getPosixFilePermissions(jettyLogs);
+    EnumSet<PosixFilePermission> stripped = EnumSet.copyOf(perms);
+    stripped.remove(PosixFilePermission.OWNER_WRITE);
+    Files.setPosixFilePermissions(jettyLogs, stripped);
+
+    FixPermissionsReport dry = FixPermissionsCommand.execute(installRoot, true);
+    assertTrue(
+        dry.getEntries().stream()
+            .anyMatch(
+                e ->
+                    e.getStatus() == FixPermissionsReport.EntryStatus.WOULD_FIX
+                        && e.getPath().equals(jettyLogs.toAbsolutePath().normalize())));
+
+    FixPermissionsReport apply = FixPermissionsCommand.execute(installRoot, false);
+    assertTrue(
+        Files.getPosixFilePermissions(jettyLogs).contains(PosixFilePermission.OWNER_WRITE));
+    assertTrue(apply.getFixedCount() >= 1);
+  }
+
+  @Test
+  @EnabledOnOs(OS.WINDOWS)
+  void windowsReportsAccessWithoutModeMutation() throws Exception {
+    FixPermissionsReport report = FixPermissionsCommand.execute(installRoot, false);
+    assertEquals(0, report.getFixedCount());
+    assertTrue(
+        report.getEntries().stream()
+            .anyMatch(
+                e ->
+                    e.getStatus() == FixPermissionsReport.EntryStatus.SKIPPED
+                        && e.getDetail() != null
+                        && e.getDetail().toLowerCase().contains("posix")));
+    // Launchers still OK/readable
+    assertTrue(
+        report.getEntries().stream()
+            .anyMatch(
+                e ->
+                    e.getPath().getFileName().toString().equals("perc-doctor.bat")
+                        && (e.getStatus() == FixPermissionsReport.EntryStatus.OK
+                            || e.getStatus() == FixPermissionsReport.EntryStatus.SKIPPED)));
+  }
+}

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/InstallRootGuardTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/InstallRootGuardTest.java
@@ -156,6 +156,29 @@ class InstallRootGuardTest {
   }
 
   @Test
+  void existingTempDirsOnlyReturnsPresentDirsUnderRoot() throws Exception {
+    Path root = Files.createDirectories(tempDir.resolve("cms-temp"));
+    Path cmsTemp = Files.createDirectories(root.resolve("temp"));
+    Path jettyWork =
+        Files.createDirectories(root.resolve("jetty").resolve("base").resolve("work"));
+    // DTS temp/work intentionally missing
+    java.util.List<Path> dirs = InstallRootGuard.existingTempDirs(root);
+    assertEquals(2, dirs.size());
+    assertTrue(dirs.contains(cmsTemp.toAbsolutePath().normalize()));
+    assertTrue(dirs.contains(jettyWork.toAbsolutePath().normalize()));
+  }
+
+  @Test
+  void tempDirRelativeAllowlistIsDocumentedAndStable() {
+    // Guard against accidental allowlist expansion without docs/tests.
+    assertEquals(4, InstallRootGuard.TEMP_DIR_RELATIVE.length);
+    assertEquals("temp", InstallRootGuard.TEMP_DIR_RELATIVE[0]);
+    assertEquals("jetty/base/work", InstallRootGuard.TEMP_DIR_RELATIVE[1]);
+    assertEquals("Deployment/Server/temp", InstallRootGuard.TEMP_DIR_RELATIVE[2]);
+    assertEquals("Deployment/Server/work", InstallRootGuard.TEMP_DIR_RELATIVE[3]);
+  }
+
+  @Test
   void resolveRelativeUnderRootRejectsDotDot() throws Exception {
     Path root = Files.createDirectories(tempDir.resolve("cms-rel")).toAbsolutePath().normalize();
     Path resolved = InstallRootGuard.resolveRelativeUnderRoot(root, "jetty/base/logs");

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/PercDoctorPackagingTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/PercDoctorPackagingTest.java
@@ -143,7 +143,9 @@ class PercDoctorPackagingTest {
     assertTrue(
         guideText.contains("clean-heap-dumps")
             && guideText.contains("clean-install-backups")
-            && guideText.contains("clean-logs"),
+            && guideText.contains("clean-logs")
+            && guideText.contains("check-config")
+            && guideText.contains("fix-permissions"),
         "install guide must cover all shipped commands");
     assertTrue(
         guideText.contains("bin/perc-doctor") || guideText.contains("bin\\perc-doctor"),

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/PercDoctorPackagingTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/PercDoctorPackagingTest.java
@@ -143,8 +143,9 @@ class PercDoctorPackagingTest {
     assertTrue(
         guideText.contains("clean-heap-dumps")
             && guideText.contains("clean-install-backups")
-            && guideText.contains("clean-logs"),
-        "install guide must cover all shipped commands");
+            && guideText.contains("clean-logs")
+            && (guideText.contains("diagnose") || guideText.contains("health")),
+        "install guide must cover all shipped commands including diagnose/health");
     assertTrue(
         guideText.contains("bin/perc-doctor") || guideText.contains("bin\\perc-doctor"),
         "install guide must document install-tree bin wrappers");

--- a/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/api/DoctorApiServiceTest.java
+++ b/modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/api/DoctorApiServiceTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.intsof.percussioncms.doctor.CleanHeapDumpsCommand;
 import com.intsof.percussioncms.doctor.CleanReport;
+import com.intsof.percussioncms.doctor.CleanTempCommand;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -131,5 +132,37 @@ class DoctorApiServiceTest {
     assertThrows(
         DoctorUnknownCommandException.class,
         () -> service.execute("not-a-real-command", new DoctorRequest()));
+  }
+
+  @Test
+  void cleanTempDryRunDefaultDoesNotDelete() throws Exception {
+    Path cmsTemp = Files.createDirectories(installRoot.resolve("temp"));
+    Path junk = cmsTemp.resolve("api-scratch.tmp");
+    Files.writeString(junk, "tmp");
+
+    DoctorReportView view = service.execute(CleanTempCommand.COMMAND_NAME, null);
+
+    assertTrue(view.isDryRun());
+    assertEquals(1, view.getCandidateCount());
+    assertEquals(0, view.getDeletedCount());
+    assertEquals(CleanReport.EntryStatus.WOULD_DELETE.name(), view.getEntries().get(0).getStatus());
+    assertTrue(Files.exists(junk), "dry-run must not delete temp files");
+    assertTrue(Files.isDirectory(cmsTemp));
+  }
+
+  @Test
+  void cleanTempApplyDeletesUnderAllowlistedDirs() throws Exception {
+    Path cmsTemp = Files.createDirectories(installRoot.resolve("temp"));
+    Path junk = cmsTemp.resolve("api-apply.tmp");
+    Files.writeString(junk, "tmp");
+
+    DoctorRequest req = new DoctorRequest();
+    req.setDryRun(false);
+    DoctorReportView view = service.execute(CleanTempCommand.COMMAND_NAME, req);
+
+    assertFalse(view.isDryRun());
+    assertEquals(1, view.getDeletedCount());
+    assertFalse(Files.exists(junk));
+    assertTrue(Files.isDirectory(cmsTemp));
   }
 }


### PR DESCRIPTION
## Summary

Overnight **same-file thrash** on `modules/perc-doctor` — three owned PRs all edited shared peer wiring / docs:

### Thrash files
- `modules/perc-doctor/src/main/java/com/intsof/percussioncms/doctor/DoctorCli.java`
- `modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/DoctorCliTest.java`
- `modules/perc-doctor/src/test/java/com/intsof/percussioncms/doctor/PercDoctorPackagingTest.java`
- `modules/perc-doctor/README.md`
- `modules/perc-doctor/docs/operator-install-guide.md`

Merging them separately would force repeated conflict resolution on CLI peer registration and operator docs. This cluster **unions** all three feature sets into one PR against `main`.

### Absorbed content (union)
1. **diagnose/health** (#2231 / #2213) — read-only install checklist
2. **clean-temp** (#2251 / #2232) — allowlisted install temp/work cleanup (dry-run first)
3. **check-config + fix-permissions** (#2252 / #2233) — value/misconfig checks + POSIX mode fixes (Windows report-only)

### Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
|------------|-------------|------|----------|-------|
| yes | #2231 | `feat/issue-2213-diagnose-health` | yes | Oldest; diagnose/health CLI + tests + docs |
| yes | #2251 | `feat/issue-2232-clean-temp` | yes | clean-temp + InstallRootGuard + API surface |
| yes | #2252 | `feat/issue-2233-check-config-fix-permissions` | yes | check-config + fix-permissions CLI + tests |

Conflict resolution used **union semantics** (never drop either side's unique commands, help lines, examples, or tests).

### Issues
- Fixes #2213 (diagnose/health slice delivered here; parent epic may retain HTTP residuals)
- Fixes #2232
- Fixes #2233
- Refs overnight cluster thrash absorption for perc-doctor

## Test plan / gates
- [x] `modules/perc-doctor` `mvnw clean install` green on cluster branch
- [x] Unit tests cover diagnose, clean-temp, check-config, fix-permissions CLI paths
- [x] Packaging test asserts install guide names all shipped commands
- [ ] Human review of CLI help / README union
- [ ] CI on this PR

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Code using grok-4.5 with agent night-issue-prs-cluster.