### PR TITLE
fix(audit-log): replace this-escape suppressions with real constructor patterns (#2018)

### DIFF
--- a/modules/jcadf-master/src/main/java/com/ibm/cadf/middleware/AuditContext.java
+++ b/modules/jcadf-master/src/main/java/com/ibm/cadf/middleware/AuditContext.java
@@ -23,6 +23,9 @@ package com.ibm.cadf.middleware;
  * target}/{@code observer} resources when assembling an {@link com.ibm.cadf.model.Event}. All
  * fields are optional and may be {@code null}; the middleware falls back to safe defaults when a
  * value is missing.
+ *
+ * <p>Setters are {@code final} so subclasses (for example Percussion audit events) may call them
+ * from constructors without {@code this-escape} under {@code -Xlint:all}.
  */
 public class AuditContext {
   private String targetName;
@@ -58,7 +61,7 @@ public class AuditContext {
    *
    * @param path the path, may be {@code null}.
    */
-  public void setPath(String path) {
+  public final void setPath(String path) {
     this.path = path;
   }
 
@@ -76,7 +79,7 @@ public class AuditContext {
    *
    * @param guidID the GUID, may be {@code null}.
    */
-  public void setGuidID(String guidID) {
+  public final void setGuidID(String guidID) {
     this.guidID = guidID;
   }
 
@@ -94,7 +97,7 @@ public class AuditContext {
    *
    * @param activity the activity, may be {@code null}.
    */
-  public void setActivity(String activity) {
+  public final void setActivity(String activity) {
     this.activity = activity;
   }
 
@@ -112,12 +115,25 @@ public class AuditContext {
    *
    * @param agentName the agent name, may be {@code null}.
    */
-  public void setAgentName(String agentName) {
+  public final void setAgentName(String agentName) {
     this.agentName = agentName;
   }
 
   /** Default no-argument constructor for {@link AuditContext}. */
   public AuditContext() {}
+
+  /**
+   * Constructs an {@link AuditContext} with observer and target names assigned by direct field
+   * writes. Subclass constructors may call this form of {@code super(...)} without invoking
+   * overridable methods on a partially constructed instance (avoids {@code this-escape}).
+   *
+   * @param observerName the observer name, may be {@code null}.
+   * @param targetName the target name, may be {@code null}.
+   */
+  protected AuditContext(String observerName, String targetName) {
+    this.observerName = observerName;
+    this.targetName = targetName;
+  }
 
   /**
    * Returns the human-readable name of the target resource (e.g., a content item title).
@@ -133,7 +149,7 @@ public class AuditContext {
    *
    * @param targetName the target name, may be {@code null}.
    */
-  public void setTargetName(String targetName) {
+  public final void setTargetName(String targetName) {
     this.targetName = targetName;
   }
 
@@ -151,7 +167,7 @@ public class AuditContext {
    *
    * @param targetUrl the target URL, may be {@code null}.
    */
-  public void setTargetUrl(String targetUrl) {
+  public final void setTargetUrl(String targetUrl) {
     this.targetUrl = targetUrl;
   }
 
@@ -169,7 +185,7 @@ public class AuditContext {
    *
    * @param targetUsername the target username, may be {@code null}.
    */
-  public void setTargetUsername(String targetUsername) {
+  public final void setTargetUsername(String targetUsername) {
     this.targetUsername = targetUsername;
   }
 
@@ -187,7 +203,7 @@ public class AuditContext {
    *
    * @param observerName the observer name, may be {@code null}.
    */
-  public void setObserverName(String observerName) {
+  public final void setObserverName(String observerName) {
     this.observerName = observerName;
   }
 
@@ -205,7 +221,7 @@ public class AuditContext {
    *
    * @param initiatorIP the initiator IP, may be {@code null}.
    */
-  public void setInitiatorIP(String initiatorIP) {
+  public final void setInitiatorIP(String initiatorIP) {
     this.initiatorIP = initiatorIP;
   }
 
@@ -223,7 +239,7 @@ public class AuditContext {
    *
    * @param iniatorName the initiator user name, may be {@code null}.
    */
-  public void setIniatorName(String iniatorName) {
+  public final void setIniatorName(String iniatorName) {
     this.iniatorName = iniatorName;
   }
 
@@ -241,7 +257,7 @@ public class AuditContext {
    *
    * @param targetEndpointName the endpoint name, may be {@code null}.
    */
-  public void setTargetEndpointName(String targetEndpointName) {
+  public final void setTargetEndpointName(String targetEndpointName) {
     this.targetEndpointName = targetEndpointName;
   }
 }

--- a/modules/perc-auditlog/pom.xml
+++ b/modules/perc-auditlog/pom.xml
@@ -16,6 +16,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <scope>provided</scope>

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/AbstractEvent.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/AbstractEvent.java
@@ -24,11 +24,17 @@ import com.ibm.cadf.middleware.AuditContext;
  * target resource URIs with the {@code service/bss/cms} system observer and defaults the action
  * outcome to {@link PSActionOutcome#UNKNOWN}. Sub-classes typically mutate the action and the
  * outcome in their own constructors before passing the event to {@link PSAuditLogService}.
+ *
+ * <p>Outcome is field-initialized and {@link #setOutcome(String)} is {@code final}; parent CADF
+ * setters are {@code final} as well, so this constructor does not leak {@code this} via overridable
+ * methods ({@code this-escape} under {@code -Xlint:all}).
  */
 public class AbstractEvent extends AuditContext {
 
   private static final String SYSTEM_OBSERVER = "service/bss/cms";
-  private String outcome;
+
+  /** Action outcome; field-initialized so the no-arg constructor need not call an overridable setter. */
+  private String outcome = PSActionOutcome.UNKNOWN.name();
 
   /**
    * Returns the action outcome recorded for this audit event.
@@ -45,17 +51,18 @@ public class AbstractEvent extends AuditContext {
    *
    * @param outcome the outcome value, typically one of {@link PSActionOutcome}, never {@code null}.
    */
-  public void setOutcome(String outcome) {
+  public final void setOutcome(String outcome) {
     this.outcome = outcome;
   }
 
-  /** Constructs an event pre-populated with the system observer and an {@code UNKNOWN} outcome. */
-  @SuppressWarnings("this-escape")
+  /**
+   * Constructs an event pre-populated with the system observer and an {@code UNKNOWN} outcome.
+   *
+   * <p>Outcome is field-initialized; observer/target names are written in the parent constructor
+   * via direct field assignment so this constructor performs no instance method calls on {@code
+   * this} ({@code this-escape} free under {@code -Xlint:all}).
+   */
   public AbstractEvent() {
-
-    // Set some defaults
-    this.setOutcome(PSActionOutcome.UNKNOWN.name());
-    this.setObserverName(SYSTEM_OBSERVER);
-    this.setTargetName(SYSTEM_OBSERVER);
+    super(SYSTEM_OBSERVER, SYSTEM_OBSERVER);
   }
 }

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSAuthenticationEvent.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSAuthenticationEvent.java
@@ -23,8 +23,12 @@ import jakarta.servlet.http.HttpServletRequest;
  * Audit event emitted whenever a user authenticates against the CMS — covering login, renewal,
  * session revocation, and logout actions. Carries the session id, role claims, and community name
  * so the downstream audit sink can attribute the action.
+ *
+ * <p>This class is {@code final} and own-field setters used only after construction assign fields
+ * directly from constructors so no overridable method observes a partially constructed instance
+ * ({@code this-escape}).
  */
-public class PSAuthenticationEvent extends AbstractEvent {
+public final class PSAuthenticationEvent extends AbstractEvent {
 
   /** Tag identifying the HTTP session id associated with the authentication action. */
   public static final String SESSIONID_TAG = "sessionid";
@@ -41,17 +45,28 @@ public class PSAuthenticationEvent extends AbstractEvent {
   /** Resource URI for the system security service that records authentication events. */
   public static final String SYSTEM_SECURITY_URI = "service/bss/cms/security";
 
-  /** Constructs an empty event with the security observer pre-assigned. */
-  @SuppressWarnings("this-escape")
+  private AuthenticationEventActions action;
+
+  private String sessionId;
+  private String roles;
+  private String communityName;
+
+  /**
+   * Constructs an empty event with the security observer pre-assigned.
+   *
+   * <p>Uses {@code final} parent setters after {@code super()} completes.
+   */
   public PSAuthenticationEvent() {
     super();
-
-    this.setObserverName(SYSTEM_SECURITY_URI);
+    setObserverName(SYSTEM_SECURITY_URI);
   }
 
   /**
    * Constructs an authentication event fully populated from the supplied servlet request and
    * metadata.
+   *
+   * <p>Own fields are assigned directly; parent CADF fields use {@code final} setters after {@code
+   * super()} completes.
    *
    * @param outcome the action outcome (typically {@code SUCCESS} or {@code FAILURE}), never {@code
    *     null}.
@@ -59,19 +74,18 @@ public class PSAuthenticationEvent extends AbstractEvent {
    * @param request the HTTP request that triggered the event, never {@code null}.
    * @param username the user name captured by the authentication attempt, never {@code null}.
    */
-  @SuppressWarnings("this-escape")
   public PSAuthenticationEvent(
       String outcome,
       AuthenticationEventActions action,
       HttpServletRequest request,
       String username) {
     super();
-    this.setObserverName(SYSTEM_SECURITY_URI);
-    this.setOutcome(outcome);
-    this.setAction(action);
-    this.setInitiatorIP(request.getRemoteAddr());
-    this.setTargetUsername(username);
-    this.setAgentName(request.getHeader("User-Agent"));
+    setObserverName(SYSTEM_SECURITY_URI);
+    setOutcome(outcome);
+    this.action = action;
+    setInitiatorIP(request.getRemoteAddr());
+    setTargetUsername(username);
+    setAgentName(request.getHeader("User-Agent"));
   }
 
   /** Enumerates the authentication lifecycle actions recorded by {@link PSAuthenticationEvent}. */
@@ -85,12 +99,6 @@ public class PSAuthenticationEvent extends AbstractEvent {
     /** The user signed out, terminating the session. */
     logout
   }
-
-  private AuthenticationEventActions action;
-
-  private String sessionId;
-  private String roles;
-  private String communityName;
 
   /**
    * Returns the action recorded for this event.

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSContentEvent.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSContentEvent.java
@@ -23,8 +23,11 @@ import jakarta.servlet.http.HttpServletRequest;
  * Audit event emitted whenever content stored in the CMS changes — covering CRUD, recycling, and
  * page publish/removal scheduling. Carries the content id and GUID so downstream consumers can
  * locate the affected item.
+ *
+ * <p>This class is {@code final}; constructors assign own fields directly and use {@code final}
+ * parent setters after {@code super()} completes (no {@code this-escape}).
  */
-public class PSContentEvent extends AbstractEvent {
+public final class PSContentEvent extends AbstractEvent {
 
   /** Tag identifying the integer content id of the affected item. */
   public static final String CONTENTID_TAG = "//percussion/contentid";
@@ -53,9 +56,13 @@ public class PSContentEvent extends AbstractEvent {
 
   private String contentId;
   private String guid;
+  private ContentEventActions action;
 
   /**
    * Constructs a content event pre-populated from the supplied servlet request and metadata.
+   *
+   * <p>Own fields are assigned directly; parent CADF fields use {@code final} setters after {@code
+   * super()} completes.
    *
    * @param guid the GUID of the affected content item, never {@code null}.
    * @param contentId the integer content id of the affected content item as a string, may be {@code
@@ -65,7 +72,6 @@ public class PSContentEvent extends AbstractEvent {
    * @param request the HTTP request that triggered the event, never {@code null}.
    * @param outcome the outcome of the action, never {@code null}.
    */
-  @SuppressWarnings("this-escape")
   public PSContentEvent(
       String guid,
       String contentId,
@@ -73,17 +79,16 @@ public class PSContentEvent extends AbstractEvent {
       ContentEventActions action,
       HttpServletRequest request,
       PSActionOutcome outcome) {
+    super();
     this.guid = guid;
     this.contentId = contentId;
-    this.setPath(path);
     this.action = action;
-    this.setTargetUsername(request.getRemoteUser());
-    this.setAgentName(request.getHeader("User-Agent"));
-    this.setInitiatorIP(request.getRemoteAddr());
-    this.setOutcome(outcome.name());
+    setPath(path);
+    setTargetUsername(request.getRemoteUser());
+    setAgentName(request.getHeader("User-Agent"));
+    setInitiatorIP(request.getRemoteAddr());
+    setOutcome(outcome.name());
   }
-
-  private ContentEventActions action;
 
   /**
    * Returns the integer content id of the affected item as a string.
@@ -139,11 +144,13 @@ public class PSContentEvent extends AbstractEvent {
     this.action = action;
   }
 
-  /** Constructs an empty event with the content observer pre-assigned. */
-  @SuppressWarnings("this-escape")
+  /**
+   * Constructs an empty event with the content observer pre-assigned.
+   *
+   * <p>Uses a {@code final} parent setter after {@code super()} completes.
+   */
   public PSContentEvent() {
     super();
-
-    this.setObserverName(CONTENT_OBSERVER);
+    setObserverName(CONTENT_OBSERVER);
   }
 }

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSUserManagementEvent.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSUserManagementEvent.java
@@ -21,10 +21,13 @@ import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Audit event emitted for user-management administrative actions (create, update, delete, disable,
- * revoke) initiated through the CMS console. Subclasses or callers may attach additional tags at
- * the time the event is constructed.
+ * revoke) initiated through the CMS console. Callers may attach additional tags at the time the
+ * event is constructed.
+ *
+ * <p>This class is {@code final}; the constructor assigns the action field directly and uses {@code
+ * final} parent setters after {@code super()} completes (no {@code this-escape}).
  */
-public class PSUserManagementEvent extends AbstractEvent {
+public final class PSUserManagementEvent extends AbstractEvent {
   // Add any user specific tags here that would be useful to an auditor
 
   /** Enumerates the user-management lifecycle actions recorded by {@link PSUserManagementEvent}. */
@@ -64,20 +67,21 @@ public class PSUserManagementEvent extends AbstractEvent {
   /**
    * Constructs a user-management event populated from the originating servlet request.
    *
+   * <p>Own fields are assigned directly; parent CADF fields use {@code final} setters after {@code
+   * super()} completes.
+   *
    * @param request the HTTP request that triggered the event, never {@code null}.
    * @param action the user-management action being recorded, never {@code null}.
    * @param outcome the outcome of the action, never {@code null}.
    */
-  @SuppressWarnings("this-escape")
   public PSUserManagementEvent(
       HttpServletRequest request, UserEventActions action, PSActionOutcome outcome) {
     super();
-
-    this.setIniatorName(request.getRemoteUser());
-    this.setInitiatorIP(request.getRemoteAddr());
-    this.setTargetName(request.getRemoteUser());
-    this.setAction(action);
-    this.setOutcome(outcome.name());
-    this.setAgentName(request.getHeader("User-Agent"));
+    this.action = action;
+    setIniatorName(request.getRemoteUser());
+    setInitiatorIP(request.getRemoteAddr());
+    setTargetName(request.getRemoteUser());
+    setOutcome(outcome.name());
+    setAgentName(request.getHeader("User-Agent"));
   }
 }

--- a/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSWorkflowEvent.java
+++ b/modules/perc-auditlog/src/main/java/com/percussion/auditlog/PSWorkflowEvent.java
@@ -23,8 +23,11 @@ import jakarta.servlet.http.HttpServletRequest;
  * Audit event emitted when a workflow transition is applied to a content item. Carries the source
  * and destination state names, the affected content id and GUID, and the user who triggered the
  * transition.
+ *
+ * <p>This class is {@code final}; constructors assign own fields directly and use {@code final}
+ * parent setters after {@code super()} completes (no {@code this-escape}).
  */
-public class PSWorkflowEvent extends AbstractEvent {
+public final class PSWorkflowEvent extends AbstractEvent {
 
   /** Tag identifying the integer content id of the item whose workflow was updated. */
   public static final String CONTENTID_TAG = "//percussion/contentid";
@@ -53,6 +56,9 @@ public class PSWorkflowEvent extends AbstractEvent {
   /**
    * Constructs a workflow event populated from the originating servlet request and metadata.
    *
+   * <p>Own fields are assigned directly; parent CADF fields use {@code final} setters after {@code
+   * super()} completes.
+   *
    * @param transitionFrom the source workflow state name, never {@code null}.
    * @param transitionTo the destination workflow state name, never {@code null}.
    * @param action the workflow transition action, never {@code null}.
@@ -61,7 +67,6 @@ public class PSWorkflowEvent extends AbstractEvent {
    * @param guid the GUID of the affected item, never {@code null}.
    * @param outcome the outcome of the transition, never {@code null}.
    */
-  @SuppressWarnings("this-escape")
   public PSWorkflowEvent(
       String transitionFrom,
       String transitionTo,
@@ -70,16 +75,16 @@ public class PSWorkflowEvent extends AbstractEvent {
       String content,
       String guid,
       String outcome) {
-
-    this.setTargetUsername(request.getRemoteUser());
-    this.setTransitionFrom(transitionFrom);
-    this.setTransitionTo(transitionTo);
-    this.setAction(action);
-    this.setAgentName(request.getHeader("User-Agent"));
-    this.setOutcome(outcome);
-    this.setInitiatorIP(request.getRemoteAddr());
-    this.setGuid(guid);
-    this.setContentId(Integer.parseInt(content));
+    super();
+    this.transitionFrom = transitionFrom;
+    this.transitionTo = transitionTo;
+    this.action = action;
+    this.guid = guid;
+    this.contentId = Integer.parseInt(content);
+    setTargetUsername(request.getRemoteUser());
+    setAgentName(request.getHeader("User-Agent"));
+    setOutcome(outcome);
+    setInitiatorIP(request.getRemoteAddr());
   }
 
   /**

--- a/modules/perc-auditlog/src/test/java/com/percussion/auditlog/AbstractEventTest.java
+++ b/modules/perc-auditlog/src/test/java/com/percussion/auditlog/AbstractEventTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.auditlog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Modifier;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for {@link AbstractEvent} constructor defaults after this-escape remediation
+ * (issue #2018).
+ */
+public class AbstractEventTest {
+
+  @Test
+  @DisplayName("no-arg constructor seeds UNKNOWN outcome and system observer/target")
+  void noArgConstructorSeedsDefaults() {
+    AbstractEvent event = new AbstractEvent();
+    assertEquals(PSActionOutcome.UNKNOWN.name(), event.getOutcome());
+    assertEquals("service/bss/cms", event.getObserverName());
+    assertEquals("service/bss/cms", event.getTargetName());
+  }
+
+  @Test
+  @DisplayName("setOutcome remains usable after construction and is final")
+  void setOutcomeIsFinalAndWorks() throws Exception {
+    assertTrue(Modifier.isFinal(AbstractEvent.class.getMethod("setOutcome", String.class).getModifiers()));
+    AbstractEvent event = new AbstractEvent();
+    event.setOutcome(PSActionOutcome.SUCCESS.name());
+    assertEquals(PSActionOutcome.SUCCESS.name(), event.getOutcome());
+  }
+}

--- a/modules/perc-auditlog/src/test/java/com/percussion/auditlog/AuditEventConstructorsTest.java
+++ b/modules/perc-auditlog/src/test/java/com/percussion/auditlog/AuditEventConstructorsTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.auditlog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.lang.reflect.Modifier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Behavioral coverage for concrete audit event constructors after replacing {@code this-escape}
+ * suppressions with real constructor patterns (issue #2018).
+ */
+@ExtendWith(MockitoExtension.class)
+public class AuditEventConstructorsTest {
+
+  @Mock private HttpServletRequest request;
+
+  @BeforeEach
+  void stubRequest() {
+    // Lenient: not every test exercises every stub (no-arg / final-class cases).
+    lenient().when(request.getRemoteAddr()).thenReturn("203.0.113.10");
+    lenient().when(request.getRemoteUser()).thenReturn("editor");
+    lenient().when(request.getHeader("User-Agent")).thenReturn("JUnit-Agent/1.0");
+  }
+
+  @Test
+  @DisplayName("concrete event types are final (no subclass this-escape)")
+  void concreteEventTypesAreFinal() {
+    assertTrue(Modifier.isFinal(PSAuthenticationEvent.class.getModifiers()));
+    assertTrue(Modifier.isFinal(PSContentEvent.class.getModifiers()));
+    assertTrue(Modifier.isFinal(PSUserManagementEvent.class.getModifiers()));
+    assertTrue(Modifier.isFinal(PSWorkflowEvent.class.getModifiers()));
+  }
+
+  @Test
+  @DisplayName("PSAuthenticationEvent no-arg sets security observer")
+  void authenticationNoArgSetsObserver() {
+    PSAuthenticationEvent event = new PSAuthenticationEvent();
+    assertEquals(PSAuthenticationEvent.SYSTEM_SECURITY_URI, event.getObserverName());
+    assertEquals(PSActionOutcome.UNKNOWN.name(), event.getOutcome());
+  }
+
+  @Test
+  @DisplayName("PSAuthenticationEvent populated constructor seeds request metadata")
+  void authenticationPopulatedConstructor() {
+    PSAuthenticationEvent event =
+        new PSAuthenticationEvent(
+            PSActionOutcome.SUCCESS.name(),
+            PSAuthenticationEvent.AuthenticationEventActions.login,
+            request,
+            "alice");
+    assertEquals(PSAuthenticationEvent.SYSTEM_SECURITY_URI, event.getObserverName());
+    assertEquals(PSActionOutcome.SUCCESS.name(), event.getOutcome());
+    assertEquals(PSAuthenticationEvent.AuthenticationEventActions.login, event.getAction());
+    assertEquals("203.0.113.10", event.getInitiatorIP());
+    assertEquals("alice", event.getTargetUsername());
+    assertEquals("JUnit-Agent/1.0", event.getAgentName());
+  }
+
+  @Test
+  @DisplayName("PSContentEvent no-arg sets content observer")
+  void contentNoArgSetsObserver() {
+    PSContentEvent event = new PSContentEvent();
+    assertEquals(PSContentEvent.CONTENT_OBSERVER, event.getObserverName());
+  }
+
+  @Test
+  @DisplayName("PSContentEvent populated constructor seeds content and request fields")
+  void contentPopulatedConstructor() {
+    PSContentEvent event =
+        new PSContentEvent(
+            "guid-1",
+            "42",
+            "/Sites/demo/page",
+            PSContentEvent.ContentEventActions.create,
+            request,
+            PSActionOutcome.SUCCESS);
+    assertEquals("guid-1", event.getGuid());
+    assertEquals("42", event.getContentId());
+    assertEquals("/Sites/demo/page", event.getPath());
+    assertEquals(PSContentEvent.ContentEventActions.create, event.getAction());
+    assertEquals("editor", event.getTargetUsername());
+    assertEquals("203.0.113.10", event.getInitiatorIP());
+    assertEquals("JUnit-Agent/1.0", event.getAgentName());
+    assertEquals(PSActionOutcome.SUCCESS.name(), event.getOutcome());
+  }
+
+  @Test
+  @DisplayName("PSUserManagementEvent constructor seeds action and request fields")
+  void userManagementConstructor() {
+    PSUserManagementEvent event =
+        new PSUserManagementEvent(
+            request,
+            PSUserManagementEvent.UserEventActions.create,
+            PSActionOutcome.FAILURE);
+    assertEquals(PSUserManagementEvent.UserEventActions.create, event.getAction());
+    assertEquals("editor", event.getIniatorName());
+    assertEquals("editor", event.getTargetName());
+    assertEquals("203.0.113.10", event.getInitiatorIP());
+    assertEquals(PSActionOutcome.FAILURE.name(), event.getOutcome());
+    assertEquals("JUnit-Agent/1.0", event.getAgentName());
+  }
+
+  @Test
+  @DisplayName("PSWorkflowEvent constructor seeds transition and content fields")
+  void workflowConstructor() {
+    PSWorkflowEvent event =
+        new PSWorkflowEvent(
+            "Draft",
+            "Review",
+            PSWorkflowEvent.WorkflowEventActions.update,
+            request,
+            "99",
+            "guid-wf",
+            PSActionOutcome.SUCCESS.name());
+    assertEquals("Draft", event.getTransitionFrom());
+    assertEquals("Review", event.getTransitionTo());
+    assertEquals(PSWorkflowEvent.WorkflowEventActions.update, event.getAction());
+    assertEquals(99, event.getContentId());
+    assertEquals("guid-wf", event.getGuid());
+    assertEquals("editor", event.getTargetUsername());
+    assertEquals("203.0.113.10", event.getInitiatorIP());
+    assertEquals(PSActionOutcome.SUCCESS.name(), event.getOutcome());
+  }
+}


### PR DESCRIPTION
## Summary

Replaces residual `@SuppressWarnings(""this-escape"")` left by suppress-only PR #2056 with real constructor/factory-safe patterns in `audit-log` (and a minimal companion change in CADF `AuditContext`).

- **AuditContext** (`modules/jcadf-master` / `auditlogger`): all simple bean setters are `final`; added `protected AuditContext(String observerName, String targetName)` that assigns fields directly so non-final subclasses can initialize via `super(...)` without method calls on `this`.
- **AbstractEvent**: field-initialized `outcome`; `setOutcome` is `final`; no-arg ctor uses `super(SYSTEM_OBSERVER, SYSTEM_OBSERVER)` only (no instance method calls).
- **PSAuthenticationEvent / PSContentEvent / PSUserManagementEvent / PSWorkflowEvent**: classes are `final`; own fields assigned directly in constructors; parent CADF fields use `final` setters after `super()`; all `@SuppressWarnings(""this-escape"")` removed.
- **Tests**: `AbstractEventTest` + `AuditEventConstructorsTest` cover defaults and request-populated constructors; mockito test deps added to `audit-log`.

Parent tracker: #2200

Supersedes the suppression approach of #2056.

## Test plan

- [x] Standalone `modules/jcadf-master`: `mvnw clean install` — BUILD SUCCESS
- [x] Standalone `modules/perc-auditlog`: `mvnw clean install` — BUILD SUCCESS
- [x] Main compile: zero `[WARNING]` lines from javac for touched audit-log sources (no residual this-escape)
- [x] No `@SuppressWarnings(""this-escape"")` remaining under `modules/perc-auditlog`
- [x] Module suite: 25 tests, 0 failures (`AbstractEventTest` 2, `AuditEventConstructorsTest` 7, `FileCreatorTest` 16)

## Gates evidence

- Erlang-style self-review: constructors no longer leak `this` via overridable methods; final classes for concrete events; portable paths N/A; change-class companions (unit tests + CADF setter/ctor companion) included
- Per-module standalone clean install: pass (auditlogger + audit-log)
- No re-introduced suppressions in audit-log

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2018

> Co-Authored by Grok Build using grok-4.5 with agent main.