### PR TITLE
fix(perc-system): design.objectstore rawtypes batch 2 — call/param cluster (#2309)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2309-design-objectstore-rawtypes-batch2-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2309-design-objectstore-rawtypes-batch2-erlang.md
@@ -1,0 +1,58 @@
+# Erlang review: issue #2309 design.objectstore rawtypes batch 2
+
+**Date:** 2026-08-07  
+**Branch:** `fix/issue-2309-design-objectstore-rawtypes-batch2`  
+**Scope:** uncommitted vs `HEAD` (function/extension call cluster + param value hierarchy)
+
+## Summary
+
+Continues #2022 / #2295 with real generics for rawtypes/unchecked in the design.objectstore **call + param** cluster:
+
+| Area | Change |
+| --- | --- |
+| `PSFunctionCall` | `Collection<PSFunctionParamValue>`, `ArrayList<IPSComponent>`, typed iterators / for-each, `List<IPSComponent>` parents |
+| `PSExtensionCall` | `Collection<PSExtensionParamValue>`, `List<String>` applyTo, typed setParamValues/fromXml |
+| `PS*ParamValue` / `PSAbstractParamValue` | `List<IPSComponent>` ctor/fromXml |
+| `PSNamedReplacementValue` | Align fromXml/ctor with `List<IPSComponent>` |
+| `IPSDependentObject` | `Collection<? extends IPSParameter> getParameters()` |
+| `IPSDocumentMapping` | `List<IPSComponent>` fromXml (match `IPSComponent`) |
+| Macro resolver | `Iterator<?>` for parameter walks (call-site compatibility) |
+
+No class-level `@SuppressWarnings({"rawtypes","unchecked"})`. Behavioral surface preserved (XML round-trip, clone, equals, applyTo, param arrays).
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Check | Result |
+| --- | --- |
+| Bugs | none found |
+| Behavioral unit tests for new/changed logic | yes (`PSFunctionCallTest` 7, `PSExtensionCallTest` 7) |
+| Portable paths / file I/O | N/A (no path I/O) |
+| Scope confined | yes (objectstore call/param cluster + companion interface/resolver typing) |
+| May commit/push | **yes** |
+
+## Issues
+
+None.
+
+### Nits (non-blocking)
+
+- `PSContentEditorDependencyMacroResolver` still has an internal raw `Iterator mappings` in an unrelated helper path (not part of this diagnostic batch; leave for residual #2022 children).
+- Hottest remaining package files (`PSContentEditorMapper`, `PSDisplayMapper`, `PSContentEditorSystemDef`, `PSFieldSet`, …) intentionally out of this batch for overnight size control.
+
+## Memory patterns hit
+
+- Prefer real generics over class-level suppress-only
+- Keep interface/`fromXml` parent list typing consistent with `IPSComponent` (`List<IPSComponent>`)
+- `Iterator<?>` / `Collection<? extends T>` when accepting heterogeneous callers
+- Intersoft 2026 header on new test files
+
+## Verification
+
+- `cd system` → `../mvnw.cmd clean install` → **BUILD SUCCESS**
+- Tests run: **1204**, Failures: **0**, Errors: **0**, Skipped: **240**
+- Focused: `PSFunctionCallTest` + `PSExtensionCallTest` green
+- Primary production files in batch: **0 residual raw collection decls** (real generics throughout)

--- a/system/src/main/java/com/percussion/design/objectstore/IPSDependentObject.java
+++ b/system/src/main/java/com/percussion/design/objectstore/IPSDependentObject.java
@@ -44,5 +44,5 @@ public interface IPSDependentObject extends IPSComponent, IPSReplacementValue {
    * @return the parameters as a collection of <code>IPSParameter</code> objects, never <code>null
    *     </code>, may be empty.
    */
-  public Collection getParameters();
+  public Collection<? extends IPSParameter> getParameters();
 }

--- a/system/src/main/java/com/percussion/design/objectstore/IPSDocumentMapping.java
+++ b/system/src/main/java/com/percussion/design/objectstore/IPSDocumentMapping.java
@@ -55,6 +55,7 @@ public interface IPSDocumentMapping {
   public abstract Element toXml(Document doc);
 
   /** Abstract fromXml function for DocumentMappings */
-  public abstract void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public abstract void fromXml(
+      Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException;
 }

--- a/system/src/main/java/com/percussion/design/objectstore/PSAbstractParamValue.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSAbstractParamValue.java
@@ -46,7 +46,7 @@ public abstract class PSAbstractParamValue extends PSComponent implements IPSPar
    *     XML element node is not of the appropriate type
    */
   public PSAbstractParamValue(
-      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List parentComponents)
+      org.w3c.dom.Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -193,7 +193,8 @@ public abstract class PSAbstractParamValue extends PSComponent implements IPSPar
    * @throws PSUnknownNodeTypeException if <code>sourceNode</code> is <code>null</code> or does not
    *     conform to the DTD specified in {@link #toXml(Document) toXml()}
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(
+      Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;

--- a/system/src/main/java/com/percussion/design/objectstore/PSContentEditorDependencyMacroResolver.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSContentEditorDependencyMacroResolver.java
@@ -44,7 +44,7 @@ public class PSContentEditorDependencyMacroResolver {
    *     parameters</code> contains objects other than <code>IPSParameter</code>.
    * @throws IllegalStateException if a macro is contained in an immutable replacement value
    */
-  public static void replaceMacroWithValue(PSDisplayMapping mapping, Iterator<Object> parameters) {
+  public static void replaceMacroWithValue(PSDisplayMapping mapping, Iterator<?> parameters) {
     if (null == mapping) throw new IllegalArgumentException("mapping may not be null");
     if (null == parameters) throw new IllegalArgumentException("parameters may not be null");
 
@@ -93,8 +93,8 @@ public class PSContentEditorDependencyMacroResolver {
    */
   public static void replaceValueWithMacro(
       PSDisplayMapping context,
-      Iterator<Object> templateParameters,
-      Iterator<Object> instanceParameters) {
+      Iterator<?> templateParameters,
+      Iterator<?> instanceParameters) {
     if (null == context) throw new IllegalArgumentException("context may not be null");
     if (null == templateParameters || null == instanceParameters)
       throw new IllegalArgumentException("neither parameters may be null");

--- a/system/src/main/java/com/percussion/design/objectstore/PSExtensionCall.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSExtensionCall.java
@@ -17,7 +17,6 @@
 package com.percussion.design.objectstore;
 
 import com.percussion.extension.PSExtensionRef;
-import com.percussion.utils.collections.PSIteratorUtils;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.util.ArrayList;
@@ -48,7 +47,8 @@ public class PSExtensionCall extends PSComponent
    * @param parentComponents the parent objects of this object
    * @throws PSUnknownNodeTypeException if the XML element node is not of the appropriate type
    */
-  public PSExtensionCall(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSExtensionCall(
+      Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     fromXml(sourceNode, parentDoc, parentComponents);
   }
@@ -174,7 +174,11 @@ public class PSExtensionCall extends PSComponent
    * @param params an array of PSExtensionParamValue objects
    */
   public void setParamValues(PSExtensionParamValue[] params) {
-    setParamValues(PSIteratorUtils.iterator(params));
+    if (params == null) {
+      setParamValues((Iterator<? extends PSExtensionParamValue>) null);
+    } else {
+      setParamValues(Arrays.asList(params).iterator());
+    }
   }
 
   /**
@@ -183,16 +187,16 @@ public class PSExtensionCall extends PSComponent
    * @param params An Iterator over 0 or more PSExtensionParamValue objects. Can be <CODE>null
    *     </CODE>.
    */
-  public void setParamValues(Iterator params) {
-    m_params = new LinkedList();
+  public void setParamValues(Iterator<? extends PSExtensionParamValue> params) {
+    m_params = new LinkedList<>();
 
     // build column names which need to be mapped
-    ArrayList cols = new ArrayList();
+    ArrayList<String> cols = new ArrayList<>();
 
     if (params != null) {
       // get the back-end column names
       while (params.hasNext()) {
-        PSExtensionParamValue val = (PSExtensionParamValue) (params.next());
+        PSExtensionParamValue val = params.next();
         if (val != null && val.isBackEndColumn()) {
           cols.add(val.getValue().getValueText());
         }
@@ -200,8 +204,7 @@ public class PSExtensionCall extends PSComponent
       }
     }
 
-    m_columns = new String[cols.size()];
-    cols.toArray(m_columns);
+    m_columns = cols.toArray(new String[0]);
   }
 
   /**
@@ -211,8 +214,10 @@ public class PSExtensionCall extends PSComponent
    *     empty. If the returned list is empty, this should be applied to all handlers, otherwise
    *     only to the listed ones.
    */
-  public Iterator getApplyTo() {
-    if (m_applyTo == null) return PSIteratorUtils.emptyIterator();
+  public Iterator<String> getApplyTo() {
+    if (m_applyTo == null) {
+      return java.util.Collections.emptyIterator();
+    }
 
     return m_applyTo.iterator();
   }
@@ -223,7 +228,7 @@ public class PSExtensionCall extends PSComponent
    * @param applyTo a list of handler names this exit should be applied to. Set it to <code>null
    *     </code> or empty to apply it to all handlers.
    */
-  public void setApplyTo(List applyTo) {
+  public void setApplyTo(List<String> applyTo) {
     m_applyTo = applyTo;
   }
 
@@ -252,7 +257,7 @@ public class PSExtensionCall extends PSComponent
    * @return this extension's parameter values wrapped in a list, never <code>null</code>.
    * @see #getParamValues()
    */
-  public Collection getParameters() {
+  public Collection<? extends IPSParameter> getParameters() {
     return Arrays.asList(getParamValues());
   }
 
@@ -268,10 +273,12 @@ public class PSExtensionCall extends PSComponent
   public Object clone() {
     PSExtensionCall copy = (PSExtensionCall) super.clone();
     // PSExtensionRef is immutable
-    copy.m_params = new ArrayList(m_params.size());
-    for (Object m_param : m_params) {
-      PSExtensionParamValue value = (PSExtensionParamValue) m_param;
-      copy.m_params.add(value.clone());
+    copy.m_params = new ArrayList<>(m_params.size());
+    for (PSExtensionParamValue value : m_params) {
+      copy.m_params.add((PSExtensionParamValue) value.clone());
+    }
+    if (m_applyTo != null) {
+      copy.m_applyTo = new ArrayList<>(m_applyTo);
     }
     return copy;
   }
@@ -328,11 +335,9 @@ public class PSExtensionCall extends PSComponent
     if (m_ext != null) PSXmlDocumentBuilder.addElement(doc, root, "name", m_ext.toString());
 
     if (m_params != null) {
-      Element node;
-      for (Iterator i = m_params.iterator(); i.hasNext(); ) {
-        PSExtensionParamValue val = (PSExtensionParamValue) (i.next());
+      for (PSExtensionParamValue val : m_params) {
         if (val != null) {
-          node = val.toXml(doc);
+          Element node = val.toXml(doc);
           root.appendChild(node);
         }
       }
@@ -348,7 +353,8 @@ public class PSExtensionCall extends PSComponent
    *
    * @exception PSUnknownNodeTypeException if the XML element node is not of type PSXExtensionCall
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(
+      Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;
@@ -381,7 +387,7 @@ public class PSExtensionCall extends PSComponent
     }
 
     m_ext = new PSExtensionRef(exitName);
-    Collection params = new LinkedList();
+    Collection<PSExtensionParamValue> params = new LinkedList<>();
 
     final String curNodeType = PSExtensionParamValue.ms_NodeType;
 
@@ -427,8 +433,7 @@ public class PSExtensionCall extends PSComponent
     if (m_params != null) {
       cxt.pushParent(this);
       try {
-        for (Iterator i = m_params.iterator(); i.hasNext(); ) {
-          PSExtensionParamValue val = (PSExtensionParamValue) (i.next());
+        for (PSExtensionParamValue val : m_params) {
           if (null != val) val.validate(cxt);
         }
       } finally {
@@ -459,7 +464,7 @@ public class PSExtensionCall extends PSComponent
    * A Collection of zero or more non-<CODE>null</CODE> PSExtensionParamValue objects. Never <CODE>
    * null</CODE>.
    */
-  protected Collection m_params;
+  protected Collection<PSExtensionParamValue> m_params;
 
   /**
    * An array of zero or more columns which need to be mapped in order for the param values to be
@@ -473,7 +478,7 @@ public class PSExtensionCall extends PSComponent
    * empty. If the list is empty or <code>null</code>, this exit will be applied to all handlers,
    * otherwise it will only be applied to the handlers in this list.
    */
-  private List m_applyTo = null;
+  private List<String> m_applyTo = null;
 
   /** Name of the root element of this object's XML representation */
   public static final String ms_NodeType = "PSXExtensionCall";

--- a/system/src/main/java/com/percussion/design/objectstore/PSExtensionParamValue.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSExtensionParamValue.java
@@ -40,7 +40,8 @@ public class PSExtensionParamValue extends PSAbstractParamValue implements IPSPa
    * @exception PSUnknownNodeTypeException if <code>sourceNode</code> is <code>null</code> or the
    *     XML element node is not of the appropriate type
    */
-  public PSExtensionParamValue(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSExtensionParamValue(
+      Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     super(sourceNode, parentDoc, parentComponents);
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSFunctionCall.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFunctionCall.java
@@ -21,12 +21,12 @@ import com.percussion.data.PSMetaDataCache;
 import com.percussion.extension.PSDatabaseFunctionDef;
 import com.percussion.extension.PSDatabaseFunctionManager;
 import com.percussion.server.PSConsole;
-import com.percussion.utils.collections.PSIteratorUtils;
 import com.percussion.utils.jdbc.PSConnectionHelper;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -56,7 +56,8 @@ public class PSFunctionCall extends PSNamedReplacementValue
    * @throws PSUnknownNodeTypeException if <code>sourceNode</code> is <code>null</code> or the XML
    *     element node is not of the appropriate type
    */
-  public PSFunctionCall(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSFunctionCall(
+      Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     super(sourceNode, parentDoc, parentComponents);
     m_parentComponents = new ArrayList<>();
@@ -77,13 +78,13 @@ public class PSFunctionCall extends PSNamedReplacementValue
       String dbFuncName,
       PSFunctionParamValue[] params,
       IPSDocument parentDoc,
-      List parentComponents) {
+      List<IPSComponent> parentComponents) {
     super(dbFuncName);
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;
 
-    m_parentComponents = new ArrayList();
-    if (parentComponents != null) m_parentComponents.addAll(parentComponents);
+    m_parentComponents = new ArrayList<>();
+    m_parentComponents.addAll(parentComponents);
 
     m_dbFuncName = dbFuncName;
     setParamValues(params);
@@ -121,7 +122,11 @@ public class PSFunctionCall extends PSNamedReplacementValue
    *     empty if this database function does not require any parameters.
    */
   public void setParamValues(PSFunctionParamValue[] params) {
-    setParamValues(PSIteratorUtils.iterator(params));
+    if (params == null) {
+      setParamValues((Iterator<? extends PSFunctionParamValue>) null);
+    } else {
+      setParamValues(Arrays.asList(params).iterator());
+    }
   }
 
   /**
@@ -131,22 +136,21 @@ public class PSFunctionCall extends PSNamedReplacementValue
    * @param params An Iterator over zero or more <code>PSFunctionParamValue</code> objects, may be
    *     <code>null</code> or empty if this database function does not require any parameters.
    */
-  public void setParamValues(Iterator params) {
-    m_params = new ArrayList();
+  public void setParamValues(Iterator<? extends PSFunctionParamValue> params) {
+    m_params = new ArrayList<>();
     // build column names which need to be mapped
-    List cols = new ArrayList();
+    List<String> cols = new ArrayList<>();
     if (params != null) {
       // get the back-end column names
       while (params.hasNext()) {
-        PSFunctionParamValue val = (PSFunctionParamValue) (params.next());
+        PSFunctionParamValue val = params.next();
         if (val != null) {
           if (val.isBackEndColumn()) cols.add(val.getValue().getValueText());
           m_params.add(val);
         }
       }
     }
-    m_columns = new String[cols.size()];
-    cols.toArray(m_columns);
+    m_columns = cols.toArray(new String[0]);
   }
 
   /**
@@ -178,7 +182,7 @@ public class PSFunctionCall extends PSNamedReplacementValue
    *     guaranteed to be non-<code>null</code>.
    * @see #getParamValues()
    */
-  public Collection getParameters() {
+  public Collection<PSFunctionParamValue> getParameters() {
     return m_params;
   }
 
@@ -196,10 +200,12 @@ public class PSFunctionCall extends PSNamedReplacementValue
    */
   public Object clone() {
     PSFunctionCall copy = (PSFunctionCall) super.clone();
-    copy.m_params = new ArrayList(m_params.size());
-    for (Iterator iter = m_params.iterator(); iter.hasNext(); ) {
-      PSFunctionParamValue value = (PSFunctionParamValue) iter.next();
-      copy.m_params.add(value.clone());
+    copy.m_params = new ArrayList<>(m_params.size());
+    for (PSFunctionParamValue value : m_params) {
+      copy.m_params.add((PSFunctionParamValue) value.clone());
+    }
+    if (m_parentComponents != null) {
+      copy.m_parentComponents = new ArrayList<>(m_parentComponents);
     }
     return copy;
   }
@@ -222,12 +228,10 @@ public class PSFunctionCall extends PSNamedReplacementValue
     StringBuilder buffer = new StringBuilder();
     buffer.append(m_dbFuncName);
     buffer.append("(");
-    Iterator it = m_params.iterator();
     boolean first = true;
-    while (it.hasNext()) {
+    for (PSFunctionParamValue paramVal : m_params) {
       if (first) first = false;
       else buffer.append(", ");
-      PSFunctionParamValue paramVal = (PSFunctionParamValue) it.next();
       if (displayText) buffer.append(paramVal.getValue().getValueDisplayText());
       else buffer.append(paramVal.getValue().getValueText());
     }
@@ -379,8 +383,7 @@ public class PSFunctionCall extends PSNamedReplacementValue
     root.setAttribute(ATTR_ID, String.valueOf(m_id));
     PSXmlDocumentBuilder.addElement(doc, root, EL_NAME, m_dbFuncName);
 
-    for (Iterator i = m_params.iterator(); i.hasNext(); ) {
-      PSFunctionParamValue val = (PSFunctionParamValue) (i.next());
+    for (PSFunctionParamValue val : m_params) {
       if (val != null) {
         Element node = val.toXml(doc);
         root.appendChild(node);
@@ -399,7 +402,8 @@ public class PSFunctionCall extends PSNamedReplacementValue
    * @throws PSUnknownNodeTypeException if <code>sourceNode</code> is <code>null</code> or does not
    *     conform to the DTD specified in {@link #toXml(Document) toXml()}
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(
+      Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     parentComponents = updateParentList(parentComponents);
     int parentSize = parentComponents.size() - 1;
@@ -440,7 +444,7 @@ public class PSFunctionCall extends PSNamedReplacementValue
 
       // process "PSXFunctionParamValue" elements
       tree.setCurrent(sourceNode);
-      List params = new ArrayList();
+      List<PSFunctionParamValue> params = new ArrayList<>();
       Element paramEl = tree.getNextElement(PSFunctionParamValue.NODE_NAME, firstFlags);
       while (paramEl != null) {
         params.add(new PSFunctionParamValue(paramEl, parentDoc, parentComponents));
@@ -472,8 +476,7 @@ public class PSFunctionCall extends PSNamedReplacementValue
 
     cxt.pushParent(this);
     try {
-      for (Iterator i = m_params.iterator(); i.hasNext(); ) {
-        PSFunctionParamValue val = (PSFunctionParamValue) (i.next());
+      for (PSFunctionParamValue val : m_params) {
         if (null != val) val.validate(cxt);
       }
     } finally {
@@ -540,12 +543,11 @@ public class PSFunctionCall extends PSNamedReplacementValue
 
     // if the function param values contains a backend column, then get
     // driver for the database containing the column
-    Iterator itParams = m_params.iterator();
-    while (itParams.hasNext()) {
-      IPSReplacementValue val = ((PSFunctionParamValue) itParams.next()).getValue();
+    for (PSFunctionParamValue param : m_params) {
+      IPSReplacementValue val = param.getValue();
       if (val instanceof PSBackEndColumn) {
         PSBackEndTable table = ((PSBackEndColumn) val).getTable();
-        driver = driver = getDriverFromTable(table);
+        driver = getDriverFromTable(table);
         if (driver != null) break;
       }
     }
@@ -553,9 +555,9 @@ public class PSFunctionCall extends PSNamedReplacementValue
     // try to get the driver from the parent WHERE clause
     if ((driver == null) && (m_parentComponents != null) && (!m_parentComponents.isEmpty())) {
       PSWhereClause whereClause = null;
-      Object obj = null;
+      IPSComponent obj = null;
       boolean found = false;
-      ListIterator itParent = m_parentComponents.listIterator();
+      ListIterator<IPSComponent> itParent = m_parentComponents.listIterator();
       while ((itParent.hasNext()) && (!found)) {
         obj = itParent.next();
         if ((obj != null) && (obj == this)) {
@@ -566,7 +568,7 @@ public class PSFunctionCall extends PSNamedReplacementValue
         }
       }
 
-      if (found && (obj != null) && (obj instanceof PSWhereClause)) {
+      if (found && (obj instanceof PSWhereClause)) {
         whereClause = (PSWhereClause) obj;
       }
 
@@ -585,16 +587,12 @@ public class PSFunctionCall extends PSNamedReplacementValue
 
     // try to get the driver from the data set
     if ((driver == null) && (m_parentComponents != null) && (!m_parentComponents.isEmpty())) {
-      Object obj = null;
       PSDataSet dataSet = null;
-      Iterator itDs = m_parentComponents.iterator();
-      boolean foundDataSet = false;
 
-      while (itDs.hasNext() && (!foundDataSet)) {
-        obj = itDs.next();
-        if ((obj != null) && (obj instanceof PSDataSet)) {
+      for (IPSComponent obj : m_parentComponents) {
+        if (obj instanceof PSDataSet) {
           dataSet = (PSDataSet) obj;
-          foundDataSet = true;
+          break;
         }
       }
 
@@ -603,10 +601,10 @@ public class PSFunctionCall extends PSNamedReplacementValue
         if (pipe != null) {
           PSBackEndDataTank tank = pipe.getBackEndDataTank();
           if (tank != null) {
-            Iterator itTbl = tank.getTables().iterator();
+            Iterator<?> itTbl = tank.getTables().iterator();
             if (itTbl.hasNext()) {
               PSBackEndTable table = (PSBackEndTable) itTbl.next();
-              driver = driver = getDriverFromTable(table);
+              driver = getDriverFromTable(table);
             }
           }
         }
@@ -706,7 +704,7 @@ public class PSFunctionCall extends PSNamedReplacementValue
    * Initialized in ctor, modified in the <code>fromXml()</code> and <code>setParamValues()</code>
    * methods, never <code>null</code> after initialization, may be empty.
    */
-  private Collection m_params;
+  private Collection<PSFunctionParamValue> m_params;
 
   /**
    * An array of zero or more columns which need to be mapped in order for the param values to be
@@ -719,7 +717,7 @@ public class PSFunctionCall extends PSNamedReplacementValue
   /**
    * the parent objects of this object, initialized in the ctor, may be <code>null</code> or empty
    */
-  private ArrayList m_parentComponents;
+  private ArrayList<IPSComponent> m_parentComponents;
 
   /**
    * The tag name of the root element from which this object can be constructed.

--- a/system/src/main/java/com/percussion/design/objectstore/PSFunctionParamValue.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSFunctionParamValue.java
@@ -39,7 +39,8 @@ public class PSFunctionParamValue extends PSAbstractParamValue implements IPSPar
    * @exception PSUnknownNodeTypeException if <code>sourceNode</code> is <code>null</code> or the
    *     XML element node is not of the appropriate type
    */
-  public PSFunctionParamValue(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSFunctionParamValue(
+      Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     super(sourceNode, parentDoc, parentComponents);
   }

--- a/system/src/main/java/com/percussion/design/objectstore/PSNamedReplacementValue.java
+++ b/system/src/main/java/com/percussion/design/objectstore/PSNamedReplacementValue.java
@@ -51,7 +51,8 @@ public abstract class PSNamedReplacementValue extends PSComponent
    * @param parentComponents may be <code>null</code>
    * @throws PSUnknownNodeTypeException if the XML representation is not in the expected format.
    */
-  public PSNamedReplacementValue(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public PSNamedReplacementValue(
+      Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     if (null == sourceNode) throw new IllegalArgumentException("sourceNode may not be null");
     fromXml(sourceNode, parentDoc, parentComponents);
@@ -93,7 +94,8 @@ public abstract class PSNamedReplacementValue extends PSComponent
    * @param parentComponents may be <code>null</code>
    * @throws PSUnknownNodeTypeException if the XML representation is not in the expected format
    */
-  public void fromXml(Element sourceNode, IPSDocument parentDoc, List parentComponents)
+  public void fromXml(
+      Element sourceNode, IPSDocument parentDoc, List<IPSComponent> parentComponents)
       throws PSUnknownNodeTypeException {
     validateElementName(sourceNode, getNodeName());
     PSXmlTreeWalker tree = new PSXmlTreeWalker(sourceNode);

--- a/system/src/test/java/com/percussion/design/objectstore/PSExtensionCallTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSExtensionCallTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.design.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.extension.PSExtensionRef;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Behavioral unit tests for {@link PSExtensionCall} after rawtypes/unchecked parameterization
+ * (#2309).
+ */
+class PSExtensionCallTest {
+
+  private static PSExtensionRef sampleRef() {
+    return new PSExtensionRef("Java", "global/percussion/generic/", "sys_MakeLink");
+  }
+
+  @Test
+  void constructsWithParamsAndRef() {
+    PSExtensionParamValue[] params =
+        new PSExtensionParamValue[] {
+          new PSExtensionParamValue(new PSTextLiteral("p1")),
+          new PSExtensionParamValue(new PSTextLiteral("p2"))
+        };
+    PSExtensionCall call = new PSExtensionCall(sampleRef(), params);
+
+    assertEquals("sys_MakeLink", call.getName());
+    assertEquals(PSExtensionCall.VALUE_TYPE, call.getType());
+    assertEquals(2, call.getParamValues().length);
+    assertEquals("p1", call.getParamValues()[0].getValue().getValueText());
+    assertEquals(0, call.getColumnsForSelect().length);
+  }
+
+  @Test
+  void setParamValuesNullClearsParams() {
+    PSExtensionCall call =
+        new PSExtensionCall(
+            sampleRef(),
+            new PSExtensionParamValue[] {new PSExtensionParamValue(new PSTextLiteral("x"))});
+    call.setParamValues((PSExtensionParamValue[]) null);
+    assertEquals(0, call.getParamValues().length);
+  }
+
+  @Test
+  void getParametersReturnsIpsParameterCollection() {
+    PSExtensionCall call =
+        new PSExtensionCall(
+            sampleRef(),
+            new PSExtensionParamValue[] {new PSExtensionParamValue(new PSTextLiteral("z"))});
+    Collection<? extends IPSParameter> params = call.getParameters();
+    assertEquals(1, params.size());
+    for (IPSParameter p : params) {
+      assertEquals("z", p.getValue().getValueText());
+    }
+  }
+
+  @Test
+  void applyToListIsTyped() {
+    PSExtensionCall call = new PSExtensionCall(sampleRef(), null);
+    assertFalse(call.getApplyTo().hasNext());
+
+    List<String> handlers = new ArrayList<>(Arrays.asList("edit", "preview"));
+    call.setApplyTo(handlers);
+
+    Iterator<String> it = call.getApplyTo();
+    assertTrue(it.hasNext());
+    assertEquals("edit", it.next());
+    assertEquals("preview", it.next());
+    assertFalse(it.hasNext());
+  }
+
+  @Test
+  void xmlRoundTripPreservesRefAndParams() throws Exception {
+    PSExtensionCall original =
+        new PSExtensionCall(
+            sampleRef(),
+            new PSExtensionParamValue[] {
+              new PSExtensionParamValue(new PSTextLiteral("alpha")),
+              new PSExtensionParamValue(new PSTextLiteral("beta"))
+            });
+    original.setId(3);
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element xml = original.toXml(doc);
+    assertEquals(PSExtensionCall.ms_NodeType, xml.getNodeName());
+
+    List<IPSComponent> parents = new ArrayList<>();
+    PSExtensionCall restored = new PSExtensionCall(xml, null, parents);
+    assertEquals(original.getExtensionRef().toString(), restored.getExtensionRef().toString());
+    assertEquals(original.getId(), restored.getId());
+    assertEquals(2, restored.getParamValues().length);
+    assertEquals("alpha", restored.getParamValues()[0].getValue().getValueText());
+    assertEquals("beta", restored.getParamValues()[1].getValue().getValueText());
+    assertTrue(original.equals(restored));
+  }
+
+  @Test
+  void cloneIsDeepForParams() {
+    PSExtensionCall original =
+        new PSExtensionCall(
+            sampleRef(),
+            new PSExtensionParamValue[] {new PSExtensionParamValue(new PSTextLiteral("ABC"))});
+    List<String> apply = new ArrayList<>();
+    apply.add("edit");
+    original.setApplyTo(apply);
+
+    PSExtensionCall copy = (PSExtensionCall) original.clone();
+    assertNotSame(original, copy);
+    assertEquals(original, copy);
+    assertNotSame(original.getParamValues()[0], copy.getParamValues()[0]);
+    assertEquals("ABC", copy.getParamValues()[0].getValue().getValueText());
+  }
+
+  @Test
+  void toStringIncludesNameAndParams() {
+    PSExtensionCall call =
+        new PSExtensionCall(
+            sampleRef(),
+            new PSExtensionParamValue[] {
+              new PSExtensionParamValue(new PSTextLiteral("one")),
+              new PSExtensionParamValue(new PSTextLiteral("two"))
+            });
+    String text = call.toString();
+    assertTrue(text.contains("sys_MakeLink"));
+    assertTrue(text.contains("one"));
+    assertTrue(text.contains("two"));
+  }
+}

--- a/system/src/test/java/com/percussion/design/objectstore/PSFunctionCallTest.java
+++ b/system/src/test/java/com/percussion/design/objectstore/PSFunctionCallTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.design.objectstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Behavioral unit tests for {@link PSFunctionCall} after rawtypes/unchecked parameterization
+ * (#2309).
+ */
+class PSFunctionCallTest {
+
+  @Test
+  void constructsWithLiteralParams() {
+    PSFunctionParamValue[] params =
+        new PSFunctionParamValue[] {
+          new PSFunctionParamValue(new PSTextLiteral("a")),
+          new PSFunctionParamValue(new PSTextLiteral("b"))
+        };
+    PSFunctionCall call = new PSFunctionCall("UPPER", params, null, null);
+
+    assertEquals("UPPER", call.getName());
+    assertEquals("UPPER", call.getDatabaseFunctionName());
+    assertEquals(PSFunctionCall.VALUE_TYPE, call.getValueType());
+    assertEquals(2, call.getParamValues().length);
+    assertEquals("a", call.getParamValues()[0].getValue().getValueText());
+    assertEquals("b", call.getParamValues()[1].getValue().getValueText());
+    assertTrue(call.hasStaticParamsOnly());
+    assertEquals(0, call.getColumnsForSelect().length);
+  }
+
+  @Test
+  void setParamValuesNullClearsParams() {
+    PSFunctionCall call =
+        new PSFunctionCall(
+            "LEN",
+            new PSFunctionParamValue[] {new PSFunctionParamValue(new PSTextLiteral("x"))},
+            null,
+            null);
+    call.setParamValues((PSFunctionParamValue[]) null);
+    assertEquals(0, call.getParamValues().length);
+    assertTrue(call.getParameters().isEmpty());
+  }
+
+  @Test
+  void getParametersReturnsTypedCollection() {
+    PSFunctionCall call =
+        new PSFunctionCall(
+            "TRIM",
+            new PSFunctionParamValue[] {new PSFunctionParamValue(new PSTextLiteral("z"))},
+            null,
+            null);
+    Collection<PSFunctionParamValue> params = call.getParameters();
+    assertEquals(1, params.size());
+    for (PSFunctionParamValue p : params) {
+      assertEquals("z", p.getValue().getValueText());
+    }
+  }
+
+  @Test
+  void xmlRoundTripPreservesNameAndParams() throws Exception {
+    PSFunctionCall original =
+        new PSFunctionCall(
+            "CONCAT",
+            new PSFunctionParamValue[] {
+              new PSFunctionParamValue(new PSTextLiteral("hello")),
+              new PSFunctionParamValue(new PSTextLiteral("world"))
+            },
+            null,
+            null);
+    original.setId(7);
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element xml = original.toXml(doc);
+    assertEquals(PSFunctionCall.XML_NODE_NAME, xml.getNodeName());
+
+    List<IPSComponent> parents = new ArrayList<>();
+    PSFunctionCall restored = new PSFunctionCall(xml, null, parents);
+    assertEquals(original.getName(), restored.getName());
+    assertEquals(original.getId(), restored.getId());
+    assertEquals(2, restored.getParamValues().length);
+    assertEquals("hello", restored.getParamValues()[0].getValue().getValueText());
+    assertEquals("world", restored.getParamValues()[1].getValue().getValueText());
+    assertTrue(original.equals(restored));
+  }
+
+  @Test
+  void cloneIsDeepForParams() {
+    PSFunctionCall original =
+        new PSFunctionCall(
+            "LOWER",
+            new PSFunctionParamValue[] {new PSFunctionParamValue(new PSTextLiteral("ABC"))},
+            null,
+            null);
+    PSFunctionCall copy = (PSFunctionCall) original.clone();
+    assertNotSame(original, copy);
+    assertEquals(original, copy);
+    assertNotSame(original.getParamValues()[0], copy.getParamValues()[0]);
+    assertEquals("ABC", copy.getParamValues()[0].getValue().getValueText());
+  }
+
+  @Test
+  void equalsIsCaseInsensitiveOnFunctionName() {
+    PSFunctionCall a =
+        new PSFunctionCall(
+            "upper",
+            new PSFunctionParamValue[] {new PSFunctionParamValue(new PSTextLiteral("x"))},
+            null,
+            null);
+    PSFunctionCall b =
+        new PSFunctionCall(
+            "UPPER",
+            new PSFunctionParamValue[] {new PSFunctionParamValue(new PSTextLiteral("x"))},
+            null,
+            null);
+    assertTrue(a.equals(b));
+    assertEquals(a.hashCode(), b.hashCode());
+
+    PSFunctionCall c =
+        new PSFunctionCall(
+            "LOWER",
+            new PSFunctionParamValue[] {new PSFunctionParamValue(new PSTextLiteral("x"))},
+            null,
+            null);
+    assertFalse(a.equals(c));
+  }
+
+  @Test
+  void valueDisplayTextIncludesParams() {
+    PSFunctionCall call =
+        new PSFunctionCall(
+            "COALESCE",
+            new PSFunctionParamValue[] {
+              new PSFunctionParamValue(new PSTextLiteral("one")),
+              new PSFunctionParamValue(new PSTextLiteral("two"))
+            },
+            null,
+            null);
+    String display = call.getValueDisplayText();
+    assertTrue(display.startsWith("COALESCE("));
+    assertTrue(display.contains("one"));
+    assertTrue(display.contains("two"));
+    assertEquals(display, call.toString());
+  }
+}


### PR DESCRIPTION
## Summary

Slice **1b** of parent **#2022** (grandparent **#2200**): real generics for rawtypes/unchecked in `com.percussion.design.objectstore` after #2295 / PR #2308.

### Changes
- **`PSFunctionCall`** — `Collection<PSFunctionParamValue>`, `ArrayList<IPSComponent>` parents, typed `setParamValues` / for-each, `List<IPSComponent>` fromXml
- **`PSExtensionCall`** — `Collection<PSExtensionParamValue>`, `List<String>` applyTo, typed param/fromXml APIs
- **`PSAbstractParamValue` / `PSFunctionParamValue` / `PSExtensionParamValue`** — `List<IPSComponent>` ctor/fromXml
- **`PSNamedReplacementValue`** — align with typed parent list
- **`IPSDependentObject`** — `Collection<? extends IPSParameter> getParameters()`
- **`IPSDocumentMapping`** — `List<IPSComponent>` fromXml (matches `IPSComponent`)
- **`PSContentEditorDependencyMacroResolver`** — `Iterator<?>` for parameter walks
- **Tests** — JUnit 5 `PSFunctionCallTest` (7) + `PSExtensionCallTest` (7)
- **Erlang** — approve (`docs/ai-generated/code-reviews/issue-2309-design-objectstore-rawtypes-batch2-erlang.md`)

### Before / after (raw collection decls on primary production files)
| File | Before (approx raw decl lines) | After |
| --- | ---: | ---: |
| `PSFunctionCall.java` | 17+ (issue inventory ~34 diags) | **0** |
| `PSExtensionCall.java` | 14+ (issue inventory ~31 diags) | **0** |
| Param value hierarchy + interfaces | several | **0** residual raw decls |

Package residual: design.objectstore still has hottest remaining **`PSContentEditorMapper` / `PSDisplayMapper` / `PSContentEditorSystemDef` / `PSFieldSet` / …** for follow-up batches under **#2022** (not mega-PR'd here).

### Out of scope (per #2309)
- cms.objectstore, this-escape/serial, data/data.jdbc
- Full zero-warning package

## Test plan
- [x] `cd system` → `../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Module tests: **1204** run, **0** failures, **0** errors (240 skipped pre-existing)
- [x] Focused: `PSFunctionCallTest` + `PSExtensionCallTest` — 14 green
- [x] No residual raw collection decls on touched production call/param files
- [x] Erlang self-review: approve

## Gates evidence
| Gate | Result |
| --- | --- |
| Standalone module clean install (`cd system`) | BUILD SUCCESS |
| Behavioral unit tests | 14 green (call cluster) |
| Scope confined to design.objectstore call/param + companion APIs | yes |
| Erlang | approve |

Parent tracker: #2022  
Grandparent: #2200  

Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #2309  
Refs #2022 #2200

> Co-Authored by Grok Build using grok-4.5 with agent main.