### PR TITLE
feat(system): pipeline Slice A2 SQL runtime + JSON I/O + hooks (#2248)

### DIFF
--- a/docs/developer-module/pipeline-ir-v1.md
+++ b/docs/developer-module/pipeline-ir-v1.md
@@ -119,21 +119,49 @@ Not imported in v1 (deferred): full where-clause trees, join graphs, exits/hooks
 
 ## Service API
 
+### IR (Slice A part 1 — #2247)
+
 `IPSPipelineIrService` / `PSPipelineIrService` / `PSPipelineIrServiceLocator`:
 
 - `importClassicXml` / `importClassicApplication`
 - `toJson` / `fromJson`
 - `save` / `load` / `exists`
 
-No REST surface in this slice (catalog list remains `GET /services/pipelines`).
+### Runtime (Slice A part 2 — #2248)
+
+`IPSPipelineRuntimeService` / `PSPipelineRuntimeService` / `PSPipelineRuntimeServiceLocator`:
+
+- `execute(appName, resourceName, request)` — load native IR, run resource
+- `execute(document, resource, request)` — in-memory IR (tests / callers)
+- SQL via `IPSPipelineSqlAdapter` / `PSJdbcPipelineSqlAdapter` (parameterized JDBC only)
+- Planner: `PSPipelineSqlPlanner` (generated single-table SELECT/INSERT, or native SELECT with `:param`)
+- Pre/post hooks: `IPSPipelinePreExecuteHook` / `IPSPipelinePostExecuteHook`
+- JSON I/O: `PipelineExecuteRequest` / `PipelineExecuteResult` + `PSPipelineExecuteJsonCodec`
+
+**Not** calling classic `PSQueryHandler` / `PSUpdateHandler` as the public path.
+
+Catalog list remains `GET /services/pipelines`. Optional thin REST **invoke** is deferred (Developer smoke residual).
+
+### Runtime security
+
+| Default | Behavior |
+|---------|----------|
+| Parameterized SQL | Request values bound as JDBC `?` only |
+| Generated identifiers | Table/column must match `[A-Za-z_][A-Za-z0-9_]*` |
+| Native SQL escape hatch | Single `SELECT`/`WITH` only; named `:param`; rejects `;`, DML/DDL keywords |
+| Joins / multi-table | Not supported in Slice A2 planner |
+
+Manual raw multi-statement SQL is **not** a product surface.
 
 ## Tests
 
 - IR JSON round-trip + file load/save
 - Golden classic fixture `sys_adminCataloger` → IR stage inventory (backend tank, mapper, selector, page tank)
+- H2 runtime: generated query + JSON params, native SELECT, pre/post hooks, minimal INSERT (`PSPipelineRuntimeServiceTest`)
 
 ## Evolution
 
 - **1.x** additive fields preferred; bump `irVersion` only for breaking shape changes.
-- Slice A2 (#2248): SQL execute + JSON I/O + hooks consume this IR.
+- Slice A2 (#2248): SQL execute + JSON I/O + hooks consume this IR (landed).
+- Residual: thin REST invoke for Developer smoke; richer UPDATE (update/delete); join graphs; full where-clause IR.
 - Slice B: designer writes native IR (`source=NATIVE`).

--- a/system/services/src/com/percussion/services/pipeline/IPSPipelineRuntimeService.java
+++ b/system/services/src/com/percussion/services/pipeline/IPSPipelineRuntimeService.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline;
+
+import com.percussion.services.pipeline.model.PipelineExecuteRequest;
+import com.percussion.services.pipeline.model.PipelineExecuteResult;
+import com.percussion.services.pipeline.model.PipelineIrDocument;
+import com.percussion.services.pipeline.model.PipelineResourceIr;
+
+/**
+ * Execute a saved (or in-memory) pipeline IR resource against a SQL adapter with JSON-oriented
+ * request/response.
+ *
+ * <p>Clean IR boundary for Slice A runtime — does <strong>not</strong> call classic {@code
+ * PSQueryHandler} / {@code PSUpdateHandler}.
+ */
+public interface IPSPipelineRuntimeService {
+
+  /**
+   * Load native IR by application name and execute the named resource.
+   *
+   * @param appName native IR application name
+   * @param resourceName resource within the document
+   * @param request JSON request values (params / rows); never {@code null}
+   */
+  PipelineExecuteResult execute(String appName, String resourceName, PipelineExecuteRequest request)
+      throws PSPipelineIrException;
+
+  /**
+   * Execute a resource from an already-loaded IR document (tests / in-process callers).
+   *
+   * @param document never {@code null}
+   * @param resource never {@code null}; must belong to {@code document}
+   * @param request never {@code null}
+   */
+  PipelineExecuteResult execute(
+      PipelineIrDocument document, PipelineResourceIr resource, PipelineExecuteRequest request)
+      throws PSPipelineIrException;
+}

--- a/system/services/src/com/percussion/services/pipeline/PSPipelineExecuteJsonCodec.java
+++ b/system/services/src/com/percussion/services/pipeline/PSPipelineExecuteJsonCodec.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline;
+
+import com.percussion.services.pipeline.model.PipelineExecuteRequest;
+import com.percussion.services.pipeline.model.PipelineExecuteResult;
+import java.util.Objects;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+/** JSON encode/decode for pipeline execute request/response DTOs. */
+public final class PSPipelineExecuteJsonCodec {
+
+  private static final ObjectMapper MAPPER =
+      JsonMapper.builder()
+          .configure(SerializationFeature.INDENT_OUTPUT, true)
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+          .build();
+
+  private PSPipelineExecuteJsonCodec() {}
+
+  public static String toJson(PipelineExecuteResult result) throws PSPipelineIrException {
+    Objects.requireNonNull(result, "result");
+    try {
+      return MAPPER.writeValueAsString(result);
+    } catch (JacksonException e) {
+      throw new PSPipelineIrException("Failed to encode pipeline execute result as JSON", e);
+    }
+  }
+
+  public static PipelineExecuteRequest requestFromJson(String json) throws PSPipelineIrException {
+    Objects.requireNonNull(json, "json");
+    try {
+      PipelineExecuteRequest req = MAPPER.readValue(json, PipelineExecuteRequest.class);
+      return req != null ? req : PipelineExecuteRequest.empty();
+    } catch (JacksonException e) {
+      throw new PSPipelineIrException("Failed to decode pipeline execute request JSON", e);
+    }
+  }
+
+  public static PipelineExecuteResult resultFromJson(String json) throws PSPipelineIrException {
+    Objects.requireNonNull(json, "json");
+    try {
+      PipelineExecuteResult result = MAPPER.readValue(json, PipelineExecuteResult.class);
+      if (result == null) {
+        throw new PSPipelineIrException("JSON decoded to null pipeline execute result");
+      }
+      return result;
+    } catch (JacksonException e) {
+      throw new PSPipelineIrException("Failed to decode pipeline execute result JSON", e);
+    }
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/PSPipelineRuntimeService.java
+++ b/system/services/src/com/percussion/services/pipeline/PSPipelineRuntimeService.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline;
+
+import com.percussion.services.pipeline.hooks.IPSPipelinePostExecuteHook;
+import com.percussion.services.pipeline.hooks.IPSPipelinePreExecuteHook;
+import com.percussion.services.pipeline.hooks.PipelineHookContext;
+import com.percussion.services.pipeline.model.PipelineExecuteRequest;
+import com.percussion.services.pipeline.model.PipelineExecuteResult;
+import com.percussion.services.pipeline.model.PipelineIrDocument;
+import com.percussion.services.pipeline.model.PipelineResourceIr;
+import com.percussion.services.pipeline.sql.IPSPipelineSqlAdapter;
+import com.percussion.services.pipeline.sql.PSPipelineSqlPlan;
+import com.percussion.services.pipeline.sql.PSPipelineSqlPlanner;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Default {@link IPSPipelineRuntimeService}: load IR → pre hooks → plan SQL → adapter → post hooks
+ * → JSON result.
+ */
+public class PSPipelineRuntimeService implements IPSPipelineRuntimeService {
+
+  private final IPSPipelineIrService irService;
+  private final IPSPipelineSqlAdapter sqlAdapter;
+  private final List<IPSPipelinePreExecuteHook> preHooks;
+  private final List<IPSPipelinePostExecuteHook> postHooks;
+
+  public PSPipelineRuntimeService(IPSPipelineIrService irService, IPSPipelineSqlAdapter sqlAdapter) {
+    this(irService, sqlAdapter, List.of(), List.of());
+  }
+
+  public PSPipelineRuntimeService(
+      IPSPipelineIrService irService,
+      IPSPipelineSqlAdapter sqlAdapter,
+      List<IPSPipelinePreExecuteHook> preHooks,
+      List<IPSPipelinePostExecuteHook> postHooks) {
+    this.irService = Objects.requireNonNull(irService, "irService");
+    this.sqlAdapter = Objects.requireNonNull(sqlAdapter, "sqlAdapter");
+    this.preHooks = preHooks != null ? List.copyOf(preHooks) : List.of();
+    this.postHooks = postHooks != null ? List.copyOf(postHooks) : List.of();
+  }
+
+  @Override
+  public PipelineExecuteResult execute(
+      String appName, String resourceName, PipelineExecuteRequest request)
+      throws PSPipelineIrException {
+    Objects.requireNonNull(appName, "appName");
+    Objects.requireNonNull(resourceName, "resourceName");
+    Optional<PipelineIrDocument> loaded = irService.load(appName);
+    if (loaded.isEmpty()) {
+      throw new PSPipelineIrException("Pipeline IR not found: " + appName);
+    }
+    PipelineIrDocument doc = loaded.get();
+    PipelineResourceIr resource = doc.findResource(resourceName);
+    if (resource == null) {
+      throw new PSPipelineIrException(
+          "Resource not found in IR " + appName + ": " + resourceName);
+    }
+    return execute(doc, resource, request);
+  }
+
+  @Override
+  public PipelineExecuteResult execute(
+      PipelineIrDocument document, PipelineResourceIr resource, PipelineExecuteRequest request)
+      throws PSPipelineIrException {
+    Objects.requireNonNull(document, "document");
+    Objects.requireNonNull(resource, "resource");
+    PipelineExecuteRequest req = request != null ? request : PipelineExecuteRequest.empty();
+
+    PipelineHookContext ctx = new PipelineHookContext(document, resource, req);
+    for (IPSPipelinePreExecuteHook hook : preHooks) {
+      hook.beforeExecute(ctx);
+    }
+
+    PipelineExecuteResult result = new PipelineExecuteResult();
+    String appName = document.getApp() != null ? document.getApp().getName() : null;
+    result.setAppName(appName);
+    result.setResourceName(resource.getName());
+    result.setKind(resource.getKind());
+
+    if (PipelineResourceIr.KIND_QUERY.equals(resource.getKind())) {
+      PSPipelineSqlPlan plan = PSPipelineSqlPlanner.planQuery(resource, req);
+      List<Map<String, Object>> rows = sqlAdapter.query(plan);
+      result.setOperation("query");
+      result.setRows(rows);
+      result.getMeta().put("sqlDescription", plan.getDescription());
+      result.getMeta().put("parameterCount", plan.getParameters().size());
+    } else if (PipelineResourceIr.KIND_UPDATE.equals(resource.getKind())) {
+      List<PSPipelineSqlPlan> plans = PSPipelineSqlPlanner.planInserts(resource, req);
+      int affected = 0;
+      for (PSPipelineSqlPlan plan : plans) {
+        affected += sqlAdapter.update(plan);
+      }
+      result.setOperation("insert");
+      result.setAffectedRows(affected);
+      result.setRowCount(0);
+      result.getMeta().put("planCount", plans.size());
+    } else {
+      throw new PSPipelineIrException(
+          "Unsupported resource kind for runtime execute: " + resource.getKind());
+    }
+
+    for (IPSPipelinePostExecuteHook hook : postHooks) {
+      hook.afterExecute(ctx, result);
+    }
+    // Post hooks may append to context trace; publish full ordered trace on the result.
+    result.setHookTrace(new ArrayList<>(ctx.getHookTrace()));
+
+    return result;
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/PSPipelineRuntimeService.java
+++ b/system/services/src/com/percussion/services/pipeline/PSPipelineRuntimeService.java
@@ -84,6 +84,13 @@ public class PSPipelineRuntimeService implements IPSPipelineRuntimeService {
       throws PSPipelineIrException {
     Objects.requireNonNull(document, "document");
     Objects.requireNonNull(resource, "resource");
+    // Interface contract: resource must belong to document (same instance from findResource).
+    String resourceName = resource.getName();
+    if (resourceName == null || document.findResource(resourceName) != resource) {
+      throw new PSPipelineIrException(
+          "Resource does not belong to the provided pipeline document"
+              + (resourceName != null ? ": " + resourceName : ""));
+    }
     PipelineExecuteRequest req = request != null ? request : PipelineExecuteRequest.empty();
 
     PipelineHookContext ctx = new PipelineHookContext(document, resource, req);

--- a/system/services/src/com/percussion/services/pipeline/PSPipelineRuntimeServiceLocator.java
+++ b/system/services/src/com/percussion/services/pipeline/PSPipelineRuntimeServiceLocator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Thread-safe locator for {@link IPSPipelineRuntimeService}.
+ *
+ * <p>No default production wiring in this slice — callers (and tests) must {@link
+ * #setPipelineRuntimeService(IPSPipelineRuntimeService)} with an instance that has a configured
+ * SQL adapter (CMS datasource / H2). Production wiring is a later integration concern.
+ */
+public final class PSPipelineRuntimeServiceLocator {
+
+  private static final AtomicReference<IPSPipelineRuntimeService> SERVICE = new AtomicReference<>();
+
+  private PSPipelineRuntimeServiceLocator() {}
+
+  /**
+   * @return configured runtime service
+   * @throws IllegalStateException when not set
+   */
+  public static IPSPipelineRuntimeService getPipelineRuntimeService() {
+    IPSPipelineRuntimeService svc = SERVICE.get();
+    if (svc == null) {
+      throw new IllegalStateException(
+          "IPSPipelineRuntimeService is not configured; call setPipelineRuntimeService with a"
+              + " SQL-backed implementation");
+    }
+    return svc;
+  }
+
+  /**
+   * Override for tests / bootstrap. Pass {@code null} to clear.
+   *
+   * @param service replacement or {@code null}
+   */
+  public static void setPipelineRuntimeService(IPSPipelineRuntimeService service) {
+    SERVICE.set(service);
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/hooks/IPSPipelinePostExecuteHook.java
+++ b/system/services/src/com/percussion/services/pipeline/hooks/IPSPipelinePostExecuteHook.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.hooks;
+
+import com.percussion.services.pipeline.PSPipelineIrException;
+import com.percussion.services.pipeline.model.PipelineExecuteResult;
+
+/**
+ * Post-execute Java hook (classic {@code IPSResultDocumentProcessor} spirit).
+ *
+ * <p>May mutate {@code result} (e.g. enrich rows or meta) after SQL execution.
+ */
+@FunctionalInterface
+public interface IPSPipelinePostExecuteHook {
+
+  void afterExecute(PipelineHookContext context, PipelineExecuteResult result)
+      throws PSPipelineIrException;
+}

--- a/system/services/src/com/percussion/services/pipeline/hooks/IPSPipelinePreExecuteHook.java
+++ b/system/services/src/com/percussion/services/pipeline/hooks/IPSPipelinePreExecuteHook.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.hooks;
+
+import com.percussion.services.pipeline.PSPipelineIrException;
+
+/**
+ * Pre-execute Java hook (classic {@code IPSRequestPreProcessor} spirit).
+ *
+ * <p>May mutate {@link PipelineHookContext#getRequest()} params before SQL planning.
+ */
+@FunctionalInterface
+public interface IPSPipelinePreExecuteHook {
+
+  void beforeExecute(PipelineHookContext context) throws PSPipelineIrException;
+}

--- a/system/services/src/com/percussion/services/pipeline/hooks/PipelineHookContext.java
+++ b/system/services/src/com/percussion/services/pipeline/hooks/PipelineHookContext.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.hooks;
+
+import com.percussion.services.pipeline.model.PipelineExecuteRequest;
+import com.percussion.services.pipeline.model.PipelineIrDocument;
+import com.percussion.services.pipeline.model.PipelineResourceIr;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Mutable context for pre/post execute hooks (spirit of classic request pre-processor / result
+ * document processor lifecycle).
+ */
+public class PipelineHookContext {
+
+  private final PipelineIrDocument document;
+  private final PipelineResourceIr resource;
+  private final PipelineExecuteRequest request;
+  private final List<String> hookTrace = new ArrayList<>();
+
+  public PipelineHookContext(
+      PipelineIrDocument document, PipelineResourceIr resource, PipelineExecuteRequest request) {
+    this.document = Objects.requireNonNull(document, "document");
+    this.resource = Objects.requireNonNull(resource, "resource");
+    this.request = Objects.requireNonNull(request, "request");
+  }
+
+  public PipelineIrDocument getDocument() {
+    return document;
+  }
+
+  public PipelineResourceIr getResource() {
+    return resource;
+  }
+
+  public PipelineExecuteRequest getRequest() {
+    return request;
+  }
+
+  public List<String> getHookTrace() {
+    return hookTrace;
+  }
+
+  public void addTrace(String entry) {
+    if (entry != null && !entry.isBlank()) {
+      hookTrace.add(entry);
+    }
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/model/PipelineExecuteRequest.java
+++ b/system/services/src/com/percussion/services/pipeline/model/PipelineExecuteRequest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.model;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * JSON request body subset for pipeline execute: named parameters and optional update rows.
+ *
+ * <p>Example query body:
+ *
+ * <pre>
+ * { "params": { "TYPE": "workflow" } }
+ * </pre>
+ *
+ * <p>Example insert body:
+ *
+ * <pre>
+ * { "rows": [ { "TYPE": "workflow", "NAME": "wf1" } ] }
+ * </pre>
+ */
+public class PipelineExecuteRequest {
+
+  private Map<String, Object> params = new LinkedHashMap<>();
+  private List<Map<String, Object>> rows = new ArrayList<>();
+
+  public static PipelineExecuteRequest ofParams(Map<String, Object> params) {
+    PipelineExecuteRequest req = new PipelineExecuteRequest();
+    if (params != null) {
+      req.params.putAll(params);
+    }
+    return req;
+  }
+
+  public static PipelineExecuteRequest empty() {
+    return new PipelineExecuteRequest();
+  }
+
+  public Map<String, Object> getParams() {
+    return params;
+  }
+
+  public void setParams(Map<String, Object> params) {
+    this.params = params != null ? new LinkedHashMap<>(params) : new LinkedHashMap<>();
+  }
+
+  public List<Map<String, Object>> getRows() {
+    return rows;
+  }
+
+  public void setRows(List<Map<String, Object>> rows) {
+    this.rows = rows != null ? new ArrayList<>(rows) : new ArrayList<>();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PipelineExecuteRequest that)) {
+      return false;
+    }
+    return Objects.equals(params, that.params) && Objects.equals(rows, that.rows);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(params, rows);
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/model/PipelineExecuteResult.java
+++ b/system/services/src/com/percussion/services/pipeline/model/PipelineExecuteResult.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.model;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * JSON response document for pipeline execute.
+ *
+ * <p>Query results use {@link #rows}; update paths set {@link #affectedRows}.
+ */
+public class PipelineExecuteResult {
+
+  private String appName;
+  private String resourceName;
+  private String kind;
+  private String operation;
+  private int rowCount;
+  private int affectedRows;
+  private List<Map<String, Object>> rows = new ArrayList<>();
+  private List<String> hookTrace = new ArrayList<>();
+  private Map<String, Object> meta = new LinkedHashMap<>();
+
+  public String getAppName() {
+    return appName;
+  }
+
+  public void setAppName(String appName) {
+    this.appName = appName;
+  }
+
+  public String getResourceName() {
+    return resourceName;
+  }
+
+  public void setResourceName(String resourceName) {
+    this.resourceName = resourceName;
+  }
+
+  public String getKind() {
+    return kind;
+  }
+
+  public void setKind(String kind) {
+    this.kind = kind;
+  }
+
+  public String getOperation() {
+    return operation;
+  }
+
+  public void setOperation(String operation) {
+    this.operation = operation;
+  }
+
+  public int getRowCount() {
+    return rowCount;
+  }
+
+  public void setRowCount(int rowCount) {
+    this.rowCount = rowCount;
+  }
+
+  public int getAffectedRows() {
+    return affectedRows;
+  }
+
+  public void setAffectedRows(int affectedRows) {
+    this.affectedRows = affectedRows;
+  }
+
+  public List<Map<String, Object>> getRows() {
+    return rows;
+  }
+
+  public void setRows(List<Map<String, Object>> rows) {
+    this.rows = rows != null ? rows : new ArrayList<>();
+    this.rowCount = this.rows.size();
+  }
+
+  public List<String> getHookTrace() {
+    return hookTrace;
+  }
+
+  public void setHookTrace(List<String> hookTrace) {
+    this.hookTrace = hookTrace != null ? hookTrace : new ArrayList<>();
+  }
+
+  public Map<String, Object> getMeta() {
+    return meta;
+  }
+
+  public void setMeta(Map<String, Object> meta) {
+    this.meta = meta != null ? new LinkedHashMap<>(meta) : new LinkedHashMap<>();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PipelineExecuteResult that)) {
+      return false;
+    }
+    return rowCount == that.rowCount
+        && affectedRows == that.affectedRows
+        && Objects.equals(appName, that.appName)
+        && Objects.equals(resourceName, that.resourceName)
+        && Objects.equals(kind, that.kind)
+        && Objects.equals(operation, that.operation)
+        && Objects.equals(rows, that.rows)
+        && Objects.equals(hookTrace, that.hookTrace)
+        && Objects.equals(meta, that.meta);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        appName, resourceName, kind, operation, rowCount, affectedRows, rows, hookTrace, meta);
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/sql/IPSPipelineSqlAdapter.java
+++ b/system/services/src/com/percussion/services/pipeline/sql/IPSPipelineSqlAdapter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.sql;
+
+import com.percussion.services.pipeline.PSPipelineIrException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * SQL adapter for pipeline runtime. Implementations execute only parameterized plans (no string
+ * concatenation of request values into SQL).
+ */
+public interface IPSPipelineSqlAdapter {
+
+  /**
+   * Execute a SELECT plan and return rows as ordered maps (column label → value).
+   *
+   * @param plan must be {@link PSPipelineSqlPlan.Kind#QUERY}
+   */
+  List<Map<String, Object>> query(PSPipelineSqlPlan plan) throws PSPipelineIrException;
+
+  /**
+   * Execute an INSERT/UPDATE/DELETE plan.
+   *
+   * @param plan must be {@link PSPipelineSqlPlan.Kind#UPDATE}
+   * @return total affected row count
+   */
+  int update(PSPipelineSqlPlan plan) throws PSPipelineIrException;
+}

--- a/system/services/src/com/percussion/services/pipeline/sql/PSJdbcPipelineSqlAdapter.java
+++ b/system/services/src/com/percussion/services/pipeline/sql/PSJdbcPipelineSqlAdapter.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.sql;
+
+import com.percussion.services.pipeline.PSPipelineIrException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+import javax.sql.DataSource;
+
+/**
+ * JDBC implementation of {@link IPSPipelineSqlAdapter} using prepared statements only.
+ *
+ * <p>Connections are obtained per call from the supplied {@link DataSource} (or supplier) and
+ * closed after use. Suitable for H2 unit tests and production datasources.
+ */
+public class PSJdbcPipelineSqlAdapter implements IPSPipelineSqlAdapter {
+
+  private final Supplier<Connection> connectionSupplier;
+
+  public PSJdbcPipelineSqlAdapter(DataSource dataSource) {
+    Objects.requireNonNull(dataSource, "dataSource");
+    this.connectionSupplier =
+        () -> {
+          try {
+            return dataSource.getConnection();
+          } catch (SQLException e) {
+            throw new IllegalStateException("Failed to obtain JDBC connection", e);
+          }
+        };
+  }
+
+  /**
+   * @param connectionSupplier must return a new open connection each call; adapter closes it
+   */
+  public PSJdbcPipelineSqlAdapter(Supplier<Connection> connectionSupplier) {
+    this.connectionSupplier = Objects.requireNonNull(connectionSupplier, "connectionSupplier");
+  }
+
+  @Override
+  public List<Map<String, Object>> query(PSPipelineSqlPlan plan) throws PSPipelineIrException {
+    Objects.requireNonNull(plan, "plan");
+    if (plan.getKind() != PSPipelineSqlPlan.Kind.QUERY) {
+      throw new PSPipelineIrException("SQL plan is not a QUERY: " + plan.getKind());
+    }
+    try (Connection conn = open();
+        PreparedStatement ps = conn.prepareStatement(plan.getSql())) {
+      bind(ps, plan.getParameters());
+      try (ResultSet rs = ps.executeQuery()) {
+        return mapRows(rs);
+      }
+    } catch (SQLException e) {
+      throw new PSPipelineIrException("Pipeline SQL query failed: " + plan.getDescription(), e);
+    } catch (RuntimeException e) {
+      throw new PSPipelineIrException("Pipeline SQL query failed: " + plan.getDescription(), e);
+    }
+  }
+
+  @Override
+  public int update(PSPipelineSqlPlan plan) throws PSPipelineIrException {
+    Objects.requireNonNull(plan, "plan");
+    if (plan.getKind() != PSPipelineSqlPlan.Kind.UPDATE) {
+      throw new PSPipelineIrException("SQL plan is not an UPDATE: " + plan.getKind());
+    }
+    try (Connection conn = open();
+        PreparedStatement ps = conn.prepareStatement(plan.getSql())) {
+      bind(ps, plan.getParameters());
+      return ps.executeUpdate();
+    } catch (SQLException e) {
+      throw new PSPipelineIrException("Pipeline SQL update failed: " + plan.getDescription(), e);
+    } catch (RuntimeException e) {
+      throw new PSPipelineIrException("Pipeline SQL update failed: " + plan.getDescription(), e);
+    }
+  }
+
+  private Connection open() throws SQLException {
+    try {
+      Connection conn = connectionSupplier.get();
+      if (conn == null) {
+        throw new SQLException("Connection supplier returned null");
+      }
+      return conn;
+    } catch (RuntimeException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SQLException sqlEx) {
+        throw sqlEx;
+      }
+      throw e;
+    }
+  }
+
+  private static void bind(PreparedStatement ps, List<Object> parameters) throws SQLException {
+    if (parameters == null) {
+      return;
+    }
+    for (int i = 0; i < parameters.size(); i++) {
+      ps.setObject(i + 1, parameters.get(i));
+    }
+  }
+
+  private static List<Map<String, Object>> mapRows(ResultSet rs) throws SQLException {
+    ResultSetMetaData meta = rs.getMetaData();
+    int cols = meta.getColumnCount();
+    List<Map<String, Object>> rows = new ArrayList<>();
+    while (rs.next()) {
+      Map<String, Object> row = new LinkedHashMap<>();
+      for (int c = 1; c <= cols; c++) {
+        String label = meta.getColumnLabel(c);
+        if (label == null || label.isBlank()) {
+          label = meta.getColumnName(c);
+        }
+        Object value = rs.getObject(c);
+        row.put(label, value);
+      }
+      rows.add(row);
+    }
+    return rows;
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/sql/PSPipelineSqlPlan.java
+++ b/system/services/src/com/percussion/services/pipeline/sql/PSPipelineSqlPlan.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.sql;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Parameterized SQL plan: JDBC SQL with {@code ?} placeholders and ordered bind values. */
+public final class PSPipelineSqlPlan {
+
+  public enum Kind {
+    QUERY,
+    UPDATE
+  }
+
+  private final Kind kind;
+  private final String sql;
+  private final List<Object> parameters;
+  private final String description;
+
+  public PSPipelineSqlPlan(Kind kind, String sql, List<Object> parameters, String description) {
+    this.kind = Objects.requireNonNull(kind, "kind");
+    this.sql = Objects.requireNonNull(sql, "sql");
+    this.parameters =
+        parameters != null
+            ? Collections.unmodifiableList(new ArrayList<>(parameters))
+            : List.of();
+    this.description = description != null ? description : kind.name();
+  }
+
+  public Kind getKind() {
+    return kind;
+  }
+
+  public String getSql() {
+    return sql;
+  }
+
+  public List<Object> getParameters() {
+    return parameters;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+}

--- a/system/services/src/com/percussion/services/pipeline/sql/PSPipelineSqlPlanner.java
+++ b/system/services/src/com/percussion/services/pipeline/sql/PSPipelineSqlPlanner.java
@@ -26,11 +26,13 @@ import com.percussion.services.pipeline.model.PipelineResourceIr;
 import com.percussion.services.pipeline.model.SelectorStageIr;
 import com.percussion.services.pipeline.model.UpdaterStageIr;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -171,17 +173,19 @@ public final class PSPipelineSqlPlanner {
               + firstToken(trimmed)
               + ")");
     }
-    // Reject obvious mutation keywords as whole words
-    if (containsWord(upper, "INSERT")
-        || containsWord(upper, "UPDATE")
-        || containsWord(upper, "DELETE")
-        || containsWord(upper, "DROP")
-        || containsWord(upper, "ALTER")
-        || containsWord(upper, "TRUNCATE")
-        || containsWord(upper, "MERGE")
-        || containsWord(upper, "EXEC")
-        || containsWord(upper, "EXECUTE")
-        || containsWord(upper, "CALL")) {
+    // Reject obvious mutation keywords as whole words outside string literals
+    // (e.g. WHERE name = 'EXEC sp' must not false-positive on EXEC inside quotes).
+    String upperOutsideLiterals = stripSqlStringLiterals(trimmed).toUpperCase(Locale.ROOT);
+    if (containsWord(upperOutsideLiterals, "INSERT")
+        || containsWord(upperOutsideLiterals, "UPDATE")
+        || containsWord(upperOutsideLiterals, "DELETE")
+        || containsWord(upperOutsideLiterals, "DROP")
+        || containsWord(upperOutsideLiterals, "ALTER")
+        || containsWord(upperOutsideLiterals, "TRUNCATE")
+        || containsWord(upperOutsideLiterals, "MERGE")
+        || containsWord(upperOutsideLiterals, "EXEC")
+        || containsWord(upperOutsideLiterals, "EXECUTE")
+        || containsWord(upperOutsideLiterals, "CALL")) {
       throw new PSPipelineIrException("Native SQL escape hatch rejected unsafe keyword in statement");
     }
 
@@ -232,11 +236,18 @@ public final class PSPipelineSqlPlanner {
         request.getParams() != null ? request.getParams() : Map.of();
     if (!params.isEmpty()) {
       List<String> whereParts = new ArrayList<>();
+      // Deduplicate by mapped column so case variants of the same param (TYPE vs type) do not
+      // produce duplicate WHERE "TYPE" = ? AND "TYPE" = ? with conflicting binds.
+      Set<String> usedColumns = new HashSet<>();
       for (Map.Entry<String, Object> e : params.entrySet()) {
         ColumnMapping match = findMappingForParam(mappings, e.getKey());
         if (match == null) {
           // Unknown params are ignored for generated WHERE (hooks may use them); only mapped cols
           // become filters.
+          continue;
+        }
+        String colKey = match.column.toUpperCase(Locale.ROOT);
+        if (!usedColumns.add(colKey)) {
           continue;
         }
         whereParts.add(quoteIdent(match.column) + " = ?");
@@ -396,6 +407,38 @@ public final class PSPipelineSqlPlanner {
   private static boolean containsWord(String upperSql, String word) {
     Pattern p = Pattern.compile("\\b" + word + "\\b");
     return p.matcher(upperSql).find();
+  }
+
+  /**
+   * Removes single-quoted SQL string literals (including {@code ''} escapes) so keyword checks do
+   * not false-positive on values such as {@code 'EXEC sp'}.
+   */
+  static String stripSqlStringLiterals(String sql) {
+    if (sql == null || sql.isEmpty()) {
+      return sql == null ? "" : sql;
+    }
+    StringBuilder out = new StringBuilder(sql.length());
+    boolean inString = false;
+    for (int i = 0; i < sql.length(); i++) {
+      char c = sql.charAt(i);
+      if (c == '\'') {
+        if (inString) {
+          // doubled quote inside a literal is an escaped apostrophe
+          if (i + 1 < sql.length() && sql.charAt(i + 1) == '\'') {
+            i++;
+            continue;
+          }
+          inString = false;
+        } else {
+          inString = true;
+        }
+        continue;
+      }
+      if (!inString) {
+        out.append(c);
+      }
+    }
+    return out.toString();
   }
 
   private static String firstToken(String sql) {

--- a/system/services/src/com/percussion/services/pipeline/sql/PSPipelineSqlPlanner.java
+++ b/system/services/src/com/percussion/services/pipeline/sql/PSPipelineSqlPlanner.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline.sql;
+
+import com.percussion.services.pipeline.PSPipelineIrException;
+import com.percussion.services.pipeline.model.BackendTableRefIr;
+import com.percussion.services.pipeline.model.MapperStageIr;
+import com.percussion.services.pipeline.model.MappingEntryIr;
+import com.percussion.services.pipeline.model.PipelineExecuteRequest;
+import com.percussion.services.pipeline.model.PipelineResourceIr;
+import com.percussion.services.pipeline.model.SelectorStageIr;
+import com.percussion.services.pipeline.model.UpdaterStageIr;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Builds parameterized {@link PSPipelineSqlPlan} instances from pipeline IR resources.
+ *
+ * <p><strong>Security defaults:</strong>
+ *
+ * <ul>
+ *   <li>Request values are always bound as JDBC parameters — never concatenated into SQL.
+ *   <li>Generated identifiers (table/column) are restricted to {@code [A-Za-z_][A-Za-z0-9_]*}.
+ *   <li>Native SQL (selector {@code nativeStatement}) is an escape hatch: single {@code SELECT}
+ *       only, named {@code :param} placeholders; multi-statement and non-SELECT rejected.
+ * </ul>
+ */
+public final class PSPipelineSqlPlanner {
+
+  private static final Pattern SAFE_IDENT = Pattern.compile("^[A-Za-z_][A-Za-z0-9_]*$");
+  private static final Pattern NAMED_PARAM = Pattern.compile(":([A-Za-z_][A-Za-z0-9_]*)");
+
+  private PSPipelineSqlPlanner() {}
+
+  /**
+   * Plan a QUERY resource.
+   *
+   * <p>Strategy:
+   *
+   * <ol>
+   *   <li>If selector uses {@code nativeStatement}, compile named-parameter SELECT.
+   *   <li>Else build projection from single backend table + COLUMN mapper mappings; optional WHERE
+   *       from request params that match mapped columns / JSON field names.
+   * </ol>
+   */
+  public static PSPipelineSqlPlan planQuery(
+      PipelineResourceIr resource, PipelineExecuteRequest request) throws PSPipelineIrException {
+    Objects.requireNonNull(resource, "resource");
+    Objects.requireNonNull(request, "request");
+    if (!PipelineResourceIr.KIND_QUERY.equals(resource.getKind())) {
+      throw new PSPipelineIrException(
+          "Resource kind is not QUERY: " + resource.getKind() + " (" + resource.getName() + ")");
+    }
+
+    SelectorStageIr selector =
+        resource.getStages() != null ? resource.getStages().getSelector() : null;
+    if (selector != null
+        && selector.isPresent()
+        && SelectorStageIr.METHOD_NATIVE.equals(selector.getMethod())
+        && selector.getNativeStatement() != null
+        && !selector.getNativeStatement().isBlank()) {
+      return planNativeSelect(selector.getNativeStatement(), request);
+    }
+
+    return planGeneratedSelect(resource, request);
+  }
+
+  /**
+   * Plan a minimal UPDATE-resource insert when updater allows insert and request has rows (or
+   * params as a single row).
+   */
+  public static List<PSPipelineSqlPlan> planInserts(
+      PipelineResourceIr resource, PipelineExecuteRequest request) throws PSPipelineIrException {
+    Objects.requireNonNull(resource, "resource");
+    Objects.requireNonNull(request, "request");
+    if (!PipelineResourceIr.KIND_UPDATE.equals(resource.getKind())) {
+      throw new PSPipelineIrException(
+          "Resource kind is not UPDATE: " + resource.getKind() + " (" + resource.getName() + ")");
+    }
+    UpdaterStageIr updater =
+        resource.getStages() != null ? resource.getStages().getUpdater() : null;
+    if (updater == null || !updater.isPresent() || !updater.isAllowInsert()) {
+      throw new PSPipelineIrException(
+          "UPDATE resource does not allow insert: " + resource.getName());
+    }
+
+    String table = requireSingleTable(resource);
+    List<ColumnMapping> mappings = columnMappings(resource);
+    if (mappings.isEmpty()) {
+      throw new PSPipelineIrException(
+          "UPDATE resource has no COLUMN mappings for insert: " + resource.getName());
+    }
+
+    List<Map<String, Object>> rows = new ArrayList<>();
+    if (request.getRows() != null && !request.getRows().isEmpty()) {
+      rows.addAll(request.getRows());
+    } else if (request.getParams() != null && !request.getParams().isEmpty()) {
+      rows.add(new LinkedHashMap<>(request.getParams()));
+    } else {
+      throw new PSPipelineIrException("Insert requires request.rows or request.params");
+    }
+
+    List<PSPipelineSqlPlan> plans = new ArrayList<>();
+    for (Map<String, Object> row : rows) {
+      List<String> cols = new ArrayList<>();
+      List<Object> values = new ArrayList<>();
+      for (ColumnMapping m : mappings) {
+        Object v = findValue(row, m);
+        if (v != null) {
+          cols.add(m.column);
+          values.add(v);
+        }
+      }
+      if (cols.isEmpty()) {
+        throw new PSPipelineIrException("Insert row has no values matching mapped columns");
+      }
+      StringBuilder sql = new StringBuilder("INSERT INTO ").append(quoteIdent(table)).append(" (");
+      for (int i = 0; i < cols.size(); i++) {
+        if (i > 0) {
+          sql.append(", ");
+        }
+        sql.append(quoteIdent(cols.get(i)));
+      }
+      sql.append(") VALUES (");
+      for (int i = 0; i < cols.size(); i++) {
+        if (i > 0) {
+          sql.append(", ");
+        }
+        sql.append('?');
+      }
+      sql.append(')');
+      plans.add(
+          new PSPipelineSqlPlan(
+              PSPipelineSqlPlan.Kind.UPDATE, sql.toString(), values, "insert:" + table));
+    }
+    return plans;
+  }
+
+  private static PSPipelineSqlPlan planNativeSelect(String nativeSql, PipelineExecuteRequest request)
+      throws PSPipelineIrException {
+    String trimmed = nativeSql.trim();
+    if (trimmed.indexOf(';') >= 0) {
+      throw new PSPipelineIrException(
+          "Native SQL escape hatch rejects multi-statement / semicolon SQL");
+    }
+    String upper = trimmed.toUpperCase(Locale.ROOT);
+    if (!upper.startsWith("SELECT") && !upper.startsWith("WITH")) {
+      throw new PSPipelineIrException(
+          "Native SQL escape hatch allows only SELECT/WITH statements (got: "
+              + firstToken(trimmed)
+              + ")");
+    }
+    // Reject obvious mutation keywords as whole words
+    if (containsWord(upper, "INSERT")
+        || containsWord(upper, "UPDATE")
+        || containsWord(upper, "DELETE")
+        || containsWord(upper, "DROP")
+        || containsWord(upper, "ALTER")
+        || containsWord(upper, "TRUNCATE")
+        || containsWord(upper, "MERGE")
+        || containsWord(upper, "EXEC")
+        || containsWord(upper, "EXECUTE")
+        || containsWord(upper, "CALL")) {
+      throw new PSPipelineIrException("Native SQL escape hatch rejected unsafe keyword in statement");
+    }
+
+    List<Object> binds = new ArrayList<>();
+    Matcher m = NAMED_PARAM.matcher(trimmed);
+    StringBuffer jdbc = new StringBuffer();
+    Map<String, Object> params =
+        request.getParams() != null ? request.getParams() : Map.of();
+    while (m.find()) {
+      String name = m.group(1);
+      Object value = findParamIgnoreCase(params, name);
+      if (value == null && !params.containsKey(name) && findParamKey(params, name) == null) {
+        // allow explicit null if key present under different case handled above
+        if (!containsKeyIgnoreCase(params, name)) {
+          throw new PSPipelineIrException("Missing request param for native SQL placeholder :" + name);
+        }
+      }
+      binds.add(value);
+      m.appendReplacement(jdbc, "?");
+    }
+    m.appendTail(jdbc);
+
+    return new PSPipelineSqlPlan(
+        PSPipelineSqlPlan.Kind.QUERY, jdbc.toString(), binds, "nativeSelect");
+  }
+
+  private static PSPipelineSqlPlan planGeneratedSelect(
+      PipelineResourceIr resource, PipelineExecuteRequest request) throws PSPipelineIrException {
+    String table = requireSingleTable(resource);
+    List<ColumnMapping> mappings = columnMappings(resource);
+    if (mappings.isEmpty()) {
+      throw new PSPipelineIrException(
+          "QUERY resource has no COLUMN mappings to project: " + resource.getName());
+    }
+
+    StringBuilder sql = new StringBuilder("SELECT ");
+    for (int i = 0; i < mappings.size(); i++) {
+      ColumnMapping m = mappings.get(i);
+      if (i > 0) {
+        sql.append(", ");
+      }
+      sql.append(quoteIdent(m.column)).append(" AS ").append(quoteIdent(m.jsonField));
+    }
+    sql.append(" FROM ").append(quoteIdent(table));
+
+    List<Object> binds = new ArrayList<>();
+    Map<String, Object> params =
+        request.getParams() != null ? request.getParams() : Map.of();
+    if (!params.isEmpty()) {
+      List<String> whereParts = new ArrayList<>();
+      for (Map.Entry<String, Object> e : params.entrySet()) {
+        ColumnMapping match = findMappingForParam(mappings, e.getKey());
+        if (match == null) {
+          // Unknown params are ignored for generated WHERE (hooks may use them); only mapped cols
+          // become filters.
+          continue;
+        }
+        whereParts.add(quoteIdent(match.column) + " = ?");
+        binds.add(e.getValue());
+      }
+      if (!whereParts.isEmpty()) {
+        sql.append(" WHERE ");
+        sql.append(String.join(" AND ", whereParts));
+      }
+    }
+
+    return new PSPipelineSqlPlan(
+        PSPipelineSqlPlan.Kind.QUERY, sql.toString(), binds, "generatedSelect:" + table);
+  }
+
+  private static String requireSingleTable(PipelineResourceIr resource) throws PSPipelineIrException {
+    if (resource.getStages() == null
+        || resource.getStages().getBackendTank() == null
+        || !resource.getStages().getBackendTank().isPresent()) {
+      throw new PSPipelineIrException("Resource missing backend tank: " + resource.getName());
+    }
+    if (resource.getStages().getBackendTank().getJoinCount() > 0) {
+      throw new PSPipelineIrException(
+          "Joined backend tanks are not supported in Slice A runtime: " + resource.getName());
+    }
+    List<BackendTableRefIr> tables = resource.getStages().getBackendTank().getTables();
+    if (tables == null || tables.size() != 1) {
+      throw new PSPipelineIrException(
+          "Slice A runtime requires exactly one backend table: " + resource.getName());
+    }
+    String table = tables.get(0).getTable();
+    if (table == null || table.isBlank()) {
+      table = tables.get(0).getAlias();
+    }
+    return requireSafeIdent(table, "table");
+  }
+
+  private static List<ColumnMapping> columnMappings(PipelineResourceIr resource)
+      throws PSPipelineIrException {
+    MapperStageIr mapper =
+        resource.getStages() != null ? resource.getStages().getMapper() : null;
+    if (mapper == null || !mapper.isPresent() || mapper.getMappings() == null) {
+      return List.of();
+    }
+    List<ColumnMapping> out = new ArrayList<>();
+    for (MappingEntryIr entry : mapper.getMappings()) {
+      if (entry == null) {
+        continue;
+      }
+      if (!MappingEntryIr.BACKEND_KIND_COLUMN.equals(entry.getBackendKind())
+          && entry.getBackendKind() != null
+          && !entry.getBackendKind().isBlank()
+          && !MappingEntryIr.BACKEND_KIND_COLUMN.equalsIgnoreCase(entry.getBackendKind())) {
+        continue;
+      }
+      String backend = entry.getBackend();
+      if (backend == null || backend.isBlank()) {
+        continue;
+      }
+      String column = columnFromBackend(backend);
+      String jsonField = jsonFieldFromDocument(entry.getDocumentField(), column);
+      out.add(new ColumnMapping(column, jsonField, entry.getDocumentField()));
+    }
+    return out;
+  }
+
+  static String columnFromBackend(String backend) throws PSPipelineIrException {
+    String b = backend.trim();
+    int dot = b.lastIndexOf('.');
+    String col = dot >= 0 ? b.substring(dot + 1) : b;
+    return requireSafeIdent(col, "column");
+  }
+
+  static String jsonFieldFromDocument(String documentField, String fallbackColumn) {
+    if (documentField == null || documentField.isBlank()) {
+      return fallbackColumn;
+    }
+    String s = documentField.trim();
+    int slash = s.lastIndexOf('/');
+    if (slash >= 0) {
+      s = s.substring(slash + 1);
+    }
+    if (s.startsWith("@")) {
+      s = s.substring(1);
+    }
+    if (s.isBlank() || !SAFE_IDENT.matcher(s).matches()) {
+      return fallbackColumn;
+    }
+    return s;
+  }
+
+  private static ColumnMapping findMappingForParam(List<ColumnMapping> mappings, String paramKey) {
+    if (paramKey == null) {
+      return null;
+    }
+    for (ColumnMapping m : mappings) {
+      if (paramKey.equalsIgnoreCase(m.column)
+          || paramKey.equalsIgnoreCase(m.jsonField)
+          || (m.documentField != null && paramKey.equalsIgnoreCase(m.documentField))) {
+        return m;
+      }
+    }
+    return null;
+  }
+
+  private static Object findValue(Map<String, Object> row, ColumnMapping m) {
+    if (row.containsKey(m.column)) {
+      return row.get(m.column);
+    }
+    if (row.containsKey(m.jsonField)) {
+      return row.get(m.jsonField);
+    }
+    for (Map.Entry<String, Object> e : row.entrySet()) {
+      if (e.getKey() != null
+          && (e.getKey().equalsIgnoreCase(m.column)
+              || e.getKey().equalsIgnoreCase(m.jsonField))) {
+        return e.getValue();
+      }
+    }
+    return null;
+  }
+
+  private static Object findParamIgnoreCase(Map<String, Object> params, String name) {
+    String key = findParamKey(params, name);
+    return key != null ? params.get(key) : null;
+  }
+
+  private static String findParamKey(Map<String, Object> params, String name) {
+    if (params.containsKey(name)) {
+      return name;
+    }
+    for (String k : params.keySet()) {
+      if (k != null && k.equalsIgnoreCase(name)) {
+        return k;
+      }
+    }
+    return null;
+  }
+
+  private static boolean containsKeyIgnoreCase(Map<String, Object> params, String name) {
+    return findParamKey(params, name) != null;
+  }
+
+  private static String requireSafeIdent(String ident, String label) throws PSPipelineIrException {
+    if (ident == null || !SAFE_IDENT.matcher(ident).matches()) {
+      throw new PSPipelineIrException(
+          "Unsafe or missing SQL " + label + " identifier: " + ident);
+    }
+    return ident;
+  }
+
+  /** Quote identifier with double-quotes (ANSI / H2). Ident already validated. */
+  static String quoteIdent(String ident) {
+    return "\"" + ident + "\"";
+  }
+
+  private static boolean containsWord(String upperSql, String word) {
+    Pattern p = Pattern.compile("\\b" + word + "\\b");
+    return p.matcher(upperSql).find();
+  }
+
+  private static String firstToken(String sql) {
+    String[] parts = sql.trim().split("\\s+", 2);
+    return parts.length > 0 ? parts[0] : "";
+  }
+
+  private static final class ColumnMapping {
+    final String column;
+    final String jsonField;
+    final String documentField;
+
+    ColumnMapping(String column, String jsonField, String documentField) {
+      this.column = column;
+      this.jsonField = jsonField;
+      this.documentField = documentField;
+    }
+  }
+}

--- a/system/src/test/java/com/percussion/services/pipeline/PSPipelineRuntimeServiceTest.java
+++ b/system/src/test/java/com/percussion/services/pipeline/PSPipelineRuntimeServiceTest.java
@@ -33,6 +33,7 @@ import com.percussion.services.pipeline.model.PipelineStagesIr;
 import com.percussion.services.pipeline.model.SelectorStageIr;
 import com.percussion.services.pipeline.model.UpdaterStageIr;
 import com.percussion.services.pipeline.sql.PSJdbcPipelineSqlAdapter;
+import com.percussion.services.pipeline.sql.PSPipelineSqlPlan;
 import com.percussion.services.pipeline.sql.PSPipelineSqlPlanner;
 import java.nio.file.Path;
 import java.sql.Connection;
@@ -187,6 +188,48 @@ class PSPipelineRuntimeServiceTest {
             PSPipelineSqlPlanner.planQuery(
                 nativeOnlyResource("DELETE FROM PSX_ADMINLOOKUP"),
                 PipelineExecuteRequest.empty()));
+  }
+
+  @Test
+  @DisplayName("security: native keyword inside string literal is not rejected")
+  void nativeSql_allowsKeywordInsideStringLiteral() throws Exception {
+    PSPipelineSqlPlan plan =
+        PSPipelineSqlPlanner.planQuery(
+            nativeOnlyResource("SELECT * FROM t WHERE name = 'EXEC sp'"),
+            PipelineExecuteRequest.empty());
+    assertNotNull(plan);
+    assertTrue(plan.getSql().contains("'EXEC sp'") || plan.getSql().toUpperCase().contains("SELECT"));
+  }
+
+  @Test
+  @DisplayName("generated SELECT dedupes case-variant params onto one WHERE bind")
+  void generatedSelect_dedupesCaseVariantParams() throws Exception {
+    PipelineIrDocument doc = nativeQueryDoc("dedupeApp", "D1");
+    PipelineResourceIr res = doc.findResource("D1");
+    Map<String, Object> params = new LinkedHashMap<>();
+    params.put("TYPE", "workflow");
+    params.put("type", "locale"); // same mapped column; first entry wins
+    PSPipelineSqlPlan plan =
+        PSPipelineSqlPlanner.planQuery(res, PipelineExecuteRequest.ofParams(params));
+    String sql = plan.getSql();
+    // Only one equality on TYPE column
+    int idx = sql.indexOf("\"TYPE\" = ?");
+    assertTrue(idx >= 0, sql);
+    assertEquals(-1, sql.indexOf("\"TYPE\" = ?", idx + 1), sql);
+    assertEquals(1, plan.getParameters().size());
+    assertEquals("workflow", plan.getParameters().get(0));
+  }
+
+  @Test
+  @DisplayName("execute rejects resource not owned by document")
+  void execute_rejectsForeignResource() {
+    PipelineIrDocument doc = nativeQueryDoc("ownApp", "R1");
+    PipelineIrDocument other = nativeQueryDoc("otherApp", "R1");
+    PipelineResourceIr foreign = other.findResource("R1");
+    IPSPipelineRuntimeService runtime = new PSPipelineRuntimeService(irService, sqlAdapter);
+    assertThrows(
+        PSPipelineIrException.class,
+        () -> runtime.execute(doc, foreign, PipelineExecuteRequest.empty()));
   }
 
   @Test

--- a/system/src/test/java/com/percussion/services/pipeline/PSPipelineRuntimeServiceTest.java
+++ b/system/src/test/java/com/percussion/services/pipeline/PSPipelineRuntimeServiceTest.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.services.pipeline;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.percussion.services.pipeline.hooks.IPSPipelinePostExecuteHook;
+import com.percussion.services.pipeline.hooks.IPSPipelinePreExecuteHook;
+import com.percussion.services.pipeline.model.BackendTableRefIr;
+import com.percussion.services.pipeline.model.BackendTankStageIr;
+import com.percussion.services.pipeline.model.MapperStageIr;
+import com.percussion.services.pipeline.model.MappingEntryIr;
+import com.percussion.services.pipeline.model.PipelineExecuteRequest;
+import com.percussion.services.pipeline.model.PipelineExecuteResult;
+import com.percussion.services.pipeline.model.PipelineIrDocument;
+import com.percussion.services.pipeline.model.PipelineResourceIr;
+import com.percussion.services.pipeline.model.PipelineStagesIr;
+import com.percussion.services.pipeline.model.SelectorStageIr;
+import com.percussion.services.pipeline.model.UpdaterStageIr;
+import com.percussion.services.pipeline.sql.PSJdbcPipelineSqlAdapter;
+import com.percussion.services.pipeline.sql.PSPipelineSqlPlanner;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * H2-backed integration tests for Slice A pipeline runtime: query SQL adapter, JSON I/O, pre/post
+ * hooks, and minimal insert path.
+ */
+@DisplayName("Pipeline runtime service (Slice A SQL + JSON + hooks)")
+class PSPipelineRuntimeServiceTest {
+
+  @TempDir Path tempDir;
+
+  private String jdbcUrl;
+  private IPSPipelineIrService irService;
+  private PSJdbcPipelineSqlAdapter sqlAdapter;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    jdbcUrl = "jdbc:h2:mem:pipeline_rt_" + System.nanoTime() + ";DB_CLOSE_DELAY=-1";
+    try (Connection c = DriverManager.getConnection(jdbcUrl);
+        Statement st = c.createStatement()) {
+      // Quote identifiers: VALUE (and others) are reserved in modern H2.
+      st.execute(
+          "CREATE TABLE \"PSX_ADMINLOOKUP\" ("
+              + "\"TYPE\" VARCHAR(64), \"NAME\" VARCHAR(128), \"LOOKUPVALUE\" VARCHAR(256))");
+      st.execute(
+          "INSERT INTO \"PSX_ADMINLOOKUP\" (\"TYPE\", \"NAME\", \"LOOKUPVALUE\") VALUES "
+              + "('workflow', 'wf1', '1'),"
+              + "('workflow', 'wf2', '2'),"
+              + "('locale', 'en-us', 'en')");
+    }
+    irService = new PSPipelineIrService(tempDir);
+    sqlAdapter =
+        new PSJdbcPipelineSqlAdapter(
+            () -> {
+              try {
+                return DriverManager.getConnection(jdbcUrl);
+              } catch (java.sql.SQLException e) {
+                throw new IllegalStateException("H2 connection failed", e);
+              }
+            });
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    try (Connection c = DriverManager.getConnection(jdbcUrl);
+        Statement st = c.createStatement()) {
+      st.execute("SHUTDOWN");
+    } catch (Exception ignored) {
+      // mem DB may already be gone
+    }
+  }
+
+  @Test
+  @DisplayName("query: generated SELECT + JSON params filter against H2")
+  void executeQuery_generatedSelectWithParams() throws Exception {
+    PipelineIrDocument doc = nativeQueryDoc("lookupApp", "DatasetQ");
+    irService.save(doc);
+
+    IPSPipelineRuntimeService runtime = new PSPipelineRuntimeService(irService, sqlAdapter);
+    PipelineExecuteRequest req =
+        PipelineExecuteRequest.ofParams(Map.of("TYPE", "workflow"));
+
+    PipelineExecuteResult result = runtime.execute("lookupApp", "DatasetQ", req);
+
+    assertEquals("lookupApp", result.getAppName());
+    assertEquals("DatasetQ", result.getResourceName());
+    assertEquals(PipelineResourceIr.KIND_QUERY, result.getKind());
+    assertEquals("query", result.getOperation());
+    assertEquals(2, result.getRowCount());
+    assertEquals(2, result.getRows().size());
+    assertEquals("workflow", result.getRows().get(0).get("Type"));
+    assertTrue(
+        result.getRows().stream().allMatch(r -> "workflow".equals(String.valueOf(r.get("Type")))));
+
+    String json = PSPipelineExecuteJsonCodec.toJson(result);
+    assertTrue(json.contains("\"rowCount\""));
+    assertTrue(json.contains("workflow"));
+    PipelineExecuteResult roundTrip = PSPipelineExecuteJsonCodec.resultFromJson(json);
+    assertEquals(result.getRowCount(), roundTrip.getRowCount());
+  }
+
+  @Test
+  @DisplayName("query: load saved IR and execute end-to-end")
+  void execute_fromSavedIr() throws Exception {
+    PipelineIrDocument doc = nativeQueryDoc("savedApp", "R1");
+    irService.save(doc);
+
+    IPSPipelineRuntimeService runtime = new PSPipelineRuntimeService(irService, sqlAdapter);
+    PipelineExecuteResult result =
+        runtime.execute("savedApp", "R1", PipelineExecuteRequest.empty());
+
+    assertEquals(3, result.getRowCount());
+    assertEquals(3, result.getRows().size());
+  }
+
+  @Test
+  @DisplayName("query: nativeStatement parameterized escape hatch")
+  void executeQuery_nativeStatement() throws Exception {
+    PipelineIrDocument doc = new PipelineIrDocument();
+    doc.setSource(PipelineIrDocument.SOURCE_NATIVE);
+    doc.getApp().setName("nativeApp");
+    PipelineResourceIr res = new PipelineResourceIr();
+    res.setName("NativeQ");
+    res.setKind(PipelineResourceIr.KIND_QUERY);
+    PipelineStagesIr stages = new PipelineStagesIr();
+    SelectorStageIr selector = new SelectorStageIr();
+    selector.setPresent(true);
+    selector.setMethod(SelectorStageIr.METHOD_NATIVE);
+    selector.setNativeStatement(
+        "SELECT \"TYPE\" AS \"Type\", \"NAME\" AS \"Name\" FROM \"PSX_ADMINLOOKUP\""
+            + " WHERE \"TYPE\" = :type");
+    stages.setSelector(selector);
+    // still need tank/mapper empty ok for native path
+    res.setStages(stages);
+    doc.getResources().add(res);
+
+    IPSPipelineRuntimeService runtime = new PSPipelineRuntimeService(irService, sqlAdapter);
+    PipelineExecuteResult result =
+        runtime.execute(
+            doc, res, PipelineExecuteRequest.ofParams(Map.of("type", "locale")));
+
+    assertEquals(1, result.getRowCount());
+    assertEquals("locale", result.getRows().get(0).get("Type"));
+    assertEquals("en-us", result.getRows().get(0).get("Name"));
+  }
+
+  @Test
+  @DisplayName("security: native multi-statement and non-SELECT rejected")
+  void nativeSql_rejectsUnsafe() {
+    assertThrows(
+        PSPipelineIrException.class,
+        () ->
+            PSPipelineSqlPlanner.planQuery(
+                nativeOnlyResource("SELECT 1; DROP TABLE X"),
+                PipelineExecuteRequest.empty()));
+    assertThrows(
+        PSPipelineIrException.class,
+        () ->
+            PSPipelineSqlPlanner.planQuery(
+                nativeOnlyResource("DELETE FROM PSX_ADMINLOOKUP"),
+                PipelineExecuteRequest.empty()));
+  }
+
+  @Test
+  @DisplayName("pre and post Java hooks fire on execute path")
+  void hooks_preAndPostInvoked() throws Exception {
+    PipelineIrDocument doc = nativeQueryDoc("hookApp", "HQ");
+    AtomicInteger pre = new AtomicInteger();
+    AtomicInteger post = new AtomicInteger();
+
+    IPSPipelinePreExecuteHook preHook =
+        ctx -> {
+          pre.incrementAndGet();
+          ctx.addTrace("pre:test");
+          // inject filter via mutable request
+          ctx.getRequest().getParams().put("TYPE", "locale");
+        };
+    IPSPipelinePostExecuteHook postHook =
+        (ctx, result) -> {
+          post.incrementAndGet();
+          ctx.addTrace("post:test");
+          result.getMeta().put("hooked", true);
+        };
+
+    IPSPipelineRuntimeService runtime =
+        new PSPipelineRuntimeService(
+            irService, sqlAdapter, List.of(preHook), List.of(postHook));
+
+    PipelineExecuteResult result =
+        runtime.execute(doc, doc.findResource("HQ"), PipelineExecuteRequest.empty());
+
+    assertEquals(1, pre.get());
+    assertEquals(1, post.get());
+    assertEquals(1, result.getRowCount());
+    assertEquals("locale", result.getRows().get(0).get("Type"));
+    assertTrue(result.getHookTrace().contains("pre:test"));
+    assertTrue(result.getHookTrace().contains("post:test"));
+    assertEquals(true, result.getMeta().get("hooked"));
+  }
+
+  @Test
+  @DisplayName("update: minimal INSERT via SQL adapter")
+  void executeInsert_minimal() throws Exception {
+    PipelineIrDocument doc = nativeUpdateDoc("updApp", "Ins");
+    irService.save(doc);
+
+    IPSPipelineRuntimeService runtime = new PSPipelineRuntimeService(irService, sqlAdapter);
+    Map<String, Object> row = new LinkedHashMap<>();
+    row.put("TYPE", "community");
+    row.put("NAME", "c1");
+    row.put("LOOKUPVALUE", "99");
+    PipelineExecuteRequest req = new PipelineExecuteRequest();
+    req.setRows(List.of(row));
+
+    PipelineExecuteResult result = runtime.execute("updApp", "Ins", req);
+    assertEquals("insert", result.getOperation());
+    assertEquals(1, result.getAffectedRows());
+
+    // verify via query resource
+    PipelineIrDocument qdoc = nativeQueryDoc("q2", "Q2");
+    PipelineExecuteResult q =
+        runtime.execute(
+            qdoc,
+            qdoc.findResource("Q2"),
+            PipelineExecuteRequest.ofParams(Map.of("TYPE", "community")));
+    assertEquals(1, q.getRowCount());
+    assertEquals("c1", q.getRows().get(0).get("Name"));
+  }
+
+  @Test
+  @DisplayName("JSON request codec parses params")
+  void requestJsonCodec() throws Exception {
+    PipelineExecuteRequest req =
+        PSPipelineExecuteJsonCodec.requestFromJson("{\"params\":{\"TYPE\":\"workflow\"}}");
+    assertEquals("workflow", req.getParams().get("TYPE"));
+  }
+
+  @Test
+  @DisplayName("missing app / resource errors")
+  void execute_missing() {
+    IPSPipelineRuntimeService runtime = new PSPipelineRuntimeService(irService, sqlAdapter);
+    assertThrows(
+        PSPipelineIrException.class,
+        () -> runtime.execute("nope", "r", PipelineExecuteRequest.empty()));
+  }
+
+  private static PipelineResourceIr nativeOnlyResource(String sql) {
+    PipelineResourceIr res = new PipelineResourceIr();
+    res.setName("N");
+    res.setKind(PipelineResourceIr.KIND_QUERY);
+    SelectorStageIr selector = new SelectorStageIr();
+    selector.setPresent(true);
+    selector.setMethod(SelectorStageIr.METHOD_NATIVE);
+    selector.setNativeStatement(sql);
+    PipelineStagesIr stages = new PipelineStagesIr();
+    stages.setSelector(selector);
+    res.setStages(stages);
+    return res;
+  }
+
+  private static PipelineIrDocument nativeQueryDoc(String appName, String resourceName) {
+    PipelineIrDocument doc = new PipelineIrDocument();
+    doc.setSource(PipelineIrDocument.SOURCE_NATIVE);
+    doc.getApp().setName(appName);
+
+    PipelineResourceIr res = new PipelineResourceIr();
+    res.setName(resourceName);
+    res.setKind(PipelineResourceIr.KIND_QUERY);
+
+    PipelineStagesIr stages = new PipelineStagesIr();
+
+    BackendTankStageIr tank = new BackendTankStageIr();
+    tank.setPresent(true);
+    BackendTableRefIr table = new BackendTableRefIr();
+    table.setTable("PSX_ADMINLOOKUP");
+    table.setAlias("PSX_ADMINLOOKUP");
+    tank.setTables(List.of(table));
+    stages.setBackendTank(tank);
+
+    MapperStageIr mapper = new MapperStageIr();
+    mapper.setPresent(true);
+    mapper.setMappings(
+        List.of(
+            mapping("Properties/@Type", "PSX_ADMINLOOKUP.TYPE"),
+            mapping("Properties/@Name", "PSX_ADMINLOOKUP.NAME"),
+            mapping("Properties/@Value", "PSX_ADMINLOOKUP.LOOKUPVALUE")));
+    stages.setMapper(mapper);
+
+    SelectorStageIr selector = new SelectorStageIr();
+    selector.setPresent(true);
+    selector.setMethod(SelectorStageIr.METHOD_WHERE);
+    stages.setSelector(selector);
+
+    res.setStages(stages);
+    doc.getResources().add(res);
+    return doc;
+  }
+
+  private static PipelineIrDocument nativeUpdateDoc(String appName, String resourceName) {
+    PipelineIrDocument doc = new PipelineIrDocument();
+    doc.setSource(PipelineIrDocument.SOURCE_NATIVE);
+    doc.getApp().setName(appName);
+
+    PipelineResourceIr res = new PipelineResourceIr();
+    res.setName(resourceName);
+    res.setKind(PipelineResourceIr.KIND_UPDATE);
+
+    PipelineStagesIr stages = new PipelineStagesIr();
+
+    BackendTankStageIr tank = new BackendTankStageIr();
+    tank.setPresent(true);
+    BackendTableRefIr table = new BackendTableRefIr();
+    table.setTable("PSX_ADMINLOOKUP");
+    tank.setTables(List.of(table));
+    stages.setBackendTank(tank);
+
+    MapperStageIr mapper = new MapperStageIr();
+    mapper.setPresent(true);
+    mapper.setMappings(
+        List.of(
+            mapping("Properties/@Type", "PSX_ADMINLOOKUP.TYPE"),
+            mapping("Properties/@Name", "PSX_ADMINLOOKUP.NAME"),
+            mapping("Properties/@Value", "PSX_ADMINLOOKUP.LOOKUPVALUE")));
+    stages.setMapper(mapper);
+
+    UpdaterStageIr updater = new UpdaterStageIr();
+    updater.setPresent(true);
+    updater.setAllowInsert(true);
+    updater.setAllowUpdate(false);
+    updater.setAllowDelete(false);
+    stages.setUpdater(updater);
+
+    res.setStages(stages);
+    doc.getResources().add(res);
+    return doc;
+  }
+
+  private static MappingEntryIr mapping(String docField, String backend) {
+    MappingEntryIr m = new MappingEntryIr();
+    m.setDocumentField(docField);
+    m.setBackend(backend);
+    m.setBackendKind(MappingEntryIr.BACKEND_KIND_COLUMN);
+    return m;
+  }
+}


### PR DESCRIPTION
## Summary
Implements **Pipelines Slice A part 2** (#2248): execute a saved pipeline IR resource against a **parameterized SQL adapter** with **JSON request/response** and **pre/post Java hooks**, on a clean IR service boundary (no classic `PSQueryHandler` public API).

**Parent tracker:** #1690  
**Depends on (merged):** #2247 / PR #2257 (IR model + load/save + classic import)

### What shipped
- `IPSPipelineRuntimeService` / `PSPipelineRuntimeService` / locator
- `IPSPipelineSqlAdapter` + `PSJdbcPipelineSqlAdapter` (PreparedStatement only)
- `PSPipelineSqlPlanner`:
  - Generated single-table `SELECT` from backend tank + COLUMN mapper; JSON `params` → `WHERE col = ?`
  - Native `selector.nativeStatement` escape hatch: single `SELECT`/`WITH`, named `:param`, rejects multi-statement/DML
  - Minimal `INSERT` for `UPDATE` resources with `allowInsert`
- Pre/post hooks: `IPSPipelinePreExecuteHook` / `IPSPipelinePostExecuteHook`
- JSON DTOs + `PSPipelineExecuteJsonCodec`
- Docs: `docs/developer-module/pipeline-ir-v1.md` runtime section + security table

### Residual
- #2269 — thin REST invoke for Developer smoke + richer UPDATE/joins (multi-module; deferred to keep this PR system-only)

## Test plan
- [x] `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Suite: `Tests run: 1167, Failures: 0, Errors: 0, Skipped: 240`
- [x] Focused: `PSPipelineRuntimeServiceTest` 8 tests + `PSPipelineIrServiceTest` 5 tests green
  - generated query + JSON params (H2)
  - saved IR execute end-to-end
  - native parameterized SELECT
  - unsafe native SQL rejected
  - pre/post hooks invoked
  - minimal INSERT
  - JSON request/result codec

## Gates evidence
- Module clean install: `cd system` → `..\mvnw.cmd clean install` (standalone; no `-am`)
- BUILD SUCCESS ~1m34s; no new failures
- Erlang self-review: parameterized SQL only; portable `Path` store unchanged; Intersoft 2026 headers on new files; H2 identifiers quoted for reserved words
- Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2248  
Refs #1690  
Residual #2269

> Co-Authored by Grok Build using grok-4.5 with agent main.