### PR TITLE
fix(install): pure-Java stripSampleLocales without Nashorn (#2303)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2303-strip-sample-locales-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2303-strip-sample-locales-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review: issue #2303 strip sample locales (pure Java)
+
+**Branch:** `fix/issue-2303-strip-sample-locales-java`  
+**Scope:** uncommitted changes for #2303  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** installer/Ant companion tasks; no Nashorn/javax.script on Java 15+; portable Path/UTF-8 I/O
+
+## Summary
+
+Install-blocking bug: ANT `stripSampleLocales` used `<script language="javascript">` (Nashorn via javax.script), removed in Java 15+. Fix promotes the existing Java mirror into production helpers and wires install via perc-ant Ant task `PSStripSampleLocales` (always on install classpath). Distribution-tree helper `SampleSiteLocaleStrip` keeps the same algorithm for CI/CLI.
+
+## Cross-platform path checklist
+
+- Uses `java.nio.file.Path` / `Files` only (no hardcoded separators).
+- UTF-8 read/write for XML seed files.
+- No Windows-only assumptions in tests (`Path.of`, temp dir).
+
+## Issues
+
+None blocking.
+
+### Note (non-blocking)
+
+Algorithm is intentionally duplicated in `SampleSiteLocaleStrip` (perc-distribution-tree) and `PSStripSampleLocales` (perc-ant) because perc-ant cannot depend on perc-distribution-tree. Both have unit tests with the same fixture shape; install XML wiring test asserts no javascript remains.
+
+## Tests
+
+- `perc-ant`: `PSStripSampleLocalesTest` (3), `AntlibTaskRegistrationTest` (2) — green
+- `perc-distribution-tree`: `SampleSiteLocaleStripTest` (5) — green
+- Module `mvnw clean install`: perc-ant BUILD SUCCESS; perc-distribution-tree BUILD SUCCESS
+
+## Re-review
+
+N/A (initial approve).

--- a/modules/perc-ant/src/main/java/com/percussion/ant/install/PSStripSampleLocales.java
+++ b/modules/perc-ant/src/main/java/com/percussion/ant/install/PSStripSampleLocales.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.ant.install;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Task;
+
+/**
+ * ANT task that strips {@code RXLOCALE} / {@code RXLOCALEFORMAT} table blocks from demo-site seed
+ * XML into a staging file (issue #2303).
+ *
+ * <p>Replaces the Nashorn / {@code javax.script} javascript block formerly embedded in {@code
+ * installRepository.xml / stripSampleLocales}. Algorithm is identical to {@code
+ * com.percussion.distribution.install.SampleSiteLocaleStrip} so CI unit tests and install-time
+ * strip stay in lockstep (same regex + marker drop).
+ *
+ * <pre>{@code
+ * <PSStripSampleLocales
+ *     inputFile="${data.dir}/RxffTableData.xml"
+ *     stagingFile="${data.dir}/RxffTableData.staging.xml"/>
+ * }</pre>
+ *
+ * <p>Portable paths only ({@link Path#of(String, String...)}); UTF-8 read/write.
+ */
+public class PSStripSampleLocales extends Task {
+
+  /**
+   * Case-insensitive match for a {@code <table name="RXLOCALE…"} opening tag, with optional
+   * whitespace and attribute quoting variants. Intentionally stops at the closing quote of the name
+   * value so {@code RXLOCALEFORMAT} is not matched by the {@code RXLOCALE} pattern.
+   */
+  static final Pattern RXLOCALE_OPEN_TAG =
+      Pattern.compile("<table\\s+name\\s*=\\s*[\"']RXLOCALE[\"']", Pattern.CASE_INSENSITIVE);
+
+  static final Pattern RXLOCALEFORMAT_OPEN_TAG =
+      Pattern.compile("<table\\s+name\\s*=\\s*[\"']RXLOCALEFORMAT[\"']", Pattern.CASE_INSENSITIVE);
+
+  private static final String MARKER = "__STRIPPED__";
+
+  private String inputFile;
+  private String stagingFile;
+
+  /** Creates the strip task. */
+  public PSStripSampleLocales() {}
+
+  /**
+   * @param inputFile path to the shipped sample seed XML (never modified)
+   */
+  public void setInputFile(String inputFile) {
+    this.inputFile = inputFile;
+  }
+
+  /**
+   * @return input file path
+   */
+  public String getInputFile() {
+    return inputFile;
+  }
+
+  /**
+   * @param stagingFile path for the stripped staging copy written for {@code PSTableAction}
+   */
+  public void setStagingFile(String stagingFile) {
+    this.stagingFile = stagingFile;
+  }
+
+  /**
+   * @return staging output path
+   */
+  public String getStagingFile() {
+    return stagingFile;
+  }
+
+  /**
+   * Remove any {@code RXLOCALE} / {@code RXLOCALEFORMAT} table blocks from sample seed XML.
+   *
+   * <p>Package-visible static entry so unit tests (and the distribution-tree mirror) exercise the
+   * same algorithm the install path runs.
+   *
+   * @param xml full document text; never null
+   * @return stripped document text
+   */
+  public static String stripLocaleBlocks(String xml) {
+    Objects.requireNonNull(xml, "xml");
+    String rxLocale = RXLOCALE_OPEN_TAG.matcher(xml).replaceAll(MARKER);
+    String rxLocaleFormat = RXLOCALEFORMAT_OPEN_TAG.matcher(rxLocale).replaceAll(MARKER);
+    return dropBlocksUntilClose(rxLocaleFormat, MARKER);
+  }
+
+  /**
+   * Read {@code input} as UTF-8, strip locale blocks, write UTF-8 to {@code staging}.
+   *
+   * @param input source seed XML
+   * @param staging staging output (parent dirs created when missing)
+   * @throws IOException on I/O failure
+   */
+  public static void stripFile(Path input, Path staging) throws IOException {
+    Objects.requireNonNull(input, "input");
+    Objects.requireNonNull(staging, "staging");
+    String xml = Files.readString(input, StandardCharsets.UTF_8);
+    String stripped = stripLocaleBlocks(xml);
+    Path parent = staging.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    Files.writeString(staging, stripped, StandardCharsets.UTF_8);
+  }
+
+  @Override
+  public void execute() throws BuildException {
+    if (inputFile == null || inputFile.isBlank()) {
+      throw new BuildException("PSStripSampleLocales: inputFile is required");
+    }
+    if (stagingFile == null || stagingFile.isBlank()) {
+      throw new BuildException("PSStripSampleLocales: stagingFile is required");
+    }
+    Path input = Path.of(inputFile);
+    Path staging = Path.of(stagingFile);
+    if (!Files.isRegularFile(input)) {
+      throw new BuildException("PSStripSampleLocales: input file not found: " + input);
+    }
+    try {
+      stripFile(input, staging);
+      log("stripSampleLocales: wrote stripped copy to " + staging);
+    } catch (IOException e) {
+      throw new BuildException("PSStripSampleLocales failed: " + e.getMessage(), e);
+    }
+  }
+
+  private static String dropBlocksUntilClose(String xml, String marker) {
+    StringBuilder out = new StringBuilder();
+    int cursor = 0;
+    while (true) {
+      int markerStart = xml.indexOf(marker, cursor);
+      if (markerStart < 0) {
+        out.append(xml, cursor, xml.length());
+        return out.toString();
+      }
+      out.append(xml, cursor, markerStart);
+      int closeStart = xml.indexOf("</table>", markerStart);
+      if (closeStart < 0) {
+        out.append(xml, markerStart, xml.length());
+        return out.toString();
+      }
+      cursor = closeStart + "</table>".length();
+    }
+  }
+}

--- a/modules/perc-ant/src/main/resources/com/percussion/ant/antlib.xml
+++ b/modules/perc-ant/src/main/resources/com/percussion/ant/antlib.xml
@@ -171,6 +171,10 @@
 	<!-- #1547 one-time i18n locale code rewrite (sys_lang + CONTENTSTATUS.LOCALE) -->
 	<taskdef name="PSMigrateI18nLocaleCodes"
 		classname="com.percussion.ant.install.PSMigrateI18nLocaleCodes" />
+	<!-- #2303 pure-Java strip of RXLOCALE/RXLOCALEFORMAT from demo-site seed XML
+		(replaces Nashorn javax.script javascript in installRepository.xml). -->
+	<taskdef name="PSStripSampleLocales"
+		classname="com.percussion.ant.install.PSStripSampleLocales" />
 	<taskdef name="PSUpgradeEncryption"
 		classname="com.percussion.ant.install.PSUpgradeEncryption" />
 	<taskdef name="PSUpgradeSiteConfig"

--- a/modules/perc-ant/src/test/java/com/percussion/ant/AntlibTaskRegistrationTest.java
+++ b/modules/perc-ant/src/test/java/com/percussion/ant/AntlibTaskRegistrationTest.java
@@ -49,4 +49,19 @@ public class AntlibTaskRegistrationTest {
         xml.contains("com.percussion.ant.install.PSGenerateRepositoryPassword"),
         "antlib classname must match install package");
   }
