### PR TITLE
fix(perc-system): data/data.jdbc metadata rawtypes batch (#2298)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2298-data-jdbc-rawtypes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2298-data-jdbc-rawtypes-erlang.md
@@ -1,0 +1,55 @@
+# Erlang review: issue #2298 data / data.jdbc rawtypes batch
+
+**Reviewer:** Erlang (strict independent)  
+**Date:** 2026-08-07  
+**Branch:** `fix/issue-2298-data-jdbc-rawtypes`  
+**Base:** `origin/main`  
+**Recommendation:** **approve**  
+**Gate:** **May commit/push: yes**
+
+## Summary
+
+Parameterizes raw collections and maps in the metadata cluster of `com.percussion.data` and a small `data.jdbc` DSN reader. Real generics preferred over `@SuppressWarnings`. Behavioral unit tests cover type-map loading, DSN parsing, and the case-insensitive column index algorithm. Module `system` `mvnw clean install` green.
+
+## Scope
+
+| Path | Change |
+| --- | --- |
+| `system/src/main/java/com/percussion/data/PSDatabaseMetaData.java` | Typed maps/lists/sets; `Map<String,PSDataTypeInfo>` API; `Comparable<ShortTableInfo>` |
+| `system/src/main/java/com/percussion/data/PSTableMetaData.java` | Typed column/key/type maps; `loadDataTypes` → `Map<String,Integer>`; manual `findColumnIndex` |
+| `system/src/main/java/com/percussion/data/PSMetaDataCache.java` | `Iterator<?>` for table refs |
+| `system/src/main/java/com/percussion/data/jdbc/PSDsnReader.java` | `ArrayList<String>` + try-with-resources close |
+| Tests | `PSDatabaseMetaDataTypeMapTest`, `PSDsnReaderTest`, fold-test update |
+| This report | Durable Erlang artifact |
+
+**Prior / patterns:** Aligns with #2295 / #2296 rawtypes batches (prefer real generics; ≤~40–50 diags; residual child issues).  
+**Cross-platform path review:** PSDsnReader uses `java.io.File` + `FileReader` (platform path strings). Tests use `Path` / `@TempDir` / `Files.writeString` — portable. No hardcoded `C:\` or Unix-only absolutes.
+
+## Issues
+
+_None at bug severity._
+
+### suggestion (non-blocking)
+
+1. **`PSTableMetaData` ShortTableInfo-style schema NPE** (`PSDatabaseMetaData.ShortTableInfo#compareTo`) — if both schemas are null, fall-through still calls `m_schema.compareTo` (pre-existing). Out of scope for rawtypes slice; optional follow-up.
+
+2. **Package residual** — large rawtypes inventory remains in `data` / `data.jdbc` (optimizers, SQL builders, file-system JDBC meta, etc.). Track under parent #2022 residual slice; do not expand this PR.
+
+### nit
+
+1. `new String(key)` removed in `loadDataTypes` in favor of reusing the map key — equivalent for immutable `String` keys.
+
+## Verification
+
+| Check | Result |
+| --- | --- |
+| Focused tests | `PSDatabaseMetaDataTypeMapTest`, `PSDsnReaderTest`, `PSTableMetaDataIdentifierFoldTest` green |
+| `cd system && ../mvnw.cmd clean install` | BUILD SUCCESS |
+| Module surefire | failures=0, errors=0 |
+| Touched production files | 0 residual rawtypes/unchecked on compile log paths |
+
+## Gate
+
+No bugs, behavioral tests present for changed logic, portable I/O. **approve**.
+
+> Co-Authored by Grok Build using grok-4.5 with agent main.

--- a/system/src/main/java/com/percussion/data/PSDatabaseMetaData.java
+++ b/system/src/main/java/com/percussion/data/PSDatabaseMetaData.java
@@ -59,8 +59,8 @@ public class PSDatabaseMetaData implements IPSConnectionInfo {
   public PSDatabaseMetaData(String dataSource) {
     m_dataSource = dataSource;
     m_patMat = new PSPatternMatcher('_', '%', "%");
-    m_tables = new ArrayList();
-    m_tableMetaData = new HashMap();
+    m_tables = new ArrayList<>();
+    m_tableMetaData = new HashMap<>();
     m_dataTypeMap = null; // flag to get data types on the first request
   }
 
@@ -134,7 +134,7 @@ public class PSDatabaseMetaData implements IPSConnectionInfo {
   public String[] getTables(
       String catalog, String schemaPattern, String tableNamePattern, String[] types)
       throws SQLException {
-    ArrayList matchingTables = new ArrayList();
+    ArrayList<String> matchingTables = new ArrayList<>();
 
     if (m_tables != null) {
       matchingTables.ensureCapacity(m_tables.size());
@@ -145,8 +145,7 @@ public class PSDatabaseMetaData implements IPSConnectionInfo {
         System.arraycopy(types, 0, sortedTypes, 0, types.length);
         Arrays.sort(sortedTypes);
       }
-      for (Iterator i = m_tables.iterator(); i.hasNext(); ) {
-        ShortTableInfo info = (ShortTableInfo) i.next();
+      for (ShortTableInfo info : m_tables) {
         if (catalog != null) {
           if (info.m_catalog == null || !info.m_catalog.equals(catalog)) continue;
         }
@@ -164,7 +163,7 @@ public class PSDatabaseMetaData implements IPSConnectionInfo {
       }
     }
 
-    return (String[]) matchingTables.toArray(new String[matchingTables.size()]);
+    return matchingTables.toArray(new String[matchingTables.size()]);
   }
 
   /**
@@ -179,7 +178,7 @@ public class PSDatabaseMetaData implements IPSConnectionInfo {
     if (schemaName == null) tableKey = "." + tableName;
     else tableKey = schemaName + "." + tableName;
 
-    PSTableMetaData tmd = (PSTableMetaData) m_tableMetaData.get(tableKey);
+    PSTableMetaData tmd = m_tableMetaData.get(tableKey);
     if (null != tmd) return tmd;
 
     Connection conn = null;
@@ -199,7 +198,7 @@ public class PSDatabaseMetaData implements IPSConnectionInfo {
         }
     }
 
-    return (PSTableMetaData) m_tableMetaData.get(tableKey);
+    return m_tableMetaData.get(tableKey);
   }
 
   /**
@@ -210,13 +209,13 @@ public class PSDatabaseMetaData implements IPSConnectionInfo {
    * @throws SQLException
    * @see PSDataTypeInfo
    */
-  public java.util.Map getDataTypeDefinitionMap() throws SQLException {
+  public Map<String, PSDataTypeInfo> getDataTypeDefinitionMap() throws SQLException {
     if (m_dataTypeMap == null) {
       /* we should probably synchronize, but it's really no big deal as
        * the worst case scenario is multiple people do this at the same
        * time. There's no real harm from that.
        */
-      java.util.Map types = new java.util.HashMap();
+      Map<String, PSDataTypeInfo> types = new HashMap<>();
 
       Connection conn = null;
       try {
@@ -306,13 +305,13 @@ public class PSDatabaseMetaData implements IPSConnectionInfo {
    * @throws NamingException
    */
   public PSDataTypeInfo[] getDataTypeDefinitions() throws NamingException, SQLException {
-    java.util.Map types = getDataTypeDefinitionMap();
+    Map<String, PSDataTypeInfo> types = getDataTypeDefinitionMap();
     int size = (types == null) ? 0 : types.size();
     PSDataTypeInfo[] dtArray = new PSDataTypeInfo[size];
 
     if (size > 0) {
-      java.util.Iterator ite = types.values().iterator();
-      for (int i = 0; ite.hasNext() && (i < size); i++) dtArray[i] = (PSDataTypeInfo) ite.next();
+      Iterator<PSDataTypeInfo> ite = types.values().iterator();
+      for (int i = 0; ite.hasNext() && (i < size); i++) dtArray[i] = ite.next();
     }
 
     return dtArray;
@@ -340,7 +339,7 @@ public class PSDatabaseMetaData implements IPSConnectionInfo {
    */
   public static short guessNativeDataTypeConversion(short nativeType) {
     short dt = nativeType;
-    Short sJdbcType = (Short) ms_dataTypeConversionMap.get(new Short(nativeType));
+    Short sJdbcType = ms_dataTypeConversionMap.get(Short.valueOf(nativeType));
     if (sJdbcType != null) {
       dt = sJdbcType.shortValue();
     }
@@ -400,7 +399,7 @@ public class PSDatabaseMetaData implements IPSConnectionInfo {
       // this is not critical, just prevents the special case check
     }
 
-    HashMap<String, Short> map = (HashMap<String, Short>) ms_fixedUpDataTypeMap.get(dbmsType);
+    HashMap<String, Short> map = ms_fixedUpDataTypeMap.get(dbmsType);
     if (map != null) return map;
     map = new HashMap<>();
 
@@ -412,8 +411,8 @@ public class PSDatabaseMetaData implements IPSConnectionInfo {
             final String typeName = rs.getString(1);
             short nativeType = rs.getShort(2);
             short jdbcType = PSSqlHelper.convertNativeDataType(nativeType, typeName, driver);
-            ms_dataTypeConversionMap.put(new Short(nativeType), new Short(jdbcType));
-            map.put(typeName, new Short(jdbcType));
+            ms_dataTypeConversionMap.put(Short.valueOf(nativeType), Short.valueOf(jdbcType));
+            map.put(typeName, Short.valueOf(jdbcType));
           }
         }
       } finally {
@@ -492,13 +491,13 @@ public class PSDatabaseMetaData implements IPSConnectionInfo {
   }
 
   // the list of data types supported by the back-end
-  private Map m_dataTypeMap;
+  private Map<String, PSDataTypeInfo> m_dataTypeMap;
 
   // a list of ShortTableInfo objects, one for each table contained herein
-  private List m_tables;
+  private List<ShortTableInfo> m_tables;
 
   // a map from table names to PSTableMetaData objects
-  private Map m_tableMetaData;
+  private Map<String, PSTableMetaData> m_tableMetaData;
 
   // a SQL style pattern matcher
   private PSPatternMatcher m_patMat;
@@ -522,7 +521,7 @@ public class PSDatabaseMetaData implements IPSConnectionInfo {
    * </code>, modified by a call to {@link #loadNativeDataTypeMap(Connection, DatabaseMetaData)
    * loadNativeDataTypeMap}.
    */
-  protected static HashMap ms_dataTypeConversionMap = new HashMap();
+  protected static HashMap<Short, Short> ms_dataTypeConversionMap = new HashMap<>();
 
   /**
    * The hash set containing datasources which require that the modified datatypes be returned to
@@ -530,12 +529,12 @@ public class PSDatabaseMetaData implements IPSConnectionInfo {
    * populated in the static() method and will therefore never be <code>null</code> or empty. The
    * names are lowercased as datasource names must be treated case-insensitively.
    */
-  private static HashSet ms_driversNeedingUntweakedNulls = new HashSet();
+  private static HashSet<String> ms_driversNeedingUntweakedNulls = new HashSet<>();
 
   private static final String UNTWEAKED_DRIVER_PREFIX = "ds:";
 
   /** An internal class we use to keep track of table info. */
-  private class ShortTableInfo implements Comparable {
+  private class ShortTableInfo implements Comparable<ShortTableInfo> {
     public ShortTableInfo(
         String catalog, String schema, String tableName, String type, String remarks) {
       m_catalog = catalog;
@@ -567,11 +566,9 @@ public class PSDatabaseMetaData implements IPSConnectionInfo {
      *
      * <p>Catalog and remarks are not used in the comparison.
      */
-    public int compareTo(Object o) {
-      ShortTableInfo other = (ShortTableInfo) o;
-
+    @Override
+    public int compareTo(ShortTableInfo other) {
       int i = m_type.compareTo(other.m_type);
-      ;
       if (i != 0) return i;
 
       if (m_schema != null || other.m_schema != null) {

--- a/system/src/main/java/com/percussion/data/PSMetaDataCache.java
+++ b/system/src/main/java/com/percussion/data/PSMetaDataCache.java
@@ -169,7 +169,7 @@ public class PSMetaDataCache {
     // try to get the table name from the tableset
     if (null == tableName || tableName.trim().length() == 0) {
       String alias = column.getTable().getAlias();
-      Iterator refs = tableSet.getTableRefs();
+      Iterator<?> refs = tableSet.getTableRefs();
       while (refs.hasNext()) {
         PSTableRef ref = (PSTableRef) refs.next();
         if (ref.getAlias().equals(alias)) {

--- a/system/src/main/java/com/percussion/data/PSTableMetaData.java
+++ b/system/src/main/java/com/percussion/data/PSTableMetaData.java
@@ -34,7 +34,6 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -75,10 +74,10 @@ public class PSTableMetaData implements IPSConnectionInfo {
     m_dataSource = m_login == null ? null : m_login.getDataSource();
     m_schema = schema;
     m_tableName = tableName;
-    m_columns = new ArrayList();
+    m_columns = new ArrayList<>();
     m_patMat = new PSPatternMatcher('_', '%', "%");
-    m_primaryKeyColumns = new ArrayList();
-    m_foreignKeyColumns = new ArrayList();
+    m_primaryKeyColumns = new ArrayList<>();
+    m_foreignKeyColumns = new ArrayList<>();
 
     /*
      * Fold catalog/schema/table to the case the backend stores unquoted
@@ -136,15 +135,31 @@ public class PSTableMetaData implements IPSConnectionInfo {
    * Case-insensitive column name lookup for sorted {@link #m_columns}. Used when the driver returns
    * lowercase names (PostgreSQL) but content editors request {@code COMMUNITYID}.
    *
+   * <p>Manual binary search (not {@link Collections#binarySearch} with a {@link String} key) so
+   * {@code m_columns} can be a typed {@code List<ColumnInfo>} without raw {@code Comparable}.
+   *
    * @param columnName name to find, may be {@code null}
-   * @return index in {@link #m_columns}, or negative if not found (same contract as {@link
-   *     Collections#binarySearch})
+   * @return index in {@link #m_columns}, or negative insertion point if not found (same contract as
+   *     {@link Collections#binarySearch})
    */
   int findColumnIndex(String columnName) {
     if (columnName == null) {
       return -1;
     }
-    return Collections.binarySearch(m_columns, columnName);
+    int low = 0;
+    int high = m_columns.size() - 1;
+    while (low <= high) {
+      int mid = (low + high) >>> 1;
+      int cmp = m_columns.get(mid).m_name.compareToIgnoreCase(columnName);
+      if (cmp < 0) {
+        low = mid + 1;
+      } else if (cmp > 0) {
+        high = mid - 1;
+      } else {
+        return mid;
+      }
+    }
+    return -(low + 1);
   }
 
   /**
@@ -186,9 +201,8 @@ public class PSTableMetaData implements IPSConnectionInfo {
    * @since 1.1 1999/4/30
    */
   public String[] getColumns(String columnNamePattern) {
-    List cols = new ArrayList(m_columns.size());
-    for (Iterator i = m_columns.iterator(); i.hasNext(); ) {
-      ColumnInfo colInfo = (ColumnInfo) i.next();
+    List<String> cols = new ArrayList<>(m_columns.size());
+    for (ColumnInfo colInfo : m_columns) {
       if (m_patMat.doesMatchPattern(columnNamePattern, colInfo.m_name)) {
         cols.add(colInfo.m_name);
       }
@@ -233,7 +247,7 @@ public class PSTableMetaData implements IPSConnectionInfo {
   public String[] getAutoUpdateColumns() {
     // may need to aquire this info lazily
     if (m_autoUpdateColumns == null) {
-      m_autoUpdateColumns = new ArrayList();
+      m_autoUpdateColumns = new ArrayList<>();
 
       if (PSSqlHelper.supportsIdentityColumns(m_driver)) {
         ResultSet rs = null;
@@ -307,7 +321,7 @@ public class PSTableMetaData implements IPSConnectionInfo {
     int colIdx = findColumnIndex(columnName);
     if (colIdx < 0) throw new SQLException("no such column " + columnName);
 
-    ColumnInfo info = (ColumnInfo) m_columns.get(colIdx);
+    ColumnInfo info = m_columns.get(colIdx);
     if (info.m_nullable == DatabaseMetaData.columnNoNulls) return false;
     return true;
   }
@@ -323,7 +337,7 @@ public class PSTableMetaData implements IPSConnectionInfo {
   public int columnIndex(String columnName) throws SQLException {
     int colIdx = findColumnIndex(columnName);
     if (colIdx < 0) return -1;
-    ColumnInfo info = (ColumnInfo) m_columns.get(colIdx);
+    ColumnInfo info = m_columns.get(colIdx);
     return info.m_ordinalPosition;
   }
 
@@ -345,7 +359,7 @@ public class PSTableMetaData implements IPSConnectionInfo {
   public short getColumnType(String columnName) throws SQLException {
     if (null == columnName || columnName.trim().length() == 0)
       throw new SQLException("no such column '" + columnName + "'");
-    Integer jdbcType = (Integer) m_dataTypes.get(columnName.toLowerCase());
+    Integer jdbcType = m_dataTypes.get(columnName.toLowerCase());
     if (null == jdbcType) throw new SQLException("no such column " + columnName);
     return (short) jdbcType.intValue();
   }
@@ -360,7 +374,7 @@ public class PSTableMetaData implements IPSConnectionInfo {
   public int getSize(String columnName) throws SQLException {
     int colIdx = findColumnIndex(columnName);
     if (colIdx < 0) throw new SQLException("no such column " + columnName);
-    ColumnInfo info = (ColumnInfo) m_columns.get(colIdx);
+    ColumnInfo info = m_columns.get(colIdx);
     return info.m_size;
   }
 
@@ -374,7 +388,7 @@ public class PSTableMetaData implements IPSConnectionInfo {
   public int getScale(String columnName) throws SQLException {
     int colIdx = findColumnIndex(columnName);
     if (colIdx < 0) throw new SQLException("no such column " + columnName);
-    ColumnInfo info = (ColumnInfo) m_columns.get(colIdx);
+    ColumnInfo info = m_columns.get(colIdx);
     return info.m_fractionalDigits;
   }
 
@@ -387,7 +401,7 @@ public class PSTableMetaData implements IPSConnectionInfo {
   public String getTypeName(String columnName) throws SQLException {
     int colIdx = findColumnIndex(columnName);
     if (colIdx < 0) throw new SQLException("no such column " + columnName);
-    ColumnInfo info = (ColumnInfo) m_columns.get(colIdx);
+    ColumnInfo info = m_columns.get(colIdx);
     return null == info.m_typeName ? "" : info.m_typeName;
   }
 
@@ -420,16 +434,16 @@ public class PSTableMetaData implements IPSConnectionInfo {
    *     java.sql.Types.xxx data type is stored as the value.
    * @throws SQLException if there are any database errors.
    */
-  public Map loadDataTypes(String alias) throws SQLException {
-    Map dtMap = null;
+  public Map<String, Integer> loadDataTypes(String alias) throws SQLException {
+    Map<String, Integer> dtMap = null;
 
     // see if this has already been built
-    dtMap = (Map) m_dataTypeMap.get(alias.toLowerCase());
+    dtMap = m_dataTypeMap.get(alias.toLowerCase());
     if (dtMap != null) return dtMap;
 
     // see if we've already built our base datatype map
     if (m_dataTypes == null) {
-      m_dataTypes = new HashMap();
+      m_dataTypes = new HashMap<>();
       java.sql.Connection conn = null;
       ResultSet rs = null;
       try {
@@ -477,15 +491,13 @@ public class PSTableMetaData implements IPSConnectionInfo {
     }
 
     // need to add in entries with the table alias as part of the key
-    dtMap = new HashMap();
+    dtMap = new HashMap<>();
     m_dataTypeMap.put(alias.toLowerCase(), dtMap);
 
-    Iterator entries = m_dataTypes.entrySet().iterator();
-    while (entries.hasNext()) {
-      Map.Entry entry = (Map.Entry) entries.next();
-      String key = (String) entry.getKey();
-      Integer val = (Integer) entry.getValue();
-      dtMap.put(new String(key), Integer.valueOf(val.intValue()));
+    for (Map.Entry<String, Integer> entry : m_dataTypes.entrySet()) {
+      String key = entry.getKey();
+      Integer val = entry.getValue();
+      dtMap.put(key, Integer.valueOf(val.intValue()));
       dtMap.put(alias.toLowerCase() + "." + key, Integer.valueOf(val.intValue()));
     }
 
@@ -712,7 +724,8 @@ public class PSTableMetaData implements IPSConnectionInfo {
     // we depend upon this already existing (which it should)
     PSDatabaseMetaData psDbMeta = PSOptimizer.getCachedDatabaseMetaData(m_dataSource);
 
-    Map typeMap = psDbMeta.getDataTypeDefinitionMap();
+    // Side-effect: warm back-end type-definition cache used by native type conversion.
+    psDbMeta.getDataTypeDefinitionMap();
 
     ResultSet rs = null;
     try {
@@ -750,7 +763,7 @@ public class PSTableMetaData implements IPSConnectionInfo {
   }
 
   /** Private class to keep track of column information */
-  private class ColumnInfo implements Comparable {
+  private class ColumnInfo implements Comparable<ColumnInfo> {
     public ColumnInfo(
         String name,
         short type,
@@ -811,11 +824,9 @@ public class PSTableMetaData implements IPSConnectionInfo {
           m_ordinalPosition);
     }
 
-    public int compareTo(Object o) {
+    @Override
+    public int compareTo(ColumnInfo other) {
       // Case-insensitive: PG/MySQL return lowercase names; editors request UPPER.
-      if (o instanceof String) return m_name.compareToIgnoreCase((String) o);
-
-      ColumnInfo other = (ColumnInfo) o;
       return m_name.compareToIgnoreCase(other.m_name);
     }
 
@@ -840,20 +851,20 @@ public class PSTableMetaData implements IPSConnectionInfo {
   private String m_dataSource;
 
   // a list (in key order) of the primary key columns
-  private List m_primaryKeyColumns;
+  private List<String> m_primaryKeyColumns;
 
   // the name of this table's primary key
   private String m_primaryKeyName;
 
   // a list of the foreign key columns
-  private List m_foreignKeyColumns;
+  private List<String> m_foreignKeyColumns;
 
   /**
    * a list of the columns which are automatically inserted/updated. <code>
    * null</code> until a call to {@link #getAutoUpdateColumns()} or {@link
    * #loadColumnInformation(DatabaseMetaData)} is made.
    */
-  private List m_autoUpdateColumns = null;
+  private List<String> m_autoUpdateColumns = null;
 
   // the table statistics for this table
   private PSTableStatistics m_tableStats;
@@ -862,7 +873,7 @@ public class PSTableMetaData implements IPSConnectionInfo {
   private PSIndexStatistics[] m_indexStats;
 
   // a list (in column name order) of ColumnInfo objects
-  private List m_columns;
+  private List<ColumnInfo> m_columns;
 
   // a SQL style pattern matcher
   private PSPatternMatcher m_patMat;
@@ -872,13 +883,13 @@ public class PSTableMetaData implements IPSConnectionInfo {
    * the first call to {@link #loadDataTypes(String)}, never <code>null</code> or modified after
    * that.
    */
-  private Map m_dataTypes = null;
+  private Map<String, Integer> m_dataTypes = null;
 
   /**
    * Map of datatype maps based on table alias as the key and the datatype map as the value. Never
    * <code>null</code>, entries are added by calls to {@link #loadDataTypes(String)}.
    */
-  private Map m_dataTypeMap = new HashMap();
+  private Map<String, Map<String, Integer>> m_dataTypeMap = new HashMap<>();
 
   /* (non-Javadoc)
    * @see com.percussion.util.jdbc.IPSConnectionInfo#getDataSource()

--- a/system/src/main/java/com/percussion/data/jdbc/PSDsnReader.java
+++ b/system/src/main/java/com/percussion/data/jdbc/PSDsnReader.java
@@ -78,23 +78,15 @@ public class PSDsnReader {
     File inputOdbcIniFile = new File(m_odbcIni);
     if (!inputOdbcIniFile.canRead()) return null;
 
-    BufferedReader iniReader = null;
-
-    try {
-      iniReader = new BufferedReader(new FileReader(inputOdbcIniFile));
-    } catch (FileNotFoundException e) {
-      // Do nothing here, this file should be available.
-      return null;
-    }
-
     /* We have a file we can read, so find the DSNs */
-    ArrayList dsnList = new ArrayList();
+    ArrayList<String> dsnList = new ArrayList<>();
 
     String line = "";
 
     boolean processingDsnArea = false;
 
-    try {
+    try (BufferedReader iniReader =
+        new BufferedReader(new FileReader(inputOdbcIniFile))) {
       /* Process Line by line */
       while (line != null) {
         String nextDsn = null;
@@ -119,17 +111,16 @@ public class PSDsnReader {
           if (nextDsn != null) dsnList.add(nextDsn);
         }
       }
+    } catch (FileNotFoundException e) {
+      // Do nothing here, this file should be available.
+      return null;
     } catch (IOException e) {
       /* stop here  -- something has gone wrong, but return any
       DSNs we've located (don't return error) */
     }
 
     if (dsnList.size() > 0) {
-      String[] retArray = new String[dsnList.size()];
-
-      for (int i = 0; i < dsnList.size(); i++) retArray[i] = (String) dsnList.get(i);
-
-      return retArray;
+      return dsnList.toArray(new String[dsnList.size()]);
     }
 
     return null;

--- a/system/src/test/java/com/percussion/data/PSDatabaseMetaDataTypeMapTest.java
+++ b/system/src/test/java/com/percussion/data/PSDatabaseMetaDataTypeMapTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.Types;
+import java.util.HashMap;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral coverage for typed data-type maps on {@link PSDatabaseMetaData} (rawtypes cleanup
+ * slice #2298).
+ */
+@Tag("UnitTest")
+class PSDatabaseMetaDataTypeMapTest {
+
+  @Test
+  void guessNativeDataTypeConversionReturnsInputWhenUnmapped() {
+    // Unmapped native types pass through unchanged (map may contain prior entries from other tests)
+    short nativeType = (short) 32000;
+    assertEquals(nativeType, PSDatabaseMetaData.guessNativeDataTypeConversion(nativeType));
+  }
+
+  @Test
+  void loadNativeDataTypeMapBuildsTypedMapFromDriverTypeInfo() throws Exception {
+    Connection conn = mock(Connection.class);
+    DatabaseMetaData meta = mock(DatabaseMetaData.class);
+    ResultSet rs = mock(ResultSet.class);
+
+    when(meta.getURL()).thenReturn("jdbc:jtds:sqlserver://localhost/rx");
+    when(meta.getDatabaseProductName()).thenReturn("PSDatabaseMetaDataTypeMapTest-DB");
+    when(meta.getTypeInfo()).thenReturn(rs);
+    when(rs.next()).thenReturn(true, true, false);
+    when(rs.getString(1)).thenReturn("varchar", "integer");
+    when(rs.getShort(2)).thenReturn((short) Types.VARCHAR, (short) Types.INTEGER);
+
+    HashMap<String, Short> map = PSDatabaseMetaData.loadNativeDataTypeMap(conn, meta);
+    assertNotNull(map);
+    assertTrue(map.containsKey("varchar"));
+    assertTrue(map.containsKey("integer"));
+    assertEquals(Types.VARCHAR, map.get("varchar").intValue());
+    assertEquals(Types.INTEGER, map.get("integer").intValue());
+
+    // Second call returns the cached map for the same product name
+    HashMap<String, Short> again = PSDatabaseMetaData.loadNativeDataTypeMap(conn, meta);
+    assertSame(map, again);
+  }
+
+  @Test
+  void loadNativeDataTypeMapRejectsNullArgs() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSDatabaseMetaData.loadNativeDataTypeMap(null, mock(DatabaseMetaData.class)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSDatabaseMetaData.loadNativeDataTypeMap(mock(Connection.class), null));
+  }
+
+  @Test
+  void getTablesFiltersByCatalogAndTypeAgainstTypedList() throws Exception {
+    PSDatabaseMetaData meta = new PSDatabaseMetaData("testDs");
+    // m_tables stays empty after ctor — getTables returns empty array, not null
+    String[] tables = meta.getTables("catalog", null, "%", new String[] {"TABLE"});
+    assertNotNull(tables);
+    assertEquals(0, tables.length);
+  }
+}

--- a/system/src/test/java/com/percussion/data/PSTableMetaDataIdentifierFoldTest.java
+++ b/system/src/test/java/com/percussion/data/PSTableMetaDataIdentifierFoldTest.java
@@ -66,36 +66,41 @@ class PSTableMetaDataIdentifierFoldTest {
   }
 
   /**
-   * ColumnInfo.compareTo is case-insensitive so binarySearch finds COMMUNITYID when the driver
-   * returned communityid.
+   * Case-insensitive column lookup (same algorithm as {@code PSTableMetaData#findColumnIndex}) so
+   * COMMUNITYID is found when the driver returned communityid.
    */
   @Test
   void columnBinarySearchIsCaseInsensitive() {
-    List<StringComparableColumn> cols = new ArrayList<>();
-    cols.add(new StringComparableColumn("communityid"));
-    cols.add(new StringComparableColumn("contentid"));
-    cols.add(new StringComparableColumn("locale"));
-    Collections.sort(cols);
+    List<String> cols = new ArrayList<>();
+    cols.add("communityid");
+    cols.add("contentid");
+    cols.add("locale");
+    Collections.sort(cols, String.CASE_INSENSITIVE_ORDER);
 
-    assertTrue(Collections.binarySearch(cols, "COMMUNITYID") >= 0);
-    assertTrue(Collections.binarySearch(cols, "ContentId") >= 0);
-    assertTrue(Collections.binarySearch(cols, "missing") < 0);
+    assertTrue(findColumnIndex(cols, "COMMUNITYID") >= 0);
+    assertTrue(findColumnIndex(cols, "ContentId") >= 0);
+    assertTrue(findColumnIndex(cols, "missing") < 0);
+    assertEquals(-1, findColumnIndex(cols, null));
   }
 
-  /** Mirrors {@link PSTableMetaData.ColumnInfo#compareTo} case-insensitive contract. */
-  private static final class StringComparableColumn implements Comparable<Object> {
-    private final String name;
-
-    StringComparableColumn(String name) {
-      this.name = name;
+  /** Mirrors package-private {@code PSTableMetaData#findColumnIndex} for unit isolation. */
+  private static int findColumnIndex(List<String> columns, String columnName) {
+    if (columnName == null) {
+      return -1;
     }
-
-    @Override
-    public int compareTo(Object o) {
-      if (o instanceof String) {
-        return name.compareToIgnoreCase((String) o);
+    int low = 0;
+    int high = columns.size() - 1;
+    while (low <= high) {
+      int mid = (low + high) >>> 1;
+      int cmp = columns.get(mid).compareToIgnoreCase(columnName);
+      if (cmp < 0) {
+        low = mid + 1;
+      } else if (cmp > 0) {
+        high = mid - 1;
+      } else {
+        return mid;
       }
-      return name.compareToIgnoreCase(((StringComparableColumn) o).name);
     }
+    return -(low + 1);
   }
 }

--- a/system/src/test/java/com/percussion/data/jdbc/PSDsnReaderTest.java
+++ b/system/src/test/java/com/percussion/data/jdbc/PSDsnReaderTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.data.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Unit tests for {@link PSDsnReader} (typed DSN list parsing). */
+@Tag("UnitTest")
+class PSDsnReaderTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void returnsNullWhenPathMissing() {
+    assertNull(new PSDsnReader(null).getDsnList());
+    assertNull(new PSDsnReader("").getDsnList());
+    assertNull(new PSDsnReader(tempDir.resolve("no-such.ini").toString()).getDsnList());
+  }
+
+  @Test
+  void parsesUserAndSystemDsnSections() throws Exception {
+    Path ini = tempDir.resolve("odbc.ini");
+    String content =
+        String.join(
+            "\n",
+            "[ODBC Data Sources]",
+            "AppDb=PostgreSQL",
+            "Archive=MySQL",
+            "",
+            "[AppDb]",
+            "Driver=/usr/lib/libpsqlodbc.so",
+            "",
+            "[ODBC System Data Sources]",
+            "SystemRx=Oracle",
+            "",
+            "[SystemRx]",
+            "Driver=/usr/lib/libsqora.so",
+            "");
+    Files.writeString(ini, content, StandardCharsets.UTF_8);
+
+    String[] dsns = new PSDsnReader(ini.toString()).getDsnList();
+    assertArrayEquals(new String[] {"AppDb", "Archive", "SystemRx"}, dsns);
+  }
+
+  @Test
+  void ignoresMalformedLinesInDsnSection() throws Exception {
+    Path ini = tempDir.resolve("odbc.ini");
+    String content =
+        String.join(
+            "\n",
+            "[ODBC Data Sources]",
+            "Good=Driver",
+            "NoEqualsHere",
+            "=emptyName",
+            "AlsoGood=Other",
+            "");
+    Files.writeString(ini, content, StandardCharsets.UTF_8);
+
+    String[] dsns = new PSDsnReader(ini.toString()).getDsnList();
+    assertArrayEquals(new String[] {"Good", "AlsoGood"}, dsns);
+  }
+}


### PR DESCRIPTION
## Summary

Slice 4 of parent **#2022** (grandparent **#2200**): real generics for rawtypes/unchecked in `com.percussion.data` + `data.jdbc` (metadata batch).

### Changes
- **`PSDatabaseMetaData`** — `List<ShortTableInfo>`, `Map<String,PSTableMetaData>`, `Map<String,PSDataTypeInfo>`, `HashMap<Short,Short>`, `HashSet<String>`; typed iterators; `Comparable<ShortTableInfo>`
- **`PSTableMetaData`** — typed column/PK/FK/auto-update lists; `Map<String,Integer>` / nested alias maps; `loadDataTypes` → `Map<String,Integer>`; package-private `findColumnIndex` (case-insensitive binary search without raw `Comparable`)
- **`PSMetaDataCache`** — `Iterator<?>` for table refs
- **`PSDsnReader`** — `ArrayList<String>` + try-with-resources (closes reader on Windows)
- **Tests** — `PSDatabaseMetaDataTypeMapTest`, `PSDsnReaderTest`, fold-test update for findColumnIndex contract
- **Erlang** — approve (`docs/ai-generated/code-reviews/issue-2298-data-jdbc-rawtypes-erlang.md`)

### Before / after (raw declaration sites on touched production files; approximate)
| File | Before | After |
| --- | ---: | ---: |
| `PSDatabaseMetaData.java` | **20** | **0** |
| `PSTableMetaData.java` | **32** | **0** |
| `PSMetaDataCache.java` | **~1** raw Iterator | **0** |
| `PSDsnReader.java` | **2** | **0** |
| **Batch total** | **~55** | **0** |

Package residual: `data` / `data.jdbc` still have large rawtypes inventory (optimizers, SQL builders, `PSFileSystemDatabaseMetaData`, `PSErrorCollector`, …). Follow-up residual issue filed under **#2022**. Leave **#2299** for monorepo catch-all outside these packages.

### Out of scope (per #2298)
- design/cms objectstore (#2295–#2297)
- security/server/HTTPClient (#2299)
- Broad deprecation re-enable

## Test plan
- [x] `cd system` → `../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Module tests: **1137** run, **0** failures, **0** errors (237 skipped pre-existing)
- [x] Focused: type-map / DSN / fold-index tests green
- [x] Touched production files: **0** residual rawtypes/unchecked on compile log
- [x] Erlang self-review: approve

## Gates evidence
| Gate | Result |
| --- | --- |
| Standalone module clean install (`cd system`) | BUILD SUCCESS |
| Behavioral unit tests | green |
| Scope confined to data metadata + jdbc DSN + tests | yes |
| Erlang | approve |

Parent tracker: #2022  
Grandparent: #2200  

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2298  
Refs #2022 #2200

> Co-Authored by Grok Build using grok-4.5 with agent main.