### PR TITLE
fix(categories): restore DTS publish of renamed categories (GH-957)

### DIFF
--- a/WebUI/src/main/webapp/cm/app/js/legacy/controllers/PercCategoryController.js
+++ b/WebUI/src/main/webapp/cm/app/js/legacy/controllers/PercCategoryController.js
@@ -238,6 +238,14 @@ var globalVar;
         }
 
         dirtyController.setDirty(false);
+        // Success was previously silent (HTTP 204 only) — users reported
+        // "nothing happens" when publish actually completed (GH-957).
+        view.alertDialog(
+          I18N.message("perc.ui.category.controller@Publish Success"),
+          I18N.message(
+            "perc.ui.category.controller@Categories Published to DTS",
+          ),
+        );
       },
     );
   }

--- a/WebUI/src/main/webapp/cm/app/js/legacy/views/PercCategoryView.js
+++ b/WebUI/src/main/webapp/cm/app/js/legacy/views/PercCategoryView.js
@@ -973,6 +973,13 @@
         if (parent.data.title == null) {
           children.push(
             node.toDict(true, function (dict) {
+              // Fancytree nests custom fields under dict.data. Flatten so the
+              // CMS category JSON retains id, previousCategoryName, etc.
+              // (regression of GH-758 / lost in #1256 fancytree port).
+              if (dict.data) {
+                $.extend(dict, dict.data);
+                delete dict.data;
+              }
               delete dict.activate;
               delete dict.addClass;
               delete dict.expand;
@@ -1139,7 +1146,6 @@
     }
 
     function publishToDTS(node, deliveryServer) {
-      var catArray = manageDynaProps();
       if (
         sitename == null ||
         typeof sitename == "undefined" ||
@@ -1151,10 +1157,21 @@
         );
         return;
       }
-      controller.publishToDTS(catArray, deliveryServer, sitename);
-
+      // Persist the tree first so previousCategoryName and other node.data
+      // fields land in category.xml, then publish from the server copy.
+      // (Previously publish raced ahead of save and used stale XML — GH-957.)
       isPublished = true;
-      save();
+      var catArray = manageDynaProps();
+      controller.editCategories(
+        catArray,
+        sitename,
+        function () {
+          controller.publishToDTS(catArray, deliveryServer, sitename);
+        },
+        function () {
+          isPublished = false;
+        },
+      );
     }
   };
 })(jQuery);

--- a/WebUI/src/main/webapp/cm/controllers/PercCategoryController.js
+++ b/WebUI/src/main/webapp/cm/controllers/PercCategoryController.js
@@ -238,6 +238,14 @@ var globalVar;
         }
 
         dirtyController.setDirty(false);
+        // Success was previously silent (HTTP 204 only) — users reported
+        // "nothing happens" when publish actually completed (GH-957).
+        view.alertDialog(
+          I18N.message("perc.ui.category.controller@Publish Success"),
+          I18N.message(
+            "perc.ui.category.controller@Categories Published to DTS",
+          ),
+        );
       },
     );
   }

--- a/WebUI/src/main/webapp/cm/views/PercCategoryView.js
+++ b/WebUI/src/main/webapp/cm/views/PercCategoryView.js
@@ -973,6 +973,13 @@
         if (parent.data.title == null) {
           children.push(
             node.toDict(true, function (dict) {
+              // Fancytree nests custom fields under dict.data. Flatten so the
+              // CMS category JSON retains id, previousCategoryName, etc.
+              // (regression of GH-758 / lost in #1256 fancytree port).
+              if (dict.data) {
+                $.extend(dict, dict.data);
+                delete dict.data;
+              }
               delete dict.activate;
               delete dict.addClass;
               delete dict.expand;
@@ -1139,7 +1146,6 @@
     }
 
     function publishToDTS(node, deliveryServer) {
-      var catArray = manageDynaProps();
       if (
         sitename == null ||
         typeof sitename == "undefined" ||
@@ -1151,10 +1157,21 @@
         );
         return;
       }
-      controller.publishToDTS(catArray, deliveryServer, sitename);
-
+      // Persist the tree first so previousCategoryName and other node.data
+      // fields land in category.xml, then publish from the server copy.
+      // (Previously publish raced ahead of save and used stale XML — GH-957.)
       isPublished = true;
-      save();
+      var catArray = manageDynaProps();
+      controller.editCategories(
+        catArray,
+        sitename,
+        function () {
+          controller.publishToDTS(catArray, deliveryServer, sitename);
+        },
+        function () {
+          isPublished = false;
+        },
+      );
     }
   };
 })(jQuery);

