### PR TITLE
fix(tlsutils): replace deprecated URL and getSubjectDN APIs (#2027)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2027-tlsutils-javac-warnings-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2027-tlsutils-javac-warnings-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review: fix/issue-2027-tlsutils-javac-warnings
+
+**Date:** 2026-08-07  
+**Branch:** fix/issue-2027-tlsutils-javac-warnings  
+**Issue:** #2027 (parent #2200)  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+
+## Summary
+
+Real-fix cleanup of three JDK 21 deprecation diagnostics in `modules/tlsutils` (no `@SuppressWarnings`). Replaces deprecated `URL(String)` and `X509Certificate#getSubjectDN()` with `URI#toURL()` and `getSubjectX500Principal()`. Package-private helpers added with unit tests. Minor dead local removal in `WrappedTrustManager`.
+
+## Scope
+
+- `modules/tlsutils/src/main/java/com/percussion/tls/TLSTester.java`
+- `modules/tlsutils/src/main/java/com/percussion/tls/WrappedTrustManager.java`
+- `modules/tlsutils/src/test/java/com/percussion/tls/TLSTesterTest.java`
+
+Cross-platform path review: N/A (no path/file I/O changes beyond existing `File` usage).
+
+## Verification
+
+- Standalone `modules/tlsutils` `mvnw clean install`: BUILD SUCCESS, 41 tests (7 skipped env-dependent), 0 failures
+- Direct `javac -Xlint:all -Xlint:-path`: 0 source warnings (was 3 deprecation warnings)
+
+## Issues
+
+None (bug/suggestion/nit).
+
+## Change-class companions
+
+| Companion | Status |
+|-----------|--------|
+| Real generics/API fix vs suppress | done |
+| Javadoc on new helpers | done |
+| Behavioral unit tests | `certificateAlias`, `toUrl` covered |
+| Module clean install | green |

--- a/modules/tlsutils/src/main/java/com/percussion/tls/TLSTester.java
+++ b/modules/tlsutils/src/main/java/com/percussion/tls/TLSTester.java
@@ -26,12 +26,12 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.security.Principal;
 import java.security.Provider;
 import java.security.Security;
 import java.security.cert.Certificate;
@@ -241,7 +241,7 @@ public class TLSTester {
     URL url;
     try {
 
-      url = new URL(https_url);
+      url = toUrl(https_url);
       HttpsURLConnection con = (HttpsURLConnection) url.openConnection();
 
       // dumpl all cert info
@@ -272,10 +272,9 @@ public class TLSTester {
       // Adapt how you load the keystore to your needs
 
       myTrustStore.load(myKeys, KEYSTORE_PASS.toCharArray());
-      Principal DN = caCert.getSubjectDN();
       try (ByteArrayInputStream bis = new ByteArrayInputStream(pem.getBytes())) {
         Certificate cert = cf.generateCertificate(bis);
-        String alias = caCert.getSubjectDN().getName().replaceAll("[^a-zA-Z0-9]", "").toLowerCase();
+        String alias = certificateAlias(caCert);
         log.debug("Adding certificate alias: {}", alias);
         myTrustStore.setCertificateEntry(alias, cert);
       }
@@ -416,6 +415,33 @@ public class TLSTester {
     String pemCertPre = new String(Base64.encodeBase64(derCert, true));
     String pemCert = cert_begin + pemCertPre + end_cert;
     return pemCert;
+  }
+
+  /**
+   * Builds a keystore-safe alias from an X.509 certificate subject.
+   *
+   * <p>Uses {@link X509Certificate#getSubjectX500Principal()} (not the deprecated {@code
+   * getSubjectDN()}) and retains only ASCII letters and digits so the alias is suitable as a
+   * keystore entry name.
+   *
+   * @param cert the certificate whose subject is used for the alias, never {@code null}
+   * @return a lowercase alphanumeric alias derived from the subject DN
+   */
+  static String certificateAlias(X509Certificate cert) {
+    return cert.getSubjectX500Principal().getName().replaceAll("[^a-zA-Z0-9]", "").toLowerCase();
+  }
+
+  /**
+   * Converts an HTTPS URL string to a {@link URL} without using the deprecated {@code URL(String)}
+   * constructor.
+   *
+   * @param httpsUrl absolute HTTPS URL string, never {@code null}
+   * @return the corresponding {@link URL}
+   * @throws MalformedURLException if the URI cannot be converted to a URL
+   * @throws IllegalArgumentException if {@code httpsUrl} is not a valid URI
+   */
+  static URL toUrl(String httpsUrl) throws MalformedURLException {
+    return URI.create(httpsUrl).toURL();
   }
 
   private static KeyStore getJKSKeystore(File store, String password, boolean create)

--- a/modules/tlsutils/src/main/java/com/percussion/tls/WrappedTrustManager.java
+++ b/modules/tlsutils/src/main/java/com/percussion/tls/WrappedTrustManager.java
@@ -81,7 +81,6 @@ public class WrappedTrustManager implements X509TrustManager {
       throws CertificateException {
 
     CertificateException exception = null;
-    Exception ex = null;
     for (Map.Entry<String, X509TrustManager> thistm : wrappedManagers.entrySet()) {
       String successTm = thistm.getKey();
       try {

--- a/modules/tlsutils/src/test/java/com/percussion/tls/TLSTesterTest.java
+++ b/modules/tlsutils/src/test/java/com/percussion/tls/TLSTesterTest.java
@@ -22,8 +22,10 @@ import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.net.URL;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
+import javax.security.auth.x500.X500Principal;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -333,5 +335,39 @@ public class TLSTesterTest {
     assertTrue(result.split("\n").length > 3, "Result should contain multiple lines");
 
     verify(mockCertificate).getEncoded();
+  }
+
+  @Test
+  public void testCertificateAlias_StripsNonAlphanumericAndLowercases() {
+    when(mockCertificate.getSubjectX500Principal())
+        .thenReturn(new X500Principal("CN=Example Cert, O=Acme Inc., C=US"));
+
+    String alias = TLSTester.certificateAlias(mockCertificate);
+
+    assertEquals("cnexamplecertoacmeinccus", alias);
+    verify(mockCertificate).getSubjectX500Principal();
+  }
+
+  @Test
+  public void testCertificateAlias_AlreadySimpleSubject() {
+    when(mockCertificate.getSubjectX500Principal()).thenReturn(new X500Principal("CN=localhost"));
+
+    String alias = TLSTester.certificateAlias(mockCertificate);
+
+    assertEquals("cnlocalhost", alias);
+  }
+
+  @Test
+  public void testToUrl_ValidHttpsUrl() throws Exception {
+    URL url = TLSTester.toUrl("https://www.example.com/path");
+
+    assertEquals("https", url.getProtocol());
+    assertEquals("www.example.com", url.getHost());
+    assertEquals("/path", url.getPath());
+  }
+
+  @Test
+  public void testToUrl_InvalidUriThrowsIllegalArgumentException() {
+    assertThrows(IllegalArgumentException.class, () -> TLSTester.toUrl("not a uri"));
   }
 }


### PR DESCRIPTION
## Summary

Resolves remaining javac diagnostics in `modules/tlsutils` with real API fixes (no `@SuppressWarnings`).

Prior #2051 already fixed try-with-resources `close()` / raw `Iterator` issues. This follow-up clears the **3** `-Xlint:all` deprecation warnings still present under JDK 21:

| Warning | Fix |
|---------|-----|
| `URL(String)` deprecated | `TLSTester.toUrl` via `URI.create(...).toURL()` |
| `X509Certificate#getSubjectDN()` (x2) | `certificateAlias` via `getSubjectX500Principal()` |
| Unused locals | Drop unused `Principal DN`; drop unused exception local in `WrappedTrustManager` |

Package-private helpers + Javadoc; unit tests for alias sanitization and URL conversion.

**Parent tracker:** #2200  
**Fixes #2027**  
**Refs #2200**

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] Standalone `cd modules/tlsutils && ../../mvnw clean install` — BUILD SUCCESS
- [x] Surefire: 41 tests, 0 failures (7 skipped env-dependent)
- [x] Direct `javac -Xlint:all -Xlint:-path` on main sources — **0** source warnings (was 3 deprecations)
- [x] Maven compile no longer reports deprecated-API note for `TLSTester`
- [x] Javadoc jar attaches cleanly (0 javadoc warnings)

## Gates evidence

- **Erlang self-review:** approve — `docs/ai-generated/code-reviews/issue-2027-tlsutils-javac-warnings-erlang.md`
- **Module clean install:** green (tlsutils only)
- **Scope:** tlsutils only; no monorepo reformat

> Co-Authored by Grok Build using grok-4.5 with agent main.