### PR TITLE
fix(metadata): migrate @Temporal Date fields to java.time (#2306)

### DIFF
--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/IPSBlogPostVisit.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/IPSBlogPostVisit.java
@@ -18,7 +18,7 @@
 package com.percussion.delivery.metadata;
 
 import java.math.BigInteger;
-import java.util.Date;
+import java.time.LocalDate;
 
 /**
  * Represents a single recorded visit to a blog post on a published site, capturing the page path,
@@ -41,18 +41,18 @@ public interface IPSBlogPostVisit {
   public void setHitCount(BigInteger count);
 
   /**
-   * Returns the date of the most recent hit on the blog post.
+   * Returns the calendar date of the most recent hit on the blog post.
    *
    * @return the hit date, may be {@code null} if never hit.
    */
-  public Date getHitDate();
+  public LocalDate getHitDate();
 
   /**
-   * Sets the date of the most recent hit on the blog post.
+   * Sets the calendar date of the most recent hit on the blog post.
    *
    * @param date the hit date to store; may be {@code null}.
    */
-  public void setHitDate(Date date);
+  public void setHitDate(LocalDate date);
 
   /**
    * Returns the published site-relative page path of the blog post that was visited.

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/IPSCookieConsent.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/IPSCookieConsent.java
@@ -17,7 +17,7 @@
 
 package com.percussion.delivery.metadata;
 
-import java.util.Date;
+import java.time.Instant;
 
 /**
  * Object to store information related to client cookie consent.
@@ -63,18 +63,18 @@ public interface IPSCookieConsent {
   public String getIP();
 
   /**
-   * Sets the date consent to use cookies was given.
+   * Sets the instant consent to use cookies was given.
    *
-   * @param consentDate the date object of consent date
+   * @param consentDate the instant consent was given
    */
-  public void setConsentDate(Date consentDate);
+  public void setConsentDate(Instant consentDate);
 
   /**
-   * Gets the date consent was given to use cookies.
+   * Gets the instant consent was given to use cookies.
    *
-   * @return the date consent was given
+   * @return the instant consent was given
    */
-  public Date getConsentDate();
+  public Instant getConsentDate();
 
   /**
    * Sets the services approved to use cookies.

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/IPSMetadataProperty.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/IPSMetadataProperty.java
@@ -17,7 +17,7 @@
 
 package com.percussion.delivery.metadata;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 /**
  * A typed value attached to an {@link IPSMetadataEntry}. Each property carries the name of the
@@ -56,11 +56,11 @@ public interface IPSMetadataProperty {
   public Object getValue();
 
   /**
-   * Returns the property as a {@link Date} when the declared value type is {@code DATE}.
+   * Returns the property as a {@link LocalDateTime} when the declared value type is {@code DATE}.
    *
    * @return the date value, may be <code>null</code>.
    */
-  public Date getDatevalue();
+  public LocalDateTime getDatevalue();
 
   /**
    * Returns the property as a {@link Double} when the declared value type is {@code NUMBER}.
@@ -81,7 +81,7 @@ public interface IPSMetadataProperty {
    *
    * @param val the date value to set; may be <code>null</code>.
    */
-  public void setDatevalue(Date val);
+  public void setDatevalue(LocalDateTime val);
 
   /**
    * Sets the numeric value of this property.

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/PSBlogPostVisit.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/PSBlogPostVisit.java
@@ -19,8 +19,7 @@ package com.percussion.delivery.metadata.data;
 
 import com.percussion.delivery.metadata.IPSBlogPostVisit;
 import java.math.BigInteger;
-import java.util.Date;
-import java.util.Optional;
+import java.time.LocalDate;
 
 /**
  * Lightweight transport model for blog-post visit data captured by the DTS blog visit tracking
@@ -32,8 +31,8 @@ public class PSBlogPostVisit implements IPSBlogPostVisit {
   /** Published site-relative page path of the visited blog post. */
   private String pagePath;
 
-  /** Date the visit occurred. Stored defensively-copied to keep the value immutable. */
-  private Date date;
+  /** Calendar date the visit occurred. {@link LocalDate} is immutable. */
+  private LocalDate date;
 
   /** Cumulative hit count for this page path. */
   private BigInteger hitCount;
@@ -48,9 +47,9 @@ public class PSBlogPostVisit implements IPSBlogPostVisit {
    * @param date the date the visit occurred; may be {@code null}.
    * @param hitCount the cumulative hit count; may be {@code null}.
    */
-  public PSBlogPostVisit(String pagePath, Date date, BigInteger hitCount) {
+  public PSBlogPostVisit(String pagePath, LocalDate date, BigInteger hitCount) {
     this.pagePath = pagePath;
-    this.date = Optional.ofNullable(date).map(Date::getTime).map(Date::new).orElse(null);
+    this.date = date;
     this.hitCount = hitCount;
   }
 
@@ -65,13 +64,13 @@ public class PSBlogPostVisit implements IPSBlogPostVisit {
   }
 
   @Override
-  public Date getHitDate() {
-    return Optional.ofNullable(date).map(Date::getTime).map(Date::new).orElse(null);
+  public LocalDate getHitDate() {
+    return date;
   }
 
   @Override
-  public void setHitDate(Date date) {
-    this.date = Optional.ofNullable(date).map(Date::getTime).map(Date::new).orElse(null);
+  public void setHitDate(LocalDate date) {
+    this.date = date;
   }
 
   @Override

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/PSCookieConsent.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/PSCookieConsent.java
@@ -18,8 +18,7 @@
 package com.percussion.delivery.metadata.data;
 
 import com.percussion.delivery.metadata.IPSCookieConsent;
-import java.util.Date;
-import java.util.Optional;
+import java.time.Instant;
 
 /**
  * Provides model for cookie consent entries. Statistics include:
@@ -40,7 +39,7 @@ public class PSCookieConsent implements IPSCookieConsent {
   private String ip;
   private String serviceName;
   private boolean optIn;
-  private Date consentDate;
+  private Instant consentDate;
 
   /** No-arg constructor required by the JSON binding layer. */
   public PSCookieConsent() {}
@@ -50,12 +49,12 @@ public class PSCookieConsent implements IPSCookieConsent {
    *
    * @param siteName the site the consent was captured for; may not be {@code null}.
    * @param serviceName the service / cookie name the consent applies to; may not be {@code null}.
-   * @param consentDate the date the consent was captured; may not be {@code null}.
+   * @param consentDate the instant the consent was captured; may not be {@code null}.
    * @param ip the originating client IP; may not be {@code null}.
    * @param optIn {@code true} if the client opted in, {@code false} otherwise.
    */
   public PSCookieConsent(
-      String siteName, String serviceName, Date consentDate, String ip, boolean optIn) {
+      String siteName, String serviceName, Instant consentDate, String ip, boolean optIn) {
 
     if (siteName == null) throw new IllegalArgumentException("siteName may not be null");
     if (serviceName == null) throw new IllegalArgumentException("serviceName may not be null");
@@ -63,10 +62,10 @@ public class PSCookieConsent implements IPSCookieConsent {
     if (ip == null) throw new IllegalArgumentException("ip may not be null");
 
     // Direct field assignment avoids this-escape from overridable setters (subclassed by
-    // PSCookieConsentQuery).
+    // PSCookieConsentQuery). Instant is immutable so no defensive copy is required.
     this.siteName = siteName;
     this.serviceName = serviceName;
-    this.consentDate = new Date(consentDate.getTime());
+    this.consentDate = consentDate;
     this.ip = ip;
     this.optIn = optIn;
   }
@@ -92,14 +91,13 @@ public class PSCookieConsent implements IPSCookieConsent {
   }
 
   @Override
-  public void setConsentDate(Date consentDate) {
-    this.consentDate =
-        Optional.ofNullable(consentDate).map(Date::getTime).map(Date::new).orElse(null);
+  public void setConsentDate(Instant consentDate) {
+    this.consentDate = consentDate;
   }
 
   @Override
-  public Date getConsentDate() {
-    return Optional.ofNullable(consentDate).map(Date::getTime).map(Date::new).orElse(null);
+  public Instant getConsentDate() {
+    return consentDate;
   }
 
   @Override

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/PSCookieConsentQuery.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/PSCookieConsentQuery.java
@@ -20,7 +20,7 @@ package com.percussion.delivery.metadata.data;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -44,14 +44,14 @@ public final class PSCookieConsentQuery extends PSCookieConsent {
    * Constructor used to call {@link PSCookieConsent} super and create PSCookieConsentQuery.
    *
    * @param siteName name of the site accessed.
-   * @param consentDate date the cookie consent was given.
+   * @param consentDate instant the cookie consent was given.
    * @param optIn <code>true</code> always. No information is saved if user does not opt in.
    * @param services the list of services/cookies approved by the client.
    */
   @JsonCreator
   public PSCookieConsentQuery(
       @JsonProperty("siteName") String siteName,
-      @JsonProperty("consentDate") Date consentDate,
+      @JsonProperty("consentDate") Instant consentDate,
       @JsonProperty("optIn") boolean optIn,
       @JsonProperty("services") List<String> services) {
     // Here "undefined" is passed for the serviceName as

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/PSMetadataRestEntry.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/data/PSMetadataRestEntry.java
@@ -17,10 +17,10 @@
 package com.percussion.delivery.metadata.data;
 
 import com.percussion.delivery.metadata.IPSMetadataProperty;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import org.apache.commons.lang3.time.FastDateFormat;
 
 /**
  * Represents a metadata entry in the REST layer. It's used to return exactly what's needed by the
@@ -28,7 +28,8 @@ import org.apache.commons.lang3.time.FastDateFormat;
  */
 public class PSMetadataRestEntry {
   /** Date format used for string-serialized date values such as {@code 2011-01-21T09:36:05}. */
-  FastDateFormat dateFormat = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss");
+  private static final DateTimeFormatter DATE_FORMAT =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
   private String pagepath;
 
@@ -192,7 +193,10 @@ public class PSMetadataRestEntry {
     if (metadataProperty.getValuetype().equals(IPSMetadataProperty.VALUETYPE.NUMBER)) {
       newValue = metadataProperty.getNumbervalue().toString();
     } else if (metadataProperty.getValuetype().equals(IPSMetadataProperty.VALUETYPE.DATE)) {
-      newValue = dateFormat.format(metadataProperty.getDatevalue());
+      newValue =
+          metadataProperty.getDatevalue() == null
+              ? ""
+              : DATE_FORMAT.format(metadataProperty.getDatevalue());
     } else {
       newValue = metadataProperty.getStringvalue();
     }

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/extractor/data/PSMetadataProperty.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/extractor/data/PSMetadataProperty.java
@@ -24,14 +24,17 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import java.io.Serializable;
-import java.text.ParseException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
 import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.commons.lang3.math.NumberUtils;
-import org.apache.commons.lang3.time.FastDateFormat;
 
 /**
  * Represents a metadata property name value pair.
@@ -45,7 +48,8 @@ public class PSMetadataProperty implements Serializable, IPSMetadataProperty {
   private static final long serialVersionUID = 1L;
 
   /** ISO-8601 formatter used when parsing date-typed properties from their string form. */
-  FastDateFormat sdf = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss");
+  private static final DateTimeFormatter DATE_TIME =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
   /** Property name. For example: {@code dcterms:creator}. */
   private String name;
@@ -54,8 +58,9 @@ public class PSMetadataProperty implements Serializable, IPSMetadataProperty {
   @XmlTransient private VALUETYPE valuetype = VALUETYPE.STRING;
 
   /**
-   * Value of the metadata property. It may be a {@link String}, {@link Date} or {@link Double}. The
-   * runtime value type can be inspected via the {@link #getValuetype() valuetype} field.
+   * Value of the metadata property. It may be a {@link String}, {@link LocalDateTime} or {@link
+   * Double}. The runtime value type can be inspected via the {@link #getValuetype() valuetype}
+   * field.
    */
   private Serializable value;
 
@@ -139,13 +144,23 @@ public class PSMetadataProperty implements Serializable, IPSMetadataProperty {
   }
 
   /**
-   * Convenience ctor to create a Date value type property.
+   * Convenience ctor to create a Date value type property from a {@link LocalDateTime}.
+   *
+   * @param name name cannot be <code>null</code> or empty.
+   * @param value may be <code>null</code>.
+   */
+  public PSMetadataProperty(String name, LocalDateTime value) {
+    this(name, VALUETYPE.DATE, value);
+  }
+
+  /**
+   * Convenience ctor to create a Date value type property from a legacy {@link Date}.
    *
    * @param name name cannot be <code>null</code> or empty.
    * @param value may be <code>null</code>.
    */
   public PSMetadataProperty(String name, Date value) {
-    this(name, VALUETYPE.DATE, value);
+    this(name, VALUETYPE.DATE, toLocalDateTime(value));
   }
 
   /* (non-Javadoc)
@@ -260,15 +275,15 @@ public class PSMetadataProperty implements Serializable, IPSMetadataProperty {
   }
 
   /**
-   * Returns the property as a {@link Date} when the declared value type is {@code DATE}.
+   * Returns the property as a {@link LocalDateTime} when the declared value type is {@code DATE}.
    *
    * @return the date value.
    * @throws RuntimeException if the value type is not {@code DATE}.
    */
-  public Date getDatevalue() {
+  public LocalDateTime getDatevalue() {
     if (valuetype != VALUETYPE.DATE)
       throw new RuntimeException("Cannot return a date for property type " + valuetype.toString());
-    return (Date) value;
+    return (LocalDateTime) value;
   }
 
   /**
@@ -299,7 +314,7 @@ public class PSMetadataProperty implements Serializable, IPSMetadataProperty {
    * @param val the date value to set; may be {@code null}.
    */
   @XmlTransient
-  public void setDatevalue(Date val) {
+  public void setDatevalue(LocalDateTime val) {
     valuetype = VALUETYPE.DATE;
     value = val;
   }
@@ -376,10 +391,10 @@ public class PSMetadataProperty implements Serializable, IPSMetadataProperty {
         throw new IllegalArgumentException("value does not match number type");
       } else if (type == VALUETYPE.DATE) {
         try {
-          Date date = sdf.parse((String) val);
+          LocalDateTime date = LocalDateTime.parse((String) val, DATE_TIME);
           valuetype = VALUETYPE.DATE;
           return date;
-        } catch (ParseException e) {
+        } catch (DateTimeParseException e) {
           throw new IllegalArgumentException("value does not match date type");
         }
       }
@@ -387,10 +402,37 @@ public class PSMetadataProperty implements Serializable, IPSMetadataProperty {
       return val;
     } else if (val instanceof Double && type != VALUETYPE.NUMBER) {
       throw new IllegalArgumentException("value type does not match Double");
-    } else if (val instanceof Date && type != VALUETYPE.DATE) {
-      throw new IllegalArgumentException("value type does not match Date");
+    } else if (val instanceof LocalDateTime && type != VALUETYPE.DATE) {
+      throw new IllegalArgumentException("value type does not match LocalDateTime");
+    } else if (val instanceof Date) {
+      if (type != VALUETYPE.DATE) {
+        throw new IllegalArgumentException("value type does not match Date");
+      }
+      valuetype = VALUETYPE.DATE;
+      return toLocalDateTime(val);
+    } else if (type == VALUETYPE.DATE) {
+      valuetype = VALUETYPE.DATE;
+      return toLocalDateTime(val);
     }
     valuetype = type;
     return val;
+  }
+
+  private static LocalDateTime toLocalDateTime(Object value) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof LocalDateTime) {
+      return (LocalDateTime) value;
+    }
+    if (value instanceof Instant) {
+      return LocalDateTime.ofInstant((Instant) value, ZoneId.systemDefault());
+    }
+    // java.sql.Date#toInstant() throws UnsupportedOperationException — use millis instead.
+    if (value instanceof Date) {
+      return LocalDateTime.ofInstant(
+          Instant.ofEpochMilli(((Date) value).getTime()), ZoneId.systemDefault());
+    }
+    throw new IllegalArgumentException("value does not match date type");
   }
 }

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/impl/PSBlogPostVisitService.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/impl/PSBlogPostVisitService.java
@@ -27,9 +27,9 @@ import com.percussion.delivery.metadata.data.PSVisitQuery;
 import com.percussion.security.error.PSExceptionUtils;
 import jakarta.annotation.PreDestroy;
 import java.math.BigInteger;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -171,7 +171,7 @@ public class PSBlogPostVisitService implements IPSBlogPostVisitService, Initiali
   public void trackBlogPost(String pagePath) {
     IPSBlogPostVisit visit = inMemoryVisitMap.get(pagePath);
     if (visit == null) {
-      inMemoryVisitMap.put(pagePath, new PSBlogPostVisit(pagePath, new Date(), BigInteger.ONE));
+      inMemoryVisitMap.put(pagePath, new PSBlogPostVisit(pagePath, LocalDate.now(), BigInteger.ONE));
     } else {
       visit.setHitCount(visit.getHitCount().add(BigInteger.ONE));
     }

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/impl/PSBlogsHelper.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/impl/PSBlogsHelper.java
@@ -22,11 +22,11 @@ import com.percussion.delivery.metadata.data.PSMetadataBlogEntry;
 import com.percussion.delivery.metadata.data.PSMetadataBlogMonth;
 import com.percussion.delivery.metadata.data.PSMetadataBlogYear;
 import com.percussion.delivery.metadata.data.PSMetadataRestBlogList;
+import java.time.LocalDateTime;
+import java.time.format.TextStyle;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
@@ -61,23 +61,21 @@ public class PSBlogsHelper {
       for (IPSMetadataEntry entryPage : results) {
         for (IPSMetadataProperty prop : entryPage.getProperties()) {
           if (BLOG_PROPERTY_NAME.equals(prop.getName()) && !prop.getStringvalue().isEmpty()) {
-            Calendar cal = Calendar.getInstance();
-            Date currentDate =
-                cal.getTime(); // used to check whether or not a page is set to publish in the
-            // future
-            cal.setTime(prop.getDatevalue());
-            Date pageDate = cal.getTime();
+            LocalDateTime pageDate = prop.getDatevalue();
+            if (pageDate == null) {
+              break;
+            }
 
             // if page date is in future, we don't want to return that value
-            if (pageDate.compareTo(currentDate) > 0) {
+            if (pageDate.isAfter(LocalDateTime.now())) {
               break;
             }
 
             PSMetadataBlogYear selectedYear = null;
             PSMetadataBlogMonth selectedMonth = null;
-            Integer currentPostYear = cal.get(Calendar.YEAR);
+            Integer currentPostYear = pageDate.getYear();
             String currentPostMonth =
-                cal.getDisplayName(Calendar.MONTH, Calendar.LONG, Locale.getDefault());
+                pageDate.getMonth().getDisplayName(TextStyle.FULL, Locale.getDefault());
 
             for (PSMetadataBlogYear year : blogs.getYears()) {
               if (year.getYear().equals(currentPostYear)) {
@@ -86,7 +84,7 @@ public class PSBlogsHelper {
               }
             }
             if (selectedYear == null) {
-              selectedYear = new PSMetadataBlogYear(cal.get(Calendar.YEAR));
+              selectedYear = new PSMetadataBlogYear(pageDate.getYear());
             }
             if (selectedYear != null) {
               for (PSMetadataBlogMonth month : selectedYear.getMonths()) {

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/impl/PSDatedEntriesHelper.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/impl/PSDatedEntriesHelper.java
@@ -20,9 +20,11 @@ import com.percussion.delivery.metadata.IPSMetadataEntry;
 import com.percussion.delivery.metadata.IPSMetadataProperty;
 import com.percussion.delivery.metadata.data.PSMetadataDatedEntries;
 import com.percussion.delivery.metadata.data.PSMetadataDatedEvent;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.time.FastDateFormat;
 
 /**
  * This class is responsible for process the dates of the page and return the JSONObject with the
@@ -41,9 +43,9 @@ public class PSDatedEntriesHelper {
   private static final String START_DATE_PROPERTY_NAME = "perc:start_date";
   private static final String END_DATE_PROPERTY_NAME = "perc:end_date";
 
-  /** Constant for the date formater. */
   /** Date formatter used to render the start / end timestamps of the dated event payload. */
-  private FastDateFormat formatter = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+  private static final DateTimeFormatter FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
   /**
    * Returns the dated-entries payload assembled from the supplied metadata index results:
@@ -84,11 +86,14 @@ public class PSDatedEntriesHelper {
           }
 
           if (START_DATE_PROPERTY_NAME.equals(prop.getName()) && prop.getDatevalue() != null) {
-            event.setStart(formatter.format(prop.getDatevalue()));
+            ZonedDateTime start =
+                prop.getDatevalue().atZone(ZoneId.systemDefault());
+            event.setStart(FORMATTER.format(start));
           }
 
           if (END_DATE_PROPERTY_NAME.equals(prop.getName()) && prop.getDatevalue() != null) {
-            event.setEnd(formatter.format(prop.getDatevalue()));
+            ZonedDateTime end = prop.getDatevalue().atZone(ZoneId.systemDefault());
+            event.setEnd(FORMATTER.format(end));
           }
         }
 

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/impl/PSMetadataQueryServiceHelper.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/impl/PSMetadataQueryServiceHelper.java
@@ -21,11 +21,12 @@ import com.percussion.delivery.metadata.IPSMetadataQueryService;
 import com.percussion.delivery.metadata.data.impl.PSCriteriaElement;
 import com.percussion.delivery.metadata.utils.PSHashCalculator;
 import java.text.ParseException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.apache.commons.lang3.time.FastDateFormat;
 
 /**
  * Static utility helpers shared by the metadata query services and friends. The class centralises
@@ -60,7 +61,8 @@ public abstract class PSMetadataQueryServiceHelper {
   }
 
   /** ISO-8601 formatter for dates such as {@code 2011-01-21T09:36:05} used in metadata queries. */
-  public static FastDateFormat dateFormat = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss");
+  public static final DateTimeFormatter dateFormat =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
   /**
    * Resolves the declared {@link VALUETYPE} for the supplied property name, stripping any namespace
@@ -84,7 +86,7 @@ public abstract class PSMetadataQueryServiceHelper {
   /**
    * Parses the supplied comma / quoted value into the typed list expected by an HQL {@code IN}
    * expression. Returns a list of {@link Double} for {@link VALUETYPE#NUMBER} entries, {@link
-   * java.util.Date} for {@link VALUETYPE#DATE} entries, and string hashes for text entries.
+   * LocalDateTime} for {@link VALUETYPE#DATE} entries, and string hashes for text entries.
    *
    * @param key the property key; may not be {@code null}.
    * @param val the raw value list string; may not be {@code null}.
@@ -110,7 +112,11 @@ public abstract class PSMetadataQueryServiceHelper {
     } else if (type == VALUETYPE.DATE) {
       for (String s : val.split("'")) {
         if (s.trim().equals(",") || s.trim().equals("")) continue;
-        results.add(dateFormat.parse(s));
+        try {
+          results.add(LocalDateTime.parse(s, dateFormat));
+        } catch (Exception e) {
+          throw new ParseException("Unparseable date: \"" + s + "\"", 0);
+        }
       }
     } else { // For text / string use value hash if it is a property
       boolean calcHash = true;

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSBlogPostVisitDao.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSBlogPostVisitDao.java
@@ -24,11 +24,10 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -138,13 +137,11 @@ public class PSBlogPostVisitDao implements IPSBlogPostVisitDao {
   public List<String> getTopVisitedPages(
       String sectionPath, int days, int limit, String sortOrder) {
     Session session = getSession();
-    Calendar cal = Calendar.getInstance();
     /*
      *  if -1, means we are looking for events from all time.
-     *  we just keep current time and filter below current time.
+     *  we just keep current date and filter on or before current date.
      */
-    if (days != -1) cal.add(Calendar.DAY_OF_YEAR, -days);
-    Date fromDate = cal.getTime();
+    LocalDate fromDate = days != -1 ? LocalDate.now().minusDays(days) : LocalDate.now();
 
     CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
     CriteriaQuery<String> criteriaQuery = criteriaBuilder.createQuery(String.class);
@@ -200,7 +197,7 @@ public class PSBlogPostVisitDao implements IPSBlogPostVisitDao {
    * @return the matching visit, or {@code null} if none was found.
    */
   @Transactional(isolation = Isolation.READ_UNCOMMITTED, readOnly = true)
-  public PSDbBlogPostVisit findBlogPostVisitByDate(String pagepath, Date date) {
+  public PSDbBlogPostVisit findBlogPostVisitByDate(String pagepath, LocalDate date) {
     Validate.notEmpty(pagepath, "pagepath cannot be null nor empty");
 
     Session session = getSession();

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSDbBlogPostVisit.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSDbBlogPostVisit.java
@@ -24,11 +24,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import java.math.BigInteger;
-import java.util.Date;
-import java.util.Optional;
+import java.time.LocalDate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.hibernate.annotations.Cache;
@@ -37,7 +34,8 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 /**
  * Hibernate-backed entity that represents a single recorded visit to a published blog post.
  *
- * <p>Page visit object.
+ * <p>Page visit object. {@code hitDate} is a {@link LocalDate} (JPA DATE) so Hibernate 7 maps it
+ * without deprecated {@code @Temporal}.
  */
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "PSBlogPostVisit")
@@ -55,9 +53,7 @@ public final class PSDbBlogPostVisit implements IPSBlogPostVisit {
   private String pagepath;
 
   /** Calendar date of the visit. */
-  @Basic
-  @Temporal(TemporalType.DATE)
-  private Date hitDate;
+  @Basic private LocalDate hitDate;
 
   /** Cumulative hit count for the page path on {@link #hitDate}. */
   @Basic private BigInteger hitCount;
@@ -72,7 +68,7 @@ public final class PSDbBlogPostVisit implements IPSBlogPostVisit {
    * @param hitDate the date the visit occurred; may not be {@code null}.
    * @param hitCount the cumulative hit count for this page path; may not be {@code null}.
    */
-  public PSDbBlogPostVisit(String pagepath, Date hitDate, BigInteger hitCount) {
+  public PSDbBlogPostVisit(String pagepath, LocalDate hitDate, BigInteger hitCount) {
     if (pagepath == null || pagepath.length() == 0)
       throw new IllegalArgumentException("pagepath cannot be null or empty");
     if (hitDate == null) throw new IllegalArgumentException("hitDate cannot be null");
@@ -80,7 +76,7 @@ public final class PSDbBlogPostVisit implements IPSBlogPostVisit {
 
     // Direct field assignment; class is final (no this-escape via overridable setters).
     this.hitCount = hitCount;
-    this.hitDate = new Date(hitDate.getTime());
+    this.hitDate = hitDate;
     this.pagepath = pagepath;
   }
 
@@ -103,8 +99,8 @@ public final class PSDbBlogPostVisit implements IPSBlogPostVisit {
    *
    * @return the hit date, may be {@code null}.
    */
-  public Date getHitDate() {
-    return Optional.ofNullable(hitDate).map(Date::getTime).map(Date::new).orElse(null);
+  public LocalDate getHitDate() {
+    return hitDate;
   }
 
   /**
@@ -112,8 +108,8 @@ public final class PSDbBlogPostVisit implements IPSBlogPostVisit {
    *
    * @param hitDate the hit date to set; may be {@code null}.
    */
-  public void setHitDate(Date hitDate) {
-    this.hitDate = Optional.ofNullable(hitDate).map(Date::getTime).map(Date::new).orElse(null);
+  public void setHitDate(LocalDate hitDate) {
+    this.hitDate = hitDate;
   }
 
   /**

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSDbCookieConsent.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSDbCookieConsent.java
@@ -24,16 +24,16 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
-import java.util.Date;
-import java.util.Optional;
+import java.time.Instant;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 /**
  * Hibernate-managed entity backing a single cookie-consent entry as recorded by the DTS metadata
  * micro-service.
+ *
+ * <p>{@code consentDate} is an {@link Instant} so Hibernate 7 maps the TIMESTAMP column without
+ * deprecated {@code @Temporal}.
  *
  * @author chriswright
  */
@@ -68,11 +68,10 @@ public final class PSDbCookieConsent implements IPSCookieConsent {
   @Column(name = "OPT_IN")
   private boolean optIn;
 
-  /** Date the consent was captured. */
+  /** Instant the consent was captured. */
   @Basic
-  @Temporal(TemporalType.TIMESTAMP)
   @Column(name = "CONSENT_DATE")
-  private Date consentDate;
+  private Instant consentDate;
 
   /** No-arg constructor required by Hibernate. */
   public PSDbCookieConsent() {}
@@ -82,12 +81,12 @@ public final class PSDbCookieConsent implements IPSCookieConsent {
    *
    * @param siteName the site the consent was captured for; may not be {@code null}.
    * @param serviceName the service / cookie name the consent applies to; may not be {@code null}.
-   * @param consentDate the date the consent was captured; may not be {@code null}.
+   * @param consentDate the instant the consent was captured; may not be {@code null}.
    * @param ip the originating client IP; may not be {@code null}.
    * @param optIn {@code true} if the client opted in, {@code false} otherwise.
    */
   public PSDbCookieConsent(
-      String siteName, String serviceName, Date consentDate, String ip, boolean optIn) {
+      String siteName, String serviceName, Instant consentDate, String ip, boolean optIn) {
 
     if (siteName == null) throw new IllegalArgumentException("siteName may not be null");
     if (serviceName == null) throw new IllegalArgumentException("serviceName may not be null");
@@ -97,7 +96,7 @@ public final class PSDbCookieConsent implements IPSCookieConsent {
     // Direct field assignment; class is final (no this-escape via overridable setters).
     this.siteName = siteName;
     this.serviceName = serviceName;
-    this.consentDate = new Date(consentDate.getTime());
+    this.consentDate = consentDate;
     this.ip = ip;
     this.optIn = optIn;
   }
@@ -123,14 +122,13 @@ public final class PSDbCookieConsent implements IPSCookieConsent {
   }
 
   @Override
-  public void setConsentDate(Date consentDate) {
-    this.consentDate =
-        Optional.ofNullable(consentDate).map(Date::getTime).map(Date::new).orElse(null);
+  public void setConsentDate(Instant consentDate) {
+    this.consentDate = consentDate;
   }
 
   @Override
-  public Date getConsentDate() {
-    return Optional.ofNullable(consentDate).map(Date::getTime).map(Date::new).orElse(null);
+  public Instant getConsentDate() {
+    return consentDate;
   }
 
   @Override

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSDbMetadataProperty.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSDbMetadataProperty.java
@@ -31,10 +31,10 @@ import jakarta.persistence.JoinColumns;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
-import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -42,6 +42,9 @@ import org.hibernate.annotations.Nationalized;
 
 /**
  * Represents a metadata property name / value pair attached to a {@link PSDbMetadataEntry}.
+ *
+ * <p>{@code datevalue} is a {@link LocalDateTime} so Hibernate 7 maps the TIMESTAMP column without
+ * deprecated {@code @Temporal}.
  *
  * @author erikserating
  */
@@ -83,9 +86,7 @@ public final class PSDbMetadataProperty implements IPSMetadataProperty {
   private String textvalue;
 
   /** Date value of this property (used for {@link VALUETYPE#DATE} entries). */
-  @Basic
-  @Temporal(TemporalType.TIMESTAMP)
-  private Date datevalue;
+  @Basic private LocalDateTime datevalue;
 
   /** Numeric value of this property (used for {@link VALUETYPE#NUMBER} entries). */
   @Basic private Double numbervalue;
@@ -123,10 +124,7 @@ public final class PSDbMetadataProperty implements IPSMetadataProperty {
     this.setName(name);
     boolean nan = true;
     if (type == VALUETYPE.DATE) {
-      if (!(value instanceof Date))
-        throw new IllegalArgumentException(
-            "Value type 'Date' was specified but the passed in value is not a date object.");
-      setDatevalue((Date) value);
+      setDatevalue(toLocalDateTime(value));
     } else if (type == VALUETYPE.NUMBER) {
       Double d = null;
       if (value instanceof Integer
@@ -224,7 +222,17 @@ public final class PSDbMetadataProperty implements IPSMetadataProperty {
   }
 
   /**
-   * Convenience ctor to create a Date value type property.
+   * Convenience ctor to create a Date value type property from a {@link LocalDateTime}.
+   *
+   * @param name name cannot be <code>null</code> or empty.
+   * @param value may be <code>null</code>.
+   */
+  public PSDbMetadataProperty(String name, LocalDateTime value) {
+    this(name, VALUETYPE.DATE, value);
+  }
+
+  /**
+   * Convenience ctor to create a Date value type property from a legacy {@link Date}.
    *
    * @param name name cannot be <code>null</code> or empty.
    * @param value may be <code>null</code>.
@@ -343,7 +351,7 @@ public final class PSDbMetadataProperty implements IPSMetadataProperty {
     if (valuetype == VALUETYPE.STRING) return stringvalue;
     if (valuetype == VALUETYPE.TEXT) return textvalue;
     if (valuetype == VALUETYPE.DATE) {
-      return datevalue.toString();
+      return datevalue == null ? "" : datevalue.toString();
     }
     if (valuetype == VALUETYPE.NUMBER) {
       return numbervalue.toString();
@@ -384,16 +392,16 @@ public final class PSDbMetadataProperty implements IPSMetadataProperty {
   /**
    * @return the datevalue
    */
-  public Date getDatevalue() {
-    return Optional.ofNullable(datevalue).map(Date::getTime).map(Date::new).orElse(null);
+  public LocalDateTime getDatevalue() {
+    return datevalue;
   }
 
   /**
    * @param datevalue the datevalue to set
    */
-  public void setDatevalue(Date datevalue) {
+  public void setDatevalue(LocalDateTime datevalue) {
     this.valuetype = VALUETYPE.DATE;
-    this.datevalue = Optional.ofNullable(datevalue).map(Date::getTime).map(Date::new).orElse(null);
+    this.datevalue = datevalue;
 
     calculateHash(this.datevalue);
   }
@@ -422,5 +430,31 @@ public final class PSDbMetadataProperty implements IPSMetadataProperty {
    */
   public int getId() {
     return this.id;
+  }
+
+  /**
+   * Coerces supported date-like inputs to {@link LocalDateTime} using the JVM default zone for
+   * legacy {@link Date} / {@link Instant} values.
+   *
+   * @param value the raw date value; may be {@code null}.
+   * @return the coerced local date-time, or {@code null} when {@code value} is {@code null}.
+   */
+  static LocalDateTime toLocalDateTime(Object value) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof LocalDateTime) {
+      return (LocalDateTime) value;
+    }
+    if (value instanceof Instant) {
+      return LocalDateTime.ofInstant((Instant) value, ZoneId.systemDefault());
+    }
+    // java.sql.Date#toInstant() throws UnsupportedOperationException — use millis instead.
+    if (value instanceof Date) {
+      return LocalDateTime.ofInstant(
+          Instant.ofEpochMilli(((Date) value).getTime()), ZoneId.systemDefault());
+    }
+    throw new IllegalArgumentException(
+        "Value type 'Date' was specified but the passed in value is not a date object.");
   }
 }

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSMetadataDao.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSMetadataDao.java
@@ -421,7 +421,7 @@ public class PSMetadataDao implements IPSMetadataDao {
     Object value = metadataProperty.getValue();
     switch (metadataProperty.getValuetype()) {
       case DATE:
-        copiedProperty.setDatevalue((java.util.Date) value);
+        copiedProperty.setDatevalue(PSDbMetadataProperty.toLocalDateTime(value));
         break;
       case NUMBER:
         copiedProperty.setNumbervalue(toDouble(value));

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSMetadataQueryService.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/main/java/com/percussion/delivery/metadata/rdbms/impl/PSMetadataQueryService.java
@@ -34,6 +34,8 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.text.MessageFormat;
 import java.text.ParseException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.*;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -214,7 +216,9 @@ public class PSMetadataQueryService implements IPSMetadataQueryService {
 
       if (valueColumn.equals(PROP_DATEVALUE_COLUMN_NAME)) {
         Calendar date = DatatypeConverter.parseDate(value.toString().replace(' ', 'T'));
-        value = new Date(date.getTimeInMillis());
+        value =
+            LocalDateTime.ofInstant(
+                date.toInstant(), ZoneId.systemDefault());
       }
 
       if ((valueColumn.equals(PROP_STRINGVALUE_COLUMN_NAME)
@@ -301,8 +305,12 @@ public class PSMetadataQueryService implements IPSMetadataQueryService {
               key,
               PSMetadataQueryServiceHelper.parseToList(
                   key, value.toString(), datatypeMappings, hashCalculator));
+        } else if (value instanceof LocalDateTime) {
+          hq.setParameter(key, (LocalDateTime) value);
         } else if (value instanceof Date) {
-          hq.setParameter(key, (Date) value);
+          hq.setParameter(
+              key,
+              LocalDateTime.ofInstant(((Date) value).toInstant(), ZoneId.systemDefault()));
         } else if (value instanceof String) {
           hq.setParameter(key, value.toString());
         }
@@ -530,7 +538,9 @@ public class PSMetadataQueryService implements IPSMetadataQueryService {
 
       if (valueColumn.equals(PROP_DATEVALUE_COLUMN_NAME)) {
         Calendar date = DatatypeConverter.parseDate(value.toString().replace(' ', 'T'));
-        value = new Date(date.getTimeInMillis());
+        value =
+            LocalDateTime.ofInstant(
+                date.toInstant(), ZoneId.systemDefault());
       }
 
       String useClause = clauseTemplate;
@@ -640,8 +650,12 @@ public class PSMetadataQueryService implements IPSMetadataQueryService {
             key,
             PSMetadataQueryServiceHelper.parseToList(
                 key, value.toString(), datatypeMappings, hashCalculator));
+      } else if (value instanceof LocalDateTime) {
+        q.setParameter(key, (LocalDateTime) value);
       } else if (value instanceof Date) {
-        q.setParameter(key, (Date) value);
+        q.setParameter(
+            key,
+            LocalDateTime.ofInstant(((Date) value).toInstant(), ZoneId.systemDefault()));
       } else if (value instanceof String) {
         q.setParameter(key, value.toString());
       }

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/PSMetadataIndexerServiceTest.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/PSMetadataIndexerServiceTest.java
@@ -166,7 +166,10 @@ public class PSMetadataIndexerServiceTest {
 
       assertTrue(props.containsKey("prop3"), "prop3 exists");
       assertEquals(VALUETYPE.DATE, props.get("prop3").get(0).getValuetype(), "prop3 value type");
-      assertEquals(Date.valueOf("2011-02-28"), props.get("prop3").get(0).getDatevalue(), "prop3 value");
+      assertEquals(
+          java.time.LocalDate.of(2011, 2, 28).atStartOfDay(),
+          props.get("prop3").get(0).getDatevalue(),
+          "prop3 value");
     }
 
     System.out.println();

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/PSMetadataQueryServiceTest.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/PSMetadataQueryServiceTest.java
@@ -31,6 +31,7 @@ import com.percussion.delivery.metadata.impl.utils.PSPair;
 import com.percussion.delivery.metadata.rdbms.impl.PSDbMetadataEntry;
 import com.percussion.delivery.metadata.rdbms.impl.PSDbMetadataProperty;
 import com.percussion.security.error.PSExceptionUtils;
+import java.time.LocalDateTime;
 import java.util.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -207,7 +208,7 @@ public class PSMetadataQueryServiceTest {
     assertNotNull(results, "entries not null");
     assertEquals(ENTRY_COUNT * 3, results.size(), "entries found");
 
-    Date previousDateValue = getTime(1900, 1, 1);
+    LocalDateTime previousDateValue = getTime(1900, 1, 1);
     IPSMetadataEntry entry;
 
     for (int i = 0; i < results.size(); i++) {
@@ -216,7 +217,7 @@ public class PSMetadataQueryServiceTest {
       props = toPropsMap(entry.getProperties());
 
       assertTrue(
-          props.get("dcterms:created").getDatevalue().compareTo(previousDateValue) >= 0,
+          !props.get("dcterms:created").getDatevalue().isBefore(previousDateValue),
           "Date greater than previous");
 
       previousDateValue = props.get("dcterms:created").getDatevalue();
@@ -732,7 +733,7 @@ public class PSMetadataQueryServiceTest {
         VALUETYPE.DATE,
         new PropertyValueChecker<Object>() {
           public boolean valueIsCorrect(Object currentValue) {
-            Date value = (Date) currentValue;
+            LocalDateTime value = (LocalDateTime) currentValue;
             return value.compareTo(getTime(2010, 12, 15, 16, 17, 18)) == 0;
           }
         });
@@ -810,7 +811,7 @@ public class PSMetadataQueryServiceTest {
         VALUETYPE.DATE,
         new PropertyValueChecker<Object>() {
           public boolean valueIsCorrect(Object currentValue) {
-            Date date = (Date) currentValue;
+            LocalDateTime date = (LocalDateTime) currentValue;
             return date.compareTo(getTime(2010, 12, 15, 16, 17, 18)) != 0;
           }
         });
@@ -825,7 +826,7 @@ public class PSMetadataQueryServiceTest {
         VALUETYPE.DATE,
         new PropertyValueChecker<Object>() {
           public boolean valueIsCorrect(Object currentValue) {
-            Date date = (Date) currentValue;
+            LocalDateTime date = (LocalDateTime) currentValue;
             return date.compareTo(getTime(2010, 12, 15, 16, 17, 18)) > 0;
           }
         });
@@ -840,7 +841,7 @@ public class PSMetadataQueryServiceTest {
         VALUETYPE.DATE,
         new PropertyValueChecker<Object>() {
           public boolean valueIsCorrect(Object currentValue) {
-            Date date = (Date) currentValue;
+            LocalDateTime date = (LocalDateTime) currentValue;
             return date.compareTo(getTime(2010, 12, 15, 16, 17, 18)) >= 0;
           }
         });
@@ -855,7 +856,7 @@ public class PSMetadataQueryServiceTest {
         VALUETYPE.DATE,
         new PropertyValueChecker<Object>() {
           public boolean valueIsCorrect(Object currentValue) {
-            Date date = (Date) currentValue;
+            LocalDateTime date = (LocalDateTime) currentValue;
             return date.compareTo(getTime(2010, 12, 15)) < 0;
           }
         });
@@ -870,7 +871,7 @@ public class PSMetadataQueryServiceTest {
         VALUETYPE.DATE,
         new PropertyValueChecker<Object>() {
           public boolean valueIsCorrect(Object currentValue) {
-            Date date = (Date) currentValue;
+            LocalDateTime date = (LocalDateTime) currentValue;
             return date.compareTo(getTime(2010, 12, 15, 16, 17, 18)) <= 0;
           }
         });
@@ -885,7 +886,7 @@ public class PSMetadataQueryServiceTest {
         VALUETYPE.DATE,
         new PropertyValueChecker<Object>() {
           public boolean valueIsCorrect(Object currentValue) {
-            Date date = (Date) currentValue;
+            LocalDateTime date = (LocalDateTime) currentValue;
             return date.compareTo(getTime(2010, 12, 15, 16, 17, 18)) <= 0;
           }
         });
@@ -908,7 +909,7 @@ public class PSMetadataQueryServiceTest {
     assertNotNull(results, "entries not null");
     assertEquals(ENTRY_COUNT * 3, results.size(), "entries found");
 
-    Date previousDateValue = getTime(1900, 1, 1);
+    LocalDateTime previousDateValue = getTime(1900, 1, 1);
     PSDbMetadataEntry entry;
 
     for (int i = 0; i < results.size(); i++) {
@@ -917,7 +918,7 @@ public class PSMetadataQueryServiceTest {
       props = toPropsMap(entry.getProperties());
 
       assertTrue(
-          props.get("dcterms:created").getDatevalue().compareTo(previousDateValue) >= 0,
+          !props.get("dcterms:created").getDatevalue().isBefore(previousDateValue),
           "Date greater than previous");
 
       previousDateValue = props.get("dcterms:created").getDatevalue();
@@ -1354,23 +1355,12 @@ public class PSMetadataQueryServiceTest {
     return entries;
   }
 
-  private Date getTime(int year, int month, int day) {
+  private LocalDateTime getTime(int year, int month, int day) {
     return getTime(year, month, day, 0, 0, 0);
   }
 
-  private Date getTime(int year, int month, int day, int hour, int minute, int second) {
-    Calendar cal = Calendar.getInstance();
-
-    cal.clear();
-
-    cal.set(Calendar.YEAR, year);
-    cal.set(Calendar.MONTH, month - 1);
-    cal.set(Calendar.DAY_OF_MONTH, day);
-    cal.set(Calendar.HOUR_OF_DAY, hour);
-    cal.set(Calendar.MINUTE, minute);
-    cal.set(Calendar.SECOND, second);
-
-    return cal.getTime();
+  private LocalDateTime getTime(int year, int month, int day, int hour, int minute, int second) {
+    return LocalDateTime.of(year, month, day, hour, minute, second);
   }
 
   private void runEntryTest(
@@ -1503,18 +1493,18 @@ public class PSMetadataQueryServiceTest {
   }
 
   private PSDbMetadataEntry createEntry(
-      String folder, String linktext, Date date, String type, int idx) {
+      String folder, String linktext, LocalDateTime date, String type, int idx) {
     return createEntry("testsite", folder, linktext, date, type, idx);
   }
 
   private PSDbMetadataEntry createEntry(
-      String folder, String linktext, Date date, String template, String type, int idx) {
+      String folder, String linktext, LocalDateTime date, String template, String type, int idx) {
     return createEntry(
         "testsite", folder, linktext, date, "a summary of the page", template, type, idx);
   }
 
   private PSDbMetadataEntry createEntry(
-      String testsite, String folder, String linktext, Date date, String type, int idx) {
+      String testsite, String folder, String linktext, LocalDateTime date, String type, int idx) {
     return createEntry(
         testsite, folder, linktext, date, "a summary of the page", "templateName", type, idx);
   }
@@ -1523,7 +1513,7 @@ public class PSMetadataQueryServiceTest {
       String testsite,
       String folder,
       String linktext,
-      Date date,
+      LocalDateTime date,
       String abstr,
       String template,
       String type,
@@ -1537,7 +1527,7 @@ public class PSMetadataQueryServiceTest {
       String title,
       String folder,
       String linktext,
-      Date date,
+      LocalDateTime date,
       String abstr,
       String template,
       String type,
@@ -1616,18 +1606,18 @@ public class PSMetadataQueryServiceTest {
 
       assertNotNull(results, "entries not null");
 
-      Date latest = null;
+      LocalDateTime latest = null;
       // Test descending query
       for (IPSMetadataEntry e : results) {
         Map<String, IPSMetadataProperty> props = toPropsMap(e.getProperties());
 
-        Date curDate = props.get("dcterms:created").getDatevalue();
+        LocalDateTime curDate = props.get("dcterms:created").getDatevalue();
 
         if (latest == null) {
           latest = curDate;
           System.out.println("Starting date is " + latest.toString());
         } else {
-          assertTrue(latest.after(curDate));
+          assertTrue(latest.isAfter(curDate));
           System.out.println(latest.toString() + " is more recent than " + curDate.toString());
           latest = curDate;
         }
@@ -1658,17 +1648,17 @@ public class PSMetadataQueryServiceTest {
 
       assertNotNull(results, "entries not null");
 
-      Date latest = null;
+      LocalDateTime latest = null;
       // Test ascending query
       for (IPSMetadataEntry e : results) {
         Map<String, IPSMetadataProperty> props = toPropsMap(e.getProperties());
 
-        Date curDate = props.get("dcterms:created").getDatevalue();
+        LocalDateTime curDate = props.get("dcterms:created").getDatevalue();
 
         if (latest == null) {
           latest = curDate;
         } else {
-          assertTrue(latest.before(curDate));
+          assertTrue(latest.isBefore(curDate));
           System.out.println(latest.toString() + " is older than " + curDate.toString());
           latest = curDate;
         }

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/PSMostReadServiceTest.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/PSMostReadServiceTest.java
@@ -27,7 +27,7 @@ import com.percussion.security.error.PSExceptionUtils;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
+
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -234,7 +234,7 @@ public class PSMostReadServiceTest {
     PSDbBlogPostVisit bpv = null;
 
     try {
-      bpv = new PSDbBlogPostVisit(null, new Date(), BigInteger.ONE);
+      bpv = new PSDbBlogPostVisit(null, java.time.LocalDate.now(), BigInteger.ONE);
     } catch (IllegalArgumentException illegalArgumentException) {
       assertEquals("pagepath cannot be null or empty", illegalArgumentException.getMessage());
     }
@@ -246,14 +246,14 @@ public class PSMostReadServiceTest {
     }
 
     try {
-      bpv = new PSDbBlogPostVisit("test", new Date(), null);
+      bpv = new PSDbBlogPostVisit("test", java.time.LocalDate.now(), null);
     } catch (IllegalArgumentException illegalArgumentException) {
       assertEquals("hitCount cannot be null", illegalArgumentException.getMessage());
     }
 
-    bpv = new PSDbBlogPostVisit("test", new Date(), BigInteger.ONE);
+    bpv = new PSDbBlogPostVisit("test", java.time.LocalDate.now(), BigInteger.ONE);
     assertEquals("test", bpv.getPagepath(), "should equal test");
-    assertTrue(bpv.getHitDate().getTime() <= System.currentTimeMillis());
+    assertTrue(!bpv.getHitDate().isAfter(java.time.LocalDate.now()));
   }
 
   /**

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/data/PSCookieConsentTest.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/data/PSCookieConsentTest.java
@@ -17,13 +17,12 @@
 package com.percussion.delivery.metadata.data;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Modifier;
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -39,8 +38,8 @@ public class PSCookieConsentTest {
   }
 
   @Test
-  public void populatedConstructorAssignsDefensiveDateCopy() {
-    Date consent = new Date(1_700_000_000_000L);
+  public void populatedConstructorAssignsInstantConsentDate() {
+    Instant consent = Instant.ofEpochMilli(1_700_000_000_000L);
     PSCookieConsent entry =
         new PSCookieConsent("siteA", "analytics", consent, "127.0.0.1", true);
 
@@ -49,12 +48,11 @@ public class PSCookieConsentTest {
     assertEquals("127.0.0.1", entry.getIP());
     assertTrue(entry.getOptIn());
     assertEquals(consent, entry.getConsentDate());
-    assertNotSame(consent, entry.getConsentDate());
   }
 
   @Test
   public void populatedConstructorRejectsNulls() {
-    Date now = new Date();
+    Instant now = Instant.now();
     assertThrows(
         IllegalArgumentException.class,
         () -> new PSCookieConsent(null, "svc", now, "1.1.1.1", true));
@@ -71,7 +69,7 @@ public class PSCookieConsentTest {
 
   @Test
   public void cookieConsentQueryConstructorSetsServices() {
-    Date now = new Date();
+    Instant now = Instant.now();
     List<String> services = Arrays.asList("cookie-a", "cookie-b");
     PSCookieConsentQuery query = new PSCookieConsentQuery("mysite", now, true, services);
 
@@ -85,6 +83,6 @@ public class PSCookieConsentTest {
   public void cookieConsentQueryRejectsNullServices() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> new PSCookieConsentQuery("site", new Date(), true, null));
+        () -> new PSCookieConsentQuery("site", Instant.now(), true, null));
   }
 }

--- a/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/rdbms/impl/PSDbEntityStructureTest.java
+++ b/deliverytiersuite/delivery-tier-suite/metadata/src/test/java/com/percussion/delivery/metadata/rdbms/impl/PSDbEntityStructureTest.java
@@ -24,7 +24,8 @@ import com.percussion.delivery.metadata.extractor.data.PSMetadataEntry;
 import java.io.Serializable;
 import java.lang.reflect.Modifier;
 import java.math.BigInteger;
-import java.util.Date;
+import java.time.Instant;
+import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -52,7 +53,7 @@ public class PSDbEntityStructureTest {
 
   @Test
   public void blogPostVisitConstructorAssignsFields() {
-    Date hit = new Date(1_700_000_000_000L);
+    LocalDate hit = LocalDate.of(2023, 11, 14);
     PSDbBlogPostVisit visit =
         new PSDbBlogPostVisit("/site/blog/post.html", hit, BigInteger.valueOf(3));
     assertEquals("/site/blog/post.html", visit.getPagepath());
@@ -62,7 +63,7 @@ public class PSDbEntityStructureTest {
 
   @Test
   public void cookieConsentConstructorAssignsFields() {
-    Date consent = new Date(1_700_000_000_000L);
+    Instant consent = Instant.ofEpochMilli(1_700_000_000_000L);
     PSDbCookieConsent entity =
         new PSDbCookieConsent("site", "svc", consent, "10.0.0.1", true);
     assertEquals("site", entity.getSiteName());


### PR DESCRIPTION
## Summary
Residual of #2041 under parent tracker #2200: migrate the three remaining `@Temporal` `java.util.Date` entity fields in `perc-metadata-services` to Hibernate 7-native `java.time` types so deprecation diagnostics under `-Dmaven.compiler.showDeprecation=true` are gone without the prior `@JdbcTypeCode` H2 `ClassCastException` path.

| Entity | Field | Was | Now |
| --- | --- | --- | --- |
| `PSDbBlogPostVisit` | `hitDate` | `@Temporal(DATE) Date` | `LocalDate` |
| `PSDbCookieConsent` | `consentDate` | `@Temporal(TIMESTAMP) Date` | `Instant` |
| `PSDbMetadataProperty` | `datevalue` | `@Temporal(TIMESTAMP) Date` | `LocalDateTime` |

Also updated `IPSBlogPostVisit` / `IPSCookieConsent` / `IPSMetadataProperty`, transport DTOs, visit/consent DAOs, query helpers (criteria params + formatting), and module tests. Legacy `java.util.Date` / `java.sql.Date` property constructors remain as conversion helpers (epoch millis — `sql.Date#toInstant()` is unsupported).

## Test plan
- [x] `cd deliverytiersuite/delivery-tier-suite/metadata && ./mvnw clean install -Dmaven.compiler.showDeprecation=true` — **BUILD SUCCESS**, 86 tests
- [x] `PSMostReadServiceTest` green (no Timestamp↔Date ClassCastException)
- [x] Cookie consent DTO / entity structure tests green
- [x] Metadata property date / query sort / criteria tests green
- [x] Compile with showDeprecation: **zero** `@Temporal` / `TemporalType` diagnostics in this module

## Gates evidence
- **Module clean install:** green (standalone `perc-metadata-services`)
- **Erlang self-review:** immutable `java.time` types (no defensive Date copies); portable (no path I/O); `sql.Date` conversion via `getTime()`; companions (interfaces, DTOs, DAOs, helpers, tests) closed in-module
- **Scope:** metadata module only (23 files)

## Links
- Fixes #2306
- Refs #2200 (parent tracker)
- Refs #2041 (originating javac cleanup)

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.