### PR TITLE
fix(installer): remove illegal -- from Ant XML comments (#2290)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2290-installer-xml-comment-double-dash-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2290-installer-xml-comment-double-dash-erlang.md
@@ -1,0 +1,43 @@
+# Erlang review: fix/issue-2290-installer-xml-comment-double-dash
+
+**Date:** 2026-08-07  
+**Branch:** fix/issue-2290-installer-xml-comment-double-dash  
+**Base:** origin/main  
+**Reviewer persona:** Erlang (strict gate)  
+**Author agent:** Grok Build / main / grok-4.5
+
+## Summary
+
+Comment-only fix for invalid XML `--` sequences inside Installer Ant comments that abort CMS install (issue #2290). Adds a cheap well-formedness + comment-body regression test for top-level Installer Ant XML.
+
+## Scope
+
+- `modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml` — reword `--demo-sites` in comment
+- `modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/remove_PercussionInstallation.xml` — reword `--clean-install-dir` in comment
+- `modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/InstallerXmlWellFormedTest.java` — new unit tests
+
+Cross-platform path review: test uses `Path.of` / `Files.list` / `Files.readString`; no hardcoded `/` or `\` joins beyond Path segments; module-relative paths match peer packaging tests. Clean.
+
+Memory patterns: none specific hit; installer packaging tests peer pattern followed.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+## Issues
+
+(none)
+
+## Evidence
+
+- Full-tree comment scan of Installer `*.xml`: only the two reworded sites had illegal `--`; post-fix count 0
+- `cd modules/perc-distribution-tree && ../../mvnw clean install` green
+- `InstallerXmlWellFormedTest`: Tests run: 2, Failures: 0, Errors: 0
+
+## Residual (ops / optional)
+
+Live install smoke remains optional human/ops follow-up; not required for this PR.

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml
@@ -202,7 +202,7 @@
 
 		<!-- Optional sample sites (Corporate Investments / Enterprise Investments).
 			Driven by the Java preinstall's demo-sites flag, propagated to ANT as -Dinstall.demo.sites=true
-			from Phase-1 options (wizard Yes / --demo-sites) via Main.execJar (#2192).
+			from Phase-1 options (wizard Yes / demo-sites CLI flag) via Main.execJar (#2192).
 			When true on new installs and upgrades: antcall installSampleSites chains an
 			RxffTableData/RxffTableDef PSTableAction pass that seeds the two sample sites plus
 			their ACLs, content types, nav, etc. RXLOCALE / RXLOCALEFORMAT are protected by

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/remove_PercussionInstallation.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/remove_PercussionInstallation.xml
@@ -3,9 +3,9 @@
 	<!-- Historical ANT stub for <InstallDir>/_Percussion_Installation. As of
 		issue #1157, obsolete install-root cleanup (including this path and PreInstall)
 		is owned by the preinstall Java helper com.percussion.preinstall.ObsoleteInstallDirCleaner,
-		invoked early on upgrade from Main when the operator confirms or passes --clean-install-dir.
-		This target remains a no-op so any antcall to this file does not double-delete
-		or fail. -->
+		invoked early on upgrade from Main when the operator confirms or passes the
+		clean-install-dir CLI flag. This target remains a no-op so any antcall to this
+		file does not double-delete or fail. -->
 	<target name="remove_PercussionInstallation">
 		<echo>Obsolete _Percussion_Installation cleanup is handled by
 			preinstall ObsoleteInstallDirCleaner (issue #1157); ANT target is a

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/InstallerXmlWellFormedTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/InstallerXmlWellFormedTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.distribution.install;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+
+/**
+ * Issue #2290: installer Ant XML must be well-formed. XML forbids the sequence {@code --} inside
+ * comments; a CLI flag mention such as {@code --demo-sites} inside {@code <!-- ... -->} causes
+ * Apache Ant to abort with {@code The string "--" is not permitted within comments} mid-install.
+ *
+ * <p>Cheap regression guard: parse each top-level Installer Ant script and scan comment bodies for
+ * consecutive hyphens. Nested {@code data/} table XML is covered by existing packaging tests.
+ */
+@Tag("UnitTest")
+class InstallerXmlWellFormedTest {
+
+  private static final Path INSTALLER_DIR =
+      Path.of("src", "main", "resources", "distribution", "rxconfig", "Installer");
+
+  /** Match XML comments (non-greedy, DOTALL). */
+  private static final Pattern XML_COMMENT = Pattern.compile("<!--(.*?)-->", Pattern.DOTALL);
+
+  @Test
+  @DisplayName("Installer Ant XML comments must not embed consecutive hyphens (#2290)")
+  void installerAntXmlCommentsHaveNoDoubleHyphen() throws IOException {
+    List<Path> scripts = listTopLevelInstallerXml();
+    assertFalse(scripts.isEmpty(), "expected Installer Ant XML under " + INSTALLER_DIR);
+
+    List<String> violations = new ArrayList<>();
+    for (Path script : scripts) {
+      String text = Files.readString(script, StandardCharsets.UTF_8);
+      Matcher m = XML_COMMENT.matcher(text);
+      while (m.find()) {
+        String inner = m.group(1);
+        if (inner.contains("--")) {
+          int line = 1 + (int) text.substring(0, m.start()).chars().filter(c -> c == '\n').count();
+          violations.add(script.getFileName() + ":" + line + " comment contains \"--\"");
+        }
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        () ->
+            "XML comments must not contain \"--\" (XML 1.0 §2.5). Reword CLI flag mentions"
+                + " (e.g. demo-sites flag instead of double-dash demo-sites). Offenders:\n"
+                + String.join("\n", violations));
+  }
+
+  @Test
+  @DisplayName("Installer Ant XML files parse as well-formed XML (#2290)")
+  void installerAntXmlIsWellFormed()
+      throws IOException, ParserConfigurationException, SAXException {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    factory.setValidating(false);
+    // Do not expand external entities; these are local packaging scripts.
+    factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    DocumentBuilder builder = factory.newDocumentBuilder();
+
+    List<Path> scripts = listTopLevelInstallerXml();
+    assertFalse(scripts.isEmpty(), "expected Installer Ant XML under " + INSTALLER_DIR);
+
+    for (Path script : scripts) {
+      try (var in = Files.newInputStream(script)) {
+        builder.parse(in);
+      } catch (SAXException e) {
+        fail("Installer Ant XML is not well-formed: " + script + " — " + e.getMessage(), e);
+      }
+    }
+  }
+
+  /** Top-level Ant scripts only (not data/*.xml table dumps). */
+  private static List<Path> listTopLevelInstallerXml() throws IOException {
+    assertTrue(
+        Files.isDirectory(INSTALLER_DIR),
+        () -> "missing Installer dir: " + INSTALLER_DIR.toAbsolutePath().normalize());
+    try (Stream<Path> stream = Files.list(INSTALLER_DIR)) {
+      return stream
+          .filter(Files::isRegularFile)
+          .filter(p -> p.getFileName().toString().endsWith(".xml"))
+          .sorted()
+          .toList();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

CMS install fails when Ant parses `installRepository.xml` because an XML comment documented the `--demo-sites` CLI flag. XML 1.0 forbids the sequence `--` inside comments, so Ant aborts with:

> The string \"--\" is not permitted within comments.

**Parent tracker:** #2290 (self)

### Changes
- Reword comments in `installRepository.xml` (`demo-sites CLI flag`) and `remove_PercussionInstallation.xml` (`clean-install-dir CLI flag`) so comments no longer embed consecutive hyphens.
- Grep of all Installer resource XML comments: only those two sites were offenders.
- Add `InstallerXmlWellFormedTest`: (1) scan top-level Installer Ant XML comments for `--`; (2) `DocumentBuilder` well-formed parse of each top-level Installer Ant script.

Comment-only product change; no Ant logic change.

## Test plan
- [x] Full comment scan of `modules/perc-distribution-tree/.../rxconfig/Installer/**/*.xml` — 0 illegal `--` after fix
- [x] `cd modules/perc-distribution-tree && ../../mvnw clean install` green
- [x] `InstallerXmlWellFormedTest` — 2 tests, 0 failures
- [x] Erlang self-review approve (`docs/ai-generated/code-reviews/issue-2290-installer-xml-comment-double-dash-erlang.md`)
- [ ] Optional ops: live install smoke (not required for this PR)

## Gates evidence
- Module: `perc-distribution-tree` standalone `mvnw clean install` PASS
- Erlang: approve / May commit-push: yes
- Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2290

> Co-Authored by Grok Build using grok-4.5 with agent main.