### PR TITLE
feat(developer): SE-05 community visibility navigator groups (#2273)

### DIFF
--- a/WebUI/src/main/ts/app/deepLinks/allowlists.ts
+++ b/WebUI/src/main/ts/app/deepLinks/allowlists.ts
@@ -102,6 +102,7 @@ export const DEVELOPER_SECTIONS = [
   "ce-controls",
   "sites",
   "communities",
+  "community-visibility",
   "pipelines",
 ] as const;
 
@@ -152,6 +153,13 @@ const DEVELOPER_SECTION_ALIASES: Record<string, DeveloperSection> = {
   sites: "sites",
   site: "sites",
   cxviews: "views",
+  communities: "communities",
+  community: "communities",
+  "community-visibility": "community-visibility",
+  communityvisibility: "community-visibility",
+  "comm-visibility": "community-visibility",
+  "visibility-navigator": "community-visibility",
+  se05: "community-visibility",
   pipeline: "pipelines",
   applications: "pipelines",
   "xml-apps": "pipelines",

--- a/WebUI/src/main/ts/developer/CommunityVisibilityNavigatorPanel.tsx
+++ b/WebUI/src/main/ts/developer/CommunityVisibilityNavigatorPanel.tsx
@@ -1,0 +1,414 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  getCommunityVisibility,
+  listCommunities,
+} from "../api/developer/assemblyApi";
+import type {
+  CommunitySummary,
+  CommunityVisibleObject,
+  RestGuid,
+} from "../api/developer/types";
+import { CatalogHint, CatalogStatus } from "./CatalogTable";
+import {
+  catalogColors,
+  monoCell,
+  mutedCell,
+} from "./catalogStyles";
+import {
+  groupVisibleObjectsByType,
+  visibleObjectRowKey,
+  type VisibilityTypeGroup,
+} from "./communityVisibilityGroups";
+import { panelErrMsg } from "./errors";
+import { DEV_MSG } from "./messages";
+
+type CommunityLoadState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; objects: CommunityVisibleObject[] };
+
+function communityKey(c: CommunitySummary, index: number): string {
+  if (c.guid?.stringValue) return c.guid.stringValue;
+  if (c.name) return `name:${c.name}`;
+  if (c.id != null) return `id:${c.id}`;
+  return `comm-idx:${index}`;
+}
+
+function communityGuid(c: CommunitySummary): RestGuid | null {
+  if (c.guid?.stringValue || c.guid?.uuid != null || c.guid?.longValue != null) {
+    return c.guid;
+  }
+  return null;
+}
+
+function communityTitle(c: CommunitySummary): string {
+  return c.label || c.name || (c.id != null ? String(c.id) : "—");
+}
+
+const treeListStyle: React.CSSProperties = {
+  listStyle: "none",
+  margin: 0,
+  padding: 0,
+};
+
+const groupButtonStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "8px",
+  width: "100%",
+  textAlign: "left",
+  padding: "8px 10px",
+  border: `1px solid ${catalogColors.headerBorder}`,
+  borderRadius: "4px",
+  background: "#fff",
+  cursor: "pointer",
+  font: "inherit",
+  color: catalogColors.text,
+};
+
+const nestedListStyle: React.CSSProperties = {
+  listStyle: "none",
+  margin: "4px 0 8px 16px",
+  padding: "0 0 0 8px",
+  borderLeft: `2px solid ${catalogColors.headerBorder}`,
+};
+
+const typeHeaderStyle: React.CSSProperties = {
+  ...groupButtonStyle,
+  background: "#f7fafc",
+  fontWeight: 600,
+  fontSize: "0.95rem",
+};
+
+const objectRowStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "minmax(6rem, 10rem) minmax(8rem, 1fr) minmax(8rem, 1fr) minmax(8rem, 1.2fr)",
+  gap: "8px",
+  padding: "6px 10px",
+  borderBottom: `1px solid ${catalogColors.headerBorder}`,
+  fontSize: "0.9rem",
+  alignItems: "baseline",
+};
+
+/**
+ * SE-05 Community visibility navigator: design objects grouped by community,
+ * then by object type. Uses existing getCommunityVisibility (lazy per community).
+ */
+export function CommunityVisibilityNavigatorPanel(): React.ReactElement {
+  const [communities, setCommunities] = useState<CommunitySummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedCommunities, setExpandedCommunities] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [expandedTypes, setExpandedTypes] = useState<Set<string>>(() => new Set());
+  const [loadByKey, setLoadByKey] = useState<Record<string, CommunityLoadState>>({});
+  /** Monotonic per-community request ids so stale visibility responses are ignored. */
+  const reqIds = useRef<Record<string, number>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    listCommunities()
+      .then((list) => {
+        if (!cancelled) setCommunities(list);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setError(panelErrMsg(e, DEV_MSG.CVN_ERROR));
+        setCommunities([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const sortedCommunities = useMemo(() => {
+    if (!communities) return [];
+    return [...communities].sort((a, b) =>
+      communityTitle(a).localeCompare(communityTitle(b), undefined, {
+        sensitivity: "base",
+      }),
+    );
+  }, [communities]);
+
+  const loadVisibility = useCallback((key: string, guid: RestGuid) => {
+    const nextReq = (reqIds.current[key] ?? 0) + 1;
+    reqIds.current[key] = nextReq;
+    setLoadByKey((prev) => ({ ...prev, [key]: { status: "loading" } }));
+    getCommunityVisibility(guid)
+      .then((objects) => {
+        if (reqIds.current[key] !== nextReq) return;
+        setLoadByKey((prev) => ({
+          ...prev,
+          [key]: { status: "ready", objects },
+        }));
+      })
+      .catch((err: unknown) => {
+        if (reqIds.current[key] !== nextReq) return;
+        setLoadByKey((prev) => ({
+          ...prev,
+          [key]: {
+            status: "error",
+            message: panelErrMsg(err, DEV_MSG.CVN_VISIBILITY_ERROR),
+          },
+        }));
+      });
+  }, []);
+
+  function toggleCommunity(c: CommunitySummary, index: number) {
+    const key = communityKey(c, index);
+    const expanding = !expandedCommunities.has(key);
+    setExpandedCommunities((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+
+    if (!expanding) return;
+
+    const guid = communityGuid(c);
+    if (!guid) {
+      setLoadByKey((prev) => ({
+        ...prev,
+        [key]: { status: "error", message: DEV_MSG.CVN_NO_GUID },
+      }));
+      return;
+    }
+    // Expand path: load when idle or previous error (retry). Keep ready cache.
+    const current = loadByKey[key];
+    if (!current || current.status === "idle" || current.status === "error") {
+      loadVisibility(key, guid);
+    }
+  }
+
+  function toggleType(communityKeyStr: string, typeKey: string) {
+    const compound = `${communityKeyStr}::${typeKey}`;
+    setExpandedTypes((prev) => {
+      const next = new Set(prev);
+      if (next.has(compound)) next.delete(compound);
+      else next.add(compound);
+      return next;
+    });
+  }
+
+  if (error) {
+    return (
+      <CatalogStatus testId="developer-cvn-error" error>
+        {error}
+      </CatalogStatus>
+    );
+  }
+  if (communities == null) {
+    return (
+      <CatalogStatus testId="developer-cvn-loading">{DEV_MSG.CVN_LOADING}</CatalogStatus>
+    );
+  }
+  if (communities.length === 0) {
+    return (
+      <CatalogStatus testId="developer-cvn-empty">{DEV_MSG.CVN_EMPTY}</CatalogStatus>
+    );
+  }
+
+  return (
+    <div data-testid="developer-cvn-panel">
+      <CatalogHint>{DEV_MSG.CVN_HINT}</CatalogHint>
+      <p
+        style={{ color: catalogColors.muted, fontSize: "0.9rem", marginTop: 0 }}
+        data-testid="developer-cvn-intro"
+      >
+        {DEV_MSG.CVN_INTRO}
+      </p>
+
+      <ul
+        role="tree"
+        aria-label={DEV_MSG.CVN_TREE_LABEL}
+        data-testid="developer-cvn-tree"
+        style={treeListStyle}
+      >
+        {sortedCommunities.map((c, index) => {
+          const key = communityKey(c, index);
+          const expanded = expandedCommunities.has(key);
+          const load = loadByKey[key] ?? { status: "idle" as const };
+          const groups: VisibilityTypeGroup[] =
+            load.status === "ready"
+              ? groupVisibleObjectsByType(load.objects)
+              : [];
+
+          return (
+            <li
+              key={key}
+              role="treeitem"
+              aria-expanded={expanded}
+              data-testid={`developer-cvn-community-${key}`}
+              style={{ marginBottom: "8px" }}
+            >
+              <button
+                type="button"
+                style={groupButtonStyle}
+                data-testid={`developer-cvn-community-toggle-${key}`}
+                aria-expanded={expanded}
+                onClick={() => toggleCommunity(c, index)}
+              >
+                <span aria-hidden="true" style={{ width: "1rem", flexShrink: 0 }}>
+                  {expanded ? "▾" : "▸"}
+                </span>
+                <span style={{ fontWeight: 600 }}>{communityTitle(c)}</span>
+                {c.name ? (
+                  <span style={{ ...monoCell, color: catalogColors.muted, fontSize: "0.85rem" }}>
+                    {c.name}
+                  </span>
+                ) : null}
+              </button>
+
+              {expanded ? (
+                <div
+                  data-testid={`developer-cvn-community-body-${key}`}
+                  style={{ marginTop: "6px" }}
+                >
+                  {load.status === "loading" || load.status === "idle" ? (
+                    <div
+                      data-testid={`developer-cvn-community-loading-${key}`}
+                      style={{ ...mutedCell, padding: "8px 12px" }}
+                    >
+                      {DEV_MSG.CVN_VISIBILITY_LOADING}
+                    </div>
+                  ) : null}
+                  {load.status === "error" ? (
+                    <div
+                      role="alert"
+                      data-testid={`developer-cvn-community-error-${key}`}
+                      style={{
+                        color: "#c53030",
+                        background: "#fff5f5",
+                        border: "1px solid #feb2b2",
+                        borderRadius: "4px",
+                        padding: "8px 12px",
+                        margin: "4px 0 4px 16px",
+                      }}
+                    >
+                      {load.message}
+                    </div>
+                  ) : null}
+                  {load.status === "ready" && groups.length === 0 ? (
+                    <div
+                      data-testid={`developer-cvn-community-empty-${key}`}
+                      style={{ ...mutedCell, padding: "8px 12px" }}
+                    >
+                      {DEV_MSG.CVN_COMMUNITY_EMPTY}
+                    </div>
+                  ) : null}
+                  {load.status === "ready" && groups.length > 0 ? (
+                    <ul
+                      role="group"
+                      data-testid={`developer-cvn-type-groups-${key}`}
+                      style={nestedListStyle}
+                    >
+                      {groups.map((g) => {
+                        const typeCompound = `${key}::${g.typeKey}`;
+                        const typeExpanded = expandedTypes.has(typeCompound);
+                        return (
+                          <li
+                            key={g.typeKey}
+                            role="treeitem"
+                            aria-expanded={typeExpanded}
+                            data-testid={`developer-cvn-type-${key}-${g.typeKey}`}
+                            style={{ marginBottom: "6px" }}
+                          >
+                            <button
+                              type="button"
+                              style={typeHeaderStyle}
+                              data-testid={`developer-cvn-type-toggle-${key}-${g.typeKey}`}
+                              aria-expanded={typeExpanded}
+                              onClick={() => toggleType(key, g.typeKey)}
+                            >
+                              <span aria-hidden="true" style={{ width: "1rem" }}>
+                                {typeExpanded ? "▾" : "▸"}
+                              </span>
+                              <span>{g.label}</span>
+                              <span
+                                style={{
+                                  ...mutedCell,
+                                  fontSize: "0.85rem",
+                                  marginLeft: "auto",
+                                }}
+                              >
+                                {g.objects.length}
+                              </span>
+                            </button>
+                            {typeExpanded ? (
+                              <ul
+                                role="group"
+                                data-testid={`developer-cvn-objects-${key}-${g.typeKey}`}
+                                style={{
+                                  listStyle: "none",
+                                  margin: "0 0 0 8px",
+                                  padding: 0,
+                                  border: `1px solid ${catalogColors.headerBorder}`,
+                                  borderRadius: "4px",
+                                  overflow: "hidden",
+                                }}
+                              >
+                                <li
+                                  style={{
+                                    ...objectRowStyle,
+                                    fontWeight: 600,
+                                    background: "#edf2f7",
+                                    borderBottom: `1px solid ${catalogColors.headerBorder}`,
+                                  }}
+                                  aria-hidden="true"
+                                >
+                                  <span>{DEV_MSG.COMM_COL_OBJ_TYPE}</span>
+                                  <span>{DEV_MSG.COMM_COL_OBJ_NAME}</span>
+                                  <span>{DEV_MSG.COMM_COL_OBJ_LABEL}</span>
+                                  <span>{DEV_MSG.COMM_COL_OBJ_GUID}</span>
+                                </li>
+                                {g.objects.map((o, oi) => (
+                                  <li
+                                    key={visibleObjectRowKey(o, oi)}
+                                    role="treeitem"
+                                    data-testid={`developer-cvn-object-${visibleObjectRowKey(o, oi)}`}
+                                    style={objectRowStyle}
+                                  >
+                                    <span style={monoCell}>{o.type || "—"}</span>
+                                    <span style={monoCell}>{o.name || "—"}</span>
+                                    <span>{o.label || "—"}</span>
+                                    <span style={{ ...monoCell, fontSize: "0.85rem" }}>
+                                      {o.guid?.stringValue ||
+                                        (o.id != null ? String(o.id) : "—")}
+                                    </span>
+                                  </li>
+                                ))}
+                              </ul>
+                            ) : null}
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  ) : null}
+                </div>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/developer/DeveloperShell.tsx
+++ b/WebUI/src/main/ts/developer/DeveloperShell.tsx
@@ -23,6 +23,7 @@ import {
 } from "../app/deepLinks/allowlists";
 import { ActionMenusPanel } from "./ActionMenusPanel";
 import { CommunitiesPanel } from "./CommunitiesPanel";
+import { CommunityVisibilityNavigatorPanel } from "./CommunityVisibilityNavigatorPanel";
 import { ContentTypesPanel } from "./ContentTypesPanel";
 import { ControlsPanel } from "./ControlsPanel";
 import { ExtensionsPanel } from "./ExtensionsPanel";
@@ -67,6 +68,7 @@ const SECTION_LABEL: Record<DeveloperSection, string> = {
   "ce-controls": DEV_MSG.TAB_CE_CONTROLS,
   sites: DEV_MSG.TAB_SITES,
   communities: DEV_MSG.TAB_COMMUNITIES,
+  "community-visibility": DEV_MSG.TAB_COMMUNITY_VISIBILITY,
   pipelines: DEV_MSG.TAB_PIPELINES,
 };
 
@@ -198,6 +200,8 @@ export const DeveloperShell: React.FC<DeveloperShellProps> = ({
           <SitesPanel />
         ) : active === "communities" ? (
           <CommunitiesPanel />
+        ) : active === "community-visibility" ? (
+          <CommunityVisibilityNavigatorPanel />
         ) : (
           <PipelinesPanel />
         )}

--- a/WebUI/src/main/ts/developer/communityVisibilityGroups.ts
+++ b/WebUI/src/main/ts/developer/communityVisibilityGroups.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { CommunityVisibleObject } from "../api/developer/types";
+import { COMMUNITY_VISIBILITY_TYPE_OPTIONS } from "./communityVisibilityFilters";
+
+/** Sentinel type key when the visibility API omits {@code type}. */
+export const UNKNOWN_VISIBILITY_TYPE_KEY = "(unknown)";
+
+/**
+ * Curated ObjectTypeEnum order for SE-05 navigator groups (§5.8 object classes).
+ * Types not in this list sort after, alphabetically.
+ */
+export const VISIBILITY_TYPE_GROUP_ORDER: readonly string[] = [
+  "NODEDEF",
+  "TEMPLATE",
+  "SLOT",
+  "DISPLAY_FORMAT",
+  "SEARCH_DEF",
+  "VIEW_DEF",
+  "SITE",
+  "WORKFLOW",
+  "ACTION",
+  "ITEM_FILTER",
+] as const;
+
+export interface VisibilityTypeGroup {
+  /** Normalized type key (e.g. NODEDEF) or {@link UNKNOWN_VISIBILITY_TYPE_KEY}. */
+  typeKey: string;
+  /** Human label for the group header. */
+  label: string;
+  objects: CommunityVisibleObject[];
+}
+
+/** Normalize object type for grouping (trim + upper case; empty → unknown). */
+export function normalizeVisibilityTypeKey(
+  type: string | undefined | null,
+): string {
+  const t = (type ?? "").trim().toUpperCase();
+  return t.length > 0 ? t : UNKNOWN_VISIBILITY_TYPE_KEY;
+}
+
+/**
+ * Label for a visibility type group. Uses curated option labels when present;
+ * otherwise the raw type key (or "Unknown type").
+ */
+export function visibilityTypeGroupLabel(typeKey: string): string {
+  if (typeKey === UNKNOWN_VISIBILITY_TYPE_KEY) {
+    return "Unknown type";
+  }
+  const opt = COMMUNITY_VISIBILITY_TYPE_OPTIONS.find(
+    (o) => o.value.length > 0 && o.value.toUpperCase() === typeKey,
+  );
+  return opt?.label ?? typeKey;
+}
+
+function objectSortKey(o: CommunityVisibleObject): string {
+  return (o.label || o.name || o.guid?.stringValue || String(o.id ?? "")).toLowerCase();
+}
+
+function compareObjects(a: CommunityVisibleObject, b: CommunityVisibleObject): number {
+  return objectSortKey(a).localeCompare(objectSortKey(b), undefined, {
+    sensitivity: "base",
+  });
+}
+
+function typeOrderIndex(typeKey: string): number {
+  if (typeKey === UNKNOWN_VISIBILITY_TYPE_KEY) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  const idx = VISIBILITY_TYPE_GROUP_ORDER.indexOf(typeKey);
+  return idx >= 0 ? idx : VISIBILITY_TYPE_GROUP_ORDER.length;
+}
+
+/**
+ * Group design objects by type for the SE-05 community visibility navigator.
+ * Empty input → empty array. Groups and objects are sorted stably for display.
+ */
+export function groupVisibleObjectsByType(
+  objects: CommunityVisibleObject[],
+): VisibilityTypeGroup[] {
+  if (!objects || objects.length === 0) return [];
+
+  const map = new Map<string, CommunityVisibleObject[]>();
+  for (const o of objects) {
+    const key = normalizeVisibilityTypeKey(o.type);
+    const list = map.get(key);
+    if (list) list.push(o);
+    else map.set(key, [o]);
+  }
+
+  const groups: VisibilityTypeGroup[] = [];
+  for (const [typeKey, objs] of map) {
+    groups.push({
+      typeKey,
+      label: visibilityTypeGroupLabel(typeKey),
+      objects: [...objs].sort(compareObjects),
+    });
+  }
+
+  groups.sort((a, b) => {
+    const oi = typeOrderIndex(a.typeKey) - typeOrderIndex(b.typeKey);
+    if (oi !== 0) return oi;
+    return a.label.localeCompare(b.label, undefined, { sensitivity: "base" });
+  });
+
+  return groups;
+}
+
+/** Stable row key for a visible object in navigator lists. */
+export function visibleObjectRowKey(
+  o: CommunityVisibleObject,
+  index = 0,
+): string {
+  if (o.guid?.stringValue) return o.guid.stringValue;
+  if (o.id != null) return `id:${o.id}`;
+  if (o.name) return `name:${o.name}`;
+  return `obj-idx:${index}`;
+}

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -74,6 +74,7 @@ export const DEV_MSG_KEYS = {
   TAB_CE_CONTROLS: "perc.ui.developer@CE Controls",
   TAB_SITES: "perc.ui.developer@Sites",
   TAB_COMMUNITIES: "perc.ui.developer@Communities",
+  TAB_COMMUNITY_VISIBILITY: "perc.ui.developer@Community Visibility",
   TAB_PIPELINES: "perc.ui.developer@Pipelines",
   CT_LOADING: "perc.ui.developer@Loading content types...",
   CT_EMPTY: "perc.ui.developer@No content types returned.",
@@ -271,7 +272,21 @@ export const DEV_MSG_KEYS = {
   COMM_COL_OBJ_GUID: "perc.ui.developer@GUID",
   COMM_GAPS: "perc.ui.developer@Known gaps",
   COMM_GAP_ACL:
-    "perc.ui.developer@Full ACL editor parity and community navigator IA remain separate slices; assign COMMUNITY principals on object ACL sections where mounted",
+    "perc.ui.developer@Full ACL editor parity remains a separate slice; assign COMMUNITY principals on object ACL sections where mounted. Use Community Visibility for the SE-05 navigator groups.",
+  CVN_LOADING: "perc.ui.developer@Loading community visibility navigator...",
+  CVN_EMPTY: "perc.ui.developer@No communities returned for the visibility navigator.",
+  CVN_ERROR: "perc.ui.developer@Could not load communities for the visibility navigator.",
+  CVN_HINT:
+    "perc.ui.developer@SE-05 navigator: expand a community to load design objects visible to it, then expand type groups (content types, templates, workflows, …).",
+  CVN_INTRO:
+    "perc.ui.developer@Groups design objects by community visibility. Complements per-object ACL editing; does not replace it. Lazy-loads via existing communities/visibility REST.",
+  CVN_TREE_LABEL: "perc.ui.developer@Community visibility navigator",
+  CVN_VISIBILITY_LOADING: "perc.ui.developer@Loading objects for this community...",
+  CVN_VISIBILITY_ERROR: "perc.ui.developer@Could not load objects for this community.",
+  CVN_NO_GUID:
+    "perc.ui.developer@Community GUID not available — cannot load visibility for this community.",
+  CVN_COMMUNITY_EMPTY:
+    "perc.ui.developer@No visible design objects returned for this community.",
   PIPE_LOADING: "perc.ui.developer@Loading pipelines...",
   PIPE_EMPTY: "perc.ui.developer@No pipeline applications returned.",
   PIPE_ERROR: "perc.ui.developer@Could not load pipelines.",

--- a/WebUI/src/test/ts/developer/CommunityVisibilityNavigatorPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/CommunityVisibilityNavigatorPanel.test.tsx
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as assemblyApi from "../../../main/ts/api/developer/assemblyApi";
+import { CommunityVisibilityNavigatorPanel } from "../../../main/ts/developer/CommunityVisibilityNavigatorPanel";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+
+vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
+  listCommunities: vi.fn(),
+  getCommunityVisibility: vi.fn(),
+}));
+
+const listCommunities = assemblyApi.listCommunities as ReturnType<typeof vi.fn>;
+const getCommunityVisibility = assemblyApi.getCommunityVisibility as ReturnType<
+  typeof vi.fn
+>;
+
+const defaultComm = {
+  id: 7,
+  name: "Default",
+  label: "Default Community",
+  guid: { stringValue: "0-1-7", longValue: 7 },
+};
+
+describe("CommunityVisibilityNavigatorPanel", () => {
+  beforeEach(() => {
+    (window as unknown as { I18N?: { message: (k: string) => string } }).I18N = {
+      message: (key: string) => key,
+    };
+    listCommunities.mockReset();
+    getCommunityVisibility.mockReset();
+  });
+
+  it("lists communities in the SE-05 navigator tree", async () => {
+    listCommunities.mockResolvedValue([defaultComm]);
+    render(<CommunityVisibilityNavigatorPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cvn-tree")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-cvn-panel").textContent).toContain(
+      "Default Community",
+    );
+    expect(screen.getByTestId("developer-cvn-intro")).toBeTruthy();
+  });
+
+  it("shows empty when no communities", async () => {
+    listCommunities.mockResolvedValue([]);
+    render(<CommunityVisibilityNavigatorPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cvn-empty")).toBeTruthy();
+    });
+  });
+
+  it("expands community, loads visibility, and groups by type", async () => {
+    listCommunities.mockResolvedValue([defaultComm]);
+    getCommunityVisibility.mockResolvedValue([
+      { name: "percPage", label: "Page", type: "NODEDEF", id: 1 },
+      { name: "rffSnTitle", label: "Title", type: "TEMPLATE", id: 2 },
+      { name: "wfDefault", label: "Default WF", type: "WORKFLOW", id: 3 },
+    ]);
+    render(<CommunityVisibilityNavigatorPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cvn-community-toggle-0-1-7")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId("developer-cvn-community-toggle-0-1-7"));
+
+    await waitFor(() => {
+      expect(getCommunityVisibility).toHaveBeenCalledWith(defaultComm.guid);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cvn-type-groups-0-1-7")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-cvn-type-0-1-7-NODEDEF")).toBeTruthy();
+    expect(screen.getByTestId("developer-cvn-type-0-1-7-TEMPLATE")).toBeTruthy();
+    expect(screen.getByTestId("developer-cvn-type-0-1-7-WORKFLOW")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("developer-cvn-type-toggle-0-1-7-NODEDEF"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cvn-objects-0-1-7-NODEDEF")).toBeTruthy();
+    });
+    expect(
+      screen.getByTestId("developer-cvn-objects-0-1-7-NODEDEF").textContent,
+    ).toMatch(/percPage/);
+  });
+
+  it("shows community empty state when visibility returns no objects", async () => {
+    listCommunities.mockResolvedValue([defaultComm]);
+    getCommunityVisibility.mockResolvedValue([]);
+    render(<CommunityVisibilityNavigatorPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cvn-community-toggle-0-1-7")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-cvn-community-toggle-0-1-7"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cvn-community-empty-0-1-7")).toBeTruthy();
+    });
+  });
+
+  it("shows visibility error when API fails for a community", async () => {
+    listCommunities.mockResolvedValue([defaultComm]);
+    getCommunityVisibility.mockRejectedValue(new Error("visibility boom"));
+    render(<CommunityVisibilityNavigatorPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cvn-community-toggle-0-1-7")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-cvn-community-toggle-0-1-7"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cvn-community-error-0-1-7")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-cvn-community-error-0-1-7").textContent).toMatch(
+      /visibility boom/,
+    );
+  });
+
+  it("does not reload visibility when collapsing and re-expanding ready community", async () => {
+    listCommunities.mockResolvedValue([defaultComm]);
+    getCommunityVisibility.mockResolvedValue([
+      { name: "percPage", label: "Page", type: "NODEDEF", id: 1 },
+    ]);
+    render(<CommunityVisibilityNavigatorPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cvn-community-toggle-0-1-7")).toBeTruthy();
+    });
+    const toggle = screen.getByTestId("developer-cvn-community-toggle-0-1-7");
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cvn-type-groups-0-1-7")).toBeTruthy();
+    });
+    expect(getCommunityVisibility).toHaveBeenCalledTimes(1);
+    fireEvent.click(toggle); // collapse
+    fireEvent.click(toggle); // expand again
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cvn-type-groups-0-1-7")).toBeTruthy();
+    });
+    expect(getCommunityVisibility).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows catalog error when listCommunities fails", async () => {
+    listCommunities.mockRejectedValue(new Error("list fail"));
+    render(<CommunityVisibilityNavigatorPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cvn-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-cvn-error").textContent).toMatch(/list fail/);
+    expect(screen.getByTestId("developer-cvn-error").textContent).toContain(
+      DEV_MSG.CVN_ERROR,
+    );
+  });
+});

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -859,6 +859,17 @@ it("loads views catalog section", async () => {
     });
   });
 
+  it("opens community-visibility navigator section (SE-05)", async () => {
+    render(<DeveloperShell initialSection="community-visibility" embedded />);
+    expect(
+      screen.getByTestId("tab-developer-community-visibility").getAttribute("aria-selected"),
+    ).toBe("true");
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-cvn-panel")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-cvn-tree")).toBeTruthy();
+  });
+
   it("loads templates slots and communities catalogs", async () => {
     const { unmount } = render(<DeveloperShell initialSection="templates" embedded />);
     await waitFor(() => {

--- a/WebUI/src/test/ts/developer/communityVisibilityGroups.test.ts
+++ b/WebUI/src/test/ts/developer/communityVisibilityGroups.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { CommunityVisibleObject } from "../../../main/ts/api/developer/types";
+import {
+  groupVisibleObjectsByType,
+  normalizeVisibilityTypeKey,
+  UNKNOWN_VISIBILITY_TYPE_KEY,
+  visibilityTypeGroupLabel,
+  visibleObjectRowKey,
+  VISIBILITY_TYPE_GROUP_ORDER,
+} from "../../../main/ts/developer/communityVisibilityGroups";
+
+const sample: CommunityVisibleObject[] = [
+  { name: "site1", label: "Corporate", type: "SITE", id: 3 },
+  { name: "percPage", label: "Page", type: "NODEDEF", id: 1 },
+  { name: "rffSnTitle", label: "Title Snippet", type: "TEMPLATE", id: 2 },
+  { name: "wf1", label: "Simple", type: "workflow", id: 4 },
+  { name: "orphan", label: "No type", id: 5 },
+];
+
+describe("communityVisibilityGroups", () => {
+  it("normalizeVisibilityTypeKey uppercases and maps empty to unknown", () => {
+    expect(normalizeVisibilityTypeKey("nodedef")).toBe("NODEDEF");
+    expect(normalizeVisibilityTypeKey("  TEMPLATE  ")).toBe("TEMPLATE");
+    expect(normalizeVisibilityTypeKey("")).toBe(UNKNOWN_VISIBILITY_TYPE_KEY);
+    expect(normalizeVisibilityTypeKey(null)).toBe(UNKNOWN_VISIBILITY_TYPE_KEY);
+    expect(normalizeVisibilityTypeKey(undefined)).toBe(UNKNOWN_VISIBILITY_TYPE_KEY);
+  });
+
+  it("visibilityTypeGroupLabel uses curated labels and fallbacks", () => {
+    expect(visibilityTypeGroupLabel("NODEDEF")).toMatch(/Content type/i);
+    expect(visibilityTypeGroupLabel("TEMPLATE")).toMatch(/Template/i);
+    expect(visibilityTypeGroupLabel("CUSTOM_X")).toBe("CUSTOM_X");
+    expect(visibilityTypeGroupLabel(UNKNOWN_VISIBILITY_TYPE_KEY)).toBe("Unknown type");
+  });
+
+  it("groupVisibleObjectsByType returns empty for empty input", () => {
+    expect(groupVisibleObjectsByType([])).toEqual([]);
+  });
+
+  it("groups by type, sorts curated order, and sorts objects by label/name", () => {
+    const groups = groupVisibleObjectsByType(sample);
+    const keys = groups.map((g) => g.typeKey);
+    expect(keys).toEqual([
+      "NODEDEF",
+      "TEMPLATE",
+      "SITE",
+      "WORKFLOW",
+      UNKNOWN_VISIBILITY_TYPE_KEY,
+    ]);
+    // Curated order positions
+    expect(VISIBILITY_TYPE_GROUP_ORDER.indexOf("NODEDEF")).toBeLessThan(
+      VISIBILITY_TYPE_GROUP_ORDER.indexOf("TEMPLATE"),
+    );
+    expect(groups[0].objects.map((o) => o.name)).toEqual(["percPage"]);
+    expect(groups[1].label).toMatch(/Template/i);
+    const unknown = groups.find((g) => g.typeKey === UNKNOWN_VISIBILITY_TYPE_KEY);
+    expect(unknown?.objects.map((o) => o.name)).toEqual(["orphan"]);
+  });
+
+  it("sorts objects within a group case-insensitively by label then name", () => {
+    const objs: CommunityVisibleObject[] = [
+      { name: "b", label: "Zebra", type: "SITE" },
+      { name: "a", label: "apple", type: "SITE" },
+      { name: "c", label: "Mango", type: "SITE" },
+    ];
+    const groups = groupVisibleObjectsByType(objs);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].objects.map((o) => o.label)).toEqual(["apple", "Mango", "Zebra"]);
+  });
+
+  it("visibleObjectRowKey prefers guid, then id, then name", () => {
+    expect(
+      visibleObjectRowKey({ guid: { stringValue: "0-2-1" }, name: "x", id: 9 }),
+    ).toBe("0-2-1");
+    expect(visibleObjectRowKey({ id: 9, name: "x" })).toBe("id:9");
+    expect(visibleObjectRowKey({ name: "x" })).toBe("name:x");
+    expect(visibleObjectRowKey({}, 3)).toBe("obj-idx:3");
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/developer-community-visibility-navigator.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-community-visibility-navigator.spec.js
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Developer SE-05 community visibility navigator (#2273 / #2262 / #1690).
+ *
+ * Opens the dedicated Community Visibility section and asserts navigator IA:
+ * communities as expandable groups, type groups under a community, object rows.
+ *
+ * Entry: spa.jsp?entry=developer&section=community-visibility
+ * Refs #2273, #2262, #1690.
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+function developerCommunityVisibilityUrl() {
+  const q = new URLSearchParams({
+    entry: "developer",
+    section: "community-visibility",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+test.describe("Developer SE-05 community visibility navigator (#2273)", () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+  });
+
+  test("navigator groups design objects by community visibility", async ({ page }) => {
+    await page.goto(developerCommunityVisibilityUrl(), {
+      waitUntil: "networkidle",
+    });
+
+    await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(
+      page.locator('[data-testid="tab-developer-community-visibility"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const error = page.locator('[data-testid="developer-cvn-error"]');
+    const panel = page.locator('[data-testid="developer-cvn-panel"]');
+    const empty = page.locator('[data-testid="developer-cvn-empty"]');
+
+    await expect(panel.or(empty).or(error).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    if (await error.isVisible()) {
+      const msg = (await error.innerText()).trim();
+      throw new Error(`Community visibility navigator error: ${msg}`);
+    }
+
+    if (await empty.isVisible()) {
+      test.skip(true, "No communities in CMS — cannot exercise SE-05 navigator");
+      return;
+    }
+
+    await expect(page.locator('[data-testid="developer-cvn-tree"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-cvn-intro"]')).toBeVisible();
+
+    // First community toggle in the tree (keys are guid/name/id-based).
+    const firstToggle = page
+      .locator('[data-testid^="developer-cvn-community-toggle-"]')
+      .first();
+    await expect(firstToggle).toBeVisible({ timeout: 15_000 });
+    await firstToggle.click();
+
+    const firstCommunityItem = page
+      .locator('[data-testid^="developer-cvn-community-"]')
+      .filter({ has: firstToggle })
+      .first();
+    // Resolve key from toggle test id suffix.
+    const toggleTestId = await firstToggle.getAttribute("data-testid");
+    const key = (toggleTestId || "").replace("developer-cvn-community-toggle-", "");
+    expect(key.length).toBeGreaterThan(0);
+
+    const loading = page.locator(
+      `[data-testid="developer-cvn-community-loading-${key}"]`,
+    );
+    const typeGroups = page.locator(
+      `[data-testid="developer-cvn-type-groups-${key}"]`,
+    );
+    const commEmpty = page.locator(
+      `[data-testid="developer-cvn-community-empty-${key}"]`,
+    );
+    const commError = page.locator(
+      `[data-testid="developer-cvn-community-error-${key}"]`,
+    );
+
+    await expect(loading).toBeHidden({ timeout: 30_000 }).catch(() => {
+      // loading may never appear if response was instant
+    });
+    await expect(typeGroups.or(commEmpty).or(commError).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    if (await commError.isVisible()) {
+      const msg = (await commError.innerText()).trim();
+      throw new Error(`Community visibility load error: ${msg}`);
+    }
+
+    if (await commEmpty.isVisible()) {
+      // Empty community is a valid navigator state on sparse H2 fixtures.
+      await expect(commEmpty).toBeVisible();
+      return;
+    }
+
+    await expect(typeGroups).toBeVisible();
+    // At least one type group under the community.
+    const typeToggle = page
+      .locator(`[data-testid^="developer-cvn-type-toggle-${key}-"]`)
+      .first();
+    await expect(typeToggle).toBeVisible({ timeout: 10_000 });
+    await typeToggle.click();
+
+    const typeTestId = await typeToggle.getAttribute("data-testid");
+    const typeKey = (typeTestId || "").replace(
+      `developer-cvn-type-toggle-${key}-`,
+      "",
+    );
+    expect(typeKey.length).toBeGreaterThan(0);
+
+    const objects = page.locator(
+      `[data-testid="developer-cvn-objects-${key}-${typeKey}"]`,
+    );
+    await expect(objects).toBeVisible({ timeout: 10_000 });
+    // Object rows use developer-cvn-object-* test ids.
+    await expect(
+      objects.locator('[data-testid^="developer-cvn-object-"]').first(),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Collapse community again — navigator chrome remains.
+    await firstToggle.click();
+    await expect(typeGroups).toBeHidden({ timeout: 5_000 });
+    await expect(page.locator('[data-testid="developer-cvn-tree"]')).toBeVisible();
+
+    // Silence unused variable when filter path unused.
+    void firstCommunityItem;
+  });
+});


### PR DESCRIPTION
## Summary
**SE-05 community visibility navigator IA** — dedicated Developer section that groups design objects by community visibility (not Community detail filter polish from #2250 / PR #2263).

Parent tracker: #2262 · Grandparent: #1690 · Slice A of #2262

### Before → after
| Area | Before | After |
|------|--------|-------|
| Navigator IA (SE-05) | Only Communities catalog + flat visibility table on detail | New **Community Visibility** section: community → type groups → objects |
| Grouping | Flat table rows | Pure `groupVisibleObjectsByType` (curated §5.8 order) |
| REST | — | Existing `POST /services/communities/visibility` only (lazy per community; no new REST) |
| Vitest | Filter helpers only | Group helpers + navigator panel + shell section |
| Playwright | Detail filter polish | New navigator path HARD GATE |

### Code
- `communityVisibilityGroups.ts` — pure grouping/sort/keys
- `CommunityVisibilityNavigatorPanel.tsx` — tree navigator UI
- `DeveloperShell` + `allowlists` — section `community-visibility` + deep-link aliases
- `messages.ts` — CVN_* copy; gap text no longer claims navigator is missing
- Vitest: groups + panel + shell
- Playwright: `developer-community-visibility-navigator.spec.js`

### Explicitly not in this PR
- Full object ACL editor parity (#2274)
- Community↔object assign REST (#2275 already skipped — no gap)
- Re-doing #2250 CommunityDetailPanel filter polish

## Test plan
- [x] WebUI Vitest: `communityVisibilityGroups`, `CommunityVisibilityNavigatorPanel`, `DeveloperShell` SE-05 case
- [x] WebUI `mvnw clean install` (standalone module)
- [x] perc-qa-automation `mvnw clean install`
- [ ] Live Playwright (when H2 qa-up available): `tests/developer-community-visibility-navigator.spec.js`
  - Surface filter: `SURFACE_PATH=tests/developer-community-visibility-navigator.spec.js`
- [ ] Manual: Developer → Community Visibility → expand community → expand type group → object rows

## Gates
- Erlang self-review: no portable-path I/O; behavioral unit tests; request-id guard for visibility races; ready-state cache on re-expand
- Change-class companions: Vitest + Playwright for user-visible navigator surface
- Operator: Grok: night-issue-prs (model grok-4.5)

## Tracking
Fixes #2273  
Refs #2262 #1690  
Residual of #2250 / PR #2263

> Co-Authored by Grok Build using grok-4.5 with agent main.