### PR TITLE
fix(deps): root-manage error_prone_annotations 2.48.0 for RequireUpperBoundDeps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -526,6 +526,7 @@ Disposition ladder: **runtime fix + test → model pack barrier → sink-line `/
 * Use Maven for Java dependency management; ensure all dependencies are defined in the `pom.xml`.
 * Use npm for typescript and javascript dependency management via the Maven frontend-plugin.
 * Use the parent POM to manage shared dependencies and plugin versions.
+* **Prefer root dependency version management:** always pin shared/transitive library versions in the root `pom.xml` (`properties` + `dependencyManagement`), not in child module POMs (e.g. RequireUpperBoundDeps alignments).
 * The parent POM (`pom.xml`) has a pluginManagement section to manage versions of plugins used in child modules. Use these plugins.
 * Ignore module folders that are not referenced directly or indirectly in the `./pom.xml` as child modules.
 

--- a/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/delivery-tier-distribution/pom.xml
@@ -45,11 +45,7 @@
                 <artifactId>fontbox</artifactId>
                 <version>3.0.6</version>
             </dependency>
-            <dependency>
-                <groupId>com.google.errorprone</groupId>
-                <artifactId>error_prone_annotations</artifactId>
-                <version>2.41.0</version>
-            </dependency>
+            <!-- error_prone_annotations managed in root pom (error.prone.annotations.version) -->
             <dependency>
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging</artifactId>

--- a/docs/ai-generated/code-reviews/error-prone-annotations-root-manage-erlang.md
+++ b/docs/ai-generated/code-reviews/error-prone-annotations-root-manage-erlang.md
@@ -1,0 +1,39 @@
+# Erlang review: root-manage error_prone_annotations
+
+## Summary
+
+Manage `com.google.errorprone:error_prone_annotations` at root (`2.48.0`) after
+Dependabot gson 2.14.0 (#1881) raised RequireUpperBoundDeps on
+`delivery-tier-distribution`. Remove the child pin at `2.41.0`. Add one-line
+AGENTS.md rule to prefer root dependency version management.
+
+## Scope
+
+- Uncommitted vs `HEAD` on `main` (pre-branch)
+- Files: `pom.xml`, `deliverytiersuite/.../delivery-tier-distribution/pom.xml`, `AGENTS.md`
+- Memory patterns hit: agent rule changes need human review (user explicitly
+  requested AGENTS update + PR); incomplete change-class not applicable (dep pin only)
+- Cross-platform path review: N/A (no file I/O code)
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- May commit/push: **yes**
+- Bugs: none
+- Missing behavioral tests: N/A (Maven property / dependencyManagement only)
+- Human AGENTS rule approval: **yes** (user requested the rule and PR)
+
+## Issues
+
+None.
+
+## Verification noted
+
+```text
+cd deliverytiersuite/delivery-tier-suite/delivery-tier-distribution
+..\..\..\mvnw.cmd validate
+# RequireUpperBoundDeps + DependencyConvergence passed; BUILD SUCCESS
+```

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,10 @@
         <google.java.format.version>1.36.1</google.java.format.version>
         <gson.version>2.14.0</gson.version>
         <guava.version>33.5.0-jre</guava.version>
+        <!-- RequireUpperBoundDeps: gson 2.14.0 pulls error_prone_annotations 2.48.0;
+             guava 33.5.0-jre pulls 2.41.0. Manage the higher version monorepo-wide
+             so delivery-tier-distribution (and peers) converge after #1881. -->
+        <error.prone.annotations.version>2.48.0</error.prone.annotations.version>
         <gwt.maven.plugin.version>2.10.0</gwt.maven.plugin.version>
         <!-- #548 default embedded replacement (bake-off primary); Derby retained for migration window -->
         <h2.version>2.4.240</h2.version>
@@ -946,6 +950,11 @@
                         <artifactId>jsr305</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+                <version>${error.prone.annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.jackrabbit</groupId>


### PR DESCRIPTION
## Summary

- Root-manage `com.google.errorprone:error_prone_annotations` at **2.48.0** so monorepo modules converge after Dependabot gson 2.14.0 ([#1881](https://github.com/intersoftdatalabs-in/percussioncms/pull/1881)).
- Remove the outdated **2.41.0** pin from `delivery-tier-distribution` local `dependencyManagement` (that pin forced the lower version and failed `RequireUpperBoundDeps`).
- Add one-line **AGENTS.md** rule: prefer managing shared/transitive dependency versions in the root `pom.xml`.

### Root cause

| Path | Declared version |
|------|------------------|
| `guava:33.5.0-jre` | `error_prone_annotations:2.41.0` |
| `csrfguard` → `gson:2.14.0` | `error_prone_annotations:2.48.0` |

Child pin kept managed version at 2.41.0 → enforcer upper-bound failure on `delivery-tier-distribution`.

## Test plan

- [x] Erlang pre-commit review: **approve** (`docs/ai-generated/code-reviews/error-prone-annotations-root-manage-erlang.md`)
- [x] Standalone enforcer / validate on the failing module:

```bat
cd deliverytiersuite\delivery-tier-suite\delivery-tier-distribution
..\..\..\mvnw.cmd validate
```

  - Rule 4 `RequireUpperBoundDeps` **passed**
  - Rule 5 `DependencyConvergence` **passed**
  - **BUILD SUCCESS**
- [ ] CI green on this PR

> Co-Authored by Grok Build using grok-4.5 with agent Grok.
