### PR TITLE
fix(deployer): force XML multipart Content-Type for Package Installer NULL_INPUT_DOC (#2265)

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/client/PSDeploymentServerConnection.java
+++ b/deployer/src/main/java/com/percussion/deployer/client/PSDeploymentServerConnection.java
@@ -22,6 +22,7 @@ import com.percussion.HTTPClient.HTTPConnection;
 import com.percussion.HTTPClient.HTTPResponse;
 import com.percussion.HTTPClient.HttpOutputStream;
 import com.percussion.HTTPClient.NVPair;
+import com.percussion.HTTPClient.PSBinaryFileData;
 import com.percussion.HTTPClient.ProtocolNotSuppException;
 import com.percussion.conn.PSServerException;
 import com.percussion.deployer.objectstore.PSDbmsInfo;
@@ -49,13 +50,16 @@ import com.percussion.utils.server.IPSCgiVariables;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.Locale;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -460,14 +464,12 @@ public class PSDeploymentServerConnection {
       // add the params
       NVPair[] opts = getParams(params);
 
-      // add the request doc as an attachment
+      // add the request doc as an attachment with explicit XML content type
+      // so PSFormContentParser always sets the input document (NULL_INPUT_DOC)
       reqFile = createAttachmentFile(req);
 
-      NVPair[] file = new NVPair[1];
-      file[0] = new NVPair(reqFile.getName(), reqFile.getPath());
-
       hdrs[1] = new NVPair(IPSCgiVariables.CGI_PS_REQUEST_TYPE, type);
-      data = Codecs.mpFormDataEncode(opts, file, hdrs);
+      data = encodeXmlDocumentMultipart(opts, reqFile, hdrs);
 
       // send the request to the Rx server
       synchronized (m_mutexObject) {
@@ -780,17 +782,14 @@ public class PSDeploymentServerConnection {
     // no options
     NVPair[] opts = null;
 
-    // add the request doc as an attachment
+    // add the request doc as an attachment with explicit XML content type
     try (PSPurgableTempFile reqFile = createAttachmentFile(req)) {
-
-      NVPair[] file = new NVPair[1];
-      file[0] = new NVPair(reqFile.getName(), reqFile.getPath());
 
       // add reqtype header after first header (will get set with
       // content-type header automatically by the formDataEncode call)
       NVPair[] hdrs = new NVPair[2];
       hdrs[1] = new NVPair(IPSCgiVariables.CGI_PS_REQUEST_TYPE, type);
-      byte[] data = Codecs.mpFormDataEncode(opts, file, hdrs);
+      byte[] data = encodeXmlDocumentMultipart(opts, reqFile, hdrs);
 
       // send the request to the Rx server
       HTTPResponse resp = null;
@@ -1044,6 +1043,114 @@ public class PSDeploymentServerConnection {
       PSXmlDocumentBuilder.write(doc, out);
     }
     return reqFile;
+  }
+
+  /**
+   * Multipart Content-Type forced on XML request document parts so the server {@code
+   * PSFormContentParser} classifies the part as XML and calls {@code setInputDocument}. Relying
+   * only on {@code URLConnection.guessContentTypeFromName} can omit or mis-classify the type on
+   * some JREs/platforms and surfaces as {@code IPSDeploymentErrors.NULL_INPUT_DOC}.
+   */
+  public static final String XML_REQUEST_CONTENT_TYPE = "application/xml";
+
+  /**
+   * Builds multipart file parts for an XML request body with an explicit {@link
+   * #XML_REQUEST_CONTENT_TYPE} Content-Type.
+   *
+   * <p>Package-private for unit tests.
+   *
+   * @param fieldName form field / disposition name; if {@code null} or blank, {@code
+   *     dpl_request.xml} is used. A {@code .xml} suffix is ensured for filename-based fallbacks.
+   * @param xmlBytes raw XML bytes, not {@code null}
+   * @return a one-element array suitable for {@link Codecs#mpFormDataEncode(NVPair[],
+   *     PSBinaryFileData[], NVPair[])}
+   */
+  static PSBinaryFileData[] createXmlRequestFileData(String fieldName, byte[] xmlBytes) {
+    if (xmlBytes == null) {
+      throw new IllegalArgumentException("xmlBytes may not be null");
+    }
+    String partName =
+        (fieldName == null || fieldName.trim().isEmpty()) ? "dpl_request.xml" : fieldName.trim();
+    // Use a simple basename (no path separators) for Content-Disposition filename.
+    int slash = Math.max(partName.lastIndexOf('/'), partName.lastIndexOf('\\'));
+    if (slash >= 0 && slash < partName.length() - 1) {
+      partName = partName.substring(slash + 1);
+    }
+    if (!partName.toLowerCase(Locale.ROOT).endsWith(".xml")) {
+      partName = partName + ".xml";
+    }
+    return new PSBinaryFileData[] {
+      new PSBinaryFileData(xmlBytes, partName, partName, XML_REQUEST_CONTENT_TYPE)
+    };
+  }
+
+  /**
+   * Multipart-encodes form fields plus an XML request document file with explicit {@link
+   * #XML_REQUEST_CONTENT_TYPE} on the file part.
+   *
+   * <p>Package-private for unit tests.
+   *
+   * @param opts form name/value pairs, may be {@code null}
+   * @param xmlFile temp file containing the XML document, not {@code null}
+   * @param hdrs header array of length &gt;= 1; element 0 is set to the multipart Content-Type by
+   *     the encoder
+   * @return encoded multipart body, never {@code null}
+   * @throws IOException if the file cannot be read or encoding fails
+   */
+  static byte[] encodeXmlDocumentMultipart(NVPair[] opts, File xmlFile, NVPair[] hdrs)
+      throws IOException {
+    if (xmlFile == null) {
+      throw new IllegalArgumentException("xmlFile may not be null");
+    }
+    if (hdrs == null || hdrs.length < 1) {
+      throw new IllegalArgumentException("hdrs must have at least one slot for Content-Type");
+    }
+    byte[] xmlBytes = java.nio.file.Files.readAllBytes(xmlFile.toPath());
+    PSBinaryFileData[] files = createXmlRequestFileData(xmlFile.getName(), xmlBytes);
+    return Codecs.mpFormDataEncode(opts, files, hdrs);
+  }
+
+  /**
+   * Multipart-encodes form fields plus an in-memory XML document with explicit {@link
+   * #XML_REQUEST_CONTENT_TYPE} on the file part. Used by unit tests and as a convenience for
+   * callers that already have a {@link Document}.
+   *
+   * <p>Package-private for unit tests.
+   *
+   * @param opts form name/value pairs, may be {@code null}
+   * @param doc XML request document, not {@code null}
+   * @param hdrs header array of length &gt;= 1
+   * @return encoded multipart body, never {@code null}
+   * @throws Exception if the document cannot be serialized or encoding fails
+   */
+  static byte[] encodeXmlDocumentMultipart(NVPair[] opts, Document doc, NVPair[] hdrs)
+      throws Exception {
+    if (doc == null) {
+      throw new IllegalArgumentException("doc may not be null");
+    }
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    PSXmlDocumentBuilder.write(doc, bos);
+    byte[] xmlBytes = bos.toByteArray();
+    PSBinaryFileData[] files = createXmlRequestFileData("dpl_request.xml", xmlBytes);
+    return Codecs.mpFormDataEncode(opts, files, hdrs);
+  }
+
+  /**
+   * Returns {@code true} if the multipart body contains a part Content-Type of {@link
+   * #XML_REQUEST_CONTENT_TYPE} or {@code text/xml}. Package-private for unit tests.
+   *
+   * @param multipartBody encoded multipart bytes, not {@code null}
+   * @return whether an XML content-type header is present for a part
+   */
+  static boolean multipartContainsXmlContentType(byte[] multipartBody) {
+    if (multipartBody == null) {
+      return false;
+    }
+    // Multipart encoding uses ISO-8859-1 / 8859_1 for headers (see Codecs).
+    String body = new String(multipartBody, StandardCharsets.ISO_8859_1);
+    String lower = body.toLowerCase(Locale.ROOT);
+    return lower.contains("content-type: application/xml")
+        || lower.contains("content-type: text/xml");
   }
 
   /**

--- a/deployer/src/main/java/com/percussion/deployer/server/PSDeploymentHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSDeploymentHandler.java
@@ -465,8 +465,8 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
       throw new PSDeployException(IPSDeploymentErrors.NULL_INPUT_DOC);
     }
 
-    // Get the list of objects
-    List<PSDeployableObject> depList = new ArrayList<>();
+    // Get the list of objects (typed as PSDependency so iterator assigns cleanly)
+    List<PSDependency> depList = new ArrayList<>();
     PSXmlTreeWalker tree = new PSXmlTreeWalker(doc);
     Element depEl = tree.getNextElement(PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     while (depEl != null) {
@@ -2025,8 +2025,13 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     // get the dependency
     PSDependency dep = getDependencyFromRequestDoc(doc);
-    List ancs =
-        PSDeployComponentUtils.cloneList(m_depMgr.getAncestors(req.getSecurityToken(), dep));
+    // getAncestors is typed as Iterator<IPSDependencyBaseline> on the manager baseline API;
+    // runtime elements are always PSDependency (see PSDependencyManager.getParentDependencies).
+    // Keep explicit cast after #2276 revert so cloneList inference still compiles.
+    @SuppressWarnings("unchecked")
+    Iterator<PSDependency> ancsIter =
+        (Iterator<PSDependency>) (Iterator<?>) m_depMgr.getAncestors(req.getSecurityToken(), dep);
+    List<PSDependency> ancs = PSDeployComponentUtils.cloneList(ancsIter);
 
     // check max count to return
     checkDepCount(ancs.size(), getMaxDepCount(doc.getDocumentElement()));

--- a/deployer/src/test/java/com/percussion/deployer/client/PSDeploymentServerConnectionXmlMultipartTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/client/PSDeploymentServerConnectionXmlMultipartTest.java
@@ -54,13 +54,26 @@ public class PSDeploymentServerConnectionXmlMultipartTest {
   @Test
   public void createXmlRequestFileDataStripsPathAndEnsuresXmlSuffix() {
     byte[] xml = "<root/>".getBytes(StandardCharsets.UTF_8);
-    PSBinaryFileData[] parts =
-        PSDeploymentServerConnection.createXmlRequestFileData("C:\\\\temp\\\\dpl_req", xml);
-    assertEquals(1, parts.length);
-    String name = parts[0].getFileName();
-    assertFalse(name.contains("\\") || name.contains("/"), "basename only: " + name);
-    assertTrue(name.toLowerCase(Locale.ROOT).endsWith(".xml"), name);
-    assertEquals(PSDeploymentServerConnection.XML_REQUEST_CONTENT_TYPE, parts[0].getContentType());
+    // Windows-style path (backslashes)
+    PSBinaryFileData[] winParts =
+        PSDeploymentServerConnection.createXmlRequestFileData("C:\\temp\\dpl_req", xml);
+    assertEquals(1, winParts.length);
+    String winName = winParts[0].getFileName();
+    assertFalse(winName.contains("\\") || winName.contains("/"), "basename only: " + winName);
+    assertTrue(winName.toLowerCase(Locale.ROOT).endsWith(".xml"), winName);
+    assertEquals(
+        PSDeploymentServerConnection.XML_REQUEST_CONTENT_TYPE, winParts[0].getContentType());
+
+    // Unix-style path (forward slashes) — same stripping on both separator families
+    PSBinaryFileData[] unixParts =
+        PSDeploymentServerConnection.createXmlRequestFileData("/tmp/dpl_req", xml);
+    assertEquals(1, unixParts.length);
+    String unixName = unixParts[0].getFileName();
+    assertFalse(unixName.contains("\\") || unixName.contains("/"), "basename only: " + unixName);
+    assertTrue(unixName.toLowerCase(Locale.ROOT).endsWith(".xml"), unixName);
+    assertEquals("dpl_req.xml", unixName);
+    assertEquals(
+        PSDeploymentServerConnection.XML_REQUEST_CONTENT_TYPE, unixParts[0].getContentType());
   }
 
   @Test
@@ -75,7 +88,8 @@ public class PSDeploymentServerConnectionXmlMultipartTest {
     Document doc = PSXmlDocumentBuilder.createXmlDocument();
     Element root = PSXmlDocumentBuilder.createRoot(doc, "PSXDeployConnectRequest");
     root.setAttribute("userId", "admin");
-    root.setAttribute("password", "secret");
+    // Placeholder only — not a real credential (REVIEW.md: no secrets in fixtures)
+    root.setAttribute("password", "test-password");
 
     NVPair[] opts = new NVPair[] {new NVPair("sessionProbe", "1")};
     NVPair[] hdrs = new NVPair[2];

--- a/deployer/src/test/java/com/percussion/deployer/client/PSDeploymentServerConnectionXmlMultipartTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/client/PSDeploymentServerConnectionXmlMultipartTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.deployer.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.HTTPClient.Codecs;
+import com.percussion.HTTPClient.NVPair;
+import com.percussion.HTTPClient.PSBinaryFileData;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Unit tests for Package Installer / deployer client multipart encoding of XML request documents.
+ *
+ * <p>Regression coverage for #955 / #2265: without an explicit XML Content-Type on the file part,
+ * {@code PSFormContentParser} may leave {@code getInputDocument()} null and handlers throw {@code
+ * IPSDeploymentErrors.NULL_INPUT_DOC}.
+ */
+public class PSDeploymentServerConnectionXmlMultipartTest {
+
+  @Test
+  public void createXmlRequestFileDataForcesApplicationXmlContentType() {
+    byte[] xml = "<root/>".getBytes(StandardCharsets.UTF_8);
+    PSBinaryFileData[] parts =
+        PSDeploymentServerConnection.createXmlRequestFileData("dpl_abc123.xml", xml);
+    assertEquals(1, parts.length);
+    assertEquals(PSDeploymentServerConnection.XML_REQUEST_CONTENT_TYPE, parts[0].getContentType());
+    assertEquals("dpl_abc123.xml", parts[0].getFileName());
+    assertEquals("dpl_abc123.xml", parts[0].getFieldName());
+  }
+
+  @Test
+  public void createXmlRequestFileDataStripsPathAndEnsuresXmlSuffix() {
+    byte[] xml = "<root/>".getBytes(StandardCharsets.UTF_8);
+    PSBinaryFileData[] parts =
+        PSDeploymentServerConnection.createXmlRequestFileData("C:\\\\temp\\\\dpl_req", xml);
+    assertEquals(1, parts.length);
+    String name = parts[0].getFileName();
+    assertFalse(name.contains("\\") || name.contains("/"), "basename only: " + name);
+    assertTrue(name.toLowerCase(Locale.ROOT).endsWith(".xml"), name);
+    assertEquals(PSDeploymentServerConnection.XML_REQUEST_CONTENT_TYPE, parts[0].getContentType());
+  }
+
+  @Test
+  public void createXmlRequestFileDataRejectsNullBytes() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSDeploymentServerConnection.createXmlRequestFileData("x.xml", null));
+  }
+
+  @Test
+  public void encodeXmlDocumentMultipartIncludesXmlContentTypeHeader() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = PSXmlDocumentBuilder.createRoot(doc, "PSXDeployConnectRequest");
+    root.setAttribute("userId", "admin");
+    root.setAttribute("password", "secret");
+
+    NVPair[] opts = new NVPair[] {new NVPair("sessionProbe", "1")};
+    NVPair[] hdrs = new NVPair[2];
+    hdrs[1] = new NVPair("PS-Request-Type", "deploy-connect");
+
+    byte[] body = PSDeploymentServerConnection.encodeXmlDocumentMultipart(opts, doc, hdrs);
+
+    assertTrue(
+        PSDeploymentServerConnection.multipartContainsXmlContentType(body),
+        "multipart body must declare application/xml (or text/xml) on the XML part");
+    String asText = new String(body, StandardCharsets.ISO_8859_1);
+    assertTrue(
+        asText.toLowerCase(Locale.ROOT).contains("content-type: application/xml"),
+        "expected explicit application/xml, body headers were:\n" + extractHeaders(asText));
+    assertTrue(asText.contains("PSXDeployConnectRequest"), "XML body must be present");
+    assertTrue(asText.contains("sessionProbe"), "form fields must be present");
+    assertEquals("Content-Type", hdrs[0].getName());
+    assertTrue(
+        hdrs[0].getValue().toLowerCase(Locale.ROOT).startsWith("multipart/form-data"),
+        hdrs[0].getValue());
+  }
+
+  @Test
+  public void encodeWithExplicitContentTypeWinsOverFilenameGuess() throws Exception {
+    // Even if the filename map is empty / wrong, explicit content type on PSBinaryFileData
+    // is what Codecs writes into the part headers.
+    byte[] xml = "<PSXDeployValidateArchiveRequest/>".getBytes(StandardCharsets.UTF_8);
+    PSBinaryFileData[] files =
+        new PSBinaryFileData[] {
+          new PSBinaryFileData(
+              xml,
+              "req",
+              "dpl_no_map.bin", // non-.xml name would not guess as XML
+              PSDeploymentServerConnection.XML_REQUEST_CONTENT_TYPE)
+        };
+    NVPair[] hdrs = new NVPair[1];
+    byte[] body = Codecs.mpFormDataEncode(null, files, hdrs);
+    assertTrue(PSDeploymentServerConnection.multipartContainsXmlContentType(body));
+  }
+
+  private static String extractHeaders(String multipartBody) {
+    StringBuilder sb = new StringBuilder();
+    for (String line : multipartBody.split("\r\n")) {
+      if (line.toLowerCase(Locale.ROOT).startsWith("content-")) {
+        sb.append(line).append('\n');
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/deployer/src/test/java/com/percussion/deployer/server/PSNullInputDocHandlerTest.java
+++ b/deployer/src/test/java/com/percussion/deployer/server/PSNullInputDocHandlerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.deployer.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.percussion.deployer.catalog.server.PSCatalogHandler;
+import com.percussion.error.IPSDeploymentErrors;
+import com.percussion.error.PSDeployException;
+import com.percussion.server.PSRequest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests locking the {@code NULL_INPUT_DOC} (error 8) throw sites that Package Installer can hit
+ * when the multipart XML part is not bound as the request input document.
+ *
+ * <p>Slice 2 of #955 / #2265 — does not remove these guards; documents expected failure when {@link
+ * PSRequest#getInputDocument()} is null.
+ */
+public class PSNullInputDocHandlerTest {
+
+  @Test
+  public void catalogHandlerThrowsNullInputDocWhenDocumentMissing() {
+    PSRequest req = mock(PSRequest.class);
+    when(req.getInputDocument()).thenReturn(null);
+
+    PSDeployException ex =
+        assertThrows(PSDeployException.class, () -> PSCatalogHandler.processRequest(req));
+    assertEquals(IPSDeploymentErrors.NULL_INPUT_DOC, ex.getErrorCode());
+  }
+
+  @Test
+  public void connectThrowsNullInputDocWhenDocumentMissing() {
+    PSRequest req = mock(PSRequest.class);
+    when(req.getInputDocument()).thenReturn(null);
+
+    PSDeploymentHandler handler = new PSDeploymentHandler();
+    PSDeployException ex =
+        assertThrows(PSDeployException.class, () -> handler.connect(req));
+    assertEquals(IPSDeploymentErrors.NULL_INPUT_DOC, ex.getErrorCode());
+  }
+
+  @Test
+  public void validateArchiveThrowsNullInputDocWhenDocumentMissing() {
+    PSRequest req = mock(PSRequest.class);
+    when(req.getInputDocument()).thenReturn(null);
+
+    PSDeploymentHandler handler = new PSDeploymentHandler();
+    PSDeployException ex =
+        assertThrows(PSDeployException.class, () -> handler.validateArchive(req));
+    assertEquals(IPSDeploymentErrors.NULL_INPUT_DOC, ex.getErrorCode());
+  }
+
+  @Test
+  public void connectRejectsNullRequest() {
+    PSDeploymentHandler handler = new PSDeploymentHandler();
+    assertThrows(IllegalArgumentException.class, () -> handler.connect(null));
+  }
+}


### PR DESCRIPTION
## Summary

Minimal client fix for **#2265** (slice 2 of 3 under parent **#955**).

Package Installer install can fail with:

`com.percussion.error.PSDeployException: Input document expected by server, none found.`

(`IPSDeploymentErrors.NULL_INPUT_DOC` / error **8**).

### Root cause (from Slice 1 #2264 / PR #2267)

Server `PSFormContentParser` only calls `setInputDocument` when a multipart part Content-Type is `text/xml` or `application/xml`. Deployer client used `Codecs.mpFormDataEncode` with `NVPair` file paths, so Content-Type came solely from `URLConnection.guessContentTypeFromName` — which can return null or non-XML on some JREs/platforms. The client already builds a non-null XML `Document` for document APIs; the loss is at the encode/parse boundary.

### Fix

- `PSDeploymentServerConnection` encodes deploy/job **XML request documents** via `PSBinaryFileData` with **explicit** `application/xml` Content-Type on the file part (both `execute(Document…)` paths).
- File-only uploads (`saveArchiveFile` / `saveConfigFile`) unchanged — they intentionally have no input document.
- **Do not** remove `NULL_INPUT_DOC` guards.

### Compile unblock (same module)

`perc-deployer` did not compile on current `main` after #2171 typing:

- `getIdTypes`: type dep list as `List<PSDependency>` so `iterator()` matches.
- `loadAncestors`: cast `getAncestors` baseline iterator for `cloneList`.

### Unit tests

- `PSDeploymentServerConnectionXmlMultipartTest` — multipart body includes `Content-Type: application/xml`; explicit CT wins over filename guess.
- `PSNullInputDocHandlerTest` — mock `PSRequest` with null input doc → error 8 from `PSCatalogHandler`, `connect`, `validateArchive`.

## Parent / slices

| Slice | Issue | This PR |
|-------|-------|---------|
| 1 Inventory + repro | #2264 | #2267 |
| 2 Minimal fix + unit tests | #2265 | **this PR** |
| 3 Residual install smoke | #2266 | later |

## Test plan

- [x] `cd deployer && ../mvnw clean install` — BUILD SUCCESS (166 tests, 0 failures; 9 new tests green)
- [x] Focused: `-Dtest=PSDeploymentServerConnectionXmlMultipartTest,PSNullInputDocHandlerTest`
- [ ] Live Package Installer install against CMS (Slice 3 / #2266 / human)

## Gates evidence

- **Change class:** installer/deployer client multipart encode for XML request docs + unit tests
- **Module `mvnw clean install`:** `deployer` standalone — SUCCESS
- **Erlang:** no null-check removal; portable basename stripping (`/` and `\`); behavioral tests for encode path and throw sites; file-only upload path untouched
- **No live E2E** per issue scope (Slice 3)

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2265  
Partial for #955 (slice 2/3)  
Parent tracker: #955  
Informed by: #2264 / #2267  
Next: #2266 residual install smoke

> Co-Authored by Grok Build using grok-4.5 with agent main.