### PR TITLE
fix(rest): replace this-escape and serial suppressions with real fixes (#2026)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2026-rest-javac-real-fixes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2026-rest-javac-real-fixes-erlang.md
@@ -1,0 +1,42 @@
+# Erlang review: issue #2026 rest javac real fixes
+
+**Branch:** `fix/issue-2026-rest-javac-real-fixes`  
+**Date:** 2026-08-07  
+**Reviewer:** Erlang (self-review, Grok Build / night-issue-prs)
+
+## Summary
+
+Replaces residual `@SuppressWarnings` in `rest` (this-escape on `Guid` / `FolderNotFoundException`; serial on `RestExceptionBase` and summary DTOs) with real constructor / field-type fixes aligned with sibling night PRs (#2285–#2287). Adds behavioral unit tests. No residual `@SuppressWarnings` in `rest` main sources.
+
+## Scope
+
+- `rest/src/main/java/com/percussion/rest/Guid.java`
+- `rest/src/main/java/com/percussion/rest/errors/FolderNotFoundException.java`
+- `rest/src/main/java/com/percussion/rest/errors/RestExceptionBase.java`
+- `rest/src/main/java/com/percussion/share/relationship/data/PSLocalDependencySummary.java`
+- `rest/src/main/java/com/percussion/share/relationship/data/PSRelationshipSummary.java`
+- `rest/src/main/java/com/percussion/share/relationship/data/PSTaxonomySummary.java`
+- New tests: `GuidTest`, `FolderNotFoundExceptionTest`, `PSSummaryDtoSerialFieldsTest`
+- Base: `origin/main`
+- Memory patterns: this-escape via overridable setters; serial non-Serializable field types; missing behavioral tests
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none
+- Behavioral tests: present for Guid ctor, FolderNotFound cause, summary defensive copies
+- Cross-platform path review: N/A (no path/file I/O in diff)
+- **May commit/push: yes**
+
+## Issues
+
+None.
+
+## Verification
+
+- `mvnw -pl rest clean install` — BUILD SUCCESS, 229 tests, 0 failures
+- Main compile: no `[WARNING]` on `rest/src/**` for this-escape or serial after fixes
+- Zero `@SuppressWarnings` remaining under `rest/`

--- a/rest/src/main/java/com/percussion/rest/Guid.java
+++ b/rest/src/main/java/com/percussion/rest/Guid.java
@@ -133,18 +133,20 @@ public class Guid {
   /**
    * Initializes a Guid from a guid string.
    *
+   * <p>Fields are assigned directly (not via setters) so this constructor does not leak {@code
+   * this} through overridable methods ({@code this-escape} free under {@code -Xlint:all}).
+   *
    * @param guid the guid string, must not be null
    */
-  @SuppressWarnings("this-escape")
   public Guid(String guid) {
     Objects.requireNonNull(guid, "guid must not be null");
     var temp = new PSGuid(guid);
 
-    setStringValue(temp.toString());
-    setHostId(temp.getHostId());
-    setLongValue(temp.longValue());
-    setType(temp.getType());
-    setUuid(temp.getUUID());
-    setUntypedString(temp.toStringUntyped());
+    this.stringValue = temp.toString();
+    this.hostId = temp.getHostId();
+    this.longValue = temp.longValue();
+    this.type = temp.getType();
+    this.uuid = temp.getUUID();
+    this.untypedString = temp.toStringUntyped();
   }
 }

--- a/rest/src/main/java/com/percussion/rest/errors/FolderNotFoundException.java
+++ b/rest/src/main/java/com/percussion/rest/errors/FolderNotFoundException.java
@@ -19,7 +19,13 @@
 
 package com.percussion.rest.errors;
 
-/** Exception thrown when a folder is not found. */
+/**
+ * Exception thrown when a folder is not found.
+ *
+ * <p>The cause is passed through {@link RestExceptionBase}'s cause-aware constructor (not via
+ * {@link #initCause(Throwable)} after {@code super}), so construction is {@code this-escape} free
+ * under {@code -Xlint:all}.
+ */
 public class FolderNotFoundException extends RestExceptionBase {
 
   private static final long serialVersionUID = -4398063672305185319L;
@@ -28,12 +34,8 @@ public class FolderNotFoundException extends RestExceptionBase {
     this((Throwable) null);
   }
 
-  @SuppressWarnings("this-escape")
   public FolderNotFoundException(Throwable cause) {
-    // always set the folder not found code, attach cause if present
-    super(RestErrorCode.FOLDER_NOT_FOUND, null, null, null, null);
-    if (cause != null) {
-      initCause(cause);
-    }
+    // always set the folder not found code; attach cause via super (not initCause)
+    super(RestErrorCode.FOLDER_NOT_FOUND, null, null, null, null, cause);
   }
 }

--- a/rest/src/main/java/com/percussion/rest/errors/RestExceptionBase.java
+++ b/rest/src/main/java/com/percussion/rest/errors/RestExceptionBase.java
@@ -25,9 +25,14 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Optional;
 import java.util.ResourceBundle;
 
-/** Base class for REST exceptions in Percussion CMS. Sunny Sal: "Exception ka baap yeh hai!" */
+/**
+ * Base class for REST exceptions in Percussion CMS. Sunny Sal: "Exception ka baap yeh hai!"
+ *
+ * <p>{@link #errorData} is {@code transient}: it may hold arbitrary non-{@link
+ * java.io.Serializable} payloads used only for in-process JAX-RS mapping, not for Java
+ * serialization of the exception hierarchy.
+ */
 @XmlRootElement(name = "Error")
-@SuppressWarnings("serial")
 public class RestExceptionBase extends WebApplicationException {
 
   private static final long serialVersionUID = 1L;
@@ -35,7 +40,8 @@ public class RestExceptionBase extends WebApplicationException {
   private RestErrorCode errorCode;
   private String message;
   private String detailMessage;
-  private Object errorData;
+  /** In-process error payload; not part of Java serialization. */
+  private transient Object errorData;
   private Status status;
 
   public RestExceptionBase() {
@@ -44,7 +50,7 @@ public class RestExceptionBase extends WebApplicationException {
 
   public RestExceptionBase(
       RestErrorCode errorCode, String detailMessage, Object errorData, Status status) {
-    this(errorCode, null, detailMessage, errorData, status);
+    this(errorCode, null, detailMessage, errorData, status, null);
   }
 
   public RestExceptionBase(
@@ -53,8 +59,32 @@ public class RestExceptionBase extends WebApplicationException {
       String detailMessage,
       Object errorData,
       Status status) {
+    this(errorCode, message, detailMessage, errorData, status, null);
+  }
+
+  /**
+   * Constructs a REST exception with an optional causal throwable attached via {@code super(cause)}
+   * so subclasses need not call {@link #initCause(Throwable)} after construction (avoids {@code
+   * this-escape} under {@code -Xlint:all}).
+   *
+   * @param errorCode the REST error code, may be {@code null} only for framework/default use
+   * @param message the message; when {@code null} and {@code errorCode} is non-null, resolved from
+   *     the error messages bundle
+   * @param detailMessage optional detail text
+   * @param errorData optional in-process payload (not Java-serialized)
+   * @param status HTTP status; defaults to {@link Status#INTERNAL_SERVER_ERROR} when {@code null}
+   * @param cause optional cause, may be {@code null}
+   */
+  public RestExceptionBase(
+      RestErrorCode errorCode,
+      String message,
+      String detailMessage,
+      Object errorData,
+      Status status,
+      Throwable cause) {
+    super(cause);
     this.errorCode = errorCode;
-    if (message == null) {
+    if (message == null && errorCode != null) {
       var errorMsg = ResourceBundle.getBundle("com.percussion.rest.errors.ErrorMessages");
       this.message = errorMsg.getString(Integer.toString(errorCode.getNumVal()));
     } else {

--- a/rest/src/main/java/com/percussion/share/relationship/data/PSLocalDependencySummary.java
+++ b/rest/src/main/java/com/percussion/share/relationship/data/PSLocalDependencySummary.java
@@ -38,7 +38,6 @@ import java.util.List;
  */
 @XmlRootElement(name = "PSLocalDependencySummary")
 @JsonRootName("PSLocalDependencySummary")
-@SuppressWarnings("serial")
 public class PSLocalDependencySummary extends PSAbstractDataObject {
 
   private static final long serialVersionUID = 1L;
@@ -46,8 +45,11 @@ public class PSLocalDependencySummary extends PSAbstractDataObject {
   /** Total number of local + linked assets incident on the supplied item. */
   private long count;
 
-  /** Per-target rows; type is one of {@code local}, {@code linked}, {@code shared}. */
-  private List<PSLocalDependencyLink> links = new ArrayList<>();
+  /**
+   * Per-target rows; type is one of {@code local}, {@code linked}, {@code shared}. Stored as {@link
+   * ArrayList} so the field type is {@link java.io.Serializable} under {@code -Xlint:serial}.
+   */
+  private ArrayList<PSLocalDependencyLink> links = new ArrayList<>();
 
   public PSLocalDependencySummary() {
     super();
@@ -55,7 +57,7 @@ public class PSLocalDependencySummary extends PSAbstractDataObject {
 
   public PSLocalDependencySummary(long count, List<PSLocalDependencyLink> links) {
     this.count = count;
-    this.links = links == null ? new ArrayList<>() : links;
+    this.links = links == null ? new ArrayList<>() : new ArrayList<>(links);
   }
 
   public long getCount() {
@@ -71,7 +73,7 @@ public class PSLocalDependencySummary extends PSAbstractDataObject {
   }
 
   public void setLinks(List<PSLocalDependencyLink> links) {
-    this.links = links == null ? new ArrayList<>() : links;
+    this.links = links == null ? new ArrayList<>() : new ArrayList<>(links);
   }
 
   /** A single local or linked target on a page / template. */

--- a/rest/src/main/java/com/percussion/share/relationship/data/PSRelationshipSummary.java
+++ b/rest/src/main/java/com/percussion/share/relationship/data/PSRelationshipSummary.java
@@ -51,7 +51,6 @@ import java.util.Objects;
  */
 @XmlRootElement(name = "PSRelationshipSummary")
 @JsonRootName("PSRelationshipSummary")
-@SuppressWarnings("serial")
 public class PSRelationshipSummary extends PSAbstractDataObject {
 
   private static final long serialVersionUID = 1L;
@@ -64,9 +63,10 @@ public class PSRelationshipSummary extends PSAbstractDataObject {
 
   /**
    * Per-type breakdown, e.g. {@code [{"type": "translation", "count": 3}]}. Empty (rather than
-   * {@code null}) when the supplied item has no relationships in this dimension.
+   * {@code null}) when the supplied item has no relationships in this dimension. Stored as {@link
+   * ArrayList} so the field type is {@link java.io.Serializable} under {@code -Xlint:serial}.
    */
-  private List<PSRelationshipTypeBucket> byType = new ArrayList<>();
+  private ArrayList<PSRelationshipTypeBucket> byType = new ArrayList<>();
 
   public PSRelationshipSummary() {
     super();
@@ -74,7 +74,7 @@ public class PSRelationshipSummary extends PSAbstractDataObject {
 
   public PSRelationshipSummary(long count, List<PSRelationshipTypeBucket> byType) {
     this.count = count;
-    this.byType = byType == null ? new ArrayList<>() : byType;
+    this.byType = byType == null ? new ArrayList<>() : new ArrayList<>(byType);
   }
 
   public long getCount() {
@@ -90,7 +90,7 @@ public class PSRelationshipSummary extends PSAbstractDataObject {
   }
 
   public void setByType(List<PSRelationshipTypeBucket> byType) {
-    this.byType = byType == null ? new ArrayList<>() : byType;
+    this.byType = byType == null ? new ArrayList<>() : new ArrayList<>(byType);
   }
 
   /** One per relationship config (translation / linkback / AA / local). */

--- a/rest/src/main/java/com/percussion/share/relationship/data/PSTaxonomySummary.java
+++ b/rest/src/main/java/com/percussion/share/relationship/data/PSTaxonomySummary.java
@@ -38,7 +38,6 @@ import java.util.List;
  */
 @XmlRootElement(name = "PSTaxonomySummary")
 @JsonRootName("PSTaxonomySummary")
-@SuppressWarnings("serial")
 public class PSTaxonomySummary extends PSAbstractDataObject {
 
   private static final long serialVersionUID = 1L;
@@ -46,8 +45,11 @@ public class PSTaxonomySummary extends PSAbstractDataObject {
   /** Number of taxonomy node paths incident on the supplied item. */
   private long count;
 
-  /** The taxonomy node paths. Empty (not {@code null}) when {@link #count} is 0. */
-  private List<String> nodes = new ArrayList<>();
+  /**
+   * The taxonomy node paths. Empty (not {@code null}) when {@link #count} is 0. Stored as {@link
+   * ArrayList} so the field type is {@link java.io.Serializable} under {@code -Xlint:serial}.
+   */
+  private ArrayList<String> nodes = new ArrayList<>();
 
   public PSTaxonomySummary() {
     super();
@@ -55,7 +57,7 @@ public class PSTaxonomySummary extends PSAbstractDataObject {
 
   public PSTaxonomySummary(long count, List<String> nodes) {
     this.count = count;
-    this.nodes = nodes == null ? new ArrayList<>() : nodes;
+    this.nodes = nodes == null ? new ArrayList<>() : new ArrayList<>(nodes);
   }
 
   public long getCount() {
@@ -71,6 +73,6 @@ public class PSTaxonomySummary extends PSAbstractDataObject {
   }
 
   public void setNodes(List<String> nodes) {
-    this.nodes = nodes == null ? new ArrayList<>() : nodes;
+    this.nodes = nodes == null ? new ArrayList<>() : new ArrayList<>(nodes);
   }
 }

--- a/rest/src/test/java/com/percussion/rest/GuidTest.java
+++ b/rest/src/test/java/com/percussion/rest/GuidTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for {@link Guid} construction after the this-escape real fix (direct field
+ * assignment in the string constructor).
+ */
+class GuidTest {
+
+  @Test
+  void stringConstructorSeedsAllFields() {
+    Guid guid = new Guid("0-2-311");
+
+    assertTrue(guid.getStringValue().isPresent());
+    assertEquals("0-2-311", guid.getStringValue().get());
+    assertEquals(0L, guid.getHostId());
+    assertEquals((short) 2, guid.getType());
+    assertEquals(311, guid.getUuid());
+    assertTrue(guid.getLongValue() != 0L || guid.getUuid() == 311);
+    assertTrue(guid.getUntypedString().isPresent());
+  }
+
+  @Test
+  void stringConstructorRejectsNull() {
+    assertThrows(NullPointerException.class, () -> new Guid(null));
+  }
+
+  @Test
+  void defaultConstructorLeavesOptionalFieldsEmpty() {
+    Guid guid = new Guid();
+    assertTrue(guid.getStringValue().isEmpty());
+    assertTrue(guid.getUntypedString().isEmpty());
+    assertEquals(0L, guid.getHostId());
+    assertEquals(0, guid.getUuid());
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/errors/FolderNotFoundExceptionTest.java
+++ b/rest/src/test/java/com/percussion/rest/errors/FolderNotFoundExceptionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.errors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import jakarta.ws.rs.core.Response.Status;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for {@link FolderNotFoundException} after the this-escape real fix (cause
+ * attached via {@link RestExceptionBase}'s cause-aware constructor).
+ */
+class FolderNotFoundExceptionTest {
+
+  @Test
+  void noArgConstructorSetsFolderNotFoundCodeAndDefaultStatus() {
+    FolderNotFoundException ex = new FolderNotFoundException();
+
+    assertEquals(RestErrorCode.FOLDER_NOT_FOUND, ex.getErrorCode());
+    assertEquals(Status.INTERNAL_SERVER_ERROR, ex.getStatus());
+    assertNull(ex.getCause());
+  }
+
+  @Test
+  void causeConstructorPreservesCauseAndErrorCode() {
+    RuntimeException cause = new RuntimeException("missing folder");
+    FolderNotFoundException ex = new FolderNotFoundException(cause);
+
+    assertEquals(RestErrorCode.FOLDER_NOT_FOUND, ex.getErrorCode());
+    assertSame(cause, ex.getCause());
+  }
+}

--- a/rest/src/test/java/com/percussion/share/relationship/data/PSSummaryDtoSerialFieldsTest.java
+++ b/rest/src/test/java/com/percussion/share/relationship/data/PSSummaryDtoSerialFieldsTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.share.relationship.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.share.relationship.data.PSLocalDependencySummary.PSLocalDependencyLink;
+import com.percussion.share.relationship.data.PSRelationshipSummary.PSRelationshipTypeBucket;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for summary DTO list fields after the serial real fix ({@link ArrayList} storage
+ * with defensive copies).
+ */
+class PSSummaryDtoSerialFieldsTest {
+
+  @Test
+  void taxonomySummaryCopiesNodesAndExposesArrayListStorage() {
+    List<String> input = new ArrayList<>(List.of("/Sites/a", "/Sites/b"));
+    PSTaxonomySummary summary = new PSTaxonomySummary(2L, input);
+
+    assertEquals(2L, summary.getCount());
+    assertEquals(input, summary.getNodes());
+    assertInstanceOf(ArrayList.class, summary.getNodes());
+    assertNotSame(input, summary.getNodes());
+
+    input.add("/Sites/c");
+    assertEquals(2, summary.getNodes().size());
+
+    summary.setNodes(null);
+    assertTrue(summary.getNodes().isEmpty());
+  }
+
+  @Test
+  void relationshipSummaryCopiesByTypeBuckets() {
+    List<PSRelationshipTypeBucket> input =
+        new ArrayList<>(List.of(new PSRelationshipTypeBucket("translation", 3L)));
+    PSRelationshipSummary summary = new PSRelationshipSummary(3L, input);
+
+    assertEquals(3L, summary.getCount());
+    assertEquals(1, summary.getByType().size());
+    assertInstanceOf(ArrayList.class, summary.getByType());
+    assertNotSame(input, summary.getByType());
+
+    summary.setByType(null);
+    assertTrue(summary.getByType().isEmpty());
+  }
+
+  @Test
+  void localDependencySummaryCopiesLinks() {
+    List<PSLocalDependencyLink> input =
+        new ArrayList<>(List.of(new PSLocalDependencyLink("local", "0-1-2")));
+    PSLocalDependencySummary summary = new PSLocalDependencySummary(1L, input);
+
+    assertEquals(1L, summary.getCount());
+    assertEquals(1, summary.getLinks().size());
+    assertEquals("local", summary.getLinks().get(0).getType());
+    assertInstanceOf(ArrayList.class, summary.getLinks());
+    assertNotSame(input, summary.getLinks());
+
+    summary.setLinks(null);
+    assertTrue(summary.getLinks().isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary

Replaces residual `@SuppressWarnings` left by suppress-only PR #2059 with real fixes in the `rest` module (team strategy for reopened javac cleanup issues under parent #2200).

- **Guid(String):** assign fields directly instead of calling overridable setters (eliminates `this-escape` under `-Xlint` without re-suppressing).
- **FolderNotFoundException:** pass cause through a new cause-aware `RestExceptionBase` constructor via `super(cause)` instead of `initCause` after construction.
- **RestExceptionBase:** cause-aware constructor; mark `errorData` as `transient` (non-serializable in-process payload).
- **PSTaxonomySummary / PSRelationshipSummary / PSLocalDependencySummary:** store list fields as `ArrayList` with defensive copies so field types are `Serializable` under `-Xlint:serial`.
- **Tests:** `GuidTest`, `FolderNotFoundExceptionTest`, `PSSummaryDtoSerialFieldsTest`.

Parent tracker: #2200

## Test plan

- [x] `mvnw -pl rest clean install` — BUILD SUCCESS
- [x] Full rest suite: 229 tests, 0 failures
- [x] Main compile: no this-escape / serial `[WARNING]` on changed `rest/src/**` sources
- [x] Zero residual `@SuppressWarnings` under `rest/`

## Gates evidence

- Erlang-style self-review: approve (report: `docs/ai-generated/code-reviews/issue-2026-rest-javac-real-fixes-erlang.md`)
- Per-module standalone clean install: pass
- No re-introduced `@SuppressWarnings` in `rest`
- Portable paths: N/A

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2026

> Co-Authored by Grok Build using grok-4.5 with agent main.