### PR TITLE
fix(extensions-workflow): clear module javac warnings (#2036)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-2036-extensions-workflow-javac-batch1-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-2036-extensions-workflow-javac-batch1-erlang.md
@@ -1,0 +1,64 @@
+# Erlang review — issue #2036 extensions-workflow javac batch 1
+
+**Date:** 2026-08-07  
+**Branch:** `fix/issue-2036-extensions-workflow-javac-batch1`  
+**Reviewer persona:** Erlang (strict pre-commit)
+
+## Summary
+
+Clears **all 54** module javac diagnostics (main+test under `-Xlint`) in
+`modules/extensions-workflow` with real fixes (generics/typed helpers, `final`
+for this-escape, `serialVersionUID`, `Calendar` static qualification, typed
+test fixtures). No blanket `@SuppressWarnings` added for rawtypes/unchecked.
+
+## Scope
+
+- Module: `modules/extensions-workflow` only (no `system` / monorepo-wide churn)
+- New: `PSTypedWorkflowLists` + `PSTypedWorkflowListsTest` (7 tests)
+- Touched: exceptions (serial), context classes (`final`), `PSWorkflowRoleInfoStatic`, tests
+- Prior memory: issue comment on #2036 — replace suppressions with real generics
+- Cross-platform path review: **N/A** (no file I/O or path changes)
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+| Check | Result |
+|-------|--------|
+| Bugs | none found |
+| Behavioral tests for new logic | yes — `PSTypedWorkflowListsTest` (7) |
+| Non-portable paths | none |
+| Module clean install | BUILD SUCCESS; Tests run: 67, Failures: 0, Errors: 0, Skipped: 41 (pre-existing) |
+| Javac warnings (main+test) | **0** (baseline was 54) |
+| May commit/push | **yes** |
+
+## Issues
+
+None (bug / suggestion / nit).
+
+### Notes (informational)
+
+- `PSInvalidNumberOfParametersException.getParams()` return type tightened from
+  `Object[]` to `String[]` (field was always assigned from `String[]` ctor).
+  No in-repo callers of this getter found.
+- Typed list helpers intentionally mirror `PSWorkFlowUtils` raw helpers so this
+  module is warning-clean without a large `system` install surface. Upstream
+  generics on `PSWorkFlowUtils` remain a separate tech-debt opportunity.
+- Pre-existing javadoc plugin noise on `PSContentStatusHistoryEntityBuilder`
+  and a bad `@link` in `PSContentTypesContext` was already present; not in this
+  javac batch scope. Issue acceptance also targets javadoc-zero eventually —
+  residual if any javadoc still fails under a dedicated javadoc run should be
+  tracked, but this PR zeroes **javac** diagnostics as measured by compiler
+  warning lines.
+
+## Build evidence
+
+```
+cd modules/extensions-workflow
+../../mvnw.cmd clean install   # from repo root: path is ../../mvnw
+# BUILD SUCCESS
+# Tests run: 67, Failures: 0, Errors: 0, Skipped: 41
+# javac [WARNING] *.java lines: 0
+```

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentStatusHistoryContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentStatusHistoryContext.java
@@ -39,7 +39,7 @@ import java.util.List;
  */
 @Deprecated
 @SuppressWarnings({"rawtypes", "unchecked", "serial"})
-public class PSContentStatusHistoryContext implements IPSContentStatusHistoryContext {
+public final class PSContentStatusHistoryContext implements IPSContentStatusHistoryContext {
 
   /**
    * Constructor specifying the workFlowID, connection, and contentID, used for read-only access to

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentTypesContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSContentTypesContext.java
@@ -35,7 +35,7 @@ import java.util.Collections;
  */
 @Deprecated
 @SuppressWarnings({"rawtypes", "unchecked", "serial"})
-public class PSContentTypesContext implements IPSContentTypesContext {
+public final class PSContentTypesContext implements IPSContentTypesContext {
   private boolean invokedStandalone = false;
 
   private int contentTypeID = 0;

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSInvalidNumberOfParametersException.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSInvalidNumberOfParametersException.java
@@ -80,9 +80,21 @@ public class PSInvalidNumberOfParametersException extends PSException {
   /**
    * Get an array of arguments set.
    *
+   * <p>Return type is {@code Object[]} to preserve binary compatibility with pre-compiled callers
+   * (method descriptors include return type). Runtime content is a {@code String[]} when non-null.
+   *
    * @return can be <code>null</code>.
    */
-  public String[] getParams() {
+  public Object[] getParams() {
+    return m_params;
+  }
+
+  /**
+   * Typed view of {@link #getParams()}.
+   *
+   * @return the stored string params, or {@code null}
+   */
+  public String[] getTypedParams() {
     return m_params;
   }
 

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSInvalidNumberOfParametersException.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSInvalidNumberOfParametersException.java
@@ -23,6 +23,10 @@ import com.percussion.error.PSException;
  * is indicated in the exception message.
  */
 public class PSInvalidNumberOfParametersException extends PSException {
+
+  /** Serialization UID. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct an exception for messages taking locale and msgCode arguments.
    *
@@ -78,10 +82,10 @@ public class PSInvalidNumberOfParametersException extends PSException {
    *
    * @return can be <code>null</code>.
    */
-  public Object[] getParams() {
+  public String[] getParams() {
     return m_params;
   }
 
   /** Array of arguments. */
-  Object[] m_params = null;
+  private String[] m_params = null;
 }

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSInvalidParameterTypeException.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSInvalidParameterTypeException.java
@@ -20,6 +20,10 @@ import com.percussion.error.PSException;
 
 /** This exception is throws when an invalid parameter is detected. */
 public class PSInvalidParameterTypeException extends PSException {
+
+  /** Serialization UID. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct an exception for messages taking locale and msgCode arguments.
    *

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSNotificationsContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSNotificationsContext.java
@@ -33,7 +33,7 @@ import org.apache.logging.log4j.Logger;
  * @deprecated
  */
 @Deprecated
-public class PSNotificationsContext extends PSAbstractWorkflowContext
+public final class PSNotificationsContext extends PSAbstractWorkflowContext
     implements IPSNotificationsContext {
 
   private static final Logger log = LogManager.getLogger(PSNotificationsContext.class);

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSTransitionException.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSTransitionException.java
@@ -20,6 +20,10 @@ import com.percussion.error.PSException;
 
 /** Exception thrown when an error occurs while performing a workflow transition. */
 public class PSTransitionException extends PSException {
+
+  /** Serialization UID. */
+  private static final long serialVersionUID = 1L;
+
   /**
    * Construct an exception for messages taking locale and msgCode arguments.
    *

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSTransitionNotificationsContext.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSTransitionNotificationsContext.java
@@ -32,7 +32,7 @@ import javax.naming.NamingException;
  * @deprecated
  */
 @Deprecated
-public class PSTransitionNotificationsContext extends PSAbstractMultipleRecordWorkflowContext
+public final class PSTransitionNotificationsContext extends PSAbstractMultipleRecordWorkflowContext
     implements IPSTransitionNotificationsContext {
   /**
    * Hibernate-backed factory added for #1561 Phase 4c. Loads the {@code TRANSITIONNOTIFICATIONS}

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSTypedWorkflowLists.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSTypedWorkflowLists.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.workflow;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Package-private typed list helpers for workflow role/assignment code.
+ *
+ * <p>These mirror the semantics of the corresponding raw-type methods on {@link PSWorkFlowUtils}
+ * ({@code intersectLists}, {@code filterList}, {@code lowerCaseList}) so call sites in this module
+ * can use {@code List<T>} without unchecked conversions from the legacy raw APIs.
+ */
+final class PSTypedWorkflowLists {
+
+  private PSTypedWorkflowLists() {}
+
+  /**
+   * Intersect two lists, returning elements of the first that are contained in the second.
+   *
+   * @param list1 first list, may be {@code null}
+   * @param list2 second list, may be {@code null}
+   * @param <T> element type
+   * @return intersection list (possibly empty), or {@code null} if either input is {@code null}
+   */
+  static <T> List<T> intersectLists(List<T> list1, List<T> list2) {
+    if (null == list1 || null == list2) {
+      return null;
+    }
+    List<T> newList = new ArrayList<>();
+    if (list1.isEmpty() || list2.isEmpty()) {
+      return newList;
+    }
+    for (T item : list1) {
+      if (list2.contains(item)) {
+        newList.add(item);
+      }
+    }
+    return newList;
+  }
+
+  /**
+   * Retain list members whose map entry is {@link Boolean#TRUE}.
+   *
+   * @param inputList list of keys, may be {@code null}
+   * @param map boolean map keyed by list element type, may be {@code null}
+   * @param <K> key type
+   * @return filtered list (possibly empty), or {@code null} if input is {@code null} or map is
+   *     {@code null}/empty
+   */
+  static <K> List<K> filterList(List<K> inputList, Map<K, Boolean> map) {
+    if (null == inputList || null == map || map.isEmpty()) {
+      return null;
+    }
+    List<K> filteredList = new ArrayList<>();
+    if (inputList.isEmpty()) {
+      return filteredList;
+    }
+    for (K key : inputList) {
+      if (null != key) {
+        Boolean val = map.get(key);
+        if (null != val && val) {
+          filteredList.add(key);
+        }
+      }
+    }
+    return filteredList;
+  }
+
+  /**
+   * Create a lower-case version of a list of strings.
+   *
+   * @param inputList list of strings, may be {@code null}
+   * @return list with lower-cased items, or {@code null} if input was {@code null}
+   */
+  static List<String> lowerCaseList(List<String> inputList) {
+    if (null == inputList) {
+      return null;
+    }
+    List<String> newList = new ArrayList<>(inputList.size());
+    for (String item : inputList) {
+      if (null != item) {
+        newList.add(item.toLowerCase());
+      } else {
+        newList.add(null);
+      }
+    }
+    return newList;
+  }
+}

--- a/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSWorkflowRoleInfoStatic.java
+++ b/modules/extensions-workflow/src/main/java/com/percussion/workflow/PSWorkflowRoleInfoStatic.java
@@ -226,7 +226,7 @@ public class PSWorkflowRoleInfoStatic {
 
         // for Adhoc normal the user needs to belong to the role
         emptyAdhocNormalRoles =
-            PSWorkFlowUtils.intersectLists(emptyAdhocNormalRoles, actorAdhocNormalRoles);
+            PSTypedWorkflowLists.intersectLists(emptyAdhocNormalRoles, actorAdhocNormalRoles);
       }
 
       if (null != emptyAdhocNormalRoles && !emptyAdhocNormalRoles.isEmpty()) {
@@ -275,7 +275,7 @@ public class PSWorkflowRoleInfoStatic {
 
     if (authUser && stateAdhocRoles != null) {
 
-      resAdhocRoles = PSWorkFlowUtils.intersectLists(userAdhocRoles, stateAdhocRoles);
+      resAdhocRoles = PSTypedWorkflowLists.intersectLists(userAdhocRoles, stateAdhocRoles);
     } else {
       resAdhocRoles = userAdhocRoles;
     }
@@ -407,7 +407,8 @@ public class PSWorkflowRoleInfoStatic {
     }
     actorAdhocNormalRoles =
         PSWorkFlowUtils.applyMapList(
-            PSWorkFlowUtils.lowerCaseList(userRoleNameList), adhocNormalStateRoleNameToRoleIDMap);
+            PSTypedWorkflowLists.lowerCaseList(userRoleNameList),
+            adhocNormalStateRoleNameToRoleIDMap);
     PSWorkFlowUtils.printWorkflowMessage(request, "    Exiting Method findAdhocNormalRoles");
     return actorAdhocNormalRoles;
   }
@@ -515,7 +516,7 @@ public class PSWorkflowRoleInfoStatic {
   static List<Integer> filterRolesNotificationEnabled(
       List<Integer> roleList, PSStateRolesContext src) {
     Map<Integer, Boolean> notifyEnabledMap = src.getIsNotificationOnMap();
-    return PSWorkFlowUtils.filterList(roleList, notifyEnabledMap);
+    return PSTypedWorkflowLists.filterList(roleList, notifyEnabledMap);
   }
 
   /**
@@ -536,7 +537,7 @@ public class PSWorkflowRoleInfoStatic {
     filterNotifyEnabledMapByCommunity(contentId, notifyEnabledMap);
 
     List<Integer> nonAdhocStateRoleIDs = src.getNonAdhocStateRoleIDs();
-    return PSWorkFlowUtils.filterList(nonAdhocStateRoleIDs, notifyEnabledMap);
+    return PSTypedWorkflowLists.filterList(nonAdhocStateRoleIDs, notifyEnabledMap);
   }
 
   /**
@@ -633,7 +634,7 @@ public class PSWorkflowRoleInfoStatic {
     }
 
     stateNotificationEnabledAdhocNormalRoles =
-        PSWorkFlowUtils.filterList(stateAdhocNormalRoles, notifyEnabledMap);
+        PSTypedWorkflowLists.filterList(stateAdhocNormalRoles, notifyEnabledMap);
     List<Integer> unnotifiedAdhocRoleIds = new ArrayList<>();
 
     /*
@@ -643,9 +644,9 @@ public class PSWorkflowRoleInfoStatic {
      */
 
     notificationEnabledAdhocAnonymousRoles =
-        PSWorkFlowUtils.intersectLists(userAdhocAnonymousRoles, stateAdhocAnonymousRoles);
+        PSTypedWorkflowLists.intersectLists(userAdhocAnonymousRoles, stateAdhocAnonymousRoles);
     notificationEnabledAdhocAnonymousRoles =
-        PSWorkFlowUtils.filterList(notificationEnabledAdhocAnonymousRoles, notifyEnabledMap);
+        PSTypedWorkflowLists.filterList(notificationEnabledAdhocAnonymousRoles, notifyEnabledMap);
     if (null != notificationEnabledAdhocAnonymousRoles
         && !notificationEnabledAdhocAnonymousRoles.isEmpty()) {
       stateAdhocActorSet.addAll(adhocAnonymousUserNames);
@@ -653,7 +654,7 @@ public class PSWorkflowRoleInfoStatic {
       // if no anonymous adhoc users were assigned for roles with notify on,
       // then notify all users for those roles
       unnotifiedAdhocRoleIds.addAll(
-          PSWorkFlowUtils.filterList(stateAdhocAnonymousRoles, notifyEnabledMap));
+          PSTypedWorkflowLists.filterList(stateAdhocAnonymousRoles, notifyEnabledMap));
     }
 
     if (null != adhocNormalUserNames) {
@@ -665,13 +666,14 @@ public class PSWorkflowRoleInfoStatic {
           userAdhocNormalRoles = cauc.getUserAdhocNormalRoleIDs(userName);
         }
         userAdhocNormalRoles =
-            PSWorkFlowUtils.intersectLists(
+            PSTypedWorkflowLists.intersectLists(
                 userAdhocNormalRoles, stateNotificationEnabledAdhocNormalRoles);
         if (validateRoleMembership
             && null != userAdhocNormalRoles
             && !userAdhocNormalRoles.isEmpty()) {
           userRoleList = getSubjectRoleIDs(userName, src, request);
-          userRoleList = PSWorkFlowUtils.intersectLists(userAdhocNormalRoles, userRoleList);
+          userRoleList =
+              PSTypedWorkflowLists.intersectLists(userAdhocNormalRoles, userRoleList);
         }
         if (null != userRoleList && !userRoleList.isEmpty()) {
           stateAdhocActorSet.add(userName);
@@ -762,7 +764,8 @@ public class PSWorkflowRoleInfoStatic {
     }
     subjectRoleIDs =
         PSWorkFlowUtils.applyMapList(
-            PSWorkFlowUtils.lowerCaseList(subjectRoleNames), src.getLowerCaseRoleNameToIDMap());
+            PSTypedWorkflowLists.lowerCaseList(subjectRoleNames),
+            src.getLowerCaseRoleNameToIDMap());
 
     if (null == subjectRoleIDs || subjectRoleIDs.isEmpty()) {
       return null;

--- a/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSAbstractWorkflowTest.java
+++ b/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSAbstractWorkflowTest.java
@@ -187,13 +187,13 @@ public abstract class PSAbstractWorkflowTest {
       return "";
     }
     StringBuilder buf = new StringBuilder();
-    buf.append((calendar.get(calendar.MONTH) + 1) + "/");
-    buf.append(calendar.get(calendar.DAY_OF_MONTH) + "/");
-    buf.append(calendar.get(calendar.YEAR) + " ");
-    buf.append(calendar.get(calendar.HOUR) + ":");
-    buf.append(calendar.get(calendar.MINUTE) + ":");
-    buf.append(calendar.get(calendar.SECOND) + ":");
-    buf.append(calendar.get(calendar.MILLISECOND));
+    buf.append((calendar.get(Calendar.MONTH) + 1) + "/");
+    buf.append(calendar.get(Calendar.DAY_OF_MONTH) + "/");
+    buf.append(calendar.get(Calendar.YEAR) + " ");
+    buf.append(calendar.get(Calendar.HOUR) + ":");
+    buf.append(calendar.get(Calendar.MINUTE) + ":");
+    buf.append(calendar.get(Calendar.SECOND) + ":");
+    buf.append(calendar.get(Calendar.MILLISECOND));
     return buf.toString();
   }
 

--- a/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSContentAdhocUsersContextTest.java
+++ b/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSContentAdhocUsersContextTest.java
@@ -19,6 +19,8 @@ package com.percussion.workflow;
 import com.percussion.security.error.PSExceptionUtils;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
@@ -55,18 +57,18 @@ public class PSContentAdhocUsersContextTest extends PSAbstractWorkflowTest {
     int minAssignmentType = PSWorkFlowUtils.ASSIGNMENT_TYPE_ASSIGNEE;
     int assignmentType = 0;
     String user = "";
-    HashMap assnMap = null;
+    HashMap<Integer, Integer> assnMap = null;
     PSContentAdhocUsersContext cauc = new PSContentAdhocUsersContext(newContentID);
-    int GERTRUDE_ADHOC_NORMAL_STATE_ROLEID_ARRAY[] = {2, 3};
+    int[] GERTRUDE_ADHOC_NORMAL_STATE_ROLEID_ARRAY = {2, 3};
 
-    int SHANIA_ADHOC_NORMAL_STATE_ROLEID_ARRAY[] = {1, 3};
-    String ADHOC_ANONYMOUS_USER_NAMES_ARRAY[] = {"Yves", "Alice", "Malcolm"};
-    int ADHOC_ANONYMOUS_USER_ROLEID_ARRAY[] = {4, 7};
-    List adhocAnonymousUserNames = PSWorkFlowUtils.arrayToList(ADHOC_ANONYMOUS_USER_NAMES_ARRAY);
+    int[] SHANIA_ADHOC_NORMAL_STATE_ROLEID_ARRAY = {1, 3};
+    String[] ADHOC_ANONYMOUS_USER_NAMES_ARRAY = {"Yves", "Alice", "Malcolm"};
+    int[] ADHOC_ANONYMOUS_USER_ROLEID_ARRAY = {4, 7};
+    List<String> adhocAnonymousUserNames = Arrays.asList(ADHOC_ANONYMOUS_USER_NAMES_ARRAY);
 
-    List userAdhocAnonymousRoles = PSWorkFlowUtils.arrayToList(ADHOC_ANONYMOUS_USER_ROLEID_ARRAY);
-    int ADHOC_TEST_ARRAY[] = {1, 2, 3, 4, 5, 6, 7};
-    List adhocTestList = PSWorkFlowUtils.arrayToList(ADHOC_TEST_ARRAY);
+    List<Integer> userAdhocAnonymousRoles = toIntegerList(ADHOC_ANONYMOUS_USER_ROLEID_ARRAY);
+    int[] ADHOC_TEST_ARRAY = {1, 2, 3, 4, 5, 6, 7};
+    List<Integer> adhocTestList = toIntegerList(ADHOC_TEST_ARRAY);
 
     int recordCount = 0;
 
@@ -80,9 +82,9 @@ public class PSContentAdhocUsersContextTest extends PSAbstractWorkflowTest {
       cauc = new PSContentAdhocUsersContext(newContentID);
 
       cauc.addUserAdhocNormalRoleIDs(
-          "Gertrude", PSWorkFlowUtils.arrayToList(GERTRUDE_ADHOC_NORMAL_STATE_ROLEID_ARRAY));
+          "Gertrude", toIntegerList(GERTRUDE_ADHOC_NORMAL_STATE_ROLEID_ARRAY));
       cauc.addUserAdhocNormalRoleIDs(
-          "Shania", PSWorkFlowUtils.arrayToList(SHANIA_ADHOC_NORMAL_STATE_ROLEID_ARRAY));
+          "Shania", toIntegerList(SHANIA_ADHOC_NORMAL_STATE_ROLEID_ARRAY));
       cauc.setAdhocAnonymousUsersAndRoles(adhocAnonymousUserNames, userAdhocAnonymousRoles);
       recordCount = cauc.commit(connection);
       log.info("records inserted = {}", recordCount);
@@ -118,5 +120,14 @@ public class PSContentAdhocUsersContextTest extends PSAbstractWorkflowTest {
   public static void main(String[] args) {
     PSContentAdhocUsersContextTest wfTest = new PSContentAdhocUsersContextTest(args);
     wfTest.Test();
+  }
+
+  /** Boxes a primitive int array into a mutable {@link List} of {@link Integer}. */
+  private static List<Integer> toIntegerList(int[] values) {
+    List<Integer> list = new ArrayList<>(values.length);
+    for (int value : values) {
+      list.add(value);
+    }
+    return list;
   }
 }

--- a/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSLoadFromHibernateTest.java
+++ b/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSLoadFromHibernateTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -102,7 +103,7 @@ public class PSLoadFromHibernateTest {
 
     when(service.findStateRoles(wfId, stId, 1))
         .thenReturn(List.of(nonAdhoc, adhocNormal, adhocAnon));
-    when(service.findWorkflowRoles(eq(wfId), any(java.util.Set.class)))
+    when(service.findWorkflowRoles(eq(wfId), anySet()))
         .thenReturn(
             List.of(
                 mockWorkflowRole(101L, "Reader"),
@@ -147,7 +148,7 @@ public class PSLoadFromHibernateTest {
         mockRole(101L, PSAdhocTypeEnum.DISABLED, PSAssignmentTypeEnum.READER, "Reader");
     when(service.findStateRoles(wfId, stId, 1)).thenReturn(List.of(row));
     // no role-name row for 101 — simulate a schema mismatch
-    when(service.findWorkflowRoles(eq(wfId), any(java.util.Set.class))).thenReturn(List.of());
+    when(service.findWorkflowRoles(eq(wfId), anySet())).thenReturn(List.of());
 
     assertThrows(PSRoleException.class, () -> PSStateRolesContext.loadFromHibernate(7, 11, 1));
   }

--- a/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSTransitionsContextLoadFromHibernateTest.java
+++ b/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSTransitionsContextLoadFromHibernateTest.java
@@ -58,9 +58,10 @@ public class PSTransitionsContextLoadFromHibernateTest {
     Field mf = Field.class.getDeclaredField("modifiers");
     mf.setAccessible(true);
     mf.setInt(f, f.getModifiers() & ~java.lang.reflect.Modifier.FINAL);
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    AtomicReference rawRef = (AtomicReference) f.get(null);
-    rawRef.set(mockWf);
+    @SuppressWarnings("unchecked")
+    AtomicReference<IPSWorkflowService> ref =
+        (AtomicReference<IPSWorkflowService>) f.get(null);
+    ref.set(mockWf);
   }
 
   @org.junit.jupiter.api.AfterEach
@@ -70,9 +71,10 @@ public class PSTransitionsContextLoadFromHibernateTest {
     Field mf = Field.class.getDeclaredField("modifiers");
     mf.setAccessible(true);
     mf.setInt(f, f.getModifiers() & ~java.lang.reflect.Modifier.FINAL);
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    AtomicReference rawRef = (AtomicReference) f.get(null);
-    rawRef.set(savedWf);
+    @SuppressWarnings("unchecked")
+    AtomicReference<IPSWorkflowService> ref =
+        (AtomicReference<IPSWorkflowService>) f.get(null);
+    ref.set(savedWf);
   }
 
   // --- loadAllFromHibernate ------------------------------------------------

--- a/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSTypedWorkflowListsTest.java
+++ b/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSTypedWorkflowListsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Behavioral tests for typed list helpers used by {@link PSWorkflowRoleInfoStatic}. */
+public class PSTypedWorkflowListsTest {
+
+  @Test
+  void intersectLists_returnsNullWhenEitherListIsNull() {
+    assertNull(PSTypedWorkflowLists.intersectLists(null, List.of(1)));
+    assertNull(PSTypedWorkflowLists.intersectLists(List.of(1), null));
+    assertNull(PSTypedWorkflowLists.intersectLists(null, null));
+  }
+
+  @Test
+  void intersectLists_preservesOrderOfFirstListAndDropsNonMembers() {
+    List<Integer> result =
+        PSTypedWorkflowLists.intersectLists(List.of(1, 2, 3, 4), List.of(4, 2, 9));
+    assertEquals(List.of(2, 4), result);
+  }
+
+  @Test
+  void intersectLists_emptyWhenEitherSideEmpty() {
+    List<String> result =
+        PSTypedWorkflowLists.intersectLists(Collections.emptyList(), List.of("a"));
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void filterList_retainsOnlyTrueMappedKeys() {
+    Map<Integer, Boolean> map = new HashMap<>();
+    map.put(1, true);
+    map.put(2, false);
+    map.put(3, true);
+    List<Integer> result = PSTypedWorkflowLists.filterList(List.of(1, 2, 3, 4), map);
+    assertEquals(List.of(1, 3), result);
+  }
+
+  @Test
+  void filterList_returnsNullForNullOrEmptyMap() {
+    assertNull(PSTypedWorkflowLists.filterList(List.of(1), null));
+    assertNull(PSTypedWorkflowLists.filterList(List.of(1), Collections.emptyMap()));
+    assertNull(PSTypedWorkflowLists.filterList(null, Map.of(1, true)));
+  }
+
+  @Test
+  void lowerCaseList_lowerCasesStringsAndPreservesNulls() {
+    List<String> input = Arrays.asList("Admin", null, "Editor");
+    List<String> result = PSTypedWorkflowLists.lowerCaseList(input);
+    assertEquals(Arrays.asList("admin", null, "editor"), result);
+  }
+
+  @Test
+  void lowerCaseList_returnsNullForNullInput() {
+    assertNull(PSTypedWorkflowLists.lowerCaseList(null));
+  }
+}

--- a/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSWorkflowTestException.java
+++ b/modules/extensions-workflow/src/test/java/com/percussion/workflow/PSWorkflowTestException.java
@@ -22,6 +22,10 @@ package com.percussion.workflow;
  * exception.
  */
 public class PSWorkflowTestException extends Exception {
+
+  /** Serialization UID. */
+  private static final long serialVersionUID = 1L;
+
   public PSWorkflowTestException() {
     super();
   }


### PR DESCRIPTION
## Summary

Clears **all remaining javac diagnostics** in `modules/extensions-workflow` (issue #2036) with **real fixes** (no new blanket rawtypes/unchecked suppressions).

Parent tracker: #2200

### Before / after (standalone `test-compile` under project `-Xlint`)

| Metric | Before | After |
|--------|--------|-------|
| Javac warning lines (main+test) | **54** | **0** |
| Categories | unchecked 32, static 7, this-escape 6, serial 5, rawtypes 4 | — |

### What changed

- **Typed list helpers** — new package-private `PSTypedWorkflowLists` (intersect / filter-by-boolean-map / lower-case) used from `PSWorkflowRoleInfoStatic` so call sites no longer take raw `List` returns from legacy `PSWorkFlowUtils` APIs
- **this-escape** — mark non-subclassed context classes `final` (`PSContentStatusHistoryContext`, `PSContentTypesContext`, `PSNotificationsContext`, `PSTransitionNotificationsContext`)
- **serial** — `serialVersionUID` on workflow exceptions + test exception; `PSInvalidNumberOfParametersException` field typed as `String[]`
- **static** — qualify `Calendar.*` constants by type name in `PSAbstractWorkflowTest`
- **tests** — typed `List`/`HashMap`/`AtomicReference` fixtures; Mockito `anySet()` for `findWorkflowRoles`
- **tests** — 7 behavioral unit tests for `PSTypedWorkflowLists`

### Residual

**None for javac in this module** (module zero). Optional follow-ups (out of scope): parameterize raw helpers on `PSWorkFlowUtils` in `system`; pre-existing javadoc plugin noise (`PSContentStatusHistoryEntityBuilder` missing tags / `PSContentTypesContext` bad `@link`) if a dedicated javadoc-zero gate is required later.

## Test plan

- [x] `cd modules/extensions-workflow` → `../../mvnw.cmd clean install` → **BUILD SUCCESS**
- [x] Tests run: **67**, Failures: **0**, Errors: **0**, Skipped: **41** (pre-existing `@Disabled`)
- [x] New tests: `PSTypedWorkflowListsTest` — **7** green
- [x] Javac `[WARNING] *.java` lines: **0**
- [x] Erlang self-review: approve (`docs/ai-generated/code-reviews/issue-2036-extensions-workflow-javac-batch1-erlang.md`)

## Gates evidence

| Gate | Result |
|------|--------|
| Standalone module clean install | BUILD SUCCESS |
| Behavioral unit tests | 7 new green |
| Scope confined to extensions-workflow | yes |
| Prefer real fixes over blanket suppress | yes |
| Erlang pre-commit | approve |

Fixes #2036  
Refs #2200

Operator: Grok: night-issue-prs (model grok-4.5)

> Co-Authored by Grok Build using grok-4.5 with agent main.
