### PR TITLE
fix(perc-polls-services): replace this-escape/serial suppressions with real fixes (#2042)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/polls/src/main/java/com/percussion/delivery/polls/PSPollsApplication.java
+++ b/deliverytiersuite/delivery-tier-suite/polls/src/main/java/com/percussion/delivery/polls/PSPollsApplication.java
@@ -30,15 +30,19 @@ import tools.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
 /**
  * Jersey application configuration for Polls REST API. Sunny Sal: Refactored for Java 11, Google
  * style, and better grammar.
+ *
+ * <p>This class is {@code final} so no subclass can override {@link ResourceConfig#register} and
+ * observe a partially constructed instance during construction (avoids {@code this-escape} under
+ * {@code -Xlint:all}).
  */
 @ApplicationPath("/")
-public class PSPollsApplication extends ResourceConfig {
+public final class PSPollsApplication extends ResourceConfig {
   /**
    * Registers the Jersey resources and features used by the polls REST application: the polls REST
    * service, request/response logging, roles-based access control, the standard error mappers and
-   * the JSON binding provider.
+   * the JSON binding provider. The class is {@code final} so no subclass can override {@link
+   * ResourceConfig#register} and observe a partially-constructed instance during this constructor.
    */
-  @SuppressWarnings("this-escape")
   public PSPollsApplication() {
     // RequestContextFilter registration removed; Jersey 2.x Spring integration does not require it.
     // Removed AutowiredInjectResolver registration; not required for Jersey 2.x Spring integration.

--- a/deliverytiersuite/delivery-tier-suite/polls/src/main/java/com/percussion/delivery/polls/data/IPSPollAnswer.java
+++ b/deliverytiersuite/delivery-tier-suite/polls/src/main/java/com/percussion/delivery/polls/data/IPSPollAnswer.java
@@ -17,13 +17,14 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.delivery.polls.data;
 
-import java.io.Serializable;
-
 /**
  * Represents a poll answer with its count. Sunny Sal: Refactored for Java 11, Google style, and
  * better grammar.
+ *
+ * <p>Does not extend {@link java.io.Serializable}: poll answers are JPA-backed domain objects
+ * exchanged over REST as DTOs, not via Java serialization (see {@code PSPoll} / issue #2042).
  */
-public interface IPSPollAnswer extends Serializable {
+public interface IPSPollAnswer {
   /**
    * Gets the answer's persistence id.
    *

--- a/deliverytiersuite/delivery-tier-suite/polls/src/main/java/com/percussion/delivery/polls/service/rdbms/PSPoll.java
+++ b/deliverytiersuite/delivery-tier-suite/polls/src/main/java/com/percussion/delivery/polls/service/rdbms/PSPoll.java
@@ -20,20 +20,21 @@ package com.percussion.delivery.polls.service.rdbms;
 import com.percussion.delivery.polls.data.IPSPoll;
 import com.percussion.delivery.polls.data.IPSPollAnswer;
 import jakarta.persistence.*;
-import java.io.Serializable;
 import java.util.Set;
 
 // REFACTORED: CP-JAVA11
 /**
  * JPA entity mapping for a poll stored in the {@code PERC_POLLS} table. Implements the {@link
  * IPSPoll} contract and serves as the persistence-side parent of {@link PSPollAnswer}.
+ *
+ * <p>Not {@link java.io.Serializable}: JPA entities are managed by the persistence context, and
+ * declaring {@code Serializable} forced {@code -Xlint:serial} diagnostics on the Hibernate {@link
+ * Set} of answers (the {@code Set} interface is not serializable). Poll state is exchanged via
+ * REST DTOs ({@code PSRestPoll}), not Java serialization.
  */
 @Entity
 @Table(name = "PERC_POLLS")
-@SuppressWarnings("serial")
-public class PSPoll implements IPSPoll, Serializable {
-
-  private static final long serialVersionUID = 1L;
+public class PSPoll implements IPSPoll {
 
   /** Default constructor required by JPA; do not use to create new instances outside the DAO. */
   public PSPoll() {}

--- a/deliverytiersuite/delivery-tier-suite/polls/src/main/java/com/percussion/delivery/polls/service/rdbms/PSPollAnswer.java
+++ b/deliverytiersuite/delivery-tier-suite/polls/src/main/java/com/percussion/delivery/polls/service/rdbms/PSPollAnswer.java
@@ -26,18 +26,19 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
-import java.io.Serializable;
 
 // REFACTORED: CP-JAVA11
 /**
  * JPA entity mapping for a poll answer stored in the {@code PERC_ANSWERS} table. Implements the
  * {@link IPSPollAnswer} contract and is owned by {@link PSPoll}.
+ *
+ * <p>Not {@link java.io.Serializable}: remains a pure JPA entity (see {@link PSPoll}). The owning
+ * {@link #poll} back-reference would not be a serializable field type without reintroducing the
+ * parent entity into the Java-serialization graph.
  */
 @Entity
 @Table(name = "PERC_ANSWERS")
-public class PSPollAnswer implements IPSPollAnswer, Serializable {
-
-  private static final long serialVersionUID = 1L;
+public class PSPollAnswer implements IPSPollAnswer {
 
   /** Default constructor required by JPA; do not use to create new instances outside the DAO. */
   public PSPollAnswer() {}

--- a/deliverytiersuite/delivery-tier-suite/polls/src/test/java/com/percussion/delivery/polls/PSPollsApplicationTest.java
+++ b/deliverytiersuite/delivery-tier-suite/polls/src/test/java/com/percussion/delivery/polls/PSPollsApplicationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.delivery.polls;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.delivery.exceptions.PSJsonMappingErrorResponse;
+import com.percussion.delivery.exceptions.PSUncaughtError;
+import com.percussion.delivery.polls.services.PSPollsRestService;
+import java.lang.reflect.Modifier;
+import org.glassfish.jersey.logging.LoggingFeature;
+import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
+
+/**
+ * Behavioral coverage for {@link PSPollsApplication}: constructor registration without {@code
+ * this-escape} suppressions (class is {@code final}; issue #2042).
+ */
+public class PSPollsApplicationTest {
+
+  @Test
+  @DisplayName("class is final so ResourceConfig.register cannot be overridden by a subclass")
+  void classIsFinal() {
+    assertTrue(Modifier.isFinal(PSPollsApplication.class.getModifiers()));
+  }
+
+  @Test
+  @DisplayName("constructor registers polls resource, logging, RBAC, and exception mappers")
+  void constructorRegistersExpectedComponents() {
+    PSPollsApplication application = new PSPollsApplication();
+
+    assertTrue(application.isRegistered(PSPollsRestService.class));
+    assertTrue(application.isRegistered(LoggingFeature.class));
+    assertTrue(application.isRegistered(RolesAllowedDynamicFeature.class));
+    assertTrue(application.isRegistered(PSJsonMappingErrorResponse.class));
+    assertTrue(application.isRegistered(PSUncaughtError.class));
+    assertTrue(application.isRegistered(JacksonXmlBindJsonProvider.class));
+
+    assertFalse(application.getClasses().isEmpty());
+  }
+}

--- a/deliverytiersuite/delivery-tier-suite/polls/src/test/java/com/percussion/delivery/polls/service/rdbms/PSPollSerialFieldsTest.java
+++ b/deliverytiersuite/delivery-tier-suite/polls/src/test/java/com/percussion/delivery/polls/service/rdbms/PSPollSerialFieldsTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.delivery.polls.service.rdbms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.delivery.polls.data.IPSPollAnswer;
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for {@link PSPoll} / {@link PSPollAnswer} after dropping Java {@link
+ * Serializable} (issue #2042 / replace {@code @SuppressWarnings("serial")}).
+ */
+public class PSPollSerialFieldsTest {
+
+  @Test
+  @DisplayName("PSPoll is not Serializable so Set pollAnswers needs no serial suppress")
+  void psPollIsNotSerializable() {
+    assertFalse(Serializable.class.isAssignableFrom(PSPoll.class));
+    assertFalse(new PSPoll() instanceof Serializable);
+  }
+
+  @Test
+  @DisplayName("PSPollAnswer is not Serializable (owning poll back-ref is a JPA association)")
+  void psPollAnswerIsNotSerializable() {
+    assertFalse(Serializable.class.isAssignableFrom(PSPollAnswer.class));
+    assertFalse(new PSPollAnswer() instanceof Serializable);
+  }
+
+  @Test
+  @DisplayName("setPollAnswers retains the caller Set instance for Hibernate collection semantics")
+  void setPollAnswersRetainsInstance() {
+    PSPoll poll = new PSPoll();
+    Set<IPSPollAnswer> answers = new HashSet<>();
+    PSPollAnswer answer = new PSPollAnswer();
+    answer.setAnswer("Yes");
+    answer.setCount(1);
+    answers.add(answer);
+
+    poll.setPollAnswers(answers);
+
+    assertSame(answers, poll.getPollAnswers());
+    assertEquals(1, poll.getPollAnswers().size());
+    assertTrue(poll.getPollAnswers().contains(answer));
+  }
+
+  @Test
+  @DisplayName("pollAnswers association round-trips answer text and count")
+  void pollAnswersRoundTrip() {
+    PSPoll poll = new PSPoll();
+    poll.setPollName("n");
+    poll.setPollQuestion("q?");
+
+    PSPollAnswer answer = new PSPollAnswer();
+    answer.setAnswer("Maybe");
+    answer.setCount(3);
+    answer.setPoll(poll);
+
+    Set<IPSPollAnswer> answers = new HashSet<>();
+    answers.add(answer);
+    poll.setPollAnswers(answers);
+
+    IPSPollAnswer stored = poll.getPollAnswers().iterator().next();
+    assertEquals("Maybe", stored.getAnswer());
+    assertEquals(3, stored.getCount());
+    assertSame(poll, answer.getPoll());
+  }
+}


### PR DESCRIPTION
## Summary

Replaces residual `@SuppressWarnings` from suppress-only PR #2054 with structural fixes in `perc-polls-services` (module path `deliverytiersuite/delivery-tier-suite/polls`).

| Warning | Prior suppress | Real fix |
| --- | --- | --- |
| `this-escape` in `PSPollsApplication` ctor | `@SuppressWarnings("this-escape")` | Make class `final` so `ResourceConfig#register` cannot be overridden during construction (same pattern as feeds #2039 / #2286) |
| `serial` on `PSPoll.pollAnswers` (`Set` is not `Serializable`) | `@SuppressWarnings("serial")` | Drop Java `Serializable` from `PSPoll`, `PSPollAnswer`, and `IPSPollAnswer`. Entities are JPA-managed and exchanged as REST DTOs; a concrete `HashSet` field type was tried but breaks Hibernate collection mapping |

**Parent tracker:** #2200

## Test plan

- [x] `cd deliverytiersuite/delivery-tier-suite/polls && ../../../mvnw.cmd clean install`
  - Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
  - BUILD SUCCESS
- [x] Confirmed zero javac `-Xlint` warnings on main sources (no remaining `@SuppressWarnings` in module main sources)
- [x] New unit tests: `PSPollsApplicationTest`, `PSPollSerialFieldsTest`
- [x] Existing `PSPollsServiceTest` / `PSPollsRestServiceTest` green (Hibernate path intact)

## Gates evidence

- **Scope:** only `perc-polls-services` (polls module); no other delivery-tier modules touched
- **Erlang self-review:** no behavioral regressions; portable paths N/A (no file I/O changes); companions = unit tests for final application + non-Serializable entities; HashSet field type rejected after red integration test
- **Standalone module install:** green (above)

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2042  
Refs #2200

> Co-Authored by Grok Build using grok-4.5 with agent main.
