### PR TITLE
fix(s3): IMDSv2-aware EC2 detection for S3 / Assume Role (#2284)

### DIFF
--- a/WebUI/src/main/webapp/cm/views/PercPublishMinuetView.js
+++ b/WebUI/src/main/webapp/cm/views/PercPublishMinuetView.js
@@ -1286,29 +1286,29 @@ function processServerPropertiesForm(eventData) {
 
   // Issue #2284: S3 Access/Secret/ARN are not hard-required. Show a non-modal footer
   // warning when empty so operators can save for EC2 instance-profile / Assume Role
-  // setups, but still notice missing static keys.
+  // setups, but still notice missing static keys. Field labels + body use I18N.
   if (driver === "AMAZONS3") {
     var emptyS3Fields = [];
     var accessKeyVal = ($("#perc-access-key").val() || "").trim();
     var secretKeyVal = ($("#perc-security-key").val() || "").trim();
     var arnRoleVal = ($("#ARNRole").val() || "").trim();
     if (!accessKeyVal) {
-      emptyS3Fields.push("Access Key");
+      emptyS3Fields.push(I18N.message("perc.ui.publish.servers.s3@Access Key"));
     }
     if (!secretKeyVal) {
-      emptyS3Fields.push("Security Key");
+      emptyS3Fields.push(I18N.message("perc.ui.publish.servers.s3@Security Key"));
     }
     if ($("#useAssumeRole").is(":checked") && !arnRoleVal) {
-      emptyS3Fields.push("Role ARN");
+      emptyS3Fields.push(I18N.message("perc.ui.publish.servers.s3@Role ARN"));
     }
     if (emptyS3Fields.length > 0) {
       var s3Warn = {};
       s3Warn.result = {};
       s3Warn.source = I18N.message("perc.ui.publish.title@Server Configuration");
-      s3Warn.result.warning =
-        "Amazon S3 fields are empty (" +
-        emptyS3Fields.join(", ") +
-        "). Save will proceed; ensure EC2 instance profile, Assume Role, or other AWS credentials are available. On Amazon Linux 2023+ IMDS uses tokens (HttpTokens=required); containers need HttpPutResponseHopLimit >= 2.";
+      s3Warn.result.warning = I18N.message(
+        "perc.ui.publish.servers.s3@Empty credentials warning",
+        [emptyS3Fields.join(", ")],
+      );
       processAlert(s3Warn);
     }
   }

--- a/WebUI/src/main/webapp/cm/views/PercPublishMinuetView.js
+++ b/WebUI/src/main/webapp/cm/views/PercPublishMinuetView.js
@@ -1284,5 +1284,34 @@ function processServerPropertiesForm(eventData) {
     },
   };
 
+  // Issue #2284: S3 Access/Secret/ARN are not hard-required. Show a non-modal footer
+  // warning when empty so operators can save for EC2 instance-profile / Assume Role
+  // setups, but still notice missing static keys.
+  if (driver === "AMAZONS3") {
+    var emptyS3Fields = [];
+    var accessKeyVal = ($("#perc-access-key").val() || "").trim();
+    var secretKeyVal = ($("#perc-security-key").val() || "").trim();
+    var arnRoleVal = ($("#ARNRole").val() || "").trim();
+    if (!accessKeyVal) {
+      emptyS3Fields.push("Access Key");
+    }
+    if (!secretKeyVal) {
+      emptyS3Fields.push("Security Key");
+    }
+    if ($("#useAssumeRole").is(":checked") && !arnRoleVal) {
+      emptyS3Fields.push("Role ARN");
+    }
+    if (emptyS3Fields.length > 0) {
+      var s3Warn = {};
+      s3Warn.result = {};
+      s3Warn.source = I18N.message("perc.ui.publish.title@Server Configuration");
+      s3Warn.result.warning =
+        "Amazon S3 fields are empty (" +
+        emptyS3Fields.join(", ") +
+        "). Save will proceed; ensure EC2 instance profile, Assume Role, or other AWS credentials are available. On Amazon Linux 2023+ IMDS uses tokens (HttpTokens=required); containers need HttpPutResponseHopLimit >= 2.";
+      processAlert(s3Warn);
+    }
+  }
+
   updateServerProperties(selectedSiteData.siteId, serverName, newServerPropObj);
 }

--- a/WebUI/war/app/includes/minuetPublishTemplates/publishTemplates.jsp
+++ b/WebUI/war/app/includes/minuetPublishTemplates/publishTemplates.jsp
@@ -519,13 +519,13 @@
             </div>
             <div style="width:75%;" >
                 <div  class="input-group">
-                    <label  style="margin-right: 10px;" for="ARNRole">* <i18n:message key="perc.ui.publish.servers.s3@Role ARN"/>:</label>
+                    <label  style="margin-right: 10px;" for="ARNRole"><i18n:message key="perc.ui.publish.servers.s3@Role ARN"/>:</label>
                     <div   class="input-group-prepend">
                         <div class="input-group-text">
                             <i aria-hidden="true" class="fas fa-lock"></i>
                         </div>
                     </div>
-                    <input autocomplete="off" aria-required="true" class="form-control" percServerFileProp="ARNRole" id="ARNRole" name="ARNRole" value="{{#filterByValue serverInfo.properties 'key' 'ARNRole'}}{{/filterByValue}}">
+                    <input autocomplete="off" class="form-control" percServerFileProp="ARNRole" id="ARNRole" name="ARNRole" value="{{#filterByValue serverInfo.properties 'key' 'ARNRole'}}{{/filterByValue}}">
                 </div>
             </div>
 
@@ -534,25 +534,25 @@
     <div class="form-group" id="s3accessSecurityKey" >
         <div class="form-row">
             <div class="col-md-6 col-sm-12 perc-stacked-form-input">
-                <label for="perc-access-key">* <i18n:message key="perc.ui.publish.servers.s3@Access Key"/>:</label>
+                <label for="perc-access-key"><i18n:message key="perc.ui.publish.servers.s3@Access Key"/>:</label>
                 <div class="input-group">
                     <div class="input-group-prepend">
                         <div class="input-group-text">
                             <i aria-hidden="true" class="fas fa-key"></i>
                         </div>
                     </div>
-                    <input autocomplete="off" type="password" aria-required="true" class="form-control" percServerFileProp="accesskey" id="perc-access-key" name="accesskey" value="{{#filterByValue serverInfo.properties 'key' 'accesskey'}}{{/filterByValue}}">
+                    <input autocomplete="off" type="password" class="form-control" percServerFileProp="accesskey" id="perc-access-key" name="accesskey" value="{{#filterByValue serverInfo.properties 'key' 'accesskey'}}{{/filterByValue}}">
                 </div>
             </div>
             <div class="col-md-6 col col-sm-12">
-                <label for="perc-security-key">* <i18n:message key="perc.ui.publish.servers.s3@Security Key"/>:</label>
+                <label for="perc-security-key"><i18n:message key="perc.ui.publish.servers.s3@Security Key"/>:</label>
                 <div class="input-group">
                     <div class="input-group-prepend">
                         <div class="input-group-text">
                             <i aria-hidden="true" class="fas fa-lock"></i>
                         </div>
                     </div>
-                    <input autocomplete="off" aria-required="true" type="password" class="form-control" percServerFileProp="securitykey" id="perc-security-key" name="securitykey" value="{{#filterByValue serverInfo.properties 'key' 'securitykey'}}{{/filterByValue}}">
+                    <input autocomplete="off" type="password" class="form-control" percServerFileProp="securitykey" id="perc-security-key" name="securitykey" value="{{#filterByValue serverInfo.properties 'key' 'securitykey'}}{{/filterByValue}}">
                 </div>
             </div>
         </div>

--- a/WebUI/war/app/includes/minuetPublishTemplates/publishTemplates.jsp
+++ b/WebUI/war/app/includes/minuetPublishTemplates/publishTemplates.jsp
@@ -525,7 +525,8 @@
                             <i aria-hidden="true" class="fas fa-lock"></i>
                         </div>
                     </div>
-                    <input autocomplete="off" class="form-control" percServerFileProp="ARNRole" id="ARNRole" name="ARNRole" value="{{#filterByValue serverInfo.properties 'key' 'ARNRole'}}{{/filterByValue}}">
+                    <!-- Issue #2284: not hard-required; aria-describedby replaces aria-required for optional EC2/AssumeRole credentials -->
+                    <input autocomplete="off" class="form-control" percServerFileProp="ARNRole" id="ARNRole" name="ARNRole" aria-describedby="perc-s3-optional-credentials-hint percFooterAlertTarget" value="{{#filterByValue serverInfo.properties 'key' 'ARNRole'}}{{/filterByValue}}">
                 </div>
             </div>
 
@@ -541,7 +542,8 @@
                             <i aria-hidden="true" class="fas fa-key"></i>
                         </div>
                     </div>
-                    <input autocomplete="off" type="password" class="form-control" percServerFileProp="accesskey" id="perc-access-key" name="accesskey" value="{{#filterByValue serverInfo.properties 'key' 'accesskey'}}{{/filterByValue}}">
+                    <!-- Issue #2284: not hard-required; aria-describedby links optional-credentials hint + footer warning target -->
+                    <input autocomplete="off" type="password" class="form-control" percServerFileProp="accesskey" id="perc-access-key" name="accesskey" aria-describedby="perc-s3-optional-credentials-hint percFooterAlertTarget" value="{{#filterByValue serverInfo.properties 'key' 'accesskey'}}{{/filterByValue}}">
                 </div>
             </div>
             <div class="col-md-6 col col-sm-12">
@@ -552,10 +554,14 @@
                             <i aria-hidden="true" class="fas fa-lock"></i>
                         </div>
                     </div>
-                    <input autocomplete="off" type="password" class="form-control" percServerFileProp="securitykey" id="perc-security-key" name="securitykey" value="{{#filterByValue serverInfo.properties 'key' 'securitykey'}}{{/filterByValue}}">
+                    <!-- Issue #2284: not hard-required; aria-describedby links optional-credentials hint + footer warning target -->
+                    <input autocomplete="off" type="password" class="form-control" percServerFileProp="securitykey" id="perc-security-key" name="securitykey" aria-describedby="perc-s3-optional-credentials-hint percFooterAlertTarget" value="{{#filterByValue serverInfo.properties 'key' 'securitykey'}}{{/filterByValue}}">
                 </div>
             </div>
         </div>
+        <p id="perc-s3-optional-credentials-hint" class="form-text text-muted">
+            <i18n:message key="perc.ui.publish.servers.s3@Optional credentials hint"/>
+        </p>
     </div>
     <div class="form-group" >
         <label for="region">* <i18n:message key="perc.ui.publish.view@Region"/>:</label>

--- a/WebUI/war/views/PercPublishMinuetView.js
+++ b/WebUI/war/views/PercPublishMinuetView.js
@@ -1074,5 +1074,32 @@ function processServerPropertiesForm(eventData) {
         }
     };
 
