### PR TITLE
Revert PR #2171: fix perc-deployer compile failure from rawtype parameterization

### DIFF
--- a/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResult.java
+++ b/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResult.java
@@ -198,7 +198,7 @@ public class PSCatalogResult implements IPSDeployComponent, Comparable<PSCatalog
       }
 
       while (column != null) {
-        String data = PSXmlTreeWalker.getElementData(column);
+        String data = tree.getElementData(column);
         String typeString = PSDeployComponentUtils.getRequiredAttribute(column, XML_COL_TYPE_ATTR);
         int type = PSCatalogResultColumn.getType(typeString);
         if (PSCatalogResultColumn.validateType(type)) {

--- a/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResultColumn.java
+++ b/deployer/src/main/java/com/percussion/deployer/catalog/PSCatalogResultColumn.java
@@ -89,7 +89,7 @@ public class PSCatalogResultColumn implements IPSDeployComponent {
 
     if (obj == null) throw new IllegalArgumentException("obj may not be null.");
 
-    Integer colType = ms_typeObjects.get(obj.getClass());
+    Integer colType = (Integer) ms_typeObjects.get(obj.getClass());
     if (colType != null) {
       return colType.intValue() == type;
     } else return false;
@@ -105,7 +105,7 @@ public class PSCatalogResultColumn implements IPSDeployComponent {
    */
   static String getTypeString(Object obj) {
     if (obj == null) throw new IllegalArgumentException("obj may not be null.");
-    Integer type = ms_typeObjects.get(obj.getClass());
+    Integer type = (Integer) ms_typeObjects.get(obj.getClass());
     if (type != null) return TYPE_ENUM[type.intValue()];
     else throw new IllegalArgumentException("obj is not a supported column type object");
   }

--- a/deployer/src/main/java/com/percussion/deployer/catalog/server/PSCatalogHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/catalog/server/PSCatalogHandler.java
@@ -91,7 +91,7 @@ public class PSCatalogHandler {
     for (var i = 0; i < children.getLength(); i++) {
       var child = children.item(i);
       if (child instanceof Element element) {
-        props.setProperty(element.getTagName(), PSXmlTreeWalker.getElementData(child));
+        props.setProperty(element.getTagName(), tree.getElementData(child));
       }
     }
 
@@ -372,10 +372,10 @@ public class PSCatalogHandler {
       throws PSDeployException, PSNotFoundException {
     if (props == null
         || props.getProperty("type") == null
-        || props.getProperty("type").trim().length() == 0)
+        || ((String) props.getProperty("type")).trim().length() == 0)
       throw new PSDeployException(IPSDeploymentErrors.CATALOG_REQD_PROP_NOT_SPECIFIED, "type");
 
-    String type = props.getProperty("type");
+    String type = (String) props.getProperty("type");
     PSCatalogResultSet typeObjects = new PSCatalogResultSet();
     PSDependencyManager mgr = (PSDependencyManager) ms_depHandler.getDependencyManager();
     mgr.getDependencies(tok, type)

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSApplicationIDTypes.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSApplicationIDTypes.java
@@ -207,11 +207,10 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
     if (ctx == null) throw new IllegalArgumentException("ctx may not be null");
 
     PSApplicationIDTypeMapping mapping = null;
-    List<PSApplicationIDTypeMapping> idTypeList =
-        getIdTypeMappingsList(resourceName, elementName, false);
-    Iterator<PSApplicationIDTypeMapping> mappings = idTypeList.iterator();
+    List idTypeList = getIdTypeMappingsList(resourceName, elementName, false);
+    Iterator mappings = idTypeList.iterator();
     while (mappings.hasNext() && mapping == null) {
-      PSApplicationIDTypeMapping test = mappings.next();
+      PSApplicationIDTypeMapping test = (PSApplicationIDTypeMapping) mappings.next();
       if (ctx.equals(test.getContext())) mapping = test;
     }
 
@@ -224,9 +223,9 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
    * @return <code>true</code> if all IDs have been mapped to a type.
    */
   public boolean isComplete() {
-    Iterator<String> resList = m_resourceMap.keySet().iterator();
+    Iterator resList = m_resourceMap.keySet().iterator();
     while (resList.hasNext()) {
-      if (!isComplete(resList.next())) return false;
+      if (!isComplete((String) resList.next())) return false;
     }
     return true;
   }
@@ -245,10 +244,10 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
 
     // Get the whole list, but do the check here, so that we don't walk
     // through the whole list, less expensive
-    Iterator<String> elemList = getElementList(resourceName, false);
+    Iterator elemList = getElementList(resourceName, false);
 
     while (elemList.hasNext()) {
-      if (!isComplete(resourceName, elemList.next())) return false;
+      if (!isComplete(resourceName, (String) elemList.next())) return false;
     }
     return true;
   }
@@ -276,7 +275,6 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
    *     may not be <code>null</code>.
    * @throws IllegalArgumentException if any parameter is invalid.
    */
-  @SuppressWarnings({"rawtypes", "unchecked"})
   public void addMappings(String resourceName, String elementName, Iterator mappings) {
     if (resourceName == null || resourceName.trim().length() == 0)
       throw new IllegalArgumentException("resourceName may not be null or empty");
@@ -310,20 +308,20 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
 
     if (mapping == null) throw new IllegalArgumentException("mapping may not be null");
 
-    Map<String, List<PSApplicationIDTypeMapping>> resElements = m_resourceMap.get(resourceName);
+    Map resElements = (Map) m_resourceMap.get(resourceName);
     if (resElements == null) // add a new resource/element name
     {
-      List<PSApplicationIDTypeMapping> idtypeList = new ArrayList<>();
+      List idtypeList = new ArrayList();
       idtypeList.add(mapping);
-      Map<String, List<PSApplicationIDTypeMapping>> elemMap = new HashMap<>();
+      Map elemMap = new HashMap();
       elemMap.put(elementName, idtypeList);
       m_resourceMap.put(resourceName, elemMap);
     } else // append to existing list
     {
-      List<PSApplicationIDTypeMapping> idTypeList = resElements.get(elementName);
+      List idTypeList = (List) resElements.get(elementName);
       if (idTypeList == null) // add a new element in current resource
       {
-        idTypeList = new ArrayList<>();
+        idTypeList = new ArrayList();
         idTypeList.add(mapping);
         resElements.put(elementName, idTypeList);
       } else // add to existing ID Type mapping list
@@ -349,12 +347,12 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
   public PSApplicationIDTypeMapping removeMapping(
       String resource, String element, PSApplicationIdContext ctx) {
     // NOTE: getIdTypeMappings() will check the parameters
-    List<PSApplicationIDTypeMapping> idTypeList = getIdTypeMappingsList(resource, element);
-    Iterator<PSApplicationIDTypeMapping> idTypeIterator = idTypeList.iterator();
+    List idTypeList = getIdTypeMappingsList(resource, element);
+    Iterator idTypeIterator = idTypeList.iterator();
 
     PSApplicationIDTypeMapping result = null;
     while (idTypeIterator.hasNext() && result == null) {
-      PSApplicationIDTypeMapping currIDType = idTypeIterator.next();
+      PSApplicationIDTypeMapping currIDType = (PSApplicationIDTypeMapping) idTypeIterator.next();
       if (ctx.equals(currIDType.getContext())) {
         idTypeList.remove(currIDType);
         // clear listeners
@@ -364,7 +362,7 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
 
       // clean up map entries
       if (idTypeList.isEmpty()) {
-        Map<String, List<PSApplicationIDTypeMapping>> elementMap = m_resourceMap.get(resource);
+        Map elementMap = (Map) m_resourceMap.get(resource);
         if (elementMap != null) elementMap.remove(element);
         if (elementMap.isEmpty()) m_resourceMap.remove(resource);
       }
@@ -384,11 +382,11 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
    * @throws IllegalArgumentException If any param is invalid.
    */
   public boolean containsMapping(String resource, String element, PSApplicationIdContext ctx) {
-    List<PSApplicationIDTypeMapping> idTypeList = getIdTypeMappingsList(resource, element);
-    Iterator<PSApplicationIDTypeMapping> idTypeIterator = idTypeList.iterator();
+    List idTypeList = getIdTypeMappingsList(resource, element);
+    Iterator idTypeIterator = idTypeList.iterator();
 
     while (idTypeIterator.hasNext()) {
-      PSApplicationIDTypeMapping currIDType = idTypeIterator.next();
+      PSApplicationIDTypeMapping currIDType = (PSApplicationIDTypeMapping) idTypeIterator.next();
       if (ctx.equals(currIDType.getContext())) return true;
     }
 
@@ -414,7 +412,6 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
    *     never <code>null</code>. Supplied map may not be <code>null</code>. Must have at least one
    *     entry.
    */
-  @SuppressWarnings({"rawtypes", "unchecked"})
   public void setChoiceFilters(Map filters) {
     if (filters != null && filters.isEmpty())
       throw new IllegalArgumentException("filters may not be empty");
@@ -424,21 +421,20 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
     // fixup mappings based on filters if provided
     if (m_choiceFilters == null) return;
 
-    Iterator<Map<String, List<PSApplicationIDTypeMapping>>> resources =
-        m_resourceMap.values().iterator();
+    Iterator resources = m_resourceMap.values().iterator();
     while (resources.hasNext()) {
-      Map<String, List<PSApplicationIDTypeMapping>> elementMap = resources.next();
-      Iterator<List<PSApplicationIDTypeMapping>> elements = elementMap.values().iterator();
+      Map elementMap = (Map) resources.next();
+      Iterator elements = elementMap.values().iterator();
       while (elements.hasNext()) {
-        List<PSApplicationIDTypeMapping> mappingList = elements.next();
-        Iterator<PSApplicationIDTypeMapping> mappings = mappingList.iterator();
+        List mappingList = (List) elements.next();
+        Iterator mappings = mappingList.iterator();
         while (mappings.hasNext()) {
-          PSApplicationIDTypeMapping mapping = mappings.next();
+          PSApplicationIDTypeMapping mapping = (PSApplicationIDTypeMapping) mappings.next();
 
           // only care if not undefined and set to an actual type
           if (mapping.isComplete() && mapping.isIdType()) {
             String id = mapping.getValue();
-            List<String> types = m_choiceFilters.get(id);
+            List types = (List) m_choiceFilters.get(id);
 
             // if we have a filter and the current type isn't in it, set
             // to undefined
@@ -457,7 +453,7 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
    *     that all ids in the filter map are included in the mappings held by this object, or that
    *     all mappings have corresponding ids in the filter map. Never empty.
    */
-  public Map<String, List<String>> getChoiceFilters() {
+  public Map getChoiceFilters() {
     return m_choiceFilters;
   }
 
@@ -522,12 +518,10 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
     Element root = doc.createElement(XML_NODE_NAME);
     root.appendChild(m_dep.toXml(doc));
 
-    Iterator<Map.Entry<String, Map<String, List<PSApplicationIDTypeMapping>>>> resEntryList =
-        m_resourceMap.entrySet().iterator();
+    Iterator resEntryList = m_resourceMap.entrySet().iterator();
     while (resEntryList.hasNext()) {
-      Map.Entry<String, Map<String, List<PSApplicationIDTypeMapping>>> resEntry =
-          resEntryList.next();
-      Element resXml = toXmlResource(resEntry.getKey(), resEntry.getValue(), doc);
+      Map.Entry resEntry = (Map.Entry) resEntryList.next();
+      Element resXml = toXmlResource((String) resEntry.getKey(), (Map) resEntry.getValue(), doc);
 
       root.appendChild(resXml);
     }
@@ -572,7 +566,7 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
     while (resEl != null) {
       String resName = PSDeployComponentUtils.getRequiredAttribute(resEl, XML_ATTR_RESOURCE_NAME);
 
-      Map<String, List<PSApplicationIDTypeMapping>> elemMap = getMappingElementsFromXml(tree);
+      Map elemMap = getMappingElementsFromXml(tree);
       m_resourceMap.put(resName, elemMap);
 
       tree.setCurrent(resEl); // get back to previous position
@@ -643,16 +637,15 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
    * @param doc The Document for creating XML Element. Assumed not <code>null</code>.
    * @return the newly created XML Element
    */
-  private Element toXmlResource(
-      String resName, Map<String, List<PSApplicationIDTypeMapping>> resElement, Document doc) {
+  private Element toXmlResource(String resName, Map resElement, Document doc) {
     Element root = doc.createElement(XML_NODE_MAPPING_RESOURCE);
     root.setAttribute(XML_ATTR_RESOURCE_NAME, resName);
 
-    Iterator<Map.Entry<String, List<PSApplicationIDTypeMapping>>> elemEntryList =
-        resElement.entrySet().iterator();
+    Iterator elemEntryList = resElement.entrySet().iterator();
     while (elemEntryList.hasNext()) {
-      Map.Entry<String, List<PSApplicationIDTypeMapping>> elemEntry = elemEntryList.next();
-      Element elemXml = toXmlMappingElement(elemEntry.getKey(), elemEntry.getValue(), doc);
+      Map.Entry elemEntry = (Map.Entry) elemEntryList.next();
+      Element elemXml =
+          toXmlMappingElement((String) elemEntry.getKey(), (List) elemEntry.getValue(), doc);
 
       root.appendChild(elemXml);
     }
@@ -673,14 +666,13 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
    * @param doc The Document for creating XML Element. Assumed not <code>null</code>.
    * @return the newly created XML Element, never <code>null</code>
    */
-  private Element toXmlMappingElement(
-      String elementName, List<PSApplicationIDTypeMapping> mappingList, Document doc) {
+  private Element toXmlMappingElement(String elementName, List mappingList, Document doc) {
     Element root = doc.createElement(XML_NODE_MAPPING_ELEMENT);
     root.setAttribute(XML_ATTR_ELEMENT_NAME, elementName);
 
-    Iterator<PSApplicationIDTypeMapping> idtypeList = mappingList.iterator();
+    Iterator idtypeList = mappingList.iterator();
     while (idtypeList.hasNext()) {
-      PSApplicationIDTypeMapping idtype = idtypeList.next();
+      PSApplicationIDTypeMapping idtype = (PSApplicationIDTypeMapping) idtypeList.next();
 
       root.appendChild(idtype.toXml(doc));
     }
@@ -696,20 +688,20 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
    * @param doc The document to use, assumed not <code>null</code>.
    * @return The element, never <code>null</code>.
    */
-  private Element toXmlFilters(Map<String, List<String>> filterMap, Document doc) {
+  private Element toXmlFilters(Map filterMap, Document doc) {
     Element root = doc.createElement(XML_NODE_CHOICE_FILTERS);
 
-    Iterator<Map.Entry<String, List<String>>> filters = filterMap.entrySet().iterator();
+    Iterator filters = filterMap.entrySet().iterator();
     while (filters.hasNext()) {
-      Map.Entry<String, List<String>> filterEntry = filters.next();
+      Map.Entry filterEntry = (Map.Entry) filters.next();
       Element filter = PSXmlDocumentBuilder.addEmptyElement(doc, root, XML_NODE_FILTER);
-      filter.setAttribute(XML_ATTR_FILTER_ID, filterEntry.getKey());
-      List<String> typeVal = filterEntry.getValue();
-      if (typeVal != null) {
-        Iterator<String> types = typeVal.iterator();
+      filter.setAttribute(XML_ATTR_FILTER_ID, filterEntry.getKey().toString());
+      Object typeVal = filterEntry.getValue();
+      if (typeVal instanceof List) {
+        Iterator types = ((List) typeVal).iterator();
         while (types.hasNext()) {
           filter.appendChild(
-              PSXmlDocumentBuilder.addElement(doc, filter, XML_NODE_TYPE, types.next()));
+              PSXmlDocumentBuilder.addElement(doc, filter, XML_NODE_TYPE, types.next().toString()));
         }
       }
     }
@@ -724,8 +716,7 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
    * @return A list of element in a <code>Map</code>. It will not be <code>null</code>
    * @throws PSUnknownNodeTypeException <code>source</code> is malformed.
    */
-  private Map<String, List<PSApplicationIDTypeMapping>> getMappingElementsFromXml(
-      PSXmlTreeWalker tree) throws PSUnknownNodeTypeException {
+  private Map getMappingElementsFromXml(PSXmlTreeWalker tree) throws PSUnknownNodeTypeException {
     // walk the element in current resource
     Element elemEl = tree.getNextElement(XML_NODE_MAPPING_ELEMENT, FIRST_FLAGS);
     // need to have at least one
@@ -733,11 +724,11 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
       throw new PSUnknownNodeTypeException(
           IPSObjectStoreErrors.XML_ELEMENT_NULL, XML_NODE_MAPPING_ELEMENT);
     }
-    Map<String, List<PSApplicationIDTypeMapping>> elemMap = new HashMap<>();
+    Map elemMap = new HashMap();
 
     while (elemEl != null) {
       String elemName = PSDeployComponentUtils.getRequiredAttribute(elemEl, XML_ATTR_ELEMENT_NAME);
-      List<PSApplicationIDTypeMapping> idTypeList = getMappingListFromXml(tree);
+      List idTypeList = getMappingListFromXml(tree);
       elemMap.put(elemName, idTypeList);
       tree.setCurrent(elemEl);
       elemEl = tree.getNextElement(XML_NODE_MAPPING_ELEMENT, NEXT_FLAGS);
@@ -753,8 +744,7 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
    *     never be <code>null</code> or empty.
    * @throws PSUnknownNodeTypeException <code>source</code> is malformed.
    */
-  private List<PSApplicationIDTypeMapping> getMappingListFromXml(PSXmlTreeWalker tree)
-      throws PSUnknownNodeTypeException {
+  private List getMappingListFromXml(PSXmlTreeWalker tree) throws PSUnknownNodeTypeException {
     // walk the mapping list in current element
     Element mappingEl = tree.getNextElement(PSApplicationIDTypeMapping.XML_NODE_NAME, FIRST_FLAGS);
     // need to have at least one
@@ -762,7 +752,7 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
       throw new PSUnknownNodeTypeException(
           IPSObjectStoreErrors.XML_ELEMENT_NULL, PSApplicationIDTypeMapping.XML_NODE_NAME);
     }
-    List<PSApplicationIDTypeMapping> mappingList = new ArrayList<>();
+    List mappingList = new ArrayList();
 
     while (mappingEl != null) {
       // need to set change listeners
@@ -783,9 +773,8 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
    * @return The map, never <code>null</code> or empty.
    * @throws PSUnknownNodeTypeException if there xml format is invalid.
    */
-  private Map<String, List<String>> getFiltersFromXml(PSXmlTreeWalker tree)
-      throws PSUnknownNodeTypeException {
-    Map<String, List<String>> filterMap = new HashMap<>();
+  private Map getFiltersFromXml(PSXmlTreeWalker tree) throws PSUnknownNodeTypeException {
+    Map filterMap = new HashMap();
 
     // must have at least one filter
     Element filterEl = tree.getNextElement(XML_NODE_FILTER, FIRST_FLAGS);
@@ -794,7 +783,7 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
     }
 
     while (filterEl != null) {
-      List<String> typeList = new ArrayList<>();
+      List typeList = new ArrayList();
 
       String id = PSXMLDomUtil.checkAttribute(filterEl, XML_ATTR_FILTER_ID, true);
 
@@ -869,11 +858,11 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
    * @return <code>true</code> if one of the object (<code>PSApplicationIDTypeMapping</code>) does
    *     not have a type; otherwise <code>false</code>.
    */
-  private boolean hasInCompleteIdTypes(List<PSApplicationIDTypeMapping> idTypeList) {
-    Iterator<PSApplicationIDTypeMapping> itIDTypes = idTypeList.iterator();
+  private boolean hasInCompleteIdTypes(List idTypeList) {
+    Iterator itIDTypes = idTypeList.iterator();
 
     while (itIDTypes.hasNext()) {
-      PSApplicationIDTypeMapping idType = itIDTypes.next();
+      PSApplicationIDTypeMapping idType = (PSApplicationIDTypeMapping) itIDTypes.next();
       if (!idType.hasDefinedType()) return true;
     }
     return false;
@@ -888,11 +877,10 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
    *     not <code>null</code>.
    * @param idTypeList The list of mappings to use, assumed not <code>null</code>.
    */
-  private void setContextListeners(
-      PSApplicationIDTypeMapping mapping, List<PSApplicationIDTypeMapping> idTypeList) {
-    Iterator<PSApplicationIDTypeMapping> types = idTypeList.iterator();
+  private void setContextListeners(PSApplicationIDTypeMapping mapping, List idTypeList) {
+    Iterator types = idTypeList.iterator();
     while (types.hasNext()) {
-      PSApplicationIDTypeMapping otherMapping = types.next();
+      PSApplicationIDTypeMapping otherMapping = (PSApplicationIDTypeMapping) types.next();
       mapping.getContext().setListeners(otherMapping.getContext());
     }
   }
@@ -906,11 +894,10 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
    *     assumed not <code>null</code>.
    * @param idTypeList The list of mappings to use, assumed not <code>null</code>.
    */
-  private void clearContextListeners(
-      PSApplicationIDTypeMapping mapping, List<PSApplicationIDTypeMapping> idTypeList) {
-    Iterator<PSApplicationIDTypeMapping> types = idTypeList.iterator();
+  private void clearContextListeners(PSApplicationIDTypeMapping mapping, List idTypeList) {
+    Iterator types = idTypeList.iterator();
     while (types.hasNext()) {
-      PSApplicationIDTypeMapping otherMapping = types.next();
+      PSApplicationIDTypeMapping otherMapping = (PSApplicationIDTypeMapping) types.next();
       mapping.getContext().clearListeners(otherMapping.getContext());
     }
   }
@@ -956,7 +943,7 @@ public class PSApplicationIDTypes implements IPSDeployComponent {
    * Map of possible type choices for literal ids found in this map. Initially <code>null</code>,
    * set by calls to {@link #setChoiceFilters(Object)}.
    */
-  private Map<String, List<String>> m_choiceFilters = null;
+  private Map m_choiceFilters = null;
 
   /** flags to walk to a child node of a XML tree */
   private static final int FIRST_FLAGS =

--- a/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependency.java
+++ b/deployer/src/main/java/com/percussion/deployer/objectstore/PSDependency.java
@@ -42,7 +42,7 @@ import org.w3c.dom.Element;
  * application, exit, etc.
  */
 public abstract class PSDependency
-    implements IPSDependencyBaseline, IPSDeployComponent, Comparable<PSDependency> {
+    implements IPSDependencyBaseline, IPSDeployComponent, Comparable {
 
   private static final Logger log = LogManager.getLogger(PSDependency.class);
 
@@ -302,18 +302,17 @@ public abstract class PSDependency
    * @throws IllegalArgumentException if <code>dependencies</code> contains a <code>null</code>
    *     element.
    */
-  @SuppressWarnings({"rawtypes", "unchecked"})
   public void setDependencies(Iterator dependencies) {
     if (m_dependencies != null) {
       // clear the parent dependency on any current children
-      for (Iterator<PSDependency> children = m_dependencies.iterator(); children.hasNext(); ) {
-        PSDependency child = children.next();
+      for (Iterator children = m_dependencies.iterator(); children.hasNext(); ) {
+        PSDependency child = (PSDependency) children.next();
         child.setParentDependency(null);
       }
     }
     if (dependencies == null) m_dependencies = null;
     else {
-      m_dependencies = new TreeSet<>();
+      m_dependencies = new TreeSet();
       while (dependencies.hasNext()) {
         PSDependency dep = (PSDependency) dependencies.next();
         if (dep == null)
@@ -377,7 +376,7 @@ public abstract class PSDependency
   public String printDependencyTree() {
     StringBuilder buf = new StringBuilder();
 
-    printDependencyTree(buf, new ArrayList<PSDependency>(), "");
+    printDependencyTree(buf, new ArrayList(), "");
 
     return buf.toString();
   }
@@ -552,9 +551,9 @@ public abstract class PSDependency
 
     boolean removed = false;
 
-    Iterator<PSDependency> deps = m_dependencies.iterator();
+    Iterator deps = m_dependencies.iterator();
     while (deps.hasNext() && !removed) {
-      PSDependency dep = deps.next();
+      PSDependency dep = (PSDependency) deps.next();
       if (dep.getDependencyType() == PSDependency.TYPE_USER) {
         PSUserDependency userDep = (PSUserDependency) dep;
         if (userDep.getPath().getPath().equals(path.getPath())) {
@@ -690,7 +689,7 @@ public abstract class PSDependency
 
     if (dep.getKey().equals(getKey())) found = true;
     else {
-      List<PSDependency> checked = new ArrayList<>();
+      List checked = new ArrayList();
       found = containsDependency(dep, checked);
     }
 
@@ -748,8 +747,8 @@ public abstract class PSDependency
       }
     } else {
       // search all dependencies
-      List<PSDependency> checked = new ArrayList<>();
-      List<PSDependency> parentStack = new ArrayList<>();
+      List checked = new ArrayList();
+      List parentStack = new ArrayList();
       included = includesDependency(dep, sameInstance, parentStack, checked);
     }
     return included;
@@ -777,10 +776,10 @@ public abstract class PSDependency
    * @throws IllegalArgumentException if obj is <code>null</code>
    * @throws ClassCastException if obj is not an instance of PSDependency.
    */
-  @Override
-  public int compareTo(PSDependency dep) {
-    if (dep == null) throw new IllegalArgumentException("dep may not be null");
+  public int compareTo(Object obj) {
+    if (obj == null) throw new IllegalArgumentException("obj may not be null");
 
+    PSDependency dep = (PSDependency) obj;
     int result = getDisplayIdentifier().compareToIgnoreCase(dep.getDisplayIdentifier());
     if (result == 0) result = getDependencyId().compareToIgnoreCase(dep.getDependencyId());
 
@@ -822,10 +821,10 @@ public abstract class PSDependency
    * @return <code>true</code> if <code>dep</code> is one of this dependency's children,
    *     recursively, <code>false</code> otherwise.
    */
-  private boolean containsDependency(PSDependency dep, List<PSDependency> checked) {
-    Iterator<PSDependency> checkedDeps = checked.iterator();
+  private boolean containsDependency(PSDependency dep, List checked) {
+    Iterator checkedDeps = checked.iterator();
     while (checkedDeps.hasNext()) {
-      PSDependency checkedDep = checkedDeps.next();
+      PSDependency checkedDep = (PSDependency) checkedDeps.next();
       if (checkedDep == this) return false;
     }
     checked.add(this);
@@ -835,9 +834,9 @@ public abstract class PSDependency
     if (m_dependencies != null) {
       // first check each child dep
       String depKey = dep.getKey();
-      Iterator<PSDependency> deps = m_dependencies.iterator();
+      Iterator deps = m_dependencies.iterator();
       while (deps.hasNext() && !found) {
-        PSDependency childDep = deps.next();
+        PSDependency childDep = (PSDependency) deps.next();
         if (depKey.equals(childDep.getKey())) found = true;
       }
 
@@ -845,7 +844,7 @@ public abstract class PSDependency
       if (!found) {
         deps = m_dependencies.iterator();
         while (deps.hasNext() && !found) {
-          PSDependency child = deps.next();
+          PSDependency child = (PSDependency) deps.next();
           found = child.containsDependency(dep, checked);
         }
       }
@@ -869,13 +868,10 @@ public abstract class PSDependency
    * @return <code>true</code> if the supplied dep is included, <code>false</code> otherwise.
    */
   private boolean includesDependency(
-      PSDependency dep,
-      boolean sameInstance,
-      List<PSDependency> parentStack,
-      List<PSDependency> checked) {
-    Iterator<PSDependency> checkedDeps = checked.iterator();
+      PSDependency dep, boolean sameInstance, List parentStack, List checked) {
+    Iterator checkedDeps = checked.iterator();
     while (checkedDeps.hasNext()) {
-      PSDependency checkedDep = checkedDeps.next();
+      PSDependency checkedDep = (PSDependency) checkedDeps.next();
       if (checkedDep == this) return false;
     }
     checked.add(this);
@@ -889,9 +885,9 @@ public abstract class PSDependency
     if ((sameInstance && this == dep) || (!sameInstance && getKey().equals(dep.getKey()))) {
       // if local, walk back up the parent stack to first non-local
       if (getDependencyType() == PSDependency.TYPE_LOCAL) {
-        Iterator<PSDependency> parents = parentStack.iterator();
+        Iterator parents = parentStack.iterator();
         while (parents.hasNext()) {
-          PSDependency parent = parents.next();
+          PSDependency parent = (PSDependency) parents.next();
           if (parent.getDependencyType() != PSDependency.TYPE_LOCAL) {
             included = parent.isIncluded();
             break;
@@ -908,9 +904,9 @@ public abstract class PSDependency
       parentStack.add(0, this);
 
       // check each child dep
-      Iterator<PSDependency> deps = m_dependencies.iterator();
+      Iterator deps = m_dependencies.iterator();
       while (deps.hasNext() && !included) {
-        PSDependency child = deps.next();
+        PSDependency child = (PSDependency) deps.next();
         included = child.includesDependency(dep, sameInstance, parentStack, checked);
       }
 
@@ -949,9 +945,9 @@ public abstract class PSDependency
   public int getChildCount(boolean includedOnly) {
     int count = 0;
     if (m_dependencies != null) {
-      Iterator<PSDependency> deps = m_dependencies.iterator();
+      Iterator deps = m_dependencies.iterator();
       while (deps.hasNext()) {
-        PSDependency dep = deps.next();
+        PSDependency dep = (PSDependency) deps.next();
         if (!(dep instanceof PSDeployableElement)) {
           if ((includedOnly && dep.isIncluded()) || !includedOnly) count++;
         }
@@ -1010,10 +1006,10 @@ public abstract class PSDependency
    */
   public boolean containsIncludedDependency() {
     boolean hasIncluded = false;
-    Iterator<PSDependency> deps = getDependencies();
+    Iterator deps = getDependencies();
     if (deps != null) {
       while (deps.hasNext() && !hasIncluded) {
-        PSDependency dep = deps.next();
+        PSDependency dep = (PSDependency) deps.next();
         if (dep instanceof PSDeployableElement) continue;
         hasIncluded = (dep.getDependencyType() != PSDependency.TYPE_LOCAL) && dep.isIncluded();
         if (!hasIncluded) hasIncluded = dep.containsIncludedDependency();
@@ -1108,18 +1104,18 @@ public abstract class PSDependency
 
     if (m_dependencies != null) {
       Element deps = PSXmlDocumentBuilder.addEmptyElement(doc, root, XML_EL_DEPENDENCIES);
-      Iterator<PSDependency> i = m_dependencies.iterator();
+      Iterator i = m_dependencies.iterator();
       while (i.hasNext()) {
-        PSDependency dep = i.next();
+        PSDependency dep = (PSDependency) i.next();
         deps.appendChild(dep.toXml(doc));
       }
     }
 
     if (m_ancestors != null) {
       Element ancs = PSXmlDocumentBuilder.addEmptyElement(doc, root, XML_EL_ANCESTORS);
-      Iterator<PSDependency> i = m_ancestors.iterator();
+      Iterator i = m_ancestors.iterator();
       while (i.hasNext()) {
-        PSDependency dep = i.next();
+        PSDependency dep = (PSDependency) i.next();
         ancs.appendChild(dep.toXml(doc));
       }
     }
@@ -1188,7 +1184,7 @@ public abstract class PSDependency
     m_dependencies = null;
     Element deps = tree.getNextElement(XML_EL_DEPENDENCIES, firstFlags);
     if (deps != null) {
-      m_dependencies = new TreeSet<>();
+      m_dependencies = new TreeSet();
       Element dep = tree.getNextElement(firstFlags);
       while (dep != null) {
         PSDependency depObj;
@@ -1215,7 +1211,7 @@ public abstract class PSDependency
     m_ancestors = null;
     Element ancs = tree.getNextElement(XML_EL_ANCESTORS, firstFlags);
     if (ancs != null) {
-      m_ancestors = new TreeSet<>();
+      m_ancestors = new TreeSet();
       Element dep = tree.getNextElement(firstFlags);
       while (dep != null) {
         PSDependency depObj;
@@ -1266,13 +1262,13 @@ public abstract class PSDependency
 
     if (dep.m_ancestors == null) m_ancestors = null;
     else {
-      m_ancestors = new TreeSet<>();
+      m_ancestors = new TreeSet();
       m_ancestors.addAll(dep.m_ancestors);
     }
 
     if (dep.m_dependencies == null) m_dependencies = null;
     else {
-      m_dependencies = new TreeSet<>();
+      m_dependencies = new TreeSet();
       m_dependencies.addAll(dep.m_dependencies);
     }
   }

--- a/deployer/src/main/java/com/percussion/deployer/server/PSDeploymentHandler.java
+++ b/deployer/src/main/java/com/percussion/deployer/server/PSDeploymentHandler.java
@@ -253,7 +253,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     respDoc.appendChild(newRoot);
 
     // get the elements
-    Iterator<PSDependency> deps = m_depMgr.getDependencies(req.getSecurityToken(), type);
+    Iterator deps = m_depMgr.getDependencies(req.getSecurityToken(), type);
     while (deps.hasNext()) {
       Object o = deps.next();
 
@@ -299,9 +299,9 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     respDoc.appendChild(newRoot);
 
     // get the elements
-    Iterator<PSDependency> deps = m_depMgr.getDependencies(req.getSecurityToken(), type, parentId);
+    Iterator deps = m_depMgr.getDependencies(req.getSecurityToken(), type, parentId);
     while (deps.hasNext()) {
-      PSDependency dep = deps.next();
+      PSDependency dep = (PSDependency) deps.next();
       newRoot.appendChild(dep.toXml(respDoc));
     }
 
@@ -482,7 +482,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     // if no dependencies, get all dependencies that support id types and are
     // deployable.
-    Iterator<PSDependency> deps;
+    Iterator deps;
     if (depList.isEmpty())
       deps =
           m_depMgr.getDependencies(
@@ -491,14 +491,13 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     else deps = depList.iterator();
 
     // get the types for all dependencies in our list
-    Iterator<PSApplicationIDTypes> types =
-        PSIdTypeManager.loadIdTypes(req.getSecurityToken(), deps);
+    Iterator types = PSIdTypeManager.loadIdTypes(req.getSecurityToken(), deps);
 
     // create the response
     Document respDoc = PSXmlDocumentBuilder.createXmlDocument();
     Element root = PSXmlDocumentBuilder.createRoot(respDoc, "PSXDeployGetIdTypesResponse");
     while (types.hasNext()) {
-      PSApplicationIDTypes type = types.next();
+      PSApplicationIDTypes type = (PSApplicationIDTypes) types.next();
       root.appendChild(type.toXml(respDoc));
     }
 
@@ -1570,7 +1569,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     IPSDeployComponent comp = null;
     try {
-      Constructor<?> compCtor = compClass.getConstructor(new Class<?>[] {Element.class});
+      Constructor compCtor = compClass.getConstructor(new Class[] {Element.class});
       comp = (IPSDeployComponent) compCtor.newInstance(new Object[] {compEl});
     } catch (Exception e) {
       if (e instanceof PSUnknownNodeTypeException) {
@@ -1981,7 +1980,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     // get the dependency
     PSDependency dep = getDependencyFromRequestDoc(doc);
-    List<PSDependency> deps =
+    List deps =
         PSDeployComponentUtils.cloneList(m_depMgr.getDependencies(req.getSecurityToken(), dep));
 
     // check max count to return
@@ -2026,7 +2025,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     // get the dependency
     PSDependency dep = getDependencyFromRequestDoc(doc);
-    List<PSDependency> ancs =
+    List ancs =
         PSDeployComponentUtils.cloneList(m_depMgr.getAncestors(req.getSecurityToken(), dep));
 
     // check max count to return
@@ -2342,7 +2341,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     if (req == null) throw new IllegalArgumentException(NULL_REQUEST_ERROR);
 
     // get the file to save
-    Iterator<?> params = req.getParametersIterator();
+    Iterator params = req.getParametersIterator();
 
     String archiveRef = req.getParameter("archiveRef");
     if (archiveRef == null || archiveRef.trim().length() == 0) {
@@ -2352,7 +2351,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     File inFile = null;
     while (params.hasNext() && inFile == null) {
-      Map.Entry<?, ?> entry = (Map.Entry<?, ?>) params.next();
+      Map.Entry entry = (Map.Entry) params.next();
       Object val = entry.getValue();
       if (val instanceof File) {
         inFile = (File) val;
@@ -2409,7 +2408,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
     if (req == null) throw new IllegalArgumentException(NULL_REQUEST_ERROR);
 
     // get the file to save
-    Iterator<?> params = req.getParametersIterator();
+    Iterator params = req.getParametersIterator();
 
     String configRef = req.getParameter("configRef");
     if (configRef == null || configRef.trim().length() == 0) {
@@ -2419,7 +2418,7 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     File inFile = null;
     while (params.hasNext() && inFile == null) {
-      Map.Entry<?, ?> entry = (Map.Entry<?, ?>) params.next();
+      Map.Entry entry = (Map.Entry) params.next();
       Object val = entry.getValue();
       if (val instanceof File) {
         inFile = (File) val;
@@ -2560,13 +2559,13 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
 
     // build our response node
     Element respRoot = PSXmlDocumentBuilder.createRoot(respDoc, "PSXDeployGetParentTypesResponse");
-    Map<String, String> types = m_depMgr.getParentTypes();
-    Iterator<Map.Entry<String, String>> entries = types.entrySet().iterator();
+    Map types = m_depMgr.getParentTypes();
+    Iterator entries = types.entrySet().iterator();
     while (entries.hasNext()) {
-      Map.Entry<String, String> entry = entries.next();
+      Map.Entry entry = (Map.Entry) entries.next();
       Element entryEl = PSXmlDocumentBuilder.addEmptyElement(respDoc, respRoot, "entry");
-      entryEl.setAttribute("childType", entry.getKey());
-      entryEl.setAttribute("parentType", entry.getValue());
+      entryEl.setAttribute("childType", (String) entry.getKey());
+      entryEl.setAttribute("parentType", (String) entry.getValue());
     }
 
     return respDoc;
@@ -2679,7 +2678,6 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
   }
 
   // Methods generated from interface IPSLoadableRequestHandler
-  @SuppressWarnings("rawtypes")
   public void init(Collection requestRoots, InputStream cfgFileIn) throws PSServerException {
     PSConsole.printMsg(activeSubsystem.name(), "Initializing Deployment Handler");
     m_requestRoots = requestRoots;
@@ -2717,7 +2715,6 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
    *     least one entry, and should not contain duplicates. Never <code>null</code> or empty. If
    *     <code>null</code> or empty the server will ignore this handler.
    */
-  @SuppressWarnings("rawtypes")
   public Iterator getRequestRoots() {
     if (m_requestRoots != null) {
       return m_requestRoots.iterator();
@@ -3388,7 +3385,6 @@ public class PSDeploymentHandler implements IPSDeploymentHandler, IPSLoadableReq
    * Request roots this handler will support, initialized during the <code>init()</code> method,
    * never <code>null</code>, empty, or modified after that.
    */
-  @SuppressWarnings("rawtypes")
   private Collection m_requestRoots;
 
   /**


### PR DESCRIPTION
## Summary

- Reverts **PR #2171** (`6ba49e6781`) which parameterized raw `Iterator`/`List` locals in `PSDeploymentHandler` (and related deployer types) as part of #2028 warning cleanup.
- That change introduced **hard compile failures** in `perc-deployer`:
  - `Iterator<PSDeployableObject>` cannot convert to `Iterator<PSDependency>` in `getIdTypes`
  - `cloneList(getAncestors(...))` equality-constraint clash: `PSDependency` vs `IPSDependencyBaseline` in `loadAncestors`
- Restores pre-#2171 sources so the module builds again.

## Why

Generics invariance + mismatched API return types (`List<PSDeployableObject>`, `Iterator<IPSDependencyBaseline>`) made the new parameterized locals illegal. Prior raw types only produced warnings.

## Verification

```bat
cd deployer
..\mvnw.cmd clean compile
```

**BUILD SUCCESS** (exit 0) after the revert.

## Follow-up

#2028 warning cleanup can re-land later with correct types/wildcards (e.g. `Iterator<? extends PSDependency>`, explicit casts from `IPSDependencyBaseline`), not blanket raw→`PSDependency` on locals that receive subtype/supertype iterators.

## Related

- Reverts: https://github.com/intersoftdatalabs-in/percussioncms/pull/2171
- Issue: #2028

> Co-Authored by Grok Build using grok-4.5 with agent grok.