### PR TITLE
fix(sitemanage): clear asset-widget relationships on recycle (#2238)

### DIFF
--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/IPSWidgetAssetRelationshipService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/IPSWidgetAssetRelationshipService.java
@@ -98,6 +98,21 @@ public interface IPSWidgetAssetRelationshipService {
       throws PSWidgetAssetRelationshipServiceException;
 
   /**
+   * Clears all page/template asset-widget relationships where the given asset is the dependent.
+   *
+   * <p>Used when recycling a shared (or local) asset so owners do not remain bound to a recycled
+   * content id (GH #777 / #2238). Does <strong>not</strong> delete the asset itself. Inline
+   * ActiveAssembly relationships are left alone (managed-link / rich-text path).
+   *
+   * @param assetId string form of the asset guid (or content id resolvable by id mapper), never
+   *     blank
+   * @return number of relationships deleted
+   * @throws PSWidgetAssetRelationshipServiceException if relationships cannot be loaded or deleted
+   */
+  int clearAssetWidgetRelationshipsForAsset(String assetId)
+      throws PSWidgetAssetRelationshipServiceException;
+
+  /**
    * Gets The criteria for a widget to allow an asset drop on a Page.
    *
    * @param page never <code>null</code>.

--- a/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSWidgetAssetRelationshipService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/assetmanagement/service/impl/PSWidgetAssetRelationshipService.java
@@ -352,6 +352,51 @@ public class PSWidgetAssetRelationshipService implements IPSWidgetAssetRelations
     }
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Deletes relationship rows only (shared non-inline ActiveAssembly + local content). Does not
+   * cascade-delete the asset; that is intentional for the recycle lifecycle.
+   */
+  @Override
+  public int clearAssetWidgetRelationshipsForAsset(String assetId)
+      throws PSWidgetAssetRelationshipServiceException {
+    notEmpty(assetId, "assetId");
+
+    try {
+      int cleared = 0;
+
+      // Shared widget bindings (e.g. File / Image widgets on pages and templates).
+      // getSharedAssetRelationships already excludes inline AA links.
+      List<PSRelationship> sharedRels = getSharedAssetRelationships(null, null, assetId);
+      for (PSRelationship rel : sharedRels) {
+        deleteRelationship(rel);
+        cleared++;
+      }
+
+      // Local content bindings if the recycled item was used as a local asset dependent.
+      List<PSRelationship> localRels = getLocalAssetRelationships(null, null, assetId);
+      for (PSRelationship rel : localRels) {
+        // Relationship only — do not call deleteAssetRelationship (would try to purge the asset).
+        deleteRelationship(rel);
+        cleared++;
+      }
+
+      if (cleared > 0) {
+        log.info(
+            "Cleared {} asset-widget relationship(s) for recycled/rebound asset id {}",
+            cleared,
+            assetId);
+      } else {
+        log.debug("No asset-widget relationships to clear for asset id {}", assetId);
+      }
+      return cleared;
+    } catch (Exception e) {
+      throw new PSWidgetAssetRelationshipServiceException(
+          "Failed to clear asset-widget relationships for asset " + assetId, e);
+    }
+  }
+
   private void deleteAssetRelationship(PSRelationship r) throws PSValidationException {
     deleteRelationship(r);
     if (r.getConfig().getName().equals(PSRelationshipConfig.TYPE_ACTIVE_ASSEMBLY))

--- a/projects/sitemanage/src/main/java/com/percussion/recycle/service/impl/PSRecycleService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/recycle/service/impl/PSRecycleService.java
@@ -395,7 +395,8 @@ public class PSRecycleService implements IPSRecycleService {
 
   /**
    * Clears asset-widget (ActiveAssembly / LocalContent) relationships that still target the
-   * recycled item as dependent. Failures are logged but do not fail the recycle operation.
+   * recycled item as dependent. Only runs for asset content types (pages/templates/folders/nav
+   * cannot be widget dependents). Failures are logged but do not fail the recycle operation.
    *
    * @param itemGuid recycled item guid, never {@code null}
    */
@@ -405,6 +406,13 @@ public class PSRecycleService implements IPSRecycleService {
     }
     try {
       String assetId = idMapper.getString(itemGuid);
+      // Skip non-assets: recycleItem also handles pages, templates, and folders; only assets can
+      // be bound as widget dependents. Avoid two loadRelationships hits per non-asset recycle.
+      if (workflowHelper != null && !isAssetForWidgetClear(assetId)) {
+        log.debug(
+            "Skipping widget relationship clear for non-asset recycled item {}", itemGuid);
+        return;
+      }
       int cleared = widgetAssetRelationshipService.clearAssetWidgetRelationshipsForAsset(assetId);
       log.debug(
           "Cleared {} widget relationship(s) for recycled item {}", cleared, itemGuid);
@@ -414,6 +422,23 @@ public class PSRecycleService implements IPSRecycleService {
           itemGuid,
           PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+    }
+  }
+
+  /**
+   * Returns whether {@code itemId} is an asset that may have widget bindings. On type-detection
+   * failure, returns {@code true} so the clear path still runs (empty relationship lists are a
+   * safe no-op for non-assets).
+   */
+  private boolean isAssetForWidgetClear(String itemId) {
+    try {
+      return workflowHelper.isAsset(itemId);
+    } catch (Exception e) {
+      log.debug(
+          "Could not determine asset type for recycled item {}; attempting widget clear: {}",
+          itemId,
+          PSExceptionUtils.getMessageForLog(e));
+      return true;
     }
   }
 

--- a/projects/sitemanage/src/main/java/com/percussion/recycle/service/impl/PSRecycleService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/recycle/service/impl/PSRecycleService.java
@@ -36,6 +36,7 @@ import com.percussion.design.objectstore.PSLocator;
 import com.percussion.design.objectstore.PSRelationship;
 import com.percussion.design.objectstore.PSRelationshipConfig;
 import com.percussion.design.objectstore.PSRelationshipSet;
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
 import com.percussion.fastforward.managednav.IPSManagedNavService;
 import com.percussion.itemmanagement.data.PSItemStateTransition;
 import com.percussion.itemmanagement.service.IPSItemWorkflowService;
@@ -138,6 +139,12 @@ public class PSRecycleService implements IPSRecycleService {
 
   private IPSManagedNavService navService;
 
+  /**
+   * Clears page/template asset-widget relationships when an asset is recycled so owners do not
+   * remain bound to a recycled content id (GH #777 / #2238).
+   */
+  private IPSWidgetAssetRelationshipService widgetAssetRelationshipService;
+
   @Autowired
   public PSRecycleService(
       IPSSystemWs systemWs,
@@ -145,13 +152,15 @@ public class PSRecycleService implements IPSRecycleService {
       IPSDataItemSummaryService itemSummaryService,
       IPSContentWs contentWs,
       IPSWorkflowHelper workflowHelper,
-      IPSManagedNavService navService) {
+      IPSManagedNavService navService,
+      IPSWidgetAssetRelationshipService widgetAssetRelationshipService) {
     this.systemWs = systemWs;
     this.idMapper = idMapper;
     this.itemSummaryService = itemSummaryService;
     this.contentWs = contentWs;
     this.workflowHelper = workflowHelper;
     this.navService = navService;
+    this.widgetAssetRelationshipService = widgetAssetRelationshipService;
   }
 
   // Create Root Relationship between Site-SiteName for Recycle Folder, if not created yet
@@ -279,6 +288,9 @@ public class PSRecycleService implements IPSRecycleService {
         log.debug("The parent locators for the item are: {}", folderRel.getDependent());
         updateParentFolders(idMapper.getGuid(folderRel.getDependent()), FOLDER_TYPE, RECYCLED_TYPE);
       }
+      // Detach page/template widgets still bound to this content id so assembly does not keep
+      // rendering recycled assets (perc-recycled-asset chrome / red border). See #777 / #2238.
+      clearWidgetRelationshipsForRecycledItem(itemGuid);
       psContentEvent =
           new PSContentEvent(
               itemGuid.toString(),
@@ -376,6 +388,30 @@ public class PSRecycleService implements IPSRecycleService {
       log.error(
           "Error recycling folder with guid: {} Error:",
           guid,
+          PSExceptionUtils.getMessageForLog(e));
+      log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+    }
+  }
+
+  /**
+   * Clears asset-widget (ActiveAssembly / LocalContent) relationships that still target the
+   * recycled item as dependent. Failures are logged but do not fail the recycle operation.
+   *
+   * @param itemGuid recycled item guid, never {@code null}
+   */
+  void clearWidgetRelationshipsForRecycledItem(IPSGuid itemGuid) {
+    if (itemGuid == null || widgetAssetRelationshipService == null) {
+      return;
+    }
+    try {
+      String assetId = idMapper.getString(itemGuid);
+      int cleared = widgetAssetRelationshipService.clearAssetWidgetRelationshipsForAsset(assetId);
+      log.debug(
+          "Cleared {} widget relationship(s) for recycled item {}", cleared, itemGuid);
+    } catch (Exception e) {
+      log.warn(
+          "Recycled item {} but failed to clear page/template widget relationships: {}",
+          itemGuid,
           PSExceptionUtils.getMessageForLog(e));
       log.debug(PSExceptionUtils.getDebugMessageForLog(e));
     }

--- a/projects/sitemanage/src/test/java/com/percussion/assetmanagement/service/impl/PSWidgetAssetRelationshipServiceClearOnRecycleTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/assetmanagement/service/impl/PSWidgetAssetRelationshipServiceClearOnRecycleTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.assetmanagement.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.assetmanagement.dao.IPSAssetDao;
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService.PSWidgetAssetRelationshipServiceException;
+import com.percussion.cms.objectstore.PSRelationshipFilter;
+import com.percussion.design.objectstore.PSLocator;
+import com.percussion.design.objectstore.PSRelationship;
+import com.percussion.design.objectstore.PSRelationshipConfig;
+import com.percussion.itemmanagement.service.IPSWorkflowHelper;
+import com.percussion.pagemanagement.assembler.IPSRenderAssemblyBridge;
+import com.percussion.pagemanagement.service.IPSWidgetAssetRelationshipDao;
+import com.percussion.pagemanagement.service.IPSWidgetService;
+import com.percussion.searchmanagement.service.IPSPageIndexService;
+import com.percussion.services.guidmgr.data.PSLegacyGuid;
+import com.percussion.services.memory.IPSCacheAccess;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.share.service.IPSNameGenerator;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.system.IPSSystemWs;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link
+ * PSWidgetAssetRelationshipService#clearAssetWidgetRelationshipsForAsset(String)} — GH #2238 /
+ * parent #777 (clear stale page↔asset widget bindings when an asset is recycled).
+ */
+@ExtendWith(MockitoExtension.class)
+class PSWidgetAssetRelationshipServiceClearOnRecycleTest {
+
+  private static final String ASSET_ID = "1-101-1";
+  private static final int ASSET_CONTENT_ID = 101;
+
+  @Mock private IPSAssetDao assetDao;
+  @Mock private IPSIdMapper idMapper;
+  @Mock private IPSSystemWs systemWs;
+  @Mock private IPSWidgetService widgetService;
+  @Mock private IPSNameGenerator nameGenerator;
+  @Mock private IPSContentDesignWs contentDesignWs;
+  @Mock private IPSRenderAssemblyBridge renderAssemblyBridge;
+  @Mock private IPSWorkflowHelper workflowHelper;
+  @Mock private IPSPageIndexService pageIndexService;
+  @Mock private IPSWidgetAssetRelationshipDao widgetAssetRelationshipDao;
+  @Mock private IPSCacheAccess ehCache;
+
+  private PSWidgetAssetRelationshipService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new PSWidgetAssetRelationshipService(
+            assetDao,
+            idMapper,
+            systemWs,
+            widgetService,
+            nameGenerator,
+            contentDesignWs,
+            renderAssemblyBridge,
+            workflowHelper,
+            pageIndexService,
+            widgetAssetRelationshipDao,
+            ehCache);
+  }
+
+  @Test
+  void clear_deletesSharedNonInlineAndLocalBindings_notAsset() throws Exception {
+    stubAssetGuid();
+
+    PSRelationship sharedWidgetRel =
+        mockRelationship(false, PSRelationshipConfig.TYPE_ACTIVE_ASSEMBLY);
+    PSRelationship localRel = mockRelationship(false, PSRelationshipConfig.TYPE_LOCAL_CONTENT);
+
+    // loadRelationships is called twice (shared filter then local filter)
+    when(systemWs.loadRelationships(any(PSRelationshipFilter.class)))
+        .thenReturn(List.of(sharedWidgetRel), List.of(localRel));
+
+    int cleared = service.clearAssetWidgetRelationshipsForAsset(ASSET_ID);
+
+    assertEquals(2, cleared);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<IPSGuid>> guidsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(systemWs, times(2)).deleteRelationships(guidsCaptor.capture());
+    assertEquals(sharedWidgetRel.getGuid(), guidsCaptor.getAllValues().get(0).get(0));
+    assertEquals(localRel.getGuid(), guidsCaptor.getAllValues().get(1).get(0));
+    // Must not cascade-delete the asset being recycled
+    verify(assetDao, never()).remove(anyString());
+  }
+
+  @Test
+  void clear_skipsInlineActiveAssembly() throws Exception {
+    stubAssetGuid();
+
+    PSRelationship inline = mockRelationship(true, PSRelationshipConfig.TYPE_ACTIVE_ASSEMBLY);
+    PSRelationship widget = mockRelationship(false, PSRelationshipConfig.TYPE_ACTIVE_ASSEMBLY);
+
+    // Shared path: both returned from AA filter; service keeps only non-inline
+    when(systemWs.loadRelationships(any(PSRelationshipFilter.class)))
+        .thenReturn(List.of(inline, widget), Collections.emptyList());
+
+    int cleared = service.clearAssetWidgetRelationshipsForAsset(ASSET_ID);
+
+    assertEquals(1, cleared);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<IPSGuid>> guidsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(systemWs, times(1)).deleteRelationships(guidsCaptor.capture());
+    assertEquals(widget.getGuid(), guidsCaptor.getValue().get(0));
+    verify(assetDao, never()).remove(anyString());
+  }
+
+  @Test
+  void clear_whenNoBindings_isIdempotent() throws Exception {
+    stubAssetGuid();
+    when(systemWs.loadRelationships(any(PSRelationshipFilter.class)))
+        .thenReturn(Collections.emptyList(), Collections.emptyList());
+
+    int cleared = service.clearAssetWidgetRelationshipsForAsset(ASSET_ID);
+
+    assertEquals(0, cleared);
+    verify(systemWs, never()).deleteRelationships(anyList());
+  }
+
+  @Test
+  void clear_whenOnlyShared_deletesOnce() throws Exception {
+    stubAssetGuid();
+
+    PSRelationship shared = mockRelationship(false, PSRelationshipConfig.TYPE_ACTIVE_ASSEMBLY);
+    when(systemWs.loadRelationships(any(PSRelationshipFilter.class)))
+        .thenReturn(List.of(shared), Collections.emptyList());
+
+    int cleared = service.clearAssetWidgetRelationshipsForAsset(ASSET_ID);
+
+    assertEquals(1, cleared);
+    verify(systemWs, times(1)).deleteRelationships(anyList());
+    verify(assetDao, never()).remove(anyString());
+  }
+
+  @Test
+  void clear_blankAssetId_rejected() {
+    assertThrows(
+        IllegalArgumentException.class, () -> service.clearAssetWidgetRelationshipsForAsset(""));
+    // Apache Validate.notEmpty(null) throws NPE (not IAE)
+    assertThrows(
+        NullPointerException.class, () -> service.clearAssetWidgetRelationshipsForAsset(null));
+  }
+
+  @Test
+  void clear_loadFailure_throwsServiceException() {
+    when(idMapper.getGuid(ASSET_ID)).thenThrow(new RuntimeException("mapper boom"));
+
+    assertThrows(
+        PSWidgetAssetRelationshipServiceException.class,
+        () -> service.clearAssetWidgetRelationshipsForAsset(ASSET_ID));
+  }
+
+  @Test
+  void clear_filterUsesDependentContentId() throws Exception {
+    stubAssetGuid();
+    when(systemWs.loadRelationships(any(PSRelationshipFilter.class)))
+        .thenReturn(Collections.emptyList());
+
+    service.clearAssetWidgetRelationshipsForAsset(ASSET_ID);
+
+    ArgumentCaptor<PSRelationshipFilter> filterCaptor =
+        ArgumentCaptor.forClass(PSRelationshipFilter.class);
+    verify(systemWs, times(2)).loadRelationships(filterCaptor.capture());
+    for (PSRelationshipFilter filter : filterCaptor.getAllValues()) {
+      assertEquals(ASSET_CONTENT_ID, filter.getDependent().getId());
+    }
+  }
+
+  private void stubAssetGuid() {
+    PSLegacyGuid assetGuid = new PSLegacyGuid(ASSET_CONTENT_ID, 1);
+    when(idMapper.getGuid(ASSET_ID)).thenReturn(assetGuid);
+  }
+
+  private static PSRelationship mockRelationship(boolean inline, String configName) {
+    PSRelationship rel = mock(PSRelationship.class);
+    PSRelationshipConfig config = mock(PSRelationshipConfig.class);
+    IPSGuid guid = mock(IPSGuid.class);
+    // Shared AA path filters inline; local path does not — lenient for mixed scenarios
+    lenient().when(rel.isInlineRelationship()).thenReturn(inline);
+    lenient().when(rel.getConfig()).thenReturn(config);
+    lenient().when(config.getName()).thenReturn(configName);
+    lenient().when(rel.getGuid()).thenReturn(guid);
+    if (PSRelationshipConfig.TYPE_LOCAL_CONTENT.equals(configName)) {
+      // deleteRelationship indexes the owner page for local content
+      lenient().when(rel.getOwner()).thenReturn(new PSLocator(900, 1));
+    }
+    return rel;
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/recycle/service/impl/PSRecycleServiceClearWidgetRelationshipsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/recycle/service/impl/PSRecycleServiceClearWidgetRelationshipsTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.recycle.service.impl;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
+import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService.PSWidgetAssetRelationshipServiceException;
+import com.percussion.fastforward.managednav.IPSManagedNavService;
+import com.percussion.itemmanagement.service.IPSWorkflowHelper;
+import com.percussion.services.guidmgr.data.PSLegacyGuid;
+import com.percussion.share.service.IPSDataItemSummaryService;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.webservices.content.IPSContentWs;
+import com.percussion.webservices.system.IPSSystemWs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link PSRecycleService#clearWidgetRelationshipsForRecycledItem(IPSGuid)} — GH
+ * #2238 / parent #777.
+ */
+@ExtendWith(MockitoExtension.class)
+class PSRecycleServiceClearWidgetRelationshipsTest {
+
+  @Mock private IPSSystemWs systemWs;
+  @Mock private IPSIdMapper idMapper;
+  @Mock private IPSDataItemSummaryService itemSummaryService;
+  @Mock private IPSContentWs contentWs;
+  @Mock private IPSWorkflowHelper workflowHelper;
+  @Mock private IPSManagedNavService navService;
+  @Mock private IPSWidgetAssetRelationshipService widgetAssetRelationshipService;
+
+  private PSRecycleService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new PSRecycleService(
+            systemWs,
+            idMapper,
+            itemSummaryService,
+            contentWs,
+            workflowHelper,
+            navService,
+            widgetAssetRelationshipService);
+  }
+
+  @Test
+  void clearWidgetRelationships_invokesWidgetServiceWithMappedId() throws Exception {
+    IPSGuid itemGuid = new PSLegacyGuid(101, 1);
+    when(idMapper.getString(itemGuid)).thenReturn("1-101-1");
+    when(widgetAssetRelationshipService.clearAssetWidgetRelationshipsForAsset("1-101-1"))
+        .thenReturn(2);
+
+    service.clearWidgetRelationshipsForRecycledItem(itemGuid);
+
+    verify(widgetAssetRelationshipService).clearAssetWidgetRelationshipsForAsset("1-101-1");
+  }
+
+  @Test
+  void clearWidgetRelationships_nullGuid_isNoOp() throws Exception {
+    service.clearWidgetRelationshipsForRecycledItem(null);
+
+    verify(widgetAssetRelationshipService, never()).clearAssetWidgetRelationshipsForAsset(anyString());
+  }
+
+  @Test
+  void clearWidgetRelationships_serviceFailure_isSwallowed() throws Exception {
+    IPSGuid itemGuid = new PSLegacyGuid(55, 1);
+    when(idMapper.getString(itemGuid)).thenReturn("1-55-1");
+    doThrow(new PSWidgetAssetRelationshipServiceException("boom"))
+        .when(widgetAssetRelationshipService)
+        .clearAssetWidgetRelationshipsForAsset(eq("1-55-1"));
+
+    // Must not throw — recycle should still succeed if clear fails
+    service.clearWidgetRelationshipsForRecycledItem(itemGuid);
+
+    verify(widgetAssetRelationshipService).clearAssetWidgetRelationshipsForAsset("1-55-1");
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/recycle/service/impl/PSRecycleServiceClearWidgetRelationshipsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/recycle/service/impl/PSRecycleServiceClearWidgetRelationshipsTest.java
@@ -16,35 +16,55 @@
  */
 package com.percussion.recycle.service.impl;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService;
 import com.percussion.assetmanagement.service.IPSWidgetAssetRelationshipService.PSWidgetAssetRelationshipServiceException;
+import com.percussion.cms.handlers.PSRelationshipCommandHandler;
+import com.percussion.cms.objectstore.server.PSRelationshipProcessor;
+import com.percussion.design.objectstore.PSLocator;
+import com.percussion.design.objectstore.PSRelationship;
+import com.percussion.design.objectstore.PSRelationshipConfig;
 import com.percussion.fastforward.managednav.IPSManagedNavService;
 import com.percussion.itemmanagement.service.IPSWorkflowHelper;
+import com.percussion.server.PSRequest;
+import com.percussion.server.cache.PSFolderRelationshipCache;
 import com.percussion.services.guidmgr.data.PSLegacyGuid;
+import com.percussion.servlets.PSSecurityFilter;
+import com.percussion.share.data.PSDataItemSummary;
 import com.percussion.share.service.IPSDataItemSummaryService;
 import com.percussion.share.service.IPSIdMapper;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.webservices.content.IPSContentWs;
 import com.percussion.webservices.system.IPSSystemWs;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
- * Unit tests for {@link PSRecycleService#clearWidgetRelationshipsForRecycledItem(IPSGuid)} — GH
- * #2238 / parent #777.
+ * Unit tests for {@link PSRecycleService#clearWidgetRelationshipsForRecycledItem(IPSGuid)} and the
+ * {@link PSRecycleService#recycleItem(int)} → clear hook — GH #2238 / parent #777.
  */
 @ExtendWith(MockitoExtension.class)
 class PSRecycleServiceClearWidgetRelationshipsTest {
+
+  private static final int DEPENDENT_ID = 101;
+  private static final String ASSET_ID = "1-101-1";
 
   @Mock private IPSSystemWs systemWs;
   @Mock private IPSIdMapper idMapper;
@@ -72,13 +92,14 @@ class PSRecycleServiceClearWidgetRelationshipsTest {
   @Test
   void clearWidgetRelationships_invokesWidgetServiceWithMappedId() throws Exception {
     IPSGuid itemGuid = new PSLegacyGuid(101, 1);
-    when(idMapper.getString(itemGuid)).thenReturn("1-101-1");
-    when(widgetAssetRelationshipService.clearAssetWidgetRelationshipsForAsset("1-101-1"))
+    when(idMapper.getString(itemGuid)).thenReturn(ASSET_ID);
+    when(workflowHelper.isAsset(ASSET_ID)).thenReturn(true);
+    when(widgetAssetRelationshipService.clearAssetWidgetRelationshipsForAsset(ASSET_ID))
         .thenReturn(2);
 
     service.clearWidgetRelationshipsForRecycledItem(itemGuid);
 
-    verify(widgetAssetRelationshipService).clearAssetWidgetRelationshipsForAsset("1-101-1");
+    verify(widgetAssetRelationshipService).clearAssetWidgetRelationshipsForAsset(ASSET_ID);
   }
 
   @Test
@@ -89,9 +110,21 @@ class PSRecycleServiceClearWidgetRelationshipsTest {
   }
 
   @Test
+  void clearWidgetRelationships_nonAsset_skipsWidgetService() throws Exception {
+    IPSGuid itemGuid = new PSLegacyGuid(202, 1);
+    when(idMapper.getString(itemGuid)).thenReturn("1-202-1");
+    when(workflowHelper.isAsset("1-202-1")).thenReturn(false);
+
+    service.clearWidgetRelationshipsForRecycledItem(itemGuid);
+
+    verify(widgetAssetRelationshipService, never()).clearAssetWidgetRelationshipsForAsset(anyString());
+  }
+
+  @Test
   void clearWidgetRelationships_serviceFailure_isSwallowed() throws Exception {
     IPSGuid itemGuid = new PSLegacyGuid(55, 1);
     when(idMapper.getString(itemGuid)).thenReturn("1-55-1");
+    when(workflowHelper.isAsset("1-55-1")).thenReturn(true);
     doThrow(new PSWidgetAssetRelationshipServiceException("boom"))
         .when(widgetAssetRelationshipService)
         .clearAssetWidgetRelationshipsForAsset(eq("1-55-1"));
@@ -100,5 +133,66 @@ class PSRecycleServiceClearWidgetRelationshipsTest {
     service.clearWidgetRelationshipsForRecycledItem(itemGuid);
 
     verify(widgetAssetRelationshipService).clearAssetWidgetRelationshipsForAsset("1-55-1");
+  }
+
+  /**
+   * Behavioral coverage: {@link PSRecycleService#recycleItem(int)} must invoke the widget-clear
+   * hook after the folder relationship is updated (Kilo review on #2268).
+   */
+  @Test
+  void recycleItem_invokesClearWidgetRelationshipsForAsset() throws Exception {
+    IPSGuid itemGuid = new PSLegacyGuid(DEPENDENT_ID, 1);
+    PSLocator dependent = new PSLocator(DEPENDENT_ID, 1);
+    PSRelationship folderRel = mock(PSRelationship.class);
+    when(folderRel.getDependent()).thenReturn(dependent);
+    lenient().when(folderRel.getId()).thenReturn(9001);
+
+    when(systemWs.loadRelationships(any())).thenReturn(List.of(folderRel));
+    when(idMapper.getGuid(dependent)).thenReturn(itemGuid);
+    when(idMapper.getString(itemGuid)).thenReturn(ASSET_ID);
+    when(idMapper.getString(dependent)).thenReturn(ASSET_ID);
+
+    PSDataItemSummary summary = mock(PSDataItemSummary.class);
+    when(summary.getFolderPaths()).thenReturn(List.of("//Sites/Demo"));
+    when(itemSummaryService.find(itemGuid.toString(), PSRelationshipConfig.TYPE_FOLDER_CONTENT))
+        .thenReturn(summary);
+
+    // Short path id list → createRootSiteDeleteRelationship returns early
+    when(contentWs.findPathIds("//Sites/Demo")).thenReturn(Collections.emptyList());
+    // Non-workflowable item → transitionWorkflowItem no-ops
+    when(workflowHelper.getTransitions(ASSET_ID)).thenReturn(null);
+    // renameIfRequired no-ops on empty load
+    when(contentWs.loadItems(any(), eq(false), eq(false), eq(false), eq(true), eq(false), anyString()))
+        .thenReturn(Collections.emptyList());
+
+    when(workflowHelper.isAsset(ASSET_ID)).thenReturn(true);
+    when(widgetAssetRelationshipService.clearAssetWidgetRelationshipsForAsset(ASSET_ID))
+        .thenReturn(1);
+
+    PSRelationshipConfig recycledConfig = mock(PSRelationshipConfig.class);
+    PSRelationshipProcessor processor = mock(PSRelationshipProcessor.class);
+    // Relationship already exists → skip saveRelationships
+    when(processor.checkIfRelationshipAlreadyExists(any())).thenReturn(folderRel);
+
+    PSRequest request = mock(PSRequest.class);
+    when(request.getServletRequest()).thenReturn(mock(HttpServletRequest.class));
+
+    try (MockedStatic<PSRelationshipCommandHandler> cmd =
+            mockStatic(PSRelationshipCommandHandler.class);
+        MockedStatic<PSRelationshipProcessor> proc = mockStatic(PSRelationshipProcessor.class);
+        MockedStatic<PSFolderRelationshipCache> cache =
+            mockStatic(PSFolderRelationshipCache.class);
+        MockedStatic<PSSecurityFilter> security = mockStatic(PSSecurityFilter.class)) {
+      cmd.when(() -> PSRelationshipCommandHandler.getRelationshipConfig(anyString()))
+          .thenReturn(recycledConfig);
+      proc.when(PSRelationshipProcessor::getInstance).thenReturn(processor);
+      // null cache → skip updateParentFolders
+      cache.when(PSFolderRelationshipCache::getInstance).thenReturn(null);
+      security.when(PSSecurityFilter::getCurrentRequest).thenReturn(request);
+
+      service.recycleItem(DEPENDENT_ID);
+    }
+
+    verify(widgetAssetRelationshipService).clearAssetWidgetRelationshipsForAsset(ASSET_ID);
   }
 }


### PR DESCRIPTION
## Summary

Minimal product fix for **File widget red dotted border** after asset recycle/recreate (parent epic **#777**, this slice **#2238**).

Slice 1 evidence (#2237 / PR #2260) classified the root cause as **stale page↔asset ActiveAssembly relationship** still pointing at a recycled content id (configId=8 RecycledContent) while assembly intentionally applies .perc-recycled-asset chrome when `isInRecycler(assetId)` is true.

This PR addresses **data integrity only**:

- On successful `recycleItem`, clear **non-inline ActiveAssembly** and **LocalContent** asset-widget relationships where the recycled item is the dependent.
- Does **not** delete the asset (recycle owns that lifecycle).
- Does **not** remove .perc-recycled-asset CSS (legitimate recycled warning chrome remains when a widget truly binds a recycled id).
- Inline AA / managed-link relationships are left alone.

After recycle, widgets unbound from the recycled asset no longer paint red chrome. User rebinds to a recreated asset at the same path as needed.

**Out of scope (leave to #2239):** Playwright residual e2e for `widget-test-page/file`. Optional path-based auto-rebind on recreate not included (clear is the minimal integrity fix).

### Parent tracker
Part of #777 (Slice 2/3). Evidence: docs/ai-generated/issue-2237-file-widget-red-border-evidence.md.

### Operator
Operator: Grok: night-issue-prs (model grok-4.5)

## Changes

| Area | Change |
|------|--------|
| `IPSWidgetAssetRelationshipService` | `clearAssetWidgetRelationshipsForAsset(String)` |
| `PSWidgetAssetRelationshipService` | Deletes shared non-inline AA + local content rels only (no asset purge) |
| `PSRecycleService` | Injects widget service; calls clear after successful recycle; swallows clear failures so recycle still succeeds |

## Test plan

- [x] Unit: `PSWidgetAssetRelationshipServiceClearOnRecycleTest` (shared+local clear, skip inline, idempotent empty, no asset delete, filter dependent id, error wrap)
- [x] Unit: `PSRecycleServiceClearWidgetRelationshipsTest` (invokes clear, null no-op, service failure swallowed)
- [x] Module: `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
- [ ] Manual (QA): bind File widget → recycle asset → widget unbound / no red border → recreate asset at path → rebind → clean chrome
- [ ] Playwright residual: #2239

## Gates evidence

- Erlang-style self-review: no bugs found; clear failures do not fail recycle; no cascade asset delete; portable paths N/A (no path I/O).
- Pre-PR Maven: standalone `projects/sitemanage` `mvnw clean install` SUCCESS.
- No CSS chrome removal; residual e2e tracked on #2239.

Fixes #2238
Refs #777

> Co-Authored by Grok Build using grok-4.5 with agent main.