+    // Issue #2284: S3 Access/Secret/ARN are not hard-required. Non-modal footer warning when empty.
+    if (driver === "AMAZONS3") {
+        var emptyS3Fields = [];
+        var accessKeyVal = ($("#perc-access-key").val() || "").trim();
+        var secretKeyVal = ($("#perc-security-key").val() || "").trim();
+        var arnRoleVal = ($("#ARNRole").val() || "").trim();
+        if (!accessKeyVal) {
+            emptyS3Fields.push("Access Key");
+        }
+        if (!secretKeyVal) {
+            emptyS3Fields.push("Security Key");
+        }
+        if ($("#useAssumeRole").is(":checked") && !arnRoleVal) {
+            emptyS3Fields.push("Role ARN");
+        }
+        if (emptyS3Fields.length > 0) {
+            var s3Warn = {};
+            s3Warn.result = {};
+            s3Warn.source = I18N.message("perc.ui.publish.title@Server Configuration");
+            s3Warn.result.warning =
+                "Amazon S3 fields are empty (" +
+                emptyS3Fields.join(", ") +
+                "). Save will proceed; ensure EC2 instance profile, Assume Role, or other AWS credentials are available. On Amazon Linux 2023+ IMDS uses tokens (HttpTokens=required); containers need HttpPutResponseHopLimit >= 2.";
+            processAlert(s3Warn);
+        }
+    }
+
     updateServerProperties(selectedSiteData.siteId, serverName, newServerPropObj);
 }

--- a/WebUI/war/views/PercPublishMinuetView.js
+++ b/WebUI/war/views/PercPublishMinuetView.js
@@ -1075,28 +1075,29 @@ function processServerPropertiesForm(eventData) {
     };
 
     // Issue #2284: S3 Access/Secret/ARN are not hard-required. Non-modal footer warning when empty.
+    // Field labels + body use I18N (lock-step with src PercPublishMinuetView.js).
     if (driver === "AMAZONS3") {
         var emptyS3Fields = [];
         var accessKeyVal = ($("#perc-access-key").val() || "").trim();
         var secretKeyVal = ($("#perc-security-key").val() || "").trim();
         var arnRoleVal = ($("#ARNRole").val() || "").trim();
         if (!accessKeyVal) {
-            emptyS3Fields.push("Access Key");
+            emptyS3Fields.push(I18N.message("perc.ui.publish.servers.s3@Access Key"));
         }
         if (!secretKeyVal) {
-            emptyS3Fields.push("Security Key");
+            emptyS3Fields.push(I18N.message("perc.ui.publish.servers.s3@Security Key"));
         }
         if ($("#useAssumeRole").is(":checked") && !arnRoleVal) {
-            emptyS3Fields.push("Role ARN");
+            emptyS3Fields.push(I18N.message("perc.ui.publish.servers.s3@Role ARN"));
         }
         if (emptyS3Fields.length > 0) {
             var s3Warn = {};
             s3Warn.result = {};
             s3Warn.source = I18N.message("perc.ui.publish.title@Server Configuration");
-            s3Warn.result.warning =
-                "Amazon S3 fields are empty (" +
-                emptyS3Fields.join(", ") +
-                "). Save will proceed; ensure EC2 instance profile, Assume Role, or other AWS credentials are available. On Amazon Linux 2023+ IMDS uses tokens (HttpTokens=required); containers need HttpPutResponseHopLimit >= 2.";
+            s3Warn.result.warning = I18N.message(
+                "perc.ui.publish.servers.s3@Empty credentials warning",
+                [emptyS3Fields.join(", ")]
+            );
             processAlert(s3Warn);
         }
     }

--- a/docker/README.md
+++ b/docker/README.md
@@ -355,6 +355,14 @@ External compose DBs (`percussion-postgres` / `percussion-mysql` / `percussion-s
 
 If a DB container was already running before the harness (e.g. long-lived dev stack), the default path **reuses** it and **does not** stop it at the end. Use `--stop-db` only when you intentionally want those containers stopped. Never uses `compose down -v` by default (named volumes / operator data are preserved).
 
+### EC2 IMDS / S3 publish from containers (issue #2284)
+
+When CMS runs **on EC2** (including this compose stack on an EC2 host) and uses Amazon S3 publish with **instance profile** credentials:
+
+* Prefer **IMDSv2** (`HttpTokens=required` on Amazon Linux 2023+). CMS probes IMDS with a session token; IMDSv1-only is no longer required for EC2 detection.
+* If CMS is **containerized**, set the instance metadata option **`HttpPutResponseHopLimit` ≥ 2** so the IMDSv2 token PUT can leave the container network namespace. Hop limit `1` is a common cause of “not on EC2” false negatives and forced Access Key / Secret fields.
+* See system site doc `s3-publish-ec2-imds.md` for the full operator checklist.
+
 ### DTS packaging notes (HTTP 9980)
 
 DTS Tomcat listens on **`${http.port}`** from `conf/perc/perc-catalina.properties` (default **9980**), not stock Tomcat 8080. The shipping tree requires:

--- a/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
+++ b/modules/perc-i18n/src/main/resources/i18n/CmsUi.tmx
@@ -26710,5 +26710,21 @@ Niet-opgeslagen wijzigingen in '{1}' kunnen verloren gaan.</seg></tuv>
     <tu tuid="perc.ui.gadgets.licenseMonitor@License Monitor">
       <tuv xml:lang="en-us"><seg>License Monitor</seg></tuv>
     <tuv xml:lang="ar"><seg>مراقب الترخيص</seg></tuv><tuv xml:lang="bn"><seg>লাইসেন্স মনিটর</seg></tuv><tuv xml:lang="de"><seg>Lizenzmonitor</seg></tuv><tuv xml:lang="es"><seg>Monitor de licencia</seg></tuv><tuv xml:lang="fr"><seg>Moniteur de licence</seg></tuv><tuv xml:lang="he"><seg>מוניטור רישיון</seg></tuv><tuv xml:lang="hi"><seg>लाइसेंस मॉनिटर</seg></tuv><tuv xml:lang="it"><seg>Monitoraggio delle licenze</seg></tuv><tuv xml:lang="ja-jp"><seg>ライセンスモニター</seg></tuv><tuv xml:lang="nl"><seg>Licentiemonitor</seg></tuv><tuv xml:lang="pl"><seg>Monitor licencji</seg></tuv><tuv xml:lang="pt"><seg>Monitor de licença</seg></tuv><tuv xml:lang="ru"><seg>Монитор лицензий</seg></tuv><tuv xml:lang="sv"><seg>Licensövervakning</seg></tuv><tuv xml:lang="te"><seg>లైసెన్స్ మానిటర్</seg></tuv><tuv xml:lang="tr"><seg>Lisans Monitörü</seg></tuv><tuv xml:lang="uk"><seg>Монітор ліцензій</seg></tuv><tuv xml:lang="zh-cn"><seg>许可证监控器</seg></tuv><tuv xml:lang="zh-tw"><seg>许可证监控器</seg></tuv></tu>
+    <!-- Issue #2284 / PR #2292: S3 optional credentials footer warning + a11y hint (en-us; other locales fall back) -->
+    <tu tuid="perc.ui.publish.servers.s3@Access Key">
+      <tuv xml:lang="en-us"><seg>Access Key</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.publish.servers.s3@Security Key">
+      <tuv xml:lang="en-us"><seg>Security Key</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.publish.servers.s3@Role ARN">
+      <tuv xml:lang="en-us"><seg>Role ARN</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.publish.servers.s3@Empty credentials warning">
+      <tuv xml:lang="en-us"><seg>Amazon S3 fields are empty ({0}). Save will proceed; ensure EC2 instance profile, Assume Role, or other AWS credentials are available. On Amazon Linux 2023+ IMDS uses tokens (HttpTokens=required); containers need HttpPutResponseHopLimit &gt;= 2.</seg></tuv>
+    </tu>
+    <tu tuid="perc.ui.publish.servers.s3@Optional credentials hint">
+      <tuv xml:lang="en-us"><seg>Optional when using an EC2 instance profile or Assume Role. Leave empty only if alternate AWS credentials will be available at publish time. Saving with empty fields shows a footer warning.</seg></tuv>
+    </tu>
   </body>
 </tmx>

--- a/modules/perc-qa-automation/frontend/package.json
+++ b/modules/perc-qa-automation/frontend/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "test": "playwright test",
-    "test:unit": "node --test tests/unit/resolve-cms-env.test.js tests/unit/surface-filter.test.js tests/unit/pick-locale-tag.test.js tests/unit/developer-catalog-selectors.test.js tests/unit/developer-smoke-set.test.js tests/unit/pathmanagement-url.test.js tests/unit/demo-sites.test.js tests/unit/empty-recycling.test.js tests/unit/file-widget-recycled-chrome.test.js tests/unit/inline-link-title.test.js",
+    "test:unit": "node --test tests/unit/resolve-cms-env.test.js tests/unit/surface-filter.test.js tests/unit/pick-locale-tag.test.js tests/unit/developer-catalog-selectors.test.js tests/unit/developer-smoke-set.test.js tests/unit/pathmanagement-url.test.js tests/unit/demo-sites.test.js tests/unit/empty-recycling.test.js tests/unit/file-widget-recycled-chrome.test.js tests/unit/inline-link-title.test.js tests/unit/s3-empty-credentials-warning.test.js",
     "test:list": "playwright test --list",
     "test:golden": "playwright test tests/golden-unattended-smoke.spec.js",
     "test:surface": "node scripts/run-surface.js",

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-2284-s3-empty-credentials-warning.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-2284-s3-empty-credentials-warning.spec.js
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Residual Playwright coverage for #2284 non-modal S3 empty-credentials footer
+ * warning on the Publish minuet server configuration screen.
+ *
+ * Product: when driver is AMAZONS3 and Access/Security (or Role ARN with
+ * Assume Role) are empty, save shows a footer alert via processAlert and still
+ * proceeds (EC2 instance profile / Assume Role use case).
+ *
+ * <h3>How to run (surface-filtered H2 QA)</h3>
+ * <pre>
+ *   python docker/scripts/perc-devctl.py qa-up
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=http://127.0.0.1:${QA_CMS_HOST_PORT} \
+ *     ADMIN_USERNAME=Admin ADMIN_PASSWORD=&lt;from-qa-up&gt; \
+ *     npm run test:surface -- --path tests/bugs/bug-2284-s3-empty-credentials-warning.spec.js
+ *
+ *   # Pure helpers (no live CMS):
+ *   node --test tests/unit/s3-empty-credentials-warning.test.js
+ * </pre>
+ *
+ * Surface filter tag: {@code @s3-empty-credentials}. Prefer stable selectors
+ * ({@code #perc-access-key}, {@code #percFooterAlertTarget}).
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("../helpers/auth");
+const {
+  SELECTORS,
+  collectEmptyS3CredentialFields,
+  buildS3EmptyCredentialsWarning,
+  isS3EmptyCredentialsWarningText,
+  s3WarningSurfaceSkipReason,
+} = require("../helpers/s3-empty-credentials-warning");
+
+test.describe("Publish S3 empty-credentials footer warning (#2284) @s3-empty-credentials", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  test("pure helper contract matches product warning copy", async () => {
+    const empty = collectEmptyS3CredentialFields({
+      accessKey: "",
+      secretKey: "",
+      arnRole: "",
+      useAssumeRole: false,
+    });
+    const msg = buildS3EmptyCredentialsWarning(empty);
+    expect(isS3EmptyCredentialsWarningText(msg)).toBeTruthy();
+  });
+
+  test("live CMS: empty S3 keys on save show non-modal footer warning", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE_URL}/cm/app/index.jsp?view=publish`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    // Site card / publish shell — soft skip if stock H2 has no publish surface.
+    const siteCard = page.locator(".perc-site-card").first();
+    try {
+      await expect(siteCard).toBeVisible({ timeout: 25_000 });
+    } catch {
+      test.skip(
+        true,
+        s3WarningSurfaceSkipReason("no .perc-site-card on publish view"),
+      );
+      return;
+    }
+    await siteCard.click();
+
+    // Prefer editing an existing server, else Add Server.
+    const addServerBtn = page.locator(
+      "button:has-text('Add Server'), #perc-add-server, .perc-add-server",
+    );
+    const existingServer = page
+      .locator(
+        ".perc-server-card, .perc-publish-server, [data-perc-server-id], .list-group-item",
+      )
+      .first();
+
+    if ((await existingServer.count()) > 0) {
+      await existingServer.click().catch(() => {});
+    } else if ((await addServerBtn.count()) > 0) {
+      await addServerBtn.first().click();
+    } else {
+      test.skip(true, s3WarningSurfaceSkipReason("no Add Server / server card"));
+      return;
+    }
+
+    // Select Amazon S3 driver when a driver control is present.
+    const driverSelect = page.locator(
+      "select[name='server-driver'], #perc-server-driver, select#driver, select.perc-server-driver",
+    );
+    if ((await driverSelect.count()) > 0) {
+      const select = driverSelect.first();
+      const options = await select.locator("option").allTextContents();
+      const s3Option = options.find(
+        (t) => /amazon\s*s3|amazons3/i.test(t) || t.trim() === "AMAZONS3",
+      );
+      if (s3Option) {
+        await select.selectOption({ label: s3Option.trim() }).catch(async () => {
+          await select.selectOption({ value: "AMAZONS3" }).catch(() => {});
+        });
+      } else {
+        // Try value AMAZONS3 directly
+        await select.selectOption({ value: "AMAZONS3" }).catch(() => {});
+      }
+    }
+
+    // Wait for S3 credential fields from minuet templates.
+    const accessKey = page.locator(SELECTORS.accessKey);
+    try {
+      await expect(accessKey).toBeVisible({ timeout: 20_000 });
+    } catch {
+      test.skip(
+        true,
+        s3WarningSurfaceSkipReason(
+          "S3 Access Key field #perc-access-key not visible after driver select",
+        ),
+      );
+      return;
+    }
+
+    await accessKey.fill("");
+    const secretKey = page.locator(SELECTORS.securityKey);
+    if ((await secretKey.count()) > 0) {
+      await secretKey.fill("");
+    }
+
+    // Ensure Assume Role is off so warning only needs Access + Security.
+    const assume = page.locator(SELECTORS.useAssumeRole);
+    if ((await assume.count()) > 0) {
+      const checked = await assume.isChecked().catch(() => false);
+      if (checked) {
+        await assume.uncheck().catch(() => {});
+      }
+    }
+
+    // Bucket may still be required server-side — fill a dummy if present.
+    const bucket = page.locator(
+      "#perc-bucket-name, #bucketName, input[name='bucketName'], #AS3Bucket",
+    );
+    if ((await bucket.count()) > 0) {
+      const val = await bucket.first().inputValue().catch(() => "");
+      if (!String(val || "").trim()) {
+        await bucket.first().fill("perc-test-bucket");
+      }
+    }
+
+    // Server name if required
+    const nameInput = page.locator(
+      "input[name='server-name'], #perc-server-name, #serverName",
+    );
+    if ((await nameInput.count()) > 0) {
+      const n = await nameInput.first().inputValue().catch(() => "");
+      if (!String(n || "").trim()) {
+        await nameInput.first().fill("s3-empty-keys-warning-test");
+      }
+    }
+
+    // Trigger save — product path that runs the empty-S3 warning then updateServerProperties.
+    const saveBtn = page.locator(
+      "button:has-text('Save'), #perc-save-server, .perc-save-server, button.perc-btn-primary:has-text('Save')",
+    );
+    if ((await saveBtn.count()) === 0) {
+      test.skip(true, s3WarningSurfaceSkipReason("no Save button on server editor"));
+      return;
+    }
+    await saveBtn.first().click();
+
+    const footer = page.locator(SELECTORS.footerAlert);
+    await expect(
+      footer,
+      "footer alert target should receive processAlert for empty S3 keys",
+    ).toBeVisible({ timeout: 15_000 });
+
+    const footerText = await footer.innerText();
+    expect(
+      isS3EmptyCredentialsWarningText(footerText),
+      `expected #2284 S3 empty-credentials warning in footer, got: ${footerText.slice(0, 240)}`,
+    ).toBeTruthy();
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-2284-s3-empty-credentials-warning.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-2284-s3-empty-credentials-warning.spec.js
@@ -45,6 +45,7 @@ const {
   collectEmptyS3CredentialFields,
   buildS3EmptyCredentialsWarning,
   isS3EmptyCredentialsWarningText,
+  messageFnFromPage,
   s3WarningSurfaceSkipReason,
 } = require("../helpers/s3-empty-credentials-warning");
 
@@ -191,8 +192,10 @@ test.describe("Publish S3 empty-credentials footer warning (#2284) @s3-empty-cre
     ).toBeVisible({ timeout: 15_000 });
 
     const footerText = await footer.innerText();
+    // Bind matcher to live CMS I18N so non-English locales still pass.
+    const pageMessage = await messageFnFromPage(page);
     expect(
-      isS3EmptyCredentialsWarningText(footerText),
+      isS3EmptyCredentialsWarningText(footerText, pageMessage),
       `expected #2284 S3 empty-credentials warning in footer, got: ${footerText.slice(0, 240)}`,
     ).toBeTruthy();
   });

