### PR TITLE
fix(feeds): remove this-escape suppress via final PSFeedsApplication (#2039)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/PSFeedsApplication.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/main/java/com/percussion/delivery/feeds/PSFeedsApplication.java
@@ -35,15 +35,20 @@ import tools.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
  * Jersey application configuration for the feeds REST endpoints. Mounted at the application root
  * and registers the Spring/Jersey integration, JSON providers, exception mappers, and the {@link
  * PSFeedService} resource.
+ *
+ * <p>This class is {@code final} so no subclass can override {@link ResourceConfig#register} and
+ * observe a partially constructed instance during construction (avoids {@code this-escape} under
+ * {@code -Xlint:all}).
  */
 @ApplicationPath("/")
-public class PSFeedsApplication extends ResourceConfig {
+public final class PSFeedsApplication extends ResourceConfig {
 
   /**
    * Registers the request-scoped filter, Spring component provider, lifecycle listeners, the feed
-   * REST service, JSON binding provider, and exception mappers used by the feeds application.
+   * REST service, JSON binding provider, and exception mappers used by the feeds application. The
+   * class is {@code final} so no subclass can override {@link ResourceConfig#register} and observe
+   * a partially-constructed instance during this constructor.
    */
-  @SuppressWarnings("this-escape")
   public PSFeedsApplication() {
     register(RequestContextFilter.class);
     register(SpringComponentProvider.class);

--- a/deliverytiersuite/delivery-tier-suite/feeds/src/test/java/com/percussion/delivery/feeds/PSFeedsApplicationTest.java
+++ b/deliverytiersuite/delivery-tier-suite/feeds/src/test/java/com/percussion/delivery/feeds/PSFeedsApplicationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.delivery.feeds;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.delivery.exceptions.PSJsonMappingErrorResponse;
+import com.percussion.delivery.exceptions.PSUncaughtError;
+import com.percussion.delivery.feeds.services.PSFeedService;
+import java.lang.reflect.Modifier;
+import org.glassfish.jersey.logging.LoggingFeature;
+import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
+import org.glassfish.jersey.server.spring.AutowiredInjectResolver;
+import org.glassfish.jersey.server.spring.SpringComponentProvider;
+import org.glassfish.jersey.server.spring.SpringLifecycleListener;
+import org.glassfish.jersey.server.spring.SpringWebApplicationInitializer;
+import org.glassfish.jersey.server.spring.scope.RequestContextFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
+
+/**
+ * Behavioral coverage for {@link PSFeedsApplication}: constructor registration without {@code
+ * this-escape} suppressions (class is {@code final}; issue #2039).
+ */
+public class PSFeedsApplicationTest {
+
+  @Test
+  @DisplayName("class is final so ResourceConfig.register cannot be overridden by a subclass")
+  void classIsFinal() {
+    assertTrue(Modifier.isFinal(PSFeedsApplication.class.getModifiers()));
+  }
+
+  @Test
+  @DisplayName("constructor registers feeds resource, Spring/Jersey glue, and exception mappers")
+  void constructorRegistersExpectedComponents() {
+    PSFeedsApplication application = new PSFeedsApplication();
+
+    assertTrue(application.isRegistered(RequestContextFilter.class));
+    assertTrue(application.isRegistered(SpringComponentProvider.class));
+    assertTrue(application.isRegistered(AutowiredInjectResolver.class));
+    assertTrue(application.isRegistered(SpringLifecycleListener.class));
+    assertTrue(application.isRegistered(SpringWebApplicationInitializer.class));
+    assertTrue(application.isRegistered(PSFeedService.class));
+    assertTrue(application.isRegistered(LoggingFeature.class));
+    assertTrue(application.isRegistered(RolesAllowedDynamicFeature.class));
+    assertTrue(application.isRegistered(PSJsonMappingErrorResponse.class));
+    assertTrue(application.isRegistered(PSUncaughtError.class));
+    assertTrue(application.isRegistered(JacksonXmlBindJsonProvider.class));
+
+    assertFalse(application.getClasses().isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary

Replaces the residual `@SuppressWarnings("this-escape")` left by suppress-only PR #2049 with a real fix in the `feeds` module.

- **PSFeedsApplication**: mark the Jersey `ResourceConfig` subclass `final` so no subclass can override `register` and observe a partially constructed instance during construction (peer pattern: comments `PSCommentsApplication`).
- Remove `@SuppressWarnings("this-escape")` from the constructor.
- Leave intentional `@SuppressWarnings("unused")` on `PSFeedService` unchanged (still required).
- **PSFeedsApplicationTest**: behavioral coverage for finality and constructor registration of Spring/Jersey components, `PSFeedService`, exception mappers, and JSON provider.

Parent tracker: #2200

## Test plan

- [x] Standalone `deliverytiersuite/delivery-tier-suite/feeds`: `mvnw clean install` — BUILD SUCCESS
- [x] Main compile: no javac `[WARNING]` / no `this-escape` diagnostics under project `-Xlint`
- [x] `PSFeedsApplicationTest` (2 tests) green
- [x] Module suite: 112 tests, 0 failures (100 pre-existing performance skips)

## Gates evidence

- Erlang-style self-review: final class prevents subclass observation of partial construction; registration list unchanged; portable paths N/A
- Per-module standalone clean install: pass
- No re-introduced `@SuppressWarnings("this-escape")` in feeds production sources
- Intentional `@SuppressWarnings("unused")` retained on `PSFeedService` only

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2039

> Co-Authored by Grok Build using grok-4.5 with agent main.