### PR TITLE
fix(ai): point Erlang pre-commit base branch at main (not development)

### DIFF
--- a/.github/agents/erlang.agent.md
+++ b/.github/agents/erlang.agent.md
@@ -19,8 +19,8 @@ Product cross-platform path rules: root `AGENTS.md` → **Cross-Platform File I/
 ## Quick start
 
 1. Open that canonical agent file and follow it exactly.
-2. Review uncommitted changes and `origin/development...HEAD` unless the user
-   specifies a PR or other base.
+2. Review uncommitted changes and `origin/main...HEAD` unless the user
+   specifies a PR or other base (formerly `origin/development`).
 3. Strict gate: any bug, missing behavioral tests for non-trivial logic, or
    non-portable path/file I/O → `request-changes` and **May commit/push: no**.
 4. When the diff touches file I/O or path assertions, apply the Erlang

--- a/.kilo/rules/no-force-push-development.md
+++ b/.kilo/rules/no-force-push-development.md
@@ -1,29 +1,29 @@
-# Never force-push to `development`; always create a feature branch + PR
+# Never force-push to `main`; always create a feature branch + PR
 
 ## Rule
 
 When the user asks to push, create a PR, or share changes for review:
 
-1. **Never `git push --force`, `git push --force-with-lease`, `git push -f`, or any non-fast-forward push to `origin/development`.** This branch is the project's protected default branch and the repository's branch-protection rule denies non-fast-forward pushes anyway — attempting them wastes a round trip and pollutes history.
-2. **Never commit directly to `development`.** The root `AGENTS.md` does not list `development` among the pre-approved direct-commit branches, and force-pushing to it is treated as an incident.
+1. **Never `git push --force`, `git push --force-with-lease`, `git push -f`, or any non-fast-forward push to `origin/main`.** This branch is the project's protected default branch (formerly `development`) and the repository's branch-protection rule denies non-fast-forward pushes anyway — attempting them wastes a round trip and pollutes history.
+2. **Never commit directly to `main`.** The root `AGENTS.md` does not list `main` among the pre-approved direct-commit branches, and force-pushing to it is treated as an incident.
 3. **Always create a feature branch first.** Convention:
    - Branch name: `fix/<issue>-<short-slug>` for fixes, `feat/<issue>-<short-slug>` for features, `chore/<short-slug>` for tooling.
-   - Base off the current `origin/development` tip (fetch first).
+   - Base off the current `origin/main` tip (fetch first).
    - Example:
 
      ```bash
      git fetch origin
-     git checkout -b fix/548-1500-h2-password-and-startjetty-launcher origin/development
+     git checkout -b fix/548-1500-h2-password-and-startjetty-launcher origin/main
      ```
-4. **Always open a PR** with `gh pr create --base development --head <branch>`. The PR description must include the test evidence required by `AGENTS.md` (clean install counts per changed module, Erlang review reference).
+4. **Always open a PR** with `gh pr create --base main --head <branch>`. The PR description must include the test evidence required by `AGENTS.md` (clean install counts per changed module, Erlang review reference).
 5. **Never use `--force-with-lease` even on feature branches unless the user explicitly instructs it** — feature-branch history rewriting still disturbs reviewers who have based work on the branch.
 
 ## Why
 