+
+  @Test
+  void antlibRegistersStripSampleLocales() throws Exception {
+    String xml;
+    try (InputStream in = getClass().getClassLoader().getResourceAsStream(ANTLIB)) {
+      assertNotNull(in, "classpath must contain " + ANTLIB);
+      xml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+    assertTrue(
+        xml.contains("name=\"PSStripSampleLocales\""),
+        "antlib must register PSStripSampleLocales for demo-site seed strip (#2303)");
+    assertTrue(
+        xml.contains("com.percussion.ant.install.PSStripSampleLocales"),
+        "antlib classname must match install package");
+  }
 }

--- a/modules/perc-ant/src/test/java/com/percussion/ant/install/PSStripSampleLocalesTest.java
+++ b/modules/perc-ant/src/test/java/com/percussion/ant/install/PSStripSampleLocalesTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.ant.install;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Behavioral tests for {@link PSStripSampleLocales} (issue #2303). Algorithm must match {@code
+ * com.percussion.distribution.install.SampleSiteLocaleStrip}.
+ */
+@Tag("UnitTest")
+public class PSStripSampleLocalesTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void stripLocaleBlocksRemovesLocaleTablesKeepsOthers() {
+    String input =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            + "<tables>\n"
+            + "  <table name=\"CONTENTSTATUS\"><row><c>X</c></row></table>\n"
+            + "  <table name=\"RXLOCALE\"><row><c>en-us</c></row></table>\n"
+            + "  <table name=\"RXSITES\"><row><c>EI</c></row></table>\n"
+            + "  <table name=\"RXLOCALEFORMAT\"><row><c>en-us</c><c>USD</c></row></table>\n"
+            + "</tables>\n";
+
+    String stripped = PSStripSampleLocales.stripLocaleBlocks(input);
+
+    assertFalse(stripped.toUpperCase().contains("NAME=\"RXLOCALE\""));
+    assertFalse(stripped.toUpperCase().contains("NAME=\"RXLOCALEFORMAT\""));
+    assertTrue(stripped.contains("CONTENTSTATUS"));
+    assertTrue(stripped.contains("RXSITES"));
+  }
+
+  @Test
+  void taskWritesStagingFileWithoutModifyingSource() throws Exception {
+    Path input = tempDir.resolve("RxffTableData.xml");
+    Path staging = tempDir.resolve("RxffTableData.staging.xml");
+    String body =
+        "<tables>\n"
+            + "  <table name=\"RXLOCALE\"><row><c>en-us</c></row></table>\n"
+            + "  <table name=\"RXSITES\"><row><c>CI</c></row></table>\n"
+            + "</tables>\n";
+    Files.writeString(input, body, StandardCharsets.UTF_8);
+
+    Project project = new Project();
+    PSStripSampleLocales task = new PSStripSampleLocales();
+    task.setProject(project);
+    task.setInputFile(input.toString());
+    task.setStagingFile(staging.toString());
+    task.execute();
+
+    assertTrue(Files.isRegularFile(staging));
+    String staged = Files.readString(staging, StandardCharsets.UTF_8);
+    assertFalse(staged.toUpperCase().contains("NAME=\"RXLOCALE\""));
+    assertTrue(staged.contains("RXSITES"));
+    // Source unchanged.
+    assertTrue(Files.readString(input, StandardCharsets.UTF_8).contains("RXLOCALE"));
+  }
+
+  @Test
+  void taskFailsWhenInputMissing() {
+    Project project = new Project();
+    PSStripSampleLocales task = new PSStripSampleLocales();
+    task.setProject(project);
+    task.setInputFile(tempDir.resolve("missing.xml").toString());
+    task.setStagingFile(tempDir.resolve("out.xml").toString());
+    assertThrows(BuildException.class, task::execute);
+  }
+}