--- a/WebUI/war/controllers/PercCategoryController.js
+++ b/WebUI/war/controllers/PercCategoryController.js
@@ -200,6 +200,12 @@ var globalVar;
             }
 
             dirtyController.setDirty(false);
+            // Success was previously silent (HTTP 204 only) — users reported
+            // "nothing happens" when publish actually completed (GH-957).
+            view.alertDialog(
+                I18N.message("perc.ui.category.controller@Publish Success"),
+                I18N.message("perc.ui.category.controller@Categories Published to DTS")
+            );
         });
     }
 })(jQuery);

--- a/WebUI/war/views/PercCategoryView.js
+++ b/WebUI/war/views/PercCategoryView.js
@@ -971,6 +971,13 @@
         if (parent.data.title == null) {
           children.push(
             node.toDict(true, function (dict) {
+              // Fancytree nests custom fields under dict.data. Flatten so the
+              // CMS category JSON retains id, previousCategoryName, etc.
+              // (regression of GH-758 / lost in #1256 fancytree port).
+              if (dict.data) {
+                $.extend(dict, dict.data);
+                delete dict.data;
+              }
               delete dict.activate;
               delete dict.addClass;
               delete dict.expand;
@@ -1137,7 +1144,6 @@
     }
 
     function publishToDTS(node, deliveryServer) {
-      var catArray = manageDynaProps();
       if (
         sitename == null ||
         typeof sitename == "undefined" ||
@@ -1149,10 +1155,21 @@
         );
         return;
       }
-      controller.publishToDTS(catArray, deliveryServer, sitename);
-
+      // Persist the tree first so previousCategoryName and other node.data
+      // fields land in category.xml, then publish from the server copy.
+      // (Previously publish raced ahead of save and used stale XML — GH-957.)
       isPublished = true;
-      save();
+      var catArray = manageDynaProps();
+      controller.editCategories(
+        catArray,
+        sitename,
+        function () {
+          controller.publishToDTS(catArray, deliveryServer, sitename);
+        },
+        function () {
+          isPublished = false;
+        },
+      );
     }
   };
 })(jQuery);

--- a/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
@@ -13306,6 +13306,12 @@ Doorgaan?</seg></tuv>
       <tuv xml:lang="zh-cn"><seg>删除类别选项卡锁时出现一些问题！</seg></tuv>
       <tuv xml:lang="zh-tw"><seg>删除类别选项卡锁时出现一些问题！</seg></tuv>
     <tuv xml:lang="ru"><seg>Возникла проблема при снятии блокировки вкладки категории!</seg></tuv><tuv xml:lang="he"><seg>התרחשה בעיה בעת הסרת נעילת לשונית הקטגוריה!</seg></tuv><tuv xml:lang="uk"><seg>Виникла проблема під час видалення блокування вкладки категорії!</seg></tuv></tu>
+    <tu tuid="perc.ui.category.controller@Publish Success">
+      <tuv xml:lang="en-us"><seg>Publish Success</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.category.controller@Categories Published to DTS">
+      <tuv xml:lang="en-us"><seg>Categories were published to the selected DTS server(s).</seg></tuv>
+    </tu>
     <tu tuid="perc.ui.category.controller@Publish Error">
       <tuv xml:lang="en-us"><seg>Publish Error</seg></tuv>
       <tuv xml:lang="ar"><seg>خطأ في النشر</seg></tuv>

--- a/projects/sitemanage/src/main/java/com/percussion/category/service/impl/PSCategoryService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/service/impl/PSCategoryService.java
@@ -383,6 +383,7 @@ public class PSCategoryService implements IPSCategoryService {
         PSCategoryServiceUtil.publishToDTS(category, sitename, deliveryserver, deliveryService);
       }
     } catch (PSDataServiceException e) {
+      // Includes PSValidationException (e.g. no recently-edited categories).
       throw new WebApplicationException(e.getMessage());
     }
   }

--- a/projects/sitemanage/src/main/java/com/percussion/category/service/impl/PSCategoryServiceUtil.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/service/impl/PSCategoryServiceUtil.java
@@ -226,28 +226,52 @@ public class PSCategoryServiceUtil {
     }
   }
 
