### PR TITLE
fix(perc-metadata-services): real-fix javac this-escape, serial, and deprecation warnings (#2041)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/metadata/pom.xml
+++ b/deliverytiersuite/delivery-tier-suite/metadata/pom.xml
@@ -103,10 +103,6 @@
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.jersey.ext</groupId>
             <artifactId>jersey-spring6</artifactId>
         </dependency>

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/PSMetadataApplication.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/PSMetadataApplication.java
@@ -39,12 +39,14 @@ import tools.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider;
  * uncaught-error mapper and the Jackson JSON provider under a single {@code "/"} application path.
  */
 @ApplicationPath("/")
-public class PSMetadataApplication extends ResourceConfig {
+public final class PSMetadataApplication extends ResourceConfig {
   /**
    * Constructs the application context and registers the Spring / Jersey integration listeners, the
    * metadata REST resources, the role filter, the uncaught-error mapper and the JSON provider.
+   *
+   * <p>Class is {@code final} so {@link ResourceConfig#register} calls in this constructor cannot
+   * observe a subclass before it is fully initialized (javac {@code this-escape}).
    */
-  @SuppressWarnings("this-escape")
   public PSMetadataApplication() {
     register(RequestContextFilter.class);
     register(SpringComponentProvider.class);

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/PSCookieConsent.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/PSCookieConsent.java
@@ -62,11 +62,13 @@ public class PSCookieConsent implements IPSCookieConsent {
     if (consentDate == null) throw new IllegalArgumentException("consentDate may not be null");
     if (ip == null) throw new IllegalArgumentException("ip may not be null");
 
-    setSiteName(siteName);
-    setService(serviceName);
-    setConsentDate(consentDate);
-    setIP(ip);
-    setOptIn(optIn);
+    // Direct field assignment avoids this-escape from overridable setters (subclassed by
+    // PSCookieConsentQuery).
+    this.siteName = siteName;
+    this.serviceName = serviceName;
+    this.consentDate = new Date(consentDate.getTime());
+    this.ip = ip;
+    this.optIn = optIn;
   }
 
   @Override

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/PSCookieConsentQuery.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/PSCookieConsentQuery.java
@@ -31,7 +31,7 @@ import java.util.List;
  * @author chriswright
  */
 @XmlRootElement(name = "consent")
-public class PSCookieConsentQuery extends PSCookieConsent {
+public final class PSCookieConsentQuery extends PSCookieConsent {
 
   private List<String> services;
 
@@ -63,7 +63,8 @@ public class PSCookieConsentQuery extends PSCookieConsent {
     if (services == null)
       throw new IllegalArgumentException("List of cookies approved by client may not be null.");
 
-    setServices(services);
+    // Direct field assignment; class is final so no this-escape via overridable setter.
+    this.services = services;
   }
 
   /**

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/impl/PSCriteriaElement.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/impl/PSCriteriaElement.java
@@ -19,10 +19,10 @@ package com.percussion.delivery.metadata.data.impl;
 import com.percussion.delivery.metadata.error.PSMalformedMetadataQueryException;
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.HashMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
-import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -246,21 +246,25 @@ public class PSCriteriaElement {
     NOT_EQUAL
   }
 
-  @SuppressWarnings("unchecked")
-  private static final Map<String, OPERATION_TYPE> OPERATORS =
-      MapUtils.orderedMap(new HashMap<String, OPERATION_TYPE>());
+  /**
+   * Operators keyed by token string. Insertion order is longest-first so multi-character operators
+   * are matched before single-character ones when scanning criteria text.
+   */
+  private static final Map<String, OPERATION_TYPE> OPERATORS;
 
   static {
+    Map<String, OPERATION_TYPE> ops = new LinkedHashMap<>();
     // Order matters largest length to smallest
-    OPERATORS.put("LIKE", OPERATION_TYPE.LIKE);
-    OPERATORS.put("IN", OPERATION_TYPE.IN);
-    OPERATORS.put("<>", OPERATION_TYPE.NOT_EQUAL);
-    OPERATORS.put("<=", OPERATION_TYPE.LESS_THAN_EQUAL);
-    OPERATORS.put(">=", OPERATION_TYPE.GREATER_THAN_EQUAL);
-    OPERATORS.put("!=", OPERATION_TYPE.NOT_EQUAL);
-    OPERATORS.put("=", OPERATION_TYPE.EQUAL);
-    OPERATORS.put("<", OPERATION_TYPE.LESS_THAN);
-    OPERATORS.put(">", OPERATION_TYPE.GREATER_THAN);
+    ops.put("LIKE", OPERATION_TYPE.LIKE);
+    ops.put("IN", OPERATION_TYPE.IN);
+    ops.put("<>", OPERATION_TYPE.NOT_EQUAL);
+    ops.put("<=", OPERATION_TYPE.LESS_THAN_EQUAL);
+    ops.put(">=", OPERATION_TYPE.GREATER_THAN_EQUAL);
+    ops.put("!=", OPERATION_TYPE.NOT_EQUAL);
+    ops.put("=", OPERATION_TYPE.EQUAL);
+    ops.put("<", OPERATION_TYPE.LESS_THAN);
+    ops.put(">", OPERATION_TYPE.GREATER_THAN);
+    OPERATORS = Collections.unmodifiableMap(ops);
   }
 
   /**

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/extractor/data/PSMetadataEntry.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/extractor/data/PSMetadataEntry.java
@@ -22,19 +22,19 @@ import com.percussion.delivery.metadata.IPSMetadataProperty;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElementWrapper;
 import jakarta.xml.bind.annotation.XmlType;
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Represents metadata for a published page on the deleivery server.
+ * Represents metadata for a published page on the delivery server.
+ *
+ * <p>Not {@link java.io.Serializable}: exchanged as REST/JAXB DTOs and indexer payloads, not via
+ * Java serialization (avoids serial warnings on collection field types).
  *
  * @author miltonpividori
  */
 @XmlType(propOrder = {"name"})
-public class PSMetadataEntry implements Serializable, IPSMetadataEntry {
-
-  private static final long serialVersionUID = 1L;
+public class PSMetadataEntry implements IPSMetadataEntry {
 
   /** Published site-relative page path of the indexed entry. */
   private String pagepath;
@@ -57,9 +57,8 @@ public class PSMetadataEntry implements Serializable, IPSMetadataEntry {
   /** Properties attached to this entry. */
   @XmlElementWrapper(name = "property")
   @XmlElement(type = PSMetadataProperty.class)
-  private Set<PSMetadataProperty> properties = new HashSet<>();
+  private Set<IPSMetadataProperty> properties = new HashSet<>();
 
-  /** No-arg constructor required by JAXB. */
   /** No-arg constructor required by JAXB. */
   public PSMetadataEntry() {}
 
@@ -177,23 +176,22 @@ public class PSMetadataEntry implements Serializable, IPSMetadataEntry {
   /* (non-Javadoc)
    * @see com.percussion.delivery.metadata.extractor.data.IPSMetadataEntry#getProperties()
    */
-  @SuppressWarnings({"rawtypes", "unchecked"})
   public Set<IPSMetadataProperty> getProperties() {
     if (properties == null) {
       properties = new HashSet<>();
     }
-    return (Set) properties;
+    return properties;
   }
 
   /* (non-Javadoc)
    * @see com.percussion.delivery.metadata.extractor.data.IPSMetadataEntry#setProperties(java.util.Set)
    */
   public void setProperties(Set<IPSMetadataProperty> properties) {
-    Set<PSMetadataProperty> convertedProperties = new HashSet<>();
+    Set<IPSMetadataProperty> convertedProperties = new HashSet<>();
     if (properties != null) {
       for (IPSMetadataProperty property : properties) {
         if (property instanceof PSMetadataProperty) {
-          convertedProperties.add((PSMetadataProperty) property);
+          convertedProperties.add(property);
         } else {
           convertedProperties.add(
               new PSMetadataProperty(
@@ -207,7 +205,7 @@ public class PSMetadataEntry implements Serializable, IPSMetadataEntry {
   public void addProperty(IPSMetadataProperty prop) {
     if (properties == null) properties = new HashSet<>();
     if (prop instanceof PSMetadataProperty) {
-      properties.add((PSMetadataProperty) prop);
+      properties.add(prop);
     } else {
       properties.add(new PSMetadataProperty(prop.getName(), prop.getValuetype(), prop.getValue()));
     }

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/extractor/data/PSMetadataProperty.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/extractor/data/PSMetadataProperty.java
@@ -368,7 +368,7 @@ public class PSMetadataProperty implements Serializable, IPSMetadataProperty {
         valuetype = type;
         return val;
       } else if (type == VALUETYPE.NUMBER) {
-        if (NumberUtils.isNumber((String) val)) {
+        if (NumberUtils.isCreatable((String) val)) {
           Double doub = Double.parseDouble((String) val);
           valuetype = VALUETYPE.NUMBER;
           return doub;

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/impl/PSMetadataQueryServiceHelper.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/impl/PSMetadataQueryServiceHelper.java
@@ -105,7 +105,7 @@ public abstract class PSMetadataQueryServiceHelper {
 
     if (type == VALUETYPE.NUMBER) {
       for (String s : val.split(",")) {
-        results.add(new Double(s));
+        results.add(Double.valueOf(s));
       }
     } else if (type == VALUETYPE.DATE) {
       for (String s : val.split("'")) {

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/impl/PSMetadataRestService.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/impl/PSMetadataRestService.java
@@ -61,6 +61,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.lang3.StringUtils;
@@ -525,7 +526,7 @@ public class PSMetadataRestService extends PSAbstractRestService implements IPSM
       List<String> promotedPagePaths =
           new ArrayList<>(
               Arrays.asList(
-                  StringUtils.defaultString(visitQuery.getPromotedPagePaths(), "").split(";")));
+                  Objects.toString(visitQuery.getPromotedPagePaths(), "").split(";")));
 
       for (String path : promotedPagePaths) {
         if (StringUtils.isBlank(path)) {
@@ -590,8 +591,7 @@ public class PSMetadataRestService extends PSAbstractRestService implements IPSM
   @Consumes(MediaType.APPLICATION_JSON)
   @RolesAllowed("deliverymanager")
   public Response exportAllSiteCookieConsentStats(@PathParam("csvFileName") String csvFileName) {
-    if ((StringUtils.isBlank(csvFileName))
-        || (!StringUtils.contains(csvFileName.toLowerCase(), ".csv"))) {
+    if ((StringUtils.isBlank(csvFileName)) || (!csvFileName.toLowerCase().contains(".csv"))) {
       log.error("CSV filename may not be blank and must contain .CSV as file extension.");
       return Response.serverError().build();
     }
@@ -623,7 +623,7 @@ public class PSMetadataRestService extends PSAbstractRestService implements IPSM
       @PathParam("siteName") String siteName, @PathParam("csvFileName") String csvFileName) {
     if ((StringUtils.isBlank(siteName))
         || (StringUtils.isBlank(csvFileName))
-        || (!StringUtils.contains(csvFileName.toLowerCase(), ".csv"))) {
+        || (!csvFileName.toLowerCase().contains(".csv"))) {
       log.error("Site name or CSV file name may not be blank and file name must contain .csv.");
       return Response.serverError().build();
     }

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSCookieConsentDao.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSCookieConsentDao.java
@@ -162,7 +162,7 @@ public class PSCookieConsentDao implements IPSCookieConsentDao {
       CriteriaDelete<PSDbCookieConsent> deleteQuery =
           builder.createCriteriaDelete(PSDbCookieConsent.class);
       deleteQuery.from(PSDbCookieConsent.class);
-      session.createQuery(deleteQuery).executeUpdate();
+      session.createMutationQuery(deleteQuery).executeUpdate();
 
     } catch (Exception e) {
       throw new Exception("Error deleting cookie consent entries from DB.", e);
@@ -180,7 +180,7 @@ public class PSCookieConsentDao implements IPSCookieConsentDao {
           builder.createCriteriaDelete(PSDbCookieConsent.class);
       Root<PSDbCookieConsent> root = deleteQuery.from(PSDbCookieConsent.class);
       deleteQuery.where(builder.like(root.get("siteName"), siteName));
-      session.createQuery(deleteQuery).executeUpdate();
+      session.createMutationQuery(deleteQuery).executeUpdate();
 
     } catch (Exception e) {
       throw new Exception("Error deleting cookie consent entries for site: " + siteName, e);
@@ -278,7 +278,7 @@ public class PSCookieConsentDao implements IPSCookieConsentDao {
     criteriaUpdate
         .set(root.get("siteName"), newSiteName)
         .where(criteriaBuilder.equal(root.get("siteName"), oldSiteName));
-    session.createQuery(criteriaUpdate).executeUpdate();
+    session.createMutationQuery(criteriaUpdate).executeUpdate();
   }
 
   private Session getSession() {

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSDbBlogPostVisit.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSDbBlogPostVisit.java
@@ -26,7 +26,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
-import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.Date;
 import java.util.Optional;
@@ -43,8 +42,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSBlogPostVisit")
 @Table(name = "BLOG_POST_VISIT")
-public class PSDbBlogPostVisit implements IPSBlogPostVisit, Serializable {
-  private static final long serialVersionUID = 1L;
+public final class PSDbBlogPostVisit implements IPSBlogPostVisit {
 
   /** Surrogate primary key for this visit row. */
   @Id
@@ -80,9 +78,10 @@ public class PSDbBlogPostVisit implements IPSBlogPostVisit, Serializable {
     if (hitDate == null) throw new IllegalArgumentException("hitDate cannot be null");
     if (hitCount == null) throw new IllegalArgumentException("hitCount cannot be null");
 
-    setHitCount(hitCount);
-    setHitDate(hitDate);
-    setPagepath(pagepath);
+    // Direct field assignment; class is final (no this-escape via overridable setters).
+    this.hitCount = hitCount;
+    this.hitDate = new Date(hitDate.getTime());
+    this.pagepath = pagepath;
   }
 
   /**

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSDbCookieConsent.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSDbCookieConsent.java
@@ -26,7 +26,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
-import java.io.Serializable;
 import java.util.Date;
 import java.util.Optional;
 import org.hibernate.annotations.Cache;
@@ -41,8 +40,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSCookieConsent")
 @Table(name = "PERC_COOKIE_CONSENT")
-public class PSDbCookieConsent implements IPSCookieConsent, Serializable {
-  private static final long serialVersionUID = 1L;
+public final class PSDbCookieConsent implements IPSCookieConsent {
 
   /** Surrogate primary key for this consent entry. */
   @Id
@@ -96,11 +94,12 @@ public class PSDbCookieConsent implements IPSCookieConsent, Serializable {
     if (consentDate == null) throw new IllegalArgumentException("consentDate may not be null");
     if (ip == null) throw new IllegalArgumentException("ip may not be null");
 
-    setSiteName(siteName);
-    setService(serviceName);
-    setConsentDate(consentDate);
-    setIP(ip);
-    setOptIn(optIn);
+    // Direct field assignment; class is final (no this-escape via overridable setters).
+    this.siteName = siteName;
+    this.serviceName = serviceName;
+    this.consentDate = new Date(consentDate.getTime());
+    this.ip = ip;
+    this.optIn = optIn;
   }
 
   @Override

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSDbMetadataEntry.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSDbMetadataEntry.java
@@ -28,7 +28,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
@@ -39,6 +38,9 @@ import org.hibernate.annotations.*;
 /**
  * Represents metadata for a published page on the delivery server.
  *
+ * <p>Not {@link java.io.Serializable}: JPA-managed entity exchanged as a DTO/graph, not via Java
+ * serialization (avoids serial warnings on non-serializable collection field types).
+ *
  * @author erikserating
  */
 @Entity
@@ -46,9 +48,8 @@ import org.hibernate.annotations.*;
 @Table(
     name = "PERC_PAGE_METADATA",
     indexes = {@Index(name = "typeIndex", columnList = "type")})
-public class PSDbMetadataEntry implements IPSMetadataEntry, Serializable {
+public final class PSDbMetadataEntry implements IPSMetadataEntry {
 
-  private static final long serialVersionUID = 1L;
 
   /** Hash of {@link #pagepath}; used as the database primary key. */
   @Id
@@ -120,11 +121,13 @@ public class PSDbMetadataEntry implements IPSMetadataEntry, Serializable {
     if (site == null || site.length() == 0)
       throw new IllegalArgumentException("site cannot be null or empty");
 
-    setName(name);
-    setFolder(folder);
-    setType(type);
-    setPagepath(pagepath);
-    setSite(site);
+    // Direct assignment + private pagepathHash update; class is final (no this-escape).
+    this.name = name;
+    this.folder = folder;
+    this.type = type == null ? "" : type;
+    this.site = site;
+    this.pagepath = pagepath;
+    this.pagepathHash = hashCalculator.calculateHash(pagepath);
   }
 
   /**

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSDbMetadataProperty.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSDbMetadataProperty.java
@@ -33,7 +33,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
-import java.io.Serializable;
 import java.util.Date;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
@@ -55,9 +54,7 @@ import org.hibernate.annotations.Nationalized;
       @Index(columnList = "NAME,DATEVALUE", name = "name_date_hidx"),
       @Index(columnList = "NAME,VALUE_HASH", name = "name_valuehash_hidx")
     })
-public class PSDbMetadataProperty implements IPSMetadataProperty, Serializable {
-
-  private static final long serialVersionUID = 1L;
+public final class PSDbMetadataProperty implements IPSMetadataProperty {
 
   /** Surrogate primary key for this property row. */
   @Id

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSMetadataDao.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSMetadataDao.java
@@ -44,7 +44,6 @@ import org.hibernate.FlushMode;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
-import org.hibernate.query.Query;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Repository;
@@ -93,9 +92,10 @@ public class PSMetadataDao implements IPSMetadataDao {
     try (Session session = getSession()) {
       String hql = "delete from PSDbMetadataEntry  where pagepathHash in (:paths)";
       tx = session.beginTransaction();
-      Query<?> q = session.createQuery(hql);
-      q.setParameterList("paths", pagepathHashes);
-      q.executeUpdate();
+      session
+          .createMutationQuery(hql)
+          .setParameterList("paths", pagepathHashes)
+          .executeUpdate();
       tx.commit();
     } catch (Exception e) {
       if (tx != null && tx.isActive()) {
@@ -144,7 +144,7 @@ public class PSMetadataDao implements IPSMetadataDao {
           builder.createCriteriaDelete(PSDbMetadataEntry.class);
       Root<PSDbMetadataEntry> root = deleteQuery.from(PSDbMetadataEntry.class);
       deleteQuery.where(builder.like(root.get("site"), prevSiteName));
-      session.createQuery(deleteQuery).executeUpdate();
+      session.createMutationQuery(deleteQuery).executeUpdate();
       tx.commit();
     } catch (Exception e) {
       if (tx != null && tx.isActive()) {
@@ -164,13 +164,13 @@ public class PSMetadataDao implements IPSMetadataDao {
       CriteriaDelete<PSDbMetadataProperty> deleteQuery =
           builder.createCriteriaDelete(PSDbMetadataProperty.class);
       deleteQuery.from(PSDbMetadataProperty.class);
-      session.createQuery(deleteQuery).executeUpdate();
+      session.createMutationQuery(deleteQuery).executeUpdate();
 
       CriteriaBuilder builder2 = session.getCriteriaBuilder();
       CriteriaDelete<PSDbMetadataEntry> deleteQuery2 =
           builder2.createCriteriaDelete(PSDbMetadataEntry.class);
       deleteQuery2.from(PSDbMetadataEntry.class);
-      session.createQuery(deleteQuery2).executeUpdate();
+      session.createMutationQuery(deleteQuery2).executeUpdate();
       tx.commit();
 
     } catch (Exception e) {
@@ -383,7 +383,7 @@ public class PSMetadataDao implements IPSMetadataDao {
     String pagePath = metadataEntry.getPagepath();
     if (pagePath != null) {
       String pagePathHash = hashCalculator.calculateHash(pagePath);
-      dbMetadataEntry = session.get(PSDbMetadataEntry.class, pagePathHash);
+      dbMetadataEntry = session.find(PSDbMetadataEntry.class, pagePathHash);
     }
 
     boolean isNewEntry = dbMetadataEntry == null;
@@ -474,7 +474,7 @@ public class PSMetadataDao implements IPSMetadataDao {
               criteriaBuilder.and(
                   criteriaBuilder.equal(employeeRoot.get("stringvalue"), oldCategoryName),
                   criteriaBuilder.equal(employeeRoot.get("name"), "perc:category")));
-      updatedRows = session.createQuery(criteriaUpdate).executeUpdate();
+      updatedRows = session.createMutationQuery(criteriaUpdate).executeUpdate();
       tx.commit();
     } catch (Exception e) {
       if (tx != null && tx.isActive()) {

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/PSMetadataApplicationTest.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/PSMetadataApplicationTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.delivery.metadata;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Modifier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Structural coverage for {@link PSMetadataApplication}: the class is {@code final} so Jersey
+ * {@code ResourceConfig#register} calls in the constructor cannot observe a subclass before full
+ * initialization (javac {@code this-escape}).
+ */
+public class PSMetadataApplicationTest {
+
+  @Test
+  public void applicationClassIsFinal() {
+    assertTrue(
+        Modifier.isFinal(PSMetadataApplication.class.getModifiers()),
+        "PSMetadataApplication must be final to avoid this-escape in the ctor");
+  }
+}

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/PSMetadataIndexerServiceTest.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/PSMetadataIndexerServiceTest.java
@@ -108,7 +108,7 @@ public class PSMetadataIndexerServiceTest {
 
       assertTrue(props.containsKey("prop2"), "prop2 exists");
       assertEquals(VALUETYPE.NUMBER, props.get("prop2").get(0).getValuetype(), "prop2 value type");
-      assertEquals(new Double(4), props.get("prop2").get(0).getNumbervalue(), "prop2 value");
+      assertEquals(Double.valueOf(4), props.get("prop2").get(0).getNumbervalue(), "prop2 value");
     }
 
     System.out.println();
@@ -137,7 +137,7 @@ public class PSMetadataIndexerServiceTest {
     for (IPSMetadataEntry e : entries) {
       e.setLinktext("New value for linktext");
 
-      e.addProperty(new PSDbMetadataProperty("prop3", new Date(2011, 01, 28)));
+      e.addProperty(new PSDbMetadataProperty("prop3", Date.valueOf("2011-02-28")));
     }
 
     System.out.println("Updating entries");
@@ -162,11 +162,11 @@ public class PSMetadataIndexerServiceTest {
 
       assertTrue(props.containsKey("prop2"), "prop2 exists");
       assertEquals(VALUETYPE.NUMBER, props.get("prop2").get(0).getValuetype(), "prop2 value type");
-      assertEquals(new Double(4), props.get("prop2").get(0).getNumbervalue(), "prop2 value");
+      assertEquals(Double.valueOf(4), props.get("prop2").get(0).getNumbervalue(), "prop2 value");
 
       assertTrue(props.containsKey("prop3"), "prop3 exists");
       assertEquals(VALUETYPE.DATE, props.get("prop3").get(0).getValuetype(), "prop3 value type");
-      assertEquals(new Date(2011, 01, 28), props.get("prop3").get(0).getDatevalue(), "prop3 value");
+      assertEquals(Date.valueOf("2011-02-28"), props.get("prop3").get(0).getDatevalue(), "prop3 value");
     }
 
     System.out.println();
@@ -282,7 +282,7 @@ public class PSMetadataIndexerServiceTest {
 
       assertTrue(props.containsKey("prop2"), "prop2 exists");
       assertEquals(VALUETYPE.NUMBER, props.get("prop2").get(0).getValuetype(), "prop2 value type");
-      assertEquals(new Double(10), props.get("prop2").get(0).getNumbervalue(), "prop2 value");
+      assertEquals(Double.valueOf(10), props.get("prop2").get(0).getNumbervalue(), "prop2 value");
     }
   }
 
@@ -366,7 +366,7 @@ public class PSMetadataIndexerServiceTest {
     }
 
     assertEquals(
-        new Double(4), propsMap.get("prop2").get(0).getNumbervalue(), "prop2 expected value");
+        Double.valueOf(4), propsMap.get("prop2").get(0).getNumbervalue(), "prop2 expected value");
 
     // Update
     entry.setName("TestEntry1_Modified");
@@ -384,9 +384,9 @@ public class PSMetadataIndexerServiceTest {
 
     propsMap = toPropsMap(updatedEntry.getProperties());
     assertEquals("TestEntry1_Modified", updatedEntry.getName());
-    assertEquals(new Double(66), propsMap.get("prop2").get(0).getNumbervalue());
+    assertEquals(Double.valueOf(66), propsMap.get("prop2").get(0).getNumbervalue());
     assertEquals("foo1", propsMap.get("prop1").get(0).getStringvalue());
-    assertEquals(new Double(77), propsMap.get("prop3").get(0).getNumbervalue());
+    assertEquals(Double.valueOf(77), propsMap.get("prop3").get(0).getNumbervalue());
 
     // Delete
     service.delete(pagepath);
@@ -466,9 +466,9 @@ public class PSMetadataIndexerServiceTest {
 
     Map<String, List<IPSMetadataProperty>> propsMap = toPropsMap(updatedEntry.getProperties());
     assertEquals("TestEntry1_Modified", updatedEntry.getName(), "Entry name");
-    assertEquals(new Double(66), propsMap.get("prop2").get(0).getNumbervalue(), "prop2 value");
+    assertEquals(Double.valueOf(66), propsMap.get("prop2").get(0).getNumbervalue(), "prop2 value");
     assertEquals("foo1", propsMap.get("prop1").get(0).getStringvalue(), "prop1 value");
-    assertEquals(new Double(77), propsMap.get("prop3").get(0).getNumbervalue(), "prop3 value");
+    assertEquals(Double.valueOf(77), propsMap.get("prop3").get(0).getNumbervalue(), "prop3 value");
 
     // Delete
     service.delete(pagepath);

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/data/PSCookieConsentTest.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/data/PSCookieConsentTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.delivery.metadata.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers direct field assignment constructors for cookie consent DTOs (this-escape real-fix) and
+ * finality of {@link PSCookieConsentQuery}.
+ */
+public class PSCookieConsentTest {
+
+  @Test
+  public void cookieConsentQueryIsFinal() {
+    assertTrue(Modifier.isFinal(PSCookieConsentQuery.class.getModifiers()));
+  }
+
+  @Test
+  public void populatedConstructorAssignsDefensiveDateCopy() {
+    Date consent = new Date(1_700_000_000_000L);
+    PSCookieConsent entry =
+        new PSCookieConsent("siteA", "analytics", consent, "127.0.0.1", true);
+
+    assertEquals("siteA", entry.getSiteName());
+    assertEquals("analytics", entry.getService());
+    assertEquals("127.0.0.1", entry.getIP());
+    assertTrue(entry.getOptIn());
+    assertEquals(consent, entry.getConsentDate());
+    assertNotSame(consent, entry.getConsentDate());
+  }
+
+  @Test
+  public void populatedConstructorRejectsNulls() {
+    Date now = new Date();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSCookieConsent(null, "svc", now, "1.1.1.1", true));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSCookieConsent("site", null, now, "1.1.1.1", true));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSCookieConsent("site", "svc", null, "1.1.1.1", true));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSCookieConsent("site", "svc", now, null, true));
+  }
+
+  @Test
+  public void cookieConsentQueryConstructorSetsServices() {
+    Date now = new Date();
+    List<String> services = Arrays.asList("cookie-a", "cookie-b");
+    PSCookieConsentQuery query = new PSCookieConsentQuery("mysite", now, true, services);
+
+    assertEquals("mysite", query.getSiteName());
+    assertEquals(services, query.getServices());
+    assertEquals("undefined", query.getService());
+    assertEquals("undefined", query.getIP());
+  }
+
+  @Test
+  public void cookieConsentQueryRejectsNullServices() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSCookieConsentQuery("site", new Date(), true, null));
+  }
+}

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/impl/PSMetadataQueryServiceHelperTest.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/impl/PSMetadataQueryServiceHelperTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.delivery.metadata.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import com.percussion.delivery.metadata.IPSMetadataProperty.VALUETYPE;
+import com.percussion.delivery.metadata.utils.PSHashCalculator;
+import java.util.List;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+/** Covers {@link PSMetadataQueryServiceHelper#parseToList} number parsing without deprecated APIs. */
+public class PSMetadataQueryServiceHelperTest {
+
+  @Test
+  public void parseToListParsesNumberCsv() throws Exception {
+    Properties props = new Properties();
+    props.setProperty("propValue", "NUMBER");
+    PSPropertyDatatypeMappings mappings = new PSPropertyDatatypeMappings();
+    mappings.setDatatypeMappings(props);
+
+    List<Object> values =
+        PSMetadataQueryServiceHelper.parseToList(
+            "propValue", "1.5,2,3.25", mappings, new PSHashCalculator());
+
+    assertEquals(3, values.size());
+    assertInstanceOf(Double.class, values.get(0));
+    assertEquals(1.5d, (Double) values.get(0), 0.0001d);
+    assertEquals(2.0d, (Double) values.get(1), 0.0001d);
+    assertEquals(3.25d, (Double) values.get(2), 0.0001d);
+  }
+}

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/rdbms/impl/PSDbEntityStructureTest.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/rdbms/impl/PSDbEntityStructureTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.delivery.metadata.rdbms.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.delivery.metadata.extractor.data.PSMetadataEntry;
+import java.io.Serializable;
+import java.lang.reflect.Modifier;
+import java.math.BigInteger;
+import java.util.Date;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Structural coverage for metadata JPA / DTO real-fixes: final entity classes (this-escape) and
+ * dropped Java {@link Serializable} on entities/DTOs that are not Java-serialized.
+ */
+public class PSDbEntityStructureTest {
+
+  @Test
+  public void entityClassesAreFinal() {
+    assertTrue(Modifier.isFinal(PSDbBlogPostVisit.class.getModifiers()));
+    assertTrue(Modifier.isFinal(PSDbCookieConsent.class.getModifiers()));
+    assertTrue(Modifier.isFinal(PSDbMetadataEntry.class.getModifiers()));
+    assertTrue(Modifier.isFinal(PSDbMetadataProperty.class.getModifiers()));
+  }
+
+  @Test
+  public void entitiesAndExtractorEntryAreNotSerializable() {
+    assertFalse(Serializable.class.isAssignableFrom(PSDbBlogPostVisit.class));
+    assertFalse(Serializable.class.isAssignableFrom(PSDbCookieConsent.class));
+    assertFalse(Serializable.class.isAssignableFrom(PSDbMetadataEntry.class));
+    assertFalse(Serializable.class.isAssignableFrom(PSDbMetadataProperty.class));
+    assertFalse(Serializable.class.isAssignableFrom(PSMetadataEntry.class));
+  }
+
+  @Test
+  public void blogPostVisitConstructorAssignsFields() {
+    Date hit = new Date(1_700_000_000_000L);
+    PSDbBlogPostVisit visit =
+        new PSDbBlogPostVisit("/site/blog/post.html", hit, BigInteger.valueOf(3));
+    assertEquals("/site/blog/post.html", visit.getPagepath());
+    assertEquals(hit, visit.getHitDate());
+    assertEquals(BigInteger.valueOf(3), visit.getHitCount());
+  }
+
+  @Test
+  public void cookieConsentConstructorAssignsFields() {
+    Date consent = new Date(1_700_000_000_000L);
+    PSDbCookieConsent entity =
+        new PSDbCookieConsent("site", "svc", consent, "10.0.0.1", true);
+    assertEquals("site", entity.getSiteName());
+    assertEquals("svc", entity.getService());
+    assertEquals("10.0.0.1", entity.getIP());
+    assertTrue(entity.getOptIn());
+    assertEquals(consent, entity.getConsentDate());
+  }
+
+  @Test
+  public void metadataEntryConstructorHashesPagepath() {
+    PSDbMetadataEntry entry =
+        new PSDbMetadataEntry("foo.html", "/folder", "/site/folder/foo.html", "page", "site");
+    assertEquals("foo.html", entry.getName());
+    assertEquals("/folder", entry.getFolder());
+    assertEquals("/site/folder/foo.html", entry.getPagepath());
+    assertEquals("page", entry.getType());
+    assertEquals("site", entry.getSite());
+    assertTrue(entry.getPagepathHash() != null && !entry.getPagepathHash().isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary
Real-fix javac warnings in `perc-metadata-services` (`deliverytiersuite/delivery-tier-suite/metadata`).

| Warning class | Real fix |
| --- | --- |
| `this-escape` | `final` on `PSMetadataApplication`, `PSCookieConsentQuery`, `PSDbBlogPostVisit`, `PSDbCookieConsent`, `PSDbMetadataEntry`, `PSDbMetadataProperty`; direct field assignment in constructors (incl. `PSCookieConsent` super) |
| `serial` | Drop Java `Serializable` on JPA entities + extractor `PSMetadataEntry` (not Java-serialized); properties field typed as `Set<IPSMetadataProperty>` without raw cast |
| Deprecated APIs | `Double.valueOf`, `NumberUtils.isCreatable`, `Objects.toString`, `String.contains`; Hibernate `createMutationQuery` + `Session.find` |
| Other | `LinkedHashMap` for criteria operators (drop commons-collections `MapUtils`); remove unused `commons-collections` dependency |

**Parent tracker:** #2200

**Residual:** #2306 — JPA `@Temporal` on three `java.util.Date` fields (only visible with deprecation lint enabled; parent POM uses `-Xlint:-deprecation`). `@JdbcTypeCode(SqlTypes.DATE)` broke most-read H2 tests; needs `java.time` migration.

## Test plan
- [x] `cd deliverytiersuite/delivery-tier-suite/metadata && ../../../mvnw.cmd clean install -B -Dai.integrity.skip=true`
  - Tests run: **86**, Failures: 0, Errors: 0, Skipped: 0
  - **BUILD SUCCESS**
- [x] Project-default `-Xlint` compile: **zero** source `[WARNING]` lines
- [x] New unit tests: `PSMetadataApplicationTest`, `PSCookieConsentTest`, `PSDbEntityStructureTest`, `PSMetadataQueryServiceHelperTest`

## Gates evidence
- Erlang-style self-review: no new bugs; portable paths N/A; companions = structural + helper unit tests; no broad `@SuppressWarnings` for this-escape/serial
- Scope: only `perc-metadata-services` (metadata module)
- Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2041  
Refs #2200  
Residual: #2306

> Co-Authored by Grok Build using grok-4.5 with agent main.