--- a/modules/perc-distribution-tree/src/main/java/com/percussion/distribution/install/SampleSiteLocaleStrip.java
+++ b/modules/perc-distribution-tree/src/main/java/com/percussion/distribution/install/SampleSiteLocaleStrip.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.distribution.install;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Pure-Java strip of {@code RXLOCALE} / {@code RXLOCALEFORMAT} table blocks from demo-site seed
+ * XML.
+ *
+ * <p>Replaces the former ANT {@code <script language="javascript">} block in {@code
+ * installRepository.xml / stripSampleLocales}, which failed on Java 15+ after Nashorn removal
+ * ({@code Unable to create javax script engine for javascript}) — issue #2303.
+ *
+ * <p>Install-time entry is the ANT task {@code PSStripSampleLocales} (same algorithm, registered in
+ * perc-ant antlib). This class is the shared production algorithm exercised by unit tests and
+ * available as a forked CLI when needed.
+ */
+public final class SampleSiteLocaleStrip {
+
+  /**
+   * Case-insensitive match for a {@code <table name="RXLOCALE…"} opening tag, with optional
+   * whitespace and attribute quoting variants. Intentionally stops at the closing quote of the name
+   * value so {@code RXLOCALEFORMAT} is not matched by the {@code RXLOCALE} pattern.
+   */
+  static final Pattern RXLOCALE_OPEN_TAG =
+      Pattern.compile("<table\\s+name\\s*=\\s*[\"']RXLOCALE[\"']", Pattern.CASE_INSENSITIVE);
+
+  static final Pattern RXLOCALEFORMAT_OPEN_TAG =
+      Pattern.compile("<table\\s+name\\s*=\\s*[\"']RXLOCALEFORMAT[\"']", Pattern.CASE_INSENSITIVE);
+
+  private static final String MARKER = "__STRIPPED__";
+
+  private SampleSiteLocaleStrip() {}
+
+  /**
+   * Remove any {@code RXLOCALE} / {@code RXLOCALEFORMAT} table blocks from sample seed XML.
+   *
+   * @param xml full document text; never null
+   * @return stripped document text
+   */
+  public static String stripLocaleBlocks(String xml) {
+    Objects.requireNonNull(xml, "xml");
+    String rxLocale = RXLOCALE_OPEN_TAG.matcher(xml).replaceAll(MARKER);
+    String rxLocaleFormat = RXLOCALEFORMAT_OPEN_TAG.matcher(rxLocale).replaceAll(MARKER);
+    return dropBlocksUntilClose(rxLocaleFormat, MARKER);
+  }
+
+  /**
+   * Read {@code input} as UTF-8, strip locale blocks, write UTF-8 to {@code staging}. Parent
+   * directories of {@code staging} are created when missing. Source file is never modified.
+   *
+   * @param input path to {@code RxffTableData.xml} (or equivalent)
+   * @param staging path for the stripped staging copy
+   * @throws IOException if read/write fails
+   */
+  public static void stripFile(Path input, Path staging) throws IOException {
+    Objects.requireNonNull(input, "input");
+    Objects.requireNonNull(staging, "staging");
+    String xml = Files.readString(input, StandardCharsets.UTF_8);
+    String stripped = stripLocaleBlocks(xml);
+    Path parent = staging.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    Files.writeString(staging, stripped, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * CLI entry: {@code SampleSiteLocaleStrip <input.xml> <staging.xml>}. Uses {@link
+   * BuildGateMains#complete(int, String)} so in-process Maven invocations do not {@code
+   * System.exit}.
+   *
+   * @param args input path, staging path
+   */
+  public static void main(String[] args) {
+    BuildGateMains.complete(run(args), "SampleSiteLocaleStrip");
+  }
+
+  /**
+   * Gate-style run returning a process exit code without calling {@link System#exit}.
+   *
+   * @param args CLI args
+   * @return {@code 0} on success; non-zero on usage or I/O failure
+   */
+  static int run(String[] args) {
+    if (args == null || args.length != 2) {
+      System.err.println(
+          "Usage: SampleSiteLocaleStrip <input-RxffTableData.xml> <staging-output.xml>");
+      return 1;
+    }
+    try {
+      stripFile(Path.of(args[0]), Path.of(args[1]));
+      return 0;
+    } catch (IOException e) {
+      System.err.println("SampleSiteLocaleStrip failed: " + e.getMessage());
+      return 2;
+    }
+  }
+
+  private static String dropBlocksUntilClose(String xml, String marker) {
+    StringBuilder out = new StringBuilder();
+    int cursor = 0;
+    while (true) {
+      int markerStart = xml.indexOf(marker, cursor);
+      if (markerStart < 0) {
+        out.append(xml, cursor, xml.length());
+        return out.toString();
+      }
+      // Emit everything before the marker.
+      out.append(xml, cursor, markerStart);
+      int closeStart = xml.indexOf("</table>", markerStart);
+      if (closeStart < 0) {
+        // Malformed; keep the rest verbatim so callers fail loudly on residual markers/tags.
+        out.append(xml, markerStart, xml.length());
+        return out.toString();
+      }
+      int afterClose = closeStart + "</table>".length();
+      cursor = afterClose;
+    }
+  }
+}

--- a/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml
+++ b/modules/perc-distribution-tree/src/main/resources/distribution/rxconfig/Installer/installRepository.xml
@@ -720,40 +720,17 @@
 		<echo>Sample sites seeded.</echo>
 	</target>
 
+	<!-- Nested ant does not inherit parent taskdefs; re-register from perc-ant
+		(same pattern as migration_i18n_locales.xml). Pure Java strip: no Nashorn /
+		javax.script (issue 2303). Algorithm lockstep with
+		com.percussion.distribution.install.SampleSiteLocaleStrip. -->
+	<taskdef name="PSStripSampleLocales"
+		classname="com.percussion.ant.install.PSStripSampleLocales" />
+
 	<target name="stripSampleLocales"
 		description="Strip RXLOCALE and RXLOCALEFORMAT table blocks from the sample seed XML to a staging copy. Source file is never modified.">
-		<loadfile property="sample.input.contents"
-			srcFile="${sample.input.file}" encoding="UTF-8" />
-		<script language="javascript"><![CDATA[
-			// Mirror of SampleSiteLocaleStripTest.stripLocaleBlocks in the Java test
-			// harness. Keep both in sync so a regex drift fails both the unit test
-			// and the install-time strip.
-			var xml = project.getProperty("sample.input.contents");
-			var stripped = xml;
-			// 1. Replace opening tag with a marker, capturing the table name token.
-			stripped = stripped.replace(
-				/<table\s+name\s*=\s*(['"])RXLOCALE\1[^>]*>/gi,
-				"__STRIPPED_DEMO_SAMPLE__");
-			stripped = stripped.replace(
-				/<table\s+name\s*=\s*(['"])RXLOCALEFORMAT\1[^>]*>/gi,
-				"__STRIPPED_DEMO_SAMPLE__");
-			// 2. Delete everything from the marker to the next </table> closing tag.
-			var marker = "__STRIPPED_DEMO_SAMPLE__";
-			var out = "";
-			var cursor = 0;
-			while (true) {
-				var idx = stripped.indexOf(marker, cursor);
-				if (idx < 0) { out += stripped.substring(cursor); break; }
-				out += stripped.substring(cursor, idx);
-				var close = stripped.indexOf("</table>", idx);
-				if (close < 0) { out += stripped.substring(idx); break; }
-				cursor = close + "</table>".length;
-			}
-			project.setProperty("sample.stripped.contents", out);
-		]]></script>
-		<echo file="${sample.staging.file}" encoding="UTF-8">${sample.stripped.contents}</echo>
-		<echo>stripSampleLocales: wrote stripped copy to
-			${sample.staging.file}</echo>
+		<PSStripSampleLocales inputFile="${sample.input.file}"
+			stagingFile="${sample.staging.file}" />
 	</target>
 
 </project>

--- a/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/SampleSiteLocaleStripTest.java
+++ b/modules/perc-distribution-tree/src/test/java/com/percussion/distribution/install/SampleSiteLocaleStripTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
@@ -39,15 +38,18 @@ import org.xml.sax.SAXException;
  * locale-row blocks. The sample installer must never overwrite the operator's {@code RXLOCALE} /
  * {@code RXLOCALEFORMAT} rows when {@code --demo-sites} is enabled.
  *
- * <p>The ANT installer already strips these tables defensively at run time ({@code
- * installRepository.xml / stripSampleLocales}); this test asserts that the source file shipped by
- * the build is also clean so a future careless edit cannot reintroduce the bug.
+ * <p>Install-time strip is pure Java ({@link SampleSiteLocaleStrip} / ANT {@code
+ * PSStripSampleLocales}) — no Nashorn / {@code javax.script} (issue #2303). This test exercises the
+ * production helper so CI and install stay in sync.
  */
 @Tag("UnitTest")
 class SampleSiteLocaleStripTest {
 
   private static final Path SAMPLE_DATA =
       Path.of("src/main/resources/distribution/rxconfig/Installer/data/RxffTableData.xml");
+
+  private static final Path INSTALL_REPOSITORY_XML =
+      Path.of("src/main/resources/distribution/rxconfig/Installer/installRepository.xml");
 
   /**
    * Case-insensitive match for a {@code <table name="RXLOCALE…"} opening tag, with optional
@@ -90,8 +92,9 @@ class SampleSiteLocaleStripTest {
   }
 
   @Test
-  void stripScratchHelperRemovesLocaleBlocks(@TempDir Path tempDir) throws IOException {
+  void productionHelperRemovesLocaleBlocks(@TempDir Path tempDir) throws IOException {
     Path sample = tempDir.resolve("RxffTableData.xml");
+    Path staging = tempDir.resolve("RxffTableData.staging.xml");
     String input =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
             + "<tables>\n"
@@ -102,8 +105,8 @@ class SampleSiteLocaleStripTest {
             + "</tables>\n";
     Files.writeString(sample, input, StandardCharsets.UTF_8);
 
-    // Mirror the regex used by the ANT installer to strip locale blocks defensively.
-    String stripped = stripLocaleBlocks(Files.readString(sample, StandardCharsets.UTF_8));
+    String stripped = SampleSiteLocaleStrip.stripLocaleBlocks(Files.readString(sample, StandardCharsets.UTF_8));
+    SampleSiteLocaleStrip.stripFile(sample, staging);
 
     assertFalse(
         RXLOCALE_OPEN_TAG.matcher(stripped).find(),
@@ -117,48 +120,44 @@ class SampleSiteLocaleStripTest {
     assertTrue(
         stripped.contains("RXSITES"),
         "non-locale tables must survive stripping; was:\n" + stripped);
-  }
 
-  /**
-   * Mirror of the ANT inline regex used by {@code installRepository.xml / stripSampleLocales}. The
-   * Java test exists here so the regex is exercised in CI; the ANT script keeps the same shape so
-   * any drift fails both the Java build and the install path.
-   */
-  static String stripLocaleBlocks(String xml) {
-    String rxLocale = RXLOCALE_OPEN_TAG.matcher(xml).replaceAll("__STRIPPED__");
-    String rxLocaleFormat = RXLOCALEFORMAT_OPEN_TAG.matcher(rxLocale).replaceAll("__STRIPPED__");
-    // Find the matching closer {@code </table>} and drop everything between (inclusive).
-    return dropBlocksUntilClose(rxLocaleFormat, "__STRIPPED__");
-  }
-
-  private static String dropBlocksUntilClose(String xml, String marker) {
-    StringBuilder out = new StringBuilder();
-    int cursor = 0;
-    while (true) {
-      int markerStart = xml.indexOf(marker, cursor);
-      if (markerStart < 0) {
-        out.append(xml, cursor, xml.length());
-        return out.toString();
-      }
-      // Emit everything before the marker.
-      out.append(xml, cursor, markerStart);
-      int blockStart = xml.lastIndexOf("<table", markerStart);
-      int closeStart = xml.indexOf("</table>", markerStart);
-      if (closeStart < 0) {
-        // Malformed; keep the rest verbatim so the test fails loudly.
-        out.append(xml, markerStart, xml.length());
-        return out.toString();
-      }
-      int afterClose = closeStart + "</table>".length();
-      cursor = afterClose;
-    }
+    String staged = Files.readString(staging, StandardCharsets.UTF_8);
+    assertFalse(RXLOCALE_OPEN_TAG.matcher(staged).find());
+    assertFalse(RXLOCALEFORMAT_OPEN_TAG.matcher(staged).find());
+    assertTrue(staged.contains("RXSITES"));
   }
 
   @Test
-  void twoArgCompatRemainsAvailable() {
-    // Pin the parsed document has <table> elements with the expected non-locale names to ensure
-    // the test harness sees the same DOM as the runtime installer.
-    Element doc = null;
-    assertTrue(doc == null || doc.getNodeName() == null); // trivial assertion to keep imports
+  void installRepositoryUsesPureJavaStripNotNashorn() throws IOException {
+    assertTrue(Files.isRegularFile(INSTALL_REPOSITORY_XML), "missing " + INSTALL_REPOSITORY_XML);
+    String body = Files.readString(INSTALL_REPOSITORY_XML, StandardCharsets.UTF_8);
+
+    assertTrue(
+        body.contains("PSStripSampleLocales"),
+        "installRepository.xml stripSampleLocales must use PSStripSampleLocales Ant task (#2303)");
+    assertTrue(
+        body.contains("com.percussion.ant.install.PSStripSampleLocales"),
+        "taskdef classname must point at PSStripSampleLocales");
+    assertFalse(
+        body.contains("language=\"javascript\""),
+        "installRepository.xml must not use Nashorn/javax.script javascript (#2303)");
+    assertFalse(
+        body.contains("language='javascript'"),
+        "installRepository.xml must not use Nashorn/javax.script javascript (#2303)");
+  }
+
+  @Test
+  void cliRunWritesStagingOnSuccess(@TempDir Path tempDir) throws IOException {
+    Path sample = tempDir.resolve("in.xml");
+    Path staging = tempDir.resolve("out.xml");
+    Files.writeString(
+        sample,
+        "<tables><table name=\"RXLOCALE\"><row/></table><table name=\"RXSITES\"><row/></table></tables>",
+        StandardCharsets.UTF_8);
+
+    int code = SampleSiteLocaleStrip.run(new String[] {sample.toString(), staging.toString()});
+    assertTrue(code == 0, "expected exit 0, was " + code);
+    assertTrue(Files.isRegularFile(staging));
+    assertFalse(RXLOCALE_OPEN_TAG.matcher(Files.readString(staging, StandardCharsets.UTF_8)).find());
   }
 }


### PR DESCRIPTION
## Summary

CMS install fails on Java 15+ during demo-site seeding when ANT `stripSampleLocales` runs `<script language="javascript">` (Nashorn / `javax.script` removed).

**Fix:**
- Promote the Java strip algorithm to production:
  - `com.percussion.distribution.install.SampleSiteLocaleStrip` (helper + CLI)
  - `com.percussion.ant.install.PSStripSampleLocales` (ANT task on install classpath)
- Replace the Nashorn block in `installRepository.xml` with `PSStripSampleLocales`
- Register the task in perc-ant `antlib.xml`
- Unit tests call the production helper; wiring test asserts no `language="javascript"` remains

Demo-site seed still writes `RxffTableData.staging.xml` without `RXLOCALE` / `RXLOCALEFORMAT` table blocks. Source seed file is never modified.

Fixes #2303

## Test plan

- [x] `cd modules/perc-ant && ../../mvnw clean install` — **BUILD SUCCESS**
  - `PSStripSampleLocalesTest`: Tests run: 3, Failures: 0
  - `AntlibTaskRegistrationTest`: Tests run: 2, Failures: 0
- [x] `cd modules/perc-distribution-tree && ../../mvnw clean install` — **BUILD SUCCESS**
  - `SampleSiteLocaleStripTest`: Tests run: 5, Failures: 0
- [x] Erlang pre-commit review: approve (`docs/ai-generated/code-reviews/issue-2303-strip-sample-locales-erlang.md`)
- [ ] Full live CMS install with `--demo-sites` on Java 21 (optional field validation; not required for this PR)

## Gates evidence

| Gate | Result |
|------|--------|
| Erlang (bugs / behavioral tests / portable paths) | approve |
| perc-ant standalone clean install | BUILD SUCCESS |
| perc-distribution-tree standalone clean install | BUILD SUCCESS |
| No new warnings attributable to change | dependency:analyze-only baseline warnings only |

## Operator

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.