### PR TITLE
fix(extensions-linkback): real-fix this-escape and rawtypes warnings (#2037)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2037-extensions-linkback-javac-warnings-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2037-extensions-linkback-javac-warnings-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — issue #2037 extensions-linkback javac real-fix
+
+**Date:** 2026-08-07  
+**Scope:** Replace residual `@SuppressWarnings` from #2052 with real fixes  
+**Verdict:** **approve**
+
+## Change class
+
+Micro-cleanup of javac diagnostics in a leaf Spring MVC extension module (peer: tlsutils / feeds / servlet-utils this-escape real-fixes).
+
+## Diff inventory
+
+| File | Change |
+|------|--------|
+| `StringLinkBackTokenImpl` | Drop `rawtypes` suppress; pattern-match `List<?>` / `String[]` |
+| `ActionPanelLinkbackController` | `final` class; remove unused logger + `this-escape` suppress; `List.of` defaults |
+| `ContentExplorerLinkbackController` | same final/this-escape cleanup; fix class Javadoc “Content Explorer” |
+| Tests | `simplifyValue` shapes; constructor seed + finality for both controllers |
+
+## Checklist
+
+| Gate | Result |
+|------|--------|
+| Bugs / behavior regression | Pass — `simplifyValue` still takes first list/array element; null input → null; empty → `""`; NPE on null list element unchanged |
+| Public API breakage | Pass — constructors, bean class names, and `simplifyValue(Object)` signature unchanged; `final` on concrete Spring bean classes only (XML uses direct class names, no subclassing) |
+| this-escape | Pass — leaf controllers `final` so parent setter calls in ctor cannot be overridden by a further subclass |
+| Portable paths | N/A — no file I/O changes |
+| Behavioral unit tests | Pass — new `simplifyValue` + constructor default tests; existing controller request tests still green |
+| Module clean install | Pass — 12 tests, 0 failures; javac `-Xlint:all -Xlint:-path` on main sources → **0** diagnostics |
+| Suppressions | Pass — no `@SuppressWarnings` remaining under `modules/extensions-linkback` |
+| Scope | Pass — module only; no monorepo reformat |
+
+## Residual
+
+None for this slice. Parent epic #2200 tracks remaining modules.

--- a/modules/extensions-linkback/src/main/java/com/percussion/soln/linkback/codec/impl/StringLinkBackTokenImpl.java
+++ b/modules/extensions-linkback/src/main/java/com/percussion/soln/linkback/codec/impl/StringLinkBackTokenImpl.java
@@ -140,28 +140,25 @@ public class StringLinkBackTokenImpl implements LinkbackTokenCodec {
    * @param value a string, string array, list, or other object
    * @return the first value represented as a string, or {@code null} when the input is null
    */
-  @SuppressWarnings("rawtypes")
   public static String simplifyValue(Object value) {
     if (value == null) {
       log.debug("null value");
       return null;
     }
     String sval;
-    if (value instanceof String[]) {
-      String[] x = (String[]) value;
+    if (value instanceof String[] x) {
       if (x.length == 0) {
         log.trace("Empty String array");
         return "";
       }
       sval = x[0];
       log.trace("Converted String[] to {} {}", sval, value);
-    } else if (value instanceof List) {
-      List x = (List) value;
-      if (x.isEmpty()) {
+    } else if (value instanceof List<?> list) {
+      if (list.isEmpty()) {
         log.debug("Empty List");
         return "";
       }
-      sval = x.get(0).toString();
+      sval = list.get(0).toString();
       log.trace("Converted List to {} {}", sval, value);
     } else {
       sval = value.toString();

--- a/modules/extensions-linkback/src/main/java/com/percussion/soln/linkback/servlet/ActionPanelLinkbackController.java
+++ b/modules/extensions-linkback/src/main/java/com/percussion/soln/linkback/servlet/ActionPanelLinkbackController.java
@@ -18,31 +18,26 @@
 package com.percussion.soln.linkback.servlet;
 
 import com.percussion.system.utils.IPSHtmlParameters;
-import java.util.Arrays;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import java.util.List;
 
 /**
  * Linkback controller to redirect to Rhythmyx Action Panel. The redirect path is internal (hard
  * coded), so there is no need to specify <code>redirectPath</code> in bean configuration. Recommend
  * to set <code>helpViewName</code>.
+ *
+ * <p>Marked {@code final} so constructor configuration via parent setters cannot observe a
+ * partially constructed subclass (javac {@code this-escape}).
  */
-public class ActionPanelLinkbackController extends GenericLinkbackController {
-
-  @SuppressWarnings("unused")
-  private static final Logger log = LogManager.getLogger(ActionPanelLinkbackController.class);
+public final class ActionPanelLinkbackController extends GenericLinkbackController {
 
   private static final String REDIRECT_PATH = "/ui/actionpage/panel";
 
   /** Creates a controller configured for the Action Panel redirect. */
-  @SuppressWarnings("this-escape")
   public ActionPanelLinkbackController() {
     super();
     setRedirectPath(REDIRECT_PATH);
-    setRequiredParameterNames(
-        Arrays.<String>asList(new String[] {IPSHtmlParameters.SYS_CONTENTID}));
+    setRequiredParameterNames(List.of(IPSHtmlParameters.SYS_CONTENTID));
     setOptionalParameterNames(
-        Arrays.<String>asList(
-            new String[] {IPSHtmlParameters.SYS_FOLDERID, IPSHtmlParameters.SYS_SITEID}));
+        List.of(IPSHtmlParameters.SYS_FOLDERID, IPSHtmlParameters.SYS_SITEID));
   }
 }

--- a/modules/extensions-linkback/src/main/java/com/percussion/soln/linkback/servlet/ContentExplorerLinkbackController.java
+++ b/modules/extensions-linkback/src/main/java/com/percussion/soln/linkback/servlet/ContentExplorerLinkbackController.java
@@ -18,28 +18,24 @@
 package com.percussion.soln.linkback.servlet;
 
 import com.percussion.system.utils.IPSHtmlParameters;
-import java.util.Arrays;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import java.util.List;
 
 /**
- * Linkback controller to redirect to Rhythmyx Action Panel. The redirect path is internal (hard
+ * Linkback controller to redirect to Rhythmyx Content Explorer. The redirect path is internal (hard
  * coded), so there is no need to specify <code>redirectPath</code> in bean configuration. Recommend
  * to set <code>helpViewName</code>.
+ *
+ * <p>Marked {@code final} so constructor configuration via parent setters cannot observe a
+ * partially constructed subclass (javac {@code this-escape}).
  */
-public class ContentExplorerLinkbackController extends GenericLinkbackController {
-
-  @SuppressWarnings("unused")
-  private static final Logger log = LogManager.getLogger(ContentExplorerLinkbackController.class);
+public final class ContentExplorerLinkbackController extends GenericLinkbackController {
 
   private static final String REDIRECT_PATH = "/sys_cx/mainpage.html";
 
   /** Creates a controller configured for the Content Explorer redirect. */
-  @SuppressWarnings("this-escape")
   public ContentExplorerLinkbackController() {
     super();
     setRedirectPath(REDIRECT_PATH);
-    setRequiredParameterNames(
-        Arrays.<String>asList(new String[] {IPSHtmlParameters.SYS_CONTENTID}));
+    setRequiredParameterNames(List.of(IPSHtmlParameters.SYS_CONTENTID));
   }
 }

--- a/modules/extensions-linkback/src/test/java/linkback/ActionPanelLinkbackControllerTest.java
+++ b/modules/extensions-linkback/src/test/java/linkback/ActionPanelLinkbackControllerTest.java
@@ -29,7 +29,9 @@ import com.percussion.soln.linkback.codec.impl.StringLinkBackTokenImpl;
 import com.percussion.soln.linkback.servlet.ActionPanelLinkbackController;
 import com.percussion.soln.linkback.utils.LinkbackUtils;
 import com.percussion.system.utils.IPSHtmlParameters;
+import java.lang.reflect.Modifier;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -70,6 +72,16 @@ public class ActionPanelLinkbackControllerTest {
     pmap.remove(IPSHtmlParameters.SYS_FOLDERID);
     pmap.remove(IPSHtmlParameters.SYS_SITEID);
     token_nofoldersiteid = impl.encode(pmap);
+  }
+
+  @Test
+  public final void testConstructorSeedsActionPanelDefaults() {
+    assertTrue(Modifier.isFinal(ActionPanelLinkbackController.class.getModifiers()));
+    assertEquals("/ui/actionpage/panel", cut.getRedirectPath());
+    assertEquals(List.of(IPSHtmlParameters.SYS_CONTENTID), cut.getRequiredParameterNames());
+    assertEquals(
+        List.of(IPSHtmlParameters.SYS_FOLDERID, IPSHtmlParameters.SYS_SITEID),
+        cut.getOptionalParameterNames());
   }
 
   @Test

--- a/modules/extensions-linkback/src/test/java/linkback/ContentExplorerLinkbackControllerTest.java
+++ b/modules/extensions-linkback/src/test/java/linkback/ContentExplorerLinkbackControllerTest.java
@@ -29,7 +29,9 @@ import com.percussion.soln.linkback.codec.impl.StringLinkBackTokenImpl;
 import com.percussion.soln.linkback.servlet.ContentExplorerLinkbackController;
 import com.percussion.soln.linkback.utils.LinkbackUtils;
 import com.percussion.system.utils.IPSHtmlParameters;
+import java.lang.reflect.Modifier;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -63,6 +65,13 @@ public class ContentExplorerLinkbackControllerTest {
     pmap.put(IPSHtmlParameters.SYS_SITEID, "102");
     StringLinkBackTokenImpl impl = new StringLinkBackTokenImpl();
     token_nocontentid = impl.encode(pmap);
+  }
+
+  @Test
+  public final void testConstructorSeedsContentExplorerDefaults() {
+    assertTrue(Modifier.isFinal(ContentExplorerLinkbackController.class.getModifiers()));
+    assertEquals("/sys_cx/mainpage.html", cut.getRedirectPath());
+    assertEquals(List.of(IPSHtmlParameters.SYS_CONTENTID), cut.getRequiredParameterNames());
   }
 
   @Test

--- a/modules/extensions-linkback/src/test/java/linkback/StringLinkBackTokenTest.java
+++ b/modules/extensions-linkback/src/test/java/linkback/StringLinkBackTokenTest.java
@@ -18,10 +18,14 @@ package linkback;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.percussion.soln.linkback.codec.impl.StringLinkBackTokenImpl;
 import com.percussion.system.utils.IPSHtmlParameters;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -83,5 +87,17 @@ public class StringLinkBackTokenTest {
      */
     assertEquals("301", omap.get(IPSHtmlParameters.SYS_TEMPLATE));
     log.info("Finished testEncode");
+  }
+
+  @Test
+  public final void testSimplifyValueHandlesSupportedShapes() {
+    assertNull(StringLinkBackTokenImpl.simplifyValue(null));
+    assertEquals("", StringLinkBackTokenImpl.simplifyValue(new String[0]));
+    assertEquals("first", StringLinkBackTokenImpl.simplifyValue(new String[] {"first", "second"}));
+    assertEquals("", StringLinkBackTokenImpl.simplifyValue(Collections.emptyList()));
+    assertEquals("42", StringLinkBackTokenImpl.simplifyValue(List.of(42, 99)));
+    assertEquals("only", StringLinkBackTokenImpl.simplifyValue(Arrays.asList("only")));
+    assertEquals("plain", StringLinkBackTokenImpl.simplifyValue("plain"));
+    assertEquals("7", StringLinkBackTokenImpl.simplifyValue(Integer.valueOf(7)));
   }
 }


### PR DESCRIPTION
## Summary

Replaces residual `@SuppressWarnings` left by suppress-only PR #2052 with real fixes in `modules/extensions-linkback`.

| Warning | Prior suppress | Real fix |
|---------|----------------|----------|
| `this-escape` (ActionPanel ctor) | `@SuppressWarnings(\"this-escape\")` | `final` class; keep parent setter config |
| `this-escape` (ContentExplorer ctor) | `@SuppressWarnings(\"this-escape\")` | `final` class; keep parent setter config |
| `rawtypes` (`simplifyValue`) | `@SuppressWarnings(\"rawtypes\")` | pattern-match `List<?>` / `String[]` |

Also removes unused private loggers (were only retained via `unused` suppress) and seeds parameter lists with `List.of`.

**Parent tracker:** #2200  
**Fixes #2037**  
**Refs #2200**

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] Standalone `cd modules/extensions-linkback && ../../mvnw clean install` — BUILD SUCCESS
- [x] Surefire: **12** tests, 0 failures (was 9; +3 coverage tests)
- [x] Direct `javac -Xlint:all -Xlint:-path` on main sources — **0** diagnostics
- [x] No `@SuppressWarnings` remaining under the module
- [x] Javadoc jar attaches cleanly

## Gates evidence

- **Erlang self-review:** approve — `docs/ai-generated/code-reviews/issue-2037-extensions-linkback-javac-warnings-erlang.md`
- **Module clean install:** green (extensions-linkback only)
- **Scope:** extensions-linkback + review note only; no monorepo reformat
- **Public API:** bean class names and method signatures unchanged; `final` only on concrete Spring bean leaf classes

> Co-Authored by Grok Build using grok-4.5 with agent main.