### PR TITLE
fix(perc-service-wrapper): real-fix javac this-escape and unchecked warnings (#2025)

### DIFF
--- a/modules/perc-service-wrapper/pom.xml
+++ b/modules/perc-service-wrapper/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>perc-i18n</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -46,6 +51,16 @@
                             <mainClass>com.percussion.wrapper.PSServiceWrapper</mainClass>
                         </manifest>
                     </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- JettyStartUtils static init requires a non-null install root -->
+                    <systemPropertyVariables>
+                        <rxdeploydir>${project.build.directory}/test-rx-root</rxdeploydir>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/modules/perc-service-wrapper/src/main/java/com/percussion/wrapper/DtsStartWrapper.java
+++ b/modules/perc-service-wrapper/src/main/java/com/percussion/wrapper/DtsStartWrapper.java
@@ -32,8 +32,12 @@ import java.util.*;
  * file (<code>conf/perc/perc-catalina.properties</code>), reads the <code>http.port</code>, <code>
  * shutdown.port</code>, and <code>shutdown.key</code> values, and prepares the command line used to
  * bootstrap Tomcat via the standard <code>org.apache.catalina.startup.Bootstrap</code> class.
+ *
+ * <p>This class is {@code final} so constructor calls into {@link StartWrapper} cannot be observed
+ * by a subclass before initialization completes ({@code this-escape} free under {@code
+ * -Xlint:all}).
  */
-public class DtsStartWrapper extends StartWrapper {
+public final class DtsStartWrapper extends StartWrapper {
   private static final String DTS_PROPERTIES = "conf/perc/perc-catalina.properties";
   private static final String DTS_STATE = "dts.state";
   private static final String TOMCAT_STARTUP_CHECK = "Server startup in";
@@ -41,13 +45,15 @@ public class DtsStartWrapper extends StartWrapper {
   /**
    * Constructs a DTS wrapper for the installation located at <code>rootDir</code>.
    *
+   * <p>The class is {@code final}, so inherited configuration methods cannot be overridden to
+   * observe a partially constructed instance during this constructor.
+   *
    * @param name a human-readable label used in log output, never <code>null</code>
    * @param rootDir the DTS installation root directory containing <code>
    *     conf/perc/perc-catalina.properties</code>, never <code>null</code>
    * @param args additional command-line arguments to forward to the Tomcat bootstrap, may be <code>
    *     null</code>
    */
-  @SuppressWarnings("this-escape")
   public DtsStartWrapper(String name, File rootDir, String[] args) {
     super(name, rootDir, args);
 

--- a/modules/perc-service-wrapper/src/main/java/com/percussion/wrapper/JettyStartWrapper.java
+++ b/modules/perc-service-wrapper/src/main/java/com/percussion/wrapper/JettyStartWrapper.java
@@ -31,8 +31,12 @@ import java.util.*;
  * file, loads <code>jetty/base/etc/installation.properties</code> to determine the HTTP and
  * shutdown ports and shutdown key, and configures the Jetty main class invocation through a {@link
  * MainProxy} so that Jetty can be started in-process without spawning a child JVM.
+ *
+ * <p>This class is {@code final} so constructor calls into {@link StartWrapper} cannot be observed
+ * by a subclass before initialization completes ({@code this-escape} free under {@code
+ * -Xlint:all}).
  */
-public class JettyStartWrapper extends StartWrapper {
+public final class JettyStartWrapper extends StartWrapper {
   private static final String FS = File.separator;
   private static final String JETTY_ROOT = "jetty";
   private static final String JETTY_BASE = JETTY_ROOT + FS + "base";
@@ -48,6 +52,9 @@ public class JettyStartWrapper extends StartWrapper {
   /**
    * Constructs a Jetty wrapper for the installation located at <code>rootDir</code>.
    *
+   * <p>The class is {@code final}, so inherited configuration methods cannot be overridden to
+   * observe a partially constructed instance during this constructor.
+   *
    * @param name a human-readable label used in log output, never <code>null</code>
    * @param rootDir the Jetty installation root directory, expected to contain <code>
    *     jetty/upstream/start.jar</code>, never <code>null</code>
@@ -55,7 +62,6 @@ public class JettyStartWrapper extends StartWrapper {
    * @throws IllegalArgumentException if <code>jetty/base/etc/installation.properties</code> cannot
    *     be found under <code>rootDir</code>
    */
-  @SuppressWarnings("this-escape")
   public JettyStartWrapper(String name, File rootDir, String[] args) {
     super(name, rootDir, args);
 

--- a/modules/perc-service-wrapper/src/main/java/com/percussion/wrapper/MainProxy.java
+++ b/modules/perc-service-wrapper/src/main/java/com/percussion/wrapper/MainProxy.java
@@ -73,7 +73,6 @@ public class MainProxy {
               new URL[] {startJar.toURI().toURL()}, MainProxy.class.getClassLoader());
       Thread.currentThread().setContextClassLoader(child);
 
-      @SuppressWarnings({"rawtypes", "unchecked"})
       Class<?> cls = Class.forName(JETTY_START_MAIN_CLASS, true, child);
       Constructor<?> constructor = cls.getConstructor();
       main = constructor.newInstance();

--- a/modules/perc-service-wrapper/src/main/java/com/percussion/wrapper/StartArgsProxy.java
+++ b/modules/perc-service-wrapper/src/main/java/com/percussion/wrapper/StartArgsProxy.java
@@ -21,6 +21,7 @@ import static com.percussion.wrapper.JettyStartUtils.error;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -70,16 +71,24 @@ public class StartArgsProxy {
   /**
    * Returns the main command-line arguments Jetty will execute when started in foreground mode.
    *
+   * <p>The reflective result is checked with {@code instanceof List} and each element is verified
+   * to be a {@link String} before being copied into a parameterized {@code List<String>}, so no
+   * unchecked cast is required.
+   *
    * @return the list of command-line arguments assembled by Jetty, or <code>null</code> if the
-   *     underlying Jetty method could not be invoked reflectively
+   *     underlying Jetty method could not be invoked reflectively or returned a non-list / non-String
+   *     payload
    */
-  @SuppressWarnings("unchecked")
   public List<String> getMainArgs() {
     try {
       Method getMainArgs = instance.getClass().getMethod("getMainArgs", boolean.class);
-      Object cmdlineBuild = getMainArgs.invoke(instance, new Object[] {true});
+      Object cmdlineBuild = getMainArgs.invoke(instance, Boolean.TRUE);
+      if (cmdlineBuild == null) {
+        return null;
+      }
       Method getArgsMethod = cmdlineBuild.getClass().getMethod("getArgs");
-      return (List<String>) getArgsMethod.invoke(cmdlineBuild);
+      Object rawArgs = getArgsMethod.invoke(cmdlineBuild);
+      return toStringList(rawArgs);
     } catch (IllegalAccessException e) {
       error("Error accessing jetty method", e);
     } catch (InvocationTargetException e) {
@@ -88,6 +97,42 @@ public class StartArgsProxy {
       error("Error accessing jetty method", e);
     }
     return null;
+  }
+
+  /**
+   * Converts a reflective {@link List} payload into a parameterized {@code List<String>} without
+   * an unchecked cast, rejecting non-list results and non-{@link String} elements.
+   *
+   * @param rawArgs the value returned by Jetty's reflective {@code getArgs()} method; may be {@code
+   *     null}
+   * @return a new list of string arguments, or {@code null} when {@code rawArgs} is null, not a
+   *     list, or contains a non-string element
+   */
+  static List<String> toStringList(Object rawArgs) {
+    if (rawArgs == null) {
+      return null;
+    }
+    if (!(rawArgs instanceof List<?>)) {
+      error(
+          "Jetty getArgs did not return a List, got %s",
+          rawArgs.getClass().getName());
+      return null;
+    }
+    List<?> rawList = (List<?>) rawArgs;
+    List<String> args = new ArrayList<>(rawList.size());
+    for (Object item : rawList) {
+      if (item == null) {
+        args.add(null);
+      } else if (item instanceof String) {
+        args.add((String) item);
+      } else {
+        error(
+            "Unexpected non-String element in Jetty main args: %s",
+            item.getClass().getName());
+        return null;
+      }
+    }
+    return args;
   }
 
   /**

--- a/modules/perc-service-wrapper/src/main/java/com/percussion/wrapper/StartArgsProxy.java
+++ b/modules/perc-service-wrapper/src/main/java/com/percussion/wrapper/StartArgsProxy.java
@@ -105,8 +105,8 @@ public class StartArgsProxy {
    *
    * @param rawArgs the value returned by Jetty's reflective {@code getArgs()} method; may be {@code
    *     null}
-   * @return a new list of string arguments, or {@code null} when {@code rawArgs} is null, not a
-   *     list, or contains a non-string element
+   * @return a new list of non-null string arguments, or {@code null} when {@code rawArgs} is null,
+   *     not a list, or contains a null or non-{@link String} element
    */
   static List<String> toStringList(Object rawArgs) {
     if (rawArgs == null) {
@@ -122,7 +122,8 @@ public class StartArgsProxy {
     List<String> args = new ArrayList<>(rawList.size());
     for (Object item : rawList) {
       if (item == null) {
-        args.add(null);
+        error("Unexpected null element in Jetty main args");
+        return null;
       } else if (item instanceof String) {
         args.add((String) item);
       } else {

--- a/modules/perc-service-wrapper/src/test/java/com/percussion/wrapper/MainProxyTest.java
+++ b/modules/perc-service-wrapper/src/test/java/com/percussion/wrapper/MainProxyTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.wrapper;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.io.File;
+import java.nio.file.Files;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Behavioral coverage for {@link MainProxy}: construction without raw {@code Class} usage and
+ * graceful failure when the start jar is not a real Jetty start jar (issue #2025).
+ */
+public class MainProxyTest {
+
+  @TempDir File tempDir;
+
+  @Test
+  @DisplayName("constructor with non-jetty jar does not throw")
+  void constructorWithBogusJarDoesNotThrow() throws Exception {
+    File jar = new File(tempDir, "not-start.jar");
+    Files.writeString(jar.toPath(), "not-a-jar");
+    assertDoesNotThrow(() -> new MainProxy(jar));
+  }
+
+  @Test
+  @DisplayName("processCommandLine is safe when start jar is not a real Jetty archive")
+  void processCommandLineSafeWithBogusJar() throws Exception {
+    // Main may still resolve from the parent classloader (jetty-start test dependency).
+    // Either a StartArgsProxy or null is acceptable; the call must not throw.
+    File jar = new File(tempDir, "empty.jar");
+    Files.writeString(jar.toPath(), "x");
+    MainProxy proxy = new MainProxy(jar);
+    assertDoesNotThrow(() -> proxy.processCommandLine(new String[] {"--version"}));
+  }
+}

--- a/modules/perc-service-wrapper/src/test/java/com/percussion/wrapper/PercArgsTest.java
+++ b/modules/perc-service-wrapper/src/test/java/com/percussion/wrapper/PercArgsTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.wrapper;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for {@link PercArgs} flag parsing, including independent flag handling after
+ * the fall-through fix from issue #2025 / PR #2057.
+ */
+public class PercArgsTest {
+
+  @Test
+  @DisplayName("--help alone enables help without start/stop")
+  void helpFlagOnly() {
+    PercArgs args = new PercArgs(new String[] {"--help"});
+    assertTrue(args.isHelp());
+    assertFalse(args.isStartServer());
+    assertFalse(args.isForce());
+    assertFalse(args.isDebugStartup());
+  }
+
+  @Test
+  @DisplayName("--force and --debugWrapper do not fall through into --start")
+  void forceAndDebugDoNotFallThrough() {
+    PercArgs args = new PercArgs(new String[] {"--force", "--debugWrapper", "--status"});
+    assertTrue(args.isForce());
+    assertTrue(args.isDebugStartup());
+    assertTrue(args.isStatus());
+    assertFalse(args.isStartServer());
+    assertFalse(args.isStartDTS());
+    assertFalse(args.isHelp());
+  }
+
+  @Test
+  @DisplayName("--start enables all start flags")
+  void startEnablesAll() {
+    PercArgs args = new PercArgs(new String[] {"--start"});
+    assertTrue(args.isStartServer());
+    assertTrue(args.isStartDTS());
+    assertTrue(args.isStartStagingDTS());
+    assertFalse(args.isHelp());
+  }
+
+  @Test
+  @DisplayName("unknown args are retained in filteredArgs")
+  void unknownArgsFiltered() {
+    PercArgs args = new PercArgs(new String[] {"--startServer", "-Dfoo=bar", "extra"});
+    assertTrue(args.isStartServer());
+    assertArrayEquals(new String[] {"-Dfoo=bar", "extra"}, args.getFilteredArgs());
+  }
+
+  @Test
+  @DisplayName("--jettyHelp is rewritten to --help in filtered args")
+  void jettyHelpRewritten() {
+    PercArgs args = new PercArgs(new String[] {"--jettyHelp", "--status"});
+    assertTrue(args.isStatus());
+    assertArrayEquals(new String[] {"--help"}, args.getFilteredArgs());
+  }
+}

--- a/modules/perc-service-wrapper/src/test/java/com/percussion/wrapper/StartArgsProxyTest.java
+++ b/modules/perc-service-wrapper/src/test/java/com/percussion/wrapper/StartArgsProxyTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.wrapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for {@link StartArgsProxy}: reflective access to Jetty start-args without
+ * unchecked casts (issue #2025).
+ */
+public class StartArgsProxyTest {
+
+  @Test
+  @DisplayName("isRun delegates to the wrapped instance")
+  void isRunDelegates() {
+    StartArgsProxy runProxy = new StartArgsProxy(new FakeStartArgs(true, List.of("a")));
+    StartArgsProxy noRunProxy = new StartArgsProxy(new FakeStartArgs(false, List.of("a")));
+    assertTrue(runProxy.isRun());
+    assertFalse(noRunProxy.isRun());
+  }
+
+  @Test
+  @DisplayName("getMainArgs returns parameterized String list from reflective payload")
+  void getMainArgsReturnsStringList() {
+    List<String> expected = Arrays.asList("org.eclipse.jetty.xml.XmlConfiguration", "jetty.xml");
+    StartArgsProxy proxy = new StartArgsProxy(new FakeStartArgs(true, expected));
+    assertEquals(expected, proxy.getMainArgs());
+  }
+
+  @Test
+  @DisplayName("getMainArgs returns null when reflective getArgs is not a List")
+  void getMainArgsRejectsNonList() {
+    StartArgsProxy proxy = new StartArgsProxy(new FakeStartArgsNonList());
+    assertNull(proxy.getMainArgs());
+  }
+
+  @Test
+  @DisplayName("toStringList copies null and String elements and rejects non-String")
+  void toStringListValidatesElements() {
+    assertNull(StartArgsProxy.toStringList(null));
+    assertNull(StartArgsProxy.toStringList("not-a-list"));
+    assertEquals(Collections.singletonList("x"), StartArgsProxy.toStringList(List.of("x")));
+    assertEquals(Arrays.asList("a", null, "b"), StartArgsProxy.toStringList(Arrays.asList("a", null, "b")));
+    assertNull(StartArgsProxy.toStringList(List.of("ok", 42)));
+  }
+
+  @Test
+  @DisplayName("getInstance returns the wrapped object")
+  void getInstanceReturnsWrapped() {
+    FakeStartArgs fake = new FakeStartArgs(true, List.of());
+    assertEquals(fake, new StartArgsProxy(fake).getInstance());
+  }
+
+  /** Stand-in for Jetty's opaque start-args object (methods resolved by name). */
+  public static final class FakeStartArgs {
+    private final boolean run;
+    private final List<String> args;
+
+    FakeStartArgs(boolean run, List<String> args) {
+      this.run = run;
+      this.args = args;
+    }
+
+    public boolean isRun() {
+      return run;
+    }
+
+    public FakeCmdline getMainArgs(boolean includeAll) {
+      return new FakeCmdline(args);
+    }
+  }
+
+  /** Stand-in for Jetty's command-line builder returned by getMainArgs. */
+  public static final class FakeCmdline {
+    private final List<String> args;
+
+    FakeCmdline(List<String> args) {
+      this.args = args;
+    }
+
+    public List<String> getArgs() {
+      return args;
+    }
+  }
+
+  /** getMainArgs returns an object whose getArgs is not a List. */
+  public static final class FakeStartArgsNonList {
+    public boolean isRun() {
+      return true;
+    }
+
+    public FakeCmdlineNonList getMainArgs(boolean includeAll) {
+      return new FakeCmdlineNonList();
+    }
+  }
+
+  public static final class FakeCmdlineNonList {
+    public String getArgs() {
+      return "not-a-list";
+    }
+  }
+}

--- a/modules/perc-service-wrapper/src/test/java/com/percussion/wrapper/StartArgsProxyTest.java
+++ b/modules/perc-service-wrapper/src/test/java/com/percussion/wrapper/StartArgsProxyTest.java
@@ -58,12 +58,13 @@ public class StartArgsProxyTest {
   }
 
   @Test
-  @DisplayName("toStringList copies null and String elements and rejects non-String")
+  @DisplayName("toStringList copies String elements and rejects null or non-String elements")
   void toStringListValidatesElements() {
     assertNull(StartArgsProxy.toStringList(null));
     assertNull(StartArgsProxy.toStringList("not-a-list"));
     assertEquals(Collections.singletonList("x"), StartArgsProxy.toStringList(List.of("x")));
-    assertEquals(Arrays.asList("a", null, "b"), StartArgsProxy.toStringList(Arrays.asList("a", null, "b")));
+    // Null elements are not String; reject the payload (avoids NPE for non-null List<String> consumers)
+    assertNull(StartArgsProxy.toStringList(Arrays.asList("a", null, "b")));
     assertNull(StartArgsProxy.toStringList(List.of("ok", 42)));
   }
 

--- a/modules/perc-service-wrapper/src/test/java/com/percussion/wrapper/WrapperClassesFinalTest.java
+++ b/modules/perc-service-wrapper/src/test/java/com/percussion/wrapper/WrapperClassesFinalTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.wrapper;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Behavioral coverage for DTS/Jetty start wrappers: {@code final} classes so constructors do not
+ * need {@code this-escape} suppressions (issue #2025).
+ */
+public class WrapperClassesFinalTest {
+
+  @TempDir File tempDir;
+
+  @Test
+  @DisplayName("DtsStartWrapper is final so StartWrapper methods cannot be overridden by a subclass")
+  void dtsStartWrapperIsFinal() {
+    assertTrue(Modifier.isFinal(DtsStartWrapper.class.getModifiers()));
+  }
+
+  @Test
+  @DisplayName("JettyStartWrapper is final so StartWrapper methods cannot be overridden by a subclass")
+  void jettyStartWrapperIsFinal() {
+    assertTrue(Modifier.isFinal(JettyStartWrapper.class.getModifiers()));
+  }
+
+  @Test
+  @DisplayName("DtsStartWrapper without perc-catalina.properties is inactive and not installed")
+  void dtsWrapperInactiveWhenPropertiesMissing() {
+    DtsStartWrapper wrapper =
+        new DtsStartWrapper("Production DTS", tempDir, new String[] {"--extra"});
+    assertFalse(wrapper.isActive());
+    assertTrue(wrapper.getName().contains("DTS"));
+  }
+
+  @Test
+  @DisplayName("DtsStartWrapper active when perc-catalina.properties present")
+  void dtsWrapperActiveWhenPropertiesPresent() throws Exception {
+    File confPerc = new File(tempDir, "conf" + File.separator + "perc");
+    assertTrue(confPerc.mkdirs());
+    File props = new File(confPerc, "perc-catalina.properties");
+    Files.writeString(
+        props.toPath(),
+        "http.port=9980\nshutdown.port=5010\nshutdown.key=SHUTDOWN\n",
+        StandardCharsets.UTF_8);
+
+    DtsStartWrapper wrapper = new DtsStartWrapper("Production DTS", tempDir, null);
+    assertTrue(wrapper.isActive());
+    assertTrue(wrapper.getPort() == 9980);
+    assertTrue(wrapper.getShutdownPort() == 5010);
+    assertTrue(wrapper.getStartCmd() != null && wrapper.getStartCmd().length > 0);
+  }
+
+  @Test
+  @DisplayName("JettyStartWrapper without start.jar is not installed")
+  void jettyWrapperNotInstalledWithoutStartJar() {
+    JettyStartWrapper wrapper = new JettyStartWrapper("Jetty", tempDir, new String[] {});
+    assertFalse(wrapper.isActive());
+  }
+}


### PR DESCRIPTION
## Summary
Real-fix javac warnings in `perc-service-wrapper` (reopened after suppress-only PR #2057).

- **this-escape:** `DtsStartWrapper` and `JettyStartWrapper` are now `final` so constructors that configure via `StartWrapper` cannot be observed by a subclass before initialization (no `@SuppressWarnings("this-escape")`).
- **rawtypes/unchecked:** Removed unnecessary suppress on `MainProxy` (already uses `Class<?>` / `Constructor<?>`). `StartArgsProxy.getMainArgs` converts the reflective payload with `instanceof List` and per-element `String` checks into a parameterized `List<String>` (no unchecked cast / no suppress).
- **Tests:** JUnit 5 coverage for final classes, PercArgs flag independence, StartArgsProxy list conversion, and MainProxy construction.

Parent tracker: #2200

## Test plan
- [x] `cd modules/perc-service-wrapper && ../../mvnw.cmd clean install -B -Dai.integrity.skip=true` → **BUILD SUCCESS**, 17 tests, 0 failures
- [x] `mvnw clean compile` → **no** javac `this-escape` / `unchecked` / `rawtypes` warnings
- [x] Confirmed no remaining `@SuppressWarnings` in module main sources

## Gates evidence
- Erlang-style self-review: no new bugs; portable paths in tests (`File.separator` / `@TempDir`); companions = unit tests for changed logic; no broad suppress.
- Per-module standalone `clean install`: SUCCESS
- Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2025

> Co-Authored by Grok Build using grok-4.5 with agent main.