--- a/modules/perc-qa-automation/frontend/tests/helpers/s3-empty-credentials-warning.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/s3-empty-credentials-warning.js
@@ -4,14 +4,43 @@
  *
  * Mirrors the client-side logic in PercPublishMinuetView.js:
  * Access Key / Security Key empty → warn; Role ARN only when Assume Role is on.
- * Message text must stay in lock-step with product UI en-us TMX strings
- * (keys under perc.ui.publish.servers.s3@* in CmsUi.tmx; UI resolves via I18N.message).
+ *
+ * Product UI resolves copy via I18N.message(key[, args]) against CmsUi.tmx
+ * keys under perc.ui.publish.servers.s3@*. Helpers accept an optional
+ * messageFn so live CMS tests can bind to page I18N (any locale). When
+ * omitted, en-us catalog strings matching CmsUi.tmx are used (unit tests /
+ * offline).
  */
 
 "use strict";
 
 /** Product issue that introduced optional S3 keys + footer warning. */
 const PRODUCT_ISSUE = 2284;
+
+/**
+ * CmsUi.tmx / I18N.message keys used by PercPublishMinuetView for #2284.
+ * @readonly
+ */
+const MESSAGE_KEYS = {
+  accessKey: "perc.ui.publish.servers.s3@Access Key",
+  securityKey: "perc.ui.publish.servers.s3@Security Key",
+  roleArn: "perc.ui.publish.servers.s3@Role ARN",
+  emptyCredentialsWarning:
+    "perc.ui.publish.servers.s3@Empty credentials warning",
+};
+
+/**
+ * en-us catalog matching modules/perc-i18n/.../CmsUi.tmx (issue #2284).
+ * Used when no page-bound I18N messageFn is provided.
+ * @readonly
+ */
+const EN_US_CATALOG = {
+  [MESSAGE_KEYS.accessKey]: "Access Key",
+  [MESSAGE_KEYS.securityKey]: "Security Key",
+  [MESSAGE_KEYS.roleArn]: "Role ARN",
+  [MESSAGE_KEYS.emptyCredentialsWarning]:
+    "Amazon S3 fields are empty ({0}). Save will proceed; ensure EC2 instance profile, Assume Role, or other AWS credentials are available. On Amazon Linux 2023+ IMDS uses tokens (HttpTokens=required); containers need HttpPutResponseHopLimit >= 2.",
+};
 
 /** Stable DOM anchors used by the minuet publish server editor + footer. */
 const SELECTORS = {
@@ -26,22 +55,92 @@ const SELECTORS = {
 };
 
 /**
+ * Apply `{0}`, `{1}`, … placeholders the same way product I18N.message does.
+ * @param {string} template
+ * @param {string[]|undefined} args
+ * @returns {string}
+ */
+function formatMessage(template, args) {
+  let s = String(template);
+  const list = Array.isArray(args) ? args : [];
+  for (let i = 0; i < list.length; i++) {
+    s = s.split("{" + i + "}").join(String(list[i]));
+  }
+  return s;
+}
+
+/**
+ * Build a messageFn from a key→template catalog (en-us or custom).
+ * @param {Record<string, string>} catalog
+ * @returns {(key: string, args?: string[]) => string}
+ */
+function messageFnFromCatalog(catalog) {
+  const cat = catalog || EN_US_CATALOG;
+  return function message(key, args) {
+    const template = Object.prototype.hasOwnProperty.call(cat, key)
+      ? cat[key]
+      : key;
+    return formatMessage(template, args);
+  };
+}
+
+/** Default en-us messageFn (CmsUi.tmx lock-step). */
+const defaultMessage = messageFnFromCatalog(EN_US_CATALOG);
+
+/**
+ * Bind a Playwright page's live I18N.message to a messageFn.
+ * Falls back to en-us catalog when I18N is not available on the page.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<(key: string, args?: string[]) => string>}
+ */
+async function messageFnFromPage(page) {
+  const keys = Object.values(MESSAGE_KEYS);
+  const resolved = await page.evaluate((keyList) => {
+    const hasI18n =
+      typeof I18N !== "undefined" && typeof I18N.message === "function";
+    if (!hasI18n) {
+      return { hasI18n: false, catalog: null };
+    }
+    // Capture templates: for the warning key, leave {0} by substituting a
+    // sentinel then restoring so offline formatMessage can re-apply args.
+    const catalog = {};
+    for (const k of keyList) {
+      if (k.indexOf("Empty credentials warning") !== -1) {
+        const withSentinel = I18N.message(k, ["\u0001"]);
+        catalog[k] = String(withSentinel).split("\u0001").join("{0}");
+      } else {
+        catalog[k] = I18N.message(k);
+      }
+    }
+    return { hasI18n: true, catalog: catalog };
+  }, keys);
+
+  if (!resolved || !resolved.hasI18n || !resolved.catalog) {
+    return defaultMessage;
+  }
+  return messageFnFromCatalog(resolved.catalog);
+}
+
+/**
  * Collect empty S3 credential field labels for the non-modal footer warning.
  *
  * @param {{ accessKey?: string|null, secretKey?: string|null, arnRole?: string|null, useAssumeRole?: boolean }} fields
- * @returns {string[]} ordered labels matching product UI
+ * @param {(key: string, args?: string[]) => string} [messageFn=defaultMessage] I18N resolver
+ * @returns {string[]} ordered labels matching product UI (localized when messageFn is)
  */
-function collectEmptyS3CredentialFields(fields) {
+function collectEmptyS3CredentialFields(fields, messageFn) {
+  const msg = typeof messageFn === "function" ? messageFn : defaultMessage;
   const f = fields || {};
   const empty = [];
   if (!String(f.accessKey || "").trim()) {
-    empty.push("Access Key");
+    empty.push(msg(MESSAGE_KEYS.accessKey));
   }
   if (!String(f.secretKey || "").trim()) {
-    empty.push("Security Key");
+    empty.push(msg(MESSAGE_KEYS.securityKey));
   }
   if (f.useAssumeRole && !String(f.arnRole || "").trim()) {
-    empty.push("Role ARN");
+    empty.push(msg(MESSAGE_KEYS.roleArn));
   }
   return empty;
 }
@@ -50,31 +149,52 @@ function collectEmptyS3CredentialFields(fields) {
  * Build the footer warning body shown via processAlert / templateResponseFooterAlert.
  *
  * @param {string[]} emptyFields labels from {@link collectEmptyS3CredentialFields}
+ * @param {(key: string, args?: string[]) => string} [messageFn=defaultMessage] I18N resolver
  * @returns {string|null} warning text, or null when nothing is empty
  */
-function buildS3EmptyCredentialsWarning(emptyFields) {
+function buildS3EmptyCredentialsWarning(emptyFields, messageFn) {
+  const msg = typeof messageFn === "function" ? messageFn : defaultMessage;
   if (!Array.isArray(emptyFields) || emptyFields.length === 0) {
     return null;
   }
-  return (
-    "Amazon S3 fields are empty (" +
-    emptyFields.join(", ") +
-    "). Save will proceed; ensure EC2 instance profile, Assume Role, or other AWS credentials are available. On Amazon Linux 2023+ IMDS uses tokens (HttpTokens=required); containers need HttpPutResponseHopLimit >= 2."
-  );
+  return msg(MESSAGE_KEYS.emptyCredentialsWarning, [emptyFields.join(", ")]);
 }
 
 /**
- * True when a footer alert text looks like the #2284 S3 empty-credentials warning.
+ * True when a footer alert text looks like the #2284 S3 empty-credentials warning
+ * for the given locale catalog (default en-us).
+ *
+ * Matching uses ordered template fragments around the `{0}` field-list slot so
+ * non-English catalogs work when messageFn is page-bound.
+ *
  * @param {string|null|undefined} text
+ * @param {(key: string, args?: string[]) => string} [messageFn=defaultMessage]
  * @returns {boolean}
  */
-function isS3EmptyCredentialsWarningText(text) {
+function isS3EmptyCredentialsWarningText(text, messageFn) {
+  const msg = typeof messageFn === "function" ? messageFn : defaultMessage;
   const t = String(text || "");
-  return (
-    t.includes("Amazon S3 fields are empty") &&
-    t.includes("Save will proceed") &&
-    t.includes("HttpPutResponseHopLimit")
-  );
+  if (!t) {
+    return false;
+  }
+  const withSentinel = msg(MESSAGE_KEYS.emptyCredentialsWarning, ["\u0001"]);
+  const parts = String(withSentinel).split("\u0001");
+  if (parts.length === 1) {
+    return t.includes(withSentinel);
+  }
+  let idx = 0;
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (!part) {
+      continue;
+    }
+    const found = t.indexOf(part, idx);
+    if (found < 0) {
+      return false;
+    }
+    idx = found + part.length;
+  }
+  return true;
 }
 
 /**
@@ -91,7 +211,13 @@ function s3WarningSurfaceSkipReason(detail) {
 
 module.exports = {
   PRODUCT_ISSUE,
+  MESSAGE_KEYS,
+  EN_US_CATALOG,
   SELECTORS,
+  formatMessage,
+  messageFnFromCatalog,
+  messageFnFromPage,
+  defaultMessage,
   collectEmptyS3CredentialFields,
   buildS3EmptyCredentialsWarning,
   isS3EmptyCredentialsWarningText,

--- a/modules/perc-qa-automation/frontend/tests/helpers/s3-empty-credentials-warning.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/s3-empty-credentials-warning.js
@@ -1,0 +1,97 @@
+/**
+ * Pure helpers for Amazon S3 empty-credentials non-modal footer warning
+ * (issue #2284 / PR residual Playwright + unit coverage).
+ *
+ * Mirrors the client-side logic in PercPublishMinuetView.js:
+ * Access Key / Security Key empty → warn; Role ARN only when Assume Role is on.
+ * Message text must stay in lock-step with product UI strings.
+ */
+
+"use strict";
+
+/** Product issue that introduced optional S3 keys + footer warning. */
+const PRODUCT_ISSUE = 2284;
+
+/** Stable DOM anchors used by the minuet publish server editor + footer. */
+const SELECTORS = {
+  accessKey: "#perc-access-key",
+  securityKey: "#perc-security-key",
+  arnRole: "#ARNRole",
+  useAssumeRole: "#useAssumeRole",
+  footerAlert: "#percFooterAlertTarget",
+  footerAlertMessage: "#percFooterAlertTarget .alert",
+  publishRoot: "#perc-publishing-root, #perc-publish-body-target",
+};
+
+/**
+ * Collect empty S3 credential field labels for the non-modal footer warning.
+ *
+ * @param {{ accessKey?: string|null, secretKey?: string|null, arnRole?: string|null, useAssumeRole?: boolean }} fields
+ * @returns {string[]} ordered labels matching product UI
+ */
+function collectEmptyS3CredentialFields(fields) {
+  const f = fields || {};
+  const empty = [];
+  if (!String(f.accessKey || "").trim()) {
+    empty.push("Access Key");
+  }
+  if (!String(f.secretKey || "").trim()) {
+    empty.push("Security Key");
+  }
+  if (f.useAssumeRole && !String(f.arnRole || "").trim()) {
+    empty.push("Role ARN");
+  }
+  return empty;
+}
+
+/**
+ * Build the footer warning body shown via processAlert / templateResponseFooterAlert.
+ *
+ * @param {string[]} emptyFields labels from {@link collectEmptyS3CredentialFields}
+ * @returns {string|null} warning text, or null when nothing is empty
+ */
+function buildS3EmptyCredentialsWarning(emptyFields) {
+  if (!Array.isArray(emptyFields) || emptyFields.length === 0) {
+    return null;
+  }
+  return (
+    "Amazon S3 fields are empty (" +
+    emptyFields.join(", ") +
+    "). Save will proceed; ensure EC2 instance profile, Assume Role, or other AWS credentials are available. On Amazon Linux 2023+ IMDS uses tokens (HttpTokens=required); containers need HttpPutResponseHopLimit >= 2."
+  );
+}
+
+/**
+ * True when a footer alert text looks like the #2284 S3 empty-credentials warning.
+ * @param {string|null|undefined} text
+ * @returns {boolean}
+ */
+function isS3EmptyCredentialsWarningText(text) {
+  const t = String(text || "");
+  return (
+    t.includes("Amazon S3 fields are empty") &&
+    t.includes("Save will proceed") &&
+    t.includes("HttpPutResponseHopLimit")
+  );
+}
+
+/**
+ * Durable skip-with-BUG reason when live CMS publish S3 surface is unavailable.
+ * @param {string} detail
+ * @returns {string}
+ */
+function s3WarningSurfaceSkipReason(detail) {
+  return (
+    `skip-with-BUG: publish S3 empty-credentials footer surface unavailable (${detail}). ` +
+    `Product issue: https://github.com/intersoftdatalabs-in/percussioncms/issues/${PRODUCT_ISSUE}`
+  );
+}
+
+module.exports = {
+  PRODUCT_ISSUE,
+  SELECTORS,
+  collectEmptyS3CredentialFields,
+  buildS3EmptyCredentialsWarning,
+  isS3EmptyCredentialsWarningText,
+  s3WarningSurfaceSkipReason,
+};

--- a/modules/perc-qa-automation/frontend/tests/helpers/s3-empty-credentials-warning.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/s3-empty-credentials-warning.js
@@ -4,7 +4,8 @@
  *
  * Mirrors the client-side logic in PercPublishMinuetView.js:
  * Access Key / Security Key empty → warn; Role ARN only when Assume Role is on.
- * Message text must stay in lock-step with product UI strings.
+ * Message text must stay in lock-step with product UI en-us TMX strings
+ * (keys under perc.ui.publish.servers.s3@* in CmsUi.tmx; UI resolves via I18N.message).
  */
 
 "use strict";
@@ -18,6 +19,7 @@ const SELECTORS = {
   securityKey: "#perc-security-key",
   arnRole: "#ARNRole",
   useAssumeRole: "#useAssumeRole",
+  optionalCredentialsHint: "#perc-s3-optional-credentials-hint",
   footerAlert: "#percFooterAlertTarget",
   footerAlertMessage: "#percFooterAlertTarget .alert",
   publishRoot: "#perc-publishing-root, #perc-publish-body-target",

--- a/modules/perc-qa-automation/frontend/tests/unit/s3-empty-credentials-warning.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/s3-empty-credentials-warning.test.js
@@ -72,10 +72,15 @@ describe("s3-empty-credentials-warning helpers", () => {
   it("skip-with-BUG reason embeds durable issue URL", () => {
     const reason = s3WarningSurfaceSkipReason("no Add Server");
     assert.ok(reason.includes("skip-with-BUG"));
-    assert.ok(
-      reason.includes(
-        "https://github.com/intersoftdatalabs-in/percussioncms/issues/2284",
-      ),
+    // Parse the embedded URL (host + path) instead of substring-matching the
+    // full URL string — avoids js/incomplete-url-substring-sanitization.
+    const urlToken = reason.match(/https:\/\/\S+/)?.[0];
+    assert.ok(urlToken, "expected absolute product-issue URL in skip reason");
+    const u = new URL(urlToken);
+    assert.equal(u.hostname, "github.com");
+    assert.equal(
+      u.pathname,
+      `/intersoftdatalabs-in/percussioncms/issues/${PRODUCT_ISSUE}`,
     );
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/unit/s3-empty-credentials-warning.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/s3-empty-credentials-warning.test.js
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for S3 empty-credentials footer warning pure helpers (no live CMS).
+ *
+ * Run from modules/perc-qa-automation/frontend:
+ *   npm run test:unit
+ *   node --test tests/unit/s3-empty-credentials-warning.test.js
+ */
+
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  PRODUCT_ISSUE,
+  SELECTORS,
+  collectEmptyS3CredentialFields,
+  buildS3EmptyCredentialsWarning,
+  isS3EmptyCredentialsWarningText,
+  s3WarningSurfaceSkipReason,
+} = require("../helpers/s3-empty-credentials-warning");
+
+describe("s3-empty-credentials-warning helpers", () => {
+  it("exposes product issue and footer selectors", () => {
+    assert.equal(PRODUCT_ISSUE, 2284);
+    assert.equal(SELECTORS.accessKey, "#perc-access-key");
+    assert.equal(SELECTORS.footerAlert, "#percFooterAlertTarget");
+  });
+
+  it("collectEmptyS3CredentialFields lists Access/Security when blank", () => {
+    assert.deepEqual(
+      collectEmptyS3CredentialFields({
+        accessKey: "",
+        secretKey: "  ",
+        arnRole: "",
+        useAssumeRole: false,
+      }),
+      ["Access Key", "Security Key"],
+    );
+  });
+
+  it("collectEmptyS3CredentialFields includes Role ARN only when Assume Role is on", () => {
+    assert.deepEqual(
+      collectEmptyS3CredentialFields({
+        accessKey: "AKIA",
+        secretKey: "secret",
+        arnRole: "",
+        useAssumeRole: true,
+      }),
+      ["Role ARN"],
+    );
+    assert.deepEqual(
+      collectEmptyS3CredentialFields({
+        accessKey: "AKIA",
+        secretKey: "secret",
+        arnRole: "",
+        useAssumeRole: false,
+      }),
+      [],
+    );
+  });
+
+  it("buildS3EmptyCredentialsWarning matches product footer copy", () => {
+    assert.equal(buildS3EmptyCredentialsWarning([]), null);
+    assert.equal(buildS3EmptyCredentialsWarning(null), null);
+    const msg = buildS3EmptyCredentialsWarning(["Access Key", "Security Key"]);
+    assert.ok(msg.includes("Amazon S3 fields are empty (Access Key, Security Key)"));
+    assert.ok(msg.includes("Save will proceed"));
+    assert.ok(msg.includes("HttpPutResponseHopLimit >= 2"));
+    assert.ok(isS3EmptyCredentialsWarningText(msg));
+  });
+
+  it("skip-with-BUG reason embeds durable issue URL", () => {
+    const reason = s3WarningSurfaceSkipReason("no Add Server");
+    assert.ok(reason.includes("skip-with-BUG"));
+    assert.ok(
+      reason.includes(
+        "https://github.com/intersoftdatalabs-in/percussioncms/issues/2284",
+      ),
+    );
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/unit/s3-empty-credentials-warning.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/s3-empty-credentials-warning.test.js
@@ -12,7 +12,10 @@ const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 const {
   PRODUCT_ISSUE,
+  MESSAGE_KEYS,
+  EN_US_CATALOG,
   SELECTORS,
+  messageFnFromCatalog,
   collectEmptyS3CredentialFields,
   buildS3EmptyCredentialsWarning,
   isS3EmptyCredentialsWarningText,
@@ -20,10 +23,15 @@ const {
 } = require("../helpers/s3-empty-credentials-warning");
 
 describe("s3-empty-credentials-warning helpers", () => {
-  it("exposes product issue and footer selectors", () => {
+  it("exposes product issue, I18N keys, and footer selectors", () => {
     assert.equal(PRODUCT_ISSUE, 2284);
     assert.equal(SELECTORS.accessKey, "#perc-access-key");
     assert.equal(SELECTORS.footerAlert, "#percFooterAlertTarget");
+    assert.equal(
+      MESSAGE_KEYS.emptyCredentialsWarning,
+      "perc.ui.publish.servers.s3@Empty credentials warning",
+    );
+    assert.ok(EN_US_CATALOG[MESSAGE_KEYS.accessKey]);
   });
 
   it("collectEmptyS3CredentialFields lists Access/Security when blank", () => {
@@ -59,7 +67,7 @@ describe("s3-empty-credentials-warning helpers", () => {
     );
   });
 
-  it("buildS3EmptyCredentialsWarning matches product footer copy", () => {
+  it("buildS3EmptyCredentialsWarning matches product footer copy (en-us catalog)", () => {
     assert.equal(buildS3EmptyCredentialsWarning([]), null);
     assert.equal(buildS3EmptyCredentialsWarning(null), null);
     const msg = buildS3EmptyCredentialsWarning(["Access Key", "Security Key"]);
@@ -67,6 +75,26 @@ describe("s3-empty-credentials-warning helpers", () => {
     assert.ok(msg.includes("Save will proceed"));
     assert.ok(msg.includes("HttpPutResponseHopLimit >= 2"));
     assert.ok(isS3EmptyCredentialsWarningText(msg));
+  });
+
+  it("resolves labels and warning body via custom I18N catalog (non-en)", () => {
+    const de = messageFnFromCatalog({
+      [MESSAGE_KEYS.accessKey]: "Zugriffsschlüssel",
+      [MESSAGE_KEYS.securityKey]: "Sicherheitsschlüssel",
+      [MESSAGE_KEYS.roleArn]: "Rollen-ARN",
+      [MESSAGE_KEYS.emptyCredentialsWarning]:
+        "Amazon-S3-Felder sind leer ({0}). Speichern fährt fort; HttpPutResponseHopLimit >= 2.",
+    });
+    const empty = collectEmptyS3CredentialFields(
+      { accessKey: "", secretKey: "", useAssumeRole: false },
+      de,
+    );
+    assert.deepEqual(empty, ["Zugriffsschlüssel", "Sicherheitsschlüssel"]);
+    const msg = buildS3EmptyCredentialsWarning(empty, de);
+    assert.ok(msg.includes("Amazon-S3-Felder sind leer (Zugriffsschlüssel, Sicherheitsschlüssel)"));
+    assert.ok(isS3EmptyCredentialsWarningText(msg, de));
+    // en-us matcher must not falsely accept German copy
+    assert.equal(isS3EmptyCredentialsWarningText(msg), false);
   });
 
   it("skip-with-BUG reason embeds durable issue URL", () => {

--- a/projects/sitemanage/src/main/java/com/percussion/pubserver/impl/PSPubServerService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pubserver/impl/PSPubServerService.java
@@ -19,7 +19,6 @@ package com.percussion.pubserver.impl;
 
 import static com.percussion.share.service.exception.PSParameterValidationUtils.validateParameters;
 import static com.percussion.utils.service.impl.PSSiteConfigUtils.removeServerEntry;
-import static jakarta.ws.rs.client.ClientBuilder.newClient;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -77,11 +76,6 @@ import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.io.PathUtils;
 import com.percussion.utils.service.IPSUtilityService;
 import com.percussion.webservices.publishing.IPSPublishingWs;
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.Invocation;
-import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
@@ -128,7 +122,6 @@ public class PSPubServerService implements IPSPubServerService {
   private final IPSPublisherService publisherService;
   private final IPSContentChangeService contentChangeService;
   private final IPSUtilityService utilityService;
-  private static Boolean isEC2Instance = null;
   private IPSPublishingWs pubWs;
   private SecureKeyRotationListener secureKeyRotationListener;
 
@@ -743,31 +736,13 @@ public class PSPubServerService implements IPSPubServerService {
     return server;
   }
 
+  /**
+   * Whether this JVM appears to be running on EC2. Delegates to {@link
+   * PSAmazonS3DeliveryHandler#isEC2Instance()} so UI REST and S3 delivery share one IMDSv2-aware
+   * probe and JVM-lifetime cache (issue #2284).
+   */
   public static Boolean isEC2Instance() {
-    if (isEC2Instance != null) {
-      return isEC2Instance;
-    }
-    try {
-      Client client = newClient();
-
-      WebTarget resource = client.target("http://169.254.169.254/latest/meta-data/");
-
-      Invocation.Builder request = resource.request();
-      request.accept(MediaType.APPLICATION_JSON);
-
-      Response response = request.get();
-
-      if (response.getStatusInfo().getFamily() == Response.Status.Family.SUCCESSFUL) {
-        isEC2Instance = Boolean.TRUE;
-        return true;
-      } else {
-        isEC2Instance = Boolean.FALSE;
-      }
-    } catch (Exception e) {
-      // means not an EC2 Server
-      isEC2Instance = Boolean.FALSE;
-    }
-    return isEC2Instance;
+    return PSAmazonS3DeliveryHandler.isEC2Instance();
   }
 
   @Override
@@ -1792,28 +1767,21 @@ public class PSPubServerService implements IPSPubServerService {
       PSPublishServerInfo pubServerInfo, String[] requieredProperties)
       throws PSValidationException {
     PSValidationErrorsBuilder builder = validateParameters("validatePropertiesByDriver");
-    String val = pubServerInfo.findProperty(IPSPubServerDao.PUBLISH_AS3_USE_ASSUME_ROLE);
-    boolean useAssumeRole = false;
-    if (val != null) {
-      useAssumeRole = Boolean.valueOf(val);
-    }
     for (String property : requieredProperties) {
       String value = pubServerInfo.findProperty(property);
       if (IPSPubServerDao.PUBLISH_AS3_BUCKET_PROPERTY.equals(property)) {
         builder.rejectIfBlank(property, value).throwIfInvalid();
-      } else if (IPSPubServerDao.PUBLISH_AS3_ACCESSKEY_PROPERTY.equals(property)) {
-        if (!isEC2Instance()) {
-          builder.rejectIfBlank(property, value).throwIfInvalid();
-        }
-      } else if (IPSPubServerDao.PUBLISH_AS3_SECURITYKEY_PROPERTY.equals(property)) {
-        if (!isEC2Instance()) {
-          builder.rejectIfBlank(property, value).throwIfInvalid();
-        }
-      } else if (IPSPubServerDao.PUBLISH_AS3_ARN_ROLE.equals(property)) {
-        if (useAssumeRole) {
-          builder.rejectIfBlank(property, value).throwIfInvalid();
-        }
+      } else if (IPSPubServerDao.PUBLISH_AS3_ACCESSKEY_PROPERTY.equals(property)
+          || IPSPubServerDao.PUBLISH_AS3_SECURITYKEY_PROPERTY.equals(property)
+          || IPSPubServerDao.PUBLISH_AS3_ARN_ROLE.equals(property)) {
+        // Access Key, Secret, and Role ARN are intentionally not hard-required when S3 is
+        // selected (issue #2284). Empty values are allowed so operators can rely on EC2
+        // instance profile / Assume Role without static keys, and as a workaround when IMDS
+        // detection fails. The publish UI shows a non-modal warning on save when these fields
+        // are empty; runtime still needs credentials via instance profile, static keys, or
+        // the default provider chain.
       }
+      // Other driver properties in the array are presence-checked by the caller shape only.
     }
   }
 

--- a/projects/sitemanage/src/main/java/com/percussion/pubserver/impl/PSPubServerService.java
+++ b/projects/sitemanage/src/main/java/com/percussion/pubserver/impl/PSPubServerService.java
@@ -1779,7 +1779,16 @@ public class PSPubServerService implements IPSPubServerService {
         // instance profile / Assume Role without static keys, and as a workaround when IMDS
         // detection fails. The publish UI shows a non-modal warning on save when these fields
         // are empty; runtime still needs credentials via instance profile, static keys, or
-        // the default provider chain.
+        // the default provider chain. Warn-log preserves server-side observability without
+        // blocking the EC2 instance-profile use case.
+        if (isBlank(value)) {
+          log.warn(
+              "S3 publish server property '{}' is blank; save allowed for EC2 instance"
+                  + " profile / Assume Role (issue #2284). Ensure runtime credentials are"
+                  + " available via instance profile, static keys, or the default AWS"
+                  + " provider chain.",
+              property);
+        }
       }
       // Other driver properties in the array are presence-checked by the caller shape only.
     }

--- a/projects/sitemanage/src/test/java/com/percussion/pubserver/impl/PSPubServerServiceEc2Test.java
+++ b/projects/sitemanage/src/test/java/com/percussion/pubserver/impl/PSPubServerServiceEc2Test.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.pubserver.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+
+import com.percussion.rx.delivery.impl.PSAmazonS3DeliveryHandler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link PSPubServerService#isEC2Instance()} delegation to the shared IMDSv2-aware
+ * probe in {@link PSAmazonS3DeliveryHandler} (issue #2284).
+ */
+@ExtendWith(MockitoExtension.class)
+class PSPubServerServiceEc2Test {
+
+  @Test
+  void isEC2Instance_delegatesToDeliveryHandler() {
+    try (MockedStatic<PSAmazonS3DeliveryHandler> handler =
+        mockStatic(PSAmazonS3DeliveryHandler.class)) {
+      handler.when(PSAmazonS3DeliveryHandler::isEC2Instance).thenReturn(true);
+      assertTrue(PSPubServerService.isEC2Instance());
+
+      handler.when(PSAmazonS3DeliveryHandler::isEC2Instance).thenReturn(false);
+      assertFalse(PSPubServerService.isEC2Instance());
+    }
+  }
+}

--- a/system/business/src/com/percussion/rx/delivery/impl/PSAmazonS3DeliveryHandler.java
+++ b/system/business/src/com/percussion/rx/delivery/impl/PSAmazonS3DeliveryHandler.java
@@ -31,8 +31,6 @@ import com.percussion.services.pubserver.IPSPubServerDao;
 import com.percussion.services.sitemgr.IPSSite;
 import com.percussion.utils.types.PSPair;
 
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -70,14 +68,16 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 
-import static jakarta.ws.rs.client.ClientBuilder.newClient;
-
 /**
  * This handler delivers content to the amazon s3.
  *
  * <p>Uses AWS SDK for Java v2 ({@code software.amazon.awssdk}). The v1 SDK and the product-local
  * {@code com.amazonaws.services.s3.transfer.TransferManagerBuilder} shim are no longer used (see
  * issue #1730).
+ *
+ * <p>EC2 detection and region resolution use {@link PSEc2MetadataClient} (IMDSv2 with IMDSv1
+ * fallback). See that class for Amazon Linux 2023+ / container hop-limit operator notes (issue
+ * #2284).
  */
 public class PSAmazonS3DeliveryHandler extends PSBaseDeliveryHandler
 {
@@ -88,7 +88,10 @@ public class PSAmazonS3DeliveryHandler extends PSBaseDeliveryHandler
     private String targetRegion = DEFAULT_REGION;
     /** Per-job S3 client (v2 {@link S3Client}) - replaces v1's cached TransferManager. */
     private final ConcurrentHashMap<Long, S3Client> jobTransferManagers = new ConcurrentHashMap<>();
+    /** JVM-lifetime cache of the EC2 probe result (null until first probe). */
     private static Boolean isEC2Instance = null;
+    /** Shared metadata client; replaceable in unit tests via {@link #setEc2MetadataClientForTests}. */
+    private static volatile PSEc2MetadataClient ec2MetadataClient = new PSEc2MetadataClient();
     private static final Logger log = LogManager.getLogger(PSAmazonS3DeliveryHandler.class);
 
     /**
@@ -302,33 +305,45 @@ public class PSAmazonS3DeliveryHandler extends PSBaseDeliveryHandler
         }
     }
 
+    /**
+     * Replace the EC2 metadata client used by {@link #isEC2Instance()} / {@link
+     * #getCurrentEc2Region()}. Intended for unit tests only; clears the JVM-lifetime EC2 cache.
+     *
+     * @param client client to use, or {@code null} to restore the production default
+     */
+    static void setEc2MetadataClientForTests(PSEc2MetadataClient client) {
+        ec2MetadataClient = client != null ? client : new PSEc2MetadataClient();
+        isEC2Instance = null;
+    }
+
+    /**
+     * Clears the JVM-lifetime EC2 detection cache. Intended for unit tests.
+     */
+    static void clearEc2InstanceCacheForTests() {
+        isEC2Instance = null;
+    }
+
+    /**
+     * @return {@code true} if this JVM appears to be running on EC2 (IMDSv2-aware probe with
+     *     IMDSv1 fallback). Result is cached for the JVM lifetime after the first call.
+     */
     public static boolean isEC2Instance() {
         if (isEC2Instance != null) {
             return isEC2Instance;
         }
         try {
-            var client = newClient();
-            var resource = client.target("http://169.254.169.254/latest/meta-data/");
-            var request = resource.request();
-            request.accept(MediaType.APPLICATION_JSON);
-            var response = request.get();
-            if (response.getStatusInfo().getFamily() == Response.Status.Family.SUCCESSFUL) {
-                isEC2Instance = Boolean.TRUE;
-                return true;
-            } else {
-                isEC2Instance = Boolean.FALSE;
-            }
+            isEC2Instance = Boolean.valueOf(ec2MetadataClient.isAvailable());
         } catch (Exception e) {
+            log.debug(PSExceptionUtils.getDebugMessageForLog(e));
             isEC2Instance = Boolean.FALSE;
         }
         return isEC2Instance;
     }
 
     /**
-     * Returns the EC2 instance region by querying the EC2 instance metadata service
-     * ({@code http://169.254.169.254/latest/meta-data/placement/availability-zone/}) and stripping
-     * the trailing AZ letter. Returns {@code null} if the host is not on EC2 or the metadata call
-     * fails.
+     * Returns the EC2 instance region by querying the EC2 instance metadata service (IMDSv2-aware)
+     * for the availability zone and stripping the trailing AZ letter. Returns {@code null} if the
+     * host is not on EC2 or the metadata call fails.
      *
      * <p>Replaces v1's {@code com.amazonaws.regions.Regions.getCurrentRegion()} which has no
      * direct v2 equivalent.
@@ -338,21 +353,11 @@ public class PSAmazonS3DeliveryHandler extends PSBaseDeliveryHandler
             return null;
         }
         try {
-            var client = newClient();
-            var resource = client.target("http://169.254.169.254/latest/meta-data/placement/availability-zone/");
-            var request = resource.request();
-            var response = request.get();
-            if (response.getStatusInfo().getFamily() == Response.Status.Family.SUCCESSFUL) {
-                String az = response.readEntity(String.class);
-                if (az != null && az.length() > 1) {
-                    // Availability zone is "<region><letter>", e.g. "us-east-1a" -> "us-east-1".
-                    return az.substring(0, az.length() - 1);
-                }
-            }
+            return ec2MetadataClient.getRegion();
         } catch (Exception e) {
             log.debug(PSExceptionUtils.getDebugMessageForLog(e));
+            return null;
         }
-        return null;
     }
 
     /**

--- a/system/business/src/com/percussion/rx/delivery/impl/PSEc2MetadataClient.java
+++ b/system/business/src/com/percussion/rx/delivery/impl/PSEc2MetadataClient.java
@@ -160,6 +160,14 @@ public class PSEc2MetadataClient {
         log.debug("IMDSv2 GET failed for {}; trying IMDSv1 fallback", path);
       }
       return getWithOptionalToken(path, null);
+    } catch (InterruptedException e) {
+      // Preserve interrupt flag so server shutdown/cancellation remains reliable.
+      Thread.currentThread().interrupt();
+      log.debug(
+          "EC2 metadata probe interrupted for {} (host is likely not EC2 or IMDS unreachable): {}",
+          path,
+          e.toString());
+      return null;
     } catch (Exception e) {
       log.debug(
           "EC2 metadata probe failed for {} (host is likely not EC2 or IMDS unreachable): {}",

--- a/system/business/src/com/percussion/rx/delivery/impl/PSEc2MetadataClient.java
+++ b/system/business/src/com/percussion/rx/delivery/impl/PSEc2MetadataClient.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rx.delivery.impl;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * IMDSv2-aware EC2 instance metadata client used for CMS EC2 detection and region resolution.
+ *
+ * <p>Amazon Linux 2023+ and many newer AMIs default instance metadata to {@code
+ * HttpTokens=required} (IMDSv2 only). A plain IMDSv1 GET against {@code
+ * http://169.254.169.254/latest/meta-data/} fails on those hosts, which previously caused the CMS
+ * to treat the instance as non-EC2 and force Access Key / Secret for S3 publishing.
+ *
+ * <p>This client:
+ *
+ * <ol>
+ *   <li>Obtains a short-lived session token via {@code PUT /latest/api/token} with header {@code
+ *       X-aws-ec2-metadata-token-ttl-seconds}
+ *   <li>Performs GETs with header {@code X-aws-ec2-metadata-token}
+ *   <li>Falls back to IMDSv1 (no token) when the token endpoint is unavailable (older AMIs with
+ *       {@code HttpTokens=optional})
+ *   <li>Uses short connect/request timeouts so non-EC2 hosts fail quickly
+ * </ol>
+ *
+ * <p><b>Operator notes (containers / hop limit):</b> When CMS runs inside a container on EC2, set
+ * the instance metadata option {@code HttpPutResponseHopLimit} to at least {@code 2} so the IMDSv2
+ * PUT from the container can reach the metadata service. On Amazon Linux 2023+ keep {@code
+ * HttpTokens=required}; after this fix the CMS probe no longer requires IMDSv1.
+ *
+ * @see <a
+ *     href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html">AWS
+ *     IMDS documentation</a>
+ */
+public class PSEc2MetadataClient {
+
+  /** Link-local EC2 metadata base URL. */
+  public static final String DEFAULT_METADATA_BASE = "http://169.254.169.254";
+
+  static final String TOKEN_PATH = "/latest/api/token";
+  static final String META_DATA_ROOT = "/latest/meta-data/";
+  static final String AVAILABILITY_ZONE_PATH =
+      "/latest/meta-data/placement/availability-zone/";
+
+  static final String TOKEN_HEADER = "X-aws-ec2-metadata-token";
+  static final String TOKEN_TTL_HEADER = "X-aws-ec2-metadata-token-ttl-seconds";
+  static final String TOKEN_TTL_SECONDS = "60";
+
+  private static final Duration CONNECT_TIMEOUT = Duration.ofMillis(1000);
+  private static final Duration REQUEST_TIMEOUT = Duration.ofMillis(1000);
+
+  private static final Logger log = LogManager.getLogger(PSEc2MetadataClient.class);
+
+  private final String metadataBase;
+  private final HttpClient httpClient;
+
+  /** Production client targeting the EC2 link-local metadata address. */
+  public PSEc2MetadataClient() {
+    this(DEFAULT_METADATA_BASE, defaultHttpClient());
+  }
+
+  /**
+   * Package-visible constructor for unit tests (custom base URL / client).
+   *
+   * @param metadataBase base URL including scheme and host (no trailing path slash required)
+   * @param httpClient HTTP client (should use short timeouts)
+   */
+  PSEc2MetadataClient(String metadataBase, HttpClient httpClient) {
+    if (metadataBase == null || metadataBase.isBlank()) {
+      throw new IllegalArgumentException("metadataBase must not be blank");
+    }
+    if (httpClient == null) {
+      throw new IllegalArgumentException("httpClient must not be null");
+    }
+    String base = metadataBase.trim();
+    if (base.endsWith("/")) {
+      base = base.substring(0, base.length() - 1);
+    }
+    this.metadataBase = base;
+    this.httpClient = httpClient;
+  }
+
+  static HttpClient defaultHttpClient() {
+    return HttpClient.newBuilder()
+        .connectTimeout(CONNECT_TIMEOUT)
+        .followRedirects(HttpClient.Redirect.NEVER)
+        .build();
+  }
+
+  /**
+   * @return {@code true} if the metadata root responds successfully (IMDSv2 or v1)
+   */
+  public boolean isAvailable() {
+    return getMetadata(META_DATA_ROOT) != null;
+  }
+
+  /**
+   * @return availability zone string (e.g. {@code us-east-1a}), or {@code null} on failure
+   */
+  public String getAvailabilityZone() {
+    String az = getMetadata(AVAILABILITY_ZONE_PATH);
+    if (az == null) {
+      return null;
+    }
+    String trimmed = az.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  /**
+   * Resolves the EC2 region by stripping the trailing AZ letter from the availability zone.
+   *
+   * @return region id (e.g. {@code us-east-1}), or {@code null} on failure
+   */
+  public String getRegion() {
+    String az = getAvailabilityZone();
+    if (az == null || az.length() <= 1) {
+      return null;
+    }
+    return az.substring(0, az.length() - 1);
+  }
+
+  /**
+   * GET a metadata path using IMDSv2 when possible, with IMDSv1 fallback.
+   *
+   * @param path absolute path starting with {@code /} (e.g. {@code /latest/meta-data/})
+   * @return response body on HTTP 2xx, else {@code null}
+   */
+  String getMetadata(String path) {
+    if (path == null || !path.startsWith("/")) {
+      throw new IllegalArgumentException("path must start with /");
+    }
+    try {
+      String token = fetchImdsV2Token();
+      if (token != null && !token.isBlank()) {
+        String body = getWithOptionalToken(path, token);
+        if (body != null) {
+          return body;
+        }
+        log.debug("IMDSv2 GET failed for {}; trying IMDSv1 fallback", path);
+      }
+      return getWithOptionalToken(path, null);
+    } catch (Exception e) {
+      log.debug(
+          "EC2 metadata probe failed for {} (host is likely not EC2 or IMDS unreachable): {}",
+          path,
+          e.toString());
+      return null;
+    }
+  }
+
+  private String fetchImdsV2Token() {
+    try {
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(metadataBase + TOKEN_PATH))
+              .timeout(REQUEST_TIMEOUT)
+              .header(TOKEN_TTL_HEADER, TOKEN_TTL_SECONDS)
+              .PUT(HttpRequest.BodyPublishers.noBody())
+              .build();
+      HttpResponse<String> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      if (isSuccess(response.statusCode())) {
+        String token = response.body();
+        return token == null ? null : token.trim();
+      }
+      log.debug("IMDSv2 token request returned status {}", response.statusCode());
+      return null;
+    } catch (IOException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+      log.debug("IMDSv2 token request failed: {}", e.toString());
+      return null;
+    }
+  }
+
+  private String getWithOptionalToken(String path, String token)
+      throws IOException, InterruptedException {
+    HttpRequest.Builder builder =
+        HttpRequest.newBuilder()
+            .uri(URI.create(metadataBase + path))
+            .timeout(REQUEST_TIMEOUT)
+            .GET();
+    if (token != null && !token.isBlank()) {
+      builder.header(TOKEN_HEADER, token);
+    }
+    HttpResponse<String> response =
+        httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    if (isSuccess(response.statusCode())) {
+      return response.body();
+    }
+    log.debug("Metadata GET {} returned status {}", path, response.statusCode());
+    return null;
+  }
+
+  private static boolean isSuccess(int statusCode) {
+    return statusCode >= 200 && statusCode < 300;
+  }
+}

--- a/system/src/site/markdown/index.md
+++ b/system/src/site/markdown/index.md
@@ -12,6 +12,7 @@ Welcome to the technical documentation for the Percussion CMS **system** module.
 - [Package Reference](packages.html) – Detailed package-by-package reference documentation
 - [Modernization Status](modernization.html) – Java modernization history (module is now on JDK 21)
 - [Legacy Code](legacy.html) – Information about legacy components and backward compatibility
+- [S3 publish on EC2 (IMDSv2)](s3-publish-ec2-imds.html) – Operator notes for Amazon Linux 2023+, hop limit, Assume Role
 
 ## Module At A Glance
 

--- a/system/src/site/markdown/s3-publish-ec2-imds.md
+++ b/system/src/site/markdown/s3-publish-ec2-imds.md
@@ -1,0 +1,32 @@
+# Amazon S3 publish on EC2 (IMDSv2)
+
+Percussion CMS detects whether it is running on EC2 so Server Properties for Amazon S3 can rely on the **instance profile** (with or without **Assume Role**) instead of static Access Key / Secret.
+
+## Why Amazon Linux 2023+ matters
+
+AWS instance metadata defaults increasingly use **IMDSv2 only** (`HttpTokens=required` on Amazon Linux 2023 and many newer AMIs). A plain IMDSv1 GET to `http://169.254.169.254/latest/meta-data/` fails on those hosts.
+
+CMS probes IMDS with an IMDSv2 session token (`PUT /latest/api/token`, then GETs with `X-aws-ec2-metadata-token`) and falls back to IMDSv1 only when the token endpoint is unavailable (older AMIs).
+
+## Operator checklist
+
+| Setting | Guidance |
+|---------|----------|
+| **HttpTokens** | Prefer `required` (IMDSv2). CMS no longer needs IMDSv1 optional for EC2 detection. |
+| **HttpPutResponseHopLimit** | On the **EC2 instance**, set to **at least 2** when CMS runs **inside a container** (Docker/Kubernetes). Hop limit `1` blocks the token PUT from the container network namespace. |
+| **S3 form fields** | Access Key, Secret, and Role ARN are **not** hard-required on save. Empty values are allowed for instance-profile / Assume Role setups; the UI shows a non-modal warning if they are empty. |
+| **Bucket / region** | Bucket name remains required. Region can be selected or derived from IMDS when blank on EC2. |
+
+## Temporary workarounds (if needed)
+
+1. Set metadata to `HttpTokens=optional` (allows IMDSv1) — not preferred long-term.
+2. Raise `HttpPutResponseHopLimit` to `2` for containerized CMS.
+3. Configure static Access Key + Secret (base identity for Assume Role if used).
+
+## Code entry points
+
+- Shared helper: `com.percussion.rx.delivery.impl.PSEc2MetadataClient`
+- Delivery / region: `PSAmazonS3DeliveryHandler.isEC2Instance()` / `getCurrentEc2Region()`
+- UI REST: `PSPubServerService.isEC2Instance()` → same probe
+
+See issue [#2284](https://github.com/intersoftdatalabs-in/percussioncms/issues/2284).

--- a/system/src/test/java/com/percussion/rx/delivery/impl/PSAmazonS3DeliveryHandlerTest.java
+++ b/system/src/test/java/com/percussion/rx/delivery/impl/PSAmazonS3DeliveryHandlerTest.java
@@ -19,6 +19,7 @@ package com.percussion.rx.delivery.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -39,6 +40,7 @@ import com.percussion.util.PSPurgableTempFile;
 import com.percussion.utils.guid.IPSGuid;
 import java.lang.reflect.Field;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -138,14 +140,9 @@ public class PSAmazonS3DeliveryHandlerTest {
   @AfterEach
   public void tearDown() {
     if (handlerStatic != null) handlerStatic.close();
-    // Reset the static isEC2Instance cache so it doesn't leak between tests.
-    try {
-      Field f = PSAmazonS3DeliveryHandler.class.getDeclaredField("isEC2Instance");
-      f.setAccessible(true);
-      f.set(null, (Object) null);
-    } catch (Exception e) {
-      // ignore
-    }
+    // Reset the static isEC2Instance cache / metadata client so state does not leak.
+    PSAmazonS3DeliveryHandler.clearEc2InstanceCacheForTests();
+    PSAmazonS3DeliveryHandler.setEc2MetadataClientForTests(null);
   }
 
   private PSBaseDeliveryHandler.JobData newJobData() {
@@ -383,6 +380,39 @@ public class PSAmazonS3DeliveryHandlerTest {
         PSAmazonS3DeliveryHandler.getS3Client(
             pubServer, software.amazon.awssdk.regions.Region.of(REGION));
     assertNotNull(s3);
+  }
+
+  @Test
+  public void isEC2Instance_usesInjectedMetadataClient_andCaches() {
+    // Use real methods (no static mock for isEC2Instance on this path).
+    handlerStatic.close();
+    handlerStatic = null;
+
+    AtomicBoolean available = new AtomicBoolean(true);
+    PSEc2MetadataClient stub =
+        new PSEc2MetadataClient("http://127.0.0.1:9", PSEc2MetadataClient.defaultHttpClient()) {
+          @Override
+          public boolean isAvailable() {
+            return available.get();
+          }
+
+          @Override
+          public String getRegion() {
+            return "eu-west-1";
+          }
+        };
+    PSAmazonS3DeliveryHandler.setEc2MetadataClientForTests(stub);
+
+    assertTrue(PSAmazonS3DeliveryHandler.isEC2Instance());
+    // Flip stub; cached value must remain true for JVM lifetime of the cache.
+    available.set(false);
+    assertTrue(PSAmazonS3DeliveryHandler.isEC2Instance());
+    assertEquals("eu-west-1", PSAmazonS3DeliveryHandler.getCurrentEc2Region());
+
+    PSAmazonS3DeliveryHandler.clearEc2InstanceCacheForTests();
+    available.set(false);
+    assertFalse(PSAmazonS3DeliveryHandler.isEC2Instance());
+    assertNull(PSAmazonS3DeliveryHandler.getCurrentEc2Region());
   }
 
   private static S3Exception s3NotFound(String msg) {

--- a/system/src/test/java/com/percussion/rx/delivery/impl/PSAmazonS3DeliveryHandlerTest.java
+++ b/system/src/test/java/com/percussion/rx/delivery/impl/PSAmazonS3DeliveryHandlerTest.java
@@ -385,8 +385,13 @@ public class PSAmazonS3DeliveryHandlerTest {
   @Test
   public void isEC2Instance_usesInjectedMetadataClient_andCaches() {
     // Use real methods (no static mock for isEC2Instance on this path).
-    handlerStatic.close();
+    // Null the field before close so @AfterEach cannot double-close if anything
+    // throws between these statements (MockitoException masks the real failure).
+    MockedStatic<PSAmazonS3DeliveryHandler> staticToClose = handlerStatic;
     handlerStatic = null;
+    if (staticToClose != null) {
+      staticToClose.close();
+    }
 
     AtomicBoolean available = new AtomicBoolean(true);
     PSEc2MetadataClient stub =

--- a/system/src/test/java/com/percussion/rx/delivery/impl/PSEc2MetadataClientTest.java
+++ b/system/src/test/java/com/percussion/rx/delivery/impl/PSEc2MetadataClientTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rx.delivery.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link PSEc2MetadataClient} using a local {@link HttpServer} to simulate IMDS
+ * (no live AWS). Covers IMDSv2 success, IMDSv1-only fallback, v2-required (v1 fails / v2 ok), and
+ * non-EC2 (connection refused / error) paths.
+ */
+class PSEc2MetadataClientTest {
+
+  private HttpServer server;
+  private String baseUrl;
+  private HttpClient httpClient;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.start();
+    baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+    httpClient =
+        HttpClient.newBuilder()
+            .connectTimeout(Duration.ofMillis(500))
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void imdsV2_success_detectsEc2AndRegion() {
+    AtomicInteger tokenPuts = new AtomicInteger();
+    AtomicBoolean sawTokenHeader = new AtomicBoolean();
+
+    server.createContext(
+        PSEc2MetadataClient.TOKEN_PATH,
+        exchange -> {
+          tokenPuts.incrementAndGet();
+          if (!"PUT".equalsIgnoreCase(exchange.getRequestMethod())) {
+            respond(exchange, 405, "method not allowed");
+            return;
+          }
+          String ttl = exchange.getRequestHeaders().getFirst(PSEc2MetadataClient.TOKEN_TTL_HEADER);
+          assertEquals(PSEc2MetadataClient.TOKEN_TTL_SECONDS, ttl);
+          respond(exchange, 200, "test-session-token");
+        });
+    server.createContext(
+        PSEc2MetadataClient.META_DATA_ROOT,
+        exchange -> {
+          String token = exchange.getRequestHeaders().getFirst(PSEc2MetadataClient.TOKEN_HEADER);
+          if ("test-session-token".equals(token)) {
+            sawTokenHeader.set(true);
+            respond(exchange, 200, "ami-id\nhostname\n");
+          } else {
+            respond(exchange, 401, "Unauthorized");
+          }
+        });
+    server.createContext(
+        PSEc2MetadataClient.AVAILABILITY_ZONE_PATH,
+        exchange -> {
+          String token = exchange.getRequestHeaders().getFirst(PSEc2MetadataClient.TOKEN_HEADER);
+          if ("test-session-token".equals(token)) {
+            respond(exchange, 200, "us-east-1a");
+          } else {
+            respond(exchange, 401, "Unauthorized");
+          }
+        });
+
+    PSEc2MetadataClient client = new PSEc2MetadataClient(baseUrl, httpClient);
+
+    assertTrue(client.isAvailable());
+    assertTrue(tokenPuts.get() >= 1);
+    assertTrue(sawTokenHeader.get());
+    assertEquals("us-east-1a", client.getAvailabilityZone());
+    assertEquals("us-east-1", client.getRegion());
+  }
+
+  @Test
+  void imdsV1Only_tokenFails_fallbackGetSucceeds() {
+    AtomicInteger unauthGets = new AtomicInteger();
+
+    server.createContext(
+        PSEc2MetadataClient.TOKEN_PATH,
+        exchange -> respond(exchange, 404, "no token on this AMI"));
+    server.createContext(
+        PSEc2MetadataClient.META_DATA_ROOT,
+        exchange -> {
+          String token = exchange.getRequestHeaders().getFirst(PSEc2MetadataClient.TOKEN_HEADER);
+          if (token != null) {
+            respond(exchange, 401, "unexpected token");
+            return;
+          }
+          unauthGets.incrementAndGet();
+          respond(exchange, 200, "instance-id\n");
+        });
+
+    PSEc2MetadataClient client = new PSEc2MetadataClient(baseUrl, httpClient);
+    assertTrue(client.isAvailable());
+    assertTrue(unauthGets.get() >= 1);
+  }
+
+  @Test
+  void imdsV2Required_v1Fails_v2Ok_doesNotFalseNegative() {
+    // Simulates HttpTokens=required: unauthenticated GET fails; token + header succeeds.
+    server.createContext(
+        PSEc2MetadataClient.TOKEN_PATH, exchange -> respond(exchange, 200, "v2-token"));
+    server.createContext(
+        PSEc2MetadataClient.META_DATA_ROOT,
+        exchange -> {
+          String token = exchange.getRequestHeaders().getFirst(PSEc2MetadataClient.TOKEN_HEADER);
+          if ("v2-token".equals(token)) {
+            respond(exchange, 200, "ok");
+          } else {
+            respond(exchange, 401, "IMDSv1 disabled");
+          }
+        });
+
+    PSEc2MetadataClient client = new PSEc2MetadataClient(baseUrl, httpClient);
+    assertTrue(client.isAvailable(), "must succeed via IMDSv2 when v1 is rejected");
+  }
+
+  @Test
+  void nonEc2_connectionRefused_returnsFalse() {
+    // Port with no listener → connection refused / fail fast.
+    String deadBase = "http://127.0.0.1:" + findFreePortThenClose();
+    PSEc2MetadataClient client = new PSEc2MetadataClient(deadBase, httpClient);
+    assertFalse(client.isAvailable());
+    assertNull(client.getRegion());
+  }
+
+  @Test
+  void nonEc2_errorStatus_returnsFalse() {
+    server.createContext(
+        PSEc2MetadataClient.TOKEN_PATH, exchange -> respond(exchange, 500, "err"));
+    server.createContext(
+        PSEc2MetadataClient.META_DATA_ROOT, exchange -> respond(exchange, 500, "err"));
+
+    PSEc2MetadataClient client = new PSEc2MetadataClient(baseUrl, httpClient);
+    assertFalse(client.isAvailable());
+  }
+
+  private static int findFreePortThenClose() {
+    try (var socket = new java.net.ServerSocket(0)) {
+      return socket.getLocalPort();
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+    byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.sendResponseHeaders(status, bytes.length);
+    try (OutputStream os = exchange.getResponseBody()) {
+      os.write(bytes);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #2284 — EC2 instance-metadata detection for Amazon S3 publishing now supports **IMDSv2** (default on Amazon Linux 2023+ with `HttpTokens=required`).

### Root cause
Custom probes in `PSAmazonS3DeliveryHandler` and `PSPubServerService` used plain IMDSv1 GETs to `169.254.169.254`. On IMDSv2-only hosts the probe failed, the product treated the host as non-EC2, and Access Key / Secret stayed required even with instance profile + Assume Role.

### Changes
- **`PSEc2MetadataClient`**: PUT `/latest/api/token` with `X-aws-ec2-metadata-token-ttl-seconds`, subsequent GETs with `X-aws-ec2-metadata-token`, short connect/request timeouts, IMDSv1 fallback.
- **`PSAmazonS3DeliveryHandler`**: `isEC2Instance()` / `getCurrentEc2Region()` use the helper; JVM-lifetime cache retained.
- **`PSPubServerService.isEC2Instance()`**: delegates to the same probe/cache (REST `/isEC2Instance` stays consistent with delivery).
- **Validation**: Access Key, Secret, and Role ARN are **not** hard-required when S3 is selected; UI shows a **non-modal** footer warning on save if empty.
- **Docs**: operator notes for AL2023 `HttpTokens=required` and container `HttpPutResponseHopLimit >= 2` (`system/src/site/markdown/s3-publish-ec2-imds.md`, `docker/README.md`).

### Out of scope (this PR)
- `percussioncms-java8` dual-ship (tracked separately).
- DefaultCredentialsProvider / IRSA-style non-EC2 chains (issue optional follow-up).
- Playwright for residual minuet Publish UI (legacy hotfix only).

## Test plan
- [x] Unit: IMDSv2 success path (`PSEc2MetadataClientTest`)
- [x] Unit: IMDSv1-only fallback
- [x] Unit: v1 fails / v2 ok (no false-negative)
- [x] Unit: non-EC2 connection refused / error → false
- [x] Unit: delivery handler cache + region via injected client
- [x] Unit: `PSPubServerService.isEC2Instance` delegates
- [ ] Manual on AL2023 EC2 with `HttpTokens=required`: `/isEC2Instance` true; S3 save without keys; publish with instance profile

## Gates evidence
- `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS**
  - `PSEc2MetadataClientTest`: Tests run: 5, Failures: 0
  - `PSAmazonS3DeliveryHandlerTest`: Tests run: 17, Failures: 0
- `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS**
  - `PSPubServerServiceEc2Test`: Tests run: 1, Failures: 0
- `cd WebUI && ../mvnw.cmd clean install` — **BUILD SUCCESS**
- No live AWS required for unit tests (local `HttpServer` / stubs)
- Erlang self-review: portable paths N/A for IMDS HTTP; behavioral tests present; dual WebUI copies updated

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Parent tracker: #2284

> Co-Authored by Grok Build using grok-4.5 with agent main.