-  private static String getCategoriesForPublish(String categoryString) {
+  /**
+   * Builds the JSON array string of category path renames to push to DTS.
+   *
+   * <p>Package-visible for unit tests. Returns {@code "[]"} when nothing was renamed, or {@code
+   * null} when the category payload cannot be read.
+   *
+   * @param categoryString marshalled category JSON; may be blank
+   * @return JSON array string of {@code previousCategoryName}/{@code title} pairs, or null
+   */
+  static String getCategoriesForPublish(String categoryString) {
     String forPublish = null;
     var category = PSCategoryUnMarshaller.unMarshalFromString(categoryString);
+    if (category == null) {
+      return null;
+    }
     log.debug("Getting categories for publish.");
     var topCategories = category.getTopLevelNodes();
     if (topCategories != null && !topCategories.isEmpty()) {
+      String treeTitle = StringUtils.defaultIfBlank(category.getTitle(), "Categories");
       forPublish =
-          findModifiedCategories(topCategories, "/" + category.getTitle(), null, false).toString();
+          findModifiedCategories(topCategories, "/" + treeTitle, null, false).toString();
     }
     return forPublish;
   }
 
-  private static JSONArray findModifiedCategories(
+  /**
+   * Walks the category tree and collects rename pairs for DTS {@code perc:category} updates.
+   *
+   * @param categories siblings at the current level; never null
+   * @param oldPrefix path prefix using previous names for ancestors
+   * @param newPrefix path prefix using new titles for renamed ancestors; may be null
+   * @param hasParentChanged true when an ancestor was renamed
+   * @return JSON array of rename objects (may be empty)
+   */
+  static JSONArray findModifiedCategories(
       List<PSCategoryNode> categories,
       String oldPrefix,
       String newPrefix,
       boolean hasParentChanged) {
     var jsonArray = new JSONArray();
-    boolean thisParentChanged = false;
     log.debug("Finding modified categories.");
     try {
       for (var parent : categories) {
+        // Must reset per sibling; previously a rename on one node incorrectly
+        // treated every following sibling as renamed (and broke child paths).
+        boolean thisParentChanged = false;
         var obj = new JSONObject();
         if (StringUtils.isNotBlank(parent.getPreviousCategoryName())
             && StringUtils.isNotBlank(parent.getTitle())) {

--- a/projects/sitemanage/src/main/java/com/percussion/category/service/impl/PSCategoryServiceUtil.java
+++ b/projects/sitemanage/src/main/java/com/percussion/category/service/impl/PSCategoryServiceUtil.java
@@ -236,19 +236,19 @@ public class PSCategoryServiceUtil {
    * @return JSON array string of {@code previousCategoryName}/{@code title} pairs, or null
    */
   static String getCategoriesForPublish(String categoryString) {
-    String forPublish = null;
     var category = PSCategoryUnMarshaller.unMarshalFromString(categoryString);
     if (category == null) {
       return null;
     }
     log.debug("Getting categories for publish.");
     var topCategories = category.getTopLevelNodes();
-    if (topCategories != null && !topCategories.isEmpty()) {
-      String treeTitle = StringUtils.defaultIfBlank(category.getTitle(), "Categories");
-      forPublish =
-          findModifiedCategories(topCategories, "/" + treeTitle, null, false).toString();
+    if (topCategories == null || topCategories.isEmpty()) {
+      // Valid empty tree: match documented contract ("[]" = nothing renamed).
+      // null is reserved for unreadable / unparseable payloads only.
+      return "[]";
     }
-    return forPublish;
+    String treeTitle = StringUtils.defaultIfBlank(category.getTitle(), "Categories");
+    return findModifiedCategories(topCategories, "/" + treeTitle, null, false).toString();
   }
 
   /**

--- a/projects/sitemanage/src/test/java/com/percussion/category/service/impl/PSCategoryServiceUtilPublishTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/category/service/impl/PSCategoryServiceUtilPublishTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.category.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.category.data.PSCategory;
+import com.percussion.category.data.PSCategoryNode;
+import com.percussion.category.marshaller.PSCategoryMarshaller;
+import java.util.ArrayList;
+import java.util.List;
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for category → DTS rename payload building (GH-957).
+ *
+ * <p>Publish Categories only rewrites {@code perc:category} metadata paths for nodes that carry
+ * {@code previousCategoryName}. These tests lock that selection logic and the sibling-rename
+ * isolation fix.
+ */
+class PSCategoryServiceUtilPublishTest {
+
+  @Test
+  void renamedTopLevelCategoryProducesPreviousAndNewPath() throws Exception {
+    PSCategoryNode renamed = node("n1", "News2", "News");
+    String json = marshalTree(List.of(renamed));
+
+    String payload = PSCategoryServiceUtil.getCategoriesForPublish(json);
+    assertNotNull(payload);
+    assertFalse("[]".equals(payload), "expected at least one rename pair");
+
+    JSONArray arr = new JSONArray(payload);
+    assertEquals(1, arr.length());
+    JSONObject pair = arr.getJSONObject(0);
+    assertEquals("/Categories/News", pair.getString("previousCategoryName"));
+    assertEquals("/Categories/News2", pair.getString("title"));
+  }
+
+  @Test
+  void unmodifiedSiblingsAreNotPublishedWhenNeighborIsRenamed() throws Exception {
+    // Sibling bleed regression: a rename on A must not invent renames for B/C.
+    PSCategoryNode a = node("a", "AlphaNew", "Alpha");
+    PSCategoryNode b = node("b", "Beta", null);
+    PSCategoryNode c = node("c", "Gamma", null);
+
+    JSONArray arr =
+        PSCategoryServiceUtil.findModifiedCategories(
+            List.of(a, b, c), "/Categories", null, false);
+
+    assertEquals(1, arr.length(), "only the renamed sibling should produce a pair");
+    assertEquals("/Categories/Alpha", arr.getJSONObject(0).getString("previousCategoryName"));
+    assertEquals("/Categories/AlphaNew", arr.getJSONObject(0).getString("title"));
+  }
+
+  @Test
+  void childPathsUpdateWhenParentIsRenamed() throws Exception {
+    PSCategoryNode child = node("child", "Leaf", null);
+    PSCategoryNode parent = node("parent", "ParentNew", "ParentOld");
+    parent.setChildNodes(List.of(child));
+
+    JSONArray arr =
+        PSCategoryServiceUtil.findModifiedCategories(
+            List.of(parent), "/Categories", null, false);
+
+    assertEquals(2, arr.length());
+    assertEquals("/Categories/ParentOld", arr.getJSONObject(0).getString("previousCategoryName"));
+    assertEquals("/Categories/ParentNew", arr.getJSONObject(0).getString("title"));
+    assertEquals(
+        "/Categories/ParentOld/Leaf", arr.getJSONObject(1).getString("previousCategoryName"));
+    assertEquals("/Categories/ParentNew/Leaf", arr.getJSONObject(1).getString("title"));
+  }
+
+  @Test
+  void emptyTreeYieldsEmptyArrayPayload() throws Exception {
+    String json = marshalTree(List.of());
+    String payload = PSCategoryServiceUtil.getCategoriesForPublish(json);
+    // No top-level nodes → method returns null (caller treats as nothing to publish)
+    // or empty array if title present with empty children. Accept either empty signal.
+    assertTrue(
+        payload == null || "[]".equals(payload),
+        "expected no renames for empty tree, got: " + payload);
+  }
+
+  @Test
+  void onlyTitleChangeWithoutPreviousNameIsNotPublished() throws Exception {
+    PSCategoryNode plain = node("p", "JustATitle", null);
+    JSONArray arr =
+        PSCategoryServiceUtil.findModifiedCategories(
+            List.of(plain), "/Categories", null, false);
+    assertEquals(0, arr.length());
+  }
+
+  private static PSCategoryNode node(String id, String title, String previousName) {
+    var n = new PSCategoryNode();
+    n.setId(id);
+    n.setTitle(title);
+    n.setPreviousCategoryName(previousName);
+    n.setChildNodes(new ArrayList<>());
+    return n;
+  }
+
+  private static String marshalTree(List<PSCategoryNode> top) {
+    var cat = new PSCategory();
+    cat.setTitle("Categories");
+    cat.setTopLevelNodes(new ArrayList<>(top));
+    return PSCategoryMarshaller.marshalToJson(cat);
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/category/service/impl/PSCategoryServiceUtilPublishTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/category/service/impl/PSCategoryServiceUtilPublishTest.java
@@ -19,7 +19,6 @@ package com.percussion.category.service.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.category.data.PSCategory;
 import com.percussion.category.data.PSCategoryNode;
@@ -93,11 +92,21 @@ class PSCategoryServiceUtilPublishTest {
   void emptyTreeYieldsEmptyArrayPayload() throws Exception {
     String json = marshalTree(List.of());
     String payload = PSCategoryServiceUtil.getCategoriesForPublish(json);
-    // No top-level nodes → method returns null (caller treats as nothing to publish)
-    // or empty array if title present with empty children. Accept either empty signal.
-    assertTrue(
-        payload == null || "[]".equals(payload),
-        "expected no renames for empty tree, got: " + payload);
+    // Valid empty tree must return "[]" (null is only for unreadable payloads).
+    assertEquals("[]", payload, "expected empty-array contract for empty tree");
+  }
+
+  @Test
+  void blankPayloadReturnsNull() {
+    // PSCategoryUnMarshaller returns null only for blank input (parse errors throw).
+    assertEquals(
+        null,
+        PSCategoryServiceUtil.getCategoriesForPublish(""),
+        "blank payload must return null, not empty array");
+    assertEquals(
+        null,
+        PSCategoryServiceUtil.getCategoriesForPublish(null),
+        "null payload must return null, not empty array");
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/CategoriesFancytreePortTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pagemanagement/service/impl/CategoriesFancytreePortTest.java
@@ -111,6 +111,44 @@ class CategoriesFancytreePortTest {
     }
   }
 
+  /**
+   * GH-957 / GH-758: Fancytree {@code toDict} nests custom fields under {@code dict.data}. Without
+   * flattening, {@code previousCategoryName} (and id) never reach category.xml, so Publish
+   * Categories finds nothing to push to DTS.
+   */
+  @Test
+  void manageDynaPropsFlattensFancytreeDictData() {
+    for (String rel : VIEW_PATHS) {
+      String js = read(rel);
+      assertTrue(
+          js.contains("dict.data") && js.contains("$.extend(dict, dict.data)"),
+          rel + " must flatten fancytree dict.data into the node dict (GH-758/957)");
+      assertTrue(
+          js.contains("delete dict.data"),
+          rel + " must remove nested data after flatten");
+    }
+  }
+
+  /** GH-957: publish must persist the tree before calling updateindts (save-then-publish). */
+  @Test
+  void publishToDTSSavesBeforePublish() {
+    for (String rel : VIEW_PATHS) {
+      String js = read(rel);
+      // Structural: publishToDTS calls editCategories then publishToDTS on success.
+      assertTrue(
+          js.contains("controller.editCategories")
+              && js.contains("controller.publishToDTS"),
+          rel + " publish flow should save (editCategories) then publish");
+      // Must not fire-and-forget publish then save() (race against category.xml).
+      Pattern race =
+          Pattern.compile(
+              "controller\\.publishToDTS\\([^)]*\\)\\s*;\\s*isPublished\\s*=\\s*true\\s*;\\s*save\\s*\\(");
+      assertTrue(
+          !race.matcher(js).find(),
+          rel + " must not publish before save (legacy race)");
+    }
+  }
+
   private static String read(String rel) {
     Path p = repoRoot.resolve(rel);
     if (!Files.isRegularFile(p)) {


### PR DESCRIPTION
## Summary

Fixes **#957** — Admin → Categories → Publish (Production / Staging / Both) appeared to do nothing, and renamed categories were not rewritten on DTS.

### Root cause
After the fancytree port (#1256), `manageDynaProps()` stopped flattening FancyTree `toDict()`'s nested `dict.data` (regression of the GH-758 flatten). That meant `previousCategoryName` (and `id`) never reached `category.xml`. Server-side `publishToDTS` reloads categories from XML and only pushes nodes with `previousCategoryName`, so the DTS update list was empty. Success was also silent (HTTP 204 only).

### Changes
- **WebUI** (all three `PercCategoryView.js` copies): restore `dict.data` flatten; **save-then-publish** so renames persist before `/category/updateindts`.
- **WebUI** (all three controllers): success dialog after DTS publish.
- **sitemanage**: reset `thisParentChanged` per sibling in `findModifiedCategories`; default tree title `Categories` when blank; package-visible helpers for tests.
- **perc-i18n**: en-us strings for publish success.
- **Tests**: `PSCategoryServiceUtilPublishTest` (rename selection / sibling isolation); extended `CategoriesFancytreePortTest` (flatten + save-before-publish guards).

### Out of scope / residual notes
- Publish Categories only rewrites **renamed** category paths already stored on published page metadata (`perc:category`). Brand-new categories still appear on DTS only after a page that uses them is published (by design of the metadata model).
- No Playwright in this PR (residual jQuery Admin Categories surface; existing path/unit tests cover the guards). Optional follow-up for E2E if a DTS-mocked env is available.

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan
- [x] `projects/sitemanage`: `mvnw clean install` (includes `PSCategoryServiceUtilPublishTest`, `CategoriesFancytreePortTest`)
- [x] `modules/perc-i18n`: `mvnw clean install`
- [x] `WebUI`: `mvnw clean install`
- [ ] Manual (with DTS): rename a category used on a published page → Admin → Categories → Publish Production/Staging → success dialog; DTS `perc:category` values reflect new path without re-publishing the page

## Gates evidence
- Erlang-style self-review: no portable path issues; three WebUI copies kept in lockstep; behavioral unit + path tests for changed logic.
- Standalone module clean installs: sitemanage, perc-i18n, WebUI — BUILD SUCCESS.

Fixes #957

> Co-Authored by Grok Build using grok-4.5 with agent main.