### PR TITLE
fix(servlet-utils): replace this-escape suppress with real constructor fix (#2021)

### DIFF
--- a/modules/servletutils/src/main/java/com/percussion/servlet_utils/servlet/PSMockHttpServletRequest.java
+++ b/modules/servletutils/src/main/java/com/percussion/servlet_utils/servlet/PSMockHttpServletRequest.java
@@ -87,13 +87,15 @@ public class PSMockHttpServletRequest implements HttpServletRequest {
   /**
    * Convenience constructor that seeds the request method and URI.
    *
+   * <p>Assigns fields directly rather than calling overridable setters so a subclass cannot observe
+   * a partially constructed instance ({@code this-escape} under {@code -Xlint:all}).
+   *
    * @param method the HTTP method, defaults to {@code GET} when {@code null}
    * @param requestURI the request URI, defaults to empty when {@code null}
    */
-  @SuppressWarnings("this-escape")
   public PSMockHttpServletRequest(String method, String requestURI) {
     this.method = method != null ? method : "GET";
-    setRequestURI(requestURI != null ? requestURI : "");
+    this.requestURI = requestURI != null ? requestURI : "";
   }
 
   /**

--- a/modules/servletutils/src/test/java/com/percussion/servlet_utils/servlet/PSMockHttpServletRequestTest.java
+++ b/modules/servletutils/src/test/java/com/percussion/servlet_utils/servlet/PSMockHttpServletRequestTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.servlet_utils.servlet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for {@link PSMockHttpServletRequest}, including the two-arg convenience
+ * constructor that must seed method and URI without invoking overridable setters (issue #2021 /
+ * this-escape remediation).
+ */
+public class PSMockHttpServletRequestTest {
+
+  @Test
+  @DisplayName("two-arg constructor seeds method and request URI")
+  void twoArgConstructorSeedsMethodAndUri() {
+    PSMockHttpServletRequest request =
+        new PSMockHttpServletRequest("POST", "/Rhythmyx/content");
+    assertEquals("POST", request.getMethod());
+    assertEquals("/Rhythmyx/content", request.getRequestURI());
+  }
+
+  @Test
+  @DisplayName("two-arg constructor defaults null method to GET and null URI to empty")
+  void twoArgConstructorNullDefaults() {
+    PSMockHttpServletRequest request = new PSMockHttpServletRequest(null, null);
+    assertEquals("GET", request.getMethod());
+    assertEquals("", request.getRequestURI());
+  }
+
+  @Test
+  @DisplayName("setRequestURI still normalizes null to empty after construction")
+  void setRequestURINullBecomesEmpty() {
+    PSMockHttpServletRequest request = new PSMockHttpServletRequest("GET", "/path");
+    request.setRequestURI(null);
+    assertEquals("", request.getRequestURI());
+  }
+}

--- a/modules/servletutils/src/test/java/com/percussion/servlet_utils/tomcat/PSTomcatConnectorTest.java
+++ b/modules/servletutils/src/test/java/com/percussion/servlet_utils/tomcat/PSTomcatConnectorTest.java
@@ -82,17 +82,18 @@ public class PSTomcatConnectorTest {
 
     ciphers.addAll(
         FunctionalUtils.commaStringToStream(DEFAULT_CIPHERS).collect(Collectors.toSet()));
-    IPSConnector tc =
-        new PSAbstractConnector.HttpsBuilder()
-            .setPort(port)
-            .setHttps()
-            .setKeystoreFile(Paths.get(file))
-            .setKeystorePass(pass)
-            .setCiphers(ciphers)
-            .setSslProtocols(sslProtocols)
-            .build();
+    // Sequential calls on a parameterized HttpsBuilder — fluent chaining would widen to the
+    // raw return types still declared on PSAbstractConnector.HttpsBuilder setters.
+    PSAbstractConnector.HttpsBuilder<?> https = new PSAbstractConnector.HttpsBuilder<>();
+    https.setPort(port);
+    https.setHttps();
+    https.setKeystoreFile(Paths.get(file));
+    https.setKeystorePass(pass);
+    https.setCiphers(ciphers);
+    https.setSslProtocols(sslProtocols);
+    IPSConnector tc = https.build();
     assertEquals(port, tc.getPort());
-    assertEquals(tc.SCHEME_HTTPS, tc.getScheme());
+    assertEquals(IPSConnector.SCHEME_HTTPS, tc.getScheme());
 
     assertEquals(pass, tc.getKeystorePass());
     assertEquals(ciphers, tc.getCiphers());
@@ -139,7 +140,7 @@ public class PSTomcatConnectorTest {
 
     PSAbstractConnector tc2 = PSAbstractConnector.getBuilder().setSource(e).build();
     assertEquals(port, tc2.getPort());
-    assertEquals(tc.SCHEME_HTTP, tc2.getScheme());
+    assertEquals(PSAbstractConnector.SCHEME_HTTP, tc2.getScheme());
 
     port = 8443;
     String file = "myFile";
@@ -147,14 +148,13 @@ public class PSTomcatConnectorTest {
     Set<String> ciphers = new HashSet<>();
     ciphers.addAll(
         FunctionalUtils.commaStringToStream(DEFAULT_CIPHERS).collect(Collectors.toSet()));
-    tc =
-        PSAbstractConnector.getBuilder()
-            .setPort(port)
-            .setHttps()
-            .setKeystoreFile(Paths.get(file))
-            .setKeystorePass(pass)
-            .setCiphers(ciphers)
-            .build();
+    PSAbstractConnector.HttpsBuilder<?> httpsBuilder = new PSAbstractConnector.HttpsBuilder<>();
+    httpsBuilder.setPort(port);
+    httpsBuilder.setHttps();
+    httpsBuilder.setKeystoreFile(Paths.get(file));
+    httpsBuilder.setKeystorePass(pass);
+    httpsBuilder.setCiphers(ciphers);
+    tc = httpsBuilder.build();
     e =
         (Element)
             tc.toXml(tc.getProperties())
@@ -187,7 +187,6 @@ public class PSTomcatConnectorTest {
    * @param port The connector's expected port.
    * @throws Exception If there are any errors or failures.
    */
-  @Test
   private void doTestHttpConnector(IPSConnector tc, int port) throws Exception {
     assertEquals(port, tc.getPort());
     assertEquals(PSTomcatConnector.SCHEME_HTTP, tc.getScheme());


### PR DESCRIPTION
## Summary

Replaces the residual `@SuppressWarnings(""this-escape"")` left by suppress-only PR #2053 with a real fix in `servlet-utils`.

- **PSMockHttpServletRequest**: two-arg constructor now assigns `method` and `requestURI` fields directly instead of calling overridable `setRequestURI` (eliminates `this-escape` under `-Xlint` without re-suppressing).
- **PSTomcatConnectorTest**: type-qualify static `SCHEME_*` access; use parameterized `HttpsBuilder` with sequential calls (no fluent raw-type chains); remove misannotated private `@Test` helper.
- **PSMockHttpServletRequestTest**: behavioral coverage for two-arg constructor seeds and null defaults.

Parent tracker: #2200

## Test plan

- [x] Standalone `modules/servletutils`: `mvnw clean install` — BUILD SUCCESS
- [x] Main + test compile: no `[WARNING]` lines from javac (project `-Xlint` / `-Xlint:-deprecation`)
- [x] `PSMockHttpServletRequestTest` (3 tests) green
- [x] Full module suite: 48 tests, 0 failures (5 pre-existing skips)

## Gates evidence

- Erlang-style self-review: constructor no longer leaks `this` via overridable methods; test changes preserve connector assertion behavior; portable paths N/A
- Per-module standalone clean install: pass
- No re-introduced `@SuppressWarnings` in `modules/servletutils`

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2021

> Co-Authored by Grok Build using grok-4.5 with agent main.