### PR TITLE
fix(perc-system): objectstore this-escape + serialVersionUID batch (#2297)

### DIFF
--- a/system/src/main/java/com/percussion/cms/objectstore/PSAction.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSAction.java
@@ -39,6 +39,10 @@ import org.w3c.dom.Text;
 /** The class that is used to represent menu actions as defined by 'sys_Action.dtd'. */
 public class PSAction extends PSVersionableDbComponent implements IPSCatalogSummary, IPSCloneTuner {
 
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
+
   @Override
   public String getType() {
     return PSTypeEnum.ACTION.name();

--- a/system/src/main/java/com/percussion/cms/objectstore/PSCloneSiteFolderRequest.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSCloneSiteFolderRequest.java
@@ -34,6 +34,10 @@ import org.w3c.dom.Node;
  * schema sys_FolderParameters.xsd.
  */
 public class PSCloneSiteFolderRequest extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct a new clone site folder request object.
    *

--- a/system/src/main/java/com/percussion/cms/objectstore/PSCloningOptions.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSCloningOptions.java
@@ -34,6 +34,10 @@ import org.w3c.dom.Element;
  * sys_FolderParameters.xsd.
  */
 public class PSCloningOptions extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Convenience constructor for copy site subfolders where no site name is required.
    *

--- a/system/src/main/java/com/percussion/cms/objectstore/PSComponentSummary.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSComponentSummary.java
@@ -159,7 +159,9 @@ public class PSComponentSummary extends PSDbComponent implements Serializable {
    *     defined in the <code>fromXml()</code> method.
    */
   public PSComponentSummary(Element source) throws PSUnknownNodeTypeException {
-    super(source);
+    // Avoid PSDbComponent(Element) which virtual-dispatches createKey before subclass init.
+    // Dummy locator is replaced by fromXml (same pattern as the no-arg Hibernate ctor).
+    super(createKey(0, -1));
     fromXml(source);
   }
 
@@ -939,7 +941,7 @@ public class PSComponentSummary extends PSDbComponent implements Serializable {
     }
   }
 
-  public void fromXml(Element sourceNode) throws PSUnknownNodeTypeException {
+  public final void fromXml(Element sourceNode) throws PSUnknownNodeTypeException {
     if (null == sourceNode) throw new IllegalArgumentException("sourceNode must be supplied");
 
     super.fromXml(sourceNode);
@@ -1486,7 +1488,8 @@ public class PSComponentSummary extends PSDbComponent implements Serializable {
   @Filter(
       name = "relationshipConfigFilter",
       condition = "CONFIG_ID = " + PSRelationshipConfig.ID_FOLDER_CONTENT)
-  private Set<PSRelationshipData> parentFolders = new HashSet<>();
+  // HashSet (not Set) so the field type is Serializable under -Xlint:serial
+  private HashSet<PSRelationshipData> parentFolders = new HashSet<>();
 
   /**
    * Specifies the permissions set on the item encapsulated by this object for the user accessing

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDbComponent.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDbComponent.java
@@ -83,7 +83,10 @@ public abstract class PSDbComponent implements IPSDbComponent {
    */
   protected PSDbComponent(Element src) throws PSUnknownNodeTypeException {
     if (null == src) throw new IllegalArgumentException("Source element cannot be null.");
-    fromXml(src);
+    // Private path avoids virtual dispatch to subclass fromXml during super construction.
+    // Skip node-name check here: custom constants (e.g. PSSFields → PSX_FIELDS) differ from
+    // the PS→PSX class mapping; subclasses re-validate in their fromXml when needed.
+    fromXmlBase(src, false);
   }
 
   /**
@@ -312,15 +315,34 @@ public abstract class PSDbComponent implements IPSDbComponent {
    *     (see {@link PSKey#fromXml(Element)}) or the state name is not valid.
    */
   public void fromXml(Element source) throws PSUnknownNodeTypeException {
+    fromXmlBase(source, true);
+  }
+
+  /**
+   * Shared implementation for {@link #fromXml(Element)} and the Element constructor. Keeps the
+   * constructor from virtually dispatching to a subclass {@code fromXml} before subclass fields are
+   * initialized. Note: {@link #createKey(Element)} remains overridable so specialized key types
+   * (e.g. {@code PSLocator}) still work when restoring from XML after construction.
+   *
+   * @param checkNodeName when {@code true} (public fromXml), validate against {@link
+   *     #getNodeName()}; when {@code false} (Element super ctor), skip that check to avoid
+   *     this-escape and allow custom node-name constants.
+   */
+  private void fromXmlBase(Element source, boolean checkNodeName)
+      throws PSUnknownNodeTypeException {
     // Threshold
     if (null == source) throw new IllegalArgumentException("Source must be provided.");
 
-    // Threshold
-    if (!getNodeName().equalsIgnoreCase(source.getNodeName())) {
-      String[] args = new String[] {"PSDbComponent.fromXml node: " + getNodeName()};
+    String nodeName = nodeNameFor(getClass());
+    if (checkNodeName) {
+      // Safe after full construction: honor getNodeName overrides (e.g. PSX_FIELDS).
+      if (!getNodeName().equalsIgnoreCase(source.getNodeName())) {
+        String[] args = new String[] {"PSDbComponent.fromXml node: " + getNodeName()};
 
-      // @todo change exceptions if needed!!
-      throw new PSUnknownNodeTypeException(IPSCmsErrors.INVALID_CONTENT_TYPE_ID, args);
+        // @todo change exceptions if needed!!
+        throw new PSUnknownNodeTypeException(IPSCmsErrors.INVALID_CONTENT_TYPE_ID, args);
+      }
+      nodeName = getNodeName();
     }
 
     // Must restore key first because it has higher priority than state
@@ -328,7 +350,7 @@ public abstract class PSDbComponent implements IPSDbComponent {
 
     // Threshold
     String strState = PSXMLDomUtil.checkAttribute(source, XML_ATTR_STATE, false);
-    if (strState.length() == 0) setState(DBSTATE_NEW);
+    if (strState.length() == 0) setStateInternal(DBSTATE_NEW);
     else {
       boolean found = false;
       int i = 0;
@@ -336,12 +358,44 @@ public abstract class PSDbComponent implements IPSDbComponent {
         if (STATE_LABELS[i].equalsIgnoreCase(strState)) found = true;
       }
       if (!found) {
-        String[] args = {getNodeName(), XML_ATTR_STATE, strState};
+        String[] args = {nodeName, XML_ATTR_STATE, strState};
         throw new PSUnknownNodeTypeException(IPSObjectStoreErrors.XML_ELEMENT_INVALID_ATTR, args);
       }
       // Handles validation of state.
-      setState(i - 1);
+      setStateInternal(i - 1);
     }
+  }
+
+  /**
+   * Default XML node name for a component class without virtual dispatch (PS → PSX).
+   *
+   * @param clazz runtime class, never {@code null}
+   * @return node name, never {@code null} or empty
+   */
+  private static String nodeNameFor(Class<?> clazz) {
+    String name = clazz.getName();
+    name = name.substring(name.lastIndexOf('.') + 1);
+    if (name.startsWith("PS")) name = "PSX" + name.substring(2);
+    return name;
+  }
+
+  /**
+   * Applies state without calling the overridable {@link #setState(int)} (safe during
+   * construction).
+   */
+  private void setStateInternal(int newState) {
+    if (!isValidState(newState)) throw new IllegalArgumentException("Invalid state.");
+
+    if ((isPersisted() && newState == DBSTATE_NEW)
+        || (!isPersisted()
+            && (newState == DBSTATE_UNMODIFIED
+                || newState == DBSTATE_MODIFIED
+                || newState == DBSTATE_MARKEDFORDELETE))) {
+      throw new IllegalStateException(
+          "Attempted to set component to illegal state given the state " + "of the key.");
+    }
+
+    m_state = newState;
   }
 
   /**
@@ -453,11 +507,11 @@ public abstract class PSDbComponent implements IPSDbComponent {
     m_key = (PSKey) locator.clone();
     if (isPersisted()) {
       if (getState() == DBSTATE_NEW || getState() == DBSTATE_MARKEDFORDELETE) {
-        setState(DBSTATE_MODIFIED);
+        setStateInternal(DBSTATE_MODIFIED);
       }
     } else {
       if (getState() == DBSTATE_MODIFIED || getState() == DBSTATE_UNMODIFIED) {
-        setState(DBSTATE_NEW);
+        setStateInternal(DBSTATE_NEW);
       }
     }
   }
@@ -512,18 +566,7 @@ public abstract class PSDbComponent implements IPSDbComponent {
 
   // see interface for description
   public void setState(int newState) {
-    if (!isValidState(newState)) throw new IllegalArgumentException("Invalid state.");
-
-    if ((isPersisted() && newState == DBSTATE_NEW)
-        || (!isPersisted()
-            && (newState == DBSTATE_UNMODIFIED
-                || newState == DBSTATE_MODIFIED
-                || newState == DBSTATE_MARKEDFORDELETE))) {
-      throw new IllegalStateException(
-          "Attempted to set component to illegal state given the state " + "of the key.");
-    }
-
-    m_state = newState;
+    setStateInternal(newState);
   }
 
   /**

--- a/system/src/main/java/com/percussion/cms/objectstore/PSDisplayFormat.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSDisplayFormat.java
@@ -43,6 +43,10 @@ import org.w3c.dom.Element;
  */
 public class PSDisplayFormat extends PSVersionableDbComponent
     implements IPSCatalogSummary, IPSCloneTuner {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Creates a new format with default values for the label, internal name, display type and
    * community. The label defaults to something of the form 'Display Format n', where n is a small

--- a/system/src/main/java/com/percussion/cms/objectstore/PSFolderPermissions.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSFolderPermissions.java
@@ -28,6 +28,10 @@ import java.util.Iterator;
  * context of a folder object.
  */
 public class PSFolderPermissions extends PSObjectPermissions {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * This constructor will typically be used on the server side.
    *
@@ -181,5 +185,6 @@ public class PSFolderPermissions extends PSObjectPermissions {
    * single arg constructor is used, otherwise initialized in the constructor, never modified after
    * initializartion.
    */
-  private PSFolderAcl m_folderAcl = null;
+  /** Server-side folder ACL; not part of the serialized permission mask. */
+  private transient PSFolderAcl m_folderAcl = null;
 }

--- a/system/src/main/java/com/percussion/cms/objectstore/PSInvalidContentTypeException.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSInvalidContentTypeException.java
@@ -25,6 +25,10 @@ import com.percussion.error.PSException;
  * user.
  */
 public class PSInvalidContentTypeException extends PSException {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Creates an exception with text describing the problem.
    *

--- a/system/src/main/java/com/percussion/cms/objectstore/PSItemChildLocator.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSItemChildLocator.java
@@ -26,6 +26,10 @@ package com.percussion.cms.objectstore;
  * @author paulhoward
  */
 public class PSItemChildLocator extends PSKey {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * @param fieldName The submit name of the complex child. Never <code>null
    * </code> or empty.

--- a/system/src/main/java/com/percussion/cms/objectstore/PSItemDefSummary.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSItemDefSummary.java
@@ -40,6 +40,10 @@ import org.w3c.dom.Element;
  * class is satisfactory.
  */
 public class PSItemDefSummary extends PSCmsComponent implements IPSCatalogSummary {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Creates an instance.
    *

--- a/system/src/main/java/com/percussion/cms/objectstore/PSItemDefinition.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSItemDefinition.java
@@ -58,6 +58,10 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 public class PSItemDefinition extends PSItemDefSummary implements IPSComponent, IPSCloneTuner {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Create a new definition.
    *

--- a/system/src/main/java/com/percussion/cms/objectstore/PSKey.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSKey.java
@@ -43,6 +43,10 @@ import org.w3c.dom.Element;
  * @version 1.0
  */
 public class PSKey implements IPSCmsComponent, Serializable {
+
+  /** Serialization id for {@link Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   private static final Logger log = LogManager.getLogger(PSKey.class);
 
   /**
@@ -193,7 +197,7 @@ public class PSKey implements IPSCmsComponent, Serializable {
    * @return <code>true</code> if this key has values assigned for its parts, otherwise <code>false
    *     </code>.
    */
-  public boolean isAssigned() {
+  public final boolean isAssigned() {
     for (int i = 0; i < m_definition.length; i++) {
       if (getPart(m_definition[i]).trim().length() == 0) return false;
     }
@@ -281,7 +285,7 @@ public class PSKey implements IPSCmsComponent, Serializable {
    *     comparison is done case- insensitive.
    * @return The value for the named part, or "" if no value has been assigned.
    */
-  public String getPart(String name) {
+  public final String getPart(String name) {
     String value = (String) m_nameValueMap.get(name.toLowerCase());
 
     if (value == null) return "";
@@ -411,7 +415,8 @@ public class PSKey implements IPSCmsComponent, Serializable {
   private void fromXml(Element src, boolean validate) throws PSUnknownNodeTypeException {
     if (null == src) throw new IllegalArgumentException("src must be supplied");
 
-    PSXMLDomUtil.checkNode(src, getNodeName());
+    // Use class-derived node name (not overridable getNodeName) so Element ctor is this-escape free.
+    PSXMLDomUtil.checkNode(src, nodeNameFor(getClass()));
 
     // get the attributes
     String sIsPersisted = PSXMLDomUtil.checkAttribute(src, XML_ATTR_IS_PERSISTED, false);
@@ -481,7 +486,18 @@ public class PSKey implements IPSCmsComponent, Serializable {
    *     null</code> or empty.
    */
   public String getNodeName() {
-    String name = getClass().getName();
+    return nodeNameFor(getClass());
+  }
+
+  /**
+   * Derives the default XML node name for a component class without virtual dispatch (safe during
+   * construction).
+   *
+   * @param clazz the runtime class, never {@code null}
+   * @return PS → PSX style node name, never {@code null} or empty
+   */
+  private static String nodeNameFor(Class<?> clazz) {
+    String name = clazz.getName();
     name = name.substring(name.lastIndexOf('.') + 1);
     if (name.startsWith("PS")) name = "PSX" + name.substring(2);
     return name;
@@ -590,9 +606,10 @@ public class PSKey implements IPSCmsComponent, Serializable {
   /**
    * Maps the definition to its corresponding value. The map key is the definition in <code>String
    * </code>, which is normalized to lower case. The map value is the value of the definition in
-   * <code>String</code>. Never <code>null</code>, but may be empty.
+   * <code>String</code>. Never <code>null</code>, but may be empty. Declared as {@link HashMap}
+   * (not {@link Map}) so the field type is {@link Serializable} under {@code -Xlint:serial}.
    */
-  private Map m_nameValueMap = new HashMap();
+  private HashMap m_nameValueMap = new HashMap();
 
   /**
    * The definitions in its original case sensitive form. Initialized by the constructor, never

--- a/system/src/main/java/com/percussion/cms/objectstore/PSObjectPermissions.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSObjectPermissions.java
@@ -47,7 +47,10 @@ import java.util.Iterator;
  * be created for a specific type of securable object. For example, <code>PSFolderPermissions</code>
  * class represents permissions on folder objects.
  */
-public abstract class PSObjectPermissions {
+public abstract class PSObjectPermissions implements java.io.Serializable {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
 
   /**
    * This constructor will typically be used on the server side. This sets the user's server access
@@ -418,14 +421,15 @@ public abstract class PSObjectPermissions {
    * <code>null</code> if single arg constructor is used, otherwise initialized in the constructor,
    * never modified after initialization.
    */
-  protected PSObjectAcl m_objectAcl = null;
+  /** Server-side ACL; not part of the serialized permission mask. */
+  protected transient PSObjectAcl m_objectAcl = null;
 
   /**
    * Contains the credentials of the user accessing the securable object, may be <code>null</code>
    * if single arg constructor is used, otherwise initialized in the constructor, never modified
-   * after initialization.
+   * after initialization. Transient: not part of the serialized permission mask.
    */
-  protected PSUserInfo m_userInfo = null;
+  protected transient PSUserInfo m_userInfo = null;
 
   /**
    * server access level for the user, initialized to <code></code> which implies no access to the

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSearch.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSearch.java
@@ -50,6 +50,10 @@ import org.w3c.dom.Element;
  * @see PSVersionableDbComponent for base class description.
  */
 public class PSSearch extends PSVersionableDbComponent implements IPSCatalogSummary, IPSCloneTuner {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * When a custom view is created, this value is set as the URL. This allows the object to be saved
    * w/o error. A custom view can be created w/ the following {@link #PSSearch(String, boolean)}

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSimpleKey.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSimpleKey.java
@@ -28,6 +28,10 @@ import org.w3c.dom.Element;
  * @version 1.0
  */
 public class PSSimpleKey extends PSKey {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Create an un-assigned key with a single part.
    *

--- a/system/src/main/java/com/percussion/cms/objectstore/PSSite.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/PSSite.java
@@ -37,6 +37,10 @@ import org.w3c.dom.NodeList;
 
 /** This object represents a site definition. See {@link #toXml(Document)} for the expected DTD. */
 public class PSSite extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Constructs the site from its XML representation.
    *

--- a/system/src/main/java/com/percussion/cms/objectstore/server/PSCorruptDatabaseException.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/server/PSCorruptDatabaseException.java
@@ -26,6 +26,10 @@ import com.percussion.error.PSRuntimeException;
  * down and fix it.
  */
 public class PSCorruptDatabaseException extends PSRuntimeException {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Creates an exception with text describing the problem.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSAbstractParamValue.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAbstractParamValue.java
@@ -30,6 +30,10 @@ import org.w3c.dom.Element;
  */
 public abstract class PSAbstractParamValue extends PSComponent implements IPSParameter {
 
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
+
   /**
    * Constructs this object from its XML representation. See the {@link #toXml(Document) toXml()}
    * method for the DTD of the <code>sourceNode</code> element.

--- a/system/src/main/java/com/percussion/design/objectstore/PSAcl.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAcl.java
@@ -39,6 +39,10 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSAcl extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSAclEntry.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAclEntry.java
@@ -38,6 +38,10 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSAclEntry extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * This entry can be used in calls to setName or the constructor to create an entry for anonynmous
    * users (not logged in).

--- a/system/src/main/java/com/percussion/design/objectstore/PSActionLink.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSActionLink.java
@@ -26,6 +26,10 @@ import org.w3c.dom.Element;
 
 /** Implementation for the PSXActionLink DTD in BasicObjects.dtd. */
 public class PSActionLink extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Creates a new action link.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSApplicationFile.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSApplicationFile.java
@@ -51,6 +51,10 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSApplicationFile extends PSFile {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /** No argument constructor for serialization, such as calling fromXml(). */
   public PSApplicationFile() {
     super();

--- a/system/src/main/java/com/percussion/design/objectstore/PSAuthentication.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAuthentication.java
@@ -40,6 +40,10 @@ import org.w3c.dom.Node;
  * the toXml(Document) method for the DTD description.
  */
 public class PSAuthentication extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   private static final Logger logger = LogManager.getLogger(PSAuthentication.class);
 
   /**

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndColumn.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndColumn.java
@@ -37,6 +37,10 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSBackEndColumn extends PSComponent implements IPSBackEndMapping, IPSReplacementValue {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndConnection.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndConnection.java
@@ -37,6 +37,10 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSBackEndConnection extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndCredential.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndCredential.java
@@ -36,6 +36,10 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSBackEndCredential extends PSComponent implements IPSConnectionInfo {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndDataTank.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndDataTank.java
@@ -37,6 +37,10 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSBackEndDataTank extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndJoin.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndJoin.java
@@ -65,6 +65,10 @@ import org.w3c.dom.Node;
  * @since 1.0
  */
 public class PSBackEndJoin extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct a Java object from its XML representation. See the {@link #toXml(Document) toXml}
    * method for a description of the XML object.

--- a/system/src/main/java/com/percussion/design/objectstore/PSBackEndTable.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSBackEndTable.java
@@ -35,6 +35,10 @@ import org.w3c.dom.Element;
  * @see PSBackEndColumn
  */
 public class PSBackEndTable extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /** Provide a suitable key for indexing database connections */
   public class PSServerKey {
 

--- a/system/src/main/java/com/percussion/design/objectstore/PSCgiVariable.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCgiVariable.java
@@ -29,6 +29,10 @@ import org.w3c.dom.Element;
  * @since 1.0
  */
 public class PSCgiVariable extends PSNamedReplacementValue {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct a Java object from its XML representation.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSChoiceFilter.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSChoiceFilter.java
@@ -28,6 +28,10 @@ import org.w3c.dom.NodeList;
 
 /** Implements the PSChoiceFilter DTD in BasicObjects.dtd. */
 public class PSChoiceFilter extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct a Java object from its XML representation.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSChoices.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSChoices.java
@@ -28,6 +28,10 @@ import org.w3c.dom.Node;
 
 /** Implements the PSXChoices DTD in BasicObjects.dtd. */
 public class PSChoices extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Create new choices of type global.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSCloneHandlerConfig.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCloneHandlerConfig.java
@@ -28,6 +28,10 @@ import org.w3c.dom.Element;
  * conforming to the sys_CloneHandlerConfig.dtd.
  */
 public class PSCloneHandlerConfig extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct a Java object from its XML representation.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSCloneOverrideField.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSCloneOverrideField.java
@@ -39,6 +39,10 @@ import org.w3c.dom.NodeList;
  * @author RammohanVangapalli
  */
 public class PSCloneOverrideField extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Constructs a clone field from supplied name and the replacement value.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditional.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditional.java
@@ -82,6 +82,10 @@ import org.w3c.dom.Node;
  * @since 1.0
  */
 public class PSConditional extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Use the boolean AND operator to join conditionals. AND has a higher precedence than OR. This
    * means all AND conditions will be evaluated, then the ORs will be evaluated.

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditionalExit.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditionalExit.java
@@ -24,6 +24,10 @@ import org.w3c.dom.Element;
 
 /** Implementation for the PSXConditionalExit DTD in BasicObjects.dtd. */
 public class PSConditionalExit extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Create a new conditional exit for the provided rules.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditionalExtension.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditionalExtension.java
@@ -26,6 +26,10 @@ import org.w3c.dom.Element;
 
 /** Implements the PSXConditionalEffect element defined in sys_RelationshipConfig.dtd. */
 public class PSConditionalExtension extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct a Java object from its XML representation.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditionalRequest.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditionalRequest.java
@@ -26,6 +26,10 @@ import org.w3c.dom.Element;
 
 /** Implements the PSXConditionalRequest DTD defined in BasicObjects.dtd. */
 public class PSConditionalRequest extends PSUrlRequest {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Creates a new conditional request for the provided conditions.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSConditionalStylesheet.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConditionalStylesheet.java
@@ -26,6 +26,10 @@ import org.w3c.dom.Element;
 
 /** Implements the PSXConditionalStylesheet DTD defined in BasicObjects.dtd. */
 public class PSConditionalStylesheet extends PSStylesheet {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Create a new conditional stylesheet for the provided request and conditions.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSConfig.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSConfig.java
@@ -47,6 +47,10 @@ import org.xml.sax.SAXException;
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSConfig")
 @Table(name = "PSX_RXCONFIGURATIONS")
 public class PSConfig extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Constructs the configuration from its XML representation.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSContainerLocator.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContainerLocator.java
@@ -31,6 +31,10 @@ import org.w3c.dom.Element;
 
 /** Implements the PSXContainerLocator DTD defined in BasicObjects.dtd. */
 public class PSContainerLocator extends PSComponent {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Create a new table locator for the provided table sets.
    *

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditor.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditor.java
@@ -38,6 +38,10 @@ import org.w3c.dom.Node;
 
 /** Implements the PSXContentEditorLocalDef DTD defined in ContentEditorLocalDef.dtd. */
 public class PSContentEditor extends PSDataSet {
+
+  /** Serialization id for {@link java.io.Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Creates a new content editor for the provided name, content type and workflow id. Related
    * content is disabled.

--- a/system/src/main/java/com/percussion/design/objectstore/PSLocator.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSLocator.java
@@ -31,6 +31,9 @@ import org.w3c.dom.Element;
  */
 public class PSLocator extends PSKey implements Serializable {
 
+  /** Serialization id for {@link Serializable}. */
+  private static final long serialVersionUID = 1L;
+
   private static final Logger log = LogManager.getLogger(PSLocator.class);
 
   /**

--- a/system/src/test/java/com/percussion/cms/objectstore/PSKeyTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSKeyTest.java
@@ -187,4 +187,56 @@ public class PSKeyTest {
 
     return true;
   }
+
+  /**
+   * Element construction and Java serialization for foundation key types after this-escape / serial
+   * cleanups (issue #2297).
+   */
+  @Test
+  public void testElementCtorAndJavaSerialization() throws Exception {
+    PSKey key = new PSKey(new String[] {"CONTENTID", "REVISIONID"}, new int[] {42, 3}, true);
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element el = key.toXml(doc);
+    PSKey restored = new PSKey(el);
+    assertEquals(key, restored);
+    assertEquals("PSXKey", key.getNodeName());
+
+    PSLocator locator = new PSLocator(100, 2);
+    Element locEl = locator.toXml(doc);
+    PSLocator locRestored = new PSLocator(locEl);
+    assertEquals(locator, locRestored);
+    assertEquals(PSLocator.XML_NODE_NAME, locRestored.getNodeName());
+
+    // Java serialization round-trip (serialVersionUID + HashMap field type)
+    byte[] bytes;
+    try (java.io.ByteArrayOutputStream bos = new java.io.ByteArrayOutputStream();
+        java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(bos)) {
+      oos.writeObject(key);
+      oos.writeObject(locator);
+      bytes = bos.toByteArray();
+    }
+    try (java.io.ObjectInputStream ois =
+        new java.io.ObjectInputStream(new java.io.ByteArrayInputStream(bytes))) {
+      PSKey serKey = (PSKey) ois.readObject();
+      PSLocator serLoc = (PSLocator) ois.readObject();
+      assertEquals(key, serKey);
+      assertEquals(locator, serLoc);
+      assertEquals(42, serKey.getPartAsInt("CONTENTID"));
+      assertEquals(100, serLoc.getId());
+      assertEquals(2, serLoc.getRevision());
+    }
+
+    PSSimpleKey simple = new PSSimpleKey("id", "99", true);
+    try (java.io.ByteArrayOutputStream bos = new java.io.ByteArrayOutputStream();
+        java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(bos)) {
+      oos.writeObject(simple);
+      bytes = bos.toByteArray();
+    }
+    try (java.io.ObjectInputStream ois =
+        new java.io.ObjectInputStream(new java.io.ByteArrayInputStream(bytes))) {
+      PSSimpleKey serSimple = (PSSimpleKey) ois.readObject();
+      assertEquals(simple, serSimple);
+      assertEquals(99, serSimple.getKeyValueAsInt());
+    }
+  }
 }


### PR DESCRIPTION
## Summary

PR-sized batch for **#2297** (parent **#2022** / grandparent **#2200**): clear `-Xlint:this-escape` and `-Xlint:serial` in hottest **design.objectstore** + **cms.objectstore** types with real constructor/serial fixes (not suppress-only).

### Real this-escape fixes
- **PSKey**: Element ctor uses private `fromXml` with class-derived node name (no virtual `getNodeName`); `isAssigned`/`getPart` made `final`; field declared as `HashMap` for serial-field.
- **PSDbComponent**: Element ctor uses private `fromXmlBase` (no virtual subclass `fromXml`); `setStateInternal` for construction-safe state; residual `createKey` virtual dispatch noted for follow-up.
- **PSComponentSummary**: Element ctor avoids `super(Element)` + double-load; `final fromXml`; `HashSet` for `parentFolders`; `PSObjectPermissions`/`PSFolderPermissions` made `Serializable` with transient server-only ACL/user fields.

### serialVersionUID batch (~40 types)
`serialVersionUID = 1L` on foundation keys (`PSKey`/`PSLocator`/`PSSimpleKey`/`PSItemChildLocator`) plus cms.objectstore hotspots and design.objectstore A–C batch (e.g. `PSAcl`, `PSChoices`, `PSContentEditor`, …).

### Metrics (objectstore packages, `-Xmaxwarns 10000` sample)
| Kind | Before | After (this PR) | Δ |
| --- | ---: | ---: | ---: |
| missing serialVersionUID | ~143 | ~104 | **−39** |
| serial-field | ~143 | ~139 | **−4** |
| this-escape | ~364 | ~362–363 | **−1–2** (foundation; bulk remains) |

Total this batch ≈ **~43–45** diagnostics, within the 40–50 cap.

## Test plan
- [x] `cd system && ../mvnw clean install` — BUILD SUCCESS, 1183 tests, 0 failures
- [x] Focused: `PSKeyTest` (5), `PSComponentSummaryTest` (4), `PSFolderTest`, related objectstore tests
- [x] New `PSKeyTest.testElementCtorAndJavaSerialization` covers Element ctor + Java serialization round-trip

## Gates evidence
- Erlang-style self-review: constructor paths preserve Element restore behavior; custom node names (e.g. `PSX_FIELDS`) still accepted on Element super ctor; portable paths N/A
- Per-module standalone clean install: pass
- No monorepo-wide reformat

## Residual
Follow-up filed for remaining objectstore this-escape + serial (createKey virtuals, design.objectstore D–Z UIDs, serial-field on large editors). Link in parent #2022 progress table.

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2297  
Refs #2022 #2200

> Co-Authored by Grok Build using grok-4.5 with agent main.