-Incident history (2026-07-27, PR #1522):
+Incident history (2026-07-27, PR #1522; default branch was then named `development`):
 
-- Author force-pushed 5 commits to `origin/development` after a fast-forward-only fetch rejection, intending to push a "feature branch." The result was that `origin/development` was rewritten to the force-pushed tip, leaving the actual `development` HEAD (commit `a16ae9061`) unreachable except via cherry-pick from local reflog.
-- Recovery required cherry-picking the 5 commits onto a fresh branch off `a16ae9061` and opening a PR. Branch protection on `development` makes the original force-push unrecoverable without admin intervention.
+- Author force-pushed 5 commits to the protected default branch after a fast-forward-only fetch rejection, intending to push a "feature branch." The result was that the default remote tip was rewritten, leaving the previous HEAD (commit `a16ae9061`) unreachable except via cherry-pick from local reflog.
+- Recovery required cherry-picking the 5 commits onto a fresh branch and opening a PR. Branch protection makes the original force-push unrecoverable without admin intervention.
 
 Force-pushing to a protected default branch breaks the team's review flow, can clobber other contributors' work, and is treated as a rule violation in this repository.
 
@@ -34,5 +34,4 @@ If `git push origin <branch>` is rejected (e.g., branch protection, stale local)
 1. Run `git fetch origin` to see the new remote tip.
 2. Inspect `git log HEAD..origin/<branch>` to see what is incoming.
 3. Decide: rebase vs merge. **Default to `git pull --rebase` for a feature branch you own.** Do **not** attempt to force-push back over the remote.
-4. If the branch is `development` itself, you have a direct-commit error — back out, create a feature branch, retry.
-
+4. If the branch is `main` itself, you have a direct-commit error — back out, create a feature branch, retry.

--- a/.kilo/workflows/erlang-review.md
+++ b/.kilo/workflows/erlang-review.md
@@ -1,7 +1,7 @@
 ---
 description: >-
   Strict Erlang pre-commit / pre-PR code review for Percussion CMS. Reviews
-  uncommitted and branch diffs vs development; blocks on bugs, missing tests,
+  uncommitted and branch diffs vs main; blocks on bugs, missing tests,
   and non-portable (Windows/Unix) path/file I/O.
 ---
 
@@ -31,8 +31,8 @@ Also load root `AGENTS.md` and any module-level `AGENTS.md` for files in the dif
 If `$ARGUMENTS` is empty:
 
 1. Uncommitted changes (`git status`, `git diff`, `git diff --cached`)
-2. Commits on the current branch not in `origin/development`
-   (`git fetch origin development` if needed; then `git diff origin/development...HEAD`)
+2. Commits on the current branch not in `origin/main`
+   (`git fetch origin main` if needed; then `git diff origin/main...HEAD`)
 
 If `$ARGUMENTS` is a number, treat it as a GitHub PR number (`gh pr diff`,
 `gh pr view`).

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -41,7 +41,7 @@ from the base branch, never from the feature branch under review.
   versions; do not duplicate plugin versions in module `pom.xml`.
 - **No new dependencies without justification.** Prefer parent POM
   `<dependencyManagement>` over per-module dependency declarations.
-  Dependabot is configured at `.github/dependabot.yml` for `development`.
+  Dependabot is configured at `.github/dependabot.yml` for `main`.
 - **Secrets and tokens never appear in code, logs, or test fixtures.**
   A `MKD-REDACTED` marker in a session indicates a leak.
 
@@ -51,7 +51,7 @@ from the base branch, never from the feature branch under review.
   escalation, remote code execution, broken installer or upgrade path,
   missing lockstep contract propagation, secrets leaked to logs or wire,
   cross-platform path bug (works only on one OS), force-push to
-  `origin/development`, bypassing the Erlang pre-commit review gate.
+  `origin/main`, bypassing the Erlang pre-commit review gate.
 - **Warning:** missing behavioral unit test for new non-trivial logic,
   raw `Throwable` catches that swallow stack traces, `null`-returning
   APIs where `Optional` would prevent misuse, untested error paths,
@@ -109,9 +109,10 @@ from the base branch, never from the feature branch under review.
   re-enable default setup without the same config and model pack.
   Suppressions go on the sink line (`// codeql[rule-id]`), not above
   multi-line builders.
-- Force-push to `origin/development` is forbidden — create a feature
+- Force-push to `origin/main` is forbidden — create a feature
   branch and open a PR instead. See
-  `.kilo/rules/no-force-push-development.md`.
+  `.kilo/rules/no-force-push-development.md` (filename historical;
+  rule text targets `main`, formerly `development`).
 
 ## Comment style
 

--- a/docs/ai-generated/code-reviews/erlang-base-branch-main-erlang.md
+++ b/docs/ai-generated/code-reviews/erlang-base-branch-main-erlang.md
@@ -1,0 +1,36 @@
+# Erlang review: align Erlang base branch to `main`
+
+## Summary
+
+Update agent/skill/prompt/workflow/mirror and related agent-facing docs so
+default branch review base is `origin/main` (formerly `development`), matching
+root `AGENTS.md`.
+
+## Scope
+
+- Branch: `fix/erlang-base-branch-main` vs `origin/main`
+- Uncommitted agent instruction / skill / REVIEW / Kilo rule/workflow docs only
+- No product Java/runtime code
+- Cross-platform path review: N/A
+- Memory: human review of agent rules required — user explicitly requested this fix
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- May commit/push: **yes**
+- Bugs: none
+- Missing behavioral tests: N/A (docs/rules only)
+- Human AGENTS/rule approval: **yes** (user: "yes please")
+
+## Issues
+
+None.
+
+## Notes
+
+Historical "formerly development" notes retained so older reports remain
+interpretable. Filename `.kilo/rules/no-force-push-development.md` kept; body
+now targets `main`.

--- a/modules/ai-shared-develop/src/main/resources/agents/erlang-code-review.md
+++ b/modules/ai-shared-develop/src/main/resources/agents/erlang-code-review.md
@@ -2,7 +2,7 @@
 name: erlang
 description: >-
   Erlang — strict independent code review for Percussion CMS. Use before commit
-  or PR when reviewing uncommitted changes, a branch vs development, or a GitHub
+  or PR when reviewing uncommitted changes, a branch vs main, or a GitHub
   PR. Catches correctness bugs, missing tests, non-portable Windows/Unix path
   handling, and convention violations early. Read-only review persona; does not
   implement fixes unless the human asks after the review. Tool-agnostic (Kilo,
@@ -95,8 +95,8 @@ Windows: `scripts\erlang-harvest-review-patterns.bat --apply`. See
 Scope → Memory load → Diff → Context → Findings → Severity → Recommend → Artifact → Memory touch
 ```
 
-1. **Scope** — Local uncommitted, branch vs base (`development` unless stated),
-   or PR number? What was the intent?
+1. **Scope** — Local uncommitted, branch vs base (`main` unless stated;
+   formerly `development`), or PR number? What was the intent?
 2. **Memory load** — `patterns.md` + prior `docs/ai-generated/code-reviews/*` for topic.
 3. **Diff** — Collect unified diff and file list. Empty diff → stop: nothing to review.
 4. **Context** — Read surrounding code for changed symbols; load root `AGENTS.md`
@@ -145,7 +145,9 @@ Repo rules that are **findings when violated**:
    and runs on **Windows, Linux, and macOS**. Violations of root `AGENTS.md`
    section **Cross-Platform File I/O & Paths** in production code, tests, or
    required scripts → **bug** (hard gate). See dedicated checklist below.
-3. **JDK / branch** — `development` = JDK 21 / Jakarta; `development-8.1.x` = JDK 8.
+3. **JDK / branch** — `main` = JDK 21 / Jakarta (formerly `development` on this
+   repo). JDK 8 maintenance lives in the separate `percussioncms-java8` repo
+   (formerly `development-8.1.x` here) — do not target JDK 8 on this monorepo.
    Use `./mvnw` / `./mvnw.cmd` awareness; do not mix assumptions.
 4. **No invented APIs** — Flag use of non-existent library methods/APIs.
 5. **Secrets** — No tokens/keys/passwords in code, tests, or logs.
@@ -285,10 +287,10 @@ git status -sb
 git diff
 git diff --cached
 
-# Branch vs development — git is required
-git fetch origin development
-git diff origin/development...HEAD
-git log --oneline origin/development..HEAD
+# Branch vs main (default base; formerly development) — git is required
+git fetch origin main
+git diff origin/main...HEAD
+git log --oneline origin/main..HEAD
 
 # Named PR — GitHub CLI (gh) is OPTIONAL
 # If gh is installed and authenticated:
@@ -299,7 +301,7 @@ gh pr view <n> --json title,body,baseRefName,headRefName,files
 ```
 
 If `git fetch` fails (offline / no remote), note it and review against the best
-local base available (`development` or `origin/development` if present).
+local base available (`main` or `origin/main` if present).
 
 Read full files for non-trivial hunks; do not review only the patch lines.
 

--- a/modules/ai-shared-develop/src/main/resources/instructions/java-17-to-java-21-upgrade.instructions.md
+++ b/modules/ai-shared-develop/src/main/resources/instructions/java-17-to-java-21-upgrade.instructions.md
@@ -1,18 +1,18 @@
 ---
 
 applyTo: "**/*.java"
-description: "Java 21 language and API practices for Percussion CMS on development (release=21). Intermediate Java 11/17 baselines are historical only."
+description: "Java 21 language and API practices for Percussion CMS on main (release=21). Intermediate Java 11/17 baselines are historical only."
 ---
 
-# Java 21 language practices (development baseline)
+# Java 21 language practices (`main` baseline)
 
-The monorepo **`development`** branch already targets **JDK 21** (parent `java.version` / compiler `release`). Do **not** treat Java 11 or Java 17 as the current product baseline.
+The monorepo **`main`** branch (formerly `development`) already targets **JDK 21** (parent `java.version` / compiler `release`). Do **not** treat Java 11 or Java 17 as the current product baseline.
 
-These notes help agents and developers **prefer Java 21-era language features and APIs** when writing or modernizing code on `development`. Comparisons to older idioms (e.g. pre-pattern-matching switch) are for migration clarity only.
+These notes help agents and developers **prefer Java 21-era language features and APIs** when writing or modernizing code on `main`. Comparisons to older idioms (e.g. pre-pattern-matching switch) are for migration clarity only.
 
-**Out of scope here:** `development-8.1.x` remains **JDK 8** — do not apply these features on that branch.
+**Out of scope here:** JDK 8 lives in the separate `percussioncms-java8` repository (formerly `development-8.1.x` on this remote) — do not apply these features on that line.
 
-## Major Language Features in JDK 18-21 (use on development)
+## Major Language Features in JDK 18-21 (use on `main`)
 
 ### Pattern Matching for switch (JEP 441 - Standard in 21)
 

--- a/modules/ai-shared-develop/src/main/resources/instructions/java-coding-standards.md
+++ b/modules/ai-shared-develop/src/main/resources/instructions/java-coding-standards.md
@@ -53,7 +53,7 @@ When addressing `[this-escape]` warnings:
 
 - **Use `var` only when the type is clearly obvious** from the right-hand side of the assignment (e.g., `var list = new ArrayList<String>();`).
 - **Avoid `var` for method return values** where the type is not immediately apparent (e.g., `var data = getMetadata();`).
-- **Toolchain:** On `development`, modules inherit **JDK 21** (`release=21`). Use `var` freely where the type is obvious. On `development-8.1.x` (JDK 8), do **not** use `var` or other post-8 language features.
+- **Toolchain:** On `main` (formerly `development`), modules inherit **JDK 21** (`release=21`). Use `var` freely where the type is obvious. JDK 8 maintenance is the separate `percussioncms-java8` repo (formerly `development-8.1.x` on this remote) — do **not** use post-8 language features if targeting that line.
 - **Consistency:** Do not mix `var` and explicit types within the same block of code; choose the most readable option for that specific context.
 
 ### Control Flow Standards

--- a/modules/ai-shared-develop/src/main/resources/prompts/erlang-review-uncommitted.md
+++ b/modules/ai-shared-develop/src/main/resources/prompts/erlang-review-uncommitted.md
@@ -20,8 +20,9 @@ any module `AGENTS.md` for paths you touch.
    `docs/ai-generated/code-reviews/`, load it. Do not use `tmp/reviews/` as memory.
 2. Collect the diff with **git** (host shell may be PowerShell, cmd, or bash —
    avoid bash-only redirects). Run: `git status -sb`, `git diff`,
-   `git diff --cached`, `git fetch origin development`, then
-   `git diff origin/development...HEAD`. `gh` is optional (PR-number mode only);
+   `git diff --cached`, `git fetch origin main`, then
+   `git diff origin/main...HEAD` (default base; formerly `development`).
+   `gh` is optional (PR-number mode only);
    if `gh` is missing, continue with git and note that in Scope.
 3. Read surrounding code for non-trivial hunks — do not review hunks alone.
 4. Produce the full Erlang report: Summary, Scope, Recommendation, Gate, Issues

--- a/modules/ai-shared-develop/src/main/resources/skills/add-locale-support/SKILL.md
+++ b/modules/ai-shared-develop/src/main/resources/skills/add-locale-support/SKILL.md
@@ -48,9 +48,9 @@ removing an existing locale (different playbook — see §7).
    `docker info` exits 0 before starting; failure is a tooling issue, not
    a content one.
 4. **Which branch / working tree?** Module-level changes span three
-   modules — start from `origin/development` (or your assigned base).
-   Per repo rules, **never** force-push to `development`; create a
-   `feat/<issue>-<code>-locale` branch.
+   modules — start from `origin/main` (or your assigned base; formerly
+   `origin/development`). Per repo rules, **never** force-push to
+   `main`; create a `feat/<issue>-<code>-locale` branch.
 
 ## The 6-step checklist
 
@@ -326,8 +326,7 @@ will block if string-by-key fall-through to English is not documented.
    `docs/ai-generated/code-reviews/<branch-slug>-erlang.md` with
    recommendation `approve`. Use the canonical review skill; this
    checklist is not a substitute.
-5. Branch off `origin/development`; PR base is `development`; **never**
-   force-push.
+5. Branch off `origin/main`; PR base is `main`; **never** force-push.
 6. If you added a Lucene `case`, include the test that exercises a
    sample analyzer for the primary sub-tag (Erlang will flag a missing
    behavioral test as a bug).

--- a/modules/ai-shared-develop/src/main/resources/skills/erlang-review/SKILL.md
+++ b/modules/ai-shared-develop/src/main/resources/skills/erlang-review/SKILL.md
@@ -38,7 +38,8 @@ Cross-platform path rules (product): root `AGENTS.md` → **Cross-Platform File 
      `docs/ai-generated/code-reviews/`, load it (re-review continuity).
    - Do **not** treat `tmp/reviews/` as authoritative (`tmp/` is wipeable).
 3. **Determine scope** (ask only if unclear):
-   - default: uncommitted + unstaged vs `HEAD`, plus commits not in `origin/development`
+   - default: uncommitted + unstaged vs `HEAD`, plus commits not in `origin/main`
+     (default base; formerly `origin/development`)
    - or: explicit PR number / branch
 4. **Collect diff** (see agent file). Use portable **git** commands (not
    bash-only `2>/dev/null || true`). Host shell may be PowerShell, cmd, Git Bash,


### PR DESCRIPTION
## Summary

- Point **Erlang pre-commit / pre-PR** scope at **`origin/main`** (not the retired `development` default).
- Align related agent-facing rules and skills that still told operators to branch off / force-protect `development`.
- Keep short **“formerly `development`”** notes so older reports stay readable.

### Why

After the default branch rename to `main`, Erlang instructions still ran:

```text
git fetch origin development
git diff origin/development...HEAD
```

That breaks or mis-scopes branch-vs-base review on current clones (as Vijay noted). Root `AGENTS.md` already documents `main` as the base.

### Files

| Path | Change |
|------|--------|
| `modules/ai-shared-develop/.../agents/erlang-code-review.md` | Base = `main`; JDK note |
| `.../skills/erlang-review/SKILL.md` | Default scope vs `origin/main` |
| `.../prompts/erlang-review-uncommitted.md` | Fetch/diff `main` |
| `.kilo/workflows/erlang-review.md` | Same |
| `.github/agents/erlang.agent.md` | Copilot mirror |
| `.kilo/rules/no-force-push-development.md` | Body targets `main` (filename kept) |
| `REVIEW.md` | Dependabot / force-push / critical cal on `main` |
| Java 21 instructions + `add-locale-support` skill | Branch conventions |

## Test plan

- [x] Erlang review on this docs-only change: **approve** (`docs/ai-generated/code-reviews/erlang-base-branch-main-erlang.md`)
- [x] Grep: no live `git fetch origin development` / `origin/development...HEAD` in Erlang agent/skill/prompt/workflow/mirror
- [ ] Human skim of rule diffs (agent instruction files — explicit request from Nate)
- [ ] CI (docs-only; no module Maven required)

> Co-Authored by Grok Build using grok-4.5 with agent Grok.
